### PR TITLE
fix(pgr): show Complaint Type on citizen list & employee inbox

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/configs/UICustomizations.js
+++ b/digit-ui-esbuild/products/pgr/src/configs/UICustomizations.js
@@ -1657,7 +1657,18 @@ export const UICustomizations = {
                   {String(value ? (column.translate ? t(column.prefix ? `${column.prefix}${value}` : value) : value) : t("ES_COMMON_NA"))}
                 </Link>
               </span>
-              <span>{t(`SERVICEDEFS.${row?.businessObject?.service?.serviceCode?.toUpperCase()}`)}</span>
+              {(() => {
+                // Show the Complaint Type (menuPath / category) instead of
+                // the sub-type (serviceCode). serviceDefs are cached in
+                // SessionStorage by useServiceDefs (the inbox filter loads
+                // them on mount). Fall back to the serviceCode key if the
+                // def or its menuPath is unavailable.
+                const sc = row?.businessObject?.service?.serviceCode;
+                const defs = Digit.SessionStorage.get("serviceDefs") || [];
+                const def = Array.isArray(defs) ? defs.find((d) => d?.serviceCode === sc) : null;
+                const typeCode = def?.menuPath || sc;
+                return <span>{t(`SERVICEDEFS.${(typeCode || "").toUpperCase()}`)}</span>;
+              })()}
             </div>
           );
 

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintsList.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintsList.js
@@ -79,12 +79,16 @@ function StatusPill({ status, t }) {
   );
 }
 
-function ComplaintRow({ data, onClick, t }) {
+function ComplaintRow({ data, onClick, t, menuPath }) {
   const { serviceCode, serviceRequestId, applicationStatus, auditDetails } = data;
-  const titleKey = `SERVICEDEFS.${(serviceCode || "").toUpperCase()}`;
+  // Card title shows the Complaint Type (menuPath / category), not the
+  // sub-type (serviceCode). Falls back to serviceCode if the matching
+  // service def has no menuPath.
+  const typeCode = menuPath || serviceCode;
+  const titleKey = `SERVICEDEFS.${(typeCode || "").toUpperCase()}`;
   const title = (() => {
     const v = t(titleKey);
-    return v === titleKey ? serviceCode : v;
+    return v === titleKey ? typeCode : v;
   })();
   const dateStr = auditDetails?.createdTime
     ? Digit.DateUtils.ConvertTimestampToDate(auditDetails.createdTime)
@@ -230,6 +234,17 @@ export const ComplaintsList = () => {
     mobileNumber
   );
 
+  // Service defs give us serviceCode -> menuPath so each card can show the
+  // Complaint Type (category) rather than the sub-type. Cached via MDMS.
+  const serviceDefs = Digit.Hooks.pgr.useServiceDefs(tenantId, "PGR");
+  const menuPathByCode = React.useMemo(() => {
+    const map = {};
+    (serviceDefs || []).forEach((def) => {
+      if (def?.serviceCode) map[def.serviceCode] = def.menuPath;
+    });
+    return map;
+  }, [serviceDefs]);
+
   useEffect(() => {
     revalidate();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -326,6 +341,7 @@ export const ComplaintsList = () => {
                 key={service.serviceRequestId}
                 data={service}
                 t={t}
+                menuPath={menuPathByCode[service.serviceCode]}
                 onClick={() => history.push(`${path}/${service.serviceRequestId}`)}
               />
             ))}


### PR DESCRIPTION
## What & why

On the **citizen "My Complaints" list** (`/digit-ui/citizen/pgr/complaints`) and the **employee inbox**, each complaint's headline showed the **sub-type** (`serviceCode`, e.g. *Recolha de Lixo*) instead of the **Complaint Type** (the service def's `menuPath` / category, e.g. *Ambiental*). The detail pages already show Type + Sub-Type correctly; this PR fixes only the list and inbox surfaces.

Closes #754

## Changes

**`digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintsList.js`**
- Load service defs via `Digit.Hooks.pgr.useServiceDefs(tenantId, "PGR")` and build a `serviceCode → menuPath` map (memoized).
- Pass `menuPath` into each `ComplaintRow`; card title now renders `SERVICEDEFS.<menuPath>` (the Complaint Type).

**`digit-ui-esbuild/products/pgr/src/configs/UICustomizations.js`**
- Under the complaint-no column, read the service defs cached in `Digit.SessionStorage` (already populated by the inbox filter's `useServiceDefs` on mount), find the matching def, and render `SERVICEDEFS.<menuPath>`.

Both paths **fall back to the `serviceCode` key** when a def or its `menuPath` is unavailable, so nothing regresses if defs aren't loaded yet.

## Decision
Display format = **Type only** (per product decision). Detail pages keep showing both Type and Sub-Type and are unchanged.

## Not included
- No change to detail pages (already correct).
- No localization change — the `SERVICEDEFS.<menuPath>` type keys are already seeded.
- Local-dev-only files (esbuild dev proxy, globalConfigs, vite config, vendor css) are intentionally **not** part of this PR.

## Testing
- Citizen list: cards show the Complaint Type; complaint no. / date / status pill still differentiate rows.
- Employee inbox: line under the complaint number shows the Complaint Type.
- Falls back gracefully to the sub-type key before defs resolve.

## Deployment
Source change in `digit-ui-esbuild` → requires a digit-ui bundle **rebuild + redeploy**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
