### PR TITLE
fix(configurator): accept Kenyan mobile with optional trunk-zero in fallback (#459 #471)

### DIFF
--- a/configurator/src/admin/hrms/useMobileValidator.ts
+++ b/configurator/src/admin/hrms/useMobileValidator.ts
@@ -10,15 +10,19 @@ export interface MobileRules {
 }
 
 // Kenya default — used when MDMS `ValidationConfigs.mobileNumberValidation`
-// is missing or unreadable. The canonical naipepea seed is `^[17][0-9]{8}$`
-// with min=max=9, matching the local subscriber number convention.
+// is missing or unreadable. Accept both the bare 9-digit subscriber number
+// (`712345678`) AND the everyday form prefixed with a trunk `0`
+// (`0712345678`) — Gurjeet's regression on #459/#471/#476 was hitting the
+// strict 9-digit fallback after typing the latter (correct local format).
+// Matches `phoneKE` in `src/admin/validation.ts` so all employee forms
+// share one accept-set.
 const FALLBACK: MobileRules = {
-  pattern: '^[17][0-9]{8}$',
+  pattern: '^0?[17][0-9]{8}$',
   minLength: 9,
-  maxLength: 9,
+  maxLength: 10,
   prefix: '+254',
   errorMessage:
-    'Please enter a valid Kenyan mobile number (9 digits starting with 1 or 7)',
+    'Please enter a valid Kenyan mobile number (9 digits starting with 1 or 7, optional leading 0)',
 };
 
 function parseRules(record: Record<string, unknown> | undefined): MobileRules {


### PR DESCRIPTION
## Summary

Unblocks Gurjeet's mobile-number rejection on **#459** and **#471** (both reported \"Unable to edit or create employee because mobile number is not validating even with correct format\"). This is also the surface contributor on #476's edit path.

## Root cause

MDMS \`ValidationConfigs.mobileNumberValidation\` is **not seeded** for tenant \`ke\` on naipepea / bomet. Verified directly:

\`\`\`
curl /mdms-v2/v2/_search?tenantId=ke
  ... ValidationConfigs.mobileNumberValidation → empty
  ... common-masters.UserValidation.mobile → pattern: \"^[6-9][0-9]{9}$\", prefix: \"+91\"  (legacy Indian seed)
\`\`\`

So \`useMobileValidator\` hits its FALLBACK constant, which previously was \`^[17][0-9]{8}$\` — **strict** 9 digits, no leading 0. Operators enter \`0712345678\` (everyday Kenyan trunk-zero form) → rejected.

## What changed

\`configurator/src/admin/hrms/useMobileValidator.ts\` — relax the FALLBACK to allow optional trunk zero, matching \`phoneKE\` in \`src/admin/validation.ts\`:

\`\`\`diff
- pattern: '^[17][0-9]{8}\$',
+ pattern: '^0?[17][0-9]{8}\$',
  minLength: 9,
- maxLength: 9,
+ maxLength: 10,
\`\`\`

Plus updated comment + error-message text to match.

When MDMS DOES provide a rule (\`parseRules\` path), behavior is unchanged — this only affects the fallback that fires today on every Kenya tenant.

## Scope

This PR fixes the **frontend** form-acceptance side. The MDMS seed for \`ValidationConfigs.mobileNumberValidation\` is a separate follow-up (MCP / tenant_bootstrap) so the citizen UI gets the same rule path instead of leaning on the legacy \`common-masters.UserValidation.mobile\` Indian seed.

#476's backend NPE half (\`Assignment.getAuditDetails() returning null\`) is also separate; that lives in egov-hrms.

## Test plan

- [ ] Configurator → Create Employee → enter \`0712345678\` → accepted, can submit
- [ ] Same, enter \`712345678\` → still accepted (backwards-compat with bare-9 form)
- [ ] Same, enter \`9876543210\` (Indian-style) → still rejected
- [ ] Same, enter \`07123\` → rejected (too short)
- [ ] Edit existing employee with bare-9 stored mobile → form pre-fills + edits accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

