### PR TITLE
feat(pgr-services): V2 analytics grains + dynamic JSON→SQL query API

### DIFF
--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsCatalog.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsCatalog.java
@@ -1,0 +1,125 @@
+package org.egov.pgr.analytics;
+
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+
+/**
+ * The served-schema catalog for the dynamic analytics query API.
+ *
+ * This is BOTH the validation layer and the SQL-injection defense: every identifier
+ * the planner can emit (table, dimension, measurable column, distinct-countable column,
+ * time-role column) must appear here. Anything not registered is rejected before SQL is
+ * built; all literals are bound as JDBC params. The grammar is closed; the catalog is open
+ * (add a column here + it is instantly queryable, no grammar change) — that is the
+ * extensibility model.
+ *
+ * Operation-level classification (per the design review): a column is independently
+ * groupable / filterable / measurable / distinct-countable. UUID/PII-adjacent columns are
+ * deliberately groupable + distinct-countable but NOT filterable (no arbitrary eq/in probing)
+ * and never returned as raw row-grain dimensions by citizen scope.
+ */
+@Component
+public class AnalyticsCatalog {
+
+    public static final class Grain {
+        public final String name;
+        public final String table;
+        public final Map<String,String> timeRoles;     // role -> column
+        public final Set<String> epochMsColumns;        // columns stored as epoch-ms (vs sql date)
+        public final Set<String> groupable;
+        public final Set<String> filterable;
+        public final Set<String> measurable;            // numeric -> sum/avg/min/max/percentile
+        public final Set<String> distinctable;          // -> count_distinct
+        public final String tenantColumn;
+        public final String boundaryColumn;             // RBAC subtree scope (LIKE prefix)
+        public final String citizenColumn;              // citizen self-scope
+        public final String defaultTimeRole;
+
+        Grain(String name, String table, Map<String,String> timeRoles, Set<String> epochMsColumns,
+              Set<String> groupable, Set<String> filterable, Set<String> measurable, Set<String> distinctable,
+              String tenantColumn, String boundaryColumn, String citizenColumn, String defaultTimeRole) {
+            this.name = name; this.table = table; this.timeRoles = timeRoles; this.epochMsColumns = epochMsColumns;
+            this.groupable = groupable; this.filterable = filterable; this.measurable = measurable;
+            this.distinctable = distinctable; this.tenantColumn = tenantColumn; this.boundaryColumn = boundaryColumn;
+            this.citizenColumn = citizenColumn; this.defaultTimeRole = defaultTimeRole;
+        }
+        public boolean isEpochMs(String col){ return epochMsColumns.contains(col); }
+    }
+
+    private final Map<String,Grain> grains = new LinkedHashMap<>();
+
+    public AnalyticsCatalog() {
+        // ---------------- complaint_facts ----------------
+        grains.put("facts", new Grain("facts", "complaint_facts",
+            mapOf("filed_at","created_at", "resolved_at","resolved_at"),
+            setOf("created_at","resolved_at","last_transition_at","first_assigned_at","facts_built_at"),
+            // groupable
+            setOf("service_code","application_status","source","ward_code","zone_code","boundary_path",
+                  "service_group","department_code","aging_bucket","sla_status_bucket","current_assignee_uuid",
+                  "is_open","is_resolved","is_reopened","was_rejected","sla_breached","current_state_sla_breached",
+                  "has_rating","is_negative_rating","is_first_time_complainant","has_geo_pin","filed_on_behalf",
+                  "current_state_seq","created_month","created_week_start","created_year","created_quarter",
+                  "created_date","created_dow","created_is_weekend","created_is_business_hr","tenant_id"),
+            // filterable (NOTE: UUID columns intentionally absent)
+            setOf("service_code","application_status","source","ward_code","zone_code","service_group",
+                  "department_code","aging_bucket","sla_status_bucket","is_open","is_resolved","is_reopened",
+                  "was_rejected","sla_breached","current_state_sla_breached","has_rating","is_negative_rating",
+                  "is_first_time_complainant","has_geo_pin","created_month","created_year","created_quarter",
+                  "created_is_weekend","created_at","resolved_at","rating","current_state_seq"),
+            // measurable (numeric)
+            setOf("resolution_ms","time_to_assign_ms","open_age_ms","current_state_age_ms","first_escalation_ms",
+                  "max_dwell_ms","assigned_dwell_ms","unassigned_dwell_ms","transition_count","assignment_count",
+                  "escalation_count","reopen_count","distinct_assignee_count","distinct_actor_count",
+                  "system_transition_count","manual_transition_count","rating","complaint_seq_for_citizen",
+                  "mdms_sla_hours","sla_target_ms"),
+            // distinct-countable
+            setOf("account_id","current_assignee_uuid","service_code","ward_code","zone_code","service_request_id"),
+            "tenant_id","boundary_path","account_id","filed_at"));
+
+        // ---------------- complaint_events ----------------
+        grains.put("events", new Grain("events", "complaint_events",
+            mapOf("event_at","entered_at"),
+            setOf("entered_at","exited_at","complaint_created_at"),
+            setOf("status","previous_status","action","escalation_source","ward_code","zone_code","service_code",
+                  "source","occurred_month","occurred_week_start","occurred_date","occurred_dow","occurred_hour",
+                  "occurred_is_weekend","occurred_is_business_hr","is_assignment","is_escalation","is_reopen",
+                  "is_backward_transition","status_is_terminal","status_is_open","has_comment","has_multiple_assignees",
+                  "actor_is_system","is_current_state","assignee_uuid","actor_uuid","status_seq","tenant_id"),
+            setOf("status","previous_status","action","escalation_source","ward_code","zone_code","service_code",
+                  "source","occurred_month","occurred_is_weekend","occurred_is_business_hr","is_assignment",
+                  "is_escalation","is_reopen","is_backward_transition","status_is_terminal","status_is_open",
+                  "has_comment","has_multiple_assignees","actor_is_system","is_current_state","entered_at","status_seq"),
+            setOf("dwell_ms","state_sla_ms","business_sla_ms","comment_length","seq_delta","complaint_age_at_event_ms",
+                  "event_rating","assignee_count"),
+            setOf("service_request_id","assignee_uuid","actor_uuid","account_id"),
+            "tenant_id","boundary_path","account_id","event_at"));
+
+        // ---------------- complaint_open_state_daily ----------------
+        grains.put("daily", new Grain("daily", "complaint_open_state_daily",
+            mapOf("snapshot_date","snapshot_date"),
+            setOf(),  // snapshot_date is a sql date, not epoch-ms
+            setOf("snapshot_date","ward_code","zone_code","service_code","sla_status_bucket","aging_bucket",
+                  "is_open","sla_breached","current_assignee_uuid","boundary_path","tenant_id"),
+            setOf("snapshot_date","ward_code","zone_code","service_code","sla_status_bucket","aging_bucket",
+                  "is_open","sla_breached"),
+            setOf(),
+            setOf("service_request_id","current_assignee_uuid","ward_code"),
+            "tenant_id","boundary_path",null,"snapshot_date"));
+    }
+
+    public Grain grain(String name){ return grains.get(name); }
+    public boolean hasGrain(String name){ return grains.containsKey(name); }
+    public Collection<Grain> grains(){ return grains.values(); }
+
+    public static final Set<String> AGG_FNS =
+        setOf("count","count_distinct","sum","avg","min","max","percentile","ratio");
+
+    // ---- helpers ----
+    @SafeVarargs private static <T> Set<T> setOf(T... a){ return new LinkedHashSet<>(Arrays.asList(a)); }
+    private static Map<String,String> mapOf(String... kv){
+        Map<String,String> m = new LinkedHashMap<>();
+        for (int i=0;i+1<kv.length;i+=2) m.put(kv[i],kv[i+1]);
+        return m;
+    }
+}

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsController.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsController.java
@@ -1,0 +1,70 @@
+package org.egov.pgr.analytics;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.egov.common.contract.request.RequestInfo;
+import org.egov.pgr.config.PGRConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Dynamic analytics query API over the V2 grains (complaint_facts / complaint_events /
+ * complaint_open_state_daily).
+ *
+ *   POST /v2/analytics/_query   — run a single query or a batch dict of named queries
+ *   POST /v2/analytics/_schema  — capabilities/catalog so the FE can build the KPI editor
+ *
+ * Body (single):  { "RequestInfo": {...}, "tenantId": "ke", "query": { ...grammar... } }
+ * Body (batch):   { "RequestInfo": {...}, "tenantId": "ke", "queries": { "name": {...}, ... } }
+ */
+@RestController
+@RequestMapping("/v2/analytics")
+@Slf4j
+public class AnalyticsController {
+
+    private final AnalyticsService service;
+    private final ObjectMapper mapper;
+    private final PGRConfiguration config;
+
+    @Autowired
+    public AnalyticsController(AnalyticsService service, ObjectMapper mapper, PGRConfiguration config){
+        this.service = service; this.mapper = mapper; this.config = config;
+    }
+
+    @PostMapping("/_query")
+    public ResponseEntity<Map<String,Object>> query(@RequestBody JsonNode body){
+        try {
+            RequestInfo requestInfo = body.has("RequestInfo")
+                    ? mapper.convertValue(body.get("RequestInfo"), RequestInfo.class) : null;
+            String tenantId = body.hasNonNull("tenantId") ? body.get("tenantId").asText() : null;
+            int stateLen = config.getStateLevelTenantIdLength() == null ? 1 : config.getStateLevelTenantIdLength();
+            Map<String,Object> result = service.query(body, requestInfo, tenantId, stateLen);
+            return ResponseEntity.ok(result);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(error(e));
+        } catch (Exception e) {
+            log.error("analytics query failed", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error(e));
+        }
+    }
+
+    @PostMapping("/_schema")
+    public ResponseEntity<Map<String,Object>> schema(){
+        return ResponseEntity.ok(service.schema());
+    }
+
+    private Map<String,Object> error(Exception e){
+        String msg = e.getMessage() == null ? e.toString() : e.getMessage();
+        String code = msg.contains(":") ? msg.substring(0, msg.indexOf(':')) : "query_failed";
+        Map<String,Object> m = new LinkedHashMap<>();
+        m.put("error", code);
+        m.put("message", msg);
+        return m;
+    }
+}

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java
@@ -1,0 +1,280 @@
+package org.egov.pgr.analytics;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.egov.pgr.analytics.AnalyticsCatalog.Grain;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.time.*;
+import java.time.temporal.IsoFields;
+import java.time.temporal.TemporalAdjusters;
+import java.util.*;
+import java.util.regex.Pattern;
+
+/**
+ * Translates one validated JSON query node into parameterized SQL against a single grain.
+ * All identifiers are whitelisted against {@link AnalyticsCatalog}; all literals are JDBC params.
+ */
+@Component
+public class AnalyticsPlanner {
+
+    private static final ZoneId EAT = ZoneId.of("Africa/Nairobi");           // UTC+3
+    private static final Pattern ALIAS = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]{0,63}$");
+    private static final Set<String> BUCKETS = new HashSet<>(Arrays.asList("day","week","month","quarter","year"));
+    private static final int MAX_LIMIT = 1000;
+
+    private final AnalyticsCatalog catalog;
+    @Autowired public AnalyticsPlanner(AnalyticsCatalog catalog){ this.catalog = catalog; }
+
+    public static final class Planned {
+        public final String sql; public final List<Object> params;
+        public final List<String> columns; public final String grain;
+        Planned(String sql, List<Object> params, List<String> columns, String grain){
+            this.sql=sql; this.params=params; this.columns=columns; this.grain=grain;
+        }
+    }
+
+    public Planned plan(JsonNode q, AnalyticsScope scope){
+        String grainName = q.hasNonNull("grain") ? q.get("grain").asText() : inferGrain(q);
+        Grain g = catalog.grain(grainName);
+        if (g == null) throw new IllegalArgumentException("unknown_grain: " + grainName);
+
+        List<Object> selectParams = new ArrayList<>();
+        List<Object> whereParams  = new ArrayList<>();
+        List<String> selectExprs  = new ArrayList<>();
+        List<String> groupExprs   = new ArrayList<>();
+        List<String> columns      = new ArrayList<>();
+
+        // ---- time role (named time-role only; no free-form column) ----
+        JsonNode window = q.get("window");
+        String timeRole = window != null && window.hasNonNull("timeRole") ? window.get("timeRole").asText() : g.defaultTimeRole;
+        if (!g.timeRoles.containsKey(timeRole))
+            throw new IllegalArgumentException("invalid_param: timeRole '" + timeRole + "' not valid for grain " + grainName);
+        String timeCol = g.timeRoles.get(timeRole);
+
+        // ---- dimensions ----
+        if (q.has("dimensions")) for (JsonNode d : q.get("dimensions")) {
+            String col = d.asText();
+            if (!g.groupable.contains(col)) throw new IllegalArgumentException("unknown_column: dimension '" + col + "' not groupable on " + grainName);
+            selectExprs.add(col + " AS " + col);
+            groupExprs.add(col);
+            columns.add(col);
+        }
+        // ---- time bucket (adds a derived grouped dimension) ----
+        if (window != null && window.hasNonNull("timeBucket")) {
+            String unit = window.get("timeBucket").asText();
+            if (!BUCKETS.contains(unit)) throw new IllegalArgumentException("invalid_param: timeBucket '" + unit + "'");
+            String expr = g.isEpochMs(timeCol)
+                ? "date_trunc('" + unit + "', to_timestamp(" + timeCol + "/1000) AT TIME ZONE 'Etc/GMT-3')::date"
+                : "date_trunc('" + unit + "', " + timeCol + ")::date";
+            String alias = "bucket";
+            selectExprs.add(expr + " AS " + alias);
+            groupExprs.add(expr);
+            columns.add(alias);
+        }
+
+        // ---- measures ----
+        if (!q.has("measures") || !q.get("measures").isArray() || q.get("measures").size()==0)
+            throw new IllegalArgumentException("invalid_param: at least one measure is required");
+        for (JsonNode m : q.get("measures")) {
+            String name = m.path("name").asText(null);
+            if (name == null || !ALIAS.matcher(name).matches())
+                throw new IllegalArgumentException("invalid_param: measure name '" + name + "' must match [a-zA-Z_][a-zA-Z0-9_]*");
+            String expr = measureExpr(m, g, selectParams);
+            selectExprs.add(expr + " AS " + name);
+            columns.add(name);
+        }
+
+        // ---- WHERE: explicit filters + window + injected RBAC scope ----
+        List<String> conj = new ArrayList<>();
+        if (q.has("filters")) {
+            Iterator<Map.Entry<String,JsonNode>> it = q.get("filters").fields();
+            while (it.hasNext()) {
+                Map.Entry<String,JsonNode> e = it.next();
+                conj.add(predicate(g, e.getKey(), e.getValue(), whereParams));
+            }
+        }
+        applyWindow(window, g, timeCol, conj, whereParams);
+        applyScope(scope, g, conj, whereParams);
+
+        // ---- assemble ----
+        StringBuilder sb = new StringBuilder("SELECT ").append(String.join(", ", selectExprs))
+            .append(" FROM ").append(g.table);
+        if (!conj.isEmpty()) sb.append(" WHERE ").append(String.join(" AND ", conj));
+        if (!groupExprs.isEmpty()) {
+            List<String> ords = new ArrayList<>();
+            for (int i=1;i<=groupExprs.size();i++) ords.add(String.valueOf(i));
+            sb.append(" GROUP BY ").append(String.join(", ", ords));
+        }
+        applySort(q.get("sort"), columns, sb);
+        int limit = q.hasNonNull("limit") ? Math.min(q.get("limit").asInt(), MAX_LIMIT) : MAX_LIMIT;
+        sb.append(" LIMIT ").append(limit);
+
+        List<Object> params = new ArrayList<>(selectParams);   // SELECT params precede WHERE params
+        params.addAll(whereParams);
+        return new Planned(sb.toString(), params, columns, grainName);
+    }
+
+    // ---------- measures ----------
+    private String measureExpr(JsonNode m, Grain g, List<Object> selectParams){
+        String agg = m.path("agg").asText("count");
+        if (!AnalyticsCatalog.AGG_FNS.contains(agg)) throw new IllegalArgumentException("unknown_agg: " + agg);
+        switch (agg) {
+            case "count":
+                return "count(*)" + filterClause(m.get("filter"), g, selectParams);
+            case "count_distinct": {
+                String c = col(m); requireIn(g.distinctable, c, "distinct-countable", g);
+                return "count(DISTINCT " + c + ")";
+            }
+            case "sum": case "avg": case "min": case "max": {
+                String c = col(m); requireIn(g.measurable, c, "measurable", g);
+                return agg + "(" + c + ")" + filterClause(m.get("filter"), g, selectParams);
+            }
+            case "percentile": {
+                String c = col(m); requireIn(g.measurable, c, "measurable", g);
+                double p = m.path("p").asDouble(-1);
+                if (!(p > 0 && p < 100)) throw new IllegalArgumentException("invalid_param: percentile p must be in (0,100)");
+                return "percentile_cont(" + String.format(Locale.US, "%.6f", p/100.0)
+                        + ") WITHIN GROUP (ORDER BY " + c + ")";
+            }
+            case "ratio": {
+                String num = ratioSide(m.get("numerator"), g, selectParams);
+                String den = ratioSide(m.get("denominator"), g, selectParams);
+                return "round((" + num + ")::numeric / NULLIF((" + den + "),0), 4)";
+            }
+            default: throw new IllegalArgumentException("unknown_agg: " + agg);
+        }
+    }
+
+    private String ratioSide(JsonNode side, Grain g, List<Object> selectParams){
+        if (side == null) throw new IllegalArgumentException("invalid_param: ratio needs numerator and denominator");
+        String agg = side.path("agg").asText("count");
+        if (agg.equals("count")) return "count(*)" + filterClause(side.get("filter"), g, selectParams);
+        if (agg.equals("sum")) { String c = col(side); requireIn(g.measurable, c, "measurable", g);
+            return "sum(" + c + ")" + filterClause(side.get("filter"), g, selectParams); }
+        throw new IllegalArgumentException("invalid_param: ratio sides support agg count|sum");
+    }
+
+    private String filterClause(JsonNode filter, Grain g, List<Object> params){
+        if (filter == null || filter.isNull()) return "";
+        List<String> conj = new ArrayList<>();
+        Iterator<Map.Entry<String,JsonNode>> it = filter.fields();
+        while (it.hasNext()) { Map.Entry<String,JsonNode> e = it.next(); conj.add(predicate(g, e.getKey(), e.getValue(), params)); }
+        return conj.isEmpty() ? "" : " FILTER (WHERE " + String.join(" AND ", conj) + ")";
+    }
+
+    private String col(JsonNode m){
+        String c = m.path("column").asText(null);
+        if (c == null) throw new IllegalArgumentException("invalid_param: this agg requires a column");
+        return c;
+    }
+
+    // ---------- predicates (filterable whitelist + bound params) ----------
+    private String predicate(Grain g, String colKey, JsonNode spec, List<Object> params){
+        if (!g.filterable.contains(colKey))
+            throw new IllegalArgumentException("op_not_allowed: column '" + colKey + "' is not filterable on " + g.name);
+        if (!spec.isObject()) { params.add(value(spec)); return colKey + " = ?"; }      // shorthand: eq
+        List<String> parts = new ArrayList<>();
+        Iterator<Map.Entry<String,JsonNode>> it = spec.fields();
+        while (it.hasNext()) {
+            Map.Entry<String,JsonNode> e = it.next();
+            String op = e.getKey(); JsonNode v = e.getValue();
+            switch (op) {
+                case "eq":  params.add(value(v)); parts.add(colKey + " = ?"); break;
+                case "ne":  params.add(value(v)); parts.add(colKey + " <> ?"); break;
+                case "gt":  params.add(value(v)); parts.add(colKey + " > ?"); break;
+                case "gte": params.add(value(v)); parts.add(colKey + " >= ?"); break;
+                case "lt":  params.add(value(v)); parts.add(colKey + " < ?"); break;
+                case "lte": params.add(value(v)); parts.add(colKey + " <= ?"); break;
+                case "isnull": parts.add(colKey + (v.asBoolean() ? " IS NULL" : " IS NOT NULL")); break;
+                case "in": {
+                    if (!v.isArray() || v.size()==0) throw new IllegalArgumentException("invalid_param: 'in' needs a non-empty array");
+                    List<String> ph = new ArrayList<>();
+                    for (JsonNode item : v) { params.add(value(item)); ph.add("?"); }
+                    parts.add(colKey + " IN (" + String.join(",", ph) + ")");
+                    break;
+                }
+                default: throw new IllegalArgumentException("invalid_param: unsupported filter op '" + op + "'");
+            }
+        }
+        return parts.size()==1 ? parts.get(0) : "(" + String.join(" AND ", parts) + ")";
+    }
+
+    private Object value(JsonNode v){
+        if (v.isBoolean()) return v.asBoolean();
+        if (v.isInt() || v.isLong()) return v.asLong();
+        if (v.isFloatingPointNumber()) return v.asDouble();
+        return v.asText();
+    }
+
+    // ---------- window ----------
+    private void applyWindow(JsonNode window, Grain g, String timeCol, List<String> conj, List<Object> params){
+        if (window == null || !window.hasNonNull("name")) return;
+        String name = window.get("name").asText();
+        if (name.equals("all")) return;
+        if (name.equals("live")) {
+            if (g.filterable.contains("is_open")) conj.add("is_open = ?"); else return;
+            params.add(true); return;
+        }
+        long now = System.currentTimeMillis();
+        ZonedDateTime nowEat = Instant.ofEpochMilli(now).atZone(EAT);
+        Long fromMs;
+        java.util.regex.Matcher lastN = Pattern.compile("^last_(\\d+)d$").matcher(name);
+        if (lastN.matches()) {
+            fromMs = now - Long.parseLong(lastN.group(1)) * 86400000L;
+        } else switch (name) {
+            case "wtd": fromMs = nowEat.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)).toLocalDate().atStartOfDay(EAT).toInstant().toEpochMilli(); break;
+            case "mtd": fromMs = nowEat.withDayOfMonth(1).toLocalDate().atStartOfDay(EAT).toInstant().toEpochMilli(); break;
+            case "qtd": { LocalDate d = nowEat.toLocalDate().with(IsoFields.DAY_OF_QUARTER, 1L); fromMs = d.atStartOfDay(EAT).toInstant().toEpochMilli(); break; }
+            case "ytd": fromMs = nowEat.withDayOfYear(1).toLocalDate().atStartOfDay(EAT).toInstant().toEpochMilli(); break;
+            default: throw new IllegalArgumentException("invalid_param: unknown window '" + name + "'");
+        }
+        if (g.isEpochMs(timeCol)) {
+            conj.add(timeCol + " >= ?"); params.add(fromMs);
+            conj.add(timeCol + " < ?");  params.add(now);
+        } else { // sql date column (daily.snapshot_date)
+            conj.add(timeCol + " >= ?"); params.add(java.sql.Date.valueOf(Instant.ofEpochMilli(fromMs).atZone(EAT).toLocalDate()));
+        }
+    }
+
+    // ---------- RBAC scope (server-injected) ----------
+    private void applyScope(AnalyticsScope scope, Grain g, List<String> conj, List<Object> params){
+        if (scope.tenantId != null) {
+            if (scope.tenantStateLevel) { conj.add(g.tenantColumn + " LIKE ?"); params.add(scope.tenantId + "%"); }
+            else { conj.add(g.tenantColumn + " = ?"); params.add(scope.tenantId); }
+        }
+        if (scope.citizenUuid != null && g.citizenColumn != null) { conj.add(g.citizenColumn + " = ?"); params.add(scope.citizenUuid); }
+        if (scope.boundaryPrefix != null && g.boundaryColumn != null) {
+            conj.add(g.boundaryColumn + " LIKE ?");
+            params.add(scope.boundaryPrefix.replace("\\","\\\\").replace("%","\\%").replace("_","\\_") + "%");
+        }
+    }
+
+    // ---------- sort ----------
+    private void applySort(JsonNode sort, List<String> columns, StringBuilder sb){
+        if (sort == null || !sort.isArray() || sort.size()==0) return;
+        List<String> parts = new ArrayList<>();
+        for (JsonNode s : sort) {
+            String by = s.path("by").asText(null);
+            if (by == null || !columns.contains(by)) throw new IllegalArgumentException("invalid_param: sort.by '" + by + "' must be a selected dimension or measure");
+            String dir = "desc".equalsIgnoreCase(s.path("dir").asText("asc")) ? "DESC" : "ASC";
+            parts.add(by + " " + dir + " NULLS LAST");
+        }
+        sb.append(" ORDER BY ").append(String.join(", ", parts));
+    }
+
+    // ---------- grain inference ----------
+    private String inferGrain(JsonNode q){
+        // if any measure column is events-only (dwell_ms etc.) → events; else facts.
+        Grain events = catalog.grain("events");
+        if (q.has("measures")) for (JsonNode m : q.get("measures")) {
+            String c = m.path("column").asText(null);
+            if (c != null && events.measurable.contains(c) && !catalog.grain("facts").measurable.contains(c)) return "events";
+        }
+        return "facts";
+    }
+
+    private void requireIn(Set<String> set, String col, String role, Grain g){
+        if (!set.contains(col)) throw new IllegalArgumentException("unknown_column: '" + col + "' is not " + role + " on " + g.name);
+    }
+}

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsScope.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsScope.java
@@ -1,0 +1,49 @@
+package org.egov.pgr.analytics;
+
+import org.egov.common.contract.request.RequestInfo;
+import org.egov.common.contract.request.Role;
+import org.egov.common.contract.request.User;
+
+import java.util.List;
+
+/**
+ * Server-resolved RBAC scope. NEVER taken from the request body — derived from the
+ * authenticated userInfo + tenantId. Clients can only narrow within this, never widen.
+ *
+ * - tenant scope: always applied (LIKE prefix at state level, = at city level).
+ * - citizen self-scope: a pure CITIZEN sees only their own complaints (account_id = their uuid).
+ * - boundary subtree scope: an employee restricted to a jurisdiction gets boundary_path LIKE.
+ *   Full HRMS jurisdiction resolution is the documented extension point; for now an admin/employee
+ *   is tenant-scoped and the boundary hook is wired but null unless a jurisdiction is supplied
+ *   by the (server-trusted) caller context.
+ */
+public final class AnalyticsScope {
+    public final String tenantId;
+    public final boolean tenantStateLevel;
+    public final String citizenUuid;     // nullable: set => restrict to this account
+    public final String boundaryPrefix;  // nullable: set => boundary_path LIKE prefix||'%'
+
+    private AnalyticsScope(String tenantId, boolean stateLevel, String citizenUuid, String boundaryPrefix){
+        this.tenantId = tenantId; this.tenantStateLevel = stateLevel;
+        this.citizenUuid = citizenUuid; this.boundaryPrefix = boundaryPrefix;
+    }
+
+    public static AnalyticsScope resolve(RequestInfo requestInfo, String tenantId, int stateLevelLen){
+        boolean stateLevel = tenantId != null && tenantId.split("\\.").length == stateLevelLen;
+        String citizenUuid = null;
+        User u = requestInfo == null ? null : requestInfo.getUserInfo();
+        if (u != null) {
+            boolean isCitizen = "CITIZEN".equalsIgnoreCase(u.getType());
+            boolean hasEmployeeRole = false;
+            List<Role> roles = u.getRoles();
+            if (roles != null) for (Role r : roles) {
+                String c = r.getCode() == null ? "" : r.getCode().toUpperCase();
+                if (!c.equals("CITIZEN")) hasEmployeeRole = true;
+            }
+            // a pure citizen is locked to their own records
+            if (isCitizen && !hasEmployeeRole) citizenUuid = u.getUuid();
+        }
+        // boundaryPrefix: extension point for HRMS-jurisdiction-restricted employees (TODO).
+        return new AnalyticsScope(tenantId, stateLevel, citizenUuid, null);
+    }
+}

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
@@ -1,0 +1,125 @@
+package org.egov.pgr.analytics;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.extern.slf4j.Slf4j;
+import org.egov.common.contract.request.RequestInfo;
+import org.egov.pgr.analytics.AnalyticsCatalog.Grain;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+/**
+ * Orchestrates the dynamic analytics query: resolve server-side RBAC scope, plan each query
+ * against the catalog, execute parameterized SQL, and shape the response (single or batch dict).
+ */
+@Service
+@Slf4j
+public class AnalyticsService {
+
+    private final AnalyticsPlanner planner;
+    private final AnalyticsCatalog catalog;
+    private final JdbcTemplate jdbc;
+
+    @Autowired
+    public AnalyticsService(AnalyticsPlanner planner, AnalyticsCatalog catalog, JdbcTemplate jdbc){
+        this.planner = planner; this.catalog = catalog; this.jdbc = jdbc;
+    }
+
+    public Map<String,Object> query(JsonNode body, RequestInfo requestInfo, String tenantId, int stateLevelLen){
+        if (tenantId == null || tenantId.isEmpty()) throw new IllegalArgumentException("invalid_param: tenantId is required");
+        AnalyticsScope scope = AnalyticsScope.resolve(requestInfo, tenantId, stateLevelLen);
+
+        Map<String,Object> out = new LinkedHashMap<>();
+        out.put("asOf", asOf());
+        out.put("scope", scopeInfo(scope));
+
+        if (body.has("queries") && body.get("queries").isObject()) {
+            // batch dict form: { name -> queryNode } => { results: { name -> result }, partial }
+            Map<String,Object> results = new LinkedHashMap<>();
+            boolean partial = false;
+            Iterator<Map.Entry<String,JsonNode>> it = body.get("queries").fields();
+            while (it.hasNext()) {
+                Map.Entry<String,JsonNode> e = it.next();
+                try { results.put(e.getKey(), runOne(e.getValue(), scope)); }
+                catch (Exception ex) { partial = true; results.put(e.getKey(), err(ex)); }
+            }
+            out.put("results", results);
+            out.put("partial", partial);
+        } else if (body.has("query")) {
+            out.putAll(runOne(body.get("query"), scope));
+        } else {
+            throw new IllegalArgumentException("invalid_param: body must contain 'query' or 'queries'");
+        }
+        return out;
+    }
+
+    private Map<String,Object> runOne(JsonNode q, AnalyticsScope scope){
+        AnalyticsPlanner.Planned p = planner.plan(q, scope);
+        long t0 = System.currentTimeMillis();
+        List<Map<String,Object>> rows = jdbc.queryForList(p.sql, p.params.toArray());
+        Map<String,Object> r = new LinkedHashMap<>();
+        r.put("grain", p.grain);
+        r.put("columns", p.columns);
+        r.put("rows", rows);
+        r.put("rowCount", rows.size());
+        r.put("tookMs", System.currentTimeMillis() - t0);
+        return r;
+    }
+
+    /** /_schema capabilities — lets the FE build the KPI editor dynamically. */
+    public Map<String,Object> schema(){
+        Map<String,Object> out = new LinkedHashMap<>();
+        out.put("aggFns", AnalyticsCatalog.AGG_FNS);
+        out.put("filterOps", Arrays.asList("eq","ne","gt","gte","lt","lte","in","isnull"));
+        out.put("windows", Arrays.asList("all","live","last_<N>d","wtd","mtd","qtd","ytd"));
+        out.put("timeBuckets", Arrays.asList("day","week","month","quarter","year"));
+        Map<String,Object> grains = new LinkedHashMap<>();
+        for (Grain g : catalog.grains()) {
+            Map<String,Object> gi = new LinkedHashMap<>();
+            gi.put("timeRoles", g.timeRoles.keySet());
+            gi.put("defaultTimeRole", g.defaultTimeRole);
+            gi.put("dimensions", g.groupable);
+            gi.put("filterable", g.filterable);
+            gi.put("measurable", g.measurable);
+            gi.put("distinctCountable", g.distinctable);
+            gi.put("scopeColumns", scopeCols(g));
+            grains.put(g.name, gi);
+        }
+        out.put("grains", grains);
+        out.put("notes", "Closed grammar over an open catalog: any listed column is queryable; "
+                + "UUID columns are groupable/distinct-countable but not filterable; RBAC scope is server-injected.");
+        return out;
+    }
+
+    private List<String> scopeCols(Grain g){
+        List<String> l = new ArrayList<>();
+        if (g.tenantColumn != null) l.add("tenant:" + g.tenantColumn);
+        if (g.boundaryColumn != null) l.add("boundary:" + g.boundaryColumn);
+        if (g.citizenColumn != null) l.add("citizen:" + g.citizenColumn);
+        return l;
+    }
+
+    private Long asOf(){
+        try { return jdbc.queryForObject("SELECT max(facts_built_at) FROM complaint_facts", Long.class); }
+        catch (Exception e) { return System.currentTimeMillis(); }
+    }
+
+    private Map<String,Object> scopeInfo(AnalyticsScope s){
+        Map<String,Object> m = new LinkedHashMap<>();
+        m.put("tenantId", s.tenantId);
+        m.put("level", s.tenantStateLevel ? "state" : "city");
+        if (s.citizenUuid != null) m.put("restrictedTo", "own-records");
+        if (s.boundaryPrefix != null) m.put("boundaryPrefix", s.boundaryPrefix);
+        return m;
+    }
+
+    private Map<String,Object> err(Exception ex){
+        Map<String,Object> m = new LinkedHashMap<>();
+        String msg = ex.getMessage()==null ? ex.toString() : ex.getMessage();
+        String code = msg.contains(":") ? msg.substring(0, msg.indexOf(':')) : "query_failed";
+        m.put("error", code); m.put("message", msg);
+        return m;
+    }
+}

--- a/backend/pgr-services/src/main/resources/db/migration/main/V20260608000000__create_v2_grain_mvs.sql
+++ b/backend/pgr-services/src/main/resources/db/migration/main/V20260608000000__create_v2_grain_mvs.sql
@@ -1,0 +1,255 @@
+-- ============================================================================
+-- V2 analytics grains: complaint_events + complaint_facts (MVs) +
+-- complaint_open_state_daily (append-only table). Validated against bomet data.
+-- Reads: eg_pgr_service_v2, eg_pgr_address_v2, eg_wf_*, eg_mdms_data, boundary_relationship, eg_user.
+-- Every dashboard KPI becomes WHERE ... GROUP BY ... on these grains (no per-KPI code).
+-- ============================================================================
+
+-- ============================================================================
+-- V2 grain 1: complaint_events — the TIMELINE (one row per workflow transition)
+-- ============================================================================
+DROP MATERIALIZED VIEW IF EXISTS complaint_events CASCADE;
+CREATE MATERIALIZED VIEW complaint_events AS
+WITH svc AS (
+  SELECT s.servicerequestid, s.id AS pgr_id, s.tenantid, s.servicecode, s.accountid,
+         s.source, s.createdtime AS complaint_created_at, s.createdby AS filed_by_uuid,
+         a.locality AS locality_code, a.latitude, a.longitude,
+         (a.latitude IS NOT NULL AND a.longitude IS NOT NULL) AS has_geo_pin
+  FROM eg_pgr_service_v2 s
+  LEFT JOIN eg_pgr_address_v2 a ON a.parentid = s.id
+),
+bnd AS (   -- dedupe by code; prefer the deepest path; '|'-delimited ancestors, append self
+  SELECT DISTINCT ON (code) code,
+         (ancestralmaterializedpath || '|' || code) AS boundary_path
+  FROM boundary_relationship
+  ORDER BY code, length(ancestralmaterializedpath) DESC
+),
+bs AS (
+  SELECT DISTINCT ON (tenantid, businessservice) tenantid, businessservice, businessservicesla
+  FROM eg_wf_businessservice_v2
+),
+asg AS (
+  SELECT processinstanceid, count(*) AS assignee_count,
+         (array_agg(assignee ORDER BY assignee))[1] AS assignee_uuid
+  FROM eg_wf_assignee_v2 GROUP BY processinstanceid
+),
+tx AS (
+  SELECT pi.id AS event_id, pi.businessid AS service_request_id, pi.tenantid,
+         pi.businessservice, pi.action, pi.assigner AS actor_uuid,
+         pi.escalated, pi.rating AS event_rating, pi.comment,
+         pi.createdtime AS entered_at,
+         st.state AS status, st.seq AS status_seq, st.sla AS state_sla_ms,
+         st.isterminatestate AS status_is_terminal,
+         lead(pi.createdtime) OVER w AS exited_at,
+         lag(st.state)        OVER w AS previous_status,
+         lag(st.seq)          OVER w AS previous_status_seq,
+         row_number()         OVER w AS seq_no,
+         (lead(pi.id) OVER w IS NULL) AS is_current_state
+  FROM eg_wf_processinstance_v2 pi
+  LEFT JOIN eg_wf_state_v2 st ON st.uuid = pi.status
+  WINDOW w AS (PARTITION BY pi.businessid ORDER BY pi.createdtime, pi.id)
+)
+SELECT
+  tx.event_id, tx.service_request_id, tx.tenantid AS tenant_id,
+  tx.businessservice AS business_service, tx.seq_no, tx.is_current_state,
+  tx.action, tx.status, tx.previous_status,
+  coalesce(tx.status_is_terminal,false)        AS status_is_terminal,
+  (NOT coalesce(tx.status_is_terminal,false))  AS status_is_open,
+  tx.actor_uuid, asg.assignee_uuid,
+  (ua.type = 'SYSTEM')                         AS actor_is_system,
+  tx.entered_at, tx.exited_at,
+  (tx.exited_at - tx.entered_at)               AS dwell_ms,
+  tx.status_seq, tx.previous_status_seq,
+  (tx.status_seq - tx.previous_status_seq)     AS seq_delta,
+  (tx.status_seq < tx.previous_status_seq)     AS is_backward_transition,
+  tx.state_sla_ms,
+  CASE WHEN tx.state_sla_ms IS NOT NULL AND tx.exited_at IS NOT NULL
+       THEN (tx.exited_at - tx.entered_at) > tx.state_sla_ms END AS state_sla_breached_on_exit,
+  bs.businessservicesla                        AS business_sla_ms,
+  (tx.action IN ('ASSIGN','REASSIGN'))         AS is_assignment,
+  (tx.action = 'REOPEN')                       AS is_reopen,
+  coalesce(tx.escalated,false)                 AS is_escalation,
+  CASE WHEN coalesce(tx.escalated,false)
+       THEN (CASE WHEN ua.type='SYSTEM' THEN 'auto' ELSE 'manual' END) END AS escalation_source,
+  (tx.comment IS NOT NULL AND tx.comment <> '') AS has_comment,
+  length(tx.comment)                           AS comment_length,
+  tx.event_rating,
+  coalesce(asg.assignee_count,0)               AS assignee_count,
+  (coalesce(asg.assignee_count,0) > 1)         AS has_multiple_assignees,
+  svc.accountid AS account_id, svc.source, svc.servicecode AS service_code, svc.locality_code, svc.has_geo_pin,
+  svc.complaint_created_at,
+  (tx.entered_at - svc.complaint_created_at)   AS complaint_age_at_event_ms,
+  bnd.boundary_path,
+  split_part(bnd.boundary_path,'|',2)          AS zone_code,   -- position-based; refine per hierarchy
+  split_part(bnd.boundary_path,'|',3)          AS ward_code,
+  (to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3')::date AS occurred_date,
+  date_trunc('week',(to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3'))::date AS occurred_week_start,
+  to_char((to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3'),'YYYY-MM') AS occurred_month,
+  extract(hour   FROM (to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3'))::smallint AS occurred_hour,
+  extract(isodow FROM (to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3'))::smallint AS occurred_dow,
+  (extract(isodow FROM (to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3')) IN (6,7)) AS occurred_is_weekend,
+  (extract(hour  FROM (to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3')) BETWEEN 8 AND 17) AS occurred_is_business_hr
+FROM tx
+LEFT JOIN svc ON svc.servicerequestid = tx.service_request_id
+LEFT JOIN bnd ON bnd.code = svc.locality_code
+LEFT JOIN bs  ON bs.tenantid = tx.tenantid AND bs.businessservice = tx.businessservice
+LEFT JOIN asg ON asg.processinstanceid = tx.event_id
+LEFT JOIN eg_user ua ON ua.uuid = tx.actor_uuid;
+
+CREATE UNIQUE INDEX ux_complaint_events ON complaint_events(event_id);
+CREATE INDEX ix_ce_timeline ON complaint_events(service_request_id, seq_no);
+CREATE INDEX ix_ce_status   ON complaint_events(status);
+CREATE INDEX ix_ce_assignee ON complaint_events(assignee_uuid);
+CREATE INDEX ix_ce_week     ON complaint_events(occurred_week_start);
+
+-- ============================================================================
+-- V2 grain 2: complaint_facts — one row per complaint (snapshot + lifecycle rollup)
+-- Folds complaint_events + current dims + MDMS ServiceDefs + boundary.
+-- ============================================================================
+DROP MATERIALIZED VIEW IF EXISTS complaint_facts CASCADE;
+CREATE MATERIALIZED VIEW complaint_facts AS
+WITH clock AS (SELECT (extract(epoch FROM now())*1000)::bigint AS now_ms),
+roll AS (
+  SELECT service_request_id,
+         min(entered_at)                                            AS created_at,
+         max(entered_at)                                            AS last_transition_at,
+         count(*)                                                   AS transition_count,
+         count(*) FILTER (WHERE is_assignment)                      AS assignment_count,
+         count(*) FILTER (WHERE is_escalation)                      AS escalation_count,
+         count(*) FILTER (WHERE is_reopen)                          AS reopen_count,
+         count(DISTINCT assignee_uuid)                              AS distinct_assignee_count,
+         count(DISTINCT actor_uuid)                                 AS distinct_actor_count,
+         count(*) FILTER (WHERE actor_is_system)                    AS system_transition_count,
+         count(*) FILTER (WHERE NOT actor_is_system)                AS manual_transition_count,
+         bool_or(status IN ('REJECTED','CLOSEDAFTERREJECTION'))     AS was_rejected,
+         min(entered_at) FILTER (WHERE is_assignment)               AS first_assigned_at,
+         min(entered_at) FILTER (WHERE status IN ('RESOLVED','CLOSEDAFTERRESOLUTION')) AS resolved_at,
+         max(entered_at) FILTER (WHERE is_escalation)               AS last_escalated_at,
+         min(entered_at) FILTER (WHERE is_escalation)               AS first_escalated_at,
+         max(dwell_ms)                                              AS max_dwell_ms,
+         sum(dwell_ms) FILTER (WHERE assignee_uuid IS NOT NULL)     AS assigned_dwell_ms,
+         sum(dwell_ms) FILTER (WHERE assignee_uuid IS NULL)         AS unassigned_dwell_ms
+  FROM complaint_events GROUP BY service_request_id
+),
+cur AS (
+  SELECT service_request_id, status AS application_status, status_seq AS current_state_seq,
+         status_is_open AS is_open, assignee_uuid AS current_assignee_uuid,
+         state_sla_ms AS current_state_sla_ms, business_sla_ms,
+         boundary_path, ward_code, zone_code
+  FROM complaint_events WHERE is_current_state
+),
+mdms AS (   -- ServiceDefs; dedupe by serviceCode preferring the root (shortest) tenant
+  SELECT DISTINCT ON (data->>'serviceCode')
+         data->>'serviceCode'            AS service_code,
+         (data->>'slaHours')::int        AS mdms_sla_hours,
+         NULLIF(data->>'menuPath','')    AS service_group,
+         (data->>'order')::smallint      AS service_order,
+         data->>'department'             AS department_code
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.ServiceDefs' AND isactive
+  ORDER BY data->>'serviceCode', length(tenantid)
+),
+seq AS (
+  SELECT id, row_number() OVER (PARTITION BY accountid ORDER BY createdtime, id) AS complaint_seq_for_citizen
+  FROM eg_pgr_service_v2
+)
+SELECT
+  s.servicerequestid AS service_request_id, s.id AS pgr_id, s.tenantid AS tenant_id,
+  s.accountid AS account_id, 'PGR'::text AS business_service,
+  s.servicecode AS service_code, cur.application_status, s.source, s.rating AS rating_raw, s.active,
+  length(s.description) AS description_length,
+  (s.description IS NOT NULL AND s.description <> '') AS has_description,
+  s.createdby AS filed_by_uuid, (s.createdby <> s.accountid) AS filed_on_behalf,
+  a.locality AS locality_code, a.pincode, a.city, a.latitude, a.longitude,
+  (a.latitude IS NOT NULL AND a.longitude IS NOT NULL) AS has_geo_pin,
+  (a.parentid IS NOT NULL) AS has_address,
+  cur.boundary_path,
+  (length(coalesce(cur.boundary_path,'')) - length(replace(coalesce(cur.boundary_path,''),'|','')) + 1)::smallint AS boundary_depth,
+  cur.ward_code, cur.zone_code,
+  m.service_group, m.service_order, m.mdms_sla_hours, m.department_code,
+  cur.current_state_seq, cur.current_state_sla_ms, cur.business_sla_ms AS sla_target_ms,
+  (m.mdms_sla_hours IS NOT NULL AND cur.business_sla_ms IS NOT NULL
+    AND m.mdms_sla_hours*3600000 <> cur.business_sla_ms) AS sla_config_mismatch,
+  -- timestamps
+  roll.created_at, roll.first_assigned_at, roll.first_assigned_at AS first_response_at,
+  roll.resolved_at, roll.last_transition_at, roll.first_escalated_at, roll.last_escalated_at,
+  -- counts
+  roll.transition_count, roll.assignment_count, roll.escalation_count, roll.reopen_count,
+  roll.distinct_assignee_count, roll.distinct_actor_count,
+  roll.system_transition_count, roll.manual_transition_count,
+  roll.was_rejected, (roll.reopen_count > 0) AS is_reopened,
+  cur.is_open, (roll.resolved_at IS NOT NULL) AS is_resolved,
+  roll.max_dwell_ms, roll.assigned_dwell_ms, roll.unassigned_dwell_ms,
+  cur.current_assignee_uuid,
+  -- durations
+  (roll.resolved_at - roll.created_at)                            AS resolution_ms,
+  (roll.first_assigned_at - roll.created_at)                      AS time_to_assign_ms,
+  CASE WHEN cur.is_open THEN clock.now_ms - roll.created_at END   AS open_age_ms,
+  CASE WHEN cur.is_open THEN clock.now_ms - roll.last_transition_at END AS current_state_age_ms,
+  (roll.first_escalated_at - roll.created_at)                     AS first_escalation_ms,
+  -- SLA
+  CASE WHEN cur.is_open  THEN (cur.business_sla_ms IS NOT NULL AND (clock.now_ms - roll.created_at) > cur.business_sla_ms)
+       WHEN roll.resolved_at IS NOT NULL THEN (cur.business_sla_ms IS NOT NULL AND (roll.resolved_at - roll.created_at) > cur.business_sla_ms)
+       ELSE false END                                            AS sla_breached,
+  (cur.is_open AND cur.current_state_sla_ms IS NOT NULL
+    AND (clock.now_ms - roll.last_transition_at) > cur.current_state_sla_ms) AS current_state_sla_breached,
+  CASE WHEN NOT cur.is_open THEN NULL
+       WHEN (clock.now_ms - roll.created_at) < 86400000  THEN '<1d'
+       WHEN (clock.now_ms - roll.created_at) < 259200000 THEN '1-3d'
+       WHEN (clock.now_ms - roll.created_at) < 604800000 THEN '3-7d'
+       ELSE '>7d' END                                            AS aging_bucket,
+  CASE WHEN NOT cur.is_open OR cur.business_sla_ms IS NULL THEN NULL
+       WHEN (clock.now_ms - roll.created_at) > cur.business_sla_ms       THEN 'breached'
+       WHEN (clock.now_ms - roll.created_at) > 0.8*cur.business_sla_ms   THEN 'approaching'
+       ELSE 'within' END                                         AS sla_status_bucket,
+  -- rating
+  (s.rating IS NOT NULL) AS has_rating, s.rating, (s.rating IS NOT NULL AND s.rating <= 2) AS is_negative_rating,
+  -- citizen sequence
+  seq.complaint_seq_for_citizen, (seq.complaint_seq_for_citizen = 1) AS is_first_time_complainant,
+  -- calendar (EAT / UTC+3)
+  (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3')::date AS created_date,
+  date_trunc('week',(to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'))::date AS created_week_start,
+  to_char((to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'),'YYYY-MM') AS created_month,
+  extract(year FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'))::smallint AS created_year,
+  to_char((to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'),'YYYY-"Q"Q') AS created_quarter,
+  extract(hour FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'))::smallint AS created_hour,
+  extract(isodow FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'))::smallint AS created_dow,
+  (extract(isodow FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3')) IN (6,7)) AS created_is_weekend,
+  (extract(hour FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3')) BETWEEN 8 AND 17) AS created_is_business_hr,
+  (to_timestamp(roll.resolved_at/1000) AT TIME ZONE 'Etc/GMT-3')::date AS resolved_date,
+  to_char((to_timestamp(roll.resolved_at/1000) AT TIME ZONE 'Etc/GMT-3'),'YYYY-MM') AS resolved_month,
+  clock.now_ms AS facts_built_at
+FROM eg_pgr_service_v2 s
+CROSS JOIN clock
+LEFT JOIN eg_pgr_address_v2 a ON a.parentid = s.id
+LEFT JOIN roll ON roll.service_request_id = s.servicerequestid
+LEFT JOIN cur  ON cur.service_request_id  = s.servicerequestid
+LEFT JOIN mdms m ON m.service_code = s.servicecode
+LEFT JOIN seq ON seq.id = s.id
+WHERE s.active = true;
+
+CREATE UNIQUE INDEX ux_complaint_facts ON complaint_facts(service_request_id);
+CREATE INDEX ix_cf_service ON complaint_facts(service_code);
+CREATE INDEX ix_cf_status  ON complaint_facts(application_status);
+CREATE INDEX ix_cf_created ON complaint_facts(created_week_start);
+CREATE INDEX ix_cf_open    ON complaint_facts(is_open) WHERE is_open;
+CREATE INDEX ix_cf_ward    ON complaint_facts(ward_code);
+
+-- ---- grain 3: complaint_open_state_daily (append-only backlog history; NOT an MV) ----
+CREATE TABLE IF NOT EXISTS complaint_open_state_daily (
+  snapshot_date         date         NOT NULL,
+  service_request_id    varchar(256) NOT NULL,
+  tenant_id             varchar(256) NOT NULL,
+  is_open               boolean      NOT NULL,
+  sla_breached          boolean,
+  sla_status_bucket     varchar(16),
+  aging_bucket          varchar(16),
+  boundary_path         text,
+  ward_code             varchar(64),
+  zone_code             varchar(64),
+  service_code          varchar(256),
+  current_assignee_uuid varchar(128),
+  PRIMARY KEY (snapshot_date, service_request_id)
+);
+CREATE INDEX IF NOT EXISTS ix_cosd_date ON complaint_open_state_daily(snapshot_date);
+-- Recurring daily snapshot is performed by the refresh scheduler (INSERT ... SELECT FROM complaint_facts WHERE is_open ON CONFLICT DO NOTHING).


### PR DESCRIPTION
## What

Adds a **V2 analytics layer** to pgr-services: three denormalized grains plus a **dynamic JSON→SQL query API**, so dashboard KPIs become filter+group-by *config* instead of per-KPI code or hand-written materialized views.

## Why

The existing dashboard (`pgr_mv_kpi`/`monthly`/`dimension` + `GET /v2/dashboard`) aggregates only `eg_pgr_service_v2` with fixed, hardcoded query shapes — it can't answer workflow-aware questions (dwell-in-state, per-officer load, SLA breach, transition matrix) or arbitrary slices without a new MV. This layer fixes both: a denormalized fact makes any reasonable KPI a `WHERE … GROUP BY …`, and the query API exposes that flexibly and safely.

## Grains (`db/migration/main/V20260608000000__create_v2_grain_mvs.sql`)

| Grain | Type | One row = |
|---|---|---|
| `complaint_events` | MATERIALIZED VIEW | one workflow transition (timeline, dwell, per-state SLA, transition matrix) |
| `complaint_facts` | MATERIALIZED VIEW | one complaint (snapshot + lifecycle rollup, folded from events + MDMS + boundary) |
| `complaint_open_state_daily` | TABLE (append-only) | one open complaint per day (backlog history — an MV refresh would erase the past) |

Status UUIDs are resolved to human names via `eg_wf_state_v2`; dwell/seq via window functions; system actor detected via `eg_user.type='SYSTEM'` (deployment-agnostic).

## Query API (`org.egov.pgr.analytics`)

- `POST /v2/analytics/_query` — single query **or** a batch dict of named queries (multi-measure, caller-supplied labels).
- `POST /v2/analytics/_schema` — catalog/capabilities so a frontend can build a KPI editor dynamically.
- **Closed grammar over an open catalog**: every identifier is whitelisted against the served schema (this is *both* the validation layer and the SQL-injection defense); every literal is a bound JDBC param.
- Measures: `count`/`count_distinct`/`sum`/`avg`/`min`/`max`/`percentile`/`ratio`; dimensions; filters (`eq/ne/gt/gte/lt/lte/in/isnull`); named time windows (`live`/`last_<N>d`/`wtd`/`mtd`/`qtd`/`ytd`) + time-bucketing; sort; limit.
- **One grain per query**; cross-grain multi-measure requests return a grain-tagged **batch** (different denominators are never blended into a row — fan-out guard).
- **RBAC scope injected server-side** (tenant LIKE + citizen-self) from `userInfo`, never the request body.
- **Operation-level PII control**: UUID columns are groupable / distinct-countable but **not** filterable.

## Validation

Exercised live against a real tenant: all three grains populate; percentile dwell-by-state, breach-by-ward, and a multi-measure batch (`count`/`ratio`/`count_distinct`) return correctly; an injection attempt in a dimension → `400 unknown_column`; filtering a UUID column → `400 op_not_allowed`. Compiles clean against `develop`.

## Deferred (documented, non-blocking)

Period-over-period delta (WoW/MoM/YoY), saved KPI defs in MDMS + publish pipeline, full HRMS jurisdiction (boundary-subtree) scoping, and adding the new grains to the dashboard refresh scheduler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
