### PR TITLE
fix(pgr): seed RAINMAKER-PGR.EscalationConfig so auto-escalate actually fires (#585)

### DIFF
--- a/ansible/nairobi-mdms/mdms/RAINMAKER-PGR/EscalationConfig.json
+++ b/ansible/nairobi-mdms/mdms/RAINMAKER-PGR/EscalationConfig.json
@@ -1,0 +1,14 @@
+[
+  {
+    "tenantId": "ke",
+    "data": {
+      "maxDepth": 3,
+      "defaultSlaByLevel": [
+        3600000,
+        14400000,
+        86400000
+      ],
+      "overrides": {}
+    }
+  }
+]

--- a/utilities/default-data-handler/src/main/resources/mdmsData-dev/RAINMAKER-PGR/RAINMAKER-PGR.EscalationConfig.json
+++ b/utilities/default-data-handler/src/main/resources/mdmsData-dev/RAINMAKER-PGR/RAINMAKER-PGR.EscalationConfig.json
@@ -1,0 +1,11 @@
+[
+  {
+    "maxDepth": 3,
+    "defaultSlaByLevel": [
+      3600000,
+      14400000,
+      86400000
+    ],
+    "overrides": {}
+  }
+]

--- a/utilities/default-data-handler/src/main/resources/schema/RAINMAKER-PGR.json
+++ b/utilities/default-data-handler/src/main/resources/schema/RAINMAKER-PGR.json
@@ -75,5 +75,46 @@
       "x-ref-schema": [],
       "additionalProperties": false
     }
+  },
+  {
+    "tenantId": "{tenantid}",
+    "code": "RAINMAKER-PGR.EscalationConfig",
+    "description": "Per-tenant auto-escalation config consumed by pgr-services EscalationScheduler. `defaultSlaByLevel` is an array of SLA windows in MILLISECONDS, one per escalation depth (level 0 = first scan); `overrides` keys by serviceCode for per-complaint-type SLA arrays; `maxDepth` caps how many times a single complaint can be auto-escalated before stopping. Without this record pgr-services falls back to its 5-day default SLA — see https://github.com/egovernments/Citizen-Complaint-Resolution-System/issues/585.",
+    "isActive": true,
+    "definition": {
+      "type": "object",
+      "title": "Generated schema for Root",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "required": [
+        "maxDepth",
+        "defaultSlaByLevel"
+      ],
+      "x-unique": [
+        "maxDepth"
+      ],
+      "properties": {
+        "maxDepth": {
+          "type": "number"
+        },
+        "defaultSlaByLevel": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 1
+        },
+        "overrides": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      "x-ref-schema": [],
+      "additionalProperties": false
+    }
   }
 ]


### PR DESCRIPTION
## Summary

Closes #585 ("CMS: auto escalate not working").

## Root cause

PGR's `EscalationScheduler` is **already running and correctly wired**:
- Master switch (`pgr.escalation.enabled`) defaults to `true`.
- Scheduler scans every 5 min and walks complaints in `PENDINGFORASSIGNMENT` + `PENDINGATLME`.
- The PGR `BusinessService` has the `ASSIGNEDBYAUTOESCALATION` transition out of `PENDINGFORASSIGNMENT` and grants it to the `AUTO_ESCALATE` role.

The reason Gurjeet's 4-hour wait never escalated is that `RAINMAKER-PGR.EscalationConfig` is **not seeded** on naipepea — verified live:
\`\`\`
GET /egov-mdms-service/v1/_search { module=RAINMAKER-PGR, master=EscalationConfig }
→ { "MdmsRes": {} }
\`\`\`

Without that record, `EscalationScheduler.resolveSla()` falls back to `pgr.escalation.default.sla.ms` = `432_000_000 ms` = **5 days**. A complaint sitting for 4 hours is nowhere near breach, so the scheduler skips it silently. From the operator's view that looks identical to "auto-escalation is broken."

## What changed

Two seed files plus a schema entry:

1. **\`ansible/nairobi-mdms/mdms/RAINMAKER-PGR/EscalationConfig.json\`** — tenant \`ke\`, 3-tier ladder. This is the file the playbook pushes to live MDMS on naipepea/bomet deploy.

2. **\`utilities/default-data-handler/src/main/resources/mdmsData-dev/RAINMAKER-PGR/RAINMAKER-PGR.EscalationConfig.json\`** + the schema entry in **\`RAINMAKER-PGR.json\`** so fresh installs (Maputo / future tenants) get the same default instead of inheriting the 5-day fallback.

Values:
| key | value | meaning |
|---|---|---|
| \`maxDepth\` | \`3\` | a single complaint can climb at most three tiers before the scheduler stops trying |
| \`defaultSlaByLevel\` | \`[3_600_000, 14_400_000, 86_400_000]\` | 1h → 4h → 24h windows |
| \`overrides\` | \`{}\` | no per-serviceCode override yet; can be added from the configurator once Nairobi product confirms per-type windows |

## Out of scope (separate follow-ups)

- **Polling jitter.** \`pgr.escalation.interval.ms\` defaults to **300_000** (5 min), so a complaint hitting the 1h mark can take up to 5 extra minutes to actually escalate. Tightening it is a service-config tweak (naipepea host_vars), not an MDMS seed.
- **Per-service overrides.** Once Nairobi product decides which complaint types deserve faster/slower SLAs (e.g. \`BROKEN_STREET_LIGHT\` vs \`SOLID_WASTE\`), populate the \`overrides\` map.
- **Backend cron for auto-close on RESOLVED→CLOSED.** The im-services autoescalation entry handles Incident CLOSE; PGR has no equivalent for RESOLVED→CLOSED yet — separate issue if/when that surfaces.

## Test plan

- [ ] Apply seed via playbook on naipepea (or push to MDMS via configurator → Auto Escalation), then file a complaint at TT+0
- [ ] Wait 1h + 5min (one scheduler tick after SLA breach)
- [ ] Confirm complaint flipped from PENDINGFORASSIGNMENT → PENDINGATLME with assignee from \`escalationService.getCurrentAssignees\` (likely an LME assigned via boundary jurisdiction)
- [ ] Verify pgr-services log: \`Escalation scan complete: scanned=N, escalated=1\`
- [ ] Fresh tenant install picks up the seed via default-data-handler — `/mdms-v2/.../EscalationConfig` non-empty post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
