### PR TITLE
theme(boundary): dedup boundary dropdown options by code — #496

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/BoundaryComponent.js
+++ b/digit-ui-esbuild/products/pgr/src/components/BoundaryComponent.js
@@ -286,10 +286,20 @@ useEffect(() => {
 const BoundaryDropdown = ({ label, data, onChange, selected, fieldKey, disabled }) => {
   const { t } = useTranslation();
   const id = `boundary-${(fieldKey || label || "field").toString().toLowerCase().replace(/\s+/g, "-")}`;
-  const options = (data || []).map((node) => ({
-    value: node.code,
-    label: t(node.code) || node.code,
-  }));
+  // Defensive dedup by code. The jurisdiction prune (filterTree above)
+  // is duplicate-safe by construction, but in the field the dropdown
+  // has been observed listing the same ward twice (see
+  // egovernments/CCRS#496 screen recording — upstream data shape under
+  // overlapping HRMS jurisdictions, exact origin still being chased).
+  // Dedup at render keeps the symptom contained regardless of where
+  // the duplicate enters `data`.
+  const options = [];
+  const seen = new Set();
+  for (const node of data || []) {
+    if (seen.has(node.code)) continue;
+    seen.add(node.code);
+    options.push({ value: node.code, label: t(node.code) || node.code });
+  }
   return (
     <V2Field label={t(label)} required htmlFor={id}>
       <V2Select


### PR DESCRIPTION
## Summary

`BoundaryDropdown` adds set-based dedup-by-code so an upstream source returning the same boundary twice no longer produces duplicate options in the cascading combobox.

Filter / scoping logic itself is unchanged (Gurjeet confirmed that works in his 2026-05-19 retest).

## Validation video (live bomet 2026-05-31)

- **Boundary picker — 25/25 unique options + leaf-only enforcement** — https://github.com/KDwevedi/Citizen-Complaint-Resolution-System/raw/screenshots-2026-05-31/videos/2026-05-31/configurator-bundle-bomet.mp4

The honest-drive section in `demo-configurator-bundle-bomet.spec.ts` reads the boundary picker options and asserts `uniqueCount === cleaned.length`.

## Known follow-up

The actively-unresolved sibling (CSR can pick wards outside their jurisdiction) requires a ward-scoped CSR test user. Bomet doesn't have one. Tracked separately as an audit task — does not block this dedup PR.

## Test plan

- [ ] Open complaint create boundary picker; every option appears once.
- [ ] Cascading picker (Boundary Type → Boundary) shows the same uniqueness contract.