### PR TITLE
fix(configurator): show & edit legacy (v1/v2) ThemeConfig records

### DIFF
--- a/configurator/packages/data-provider/src/providers/dataProvider.ts
+++ b/configurator/packages/data-provider/src/providers/dataProvider.ts
@@ -2,6 +2,7 @@ import type { DataProvider, RaRecord, GetListResult, GetOneResult, GetManyResult
 import type { DigitApiClient } from '../client/DigitApiClient.js';
 import type { MdmsRecord } from '../client/types.js';
 import { getResourceConfig, type ResourceConfig } from './resourceRegistry.js';
+import { migrateThemeConfigToV3 } from './themeConfigMigration.js';
 
 /** Extended data provider type with DIGIT-specific custom methods */
 export type DigitDataProvider = DataProvider & {
@@ -30,7 +31,14 @@ function normalizeRecord(raw: Record<string, unknown>, config: ResourceConfig): 
 }
 
 function normalizeMdmsRecord(mdms: MdmsRecord, config: ResourceConfig): RaRecord {
-  const data = mdms.data || {};
+  let data = mdms.data || {};
+  // Legacy ThemeConfig records (v1 nested / v2 semantic shapes) don't carry the
+  // flat v3 keys the Theme editor binds to, so the form would load blank. Project
+  // them into the v3 shape on read so the editor shows the live colors and saves
+  // a clean record. Idempotent for records already in v3. See themeConfigMigration.
+  if (config.schema === 'common-masters.ThemeConfig') {
+    data = migrateThemeConfigToV3(data as Record<string, unknown>);
+  }
   return {
     ...data,
     id: extractId(data, config),

--- a/configurator/packages/data-provider/src/providers/themeConfigMigration.test.ts
+++ b/configurator/packages/data-provider/src/providers/themeConfigMigration.test.ts
@@ -1,0 +1,93 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { migrateThemeConfigToV3 } from './themeConfigMigration.js';
+
+// The actual active theme record on bomet (common-masters.ThemeConfig,
+// uniqueIdentifier "bomet-county", version "1") — a v1 record carrying a few
+// stray flat keys. This is the exact shape that loads blank in the editor today.
+const BOMET_V1 = {
+  code: 'bomet-county',
+  name: 'Bomet County Blue',
+  version: '1',
+  colors: {
+    grey: { bg: '#E6E6E6', light: '#FAFAFA', lighter: '#F2F2F2', disabled: '#C5C5C5' },
+    link: { hover: '#1565A8', normal: '#1B85D2' },
+    text: { muted: '#787878', heading: '#1565A8', primary: '#1D2433', secondary: '#5F5C62' },
+    error: '#E02D3A',
+    border: '#D6D5D4',
+    digitv2: {
+      'chart-1': '#1B85D2',
+      'chart-2': '#E5202A',
+      'chart-3': '#128F21',
+      'chart-4': '#FEC931',
+      'chart-5': '#F58831',
+      'alert-info': '#1B85D2',
+      'primary-bg': '#E3F0FA',
+      'header-sidenav': '#1B85D2',
+      'text-color-disabled': '#B1B4B6',
+    },
+    primary: { dark: '#1565A8', main: '#1B85D2', light: '#E3F0FA', accent: '#E5202A', 'selected-bg': '#E3F0FA' },
+    success: '#128F21',
+    'input-border-focus': '#1B85D2',
+    'sidebar-selected-bg': '#093B50',
+    'button-primary-bg-default': '#1B85D2',
+  },
+};
+
+describe('migrateThemeConfigToV3', () => {
+  it('resolves v3 brand/text fields from a v1 record (bomet-county)', () => {
+    const out = migrateThemeConfigToV3(BOMET_V1) as typeof BOMET_V1;
+    const c = out.colors as Record<string, string>;
+    // primary-1 canonical source is primary.dark
+    assert.equal(c['primary-1'], '#1565A8');
+    // primary-2 from primary.main
+    assert.equal(c['primary-2'], '#1B85D2');
+    assert.equal(c['text-heading'], '#1565A8');
+    assert.equal(c['text-primary'], '#1D2433');
+    assert.equal(c['text-secondary'], '#5F5C62');
+    // primary-1-bg from primary.selected-bg
+    assert.equal(c['primary-1-bg'], '#E3F0FA');
+    assert.equal(out.version, '3');
+  });
+
+  it('prefers existing flat v3-ish keys over derived legacy values', () => {
+    const c = (migrateThemeConfigToV3(BOMET_V1) as typeof BOMET_V1).colors as Record<string, string>;
+    assert.equal(c['button-primary-bg-default'], '#1B85D2');
+    assert.equal(c['input-border-focus'], '#1B85D2');
+    assert.equal(c['sidebar-selected-bg'], '#093B50');
+  });
+
+  it('maps charts from digitv2.chart-N', () => {
+    const c = (migrateThemeConfigToV3(BOMET_V1) as typeof BOMET_V1).colors as Record<string, string>;
+    assert.equal(c['chart-1'], '#1B85D2');
+    assert.equal(c['chart-5'], '#F58831');
+  });
+
+  it('retains original legacy keys (lossless)', () => {
+    const c = (migrateThemeConfigToV3(BOMET_V1) as typeof BOMET_V1).colors as Record<string, unknown>;
+    assert.deepEqual(c.primary, BOMET_V1.colors.primary);
+    assert.equal((c.text as Record<string, string>).heading, '#1565A8');
+  });
+
+  it('fans out v2 semantic records', () => {
+    const v2 = {
+      code: 't', name: 'T', version: '2',
+      colors: { brand: '#AA0000', 'brand-on': '#FFFFFF', 'text-primary': '#111111' },
+    };
+    const c = (migrateThemeConfigToV3(v2) as typeof v2).colors as Record<string, string>;
+    assert.equal(c['primary-2'], '#AA0000'); // brand → --color-primary-main → primary-2
+    assert.equal(c['primary-1'], '#FFFFFF'); // brand-on → --color-primary-dark → primary-1
+    assert.equal(c['text-primary'], '#111111');
+  });
+
+  it('is idempotent for records already in v3', () => {
+    const v3 = { code: 'g', name: 'G', version: '3', colors: { 'primary-1': '#006B3F', 'primary-2': '#FEC931' } };
+    const out = migrateThemeConfigToV3(v3);
+    assert.strictEqual(out, v3); // untouched, same reference
+  });
+
+  it('leaves non-theme / malformed data alone', () => {
+    assert.deepEqual(migrateThemeConfigToV3({ code: 'x' }), { code: 'x' });
+    assert.deepEqual(migrateThemeConfigToV3({ colors: [] as unknown }), { colors: [] });
+  });
+});

--- a/configurator/packages/data-provider/src/providers/themeConfigMigration.ts
+++ b/configurator/packages/data-provider/src/providers/themeConfigMigration.ts
@@ -1,0 +1,232 @@
+// Theme config migration: legacy (v1) and semantic (v2) `common-masters.ThemeConfig`
+// records → the v3 "designer 1:1" field shape the configurator's Theme editor binds to.
+//
+// WHY: the editor was rebuilt around v3 (flat granular keys: `primary-1`,
+// `button-primary-bg-default`, `sidebar-selected-bg`, …). Existing tenant
+// records are stored as v1 (nested groups: `primary.main`, `digitv2.header-sidenav`,
+// `text.heading`, …) or v2 (12 semantic keys). On load the v3 form binds against
+// those paths, finds nothing, and shows every color field blank — so the admin
+// can neither see nor safely edit the live theme.
+//
+// This is the inverse of the runtime `V3_EXPANSION` / `SEMANTIC_EXPANSION` in
+// theflywheel/digit-ui-esbuild `src/theme/applyTheme.js` — the same source of
+// truth the configurator's `ThemePreview` already mirrors (v3→v1 fallback).
+// Here we go forward (v1/v2 → v3): flatten the record exactly like applyTheme's
+// Pass 1, fan v2 keys out via Pass 2, then for each v3 field pick the first
+// matching legacy CSS var. The result drives the form AND, on save, persists a
+// clean v3 record the runtime renders via Pass 3. Original legacy keys are
+// retained so nothing is ever lost on a partial migration.
+
+// v2 → CSS var(s). Mirror of SEMANTIC_EXPANSION (applyTheme.js).
+const SEMANTIC_EXPANSION: Record<string, string[]> = {
+  brand: ['--color-primary-main'],
+  'brand-on': [
+    '--color-primary-dark',
+    '--color-primary-accent',
+    '--color-link-normal',
+    '--color-link-hover',
+    '--color-text-heading',
+  ],
+  'surface-header': ['--color-secondary', '--color-digitv2-header-sidenav'],
+  'surface-page': ['--color-grey-light'],
+  'text-primary': ['--color-text-primary'],
+  'text-secondary': ['--color-text-secondary', '--color-text-muted'],
+  'text-disabled': ['--color-grey-disabled', '--color-digitv2-text-color-disabled'],
+  border: ['--color-border', '--color-input-border'],
+  error: ['--color-error', '--color-error-dark'],
+  success: ['--color-success'],
+  info: ['--color-digitv2-alert-info', '--color-info-dark'],
+  warning: ['--color-warning-dark'],
+  'selected-bg': ['--color-primary-selected-bg', '--color-digitv2-primary-bg'],
+};
+
+// v3 field → CSS var(s), in priority order. Mirror of V3_EXPANSION (applyTheme.js).
+// The FIRST var present in the flattened legacy record supplies the field's value,
+// so the ordering encodes the designer's "canonical source" for each collapsed role.
+const V3_EXPANSION: Record<string, string[]> = {
+  'primary-1': [
+    '--color-primary-1',
+    '--color-primary-dark',
+    '--color-primary-accent',
+    '--color-link-normal',
+    '--color-link-hover',
+    '--color-text-heading',
+    '--color-secondary',
+    '--color-digitv2-header-sidenav',
+  ],
+  'primary-2': ['--color-primary-2', '--color-primary-main'],
+  'primary-1-bg': [
+    '--color-primary-1-bg',
+    '--color-primary-selected-bg',
+    '--color-digitv2-primary-bg',
+  ],
+  'primary-2-bg': ['--color-primary-2-bg'],
+
+  'text-heading': ['--color-text-heading'],
+  'text-primary': ['--color-text-primary'],
+  'text-secondary': ['--color-text-secondary', '--color-text-muted'],
+  'text-disabled': [
+    '--color-text-disabled',
+    '--color-grey-disabled',
+    '--color-digitv2-text-color-disabled',
+  ],
+
+  'page-bg': ['--color-page-bg'],
+  'page-secondary-bg': [
+    '--color-page-secondary-bg',
+    '--color-grey-light',
+    '--color-grey-lighter',
+    '--color-grey-bg',
+  ],
+
+  'button-primary-bg-default': ['--color-button-primary-bg-default'],
+  'button-primary-bg-hover': ['--color-button-primary-bg-hover'],
+  'button-primary-bg-pressed': ['--color-button-primary-bg-pressed'],
+  'button-primary-text': ['--color-button-primary-text'],
+  'button-primary-border': ['--color-button-primary-border'],
+  'button-primary-disabled-bg': ['--color-button-primary-disabled-bg'],
+  'button-primary-disabled-text': ['--color-button-primary-disabled-text'],
+
+  'button-secondary-bg-default': ['--color-button-secondary-bg-default'],
+  'button-secondary-bg-hover': ['--color-button-secondary-bg-hover'],
+  'button-secondary-bg-pressed': ['--color-button-secondary-bg-pressed'],
+  'button-secondary-text': ['--color-button-secondary-text'],
+  'button-secondary-border': ['--color-button-secondary-border'],
+
+  'button-tertiary-text': [
+    '--color-button-tertiary-text',
+    '--color-link-normal',
+    '--color-link-hover',
+  ],
+
+  'input-bg': ['--color-input-bg'],
+  'input-border-default': ['--color-input-border-default', '--color-input-border'],
+  'input-border-focus': ['--color-input-border-focus'],
+  'input-border-error': ['--color-input-border-error'],
+  'input-placeholder': ['--color-input-placeholder'],
+  'input-text': ['--color-input-text'],
+  'input-label': ['--color-input-label'],
+  'input-helper': ['--color-input-helper'],
+
+  'header-bg': ['--color-header-bg'],
+  'header-text': ['--color-header-text'],
+  'header-icon': ['--color-header-icon'],
+
+  'sidebar-bg': ['--color-sidebar-bg'],
+  'sidebar-text-active': ['--color-sidebar-text-active'],
+  'sidebar-text-default': ['--color-sidebar-text-default'],
+  'sidebar-hover-text': ['--color-sidebar-hover-text'],
+  'sidebar-hover-bg': ['--color-sidebar-hover-bg'],
+  'sidebar-icon-active': ['--color-sidebar-icon-active'],
+  'sidebar-selected-bg': ['--color-sidebar-selected-bg'],
+  'sidebar-selected-text': ['--color-sidebar-selected-text'],
+
+  'card-border': ['--color-card-border', '--color-border'],
+  'card-divider': ['--color-card-divider'],
+  'card-success': ['--color-card-success'],
+  'card-error': ['--color-card-error'],
+
+  'status-success-text': ['--color-status-success-text', '--color-success'],
+  'status-success-bg': ['--color-status-success-bg', '--color-digitv2-alert-success-bg'],
+  'status-success-border': ['--color-status-success-border'],
+  'status-error-text': ['--color-status-error-text', '--color-error', '--color-error-dark'],
+  'status-error-bg': ['--color-status-error-bg', '--color-digitv2-alert-error-bg'],
+  'status-error-border': ['--color-status-error-border'],
+  'status-warning-text': ['--color-status-warning-text', '--color-warning-dark'],
+  'status-warning-bg': ['--color-status-warning-bg'],
+  'status-warning-border': ['--color-status-warning-border'],
+  'status-info-text': [
+    '--color-status-info-text',
+    '--color-info-dark',
+    '--color-digitv2-alert-info',
+  ],
+  'status-info-bg': ['--color-status-info-bg', '--color-digitv2-alert-info-bg'],
+  'status-info-border': ['--color-status-info-border'],
+
+  'table-header-bg': ['--color-table-header-bg'],
+  'table-header-text': ['--color-table-header-text'],
+  'table-row-bg': ['--color-table-row-bg'],
+  'table-alt-row': ['--color-table-alt-row'],
+  'table-row-text': ['--color-table-row-text'],
+  'table-border': ['--color-table-border'],
+  'table-hover': ['--color-table-hover'],
+  'table-selected': ['--color-table-selected'],
+  'table-hover-text': ['--color-table-hover-text'],
+  'table-selected-text': ['--color-table-selected-text'],
+
+  loader: ['--color-loader'],
+  progress: ['--color-progress'],
+  'tooltip-bg': ['--color-tooltip-bg'],
+  'tooltip-text': ['--color-tooltip-text'],
+};
+
+type Colors = Record<string, unknown>;
+
+/** Flatten nested color groups into `--color-<dashed-path>` keys, exactly like
+ *  applyTheme.js Pass 1. Top-level string keys become `--color-<key>`. */
+function flattenToVars(obj: Colors, prefix = '', out: Record<string, string> = {}): Record<string, string> {
+  for (const key of Object.keys(obj)) {
+    const value = obj[key];
+    const next = prefix ? `${prefix}-${key}` : key;
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      flattenToVars(value as Colors, next, out);
+    } else if (typeof value === 'string') {
+      out[`--color-${next}`] = value;
+    }
+  }
+  return out;
+}
+
+/** True once the record already carries the v3 marker key. */
+function isV3(colors: Colors): boolean {
+  return typeof colors['primary-1'] === 'string';
+}
+
+/**
+ * Migrate a `common-masters.ThemeConfig` record's `data` into the v3 shape the
+ * editor binds to. Idempotent — a record already in v3 is returned untouched.
+ * Non-theme / malformed input is returned as-is.
+ */
+export function migrateThemeConfigToV3<T extends Record<string, unknown>>(data: T): T {
+  const colors = data?.colors as Colors | undefined;
+  if (!colors || typeof colors !== 'object' || Array.isArray(colors)) return data;
+  if (isV3(colors)) return data;
+
+  // Pass 1: flatten legacy nested + flat keys to the CSS-var namespace.
+  const vars = flattenToVars(colors);
+
+  // Pass 2: fan v2 semantic keys out, so v2 records resolve too.
+  if (typeof colors['brand'] === 'string') {
+    for (const [token, cssVars] of Object.entries(SEMANTIC_EXPANSION)) {
+      const value = colors[token];
+      if (typeof value === 'string') for (const name of cssVars) vars[name] = value;
+    }
+  }
+
+  // Resolve each v3 field from the first matching legacy var.
+  const v3: Record<string, string> = {};
+  for (const [field, cssVars] of Object.entries(V3_EXPANSION)) {
+    for (const name of cssVars) {
+      const v = vars[name];
+      if (typeof v === 'string') {
+        v3[field] = v;
+        break;
+      }
+    }
+  }
+
+  // Charts: v3 reads `chart-N`; legacy stores them under `digitv2.chart-N`.
+  for (let i = 1; i <= 5; i++) {
+    const v = vars[`--color-digitv2-chart-${i}`] ?? vars[`--color-chart-${i}`];
+    if (typeof v === 'string') v3[`chart-${i}`] = v;
+  }
+
+  // Retain original legacy keys (lossless) and overlay the resolved v3 keys.
+  return {
+    ...data,
+    colors: { ...colors, ...v3 },
+    version: '3',
+  } as T;
+}
+
+export const __testing = { flattenToVars, SEMANTIC_EXPANSION, V3_EXPANSION };


### PR DESCRIPTION
## Problem

The configurator's **Theme editor** (`common-masters.ThemeConfig`) loads **blank** for any tenant whose theme is stored in the legacy **v1** (nested) or **v2** (semantic) shape — e.g. bomet's active `bomet-county` ("Bomet County Blue", `version: "1"`).

The editor was rebuilt around the **v3** "designer 1:1" schema: every color input binds to a flat granular path (`colors.primary-1`, `colors.button-primary-bg-default`, `colors.sidebar-selected-bg`, …). A v1 record stores `colors.primary.main`, `colors.digitv2.header-sidenav`, `colors.text.heading`, … — none of which match the v3 paths, so every field comes up empty/`#000000` and **a save would wipe most of the live colors**.

The live digit-ui still renders correctly because `applyTheme.js` keeps a Pass-1 legacy flatten — so this is an editor-side load gap, not a runtime regression.

## Fix

Project legacy records into the v3 field shape on read (`normalizeMdmsRecord`, gated on `schema === 'common-masters.ThemeConfig'`). The new `themeConfigMigration.ts` is the **inverse of the runtime `V3_EXPANSION` / `SEMANTIC_EXPANSION`** in `applyTheme.js` — the same maps `ThemePreview` already mirrors:

1. Flatten the record's `colors` to the `--color-*` namespace (exactly like applyTheme Pass 1).
2. Fan v2 semantic keys out (Pass 2) when `colors.brand` is present.
3. Resolve each v3 field from the first matching legacy var, in V3_EXPANSION priority order.
4. Map charts from `digitv2.chart-N`.

Original legacy keys are **retained** (lossless), and the pass is **idempotent** — records already in v3 (marker key `primary-1`) are returned untouched. v3-only roles the legacy theme never defined (e.g. `header-bg`, `primary-2-bg`) stay blank for the admin to fill; the brand colors that actually drove those surfaces in v1 are populated via `primary-1`/`primary-2`.

## Validation (live bomet, `bometfeedbackhub.digit.org`)

- Opened `bomet-county` (v1) in the editor → fields now populate the live palette: **Primary 1 `#1565A8`**, **Primary 2 `#1B85D2`**, status success `#128F21`, error `#E02D3A`, etc. (all previously blank). Live preview renders the Bomet blue header.
- Edited Primary 1 → `#FF0000`, **Save succeeded** → persisted as `version: "3"` with the new value; `mdms-v2 _update` accepted the v3 payload (schema allows additional `colors` keys).
- Restored the original v1 record afterward — **live bomet is unchanged**.
- Unit tests: 7/7 new (`themeConfigMigration.test.ts`, real bomet record + v2 + idempotency + lossless), 23/23 existing data-provider tests still green.

## Scope
Editor-load normalization only. Other tenants' records migrate naturally on their next save; no bulk backfill.

Closes #741

🤖 Generated with [Claude Code](https://claude.com/claude-code)
