### PR TITLE
fix(digit-ui): keep header-dropdown menu on-screen (offset-parent-aware clamp)

### DIFF
--- a/digit-ui-esbuild/public/index.html
+++ b/digit-ui-esbuild/public/index.html
@@ -96,10 +96,19 @@
         if (rect.width === 0) return;
         var vw = document.documentElement.clientWidth;
         if (rect.right <= vw - MARGIN) return;
-        var newLeft = Math.max(MARGIN, vw - rect.width - MARGIN);
+        // `el.style.left` is relative to the menu's positioned ancestor
+        // (.header-dropdown-container), NOT the viewport. A trigger that sits
+        // far from the left edge (e.g. the footer action bar on desktop) would
+        // otherwise get the viewport-relative value added on top of its own
+        // offset, pushing the menu off-screen. Subtract the ancestor's offset
+        // so the menu's right edge lands MARGIN from the viewport's right edge.
+        var parentLeft = el.offsetParent ? el.offsetParent.getBoundingClientRect().left : 0;
+        var desiredViewportLeft = Math.max(MARGIN, vw - rect.width - MARGIN);
+        var newLeft = desiredViewportLeft - parentLeft;
         var currentLeft = parseFloat(el.style.left);
         if (isNaN(currentLeft) || Math.abs(currentLeft - newLeft) > 0.5) {
           el.style.left = newLeft + "px";
+          el.style.right = "auto";
         }
       }
       function clampAll() {


### PR DESCRIPTION
## Problem
On desktop, the PGR complaint **Acções** (Actions) menu rendered off-screen and appeared empty. The menu mounted with the correct options and labels, so it was purely a **positioning** bug — not localization. (Mobile worked; English usually worked; Portuguese consistently failed.)

## Root cause
The header-dropdown clamp in `index.html` set `el.style.left` to a **viewport-relative** value (`vw - width - MARGIN`), but `left` is relative to the menu's **positioned ancestor** (`.header-dropdown-container`). When the trigger sits far from the left edge (the footer action bar on desktop), its offset got **double-counted** and the menu landed off-screen right — measured `left: 3472` in a 1920px viewport.

- **Mobile** worked because the container is ~full-width (`left ≈ 0`).
- The **EN vs PT** difference was only whether that render tripped the clamp's "overflowing right" check (Portuguese pages are taller).

## Fix
Subtract the offset parent's position when clamping, so the menu's right edge stays `MARGIN` from the viewport edge regardless of trigger position.

## Files changed
- `digit-ui-esbuild/public/index.html`

## Notes
- Purely layout; labels resolved correctly all along.
- The clamp lives in the HTML template, so it ships with a digit-ui rebuild + redeploy.

Commit: a9c8fff3ae
