### PR TITLE
feat(configurator): show all modules in localization Module dropdown

### DIFF
--- a/configurator/src/hooks/useLocalizationModules.ts
+++ b/configurator/src/hooks/useLocalizationModules.ts
@@ -1,0 +1,87 @@
+import { useQuery } from '@tanstack/react-query';
+import { digitClient } from '@/providers/bridge';
+
+const DEFAULT_MODULE = 'rainmaker-common';
+
+/**
+ * Reads DIGIT's own cached module list from localStorage. digit-ui's
+ * Localization service accumulates loaded modules under `Digit.Locale.<locale>.List`
+ * and the cross-locale union `Digit.Locale.List`, each wrapped as
+ * `{ value, ttl, expiry }`. Same-origin in production, so we can read it for an
+ * instant, sync seed while the authoritative fetch runs. Returns [] if
+ * absent/expired (incognito, configurator-only, or a different dev origin).
+ */
+function readDigitModuleList(locale: string): string[] {
+  if (typeof localStorage === 'undefined') return [];
+  for (const key of ['Digit.Locale.List', `Digit.Locale.${locale}.List`]) {
+    const raw = localStorage.getItem(key);
+    if (!raw) continue;
+    try {
+      const parsed = JSON.parse(raw) as { value?: unknown; expiry?: number };
+      if (parsed?.expiry && Date.now() > parsed.expiry) continue; // expired
+      if (Array.isArray(parsed?.value)) {
+        const mods = parsed.value.filter((m): m is string => typeof m === 'string');
+        if (mods.length) return mods.slice().sort();
+      }
+    } catch {
+      /* ignore malformed cache entry */
+    }
+  }
+  return [];
+}
+
+/**
+ * Returns the localization module names for the tenant, derived from the
+ * localization messages themselves -- the only authoritative source for which
+ * modules actually have localizations. (MDMS StateInfo.localizationModules is
+ * often stale: it omits in-use digit- and tenant-specific modules, and lists
+ * unused ones.)
+ *
+ * Performance: the message table can be very large, so we don't make this cheap
+ * by guessing -- we make it cheap by NOT repeating it:
+ *   - staleTime 30 min: the full search runs at most once per session; repeat
+ *     visits are served from cache instantly.
+ *   - placeholderData: the dropdown renders immediately from DIGIT's cached
+ *     localStorage list while the authoritative fetch resolves in the
+ *     background, so it is never empty and never blocks opening the form.
+ *   - distinct via Set is O(n) -- negligible next to the network payload, which
+ *     the caching amortizes. (This is the same data the localization list page
+ *     already fetches.)
+ *
+ * There is no server-side distinct-modules endpoint and no index on the module
+ * column, so a single cached scan is the most effective authoritative option.
+ */
+export function useLocalizationModules(locale = 'en_IN'): {
+  modules: string[];
+  isLoading: boolean;
+  error: Error | null;
+} {
+  const tenantId = digitClient.stateTenantId;
+
+  const { data, isLoading, error } = useQuery<string[], Error>({
+    queryKey: ['localization-modules', tenantId, locale],
+    queryFn: async () => {
+      // No module arg -> every message for the locale, across all modules.
+      const messages = await digitClient.localizationSearch(tenantId!, locale);
+      const unique = [...new Set(messages.map((m: Record<string, unknown>) => String(m.module ?? '')))]
+        .filter(Boolean)
+        .sort();
+      return unique.length ? unique : [DEFAULT_MODULE];
+    },
+    // Module set rarely changes -> fetch the heavy payload at most once/session.
+    staleTime: 30 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+    // Instant, non-blocking seed from DIGIT's cache while the fetch runs.
+    placeholderData: () => {
+      const cached = readDigitModuleList(locale);
+      return cached.length ? cached : undefined;
+    },
+    enabled: !!tenantId,
+  });
+
+  return {
+    modules: data ?? [DEFAULT_MODULE],
+    isLoading,
+    error: error ?? null,
+  };
+}

--- a/configurator/src/resources/localization/LocalizationCreate.tsx
+++ b/configurator/src/resources/localization/LocalizationCreate.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { DigitCreate, DigitFormCodeInput, DigitFormInput, DigitFormSelect, v } from '@/admin';
-import { useGetList } from 'ra-core';
 import { useAvailableLocales } from '@/hooks/useAvailableLocales';
+import { useLocalizationModules } from '@/hooks/useLocalizationModules';
 
 const DEFAULT_MODULE = 'rainmaker-common';
 
@@ -11,19 +11,16 @@ const defaultRecord = {
 };
 
 export function LocalizationCreate() {
-  const { data } = useGetList('localization', {
-    pagination: { page: 1, perPage: 1000 },
-    sort: { field: 'module', order: 'ASC' },
-  });
+  // Module options come from the localization data itself (distinct modules
+  // across all messages for the locale), via useLocalizationModules — not the
+  // list view's paginated rows, which truncate at perPage and drop modules.
+  const { modules } = useLocalizationModules(defaultRecord.locale);
   const { locales } = useAvailableLocales();
 
-  const moduleChoices = useMemo(() => {
-    if (!data || data.length === 0) {
-      return [{ value: DEFAULT_MODULE, label: DEFAULT_MODULE }];
-    }
-    const unique = [...new Set(data.map((r) => r.module))].filter(Boolean).sort();
-    return unique.map((m) => ({ value: m, label: m }));
-  }, [data]);
+  const moduleChoices = useMemo(
+    () => modules.map((m) => ({ value: m, label: m })),
+    [modules],
+  );
 
   const localeChoices = locales.map((l) => ({ value: l.value, label: l.label }));
 


### PR DESCRIPTION
The Create Localization screen derived the Module dropdown options from useGetList('localization', { perPage: 1000 }), which fetches all messages then client-side slices to the first 1000 rows (sorted by module) — silently dropping any module whose messages sort past that cutoff.

Replace it with a dedicated useLocalizationModules hook that fetches the localization messages once (React Query, 30-min staleTime) and extracts the full set of distinct module names — no truncation. A synchronous placeholderData seed from DIGIT's Digit.Locale.* localStorage cache keeps the dropdown populated and non-blocking while the fetch resolves.