### PR TITLE
fix(pgr): dedup boundary dropdown options by code (#496)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/BoundaryComponent.js
+++ b/digit-ui-esbuild/products/pgr/src/components/BoundaryComponent.js
@@ -286,10 +286,20 @@ useEffect(() => {
 const BoundaryDropdown = ({ label, data, onChange, selected, fieldKey, disabled }) => {
   const { t } = useTranslation();
   const id = `boundary-${(fieldKey || label || "field").toString().toLowerCase().replace(/\s+/g, "-")}`;
-  const options = (data || []).map((node) => ({
-    value: node.code,
-    label: t(node.code) || node.code,
-  }));
+  // Defensive dedup by code. The jurisdiction prune (filterTree above)
+  // is duplicate-safe by construction, but in the field the dropdown
+  // has been observed listing the same ward twice (see
+  // egovernments/CCRS#496 screen recording — upstream data shape under
+  // overlapping HRMS jurisdictions, exact origin still being chased).
+  // Dedup at render keeps the symptom contained regardless of where
+  // the duplicate enters `data`.
+  const options = [];
+  const seen = new Set();
+  for (const node of data || []) {
+    if (seen.has(node.code)) continue;
+    seen.add(node.code);
+    options.push({ value: node.code, label: t(node.code) || node.code });
+  }
   return (
     <V2Field label={t(label)} required htmlFor={id}>
       <V2Select


### PR DESCRIPTION
## Summary

CSR boundary cascade has been observed listing the same ward twice in the dropdown — egovernments/CCRS#496 screen recording from the field.

The jurisdiction prune (\`filterTree\`, BoundaryComponent.js:65) is duplicate-safe by construction, so duplicates enter \`data\` further upstream (likely an interaction between overlapping HRMS jurisdictions and the per-level walk that feeds \`value[type]\`). Exact origin still being chased.

Dedup at render in \`BoundaryDropdown\` keeps the symptom contained regardless of where the duplicate enters \`data\` — a Set keyed on \`node.code\` drops repeats while preserving first-occurrence ordering.

## Validation

- ovh-cloud-dev rebuilt with the patch (\`./deploy.sh bomet\`, PLAY RECAP failed=0)
- esbuild build succeeded; SPA loads + boundary cascade renders without JS errors
- True end-to-end (an HRMS user with overlapping jurisdictions actually seeing duplicates → seeing none) hasn't been reproduced in this PR; the patch is contained enough to be safe to land while the upstream investigation continues

## Test plan

- [ ] CSR with overlapping HRMS jurisdictions sees each ward only once in the cascade
- [ ] CSR with single jurisdiction behavior unchanged
- [ ] Citizen path (no HRMS) behavior unchanged

Closes #496 (rendering symptom; deeper root cause to be addressed if the dedup masks an actionable upstream bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)