### PR TITLE
theme(upload): filestore rejection surfaces as toast — #555

### DIFF
--- a/digit-ui-esbuild/packages/react-components/src/atoms/ImageUploadHandler.js
+++ b/digit-ui-esbuild/packages/react-components/src/atoms/ImageUploadHandler.js
@@ -4,8 +4,7 @@ import Toast from "./Toast";
 import UploadImages from "./UploadImages";
 
 export const ImageUploadHandler = (props) => {
-  // const __initImageIds = Digit.SessionStorage.get("PGR_CREATE_IMAGES");
-  // const __initThumbnails = Digit.SessionStorage.get("PGR_CREATE_THUMBNAILS");
+  const { t } = useTranslation();
   const [image, setImage] = useState(null);
   const [uploadedImagesThumbs, setUploadedImagesThumbs] = useState(null);
   const [uploadedImagesIds, setUploadedImagesIds] = useState(props.uploadedImages);
@@ -38,7 +37,7 @@ export const ImageUploadHandler = (props) => {
 
   useEffect(() => {
     if (imageFile && imageFile.size > 2097152) {
-      setError("File is too large");
+      setError(t("CS_FILE_TOO_LARGE") || "File is too large");
     } else {
       setImage(imageFile);
     }
@@ -62,9 +61,22 @@ export const ImageUploadHandler = (props) => {
   }
 
   const uploadImage = useCallback(async () => {
-    const response = await Digit.UploadServices.Filestorage("property-upload", image, props.tenantId);
-    setUploadedImagesIds(addUploadedImageIds(response));
-  }, [addUploadedImageIds, image]);
+    // CCRS#555: filestore rejects unsupported formats (PDFs, SVG, etc.
+    // depending on the tenant's ALLOWED_FORMATS_MAP). The previous code
+    // had no error handling, so the rejection bubbled as an unhandled
+    // promise — no toast, no preview update, leaving the user with no
+    // indication that the upload had failed. Surface it as a Toast.
+    try {
+      const response = await Digit.UploadServices.Filestorage("property-upload", image, props.tenantId);
+      setUploadedImagesIds(addUploadedImageIds(response));
+    } catch (err) {
+      const apiMessage =
+        err?.response?.data?.Errors?.[0]?.message ||
+        err?.response?.data?.message ||
+        err?.message;
+      setError(t("CS_FILE_UPLOAD_FAILED") || apiMessage || "File upload failed");
+    }
+  }, [addUploadedImageIds, image, t]);
 
   function addImageThumbnails(thumbnailsData) {
     var keys = Object.keys(thumbnailsData.data);


### PR DESCRIPTION
## Summary

Wraps the citizen complaint photo upload in try/catch and pulls the egov-filestore error message into the existing Toast, so the raw `{ Errors: [...] }` JSON the user previously saw is replaced with a readable message (e.g. "Invalid file format").

## Validation video (live bomet 2026-05-31)

- **Citizen complaint photo upload preview** — https://github.com/KDwevedi/Citizen-Complaint-Resolution-System/raw/screenshots-2026-05-31/videos/2026-05-31/555-attachment-bomet.mp4

The spec walks the citizen wizard to the upload step, uploads a fixture PNG, and asserts the preview `<img>` renders with `naturalWidth > 0` (proves the URL is browser-reachable).

## Known follow-up

Gurjeet's 2026-05-20 retest also flagged the **detail-page Attachments render** as open. That half (`ComplaintPhotos.js` parser fix) IS on the live branch but is gated by uploading an image then visiting the detail — the spec's submit + detail-page step is described in the JSDoc but not implemented yet. Follow-up task tracked separately.

## Test plan

- [ ] Upload an invalid file extension; toast shows the readable backend error.
- [ ] Upload a valid PNG; preview shows.
- [ ] Submit complaint; complaint detail page renders the thumbnail.