### PR TITLE
fix(ddh): idempotent MDMS seed — prevent DataSecurity double-seed crashing egov-user

### DIFF
--- a/utilities/default-data-handler/src/main/java/org/egov/handler/util/MdmsBulkLoader.java
+++ b/utilities/default-data-handler/src/main/java/org/egov/handler/util/MdmsBulkLoader.java
@@ -6,6 +6,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.egov.common.contract.request.RequestInfo;
 import org.egov.handler.config.ServiceConfiguration;
+import org.egov.handler.web.models.MdmsCriteriaReqV2;
+import org.egov.handler.web.models.MdmsCriteriaV2;
+import org.egov.handler.web.models.MdmsResponseV2;
 import org.egov.tracer.model.CustomException;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
@@ -27,6 +30,7 @@ public class MdmsBulkLoader {
     private final ObjectMapper objectMapper;
     private final RestTemplate restTemplate;
     private final ServiceConfiguration serviceConfig;
+    private final MdmsV2Util mdmsV2Util;
 
 
     public void loadAllMdmsData(String tenantId, RequestInfo requestInfo, String mdmsDataPath) {
@@ -50,6 +54,31 @@ public class MdmsBulkLoader {
                 if (fileName == null || !fileName.endsWith(".json")) continue;
 
                 String schemaCode = fileName.replace(".json", "");
+
+                // Idempotency guard: skip seeding this schemaCode's bundled data if the
+                // target tenant already has rows for it. Seed bundles are fixed/all-or-
+                // nothing, so any existing row means it was already seeded (e.g. by the
+                // db_fast_path DB dump, or a previous deploy/converge). Without this,
+                // re-seeding duplicates records — and for DataSecurity.SecurityPolicy a
+                // duplicate crashes egov-user's encryption client (Collectors.toMap →
+                // "Duplicate key"), failing compose-up. mdms-v2 does not reject these as
+                // duplicates because the dump-inserted rows bypass its uniqueness check.
+                // Fail-open: if the pre-check errors, fall through and seed as before.
+                try {
+                    MdmsCriteriaV2 existsCriteria = MdmsCriteriaV2.builder()
+                            .tenantId(tenantId).schemaCode(schemaCode).offset(0).limit(1).build();
+                    MdmsCriteriaReqV2 existsReq = MdmsCriteriaReqV2.builder()
+                            .requestInfo(requestInfo).mdmsCriteria(existsCriteria).build();
+                    MdmsResponseV2 existing = mdmsV2Util.searchMdmsData(existsReq);
+                    if (existing != null && existing.getMdms() != null && !existing.getMdms().isEmpty()) {
+                        log.info("MDMS data already present for schemaCode {} in tenant {} — skipping seed (idempotent)",
+                                schemaCode, tenantId);
+                        continue;
+                    }
+                } catch (Exception preCheckEx) {
+                    log.warn("Idempotency pre-check failed for schemaCode {} in tenant {}; proceeding with seed: {}",
+                            schemaCode, tenantId, preCheckEx.getMessage());
+                }
 
                 // Read JSON content
                 String rawJson = StreamUtils.copyToString(resource.getInputStream(), StandardCharsets.UTF_8);


### PR DESCRIPTION
## Summary
Makes `default-data-handler`'s MDMS seed **idempotent**. `MdmsBulkLoader.loadAllMdmsData` blind-created every bundled record with no existence check, so on a `db_fast_path` deploy (or any re-converge) — where the data already exists — it **duplicates** every record.

For `DataSecurity.SecurityPolicy` this is fatal: a duplicate policy crashes egov-user's encryption client on startup —
```
java.lang.IllegalStateException: Duplicate key [Attribute@.., Attribute@..]
  at EncryptionPolicyConfiguration.initializeEncryptionPolicyAttributesMapFromMdms (Collectors.toMap, no merge fn)
```
— so `egov-user` exits(1) → `dependency failed to start` → `docker compose up -d` returns rc=1 → the Ansible **`Start DIGIT stack`** task fails and the deploy aborts. mdms-v2 does not reject the duplicates because the dump-inserted rows bypass its uniqueness check.

## Root cause evidence (clean `develop` deploy on a dev box)
```
pg DataSecurity.SecurityPolicy:  total=64, distinct models=32   ← each policy duplicated 2x
   2025-12-18 | 32   ← db_fast_path dump baseline
   <deploy day> | 32 ← default-data-handler re-seeded the same 32
statea (not the active state tenant): 32, single cluster
```

## Fix
Add a per-`schemaCode` idempotency guard to `MdmsBulkLoader`: before seeding a bundle, search the target tenant for existing rows of that `schemaCode`; if any exist, skip the bundle. Seed bundles are fixed/all-or-nothing, so any existing row means it was already seeded. **Fail-open** — if the pre-check errors, fall through and seed as before. This also makes re-converges (the nightly dev-deploy cycle) safe.

## Validation
- ✅ Image builds clean (`build_default_data_handler` → `default-data-handler:local`).
- ⏳ Behavioral: fresh `db_fast_path` deploy on a dev box — expect `DataSecurity.SecurityPolicy` to stay at **32** (not 64) and `egov-user` healthy / `PLAY RECAP failed=0`. (Evidence to follow in a comment.)

Found while validating #567 on a fresh machine (the `user-proxy.conf` mount fix holds; this was the *next* blocker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
