### PR TITLE
feat(playbook): nginx_preserve_vhost flag to skip host nginx site templating

### DIFF
--- a/local-setup/ansible/README.md
+++ b/local-setup/ansible/README.md
@@ -137,6 +137,18 @@ The first deploy:
 Subsequent deploys are idempotent — only changed configs / templated
 files trigger restarts.
 
+### Preserve a hand-crafted nginx vhost — `nginx_preserve_vhost: true`
+
+Some production tenants have hand-crafted `/etc/nginx/sites-enabled/<domain>`
+files with routing the templated `nginx-site.conf.j2` doesn't render
+(e.g. Bomet's `/egov-rainmaker/` filestore passthrough, `/novu/`+`/novu-api/`,
+the `/digit-ui/` host-alias). Set `nginx_preserve_vhost: true` in their
+host_vars and the playbook will still install nginx, but will skip
+rendering/symlinking the site file — your hand-managed vhost is left
+alone across every redeploy.
+
+Default `false`. New tenants get the standard templated vhost.
+
 ## Testing the deploy (Postman / Newman)
 
 `db/full-dump.sql` ships with a fully-bootstrapped test tenant

--- a/local-setup/ansible/inventory/host_vars/_example.yml
+++ b/local-setup/ansible/inventory/host_vars/_example.yml
@@ -205,6 +205,16 @@ nginx_features:
   api_pgr: false             # /api/pgr/ — proxied to MCP server
   mcp: true                  # /mcp + /v1/* — MCP HTTP transport + REST shim (requires enable_mcp: true)
 
+# If true, the playbook will NOT render `templates/nginx-site.conf.j2` into
+# /etc/nginx/sites-available/ and will NOT touch /etc/nginx/sites-enabled/.
+# nginx still gets installed (apt task is unconditional) but the operator's
+# hand-managed vhost is left as-is. Use for tenants whose production vhost
+# has hand-crafted routing the template can't (yet) render — e.g. Bomet's
+# /egov-rainmaker/ filestore passthrough, /novu/+/novu-api/ routing, the
+# /digit-ui/ host-alias. Default false so new tenants get the standard
+# templated vhost.
+nginx_preserve_vhost: false
+
 # ────────── OpenBao (per-tenant secrets backend) ──────────
 
 # REQUIRED. Path under the kv/ mount where this tenant's secrets live.

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -1131,12 +1131,21 @@
           name: nginx
           state: present
 
+      # `nginx_preserve_vhost: true` in host_vars makes the next three tasks
+      # (render / enable / remove-default) no-op. Use it for tenants whose
+      # production vhost has hand-crafted routing the template can't (yet)
+      # render — e.g. Bomet's /egov-rainmaker/ filestore passthrough,
+      # /novu/+/novu-api/ routing, and the /digit-ui/ host-alias. The nginx
+      # install task above still runs (idempotent), so the package is
+      # always present; only the site file is left alone.
+
       - name: "Host nginx — render site config from template"
         ansible.builtin.template:
           src: templates/nginx-site.conf.j2
           dest: "/etc/nginx/sites-available/{{ domain }}"
           mode: '0644'
         notify: Reload nginx
+        when: not (nginx_preserve_vhost | default(false))
 
       - name: "Host nginx — enable site"
         ansible.builtin.file:
@@ -1145,12 +1154,14 @@
           state: link
           force: yes   # convert pre-existing regular-file copies (older deploys) into a symlink
         notify: Reload nginx
+        when: not (nginx_preserve_vhost | default(false))
 
       - name: "Host nginx — remove default site"
         ansible.builtin.file:
           path: /etc/nginx/sites-enabled/default
           state: absent
         notify: Reload nginx
+        when: not (nginx_preserve_vhost | default(false))
 
       - name: "Host nginx — flush handlers so reload happens before validation"
         ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
## Summary
Adds a host_vars flag — **`nginx_preserve_vhost: true`** — that makes the playbook skip rendering the templated nginx vhost into `/etc/nginx/sites-available/` and skip touching `/etc/nginx/sites-enabled/`. The nginx install task still runs (so the package is always present); only the site file is left alone.

## Why
Bomet (and similar production tenants) have hand-crafted nginx vhosts the standard template doesn't render — Bomet's `/egov-rainmaker/` filestore passthrough, `/novu/` + `/novu-api/` routing, the `/digit-ui/` host-alias, etc. Every full re-run of `deploy.sh` currently:
1. Templates `nginx-site.conf.j2` into `/etc/nginx/sites-available/<domain>`.
2. Symlinks it into `sites-enabled/`.
3. Reloads nginx.

That overwrites the operator's hand-crafted vhost, breaking presigned filestore URLs, novu routing, etc., until they manually restore their site file.

## Change
Gates the three site-management tasks (render / enable / remove-default) inside the existing Linux nginx block:

```diff
   - name: "Host nginx — render site config from template"
     ...
+    when: not (nginx_preserve_vhost | default(false))

   - name: "Host nginx — enable site"
     ...
+    when: not (nginx_preserve_vhost | default(false))

   - name: "Host nginx — remove default site"
     ...
+    when: not (nginx_preserve_vhost | default(false))
```

Documented in `inventory/host_vars/_example.yml`; default `false` so new tenants get the standard templated vhost.

Mac nginx (container path) intentionally not gated — preserve_vhost is a production-Linux concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
