### PR TITLE
fix(ansible): simplify docker daemon configuration and remove redunda…

### DIFF
--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -188,8 +188,7 @@
           content: "{{ {'insecure-registries': insecure_registries} | to_nice_json }}\n"
           mode: '0644'
         register: daemon_json
-        vars:
-          insecure_registries: "{{ insecure_registries | default([]) }}"
+        when: insecure_registries | default([]) | length > 0
 
       - name: Restart docker if daemon.json changed
         service:
@@ -1712,15 +1711,6 @@
         docker compose {{ compose_files }} restart egov-hrms
       args:
         chdir: "{{ digit_dir }}"
-      when: state_root != 'pg'
-
-    - name: "post-bootstrap — wait for egov-hrms to be healthy after restart"
-      ansible.builtin.shell: docker inspect --format '{{ "{{" }}.State.Health.Status{{ "}}" }}' egov-hrms
-      register: hrms_health_post
-      retries: 30
-      delay: 10
-      until: hrms_health_post.stdout == 'healthy'
-      changed_when: false
       when: state_root != 'pg'
 
     # `docker compose restart egov-user` above does NOT cascade to


### PR DESCRIPTION
…nt health check

- Remove redundant vars block for insecure_registries in daemon.json task
- Add conditional check to only write daemon.json when insecure_registries is non-empty
- Remove post-bootstrap health check for egov-hrms after restart
- Reduces unnecessary Docker daemon restarts and redundant health monitoring logic