### PR TITLE
feat(configurator): "Use existing tenant" path on Phase 1 + move polygon picker to verify step

### DIFF
--- a/configurator/src/pages/Phase1Page.tsx
+++ b/configurator/src/pages/Phase1Page.tsx
@@ -30,7 +30,7 @@ import { mdmsService, localizationService, apiClient, ApiClientError } from '@/a
 import { bootstrapStateRoot, stateNeedsBootstrap, type BootstrapProgress } from '@/api/services/tenantBootstrap';
 import type { TenantExcelRow, Tenant, ValidationResult } from '@/api/types';
 
-type Step = 'landing' | 'upload' | 'preview' | 'branding' | 'complete';
+type Step = 'landing' | 'upload' | 'preview' | 'branding' | 'complete' | 'select-existing';
 
 interface BrandingData {
   bannerUrl?: string;
@@ -109,6 +109,35 @@ export default function Phase1Page() {
 
   // Created tenant
   const [createdTenant, setCreatedTenant] = useState<Tenant | null>(null);
+
+  // Existing-tenant picker — for the common case where the playbook
+  // already created the tenant (state_root: mz + auto-bootstrap) and
+  // running Phase 1 fresh would just hit "Duplicate record". State root
+  // is derived from the login tenant: `mz.maputo` → `mz`, `mz` → `mz`.
+  const stateRoot = state.tenant.includes('.') ? state.tenant.split('.')[0] : state.tenant;
+  const [existingTenants, setExistingTenants] = useState<Tenant[] | null>(null);
+  const [existingTenantsLoading, setExistingTenantsLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setExistingTenantsLoading(true);
+    mdmsService.getTenants(stateRoot)
+      .then((tenants) => { if (!cancelled) setExistingTenants(tenants); })
+      .catch((err) => {
+        if (!cancelled) {
+          console.warn('Failed to list existing tenants:', err);
+          setExistingTenants([]);
+        }
+      })
+      .finally(() => { if (!cancelled) setExistingTenantsLoading(false); });
+    return () => { cancelled = true; };
+  }, [stateRoot]);
+
+  const handleUseExistingTenant = (tenant: Tenant) => {
+    setTargetTenant(tenant.code);
+    completePhase(1);
+    navigate('/phase/2');
+  };
 
   const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -381,6 +410,29 @@ export default function Phase1Page() {
       {/* Landing */}
       {step === 'landing' && (
         <DigitCard>
+          {/* Existing-tenant banner — surfaces upfront when the tenant is
+              already in MDMS (deploy auto-bootstrap, prior wizard run,
+              second operator joining). Skips the duplicate-record cliff
+              the create-new path would otherwise hit. */}
+          {existingTenants && existingTenants.length > 0 && (
+            <Alert variant="info" className="mb-4 sm:mb-6">
+              <AlertDescription className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                <span className="text-xs sm:text-sm">
+                  <strong>{existingTenants.length} existing tenant{existingTenants.length === 1 ? '' : 's'}</strong> already configured under <code className="text-primary">{stateRoot}</code>.
+                  Skip Phase 1 by selecting one.
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="border-primary text-primary hover:bg-primary/10 shrink-0"
+                  onClick={() => setStep('select-existing')}
+                >
+                  Use existing tenant →
+                </Button>
+              </AlertDescription>
+            </Alert>
+          )}
+
           <Alert variant="info" className="mb-4 sm:mb-6">
             <AlertDescription>
               <strong className="block mb-2 text-sm sm:text-base">What You'll Do:</strong>
@@ -430,12 +482,89 @@ export default function Phase1Page() {
             </div>
           </div>
 
-          <div className="mt-4 sm:mt-6 flex justify-end">
+          <div className="mt-4 sm:mt-6 flex flex-col sm:flex-row justify-end gap-2">
+            {existingTenants && existingTenants.length > 0 && (
+              <Button
+                variant="outline"
+                onClick={() => setStep('select-existing')}
+                className="border-primary text-primary hover:bg-primary/10"
+              >
+                Use existing tenant
+              </Button>
+            )}
             <SubmitBar
               label="Start Setup"
               onSubmit={() => setStep('upload')}
               icon={<ChevronRight className="w-4 h-4" />}
             />
+          </div>
+        </DigitCard>
+      )}
+
+      {/* Use Existing Tenant — picker shown when tenants already exist at the
+          chosen state root (deploy auto-bootstrap, prior wizard runs, etc.) */}
+      {step === 'select-existing' && (
+        <DigitCard>
+          <SubHeader>Use Existing Tenant</SubHeader>
+          <p className="text-xs sm:text-sm text-muted-foreground mb-4 sm:mb-6">
+            These tenants are already configured under <code className="text-primary">{stateRoot}</code> (created via deploy bootstrap, MCP, or a previous wizard run).
+            Pick one to skip tenant creation and jump straight to Phase 2.
+          </p>
+
+          {existingTenantsLoading && (
+            <div className="flex items-center gap-2 text-muted-foreground text-sm py-4">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Loading existing tenants…
+            </div>
+          )}
+
+          {!existingTenantsLoading && (!existingTenants || existingTenants.length === 0) && (
+            <Alert variant="info" className="mb-4">
+              <AlertDescription className="text-xs sm:text-sm">
+                No tenants found under <code className="text-primary">{stateRoot}</code>. Use the Create New flow on the landing page.
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {existingTenants && existingTenants.length > 0 && (
+            <div className="overflow-x-auto -mx-4 sm:mx-0 mb-4 sm:mb-6">
+              <div className="px-4 sm:px-0">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Code</TableHead>
+                      <TableHead>Name</TableHead>
+                      <TableHead className="hidden sm:table-cell">Description</TableHead>
+                      <TableHead className="text-right">Action</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {existingTenants.map((t) => (
+                      <TableRow key={t.code}>
+                        <TableCell><code className="text-primary text-xs">{t.code}</code></TableCell>
+                        <TableCell className="font-medium text-sm">{t.name}</TableCell>
+                        <TableCell className="hidden sm:table-cell text-xs text-muted-foreground truncate max-w-xs">{t.description || '—'}</TableCell>
+                        <TableCell className="text-right">
+                          <Button
+                            size="sm"
+                            className="bg-primary hover:bg-primary/90 text-white"
+                            onClick={() => handleUseExistingTenant(t)}
+                          >
+                            Use this <ChevronRight className="w-4 h-4 ml-1" />
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </div>
+          )}
+
+          <div className="flex justify-between">
+            <Button variant="ghost" size="sm" onClick={() => setStep('landing')} className="text-muted-foreground hover:text-primary">
+              ← Back
+            </Button>
           </div>
         </DigitCard>
       )}

--- a/configurator/src/pages/Phase2Page.tsx
+++ b/configurator/src/pages/Phase2Page.tsx
@@ -639,48 +639,14 @@ export default function Phase2Page() {
             )}
           </div>
 
-          {/* Optional polygon GeoJSON sidecar — supplies real outlines for
-              the citizen UI's OSM map. Without it boundaries land with a
-              unit-square placeholder (which is what Bomet + Nairobi ship
-              today). Match by `properties.code` (preferred) or normalized
-              `properties.name` (lowercase, strip diacritics + "Distrito
-              Municipal de " prefix). */}
-          <div
-            className="border border-dashed border-primary/20 rounded p-4 mb-4 hover:border-primary/40 transition-colors cursor-pointer"
-            onClick={() => !polygonFile && document.getElementById('boundary-polygon-upload')?.click()}
-          >
-            <div className="flex items-start justify-between gap-3">
-              <div className="min-w-0">
-                <div className="flex items-center gap-2 text-foreground mb-1">
-                  <MapPin className="w-4 h-4 text-primary" />
-                  <strong className="text-sm font-condensed">Polygon outlines (optional)</strong>
-                </div>
-                {!polygonFile && (
-                  <p className="text-xs text-muted-foreground">
-                    Drop a GeoJSON FeatureCollection to draw real boundary outlines on the citizen map.
-                    Without it, boundaries get a placeholder shape.
-                  </p>
-                )}
-                {polygonFile && polygonSidecar && (
-                  <p className="text-xs text-muted-foreground truncate">
-                    <span className="text-primary font-medium">{polygonFile.name}</span> •
-                    {' '}{polygonSidecar.totalFeatures} features
-                    {' '}({polygonSidecar.matchedByCode} by code, {polygonSidecar.matchedByName} by name)
-                  </p>
-                )}
-                {polygonError && (
-                  <p className="text-xs text-destructive">{polygonError}</p>
-                )}
-              </div>
-              {polygonFile ? (
-                <Button variant="ghost" size="sm" onClick={(e) => { e.stopPropagation(); handlePolygonClear(); }} className="h-6 w-6 p-0 shrink-0">
-                  <X className="h-4 w-4" />
-                </Button>
-              ) : (
-                <Upload className="w-5 h-5 text-primary shrink-0" />
-              )}
-            </div>
-          </div>
+          {/* Hint about the optional polygon sidecar — the actual picker
+              lives on the verify step (after XLSX parse). Putting it here
+              would be invisible: handleFileUpload immediately transitions
+              to 'verify' the moment a file is dropped. */}
+          <p className="text-xs text-muted-foreground mb-4 flex items-center gap-2">
+            <MapPin className="w-3 h-3 inline" />
+            After upload, you'll be able to attach an optional GeoJSON file for real boundary outlines on the map.
+          </p>
 
           <Alert variant="warning" className="mb-4 sm:mb-6">
             <AlertTriangle className="w-4 h-4" />
@@ -709,23 +675,54 @@ export default function Phase2Page() {
             <Check className="w-4 h-4 sm:w-5 sm:h-5" />
             <span className="text-sm sm:text-base truncate">File: {uploadedFile?.name}</span>
           </div>
-          {polygonFile && polygonSidecar && (() => {
-            // Count how many of the rows we're about to create will pick up
-            // real geometry from the sidecar — operator-visible signal that
-            // the matching actually worked before they click Upload.
-            const matched = validBoundaries.filter(r =>
-              geometryForBoundary(r, polygonSidecar)?.type === 'Polygon'
-            ).length;
-            return (
-              <div className="flex items-center gap-2 text-muted-foreground mb-3 sm:mb-4 text-xs sm:text-sm">
-                <MapPin className="w-4 h-4 text-primary shrink-0" />
-                <span>
-                  Polygons: <span className="text-primary font-medium">{polygonFile.name}</span> —
-                  {' '}<span className="text-primary font-medium">{matched}</span> of {validBoundaries.length} boundaries will get real outlines
-                </span>
+
+          {/* Optional polygon GeoJSON sidecar — real outlines for the
+              citizen UI's OSM map. Without it boundaries land with the
+              unit-square placeholder (same as Bomet/Naipepea today).
+              Match by `properties.code` (preferred) or normalized
+              `properties.name`. Sits on the verify step because the
+              template step transitions away the instant an XLSX drops. */}
+          <div
+            className="border border-dashed border-primary/30 rounded p-4 mb-4 hover:border-primary/60 transition-colors cursor-pointer"
+            onClick={() => !polygonFile && document.getElementById('boundary-polygon-upload')?.click()}
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2 text-foreground mb-1">
+                  <MapPin className="w-4 h-4 text-primary" />
+                  <strong className="text-sm font-condensed">Polygon outlines (optional)</strong>
+                </div>
+                {!polygonFile && !polygonError && (
+                  <p className="text-xs text-muted-foreground">
+                    Drop a GeoJSON FeatureCollection to draw real boundary outlines on the citizen map.
+                    Skip to use the default placeholder shape.
+                  </p>
+                )}
+                {polygonFile && polygonSidecar && (() => {
+                  const matched = validBoundaries.filter(r =>
+                    geometryForBoundary(r, polygonSidecar)?.type === 'Polygon'
+                  ).length;
+                  return (
+                    <p className="text-xs text-muted-foreground">
+                      <span className="text-primary font-medium">{polygonFile.name}</span>
+                      {' '}— <span className="text-primary font-medium">{matched}</span> of {validBoundaries.length} boundaries will get real outlines
+                      {' '}({polygonSidecar.totalFeatures} features in file, {polygonSidecar.matchedByCode} matched by code, {polygonSidecar.matchedByName} by name).
+                    </p>
+                  );
+                })()}
+                {polygonError && (
+                  <p className="text-xs text-destructive">{polygonError}</p>
+                )}
               </div>
-            );
-          })()}
+              {polygonFile ? (
+                <Button variant="ghost" size="sm" onClick={(e) => { e.stopPropagation(); handlePolygonClear(); }} className="h-6 w-6 p-0 shrink-0">
+                  <X className="h-4 w-4" />
+                </Button>
+              ) : (
+                <Upload className="w-5 h-5 text-primary shrink-0" />
+              )}
+            </div>
+          </div>
 
           <div className="overflow-x-auto -mx-4 sm:mx-0 mb-3 sm:mb-4">
             <div className="px-4 sm:px-0">


### PR DESCRIPTION
## Summary

Two Phase 1 / Phase 2 UX fixes from the live demo run today. Both were on the same fork branch as PR #621 but got pushed *after* #621 merged, so they didn't ride along.

## 1. Phase 1 — "Use existing tenant" picker

The deploy's auto-bootstrap (`state_root != 'pg'`) already calls MCP `tenant_bootstrap`, which creates `tenant.tenants` for the target city before any operator touches the wizard. Phase 1's create-new path then hits **"Duplicate record"** on every re-run, demo replay, or second operator joining a deploy.

Adds an existing-tenant detection: on Phase 1 landing, query `mdmsService.getTenants(stateRoot)` for cities already configured under the operator's state root. When any exist, surface:

- A top-of-page banner: *"N existing tenants under `<stateRoot>`. Use existing tenant →"*
- A secondary CTA next to "Start Setup" on the landing card
- A new `select-existing` step with a `code | name | description` table + per-row "Use this →" button that calls `setTargetTenant(code)` + `completePhase(1)` + `navigate('/phase/2')`

State root is derived from the login tenant: `mz.maputo` → `mz`, `mz` → `mz`. No backend change; just a read of `tenant.tenants` via the existing `mdmsService.getTenants` helper.

**Exercised end-to-end in today's Maputo recording** — operator logged in as `mz.maputo`, saw the "1 existing tenant under mz" banner, clicked through to Phase 2 with `targetTenant` correctly set. This worked.

## 2. Phase 2 — polygon picker moved from `template` → `verify` step

Original placement bug from PR #621: `handleFileUpload` immediately transitions to `verify` the moment a boundary XLSX is parsed, so the polygon picker on the `template` step was visible for ~0 seconds. **Operator could never see the picker before the page moved on.**

Fix:
- Hint on the `template` step (*"After upload, you'll be able to attach an optional GeoJSON file…"*)
- Full picker UI rendered on the `verify` step right under the parsed-file banner. Same picker behavior (border-dashed dropzone, X to clear, match summary). This is the step where the operator commits, so it's the right moment for the optional sidecar choice.

**Honest status on this half:** the picker shows up in the bundled JS (`grep` confirms it's in the deployed `index-*.js`), but it was NOT exercised in today's recording — operator went straight through Phase 2 without uploading the geojson sidecar. The placement fix is straightforward (same picker component, different step gate) so I'm confident in it, but a clean re-run will be the actual visible validation. Tracking for the next demo.

The underlying polygon-upload path (sidecar → boundary-service with real Polygon coordinates) IS independently validated via direct MCP REST calls on ovh-cloud-dev (PR #621 test plan), so the picker-placement change is the only thing that's not exercised end-to-end in a recording yet.

## Diff scope

```
 configurator/src/pages/Phase1Page.tsx | 133 ++++++++++++++++++++++++++++++++-
 configurator/src/pages/Phase2Page.tsx | 113 ++++++++++++++---------------
 2 files changed, 186 insertions(+), 60 deletions(-)
```

No new dependencies. No backend touched. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)