### PR TITLE
Add epic issue template for feature planning

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic-template.md
+++ b/.github/ISSUE_TEMPLATE/epic-template.md
@@ -1,0 +1,29 @@
+---
+name: Epic Template
+about: For high-level, related sets of features and journeys.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Problem
+What problem are we solving with? Is this epic part of the planned features [here](https://github.com/near/near-wallet-roadmap/projects/1), and which ones?
+
+## How did we discover this problem?
+How did this problem originate? If it was revealed through user feedback, how was that feedback received and from whom?
+
+## Job Story(s)
+- What are the [job stories](https://thoughtbot.com/blog/converting-to-jobs-stories) that frame the users' context, motivations and goals?
+- Template: When I [situation], I want to [motivation] so I can [outcome/benefit].
+
+## What are we planning to do about it?
+- What is the scope of the design and engineering work required for this project?
+Along the way, this epic will be linked with issues and pull requests
+
+## What are we not planning to do about it?
+- What items have been considered but may fall out of the scope of design and engineering work for this project?
+Sometimes the scope is too large, and this section may lead other epics, other features [here](https://github.com/near/near-wallet-roadmap/projects/1) or even other products
+
+## How will we measure success?
+- Are there a set of quantifiable metrics that we can surface once the work has been completed in order to determine how successful our solution was?


### PR DESCRIPTION
Added a template for creating epics to the issue tracker, outlining key sections for problem identification, planning, and success measurement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a GitHub issue template to standardize Epic definition and tracking with structured sections for problem framing, discovery, job stories, planned work, scope exclusions, and success metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->