### PR TITLE
fix(configurator): write dept/designation localizations to rainmaker-common

### DIFF
--- a/configurator/src/api/services/localization.ts
+++ b/configurator/src/api/services/localization.ts
@@ -102,7 +102,7 @@ export const localizationService = {
       {
         code: `COMMON_MASTERS_DEPARTMENT_${code}`,
         message: name,
-        module: 'rainmaker-common-masters',
+        module: 'rainmaker-common',
         locale,
       },
     ];
@@ -119,7 +119,7 @@ export const localizationService = {
       {
         code: `COMMON_MASTERS_DESIGNATION_${code}`,
         message: name,
-        module: 'rainmaker-common-masters',
+        module: 'rainmaker-common',
         locale,
       },
     ];

--- a/local-setup/tests/e2e/specs/configurator/localization-modules.spec.ts
+++ b/local-setup/tests/e2e/specs/configurator/localization-modules.spec.ts
@@ -1,0 +1,161 @@
+/**
+ * Configurator localization module correctness.
+ *
+ * Regression test for egovernments/Citizen-Complaint-Resolution-System#636:
+ * buildDepartmentLocalizations() and buildDesignationLocalizations() were
+ * writing COMMON_MASTERS_DEPARTMENT_* and COMMON_MASTERS_DESIGNATION_* keys
+ * into module "rainmaker-common-masters". The DIGIT-UI loads
+ * "rainmaker-common" at startup (via StateInfo.localizationModules), not
+ * "rainmaker-common-masters" — so department and designation labels displayed
+ * as raw keys in employee screens.
+ *
+ * These tests verify that the localization API returns department/designation
+ * keys under the correct module ("rainmaker-common"), and that no keys leak
+ * into the incorrect module ("rainmaker-common-masters").
+ */
+
+import { test, expect } from '@playwright/test';
+import { getDigitToken } from '../../utils/auth';
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:18080';
+const TENANT = process.env.DIGIT_TENANT || 'pg';
+const ADMIN_USER = process.env.DIGIT_USERNAME || 'ADMIN';
+const ADMIN_PASS = process.env.DIGIT_PASSWORD || 'eGov@123';
+const LOCALE = 'en_IN';
+
+/** The module that StateInfo.localizationModules includes — the UI loads this. */
+const CORRECT_MODULE = 'rainmaker-common';
+/** The module that was used by mistake — the UI never loads this. */
+const WRONG_MODULE = 'rainmaker-common-masters';
+
+interface LocalizationMessage {
+  code: string;
+  message: string;
+  module: string;
+  locale: string;
+}
+
+async function searchLocalizations(
+  accessToken: string,
+  module: string,
+): Promise<LocalizationMessage[]> {
+  const url = `${BASE_URL}/localization/messages/v1/_search?locale=${LOCALE}&tenantId=${TENANT}&module=${module}`;
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      RequestInfo: { apiId: 'Rainmaker', authToken: accessToken },
+    }),
+  });
+  expect(resp.ok, `Localization search failed (${resp.status})`).toBe(true);
+  const data = await resp.json();
+  return (data.messages || []) as LocalizationMessage[];
+}
+
+test.describe('Configurator localization modules (#636)', () => {
+  let accessToken: string;
+
+  test.beforeAll(async () => {
+    const tokenResponse = await getDigitToken({
+      baseURL: BASE_URL,
+      tenant: TENANT,
+      username: ADMIN_USER,
+      password: ADMIN_PASS,
+    });
+    accessToken = tokenResponse.access_token;
+  });
+
+  test('department localizations are in rainmaker-common, not rainmaker-common-masters', async () => {
+    // Search the correct module for department keys
+    const correctMessages = await searchLocalizations(accessToken, CORRECT_MODULE);
+    const deptKeysInCorrect = correctMessages.filter((m) =>
+      m.code.startsWith('COMMON_MASTERS_DEPARTMENT_'),
+    );
+
+    test.info().annotations.push({
+      type: 'dept-keys-correct-module',
+      description: `Found ${deptKeysInCorrect.length} COMMON_MASTERS_DEPARTMENT_* keys in ${CORRECT_MODULE}`,
+    });
+
+    // There should be department keys in the correct module (seeded by bootstrap)
+    expect(
+      deptKeysInCorrect.length,
+      `Expected COMMON_MASTERS_DEPARTMENT_* keys in "${CORRECT_MODULE}" — ` +
+        'these are seeded during tenant bootstrap',
+    ).toBeGreaterThan(0);
+
+    // Search the WRONG module — it should have zero department keys
+    const wrongMessages = await searchLocalizations(accessToken, WRONG_MODULE);
+    const deptKeysInWrong = wrongMessages.filter((m) =>
+      m.code.startsWith('COMMON_MASTERS_DEPARTMENT_'),
+    );
+
+    test.info().annotations.push({
+      type: 'dept-keys-wrong-module',
+      description: `Found ${deptKeysInWrong.length} COMMON_MASTERS_DEPARTMENT_* keys in ${WRONG_MODULE}`,
+    });
+
+    expect(
+      deptKeysInWrong.length,
+      `COMMON_MASTERS_DEPARTMENT_* keys found in "${WRONG_MODULE}" — ` +
+        `these should be in "${CORRECT_MODULE}" instead (see #636)`,
+    ).toBe(0);
+  });
+
+  test('designation localizations are in rainmaker-common, not rainmaker-common-masters', async () => {
+    // Search the correct module for designation keys
+    const correctMessages = await searchLocalizations(accessToken, CORRECT_MODULE);
+    const desigKeysInCorrect = correctMessages.filter((m) =>
+      m.code.startsWith('COMMON_MASTERS_DESIGNATION_'),
+    );
+
+    test.info().annotations.push({
+      type: 'desig-keys-correct-module',
+      description: `Found ${desigKeysInCorrect.length} COMMON_MASTERS_DESIGNATION_* keys in ${CORRECT_MODULE}`,
+    });
+
+    expect(
+      desigKeysInCorrect.length,
+      `Expected COMMON_MASTERS_DESIGNATION_* keys in "${CORRECT_MODULE}" — ` +
+        'these are seeded during tenant bootstrap',
+    ).toBeGreaterThan(0);
+
+    // Search the WRONG module — it should have zero designation keys
+    const wrongMessages = await searchLocalizations(accessToken, WRONG_MODULE);
+    const desigKeysInWrong = wrongMessages.filter((m) =>
+      m.code.startsWith('COMMON_MASTERS_DESIGNATION_'),
+    );
+
+    test.info().annotations.push({
+      type: 'desig-keys-wrong-module',
+      description: `Found ${desigKeysInWrong.length} COMMON_MASTERS_DESIGNATION_* keys in ${WRONG_MODULE}`,
+    });
+
+    expect(
+      desigKeysInWrong.length,
+      `COMMON_MASTERS_DESIGNATION_* keys found in "${WRONG_MODULE}" — ` +
+        `these should be in "${CORRECT_MODULE}" instead (see #636)`,
+    ).toBe(0);
+  });
+
+  test('rainmaker-common-masters module has no localization data at all', async () => {
+    // This module should not exist in the localization system — any data here
+    // indicates a bug in one of the localization builders.
+    const wrongMessages = await searchLocalizations(accessToken, WRONG_MODULE);
+
+    test.info().annotations.push({
+      type: 'wrong-module-total',
+      description: `Total keys in ${WRONG_MODULE}: ${wrongMessages.length}`,
+    });
+
+    expect(
+      wrongMessages.length,
+      `Module "${WRONG_MODULE}" should have no localization data — ` +
+        `the UI loads "${CORRECT_MODULE}" via StateInfo.localizationModules. ` +
+        `Found ${wrongMessages.length} orphaned keys.`,
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Fix `buildDepartmentLocalizations()` and `buildDesignationLocalizations()` to write to module `rainmaker-common` instead of `rainmaker-common-masters`
- Add Playwright regression test suite under `local-setup/tests/e2e/specs/configurator/`

## Root Cause

The DIGIT-UI loads localization modules listed in `StateInfo.localizationModules` at startup. That list includes `rainmaker-common` but NOT `rainmaker-common-masters`. The configurator was writing department and designation keys to the wrong module, so the UI could never find them — they displayed as raw keys like `COMMON_MASTERS_DEPARTMENT_DEPT_1`.

## Changes

| File | Change |
|------|--------|
| `configurator/src/api/services/localization.ts` | `rainmaker-common-masters` → `rainmaker-common` in both builder functions |
| `local-setup/tests/e2e/specs/configurator/localization-modules.spec.ts` | New — 3 tests verifying keys are in correct module and absent from wrong module |

## Test plan

- [ ] Run `npx playwright test specs/configurator/localization-modules.spec.ts` against a bootstrapped tenant
- [ ] Verify department/designation labels render correctly in employee HRMS screens (no raw keys)
- [ ] Verify existing localizations written to the wrong module are re-upserted to the correct module on next configurator save

Fixes #636

🤖 Generated with [Claude Code](https://claude.com/claude-code)