### PR TITLE
fix(core): employee profile fixes — render crash + mobile validation fallback

### DIFF
--- a/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Home/UserProfile.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Home/UserProfile.js
@@ -67,7 +67,16 @@ const defaultValidationConfig = {
       // contain "O'Brien" / "Mary-Anne" / "John Jr." which the
       // alpha-only regex rejected too.
       name: "/^[a-zA-Z0-9 .'\\-]+$/i",
-      mobileNumber: "/^[6-9]{1}[0-9]{9}$/",
+      // Fallback mobile pattern for when the MDMS ValidationConfigs master
+      // isn't seeded for the tenant. Pull the tenant's pattern from
+      // globalConfigs.CORE_MOBILE_CONFIGS (e.g. Mozambique "^8[0-9]{8}$")
+      // instead of the old hardcoded India regex (/^[6-9][0-9]{9}$/), which
+      // rejected valid 9-digit numbers on save. globalConfigs.js is loaded
+      // before the bundle, so getConfig is available at module init. The
+      // generic numeric pattern is only a last resort if the config is absent.
+      mobileNumber:
+        window?.globalConfigs?.getConfig?.("CORE_MOBILE_CONFIGS")?.mobileNumberPattern ||
+        "/^[0-9]{6,15}$/",
       password: "/^([a-zA-Z0-9@#$%]{8,15})$/i",
     },
   ],
@@ -279,7 +288,13 @@ const UserProfile = ({ stateCode, userType, cityDetails }) => {
 
   useEffect(() => {
     if (mdmsValidationData && mdmsValidationData?.UserProfileValidationConfig?.[0]) {
-      const updatedValidationConfig = mapConfigToRegExp(mdmsValidationData);
+      const updatedValidationConfig = mapConfigToRegExp(mdmsValidationData) || {};
+      // When the MDMS master isn't seeded, the select still yields keys with
+      // `undefined` values (e.g. mobileNumber). Drop those so they don't
+      // clobber the globalConfigs/default fallback established above.
+      Object.keys(updatedValidationConfig).forEach((key) => {
+        if (updatedValidationConfig[key] === undefined) delete updatedValidationConfig[key];
+      });
       if (mdmsValidationData?.prefix) {
         updatedValidationConfig.prefix = mdmsValidationData.prefix;
       }

--- a/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Home/UserProfile.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Home/UserProfile.js
@@ -776,6 +776,20 @@ const UserProfile = ({ stateCode, userType, cityDetails }) => {
 
   if (loading || isValidationConfigLoading) return <Loader></Loader>;
 
+  // The mobile-edit affordance is only honest when the save path actually
+  // accepts the new number. The Individual-service write
+  // (`/individual/v1/_update`) does; the legacy egov-user write
+  // (`/user/profile/_update`) silently strips `mobileNumber` server-side
+  // via `User.nullifySensitiveFields()` because the mobile is the login
+  // handle and self-service rotation has no OTP-verify guard. On
+  // deployments without the Individual service wired (e.g. naipepea), the
+  // editable input is therefore a lie — render it read-only so we don't
+  // promise behavior the backend prohibits. CCRS#555 follow-up. Defined at
+  // component scope so both the citizen and employee profile branches can
+  // read it (previously scoped inside the citizen branch only, which
+  // crashed the employee profile with "canEditMobile is not defined").
+  const canEditMobile = !!window?.globalConfigs?.getConfig("INDIVIDUAL_SERVICE_CONTEXT_PATH");
+
   // ----------------------------------------------------------------------
   // v2 Citizen branch — modernized chrome (form sections in a Card,
   // inline sticky save bar, theme-aware tokens). Employee path below
@@ -794,16 +808,6 @@ const UserProfile = ({ stateCode, userType, cityDetails }) => {
       value: l.value,
       label: l.label,
     }));
-    // The mobile-edit affordance is only honest when the save path actually
-    // accepts the new number. The Individual-service write
-    // (`/individual/v1/_update`) does; the legacy egov-user write
-    // (`/user/profile/_update`) silently strips `mobileNumber` server-side
-    // via `User.nullifySensitiveFields()` because the mobile is the login
-    // handle and self-service rotation has no OTP-verify guard. On
-    // deployments without the Individual service wired (e.g. naipepea), the
-    // editable input is therefore a lie — render it read-only so we don't
-    // promise behavior the backend prohibits. CCRS#555 follow-up.
-    const canEditMobile = !!window?.globalConfigs?.getConfig("INDIVIDUAL_SERVICE_CONTEXT_PATH");
     return (
       <div
         className="v2-scope"


### PR DESCRIPTION
﻿## What & why

The employee profile page (`/digit-ui/employee/user/profile`) crashed with **`Uncaught ReferenceError: canEditMobile is not defined`** — the whole `UserProfile` component threw to the app ErrorBoundary, so the profile screen failed to render.

Closes #761

## Root cause

`canEditMobile` (which gates the mobile-number field's `required` / `readOnly` / styling) was declared **inside the `if (userType === "citizen")` branch**, but it's referenced **only in the employee render path**. For employee users the citizen branch is skipped, so the variable was undefined in scope at render → `ReferenceError`. The citizen-branch declaration was also effectively unused there.

## Change

`digit-ui-esbuild/packages/modules/core/src/pages/citizen/Home/UserProfile.js`

- Hoist `canEditMobile` to the component's top-level scope (after the loader guard) so both the citizen and employee branches read the same value.
- Remove the misplaced duplicate from the citizen branch.

```js
// component scope, shared by both branches
const canEditMobile = !!window?.globalConfigs?.getConfig("INDIVIDUAL_SERVICE_CONTEXT_PATH");
```

## Impact / behaviour

- Employee profile page renders again (crash resolved); citizen profile unchanged.
- **No behavioural change** to the mobile-edit gating — still driven by `globalConfigs.INDIVIDUAL_SERVICE_CONTEXT_PATH` (mobile editable only when the Individual service is wired, per CCRS#555).

## Testing

- Employee: open `/employee/user/profile` → form renders, no console ReferenceError.
- Citizen: `/citizen/user/profile` unchanged.
- Mobile field stays read-only when `INDIVIDUAL_SERVICE_CONTEXT_PATH` is absent, editable when present.

## Deployment

Source change in `digit-ui-esbuild` (core module) → requires a digit-ui bundle **rebuild + redeploy** (clean dev-server restart locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Second fix in this PR — mobile validation fallback

Employee profile **Save** rejected valid 9-digit Mozambique numbers with "enter a valid mobile number". The validation regex is read from the MDMS `ValidationConfigs.mobileNumberValidation` master; when that isn't seeded for the tenant, the code fell back to a hardcoded **India** regex (`/^[6-9][0-9]{9}$/`, 10 digits) which rejects 9-digit numbers.

- `defaultValidationConfig.mobileNumber` now falls back to the tenant's `globalConfigs.CORE_MOBILE_CONFIGS.mobileNumberPattern` (e.g. Mozambique `^8[0-9]{8}$`) instead of the India regex; a generic numeric pattern is the only last resort.
- The MDMS merge effect now drops `undefined` keys so an unseeded master doesn't clobber the fallback with an empty pattern.

Commit: `23f1567e22`. (MDMS `ValidationConfigs` seeding can replace this fallback later; until then the profile validates against the tenant's globalConfigs pattern.)
