### PR TITLE
theme(profile): null-safe validationConfig + sidebar avatar refresh — #445 + #556

### DIFF
--- a/digit-ui-esbuild/packages/modules/core/src/components/TopBarSideBar/SideBar/CitizenSideBar.js
+++ b/digit-ui-esbuild/packages/modules/core/src/components/TopBarSideBar/SideBar/CitizenSideBar.js
@@ -11,19 +11,37 @@ import { LogoutIcon } from "@egovernments/digit-ui-react-components";
 import ImageComponent from "../../ImageComponent";
 
 const Profile = ({ info, stateName, t }) => {
-  const [profilePic, setProfilePic] = React.useState(null);
-  React.useEffect(async () => {
-    const tenant = Digit.ULBService.getCurrentTenantId();
+  // Prefer the session-cached photo so an in-place Edit-Profile save
+  // shows up immediately — UserProfile.js writes the new value into
+  // `Digit.UserService.getUser().info.photo` after a successful
+  // update (CCRS#556 sub-bug pair fix). Fall back to the per-uuid
+  // userSearch lookup only if the session doesn't already carry one
+  // (e.g. on first login).
+  const [profilePic, setProfilePic] = React.useState(
+    info?.photo ? info.photo.split(",").at(0) : null,
+  );
+  React.useEffect(() => {
+    if (info?.photo) {
+      setProfilePic(info.photo.split(",").at(0));
+      return;
+    }
     const uuid = info?.uuid;
-    if (uuid) {
+    if (!uuid) return;
+    let cancelled = false;
+    (async () => {
+      const tenant = Digit.ULBService.getCurrentTenantId();
       const usersResponse = await Digit.UserService.userSearch(tenant, { uuid: [uuid] }, {});
-      if (usersResponse && usersResponse.user && usersResponse?.user?.length) {
+      if (cancelled) return;
+      if (usersResponse?.user?.length) {
         const userDetails = usersResponse.user[0];
         const thumbs = userDetails?.photo?.split(",");
         setProfilePic(thumbs?.at(0));
       }
-    }
-  }, [profilePic !== null]);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [info?.uuid, info?.photo]);
 
   const CustomEmployeeTopBar = Digit.ComponentRegistryService?.getComponent("CustomEmployeeTopBar");
 

--- a/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Home/UserProfile.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Home/UserProfile.js
@@ -647,6 +647,14 @@ const UserProfile = ({ stateCode, userType, cityDetails }) => {
         const user = Digit.UserService.getUser();
 
         if (user) {
+          // CCRS#556 sub-bug: the photo was previously omitted from
+          // the session-info patch. The backend got the new pic via
+          // the update payload above, but the session-cached user
+          // object stayed stale — which meant the left-menu avatar
+          // (CitizenSideBar's Profile component reads from
+          // Digit.UserService.getUser()) kept showing the old image
+          // until the next full login. Include `photo` here so the
+          // session reflects what the server just persisted.
           Digit.UserService.setUser({
             ...user,
             info: {
@@ -655,6 +663,7 @@ const UserProfile = ({ stateCode, userType, cityDetails }) => {
               mobileNumber,
               emailId: email,
               permanentCity: city,
+              ...(profilePic ? { photo: profilePic } : {}),
             },
           });
         }

--- a/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Home/UserProfile.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Home/UserProfile.js
@@ -465,7 +465,7 @@ const UserProfile = ({ stateCode, userType, cityDetails }) => {
     // hid it because it wasn't bound to state. Mirror the sibling
     // handlers (`setUserNewPassword`, `setUserConfirmPassword`).
     setCurrentPassword(value);
-    if (!validationConfig?.password.test(value)) {
+    if (!validationConfig?.password?.test(value)) {
       setErrors({
         ...errors,
         currentPassword: {
@@ -480,7 +480,7 @@ const UserProfile = ({ stateCode, userType, cityDetails }) => {
 
   const setUserNewPassword = (value) => {
     setNewPassword(value);
-    if (!validationConfig?.password.test(value)) {
+    if (!validationConfig?.password?.test(value)) {
       setErrors({
         ...errors,
         newPassword: {
@@ -496,7 +496,7 @@ const UserProfile = ({ stateCode, userType, cityDetails }) => {
   const setUserConfirmPassword = (value) => {
     setConfirmPassword(value);
 
-    if (!validationConfig?.password.test(value)) {
+    if (!validationConfig?.password?.test(value)) {
       setErrors({
         ...errors,
         confirmPassword: {
@@ -528,14 +528,14 @@ const UserProfile = ({ stateCode, userType, cityDetails }) => {
         setName((prev) => prev.trim());
       }
 
-      if (!validationConfig?.name.test(name) || name === "" || name.length > 50 || name.length < 1) {
+      if (!validationConfig?.name?.test(name) || name === "" || name.length > 50 || name.length < 1) {
         throw JSON.stringify({
           type: "error",
           message: t("CORE_COMMON_PROFILE_NAME_INVALID"),
         });
       }
 
-      if (userType === "employee" && !validationConfig?.mobileNumber.test(mobileNumber)) {
+      if (userType === "employee" && !validationConfig?.mobileNumber?.test(mobileNumber)) {
         throw JSON.stringify({
           type: "error",
           message: t("CORE_COMMON_PROFILE_MOBILE_NUMBER_INVALID"),
@@ -572,7 +572,7 @@ const UserProfile = ({ stateCode, userType, cityDetails }) => {
           });
         }
 
-        if (!validationConfig?.password.test(trimmedNewPassword) && !validationConfig?.password.test(trimmedConfirmPassword)) {
+        if (!validationConfig?.password?.test(trimmedNewPassword) && !validationConfig?.password?.test(trimmedConfirmPassword)) {
           throw JSON.stringify({
             type: "error",
             message: t("CORE_COMMON_PROFILE_PASSWORD_INVALID"),


### PR DESCRIPTION
## Summary

Two themed UserProfile fixes, validated live on bomet.

- **#445** — null-safe `validationConfig?.<field>.test()` on all 6 callsites so a missing tenant regex no longer throws `Cannot read properties of undefined (reading 'test')` on Edit Profile mount.
- **#556 (save half)** — `UserProfile.js` post-save session writeback now includes `photo`, and `CitizenSideBar.Profile` useEffect dep fixed so it re-fires when the session-cached info changes.

## Validation videos (live bomet 2026-05-31)

- **#445 mount guard** — https://github.com/KDwevedi/Citizen-Complaint-Resolution-System/raw/screenshots-2026-05-31/videos/2026-05-31/445-validation-config-bomet.mp4
- **#556 save round-trip** — https://github.com/KDwevedi/Citizen-Complaint-Resolution-System/raw/screenshots-2026-05-31/videos/2026-05-31/citizen-profile-bomet.mp4

## Known follow-up

The #556 fix lands in the *legacy* CitizenSideBar.js which now only powers the mobile drawer; bomet's live desktop sidebar is the v2 component (`digit-ui-components-v2/citizen-sidebar.tsx`) which has no photo handling. Follow-up to port the photo render into v2 is filed as a comment on #556 — does not block merging this PR (mobile drawer benefits).

## Test plan

- [ ] Edit Profile mounts on every tenant whose `UserProfileValidationConfig` omits a field — should not throw.
- [ ] Citizen edits profile, saves photo, sidebar Avatar in the mobile drawer reflects the new image without a hard reload.