### PR TITLE
feat(notif): vendor otp-publisher into the repo + compose/build wiring

### DIFF
--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -558,6 +558,24 @@
       when:
         - build_default_data_handler | default(false)
 
+    # ==================== Build otp-publisher image locally ===============
+    # When `build_otp_publisher: true`, build the vendored Node service at
+    # utilities/otp-publisher (its own Dockerfile, NOT the maven one) and tag
+    # it otp-publisher:local; compose picks it up via OTP_PUBLISHER_IMAGE.
+    # Only needed when the notifications profile (SMS-OTP path) is enabled.
+    - name: "Build otp-publisher image locally (when build_otp_publisher)"
+      ansible.builtin.command: >-
+        docker build
+        -t otp-publisher:local
+        -f utilities/otp-publisher/Dockerfile
+        utilities/otp-publisher
+      args:
+        chdir: "{{ playbook_dir }}/../.."
+      register: otp_publisher_build_run
+      changed_when: true
+      when:
+        - build_otp_publisher | default(false)
+
     # ==================== Build digit-ui from source ====================
     # Mirrors the configurator + mcp fold-ins: when `build_digit_ui: true`,
     # clone digit-ui-esbuild + `npm run build` here (files/digit-ui-build.sh).

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -2004,6 +2004,42 @@ services:
     networks:
       - egov-network
 
+  # otp-publisher — replaces Kong's mock /user-otp termination with a real
+  # OTP generator: mint a 6-digit OTP -> cache in Redis -> publish OTP.SEND to
+  # kafka complaints.domain.events -> novu-bridge -> Twilio SMS. Part of the
+  # SMS-OTP path; gated behind the notifications profile (off by default).
+  # Node service vendored at utilities/otp-publisher; built locally via
+  # `build_otp_publisher: true` (tag otp-publisher:local) or override with
+  # OTP_PUBLISHER_IMAGE.
+  otp-publisher:
+    image: ${OTP_PUBLISHER_IMAGE:-otp-publisher:local}
+    container_name: otp-publisher
+    restart: unless-stopped
+    profiles: ["notifications"]
+    depends_on:
+      redis:
+        condition: service_healthy
+      redpanda:
+        condition: service_healthy
+    environment:
+      PORT: '3030'
+      REDIS_URL: redis://redis:6379
+      KAFKA_BROKERS: redpanda:9092
+      EVENT_TOPIC: complaints.domain.events
+      OTP_TTL_SECONDS: ${OTP_TTL_SECONDS:-600}
+      DEFAULT_TENANT_ID: ${DEFAULT_TENANT_ID:-pg}
+      STATIC_OTP: ${OTP_PUBLISHER_STATIC_OTP:-}
+      # Per-tenant recipient for OTP routing; set in host_vars when wiring SMS.
+      OTP_RECIPIENT_USER_ID: ${OTP_RECIPIENT_USER_ID:-}
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3030/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 15s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
+    networks:
+      - egov-network
+
 networks:
   egov-network:
     driver: bridge

--- a/utilities/otp-publisher/.dockerignore
+++ b/utilities/otp-publisher/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+npm-debug.log
+.git
+.gitignore
+README.md
+Dockerfile
+.dockerignore

--- a/utilities/otp-publisher/Dockerfile
+++ b/utilities/otp-publisher/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install --omit=dev --no-audit --no-fund
+COPY server.js ./
+ENV NODE_ENV=production
+EXPOSE 3030
+HEALTHCHECK --interval=15s --timeout=3s --retries=5 --start-period=10s \
+  CMD wget -qO- http://127.0.0.1:3030/healthz >/dev/null 2>&1 || exit 1
+USER node
+CMD ["node", "server.js"]

--- a/utilities/otp-publisher/README.md
+++ b/utilities/otp-publisher/README.md
@@ -1,0 +1,115 @@
+# otp-publisher — real OTPs over Novu + Twilio
+
+Replaces Kong's `request-termination` mock on `/user-otp/v1/_send`
+with a tiny Node service that mints OTPs, caches them in Redis, and
+publishes an `OTP.SEND` event to the same Kafka topic
+(`complaints.domain.events`) that novu-bridge already consumes.
+
+The bridge's existing `DispatchPipelineService` then routes through:
+
+- `TemplateBinding(tenantId, eventName=OTP.SEND)` → workflow id `otp-send`
+- `ProviderDetail(tenantId, channel=sms)` → Twilio Account SID / token / FROM
+- `otpSendWorkflow` in `backend/novu-bridge-endpoint/workflows.js` (registered by PR #36) → renders the SMS body
+
+No bridge-side change needed.
+
+```
+SPA → Kong → otp-publisher → kafka(complaints.domain.events) → novu-bridge → Novu → Twilio → citizen phone
+              │
+              └→ Redis (otp:tenantId:mobile, TTL 10min)
+
+SPA → Kong → otp-publisher → /otp/v1/_validate → Redis lookup → 200/400
+```
+
+## Endpoints
+
+| Path | What it does |
+|---|---|
+| `POST /user-otp/v1/_send` | Generates a 6-digit OTP, caches `otp:<tenantId>:<mobile>` with `OTP_TTL_SECONDS` TTL, publishes `OTP.SEND` to Kafka, responds with the legacy mock-shape envelope so the SPA notices nothing. |
+| `POST /otp/v1/_validate` | Looks up the cached OTP and confirms (single-use — deletes on success). Falls back to `STATIC_OTP` if set. |
+| `GET  /healthz` | Liveness — returns `{"ok":true}` when Redis + Kafka are up. |
+
+## Env
+
+| Var | Default | Notes |
+|---|---|---|
+| `PORT` | `3030` | Container port. Kong upstream is `http://otp-publisher:3030`. |
+| `REDIS_URL` | `redis://digit-redis:6379` | Shared with the rest of the stack. |
+| `KAFKA_BROKERS` | `digit-redpanda:9092` | Comma-separated for clustered. |
+| `EVENT_TOPIC` | `complaints.domain.events` | Must match `NOVU_BRIDGE_KAFKA_INPUT_TOPIC` on novu-bridge. |
+| `OTP_TTL_SECONDS` | `600` | 10-minute expiry. Citizen UI shows a 30 s resend timer. |
+| `DEFAULT_TENANT_ID` | `ke` | Used when the request body omits `tenantId` (digit-ui sometimes does). |
+| `STATIC_OTP` | _unset_ | Optional fixed OTP. When set, every send returns this code and validate accepts it. Mirrors `CITIZEN_LOGIN_PASSWORD_OTP_FIXED_VALUE` on egov-user — handy for CI / dev. |
+| `REDIS_KEY_PREFIX` | `otp:` | Namespace for OTP keys. |
+
+## Event envelope on Kafka
+
+Matches `ComplaintsDomainEvent` so the bridge consumer can deserialize
+without any code change. The recipient is carried as a single
+stakeholder; subscriber id is the phone number itself (OTP precedes
+user-create, so we have no DIGIT uuid yet — Novu accepts any string id).
+
+```json
+{
+  "eventId": "<uuid>",
+  "eventType": "OTP",
+  "eventTime": "2026-05-15T13:14:15.000Z",
+  "producer": "otp-publisher",
+  "module": "USER-OTP",
+  "eventName": "OTP.SEND",
+  "entityType": "OTP_CODE",
+  "entityId": "<same uuid>",
+  "tenantId": "ke",
+  "actor": { "uuid": "system", "type": "SYSTEM" },
+  "stakeholders": [
+    { "role": "RECIPIENT", "uuid": "0712345678", "mobileNumber": "0712345678" }
+  ],
+  "context": { "source": "citizen-login" },
+  "data": { "otp": "123456", "userType": "CITIZEN" }
+}
+```
+
+## Kong config
+
+The legacy `user-otp-mock` upstream + `request-termination` plugin are
+replaced with a real proxy. See `local-setup/kong/kong.yml`.
+
+`/otp/v1/_validate` is also routed here so the validate step doesn't
+keep hitting the old mock. egov-user's own `/user/_create` path is
+unchanged — autocreate-on-validate still flows through the existing
+citizen create endpoint after we confirm the OTP.
+
+## TemplateBinding for OTP.SEND
+
+The seed in `local-setup/db/notif-mdms-seed/data/template-bindings.json`
+includes a row binding `OTP.SEND` → `otp-send` workflow with
+`paramOrder: ["otp"]`. Run the existing `seed.sh` to apply.
+
+## Local dev
+
+```bash
+cd local-setup/scripts/otp-publisher
+npm install
+REDIS_URL=redis://localhost:6379 KAFKA_BROKERS=localhost:9092 \
+  STATIC_OTP=123456 node server.js
+# then:
+curl -X POST http://localhost:3030/user-otp/v1/_send \
+  -H 'Content-Type: application/json' \
+  -d '{"otp":{"mobileNumber":"0712345678","tenantId":"ke","type":"login"}}'
+```
+
+## Failure modes
+
+| Failure | Behavior |
+|---|---|
+| Redis down | `_send` still returns 200 (citizen UI doesn't lock up); `_validate` returns 500. Re-send needed once Redis is back. |
+| Kafka down | `_send` returns 200 (OTP still cached, can be validated locally); the SMS just doesn't go out. Visible in `digit-redpanda` logs. |
+| Twilio rejects (trial / unverified) | The publisher doesn't know — the bridge logs the failure to its DLQ topic. Verify recipient in Twilio console for trial accounts. |
+| `STATIC_OTP` set in production | Big footgun. Don't. Only set in dev / CI. |
+
+## Future work
+
+- Per-tenant `STATIC_OTP` override (currently global).
+- Rate-limit `_send` by mobile to mitigate enumeration.
+- Switch to `OTP.SEND.WHATSAPP` channel when Twilio WA is verified for
+  the tenant — bridge already supports `channel: whatsapp` template bindings.

--- a/utilities/otp-publisher/package.json
+++ b/utilities/otp-publisher/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "otp-publisher",
+  "version": "0.1.0",
+  "description": "Replaces Kong's mock /user-otp termination with a real OTP generator that caches in Redis and publishes to Kafka so novu-bridge can deliver real SMS via Twilio.",
+  "private": true,
+  "type": "module",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "ioredis": "^5.4.1",
+    "kafkajs": "^2.2.4"
+  }
+}

--- a/utilities/otp-publisher/server.js
+++ b/utilities/otp-publisher/server.js
@@ -1,0 +1,186 @@
+// otp-publisher — Kong forwards /user-otp/v1/_send + /otp/v1/_validate here.
+//
+// Replaces the legacy Kong `request-termination` mock with a real
+// generator that:
+//   1. mints a 6-digit OTP
+//   2. caches `(otp, mobileNumber)` in Redis with a TTL (default 10 min)
+//   3. publishes `OTP.SEND` to the same kafka topic novu-bridge already
+//      consumes (`complaints.domain.events`), letting the existing
+//      DispatchPipelineService route through the OTP TemplateBinding +
+//      Twilio integration without any bridge-side change.
+//
+// On `_validate`, looks up the cached OTP and confirms.
+//
+// Response shapes mirror the previous Kong mock so the digit-ui SPA
+// doesn't notice anything has changed:
+//   _send  → { ResponseInfo:{...}, otp:{otp:"", UUID:"<id>", isValidationSuccessful:true} }
+//   _validate → same shape; isValidationSuccessful reflects the Redis check
+//
+// Env:
+//   PORT (default 3030)
+//   REDIS_URL (default redis://digit-redis:6379)
+//   KAFKA_BROKERS (default digit-redpanda:9092)
+//   EVENT_TOPIC (default complaints.domain.events)
+//   OTP_TTL_SECONDS (default 600)
+//   DEFAULT_TENANT_ID (default ke — used when request body omits tenantId)
+//   STATIC_OTP (optional — when set, every _send returns this code
+//     and _validate accepts it. Useful for dev / CI without flipping to
+//     a separate mock. Mirrors CITIZEN_LOGIN_PASSWORD_OTP_FIXED_VALUE.)
+
+import express from 'express';
+import { randomInt, randomUUID } from 'node:crypto';
+import Redis from 'ioredis';
+import { Kafka } from 'kafkajs';
+
+const PORT = Number(process.env.PORT || 3030);
+const REDIS_URL = process.env.REDIS_URL || 'redis://digit-redis:6379';
+const KAFKA_BROKERS = (process.env.KAFKA_BROKERS || 'digit-redpanda:9092').split(',').map((s) => s.trim()).filter(Boolean);
+const EVENT_TOPIC = process.env.EVENT_TOPIC || 'complaints.domain.events';
+const OTP_TTL_SECONDS = Number(process.env.OTP_TTL_SECONDS || 600);
+const DEFAULT_TENANT_ID = process.env.DEFAULT_TENANT_ID || 'ke';
+const STATIC_OTP = process.env.STATIC_OTP || null;
+const REDIS_KEY_PREFIX = process.env.REDIS_KEY_PREFIX || 'otp:';
+
+const redis = new Redis(REDIS_URL, { lazyConnect: true, maxRetriesPerRequest: 3 });
+redis.on('error', (e) => console.error('[redis] error:', e.message));
+
+const kafka = new Kafka({ clientId: 'otp-publisher', brokers: KAFKA_BROKERS });
+const producer = kafka.producer({ allowAutoTopicCreation: true });
+
+const app = express();
+app.use(express.json({ limit: '64kb' }));
+
+const log = (level, msg, extra = {}) =>
+  console.log(JSON.stringify({ t: new Date().toISOString(), level, msg, ...extra }));
+
+const mockOk = (extra = {}) => ({
+  ResponseInfo: {
+    apiId: 'Rainmaker',
+    ver: '.01',
+    ts: '',
+    resMsgId: 'uief87324',
+    msgId: '',
+    status: 'successful',
+  },
+  otp: { otp: '', UUID: '', isValidationSuccessful: true, ...extra },
+});
+
+const generateOtp = () => {
+  if (STATIC_OTP) return STATIC_OTP;
+  // 6-digit, zero-padded
+  return String(randomInt(0, 1_000_000)).padStart(6, '0');
+};
+
+const keyFor = (mobile, tenantId) => `${REDIS_KEY_PREFIX}${tenantId}:${mobile}`;
+
+const publishEvent = async ({ tenantId, mobile, otp, userType }) => {
+  const eventId = randomUUID();
+  const event = {
+    eventId,
+    eventType: 'OTP',
+    eventTime: new Date().toISOString(),
+    producer: 'otp-publisher',
+    module: 'USER-OTP',
+    eventName: 'OTP.SEND',
+    entityType: 'OTP_CODE',
+    entityId: eventId,
+    tenantId,
+    actor: { uuid: 'system', type: 'SYSTEM' },
+    stakeholders: [
+      {
+        // novu-bridge's Stakeholder model uses fields: type, userId, mobile.
+        // OTP is pre-account: the citizen doesn't have a DIGIT user yet.
+        // We pass userId so the bridge's UserServiceClient lookup is
+        // satisfied (set via OTP_RECIPIENT_USER_ID env — point at a
+        // throwaway placeholder user that exists at the target tenant).
+        type: 'RECIPIENT',
+        userId: process.env.OTP_RECIPIENT_USER_ID || mobile,
+        mobile,
+      },
+    ],
+    // novu-bridge's DispatchPipelineService enforces workflow.toState as
+    // required even for non-stateful events. Stub it so the OTP event
+    // passes validation and reaches the OTP_SEND TemplateBinding.
+    workflow: { fromState: null, toState: 'SENT', action: 'SEND' },
+    context: { source: 'citizen-login' },
+    data: { otp, userType: userType || 'CITIZEN' },
+  };
+  await producer.send({
+    topic: EVENT_TOPIC,
+    messages: [{ key: mobile, value: JSON.stringify(event) }],
+  });
+  return eventId;
+};
+
+const extractMobile = (body) => {
+  const otp = body?.otp || body?.Otp || {};
+  return (otp.mobileNumber || otp.identity || body?.mobileNumber || '').trim();
+};
+const extractTenant = (body) => {
+  const otp = body?.otp || body?.Otp || {};
+  return (otp.tenantId || body?.tenantId || DEFAULT_TENANT_ID).trim();
+};
+const extractType = (body) => {
+  const otp = body?.otp || body?.Otp || {};
+  return (otp.type || otp.userType || body?.userType || 'login').trim();
+};
+
+app.get('/healthz', (_req, res) => res.status(200).json({ ok: true }));
+
+app.post('/user-otp/v1/_send', async (req, res) => {
+  const mobile = extractMobile(req.body);
+  const tenantId = extractTenant(req.body);
+  if (!mobile) return res.status(400).json(mockOk({ isValidationSuccessful: false }));
+  const otp = generateOtp();
+  try {
+    await redis.set(keyFor(mobile, tenantId), otp, 'EX', OTP_TTL_SECONDS);
+    const eventId = await publishEvent({ tenantId, mobile, otp, userType: extractType(req.body) });
+    log('info', 'otp.sent', { tenantId, mobile_redacted: mobile.replace(/.(?=.{2})/g, '*'), eventId });
+    res.json(mockOk({ UUID: eventId }));
+  } catch (e) {
+    log('error', 'otp.send.failed', { err: e.message });
+    // Mirror the legacy mock: still respond 200 (the SPA polls) so a transient
+    // kafka/redis blip doesn't lock citizens out. SMS just won't land.
+    res.json(mockOk());
+  }
+});
+
+app.post('/otp/v1/_validate', async (req, res) => {
+  const mobile = extractMobile(req.body);
+  const tenantId = extractTenant(req.body);
+  const supplied = (req.body?.otp?.otp || req.body?.otp?.Otp || req.body?.otp || '').toString().trim();
+  if (!mobile || !supplied) return res.status(400).json(mockOk({ isValidationSuccessful: false }));
+  if (STATIC_OTP && supplied === STATIC_OTP) {
+    return res.json(mockOk({ isValidationSuccessful: true }));
+  }
+  try {
+    const cached = await redis.get(keyFor(mobile, tenantId));
+    const ok = cached && cached === supplied;
+    if (ok) await redis.del(keyFor(mobile, tenantId)); // single-use
+    res.json(mockOk({ isValidationSuccessful: !!ok }));
+  } catch (e) {
+    log('error', 'otp.validate.failed', { err: e.message });
+    res.status(500).json(mockOk({ isValidationSuccessful: false }));
+  }
+});
+
+const start = async () => {
+  await redis.connect();
+  await producer.connect();
+  log('info', 'otp-publisher.up', { port: PORT, topic: EVENT_TOPIC, ttl: OTP_TTL_SECONDS, static: !!STATIC_OTP });
+  app.listen(PORT, '0.0.0.0');
+};
+
+const shutdown = async (sig) => {
+  log('info', 'shutdown', { sig });
+  try { await producer.disconnect(); } catch {}
+  try { await redis.quit(); } catch {}
+  process.exit(0);
+};
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));
+
+start().catch((e) => {
+  console.error('startup failed:', e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Vendors **otp-publisher** into the repo and wires it into compose + the playbook.

`otp-publisher` is a small Node service that replaces Kong's mock `/user-otp` termination with a real OTP generator: mint a 6-digit OTP → cache in Redis → publish `OTP.SEND` to kafka `complaints.domain.events` → `novu-bridge` → Twilio SMS. Its source previously existed **only on the bomet box** (`/opt/digit/scripts/otp-publisher`), so bomet could not be reproduced from this repo — this closes that gap.

## Changes
- **`utilities/otp-publisher/`** — the 5 source files (package.json, server.js, Dockerfile, README, .dockerignore).
- **compose** — `otp-publisher` service under `profiles: ["notifications"]` (off by default), `image: ${OTP_PUBLISHER_IMAGE:-otp-publisher:local}`, depends_on redis+redpanda (both healthchecked), its own healthcheck.
- **playbook** — `build_otp_publisher` task that builds the Node image from its own Dockerfile (not the maven one), mirroring `build_default_data_handler`.
- Bomet-specific values (`DEFAULT_TENANT_ID`, `OTP_RECIPIENT_USER_ID`) are now env-parameterized instead of hardcoded.

## Validation
- compose + playbook YAML parse clean.
- `otp-publisher:local` builds successfully from `utilities/otp-publisher/Dockerfile`.
- Gated behind the `notifications` profile (SMS-OTP path is currently paused), so default deploys are unaffected.

Part of the bomet → `develop` migration (so `develop` can build everything bomet runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
