### PR TITLE
docs: Sprint Goal 2 — deployment modes & rapid-release approach

### DIFF
--- a/docs/deployment-modes.md
+++ b/docs/deployment-modes.md
@@ -1,0 +1,135 @@
+# CCRS Deployment Modes — Approach Documentation
+
+**Status:** Accepted (Sprint Goal 2) · **Last updated:** 2026-05-29
+
+CCRS ships as one product (`egovernments/CCRS` monorepo, `develop`) but must deploy to
+a range of targets: a developer laptop, a single demo box, and a high-availability
+production cluster. The same service images and configuration model (tenant config,
+MDMS, boundaries, branding) feed every mode; the orchestrator and backbone wiring
+underneath differ (see the A↔C drift note in Open Questions).
+
+## Pick a mode
+
+| Mode | Substrate | Use for | HA | Source |
+|------|-----------|---------|----|--------|
+| **A. Ansible + Compose** | Single VM, Docker Compose | Dev, demos, pilots, CI | No | `local-setup/ansible/` |
+| **B. Local Kubernetes** | kind / k3d / single-node k8s | Developing the k8s path | No | `local-setup/k8s/` + `Tiltfile.k8s` |
+| **C. Helm + Rancher/RKE2** | Multi-node K8s cluster | Production SaaS | **Capable** | `devops/deploy-as-code/charts/` + `devops/infra-as-code/terraform/` |
+
+Everything non-production runs on **Mode A** (fastest, most reproducible bring-up).
+Paying tenants run on **Mode C**. **Mode B** exists only to develop and validate the
+k8s manifests without a cloud cluster.
+
+## Mode A — Ansible + Docker Compose (single node)
+
+**Entry point:** `local-setup/ansible/deploy.sh <tenant>`
+
+An Ansible playbook (`playbook-deploy.yml`) converges a single host: renders
+`digit.env`, `globalConfigs.js`, and the nginx site from `templates/`, brings up the
+Docker Compose stack (~36 containers — Postgres, Redpanda, Redis, MinIO, Kong, all
+core-services, PGR, configurator, digit-ui behind a host nginx), runs DB migrations, and
+bootstraps the tenant.
+
+- **Strengths:** blank VM → green in ~5 min; idempotent re-converge (what the nightly
+  bomet redeploy relies on); per-tenant values in one file (`inventory/host_vars/<tenant>.yml`);
+  no cluster to operate; Mac- and Linux-capable.
+- **Limits:** no HA (single host, one Postgres, no failover); vertical scaling only;
+  stateful data on local volumes with operator-managed backup (note the bomet
+  anonymous-volume hazard — `down -v` destroys everything).
+
+Runs today on bomet (dev, nightly), naipepea (demo), maputo. CI uses it for E2E validation.
+
+## Mode B — Local Kubernetes (dev cluster)
+
+**Entry point:** `Tiltfile.k8s` + manifests in `local-setup/k8s/`
+
+Plain manifests grouped as `infrastructure/` (postgres, redis, redpanda, minio,
+pgbouncer), `core-services/`, and `app-services/` (kong, pgr-services, digit-ui), with
+Tilt live-reloading into a local cluster. This is the development harness for the k8s
+path — not a tenant target.
+
+- **Strengths:** validates k8s wiring (probes, service DNS, config maps) without cloud
+  spend; fast inner loop via Tilt.
+- **Limits:** single-node, no real load; uses raw manifests rather than the production
+  Helm charts, so it's representative of Mode C, not identical (see open questions).
+
+## Mode C — Helm + Rancher/RKE2 (production HA)
+
+**Charts:** `devops/deploy-as-code/charts/` · **Infra:** `devops/infra-as-code/terraform/`
+(AWS/Azure/GCP samples + node-pool modules) and `infra-as-code/ansible/` (`haconfig.cfg`)
+
+The production substrate, following DIGIT on-premise / RKE2 guidance:
+
+- **Cluster:** HA RKE2 managed by Rancher (≥3 control-plane nodes for etcd quorum +
+  worker nodes). Cloud clusters (EKS/AKS/GKE) provisioned via the Terraform samples.
+- **Charts:** organised by tier — `backbone-services` (Postgres, Kafka, Redis,
+  Elasticsearch/Kibana), `core-services`, `urban` (PGR/CCRS, digit-ui, boundary-mgmt,
+  default-data-handler), `common-services`, `monitoring`, `analytics`.
+- **Environments:** `charts/environments/env.yaml` + `env-secrets.yaml` hold the
+  per-environment (cluster) overrides — db-host, domain, state tenant id. This
+  parameterises one deployment environment, not individual DIGIT tenants.
+
+**HA is available but not default.** The platform *can* run HA; the shipped chart values
+do not. The Postgres chart defaults to `architecture: standalone` and most services to
+`replicas: 1`, so a production HA setup must explicitly enable: `architecture:
+replication` (primary + read replica statefulsets — note this is read-scaling/standby,
+not automatic failover unless paired with a failover mechanism), `replicas > 1` with
+anti-affinity/PDBs for stateless services, ≥3 RKE2 control-plane nodes for etcd quorum,
+and shared storage (NFS or object store) for the filestore.
+
+- **Strengths (when configured for HA):** horizontal scale, rolling deploys, self-healing,
+  optional autoscaling; built-in monitoring/analytics tiers (Prometheus, Kibana).
+- **Costs:** a cluster to run, upgrade, secure, and observe; slower inner loop (chart
+  values + Helm release); requires infra provisioned first.
+
+**Reference docs**
+- On-prem RKE2 HA: `docs.digit.org/.../infrastructure-setup/sdc/create-infrastructure-on-premise`
+- CCRS v2.10 production setup: `docs.digit.org/complaints-management/complaints-resolution-v2.10/deploy/setup/production-setup/setup-infrastructure/on-premise`
+- NFS server on Rancher: `.../on-premise/deploy-network-file-system-nfs-server`
+- Cloud (Terraform): `.../infrastructure-setup/azure/3.-infra-as-code-terraform`
+
+## Ansible vs Kubernetes
+
+| Dimension | Ansible + Compose (A) | Helm + RKE2 (C) |
+|-----------|----------------------|-----------------|
+| Time to first green stack | ~5 min | Hours (cluster) → minutes (release) |
+| High availability | None | Capable, opt-in (replicas + DB replication must be enabled) |
+| Horizontal scale | No (vertical only) | Yes |
+| Operational burden | Low (one box) | High (cluster lifecycle) |
+| Failover / self-healing | None | Pod & node level |
+| Inner-loop speed | Fast | Moderate (Tilt in Mode B) |
+| Backup/restore | Operator scripts | Snapshots + replication |
+| Cost | One VM | Cluster + storage + ops |
+
+**Decision guide:** pilot or internal environment → **A**. Paying tenant or multi-tenant
+scale → **C**. Developing the k8s path → **B**.
+
+## Promotion path: single-node → HA
+
+Because both modes share the same config model, graduating a tenant is a data + config
+migration, not a rewrite:
+
+1. Snapshot the Mode-A Postgres and filestore.
+2. Provision the cluster (Terraform/Rancher) if needed.
+3. Add the tenant's override to `charts/environments/env.yaml` (+ secrets).
+4. `helm upgrade --install` the chart set.
+5. Restore data into the replicated Postgres; sync filestore to NFS/object store.
+6. Validate (logins, PGR lifecycle, branding), then cut DNS over.
+
+## Open questions
+
+- **Tenancy model.** Each city today (bomet, naipepea, maputo) is a *separate
+  deployment*, not a logical tenant in one cluster. Is the SaaS target one
+  environment-per-customer (current de-facto) or a shared cluster with DIGIT logical
+  tenants sharing db/schema/bucket? This decides isolation, blast radius on
+  release/rollback, backup granularity, and data residency, and should be stated before
+  the first production tenant.
+- **A↔C drift.** Modes A and C share images and config intent but not orchestration
+  artifacts (and Mode B uses raw manifests, not the prod charts). Should Mode B consume
+  the production Helm charts so local == prod? Closing this makes promotion cheaper and
+  safer.
+- Standardise production on **on-prem RKE2** (data-residency) or **cloud managed k8s**
+  (EKS/AKS/GKE via Terraform), or offer both?
+- Backup/restore: platform-level guarantee for Mode A pilots vs. the replication +
+  snapshot story for Mode C?
+

--- a/docs/rapid-release-approach.md
+++ b/docs/rapid-release-approach.md
@@ -1,0 +1,113 @@
+# CCRS Rapid Release Approach
+
+**Status:** Accepted (Sprint Goal 2) · **Last updated:** 2026-05-29
+
+CCRS is becoming a multi-tenant SaaS product, so we need a repeatable release process
+rather than bespoke per-county installs. This extends the workflow proposed on the
+channel with an explicit cadence, a versioning/promotion model, and quality gates.
+
+## Proposal (recap)
+
+> - `egov/ccrs` `develop` is trunk; cut feature/fix branches, merge with 1 review.
+> - Nightly builds + deploys to dev (bomet) off `develop`, auto-rollback on break.
+> - Nai Pepea built off a release tag as the demo-able, stable instance.
+> - eGov servers host a self-hosted GHA runner for scheduled + triggered builds and tests.
+> - Rebase bomet & Nai Pepea onto `develop` (both predate the merger) and validate.
+
+## 1. Branching
+
+- **`develop` is trunk** and always releasable.
+- **Short-lived branches** — `feature/<slug>`, `fix/<slug>`, `chore/<slug>` — merged
+  back within days behind **one review + green CI**. Squash-merge.
+- **Feature flags** (config/MDMS or env toggle) for incomplete work, so trunk keeps
+  moving and deploy is decoupled from release.
+
+```
+feature/x ─┐
+fix/y ─────┼──▶ develop (trunk) ──tag──▶ vX.Y.Z
+chore/z ───┘
+```
+
+## 2. Environments & promotion
+
+A build is promoted to the next environment only after it's green in the current one.
+
+| Env | Tracks | Cadence | Purpose |
+|-----|--------|---------|---------|
+| **Dev — bomet** | `develop` HEAD | Nightly, automated | Proves trunk builds & deploys daily |
+| **Staging — Nai Pepea** | latest release tag | Per release | Stable, demo-able reference |
+| **Production — tenant(s)** | promoted release tag | Per release, gated | Paying tenants |
+
+```
+develop ──nightly──▶ bomet ──tag──▶ Nai Pepea ──promote──▶ production
+```
+
+## 3. Cadence
+
+- **Dev (bomet):** nightly off `develop`, no human in the loop.
+- **Staging (Nai Pepea):** weekly release tag (e.g. Tuesday), deployed and validated.
+- **Production:** promote a validated staging release bi-weekly or on-demand per tenant
+  SLA, after sign-off.
+
+Production stays human-gated until test coverage and rollback are proven; shorten the
+intervals as confidence grows.
+
+## 4. Versioning
+
+- **SemVer release tags** `vMAJOR.MINOR.PATCH` — PATCH (fixes, auto-promotable), MINOR
+  (backward-compatible features), MAJOR (breaking changes: non-backward-compatible DB
+  migration, config schema, or API contract — extra scrutiny + documented migration).
+- **Tags are immutable and are the unit of deployment** to staging/prod — staging and
+  tenants run a tag, never a moving branch.
+- **Release notes** generated per tag from PR titles.
+
+## 5. CI/CD (self-hosted runners)
+
+1. **PR check** (every PR to `develop`): build, test suite (unit + `digit-integration-tests`
+   E2E), lint. Required to merge.
+2. **Nightly dev deploy** (off `develop`): build → deploy to bomet → smoke/E2E →
+   auto-rollback on failure + alert.
+3. **Release cut** (weekly or `workflow_dispatch`): tag `vX.Y.Z`, publish
+   versioned images, deploy to Nai Pepea, run regression, generate notes.
+4. **Production promotion** (`workflow_dispatch`, approval-gated): deploy the chosen tag
+   to the tenant environment, validate, one-command rollback available.
+
+**Rollback:** every automated deploy records the previous good tag; a failed health
+check (Gatus, smoke tests) redeploys it and posts the failure. Image rollback is only
+safe if migrations are backward-compatible with the prior release (expand-contract — see
+§6). A release that includes a destructive/non-compatible migration is **roll-forward
+only**; recovery is a hotfix, not a redeploy, and the release notes must say so.
+
+## 6. Quality gates
+
+- Build passes for all service images.
+- Test suite passes (unit + integration). Growing `digit-integration-tests` coverage is
+  the long-pole investment.
+- Post-deploy smoke checks: logins, PGR lifecycle, branding/localization, health endpoints.
+- DB migrations follow **expand-contract**: each release is backward-compatible with the
+  previous one so an image rollback is safe within a release window. Migrations are tested
+  on a restored snapshot; any non-compatible/destructive change is flagged at MAJOR and
+  marked roll-forward-only.
+
+## 7. Hotfix
+
+1. Branch `hotfix/<slug>` off the production release tag (not `develop` HEAD).
+2. Fix, review, targeted tests.
+3. Tag a PATCH release, deploy to staging, validate, promote.
+4. Merge back into `develop`.
+
+## 8. Immediate action
+
+bomet and Nai Pepea predate the merger into `egov/ccrs develop` and run pre-merger
+code/config. To put them on trunk:
+
+- [ ] Rebase **bomet** onto `develop`, redeploy, validate (logins, PGR lifecycle,
+      notifications, branding). bomet already redeploys nightly via cron; upgrade that to
+      the CI pipeline (off `develop`, with smoke gate + auto-rollback).
+- [ ] Rebase **Nai Pepea** onto `develop`, cut the first `vX.Y.Z` release tag, redeploy
+      from that tag, validate.
+- [ ] Stand up the self-hosted runner(s) and land the pipelines (PR-check + nightly
+      first, then release-cut + prod-promotion).
+
+Estimate: ~1–2 evenings for the rebase + validation.
+


### PR DESCRIPTION
Folds the two **Sprint Goal 2** documents (drafted and team-reviewed in the fork — see issue #632) into `docs/`.

### What's added
- **`docs/deployment-modes.md`** — Ansible+Compose (A), local Kubernetes (B), and Helm + Rancher/RKE2 HA (C). One product, multiple substrates sharing the same config model; trade-offs, decision guide, and the single-node → HA promotion path.
- **`docs/rapid-release-approach.md`** — trunk-based development on `develop`, environment promotion (bomet dev → Nai Pepea staging → tenant prod), release-train cadence, SemVer release tags, self-hosted GHA pipelines, auto-rollback, quality gates, and the hotfix path.

Both were previously checked in only as fork issue drafts (KDwevedi#12, KDwevedi#13); this is the "fold finalized docs into `docs/` and PR against `develop`" step from the issue checklist.

Docs-only change — no code or config touched.

Refs #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)