### PR TITLE
compose: bump egov-enc-service to :generatekey-endpoint (new-root provisioning fix)

### DIFF
--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -389,7 +389,15 @@ services:
     - egov-network
 
   egov-enc-service:
-    image: registry.preview.egov.theflywheel.in/egovio/egov-enc-service:v2.9.2-4a60f20
+    # `:generatekey-endpoint` stacks the POST /crypto/v1/_generatekey
+    # endpoint (Digit-Core #1354) on top of :v2.9.2-4a60f20. Without
+    # _generatekey, the first encrypt for a brand-new state root (created
+    # by MCP tenant_bootstrap or similar) throws "Tenant Id not found" —
+    # enc-service only discovers tenants via MDMS search under
+    # STATE_LEVEL_TENANT_ID, and a brand-new root isn't under any
+    # existing root's tenant.tenants list. Bump can be replaced with a
+    # versioned tag once Digit-Core #1354 lands and a release ships.
+    image: registry.preview.egov.theflywheel.in/egovio/egov-enc-service:generatekey-endpoint
     container_name: egov-enc-service
     depends_on:
       egov-mdms-service:


### PR DESCRIPTION
## Summary

- Bumps `egov-enc-service` image tag from `:v2.9.2-4a60f20` → `:generatekey-endpoint`.
- The new image adds `POST /crypto/v1/_generatekey` (egovernments/Digit-Core#1354) which lets provisioning callers create a tenant key on demand. Without it, the first encrypt call for a brand-new state root throws `\"Tenant Id not found\"` and breaks the platform-admin `tenant_bootstrap` chain at the admin-user step.
- Compatible with all existing tenants — `:generatekey-endpoint` is `:v2.9.2-4a60f20` + the new endpoint + a lombok bump for JDK 21 compile. No behavior change for existing callers.

## Why

Enc-service's tenant discovery (`KeyManagementService.makeComprehensiveListOfTenantIds()`) walks MDMS under `STATE_LEVEL_TENANT_ID`. A brand-new state root (e.g. created by MCP `tenant_bootstrap`) isn't under any existing root's `tenant.tenants` list, so it's invisible to that discovery path. The first encrypt for the new root fails — most visibly when MCP tries to create the ADMIN user for the new tenant.

This bug is the encryption half of the CCRS [#622](https://github.com/egovernments/Citizen-Complaint-Resolution-System/issues/622) chain. The other half (egov-user passing per-request tenantId instead of `STATE_LEVEL_TENANT_ID`) is in egovernments/Digit-Core#1044.

## Dependency

- **Blocks on:** egovernments/Digit-Core#1354 — the source PR adding `_generatekey`. The image is already published (proxied through `registry.preview.egov.theflywheel.in`) so this can deploy today, but the canonical version-bump should follow once #1354 merges and a release ships.

## Verified end-to-end on `bometfeedbackhub.digit.org`

```
_generatekey { genkfnr }                              → 200 { created: true, keyId: 32 }
_generatekey { genkfnr }                              → 200 { created: false, keyId: 32 }  (idempotent)
tenant_bootstrap { target: genkfnr, source: ke }      → admin provisioned ✓  (was 500 before)
login ADMIN@genkfnr                                   → 200

eg_user.username encrypted under genkfnr's OWN key (393665), NOT ke's (8234)

Regression:
  ADMIN@ke login → 200  (existing ciphertexts still decryptable)
  /user/_search → 200
```

## Test plan

- [x] Image pulls clean for `linux/amd64` (built via buildx, multi-arch manifest)
- [x] enc-service starts healthy
- [x] `_generatekey` returns 200 with `created=true` on fresh tenant, `created=false` on repeat
- [x] Full chain (`_generatekey` → `tenant_bootstrap` → login) works for a brand-new state root
- [x] Existing tenants (`ke`, `ke.bomet`) unaffected — `ADMIN@ke` login still 200
- [x] 4 new automated tests added to [digit-integration-tests](https://github.com/ChakshuGautam/digit-integration-tests/pull/29) — 14/14 pass in 33.1s against bomet

🤖 Generated with [Claude Code](https://claude.com/claude-code)