### PR TITLE
fix(egov-user): pin tenant-aware encryption image in base compose, drop per-tenant overlay

### DIFF
--- a/local-setup/docker-compose.bomet.yml
+++ b/local-setup/docker-compose.bomet.yml
@@ -19,19 +19,3 @@ services:
     environment:
       SPRING_FLYWAY_ENABLED: "false"
 
-  # CCRS #622 / Digit-Core #1044: tenant-aware encryption.
-  #
-  # Custom image built on egov-ci (89.167.55.190) by cherry-picking c6f5438
-  # ("add tenant-aware encryption overloads") onto ccc0e13 ("prevent NPE in
-  # _updatenovalidate and profile _update"), then migrating the 6
-  # encryptObject(...) call sites in UserService.java to pass the request's
-  # tenantId. See https://github.com/egovernments/Digit-Core/pull/1044 —
-  # once the upstream `egovio/egov-user` image carries the same fix this
-  # block can be dropped.
-  #
-  # `registry.preview.egov.theflywheel.in` is a read-only TLS proxy
-  # (nginx vhost on the egov dev box) in front of the egov-ci VPC
-  # registry — same blob storage, valid public certificate, pullable
-  # from anywhere without insecure-registries setup.
-  egov-user:
-    image: registry.preview.egov.theflywheel.in/egovio/egov-user:dynamic-tenant-bomet

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -584,7 +584,22 @@ services:
     restart: "no"
 
   egov-user:
-    image: egovio/egov-user:maven-jdk21-9f83afb
+    # Custom image stacks (a) the tenant-aware encryption fix from
+    # egovernments/Digit-Core#1044 — cherry-pick of c6f5438 + call-site
+    # migration 884c5e6 — on (b) the ccc0e13 NPE fix base in
+    # _updatenovalidate / profile/_update. Built off the pre-d69ce29
+    # commit lineage, so it also sidesteps the SafeHtmlValidator
+    # BeanCreationException regression that blocks citizen registration on
+    # the stock maven-jdk21-* images (CCRS#771).
+    #
+    # When Digit-Core#1044 merges upstream and an official
+    # `egovio/egov-user:<post-1044>` tag exists, replace this pin with
+    # the canonical image.
+    #
+    # `registry.preview.egov.theflywheel.in` is a read-only HTTPS proxy
+    # in front of the egov-ci VPC registry — public cert, no
+    # insecure-registries trust required, pullable from anywhere.
+    image: registry.preview.egov.theflywheel.in/egovio/egov-user:1044-preview
     depends_on:
       pgbouncer:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Refactors the egov-user image pin out of the per-tenant overlay and into the base compose, and renames the tag to drop the misleading `-bomet` suffix.

## Why

PR #706 landed the pin in `local-setup/docker-compose.bomet.yml`. The trouble: the fix isn't bomet-specific — any single-state deploy benefits, any multi-state deploy needs it. Hiding it in an overlay made it trivially bypassable by routine `docker compose -f docker-compose.egov-digit.yaml up egov-user` calls.

That bypass just happened on bomet earlier today:

- The base compose was bumped to `egovio/egov-user:maven-jdk21-9f83afb`.
- A subsequent `docker compose -f docker-compose.egov-digit.yaml up -d egov-user` (no `-f docker-compose.bomet.yml`) silently dropped the overlay.
- The container booted on the upstream image with **no encryption fix** and (separately) tripped the `SafeHtmlValidator` `BeanCreationException` regression tracked in #771 — so citizen registration was blocked.

## What this PR does

1. **Move the pin to the base compose** (`local-setup/docker-compose.egov-digit.yaml`). The file every `docker compose` call includes — impossible to skip.
2. **Rename the tag** `dynamic-tenant-bomet` → `1044-preview` to describe the upstream PR it carries, not the deploy. Re-tagged on the egov-ci VPC registry via `docker buildx imagetools create`; both tags point at the same digest (`sha256:c7252be8…`).
3. **Strip the `egov-user` block from `docker-compose.bomet.yml`** — the overlay should only carry genuinely bomet-specific overrides (inbox state-tenant pin, url-shortening Flyway-off).

## What's in the image

The `1044-preview` tag stacks:

- `c6f5438` + `884c5e6` from egovernments/Digit-Core#1044 — tenant-aware encryption + the `UserService.java` call-site migration
- on top of `ccc0e13` — NPE fix in `_updatenovalidate` and `profile/_update`

Built off the pre-`d69ce29` commit lineage, so it sidesteps the `SafeHtmlValidator` regression that breaks citizen registration on the stock `maven-jdk21-*` images (#771).

## Test plan

- [x] `1044-preview` re-tag pulled clean on bomet (`amd64/linux`, digest `sha256:c7252be8…`)
- [x] `egov-user` container recreated using the corrected file stack; healthcheck `healthy`
- [x] `/user-otp/v1/_send` → 200
- [x] `/user/citizen/_create` → 200 (proves `SafeHtmlValidator` works — closes #771's symptom)
- [x] `/user/profile/_update` → 200 (proves the NPE fix is preserved)
- [x] `/user/_search` → 200 against pre-existing rows (ciphertext-prefix continuity)
- [ ] Next clean `./deploy.sh bomet` run on a controller picks up the base-compose pin without the overlay (post-merge)

## Sunset

When egovernments/Digit-Core#1044 merges and an official `egovio/egov-user:<post-1044>` tag is cut, replace the `1044-preview` pin in the base compose with that tag. This whole change goes away.

## Refs

- Fixes #771 — egov-user image fails `SafeHtmlValidator` bean creation
- Refs egovernments/Digit-Core#1044 — upstream encryption fix
- Supersedes #706 (which already merged with the bomet-overlay pin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
