### PR TITLE
fix(pgr): align citizen list Complaint Type with details pages

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintsList.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintsList.js
@@ -80,16 +80,13 @@ function StatusPill({ status, t }) {
 }
 
 function ComplaintRow({ data, onClick, t, menuPath }) {
-  const { serviceCode, serviceRequestId, applicationStatus, auditDetails } = data;
-  // Card title shows the Complaint Type (menuPath / category), not the
-  // sub-type (serviceCode). Falls back to serviceCode if the matching
-  // service def has no menuPath.
-  const typeCode = menuPath || serviceCode;
-  const titleKey = `SERVICEDEFS.${(typeCode || "").toUpperCase()}`;
-  const title = (() => {
-    const v = t(titleKey);
-    return v === titleKey ? typeCode : v;
-  })();
+  const { serviceRequestId, applicationStatus, auditDetails } = data;
+  // Complaint Type = the service def's menuPath, shown through the
+  // SERVICEDEFS localization key — identical to the employee/citizen
+  // details pages. When the message isn't seeded, t() returns the key
+  // (e.g. "SERVICEDEFS.COMPLAINT"), same as the details screens.
+  const titleKey = menuPath ? `SERVICEDEFS.${menuPath.toUpperCase()}` : "SERVICEDEFS.OTHERS";
+  const title = t(titleKey);
   const dateStr = auditDetails?.createdTime
     ? Digit.DateUtils.ConvertTimestampToDate(auditDetails.createdTime)
     : "";


### PR DESCRIPTION
## What & why

Follow-up to #755. On the citizen "My Complaints" list, the card title resolved the Complaint Type with a **custom fallback** that showed the bare menuPath word (e.g. `"Complaint"`) when the `SERVICEDEFS.<menuPath>` message wasn't seeded.

The **employee and citizen details pages** instead render `t("SERVICEDEFS.<menuPath>")` and surface the **raw key** (e.g. `SERVICEDEFS.COMPLAINT`) when a message is missing. This PR aligns the list card to that exact behaviour so all three surfaces show the Complaint Type identically.

Relates to #754

## Change

`digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintsList.js`

```js
// before — bespoke word fallback
const typeCode = menuPath || serviceCode;
const titleKey = `SERVICEDEFS.${typeCode.toUpperCase()}`;
const title = (() => { const v = t(titleKey); return v === titleKey ? typeCode : v; })();

// after — mirrors the details pages
const titleKey = menuPath ? `SERVICEDEFS.${menuPath.toUpperCase()}` : "SERVICEDEFS.OTHERS";
const title = t(titleKey);
```

- Complaint Type now comes from the service def `menuPath`, shown via `t("SERVICEDEFS.<menuPath>")` — same as employee details (`getServiceCategoryByCode`) and citizen details (`useComplaintDetails`).
- When the message isn't seeded, the card shows the **key** (`SERVICEDEFS.COMPLAINT`), consistent with the details screens, rather than the bare word.
- Falls back to `SERVICEDEFS.OTHERS` when a def has no menuPath (mirrors citizen details).

## Notes
- Behaviour-only alignment; the `useServiceDefs` → `serviceCode → menuPath` mapping from #755 is unchanged.
- Data caveat (out of scope): some service defs have free-text menuPath values (e.g. `"Water not coming"`) which produce malformed keys like `SERVICEDEFS.WATER NOT COMING`. Those should be cleaned in the configurator's Complaint Type field; once the `SERVICEDEFS.<menuPath>` messages are seeded the cards localize correctly.

## Deployment
Source change in `digit-ui-esbuild` → requires a digit-ui bundle **rebuild + redeploy** (dev server restart locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
