### PR TITLE
fix(playbook): drop egov-hrms from post-bootstrap restart (kills HRMS bootstrap race)

### DIFF
--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -1555,10 +1555,33 @@
         replace: '\1STATE_LEVEL_TENANT_ID: {{ state_root }}'
       when: state_root != 'pg'
 
+    # `docker compose restart` with multiple services starts them in
+    # PARALLEL — it does not respect depends_on. So every service named
+    # here gets SIGTERM at the same moment, then they all come back up at
+    # their own pace. egov-hrms has historically been in this list, but
+    # that combination is a sharp edge:
+    #
+    #   1. HRMS comes back faster than egov-user (less seed work to do).
+    #   2. HRMS's @PostConstruct initalizeSystemuser does a synchronous
+    #      `/user/v1/_search` for its INTERNAL_USER on boot.
+    #   3. That search hits egov-user mid-boot, the proxy returns 502,
+    #      HRMS interprets null → CustomException → JVM exits 1.
+    #   4. Kong negative-caches the now-missing egov-hrms host (~1h TTL)
+    #      and serves 503 to every subsequent /egov-hrms request until
+    #      Kong is restarted.
+    #
+    # HRMS does NOT need to be restarted here regardless of state_root:
+    #   - Its INTERNAL_USER lives at `pg` (from db/full-dump.sql) and
+    #     stays there even when state_root: mz. Bootstrapping HRMS at
+    #     mz would just fail to find INTERNAL_USER.
+    #   - With `restart` (not --force-recreate, reverted via #622 due to
+    #     enc-key drift), env vars don't change on restart anyway, so
+    #     restarting HRMS is a no-op for state_root purposes.
+    # Excluded.
     - name: "post-bootstrap — restart services to pick up new STATE_LEVEL_TENANT_ID"
       ansible.builtin.shell: >-
         docker compose {{ compose_files }}
-        restart egov-user egov-workflow-v2 egov-enc-service pgr-services egov-hrms
+        restart egov-user egov-workflow-v2 egov-enc-service pgr-services
       args:
         chdir: "{{ digit_dir }}"
       when: state_root != 'pg'


### PR DESCRIPTION
## Symptom

After ./deploy.sh for any tenant with `state_root != 'pg'`, `egov-hrms` is healthy at first, then dies during the post-bootstrap restart cascade. Subsequent /egov-hrms requests through Kong return **503 + "name resolution failed"** until Kong itself is restarted. Reproduced 3× today on ovh-cloud-dev (Maputo).

## Root cause

`docker compose restart` with multiple services starts them in **parallel** — it doesn't respect `depends_on`. The post-bootstrap restart task at line 1558 was:

```
docker compose ... restart egov-user egov-workflow-v2 egov-enc-service pgr-services egov-hrms
```

Sequence:
1. All 5 services get SIGTERM at the same moment.
2. HRMS comes back faster than egov-user (less seed work).
3. HRMS's `@PostConstruct initalizeSystemuser` does a synchronous `/user/v1/_search` for `INTERNAL_USER` on boot.
4. That search hits egov-user mid-boot → 502 → HRMS interprets null → `CustomException("Service returned null while fetching user")` → JVM exits 1.

Bonus damage: Kong negative-caches the now-missing `egov-hrms` host (default TTL ~1h) and serves 503 to every subsequent `/egov-hrms` request until **Kong itself is restarted**.

Live log (today, 3rd repro):
```
2026/05/28 06:45:34 [error] DNS resolution failed: dns server error: 3 name error.
Tried: ["egov-hrms:33 - cache-hit/stale/scheduled/dns server error: 3 name error", ...]
```

## Fix

**Drop `egov-hrms` from the restart list.** HRMS doesn't need restarting here regardless of `state_root`:

- Its `INTERNAL_USER` lives at `pg` (from `db/full-dump.sql`) and stays there even when `state_root: mz`. Bootstrapping HRMS into an `mz` state root would just fail to find `INTERNAL_USER` for a different reason.
- We use `restart` (not `--force-recreate`, reverted via #622 due to enc-key drift) so env vars don't change on restart anyway. The restart is a no-op for `STATE_LEVEL` purposes.

Added a long comment block above the task explaining why HRMS is excluded so a future change doesn't re-add it and walk into the same trap.

## Diff scope

```
 local-setup/ansible/playbook-deploy.yml | 25 ++++++++++++++++++++++++-
 1 file changed, 24 insertions(+), 1 deletion(-)
```

The shell command on line 1561 loses one word (`egov-hrms`). Everything else is the explanatory comment.

## Test plan

- [x] Issue reproduced 3× today on ovh-cloud-dev (Maputo / state_root: mz) before the fix
- [ ] Re-deploy maputo after merge → `egov-hrms` should stay Up (healthy) for the duration; no Kong 503s on `/egov-hrms/employees/_create`
- [ ] State_root=pg deploys (Bomet) unaffected — the post-bootstrap restart task is gated on `state_root != 'pg'`

## Out of scope (will follow up)

- The broader issue that the post-bootstrap restart cascade has no end-of-deploy "is every container still healthy" gate. A separate PR will add a re-validation pass after line 1605 so any service that dies during the restart cascade fails the deploy instead of going silently green.
- Two follow-ups already noted in the inline comment also apply: Kong negative-cache TTL is too long; HRMS init should probably retry on 502 instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)