### PR TITLE
Add insert query for document details

### DIFF
--- a/configs/egov-persister/pgr-migration-batch.yml
+++ b/configs/egov-persister/pgr-migration-batch.yml
@@ -90,7 +90,32 @@ serviceMaps:
       - jsonPath: $.service.auditDetails.lastModifiedBy
 
       - jsonPath: $.service.auditDetails.lastModifiedTime
+    
+    - query: INSERT INTO eg_pgr_document_v2(id, document_type, filestore_id, document_uid, service_id, additional_details, created_by, last_modified_by, created_time, last_modified_time) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+      basePath: service.documents.*
+      jsonMaps:
+      - jsonPath: $.service.documents.*.id
 
+      - jsonPath: $.service.documents.*.documentType
+
+      - jsonPath: $.service.documents.*.fileStoreId
+
+      - jsonPath: $.service.documents.*.documentUid
+
+      - jsonPath: $.service.id
+
+      - jsonPath: $.service.documents.*.additionalDetails
+        type: JSON
+        dbType: JSONB
+
+      - jsonPath: $.service.auditDetails.createdBy
+
+      - jsonPath: $.service.auditDetails.lastModifiedBy
+
+      - jsonPath: $.service.auditDetails.createdTime
+
+      - jsonPath: $.service.auditDetails.lastModifiedTime
+  
   - version: 1.0
     description: Persists workflow processInstanceFromRequest details in eg_workflow_v2  table
     fromTopic: save-wf-transitions-batch

--- a/configs/egov-persister/pgr-services-persister.yml
+++ b/configs/egov-persister/pgr-services-persister.yml
@@ -87,6 +87,31 @@ serviceMaps:
 
       - jsonPath: $.service.auditDetails.lastModifiedTime
 
+    - query: INSERT INTO eg_pgr_document_v2(id, document_type, filestore_id, document_uid, service_id, additional_details, created_by, last_modified_by, created_time, last_modified_time) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+      basePath: service.documents.*
+      jsonMaps:
+      - jsonPath: $.service.documents.*.id
+
+      - jsonPath: $.service.documents.*.documentType
+
+      - jsonPath: $.service.documents.*.fileStoreId
+
+      - jsonPath: $.service.documents.*.documentUid
+
+      - jsonPath: $.service.id
+
+      - jsonPath: $.service.documents.*.additionalDetails
+        type: JSON
+        dbType: JSONB
+
+      - jsonPath: $.service.auditDetails.createdBy
+
+      - jsonPath: $.service.auditDetails.lastModifiedBy
+
+      - jsonPath: $.service.auditDetails.createdTime
+
+      - jsonPath: $.service.auditDetails.lastModifiedTime
+
 
 
   - version: 1.0
@@ -124,7 +149,6 @@ serviceMaps:
     - query: UPDATE eg_pgr_address_v2 SET doorno=?, plotno=?, buildingname=?, street=?, landmark=?, city=?, pincode=?, locality=?, district=?, region=?, state=?, country=?, latitude=?, longitude=?,additionaldetails=?, lastmodifiedby=?, lastmodifiedtime=? WHERE id=?;
       basePath: service.address
       jsonMaps:
-
       - jsonPath: $.service.address.doorNo
 
       - jsonPath: $.service.address.plotNo


### PR DESCRIPTION
Added SQL insert query for document details in pgr-services-persister.yml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Service documents are now properly persisted and stored in the system with complete audit trail information.

* **Chores**
  * Cleaned up unused configuration entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->