### PR TITLE
PG_VIEWER role added CSR action Card rendereing changes

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/pgr/src/components/PGRCard.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/pgr/src/components/PGRCard.js
@@ -34,7 +34,7 @@ const PGRCard = () => {
   }
 
   let links = [
-    generateLink("ACTION_TEST_CREATE_COMPLAINT", "create-complaint"),
+    generateLink("ACTION_TEST_CREATE_COMPLAINT", "create-complaint", ["CSR"]),
     generateLink("ACTION_TEST_SEARCH_COMPLAINT", "inbox-v2"),
   ];
   const hasRequiredRoles = (link) => { 

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/pgr/src/pages/employee/PGRDetails.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/pgr/src/pages/employee/PGRDetails.js
@@ -338,6 +338,41 @@ const PGRDetails = () => {
       : [];
   };
 
+  // Check if action button should be visible based on user roles
+  const shouldShowActionButton = () => {
+    const userRoles = userInfo?.info?.roles?.map((role) => role.code) || [];
+    
+    // Get current state from ProcessInstances[0]
+    const currentState = workflowData?.ProcessInstances?.[0]?.state;
+    
+    if (!currentState?.actions) {
+      return false;
+    }
+    
+    // Get all roles from current state actions
+    const allActionRoles = [];
+    currentState.actions.forEach(action => {
+      if (action.roles) {
+        allActionRoles.push(...action.roles);
+      }
+    });
+    
+    // Check if user has PGR_VIEWER role
+    const hasViewerRole = userRoles.includes("PGR_VIEWER");
+    
+    // Get user roles excluding PGR_VIEWER
+    const userNonViewerRoles = userRoles.filter(role => role !== "PGR_VIEWER");
+    
+    // Check if any non-viewer user role matches with action roles
+    const hasMatchingRole = userNonViewerRoles.some(userRole => 
+      allActionRoles.includes(userRole)
+    );
+  
+    
+    // Show button only if user has BOTH PGR_VIEWER AND other matching roles
+    return hasViewerRole && hasMatchingRole;
+  };
+
   // Display loader until required data loads
   if (isLoading || isMDMSLoading || isWorkflowLoading) return <Loader />;
 
@@ -430,34 +465,36 @@ const PGRDetails = () => {
       </div>
 
       {/* Footer Action Bar */}
-      <Footer
-      actionFields={[
-        <Button 
-          className="custom-class"
-          isSearchable 
-          onClick={function noRefCheck() {}}
-          menuStyles={{
-                  bottom: "40px",
-                }}
-          isDisabled={getNextActionOptions(workflowData, businessServiceData?.BusinessServices?.[0]).length === 0}
-          key="action-button"
-          label={t("ES_COMMON_TAKE_ACTION")}
-          onOptionSelect={(selected) => {
-            console.log("*** Log ===> selected", selected);
-            setSelectedAction(selected);
-            setOpenModal(true);
-          }}
-          options={getNextActionOptions(workflowData, businessServiceData?.BusinessServices?.[0])}
-          optionsKey="action"
-          type="actionButton"
-          />,
-      ]}
-      className=""
-      maxActionFieldsAllowed={5}
-      setactionFieldsToRight
-      sortActionFields
-      style={{}}
-      />
+      {shouldShowActionButton() && (
+        <Footer
+        actionFields={[
+          <Button 
+            className="custom-class"
+            isSearchable 
+            onClick={function noRefCheck() {}}
+            menuStyles={{
+                    bottom: "40px",
+                  }}
+            isDisabled={getNextActionOptions(workflowData, businessServiceData?.BusinessServices?.[0]).length === 0}
+            key="action-button"
+            label={t("ES_COMMON_TAKE_ACTION")}
+            onOptionSelect={(selected) => {
+              console.log("*** Log ===> selected", selected);
+              setSelectedAction(selected);
+              setOpenModal(true);
+            }}
+            options={getNextActionOptions(workflowData, businessServiceData?.BusinessServices?.[0])}
+            optionsKey="action"
+            type="actionButton"
+            />,
+        ]}
+        className=""
+        maxActionFieldsAllowed={5}
+        setactionFieldsToRight
+        sortActionFields
+        style={{}}
+        />
+      )}
 
       {/* Toast Message */}
       {toast?.show && <Toast type={toast?.type} label={toast?.label} isDleteBtn onClose={handleToastClose} />}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted “Create Complaint” access to Customer Service Representatives (CSR) only, preventing unintended visibility for other roles.
  * Action buttons on the complaint details page now appear only when the signed-in user holds at least one eligible non-viewer role aligned with the current workflow actions; viewer-only users will no longer see actionable controls.
  * No impact to other links or loading/submission flows; overall behavior remains consistent aside from corrected role-based visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->