### PR TITLE
fix(pgr): tenant-aware length on employee complaint phone field (#447 item 3)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
+++ b/digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
@@ -16,15 +16,36 @@ export const CreateComplaintConfig = {
               populators: {
                 name: "ComplainantContactNumber",
                 error: "CORE_COMMON_MOBILE_ERROR",
-                // componentInFront: "+91",
-                // prefix:"+91",
+                // Length is tenant-specific (Kenya = 9, India = 10, …).
+                // Source from globalConfigs `CORE_MOBILE_CONFIGS`, same
+                // key the central `useMobileValidation` hook reads
+                // (`mobileNumberLength`), so the field, the form's
+                // submit-time check, and the citizen UI all agree on
+                // one number per deployment. Falls back to the legacy
+                // hardcoded India value when the host hasn't set one.
+                // Getters re-evaluate on every read so a tenant switch
+                // mid-session picks up the new globalConfigs value.
+                get maxLength() {
+                  return (
+                    window?.globalConfigs?.getConfig?.("CORE_MOBILE_CONFIGS")
+                      ?.mobileNumberLength || 10
+                  );
+                },
                 validation: {
                   required: true,
-                  // minLength: 10,
-                  // maxLength: 10,
-                  // min: 6000000000,
-                  // max: 9999999999
-                }, // 10-digit phone number validation
+                  get minLength() {
+                    return (
+                      window?.globalConfigs?.getConfig?.("CORE_MOBILE_CONFIGS")
+                        ?.mobileNumberLength || 10
+                    );
+                  },
+                  get maxLength() {
+                    return (
+                      window?.globalConfigs?.getConfig?.("CORE_MOBILE_CONFIGS")
+                        ?.mobileNumberLength || 10
+                    );
+                  },
+                },
               },
             },
             {


### PR DESCRIPTION
## Summary

Closes Gurjeet's last remaining #447 sub-bug: *"Complainant Phone Number field currently allows 10 digits, whereas it should be 9 digits… restrict the text field to 9 digit length."* All other items (1, 2, 4–9) were confirmed RESOLVED in his 2026-05-20 retest.

## Root cause

`CreateComplaintConfig.js` had the phone validation commented out:
\`\`\`js
validation: {
  required: true,
  // minLength: 10,
  // maxLength: 10,
  // ...
}, // 10-digit phone number validation
\`\`\`

So `validatePhoneNumber` (in createComplaintForm.js:55-69) silently accepted any length, and the underlying `MobileNumber` atom (MobileNumber.js:9) defaulted its slice cap to 10. On a Kenya tenant the operator could type a 10-digit number that then mismatched what the citizen stored in HRMS (9-digit `^[17][0-9]{8}$`).

## Fix — holistic, host-config-driven

Source the length from \`globalConfigs.CORE_MOBILE_CONFIGS.mobileNumberLength\` — the same key the central \`Digit.Hooks.pgr.useMobileValidation\` hook reads (see [useMobileValidation.js:91,96](https://github.com/egovernments/Citizen-Complaint-Resolution-System/blob/develop/digit-ui-esbuild/products/pgr/src/hooks/pgr/useMobileValidation.js#L91-L96)). All three consumers — field-level \`maxLength\` on the input, submit-time check in \`validatePhoneNumber\`, and the central hook elsewhere — now share **one number per deployment**.

Falls back to the legacy hardcoded \`10\` when the host hasn't set one, preserving India behavior with zero code change required for non-Kenya callers.

Tenants override by setting \`mobileNumberLength: 9\` in their globalConfigs.js — already the established host-side mechanism for mobile prefix / pattern overrides (see [MobileNumber.js:19-21](https://github.com/egovernments/Citizen-Complaint-Resolution-System/blob/develop/digit-ui-esbuild/packages/react-components/src/atoms/MobileNumber.js#L19-L21)).

Getters re-evaluate on every read so a tenant switch mid-session picks up the new globalConfigs value without re-importing the config module.

## What deploy needs

For the **Kenya / Nai Pepea / bomet** rollout, the host-side globalConfigs.js wants:

\`\`\`js
window.globalConfigs.CORE_MOBILE_CONFIGS = {
  mobilePrefix: "+254",
  mobileNumberLength: 9,
  // …existing keys
};
\`\`\`

This already maps to the same shape \`useMobileValidation\` consumes; no schema change. If your globalConfigs.js doesn't yet have a \`CORE_MOBILE_CONFIGS\` entry the field will keep behaving like before (length 10).

## Test plan

- [ ] Kenya tenant globalConfigs has \`mobileNumberLength: 9\` → employee complaint create phone field caps input at 9 chars; submit with 8 chars shows error; submit with 9 chars passes through
- [ ] India / default tenant (no globalConfigs override) → still caps at 10, no regression
- [ ] Citizen UI on same tenant uses same length (because both consumers read the same key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)