### PR TITLE
fix(pgr): add ESCALATE to ACTION_CONFIGS so Escalate modal opens (#521)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
@@ -194,6 +194,52 @@ const ACTION_CONFIGS = [
       ],
     },
   },
+  {
+    // ESCALATE was missing from this list, so getUpdatedConfig() returned null
+    // and PGRWorkflowModal short-circuited (`if (!config) return null`) — the
+    // "Escalate" action rendered an empty no-op modal (issue #521). The PGR
+    // BusinessService defines ESCALATE as a valid action at PENDINGFORASSIGNMENT
+    // (GRO/PGR_VIEWER) and PENDINGATLME (GRO/PGR_LME/PGR_VIEWER), so the backend
+    // already accepts the transition; only this front-end config was absent.
+    // Mirrors REASSIGN: pick a forward assignee + mandatory comments. The
+    // assignee role set is injected dynamically by computeAssigneeRoles()/
+    // getUpdatedConfig(), and handleActionSubmit() already maps
+    // SelectedAssignee.uuid -> workflow.assignes/hrmsAssignes.
+    actionType: "ESCALATE",
+    formConfig: {
+      label: {
+        heading: "CS_ACTION_ESCALATE",
+        cancel: "CS_COMMON_CANCEL",
+        submit: "CS_COMMON_SUBMIT",
+      },
+      form: [
+        {
+          body: [
+            {
+              type: "component",
+              isMandatory: false,
+              component: "PGRAssigneeComponent",
+              key: "SelectedAssignee",
+              label: "CS_COMMON_EMPLOYEE_NAME",
+              populators: { name: "SelectedAssignee" },
+            },
+            {
+              type: "textarea",
+              isMandatory: true,
+              key: "SelectedComments",
+              label: "CS_COMMON_EMPLOYEE_COMMENTS",
+              populators: {
+                name: "SelectedComments",
+                maxLength: 1000,
+                validation: { required: true },
+                error: "CORE_COMMON_REQUIRED_ERRMSG",
+              },
+            },
+          ],
+        },
+      ],
+    },
+  },
 ];
 
 const PGRDetails = () => {


### PR DESCRIPTION
## What
Fixes the non-functional **Escalate** action on the employee complaint-details page (issue #521, dup #475).

## Root cause
`digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js` defined `ACTION_CONFIGS` for ASSIGN / REOPEN / REJECT / RESOLVE / REASSIGN but **not ESCALATE**. On selecting *Escalate*, `getUpdatedConfig()` does `configs.find(c => c.actionType === 'ESCALATE')` → `null`, and `PGRWorkflowModal` short-circuits (`if (!config) return null`) — so the button opened an empty, no-op modal.

(Note: this is the **live** PGR tree. The bundle aliases `@egovernments/digit-ui-module-pgr` → `products/pgr/`; the `packages/modules/pgr/` copy is dead code.)

## Fix
Add an `ESCALATE` entry to `ACTION_CONFIGS` mirroring `REASSIGN`: a `PGRAssigneeComponent` assignee picker + mandatory comments. No other wiring needed —
- assignee roles are injected dynamically by `computeAssigneeRoles()` / `getUpdatedConfig()` (forward-state roles of the escalation target);
- `handleActionSubmit()` already maps `SelectedAssignee.uuid → workflow.assignes` / `hrmsAssignes`.

## Backend is already correct
The deployed PGR `BusinessService` (verified on naipepea) lists `ESCALATE` as a valid action at `PENDINGFORASSIGNMENT` (roles `GRO, PGR_VIEWER, SYSTEM`) and `PENDINGATLME` (`GRO, PGR_LME, PGR_VIEWER, SYSTEM`). The role gate passes for a GRO user — the bug was front-end only.

## Follow-up (not in this PR)
Seed a `CS_ACTION_ESCALATE` localization message (`en_IN` + `sw_KE`) in egov-localization, else the modal heading falls back to the raw key.

## Validation
Mirror branch pushed to `theflywheel/digit-ui-esbuild` (`fix/521-escalate-action-config`) so naipepea can `git pull` + rebuild the bundle to verify: log in as a GRO, open a `PENDINGFORASSIGNMENT` complaint → Take Action → Escalate → the assignee+comments modal should now open and submit a valid ESCALATE transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
