### PR TITLE
fix(playbook): docker_default_platform default('') instead of default(omit) to avoid env-dict leak

### DIFF
--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -14,11 +14,17 @@
 
   # Apple-Silicon Macs must pull amd64 images under Rosetta — Mac host_vars
   # sets `docker_default_platform: linux/amd64`. Undefined on Linux ->
-  # omit -> no env change, zero impact on Bomet/naipepea. Must be an
-  # inventory var, not a gathered fact: play-level environment is
-  # evaluated before fact-gathering (ansible_system undefined here).
+  # empty string, which Docker treats as "use host platform" (linux/amd64
+  # on x86_64 boxes) — zero impact on Bomet/naipepea. Must be an inventory
+  # var, not a gathered fact: play-level environment is evaluated before
+  # fact-gathering (ansible_system undefined here).
+  #
+  # NB: must NOT use `default(omit)` here — `omit` works as a module-arg
+  # sentinel but is rendered literally inside an environment dict value
+  # ("__omit_place_holder__..." gets exported as DOCKER_DEFAULT_PLATFORM
+  # and breaks every subsequent `docker build`).
   environment:
-    DOCKER_DEFAULT_PLATFORM: "{{ docker_default_platform | default(omit) }}"
+    DOCKER_DEFAULT_PLATFORM: "{{ docker_default_platform | default('') }}"
 
   pre_tasks:
     # digit-ui can be served two ways, both binding port 18080:


### PR DESCRIPTION
## Summary
One-line fix to the play-level `environment:` dict in `playbook-deploy.yml`:

```diff
-    DOCKER_DEFAULT_PLATFORM: "{{ docker_default_platform | default(omit) }}"
+    DOCKER_DEFAULT_PLATFORM: "{{ docker_default_platform | default('') }}"
```

## Why
Ansible's `omit` sentinel only suppresses **module arguments** — inside an `environment:` dict it's rendered literally. So whenever a host_vars file doesn't set `docker_default_platform` (most Linux tenants), the dict resolves to:

```
DOCKER_DEFAULT_PLATFORM=__omit_place_holder__<hash>
```

Every subsequent `docker build` task then dies with:

```
ERROR: failed to build: "__omit_place_holder__fb2ae92cc696d203268a76e81d3bb90e21e0a04f":
unknown operating system or architecture: invalid argument
```

Found while running `./deploy.sh` on a host_vars file that didn't pin the platform — the first local build (`build_default_data_handler`) failed at the docker build step before any containers were touched.

## Fix
`default('')` instead. An empty `DOCKER_DEFAULT_PLATFORM` is what Docker interprets as "use host platform" (linux/amd64 on x86_64 Linux) — exactly the intent on every non-Mac path. The Mac host_vars (`maputo.yml.example`) still pins `docker_default_platform: linux/amd64` explicitly, so the Rosetta path is unchanged.

Added a code comment noting the omit-in-env gotcha so future-maintainer-me doesn't reintroduce it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
