### PR TITLE
fix(security): grant PGR roles PLAIN decryption on User SecurityPolicy

### DIFF
--- a/utilities/default-data-handler/src/main/resources/mdmsData/DataSecurity/DataSecurity.SecurityPolicy.json
+++ b/utilities/default-data-handler/src/main/resources/mdmsData/DataSecurity/DataSecurity.SecurityPolicy.json
@@ -161,6 +161,80 @@
               "secondLevelVisibility": "PLAIN"
             }
           ]
+        },
+        {
+          "roles": [
+            "EMPLOYEE",
+            "GRO",
+            "PGR_LME",
+            "DGRO",
+            "CSR",
+            "SUPERUSER",
+            "PGR_VIEWER",
+            "MDMS_ADMIN"
+          ],
+          "attributeAccessList": [
+            {
+              "attribute": "name",
+              "firstLevelVisibility": "PLAIN",
+              "secondLevelVisibility": "PLAIN"
+            },
+            {
+              "attribute": "mobileNumber",
+              "firstLevelVisibility": "PLAIN",
+              "secondLevelVisibility": "PLAIN"
+            },
+            {
+              "attribute": "emailId",
+              "firstLevelVisibility": "PLAIN",
+              "secondLevelVisibility": "PLAIN"
+            },
+            {
+              "attribute": "username",
+              "firstLevelVisibility": "PLAIN",
+              "secondLevelVisibility": "PLAIN"
+            },
+            {
+              "attribute": "altContactNumber",
+              "firstLevelVisibility": "PLAIN",
+              "secondLevelVisibility": "PLAIN"
+            },
+            {
+              "attribute": "alternatemobilenumber",
+              "firstLevelVisibility": "PLAIN",
+              "secondLevelVisibility": "PLAIN"
+            },
+            {
+              "attribute": "pan",
+              "firstLevelVisibility": "PLAIN",
+              "secondLevelVisibility": "PLAIN"
+            },
+            {
+              "attribute": "aadhaarNumber",
+              "firstLevelVisibility": "PLAIN",
+              "secondLevelVisibility": "PLAIN"
+            },
+            {
+              "attribute": "guardian",
+              "firstLevelVisibility": "PLAIN",
+              "secondLevelVisibility": "PLAIN"
+            },
+            {
+              "attribute": "fatherOrHusbandName",
+              "firstLevelVisibility": "PLAIN",
+              "secondLevelVisibility": "PLAIN"
+            },
+            {
+              "attribute": "correspondenceAddress",
+              "firstLevelVisibility": "PLAIN",
+              "secondLevelVisibility": "PLAIN"
+            },
+            {
+              "attribute": "permanentAddress",
+              "firstLevelVisibility": "PLAIN",
+              "secondLevelVisibility": "PLAIN"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
## What

Adds a `roleBasedDecryptionPolicy` entry to the `DataSecurity.SecurityPolicy` (model **User**, tenant `pg`) granting PLAIN/PLAIN visibility to the PGR roles: `EMPLOYEE, GRO, PGR_LME, DGRO, CSR, SUPERUSER, PGR_VIEWER, MDMS_ADMIN`.

## Why

On any develop-based PGR deployment, employee names render **masked** as `B*XXXXXXXXX` on the **Assign Complaint** screen, because none of the PGR roles are in the User decryption policy. Verified absent in current develop in both seed sources.

## Provenance

This is a port of the **only** still-relevant fix from the stale Bomet branch (PR #344, squashed commit `cd22a058`). That commit bundled 9 fixes; the other 8 are already in develop or obsolete:

| Bundled fix | Status in develop |
|---|---|
| Kong `/egov-mdms-service` route | already present (`kong.yml`) |
| Kong `KONG_UNTRUSTED_LUA_SANDBOX_REQUIRES` | present in deploy file `docker-compose.egov-digit.yaml` |
| boundary-service `v2.9.2-dual-mode` | already on deploy file |
| Root TenantBoundary code = tenant code | obsolete (legacy `egov-location.TenantBoundary`; HRMS now uses boundary-service entity codes) |
| Boundary code→name localizations | configurator `buildBoundaryLocalizations` |
| ServiceDefs `SERVICEDEFS_` prefix | configurator + chatbot |
| crs_loader bootstrap simplification | superseded by MCP `tenant_bootstrap` |
| Boundary **type** labels for non-default levels | minor gap, belongs in configurator — out of scope here |
| **SecurityPolicy PGR roles** | **missing → this PR** |

## Changes

The original commit edited `local-setup/db/mdms-security-seed.sql`, which no longer exists in develop. The two live seed sources are updated and kept consistent:

- `utilities/default-data-handler/.../DataSecurity/DataSecurity.SecurityPolicy.json` (DDH seeder)
- `local-setup/db/full-dump.sql` (row `a5164fd2`, tenant `pg`)

Seeded at the state root `pg`; configurator/MCP tenant bootstrap clone the root policy verbatim per tenant, so this covers all PGR deployments.

## Testing

- Both files re-validate as JSON after the edit.
- Manual verification: log in as a GRO/PGR_LME employee, open Assign Complaint — employee names should render in plain text rather than `B*XXXXXXXXX`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)