### PR TITLE
fix(configurator): postal-code validator on complaint forms (#478 — postal half)

### DIFF
--- a/configurator/src/admin/validation.ts
+++ b/configurator/src/admin/validation.ts
@@ -45,6 +45,17 @@ export const phoneKE = raRegex(
   'Enter a valid Kenyan mobile starting with 7 or 1 (e.g. 712345678)',
 );
 
+/**
+ * Kenya postal code: 5 digits (e.g. `00100` Nairobi GPO). The form is
+ * optional in the complaint create flow, but if the operator types
+ * anything it has to be the right shape — Gurjeet's #478 retest flagged
+ * "random pincode accepted" because there was no validator wired.
+ */
+export const postalCodeKE = raRegex(
+  /^[0-9]{5}$/,
+  'Enter a valid 5-digit postal code (e.g. 00100)',
+);
+
 export const code = raRegex(
   /^[A-Za-z0-9][A-Za-z0-9_.\-/]*$/,
   'Use letters, numbers, underscores, dots, hyphens, or slashes',

--- a/configurator/src/resources/complaints/ComplaintCreate.tsx
+++ b/configurator/src/resources/complaints/ComplaintCreate.tsx
@@ -51,7 +51,7 @@ export function ComplaintCreate() {
             help="Cascades from hierarchy → boundary type → locality."
           />
           <DigitFormInput source="address.landmark" label="Landmark" />
-          <DigitFormInput source="address.pincode" label="Pincode" />
+          <DigitFormInput source="address.pincode" label="Pincode" validate={v.postalCodeKE} />
         </div>
       </FieldSection>
 

--- a/configurator/src/resources/complaints/ComplaintEdit.tsx
+++ b/configurator/src/resources/complaints/ComplaintEdit.tsx
@@ -1,4 +1,4 @@
-import { DigitEdit, DigitFormInput, DigitFormSelect, WorkflowActionSelect } from '@/admin';
+import { DigitEdit, DigitFormInput, DigitFormSelect, WorkflowActionSelect, v } from '@/admin';
 import { FieldSection } from '@/admin/fields';
 import { LocalityPicker } from './LocalityPicker';
 
@@ -61,7 +61,7 @@ export function ComplaintEdit() {
         <div className="space-y-4">
           <LocalityPicker source="address.locality.code" label="Locality" />
           <DigitFormInput source="address.landmark" label="Landmark" />
-          <DigitFormInput source="address.pincode" label="Pincode" />
+          <DigitFormInput source="address.pincode" label="Pincode" validate={v.postalCodeKE} />
           <DigitFormInput source="address.street" label="Street" />
         </div>
       </FieldSection>


### PR DESCRIPTION
## Summary

Half of the original #478 fix bundle, split per one-concern-per-PR. The other half (LocalityPicker leaf-only filter) is now in **#680**.

Closes Gurjeet's *"user is able to create complaint with random pincode"* point on his 2026-05-19 retest of #478.

## What changed

`configurator/src/admin/validation.ts` — new exported validator:
```ts
export const postalCodeKE = raRegex(
  /^[0-9]{5}$/,
  'Enter a valid 5-digit postal code (e.g. 00100)',
);
```

`configurator/src/resources/complaints/ComplaintCreate.tsx` + `ComplaintEdit.tsx` — wire `validate={v.postalCodeKE}` to `address.pincode`. Stays optional (empty passes); only shape-checks when filled.

## Scope / out-of-scope

- Kenya-specific pattern by name — matches what `useMobileValidator` already does for mobile in the same codebase. A future tenant-pluggable form (sourcing from MDMS `ValidationConfigs.postalCodeValidation` or similar) is the right next step; explicitly out of scope here.
- LocalityPicker leaf-only enforcement — split out to **#680** so it can land/iterate on its own (it's a UX change that affects every tenant, not just Nairobi).

## Test plan

- [ ] Configurator → Complaints → Create → enter pincode `00100` → accepted
- [ ] Same form, enter pincode `12abc` → validation error shown
- [ ] Same form, leave pincode blank → form submits (optional field)
- [ ] ComplaintEdit also rejects malformed pincode on save

🤖 Generated with [Claude Code](https://claude.com/claude-code)