### PR TITLE
theme(complaint-form): postal validator + LocalityPicker leaf-only — #478

### DIFF
--- a/configurator/src/admin/validation.ts
+++ b/configurator/src/admin/validation.ts
@@ -46,15 +46,73 @@ export const phoneKE = raRegex(
 );
 
 /**
- * Kenya postal code: 5 digits (e.g. `00100` Nairobi GPO). The form is
- * optional in the complaint create flow, but if the operator types
- * anything it has to be the right shape — Gurjeet's #478 retest flagged
- * "random pincode accepted" because there was no validator wired.
+ * Postal code validator — country-configurable.
+ *
+ * Per @vinothrallapalli-eGov review on PR #690: don't hardcode the
+ * length / starting-digit constraints, because each country has its
+ * own postal-code rule. The canonical source is the
+ * `common-masters.UserValidation` MDMS master — same master used for
+ * mobile validation — with `fieldType === "postalCode"`.
+ *
+ * Read order (matches `useMobileValidation`):
+ *   1. `window.__DIGIT_USER_VALIDATION.postalCode` — populated by the
+ *      `useUserValidation` hook from the MDMS master.
+ *   2. `globalConfigs.CORE_POSTAL_CODE_CONFIGS` — build-time fallback
+ *      rendered by the playbook.
+ *   3. Sensible default — `^[0-9]{5}$` (Kenya rule). Tenants with a
+ *      different rule MUST seed a UserValidation row OR set the
+ *      globalConfigs key.
+ *
+ * `postalCode` is a function-valued validator so the resolution runs
+ * at validation time (every keystroke), not at module-import time.
+ * That way a tenant switch mid-session picks up the latest rule.
+ *
+ * Form usage: `<DigitFormInput validate={v.postalCode} ... />` — the
+ * old `postalCodeKE` alias still works as a backward-compat shim
+ * pointing at the same dynamic validator.
  */
-export const postalCodeKE = raRegex(
-  /^[0-9]{5}$/,
-  'Enter a valid 5-digit postal code (e.g. 00100)',
-);
+const DEFAULT_POSTAL_PATTERN = /^[0-9]{5}$/;
+const DEFAULT_POSTAL_MESSAGE = 'Enter a valid 5-digit postal code (e.g. 00100)';
+
+function resolvePostalRule(): { pattern: RegExp; message: string } {
+  const userValidation =
+    typeof window !== 'undefined'
+      ? (window as Record<string, unknown>).__DIGIT_USER_VALIDATION
+      : undefined;
+  const mdmsRule = (userValidation as Record<string, Record<string, unknown>> | undefined)?.postalCode;
+  const globalRule =
+    typeof window !== 'undefined'
+      ? (window as Record<string, { getConfig?: (key: string) => Record<string, unknown> }>)
+          .globalConfigs?.getConfig?.('CORE_POSTAL_CODE_CONFIGS')
+      : undefined;
+
+  const patternStr =
+    (mdmsRule?.pattern as string | undefined) ||
+    (globalRule?.postalCodePattern as string | undefined);
+  const message =
+    (mdmsRule?.errorMessage as string | undefined) ||
+    (globalRule?.postalCodeErrorMessage as string | undefined) ||
+    DEFAULT_POSTAL_MESSAGE;
+
+  if (patternStr) {
+    try {
+      return { pattern: new RegExp(patternStr), message };
+    } catch {
+      // Bad pattern in MDMS — fall through to the default rather than
+      // throwing during validation.
+    }
+  }
+  return { pattern: DEFAULT_POSTAL_PATTERN, message };
+}
+
+export const postalCode = (value: unknown) => {
+  if (value === undefined || value === null || value === '') return undefined;
+  const { pattern, message } = resolvePostalRule();
+  return pattern.test(String(value)) ? undefined : message;
+};
+
+/** Backward-compat alias for existing callers. Same dynamic validator. */
+export const postalCodeKE = postalCode;
 
 export const code = raRegex(
   /^[A-Za-z0-9][A-Za-z0-9_.\-/]*$/,

--- a/configurator/src/admin/validation.ts
+++ b/configurator/src/admin/validation.ts
@@ -45,6 +45,17 @@ export const phoneKE = raRegex(
   'Enter a valid Kenyan mobile starting with 7 or 1 (e.g. 712345678)',
 );
 
+/**
+ * Kenya postal code: 5 digits (e.g. `00100` Nairobi GPO). The form is
+ * optional in the complaint create flow, but if the operator types
+ * anything it has to be the right shape — Gurjeet's #478 retest flagged
+ * "random pincode accepted" because there was no validator wired.
+ */
+export const postalCodeKE = raRegex(
+  /^[0-9]{5}$/,
+  'Enter a valid 5-digit postal code (e.g. 00100)',
+);
+
 export const code = raRegex(
   /^[A-Za-z0-9][A-Za-z0-9_.\-/]*$/,
   'Use letters, numbers, underscores, dots, hyphens, or slashes',

--- a/configurator/src/resources/complaints/ComplaintCreate.tsx
+++ b/configurator/src/resources/complaints/ComplaintCreate.tsx
@@ -51,7 +51,7 @@ export function ComplaintCreate() {
             help="Cascades from hierarchy → boundary type → locality."
           />
           <DigitFormInput source="address.landmark" label="Landmark" />
-          <DigitFormInput source="address.pincode" label="Pincode" />
+          <DigitFormInput source="address.pincode" label="Pincode" validate={v.postalCodeKE} />
         </div>
       </FieldSection>
 

--- a/configurator/src/resources/complaints/ComplaintEdit.tsx
+++ b/configurator/src/resources/complaints/ComplaintEdit.tsx
@@ -1,4 +1,4 @@
-import { DigitEdit, DigitFormInput, DigitFormSelect, WorkflowActionSelect } from '@/admin';
+import { DigitEdit, DigitFormInput, DigitFormSelect, WorkflowActionSelect, v } from '@/admin';
 import { FieldSection } from '@/admin/fields';
 import { LocalityPicker } from './LocalityPicker';
 
@@ -61,7 +61,7 @@ export function ComplaintEdit() {
         <div className="space-y-4">
           <LocalityPicker source="address.locality.code" label="Locality" />
           <DigitFormInput source="address.landmark" label="Landmark" />
-          <DigitFormInput source="address.pincode" label="Pincode" />
+          <DigitFormInput source="address.pincode" label="Pincode" validate={v.postalCodeKE} />
           <DigitFormInput source="address.street" label="Street" />
         </div>
       </FieldSection>

--- a/configurator/src/resources/complaints/LocalityPicker.tsx
+++ b/configurator/src/resources/complaints/LocalityPicker.tsx
@@ -75,19 +75,36 @@ export function LocalityPicker({
     return hierarchies.map((h) => ({ value: h.hierarchyType, label: h.hierarchyType }));
   }, [hierarchies]);
 
+  // Only expose the LEAF boundary type(s) per hierarchy — types that
+  // aren't anyone's `parentBoundaryType` within the same hierarchy.
+  // Gurjeet's #478 retest showed operators filing complaints at
+  // "Nairobi City County" (root), which the PGR backend will route to
+  // no ward and the resolver UI then can't show a sane assignment
+  // surface. The original digit-ui side enforced this with
+  // `isBoundaryLeaf` at submit; mirror that constraint here at the
+  // picker so the operator is structurally prevented from choosing a
+  // non-leaf rather than seeing a late toast.
   const boundaryTypesByHierarchy = useMemo(() => {
     const map = new Map<string, string[]>();
     if (!hierarchies) return map;
     for (const h of hierarchies) {
-      const seen = new Set<string>();
-      const types: string[] = [];
-      for (const lvl of h.boundaryHierarchy ?? []) {
-        if (!lvl || lvl.active === false) continue;
-        if (!lvl.boundaryType || seen.has(lvl.boundaryType)) continue;
-        seen.add(lvl.boundaryType);
-        types.push(lvl.boundaryType);
+      const levels = (h.boundaryHierarchy ?? []).filter(
+        (lvl): lvl is HierarchyLevel => !!lvl && lvl.active !== false && !!lvl.boundaryType,
+      );
+      const parents = new Set<string>();
+      for (const lvl of levels) {
+        if (lvl.parentBoundaryType) parents.add(lvl.parentBoundaryType);
       }
-      map.set(h.hierarchyType, types);
+      const seen = new Set<string>();
+      const leafTypes: string[] = [];
+      for (const lvl of levels) {
+        // Leaf = not the parent of anything else in this hierarchy.
+        if (parents.has(lvl.boundaryType)) continue;
+        if (seen.has(lvl.boundaryType)) continue;
+        seen.add(lvl.boundaryType);
+        leafTypes.push(lvl.boundaryType);
+      }
+      map.set(h.hierarchyType, leafTypes);
     }
     return map;
   }, [hierarchies]);


### PR DESCRIPTION
## Summary

Two commits closing both halves of #478.

- **postal-code validator** — surfaces "Enter a valid 5-digit postal code" on the complaint create form for invalid `1234`, accepts `00100`.
- **LocalityPicker leaf-only** — `BoundaryDropdown` filters its option list to leaf boundary types only so an operator cannot file a complaint at County / Sub-County / Ward level (closes the actively-unresolved item from Gurjeet's 2026-05-19 retest).

## Validation video (live bomet 2026-05-31)

- **Bundled flow** — https://github.com/KDwevedi/Citizen-Complaint-Resolution-System/raw/screenshots-2026-05-31/videos/2026-05-31/configurator-bundle-bomet.mp4

The honest-drive section in `demo-configurator-bundle-bomet.spec.ts` reads the boundary picker option list and asserts no non-leaf admin labels (`County`, `Sub-County`, `Ward`, etc.) appear — flips red on a regression of the leaf-only filter.

## Test plan

- [ ] Complaint create with invalid pincode `1234` shows the help text.
- [ ] Postal `00100` accepted, complaint submits.
- [ ] Boundary picker on the complaint form lists only leaf boundary labels (no admin levels).