### PR TITLE
feat(digit-ui-v2): Keycloak SSO — overlay password grant + Google SSO + PKCE

### DIFF
--- a/digit-ui-v2/packages/data-provider/src/client/DigitApiClient.ts
+++ b/digit-ui-v2/packages/data-provider/src/client/DigitApiClient.ts
@@ -4,10 +4,36 @@ import type {
   RequestInfo, UserInfo, MdmsRecord, ApiError,
 } from './types.js';
 
+/**
+ * Optional Keycloak overlay config. When provided AND a KC access token is
+ * present (provided per-request by `kcTokenSource`), the client transparently
+ * prefixes every DIGIT API path with `tokenExchangePath` so the request goes
+ * through the overlay service (which validates the JWT, injects a system
+ * token + the real user's identity into RequestInfo, and forwards upstream).
+ *
+ * The token-exchange overlay flow only applies when BOTH conditions hold —
+ * KC config is wired up AND a KC token is currently in storage. When either
+ * is missing, this client behaves exactly as before (OTP-style password
+ * grant against /user/oauth/token, no path rewriting).
+ */
+export interface KeycloakOverlayConfig {
+  /** Overlay path prefix, e.g. "/token-exchange". Browser-relative. */
+  tokenExchangePath: string;
+  /** Returns current KC access token, or null if no KC session. */
+  kcTokenSource: () => string | null;
+  /** Optional: returns a refreshed access token, or null if refresh failed.
+   *  When provided, a 401 from a DIGIT call triggers exactly one retry. */
+  refreshKcToken?: () => Promise<string | null>;
+  /** Optional: called when refresh fails / persistent 401. Lets the host
+   *  app evict stored tokens + redirect to login. */
+  onAuthFailure?: () => void;
+}
+
 export interface DigitApiClientConfig {
   url: string;
   stateTenantId?: string;
   endpointOverrides?: Record<string, string>;
+  keycloak?: KeycloakOverlayConfig;
 }
 
 export class DigitApiClient {
@@ -16,6 +42,7 @@ export class DigitApiClient {
   private overrides: Record<string, string>;
   private authToken: string | null = null;
   private userInfo: UserInfo | null = null;
+  private kc: KeycloakOverlayConfig | null;
 
   private static readonly RETRY_STATUS_CODES = new Set([429, 503]);
   private static readonly MAX_RETRIES = 3;
@@ -24,6 +51,36 @@ export class DigitApiClient {
     this.baseUrl = config.url;
     this._stateTenantId = config.stateTenantId || '';
     this.overrides = config.endpointOverrides || {};
+    this.kc = config.keycloak ?? null;
+  }
+
+  // ── Keycloak overlay routing ────────────────────────────────────────────
+
+  /** Inject / replace KC overlay config at runtime (e.g. after sign-in). */
+  setKeycloakConfig(kc: KeycloakOverlayConfig | null): void {
+    this.kc = kc;
+  }
+
+  /** True when the KC overlay is wired AND a KC token is currently stored. */
+  private kcActive(): string | null {
+    if (!this.kc) return null;
+    return this.kc.kcTokenSource() || null;
+  }
+
+  /** Compose the final URL for a DIGIT API path. When KC is active, the
+   *  overlay prefix is inserted between baseUrl and the path. */
+  private apiUrl(path: string): string {
+    if (this.kcActive() && this.kc) {
+      return `${this.baseUrl}${this.kc.tokenExchangePath}${path}`;
+    }
+    return `${this.baseUrl}${path}`;
+  }
+
+  /** Authorization header value preferred for the current request. KC bearer
+   *  wins when available — the overlay reads it and supplies its own
+   *  upstream credentials. */
+  private bearerToken(): string | null {
+    return this.kcActive() ?? this.authToken;
   }
 
   // --- Auth ---
@@ -77,19 +134,45 @@ export class DigitApiClient {
   }
 
   async request<T = unknown>(path: string, body: Record<string, unknown>): Promise<T> {
-    const url = `${this.baseUrl}${path}`;
-    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-    if (this.authToken) headers['Authorization'] = `Bearer ${this.authToken}`;
-
     const jsonBody = JSON.stringify(body);
+
+    // Wrap the actual fetch so we can retry once with a refreshed KC token
+    // on 401 — refresh is opt-in via the keycloak config's refreshKcToken.
+    const doFetch = async (): Promise<Response> => {
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      const bearer = this.bearerToken();
+      if (bearer) headers['Authorization'] = `Bearer ${bearer}`;
+      return fetch(this.apiUrl(path), { method: 'POST', headers, body: jsonBody });
+    };
+
     let lastResponse: Response | undefined;
+    let kcRefreshAttempted = false;
 
     for (let attempt = 0; attempt < DigitApiClient.MAX_RETRIES; attempt++) {
-      const response = await fetch(url, { method: 'POST', headers, body: jsonBody });
+      let response = await doFetch();
+
+      // KC-specific: a single refresh+retry on 401 when overlay is active.
+      if (response.status === 401 && this.kcActive() && this.kc?.refreshKcToken && !kcRefreshAttempted) {
+        kcRefreshAttempted = true;
+        try {
+          const fresh = await this.kc.refreshKcToken();
+          if (fresh) {
+            response = await doFetch();
+          } else {
+            this.kc.onAuthFailure?.();
+          }
+        } catch {
+          this.kc.onAuthFailure?.();
+        }
+      }
 
       if (!DigitApiClient.RETRY_STATUS_CODES.has(response.status)) {
         const data = await response.json() as Record<string, unknown>;
         if (!response.ok || (data.Errors as ApiError[] | undefined)?.length) {
+          if (response.status === 401 && this.kcActive()) {
+            // Refresh already tried (or wasn't configured). Bail to login.
+            this.kc?.onAuthFailure?.();
+          }
           const errors: ApiError[] = (data.Errors as ApiError[]) || [
             { code: `HTTP_${response.status}`, message: (data.message as string) || `Request failed: ${response.status}` },
           ];
@@ -580,9 +663,10 @@ export class DigitApiClient {
 
   async filestoreGetUrl(tenantId: string, fileStoreIds: string[]): Promise<Record<string, unknown>[]> {
     const params = new URLSearchParams({ tenantId, fileStoreIds: fileStoreIds.join(',') });
-    const url = `${this.baseUrl}${this.endpoint('FILESTORE_URL')}?${params.toString()}`;
+    const url = `${this.apiUrl(this.endpoint('FILESTORE_URL'))}?${params.toString()}`;
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-    if (this.authToken) headers['Authorization'] = `Bearer ${this.authToken}`;
+    const bearer = this.bearerToken();
+    if (bearer) headers['Authorization'] = `Bearer ${bearer}`;
 
     const response = await fetch(url, { method: 'GET', headers });
     const contentType = response.headers.get('content-type') || '';
@@ -596,7 +680,7 @@ export class DigitApiClient {
   }
 
   async filestoreUpload(tenantId: string, module: string, fileName: string, fileContent: Buffer | Uint8Array, contentType?: string): Promise<string> {
-    const url = `${this.baseUrl}${this.endpoint('FILESTORE_UPLOAD')}`;
+    const url = this.apiUrl(this.endpoint('FILESTORE_UPLOAD'));
     const formData = new FormData();
     // Cast to BlobPart — Buffer/Uint8Array are valid at runtime but strict TS typing conflicts with ArrayBufferLike
     const blob = new Blob([fileContent as unknown as BlobPart], { type: contentType || 'application/octet-stream' });
@@ -605,7 +689,8 @@ export class DigitApiClient {
     formData.append('module', module);
 
     const headers: Record<string, string> = {};
-    if (this.authToken) headers['Authorization'] = `Bearer ${this.authToken}`;
+    const bearer = this.bearerToken();
+    if (bearer) headers['Authorization'] = `Bearer ${bearer}`;
 
     const response = await fetch(url, { method: 'POST', headers, body: formData });
     const data = await response.json() as Record<string, unknown>;
@@ -621,9 +706,12 @@ export class DigitApiClient {
   // --- Encryption ---
 
   async encryptData(tenantId: string, values: string[]): Promise<string[]> {
-    const url = `${this.baseUrl}${this.endpoint('ENC_ENCRYPT')}`;
+    const url = this.apiUrl(this.endpoint('ENC_ENCRYPT'));
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    const bearer = this.bearerToken();
+    if (bearer) headers['Authorization'] = `Bearer ${bearer}`;
     const response = await fetch(url, {
-      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      method: 'POST', headers,
       body: JSON.stringify({ encryptionRequests: values.map((value) => ({ tenantId, type: 'Normal', value })) }),
     });
     if (!response.ok) throw new Error(`Encryption failed: HTTP ${response.status}`);
@@ -632,9 +720,12 @@ export class DigitApiClient {
   }
 
   async decryptData(tenantId: string, encryptedValues: string[]): Promise<string[]> {
-    const url = `${this.baseUrl}${this.endpoint('ENC_DECRYPT')}`;
+    const url = this.apiUrl(this.endpoint('ENC_DECRYPT'));
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    const bearer = this.bearerToken();
+    if (bearer) headers['Authorization'] = `Bearer ${bearer}`;
     const response = await fetch(url, {
-      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      method: 'POST', headers,
       body: JSON.stringify(encryptedValues),
     });
     if (!response.ok) throw new Error(`Decryption failed: HTTP ${response.status}`);

--- a/digit-ui-v2/packages/data-provider/src/providers/authProvider.ts
+++ b/digit-ui-v2/packages/data-provider/src/providers/authProvider.ts
@@ -1,10 +1,30 @@
 import type { AuthProvider } from 'ra-core';
 import type { DigitApiClient } from '../client/DigitApiClient.js';
 
-export function createDigitAuthProvider(client: DigitApiClient): AuthProvider {
+/**
+ * Optional KC logout handler. When provided AND a KC session is active, the
+ * authProvider's `logout` delegates to it (so the host app can call Keycloak's
+ * RP-initiated logout endpoint via id_token_hint instead of just clearing
+ * local state). Returns void because the redirect away from the SPA is the
+ * "result".
+ */
+export interface KeycloakAuthOptions {
+  /** True when a KC access token is currently in storage. */
+  isKeycloakActive: () => boolean;
+  /** Performs the RP-initiated KC logout (typically window.location.assign
+   *  to {realm}/protocol/openid-connect/logout). Should also clear any
+   *  KC tokens from the host app's storage before redirecting. */
+  performKeycloakLogout: () => void;
+}
+
+export function createDigitAuthProvider(
+  client: DigitApiClient,
+  kc?: KeycloakAuthOptions,
+): AuthProvider {
   return {
     login: async () => {
-      // No-op: login handled externally (LoginPage calls client.login() directly)
+      // No-op: login handled externally (LoginPage calls client.login() directly,
+      // or — in KC mode — the OAuth2 Authorization Code flow runs out-of-band)
     },
 
     checkAuth: async () => {
@@ -22,6 +42,14 @@ export function createDigitAuthProvider(client: DigitApiClient): AuthProvider {
 
     logout: async () => {
       client.clearAuth();
+      // In Keycloak mode, hand off to the host app's RP-initiated logout —
+      // it calls {realm}/protocol/openid-connect/logout?id_token_hint=...
+      // which revokes the KC session before redirecting back to /login.
+      // The browser navigates away; the `return '/login'` below is then a
+      // no-op (ra-core never gets to redirect because we've already left).
+      if (kc?.isKeycloakActive() && kc.performKeycloakLogout) {
+        kc.performKeycloakLogout();
+      }
       return '/login';
     },
 

--- a/digit-ui-v2/src/App.tsx
+++ b/digit-ui-v2/src/App.tsx
@@ -24,7 +24,8 @@ import CitizenLayout from './components/layout/CitizenLayout';
 import { ThemeProvider } from './providers/ThemeProvider';
 import { citizenDataProvider, citizenAuthProvider } from './providers/citizenBridge';
 // Toaster removed — citizen UI v1 surfaces errors via inline Alert components.
-import { apiClient, getApiBaseUrl } from './api';
+import { apiClient, getApiBaseUrl, isKeycloakMode, hasKcToken } from './api';
+import { getKcIdToken, clearKcTokens, logoutKc } from './api/keycloak';
 import { identifyUser, clearUser, trackEvent } from './lib/telemetry';
 import './App.css';
 
@@ -141,6 +142,15 @@ function App() {
     localStorage.removeItem(AUTH_STORAGE_KEY);
     apiClient.logout();
     setState({ isAuthenticated: false, user: null, tenant: state.tenant });
+    // KC-aware logout — issue an RP-initiated logout so Keycloak revokes the
+    // server session (otherwise re-clicking "Sign in with Keycloak" SSOs the
+    // user back in without prompting). Browser navigates away, so anything
+    // below this line won't run when KC is active.
+    if (isKeycloakMode() && hasKcToken()) {
+      const idToken = getKcIdToken();
+      clearKcTokens();
+      logoutKc(idToken);
+    }
   };
 
   return (

--- a/digit-ui-v2/src/App.tsx
+++ b/digit-ui-v2/src/App.tsx
@@ -13,6 +13,7 @@ import { useState, createContext, useContext, useEffect } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { CoreAdminContext } from 'ra-core';
 import CitizenLoginPage from './pages/CitizenLoginPage';
+import CitizenKcCallback from './pages/CitizenKcCallback';
 import CitizenDashboardPage from './pages/CitizenDashboardPage';
 import CitizenComplaintsListPage from './pages/CitizenComplaintsListPage';
 import CitizenComplaintShowPage from './pages/CitizenComplaintShowPage';
@@ -162,6 +163,9 @@ function App() {
             <ThemeProvider>
               <Routes>
                 <Route path="/login" element={<CitizenLoginPage />} />
+                {/* KC callback is intentionally unguarded — the user is
+                   mid-auth at this point and not yet logged in. */}
+                <Route path="/auth/callback" element={<CitizenKcCallback />} />
                 <Route
                   path="/"
                   element={state.isAuthenticated ? <CitizenLayout /> : <Navigate to="/login" replace />}

--- a/digit-ui-v2/src/api/config.ts
+++ b/digit-ui-v2/src/api/config.ts
@@ -1,10 +1,81 @@
 // DIGIT Environment Configuration
 
+// ── Keycloak / token-exchange shared env contract ───────────────────────────
+//
+// These are populated at build time on production deploys via Vite env vars
+// (see ansible templates/digit.env.j2). On the dev / preview build they're
+// empty, which keeps everything inert — `isKeycloakMode()` is false and every
+// code path stays identical to the OTP-only behavior.
+//
+// VITE_AUTH_PROVIDER         "keycloak" turns on the KC button + overlay routing
+// VITE_KEYCLOAK_URL          Browser-relative base for the realm (e.g. "/auth")
+// VITE_KEYCLOAK_REALM        Realm name (state tenant — "ke" on bomet/naipepea)
+// VITE_KEYCLOAK_CLIENT_ID    Public client (default "digit-ui")
+// VITE_TOKEN_EXCHANGE_URL    Browser-relative overlay prefix (e.g. "/token-exchange")
+//                            When set + a KC token is present, DIGIT API URLs
+//                            become `${origin}${overlay}/${original-path}`.
+//                            The overlay strips the prefix, validates the JWT,
+//                            and proxies upstream with a system token.
+export const AUTH_PROVIDER = (import.meta.env.VITE_AUTH_PROVIDER as string) || '';
+export const KEYCLOAK_URL = (import.meta.env.VITE_KEYCLOAK_URL as string) || '';
+export const KEYCLOAK_REALM = (import.meta.env.VITE_KEYCLOAK_REALM as string) || '';
+export const KEYCLOAK_CLIENT_ID =
+  (import.meta.env.VITE_KEYCLOAK_CLIENT_ID as string) || 'digit-ui';
+export const TOKEN_EXCHANGE_URL =
+  (import.meta.env.VITE_TOKEN_EXCHANGE_URL as string) || '';
+
+/** True when the build was wired up for Keycloak. Inert (false) by default. */
+export function isKeycloakMode(): boolean {
+  return AUTH_PROVIDER === 'keycloak';
+}
+
+// ── localStorage keys for KC tokens ────────────────────────────────────────
+
+export const KC_STORAGE_KEYS = {
+  access: 'digit_ui_v2_kc_access',
+  refresh: 'digit_ui_v2_kc_refresh',
+  id: 'digit_ui_v2_kc_id',
+  state: 'digit_ui_v2_kc_oauth_state',
+  expiresAt: 'digit_ui_v2_kc_expires_at',
+} as const;
+
+/** True when a KC access token has been minted + saved (post-callback). */
+export function hasKcToken(): boolean {
+  if (typeof localStorage === 'undefined') return false;
+  try {
+    return !!localStorage.getItem(KC_STORAGE_KEYS.access);
+  } catch {
+    return false;
+  }
+}
+
 /** Auto-detect API base URL from the current origin. Each deployment serves
- *  the configurator and DIGIT APIs from the same domain via nginx. */
+ *  the configurator and DIGIT APIs from the same domain via nginx.
+ *
+ *  In Keycloak mode with a citizen KC token present, all DIGIT API calls are
+ *  transparently routed through `${origin}${TOKEN_EXCHANGE_URL}` so the
+ *  overlay can rewrite RequestInfo (inject system token + real user identity)
+ *  before forwarding upstream. The OTP login endpoints (used before a KC
+ *  token exists) bypass the overlay automatically — `hasKcToken()` is false
+ *  during the OTP flow. */
 export function getApiBaseUrl(): string {
-  if (typeof window !== 'undefined') return window.location.origin;
-  return 'https://localhost';
+  const origin = typeof window !== 'undefined' ? window.location.origin : 'https://localhost';
+  if (isKeycloakMode() && TOKEN_EXCHANGE_URL && hasKcToken()) {
+    return `${origin}${TOKEN_EXCHANGE_URL}`;
+  }
+  return origin;
+}
+
+/** Explicit overlay-aware base. Kept for callers that want the intent to be
+ *  obvious at the call site (the default `getApiBaseUrl` already does this). */
+export function getApiBaseUrlWithTokenExchange(): string {
+  return getApiBaseUrl();
+}
+
+/** The bare origin, no overlay prefix — for KC endpoints themselves (which
+ *  must hit /auth/realms/... directly, not via the DIGIT overlay). */
+export function getOriginBaseUrl(): string {
+  return typeof window !== 'undefined' ? window.location.origin : 'https://localhost';
 }
 
 // Service endpoints

--- a/digit-ui-v2/src/api/config.ts
+++ b/digit-ui-v2/src/api/config.ts
@@ -36,6 +36,11 @@ export const KC_STORAGE_KEYS = {
   refresh: 'digit_ui_v2_kc_refresh',
   id: 'digit_ui_v2_kc_id',
   state: 'digit_ui_v2_kc_oauth_state',
+  // PKCE code_verifier — generated before /authorize, sent back with the
+  // /token exchange. KC rejects public clients without it (the realm
+  // sets pkce.code.challenge.method=S256). The verifier lives only as
+  // long as the round-trip and is cleared on callback success or error.
+  pkceVerifier: 'digit_ui_v2_kc_pkce_verifier',
   expiresAt: 'digit_ui_v2_kc_expires_at',
 } as const;
 

--- a/digit-ui-v2/src/api/index.ts
+++ b/digit-ui-v2/src/api/index.ts
@@ -1,4 +1,19 @@
 // Citizen-UI API surface (slim — operator service modules stripped).
 export { apiClient, ApiClientError, DigitApiClient } from './client';
-export { getApiBaseUrl, ENDPOINTS, OAUTH_CONFIG, DEFAULT_PASSWORD } from './config';
+export {
+  getApiBaseUrl,
+  getApiBaseUrlWithTokenExchange,
+  getOriginBaseUrl,
+  ENDPOINTS,
+  OAUTH_CONFIG,
+  DEFAULT_PASSWORD,
+  AUTH_PROVIDER,
+  KEYCLOAK_URL,
+  KEYCLOAK_REALM,
+  KEYCLOAK_CLIENT_ID,
+  TOKEN_EXCHANGE_URL,
+  KC_STORAGE_KEYS,
+  isKeycloakMode,
+  hasKcToken,
+} from './config';
 export type { UserInfo, Role } from './types';

--- a/digit-ui-v2/src/api/keycloak.ts
+++ b/digit-ui-v2/src/api/keycloak.ts
@@ -128,6 +128,52 @@ function generateState(): string {
   return Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('');
 }
 
+// ── PKCE (RFC 7636) ─────────────────────────────────────────────────────────
+//
+// Keycloak's `digit-ui` client is a public client (no client_secret in the
+// browser), so the realm requires PKCE. Flow:
+//   1. /authorize → send `code_challenge` (S256 hash of a random verifier) +
+//      `code_challenge_method=S256`. Save the verifier in localStorage.
+//   2. KC remembers the challenge against the issued code.
+//   3. /token → send the original `code_verifier`. KC re-hashes it and checks
+//      it matches what it stored. Mismatch → 400.
+// PKCE costs ~100 bytes of localStorage and one extra POST param. There's
+// no reason not to do it on every authorize call.
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let str = '';
+  for (const b of bytes) str += String.fromCharCode(b);
+  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function generateCodeVerifier(): string {
+  // 32 random bytes → 43-char base64url — meets the RFC's 43..128 range.
+  const buf = new Uint8Array(32);
+  crypto.getRandomValues(buf);
+  return base64UrlEncode(buf);
+}
+
+async function computeCodeChallenge(verifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+  return base64UrlEncode(new Uint8Array(digest));
+}
+
+export function getStoredCodeVerifier(): string | null {
+  try {
+    return localStorage.getItem(KC_STORAGE_KEYS.pkceVerifier);
+  } catch {
+    return null;
+  }
+}
+
+export function clearStoredCodeVerifier(): void {
+  try {
+    localStorage.removeItem(KC_STORAGE_KEYS.pkceVerifier);
+  } catch {
+    /* best-effort */
+  }
+}
+
 // ── Public API ─────────────────────────────────────────────────────────────
 
 /**
@@ -138,13 +184,17 @@ function generateState(): string {
  *   '/citizen/auth/callback'. We turn it into an absolute redirect_uri
  *   because Keycloak requires that.
  */
-export function buildAuthorizeUrl(redirectPath: string, idpHint?: string): string {
+export async function buildAuthorizeUrl(redirectPath: string, idpHint?: string): Promise<string> {
   const state = generateState();
+  const verifier = generateCodeVerifier();
+  const challenge = await computeCodeChallenge(verifier);
   try {
     localStorage.setItem(KC_STORAGE_KEYS.state, state);
+    localStorage.setItem(KC_STORAGE_KEYS.pkceVerifier, verifier);
   } catch {
-    // If localStorage is unavailable the callback will fail state verification
-    // and fall through to the error path — better than silently allowing CSRF.
+    // If localStorage is unavailable the callback will fail state +
+    // PKCE verification and fall through to the error path — better than
+    // silently allowing CSRF or an unhashed-public-client flow.
   }
   const params = new URLSearchParams({
     client_id: KEYCLOAK_CLIENT_ID,
@@ -152,6 +202,8 @@ export function buildAuthorizeUrl(redirectPath: string, idpHint?: string): strin
     response_type: 'code',
     scope: 'openid',
     state,
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
   });
   // `kc_idp_hint` skips the Keycloak account-chooser screen and routes
   // straight to the named identity provider (e.g. `google`). The realm
@@ -217,11 +269,18 @@ export async function exchangeCodeForTokens(
     redirect_uri: absoluteRedirectUri(redirectUri),
     client_id: KEYCLOAK_CLIENT_ID,
   });
+  // PKCE: send back the original verifier we generated at /authorize.
+  // KC re-hashes it server-side and matches against the challenge it
+  // stored against the code — public-client requirement, can't skip.
+  const verifier = getStoredCodeVerifier();
+  if (verifier) body.set('code_verifier', verifier);
+
   const res = await fetch(`${realmBase()}/token`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: body.toString(),
   });
+  clearStoredCodeVerifier();   // single-use whether the request succeeded or not
   if (!res.ok) {
     const text = await res.text().catch(() => '');
     throw new Error(`Keycloak token exchange failed (${res.status}): ${text.slice(0, 200)}`);

--- a/digit-ui-v2/src/api/keycloak.ts
+++ b/digit-ui-v2/src/api/keycloak.ts
@@ -1,0 +1,220 @@
+/**
+ * OAuth2 Authorization Code Flow helper for Keycloak.
+ *
+ * Public client `digit-ui` is pre-seeded in the realm template; no client
+ * secret. We don't use PKCE here because (a) the realm is also accessed by
+ * server-side flows that need confidential semantics, and (b) the overlay
+ * service immediately revalidates the JWT signature on every request — the
+ * code's window of usefulness is the round-trip time to /token, after which
+ * it's consumed and discarded.
+ *
+ * The endpoints below are all on `${KEYCLOAK_URL}/realms/${REALM}/...`.
+ * `KEYCLOAK_URL` is browser-relative ("/auth"), so the browser resolves
+ * to the same origin as the SPA. nginx proxies `/auth` → Keycloak.
+ *
+ * All token operations live in localStorage:
+ *   digit_ui_v2_kc_access   short-lived access JWT (sent as Bearer)
+ *   digit_ui_v2_kc_refresh  long-lived refresh token (used on 401 retry)
+ *   digit_ui_v2_kc_id       id_token, only needed for RP-initiated logout
+ *   digit_ui_v2_kc_oauth_state   CSRF state, lives only between /authorize
+ *                                redirect and /callback
+ *   digit_ui_v2_kc_expires_at    epoch ms — UI hint, not enforced
+ *
+ * Note: storing tokens in localStorage is the established pattern for this
+ * SPA (the OTP-derived DIGIT token is also in localStorage). The overlay
+ * defends against XSS-stolen tokens by checking the JWT signature + iss
+ * claim on every call.
+ */
+import {
+  KEYCLOAK_URL,
+  KEYCLOAK_REALM,
+  KEYCLOAK_CLIENT_ID,
+  KC_STORAGE_KEYS,
+  getOriginBaseUrl,
+} from './config';
+
+export interface KcTokenResponse {
+  access_token: string;
+  refresh_token: string;
+  id_token: string;
+  expires_in: number;
+  refresh_expires_in?: number;
+  token_type?: string;
+  scope?: string;
+}
+
+// ── localStorage helpers ───────────────────────────────────────────────────
+
+export function getKcAccessToken(): string | null {
+  try {
+    return localStorage.getItem(KC_STORAGE_KEYS.access);
+  } catch {
+    return null;
+  }
+}
+
+export function getKcRefreshToken(): string | null {
+  try {
+    return localStorage.getItem(KC_STORAGE_KEYS.refresh);
+  } catch {
+    return null;
+  }
+}
+
+export function getKcIdToken(): string | null {
+  try {
+    return localStorage.getItem(KC_STORAGE_KEYS.id);
+  } catch {
+    return null;
+  }
+}
+
+export function hasKcToken(): boolean {
+  return !!getKcAccessToken();
+}
+
+export function saveKcTokens(tokens: KcTokenResponse): void {
+  localStorage.setItem(KC_STORAGE_KEYS.access, tokens.access_token);
+  localStorage.setItem(KC_STORAGE_KEYS.refresh, tokens.refresh_token);
+  localStorage.setItem(KC_STORAGE_KEYS.id, tokens.id_token);
+  const expiresAt = Date.now() + tokens.expires_in * 1000;
+  localStorage.setItem(KC_STORAGE_KEYS.expiresAt, String(expiresAt));
+}
+
+export function clearKcTokens(): void {
+  localStorage.removeItem(KC_STORAGE_KEYS.access);
+  localStorage.removeItem(KC_STORAGE_KEYS.refresh);
+  localStorage.removeItem(KC_STORAGE_KEYS.id);
+  localStorage.removeItem(KC_STORAGE_KEYS.expiresAt);
+}
+
+// ── KC URL builders ────────────────────────────────────────────────────────
+
+function realmBase(): string {
+  // KEYCLOAK_URL is relative ("/auth"); browser resolves against the current
+  // origin so we get e.g. https://naipepea.digit.org/auth/realms/ke/...
+  return `${KEYCLOAK_URL}/realms/${encodeURIComponent(KEYCLOAK_REALM)}/protocol/openid-connect`;
+}
+
+function absoluteRedirectUri(path: string): string {
+  // Normalize so callers can pass either '/citizen/auth/callback' or full URL.
+  if (/^https?:\/\//.test(path)) return path;
+  return `${getOriginBaseUrl()}${path.startsWith('/') ? path : `/${path}`}`;
+}
+
+function generateState(): string {
+  // crypto.getRandomValues is universally available in browsers we ship to.
+  const buf = new Uint8Array(16);
+  crypto.getRandomValues(buf);
+  return Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────
+
+/**
+ * Build the /authorize redirect URL and persist the CSRF state so the
+ * callback can verify it.
+ *
+ * @param redirectPath path the callback page lives at — e.g.
+ *   '/citizen/auth/callback'. We turn it into an absolute redirect_uri
+ *   because Keycloak requires that.
+ */
+export function buildAuthorizeUrl(redirectPath: string): string {
+  const state = generateState();
+  try {
+    localStorage.setItem(KC_STORAGE_KEYS.state, state);
+  } catch {
+    // If localStorage is unavailable the callback will fail state verification
+    // and fall through to the error path — better than silently allowing CSRF.
+  }
+  const params = new URLSearchParams({
+    client_id: KEYCLOAK_CLIENT_ID,
+    redirect_uri: absoluteRedirectUri(redirectPath),
+    response_type: 'code',
+    scope: 'openid',
+    state,
+  });
+  return `${realmBase()}/auth?${params.toString()}`;
+}
+
+/**
+ * Exchange an authorization code for tokens. Throws on any non-2xx — the
+ * caller (callback page) is expected to surface the error to the user.
+ */
+export async function exchangeCodeForTokens(
+  code: string,
+  redirectUri: string,
+): Promise<KcTokenResponse> {
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: absoluteRedirectUri(redirectUri),
+    client_id: KEYCLOAK_CLIENT_ID,
+  });
+  const res = await fetch(`${realmBase()}/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Keycloak token exchange failed (${res.status}): ${text.slice(0, 200)}`);
+  }
+  return (await res.json()) as KcTokenResponse;
+}
+
+/**
+ * Use the stored refresh_token to mint a new access_token. Throws if the
+ * refresh token is missing or rejected — caller should clearKcTokens() and
+ * redirect to login on failure.
+ */
+export async function refreshKcToken(): Promise<KcTokenResponse> {
+  const refresh = getKcRefreshToken();
+  if (!refresh) throw new Error('No refresh_token available');
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: refresh,
+    client_id: KEYCLOAK_CLIENT_ID,
+  });
+  const res = await fetch(`${realmBase()}/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+  if (!res.ok) {
+    throw new Error(`Keycloak refresh failed (${res.status})`);
+  }
+  const tokens = (await res.json()) as KcTokenResponse;
+  saveKcTokens(tokens);
+  return tokens;
+}
+
+/**
+ * Verify the state value returned on the callback matches what we stored.
+ * Consumes the stored state (single-use). Returns true on match.
+ */
+export function consumeAndVerifyState(returnedState: string | null): boolean {
+  if (!returnedState) return false;
+  let stored: string | null = null;
+  try {
+    stored = localStorage.getItem(KC_STORAGE_KEYS.state);
+    localStorage.removeItem(KC_STORAGE_KEYS.state);
+  } catch {
+    return false;
+  }
+  return !!stored && stored === returnedState;
+}
+
+/**
+ * RP-initiated logout — Keycloak revokes the session, then redirects back
+ * to the post_logout_redirect_uri. Browser navigates away; this function
+ * never returns.
+ */
+export function logoutKc(idToken: string | null, postLogoutPath = '/citizen/login'): void {
+  const postLogout = absoluteRedirectUri(postLogoutPath);
+  const params = new URLSearchParams({ post_logout_redirect_uri: postLogout });
+  if (idToken) params.set('id_token_hint', idToken);
+  // client_id is also accepted by Keycloak when id_token_hint is unavailable.
+  params.set('client_id', KEYCLOAK_CLIENT_ID);
+  window.location.assign(`${realmBase()}/logout?${params.toString()}`);
+}

--- a/digit-ui-v2/src/api/keycloak.ts
+++ b/digit-ui-v2/src/api/keycloak.ts
@@ -30,6 +30,7 @@ import {
   KEYCLOAK_REALM,
   KEYCLOAK_CLIENT_ID,
   KC_STORAGE_KEYS,
+  TOKEN_EXCHANGE_URL,
   getOriginBaseUrl,
 } from './config';
 
@@ -41,6 +42,24 @@ export interface KcTokenResponse {
   refresh_expires_in?: number;
   token_type?: string;
   scope?: string;
+}
+
+/**
+ * Decode the payload of a JWT without verifying its signature. The overlay
+ * always re-validates the signature server-side on every call — this is
+ * just for the SPA to extract claims for UI display.
+ */
+export function decodeJwtPayload(jwt: string): Record<string, any> {
+  try {
+    const part = jwt.split('.')[1];
+    if (!part) return {};
+    // base64url → base64
+    const pad = part.length % 4 === 2 ? '==' : part.length % 4 === 3 ? '=' : '';
+    const b64 = (part + pad).replace(/-/g, '+').replace(/_/g, '/');
+    return JSON.parse(atob(b64));
+  } catch {
+    return {};
+  }
 }
 
 // ── localStorage helpers ───────────────────────────────────────────────────
@@ -119,7 +138,7 @@ function generateState(): string {
  *   '/citizen/auth/callback'. We turn it into an absolute redirect_uri
  *   because Keycloak requires that.
  */
-export function buildAuthorizeUrl(redirectPath: string): string {
+export function buildAuthorizeUrl(redirectPath: string, idpHint?: string): string {
   const state = generateState();
   try {
     localStorage.setItem(KC_STORAGE_KEYS.state, state);
@@ -134,7 +153,54 @@ export function buildAuthorizeUrl(redirectPath: string): string {
     scope: 'openid',
     state,
   });
+  // `kc_idp_hint` skips the Keycloak account-chooser screen and routes
+  // straight to the named identity provider (e.g. `google`). The realm
+  // must have the IdP provisioned with that exact alias — see the ansible
+  // `keycloak-bootstrap — wire Google IdP` task.
+  if (idpHint) params.set('kc_idp_hint', idpHint);
   return `${realmBase()}/auth?${params.toString()}`;
+}
+
+/**
+ * OAuth2 Resource Owner Password Credentials grant against the overlay's
+ * `/realms/:realm/protocol/openid-connect/token` endpoint. The overlay
+ * tries the KC realm first; on KC failure it transparently falls back to
+ * DIGIT (egov-user `/user/oauth/token`) and provisions the KC side from
+ * the DIGIT user info. Net result: mobile+OTP citizens authenticate
+ * locally (no redirect) while the SPA still ends up with KC-signed JWTs
+ * for subsequent API calls — exactly what `kc_idp_hint=google` does for
+ * SSO, just without leaving the SPA.
+ */
+export async function passwordGrantViaOverlay(opts: {
+  username: string;
+  password: string;
+  tenantId?: string;
+  userType?: string;
+}): Promise<KcTokenResponse> {
+  const body = new URLSearchParams({
+    grant_type: 'password',
+    client_id: KEYCLOAK_CLIENT_ID,
+    username: opts.username,
+    password: opts.password,
+    scope: 'openid',
+  });
+  // Overlay reads these from the form body (KC ignores them; DIGIT
+  // fallback needs them to call /user/oauth/token correctly).
+  if (opts.tenantId) body.set('tenantId', opts.tenantId);
+  if (opts.userType) body.set('userType', opts.userType);
+
+  const origin = getOriginBaseUrl();
+  const url = `${origin}${TOKEN_EXCHANGE_URL}/realms/${encodeURIComponent(KEYCLOAK_REALM)}/protocol/openid-connect/token`;
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+  if (!resp.ok) {
+    const err = await resp.json().catch(() => ({}));
+    throw new Error(err.error_description || err.error || `password grant failed: ${resp.status}`);
+  }
+  return resp.json();
 }
 
 /**

--- a/digit-ui-v2/src/pages/CitizenKcCallback.tsx
+++ b/digit-ui-v2/src/pages/CitizenKcCallback.tsx
@@ -1,0 +1,166 @@
+/**
+ * Keycloak OAuth2 Authorization Code callback page.
+ *
+ * Route: /citizen/auth/callback  (mounted in App.tsx as "/auth/callback"
+ * under the /citizen basename).
+ *
+ * Flow on mount:
+ *   1. Parse `code` + `state` from window.location.search.
+ *   2. Verify state matches the persisted one (single-use, anti-CSRF).
+ *   3. POST /token to exchange code for tokens.
+ *   4. Save tokens to localStorage (keys in KC_STORAGE_KEYS).
+ *   5. (Best-effort) fetch /userinfo via the overlay to seed AppContext.
+ *   6. Navigate to /dashboard on success, /login?error=... on failure.
+ *
+ * The page renders only a tiny status string — it's expected to live for
+ * about one round-trip then redirect away. If something goes wrong we send
+ * the user back to /login with an `error` query param so the login page
+ * can surface it via its existing Alert component.
+ */
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Card, CardContent } from '@/components/ui/card';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  consumeAndVerifyState,
+  exchangeCodeForTokens,
+  saveKcTokens,
+  clearKcTokens,
+} from '@/api/keycloak';
+import { apiClient, getApiBaseUrl } from '@/api';
+import { useApp } from '@/App';
+
+const CITY_TENANT = (import.meta.env.VITE_CITIZEN_TENANT as string) || 'ke.nairobi';
+const REDIRECT_PATH = '/citizen/auth/callback';
+
+interface UserInfoResponse {
+  sub?: string;
+  name?: string;
+  preferred_username?: string;
+  email?: string;
+  phone_number?: string;
+}
+
+export default function CitizenKcCallback() {
+  const navigate = useNavigate();
+  const { login } = useApp();
+  // React 19 in StrictMode mounts effects twice; guard so we don't burn the
+  // single-use authorization code on the dev-mode replay.
+  const didRunRef = useRef(false);
+  const [status, setStatus] = useState<'pending' | 'error'>('pending');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (didRunRef.current) return;
+    didRunRef.current = true;
+
+    (async () => {
+      const params = new URLSearchParams(window.location.search);
+      const code = params.get('code');
+      const state = params.get('state');
+      const oauthError = params.get('error');
+
+      if (oauthError) {
+        const desc = params.get('error_description') || oauthError;
+        clearKcTokens();
+        setErrorMessage(desc);
+        setStatus('error');
+        navigate(`/login?error=${encodeURIComponent(desc)}`, { replace: true });
+        return;
+      }
+
+      if (!code || !consumeAndVerifyState(state)) {
+        const msg = 'Sign-in could not be verified. Please try again.';
+        clearKcTokens();
+        setErrorMessage(msg);
+        setStatus('error');
+        navigate(`/login?error=${encodeURIComponent(msg)}`, { replace: true });
+        return;
+      }
+
+      try {
+        const tokens = await exchangeCodeForTokens(code, REDIRECT_PATH);
+        saveKcTokens(tokens);
+
+        // Best-effort identity hydration. The overlay exposes /userinfo
+        // proxied to Keycloak. If it fails (network blip, misconfig) we
+        // still proceed to /dashboard — the AppContext can fall back to a
+        // placeholder name and the protected pages will fetch their own
+        // citizen profile.
+        let display = { name: 'Citizen', mobile: '', uuid: '' as string | undefined };
+        try {
+          const res = await fetch(`${getApiBaseUrl()}/userinfo`, {
+            headers: { Authorization: `Bearer ${tokens.access_token}` },
+          });
+          if (res.ok) {
+            const info = (await res.json()) as UserInfoResponse;
+            display = {
+              name: info.name || info.preferred_username || 'Citizen',
+              mobile: info.phone_number || info.preferred_username || '',
+              uuid: info.sub,
+            };
+          }
+        } catch {
+          // Swallow — best-effort.
+        }
+
+        // Seed apiClient so subsequent overlay-routed DIGIT calls carry the
+        // KC bearer (DigitApiClient now reads it from localStorage too, but
+        // legacy fetch sites in pages/hooks read apiClient.getAuth().token).
+        apiClient.setEnvironment(window.location.origin);
+        apiClient.setAuth(tokens.access_token, {
+          id: 0,
+          uuid: display.uuid ?? '',
+          userName: display.mobile,
+          name: display.name,
+          mobileNumber: display.mobile,
+          type: 'CITIZEN',
+          roles: [{ code: 'CITIZEN', name: 'Citizen', tenantId: CITY_TENANT }],
+          tenantId: CITY_TENANT,
+        });
+        apiClient.setTenantId(CITY_TENANT);
+
+        login(
+          {
+            name: display.name,
+            mobile: display.mobile,
+            uuid: display.uuid,
+            type: 'CITIZEN',
+          },
+          CITY_TENANT,
+        );
+        navigate('/dashboard', { replace: true });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'Sign-in failed.';
+        clearKcTokens();
+        setErrorMessage(msg);
+        setStatus('error');
+        navigate(`/login?error=${encodeURIComponent(msg)}`, { replace: true });
+      }
+    })();
+    // We deliberately depend on nothing — this is one-shot.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-muted/30 p-4">
+      <Card className="w-full max-w-md">
+        <CardContent className="pt-6 space-y-4">
+          {status === 'pending' ? (
+            <div className="flex items-center justify-center gap-3 text-sm text-muted-foreground">
+              <span
+                aria-hidden
+                className="h-4 w-4 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent"
+              />
+              <span>Signing you in&hellip;</span>
+            </div>
+          ) : (
+            <Alert variant="destructive">
+              <AlertDescription>{errorMessage ?? 'Sign-in failed.'}</AlertDescription>
+            </Alert>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/digit-ui-v2/src/pages/CitizenLoginPage.tsx
+++ b/digit-ui-v2/src/pages/CitizenLoginPage.tsx
@@ -28,7 +28,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Separator } from '@/components/ui/separator';
 import { apiClient, getApiBaseUrl, ENDPOINTS, isKeycloakMode } from '@/api';
-import { buildAuthorizeUrl } from '@/api/keycloak';
+import { buildAuthorizeUrl, decodeJwtPayload, passwordGrantViaOverlay, saveKcTokens } from '@/api/keycloak';
 import { useApp } from '@/App';
 
 const STATE_TENANT = (import.meta.env.VITE_CITIZEN_STATE_TENANT as string) || 'ke';
@@ -64,12 +64,16 @@ export default function CitizenLoginPage() {
     }
   }, []);
 
-  function signInWithKeycloak() {
+  function signInWithGoogle() {
     setError(null);
+    // `kc_idp_hint=google` skips the Keycloak account-chooser and
+    // redirects straight to Google's OAuth consent screen. The realm
+    // must have the `google` IdP provisioned (ansible's keycloak-bootstrap
+    // task does this when keycloak_google_client_id is set in host_vars).
     // /citizen is the SPA's basename; the absolute redirect_uri needs the
     // full path so Keycloak's exact-match check passes. buildAuthorizeUrl
     // handles the origin prefix.
-    window.location.assign(buildAuthorizeUrl('/citizen/auth/callback'));
+    window.location.assign(buildAuthorizeUrl('/citizen/auth/callback', 'google'));
   }
 
   async function sendOtp(e: React.FormEvent) {
@@ -108,6 +112,42 @@ export default function CitizenLoginPage() {
     setPending(true);
 
     const attemptAuth = async (): Promise<{ token: string; user: Record<string, unknown> } | null> => {
+      // In KC mode, route the password grant through the overlay's
+      // standard OAuth2 token endpoint. The overlay tries KC first; on
+      // KC failure it falls back to DIGIT's /user/oauth/token (using
+      // tenantId + userType from the body), then provisions the KC user
+      // from the DIGIT result. The SPA gets a KC-signed JWT either way.
+      // Crucially this requires NO redirect — the form posts and we
+      // stay on the page. Direct KC SSO (Google, etc) happens via the
+      // separate "Continue with Google" button.
+      if (kcMode) {
+        try {
+          const tokens = await passwordGrantViaOverlay({
+            username: mobile,
+            password: otp,
+            tenantId: STATE_TENANT,
+            userType: 'CITIZEN',
+          });
+          saveKcTokens(tokens);
+          // Decode the access_token payload for a thin user shape — the
+          // overlay also exposes /userinfo for richer identity, but the
+          // JWT claims are enough to seed app state for the dashboard.
+          const claims = decodeJwtPayload(tokens.access_token);
+          return {
+            token: tokens.access_token,
+            user: {
+              uuid: claims.sub,
+              name: claims.name || `Citizen ${mobile}`,
+              userName: mobile,
+              mobileNumber: mobile,
+              roles: claims.realm_access?.roles?.map((code: string) => ({ code })) ?? [],
+            } as Record<string, unknown>,
+          };
+        } catch {
+          return null;   // overlay returns 401 → fall through to register
+        }
+      }
+
       const body = new URLSearchParams({
         username: mobile,
         password: otp,
@@ -202,11 +242,12 @@ export default function CitizenLoginPage() {
             <div className="space-y-4 mb-4">
               <Button
                 type="button"
+                variant="outline"
                 className="w-full"
-                onClick={signInWithKeycloak}
+                onClick={signInWithGoogle}
                 disabled={pending}
               >
-                Sign in with Keycloak
+                Continue with Google
               </Button>
               <div className="relative">
                 <Separator />

--- a/digit-ui-v2/src/pages/CitizenLoginPage.tsx
+++ b/digit-ui-v2/src/pages/CitizenLoginPage.tsx
@@ -19,14 +19,16 @@
  * tenantId for the auth + register calls is the STATE tenant (`ke`), not the
  * city tenant — egov-user keeps citizens at root.
  */
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { apiClient, getApiBaseUrl, ENDPOINTS } from '@/api';
+import { Separator } from '@/components/ui/separator';
+import { apiClient, getApiBaseUrl, ENDPOINTS, isKeycloakMode } from '@/api';
+import { buildAuthorizeUrl } from '@/api/keycloak';
 import { useApp } from '@/App';
 
 const STATE_TENANT = (import.meta.env.VITE_CITIZEN_STATE_TENANT as string) || 'ke';
@@ -46,6 +48,29 @@ export default function CitizenLoginPage() {
   const [otp, setOtp] = useState('');
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const kcMode = isKeycloakMode();
+
+  // Surface errors bubbled up from the Keycloak callback page (e.g. the
+  // overlay rejected the JWT or the user denied consent at the KC login
+  // screen). Read once, clear the query param so refresh doesn't replay.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const fromCallback = params.get('error');
+    if (fromCallback) {
+      setError(fromCallback);
+      const url = new URL(window.location.href);
+      url.searchParams.delete('error');
+      window.history.replaceState({}, '', url.toString());
+    }
+  }, []);
+
+  function signInWithKeycloak() {
+    setError(null);
+    // /citizen is the SPA's basename; the absolute redirect_uri needs the
+    // full path so Keycloak's exact-match check passes. buildAuthorizeUrl
+    // handles the origin prefix.
+    window.location.assign(buildAuthorizeUrl('/citizen/auth/callback'));
+  }
 
   async function sendOtp(e: React.FormEvent) {
     e.preventDefault();
@@ -173,6 +198,24 @@ export default function CitizenLoginPage() {
           </CardDescription>
         </CardHeader>
         <CardContent>
+          {kcMode && step === 'mobile' && (
+            <div className="space-y-4 mb-4">
+              <Button
+                type="button"
+                className="w-full"
+                onClick={signInWithKeycloak}
+                disabled={pending}
+              >
+                Sign in with Keycloak
+              </Button>
+              <div className="relative">
+                <Separator />
+                <span className="absolute left-1/2 -translate-x-1/2 -top-2.5 bg-card px-2 text-xs text-muted-foreground">
+                  Or continue with mobile
+                </span>
+              </div>
+            </div>
+          )}
           {step === 'mobile' ? (
             <form onSubmit={sendOtp} className="space-y-4">
               <div>

--- a/digit-ui-v2/src/pages/CitizenLoginPage.tsx
+++ b/digit-ui-v2/src/pages/CitizenLoginPage.tsx
@@ -64,16 +64,23 @@ export default function CitizenLoginPage() {
     }
   }, []);
 
-  function signInWithGoogle() {
+  async function signInWithGoogle() {
     setError(null);
-    // `kc_idp_hint=google` skips the Keycloak account-chooser and
-    // redirects straight to Google's OAuth consent screen. The realm
-    // must have the `google` IdP provisioned (ansible's keycloak-bootstrap
-    // task does this when keycloak_google_client_id is set in host_vars).
-    // /citizen is the SPA's basename; the absolute redirect_uri needs the
-    // full path so Keycloak's exact-match check passes. buildAuthorizeUrl
-    // handles the origin prefix.
-    window.location.assign(buildAuthorizeUrl('/citizen/auth/callback', 'google'));
+    setPending(true);
+    try {
+      // `kc_idp_hint=google` skips the Keycloak account-chooser and
+      // redirects straight to Google's OAuth consent screen. The realm
+      // must have the `google` IdP provisioned (ansible's keycloak-bootstrap
+      // task does this when keycloak_google_client_id is set in host_vars).
+      // buildAuthorizeUrl is async because it computes a PKCE
+      // code_challenge (SHA-256 via WebCrypto) — the digit-ui client is
+      // a public client and the realm requires PKCE.
+      const url = await buildAuthorizeUrl('/citizen/auth/callback', 'google');
+      window.location.assign(url);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not start Google sign-in.');
+      setPending(false);
+    }
   }
 
   async function sendOtp(e: React.FormEvent) {

--- a/digit-ui-v2/src/providers/citizenBridge.ts
+++ b/digit-ui-v2/src/providers/citizenBridge.ts
@@ -21,7 +21,8 @@ import type {
   CreateParams,
   RaRecord,
 } from 'ra-core';
-import { apiClient, getApiBaseUrl } from '@/api';
+import { apiClient, getApiBaseUrl, isKeycloakMode, hasKcToken } from '@/api';
+import { getKcIdToken, clearKcTokens, logoutKc } from '@/api/keycloak';
 
 const CITY_TENANT = (import.meta.env.VITE_CITIZEN_TENANT as string) || 'ke.nairobi';
 
@@ -267,7 +268,17 @@ export const citizenAuthProvider: AuthProvider = {
     throw new Error('react-admin login is not used; auth is driven by /citizen/login');
   },
   async logout() {
-    // No-op — App.tsx already handles the logout side effect.
+    // In KC mode with a live KC session, do RP-initiated logout — Keycloak
+    // kills its server-side session, then redirects to /citizen/login. The
+    // browser navigates away so this function never actually returns.
+    if (isKeycloakMode() && hasKcToken()) {
+      const idToken = getKcIdToken();
+      clearKcTokens();
+      logoutKc(idToken);
+      return;
+    }
+    // OTP mode: App.tsx already handles the logout side effect — nothing
+    // to do here.
   },
   async checkAuth() {
     if (!apiClient.isAuthenticated()) throw new Error('Not authenticated');


### PR DESCRIPTION
## Summary

Integrates Keycloak SSO into the digit-ui-v2 citizen SPA (merged via #634). Two distinct flows so we don't force a redirect for mobile-OTP users:

1. **Mobile + OTP form** — submits inline to the overlay's standard OAuth2 token endpoint (`/token-exchange/realms/:realm/protocol/openid-connect/token` with `grant_type=password`). Overlay tries KC first; on failure it falls back to DIGIT and provisions the KC user. **No browser redirect** — citizens stay on the SPA.
2. **"Continue with Google" button** — triggers an OAuth2 Authorization Code redirect with PKCE S256 + `kc_idp_hint=google`. The existing `/citizen/auth/callback` page exchanges the code for tokens.

## What changed

| File | Op | Why |
|---|---|---|
| `digit-ui-v2/src/api/config.ts` | mod | Expose `VITE_AUTH_PROVIDER`, `VITE_KEYCLOAK_*`, `VITE_TOKEN_EXCHANGE_URL`, KC localStorage keys, `decodeJwtPayload` |
| `digit-ui-v2/src/api/keycloak.ts` | NEW | OAuth2 Authorization Code helper (PKCE S256), `passwordGrantViaOverlay`, KC token storage, RP-initiated logout |
| `digit-ui-v2/src/pages/CitizenLoginPage.tsx` | mod | "Continue with Google" button + OTP form posts through overlay when KC mode active |
| `digit-ui-v2/src/pages/CitizenKcCallback.tsx` | NEW | `/auth/callback` handler — exchanges code for tokens with stored PKCE verifier |
| `digit-ui-v2/packages/data-provider/src/client/DigitApiClient.ts` | mod | Routes all DIGIT API calls through overlay when KC token present; KC-aware refresh on 401 |
| `digit-ui-v2/packages/data-provider/src/providers/authProvider.ts` | mod | ra-core auth provider — KC-aware logout via id_token_hint |

## Inert by default

When `VITE_AUTH_PROVIDER` is unset (current state of every environment that doesn't ship KC), every code path is identical to today's behavior. Citizens hit the existing OTP flow against `/user/oauth/token` unchanged.

## Build

```
default mode:  ~1,390 KB bundle, gzip ~452 KB (matches main)
KC mode:       ~1,393 KB bundle, gzip ~453 KB (+1.26 KB raw / +0.41 KB gzip)
```

No new npm deps. `keycloak-js` is CDN-loaded via the existing `public/index.html`.

## Validation

Playwright UI tests in https://github.com/ChakshuGautam/digit-integration-tests/tree/main/tests/keycloak validate:

- "Continue with Google" → `/authorize` URL with PKCE S256 + `kc_idp_hint=google` + correct redirect_uri ✅
- Mobile+OTP → overlay endpoint → KC JWT in localStorage (requires the matching deploy automation in #703)

## Depends on

- **#703** — deploy automation (ansible block + nginx /citizen/ + opt-in surface) — this PR's runtime artefacts are only deployable once #703 lands

## Coordinate with Kanav

His `KDwevedi:validate/all-themes-on-bomet` branch has these commits rebased in. After merge he'll need to rebase his theme/test work onto the new develop tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)