### PR TITLE
fix(local-setup): update jdk21 core services builds in ansible setup

### DIFF
--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -259,7 +259,7 @@ services:
   # Elasticsearch Indexer - Reads Kafka topics, indexes into Elasticsearch
   # ===========================================================================
   egov-indexer:
-    image: registry.preview.egov.theflywheel.in/egovio/egov-indexer:v2.9.2-4a60f20
+    image: egovio/egov-indexer:maven-jdk21-9f83afb
     profiles: ["search"]
     container_name: egov-indexer
     depends_on:
@@ -442,7 +442,7 @@ services:
 
   # MDMS Backend (actual service)
   mdms-backend:
-    image: registry.preview.egov.theflywheel.in/egovio/mdms-v2:v2.9.2-4a60f20
+    image: egovio/mdms-v2:maven-jdk21-9f83afb
     depends_on:
       pgbouncer:
         condition: service_healthy
@@ -510,7 +510,7 @@ services:
     - egov-network
 
   egov-idgen:
-    image: registry.preview.egov.theflywheel.in/egovio/egov-idgen:v2.9.2-4a60f20
+    image: egovio/egov-idgen:maven-jdk21-9f83afb
     depends_on:
       pgbouncer:
         condition: service_healthy
@@ -576,7 +576,7 @@ services:
     restart: "no"
 
   egov-user:
-    image: registry.preview.egov.theflywheel.in/egovio/egov-user:updatenovalidate-fix
+    image: egovio/egov-user:maven-jdk21-9f83afb
     depends_on:
       pgbouncer:
         condition: service_healthy
@@ -657,7 +657,7 @@ services:
     - egov-network
 
   egov-workflow-v2:
-    image: registry.preview.egov.theflywheel.in/egovio/egov-workflow-v2:jdk21-cds
+    image: egovio/egov-workflow-v2:maven-jdk21-983e8b2
     depends_on:
       pgbouncer:
         condition: service_healthy
@@ -739,7 +739,7 @@ services:
     - egov-network
 
   egov-localization:
-    image: registry.preview.egov.theflywheel.in/egovio/egov-localization:jdk21-cds
+    image: egovio/egov-localization:maven-jdk21-9f83afb
     container_name: egov-localization
     depends_on:
       pgbouncer:
@@ -787,7 +787,7 @@ services:
     - egov-network
 
   boundary-service:
-    image: registry.preview.egov.theflywheel.in/egovio/boundary-service:v2.9.2-dual-mode
+    image: egovio/boundary-service:maven-jdk21-9f83afb
     container_name: boundary-service
     depends_on:
       pgbouncer:
@@ -845,7 +845,7 @@ services:
     - egov-network
 
   egov-accesscontrol:
-    image: registry.preview.egov.theflywheel.in/egovio/egov-accesscontrol:v2.9.2-4a60f20
+    image: egovio/egov-accesscontrol:maven-jdk21-9f83afb
     container_name: egov-accesscontrol
     depends_on:
       pgbouncer:
@@ -923,7 +923,7 @@ services:
       - egov-network
 
   egov-persister:
-    image: registry.preview.egov.theflywheel.in/egovio/egov-persister:v2.9.2-4a60f20
+    image: egovio/egov-persister:maven-jdk21-9f83afb
     container_name: egov-persister
     depends_on:
       pgbouncer:
@@ -973,7 +973,7 @@ services:
   # Filestore Service - File upload/download
   # ===========================================================================
   egov-filestore:
-    image: registry.preview.egov.theflywheel.in/egovio/egov-filestore:v2.9.2-4a60f20
+    image: egovio/egov-filestore:maven-jdk21-9f83afb
     container_name: egov-filestore
     depends_on:
       pgbouncer:
@@ -1303,7 +1303,7 @@ services:
   # URL Shortening Service (required by PGR for notification links)
   # ===========================================================================
   egov-url-shortening:
-    image: registry.preview.egov.theflywheel.in/egovio/egov-url-shortening:v2.9.2-4a60f20
+    image: egovio/egov-url-shortening:maven-jdk21-983e8b2
     container_name: egov-url-shortening
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
## Summary
- Updated 11 core DIGIT service images in `local-setup/docker-compose.egov-digit.yaml` to use new `maven-jdk21-9f83afb` / `maven-jdk21-983e8b2` builds
- Removed private registry prefix (`registry.preview.egov.theflywheel.in/`) so images are pulled directly from Docker Hub, where the new tags are published
- Services updated: `egov-indexer`, `mdms-v2`, `egov-idgen`, `egov-user`, `egov-workflow-v2`, `egov-localization`, `boundary-service`, `egov-accesscontrol`, `egov-persister`, `egov-filestore`, `egov-url-shortening`

## Test plan
- [ ] Run `docker compose -f local-setup/docker-compose.egov-digit.yaml pull` and verify all updated images pull successfully from Docker Hub
- [ ] Bring up the stack and confirm services start healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)