### PR TITLE
feat(playbook): per-tenant compose overlay convention (docker-compose.<tenant>.yml)

### DIFF
--- a/local-setup/ansible/README.md
+++ b/local-setup/ansible/README.md
@@ -137,6 +137,53 @@ The first deploy:
 Subsequent deploys are idempotent — only changed configs / templated
 files trigger restarts.
 
+## Per-tenant overrides
+
+Most tenants share the base compose + the templated nginx vhost. Some
+production tenants need a little more — extra env on a service, a
+hand-crafted nginx vhost the standard template doesn't render. Two
+mechanisms support that without forking the playbook:
+
+### Per-tenant compose overlay — `docker-compose.<tenant>.yml`
+
+If a file named `local-setup/docker-compose.<inventory_hostname>.yml`
+exists on the controller, the playbook copies it to the target alongside
+the base compose and appends `-f docker-compose.<tenant>.yml` to every
+compose invocation (`pull`, `up -d`, `recreate`). Use it for tenant-local
+env overrides without touching the base compose.
+
+Example — `local-setup/docker-compose.bomet.yml` ships:
+
+```yaml
+services:
+  egov-url-shortening:
+    environment:
+      # bomet's restored Flyway state has no V1 record → re-running V1
+      # collides with the existing eg_url_shortener table. Skip Flyway;
+      # the schema is stable on this tenant.
+      SPRING_FLYWAY_ENABLED: "false"
+  inbox:
+    environment:
+      # base compose's inbox defaults to STATE_LEVEL_TENANT_ID=mz; bomet
+      # has no DataSecurity for mz, which crashes the encryption client
+      # on startup. Pin to bomet's real state tenant.
+      STATE_LEVEL_TENANT_ID: "ke"
+```
+
+Convention: file path relative to `local-setup/`. Empty/missing = no-op,
+so deploys on tenants without an overlay are unaffected.
+
+### Preserve a hand-crafted nginx vhost — `nginx_preserve_vhost: true`
+
+Set in host_vars when the tenant's `/etc/nginx/sites-enabled/<domain>`
+has routing the templated `nginx-site.conf.j2` doesn't render (Bomet's
+`/egov-rainmaker/` filestore passthrough, `/novu/`+`/novu-api/`, the
+`/digit-ui/` host-alias). The playbook still installs nginx, but skips
+templating + symlinking the site file — your hand-managed vhost is left
+alone across every redeploy.
+
+Default `false`. New tenants get the standard templated vhost.
+
 ## Testing the deploy (Postman / Newman)
 
 `db/full-dump.sql` ships with a fully-bootstrapped test tenant

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -228,6 +228,27 @@
         src: ../docker-compose.fast-path.yml
         dest: "{{ digit_dir }}/docker-compose.fast-path.yml"
 
+    # Per-tenant compose overlay convention. If a file named
+    # local-setup/docker-compose.<inventory_hostname>.yml exists on the
+    # controller, copy it to the target and include it in every compose
+    # invocation below. Use it to ship per-tenant env overrides (Flyway
+    # table quirks, STATE_LEVEL_TENANT_ID adjustments, image tag pins,
+    # extra services, etc.) without touching the base compose file. Bomet
+    # uses this for url-shortening SPRING_FLYWAY_ENABLED:false + inbox
+    # STATE_LEVEL_TENANT_ID:ke overrides.
+    - name: "Per-tenant compose overlay — check for docker-compose.{{ inventory_hostname }}.yml"
+      ansible.builtin.stat:
+        path: "{{ playbook_dir }}/../docker-compose.{{ inventory_hostname }}.yml"
+      register: per_tenant_overlay
+      delegate_to: localhost
+      become: false
+
+    - name: "Per-tenant compose overlay — copy to target (if present)"
+      copy:
+        src: "../docker-compose.{{ inventory_hostname }}.yml"
+        dest: "{{ digit_dir }}/docker-compose.{{ inventory_hostname }}.yml"
+      when: per_tenant_overlay.stat.exists
+
 
     # ==================== OTEL Java Agent (fetched, not in git) ====================
     # The 21 MB OTEL javaagent JAR is downloaded on the controller before the
@@ -471,12 +492,13 @@
     # Tenants opt into the DB fast-path with `db_fast_path: true` in their
     # host_vars. When on, layer the overlay onto every compose invocation
     # below (pull, up, recreate). Default off — never touches live tenants.
-    - name: "Compute compose -f flags (fast-path overlay opt-in)"
+    - name: "Compute compose -f flags (fast-path + per-tenant overlay opt-in)"
       ansible.builtin.set_fact:
         compose_files: >-
           {{
             '-f docker-compose.egov-digit.yaml' +
-            (' -f docker-compose.fast-path.yml' if (db_fast_path | default(false)) else '')
+            (' -f docker-compose.fast-path.yml' if (db_fast_path | default(false)) else '') +
+            (' -f docker-compose.' ~ inventory_hostname ~ '.yml' if per_tenant_overlay.stat.exists else '')
           }}
 
     - name: "Show compose file stack"


### PR DESCRIPTION
## Summary
Adds a per-tenant compose-overlay convention: if `local-setup/docker-compose.<inventory_hostname>.yml` exists on the controller, the playbook copies it to the target and appends `-f docker-compose.<tenant>.yml` to every compose invocation. Tenants without an overlay are unaffected (no-op).

## Why
Some production tenants need a little more than what the base compose provides — extra env on a service, image-tag pins, occasionally extra services. Today the only way to ship that is fork the base compose. With this convention, tenant-specific tweaks live in a tenant-specific file, the base compose stays clean.

## Example — `docker-compose.bomet.yml`
Two surgical env overrides bomet needs after the cutover:

```yaml
services:
  egov-url-shortening:
    environment:
      # Bomet's restored Flyway state has no V1 record → re-running V1
      # would collide with the existing eg_url_shortener table.
      SPRING_FLYWAY_ENABLED: "false"
  inbox:
    environment:
      # Base compose's inbox defaults to STATE_LEVEL_TENANT_ID=mz; bomet
      # has no DataSecurity for mz → encryption client crashes on boot.
      STATE_LEVEL_TENANT_ID: "ke"
```

Without the overlay convention these would either fork the base compose or live as ad-hoc env tweaks on the box that every `deploy.sh` re-run wipes out.

## Mechanism
1. `stat` on the controller for `docker-compose.<inventory_hostname>.yml` (delegate_to: localhost).
2. If present, `copy` to `{{ digit_dir }}/`.
3. `compose_files` set_fact appends the overlay flag conditionally.

Zero overhead when the file doesn't exist.

## Docs
- `inventory/host_vars/_example.yml` — no change (the convention is file-presence-driven, not host_vars-driven).
- `local-setup/ansible/README.md` — new "Per-tenant overrides" section covering this + the related `nginx_preserve_vhost: true` flag (separate PR — link from this PR once merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
