### PR TITLE
fix(pgr): postal-code field validation reads CORE_POSTAL_CONFIGS pattern

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
+++ b/digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
@@ -183,7 +183,14 @@ export const CreateComplaintConfig = {
                 required: false,
                 validation: {
                   required: false,
-                  pattern: /^[0-9]{5}$/,
+                  // Postal-code shape is per-country. Read the pattern from
+                  // globalConfigs CORE_POSTAL_CONFIGS (e.g. MZ = 4 digits)
+                  // instead of hardcoding 5, so this field rule matches the
+                  // config-driven check in createComplaintForm.js. Falls back
+                  // to the legacy 5-digit default when the host hasn't set it.
+                  pattern: new RegExp(
+                    window?.globalConfigs?.getConfig?.("CORE_POSTAL_CONFIGS")?.postalCodePattern || "^[0-9]{5}$"
+                  ),
                 },
                 error: "CS_COMPLAINT_POSTALCODE_INVALID_ERROR",
               },


### PR DESCRIPTION
Description
The Postal Code field on the employee Create Complaint screen (/digit-ui/employee/pgr/create-complaint) was validating input against a hardcoded 5-digit regex (/^[0-9]{5}$/) in the form config, rather than reading the tenant's configured postal-code pattern.

As a result, on tenants whose postal codes are not 5 digits — e.g. Mozambique (4 digits) — entering a perfectly valid postal code was rejected with the error CS_COMPLAINT_POSTALCODE_INVALID_ERROR, blocking complaint submission.

The platform already exposes a per-tenant postal pattern via globalConfigs → CORE_POSTAL_CONFIGS, and the submit handler (createComplaintForm.js) already reads it — but the field-level validation ignored it and stayed hardcoded, so the two checks disagreed.

Root Cause
CreateComplaintConfig.js defined the field validation as a fixed pattern:


validation: { required: false, pattern: /^[0-9]{5}$/ }
This is compiled into the digit-ui bundle and is independent of CORE_POSTAL_CONFIGS, so no runtime/global-config change could correct it.

Fix
Build the field's validation pattern dynamically from CORE_POSTAL_CONFIGS.postalCodePattern, with the legacy 5-digit value as a safe fallback — making the field rule consistent with the existing submit-handler check:


pattern: new RegExp(
  window?.globalConfigs?.getConfig?.("CORE_POSTAL_CONFIGS")?.postalCodePattern || "^[0-9]{5}$"
)
Impact
Tenants with non-5-digit postal codes (e.g. mz = 4 digits) can now enter valid postal codes without false rejection.
No behaviour change for tenants without CORE_POSTAL_CONFIGS (falls back to 5 digits).
Postal-code validation is now driven entirely by tenant config — the same source the submit handler already uses.
Files Changed
digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
Deployment Note
This is compiled UI code, not runtime config — it requires a digit-ui bundle rebuild + redeploy to take effect. The tenant pattern itself (core_postal_configs: ^[0-9]{4}$) is already present in the Maputo host_vars and served via globalConfigs.js.

Testing
Maputo (mz, 4-digit): valid 4-digit code (e.g. 1100) is accepted; an invalid value still shows the error.
A tenant without CORE_POSTAL_CONFIGS: behaviour unchanged (5-digit rule).