### PR TITLE
fix: boundary config fallback when MDMS HierarchySchema missing (#406)

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/pgr/src/pages/employee/CreateComplaint/createComplaintForm.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/pgr/src/pages/employee/CreateComplaint/createComplaintForm.js
@@ -256,20 +256,20 @@ const CreateComplaintForm = ({
               disable: disabledFields[field.populators.name],
             };
           }
-          if (field.key === "boundaryComponent" && hierarchyData) {
+          if (field.key === "boundaryComponent") {
             return {
               ...field,
               populators: {
                 ...field.populators,
                 levelConfig: {
                   ...field.populators.levelConfig,
-                  lowestLevel: hierarchyData.lowestHierarchy || window?.globalConfigs?.getConfig("PGR_BOUNDARY_LOWEST_LEVEL") || "Ward",
-                  highestLevel: hierarchyData.highestHierarchy || window?.globalConfigs?.getConfig("PGR_BOUNDARY_HIGHEST_LEVEL") || "City",
+                  lowestLevel: hierarchyData?.lowestHierarchy || window?.globalConfigs?.getConfig("PGR_BOUNDARY_LOWEST_LEVEL") || "Ward",
+                  highestLevel: hierarchyData?.highestHierarchy || window?.globalConfigs?.getConfig("PGR_BOUNDARY_HIGHEST_LEVEL") || "City",
                   isSingleSelect: [
-                    hierarchyData.lowestHierarchy || window?.globalConfigs?.getConfig("PGR_BOUNDARY_LOWEST_LEVEL") || "Ward",
-                    hierarchyData.highestHierarchy || window?.globalConfigs?.getConfig("PGR_BOUNDARY_HIGHEST_LEVEL") || "City"]
+                    hierarchyData?.lowestHierarchy || window?.globalConfigs?.getConfig("PGR_BOUNDARY_LOWEST_LEVEL") || "Ward",
+                    hierarchyData?.highestHierarchy || window?.globalConfigs?.getConfig("PGR_BOUNDARY_HIGHEST_LEVEL") || "City"]
                 },
-                hierarchyType: hierarchyData.hierarchy || window?.globalConfigs?.getConfig("HIERARCHY_TYPE") || "ADMIN",
+                hierarchyType: hierarchyData?.hierarchy || window?.globalConfigs?.getConfig("HIERARCHY_TYPE") || "ADMIN",
               },
             };
           }


### PR DESCRIPTION
## Summary
Fixes #406 — CSR Employee unable to create complaint (LOWEST_LEVEL_CONFIG_NOT_PRESENT)

## Root Cause
In `createComplaintForm.js`, the boundary config block was gated behind `hierarchyData` being truthy:
```js
if (field.key === "boundaryComponent" && hierarchyData) {
```
When `CMS-BOUNDARY.HierarchySchema` MDMS data doesn't exist (common in new deployments that rely on `globalConfigs`), `hierarchyData` is `null`. The entire config block is skipped, so `lowestLevel`, `highestLevel`, and `hierarchyType` are never set. The `BoundaryFilter` component then shows `LOWEST_LEVEL_CONFIG_NOT_PRESENT`.

## Fix
1. Remove `&& hierarchyData` guard so the config block always runs for `boundaryComponent` fields
2. Use optional chaining (`hierarchyData?.lowestHierarchy`) so null `hierarchyData` gracefully falls through to `globalConfigs` values

## Test plan
- [ ] Deploy on a tenant **without** `CMS-BOUNDARY.HierarchySchema` MDMS data
- [ ] Navigate to Employee > Create Complaint — boundary dropdowns should render using globalConfigs values
- [ ] Deploy on a tenant **with** `CMS-BOUNDARY.HierarchySchema` — verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)