### PR TITLE
feat(ansible): serve integration-tests dashboards from the deployer

### DIFF
--- a/local-setup/ansible/files/integration-tests-build.sh
+++ b/local-setup/ansible/files/integration-tests-build.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# integration-tests-build.sh — build the react-admin test-catalog dashboard.
+#
+# Invoked by the playbook when `enable_integration_tests: true`. The source is
+# VENDORED in-tree at CCRS tests/integration-tests/ (no clone). The vanilla
+# dashboard/ is plain static files (no build); only the react-admin rebuild
+# under dashboard-react-admin/ needs a vite build. The playbook syncs:
+#   tests/integration-tests/dashboard/             -> /var/www/integration-tests/
+#   tests/integration-tests/dashboard-react-admin/dist/ -> /var/www/integration-tests-v2/
+#
+# Usage: integration-tests-build.sh <integration_tests_dir> <dashboard_base>
+#   <integration_tests_dir>  absolute path to the vendored tests/integration-tests
+#   <dashboard_base>         vite base for the react-admin build (e.g. /integration-tests-v2/)
+#   prints the integration-tests source dir on the last line (playbook captures it).
+set -uo pipefail
+
+IT_DIR="$1"
+DASHBOARD_BASE="${2:-/integration-tests-v2/}"
+NEED_NODE="20.0.0"
+
+command -v npm >/dev/null 2>&1 || { echo "ERROR: npm not on PATH (need Node >= $NEED_NODE)" >&2; exit 1; }
+NV="$(node -v 2>/dev/null | sed 's/^v//')"
+ver_ge(){ [ "$(printf '%s\n%s\n' "$2" "$1" | sort -t. -k1,1n -k2,2n -k3,3n | head -1)" = "$2" ]; }
+ver_ge "$NV" "$NEED_NODE" || { echo "ERROR: node v$NV < $NEED_NODE (Vite needs it)" >&2; exit 1; }
+
+V2="$IT_DIR/dashboard-react-admin"
+[ -f "$V2/package.json" ] || { echo "ERROR: no package.json at vendored $V2" >&2; exit 2; }
+[ -f "$IT_DIR/dashboard/index.html" ] || { echo "ERROR: vanilla dashboard/index.html missing at $IT_DIR" >&2; exit 2; }
+
+cd "$V2" || { echo "ERROR: cannot cd $V2" >&2; exit 2; }
+echo "integration-tests-build: npm ci (fallback npm install)" >&2
+npm ci >/dev/null 2>&1 || npm install >/dev/null 2>&1
+
+echo "integration-tests-build: vite build (base=$DASHBOARD_BASE)" >&2
+DASHBOARD_BASE="$DASHBOARD_BASE" npm run build >&2
+[ -f dist/index.html ] || { echo "ERROR: dist/index.html missing after build" >&2; exit 3; }
+
+# last line = source root, captured by the playbook for the two sync tasks
+echo "$IT_DIR"

--- a/local-setup/ansible/inventory/host_vars/_example.yml
+++ b/local-setup/ansible/inventory/host_vars/_example.yml
@@ -152,6 +152,20 @@ enable_digit_ui_v2: false
 digit_ui_v2_repo: "https://github.com/ChakshuGautam/Citizen-Complaint-Resolution-System.git"
 digit_ui_v2_branch: "feat/digit-ui-v2-keycloak"
 
+# digit-integration-tests dashboards. Builds the react-admin catalog dashboard
+# from the VENDORED in-tree source (tests/integration-tests/) and serves both
+# the vanilla (/integration-tests/) and react-admin (/integration-tests-v2/)
+# dashboards from /var/www. The deploy only SERVES them — catalog.json + runs/
+# are produced out-of-band by a test runner (`make publish` from
+# tests/integration-tests/). Pair with `nginx_features.integration_tests: true`
+# below (ignored on hosts with nginx_preserve_vhost — wire those by hand from
+# tests/integration-tests/deploy/nginx-integration-tests.conf).
+enable_integration_tests: false
+integration_tests_dashboard_base: "/integration-tests-v2/"
+integration_tests_basic_auth_user: "digit-tests"
+# Set in vault (never commit a real password). The htpasswd task skips if unset.
+# integration_tests_basic_auth_password: "{{ vault_integration_tests_password }}"
+
 # ────────── Optional services (opt-in via flags) ──────────
 
 # Bring up Elasticsearch + egov-indexer + inbox-v2. Heavy (~3GB RAM
@@ -274,6 +288,7 @@ nginx_features:
   mcp: true                  # /mcp + /v1/* — MCP HTTP transport + REST shim (requires enable_mcp: true)
   keycloak: false            # /auth/ + /token-exchange/ — requires enable_keycloak: true
   digit_ui_v2: false         # /citizen/ — Vite + React 19 SPA (requires enable_digit_ui_v2: true)
+  integration_tests: false   # /integration-tests/ + -v2/ — test dashboards (requires enable_integration_tests: true)
 
 # If true, the playbook will NOT render `templates/nginx-site.conf.j2` into
 # /etc/nginx/sites-available/ and will NOT touch /etc/nginx/sites-enabled/.

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -1292,6 +1292,124 @@
         - nginx_features.configurator | default(false)
         - configurator_build is defined
 
+    # ---- digit-integration-tests dashboards (opt-in: enable_integration_tests) ----
+    # Builds the react-admin catalog dashboard from the VENDORED in-tree source
+    # (tests/integration-tests/) and serves both the vanilla + react-admin
+    # dashboards as static files under /var/www. catalog.json + runs/ are
+    # produced out-of-band by a test runner (`make publish`), NOT this deploy —
+    # a placeholder catalog is seeded only if none exists yet so a fresh box
+    # renders. The nginx location blocks live in templates/nginx-site.conf.j2
+    # behind `nginx_features.integration_tests`; on hosts with
+    # nginx_preserve_vhost (e.g. Bomet) the template is NOT rendered, so wire
+    # the blocks from tests/integration-tests/deploy/nginx-integration-tests.conf
+    # by hand there.
+    - name: "integration-tests — install Node 20 if missing (Vite build needs it)"
+      ansible.builtin.apt:
+        name: nodejs
+        state: present
+      when:
+        - enable_integration_tests | default(false)
+        - ansible_system != "Darwin"
+
+    - name: "integration-tests — build react-admin dashboard (vendored in-tree source)"
+      ansible.builtin.command: >-
+        bash {{ playbook_dir }}/files/integration-tests-build.sh
+        "{{ integration_tests_src | default(playbook_dir ~ '/../../tests/integration-tests') }}"
+        "{{ integration_tests_dashboard_base | default('/integration-tests-v2/') }}"
+      register: it_build
+      changed_when: true
+      when: enable_integration_tests | default(false)
+
+    - name: "integration-tests — resolve vendored source dir"
+      ansible.builtin.set_fact:
+        integration_tests_dir: "{{ it_build.stdout_lines | last }}"
+      when:
+        - enable_integration_tests | default(false)
+        - it_build is defined
+        - it_build.stdout_lines | default([]) | length > 0
+
+    - name: "integration-tests — ensure web roots exist"
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: '0755'
+      loop:
+        - /var/www/integration-tests
+        - /var/www/integration-tests-v2
+      when:
+        - enable_integration_tests | default(false)
+        - integration_tests_dir is defined
+
+    # rsync on the target; exclude the runner-owned data so re-deploying the
+    # static dashboard never clobbers a published run.
+    - name: "integration-tests — sync vanilla dashboard → /var/www/integration-tests/"
+      ansible.builtin.command: >-
+        rsync -a --no-perms --no-times --no-owner --no-group
+        --exclude=catalog.json --exclude=history.json --exclude=runs
+        "{{ integration_tests_dir }}/dashboard/" /var/www/integration-tests/
+      changed_when: true
+      when:
+        - enable_integration_tests | default(false)
+        - integration_tests_dir is defined
+
+    - name: "integration-tests — sync react-admin dist → /var/www/integration-tests-v2/"
+      ansible.builtin.command: >-
+        rsync -a --delete --no-perms --no-times --no-owner --no-group
+        "{{ integration_tests_dir }}/dashboard-react-admin/dist/" /var/www/integration-tests-v2/
+      changed_when: true
+      when:
+        - enable_integration_tests | default(false)
+        - integration_tests_dir is defined
+
+    - name: "integration-tests — seed placeholder catalog/history (only if absent; a real publish overwrites)"
+      ansible.builtin.copy:
+        dest: "/var/www/integration-tests/{{ item.name }}"
+        content: "{{ item.content }}"
+        force: false
+        mode: '0644'
+      loop:
+        - { name: 'catalog.json', content: '{"tests":[],"runs":[]}' }
+        - { name: 'history.json', content: '{"perTest":{},"runs":[]}' }
+      when:
+        - enable_integration_tests | default(false)
+        - integration_tests_dir is defined
+
+    - name: "integration-tests — point v2 dashboard at the shared catalog/runs (symlinks)"
+      ansible.builtin.file:
+        src: "../integration-tests/{{ item }}"
+        dest: "/var/www/integration-tests-v2/{{ item }}"
+        state: link
+        force: true
+      loop: [ 'catalog.json', 'history.json', 'runs' ]
+      when:
+        - enable_integration_tests | default(false)
+        - integration_tests_dir is defined
+
+    - name: "integration-tests — ensure htpasswd tooling for basic-auth"
+      ansible.builtin.apt:
+        name: apache2-utils
+        state: present
+      when:
+        - enable_integration_tests | default(false)
+        - integration_tests_basic_auth_password is defined
+        - ansible_system != "Darwin"
+
+    # Idempotent via `creates`: rotate the password by deleting the file and
+    # re-running. Password comes from vault/host_vars; the task skips entirely
+    # if unset (dashboards would then 401 with no valid user — set it).
+    - name: "integration-tests — basic-auth user in /etc/nginx/.htpasswd-tests"
+      ansible.builtin.command: >-
+        htpasswd -bBc /etc/nginx/.htpasswd-tests
+        "{{ integration_tests_basic_auth_user | default('digit-tests') }}"
+        "{{ integration_tests_basic_auth_password }}"
+      args:
+        creates: /etc/nginx/.htpasswd-tests
+      no_log: true
+      when:
+        - enable_integration_tests | default(false)
+        - integration_tests_basic_auth_password is defined
+        - ansible_system != "Darwin"
+
     # Host nginx (Linux/Debian) — apt nginx + /etc/nginx site. Skipped on
     # macOS, where nginx runs as a container instead (next block).
     - name: "Host nginx — Linux/Debian only"

--- a/local-setup/ansible/templates/nginx-site.conf.j2
+++ b/local-setup/ansible/templates/nginx-site.conf.j2
@@ -66,6 +66,31 @@ server {
   }
 
 {% endif %}
+{% if nginx_features.integration_tests | default(false) %}
+  # digit-integration-tests dashboards — vanilla catalog SPA at
+  # /integration-tests/ and the react-admin rebuild at /integration-tests-v2/.
+  # Built from the vendored tests/integration-tests/ source and synced to
+  # /var/www/integration-tests{,-v2}/ by the deploy. Behind basic-auth
+  # (/etc/nginx/.htpasswd-tests, created by the playbook). catalog.json + runs/
+  # are produced out-of-band by a test runner (make publish), not the deploy.
+  location = /integration-tests    { return 301 /integration-tests/; }
+  location = /integration-tests-v2 { return 301 /integration-tests-v2/; }
+  location /integration-tests/ {
+    alias /var/www/integration-tests/;
+    auth_basic "DIGIT integration tests";
+    auth_basic_user_file /etc/nginx/.htpasswd-tests;
+    add_header Cache-Control "no-cache, must-revalidate" always;
+    try_files $uri $uri/ $uri/index.html =404;
+  }
+  location /integration-tests-v2/ {
+    alias /var/www/integration-tests-v2/;
+    auth_basic "DIGIT integration tests";
+    auth_basic_user_file /etc/nginx/.htpasswd-tests;
+    add_header Cache-Control "no-cache, must-revalidate" always;
+    try_files $uri $uri/ /integration-tests-v2/index.html =404;
+  }
+
+{% endif %}
   # Grafana dashboard
   location /grafana/ {
     proxy_pass http://{{ nginx_upstream_host | default('127.0.0.1') }}:{{ upstream_grafana_port }};


### PR DESCRIPTION
Codifies the (currently manual, runtime-only) bomet setup of the integration-tests dashboards into the ansible deployer — **opt-in per host**, idempotent, re-deploy-safe. Follow-up to #712 (which vendored `tests/integration-tests/`).

## What it adds
- **`templates/nginx-site.conf.j2`** — feature-gated (`nginx_features.integration_tests`) location blocks for `/integration-tests/` (vanilla) + `/integration-tests-v2/` (react-admin), both basic-auth, plus the no-trailing-slash 301 redirects.
- **`playbook-deploy.yml`** — new opt-in task group: build the react-admin dashboard from the **vendored in-tree source** (no clone), sync both dashboards to `/var/www/integration-tests{,-v2}`, seed a placeholder `catalog.json` only if absent, symlink the v2 data to the shared catalog/runs, create the htpasswd user.
- **`files/integration-tests-build.sh`** — `vite build` with `DASHBOARD_BASE` (mirrors `configurator-build.sh`).
- **`host_vars/_example.yml`** — documents `enable_integration_tests`, `integration_tests_dashboard_base`, the basic-auth user, and the `nginx_features` flag.

## Design
- **Serves only.** `catalog.json` + `runs/` are produced out-of-band by a test runner (`make publish` from `tests/integration-tests/`); the deploy never runs Playwright and the sync excludes runner-owned data, so a re-deploy can't clobber a published run.
- **Opt-in** via `enable_integration_tests` + `nginx_features.integration_tests` (both default false).
- **Basic-auth password** comes from vault/host_vars; the htpasswd task skips if unset.

## Operator notes
- **Path standardized to `/var/www`** (matches `citizen`/`configurator`), not the manual `/opt/integration-tests`. The bomet test runner's `HOST_DIR`/publish target must move to `/var/www/integration-tests` at cutover.
- **Bomet uses `nginx_preserve_vhost: true`**, so the template isn't rendered there — the build+serve tasks still run, but the nginx blocks stay hand-wired from `tests/integration-tests/deploy/nginx-integration-tests.conf` until bomet's vhost is fully templated.

## Validation
- Syntax: `ansible-playbook --syntax-check` passes; YAML + bash lint clean.
- Recommend a full `./deploy.sh` run on ovh-cloud-dev (bomet repro) with the flags on before merge — assert 401-no-auth / 200-with-auth on both paths and existing surfaces unchanged. (Not yet run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)