### PR TITLE
fixed ingress-rule to serve static-assets

### DIFF
--- a/devops/deploy-as-code/charts/backbone-services/minio/templates/ingress.yaml
+++ b/devops/deploy-as-code/charts/backbone-services/minio/templates/ingress.yaml
@@ -27,9 +27,9 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
       {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ tpl . $ | quote }}
       {{- end }}
-      secretName: {{ .secretName }}
+      secretName: {{ tpl .secretName $ }}
     {{- end }}
   {{- end }}
   rules:

--- a/devops/deploy-as-code/charts/backbone-services/minio/values.yaml
+++ b/devops/deploy-as-code/charts/backbone-services/minio/values.yaml
@@ -199,7 +199,7 @@ service:
 ##
 
 ingress:
-  enabled: false
+  enabled: true
   ingressClassName: ~
   labels: {}
     # node-role.kubernetes.io/ingress: platform
@@ -211,13 +211,13 @@ ingress:
     # nginx.ingress.kubernetes.io/secure-backends: "true"
     # nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     # nginx.ingress.kubernetes.io/whitelist-source-range: 0.0.0.0/0
-  path: /
+  path: /static-assets
   hosts:
-    - minio-example.local
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
+    - "{{ .Values.global.domain }}"
+  tls:
+    - secretName: "{{ .Values.global.domain }}-tls-certs"
+      hosts:
+        - "{{ .Values.global.domain }}"
 
 consoleService:
   type: ClusterIP


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MinIO is now accessible via HTTPS Ingress on your environment’s domain, secured with TLS certificates.
  * Default public path updated to “/static-assets” for serving static content.
  * Host and certificate selection automatically align with the configured global domain, improving consistency across environments.
  * Simplified external access to MinIO without requiring direct service exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->