### PR TITLE
changed default reservation to ON-DEMAND

### DIFF
--- a/devops/infra-as-code/terraform/sample-aws/main.tf
+++ b/devops/infra-as-code/terraform/sample-aws/main.tf
@@ -198,8 +198,8 @@ module "db" {
   subnet_ids                    = "${module.network.private_subnets}"
   vpc_security_group_ids        = ["${module.network.rds_db_sg_id}"]
   availability_zone             = "${element(var.availability_zones, 0)}"
-  instance_class                = "db.t4g.medium"  ## postgres db instance type
-  engine_version                = "15.8"   ## postgres version
+  instance_class                = "${var.db_instance_type}"
+  engine_version                = "${var.db_version}"
   storage_type                  = "gp3"
   storage_gb                    = "20"     ## postgres disk size
   backup_retention_days         = "7"
@@ -280,7 +280,7 @@ module "eks_managed_node_group" {
   max_size     = var.max_worker_nodes
   desired_size = var.desired_worker_nodes
   instance_types = var.instance_types
-  capacity_type  = "SPOT"
+  capacity_type  = "${var.instance_reservation}"
   ebs_optimized  = "true"
   enable_monitoring = "true"
   iam_role_additional_policies = {

--- a/devops/infra-as-code/terraform/sample-aws/variables.tf
+++ b/devops/infra-as-code/terraform/sample-aws/variables.tf
@@ -32,7 +32,11 @@ variable "kubernetes_version" {
 variable "instance_types" {
   description = "Arry of instance types for SPOT instances"
   default = ["m5a.xlarge"]
-  
+}
+
+variable "instance_reservation" {
+  description = "instance reservation SPOT or ON_DEMAND"
+  default = "ON_DEMAND"
 }
 
 variable "min_worker_nodes" {
@@ -50,6 +54,15 @@ variable "max_worker_nodes" {
   default = "5" #REPLACE IF NEEDED
 }
 
+variable "db_version" {
+  description = "postgres version"
+  default = "15.8"
+}
+
+variable "db_instance_type" {
+  description = "Instance type for RDS instance"
+  default = "db.t4g.medium"
+}
 
 variable "db_name" {
   description = "RDS DB name. Make sure there are no hyphens or other special characters in the DB name. Else, DB creation will fail"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable database version (default: 15.8).
  * Added configurable database instance type (default: db.t4g.medium).
  * Added configurable instance reservation mode (SPOT or ON_DEMAND; default: ON_DEMAND).
  * Database and node group settings now use these configurable values instead of fixed defaults.

* **Bug Fixes**
  * Fixed a configuration syntax issue to ensure proper parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->