### PR TITLE
fix(configurator): restrict LocalityPicker to LEAF boundary types only (#478 — leaf half)

### DIFF
--- a/configurator/src/resources/complaints/LocalityPicker.tsx
+++ b/configurator/src/resources/complaints/LocalityPicker.tsx
@@ -75,19 +75,36 @@ export function LocalityPicker({
     return hierarchies.map((h) => ({ value: h.hierarchyType, label: h.hierarchyType }));
   }, [hierarchies]);
 
+  // Only expose the LEAF boundary type(s) per hierarchy — types that
+  // aren't anyone's `parentBoundaryType` within the same hierarchy.
+  // Gurjeet's #478 retest showed operators filing complaints at
+  // "Nairobi City County" (root), which the PGR backend will route to
+  // no ward and the resolver UI then can't show a sane assignment
+  // surface. The original digit-ui side enforced this with
+  // `isBoundaryLeaf` at submit; mirror that constraint here at the
+  // picker so the operator is structurally prevented from choosing a
+  // non-leaf rather than seeing a late toast.
   const boundaryTypesByHierarchy = useMemo(() => {
     const map = new Map<string, string[]>();
     if (!hierarchies) return map;
     for (const h of hierarchies) {
-      const seen = new Set<string>();
-      const types: string[] = [];
-      for (const lvl of h.boundaryHierarchy ?? []) {
-        if (!lvl || lvl.active === false) continue;
-        if (!lvl.boundaryType || seen.has(lvl.boundaryType)) continue;
-        seen.add(lvl.boundaryType);
-        types.push(lvl.boundaryType);
+      const levels = (h.boundaryHierarchy ?? []).filter(
+        (lvl): lvl is HierarchyLevel => !!lvl && lvl.active !== false && !!lvl.boundaryType,
+      );
+      const parents = new Set<string>();
+      for (const lvl of levels) {
+        if (lvl.parentBoundaryType) parents.add(lvl.parentBoundaryType);
       }
-      map.set(h.hierarchyType, types);
+      const seen = new Set<string>();
+      const leafTypes: string[] = [];
+      for (const lvl of levels) {
+        // Leaf = not the parent of anything else in this hierarchy.
+        if (parents.has(lvl.boundaryType)) continue;
+        if (seen.has(lvl.boundaryType)) continue;
+        seen.add(lvl.boundaryType);
+        leafTypes.push(lvl.boundaryType);
+      }
+      map.set(h.hierarchyType, leafTypes);
     }
     return map;
   }, [hierarchies]);


### PR DESCRIPTION
## Summary

Companion half to **#675**. Original #478 retest had two distinct items; splitting per the one-concern-per-PR principle so each can land/iterate independently.

Closes Gurjeet's *"user is able to create complaint at Nairobi City County level"* point on his 2026-05-19 retest of #478.

## What changed

`configurator/src/resources/complaints/LocalityPicker.tsx` — filter the boundary-type select to **leaf** types per hierarchy (types that aren't anyone's `parentBoundaryType` within the same hierarchy).

On Nairobi (ADMIN: County → Sub-County → Ward → Locality) only Locality remains in the type select; the operator is structurally prevented from selecting a non-leaf rather than seeing a late toast. Mirrors the digit-ui-side `isBoundaryLeaf` rule already enforced for citizens.

## UX impact + why this is split

This change affects **every** hierarchy in **every** tenant — anywhere `LocalityPicker` is used, only leaf boundaries become selectable. That's the intended behavior (PGR complaints have to route to a ward to assign), but it's a meaningful UX change worth landing on its own merits rather than bundled with the postal-code fix.

If a tenant has a hierarchy where higher-level filing makes sense, this PR is the wrong shape and we'd need a configurable "allow non-leaf" prop on the picker. Open to that direction.

## Out of scope

- Backend enforcement. PGR-services itself currently accepts a complaint with a non-leaf `locality.code`, so an API-direct caller can still file at County level. Separate service-layer guard worth opening if that ever surfaces.

## Test plan

- [ ] Configurator → Complaints → Create → Locality cascade: pick ADMIN hierarchy → Boundary Type select only shows Locality (not County / Sub-County / Ward)
- [ ] Existing complaint loaded for Edit at a non-leaf boundary (legacy data) → form still mounts cleanly, but operator can't switch the type to a non-leaf
- [ ] Tenant with a flat hierarchy (single boundaryType, no parents) → that one type still appears as a leaf

🤖 Generated with [Claude Code](https://claude.com/claude-code)