### PR TITLE
feat(digit-mcp): real boundary geometry pipeline (lat/long + GeoJSON polygons) for city_setup_from_xlsx

### DIFF
--- a/.github/workflows/digit-mcp-ci.yml
+++ b/.github/workflows/digit-mcp-ci.yml
@@ -1,0 +1,38 @@
+name: DIGIT-MCP CI
+
+on:
+  push:
+    branches: [develop, main]
+    paths:
+      - 'digit-mcp/**'
+      - '.github/workflows/digit-mcp-ci.yml'
+  pull_request:
+    branches: [develop, main]
+    paths:
+      - 'digit-mcp/**'
+      - '.github/workflows/digit-mcp-ci.yml'
+  workflow_dispatch:
+
+defaults:
+  run:
+    working-directory: digit-mcp
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: 'digit-mcp/package-lock.json'
+
+      - run: npm ci
+
+      - name: Build (data-provider workspace + tsc)
+        run: npm run build
+
+      - name: Typecheck (no emit) as a separate gate
+        run: npx tsc --noEmit

--- a/configurator/src/api/services/boundary.ts
+++ b/configurator/src/api/services/boundary.ts
@@ -160,14 +160,27 @@ export const boundaryService = {
   // a direct DB cleanup, before the service's in-memory dedup cache times
   // out). Blanket-swallowing that error made Phase 2 claim success while
   // creating nothing.
-  async createBoundaryEntity(tenantId: string, code: string): Promise<boolean> {
+  async createBoundaryEntity(
+    tenantId: string,
+    code: string,
+    geometry?: { type: 'Point' | 'Polygon'; coordinates: number[] | number[][][] },
+  ): Promise<boolean> {
+    // Default unit-square Polygon placeholder when the operator hasn't
+    // supplied real geometry. Same shape Naipepea / Bomet have shipped for
+    // every boundary to date — kept for compatibility so existing flows
+    // don't change. Pass a real Point / Polygon to get an actual outline
+    // on the citizen map.
+    const PLACEHOLDER = {
+      type: 'Polygon' as const,
+      coordinates: [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]],
+    };
     try {
       await apiClient.post(ENDPOINTS.BOUNDARY_CREATE, {
         RequestInfo: apiClient.buildRequestInfo(),
         Boundary: [{
           tenantId,
           code,
-          geometry: { type: 'Polygon', coordinates: [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]] },
+          geometry: geometry ?? PLACEHOLDER,
         }],
       });
       return true;
@@ -294,8 +307,9 @@ export const boundaryService = {
 
   // Create a single boundary (entity + relationship)
   async createBoundary(boundary: Boundary): Promise<Boundary> {
-    // Step 1: Create the boundary entity
-    await this.createBoundaryEntity(boundary.tenantId, boundary.code);
+    // Step 1: Create the boundary entity (with geometry if attached, else
+    // the unit-square placeholder).
+    await this.createBoundaryEntity(boundary.tenantId, boundary.code, boundary.geometry);
 
     // Step 2: Create the boundary relationship
     if (boundary.hierarchyType && boundary.boundaryType) {
@@ -333,12 +347,14 @@ export const boundaryService = {
     const tenantId = boundaries[0].tenantId;
     const byLevel = this.groupByLevel(boundaries);
 
-    // Pass 1: create ALL entities first (every level).
+    // Pass 1: create ALL entities first (every level). Forward each row's
+    // geometry (from GeoJSON sidecar or lat/long) so the citizen UI gets
+    // real outlines instead of unit-square placeholders.
     const failedEntities = new Set<string>();
     for (const levelBoundaries of byLevel) {
       for (const b of levelBoundaries) {
         try {
-          await this.createBoundaryEntity(b.tenantId, b.code);
+          await this.createBoundaryEntity(b.tenantId, b.code, b.geometry);
         } catch (error) {
           failedEntities.add(b.code);
           failed.push({

--- a/configurator/src/api/types.ts
+++ b/configurator/src/api/types.ts
@@ -191,6 +191,16 @@ export interface BoundaryLevel {
   active: boolean;
 }
 
+// GeoJSON-shaped geometry the boundary-service accepts. Today that's just
+// Point + Polygon — MultiPolygon is rejected at /boundary/_create even
+// though jsonb storage would hold it, so callers should collapse
+// MultiPolygon to its largest Polygon before sending (see
+// coerceForBoundaryService in utils/boundaryGeoJson.ts).
+export interface BoundaryGeometry {
+  type: 'Point' | 'Polygon';
+  coordinates: number[] | number[][][];
+}
+
 export interface Boundary {
   id?: string;
   tenantId: string;
@@ -201,6 +211,7 @@ export interface Boundary {
   hierarchyType: string;
   latitude?: number;
   longitude?: number;
+  geometry?: BoundaryGeometry;
   children?: Boundary[];
 }
 

--- a/configurator/src/pages/Phase2Page.tsx
+++ b/configurator/src/pages/Phase2Page.tsx
@@ -29,6 +29,7 @@ import { Banner } from '@/components/digit/Banner';
 import { boundaryService, localizationService, ApiClientError } from '@/api';
 import { parseExcelFile, parseBoundaryExcel } from '@/utils/excelParser';
 import { downloadBoundaryTemplate } from '@/utils/templateBuilder';
+import { parseGeoJsonSidecar, geometryForBoundary, type ParsedGeoJsonSidecar } from '@/utils/boundaryGeoJson';
 import type { BoundaryHierarchy, Boundary, BoundaryExcelRow } from '@/api/types';
 
 type Step = 'landing' | 'create-hierarchy' | 'select-hierarchy' | 'template' | 'upload' | 'verify' | 'complete';
@@ -64,6 +65,13 @@ export default function Phase2Page() {
   const [, setParsedLevels] = useState<string[]>([]);
   const [validBoundaries, setValidBoundaries] = useState<BoundaryExcelRow[]>([]);
   const [invalidBoundaries, setInvalidBoundaries] = useState<{ boundary: BoundaryExcelRow; error: string }[]>([]);
+
+  // Optional polygon sidecar: GeoJSON FeatureCollection that supplies real
+  // outlines for the citizen UI's OSM map. Without it every boundary gets
+  // the unit-square placeholder that Bomet + Nairobi ship with today.
+  const [polygonFile, setPolygonFile] = useState<File | null>(null);
+  const [polygonSidecar, setPolygonSidecar] = useState<ParsedGeoJsonSidecar | null>(null);
+  const [polygonError, setPolygonError] = useState<string | null>(null);
 
   // Created boundaries tracking
   const [createdCounts, setCreatedCounts] = useState<Record<string, number>>({});
@@ -172,6 +180,29 @@ export default function Phase2Page() {
     }
   };
 
+  const handlePolygonUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = '';
+    if (!file) return;
+    setPolygonError(null);
+    try {
+      const text = await file.text();
+      const parsed = parseGeoJsonSidecar(text);
+      setPolygonFile(file);
+      setPolygonSidecar(parsed);
+    } catch (err) {
+      setPolygonError(err instanceof Error ? err.message : String(err));
+      setPolygonFile(null);
+      setPolygonSidecar(null);
+    }
+  };
+
+  const handlePolygonClear = () => {
+    setPolygonFile(null);
+    setPolygonSidecar(null);
+    setPolygonError(null);
+  };
+
   const validateBoundaries = (boundaries: BoundaryExcelRow[]) => {
     const valid: BoundaryExcelRow[] = [];
     const invalid: { boundary: BoundaryExcelRow; error: string }[] = [];
@@ -222,7 +253,9 @@ export default function Phase2Page() {
     setError(null);
 
     try {
-      // Convert Excel rows to Boundary objects
+      // Convert Excel rows to Boundary objects, attaching real geometry
+      // (polygon sidecar > lat/long > undefined → service defaults to the
+      // unit-square placeholder for unmatched rows).
       const boundariesToCreate: Boundary[] = validBoundaries.map(row => ({
         tenantId: boundaryTenant,
         code: row.code,
@@ -232,6 +265,7 @@ export default function Phase2Page() {
         hierarchyType: selectedHierarchy.hierarchyType,
         latitude: row.latitude,
         longitude: row.longitude,
+        geometry: geometryForBoundary(row, polygonSidecar ?? undefined),
       }));
 
       // Create boundaries
@@ -312,6 +346,17 @@ export default function Phase2Page() {
         type="file"
         accept=".xlsx,.xls"
         onChange={handleFileUpload}
+        className="hidden"
+        disabled={loading}
+      />
+      {/* Hidden picker for the optional polygon GeoJSON sidecar — opens
+          from the "Polygon outlines (optional)" picker rendered on the
+          template & verify steps. */}
+      <input
+        id="boundary-polygon-upload"
+        type="file"
+        accept=".geojson,.json,application/geo+json,application/json"
+        onChange={handlePolygonUpload}
         className="hidden"
         disabled={loading}
       />
@@ -594,6 +639,49 @@ export default function Phase2Page() {
             )}
           </div>
 
+          {/* Optional polygon GeoJSON sidecar — supplies real outlines for
+              the citizen UI's OSM map. Without it boundaries land with a
+              unit-square placeholder (which is what Bomet + Nairobi ship
+              today). Match by `properties.code` (preferred) or normalized
+              `properties.name` (lowercase, strip diacritics + "Distrito
+              Municipal de " prefix). */}
+          <div
+            className="border border-dashed border-primary/20 rounded p-4 mb-4 hover:border-primary/40 transition-colors cursor-pointer"
+            onClick={() => !polygonFile && document.getElementById('boundary-polygon-upload')?.click()}
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2 text-foreground mb-1">
+                  <MapPin className="w-4 h-4 text-primary" />
+                  <strong className="text-sm font-condensed">Polygon outlines (optional)</strong>
+                </div>
+                {!polygonFile && (
+                  <p className="text-xs text-muted-foreground">
+                    Drop a GeoJSON FeatureCollection to draw real boundary outlines on the citizen map.
+                    Without it, boundaries get a placeholder shape.
+                  </p>
+                )}
+                {polygonFile && polygonSidecar && (
+                  <p className="text-xs text-muted-foreground truncate">
+                    <span className="text-primary font-medium">{polygonFile.name}</span> •
+                    {' '}{polygonSidecar.totalFeatures} features
+                    {' '}({polygonSidecar.matchedByCode} by code, {polygonSidecar.matchedByName} by name)
+                  </p>
+                )}
+                {polygonError && (
+                  <p className="text-xs text-destructive">{polygonError}</p>
+                )}
+              </div>
+              {polygonFile ? (
+                <Button variant="ghost" size="sm" onClick={(e) => { e.stopPropagation(); handlePolygonClear(); }} className="h-6 w-6 p-0 shrink-0">
+                  <X className="h-4 w-4" />
+                </Button>
+              ) : (
+                <Upload className="w-5 h-5 text-primary shrink-0" />
+              )}
+            </div>
+          </div>
+
           <Alert variant="warning" className="mb-4 sm:mb-6">
             <AlertTriangle className="w-4 h-4" />
             <AlertDescription>
@@ -621,6 +709,23 @@ export default function Phase2Page() {
             <Check className="w-4 h-4 sm:w-5 sm:h-5" />
             <span className="text-sm sm:text-base truncate">File: {uploadedFile?.name}</span>
           </div>
+          {polygonFile && polygonSidecar && (() => {
+            // Count how many of the rows we're about to create will pick up
+            // real geometry from the sidecar — operator-visible signal that
+            // the matching actually worked before they click Upload.
+            const matched = validBoundaries.filter(r =>
+              geometryForBoundary(r, polygonSidecar)?.type === 'Polygon'
+            ).length;
+            return (
+              <div className="flex items-center gap-2 text-muted-foreground mb-3 sm:mb-4 text-xs sm:text-sm">
+                <MapPin className="w-4 h-4 text-primary shrink-0" />
+                <span>
+                  Polygons: <span className="text-primary font-medium">{polygonFile.name}</span> —
+                  {' '}<span className="text-primary font-medium">{matched}</span> of {validBoundaries.length} boundaries will get real outlines
+                </span>
+              </div>
+            );
+          })()}
 
           <div className="overflow-x-auto -mx-4 sm:mx-0 mb-3 sm:mb-4">
             <div className="px-4 sm:px-0">

--- a/configurator/src/utils/boundaryGeoJson.ts
+++ b/configurator/src/utils/boundaryGeoJson.ts
@@ -1,0 +1,105 @@
+// Client-side counterpart to digit-mcp's xlsx-loader polygon sidecar logic.
+// Operator picks a `02-Boundaries-Polygons.geojson` in Phase 2 alongside
+// the boundary XLSX; we parse the FeatureCollection, key each feature by
+// `properties.code` (preferred) or normalized `properties.name`, and
+// attach the matching geometry to each boundary row before it's POSTed to
+// boundary-service. boundary-service only accepts Point + Polygon, so
+// MultiPolygons are collapsed to their largest ring.
+import type { BoundaryGeometry } from '@/api/types';
+
+/** Lowercase, strip diacritics, strip "Distrito Municipal de " prefix,
+ *  replace any non-alphanumeric with `_`. Brings OSM display names
+ *  (`KaMavota`, `Distrito Municipal de KaMpfumu`) and XLSX codes
+ *  (`kamavota`, `kampfumu`) to the same shape so they can be matched. */
+export function normalizeForMatch(s: string): string {
+  return s
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/^distrito municipal de\s+/, '')
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+/** boundary-service /boundary/_create rejects MultiPolygon. Collapse to
+ *  the ring set with the most coordinates (the main contiguous piece). */
+export function coerceForBoundaryService(geom: { type?: string; coordinates?: unknown }): BoundaryGeometry | undefined {
+  if (!geom || !geom.type) return undefined;
+  if (geom.type === 'Point' || geom.type === 'Polygon') {
+    return geom as BoundaryGeometry;
+  }
+  if (geom.type === 'MultiPolygon' && Array.isArray(geom.coordinates)) {
+    const polys = geom.coordinates as unknown[][][];
+    if (polys.length === 0) return undefined;
+    let largestIdx = 0;
+    let largestPoints = 0;
+    for (let i = 0; i < polys.length; i++) {
+      const outer = polys[i]?.[0];
+      const pts = Array.isArray(outer) ? outer.length : 0;
+      if (pts > largestPoints) { largestPoints = pts; largestIdx = i; }
+    }
+    return { type: 'Polygon', coordinates: polys[largestIdx] as number[][][] };
+  }
+  return undefined; // LineString, MultiPoint, etc. — unsupported here
+}
+
+export interface ParsedGeoJsonSidecar {
+  byCode: Map<string, BoundaryGeometry>;
+  totalFeatures: number;
+  matchedByCode: number;
+  matchedByName: number;
+  skipped: number;
+}
+
+export function parseGeoJsonSidecar(text: string): ParsedGeoJsonSidecar {
+  let parsed: { features?: Array<{ properties?: Record<string, unknown>; geometry?: { type?: string; coordinates?: unknown } }> };
+  try {
+    parsed = JSON.parse(text);
+  } catch (e) {
+    throw new Error(`Polygon GeoJSON: invalid JSON — ${e instanceof Error ? e.message : String(e)}`);
+  }
+  const features = parsed.features ?? [];
+  const byCode = new Map<string, BoundaryGeometry>();
+  let matchedByCode = 0;
+  let matchedByName = 0;
+  let skipped = 0;
+  for (const f of features) {
+    const props = f.properties ?? {};
+    const geom = coerceForBoundaryService(f.geometry ?? {});
+    if (!geom) { skipped++; continue; }
+    const explicitCode = typeof props.code === 'string' ? props.code.trim() : '';
+    if (explicitCode) {
+      byCode.set(explicitCode, geom);
+      matchedByCode++;
+      continue;
+    }
+    const name = typeof props.name === 'string' ? props.name.trim() : '';
+    if (name) {
+      byCode.set(normalizeForMatch(name), geom);
+      matchedByName++;
+      continue;
+    }
+    skipped++;
+  }
+  return { byCode, totalFeatures: features.length, matchedByCode, matchedByName, skipped };
+}
+
+/** Return the geometry to use for a boundary row, or undefined to fall
+ *  back to the unit-square placeholder. Sidecar > lat/long. */
+export function geometryForBoundary(
+  row: { code: string; name?: string; latitude?: number; longitude?: number },
+  sidecar?: ParsedGeoJsonSidecar,
+): BoundaryGeometry | undefined {
+  if (sidecar) {
+    const fromCode = sidecar.byCode.get(row.code);
+    if (fromCode) return fromCode;
+    if (row.name) {
+      const fromName = sidecar.byCode.get(normalizeForMatch(row.name));
+      if (fromName) return fromName;
+    }
+  }
+  if (Number.isFinite(row.longitude) && Number.isFinite(row.latitude)) {
+    return { type: 'Point', coordinates: [row.longitude as number, row.latitude as number] };
+  }
+  return undefined;
+}

--- a/digit-mcp/src/tools/mdms-tenant.ts
+++ b/digit-mcp/src/tools/mdms-tenant.ts
@@ -3600,6 +3600,16 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
             'Local path or fileStoreId for Boundary xlsx. ' +
             'Uploaded to filestore and processed via boundary management service.',
         },
+        boundary_geojson_file: {
+          type: 'string',
+          description:
+            'OPTIONAL sidecar: local path or fileStoreId for a GeoJSON FeatureCollection that supplies ' +
+            'real Polygon / MultiPolygon outlines for boundary entities (so the citizen UI can render them ' +
+            'on the OSM map). Each feature is matched to a boundary by `properties.code` (preferred) or by ' +
+            'normalized `properties.name` (fallback: lowercase, strip diacritics, replace non-alphanumerics ' +
+            'with underscore, strip "Distrito Municipal de " prefix). Falls back to per-row lat/long, then ' +
+            'to digit-api Point[0,0] default.',
+        },
         masters_file: {
           type: 'string',
           description:
@@ -3621,6 +3631,7 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
       const tenantId = args.tenant_id as string;
       const tenantFile = args.tenant_file as string | undefined;
       const boundaryFile = args.boundary_file as string | undefined;
+      const boundaryGeojsonFile = args.boundary_geojson_file as string | undefined;
       const mastersFile = args.masters_file as string | undefined;
       const employeeFile = args.employee_file as string | undefined;
 
@@ -3641,11 +3652,20 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
         }, null, 2);
       }
 
+      // GeoJSON sidecar only makes sense alongside a boundary file
+      if (boundaryGeojsonFile && !boundaryFile) {
+        return JSON.stringify({
+          success: false,
+          error: 'boundary_geojson_file requires boundary_file (the sidecar only attaches geometry to rows defined in the XLSX).',
+        }, null, 2);
+      }
+
       try {
         const result = await loadFromXlsx({
           tenant_id: tenantId,
           tenant_file: tenantFile,
           boundary_file: boundaryFile,
+          boundary_geojson_file: boundaryGeojsonFile,
           masters_file: mastersFile,
           employee_file: employeeFile,
         });

--- a/digit-mcp/src/utils/xlsx-loader.ts
+++ b/digit-mcp/src/utils/xlsx-loader.ts
@@ -199,6 +199,29 @@ function normalizeForMatch(s: string): string {
 }
 
 /**
+ * boundary-service /boundary/_create only accepts `Point` and `Polygon`
+ * geometries — it 400s on `MultiPolygon` even though jsonb storage doesn't
+ * care. OSM exports (e.g. Maputo bairros) come back as MultiPolygon for
+ * any feature with disconnected islands or stray fragments. To stay in
+ * compatible territory we collapse MultiPolygon to a single Polygon by
+ * picking the ring set with the most coordinates (i.e. the largest
+ * contiguous piece), which is the right call ~always for admin boundaries.
+ */
+function coerceForBoundaryService(geom: Record<string, unknown>): Record<string, unknown> {
+  if (geom?.type !== 'MultiPolygon' || !Array.isArray(geom.coordinates)) return geom;
+  const polys = geom.coordinates as unknown[][][];
+  if (polys.length === 0) return geom;
+  let largestIdx = 0;
+  let largestPoints = 0;
+  for (let i = 0; i < polys.length; i++) {
+    const outer = polys[i]?.[0];
+    const pts = Array.isArray(outer) ? outer.length : 0;
+    if (pts > largestPoints) { largestPoints = pts; largestIdx = i; }
+  }
+  return { type: 'Polygon', coordinates: polys[largestIdx] };
+}
+
+/**
  * Parse a GeoJSON sidecar file into a `code → geometry` lookup. Each feature
  * is keyed by `properties.code` (preferred) or normalized `properties.name`
  * (fallback). Returns the map plus stats so the caller can surface how many
@@ -329,7 +352,7 @@ async function runBoundaryPhase(
   const geometryFor = (b: BoundaryRow): Record<string, unknown> | undefined => {
     if (geojsonByCode) {
       const hit = geojsonByCode.get(b.code) ?? geojsonByCode.get(normalizeForMatch(b.name));
-      if (hit) return hit;
+      if (hit) return coerceForBoundaryService(hit);
     }
     if (Number.isFinite(b.longitude) && Number.isFinite(b.latitude)) {
       return { type: 'Point', coordinates: [b.longitude, b.latitude] };

--- a/digit-mcp/src/utils/xlsx-loader.ts
+++ b/digit-mcp/src/utils/xlsx-loader.ts
@@ -181,10 +181,73 @@ export interface BoundaryContext {
   levels: string[];
 }
 
+/**
+ * Normalize a string for fuzzy matching of GeoJSON feature names to boundary
+ * codes. The XLSX side typically stores codes as lowercase ascii with
+ * underscores (`kamavota`), while OSM / GIS exports use mixed-case display
+ * names with diacritics and spaces (`KaMavota`, `KaMpfumu`, `Distrito
+ * Municipal de KaMpfumu`). This brings both to a common shape.
+ */
+function normalizeForMatch(s: string): string {
+  return s
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '') // strip diacritics
+    .toLowerCase()
+    .replace(/^distrito municipal de\s+/, '') // OSM-style prefix on Maputo distritos
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+/**
+ * Parse a GeoJSON sidecar file into a `code → geometry` lookup. Each feature
+ * is keyed by `properties.code` (preferred) or normalized `properties.name`
+ * (fallback). Returns the map plus stats so the caller can surface how many
+ * boundaries got matched vs. dropped to the operator.
+ */
+function loadGeoJsonSidecar(geojsonText: string): {
+  byCode: Map<string, Record<string, unknown>>;
+  totalFeatures: number;
+  withCode: number;
+  withName: number;
+  skipped: number;
+} {
+  const byCode = new Map<string, Record<string, unknown>>();
+  let withCode = 0;
+  let withName = 0;
+  let skipped = 0;
+  let parsed: { features?: Array<{ properties?: Record<string, unknown>; geometry?: Record<string, unknown> }> };
+  try {
+    parsed = JSON.parse(geojsonText);
+  } catch (e) {
+    throw new Error(`Could not parse boundary_geojson_file as JSON: ${e instanceof Error ? e.message : String(e)}`);
+  }
+  const features = parsed.features ?? [];
+  for (const f of features) {
+    const props = f.properties ?? {};
+    const geom = f.geometry;
+    if (!geom) { skipped++; continue; }
+    const explicitCode = typeof props.code === 'string' ? props.code.trim() : '';
+    if (explicitCode) {
+      byCode.set(explicitCode, geom);
+      withCode++;
+      continue;
+    }
+    const name = typeof props.name === 'string' ? props.name.trim() : '';
+    if (name) {
+      byCode.set(normalizeForMatch(name), geom);
+      withName++;
+      continue;
+    }
+    skipped++;
+  }
+  return { byCode, totalFeatures: features.length, withCode, withName, skipped };
+}
+
 async function runBoundaryPhase(
   tenantId: string,
   fileRef: string,
   hierarchyTypeOverride?: string,
+  geojsonFileRef?: string,
 ): Promise<PhaseResult & { context?: BoundaryContext }> {
   const buf = await resolveFile(fileRef, tenantId);
 
@@ -251,15 +314,36 @@ async function runBoundaryPhase(
   const entityFailures: string[] = [];
   const relFailures: string[] = [];
 
-  // Build the boundary-service payload for a parsed row. When the XLSX has
-  // numeric `latitude` + `longitude` columns we forward them as a GeoJSON
-  // Point; otherwise digit-api supplies its Point[0,0] default so the
-  // entity still creates (operators can edit geometry later).
+  // Optional GeoJSON sidecar: map of boundary code (or normalized name) →
+  // GeoJSON geometry. Lets operators ship real Polygon / MultiPolygon
+  // outlines without trying to cram them into an XLSX cell. Sidecar wins
+  // over per-row lat/long; lat/long wins over the digit-api Point[0,0]
+  // default.
+  let geojsonByCode: Map<string, Record<string, unknown>> | undefined;
+  let geojsonStats: ReturnType<typeof loadGeoJsonSidecar> | undefined;
+  if (geojsonFileRef) {
+    const geojsonBuf = await resolveFile(geojsonFileRef, tenantId);
+    geojsonStats = loadGeoJsonSidecar(geojsonBuf.toString('utf8'));
+    geojsonByCode = geojsonStats.byCode;
+  }
+  const geometryFor = (b: BoundaryRow): Record<string, unknown> | undefined => {
+    if (geojsonByCode) {
+      const hit = geojsonByCode.get(b.code) ?? geojsonByCode.get(normalizeForMatch(b.name));
+      if (hit) return hit;
+    }
+    if (Number.isFinite(b.longitude) && Number.isFinite(b.latitude)) {
+      return { type: 'Point', coordinates: [b.longitude, b.latitude] };
+    }
+    return undefined;
+  };
+
+  // Build the boundary-service payload for a parsed row. Geometry comes from
+  // (in order): geojson sidecar by code, geojson sidecar by normalized name,
+  // XLSX latitude/longitude, or the digit-api default Point[0,0].
   const toBoundaryPayload = (b: BoundaryRow) => {
     const payload: { code: string; geometry?: Record<string, unknown> } = { code: b.code };
-    if (Number.isFinite(b.longitude) && Number.isFinite(b.latitude)) {
-      payload.geometry = { type: 'Point', coordinates: [b.longitude, b.latitude] };
-    }
+    const g = geometryFor(b);
+    if (g) payload.geometry = g;
     return payload;
   };
 
@@ -391,11 +475,25 @@ async function runBoundaryPhase(
   const failed = entityStats.failed + relStats.failed;
   const created = entityStats.created + relStats.created;
 
+  // Track how many rows actually picked up geometry from the sidecar — useful
+  // operator feedback when feature names don't line up with boundary codes.
+  let geojsonMatchedRows = 0;
+  if (geojsonByCode) {
+    for (const r of rows) {
+      if (geojsonByCode.get(r.code) || geojsonByCode.get(normalizeForMatch(r.name))) {
+        geojsonMatchedRows++;
+      }
+    }
+  }
+
   return {
     status: failed > 0 && created === 0 ? 'failed' : 'completed',
     message: `Hierarchy ${hierarchyAction}: ${hierarchyType}. ` +
       `Entities ${entityStats.created} created, ${entityStats.exists} existed, ${entityStats.failed} failed. ` +
-      `Relationships ${relStats.created} created, ${relStats.exists} existed, ${relStats.failed} failed.`,
+      `Relationships ${relStats.created} created, ${relStats.exists} existed, ${relStats.failed} failed.` +
+      (geojsonStats
+        ? ` Polygon sidecar: ${geojsonMatchedRows}/${rows.length} rows matched (${geojsonStats.totalFeatures} features in file).`
+        : ''),
     hierarchyType,
     hierarchyAction,
     levels: fileLevels,
@@ -403,6 +501,15 @@ async function runBoundaryPhase(
     entity_failures: entityFailures,
     relationship_failures: relFailures,
     context,
+    ...(geojsonStats && {
+      geojson: {
+        features: geojsonStats.totalFeatures,
+        matched_by_code: geojsonStats.withCode,
+        matched_by_name: geojsonStats.withName,
+        rows_with_geometry: geojsonMatchedRows,
+        rows_without_geometry: rows.length - geojsonMatchedRows,
+      },
+    }),
   };
 }
 
@@ -783,6 +890,7 @@ export interface XlsxLoadOptions {
   tenant_id: string;
   tenant_file?: string;
   boundary_file?: string;
+  boundary_geojson_file?: string;
   masters_file?: string;
   employee_file?: string;
 }
@@ -792,7 +900,7 @@ export interface XlsxLoadOptions {
  * Phases execute in dependency order: Tenant → Boundaries → Masters → Employees.
  */
 export async function loadFromXlsx(options: XlsxLoadOptions): Promise<XlsxLoadResult> {
-  const { tenant_id, tenant_file, boundary_file, masters_file, employee_file } = options;
+  const { tenant_id, tenant_file, boundary_file, boundary_geojson_file, masters_file, employee_file } = options;
 
   const result: XlsxLoadResult = {
     success: true,
@@ -819,7 +927,7 @@ export async function loadFromXlsx(options: XlsxLoadOptions): Promise<XlsxLoadRe
   // Phase 2: Boundaries
   if (boundary_file) {
     try {
-      const boundaryResult = await runBoundaryPhase(tenant_id, boundary_file);
+      const boundaryResult = await runBoundaryPhase(tenant_id, boundary_file, undefined, boundary_geojson_file);
       boundaryContext = boundaryResult.context;
       const { context: _bctx, ...serializable } = boundaryResult;
       result.phases.boundaries = serializable;

--- a/digit-mcp/src/utils/xlsx-loader.ts
+++ b/digit-mcp/src/utils/xlsx-loader.ts
@@ -251,6 +251,18 @@ async function runBoundaryPhase(
   const entityFailures: string[] = [];
   const relFailures: string[] = [];
 
+  // Build the boundary-service payload for a parsed row. When the XLSX has
+  // numeric `latitude` + `longitude` columns we forward them as a GeoJSON
+  // Point; otherwise digit-api supplies its Point[0,0] default so the
+  // entity still creates (operators can edit geometry later).
+  const toBoundaryPayload = (b: BoundaryRow) => {
+    const payload: { code: string; geometry?: Record<string, unknown> } = { code: b.code };
+    if (Number.isFinite(b.longitude) && Number.isFinite(b.latitude)) {
+      payload.geometry = { type: 'Point', coordinates: [b.longitude, b.latitude] };
+    }
+    return payload;
+  };
+
   // ── Phase A: create ALL entities first (every level), batched ──
   // egov-boundary-service /boundary/_create takes an array, so 100-at-a-time
   // keeps round-trips low without blowing past payload limits.
@@ -260,7 +272,7 @@ async function runBoundaryPhase(
     for (let i = 0; i < levelRows.length; i += BATCH) {
       const batch = levelRows.slice(i, i + BATCH);
       try {
-        await digitApi.boundaryCreate(tenantId, batch.map((b) => ({ code: b.code })));
+        await digitApi.boundaryCreate(tenantId, batch.map(toBoundaryPayload));
         entityStats.created += batch.length;
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
@@ -269,7 +281,7 @@ async function runBoundaryPhase(
           // so we can count exists vs. created cleanly without re-failing.
           for (const b of batch) {
             try {
-              await digitApi.boundaryCreate(tenantId, [{ code: b.code }]);
+              await digitApi.boundaryCreate(tenantId, [toBoundaryPayload(b)]);
               entityStats.created++;
             } catch (innerErr) {
               const innerMsg = innerErr instanceof Error ? innerErr.message : String(innerErr);


### PR DESCRIPTION
## Summary

Makes `city_setup_from_xlsx` actually deliver real boundary geometry to boundary-service so the citizen UI can render polygons on the OSM map. Until now, every entity created via this path landed with the digit-api `Point[0,0]` default — confirmed across Bomet (35 of 42 rows) and Naipepea (65 of 77 rows with placeholder unit-squares; 12 NULL). Maputo would have been the third deploy with no real outlines unless we fixed this end-to-end.

Validated on ovh-cloud-dev: 1256 mz.maputo boundaries fresh-created, 68 with real OSM-sourced Polygons (1 Município + 6 Distritos + 61 of 63 Bairros), 1188 left at Point[0,0] (Quarteirões — no OSM data at that granularity).

## What's in this PR

### 1. `digit-mcp` xlsx-loader: forward XLSX boundary lat/long → boundary-service `geometry`
Previously: `latitude`/`longitude` columns were parsed off boundary rows (`extractBoundaryFile` line ~445) but the boundary-service POST built its payload as `{ code }` only — values dropped on the floor. Now: build through a `toBoundaryPayload(b)` helper that forwards `{ type: 'Point', coordinates: [lng, lat] }` when both finite. Falls back to the `Point[0,0]` default.

### 2. `boundary_geojson_file` sidecar on `city_setup_from_xlsx`
For real outlines, packing multi-KB MultiPolygon JSON into an XLSX cell is operator-hostile (Maputo's KaMavota MultiPolygon is ~16 KB escaped — Excel mangles it). Instead, accept an optional GeoJSON sidecar:
- Match feature to boundary row by `properties.code` (preferred) or normalized `properties.name` (lowercase, strip diacritics, strip `Distrito Municipal de ` prefix, replace non-alphanumerics with `_` — handles OSM's `KaMavota` → kit's `kamavota`).
- Sidecar wins over per-row lat/long; lat/long wins over the digit-api default.
- Phase result reports `geojson: { features, matched_by_code, matched_by_name, rows_with_geometry, rows_without_geometry }` so operators see name-mismatch gaps.

### 3. MultiPolygon → largest Polygon coercion
boundary-service `/boundary/_create` rejects MultiPolygon with `Provided geometry type is not supported. Supported geometry types are Point and Polygon.` Real-world OSM exports return MultiPolygon for any feature with disconnected fragments. To keep the sidecar path working today, collapse MultiPolygon to the ring set with the most coordinates (the main contiguous piece). Long-term fix lives in boundary-service (accept MultiPolygon since jsonb stores it fine) — filing separately.

### 4. CI: `digit-mcp` build + typecheck gate
Parent CCRS had **no CI** for `digit-mcp/**` changes (the vendored `ci.yml` inside `digit-mcp/.github/` is dead code — GitHub only reads root `.github/workflows/`). Added `.github/workflows/digit-mcp-ci.yml` that runs `npm ci` + `npm run build` + `tsc --noEmit` on PRs / pushes touching `digit-mcp/**` or the workflow itself. Validated green on my fork (https://github.com/KDwevedi/Citizen-Complaint-Resolution-System/actions/runs/26554062754).

## Test plan

- [x] tsc + build clean on `digit-mcp` (CI workflow ⇒ green on fork)
- [x] Synthetic 5-row test on ovh-cloud-dev (4 features matched by `code`, 1 by `name` fallback, 1 MultiPolygon coerced) → all 5 rows land with real `Polygon` geometry, none failed
- [x] Real Maputo deploy on ovh-cloud-dev: 1256/1256 boundaries created in 11.9s; the 7 key boundaries (Município + 6 Distritos) show `Polygon` with 200–1500 outer-ring points each:
  ```
  maputo       | Polygon | 1544 pts   (Município — whole Cidade de Maputo)
  kamavota     | Polygon |  588 pts   (Distrito)
  kamaxakeni   | Polygon |  288 pts
  kampfumu     | Polygon |  356 pts
  kamubukwana  | Polygon |  712 pts
  katembe      | Polygon |  507 pts
  nlhamankulu  | Polygon |  204 pts
  ```
- [x] Quarteirões + unmatched bairros gracefully fall back to `Point[0,0]` (unchanged behavior)

## Follow-ups (not in this PR)

- boundary-service: accept MultiPolygon at `/boundary/_create` (currently coerced client-side, lossy for boundaries with real island geometry)
- boundary-service: add `/boundary/_update` so the polygon sidecar can refresh geometry on existing boundaries without delete-and-recreate
- Maputo kit: ship `02-Boundaries-Polygons.geojson` (sourced from OSM via Overpass; 70 features / 68 matched / 367 KB) — separate PR against the kit

🤖 Generated with [Claude Code](https://claude.com/claude-code)