### PR TITLE
feat(mdms): seed ValidationConfigs.mobileNumberValidation with Kenya rule

### DIFF
--- a/ansible/nairobi-mdms/mdms/ValidationConfigs/mobileNumberValidation.json
+++ b/ansible/nairobi-mdms/mdms/ValidationConfigs/mobileNumberValidation.json
@@ -1,0 +1,16 @@
+[
+  {
+    "tenantId": "ke",
+    "data": {
+      "validationName": "defaultMobileValidation",
+      "rules": {
+        "pattern": "^0?[17][0-9]{8}$",
+        "minLength": 9,
+        "maxLength": 10,
+        "prefix": "+254",
+        "allowedStartingDigits": ["1", "7"],
+        "errorMessage": "Please enter a valid Kenyan mobile number (9 digits starting with 1 or 7, optional leading 0)"
+      }
+    }
+  }
+]

--- a/utilities/default-data-handler/src/main/resources/mdmsData-dev/ValidationConfigs/ValidationConfigs.mobileNumberValidation.json
+++ b/utilities/default-data-handler/src/main/resources/mdmsData-dev/ValidationConfigs/ValidationConfigs.mobileNumberValidation.json
@@ -1,0 +1,13 @@
+[
+  {
+    "validationName": "defaultMobileValidation",
+    "rules": {
+      "pattern": "^0?[17][0-9]{8}$",
+      "minLength": 9,
+      "maxLength": 10,
+      "prefix": "+254",
+      "allowedStartingDigits": ["1", "7"],
+      "errorMessage": "Please enter a valid Kenyan mobile number (9 digits starting with 1 or 7, optional leading 0)"
+    }
+  }
+]

--- a/utilities/default-data-handler/src/main/resources/mdmsData/ValidationConfigs/ValidationConfigs.mobileNumberValidation.json
+++ b/utilities/default-data-handler/src/main/resources/mdmsData/ValidationConfigs/ValidationConfigs.mobileNumberValidation.json
@@ -1,0 +1,13 @@
+[
+  {
+    "validationName": "defaultMobileValidation",
+    "rules": {
+      "pattern": "^0?[17][0-9]{8}$",
+      "minLength": 9,
+      "maxLength": 10,
+      "prefix": "+254",
+      "allowedStartingDigits": ["1", "7"],
+      "errorMessage": "Please enter a valid Kenyan mobile number (9 digits starting with 1 or 7, optional leading 0)"
+    }
+  }
+]

--- a/utilities/default-data-handler/src/main/resources/schema/ValidationConfigs.json
+++ b/utilities/default-data-handler/src/main/resources/schema/ValidationConfigs.json
@@ -1,0 +1,57 @@
+[
+  {
+    "tenantId": "{tenantid}",
+    "code": "ValidationConfigs.mobileNumberValidation",
+    "description": "Per-tenant mobile number validation rule consumed by both the citizen UI's useMobileValidation hook (priority 2 above globalConfigs / below the hardcoded India default) and the configurator's useMobileValidator (priority 1 above its in-code FALLBACK). `validationName: defaultMobileValidation` is the lookup key both consumers use. Seeding this avoids leaning on tenant-specific hardcoded fallbacks in code — see feedback_holistic_fixes_no_deployment_specificity.",
+    "isActive": true,
+    "definition": {
+      "type": "object",
+      "title": "Generated schema for Root",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "required": [
+        "validationName",
+        "rules"
+      ],
+      "x-unique": [
+        "validationName"
+      ],
+      "properties": {
+        "validationName": {
+          "type": "string"
+        },
+        "rules": {
+          "type": "object",
+          "required": [
+            "pattern"
+          ],
+          "properties": {
+            "pattern": {
+              "type": "string"
+            },
+            "minLength": {
+              "type": "number"
+            },
+            "maxLength": {
+              "type": "number"
+            },
+            "prefix": {
+              "type": "string"
+            },
+            "allowedStartingDigits": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "errorMessage": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "x-ref-schema": [],
+      "additionalProperties": false
+    }
+  }
+]


### PR DESCRIPTION
## Summary

Follow-up to **#674** that closes the loop on the holistic-fix principle (see `feedback_holistic_fixes_no_deployment_specificity` memory). #674 loosened the configurator's in-code Kenya FALLBACK so operators could enter `0712345678`; this PR seeds the proper MDMS rule so the FALLBACK becomes a true defensive last-resort instead of the actual runtime rule.

## What this seeds

Three copies of the same Kenya rule (pattern `^0?[17][0-9]{8}$`, min=9, max=10, prefix +254):

- **`ansible/nairobi-mdms/mdms/ValidationConfigs/mobileNumberValidation.json`** — tenant `ke`, picked up by the playbook's MDMS push to naipepea / bomet on the next deploy.
- **`utilities/default-data-handler/.../mdmsData/ValidationConfigs/...`** + **`mdmsData-dev/ValidationConfigs/...`** — tenant-less default, so fresh installs (Maputo before its own override / future tenants) start with the Kenya rule instead of inheriting the legacy India default baked into `packages/libraries/src/constants/mobileValidation.js`.
- **`utilities/default-data-handler/.../schema/ValidationConfigs.json`** — new schema definition for the `mobileNumberValidation` master so MDMS v2 accepts the records.

## Consumers (already in place, no code change here)

Both already query this exact module/master:

1. **citizen UI** — `digit-ui-esbuild/products/pgr/src/hooks/pgr/useMobileValidation.js`  
   priority: globalConfigs > MDMS > in-code default.

2. **configurator** — `configurator/src/admin/hrms/useMobileValidator.ts`  
   priority: MDMS > in-code FALLBACK.

With this seed live, neither consumer falls through to the in-code constant on any tenant. PR #674's relaxed FALLBACK remains as defensive cover for genuinely broken MDMS reads.

## Non-Kenya tenants

Maputo and any future non-KE tenant override this by upserting their own record at their own tenantId — the in-code defaults are no longer their concern.

## Test plan

- [ ] After deploy: `curl /egov-mdms-service/v1/_search { module=ValidationConfigs, master=mobileNumberValidation }` returns the Kenya record (not empty)
- [ ] Configurator → Create Employee → enter `0712345678` → accepted, no FALLBACK in play (verify via browser devtools: the rules come from MDMS, not the constant)
- [ ] Citizen profile mobile field uses the same Kenya rule (no longer hitting `^[6-9]{10}$` Indian default from `mobileValidation.js`)
- [ ] Fresh \`./deploy.sh maputo\` (or similar non-KE) deploy lands the same Kenya seed by default; if Maputo product wants a different rule, they upsert at \`tenantId=pg\` (this PR doesn't lock anyone in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
