### PR TITLE
fix(profile): refresh citizen sidebar avatar after Edit Profile save (#556)

### DIFF
--- a/digit-ui-esbuild/packages/modules/core/src/components/TopBarSideBar/SideBar/CitizenSideBar.js
+++ b/digit-ui-esbuild/packages/modules/core/src/components/TopBarSideBar/SideBar/CitizenSideBar.js
@@ -11,19 +11,37 @@ import { LogoutIcon } from "@egovernments/digit-ui-react-components";
 import ImageComponent from "../../ImageComponent";
 
 const Profile = ({ info, stateName, t }) => {
-  const [profilePic, setProfilePic] = React.useState(null);
-  React.useEffect(async () => {
-    const tenant = Digit.ULBService.getCurrentTenantId();
+  // Prefer the session-cached photo so an in-place Edit-Profile save
+  // shows up immediately — UserProfile.js writes the new value into
+  // `Digit.UserService.getUser().info.photo` after a successful
+  // update (CCRS#556 sub-bug pair fix). Fall back to the per-uuid
+  // userSearch lookup only if the session doesn't already carry one
+  // (e.g. on first login).
+  const [profilePic, setProfilePic] = React.useState(
+    info?.photo ? info.photo.split(",").at(0) : null,
+  );
+  React.useEffect(() => {
+    if (info?.photo) {
+      setProfilePic(info.photo.split(",").at(0));
+      return;
+    }
     const uuid = info?.uuid;
-    if (uuid) {
+    if (!uuid) return;
+    let cancelled = false;
+    (async () => {
+      const tenant = Digit.ULBService.getCurrentTenantId();
       const usersResponse = await Digit.UserService.userSearch(tenant, { uuid: [uuid] }, {});
-      if (usersResponse && usersResponse.user && usersResponse?.user?.length) {
+      if (cancelled) return;
+      if (usersResponse?.user?.length) {
         const userDetails = usersResponse.user[0];
         const thumbs = userDetails?.photo?.split(",");
         setProfilePic(thumbs?.at(0));
       }
-    }
-  }, [profilePic !== null]);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [info?.uuid, info?.photo]);
 
   const CustomEmployeeTopBar = Digit.ComponentRegistryService?.getComponent("CustomEmployeeTopBar");
 

--- a/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Home/UserProfile.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Home/UserProfile.js
@@ -647,6 +647,14 @@ const UserProfile = ({ stateCode, userType, cityDetails }) => {
         const user = Digit.UserService.getUser();
 
         if (user) {
+          // CCRS#556 sub-bug: the photo was previously omitted from
+          // the session-info patch. The backend got the new pic via
+          // the update payload above, but the session-cached user
+          // object stayed stale — which meant the left-menu avatar
+          // (CitizenSideBar's Profile component reads from
+          // Digit.UserService.getUser()) kept showing the old image
+          // until the next full login. Include `photo` here so the
+          // session reflects what the server just persisted.
           Digit.UserService.setUser({
             ...user,
             info: {
@@ -655,6 +663,7 @@ const UserProfile = ({ stateCode, userType, cityDetails }) => {
               mobileNumber,
               emailId: email,
               permanentCity: city,
+              ...(profilePic ? { photo: profilePic } : {}),
             },
           });
         }


### PR DESCRIPTION
## Summary

Closes Gurjeet's remaining #556 sub-bug: *"Profile image is uploaded but its not displayed in citizen left menu"* (2026-05-20 retest after the Edit-save half was confirmed RESOLVED).

## Root cause — two-layer bug

### Layer 1: `UserProfile.js` setUser patch omitted `photo`

The post-save handler refreshes the session-cached user object, but only with name / mobileNumber / emailId / permanentCity:

```js
Digit.UserService.setUser({
  ...user,
  info: {
    ...user.info,
    name, mobileNumber, emailId, permanentCity,
    // photo NOT here
  },
});
```

The backend got the new photo via the `_update` payload, but the in-memory session stayed stale. Sidebar — which reads `Digit.UserService.getUser().info` — kept showing the old picture until a full re-login.

### Layer 2: `CitizenSideBar` Profile useEffect dep was misshaped

```js
const [profilePic, setProfilePic] = React.useState(null);
React.useEffect(async () => {
  // ... userSearch + setProfilePic ...
}, [profilePic !== null]);
```

The dep `[profilePic !== null]` evaluates to a boolean. It flips `false → true` once on first fetch and then stays put — so after the initial userSearch the effect never runs again, even if the underlying user info changes. The effect also always fired a userSearch on mount, ignoring whatever the session already had.

## Fix

**`UserProfile.js`** — include the photo in the post-save session patch:

```js
Digit.UserService.setUser({
  ...user,
  info: {
    ...user.info, name, mobileNumber, emailId, permanentCity,
    ...(profilePic ? { photo: profilePic } : {}),
  },
});
```

**`CitizenSideBar.js` Profile** — rewrite so:
- State seeds from `info.photo` if present (session is source of truth).
- Effect uses session value first; falls back to userSearch only when `info.photo` is missing (e.g. first login).
- Deps are `[info?.uuid, info?.photo]` so the next save propagates immediately.
- Guard against the fire-and-forget async overwriting state after unmount (cancellation flag).

## Out of scope

- Employee-side avatar refresh — that path doesn't use `CitizenSideBar`. If Gurjeet sees the same staleness on /employee, that's a separate TopBar component and a separate ticket.
- The legacy non-Individual update branch (`Digit.UserService.updateUser`) also routes through the same setUser patch, so the photo fix covers it too.

## Test plan (for QA on a deployable env)

- [ ] Citizen login → Edit Profile → upload a new image → Save → left-menu avatar updates **without** logging out and back in
- [ ] Same flow but with name/mobile changes only (no new image) → no regression to existing fields
- [ ] First-time login of a user who has a photo from server-side seeding → avatar appears via the userSearch fallback path
- [ ] First-time login of a user with no photo → defaultImage shown, no broken userSearch call left in flight when navigating away

🤖 Generated with [Claude Code](https://claude.com/claude-code)