### PR TITLE
theme(escalation): EscalationConfig seed + manual ESCALATE workflow + scheduler tenant resolution — #585 + #521

### DIFF
--- a/ansible/nairobi-mdms/mdms/RAINMAKER-PGR/EscalationConfig.json
+++ b/ansible/nairobi-mdms/mdms/RAINMAKER-PGR/EscalationConfig.json
@@ -1,0 +1,14 @@
+[
+  {
+    "tenantId": "ke",
+    "data": {
+      "maxDepth": 3,
+      "defaultSlaByLevel": [
+        3600000,
+        14400000,
+        86400000
+      ],
+      "overrides": {}
+    }
+  }
+]

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -1592,6 +1592,21 @@
         replace: '\1PGR_STATELEVEL_TENANTID: {{ state_root }}'
       when: state_root != 'pg'
 
+    # And the matching EGOV_UI_APP_HOST_MAP rewrite. Empirically the
+    # scheduler actually uses the FIRST KEY of this map to resolve the
+    # tenant for its MDMS query (PGRConfiguration#getUiAppHostMap →
+    # EscalationScheduler#getStateLevelTenantId). With the hardcoded
+    # `{pg:…}` placeholder it queries MDMS for pg.RAINMAKER-PGR
+    # .EscalationConfig and gets nothing back. Aligning the key with
+    # state_root lets the scheduler reach the seeded config and
+    # actually use the 1h/4h/24h SLAs we set in MDMS.
+    - name: "post-bootstrap — set EGOV_UI_APP_HOST_MAP (pgr-services tenant key) in compose"
+      replace:
+        path: "{{ digit_dir }}/docker-compose.egov-digit.yaml"
+        regexp: '^(\s+)EGOV_UI_APP_HOST_MAP: "\{pg:'
+        replace: '\1EGOV_UI_APP_HOST_MAP: "{{ "{" }}{{ state_root }}:'
+      when: state_root != 'pg'
+
     - name: "post-bootstrap — set STATE_LEVEL_TENANT_ID (city tier — enc-service + workflow) in compose"
       replace:
         path: "{{ digit_dir }}/docker-compose.egov-digit.yaml"

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -1576,6 +1576,22 @@
         replace: '\1EGOV_STATELEVEL_TENANT: {{ state_root }}'
       when: state_root != 'pg'
 
+    # pgr-services' EscalationScheduler reads
+    # `PGR_STATELEVEL_TENANTID` (no `_` between STATE/LEVEL, no `_ID` —
+    # third spelling variant in this stack) to pick which tenant to
+    # query MDMS RAINMAKER-PGR.EscalationConfig at. Without this
+    # rewrite the scheduler asks MDMS at tenant `pg`, gets no result,
+    # logs "Failed to fetch EscalationConfig from MDMS, using defaults"
+    # and falls back to a 5-day SLA — so auto-escalation effectively
+    # never fires on tenants whose state_root is anything other than
+    # `pg`. Closes the deploy-side half of #585.
+    - name: "post-bootstrap — set PGR_STATELEVEL_TENANTID (pgr-services variant) in compose"
+      replace:
+        path: "{{ digit_dir }}/docker-compose.egov-digit.yaml"
+        regexp: '^(\s+)PGR_STATELEVEL_TENANTID: pg$'
+        replace: '\1PGR_STATELEVEL_TENANTID: {{ state_root }}'
+      when: state_root != 'pg'
+
     - name: "post-bootstrap — set STATE_LEVEL_TENANT_ID (city tier — enc-service + workflow) in compose"
       replace:
         path: "{{ digit_dir }}/docker-compose.egov-digit.yaml"

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -1562,6 +1562,20 @@
         replace: '\1EGOV_STATE_LEVEL_TENANT_ID: {{ state_root }}'
       when: state_root != 'pg'
 
+    # egov-hrms reads `EGOV_STATELEVEL_TENANT` (no underscore between
+    # STATE/LEVEL) — distinct from `EGOV_STATE_LEVEL_TENANT_ID` above —
+    # to know which tenant to look up its INTERNAL_USER system user
+    # at boot. Without this rewrite the hardcoded `pg` survives and
+    # DefaultUserService.initalizeSystemuser throws
+    # "Service returned null while fetching user" → HRMS crash-loops
+    # on tenants whose state_root isn't pg. Manifest of #622.
+    - name: "post-bootstrap — set EGOV_STATELEVEL_TENANT (HRMS variant) in compose"
+      replace:
+        path: "{{ digit_dir }}/docker-compose.egov-digit.yaml"
+        regexp: '^(\s+)EGOV_STATELEVEL_TENANT: pg$'
+        replace: '\1EGOV_STATELEVEL_TENANT: {{ state_root }}'
+      when: state_root != 'pg'
+
     - name: "post-bootstrap — set STATE_LEVEL_TENANT_ID (city tier — enc-service + workflow) in compose"
       replace:
         path: "{{ digit_dir }}/docker-compose.egov-digit.yaml"

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -1267,6 +1267,15 @@ services:
       EGOV_HRMS_HOST: http://egov-hrms:8092/
       EGOV_URL_SHORTNER_HOST: http://egov-url-shortening:8080/
       EGOV_UI_APP_HOST: http://localhost:18080
+      # pgr-services' EscalationScheduler resolves the tenant to query
+      # MDMS at from the KEYS of this map (PGRConfiguration#getUiAppHostMap,
+      # consumed by EscalationScheduler#getStateLevelTenantId). Without
+      # this set, getUiAppHostMap() returns empty → getStateLevelTenantId()
+      # returns null → fetchEscalationConfig short-circuits → scheduler
+      # falls back to the 5-day default SLA and auto-escalation silently
+      # never fires. The "pg" placeholder is rewritten per-tenant by the
+      # playbook's post-bootstrap task.
+      EGOV_UI_APP_HOST_MAP: "{pg:'http://localhost:18080'}"
       NOTIFICATION_SMS_ENABLED: 'false'
       NOTIFICATION_EMAIL_ENABLED: 'false'
       NEW_COMPLAINT_ENABLED: 'true'

--- a/utilities/default-data-handler/src/main/resources/PgrWorkflowConfig.json
+++ b/utilities/default-data-handler/src/main/resources/PgrWorkflowConfig.json
@@ -206,6 +206,17 @@
                 "AUTO_ESCALATE"
               ],
               "active": true
+            },
+            {
+              "tenantId": "{tenantid}",
+              "currentState": "PENDINGATLME",
+              "action": "ESCALATE",
+              "nextState": "PENDINGATSUPERVISOR",
+              "roles": [
+                "PGR_LME",
+                "PGR_VIEWER"
+              ],
+              "active": true
             }
           ]
         },

--- a/utilities/default-data-handler/src/main/resources/mdmsData-dev/RAINMAKER-PGR/RAINMAKER-PGR.EscalationConfig.json
+++ b/utilities/default-data-handler/src/main/resources/mdmsData-dev/RAINMAKER-PGR/RAINMAKER-PGR.EscalationConfig.json
@@ -1,0 +1,11 @@
+[
+  {
+    "maxDepth": 3,
+    "defaultSlaByLevel": [
+      3600000,
+      14400000,
+      86400000
+    ],
+    "overrides": {}
+  }
+]

--- a/utilities/default-data-handler/src/main/resources/schema/RAINMAKER-PGR.json
+++ b/utilities/default-data-handler/src/main/resources/schema/RAINMAKER-PGR.json
@@ -75,5 +75,46 @@
       "x-ref-schema": [],
       "additionalProperties": false
     }
+  },
+  {
+    "tenantId": "{tenantid}",
+    "code": "RAINMAKER-PGR.EscalationConfig",
+    "description": "Per-tenant auto-escalation config consumed by pgr-services EscalationScheduler. `defaultSlaByLevel` is an array of SLA windows in MILLISECONDS, one per escalation depth (level 0 = first scan); `overrides` keys by serviceCode for per-complaint-type SLA arrays; `maxDepth` caps how many times a single complaint can be auto-escalated before stopping. Without this record pgr-services falls back to its 5-day default SLA — see https://github.com/egovernments/Citizen-Complaint-Resolution-System/issues/585.",
+    "isActive": true,
+    "definition": {
+      "type": "object",
+      "title": "Generated schema for Root",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "required": [
+        "maxDepth",
+        "defaultSlaByLevel"
+      ],
+      "x-unique": [
+        "maxDepth"
+      ],
+      "properties": {
+        "maxDepth": {
+          "type": "number"
+        },
+        "defaultSlaByLevel": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 1
+        },
+        "overrides": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      "x-ref-schema": [],
+      "additionalProperties": false
+    }
   }
 ]

--- a/utilities/default-data-handler/src/main/resources/schema/RAINMAKER-PGR.json
+++ b/utilities/default-data-handler/src/main/resources/schema/RAINMAKER-PGR.json
@@ -79,7 +79,7 @@
   {
     "tenantId": "{tenantid}",
     "code": "RAINMAKER-PGR.EscalationConfig",
-    "description": "Per-tenant auto-escalation config consumed by pgr-services EscalationScheduler. `defaultSlaByLevel` is an array of SLA windows in MILLISECONDS, one per escalation depth (level 0 = first scan); `overrides` keys by serviceCode for per-complaint-type SLA arrays; `maxDepth` caps how many times a single complaint can be auto-escalated before stopping. Without this record pgr-services falls back to its 5-day default SLA — see https://github.com/egovernments/Citizen-Complaint-Resolution-System/issues/585.",
+    "description": "Per-tenant auto-escalation config consumed by pgr-services EscalationScheduler. `defaultSlaByLevel` is an array of SLA windows in MILLISECONDS, one per escalation depth (level 0 = first scan); `overrides` keys by serviceCode for per-complaint-type SLA arrays; `maxDepth` caps how many times a single complaint can be auto-escalated before stopping. Per-level enablement is opt-in via `enabledByLevel` (boolean array, same length as `defaultSlaByLevel`; defaults to all-true when omitted) and `overrides[<serviceCode>].enabledByLevel` for per-service-code overrides. Without an EscalationConfig record pgr-services falls back to its 5-day default SLA — see https://github.com/egovernments/Citizen-Complaint-Resolution-System/issues/585.",
     "isActive": true,
     "definition": {
       "type": "object",
@@ -103,13 +103,43 @@
           },
           "minItems": 1
         },
+        "enabledByLevel": {
+          "type": "array",
+          "description": "Optional per-level enablement flags. Same length as defaultSlaByLevel. Missing or empty = all levels enabled (current behaviour). Per @vinothrallapalli-eGov review on PR #692 — keeps the door open for tenants that want escalation only at level N without rewriting the schema.",
+          "items": {
+            "type": "boolean"
+          }
+        },
         "overrides": {
           "type": "object",
+          "description": "Per-serviceCode SLA override. Value may be EITHER (a) a plain array of SLA windows (same shape as defaultSlaByLevel, applies to all levels) for backward compatibility, OR (b) an object with explicit `slaByLevel` and optional `enabledByLevel` for per-service-code per-level control.",
           "additionalProperties": {
-            "type": "array",
-            "items": {
-              "type": "number"
-            }
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "slaByLevel": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    }
+                  },
+                  "enabledByLevel": {
+                    "type": "array",
+                    "items": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
           }
         }
       },


### PR DESCRIPTION
## Summary

End-to-end auto + manual escalation for PGR. Five commits, three layers.

### Code / data

- **#585 EscalationConfig MDMS seed** — `RAINMAKER-PGR.EscalationConfig` ships `[{maxDepth:3, defaultSlaByLevel:[3600000, 14400000, 86400000]}]` (1h / 4h / 24h tiers) so the scheduler stops falling back to its 5-day default SLA.
- **#521 manual ESCALATE workflow** — seeds the `PENDINGATLME → ESCALATE → PENDINGATSUPERVISOR` action with `[PGR_LME, PGR_VIEWER]` roles in `PgrWorkflowConfig.json`. The companion ACTION_CONFIGS / dropdown wiring landed in #635 (already merged).

### Playbook / scheduler tenant resolution

`EscalationScheduler.getStateLevelTenantId()` actually reads `config.getUiAppHostMap()` keys, not `STATE_LEVEL_TENANT_ID` directly — the playbook needs all THREE variants set to the operator tenant so the scheduler resolves a non-null tenant per scan.

- `EGOV_STATELEVEL_TENANT` (HRMS-side variant)
- `PGR_STATELEVEL_TENANTID` (pgr-services variant)
- `EGOV_UI_APP_HOST_MAP` (the actual scheduler tenant resolution path)

## Validation video (live bomet 2026-05-31)

- **#521 manual escalate full action** — https://github.com/KDwevedi/Citizen-Complaint-Resolution-System/raw/screenshots-2026-05-31/videos/2026-05-31/521-escalate-full-action.mp4

The spec drives the LME flow: open complaint at `PENDINGATLME` → Take action → Escalate → fill comment → submit → DB row confirms `state moved PENDINGATLME → PENDINGATSUPERVISOR`.

**Auto-escalation** was driven on bomet to first green ESCALATE row (`PG-PGR-2026-04-13-000826 ESCALATE` at 2026-05-31 12:30:23 UTC) — see issue #585 comment for the audit row. Code is fully on this branch; **data prerequisites** (SYSTEM user UUID, HRMS reportingTo chain per LME, supervisor user with `SUPERVISOR` role) are documented in #687 (persistence) as the remaining onboarding work.

## Test plan

- [ ] LME login → complaint at PENDINGATLME → Take action → Escalate option visible.
- [ ] Submit escalate → state moves to PENDINGATSUPERVISOR (DB audit row).
- [ ] Scheduler resolves a tenant per scan (`EscalationScheduler.getStateLevelTenantId()` returns non-null).
- [ ] EscalationConfig MDMS seed loads and `escalationMaxDepth` reads `3`.