### PR TITLE
ansible(keycloak): enable fullScopeAllowed on master/admin-cli for platform-admin JWTs

### DIFF
--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -1918,6 +1918,21 @@
       no_log: true
       changed_when: false
 
+    # admin-cli ships with fullScopeAllowed=false, which strips realm roles
+    # out of JWTs minted via the password grant against the master realm.
+    # The platform-admin overlay route (DIGIT-keycloak-overlay) needs those
+    # roles to gate scoped admins (bootstrap:<tenantId>) — without this
+    # flip, every scoped JWT carries an empty realm_access.roles and the
+    # overlay 403s every call. Idempotent: kcadm update is a no-op if the
+    # flag is already true.
+    - name: "keycloak-bootstrap — enable fullScopeAllowed on master/admin-cli for platform-admin JWTs"
+      ansible.builtin.shell: |
+        set -e
+        CLI_ID=$(docker exec keycloak /opt/keycloak/bin/kcadm.sh get clients -r master -q clientId=admin-cli --fields id --format csv --noquotes | tail -1)
+        docker exec keycloak /opt/keycloak/bin/kcadm.sh update "clients/$CLI_ID" -r master -s 'fullScopeAllowed=true'
+      when: enable_keycloak | default(false)
+      changed_when: false
+
     # ────────────────────────────────────────────────────────────────
     # Update digit-ui client redirect URIs in-place every deploy.
     #


### PR DESCRIPTION
## Summary

- Adds one idempotent Ansible task that flips `fullScopeAllowed=true` on the `admin-cli` client in Keycloak's master realm.
- Required for the [DIGIT-keycloak-overlay](https://github.com/ChakshuGautam/DIGIT-keycloak-overlay) platform-admin gateway to gate scoped admins.

## Why

`admin-cli` ships with `fullScopeAllowed=false`. That setting strips realm roles out of JWTs minted via the password grant against the master realm. The platform-admin overlay route gates per-tenant scoped admins on a `bootstrap:<tenantId>` realm role they carry; without this flip the role never reaches the JWT and every scoped call returns 403.

Verified live on Bomet — without the flip, `realm_access.roles` is absent from the JWT; after the flip it carries the scoped role and the overlay routes accordingly.

The task is idempotent (kcadm update no-ops when already true) and gated on `enable_keycloak | default(false)` so it only fires on deployments that actually run Keycloak.

## Related work (same epic — KC platform-admin gateway + new-root tenant provisioning)

- **#724** — bumps `egov-enc-service` to `:generatekey-endpoint` so brand-new state roots can be encrypted for. Closes the encryption half of #622 when paired with egovernments/Digit-Core#1044.
- **egovernments/Digit-Core#1354** — source PR for the `_generatekey` endpoint that #724 deploys.
- **egovernments/Digit-Core#1044** — egov-user dynamic-tenant fix (per-request tenantId for encryption). Already deployed on Bomet as `egov-user:dynamic-tenant-bomet`.
- **[digit-integration-tests #29](https://github.com/ChakshuGautam/digit-integration-tests/pull/29)** — 14 Playwright tests covering the full platform-admin + enc-service chain.

## Test plan

- [x] Verified on Bomet — scoped admin (`bootstrap-ke-public82092`) can call `tenant_bootstrap` for `ke.public82092` (200) and is rejected when targeting any other tenant (403)
- [x] Verified ADMIN/EMPLOYEE direct DIGIT auth unaffected (no master-realm scope crossover)
- [x] `kcadm update` confirmed idempotent — re-running gives no error
- [x] Covered by automated tests in [digit-integration-tests #29](https://github.com/ChakshuGautam/digit-integration-tests/pull/29) — tests 4-7 specifically validate that the master JWT carries `realm_access.roles` (the `fullScopeAllowed` regression guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)