### PR TITLE
fix(configurator): trust MDMS for employee mobile rule, drop HRMS 10-digit clamp (#484, #540)

### DIFF
--- a/configurator/src/admin/hrms/useMobileValidator.ts
+++ b/configurator/src/admin/hrms/useMobileValidator.ts
@@ -9,44 +9,31 @@ export interface MobileRules {
   prefix?: string;
 }
 
-// HRMS-side hard minimum. Its DTO has a @Pattern that requires exactly 10
-// digits regardless of what MDMS's ValidationConfigs.mobileNumberValidation
-// permits. Clamp the effective rules so the form never accepts 9-digit input
-// that HRMS will reject downstream.
-const HRMS_MIN_LENGTH = 10;
-
-// Kenya default — matches MDMS `ValidationConfigs.mobileNumberValidation`
-// at tenant `ke`, tightened to HRMS's 10-digit floor.
+// Kenya default — used when MDMS `ValidationConfigs.mobileNumberValidation`
+// is missing or unreadable. The canonical naipepea seed is `^[17][0-9]{8}$`
+// with min=max=9, matching the local subscriber number convention.
 const FALLBACK: MobileRules = {
-  pattern: '^0?[17][0-9]{8}$',
-  minLength: HRMS_MIN_LENGTH,
-  maxLength: 10,
+  pattern: '^[17][0-9]{8}$',
+  minLength: 9,
+  maxLength: 9,
   prefix: '+254',
   errorMessage:
-    'Enter a 10-digit Kenyan mobile starting with 07 or 01 (e.g. 0712345678)',
+    'Please enter a valid Kenyan mobile number (9 digits starting with 1 or 7)',
 };
 
 function parseRules(record: Record<string, unknown> | undefined): MobileRules {
   if (!record) return FALLBACK;
   const raw = record.rules as Record<string, unknown> | undefined;
   if (!raw) return FALLBACK;
-  const mdmsMin = typeof raw.minLength === 'number' ? raw.minLength : FALLBACK.minLength;
-  const minLength = Math.max(mdmsMin, HRMS_MIN_LENGTH);
-  const clamped = minLength > mdmsMin;
   return {
     pattern: typeof raw.pattern === 'string' ? raw.pattern : FALLBACK.pattern,
-    minLength,
-    maxLength:
-      typeof raw.maxLength === 'number' ? raw.maxLength : FALLBACK.maxLength,
+    minLength: typeof raw.minLength === 'number' ? raw.minLength : FALLBACK.minLength,
+    maxLength: typeof raw.maxLength === 'number' ? raw.maxLength : FALLBACK.maxLength,
     prefix: typeof raw.prefix === 'string' ? raw.prefix : FALLBACK.prefix,
-    // HRMS rejects 9-digit input even if MDMS allows it, so when the MDMS
-    // rule was looser than HRMS's 10-digit floor we replace the message
-    // rather than mislead operators with MDMS's "9 or 10 digits" phrasing.
-    errorMessage: clamped
-      ? FALLBACK.errorMessage
-      : typeof raw.errorMessage === 'string' && raw.errorMessage
-      ? raw.errorMessage
-      : FALLBACK.errorMessage,
+    errorMessage:
+      typeof raw.errorMessage === 'string' && raw.errorMessage
+        ? raw.errorMessage
+        : FALLBACK.errorMessage,
   };
 }
 

--- a/configurator/src/resources/employees/EmployeeBulkImport.tsx
+++ b/configurator/src/resources/employees/EmployeeBulkImport.tsx
@@ -197,11 +197,17 @@ export function EmployeeBulkImport() {
         }
       }
       if (row.mobileNumber) {
+        // MDMS is the source of truth — egov-hrms's User.java no longer
+        // carries its own `@Pattern("^[0-9]{10}$")`, validation is delegated
+        // to MDMS via egov-user's MobileNumberValidator. Trust the rule
+        // returned by `mdmsService.getMobileValidation` exactly. Closes the
+        // bulk-import side of the CCRS#484/#540 BLOCKER.
+        const minLen = mobileRules?.minLength ?? 9;
+        const maxLen = mobileRules?.maxLength ?? 9;
+        const msg = mobileRules?.errorMessage ?? 'Please enter a valid Kenyan mobile number (9 digits starting with 1 or 7)';
         const len = row.mobileNumber.length;
-        const effMin = Math.max(mobileRules?.minLength ?? 10, 10);
-        const effMax = mobileRules?.maxLength ?? 10;
-        if (len < effMin || len > effMax || (compiled && !compiled.test(row.mobileNumber))) {
-          errors.push(mobileRules?.errorMessage ?? 'Mobile number must be 10 digits starting with 07 or 01');
+        if (len < minLen || len > maxLen || (compiled && !compiled.test(row.mobileNumber))) {
+          errors.push(msg);
         }
       }
       if (!row.dob || !/^\d{4}-\d{2}-\d{2}$/.test(row.dob)) {

--- a/configurator/src/utils/excelParser.ts
+++ b/configurator/src/utils/excelParser.ts
@@ -731,12 +731,16 @@ export function parseEmployeeExcel(workbook: XLSX.WorkBook): {
         code: 'REQUIRED_FIELD',
       });
       return;
-    } else if (!/^\d{10}$/.test(mobileNumber)) {
+    } else if (!/^\d{9,10}$/.test(mobileNumber)) {
+      // Loosened from `^\d{10}$` so 9-digit MDMS-valid Kenyan numbers
+      // (`712345678`) survive parsing. EmployeeBulkImport's tenant-aware
+      // validateRow then enforces the per-tenant rule from MDMS, and
+      // `normalizeMobileForHrms` pads to 10 before HRMS submission.
       errors.push({
         row: index + 2,
         field: 'mobileNumber',
         value: mobileNumber,
-        message: 'Mobile number must be 10 digits',
+        message: 'Mobile number must be 9 or 10 digits',
         code: 'INVALID_FORMAT',
       });
     }


### PR DESCRIPTION
## Summary
Fixes the BLOCKER on #484 (and the root cause of #540, "Unable to create employees during onboarding"): **every** mobile number is rejected on the Create-Employee form and bulk import, so no employee can be created.

This ports ChakshuGautam/digit-configurator#63 onto the **vendored `configurator/`** tree, per the move to land configurator fixes against `egovernments/CCRS` rather than the standalone repo. The three files were byte-identical to standalone `main`, so this is the same reviewed diff applied under `configurator/`.

## Root cause
`useMobileValidator` and the bulk-import validator both clamped `minLength = max(mdmsMin, 10)` to respect HRMS's *old* `@Pattern("^[0-9]{10}$")`, while leaving `maxLength` at the MDMS value. The live Kenya rule `ValidationConfigs.mobileNumberValidation` is `min=max=9` (`^[17][0-9]{8}$`), so the effective validator became **"length ≥ 10 AND ≤ 9" — impossible — and rejected every input.**

## Verified live on naipepea
egov-hrms no longer enforces its own 10-digit `@Pattern`; validation now flows through egov-user's `MobileNumberValidator`, which reads MDMS directly:

```
POST /egov-hrms/employees/_create
  712345678   → 202 Accepted
  0712345678  → 400 INVALID_MOBILE_LENGTH ("must not exceed 9 digits")
```

MDMS record on naipepea (`ke` and `ke.nairobi`): `{ pattern: "^[17][0-9]{8}$", minLength: 9, maxLength: 9, prefix: "+254" }`.

## Fix — trust MDMS verbatim
| File | Change |
|---|---|
| `configurator/src/admin/hrms/useMobileValidator.ts` | Remove `HRMS_MIN_LENGTH = 10` clamp; `parseRules` returns MDMS `min`/`max`/`pattern` verbatim; `FALLBACK` reset to the 9-digit Kenya seed. |
| `configurator/src/resources/employees/EmployeeBulkImport.tsx` | Validator uses `mobileRules.{minLength,maxLength,pattern}` directly — no clamp arithmetic. |
| `configurator/src/utils/excelParser.ts` | Parser gate loosened `^\d{10}$` → `^\d{9,10}$`; per-tenant enforcement stays in the row validator. |

## Net effect
- Form + bulk import accept exactly the MDMS rule (9-digit Kenya).
- 10-digit legacy input rejected at the validator with the Kenya message (never reaches HRMS).
- For a 10-digit-configured tenant, the MDMS rule would say `min=max=10` and the validator follows it — the rule is now per-tenant, sourced from MDMS, with no hardcoded floor.

## Test plan
- [x] `npx tsc --noEmit` clean (verified on the source PR).
- [ ] Create Employee with `712345678` → form passes, HRMS create succeeds.
- [ ] Create Employee with `0712345678` → rejected with the Kenya error.
- [ ] Phase-4 bulk import: valid 9-digit row ingests; 10-digit row rejected.

Refs: #484, #540
Supersedes: ChakshuGautam/digit-configurator#63

🤖 Generated with [Claude Code](https://claude.com/claude-code)