### PR TITLE
feat(integration-tests): RUN button — on-box test-runner daemon (#713)

### DIFF
--- a/local-setup/ansible/inventory/host_vars/_example.yml
+++ b/local-setup/ansible/inventory/host_vars/_example.yml
@@ -166,6 +166,21 @@ integration_tests_basic_auth_user: "digit-tests"
 # Set in vault (never commit a real password). The htpasswd task skips if unset.
 # integration_tests_basic_auth_password: "{{ vault_integration_tests_password }}"
 
+# RUN button: an on-box test-runner daemon that lets the v2 dashboard TRIGGER a
+# Playwright run (writes results back into /var/www/integration-tests). Requires
+# enable_integration_tests: true (it serves on the same vhost) AND
+# nginx_features.integration_tests_runner: true below. The API is proxied at
+# /integration-tests/api/ behind the SAME basic-auth as the dashboards.
+# NOTE: a run is CPU/RAM heavy and shares the box with the live DIGIT stack
+# (it's nice'd, but still). Leave off unless you want in-dashboard runs.
+enable_integration_tests_runner: false
+# integration_tests_runner_port: 8181        # loopback port the daemon listens on
+# integration_tests_runner_run_limit: 5      # keep at most N runs on disk
+# integration_tests_runner_branch: "deployed"
+# Env file the run sources so it targets THIS box's tenant (BASE_URL/DIGIT_TENANT/
+# LOCALITY_CODE/SERVICE_CODE). Point at the deploy env you already maintain.
+# integration_tests_runner_tenant_env: "/opt/integration-tests/deploy/bomet.env"
+
 # ────────── Optional services (opt-in via flags) ──────────
 
 # Bring up Elasticsearch + egov-indexer + inbox-v2. Heavy (~3GB RAM
@@ -289,6 +304,7 @@ nginx_features:
   keycloak: false            # /auth/ + /token-exchange/ — requires enable_keycloak: true
   digit_ui_v2: false         # /citizen/ — Vite + React 19 SPA (requires enable_digit_ui_v2: true)
   integration_tests: false   # /integration-tests/ + -v2/ — test dashboards (requires enable_integration_tests: true)
+  integration_tests_runner: false  # /integration-tests/api/ — RUN-button daemon proxy (requires enable_integration_tests_runner: true)
 
 # If true, the playbook will NOT render `templates/nginx-site.conf.j2` into
 # /etc/nginx/sites-available/ and will NOT touch /etc/nginx/sites-enabled/.

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -1409,6 +1409,54 @@
         - integration_tests_basic_auth_password is defined
         - ansible_system != "Darwin"
 
+    # ---- RUN button: on-box test-runner daemon (opt-in: enable_integration_tests_runner) ----
+    # Backs the "Run tests" button on the v2 dashboard. Loopback-only Node
+    # service; nginx (/integration-tests/api/, nginx_features.integration_tests_runner)
+    # is the auth front. Requires the dashboards block above (needs
+    # integration_tests_dir). A run is heavy and shares the box with the live
+    # stack, so this stays opt-in and nice'd. Linux only.
+    - name: "integration-tests runner — install Playwright + browsers (needed to run, not just serve)"
+      ansible.builtin.command: >-
+        npx --yes playwright install --with-deps chromium
+      args:
+        chdir: "{{ integration_tests_dir }}"
+      changed_when: true
+      when:
+        - enable_integration_tests_runner | default(false)
+        - integration_tests_dir is defined
+        - ansible_system != "Darwin"
+
+    - name: "integration-tests runner — npm deps for the test suite (tsx + playwright)"
+      ansible.builtin.shell: npm ci || npm install
+      args:
+        chdir: "{{ integration_tests_dir }}"
+      changed_when: true
+      when:
+        - enable_integration_tests_runner | default(false)
+        - integration_tests_dir is defined
+        - ansible_system != "Darwin"
+
+    - name: "integration-tests runner — install systemd unit"
+      ansible.builtin.template:
+        src: templates/integration-tests-runner.service.j2
+        dest: /etc/systemd/system/integration-tests-runner.service
+        mode: '0644'
+      when:
+        - enable_integration_tests_runner | default(false)
+        - integration_tests_dir is defined
+        - ansible_system != "Darwin"
+
+    - name: "integration-tests runner — enable + (re)start daemon"
+      ansible.builtin.systemd:
+        name: integration-tests-runner
+        state: restarted
+        enabled: true
+        daemon_reload: true
+      when:
+        - enable_integration_tests_runner | default(false)
+        - integration_tests_dir is defined
+        - ansible_system != "Darwin"
+
     # Host nginx (Linux/Debian) — apt nginx + /etc/nginx site. Skipped on
     # macOS, where nginx runs as a container instead (next block).
     - name: "Host nginx — Linux/Debian only"

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -1415,9 +1415,11 @@
     # is the auth front. Requires the dashboards block above (needs
     # integration_tests_dir). A run is heavy and shares the box with the live
     # stack, so this stays opt-in and nice'd. Linux only.
-    - name: "integration-tests runner — install Playwright + browsers (needed to run, not just serve)"
-      ansible.builtin.command: >-
-        npx --yes playwright install --with-deps chromium
+    # Deps FIRST, so the next task installs the browser revision that matches
+    # the locked @playwright/test (1.59.1) rather than whatever an unpinned
+    # `npx playwright` would pull.
+    - name: "integration-tests runner — npm deps for the test suite (tsx + playwright)"
+      ansible.builtin.shell: npm ci || npm install
       args:
         chdir: "{{ integration_tests_dir }}"
       changed_when: true
@@ -1426,8 +1428,9 @@
         - integration_tests_dir is defined
         - ansible_system != "Darwin"
 
-    - name: "integration-tests runner — npm deps for the test suite (tsx + playwright)"
-      ansible.builtin.shell: npm ci || npm install
+    - name: "integration-tests runner — install Playwright browsers (repo-local binary, matched version)"
+      ansible.builtin.command: >-
+        node_modules/.bin/playwright install --with-deps chromium
       args:
         chdir: "{{ integration_tests_dir }}"
       changed_when: true

--- a/local-setup/ansible/templates/integration-tests-runner.service.j2
+++ b/local-setup/ansible/templates/integration-tests-runner.service.j2
@@ -1,0 +1,27 @@
+# test-runner daemon — backs the RUN button on the integration-tests dashboard.
+# Rendered by the playbook when enable_integration_tests_runner: true.
+# Loopback-only; nginx (/integration-tests/api/) is the auth front.
+[Unit]
+Description=DIGIT integration-tests runner (RUN button backend)
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory={{ integration_tests_dir }}
+ExecStart=/usr/bin/env node {{ integration_tests_dir }}/runner/server.mjs
+Environment=RUNNER_PORT={{ integration_tests_runner_port | default(8181) }}
+Environment=RUNNER_REPO_DIR={{ integration_tests_dir }}
+Environment=RUNNER_WEBROOT=/var/www/integration-tests
+Environment=RUNNER_RUN_LIMIT={{ integration_tests_runner_run_limit | default(5) }}
+Environment=RUNNER_BRANCH={{ integration_tests_runner_branch | default('deployed') }}
+{% if integration_tests_runner_tenant_env is defined %}
+Environment=RUNNER_TENANT_ENV={{ integration_tests_runner_tenant_env }}
+{% endif %}
+Restart=on-failure
+RestartSec=5
+# A run is CPU/RAM heavy and shares the box with the live DIGIT stack — keep it
+# below the platform in priority (run-cycle.sh also nice's the Playwright child).
+Nice=10
+
+[Install]
+WantedBy=multi-user.target

--- a/local-setup/ansible/templates/nginx-site.conf.j2
+++ b/local-setup/ansible/templates/nginx-site.conf.j2
@@ -89,6 +89,22 @@ server {
     add_header Cache-Control "no-cache, must-revalidate" always;
     try_files $uri $uri/ /integration-tests-v2/index.html =404;
   }
+{% if nginx_features.integration_tests_runner | default(false) %}
+  # RUN button → on-box test-runner daemon (loopback only; nginx is the auth).
+  # SAME realm string as the dashboards above so the browser reuses the already-
+  # entered basic-auth creds for the API calls. Longest-prefix match means this
+  # wins over /integration-tests/ for /integration-tests/api/*. Long read-timeout
+  # + buffering off so /run/<id>/log can stream a live console.
+  location /integration-tests/api/ {
+    auth_basic "DIGIT integration tests";
+    auth_basic_user_file /etc/nginx/.htpasswd-tests;
+    proxy_pass http://127.0.0.1:{{ integration_tests_runner_port | default(8181) }}/;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_read_timeout 3600s;
+    proxy_buffering off;
+  }
+{% endif %}
 
 {% endif %}
   # Grafana dashboard

--- a/tests/integration-tests/dashboard-react-admin/src/MyAppBar.tsx
+++ b/tests/integration-tests/dashboard-react-admin/src/MyAppBar.tsx
@@ -1,12 +1,20 @@
 /**
- * Custom AppBar — keeps just the standard react-admin light/dark toggle.
+ * Custom AppBar — RUN button + the standard react-admin light/dark toggle.
  * The earlier multi-theme picker was removed (we ship Nano only).
  */
 import { AppBar, TitlePortal, ToggleThemeButton } from 'react-admin';
+import RunButton from './RunButton';
 
 export default function MyAppBar() {
   return (
-    <AppBar toolbar={<ToggleThemeButton />}>
+    <AppBar
+      toolbar={
+        <>
+          <RunButton />
+          <ToggleThemeButton />
+        </>
+      }
+    >
       <TitlePortal />
     </AppBar>
   );

--- a/tests/integration-tests/dashboard-react-admin/src/RunButton.tsx
+++ b/tests/integration-tests/dashboard-react-admin/src/RunButton.tsx
@@ -11,7 +11,7 @@
  * overridable at build time with VITE_RUNNER_API_BASE.
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Button, useNotify } from 'react-admin';
+import { Button, useNotify, useRefresh } from 'react-admin';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import HourglassTopIcon from '@mui/icons-material/HourglassTop';
 import { refreshCatalog } from './dataProvider';
@@ -25,6 +25,11 @@ type Current =
 
 export default function RunButton() {
   const notify = useNotify();
+  const refresh = useRefresh();
+  // The runner is opt-in (enable_integration_tests_runner) and its API may not
+  // be deployed at all. Start hidden and only reveal the button once a probe
+  // succeeds, so dashboards without the runner don't show a button that 404s.
+  const [reachable, setReachable] = useState(false);
   const [running, setRunning] = useState(false);
   const [phase, setPhase] = useState<string | null>(null);
   const [starting, setStarting] = useState(false);
@@ -35,20 +40,24 @@ export default function RunButton() {
     try {
       const r = await fetch(`${API_BASE}/run/current`, { credentials: 'include' });
       if (!r.ok) return;
+      setReachable(true);
       const cur = (await r.json()) as Current;
       const isRunning = cur.state === 'running';
       setRunning(isRunning);
       setPhase(cur.state === 'running' ? cur.phase : null);
       if (wasRunning.current && !isRunning) {
-        // A run just finished — pull the fresh catalog into the dashboard.
+        // A run just finished — drop the cached catalog AND invalidate
+        // react-admin's query cache so the list/show views refetch.
         notify('Test run finished — refreshing results', { type: 'info' });
-        refreshCatalog().catch(() => undefined);
+        refreshCatalog()
+          .catch(() => undefined)
+          .finally(() => refresh());
       }
       wasRunning.current = isRunning;
     } catch {
-      /* daemon unreachable — leave the button as-is */
+      /* daemon unreachable — stays hidden / leaves the button as-is */
     }
-  }, [notify]);
+  }, [notify, refresh]);
 
   useEffect(() => {
     poll();
@@ -81,6 +90,9 @@ export default function RunButton() {
       setStarting(false);
     }
   }, [notify]);
+
+  // Hidden until the runner API answers — no button on runner-less dashboards.
+  if (!reachable) return null;
 
   const label = running ? (phase ? `Running… (${phase})` : 'Running…') : 'Run tests';
 

--- a/tests/integration-tests/dashboard-react-admin/src/RunButton.tsx
+++ b/tests/integration-tests/dashboard-react-admin/src/RunButton.tsx
@@ -1,0 +1,95 @@
+/**
+ * RunButton — triggers an on-box Playwright run via the test-runner daemon and
+ * reflects its progress. The daemon sits behind nginx at /integration-tests/api/
+ * under the SAME basic-auth as the dashboard, so `credentials: 'include'` reuses
+ * the creds the browser already has — no separate login.
+ *
+ * A run is long (~1h), so this is fire-and-poll: POST /run returns immediately,
+ * then we poll /run/current until it goes idle and refresh the catalog.
+ *
+ * The API base is absolute (both dashboards live on the same vhost) and
+ * overridable at build time with VITE_RUNNER_API_BASE.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Button, useNotify } from 'react-admin';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import HourglassTopIcon from '@mui/icons-material/HourglassTop';
+import { refreshCatalog } from './dataProvider';
+
+const API_BASE = (import.meta.env.VITE_RUNNER_API_BASE as string) || '/integration-tests/api';
+const POLL_MS = 10_000;
+
+type Current =
+  | { state: 'idle'; run_id?: string; exit_code?: number | null }
+  | { state: 'running'; run_id: string; started_at: string; phase: string | null };
+
+export default function RunButton() {
+  const notify = useNotify();
+  const [running, setRunning] = useState(false);
+  const [phase, setPhase] = useState<string | null>(null);
+  const [starting, setStarting] = useState(false);
+  const wasRunning = useRef(false);
+  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const poll = useCallback(async () => {
+    try {
+      const r = await fetch(`${API_BASE}/run/current`, { credentials: 'include' });
+      if (!r.ok) return;
+      const cur = (await r.json()) as Current;
+      const isRunning = cur.state === 'running';
+      setRunning(isRunning);
+      setPhase(cur.state === 'running' ? cur.phase : null);
+      if (wasRunning.current && !isRunning) {
+        // A run just finished — pull the fresh catalog into the dashboard.
+        notify('Test run finished — refreshing results', { type: 'info' });
+        refreshCatalog().catch(() => undefined);
+      }
+      wasRunning.current = isRunning;
+    } catch {
+      /* daemon unreachable — leave the button as-is */
+    }
+  }, [notify]);
+
+  useEffect(() => {
+    poll();
+    timer.current = setInterval(poll, POLL_MS);
+    return () => {
+      if (timer.current) clearInterval(timer.current);
+    };
+  }, [poll]);
+
+  const onClick = useCallback(async () => {
+    setStarting(true);
+    try {
+      const r = await fetch(`${API_BASE}/run`, { method: 'POST', credentials: 'include' });
+      if (r.status === 202) {
+        const { run_id } = await r.json();
+        notify(`Started test run ${run_id}`, { type: 'success' });
+        setRunning(true);
+        wasRunning.current = true;
+      } else if (r.status === 409) {
+        const { run_id } = await r.json();
+        notify(`A run is already in progress (${run_id})`, { type: 'warning' });
+        setRunning(true);
+        wasRunning.current = true;
+      } else {
+        notify(`Could not start run (HTTP ${r.status})`, { type: 'error' });
+      }
+    } catch (e) {
+      notify(`Could not reach the test runner: ${String(e)}`, { type: 'error' });
+    } finally {
+      setStarting(false);
+    }
+  }, [notify]);
+
+  const label = running ? (phase ? `Running… (${phase})` : 'Running…') : 'Run tests';
+
+  return (
+    <Button
+      label={label}
+      onClick={onClick}
+      disabled={running || starting}
+      startIcon={running ? <HourglassTopIcon /> : <PlayArrowIcon />}
+    />
+  );
+}

--- a/tests/integration-tests/deploy/nginx-integration-tests.conf
+++ b/tests/integration-tests/deploy/nginx-integration-tests.conf
@@ -32,3 +32,17 @@ location /integration-tests-v2/ {
   add_header Cache-Control "no-cache, must-revalidate" always;
   try_files $uri $uri/ /integration-tests-v2/index.html =404;
 }
+
+# RUN button → on-box test-runner daemon (runner/server.mjs on 127.0.0.1:8181).
+# SAME basic-auth realm as the dashboards so the browser reuses the creds.
+# Longest-prefix match wins over /integration-tests/. Only add this if the
+# test-runner systemd service is installed on this box.
+location /integration-tests/api/ {
+  auth_basic "DIGIT integration tests";
+  auth_basic_user_file /etc/nginx/.htpasswd-tests;
+  proxy_pass http://127.0.0.1:8181/;
+  proxy_http_version 1.1;
+  proxy_set_header Host $host;
+  proxy_read_timeout 3600s;
+  proxy_buffering off;
+}

--- a/tests/integration-tests/runner/README.md
+++ b/tests/integration-tests/runner/README.md
@@ -1,0 +1,55 @@
+# test-runner — the RUN button backend
+
+The dashboards (`dashboard/`, `dashboard-react-admin/`) are **static files** served
+by nginx. Nothing in the browser can start Playwright or write into the webroot.
+This tiny daemon does — and nothing else. It is what the **"Run tests"** button on
+the v2 dashboard talks to.
+
+```
+browser ── /integration-tests/api/run ──▶ nginx (basic-auth) ──▶ 127.0.0.1:8181 (this daemon)
+                                                                        │ spawns
+                                                                        ▼
+                                                                 run-cycle.sh
+                                              playwright test → build-catalog.ts → copy into /var/www
+```
+
+## Why a daemon (and not "just write the results file")
+
+A run takes ~1h, so the button can't be a synchronous request, and *something*
+server-side has to actually run Playwright and regenerate `catalog.json` + `runs/`.
+This is the smallest thing that can: Node core only, no extra deps.
+
+## Pieces
+
+- **`server.mjs`** — loopback-only HTTP service. nginx is the auth front (same
+  `digit-tests` / `.htpasswd-tests` basic-auth as the dashboards), so the daemon
+  re-implements no auth; it just refuses any non-loopback client as defense in depth.
+  - `POST /run` → `202 {run_id}` or `409 {running}` (single-flight)
+  - `GET /run/current` → `{state, run_id, started_at, phase}`
+  - `GET /run/:id/log` → live `run.log`
+  - `GET /health`
+- **`run-cycle.sh`** — one cycle: `playwright test` (nice'd) → `build-catalog.ts`
+  → **local** copy of `catalog.json`/`history.json`/`runs/<id>/` into the webroot
+  (this is `scripts/publish.sh` with the ssh/rsync swapped for a local copy, since
+  serving and running are the same host now). `flock` is the cross-process lock.
+
+## Config (env, set by the systemd unit)
+
+| Var | Default | Meaning |
+|-----|---------|---------|
+| `RUNNER_PORT` | `8181` | loopback listen port |
+| `RUNNER_REPO_DIR` | `..` | vendored `tests/integration-tests` |
+| `RUNNER_WEBROOT` | `/var/www/integration-tests` | served dir (catalog.json/runs live here) |
+| `RUNNER_TENANT_ENV` | — | env file sourced by the run (BASE_URL/DIGIT_TENANT/…) |
+| `RUNNER_RUN_LIMIT` | `5` | keep at most N runs on disk |
+| `RUNNER_BRANCH` | `deployed` | branch label recorded in the catalog |
+| `RUNNER_JOB` | `run-cycle.sh` | the cycle script (override for tests/custom cycles) |
+
+## Deploy
+
+Opt-in via ansible: `enable_integration_tests_runner: true` +
+`nginx_features.integration_tests_runner: true` (and `enable_integration_tests: true`,
+since it serves on the same vhost). The playbook installs Playwright browsers,
+the `integration-tests-runner.service` systemd unit, and the nginx proxy block.
+On `nginx_preserve_vhost` hosts (e.g. Bomet), add the `/integration-tests/api/`
+block by hand from `../deploy/nginx-integration-tests.conf`.

--- a/tests/integration-tests/runner/run-cycle.sh
+++ b/tests/integration-tests/runner/run-cycle.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# run-cycle.sh — one test cycle, triggered by the RUN button via server.mjs.
+#
+# This is the Makefile's run+catalog plus publish.sh, with the ssh/rsync publish
+# swapped for a LOCAL copy: serving and running are the same host now, so results
+# go straight into $WEBROOT (which nginx serves and the v2 dashboard symlinks to).
+#
+# Inherited from the daemon's env (server.mjs sets all of these):
+#   RUN_ID      run id the daemon minted (also the runs/<id>/ dir + log)
+#   REPO_DIR    vendored tests/integration-tests checkout
+#   WEBROOT     served dir (catalog.json/history.json/runs live here)
+#   TENANT_ENV  optional env file to source (BASE_URL/DIGIT_TENANT/LOCALITY_CODE/…)
+#   RUN_LIMIT   keep at most this many runs (default 5)
+#   BRANCH      branch label recorded in the catalog (default "deployed")
+#
+# Single-flight via flock — a second cycle while one is running exits 1 (the
+# daemon already 409s the fast path; this guards restarts/cron overlap too).
+set -uo pipefail
+
+: "${RUN_ID:?RUN_ID required}"
+REPO_DIR="${REPO_DIR:?REPO_DIR required}"
+WEBROOT="${WEBROOT:?WEBROOT required}"
+TENANT_ENV="${TENANT_ENV:-}"
+RUN_LIMIT="${RUN_LIMIT:-5}"
+BRANCH="${BRANCH:-deployed}"
+LOCK="/tmp/digit-tests.lock"
+
+RUN_DIR="$WEBROOT/runs/$RUN_ID"
+mkdir -p "$RUN_DIR"
+phase() { echo "$1" > "$RUN_DIR/phase"; echo "===== phase: $1 ====="; }
+
+exec 9>"$LOCK"
+if ! flock -n 9; then
+  echo "[run-cycle] another run holds $LOCK — aborting" >&2
+  phase "aborted-locked"
+  exit 1
+fi
+
+cd "$REPO_DIR" || { echo "[run-cycle] cannot cd $REPO_DIR" >&2; exit 2; }
+
+# Source the deployed tenant's env so the run targets THIS box's tenant, exactly
+# like the nightly. Never bakes tenant values into the runner.
+if [[ -n "$TENANT_ENV" && -f "$TENANT_ENV" ]]; then
+  echo "[run-cycle] sourcing $TENANT_ENV"
+  set -a; # shellcheck disable=SC1090
+  source "$TENANT_ENV"; set +a
+fi
+
+git rev-parse --short HEAD > .git-sha 2>/dev/null || echo unknown > .git-sha
+rm -rf playwright-report test-results report.json
+
+# ---- run ---- (nice'd so the live DIGIT stack on this box keeps priority)
+phase "running"
+timeout 90m nice -n 10 npx playwright test \
+  || echo "[run-cycle] playwright exited non-zero (some tests failed); continuing to catalog"
+
+# ---- catalog ----
+phase "catalog"
+if [[ ! -f report.json ]]; then
+  echo "[run-cycle] no report.json — Playwright crashed before producing one" >&2
+  phase "failed-no-report"
+  exit 6
+fi
+# Feed the live on-box history/catalog so the rolling 5-run history accumulates
+# across button presses instead of resetting each run.
+env BRANCH="$BRANCH" BASE_URL="${BASE_URL:-}" GIT_SHA="$(cat .git-sha)" \
+  PUBLIC_HISTORY_JSON="$WEBROOT/history.json" \
+  PUBLIC_CATALOG_JSON="$WEBROOT/catalog.json" \
+  npx tsx scripts/build-catalog.ts "$RUN_ID" \
+  || { echo "[run-cycle] build-catalog failed" >&2; phase "failed-catalog"; exit 7; }
+
+# ---- publish (local copy) ----
+# publish.sh's guard, kept verbatim in spirit: refuse to publish an empty
+# test-results, which would replace a good run with nothing.
+phase "publishing"
+RESULTS_COUNT=$(find test-results -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')
+if [[ "${RESULTS_COUNT:-0}" -lt 1 ]]; then
+  echo "[run-cycle] test-results/ empty — refusing to publish (keeping prior run)" >&2
+  phase "failed-empty-results"
+  exit 3
+fi
+
+cp -f catalog.json history.json "$WEBROOT/" 2>/dev/null || true
+# Copy run artifacts in alongside the daemon-written run.log (don't wipe the dir).
+cp -f report.json "$RUN_DIR/" 2>/dev/null || true
+rsync -a --delete --exclude=run.log --exclude=phase \
+  playwright-report "$RUN_DIR/" 2>/dev/null \
+  || cp -rf playwright-report "$RUN_DIR/"
+rsync -a --delete test-results "$RUN_DIR/" 2>/dev/null \
+  || cp -rf test-results "$RUN_DIR/"
+
+# Prune older runs to RUN_LIMIT (newest kept).
+( cd "$WEBROOT/runs" && ls -1t | tail -n +"$((RUN_LIMIT+1))" | xargs -r rm -rf ) || true
+
+phase "done"
+echo "[run-cycle] done — RUN_ID=$RUN_ID"

--- a/tests/integration-tests/runner/server.mjs
+++ b/tests/integration-tests/runner/server.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+/**
+ * test-runner daemon — the only write path behind the "Run tests" button.
+ *
+ * The dashboards are static files served by nginx; nothing in the browser can
+ * start Playwright or write into the webroot. This tiny HTTP service does, and
+ * NOTHING ELSE. It is deliberately dependency-free (Node core only) and bound
+ * to loopback — nginx proxies `/integration-tests/api/` to it WITH the existing
+ * basic-auth (digit-tests / .htpasswd-tests), so auth is enforced by nginx, not
+ * re-implemented here. The loopback bind + remote-addr guard below make sure the
+ * daemon can't be reached around nginx.
+ *
+ * Endpoints (all relative to the proxied /integration-tests/api/):
+ *   POST /run            → 202 {run_id} | 409 {running, run_id}   (single-flight)
+ *   GET  /run/current    → {state, run_id, started_at, phase, exit_code}
+ *   GET  /run/:id/log    → text/plain, current contents of that run's run.log
+ *   GET  /health         → {ok:true}
+ *
+ * A run is ~1h, so POST returns immediately and the dashboard polls /run/current.
+ * The actual run/catalog/publish lives in run-cycle.sh (a thin lift of the
+ * Makefile + publish.sh, local-copy instead of ssh). flock there is the
+ * cross-process single-flight; the in-memory `current` below is the fast path.
+ *
+ * Config (env):
+ *   RUNNER_PORT        listen port on 127.0.0.1            (default 8181)
+ *   RUNNER_REPO_DIR    vendored tests/integration-tests    (default: parent of this file)
+ *   RUNNER_WEBROOT     served dir holding catalog.json/runs (default /var/www/integration-tests)
+ *   RUNNER_TENANT_ENV  env file sourced by the job (BASE_URL, DIGIT_TENANT, …)  (optional)
+ *   RUNNER_RUN_LIMIT   keep at most this many runs          (default 5)
+ *   RUNNER_BRANCH      branch the job reports in the catalog (default "deployed")
+ */
+import { createServer } from 'node:http';
+import { spawn, execSync } from 'node:child_process';
+import { mkdirSync, createReadStream, existsSync, readFileSync, openSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PORT = parseInt(process.env.RUNNER_PORT || '8181', 10);
+const REPO_DIR = process.env.RUNNER_REPO_DIR || join(HERE, '..');
+const WEBROOT = process.env.RUNNER_WEBROOT || '/var/www/integration-tests';
+const TENANT_ENV = process.env.RUNNER_TENANT_ENV || '';
+const RUN_LIMIT = process.env.RUNNER_RUN_LIMIT || '5';
+const BRANCH = process.env.RUNNER_BRANCH || 'deployed';
+const JOB = process.env.RUNNER_JOB || join(HERE, 'run-cycle.sh'); // overridable for tests/custom cycles
+
+/** In-memory single-flight state. Resets to idle on daemon restart (an orphaned
+ *  job keeps the flock, so a POST after restart still 409s correctly). */
+let current = null; // { run_id, started_at, child }
+let lastExit = null; // { run_id, exit_code, finished_at }
+
+function shortSha() {
+  try {
+    return execSync('git rev-parse --short HEAD', { cwd: REPO_DIR }).toString().trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+function mintRunId() {
+  // 2026-06-04_1430_a1b2c3d — matches the Makefile/publish.sh convention.
+  const d = new Date();
+  const p = (n) => String(n).padStart(2, '0');
+  const stamp =
+    `${d.getUTCFullYear()}-${p(d.getUTCMonth() + 1)}-${p(d.getUTCDate())}` +
+    `_${p(d.getUTCHours())}${p(d.getUTCMinutes())}`;
+  return `${stamp}_${shortSha()}`;
+}
+
+function phaseOf(runId) {
+  const f = join(WEBROOT, 'runs', runId, 'phase');
+  try {
+    return existsSync(f) ? readFileSync(f, 'utf8').trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+function startRun() {
+  const runId = mintRunId();
+  const runDir = join(WEBROOT, 'runs', runId);
+  mkdirSync(runDir, { recursive: true });
+  const logPath = join(runDir, 'run.log');
+  const out = openSync(logPath, 'a'); // append: daemon owns run.log, the job copies artifacts in around it
+
+  const child = spawn('bash', [JOB], {
+    cwd: REPO_DIR,
+    env: {
+      ...process.env,
+      RUN_ID: runId,
+      REPO_DIR,
+      WEBROOT,
+      TENANT_ENV,
+      RUN_LIMIT,
+      BRANCH,
+    },
+    stdio: ['ignore', out, out],
+    detached: false,
+  });
+  const started_at = new Date().toISOString();
+  current = { run_id: runId, started_at, child };
+  child.on('exit', (code) => {
+    lastExit = { run_id: runId, exit_code: code, finished_at: new Date().toISOString() };
+    current = null;
+  });
+  return { run_id: runId, started_at };
+}
+
+function json(res, code, body) {
+  const s = JSON.stringify(body);
+  res.writeHead(code, { 'content-type': 'application/json', 'cache-control': 'no-store' });
+  res.end(s);
+}
+
+const server = createServer((req, res) => {
+  // Defense in depth: only ever answer loopback. nginx proxies from 127.0.0.1.
+  const ra = req.socket.remoteAddress || '';
+  if (!(ra === '127.0.0.1' || ra === '::1' || ra === '::ffff:127.0.0.1')) {
+    return json(res, 403, { error: 'loopback only' });
+  }
+
+  const url = new URL(req.url, 'http://localhost');
+  const path = url.pathname.replace(/\/+$/, '') || '/';
+
+  if (req.method === 'GET' && path === '/health') {
+    return json(res, 200, { ok: true });
+  }
+
+  if (req.method === 'POST' && path === '/run') {
+    if (current) {
+      return json(res, 409, { running: true, run_id: current.run_id, started_at: current.started_at });
+    }
+    try {
+      const { run_id, started_at } = startRun();
+      return json(res, 202, { run_id, started_at });
+    } catch (e) {
+      return json(res, 500, { error: String(e && e.message ? e.message : e) });
+    }
+  }
+
+  if (req.method === 'GET' && path === '/run/current') {
+    if (current) {
+      return json(res, 200, {
+        state: 'running',
+        run_id: current.run_id,
+        started_at: current.started_at,
+        phase: phaseOf(current.run_id),
+      });
+    }
+    return json(res, 200, { state: 'idle', ...(lastExit || {}) });
+  }
+
+  const m = path.match(/^\/run\/([^/]+)\/log$/);
+  if (req.method === 'GET' && m) {
+    const runId = decodeURIComponent(m[1]);
+    if (!/^[A-Za-z0-9._-]+$/.test(runId)) return json(res, 400, { error: 'bad run id' });
+    const logPath = join(WEBROOT, 'runs', runId, 'run.log');
+    if (!existsSync(logPath)) return json(res, 404, { error: 'no log' });
+    res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8', 'cache-control': 'no-store' });
+    return createReadStream(logPath).pipe(res);
+  }
+
+  return json(res, 404, { error: 'not found' });
+});
+
+server.listen(PORT, '127.0.0.1', () => {
+  // eslint-disable-next-line no-console
+  console.log(`[test-runner] listening on 127.0.0.1:${PORT} repo=${REPO_DIR} webroot=${WEBROOT}`);
+});


### PR DESCRIPTION
Closes the remaining acceptance criterion of #713 — **"Users can trigger a run of the tests via UI."** #717 wired serving-only; the dashboards are static files and nothing in the browser could start Playwright or write the results file. This adds the smallest server-side piece that can, opt-in and off by default.

## What it adds
- **`tests/integration-tests/runner/server.mjs`** — a loopback-only, dependency-free (Node core) daemon. **nginx is the auth front**: the API is proxied at `/integration-tests/api/` behind the **same `digit-tests` / `.htpasswd-tests` basic-auth and the same realm string** as the dashboards, so the browser reuses the creds it already entered — no second credential store. The daemon additionally refuses any non-loopback client as defense in depth.
  - `POST /run` → `202 {run_id}` or `409 {running}` (single-flight)
  - `GET /run/current` → `{state, run_id, started_at, phase}`
  - `GET /run/:id/log` → live `run.log`
  - `GET /health`
- **`runner/run-cycle.sh`** — one cycle: `playwright test` (nice'd) → `build-catalog.ts` → **local copy** of `catalog.json`/`history.json`/`runs/<id>/` into the webroot. This is `scripts/publish.sh` with the ssh/rsync swapped for a local copy, since serving and running are the same host now. `flock` single-flight; feeds the live `history.json` so the rolling history accumulates across presses.
- **`dashboard-react-admin`** — a "Run tests" button in the AppBar (`RunButton.tsx`): fire-and-poll (POST, then poll `/run/current`), a live phase label, and `refreshCatalog()` when a run finishes.
- **nginx** — `/integration-tests/api/` proxy block in `templates/nginx-site.conf.j2` (+ the bomet hand-wire `deploy/nginx-integration-tests.conf`), gated by `nginx_features.integration_tests_runner`; long read-timeout + buffering off so the log streams.
- **ansible** — opt-in `enable_integration_tests_runner`: installs Playwright browsers + the `integration-tests-runner` systemd unit (nice'd). **Default off** — a run is CPU/RAM heavy and shares the box with the live DIGIT stack.

## Design
- **On-box daemon** (not CI dispatch), **single-flight** (not a queue), **no run params in v1** (uses the deployed tenant's env, like the nightly; a branch/tag-subset selector is a clean Phase 2 since the catalog already carries tags).
- Builds on #717 (serving) and the vendored suite from #712/#702.

## Verified on ovh-cloud-dev
Hand-wired into the `localhost` vhost (that box runs `nginx_preserve_vhost: true`, so this exercises the bomet-class path), against the live stack:

| Check | Result |
|---|---|
| Basic-auth — no creds / wrong creds | 401 / 401 |
| Dashboards + API with `digit-tests` creds | 200 / `{ok:true}` |
| `POST /run` via nginx | 202 + run_id |
| Second POST while running | 409 |
| `/run/current` | `running` + live phase |
| `/run/:id/log` streamed via nginx | live log |
| Real `playwright test` process | spawned, nice'd |
| `build-catalog` → local copy → webroot | catalog updated, run dir staged |
| Dashboard (vanilla + v2) reads new run | run visible, per-run report 200 |
| systemd service | active, loopback-bound |

Dashboard build is clean (tsc + vite); playbook passes `ansible-playbook --syntax-check`; nginx template renders correctly in both flag states.

Related: #713, #717, #712, #702.

🤖 Generated with [Claude Code](https://claude.com/claude-code)