### PR TITLE
fix(profile): null-safe validationConfig regex access in UserProfile (#445)

### DIFF
--- a/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Home/UserProfile.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Home/UserProfile.js
@@ -465,7 +465,7 @@ const UserProfile = ({ stateCode, userType, cityDetails }) => {
     // hid it because it wasn't bound to state. Mirror the sibling
     // handlers (`setUserNewPassword`, `setUserConfirmPassword`).
     setCurrentPassword(value);
-    if (!validationConfig?.password.test(value)) {
+    if (!validationConfig?.password?.test(value)) {
       setErrors({
         ...errors,
         currentPassword: {
@@ -480,7 +480,7 @@ const UserProfile = ({ stateCode, userType, cityDetails }) => {
 
   const setUserNewPassword = (value) => {
     setNewPassword(value);
-    if (!validationConfig?.password.test(value)) {
+    if (!validationConfig?.password?.test(value)) {
       setErrors({
         ...errors,
         newPassword: {
@@ -496,7 +496,7 @@ const UserProfile = ({ stateCode, userType, cityDetails }) => {
   const setUserConfirmPassword = (value) => {
     setConfirmPassword(value);
 
-    if (!validationConfig?.password.test(value)) {
+    if (!validationConfig?.password?.test(value)) {
       setErrors({
         ...errors,
         confirmPassword: {
@@ -528,14 +528,14 @@ const UserProfile = ({ stateCode, userType, cityDetails }) => {
         setName((prev) => prev.trim());
       }
 
-      if (!validationConfig?.name.test(name) || name === "" || name.length > 50 || name.length < 1) {
+      if (!validationConfig?.name?.test(name) || name === "" || name.length > 50 || name.length < 1) {
         throw JSON.stringify({
           type: "error",
           message: t("CORE_COMMON_PROFILE_NAME_INVALID"),
         });
       }
 
-      if (userType === "employee" && !validationConfig?.mobileNumber.test(mobileNumber)) {
+      if (userType === "employee" && !validationConfig?.mobileNumber?.test(mobileNumber)) {
         throw JSON.stringify({
           type: "error",
           message: t("CORE_COMMON_PROFILE_MOBILE_NUMBER_INVALID"),
@@ -572,7 +572,7 @@ const UserProfile = ({ stateCode, userType, cityDetails }) => {
           });
         }
 
-        if (!validationConfig?.password.test(trimmedNewPassword) && !validationConfig?.password.test(trimmedConfirmPassword)) {
+        if (!validationConfig?.password?.test(trimmedNewPassword) && !validationConfig?.password?.test(trimmedConfirmPassword)) {
           throw JSON.stringify({
             type: "error",
             message: t("CORE_COMMON_PROFILE_PASSWORD_INVALID"),


### PR DESCRIPTION
## Summary

Closes the **Edit Profile crash** half of #445 ("Edit Profile: Upload Profile Image feature not working").

When `validationConfig` is fetched asynchronously, or a tenant config omits a field (e.g. tenant ships a `name` regex but no `password` regex), the inner regex is undefined and
```js
validationConfig?.password.test(value)
```
throws `Cannot read properties of undefined (reading 'test')` on first keystroke / mount, taking the whole Edit Profile screen down.

Six call sites in `UserProfile.js` had the outer optional-chain but not the inner. This PR adds the inner `?.` so a missing regex returns `undefined` (and the surrounding `!` guard treats it as invalid input) instead of throwing.

## What changed

`digit-ui-esbuild/packages/modules/core/src/pages/citizen/Home/UserProfile.js` — 6 lines:

| Line | Before | After |
|---:|---|---|
| 468 | `validationConfig?.password.test(value)` | `validationConfig?.password?.test(value)` |
| 483 | `validationConfig?.password.test(value)` | `validationConfig?.password?.test(value)` |
| 499 | `validationConfig?.password.test(value)` | `validationConfig?.password?.test(value)` |
| 531 | `validationConfig?.name.test(name)` | `validationConfig?.name?.test(name)` |
| 538 | `validationConfig?.mobileNumber.test(mobileNumber)` | `validationConfig?.mobileNumber?.test(mobileNumber)` |
| 575 | `validationConfig?.password.test(trimmedNewPassword) && !validationConfig?.password.test(trimmedConfirmPassword)` | `validationConfig?.password?.test(trimmedNewPassword) && !validationConfig?.password?.test(trimmedConfirmPassword)` |

Lines 406 and 442 already had the inner `?.`; this PR brings the rest of the file to parity.

## Scope

This PR addresses the **crash** symptom (the screenshot in the issue where the page goes blank on edit). The **"Upload Profile Image not working"** symptom (file picker / preview) is *not* covered here — that lives in `UploadDrawer.js` and the `useUploadFiles` hook and will need a separate dig once we can reproduce on a tenant where the crash no longer masks it.

## Test plan

- [x] Patch verified green on local dev rebuild
- [ ] Confirm Edit Profile screen renders for both citizen & employee on a tenant where `validationConfig.password` is undefined (e.g. ke / bomet)
- [ ] Confirm Save still rejects invalid `name` / `mobileNumber` when the regex IS defined (no regression to validation behavior)
- [ ] Re-open issue if upload symptom remains after this fix lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)
