### PR TITLE
fix(deploy): cap Node heap in configurator-build.sh to dodge OOM on low-RAM boxes

### DIFF
--- a/local-setup/ansible/files/configurator-build.sh
+++ b/local-setup/ansible/files/configurator-build.sh
@@ -55,7 +55,13 @@ for sp in packages/*/; do
 done
 
 echo "configurator-build: vite build --base=/configurator/" >&2
-npx vite build --base=/configurator/ >&2
+# Cap Node heap explicitly. On low-RAM repro envs (11GB ovh-cloud-dev) the
+# default V8 heap budget plus the running docker stack ran the box out of
+# memory mid-build, leaving the dist half-written and the host_vars
+# `build_configurator: false` workaround in place (PR #644 cycle 4). 8192 MB
+# is well under what a real production node can spare and is plenty for the
+# current configurator bundle (~2.3 MB minified).
+NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=8192}" npx vite build --base=/configurator/ >&2
 
 [ -f dist/index.html ] || { echo "ERROR: dist/index.html missing after build" >&2; exit 3; }
 # Last line = the dist path (captured by the playbook).


### PR DESCRIPTION
## Summary

Surfaced today by a validation gap on the bomet repro env: the served `/var/www/configurator/` dist was 24 hours stale because `build_configurator: false` was set in that host's host_vars — itself a workaround for a vite OOM during PR #644 cycle 4. Net effect: configurator PRs (#674 mobile fallback, #675 postal, #680 leaf-only) couldn't be exercised end-to-end on the repro env without manually building and copying the dist out-of-band.

Cap the Node heap explicitly at 8192 MB via `NODE_OPTIONS` in `configurator-build.sh`, so vite has a deterministic budget and the build doesn't OOM-kill mid-rollup. The current configurator bundle is ~2.3 MB minified, so 8 GB is comfortable headroom; honours any externally-set `NODE_OPTIONS`.

## What changed

`local-setup/ansible/files/configurator-build.sh` — one line:

```diff
- npx vite build --base=/configurator/ >&2
+ NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=8192}" npx vite build --base=/configurator/ >&2
```

Plus a comment block explaining why the cap is there.

## Effect on bomet-style hosts

The `build_configurator: false` host_vars workaround is no longer needed on low-RAM repro boxes. Flip it back to `true` and the build will land instead of being skipped. No change is forced on hosts that don't override.

## Out of scope

- Source-vs-dist mtime gating in the playbook (so a build only fires when source is fresher). Useful follow-up but separate concern.
- Adding swap to repro boxes as a long-term safety net.

## Test plan

- [x] Manual `NODE_OPTIONS=--max-old-space-size=8192 npx vite build --base=/configurator/` on ovh-cloud-dev (11GB RAM, ~10GB used pre-build) — 15s, exit 0, 2.25 MB bundle, included recent source changes
- [ ] Flip `build_configurator: true` in a low-RAM host's host_vars + `./deploy.sh` → build task runs to completion, dist is updated, no OOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)