### PR TITLE
added cert issuer for kibana service

### DIFF
--- a/devops/deploy-as-code/charts/backbone-services/kibana/values.yaml
+++ b/devops/deploy-as-code/charts/backbone-services/kibana/values.yaml
@@ -143,6 +143,7 @@ ingress:
   # kubernetes.io/ingress.class: nginx
   # kubernetes.io/tls-acme: "true"
     kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     # nginx.ingress.kubernetes.io/auth-signin: https://$host/oauth2/start?rd=$escaped_request_uri
     # nginx.ingress.kubernetes.io/auth-url: https://$host/oauth2/auth
     nginx.ingress.kubernetes.io/limit-rpm: "1200"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kibana ingress configuration to include a production certificate issuer annotation for automated TLS via Let’s Encrypt. This enhances HTTPS certificate provisioning and renewals for the Kibana endpoint, improving stability and reducing manual maintenance. No changes to functionality or UI; existing ingress class and other TLS settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->