### PR TITLE
feat(digit-ui-v2): platform-admin login + dashboard + bootstrap wizard

### DIFF
--- a/digit-ui-v2/src/App.tsx
+++ b/digit-ui-v2/src/App.tsx
@@ -21,6 +21,9 @@ import CitizenComplaintCreatePage from './pages/CitizenComplaintCreatePage';
 import CitizenProfilePage from './pages/CitizenProfilePage';
 import CitizenDashboardV2Page from './pages/CitizenDashboardV2Page';
 import CitizenLayout from './components/layout/CitizenLayout';
+import AdminLoginPage from './pages/AdminLoginPage';
+import AdminDashboardPage from './pages/AdminDashboardPage';
+import AdminBootstrapPage from './pages/AdminBootstrapPage';
 import { ThemeProvider } from './providers/ThemeProvider';
 import { citizenDataProvider, citizenAuthProvider } from './providers/citizenBridge';
 // Toaster removed — citizen UI v1 surfaces errors via inline Alert components.
@@ -176,6 +179,13 @@ function App() {
                 {/* KC callback is intentionally unguarded — the user is
                    mid-auth at this point and not yet logged in. */}
                 <Route path="/auth/callback" element={<CitizenKcCallback />} />
+                {/* Platform-admin surface — separate auth state from
+                    citizen (KC master realm, different localStorage key,
+                    different role model). Each page gates itself. */}
+                <Route path="/admin/login" element={<AdminLoginPage />} />
+                <Route path="/admin/dashboard" element={<AdminDashboardPage />} />
+                <Route path="/admin/bootstrap" element={<AdminBootstrapPage />} />
+                <Route path="/admin" element={<Navigate to="/admin/login" replace />} />
                 <Route
                   path="/"
                   element={state.isAuthenticated ? <CitizenLayout /> : <Navigate to="/login" replace />}

--- a/digit-ui-v2/src/api/platformAdmin.ts
+++ b/digit-ui-v2/src/api/platformAdmin.ts
@@ -1,0 +1,165 @@
+/**
+ * Platform-admin client helpers — KC master realm auth + scoped JWT decode.
+ *
+ * Separate from the citizen apiClient on purpose: the admin surface uses
+ * a different KC realm (master vs ke) and a different localStorage key
+ * (digit_ui_v2_admin_*) so the two sessions don't trample each other.
+ *
+ * Two persona shapes the SPA cares about:
+ *   - god   — built-in master admin OR holds PLATFORM_ADMIN role.
+ *             /admin/dashboard with invite form + list.
+ *   - scoped — holds bootstrap:<tenantId> role.
+ *             /admin/bootstrap wizard for THAT tenant.
+ */
+import { getApiBaseUrl } from './config';
+import { decodeJwtPayload } from './keycloak';
+
+const KC_BASE = (import.meta.env.VITE_KC_BASE as string) || `${window.location.origin}/auth`;
+export const PLATFORM_ADMIN_REALM =
+  (import.meta.env.VITE_KC_MASTER_REALM as string) || 'master';
+const OVERLAY_BASE = `${getApiBaseUrl()}/token-exchange`;
+export const PLATFORM_ADMIN_BASE = `${OVERLAY_BASE}/platform-admin`;
+
+const LS_TOKEN = 'digit_ui_v2_admin_token';
+const LS_TOKEN_EXP = 'digit_ui_v2_admin_token_exp';
+
+export interface AdminClaims {
+  sub: string;
+  preferred_username: string;
+  email?: string;
+  realm_access?: { roles: string[] };
+  exp: number;
+}
+
+export type AdminScope =
+  | { kind: 'god'; sub: string; username: string }
+  | { kind: 'scoped'; sub: string; username: string; tenantId: string };
+
+const GOD_ROLE = 'PLATFORM_ADMIN';
+const SCOPED_ROLE_PREFIX = 'bootstrap:';
+
+export function deriveScope(claims: AdminClaims): AdminScope | null {
+  const roles = claims.realm_access?.roles || [];
+  const preferred = claims.preferred_username || '';
+
+  if (preferred === 'admin' || roles.includes(GOD_ROLE)) {
+    return { kind: 'god', sub: claims.sub, username: preferred };
+  }
+
+  const scopedRole = roles.find((r) => r.startsWith(SCOPED_ROLE_PREFIX));
+  if (scopedRole) {
+    return {
+      kind: 'scoped',
+      sub: claims.sub,
+      username: preferred,
+      tenantId: scopedRole.slice(SCOPED_ROLE_PREFIX.length),
+    };
+  }
+  return null;
+}
+
+/**
+ * Mint a JWT via KC master realm password grant. admin-cli is the only
+ * client guaranteed to allow direct grants on master. The overlay
+ * separately gates which JWTs can hit /platform-admin/* — this just
+ * gets the token.
+ */
+export async function adminLogin(username: string, password: string): Promise<{
+  token: string;
+  claims: AdminClaims;
+  scope: AdminScope;
+}> {
+  const resp = await fetch(
+    `${KC_BASE}/realms/${encodeURIComponent(PLATFORM_ADMIN_REALM)}/protocol/openid-connect/token`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'password',
+        client_id: 'admin-cli',
+        username,
+        password,
+      }).toString(),
+    },
+  );
+  if (!resp.ok) {
+    const body = await resp.json().catch(() => ({}));
+    const desc = (body as { error_description?: string }).error_description;
+    throw new Error(desc || `Login failed (${resp.status})`);
+  }
+  const data = (await resp.json()) as { access_token: string };
+  const token = data.access_token;
+  const claims = decodeJwtPayload(token) as AdminClaims;
+  const scope = deriveScope(claims);
+  if (!scope) {
+    throw new Error(
+      'This account has no platform-admin role. Ask a god admin for either PLATFORM_ADMIN or bootstrap:<tenantId>.',
+    );
+  }
+  localStorage.setItem(LS_TOKEN, token);
+  localStorage.setItem(LS_TOKEN_EXP, String(claims.exp * 1000));
+  return { token, claims, scope };
+}
+
+export function adminLogout() {
+  localStorage.removeItem(LS_TOKEN);
+  localStorage.removeItem(LS_TOKEN_EXP);
+}
+
+/**
+ * Load the current admin session from localStorage. Returns null on
+ * missing or expired token — UI should redirect to /admin/login.
+ */
+export function loadAdminSession(): {
+  token: string;
+  claims: AdminClaims;
+  scope: AdminScope;
+} | null {
+  const token = localStorage.getItem(LS_TOKEN);
+  const expMs = Number(localStorage.getItem(LS_TOKEN_EXP) || 0);
+  if (!token || !expMs || expMs < Date.now()) {
+    adminLogout();
+    return null;
+  }
+  try {
+    const claims = decodeJwtPayload(token) as AdminClaims;
+    const scope = deriveScope(claims);
+    if (!scope) return null;
+    return { token, claims, scope };
+  } catch {
+    adminLogout();
+    return null;
+  }
+}
+
+/** Fetch wrapper that auto-injects the admin JWT + handles JSON */
+export async function adminFetch<T = unknown>(
+  path: string,
+  init: RequestInit = {},
+): Promise<T> {
+  const session = loadAdminSession();
+  if (!session) throw new Error('Not authenticated');
+  const resp = await fetch(`${PLATFORM_ADMIN_BASE}${path}`, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init.headers || {}),
+      Authorization: `Bearer ${session.token}`,
+    },
+  });
+  const text = await resp.text();
+  let body: unknown;
+  try {
+    body = text ? JSON.parse(text) : {};
+  } catch {
+    body = { error: 'invalid_json', raw: text.slice(0, 500) };
+  }
+  if (!resp.ok) {
+    const msg =
+      (body as { message?: string; error?: string }).message ||
+      (body as { error?: string }).error ||
+      `HTTP ${resp.status}`;
+    throw new Error(msg);
+  }
+  return body as T;
+}

--- a/digit-ui-v2/src/pages/AdminBootstrapPage.tsx
+++ b/digit-ui-v2/src/pages/AdminBootstrapPage.tsx
@@ -1,0 +1,243 @@
+/**
+ * /admin/bootstrap — scoped tenant-admin wizard.
+ *
+ * Landing page for invitees right after they complete the email
+ * UPDATE_PASSWORD flow and sign in at /admin/login. Their JWT carries
+ * a bootstrap:<tenantId> role; this page reads it, confirms the tenant,
+ * and lets them bootstrap with one click.
+ *
+ * God admins are NOT redirected away — they may legitimately want to
+ * use this wizard to bootstrap a tenant after granting themselves the
+ * role. The wizard accepts both scopes and shows the active tenant.
+ */
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { adminFetch, adminLogout, loadAdminSession } from '@/api/platformAdmin';
+
+function Badge({
+  children,
+  variant = 'default',
+  className = '',
+}: {
+  children: React.ReactNode;
+  variant?: 'default' | 'outline';
+  className?: string;
+}) {
+  const styles: Record<string, string> = {
+    default: 'bg-primary text-primary-foreground',
+    outline: 'border border-input text-foreground',
+  };
+  return (
+    <span
+      className={`inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium ${styles[variant]} ${className}`}
+    >
+      {children}
+    </span>
+  );
+}
+
+interface BootstrapSummary {
+  schemas_copied: number;
+  schemas_skipped: number;
+  schemas_failed: number;
+  data_copied: number;
+  localizations_copied: number;
+  admin_user_provisioned: boolean;
+}
+
+interface BootstrapResult {
+  success: boolean;
+  source: string;
+  target: string;
+  summary?: BootstrapSummary;
+  adminUser?: { username?: string; password?: string; provisioned?: boolean; error?: string };
+}
+
+export default function AdminBootstrapPage() {
+  const navigate = useNavigate();
+  const session = loadAdminSession();
+
+  useEffect(() => {
+    if (!session) navigate('/admin/login', { replace: true });
+  }, [navigate, session]);
+
+  // Default source tenant — most deployments copy from "ke" (the live
+  // root). Operators can override.
+  const [sourceTenant, setSourceTenant] = useState('ke');
+
+  // Scoped admins are locked to their tenant; god can pick anything.
+  const isGod = session?.scope.kind === 'god';
+  const lockedTenant = !isGod && session?.scope.kind === 'scoped' ? session.scope.tenantId : '';
+  const [targetTenant, setTargetTenant] = useState(lockedTenant);
+
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<BootstrapResult | null>(null);
+
+  function handleLogout() {
+    adminLogout();
+    navigate('/admin/login', { replace: true });
+  }
+
+  async function handleBootstrap(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setResult(null);
+    if (!targetTenant) {
+      setError('Target tenant is required.');
+      return;
+    }
+    setRunning(true);
+    try {
+      const res = await adminFetch<BootstrapResult>('/v1/tenant/bootstrap', {
+        method: 'POST',
+        body: JSON.stringify({
+          target_tenant: targetTenant.trim(),
+          source_tenant: sourceTenant.trim(),
+        }),
+      });
+      setResult(res);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  if (!session) return null;
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6 p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Bootstrap your tenant</h1>
+          <p className="text-sm text-muted-foreground">
+            Signed in as <span className="font-mono">{session.scope.username}</span>{' '}
+            <Badge variant="outline" className="ml-1">
+              {session.scope.kind === 'god' ? 'god' : `scoped: ${session.scope.tenantId}`}
+            </Badge>
+          </p>
+        </div>
+        <Button variant="outline" onClick={handleLogout}>
+          Sign out
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Provision a new tenant</CardTitle>
+          <CardDescription>
+            Copies schemas, MDMS data, localizations, and (when possible) an
+            ADMIN user from the source tenant into your new tenant. Idempotent —
+            safe to re-run.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleBootstrap} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="target">Target tenant</Label>
+              <Input
+                id="target"
+                type="text"
+                value={targetTenant}
+                onChange={(e) => setTargetTenant(e.target.value)}
+                placeholder="ke.kisumu"
+                disabled={!isGod || running}
+                readOnly={!isGod}
+              />
+              {!isGod && (
+                <p className="text-xs text-muted-foreground">
+                  Your invite limits you to this tenant.
+                </p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="source">Source tenant (template)</Label>
+              <Input
+                id="source"
+                type="text"
+                value={sourceTenant}
+                onChange={(e) => setSourceTenant(e.target.value)}
+                placeholder="ke"
+                disabled={running}
+              />
+              <p className="text-xs text-muted-foreground">
+                Schemas + reference data are copied from here. Default <span className="font-mono">ke</span>.
+              </p>
+            </div>
+            {error && (
+              <Alert variant="destructive">
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+            <Button type="submit" disabled={running || !targetTenant}>
+              {running ? 'Bootstrapping… (up to 90s)' : 'Bootstrap tenant'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      {result && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Bootstrap result</CardTitle>
+            <CardDescription>
+              Target: <span className="font-mono">{result.target}</span> from{' '}
+              <span className="font-mono">{result.source}</span>
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {result.summary && (
+              <div className="grid grid-cols-2 gap-3 md:grid-cols-3">
+                <Stat label="Schemas copied" value={result.summary.schemas_copied} />
+                <Stat label="Schemas skipped" value={result.summary.schemas_skipped} />
+                <Stat label="Schemas failed" value={result.summary.schemas_failed} warn={result.summary.schemas_failed > 0} />
+                <Stat label="Data records" value={result.summary.data_copied} />
+                <Stat label="Localizations" value={result.summary.localizations_copied} />
+                <Stat
+                  label="Admin user"
+                  value={result.summary.admin_user_provisioned ? 'OK' : 'Failed'}
+                  warn={!result.summary.admin_user_provisioned}
+                />
+              </div>
+            )}
+            {result.adminUser?.provisioned && result.adminUser.username && (
+              <Alert className="mt-4">
+                <AlertDescription>
+                  ADMIN user <span className="font-mono">{result.adminUser.username}</span> created.
+                  {result.adminUser.password && (
+                    <>
+                      {' '}Temporary password:{' '}
+                      <span className="font-mono">{result.adminUser.password}</span>
+                    </>
+                  )}
+                </AlertDescription>
+              </Alert>
+            )}
+            {result.adminUser?.error && (
+              <Alert variant="destructive" className="mt-4">
+                <AlertDescription>
+                  Admin user not provisioned: {result.adminUser.error}
+                </AlertDescription>
+              </Alert>
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value, warn = false }: { label: string; value: number | string; warn?: boolean }) {
+  return (
+    <div className="rounded-md border p-3">
+      <div className="text-xs uppercase text-muted-foreground">{label}</div>
+      <div className={`text-xl font-semibold ${warn ? 'text-destructive' : ''}`}>{value}</div>
+    </div>
+  );
+}

--- a/digit-ui-v2/src/pages/AdminDashboardPage.tsx
+++ b/digit-ui-v2/src/pages/AdminDashboardPage.tsx
@@ -1,0 +1,287 @@
+/**
+ * /admin/dashboard — god-only platform-admin home.
+ *
+ * Two surfaces:
+ *   - "Invite a tenant admin" form: email + tenantId → POSTs to the
+ *     overlay's /platform-admin/scoped-admins/_invite. KC sends the
+ *     invitee an email with a magic link that lands them on
+ *     /admin/login?invited=true&email=… after they set their password.
+ *   - List of existing scoped admins (one row per bootstrap:<tenant>
+ *     role assignment) so the operator can see who's been invited and
+ *     whether they've completed onboarding (email verified, required
+ *     actions pending).
+ *
+ * Scoped-only admins who land here are immediately redirected to their
+ * /admin/bootstrap wizard — they have no business sending invites.
+ */
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { adminFetch, adminLogout, loadAdminSession } from '@/api/platformAdmin';
+
+// Local Badge — the citizen UI doesn't ship one and pulling in shadcn's
+// just for these three pages would inflate the build pointlessly.
+function Badge({
+  children,
+  variant = 'default',
+}: {
+  children: React.ReactNode;
+  variant?: 'default' | 'secondary' | 'outline';
+}) {
+  const styles: Record<string, string> = {
+    default: 'bg-primary text-primary-foreground',
+    secondary: 'bg-secondary text-secondary-foreground',
+    outline: 'border border-input text-foreground',
+  };
+  return (
+    <span className={`inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium ${styles[variant]}`}>
+      {children}
+    </span>
+  );
+}
+
+interface ScopedAdmin {
+  username: string;
+  email: string;
+  tenantId: string;
+  role: string;
+  emailVerified: boolean;
+  requiredActions: string[];
+  createdTimestamp?: number;
+}
+
+interface InviteResponse {
+  username: string;
+  email: string;
+  tenantId: string;
+  role: string;
+  inviteSent: boolean;
+  inviteError?: string;
+  hint?: string;
+  expiresAt?: string;
+}
+
+export default function AdminDashboardPage() {
+  const navigate = useNavigate();
+
+  // Auth gate — god only
+  const session = loadAdminSession();
+  useEffect(() => {
+    if (!session) {
+      navigate('/admin/login', { replace: true });
+      return;
+    }
+    if (session.scope.kind !== 'god') {
+      navigate('/admin/bootstrap', { replace: true });
+    }
+  }, [navigate, session]);
+
+  // Invite form state
+  const [email, setEmail] = useState('');
+  const [tenantId, setTenantId] = useState('');
+  const [inviting, setInviting] = useState(false);
+  const [inviteError, setInviteError] = useState<string | null>(null);
+  const [inviteResult, setInviteResult] = useState<InviteResponse | null>(null);
+
+  // Scoped-admins list state
+  const [admins, setAdmins] = useState<ScopedAdmin[]>([]);
+  const [listLoading, setListLoading] = useState(true);
+  const [listError, setListError] = useState<string | null>(null);
+
+  async function refreshList() {
+    setListLoading(true);
+    setListError(null);
+    try {
+      const data = await adminFetch<{ scopedAdmins: ScopedAdmin[] }>(
+        '/scoped-admins',
+      );
+      setAdmins(data.scopedAdmins || []);
+    } catch (err) {
+      setListError((err as Error).message);
+    } finally {
+      setListLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (session?.scope.kind === 'god') refreshList();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [session?.scope.kind]);
+
+  async function handleInvite(e: React.FormEvent) {
+    e.preventDefault();
+    setInviteError(null);
+    setInviteResult(null);
+    if (!email || !tenantId) {
+      setInviteError('Email and tenant ID are required.');
+      return;
+    }
+    setInviting(true);
+    try {
+      const res = await adminFetch<InviteResponse>('/scoped-admins/_invite', {
+        method: 'POST',
+        body: JSON.stringify({
+          email: email.trim(),
+          tenantId: tenantId.trim(),
+        }),
+      });
+      setInviteResult(res);
+      if (res.inviteSent) {
+        setEmail('');
+        setTenantId('');
+        refreshList();
+      }
+    } catch (err) {
+      setInviteError((err as Error).message);
+    } finally {
+      setInviting(false);
+    }
+  }
+
+  function handleLogout() {
+    adminLogout();
+    navigate('/admin/login', { replace: true });
+  }
+
+  if (!session || session.scope.kind !== 'god') return null;
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Platform admin</h1>
+          <p className="text-sm text-muted-foreground">
+            Signed in as <span className="font-mono">{session.scope.username}</span>
+          </p>
+        </div>
+        <Button variant="outline" onClick={handleLogout}>
+          Sign out
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Invite a tenant admin</CardTitle>
+          <CardDescription>
+            Sends a Keycloak set-password email. After the invitee completes
+            it, they can sign in at /admin/login and bootstrap their tenant.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleInvite} className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="invite-email">Invitee email</Label>
+              <Input
+                id="invite-email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="admin@kisumu.go.ke"
+                disabled={inviting}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="invite-tenant">Tenant ID</Label>
+              <Input
+                id="invite-tenant"
+                type="text"
+                value={tenantId}
+                onChange={(e) => setTenantId(e.target.value)}
+                placeholder="ke.kisumu"
+                disabled={inviting}
+              />
+            </div>
+            <div className="md:col-span-2">
+              {inviteError && (
+                <Alert variant="destructive" className="mb-3">
+                  <AlertDescription>{inviteError}</AlertDescription>
+                </Alert>
+              )}
+              {inviteResult && (
+                <Alert variant={inviteResult.inviteSent ? 'default' : 'destructive'} className="mb-3">
+                  <AlertDescription>
+                    {inviteResult.inviteSent
+                      ? `Invite sent to ${inviteResult.email}. They'll receive an email with a set-password link, valid until ${inviteResult.expiresAt}.`
+                      : `User ${inviteResult.username} created with role ${inviteResult.role}, but email failed: ${inviteResult.inviteError}${inviteResult.hint ? ' — ' + inviteResult.hint : ''}`}
+                  </AlertDescription>
+                </Alert>
+              )}
+              <Button type="submit" disabled={inviting}>
+                {inviting ? 'Sending…' : 'Send invite'}
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <div>
+            <CardTitle>Tenant admins</CardTitle>
+            <CardDescription>
+              Existing scoped admins (one row per tenant assignment).
+            </CardDescription>
+          </div>
+          <Button variant="ghost" size="sm" onClick={refreshList} disabled={listLoading}>
+            {listLoading ? 'Loading…' : 'Refresh'}
+          </Button>
+        </CardHeader>
+        <CardContent>
+          {listError && (
+            <Alert variant="destructive" className="mb-3">
+              <AlertDescription>{listError}</AlertDescription>
+            </Alert>
+          )}
+          {!listLoading && admins.length === 0 && (
+            <p className="text-sm text-muted-foreground">No tenant admins yet — send an invite above.</p>
+          )}
+          {admins.length > 0 && (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-left text-muted-foreground">
+                    <th className="py-2 pr-4">Email / Username</th>
+                    <th className="py-2 pr-4">Tenant</th>
+                    <th className="py-2 pr-4">Status</th>
+                    <th className="py-2">Created</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {admins.map((a) => (
+                    <tr key={`${a.username}-${a.tenantId}`} className="border-b last:border-0">
+                      <td className="py-2 pr-4">
+                        <div className="font-mono text-xs">{a.email || a.username}</div>
+                        {a.email && a.username !== a.email && (
+                          <div className="text-xs text-muted-foreground">{a.username}</div>
+                        )}
+                      </td>
+                      <td className="py-2 pr-4 font-mono text-xs">{a.tenantId}</td>
+                      <td className="py-2 pr-4">
+                        {a.requiredActions.includes('UPDATE_PASSWORD') ? (
+                          <Badge variant="secondary">Pending invite</Badge>
+                        ) : a.emailVerified ? (
+                          <Badge>Active</Badge>
+                        ) : (
+                          <Badge variant="outline">Email unverified</Badge>
+                        )}
+                      </td>
+                      <td className="py-2 text-xs text-muted-foreground">
+                        {a.createdTimestamp
+                          ? new Date(a.createdTimestamp).toLocaleString()
+                          : '—'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/digit-ui-v2/src/pages/AdminLoginPage.tsx
+++ b/digit-ui-v2/src/pages/AdminLoginPage.tsx
@@ -1,0 +1,115 @@
+/**
+ * /admin/login — platform-admin login (KC master realm).
+ *
+ * Two personas land here:
+ *   - The god admin (preferred_username=admin or PLATFORM_ADMIN role) →
+ *     /admin/dashboard for sending invites.
+ *   - A scoped admin (bootstrap:<tenantId> role), typically arriving from
+ *     an email invite with ?invited=true&email=… → /admin/bootstrap for
+ *     their tenant.
+ *
+ * Auth: KC master realm password grant via admin-cli client (the only
+ * built-in client that allows direct grants on master).
+ */
+import { useEffect, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { adminLogin, loadAdminSession } from '@/api/platformAdmin';
+
+export default function AdminLoginPage() {
+  const navigate = useNavigate();
+  const [params] = useSearchParams();
+  const invited = params.get('invited') === 'true';
+  const emailHint = params.get('email') || '';
+
+  const [username, setUsername] = useState(emailHint);
+  const [password, setPassword] = useState('');
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // If already logged in, fast-forward
+  useEffect(() => {
+    const s = loadAdminSession();
+    if (!s) return;
+    navigate(s.scope.kind === 'god' ? '/admin/dashboard' : '/admin/bootstrap', {
+      replace: true,
+    });
+  }, [navigate]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (!username || !password) {
+      setError('Username and password are required.');
+      return;
+    }
+    setPending(true);
+    try {
+      const { scope } = await adminLogin(username.trim(), password);
+      navigate(scope.kind === 'god' ? '/admin/dashboard' : '/admin/bootstrap', {
+        replace: true,
+      });
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted/30 p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Platform admin</CardTitle>
+          <CardDescription>
+            {invited
+              ? "Welcome — you've just been invited to administer a tenant. Sign in with the password you just set to continue to your bootstrap wizard."
+              : 'Sign in to send tenant-admin invites or to bootstrap a tenant.'}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="username">Email or username</Label>
+              <Input
+                id="username"
+                type="text"
+                autoComplete="username"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                placeholder="admin or you@example.com"
+                disabled={pending}
+                autoFocus={!emailHint}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="password">Password</Label>
+              <Input
+                id="password"
+                type="password"
+                autoComplete="current-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="••••••••"
+                disabled={pending}
+                autoFocus={!!emailHint}
+              />
+            </div>
+            {error && (
+              <Alert variant="destructive">
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+            <Button type="submit" className="w-full" disabled={pending}>
+              {pending ? 'Signing in…' : 'Sign in'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Three new pages under `/citizen/admin/*` that complete the email-driven tenant-admin onboarding flow:

| Page | URL | Persona |
|---|---|---|
| Login | `/citizen/admin/login` | Either — routes by JWT role |
| Dashboard | `/citizen/admin/dashboard` | God admin (master `admin` user or `PLATFORM_ADMIN` role) |
| Bootstrap | `/citizen/admin/bootstrap` | Scoped admin (`bootstrap:<tenantId>` role) |

End-to-end demo flow:

```
God logs in at /admin/login                              (KC master realm password grant)
  → /admin/dashboard
    → "Invite tenant admin" form (email + tenantId)
      → POST /token-exchange/platform-admin/scoped-admins/_invite
        → KC sends email (master realm Gmail SMTP)
Invitee clicks the magic link in their email
  → KC set-password page
  → KC redirect to /admin/login
    → invitee logs in with the password they just set
      → /admin/bootstrap
        → wizard locked to their tenant
        → submit → POST /token-exchange/platform-admin/v1/tenant/bootstrap
        → result card with schemas/data/localizations copied + admin user provisioned
```

## Files

| File | Lines | What |
|---|---|---|
| `src/api/platformAdmin.ts` | +165 | KC master-realm password grant, JWT decode, scope detection, fetch wrapper, separate localStorage namespace from the citizen session |
| `src/pages/AdminLoginPage.tsx` | +115 | Login form. Reads `?invited=true&email=...` to pre-fill. Routes by scope. |
| `src/pages/AdminDashboardPage.tsx` | +287 | God-only. Invite form + tenant admins table. |
| `src/pages/AdminBootstrapPage.tsx` | +243 | Scoped wizard. Reads `bootstrap:<X>` from JWT, locks target tenant, submits to MCP. |
| `src/App.tsx` | +10 | Three new routes outside the protected `<CitizenLayout>`. |

## Companion backend

These pages depend on endpoints in [DIGIT-keycloak-overlay](https://github.com/ChakshuGautam/DIGIT-keycloak-overlay):
- `POST /platform-admin/scoped-admins/_invite` — creates KC user + triggers email (commit `1cc7f37`)
- `GET /platform-admin/scoped-admins` — lists scoped admins per tenant (commit `1cc7f37`)
- `POST /platform-admin/v1/tenant/bootstrap` — MCP passthrough (earlier commits)
- The overlay image is already published as `registry.preview.egov.theflywheel.in/token-exchange-svc:dev` and consumed by this CCRS repo via its compose.

KC realm SMTP must be configured on the master realm for invite emails to land. The token-exchange-svc returns `inviteSent: false` + an actionable hint if SMTP is missing, so this is a deployment-time setup task rather than a code change.

## Test coverage

`digit-integration-tests/tests/keycloak/kc-platform-admin.spec.ts` ([PR #29](https://github.com/ChakshuGautam/digit-integration-tests/pull/29)) covers the backend contract — 5 new API tests for `_invite` + `scoped-admins` listing (god gate, body validation, happy-path KC user shape with `requiredActions: ["UPDATE_PASSWORD"]` + role assignment, list shape, list god gate). Combined with the existing 14 platform-admin tests, the suite runs 19/19 green against bomet.

UI-level Playwright coverage for the three pages is a follow-up — the SMTP-capture infra (Mailpit / Mailhog) needs to land first so we don't spam a real Gmail on every CI run.

## Test plan

- [x] `npm run build` (typecheck + Vite build) clean
- [x] All three pages render at the right routes
- [x] Login routes by scope (god → dashboard, scoped → bootstrap)
- [x] Invite form delivers email end-to-end against Bomet
- [x] Scoped wizard runs tenant_bootstrap and renders the result
- [x] Backend contract: 19/19 platform-admin specs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)