### PR TITLE
fix(deploy): static-mode vendored UI + bomet template + novu-worker

### DIFF
--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -77,6 +77,27 @@
       when:
         - digit_ui_mode in ['static', 'hmr']
         - ansible_system != 'Darwin'
+        # Skip when build_digit_ui:true — the vendored copy in /opt/ccrs/digit-ui-esbuild
+        # is the source of truth; the symlink task below points /opt/digit-ui-esbuild
+        # at it so the static-mode build runs against vendored, not theflywheel main.
+        - not (build_digit_ui | default(false))
+
+    # When build_digit_ui:true on a static/hmr host, point /opt/digit-ui-esbuild
+    # at the vendored copy inside this CCRS checkout. Static-mode npm install +
+    # esbuild.build.js then operate on develop's vendored source via the symlink,
+    # producing a build the host nginx (alias /opt/digit-ui-esbuild/build/) serves.
+    # Without this, the clone task above puts theflywheel main on disk and the
+    # vendored build only lands in the (stopped) digit-ui container — silent gap.
+    - name: "digit-ui — symlink /opt/digit-ui-esbuild → vendored copy (when build_digit_ui)"
+      ansible.builtin.file:
+        src: "{{ playbook_dir }}/../../digit-ui-esbuild"
+        dest: /opt/digit-ui-esbuild
+        state: link
+        force: yes
+      when:
+        - digit_ui_mode in ['static', 'hmr']
+        - ansible_system != 'Darwin'
+        - build_digit_ui | default(false)
 
 
   tasks:

--- a/local-setup/ansible/templates/nginx-site.conf.j2
+++ b/local-setup/ansible/templates/nginx-site.conf.j2
@@ -268,7 +268,12 @@ server {
     try_files $uri $uri/ /digit-ui/index.html;
     sub_filter_once on;
     sub_filter_types text/html;
-    sub_filter '</head>' '<script src="/digit-ui/globalConfigs.js"></script></head>';
+    # Inject globalConfigs.js + (optional) tenant theme tokens into <head>. Theme
+    # tokens override --color-primary-1 etc. defined in vendored digit-ui-css /
+    # overrides.css, so the SPA picks up tenant branding without touching the
+    # built CSS. Driven by host_vars `theme_primary_color` (dark) +
+    # `theme_primary_color_2` (light); omit either to keep DIGIT defaults.
+    sub_filter '</head>' '{% if theme_primary_color is defined %}<style>:root{--color-primary-1:{{ theme_primary_color }};{% if theme_primary_color_2 is defined %}--color-primary-2:{{ theme_primary_color_2 }};--color-button-primary-bg-default:{{ theme_primary_color_2 }};--color-button-primary-border:{{ theme_primary_color_2 }};--color-button-secondary-text:{{ theme_primary_color_2 }};--color-button-secondary-border:{{ theme_primary_color_2 }};--color-input-border-focus:{{ theme_primary_color_2 }};--color-link-default:{{ theme_primary_color_2 }};{% endif %}--color-button-primary-bg-hover:{{ theme_primary_color }};--color-link-hover:{{ theme_primary_color }};{% if theme_sidebar_selected_bg is defined %}--color-sidebar-selected-bg:{{ theme_sidebar_selected_bg }};{% endif %}}</style>{% endif %}<script src="/digit-ui/globalConfigs.js"></script></head>';
   }
   # Per-tenant boot config — overrides whatever was baked into the bundle.
   location = /digit-ui/globalConfigs.js {
@@ -312,6 +317,32 @@ server {
     client_max_body_size 25M;
     proxy_buffering off;
   }
+
+{% if nginx_features.minio_egov_rainmaker_alias | default(false) %}
+  # Legacy /egov-rainmaker/ MinIO passthrough. Used when egov-filestore
+  # signs presigned URLs with the public domain (MINIO_URL=https://<domain>)
+  # under the `egov-rainmaker` bucket instead of the internal minio:9000.
+  # Host is preserved so the AWS4 signature ($host) keeps validating.
+  # ^~ prefix beats the Kong catch-all below.
+  location ^~ /egov-rainmaker/ {
+    proxy_pass http://{{ nginx_upstream_host | default('127.0.0.1') }}:{{ upstream_minio_port | default(19000) }};
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_buffering off;
+    proxy_request_buffering off;
+    client_max_body_size 100m;
+    proxy_read_timeout 120s;
+  }
+{% endif %}
+
+{% if nginx_features.root_to_digit_ui | default(false) %}
+  # Bare domain -> citizen app login. Lands users in the digit-ui SPA
+  # instead of Kong's default response. Exact match (=), so the catch-all
+  # below still proxies everything else to Kong.
+  location = / { return 302 /digit-ui/citizen/login; }
+{% endif %}
 
   # API calls go to Kong directly.
   location / {

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -1712,6 +1712,10 @@ services:
         condition: service_healthy
     environment:
       NODE_ENV: ${NOVU_NODE_ENV:-local}
+      # Worker is the queue consumer for novu-api jobs; without API_ROOT_URL
+      # set it boots with `Missing environment variables: API_ROOT_URL` and
+      # exits 1 in a tight restart loop. Default targets the in-network API.
+      API_ROOT_URL: ${NOVU_API_ROOT_URL:-http://novu-api:3000}
       MONGO_URL: mongodb://${NOVU_MONGO_USERNAME:-root}:${NOVU_MONGO_PASSWORD:-secret}@novu-mongo:27017/novu-db?authSource=admin
       MONGO_MAX_POOL_SIZE: '500'
       REDIS_HOST: redis


### PR DESCRIPTION
## Summary

Four small fixes surfaced by a 4-cycle bomet reproducibility audit on a clean Linux VM. Each landed `./deploy.sh bomet` **failed=0** and narrowed the artifact diff vs the live bomet reference install.

### 1. Static-mode + `build_digit_ui:true` now actually serves vendored develop

`playbook-deploy.yml` line 67 clones `theflywheel/digit-ui-esbuild` whenever `digit_ui_mode in ['static','hmr']` — independent of `build_digit_ui`. With both flags set:
- Clone task puts theflywheel main at `/opt/digit-ui-esbuild`
- Static-mode \`npm install\` + \`esbuild.build.js\` run on that clone
- The vendored \`build_digit_ui\` output lands at \`/opt/ccrs/digit-ui-esbuild/build/\` and only gets tarred into the (later-stopped) digit-ui container
- Host nginx aliases \`/opt/digit-ui-esbuild/build/\` → serves theflywheel main

**Fix:** gate the clone on \`not build_digit_ui\`; add a symlink task pointing \`/opt/digit-ui-esbuild → /opt/ccrs/digit-ui-esbuild\` so static-mode tasks naturally operate on the vendored source.

### 2. Two new nginx template feature flags

- \`nginx_features.minio_egov_rainmaker_alias\` — legacy \`/egov-rainmaker/\` MinIO presigned-URL passthrough (preserves \`\$host\` so AWS4 signatures stay valid). Bomet uses this; the host-nginx render task comment explicitly flagged it as a template gap kept via \`nginx_preserve_vhost\`.
- \`nginx_features.root_to_digit_ui\` — bare-domain \`/\` → \`/digit-ui/citizen/login\`. Friendly default instead of Kong's bare response.

Both default off; flip per-tenant in host_vars.

### 3. Tenant theme overlay via sub_filter

The existing \`/digit-ui/\` sub_filter that injects \`globalConfigs.js\` into \`<head>\` now also injects a \`<style>:root{...}</style>\` block when \`theme_primary_color\` is defined. Sets \`--color-primary-1\` etc., overriding the green DIGIT defaults in \`digit-ui-css\` / \`overrides.css\`.

No build-time mutation; tenant branding becomes pure deploy-time config:
\`\`\`yaml
theme_primary_color:        \"#1565A8\"   # required
theme_primary_color_2:      \"#1B85D2\"   # optional (light shade for buttons / links)
theme_sidebar_selected_bg:  \"#E3F0FA\"   # optional
\`\`\`

### 4. \`novu-worker\` \`API_ROOT_URL\`

Worker block was missing \`API_ROOT_URL\`; upstream Novu image exits 1 in a tight restart loop with \`Missing environment variables: API_ROOT_URL\`. Added with default targeting in-network \`novu-api:3000\` (mirrors what \`novu-api\` already has).

## Validation

- ovh-cloud-dev fresh deploy: 4 cycles, all PLAY RECAP \`failed=0\`
- \`ui-index.html\` byte-identical to live bomet (vendored develop served, not theflywheel)
- \`/egov-rainmaker/foo\` → MinIO 404 (proxy reaches MinIO), \`/\` → 302 \`/digit-ui/citizen/login\`
- Served HTML at \`/digit-ui/\` contains \`#1565A8\`, \`#1B85D2\`, \`#E3F0FA\` — bomet's blue tokens
- Live bomet \`novu-worker\` recovered from restart loop after the same compose patch

## Test plan

- [x] Static-mode + \`build_digit_ui:true\` builds vendored, not theflywheel (verified: \`/opt/digit-ui-esbuild\` is a symlink; build/index.html matches vendored)
- [x] \`nginx_features.minio_egov_rainmaker_alias: true\` renders the proxy block (curl 404 from MinIO)
- [x] \`nginx_features.root_to_digit_ui: true\` renders the bare-domain redirect (curl 302)
- [x] \`theme_primary_color\` injects \`<style>\` block (curl HTML grep)
- [x] \`novu-worker\` starts and stays healthy with the new env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)