### PR TITLE
feat(chatbot): add provider-based tenant selection with WhatsApp inte…

### DIFF
--- a/backend/xstate-chatbot/nodejs/src/channel/twilio.js
+++ b/backend/xstate-chatbot/nodejs/src/channel/twilio.js
@@ -286,6 +286,42 @@ class TwilioWhatsAppProvider {
         return this.sendTwilioRequest(params);
     }
 
+    async sendInteractiveListMessage(to, body, buttonText, items) {
+        const contentApiUrl = 'https://content.twilio.com/v1/Contents';
+        const contentBody = {
+            friendly_name: `provider_tenant_picker_${Date.now()}`,
+            language: 'en',
+            types: {
+                'twilio/list-picker': {
+                    body: body,
+                    button: buttonText,
+                    items: items.map(item => ({ id: item.id, item: item.title }))
+                }
+            }
+        };
+
+        const contentResponse = await fetch(contentApiUrl, {
+            method: 'POST',
+            headers: {
+                'Authorization': this.getAuthHeader(),
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(contentBody)
+        });
+
+        if (!contentResponse.ok) {
+            const errBody = await contentResponse.text();
+            console.error('Twilio - Content API error:', contentResponse.status, errBody);
+            throw new Error(`Twilio Content API returned ${contentResponse.status}`);
+        }
+
+        const contentData = await contentResponse.json();
+        const contentSid = contentData.sid;
+        console.log('Twilio - Created list-picker content template:', contentSid);
+
+        await this.sendTemplateMessage(to, contentSid, {});
+    }
+
     async sendTemplateMessage(to, contentSid, contentVariables = {}) {
         const params = new URLSearchParams();
         params.append('To', `whatsapp:+91${to}`);
@@ -361,6 +397,14 @@ class TwilioWhatsAppProvider {
                     }
 
                     await this.sendTemplateMessage(userMobile, templateId, contentVariables);
+                }
+                else if (type === 'interactive_list') {
+                    await this.sendInteractiveListMessage(
+                        userMobile,
+                        message.body,
+                        message.button,
+                        message.items
+                    );
                 }
                 else if (type === 'image' || type === 'pdf') {
                     // For media messages, get the file URL

--- a/backend/xstate-chatbot/nodejs/src/env-variables.js
+++ b/backend/xstate-chatbot/nodejs/src/env-variables.js
@@ -142,6 +142,12 @@ const envVariables = {
         geoSearch: process.env.GEO_SEARCH === 'false' ? false : true
     },
 
+    configService: {
+        host: process.env.CONFIG_SERVICE_HOST || 'http://localhost:8092',
+        tenantId: process.env.CONFIG_SERVICE_TENANT_ID || 'DEFAULT',
+        providerTenantSchemaCode: process.env.CONFIG_SERVICE_PROVIDER_TENANT_SCHEMA_CODE || 'WhatsAppProviderTenantMap',
+    },
+
     billsAndReceiptsUseCase: {
         billSearchLimit: process.env.BILL_SEARCH_LIMIT || 3,
         receiptSearchLimit: process.env.RECEIPT_SEARCH_LIMIT || 3,

--- a/backend/xstate-chatbot/nodejs/src/machine/pgr.js
+++ b/backend/xstate-chatbot/nodejs/src/machine/pgr.js
@@ -1,5 +1,6 @@
 const { assign } = require('xstate');
 const { pgrService } = require('./service/service-loader');
+const configService = require('./service/config-service');
 const dialog = require('./util/dialog');
 const localisationService = require('./util/localisation-service');
 const config = require('../env-variables');
@@ -306,13 +307,8 @@ const pgr =  {
                         })
                       },
                       {
-                        target: '#city',
-                        cond: (context, event) => !event.data && context.message ==='1' && !config.pgrUseCase.geoSearch
-                        
-                      },
-                      {
-                        target: '#nlpCitySearch',
-                        cond: (context, event) => !event.data && context.message ==='1' && config.pgrUseCase.geoSearch
+                        target: '#tenantSelection',
+                        cond: (context, event) => !event.data && context.message === '1'
                       },
                       {
                         target: '#geoLocation',
@@ -323,18 +319,9 @@ const pgr =  {
                         })
                       }
                     ],
-                    onError: [
-                      {
-                        target: '#city',
-                        cond: (context, event) => !config.pgrUseCase.geoSearch,
-
-                      },
-                      {
-                        target: '#nlpCitySearch',
-                        cond: (context, event) => config.pgrUseCase.geoSearch,
-                      }
-
-                    ],
+                    onError: {
+                      target: '#tenantSelection'
+                    },
                   },
                 }
               }
@@ -402,19 +389,111 @@ const pgr =  {
                       cond: (context, event) => context.message.isValid && config.pgrUseCase.geoSearch && context.slots.pgr["locationConfirmed"] 
                     },
                     {
-                      target: '#city',
-                      cond: (context, event) => context.message.isValid && !config.pgrUseCase.geoSearch,
-
-                    },
-                    {
-                      target: '#nlpCitySearch',
-                      cond: (context, event) => context.message.isValid && config.pgrUseCase.geoSearch,
+                      target: '#tenantSelection',
+                      cond: (context) => context.message.isValid
                     },
                     {
                       target: 'process',
                       cond: (context, event) => {return !context.message.isValid;}                    
                     }
                   ]
+                }
+              }
+            },
+            tenantSelection: {
+              id: 'tenantSelection',
+              initial: 'question',
+              states: {
+                question: {
+                  invoke: {
+                    id: 'fetchTenantsByProvider',
+                    src: (context) => configService.fetchTenantsByProvider(
+                      context.extraInfo.whatsAppBusinessNumber,
+                      context.user.authToken,
+                      context.user.userId
+                    ),
+                    onDone: [
+                      {
+                        // Single tenant: auto-select, no prompt needed
+                        cond: (context, event) => event.data && event.data.length === 1,
+                        target: 'route',
+                        actions: assign((context, event) => {
+                          context.slots.pgr.city = event.data[0];
+                          context.extraInfo.tenantId = event.data[0];
+                        })
+                      },
+                      {
+                        // Multiple tenants: send interactive list, stay in question
+                        cond: (context, event) => event.data && event.data.length > 1,
+                        actions: assign((context, event) => {
+                          const tenants = event.data;
+                          context.grammer = tenants.map((t, i) => ({
+                            intention: t,
+                            recognize: [(i + 1).toString(), t]
+                          }));
+                          const interactiveMsg = {
+                            type: 'interactive_list',
+                            body: dialog.get_message(messages.tenantSelection.question, context.user.locale),
+                            button: dialog.get_message(messages.tenantSelection.button, context.user.locale),
+                            items: tenants.map(t => ({ id: t, title: t }))
+                          };
+                          dialog.sendMessage(context, interactiveMsg);
+                        })
+                      },
+                      {
+                        // No tenants configured for this provider: fall back to MDMS city list
+                        target: '#city'
+                      }
+                    ],
+                    onError: {
+                      // Config service unreachable: fall back to MDMS city list
+                      target: '#city'
+                    }
+                  },
+                  on: {
+                    USER_MESSAGE: 'process'
+                  }
+                },
+                process: {
+                  onEntry: assign((context, event) => {
+                    const isText = dialog.validateInputType(event, 'text');
+                    const isButton = dialog.validateInputType(event, 'button');
+                    if (isText || isButton) {
+                      context.intention = dialog.get_intention(context.grammer, event, true);
+                    } else {
+                      context.intention = dialog.INTENTION_UNKOWN;
+                    }
+                  }),
+                  always: [
+                    {
+                      target: 'route',
+                      cond: (context) => context.intention !== dialog.INTENTION_UNKOWN,
+                      actions: assign((context) => {
+                        context.slots.pgr.city = context.intention;
+                        context.extraInfo.tenantId = context.intention;
+                      })
+                    },
+                    {
+                      target: 'error'
+                    }
+                  ]
+                },
+                route: {
+                  always: [
+                    {
+                      target: '#nlpLocalitySearch',
+                      cond: () => config.pgrUseCase.geoSearch
+                    },
+                    {
+                      target: '#locality'
+                    }
+                  ]
+                },
+                error: {
+                  onEntry: assign((context) => {
+                    dialog.sendMessage(context, dialog.get_message(dialog.global_messages.error.retry, context.user.locale), false);
+                  }),
+                  always: 'question'
                 }
               }
             },
@@ -1052,6 +1131,16 @@ let messages = {
         en_IN: 'Provided locality is miss-spelled or not present in our system record.\nPlease enter the details again.',
         hi_IN: 'आपके द्वारा दर्ज किया गया स्थान गलत वर्तनी वाला है या हमारे सिस्टम रिकॉर्ड में मौजूद नहीं है।\nकृपया फिर से विवरण दर्ज करें।'
       }
+    }
+  },
+  tenantSelection: {
+    question: {
+      en_IN: 'Please select your city from the list below 👇',
+      hi_IN: 'नीचे दी गई सूची से अपना शहर चुनें 👇'
+    },
+    button: {
+      en_IN: 'Select City',
+      hi_IN: 'शहर चुनें'
     }
   },
   trackComplaint: {

--- a/backend/xstate-chatbot/nodejs/src/machine/service/config-service.js
+++ b/backend/xstate-chatbot/nodejs/src/machine/service/config-service.js
@@ -1,0 +1,39 @@
+const axios = require('axios');
+const config = require('../../env-variables');
+
+const fetchTenantsByProvider = async (providerNumber, authToken, userUuid) => {
+  const url = `${config.configService.host}/config-service/config/v1/_search`;
+
+  const requestBody = {
+    RequestInfo: {
+      apiId: 'Rainmaker',
+      ver: '1.0',
+      ts: Date.now(),
+      action: '_search',
+      msgId: `chatbot-provider-tenant-${Date.now()}`,
+      authToken: authToken || '',
+      userInfo: { uuid: userUuid || '' }
+    },
+    criteria: {
+      tenantId: config.configService.tenantId,
+      schemaCode: config.configService.providerTenantSchemaCode,
+      criteria: {
+        providerNumber: providerNumber
+      }
+    }
+  };
+
+  const response = await axios.post(url, requestBody, {
+    headers: { 'Content-Type': 'application/json' },
+    timeout: 10000
+  });
+
+  const configData = response.data && response.data.configData;
+  if (!Array.isArray(configData) || configData.length === 0) return [];
+
+  return configData
+    .map(entry => entry.data && entry.data.tenantid)
+    .filter(Boolean);
+};
+
+module.exports = { fetchTenantsByProvider };


### PR DESCRIPTION
…ractive list picker

- Add config-service.js to fetch tenantIds mapped to WhatsApp provider number from digit-config-service
- Add tenantSelection state in pgr.js replacing city/NLP city step with interactive dropdown
- Add sendInteractiveListMessage in twilio.js using Twilio Content API (list-picker template)
- Add configService env vars (host, tenantId, schemaCode) in env-variables.js
- Single tenant auto-selects silently; multiple tenants show WhatsApp list picker
- Falls back to MDMS city list if config service is unreachable or returns no data