### PR TITLE
feat: Keycloak SSO stack — compose + ansible bootstrap + UI auth-adapter (in-tree)

### DIFF
--- a/digit-ui-esbuild/esbuild.dev.js
+++ b/digit-ui-esbuild/esbuild.dev.js
@@ -342,7 +342,7 @@ async function start() {
     }
 
     // Proxy all non-static requests to Kong or Keycloak, with logging.
-    const kcPrefixes = ["/realms/", "/token-exchange/", "/register", "/check-email"];
+    const kcPrefixes = ["/realms/", "/kc/", "/register", "/check-email"];
     const isKc = kcPrefixes.some((p) => pathname.startsWith(p));
 
     // Everything that isn't a /digit-ui/ asset goes to the backend

--- a/digit-ui-esbuild/packages/digit-ui-components/src/atoms/PrivateRoute.js
+++ b/digit-ui-esbuild/packages/digit-ui-components/src/atoms/PrivateRoute.js
@@ -2,6 +2,10 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Route, Redirect } from "react-router-dom";
 
+function isKeycloakAuth() {
+  return window?.globalConfigs?.getConfig("AUTH_PROVIDER") === "keycloak";
+}
+
 export const PrivateRoute = ({ component: Component, roles, ...rest }) => {
   return (
     <Route
@@ -14,10 +18,11 @@ export const PrivateRoute = ({ component: Component, roles, ...rest }) => {
         // `/<contextPath>/employee/...` → employee, anything else → citizen.
         const pathParts = (props.location.pathname || "").split("/").filter(Boolean);
         const pathUserType = pathParts[1] === "employee" ? "employee" : "citizen";
-        const loginPath =
-          pathUserType === "employee"
+        const loginPath = isKeycloakAuth()
+          ? `/${window?.contextPath}/user/login`
+          : (pathUserType === "employee"
             ? `/${window?.contextPath}/employee/user/language-selection`
-            : `/${window?.contextPath}/citizen/login`;
+            : `/${window?.contextPath}/citizen/login`);
 
         // No token at all → bounce to the login page that matches the
         // URL the user was trying to reach.

--- a/digit-ui-esbuild/packages/libraries/src/index.js
+++ b/digit-ui-esbuild/packages/libraries/src/index.js
@@ -39,6 +39,7 @@ import Hooks from "./hooks";
 import Utils from "./utils";
 import { subFormRegistry } from "./subFormRegistry";
 import AccessControlService from "./services/elements/Access";
+import { getAuthAdapter, initAuthAdapter, AuthAdapter } from "./services/auth/index";
 
 const setupLibraries = (Library, props) => {
   window.Digit = window.Digit || {};
@@ -92,4 +93,4 @@ const initLibraries = () => {
 
 export * from "./constants/mobileValidation";
 
-export { initLibraries, Enums, Hooks, subFormRegistry, Request, MdmsService };
+export { initLibraries, Enums, Hooks, subFormRegistry, Request, MdmsService, getAuthAdapter, initAuthAdapter, AuthAdapter };

--- a/digit-ui-esbuild/packages/libraries/src/services/atoms/Utils/Request.js
+++ b/digit-ui-esbuild/packages/libraries/src/services/atoms/Utils/Request.js
@@ -1,5 +1,17 @@
 import Axios from "axios";
 
+function isKeycloakAuth() {
+  return window?.globalConfigs?.getConfig("AUTH_PROVIDER") === "keycloak";
+}
+
+function getTokenExchangeUrl() {
+  return window?.globalConfigs?.getConfig("TOKEN_EXCHANGE_URL") || "";
+}
+
+function getKeycloakToken() {
+  return window.localStorage.getItem("token") || null;
+}
+
 /**
  * Custom Request to make all api calls
  *
@@ -16,8 +28,10 @@ Axios.interceptors.response.use(
         if (error.message.includes("InvalidAccessTokenException")) {
           localStorage.clear();
           sessionStorage.clear();
-          window.location.href =
-          (isEmployee ? `/${window?.contextPath}/employee/user/login` : `/${window?.contextPath}/citizen/login`) +
+          const loginPath = isKeycloakAuth()
+            ? `/${window?.contextPath}/user/login`
+            : (isEmployee ? `/${window?.contextPath}/employee/user/login` : `/${window?.contextPath}/citizen/login`);
+          window.location.href = loginPath +
             `?from=${encodeURIComponent(window.location.pathname + window.location.search)}`;
         } else if (
           error?.message?.toLowerCase()?.includes("internal server error") ||
@@ -133,13 +147,33 @@ export const Request = async ({
     })
     .join("/");
 
+  // Keycloak mode: proxy through token-exchange only when we have a token.
+  // Pre-login calls (MDMS init, localization) go direct to Kong.
+  if (isKeycloakAuth() && auth) {
+    const kcToken = getKeycloakToken();
+    if (kcToken) {
+      const teUrl = getTokenExchangeUrl();
+      if (teUrl) {
+        _url = `${teUrl}${_url}`;
+        headers = { ...headers, Authorization: `Bearer ${kcToken}` };
+      }
+    }
+  }
+
   if (multipartFormData) {
+    const multipartHeaders = { "Content-Type": "multipart/form-data" };
+    if (isKeycloakAuth()) {
+      const kcToken = getKeycloakToken();
+      if (kcToken) multipartHeaders["Authorization"] = `Bearer ${kcToken}`;
+    } else {
+      multipartHeaders["auth-token"] = Digit.UserService.getUser()?.access_token || null;
+    }
     const multipartFormDataRes = await Axios({
       method,
       url: _url,
       data: multipartData.data,
       params,
-      headers: { "Content-Type": "multipart/form-data", "auth-token": Digit.UserService.getUser()?.access_token || null },
+      headers: multipartHeaders,
     });
     return multipartFormDataRes;
   }

--- a/digit-ui-esbuild/packages/libraries/src/services/auth/AuthAdapter.js
+++ b/digit-ui-esbuild/packages/libraries/src/services/auth/AuthAdapter.js
@@ -1,0 +1,19 @@
+/**
+ * AuthAdapter interface.
+ * All implementations must provide these methods.
+ * Active adapter is selected via globalConfigs.getConfig("AUTH_PROVIDER").
+ */
+
+export class AuthAdapter {
+  async init() { throw new Error("Not implemented"); }
+  isAuthenticated() { throw new Error("Not implemented"); }
+  getToken() { throw new Error("Not implemented"); }
+  getUser() { throw new Error("Not implemented"); }
+  async login({ email, password }) { throw new Error("Not implemented"); }
+  async signup({ email, password, name }) { throw new Error("Not implemented"); }
+  async logout() { throw new Error("Not implemented"); }
+  async refreshToken() { throw new Error("Not implemented"); }
+  async checkEmailExists(email) { throw new Error("Not implemented"); }
+  async loginWithProvider(provider) { throw new Error("Not implemented"); }
+  getSupportedProviders() { return []; }
+}

--- a/digit-ui-esbuild/packages/libraries/src/services/auth/DigitAuthAdapter.js
+++ b/digit-ui-esbuild/packages/libraries/src/services/auth/DigitAuthAdapter.js
@@ -1,0 +1,72 @@
+import { AuthAdapter } from "./AuthAdapter";
+
+/**
+ * DigitAuthAdapter wraps the existing DIGIT auth system.
+ * When AUTH_PROVIDER=digit (default), this adapter is used.
+ * It delegates to the existing UserService and localStorage session recovery.
+ */
+export class DigitAuthAdapter extends AuthAdapter {
+  async init() {
+    // No-op: existing session recovery in index.js handles this
+  }
+
+  isAuthenticated() {
+    const user = Digit.UserService.getUser();
+    return !!(user && user.access_token);
+  }
+
+  getToken() {
+    const user = Digit.UserService.getUser();
+    return user?.access_token || null;
+  }
+
+  getUser() {
+    const user = Digit.UserService.getUser();
+    if (!user?.info) return null;
+    return {
+      uuid: user.info.uuid,
+      email: user.info.emailId || user.info.userName,
+      name: user.info.name,
+      roles: user.info.roles || [],
+      tenantId: user.info.tenantId,
+      type: user.info.type,
+    };
+  }
+
+  async login({ email, password, tenantId }) {
+    const requestData = {
+      username: email,
+      password,
+      tenantId: tenantId || Digit.ULBService.getStateId(),
+      userType: "CITIZEN",
+    };
+    const { UserRequest: info, ...tokens } = await Digit.UserService.authenticate(requestData);
+    const user = { info, ...tokens };
+    Digit.UserService.setUser(user);
+    return { success: true, user: info, token: tokens.access_token };
+  }
+
+  async signup() {
+    throw new Error("Signup not supported in DIGIT adapter. Use OTP flow.");
+  }
+
+  async logout() {
+    return Digit.UserService.logout();
+  }
+
+  async refreshToken() {
+    return this.getToken();
+  }
+
+  async checkEmailExists() {
+    return false;
+  }
+
+  async loginWithProvider() {
+    throw new Error("SSO not supported in DIGIT adapter");
+  }
+
+  getSupportedProviders() {
+    return [];
+  }
+}

--- a/digit-ui-esbuild/packages/libraries/src/services/auth/KeycloakAuthAdapter.js
+++ b/digit-ui-esbuild/packages/libraries/src/services/auth/KeycloakAuthAdapter.js
@@ -1,0 +1,314 @@
+import { AuthAdapter } from "./AuthAdapter";
+
+// keycloak-js is loaded from CDN via <script> tag in index.html
+// Available as window.Keycloak
+function getKeycloakConstructor() {
+  if (typeof window !== "undefined" && window.Keycloak) return window.Keycloak;
+  throw new Error("keycloak-js not loaded. Ensure the CDN script is in index.html.");
+}
+
+// Decode JWT payload without keycloak-js re-init
+function b64decode(str) {
+  let b = str.replace(/-/g, "+").replace(/_/g, "/");
+  while (b.length % 4) b += "=";
+  return JSON.parse(atob(b));
+}
+
+export class KeycloakAuthAdapter extends AuthAdapter {
+  constructor() {
+    super();
+    this._kc = null;
+    this._user = null;
+    this._tokenExchangeUrl = null;
+    this._tenantId = null;
+    this._digitUserType = null;
+    this._digitRoles = null;
+  }
+
+  async init() {
+    const kcUrl = window?.globalConfigs?.getConfig("KEYCLOAK_URL");
+    const realm = window?.globalConfigs?.getConfig("KEYCLOAK_REALM");
+    const clientId = window?.globalConfigs?.getConfig("KEYCLOAK_CLIENT_ID");
+    this._tokenExchangeUrl = window?.globalConfigs?.getConfig("TOKEN_EXCHANGE_URL");
+
+    const Keycloak = getKeycloakConstructor();
+    this._kc = new Keycloak({ url: kcUrl, realm, clientId });
+
+    try {
+      const contextPath = window?.contextPath || "digit-ui";
+      const authenticated = await this._kc.init({
+        onLoad: "check-sso",
+        pkceMethod: "S256",
+        silentCheckSsoRedirectUri: window.location.origin + "/" + contextPath + "/silent-check-sso.html",
+      });
+
+      console.log("[KC-AUTH] init: authenticated=" + authenticated + " pathname=" + window.location.pathname);
+      if (authenticated) {
+        await this._loadUserFromToken();
+        console.log("[KC-AUTH] init: user=" + JSON.stringify(this._user?.type) + " roles=" + JSON.stringify(this._user?.roles?.map(r=>r.code)));
+        if (window.location.pathname.includes("/user/login")) {
+          const user = this._user;
+          const targetType = (user && user.type === "EMPLOYEE") ? "employee" : "citizen";
+          console.log("[KC-AUTH] init: redirecting to /" + targetType + " (user.type=" + user?.type + ")");
+          Digit.SessionStorage.set("userType", targetType);
+          Digit.SessionStorage.set("user_type", targetType);
+          window.location.replace(window.location.origin + "/" + contextPath + "/" + targetType);
+        } else {
+          console.log("[KC-AUTH] init: NOT on login page, no redirect. pathname=" + window.location.pathname);
+        }
+      }
+    } catch (err) {
+      console.warn("[KeycloakAuthAdapter] SSO check failed, continuing without SSO:", err);
+    }
+
+    this._kc.onTokenExpired = () => {
+      this._kc.updateToken(30).then(() => {
+        window.localStorage.setItem("token", this._kc.token);
+        const sessionType = this._digitUserType === "EMPLOYEE" ? "Employee" : "Citizen";
+        window.localStorage.setItem(sessionType + ".token", this._kc.token);
+      }).catch(() => {
+        this._user = null;
+      });
+    };
+  }
+
+  isAuthenticated() {
+    return !!this._kc?.authenticated && !!this._user;
+  }
+
+  getToken() {
+    return this._kc?.token || null;
+  }
+
+  getUser() {
+    return this._user;
+  }
+
+  // Manually set tokens on the keycloak instance by decoding JWTs directly.
+  // Required because kc.init() with raw tokens from a password grant triggers
+  // a full OIDC flow or fails silently in some keycloak-js versions.
+  _setTokens(access, refresh, id) {
+    this._kc.token = access;
+    this._kc.refreshToken = refresh || null;
+    this._kc.idToken = id || null;
+    this._kc.authenticated = true;
+
+    try {
+      this._kc.tokenParsed = b64decode(access.split(".")[1]);
+      this._kc.subject = this._kc.tokenParsed.sub;
+      this._kc.realmAccess = this._kc.tokenParsed.realm_access;
+      this._kc.resourceAccess = this._kc.tokenParsed.resource_access;
+    } catch (e) {
+      console.warn("[KeycloakAuthAdapter] Failed to decode access token:", e);
+    }
+
+    if (refresh) {
+      try {
+        this._kc.refreshTokenParsed = b64decode(refresh.split(".")[1]);
+      } catch (e) { /* refresh token may not be a JWT */ }
+    }
+
+    if (id) {
+      try {
+        this._kc.idTokenParsed = b64decode(id.split(".")[1]);
+      } catch (e) { /* id token decode failure is non-fatal */ }
+    }
+  }
+
+  async login({ email, password, tenantId }) {
+    // If no tenantId passed by caller, read from KC tenant dropdown
+    if (!tenantId) {
+      const kcSel = document.getElementById("kc-tenant-select");
+      if (kcSel && kcSel.value) tenantId = kcSel.value;
+    }
+    this._tenantId = tenantId || null;
+
+    const tokenExchangeUrl = this._tokenExchangeUrl || window.location.origin;
+    const resp = await fetch(`${tokenExchangeUrl}/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password, tenantId }),
+    });
+
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({}));
+      throw new Error(err.error || err.message || "Login failed");
+    }
+
+    const tokens = await resp.json();
+
+    // BFF does not return refresh_token — pass null
+    this._setTokens(tokens.access_token, null, tokens.id_token);
+    this._digitUserType = tokens.digit_user_type || null;
+    this._digitRoles = tokens.digit_roles || null;
+
+    await this._loadUserFromToken();
+    return { token: tokens.access_token, user: this._user };
+  }
+
+  async signup({ email, password, name, tenantId }) {
+    this._tenantId = tenantId || null;
+
+    const resp = await fetch(`${this._tokenExchangeUrl}/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password, name, tenantId }),
+    });
+
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({}));
+      throw new Error(err.message || err.error || "Registration failed");
+    }
+
+    return this.login({ email, password, tenantId });
+  }
+
+  async logout() {
+    // Build the redirect URL before clearing anything
+    const contextPath = window?.contextPath || "digit-ui";
+    const redirectUri = `${window.location.origin}/${contextPath}/user/login`;
+
+    // Build the KC logout URL directly from config.
+    // We can't rely on this._kc.authenticated because password-grant logins
+    // use _setTokens() on a previous page's adapter instance — after navigation,
+    // the new adapter's init(check-sso) sees no KC session cookie, so
+    // _kc.authenticated is false even though the user is logged in.
+    const kcUrl = window?.globalConfigs?.getConfig("KEYCLOAK_URL");
+    const realm = window?.globalConfigs?.getConfig("KEYCLOAK_REALM");
+    const clientId = window?.globalConfigs?.getConfig("KEYCLOAK_CLIENT_ID");
+
+    // Clear in-memory state
+    this._user = null;
+    this._tenantId = null;
+    this._digitUserType = null;
+    this._digitRoles = null;
+
+    // Grab id_token_hint before clearing storage (needed for KC to skip confirmation page)
+    const idTokenHint = this._kc?.idToken
+      || window.localStorage.getItem("kc_id_token")
+      || null;
+
+    // Clear all browser storage
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+
+    // Always redirect through KC's logout endpoint to clear any session cookies
+    // (from SSO/Google login or future flows that create KC sessions).
+    // For password-grant-only sessions there's no cookie, but the redirect is
+    // harmless and ensures consistent behavior.
+    if (kcUrl && realm) {
+      const logoutUrl = new URL(`${kcUrl}/realms/${realm}/protocol/openid-connect/logout`);
+      logoutUrl.searchParams.set("client_id", clientId);
+      logoutUrl.searchParams.set("post_logout_redirect_uri", redirectUri);
+      if (idTokenHint) {
+        logoutUrl.searchParams.set("id_token_hint", idTokenHint);
+      }
+      window.location.replace(logoutUrl.toString());
+    } else {
+      window.location.replace(redirectUri);
+    }
+  }
+
+  async refreshToken() {
+    if (!this._kc) return null;
+    await this._kc.updateToken(30);
+    return this._kc.token;
+  }
+
+  async checkEmailExists(email) {
+    const resp = await fetch(
+      `${this._tokenExchangeUrl}/check-email?email=${encodeURIComponent(email)}`
+    );
+    if (!resp.ok) return false;
+    const data = await resp.json();
+    return data.exists === true;
+  }
+
+  async loginWithProvider(provider) {
+    console.log("[KC-AUTH] loginWithProvider: " + provider + " redirectUri=" + window.location.href);
+    this._kc.login({ idpHint: provider });
+  }
+
+  getSupportedProviders() {
+    return ["google"];
+  }
+
+  async _loadUserFromToken() {
+    if (!this._kc?.tokenParsed) {
+      console.log("[KC-AUTH] _loadUserFromToken: no tokenParsed, skipping");
+      return;
+    }
+
+    const parsed = this._kc.tokenParsed;
+    console.log("[KC-AUTH] _loadUserFromToken: sub=" + parsed.sub + " email=" + parsed.email);
+    console.log("[KC-AUTH] _digitUserType=" + this._digitUserType + " _digitRoles=" + JSON.stringify(this._digitRoles));
+    console.log("[KC-AUTH] realm_access.roles=" + JSON.stringify(parsed.realm_access?.roles));
+    const stateTenant = window?.globalConfigs?.getConfig("STATE_LEVEL_TENANT_ID") || "pg";
+    const defaultCityTenant = stateTenant + ".citya"; // TODO: make configurable
+    const tenantId = this._tenantId || defaultCityTenant;
+
+    const isEmployee = this._digitUserType === "EMPLOYEE";
+    const userType = isEmployee ? "EMPLOYEE" : "CITIZEN";
+    const sessionType = isEmployee ? "employee" : "citizen";
+    console.log("[KC-AUTH] isEmployee=" + isEmployee + " userType=" + userType + " sessionType=" + sessionType);
+
+    // Use digit_roles from token response if available, else fall back to KC realm roles
+    const roles = (this._digitRoles && this._digitRoles.length > 0)
+      ? this._digitRoles.map(r => ({
+          code: r.code,
+          name: r.name || r.code,
+          tenantId: isEmployee ? tenantId : (r.tenantId || tenantId),
+        }))
+      : (parsed.realm_access?.roles || []).map(code => ({
+          code, name: code, tenantId,
+        }));
+
+    this._user = {
+      uuid: parsed.sub,
+      email: parsed.email,
+      name: parsed.name || parsed.preferred_username || parsed.email,
+      roles,
+      tenantId,
+      type: userType,
+    };
+
+    const sessionUser = {
+      access_token: this._kc.token,
+      token: this._kc.token,
+      info: {
+        uuid: this._user.uuid,
+        userName: this._user.userName,
+        name: this._user.name,
+        emailId: this._user.email,
+        tenantId,
+        type: userType,
+        roles,
+      },
+    };
+
+    // Common storage
+    Digit.SessionStorage.set("User", sessionUser);
+    Digit.SessionStorage.set("userType", sessionType);
+    Digit.SessionStorage.set("user_type", sessionType);
+    window.localStorage.setItem("token", this._kc.token);
+    // Store id_token for logout (KC needs it to skip confirmation page)
+    if (this._kc.idToken) {
+      window.localStorage.setItem("kc_id_token", this._kc.idToken);
+    }
+
+    if (isEmployee) {
+      Digit.SessionStorage.set("Employee.tenantId", tenantId);
+      window.localStorage.setItem("Employee.token", this._kc.token);
+      window.localStorage.setItem("Employee.user-info", JSON.stringify(sessionUser.info));
+      window.localStorage.setItem("Employee.tenant-id", tenantId);
+    } else {
+      Digit.SessionStorage.set("Citizen.tenantId", tenantId);
+      window.localStorage.setItem("Citizen.token", this._kc.token);
+      window.localStorage.setItem("Citizen.user-info", JSON.stringify(sessionUser.info));
+      window.localStorage.setItem("Citizen.tenant-id", tenantId);
+      if (!Digit.SessionStorage.get("CITIZEN.COMMON.HOME.CITY")) {
+        Digit.SessionStorage.set("CITIZEN.COMMON.HOME.CITY", { code: tenantId });
+      }
+    }
+  }
+}

--- a/digit-ui-esbuild/packages/libraries/src/services/auth/KeycloakAuthAdapter.js
+++ b/digit-ui-esbuild/packages/libraries/src/services/auth/KeycloakAuthAdapter.js
@@ -123,24 +123,41 @@ export class KeycloakAuthAdapter extends AuthAdapter {
     }
     this._tenantId = tenantId || null;
 
+    // OAuth2 password grant against the realm's standard token endpoint.
+    // Routed through Kong's /kc/* path (strip_path: true) so the URL the
+    // browser sends is `/kc/realms/{realm}/protocol/openid-connect/token`,
+    // which arrives at token-exchange-svc as
+    // `/realms/{realm}/protocol/openid-connect/token`. The overlay
+    // intercepts this exact path and adds KC→DIGIT fallback (if KC auth
+    // fails, retries against egov-user and lazy-provisions the KC side).
+    // We deliberately use the standard endpoint rather than a custom BFF
+    // route so the adapter remains compatible with any vanilla Keycloak.
     const tokenExchangeUrl = this._tokenExchangeUrl || window.location.origin;
-    const resp = await fetch(`${tokenExchangeUrl}/auth/login`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ email, password, tenantId }),
-    });
+    const realm = window?.globalConfigs?.getConfig("KEYCLOAK_REALM") || tenantId;
+    const clientId = window?.globalConfigs?.getConfig("KEYCLOAK_CLIENT_ID") || "digit-ui";
+
+    const resp = await fetch(
+      `${tokenExchangeUrl}/realms/${encodeURIComponent(realm)}/protocol/openid-connect/token`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "password",
+          client_id: clientId,
+          username: email,
+          password,
+          scope: "openid",
+        }),
+      }
+    );
 
     if (!resp.ok) {
       const err = await resp.json().catch(() => ({}));
-      throw new Error(err.error || err.message || "Login failed");
+      throw new Error(err.error_description || err.error || err.message || "Login failed");
     }
 
     const tokens = await resp.json();
-
-    // BFF does not return refresh_token — pass null
-    this._setTokens(tokens.access_token, null, tokens.id_token);
-    this._digitUserType = tokens.digit_user_type || null;
-    this._digitRoles = tokens.digit_roles || null;
+    this._setTokens(tokens.access_token, tokens.refresh_token, tokens.id_token);
 
     await this._loadUserFromToken();
     return { token: tokens.access_token, user: this._user };

--- a/digit-ui-esbuild/packages/libraries/src/services/auth/index.js
+++ b/digit-ui-esbuild/packages/libraries/src/services/auth/index.js
@@ -1,0 +1,25 @@
+import { AuthAdapter } from "./AuthAdapter";
+
+let _adapter = null;
+
+export function getAuthAdapter() {
+  if (_adapter) return _adapter;
+  throw new Error("AuthAdapter not initialized. Call initAuthAdapter() first.");
+}
+
+export async function initAuthAdapter() {
+  const provider = window?.globalConfigs?.getConfig("AUTH_PROVIDER") || "digit";
+
+  if (provider === "keycloak") {
+    const { KeycloakAuthAdapter } = await import("./KeycloakAuthAdapter");
+    _adapter = new KeycloakAuthAdapter();
+  } else {
+    const { DigitAuthAdapter } = await import("./DigitAuthAdapter");
+    _adapter = new DigitAuthAdapter();
+  }
+
+  await _adapter.init();
+  return _adapter;
+}
+
+export { AuthAdapter };

--- a/digit-ui-esbuild/packages/libraries/src/services/elements/User/index.js
+++ b/digit-ui-esbuild/packages/libraries/src/services/elements/User/index.js
@@ -1,9 +1,24 @@
 import Urls from "../../atoms/urls";
 import { Request, ServiceRequest } from "../../atoms/Utils/Request";
 import { Storage } from "../../atoms/Utils/Storage";
+import { getAuthAdapter } from "../../auth/index";
 
 export const UserService = {
   authenticate: async (details) => {
+    if (window?.globalConfigs?.getConfig("AUTH_PROVIDER") === "keycloak") {
+      const adapter = getAuthAdapter();
+      const result = await adapter.login({
+        email: details.username,
+        password: details.password,
+        tenantId: details.tenantId,
+      });
+      return {
+        UserRequest: result.user,
+        access_token: result.token,
+        token_type: "bearer",
+      };
+    }
+
     const data = new URLSearchParams();
     Object.entries(details).forEach(([key, value]) => data.append(key, value));
     data.append("scope", "read");
@@ -47,6 +62,11 @@ export const UserService = {
     return Digit.SessionStorage.get("User");
   },
   logout: async () => {
+    if (window?.globalConfigs?.getConfig("AUTH_PROVIDER") === "keycloak") {
+      const adapter = getAuthAdapter();
+      return adapter.logout();
+    }
+
     const userType = UserService.getType();
     // Capture userType BEFORE we clear storage. The redirect URL has
     // to be the explicit `/citizen/login` (not `/citizen`) — landing

--- a/digit-ui-esbuild/packages/modules/core/src/App.js
+++ b/digit-ui-esbuild/packages/modules/core/src/App.js
@@ -9,6 +9,10 @@ import CustomErrorComponent from "./components/CustomErrorComponent";
 import DummyLoaderScreen from "./components/DummyLoader";
 import SignUpV2 from "./pages/employee/SignUp-v2";
 import LoginV2 from "./pages/employee/Login-v2";
+import UnifiedLogin from "./pages/common/Login/index";
+
+const isKeycloakAuth = () =>
+  window?.globalConfigs?.getConfig("AUTH_PROVIDER") === "keycloak";
 
 export const DigitApp = ({ stateCode, modules, appTenants, logoUrl, logoUrlWhite, initData, defaultLanding = "citizen",allowedUserTypes=["citizen","employee"] }) => {
   const history = useHistory();
@@ -120,10 +124,14 @@ export const DigitAppWrapper = ({ stateCode, modules, appTenants, logoUrl, logoU
           <CustomErrorComponent />
         </Route>
         <Route exact path={`/${window?.globalPath}/user/sign-up`}>
-          <SignUpV2 stateCode={stateCode} />
+          {isKeycloakAuth()
+            ? <UnifiedLogin stateCode={stateCode} />
+            : <SignUpV2 stateCode={stateCode} />}
         </Route>
         <Route exact path={`/${window?.globalPath}/user/login`}>
-          <LoginV2 stateCode={stateCode} />
+          {isKeycloakAuth()
+            ? <UnifiedLogin stateCode={stateCode} />
+            : <LoginV2 stateCode={stateCode} />}
         </Route>
         {/* <Route exact path={`/${window?.globalPath}/user/sign-up`}>
           <SignUp stateCode={stateCode} />
@@ -137,7 +145,7 @@ export const DigitAppWrapper = ({ stateCode, modules, appTenants, logoUrl, logoU
         <Route exact path={`/${window?.globalPath}/user/url`}>
           <ViewUrl />
         </Route>
-        {window?.globalPath !== window?.contextPath && (
+        {(window?.globalPath !== window?.contextPath || isKeycloakAuth()) && (
           <Route path={`/${window?.contextPath}`}>
             <DigitApp
               stateCode={stateCode}
@@ -152,7 +160,11 @@ export const DigitAppWrapper = ({ stateCode, modules, appTenants, logoUrl, logoU
           </Route>
         )}
         <Route>
-          <Redirect to={`/${window?.globalPath}/user/sign-up`} />
+          <Redirect to={
+            isKeycloakAuth()
+              ? `/${window?.globalPath}/user/login`
+              : `/${window?.globalPath}/user/sign-up`
+          } />
         </Route>
       </Switch>
     </div>

--- a/digit-ui-esbuild/packages/modules/core/src/pages/common/Login/index.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/common/Login/index.js
@@ -1,0 +1,287 @@
+import React, { useState, useEffect } from "react";
+import { useHistory, useLocation } from "react-router-dom";
+import { Toast } from "@egovernments/digit-ui-components";
+import { getAuthAdapter } from "@egovernments/digit-ui-libraries";
+import SandBoxHeader from "../../../components/SandBoxHeader";
+import ImageComponent from "../../../components/ImageComponent";
+
+const GoogleIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 48 48">
+    <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z" />
+    <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z" />
+    <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z" />
+    <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z" />
+  </svg>
+);
+
+const UnifiedLogin = ({ stateCode }) => {
+  const history = useHistory();
+  const location = useLocation();
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [tenantId, setTenantId] = useState("");
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const contextPath = window?.contextPath || "digit-ui";
+  const adapter = getAuthAdapter();
+  const providers = adapter ? adapter.getSupportedProviders() : [];
+
+  const tenants =
+    Digit.SessionStorage.get("initData")?.tenants ||
+    window?.globalConfigs?.getConfig("TENANTS") ||
+    [];
+
+  useEffect(() => {
+    if (adapter && adapter.isAuthenticated()) {
+      const user = adapter.getUser();
+      if (user && user.type === "EMPLOYEE") {
+        history.replace(`/${contextPath}/employee`);
+      } else {
+        history.replace(location.state?.from || `/${contextPath}/citizen`);
+      }
+    }
+  }, []);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    try {
+      const loginTenant = tenantId || stateCode;
+      const result = await adapter.login({
+        email,
+        password,
+        tenantId: loginTenant,
+      });
+
+      const user = result?.user || (adapter && adapter.getUser());
+      if (user && user.type === "EMPLOYEE") {
+        window.location.replace(
+          window.location.origin + "/" + contextPath + "/employee"
+        );
+      } else {
+        history.replace(location.state?.from || `/${contextPath}/citizen`);
+      }
+    } catch (err) {
+      setError(err.message || "Authentication failed");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSSO = (provider) => {
+    if (adapter) adapter.loginWithProvider(provider);
+  };
+
+  const isSubmitDisabled = !email || !password || loading;
+
+  const fieldStyle = {
+    width: "100%",
+    padding: "0.625rem 0.75rem",
+    border: "1px solid #B1B4B6",
+    borderRadius: "4px",
+    fontSize: "0.9375rem",
+    fontFamily: "Roboto, sans-serif",
+    backgroundColor: "#fff",
+    height: "42px",
+    boxSizing: "border-box",
+    outline: "none",
+  };
+
+  const labelStyle = {
+    display: "block",
+    marginBottom: "0.375rem",
+    fontSize: "0.875rem",
+    fontWeight: 600,
+    color: "#0B0C0C",
+  };
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        minHeight: "100vh",
+        backgroundColor: "#F0F0F0",
+        padding: "1rem",
+      }}
+    >
+      <div
+        style={{
+          width: "100%",
+          maxWidth: "420px",
+          backgroundColor: "#fff",
+          borderRadius: "8px",
+          boxShadow: "0 1px 4px rgba(0,0,0,0.08), 0 4px 16px rgba(0,0,0,0.06)",
+          padding: "2rem 2rem 1.5rem",
+        }}
+      >
+        <div style={{ marginBottom: "1.5rem" }}>
+          <SandBoxHeader showTenant={false} />
+        </div>
+
+        <h2
+          style={{
+            fontSize: "1.375rem",
+            fontWeight: 700,
+            color: "#0B0C0C",
+            margin: "0 0 0.25rem",
+          }}
+        >
+          Login
+        </h2>
+        <p
+          style={{
+            fontSize: "0.8125rem",
+            color: "#505A5F",
+            margin: "0 0 1.5rem",
+          }}
+        >
+          Sign in to access employee services
+        </p>
+
+        <form onSubmit={handleSubmit}>
+          {tenants.length > 1 && (
+            <div style={{ marginBottom: "1rem" }}>
+              <label style={labelStyle}>
+                City <span style={{ color: "#D4351C" }}>*</span>
+              </label>
+              <select
+                id="kc-tenant-select"
+                value={tenantId}
+                onChange={(e) => setTenantId(e.target.value)}
+                style={{ ...fieldStyle, cursor: "pointer" }}
+              >
+                <option value="">Select city</option>
+                {tenants
+                  .filter((t) => t.code !== stateCode)
+                  .map((t) => (
+                    <option key={t.code} value={t.code}>
+                      {t.name || t.code}
+                    </option>
+                  ))}
+              </select>
+            </div>
+          )}
+
+          <div style={{ marginBottom: "1rem" }}>
+            <label style={labelStyle}>
+              Username / Email <span style={{ color: "#D4351C" }}>*</span>
+            </label>
+            <input
+              type="text"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="Enter username or email"
+              required
+              style={fieldStyle}
+            />
+          </div>
+
+          <div style={{ marginBottom: "1.5rem" }}>
+            <label style={labelStyle}>
+              Password <span style={{ color: "#D4351C" }}>*</span>
+            </label>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="Enter password"
+              required
+              style={fieldStyle}
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitDisabled}
+            style={{
+              width: "100%",
+              padding: "0.625rem 1rem",
+              backgroundColor: isSubmitDisabled ? "#B1B4B6" : "#F47738",
+              color: "#fff",
+              border: "none",
+              borderRadius: "4px",
+              fontSize: "1rem",
+              fontWeight: 700,
+              fontFamily: "Roboto, sans-serif",
+              cursor: isSubmitDisabled ? "not-allowed" : "pointer",
+              height: "42px",
+            }}
+          >
+            {loading ? "Signing in..." : "Login"}
+          </button>
+
+          {providers.length > 0 && (
+            <React.Fragment>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  margin: "1.25rem 0",
+                  gap: "0.75rem",
+                }}
+              >
+                <div style={{ flex: 1, height: "1px", backgroundColor: "#D6D6D6" }} />
+                <span style={{ fontSize: "0.8125rem", color: "#505A5F" }}>or</span>
+                <div style={{ flex: 1, height: "1px", backgroundColor: "#D6D6D6" }} />
+              </div>
+
+              {providers.map((provider) => (
+                <button
+                  key={provider}
+                  type="button"
+                  onClick={() => handleSSO(provider)}
+                  style={{
+                    width: "100%",
+                    padding: "0.5rem 1rem",
+                    border: "1px solid #B1B4B6",
+                    borderRadius: "4px",
+                    backgroundColor: "#fff",
+                    cursor: "pointer",
+                    fontSize: "0.9375rem",
+                    fontWeight: 500,
+                    fontFamily: "Roboto, sans-serif",
+                    height: "42px",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    gap: "0.625rem",
+                    marginBottom: "0.5rem",
+                  }}
+                >
+                  {provider.toLowerCase() === "google" && <GoogleIcon />}
+                  <span>Sign in with {provider.charAt(0).toUpperCase() + provider.slice(1)}</span>
+                </button>
+              ))}
+            </React.Fragment>
+          )}
+        </form>
+
+        {error && (
+          <Toast type="error" label={error} onClose={() => setError(null)} />
+        )}
+      </div>
+
+      <div style={{ marginTop: "1.5rem" }}>
+        <ImageComponent
+          alt="Powered by DIGIT"
+          src={window?.globalConfigs?.getConfig?.("DIGIT_FOOTER_BW")}
+          style={{ cursor: "pointer", height: "1.25em" }}
+          onClick={() => {
+            window
+              .open(window?.globalConfigs?.getConfig?.("DIGIT_HOME_URL"), "_blank")
+              .focus();
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default UnifiedLogin;

--- a/digit-ui-esbuild/packages/react-components/src/atoms/PrivateRoute.js
+++ b/digit-ui-esbuild/packages/react-components/src/atoms/PrivateRoute.js
@@ -1,6 +1,10 @@
 import React from "react";
 import { Route, Redirect } from "react-router-dom";
 
+function isKeycloakAuth() {
+  return window?.globalConfigs?.getConfig("AUTH_PROVIDER") === "keycloak";
+}
+
 export const PrivateRoute = ({ component: Component, roles, ...rest }) => {
   return (
     <Route
@@ -13,10 +17,11 @@ export const PrivateRoute = ({ component: Component, roles, ...rest }) => {
         // `/<contextPath>/employee/...` → employee, anything else → citizen.
         const pathParts = (props.location.pathname || "").split("/").filter(Boolean);
         const pathUserType = pathParts[1] === "employee" ? "employee" : "citizen";
-        const loginPath =
-          pathUserType === "employee"
+        const loginPath = isKeycloakAuth()
+          ? `/${window?.contextPath}/user/login`
+          : (pathUserType === "employee"
             ? `/${window?.contextPath}/employee/user/language-selection`
-            : `/${window?.contextPath}/citizen/login`;
+            : `/${window?.contextPath}/citizen/login`);
 
         // No token at all → bounce to the login page that matches the
         // URL the user was trying to reach.

--- a/digit-ui-esbuild/src/App.js
+++ b/digit-ui-esbuild/src/App.js
@@ -6,6 +6,7 @@ import { initPGRComponents, PGRReducers, } from "@egovernments/digit-ui-module-p
 import { Loader } from "@egovernments/digit-ui-components";
 
 window.contextPath = window?.globalConfigs?.getConfig("CONTEXT_PATH");
+window.globalPath = window.contextPath;
 
 // Lazy load DigitUI
 const DigitUI = React.lazy(() =>

--- a/digit-ui-esbuild/src/index.js
+++ b/digit-ui-esbuild/src/index.js
@@ -52,7 +52,47 @@ const isKeycloakAuth = () =>
   window?.globalConfigs?.getConfig("AUTH_PROVIDER") === "keycloak";
 
 async function bootstrap() {
-  {
+  if (isKeycloakAuth()) {
+    const { initAuthAdapter } = await import(
+      "../packages/libraries/src/services/auth/index"
+    );
+    console.log("[bootstrap] Starting initAuthAdapter...");
+    await Promise.race([
+      initAuthAdapter(),
+      new Promise((_, reject) => setTimeout(() => reject(new Error("initAuthAdapter timeout after 15s")), 15000))
+    ]).catch(err => {
+      console.error("[bootstrap] initAuthAdapter failed:", err.message);
+    });
+    console.log("[bootstrap] initAuthAdapter done");
+    // If KC adapter didn't authenticate (SSO check failed/timed out),
+    // fall back to localStorage tokens (same as non-KC path).
+    const user = window.Digit.SessionStorage.get("User");
+    if (!user || !user.access_token) {
+      console.log("[bootstrap] KC adapter not authenticated, recovering from localStorage");
+      const token = getFromStorage("token");
+      const citizenToken = getFromStorage("Citizen.token");
+      const citizenInfo = getFromStorage("Citizen.user-info");
+      const stateCode = window?.globalConfigs?.getConfig("STATE_LEVEL_TENANT_ID");
+      const citizenTenantId = getFromStorage("Citizen.tenant-id") || getFromInfo(citizenInfo) || stateCode;
+      const employeeToken = getFromStorage("Employee.token");
+      const employeeInfo = getFromStorage("Employee.user-info");
+      const employeeTenantId = getFromStorage("Employee.tenant-id") || getFromInfo(employeeInfo) || stateCode;
+      const userType = token === citizenToken ? "citizen" : (employeeToken ? "employee" : "citizen");
+
+      if (token) {
+        window.Digit.SessionStorage.set("user_type", userType);
+        window.Digit.SessionStorage.set("userType", userType);
+        const getUserDetails = (access_token, info) => ({ token: access_token, access_token, info });
+        const userDetails = userType === "citizen"
+          ? getUserDetails(citizenToken, citizenInfo)
+          : getUserDetails(employeeToken, employeeInfo);
+        window.Digit.SessionStorage.set("User", userDetails);
+        window.Digit.SessionStorage.set("Citizen.tenantId", citizenTenantId);
+        window.Digit.SessionStorage.set("Employee.tenantId", employeeTenantId);
+        console.log("[bootstrap] Recovered session from localStorage as " + userType);
+      }
+    }
+  } else {
     const user = window.Digit.SessionStorage.get("User");
     if (!user || !user.access_token || !user.info) {
       const token = getFromStorage("token");

--- a/local-setup/ansible/inventory/host_vars/_example.yml
+++ b/local-setup/ansible/inventory/host_vars/_example.yml
@@ -180,6 +180,61 @@ twilio_account_sid: ""
 twilio_auth_token: ""
 twilio_whatsapp_from: "whatsapp:+14155238886"   # Twilio Sandbox default
 
+# ────────── Keycloak SSO (opt-in) ──────────
+# Adds 2 containers (keycloak + token-exchange-svc) plus uses upstream's
+# existing Kong routes:
+#   /auth → keycloak:8180     (strip_path:false)
+#   /kc   → token-exchange-svc:3000  (strip_path:true)
+# Inert in the rest of the stack — DIGIT keeps booting fine with OTP
+# login. The UI only switches to the Keycloak code path when
+# auth_provider: 'keycloak'.
+#
+# Workflow when enable_keycloak: true:
+#   1. First deploy creates the `keycloak` Postgres DB (via the
+#      first-boot init script), starts the keycloak + token-exchange
+#      containers, and the playbook's keycloak-bootstrap block
+#      imports a per-tenant realm rendered from
+#      local-setup/keycloak/realm-template.json. Realm name =
+#      state_tenant_id.
+#   2. (Optional) set keycloak_google_client_id +
+#      keycloak_google_client_secret in bootstrap_secrets to add Google
+#      as a federated IdP.
+#   3. Flip auth_provider: 'keycloak' to switch the SPA's auth-adapter
+#      to OIDC PKCE.
+enable_keycloak: false
+
+# '' (default) keeps OTP login. 'keycloak' activates the SSO path
+# inside the digit-ui auth-adapter. Don't flip this until the realm
+# is imported and the operator has verified a successful test login
+# via /auth/realms/<realm>/account.
+auth_provider: ""
+
+# OIDC public client id in the per-tenant realm. The realm template
+# ships `digit-ui`; only change this if you've forked the template
+# and added a different client.
+keycloak_client_id: "digit-ui"
+
+# Where the browser reaches Keycloak. Leave blank to use the relative
+# `/auth` path on this deployment's own domain (proxied through Kong).
+# Set to a separate origin like `https://keycloak.example.org` when KC
+# lives on its own subdomain.
+keycloak_url: ""
+
+# Realm name override. Defaults to state_tenant_id at deploy time
+# (see globalConfigs.js.j2). Set explicitly only if your realm doesn't
+# match the tenant slug.
+keycloak_realm: ""
+
+# Where the browser reaches the token-exchange service. Defaults to
+# `/kc` (relative, via Kong's /kc route — strip_path:true). Override
+# only if you've put the exchange on a separate origin.
+token_exchange_url: ""
+
+# Federated Google login (optional). Leave blank to skip Google IdP
+# wiring entirely. When set, the bootstrap will register a Google
+# identity-provider in the realm during deploy.
+keycloak_google_client_id: ""
+
 # Init the nairobi-mdms git submodule on the controller. The submodule
 # lives in a separate repo and isn't auto-fetched on clone — turn this
 # on only if your tenant onboarding uses those JSONs. See
@@ -248,3 +303,10 @@ bootstrap_secrets:
   minio_root_password: change-me-strong
   elasticsearch_master_password: "asd@#$@$!132123"  # see comment above
   egov_hrms_default_password: "eGov@123"
+  # Keycloak secrets — only consumed when enable_keycloak: true.
+  # Leave empty on tenants without Keycloak; the playbook only resolves
+  # these inside the enable_keycloak-gated keycloak-bootstrap block.
+  keycloak_admin_password: ""               # master realm admin login
+  keycloak_db_password: ""                  # Keycloak's Postgres connection
+  keycloak_google_client_secret: ""         # only if keycloak_google_client_id is set
+  token_exchange_system_password: "eGov@123"  # DIGIT system user the exchange impersonates

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -302,16 +302,18 @@
       loop: "{{ digit_config_dirs | dict2items }}"
       vars:
         digit_config_dirs:
-          otel:    ../otel
-          configs: ../configs
-          nginx:   ../nginx
-          kong:    ../kong
-          postman: ../postman
-          db:      ../db
-          seeds:   ../seeds
-          gatus:   ../gatus
-          jupyter: ../jupyter
-          scripts: ../scripts
+          otel:     ../otel
+          configs:  ../configs
+          nginx:    ../nginx
+          kong:     ../kong
+          postman:  ../postman
+          db:       ../db
+          seeds:    ../seeds
+          gatus:    ../gatus
+          jupyter:  ../jupyter
+          scripts:  ../scripts
+          keycloak: ../keycloak
+          keycloak-realms: ../keycloak-realms
 
     # docker/ contains build contexts (db-migrations, pgr-services).
     # Even though we use pre-built images, compose may validate volume mount paths.
@@ -488,6 +490,7 @@
               + (['search']        if enable_search_stack | default(false) else [])
               + (['mcp']           if enable_mcp          | default(false) else [])
               + (['notifications'] if enable_novu         | default(false) else [])
+              + (['keycloak']      if enable_keycloak     | default(false) else [])
             ) | join(',')
           }}
 
@@ -1009,6 +1012,39 @@
         create: false           # .env was already written by the digit.env.j2 template earlier
         mode: '0600'            # tighten — was 0644 from the template; secrets bump to 0600
       no_log: true
+
+    # Keycloak-tier secrets — appended as a separate marked block so the
+    # main TENANT SECRETS block stays untouched on Keycloak-free
+    # tenants. Same OpenBao read; we just pick a different subset of
+    # keys. Default-empty strings on every lookup so a missing key in
+    # OpenBao (e.g. first deploy before the operator filled them in)
+    # doesn't fail template rendering — it just writes empty values, and
+    # the keycloak containers fail their healthcheck loudly enough that
+    # the operator notices.
+    - name: "OpenBao — write Keycloak secrets into compose .env (when enable_keycloak)"
+      ansible.builtin.blockinfile:
+        path: "{{ digit_dir }}/.env"
+        block: |
+          KC_ADMIN_PASSWORD={{ bao_secrets.json.data.data.keycloak_admin_password | default('') }}
+          KC_DB_PASSWORD={{ bao_secrets.json.data.data.keycloak_db_password | default('') }}
+          TOKEN_EXCHANGE_SYSTEM_PASSWORD={{ bao_secrets.json.data.data.token_exchange_system_password | default('eGov@123') }}
+        marker: "# {mark} KEYCLOAK SECRETS"
+        create: false
+        mode: '0600'
+      no_log: true
+      when: enable_keycloak | default(false)
+
+    - name: "OpenBao — append Google IdP secret into compose .env (when configured)"
+      ansible.builtin.lineinfile:
+        path: "{{ digit_dir }}/.env"
+        regexp: '^KC_GOOGLE_CLIENT_SECRET='
+        line: "KC_GOOGLE_CLIENT_SECRET={{ bao_secrets.json.data.data.keycloak_google_client_secret | default('') }}"
+        create: false
+        mode: '0600'
+      no_log: true
+      when:
+        - enable_keycloak | default(false)
+        - (keycloak_google_client_id | default('')) | length > 0
 
     # The first `up -d` started postgres with POSTGRES_PASSWORD=egov123
     # (the default before OpenBao secrets were available). initdb created
@@ -1657,6 +1693,101 @@
       when:
         - enable_novu | default(false)
         - (novu_api_key | default('')) | length == 0
+
+    # ────────────────────────────────────────────────────────────────
+    # Keycloak bootstrap. Once the keycloak container is up (created the
+    # `keycloak` DB via the postgres init script, started, healthy), we
+    # render a per-tenant realm from the template and import it via
+    # kcadm.sh. Idempotent: a re-import is skipped when the realm
+    # already exists. Google IdP wiring is opt-in (keycloak_google_*).
+    #
+    # Why kcadm.sh and not `--import-realm`: the start-dev flag only
+    # imports the static template that ships in the image. Realm names
+    # are tenant-specific (`state_tenant_id`), so we render at deploy
+    # time and import explicitly.
+    #
+    # Pre-req: enable_keycloak: true in host_vars (puts the `keycloak`
+    # profile into COMPOSE_PROFILES so the containers actually start).
+    # ────────────────────────────────────────────────────────────────
+    - name: "keycloak-bootstrap — render per-tenant realm from template"
+      ansible.builtin.template:
+        src: templates/keycloak-realm.json.j2
+        dest: "{{ digit_dir }}/keycloak-realms/{{ state_tenant_id }}-realm.json"
+        mode: '0640'
+      when:
+        - enable_keycloak | default(false)
+        - (state_tenant_id | default('')) | length > 0
+
+    - name: "keycloak-bootstrap — wait for keycloak to bind :8180 (up to 5 min)"
+      ansible.builtin.shell: |
+        timeout 300 bash -c 'until docker exec keycloak curl -fsS http://127.0.0.1:8180/realms/master >/dev/null 2>&1; do sleep 5; done && echo ready'
+      register: kc_wait
+      changed_when: false
+      when: enable_keycloak | default(false)
+
+    - name: "keycloak-bootstrap — kcadm login as master admin"
+      ansible.builtin.shell: |
+        docker exec keycloak /opt/keycloak/bin/kcadm.sh config credentials \
+          --server http://127.0.0.1:8180 --realm master \
+          --user admin --password "{{ bao_secrets.json.data.data.keycloak_admin_password | default('') }}"
+      when: enable_keycloak | default(false)
+      no_log: true
+      changed_when: false
+
+    - name: "keycloak-bootstrap — check if per-tenant realm exists"
+      ansible.builtin.shell: |
+        docker exec keycloak /opt/keycloak/bin/kcadm.sh get "realms/{{ state_tenant_id }}" >/dev/null 2>&1 && echo exists || echo missing
+      register: kc_realm_check
+      changed_when: false
+      when: enable_keycloak | default(false)
+
+    - name: "keycloak-bootstrap — import per-tenant realm (first time only)"
+      ansible.builtin.shell: |
+        docker cp "{{ digit_dir }}/keycloak-realms/{{ state_tenant_id }}-realm.json" keycloak:/tmp/realm.json
+        docker exec keycloak /opt/keycloak/bin/kcadm.sh create realms -f /tmp/realm.json
+      when:
+        - enable_keycloak | default(false)
+        - kc_realm_check is defined
+        - (kc_realm_check.stdout | default('')) == "missing"
+      changed_when: true
+
+    - name: "keycloak-bootstrap — wire Google IdP (when configured)"
+      ansible.builtin.shell: |
+        docker exec keycloak /opt/keycloak/bin/kcadm.sh create identity-provider/instances \
+          -r "{{ state_tenant_id }}" \
+          -s alias=google \
+          -s providerId=google \
+          -s 'config.clientId={{ keycloak_google_client_id }}' \
+          -s 'config.clientSecret={{ bao_secrets.json.data.data.keycloak_google_client_secret | default('') }}' 2>&1 | grep -v "Conflict" || true
+      when:
+        - enable_keycloak | default(false)
+        - (keycloak_google_client_id | default('')) | length > 0
+      no_log: true
+      changed_when: false
+
+    # Keycloak end-to-end validation. Runs AFTER the realm import so the
+    # well-known endpoint actually resolves. Both routes are served by
+    # upstream's Kong (/auth → keycloak, /kc → token-exchange-svc) —
+    # no nginx_features.keycloak gate is needed (Kong is always up).
+    - name: "validate — keycloak per-tenant realm reachable via /auth/"
+      ansible.builtin.uri:
+        url: "{{ 'https://' + domain if (tls_enabled | default(true)) else 'http://127.0.0.1' }}/auth/realms/{{ state_tenant_id }}/.well-known/openid-configuration"
+        status_code: [200]
+        timeout: 10
+        validate_certs: "{{ tls_enabled | default(true) }}"
+        headers: "{{ {} if (tls_enabled | default(true)) else {'Host': domain} }}"
+      retries: 3
+      delay: 5
+      when: enable_keycloak | default(false)
+
+    - name: "validate — token-exchange-svc healthz reachable via /kc/"
+      ansible.builtin.uri:
+        url: "{{ 'https://' + domain if (tls_enabled | default(true)) else 'http://127.0.0.1' }}/kc/healthz"
+        status_code: [200]
+        timeout: 10
+        validate_certs: "{{ tls_enabled | default(true) }}"
+        headers: "{{ {} if (tls_enabled | default(true)) else {'Host': domain} }}"
+      when: enable_keycloak | default(false)
 
     # ────────────────────────────────────────────────────────────────
     # UI-tenant fall-back: until the operator's chosen state_tenant_id is

--- a/local-setup/ansible/templates/digit.env.j2
+++ b/local-setup/ansible/templates/digit.env.j2
@@ -36,3 +36,17 @@ NOVU_WS_PUBLIC_URL={{ 'https://' + domain if (tls_enabled | default(true)) else 
 NOVU_API_ROOT_URL={{ 'https://' + domain if (tls_enabled | default(true)) else 'http://' + domain }}/novu-api
 NOVU_FRONT_BASE_URL={{ 'https://' + domain if (tls_enabled | default(true)) else 'http://' + domain }}/novu
 {% endif %}
+
+{% if enable_keycloak | default(false) %}
+# Keycloak + token-exchange-svc — non-secret values. The matching
+# secrets (KC_ADMIN_PASSWORD, KC_DB_PASSWORD,
+# TOKEN_EXCHANGE_SYSTEM_PASSWORD, KC_GOOGLE_CLIENT_SECRET) are pulled
+# from OpenBao later in the deploy and appended to this .env via a
+# `blockinfile` task, so they're not rendered here.
+KC_HOSTNAME={{ 'https://' + domain if (tls_enabled | default(true)) else 'http://' + domain }}/auth
+TOKEN_EXCHANGE_SYSTEM_USERNAME={{ token_exchange_system_username | default('INTERNAL_MICROSERVICE_ROLE') }}
+TOKEN_EXCHANGE_SYSTEM_TENANT={{ state_tenant_id }}
+{% if (keycloak_google_client_id | default('')) | length > 0 %}
+KC_GOOGLE_CLIENT_ID={{ keycloak_google_client_id }}
+{% endif %}
+{% endif %}

--- a/local-setup/ansible/templates/globalConfigs.js.j2
+++ b/local-setup/ansible/templates/globalConfigs.js.j2
@@ -41,6 +41,20 @@ var globalConfigs = (function () {
   var coreMobileConfigs = {{ core_mobile_configs | to_json }};
   var corePostalConfigs = {{ core_postal_configs | default({}) | to_json }};
 
+  // Keycloak SSO settings. Inert when authProvider !== 'keycloak'
+  // (which is the default). The auth-adapter inside digit-ui reads
+  // these via Digit.Utils.getConfig() when it switches into the
+  // Keycloak code path. Empty keycloak_url defaults to the relative
+  // `/auth` path that Kong proxies to the keycloak container; set
+  // keycloak_url explicitly when KC lives on a separate subdomain.
+  // tokenExchangeUrl defaults to `/kc` (Kong route /kc → token-exchange-svc).
+  var keycloakUrl = {{ (keycloak_url | default('')) | to_json }};
+  if (!keycloakUrl) { keycloakUrl = "/auth"; }
+  var keycloakRealm = {{ ((keycloak_realm | default('')) or (state_tenant_id | default('pg'))) | to_json }};
+  var keycloakClientId = {{ (keycloak_client_id | default('digit-ui')) | to_json }};
+  var tokenExchangeUrl = {{ (token_exchange_url | default('')) | to_json }};
+  if (!tokenExchangeUrl) { tokenExchangeUrl = "/kc"; }
+
   var getConfig = function (key) {
     if (key === "EMPLOYEE_MODULE_DENYLIST") return employeeModuleDenylist;
     if (key === "LOGIN_TENANT_ALLOWLIST") return loginTenantAllowlist;
@@ -94,6 +108,14 @@ var globalConfigs = (function () {
       return coreMobileConfigs;
     } else if (key === "CORE_POSTAL_CONFIGS") {
       return corePostalConfigs;
+    } else if (key === "KEYCLOAK_URL") {
+      return keycloakUrl;
+    } else if (key === "KEYCLOAK_REALM") {
+      return keycloakRealm;
+    } else if (key === "KEYCLOAK_CLIENT_ID") {
+      return keycloakClientId;
+    } else if (key === "TOKEN_EXCHANGE_URL") {
+      return tokenExchangeUrl;
     }
   };
 

--- a/local-setup/ansible/templates/keycloak-realm.json.j2
+++ b/local-setup/ansible/templates/keycloak-realm.json.j2
@@ -1,0 +1,74 @@
+{#-
+  Per-tenant Keycloak realm. Renders by:
+    1. Loading the canonical template from local-setup/keycloak/realm-template.json
+       (shipped from /root/DIGIT-keycloak-overlay).
+    2. Substituting __REALM_NAME__ with the tenant's state_tenant_id.
+    3. Setting the digit-ui client's rootUrl + redirectUris + webOrigins
+       to point at this tenant's public domain (so OAuth callbacks land
+       on the right host instead of the template's placeholders).
+    4. Injecting a Google identityProvider when keycloak_google_client_id
+       is set in host_vars (skipped otherwise — the template ships an
+       empty identityProviders list).
+
+  All substitution happens through ansible-style Jinja filters (no shell-
+  out, no jq), so the rendered file is just plain JSON with no further
+  processing required by kcadm import.
+-#}
+{%- set tpl_path = playbook_dir + '/../keycloak/realm-template.json' -%}
+{%- set tpl = lookup('file', tpl_path) | from_json -%}
+{%- set _ = tpl.update({'realm': state_tenant_id}) -%}
+
+{%- set scheme = 'https://' if (tls_enabled | default(true)) else 'http://' -%}
+{%- set base = (keycloak_url | default('')) or (scheme + domain) -%}
+
+{#- Patch the digit-ui client in place. The template ships one client
+    (digit-ui); if that ever changes, this loop tolerates extra clients
+    by only mutating the one we know about. -#}
+{%- for client in tpl.clients -%}
+  {%- if client.clientId == (keycloak_client_id | default('digit-ui')) -%}
+    {%- set _ = client.update({'rootUrl': base}) -%}
+    {%- set _ = client.update({'baseUrl': '/digit-ui/'}) -%}
+    {%- set new_redirects = [
+        base + '/*',
+        base + '/digit-ui/*',
+        'http://localhost:*'
+    ] -%}
+    {%- set _ = client.update({'redirectUris': new_redirects}) -%}
+    {%- set new_origins = [
+        base,
+        'http://localhost:3000',
+        'http://localhost:5173'
+    ] -%}
+    {%- set _ = client.update({'webOrigins': new_origins}) -%}
+  {%- endif -%}
+{%- endfor -%}
+
+{#- Google IdP wiring is opt-in. When keycloak_google_client_id is set,
+    inject the standard google providerId entry; otherwise leave the
+    empty list the template ships. kcadm-driven IdP creation (in the
+    playbook) is the runtime path, but baking it into the realm import
+    keeps a fresh re-import idempotent. -#}
+{%- if (keycloak_google_client_id | default('')) | length > 0 -%}
+  {#- The client secret lives in OpenBao (bootstrap_secrets.keycloak_google_client_secret),
+      so prefer bao_secrets if available; fall back to a host_var of the
+      same name for sandbox/test renders without OpenBao. -#}
+  {%- set google_secret = (bao_secrets.json.data.data.keycloak_google_client_secret
+                            if (bao_secrets is defined
+                                and bao_secrets.json is defined)
+                            else (keycloak_google_client_secret | default(''))) -%}
+  {%- set idp = {
+      'alias': 'google',
+      'providerId': 'google',
+      'enabled': true,
+      'trustEmail': true,
+      'firstBrokerLoginFlowAlias': 'first broker login',
+      'config': {
+          'clientId': keycloak_google_client_id,
+          'clientSecret': google_secret,
+          'syncMode': 'IMPORT'
+      }
+  } -%}
+  {%- set _ = tpl.update({'identityProviders': [idp]}) -%}
+{%- endif -%}
+
+{{ tpl | to_nice_json(indent=2) }}

--- a/local-setup/db/keycloak-init.sql
+++ b/local-setup/db/keycloak-init.sql
@@ -1,0 +1,9 @@
+-- First-boot init: ensure the `keycloak` database exists so the keycloak
+-- container has somewhere to land. Postgres runs this exactly once when
+-- PGDATA is empty (the /docker-entrypoint-initdb.d/ contract).
+--
+-- Idempotent guard: SELECT … \gexec only fires the CREATE when the row
+-- is missing. If a sibling deploy already created it, this no-ops.
+-- Inert when `enable_keycloak: false` — nothing else references the DB.
+SELECT 'CREATE DATABASE keycloak'
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'keycloak')\gexec

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -2118,7 +2118,10 @@ services:
   # unavailable, switch to a `build:` block pointing at the overlay
   # repo path.
   token-exchange-svc:
-    image: registry.preview.egov.theflywheel.in/egovio/token-exchange-svc:latest
+    # Published unscoped (not under egovio/) at registry.preview because
+    # it predates the namespace standardisation. Pin to :dev for now;
+    # bump when a versioned tag is published.
+    image: registry.preview.egov.theflywheel.in/token-exchange-svc:dev
     container_name: token-exchange-svc
     restart: unless-stopped
     profiles: ["keycloak"]

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -102,6 +102,11 @@ services:
     command: postgres -c max_connections=200
     volumes:
     - postgres_data:/var/lib/docker-postgresql/data
+    # First-boot init: ensure the `keycloak` DB exists. Postgres only runs
+    # /docker-entrypoint-initdb.d/*.sql when PGDATA is empty, so this is
+    # idempotent (skipped on subsequent boots). Inert when enable_keycloak
+    # is false on the tenant — nothing else references the DB.
+    - ./db/keycloak-init.sql:/docker-entrypoint-initdb.d/02-keycloak-init.sql:ro
     ports:
     - 15432:5432
     healthcheck:
@@ -2037,6 +2042,113 @@ services:
       timeout: 3s
       retries: 5
       start_period: 10s
+    networks:
+      - egov-network
+
+  # ==================== Keycloak SSO stack (opt-in) ====================
+  # `keycloak` + `token-exchange-svc` add OIDC-based SSO on top of DIGIT
+  # without touching egov-user's OTP flow. Architecture (Option 4 in the
+  # keycloak overlay design doc — no Kong OIDC plugin):
+  #
+  #   Browser → (OIDC PKCE) → Keycloak → access_token (RS256)
+  #   Browser → /kc/exchange (POSTs the access_token via Kong)
+  #   token-exchange-svc → validates JWT against Keycloak JWKS
+  #                      → looks up / creates the matching eg_user via
+  #                        egov-user (using DIGIT_SYSTEM_USERNAME)
+  #                      → mints a DIGIT access_token and returns it
+  #   Browser → uses DIGIT access_token for all downstream API calls
+  #
+  # Both services are profile-gated — they don't start on a default
+  # `docker compose up`. Opt in with `COMPOSE_PROFILES=keycloak`. The
+  # Ansible playbook flips this on when `enable_keycloak: true` in
+  # host_vars.
+  #
+  # The base DB for Keycloak (the `keycloak` database) is created at
+  # Postgres first-boot via local-setup/db/keycloak-init.sql. The realm
+  # is rendered per-tenant by the playbook and imported via kcadm.sh
+  # (NOT via the `--import-realm` start flag, which only handles the
+  # static template that ships in the image).
+  #
+  # Kong routes /auth → keycloak:8180 (strip_path:false) and /kc →
+  # token-exchange-svc:3000 (strip_path:true) — see local-setup/kong/kong.yml.
+  keycloak:
+    image: quay.io/keycloak/keycloak:24.0
+    container_name: keycloak
+    restart: unless-stopped
+    profiles: ["keycloak"]
+    command: ["start-dev", "--import-realm"]
+    depends_on:
+      postgres-db:
+        condition: service_healthy
+    environment:
+      KC_DB: postgres
+      KC_DB_URL: jdbc:postgresql://postgres:5432/keycloak
+      KC_DB_USERNAME: ${POSTGRES_USER:-egov}
+      KC_DB_PASSWORD: ${KC_DB_PASSWORD:-${POSTGRES_PASSWORD:-egov123}}
+      KC_HOSTNAME_STRICT: 'false'
+      KC_HOSTNAME_STRICT_HTTPS: 'false'
+      KC_HTTP_ENABLED: 'true'
+      KC_HTTP_PORT: '8180'
+      KC_PROXY_HEADERS: xforwarded
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: ${KC_ADMIN_PASSWORD:-admin}
+    ports:
+      - 18180:8180
+    volumes:
+      # Realm template shipped from /root/DIGIT-keycloak-overlay/keycloak/
+      # is mounted in /opt/keycloak/data/import. The shipped template is
+      # NOT auto-imported because realm names are tenant-specific; the
+      # playbook's keycloak-bootstrap block writes the rendered per-tenant
+      # realm to keycloak-realms/ and runs kcadm.sh create realms.
+      - ../keycloak/realm-template.json:/opt/keycloak/data/import/realm-template.json:ro
+      - ./keycloak-realms:/opt/keycloak/data/import/tenants:ro
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/8180 && printf 'GET /realms/master HTTP/1.0\\r\\n\\r\\n' >&3 && grep -q '200' <&3 || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+    networks:
+      - egov-network
+
+  # token-exchange-svc — bridges a Keycloak access_token to a DIGIT
+  # access_token (and resolves / provisions the matching eg_user).
+  # Source: /root/DIGIT-keycloak-overlay (Dockerfile, TypeScript).
+  # If the published image at registry.preview.egov.theflywheel.in is
+  # unavailable, switch to a `build:` block pointing at the overlay
+  # repo path.
+  token-exchange-svc:
+    image: registry.preview.egov.theflywheel.in/egovio/token-exchange-svc:latest
+    container_name: token-exchange-svc
+    restart: unless-stopped
+    profiles: ["keycloak"]
+    depends_on:
+      keycloak:
+        condition: service_healthy
+      egov-user:
+        condition: service_started
+      redis:
+        condition: service_healthy
+    environment:
+      PORT: '3000'
+      KEYCLOAK_ISSUER: http://keycloak:8180/realms/${TOKEN_EXCHANGE_SYSTEM_TENANT:-pg}
+      KEYCLOAK_JWKS_URI: http://keycloak:8180/realms/${TOKEN_EXCHANGE_SYSTEM_TENANT:-pg}/protocol/openid-connect/certs
+      DIGIT_USER_HOST: http://egov-user:8080
+      DIGIT_SYSTEM_USERNAME: ${TOKEN_EXCHANGE_SYSTEM_USERNAME:-INTERNAL_MICROSERVICE_ROLE}
+      DIGIT_SYSTEM_PASSWORD: ${TOKEN_EXCHANGE_SYSTEM_PASSWORD:-eGov@123}
+      DIGIT_SYSTEM_TENANT: ${TOKEN_EXCHANGE_SYSTEM_TENANT:-pg}
+      REDIS_HOST: redis
+      REDIS_PORT: '6379'
+      CACHE_PREFIX: keycloak
+      CACHE_TTL_SECONDS: '604800'
+    ports:
+      - 18200:3000
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3000/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     networks:
       - egov-network
 

--- a/local-setup/docker-compose.fast-path.yml
+++ b/local-setup/docker-compose.fast-path.yml
@@ -47,3 +47,7 @@ services:
       # when PGDATA is empty. Numeric prefix sets ordering (in case we
       # add more init steps later).
       - ./db/full-dump.sql:/docker-entrypoint-initdb.d/01-full-dump.sql:ro
+      # The base compose mounts keycloak-init.sql too — fast-path
+      # overrides the entire volumes list, so we have to re-declare it
+      # here. Inert when enable_keycloak is false.
+      - ./db/keycloak-init.sql:/docker-entrypoint-initdb.d/02-keycloak-init.sql:ro

--- a/local-setup/keycloak-realms/.gitkeep
+++ b/local-setup/keycloak-realms/.gitkeep
@@ -1,0 +1,1 @@
+# Per-tenant rendered realm JSON files land here at deploy time

--- a/local-setup/keycloak/realm-template.json
+++ b/local-setup/keycloak/realm-template.json
@@ -1,0 +1,285 @@
+{
+  "realm": "__REALM_NAME__",
+  "enabled": true,
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": true,
+  "bruteForceProtected": true,
+  "permanentLockout": false,
+  "maxFailureWaitSeconds": 900,
+  "failureFactor": 5,
+  "passwordPolicy": "length(8)",
+  "sslRequired": "none",
+  "accessTokenLifespan": 900,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 604800,
+  "roles": {
+    "realm": [
+      { "name": "CITIZEN", "description": "Default citizen role" },
+      { "name": "EMPLOYEE", "description": "Base employee role" },
+      { "name": "SUPERUSER", "description": "Full system access" },
+      { "name": "GRO", "description": "Grievance Routing Officer" },
+      { "name": "PGR_LME", "description": "PGR Last Mile Employee" },
+      { "name": "DGRO", "description": "Department GRO" },
+      { "name": "CSR", "description": "Customer Service Rep" },
+      { "name": "SUPERVISOR", "description": "Supervisor" },
+      { "name": "AUTO_ESCALATE", "description": "Auto escalation" },
+      { "name": "PGR_VIEWER", "description": "PGR read-only access" },
+      { "name": "TICKET_REPORT_VIEWER", "description": "Report viewer" },
+      { "name": "LOC_ADMIN", "description": "Localization admin" },
+      { "name": "MDMS_ADMIN", "description": "Master data admin" },
+      { "name": "HRMS_ADMIN", "description": "HR admin" },
+      { "name": "WORKFLOW_ADMIN", "description": "Workflow admin" },
+      { "name": "COMMON_EMPLOYEE", "description": "Common employee" },
+      { "name": "REINDEXING_ROLE", "description": "Elasticsearch reindexing" },
+      { "name": "QA_AUTOMATION", "description": "Automated testing" },
+      { "name": "SYSTEM", "description": "Internal system role" },
+      { "name": "ANONYMOUS", "description": "Unauthenticated access" },
+      { "name": "INTERNAL_MICROSERVICE_ROLE", "description": "Inter-service communication" }
+    ]
+  },
+  "defaultRoles": ["CITIZEN"],
+  "clients": [
+    {
+      "clientId": "digit-ui",
+      "enabled": true,
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "implicitFlowEnabled": false,
+      "protocol": "openid-connect",
+      "rootUrl": "",
+      "baseUrl": "/",
+      "redirectUris": [
+        "http://localhost:*",
+        "https://*.egov.theflywheel.in/*"
+      ],
+      "webOrigins": [
+        "http://localhost:3000",
+        "http://localhost:5173",
+        "https://*.egov.theflywheel.in"
+      ],
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      },
+      "protocolMappers": [
+        {
+          "name": "digit-ui-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "digit-ui",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email",
+        "groups"
+      ]
+    }
+  ],
+  "clientScopes": [
+    {
+      "name": "groups",
+      "protocol": "openid-connect",
+      "attributes": {
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-group-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "full.path": "false",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "name": "email",
+      "protocol": "openid-connect",
+      "attributes": {
+        "display.on.consent.screen": "true",
+        "include.in.token.scope": "true"
+      },
+      "protocolMappers": [
+        {
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "userinfo.token.claim": "true",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "email verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "emailVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email_verified",
+            "userinfo.token.claim": "true",
+            "jsonType.label": "boolean"
+          }
+        }
+      ]
+    },
+    {
+      "name": "profile",
+      "protocol": "openid-connect",
+      "attributes": {
+        "display.on.consent.screen": "true",
+        "include.in.token.scope": "true"
+      },
+      "protocolMappers": [
+        {
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "userinfo.token.claim": "true",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "userinfo.token.claim": "true",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "userinfo.token.claim": "true",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "name": "roles",
+      "protocol": "openid-connect",
+      "attributes": {
+        "display.on.consent.screen": "false",
+        "include.in.token.scope": "false"
+      },
+      "protocolMappers": [
+        {
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "user.attribute": "foo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "client roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-client-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "user.attribute": "foo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "resource_access.${client_id}.roles",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ]
+    },
+    {
+      "name": "web-origins",
+      "protocol": "openid-connect",
+      "attributes": {
+        "display.on.consent.screen": "false",
+        "include.in.token.scope": "false"
+      },
+      "protocolMappers": [
+        {
+          "name": "allowed web origins",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-allowed-origins-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ]
+    }
+  ],
+  "defaultDefaultClientScopes": [
+    "web-origins",
+    "profile",
+    "roles",
+    "email",
+    "groups"
+  ],
+  "scopeMappings": [],
+  "identityProviders": [],
+  "smtpServer": {}
+}

--- a/local-setup/tests/e2e/specs/keycloak-login.spec.ts
+++ b/local-setup/tests/e2e/specs/keycloak-login.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * Keycloak SSO login smoke tests
+ *
+ * Exercises a deployment where `enable_keycloak: true` AND
+ * `auth_provider: keycloak` are set in host_vars (so the UI's
+ * auth-adapter switches to the OIDC PKCE flow).
+ *
+ * The whole suite is gated by AUTH_PROVIDER=keycloak — running it
+ * against an OTP-mode deployment is meaningless and would just
+ * produce noisy failures.
+ *
+ * Complementary to specs/google-sso-config.spec.ts (which validates
+ * the realm's frontendUrl + Google IdP config from the KC side); this
+ * spec exercises the UI redirect + token-exchange path end-to-end.
+ *
+ * Run against a deployment:
+ *   AUTH_PROVIDER=keycloak \
+ *   BASE_URL=https://deployment.example.org \
+ *   DIGIT_TENANT=ke.mycity \
+ *   npx playwright test specs/keycloak-login.spec.ts
+ */
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:18080';
+const AUTH_PROVIDER = process.env.AUTH_PROVIDER || '';
+
+test.describe('Keycloak SSO login', () => {
+  test.skip(
+    () => AUTH_PROVIDER !== 'keycloak',
+    "AUTH_PROVIDER env must be 'keycloak' to run this suite (set it after cutover)",
+  );
+
+  test('citizen login page redirects to Keycloak realm', async ({ page }) => {
+    await page.goto('/digit-ui/citizen/login', { waitUntil: 'domcontentloaded' });
+    // AuthAdapter sees AUTH_PROVIDER=keycloak in globalConfigs and
+    // immediately replaces the location with the realm authorize URL.
+    await page.waitForURL(
+      /\/auth\/realms\/[^\/]+\/protocol\/openid-connect\/auth/,
+      { timeout: 15_000 },
+    );
+    expect(page.url()).toContain('/auth/realms/');
+    expect(page.url()).toContain('/protocol/openid-connect/auth');
+  });
+
+  test('employee login also routes through Keycloak', async ({ page }) => {
+    await page.goto('/digit-ui/employee/user/login', { waitUntil: 'domcontentloaded' });
+    await page.waitForURL(/\/auth\/realms\//, { timeout: 15_000 });
+    expect(page.url()).toContain('/auth/realms/');
+  });
+
+  test('Keycloak login page renders Google SSO button when IdP configured', async ({ page }) => {
+    await page.goto('/digit-ui/citizen/login', { waitUntil: 'domcontentloaded' });
+    await page.waitForURL(/\/auth\/realms\//, { timeout: 15_000 });
+    // Google IdP is optional (keycloak_google_client_id may be unset).
+    // If wired, KC renders an "alternate login" anchor; if not, the form
+    // is username+password only. Skip silently when absent.
+    const googleButton = page.getByRole('link', { name: /google/i });
+    const count = await googleButton.count();
+    if (count > 0) {
+      await expect(googleButton.first()).toBeVisible();
+    } else {
+      test.info().annotations.push({
+        type: 'note',
+        description: 'Google IdP not configured on this realm — skipped Google button check.',
+      });
+    }
+  });
+
+  test('token-exchange-svc health endpoint reachable via /kc/', async ({ request }) => {
+    // Kong route /kc → token-exchange-svc:3000 (strip_path:true), so the
+    // path on the service is /healthz.
+    const r = await request.get('/kc/healthz');
+    expect(r.ok(), `expected /kc/healthz to return 2xx, got ${r.status()}`).toBeTruthy();
+  });
+
+  test('OIDC discovery doc has correct issuer for this deployment', async ({ request }) => {
+    // Auto-derive the realm from the first redirect, so this test works on
+    // any tenant where AUTH_PROVIDER=keycloak (not just ke.mycity).
+    const page = await request.get('/digit-ui/citizen/login', { maxRedirects: 0 });
+    const location = page.headers()['location'] || '';
+    const m = location.match(/\/auth\/realms\/([^\/]+)\//);
+    // Fall back to the most common realm name when the SPA does a JS-side
+    // redirect we can't catch in a single HTTP hop.
+    const realm = m?.[1] || (process.env.DIGIT_TENANT || 'pg');
+
+    const resp = await request.get(`/auth/realms/${realm}/.well-known/openid-configuration`);
+    expect(resp.ok(), `OIDC discovery for realm '${realm}' returned ${resp.status()}`).toBeTruthy();
+
+    const discovery = await resp.json();
+    const deploymentOrigin = new URL(BASE_URL).origin;
+    expect(
+      discovery.issuer,
+      `issuer "${discovery.issuer}" should start with deployment origin "${deploymentOrigin}". ` +
+        `Fix: update realm frontendUrl in KC admin → Realm Settings → General → Frontend URL.`,
+    ).toContain(deploymentOrigin);
+    expect(discovery.authorization_endpoint).toContain(deploymentOrigin);
+    expect(discovery.token_endpoint).toContain(deploymentOrigin);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the missing pieces to enable Keycloak SSO end-to-end on top of upstream `develop`'s existing keycloak infrastructure:

| Already on `develop` | This PR adds |
|---|---|
| Kong `/auth` → keycloak route | Keycloak container + per-tenant `realm-template.json` |
| Kong `/kc` → token-exchange-svc route | token-exchange-svc container |
| `auth_provider` piped through `globalConfigs.js.j2` | `KEYCLOAK_URL` / `KEYCLOAK_REALM` / `KEYCLOAK_CLIENT_ID` / `TOKEN_EXCHANGE_URL` |
| `keycloak/realm-export.json` (sandbox `digit-sandbox`) | `local-setup/keycloak/realm-template.json` (per-tenant, 21 DIGIT roles) |
| `google-sso-config.spec.ts` (Playwright) | `keycloak-login.spec.ts` (complementary) |
| `digit-ui-esbuild/` vendored | UI auth-adapter scaffold (4 new files in `…/services/auth/` + 9 modifies) |

Every change is gated behind `enable_keycloak: false` (default in tracked `_example.yml`). **No runtime effect until an operator opts in.** Replaces and supersedes #610 (closed) which was built for the fork's nginx-direct architecture.

Architecture follows the existing anti-corruption-layer design in `DIGIT-keycloak-overlay/`:
- **Realm-per-tenant**: each DIGIT root tenant → a Keycloak realm; cities are KC groups; all 21 DIGIT roles mapped as realm roles
- **Lazy DIGIT-user provisioning** in the overlay on first API call via `_createnovalidate`
- **System-token model**: overlay authenticates once as `INTERNAL_MICROSERVICE_ROLE`, injects user identity into `RequestInfo`. No per-user DIGIT passwords stored.
- **Redis caching** with `keycloak:{sub}:{tenant}` key, 7-day TTL
- **JWT validation** in the overlay (JWKS / RS256). No Kong OIDC plugin needed — the overlay does it.

## What changed (11 commits, 25 files, +1694 / -26)

### Compose + assets
- `local-setup/docker-compose.egov-digit.yaml` — adds `keycloak` (`quay.io/keycloak/keycloak:24.0`) and `token-exchange-svc` (`registry.preview.egov.theflywheel.in/token-exchange-svc:dev`) behind `profiles: [keycloak]`, reusing existing `postgres-db` + `redis`
- `local-setup/docker-compose.fast-path.yml` — mount `keycloak-init.sql` into postgres init
- `keycloak/realm-template.json` — 21 DIGIT roles + `__REALM_NAME__` placeholder, copied from overlay (alongside upstream's existing `keycloak/realm-export.json`)
- `local-setup/db/keycloak-init.sql` — idempotent `CREATE DATABASE keycloak`
- `local-setup/keycloak-realms/.gitkeep` — output dir for rendered per-tenant realms

### Ansible
- `playbook-deploy.yml` — compose-profile extension, `keycloak-bootstrap` block (wait → kcadm idempotent realm import → Google IdP wiring), OpenBao-driven `.env` secret writes (KEYCLOAK_ADMIN_PASSWORD, KC_DB_PASSWORD, TOKEN_EXCHANGE_SYSTEM_PASSWORD, KC_GOOGLE_CLIENT_SECRET), 2 new validation tasks (`/auth/realms/{tenant}` 200, `/kc/healthz` 200)
- `templates/keycloak-realm.json.j2` — Jinja loads + mutates the realm-template via `lookup('file')` + `from_json`; substitutes `__REALM_NAME__`, sets client URLs, optionally injects `identityProviders`
- `templates/digit.env.j2` — gated KC env block
- `templates/globalConfigs.js.j2` — adds `KEYCLOAK_URL` / `KEYCLOAK_REALM` / `KEYCLOAK_CLIENT_ID` / `TOKEN_EXCHANGE_URL` to existing `getConfig` switch
- `inventory/host_vars/_example.yml` — opt-in surface (4 flags + 4 bootstrap_secrets keys; all default OFF)

### UI (in-tree, no separate repo PR needed)
- `digit-ui-esbuild/packages/libraries/src/services/auth/{AuthAdapter,DigitAuthAdapter,KeycloakAuthAdapter,index}.js` — NEW pluggable auth layer
- `…/services/atoms/Utils/Request.js` — routes through `/kc/*` when KC token is present
- `…/services/elements/User/index.js` — delegates `authenticate` / `logout` / `setType` to active adapter
- `…/react-components/src/atoms/PrivateRoute.js` — `adapter.isAuthenticated()` route guard
- `…/digit-ui-components/src/atoms/PrivateRoute.js` — same (the other PrivateRoute copy; no `digit-ui-components-v2` copy exists)
- `…/modules/core/src/App.js` — conditional `UnifiedLogin` vs `LoginV2` routing
- `…/modules/core/src/pages/common/Login/index.js` — NEW UnifiedLogin page (built with DIGIT UI components)
- `…/libraries/src/index.js` — exports `initAuthAdapter` / `getAuthAdapter`
- `digit-ui-esbuild/src/{App,index}.js` — set `window.globalPath`, lazy-import `initAuthAdapter()` with 15s timeout + localStorage fallback
- `esbuild.dev.js` — dev-server proxy passthrough for the new auth surface

**No new npm dependencies** — `keycloak-js` is CDN-loaded via `public/index.html`.

### Tests
- `local-setup/tests/e2e/specs/keycloak-login.spec.ts` — 5 Playwright tests gated on `AUTH_PROVIDER=keycloak` (citizen/employee redirect, Google IdP button visibility, token-exchange healthcheck). Complements the existing `google-sso-config.spec.ts`.

## How to enable on a tenant

1. In `inventory/host_vars/<tenant>.yml`:
   ```yaml
   enable_keycloak: true
   auth_provider: keycloak
   bootstrap_secrets:
     keycloak_admin_password: "<strong>"
     keycloak_db_password:    "<strong>"
     token_exchange_system_password: "eGov@123"
   ```
2. `cd local-setup/ansible && ./deploy.sh <tenant>` — brings up keycloak + token-exchange-svc, imports the realm, wires globalConfigs.
3. Browser load triggers `KeycloakAuthAdapter`; login form POSTs to `/kc/realms/{tenant}/protocol/openid-connect/token` (standard OAuth2 password grant; overlay adds KC→DIGIT fallback).

To roll back: flip both flags to false, redeploy. Containers stop within ~30s.

## Notable design decisions

- **Standard OAuth2 token endpoint, not a custom BFF.** The KeycloakAuthAdapter calls `POST /kc/realms/{realm}/protocol/openid-connect/token` (OAuth2 password grant) — the same path any vanilla Keycloak client would use. The overlay intercepts this path and adds KC→DIGIT fallback transparently. No custom `/auth/login` BFF route is required.
- **No nginx changes.** Upstream's `/auth/` block is reserved for the dashboard's React-router routes (per the comment in `nginx-site.conf.j2`). Keycloak is reached via Kong's `/auth` route (already in `kong.yml`); for hosted deployments where KC needs its own subdomain (e.g. `keycloak-sandbox.live.digit.org`), the operator wires that separately.
- **Build, not bake.** `keycloak/realm-template.json` is per-tenant; the playbook renders one realm JSON per `state_tenant_id` at deploy time. The existing `keycloak/realm-export.json` (sandbox) is left untouched — both files ship.

## Test plan

- [x] `ansible-playbook --syntax-check local-setup/ansible/playbook-deploy.yml` exit 0
- [x] `docker compose -f local-setup/docker-compose.egov-digit.yaml config` valid; `keycloak` profile correctly gates services
- [x] `digit-ui-esbuild` `npm run build` exit 0; bundle size unchanged; no new warnings
- [x] Realm template Jinja renders cleanly with + without Google IdP
- [x] Playwright spec type-checks
- [ ] On an opted-in tenant: `curl -fsS https://{domain}/auth/realms/{tenant}` returns 200
- [ ] On an opted-in tenant: `curl -fsS https://{domain}/kc/healthz` returns 200
- [ ] Citizen + employee login redirect through `UnifiedLogin` → `/kc/.../token` → DIGIT
- [ ] PGR complaint creation works post-SSO with lazy-provisioned DIGIT user

🤖 Generated with [Claude Code](https://claude.com/claude-code)