### PR TITLE
Update v.211 tags for CMS services

### DIFF
--- a/devops/deploy-as-code/charts/common-services/digit-config-service/values.yaml
+++ b/devops/deploy-as-code/charts/common-services/digit-config-service/values.yaml
@@ -17,12 +17,12 @@ initContainers:
     schemaTable: "digit_config_service_schema"
     image:
       repository: "digit-config-service-db"
-      tag: "master-2242e47"
+      tag: "v2.11-a520687"
 
 # Container Configs
 image:
   repository: "digit-config-service"
-  tag: "master-2242e47"
+  tag: "v2.11-a520687"
 replicas: "1"
 httpPort: 8080
 appType: "java-spring"

--- a/devops/deploy-as-code/charts/common-services/digit-user-preferences-service/values.yaml
+++ b/devops/deploy-as-code/charts/common-services/digit-user-preferences-service/values.yaml
@@ -19,7 +19,7 @@ initContainers:
 # Container Configs
 image:
   repository: "digit-user-preferences-service"
-  tag: "master-2242e47"
+  tag: "v2.11-a520687"
 replicas: "1"
 httpPort: 8080
 

--- a/devops/deploy-as-code/charts/common-services/novu-bridge/values.yaml
+++ b/devops/deploy-as-code/charts/common-services/novu-bridge/values.yaml
@@ -17,12 +17,12 @@ initContainers:
     schemaTable: "novu_bridge_schema"
     image:
       repository: "novu-bridge-db"
-      tag: "develop-0a8b0a7"
+      tag: "v2.11-a520687"
 
 # Container Configs
 image:
   repository: "novu-bridge"
-  tag: "develop-0a8b0a7"
+  tag: "v2.11-a520687"
 replicas: "1"
 httpPort: 8080
 appType: "java-spring"

--- a/devops/deploy-as-code/charts/core-services/egov-notification-sms/values.yaml
+++ b/devops/deploy-as-code/charts/core-services/egov-notification-sms/values.yaml
@@ -9,7 +9,7 @@ initContainers: {}
 # Container Configs
 image:
   repository: "egov-notification-sms"
-  tag: mobile-validation-user-otp-db06ec6
+  tag: "mobile-validation-user-otp-db06ec6"
 replicas: "1"
 appType: "java-spring"
 tracing-enabled: true

--- a/devops/deploy-as-code/charts/core-services/user-otp/values.yaml
+++ b/devops/deploy-as-code/charts/core-services/user-otp/values.yaml
@@ -15,7 +15,7 @@ initContainers: {}
 # Container Configs
 image:
   repository: "user-otp"
-  tag: mobile-validation-user-otp-12b1961
+  tag: "mobile-validation-user-otp-12b1961"
 healthChecks:
   enabled: true
   livenessProbePath: "/user-otp/health"

--- a/devops/deploy-as-code/charts/urban/default-data-handler/values.yaml
+++ b/devops/deploy-as-code/charts/urban/default-data-handler/values.yaml
@@ -29,7 +29,7 @@ initContainers:
 # Container Configs
 image:
   repository: "default-data-handler"
-  tag: "develop-773002d"
+  tag: "v2.11-a520687"
 replicas: "1"
 healthChecks:
   enabled: true

--- a/devops/deploy-as-code/charts/urban/digit-ui/values.yaml
+++ b/devops/deploy-as-code/charts/urban/digit-ui/values.yaml
@@ -14,7 +14,7 @@ initContainers: {}
 # Container Configs
 image:
   repository: "digit-ui"
-  tag: "develop-773002d"
+  tag: "v2.11-a520687"
 replicas: "1"
 httpPort: 80
 healthChecks:

--- a/devops/deploy-as-code/charts/urban/pgr-services/values.yaml
+++ b/devops/deploy-as-code/charts/urban/pgr-services/values.yaml
@@ -17,7 +17,7 @@ initContainers:
     schemaTable: "pgr_services_schema"
     image:
       repository: "pgr-services-db"
-      tag: "develop-8392b8c"
+      tag: "v2.11-a520687"
     env: |
         {{- if index .Values "pgr-ismultischema-enabled" }}        
         - name: SCHEMA_NAME
@@ -49,7 +49,7 @@ initContainers:
 # Container Configs
 image:
   repository: "pgr-services"
-  tag: "develop-8392b8c"
+  tag: "v2.11-a520687"
 replicas: "1"
 healthChecks:
   enabled: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image versions for multiple services (`digit-config-service`, `digit-user-preferences-service`, `novu-bridge`, `egov-notification-sms`, `user-otp`, `default-data-handler`, `digit-ui`, `pgr-services`) to align with the `v2.11` release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->