### PR TITLE
- **Employee Complaint Details — Address Display (`PGRDetails.js`)**:

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/example/package.json
+++ b/frontend/micro-ui/web/micro-ui-internals/example/package.json
@@ -14,7 +14,7 @@
     "@egovernments/digit-ui-module-core": "1.9.21-cms",
     "@egovernments/digit-ui-module-utilities": "1.0.12",
     "@egovernments/digit-ui-react-components": "1.8.21",
-    "@egovernments/digit-ui-module-cms": "1.0.24",
+    "@egovernments/digit-ui-module-cms": "1.0.27",
     "@egovernments/digit-ui-module-workbench": "1.0.28",
     "@egovernments/digit-ui-module-hrms": "1.9.7",
     "http-proxy-middleware": "^1.0.5",

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/pgr/CHANGELOG.md
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/pgr/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 All notable changes to this module will be documented in this file.
 
+## [1.0.28] - 2026-04-27
+
+### Fixed
+
+- **Employee Complaint Details — Address Display (`PGRDetails.js`)**:
+  - Added combined address field to the employee complaint details page, mirroring the citizen-side pattern.
+  - Locality code is used directly as a translation key (no double `ADMIN_` prefix) for multi-root tenant deployments.
+  - Address parts (landmark, locality, tenant, pincode) now render line by line instead of comma-separated.
+
+- **PGR Inbox Search — Country Code (`UICustomizations.js`)**:
+  - Added `countryCode` alongside `mobileNumber` in the inbox search API criteria so mobile number lookups work correctly with country prefix validation.
+  - Falls back to `MDMSValidationPatterns.mobileNumberValidation.prefix` or `+91` when not set in the search form.
+
 ## [1.0.27] - 2026-04-27 - Code Merge
 
 ### Added / Fixed

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/pgr/package.json
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/pgr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@egovernments/digit-ui-module-cms",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "description": "CMS Module UI for DIGIT Platform",
   "main": "dist/index.js",
   "module": "dist/index.modern.js",

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/pgr/src/configs/UICustomizations.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/pgr/src/configs/UICustomizations.js
@@ -296,8 +296,13 @@ export const UICustomizations = {
 
       if (searchForm.mobileNumber) {
         clonedData.body.inbox.moduleSearchCriteria.mobileNumber = searchForm.mobileNumber;
+        clonedData.body.inbox.moduleSearchCriteria.countryCode =
+          searchForm.countryCode ||
+          window?.Digit?.MDMSValidationPatterns?.mobileNumberValidation?.prefix ||
+          "+91";
       } else {
         delete clonedData.body.inbox.moduleSearchCriteria.mobileNumber;
+        delete clonedData.body.inbox.moduleSearchCriteria.countryCode;
       }
 
       // Handle date range from search form directly

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/pgr/src/pages/employee/PGRDetails.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/pgr/src/pages/employee/PGRDetails.js
@@ -525,8 +525,27 @@ const PGRDetails = () => {
                   },
                   {
                     inline: true,
-                    label: t("CS_COMPLAINT_LANDMARK__DETAILS"),
-                    value: pgrData?.ServiceWrappers[0].service?.address?.landmark || "NA",
+                    label: t("ES_CREATECOMPLAINT_ADDRESS"),
+                    value: (() => {
+                      const address = pgrData?.ServiceWrappers[0]?.service?.address;
+                      const tenantId = pgrData?.ServiceWrappers[0]?.service?.tenantId;
+                      const isMultiRoot = Digit.Utils.getMultiRootTenant();
+                      const localityKey = isMultiRoot
+                        ? address?.locality?.code
+                        : address?.locality?.name || address?.locality?.code;
+                      const parts = [
+                        address?.landmark,
+                        localityKey ? t(localityKey) : null,
+                        tenantId ? t(`TENANT_TENANTS_${tenantId?.toUpperCase?.()?.replace(".", "_")}`) : null,
+                        address?.pincode,
+                      ].filter(Boolean);
+                      if (parts.length === 0) return "NA";
+                      return (
+                        <div>
+                          {parts.map((p, i) => <div key={i}>{p}</div>)}
+                        </div>
+                      );
+                    })(),
                   },
                   {
                     inline: true,


### PR DESCRIPTION
## [1.0.28] - 2026-04-27

### Fixed

- **Employee Complaint Details — Address Display (`PGRDetails.js`)**:
  - Added combined address field to the employee complaint details page, mirroring the citizen-side pattern.
  - Locality code is used directly as a translation key (no double `ADMIN_` prefix) for multi-root tenant deployments.
  - Address parts (landmark, locality, tenant, pincode) now render line by line instead of comma-separated.

- **PGR Inbox Search — Country Code (`UICustomizations.js`)**:
  - Added `countryCode` alongside `mobileNumber` in the inbox search API criteria so mobile number lookups work correctly with country prefix validation.
  - Falls back to `MDMSValidationPatterns.mobileNumberValidation.prefix` or `+91` when not set in the search form.