### PR TITLE
fix(pgr-services): pin to escalation-otel-amd64-crs-sla-7326e9ce1, drop :latest

### DIFF
--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -1238,7 +1238,16 @@ services:
   # PGR Services (Public Grievance Redressal)
   # ===========================================================================
   pgr-services:
-    image: registry.preview.egov.theflywheel.in/pgr-services-dev:latest
+    # Pinned to the CRS-SLA build cut from
+    # backend/pgr-services @ 7326e9ce1 ("fix(crs-seed): recovery SQL for
+    # x-ref-schema regression on CRS.* schemas") on branch
+    # feat/escalation-otel-configurator-designer. It carries the structured
+    # escalation skip reasons + OTEL + /escalation/_trigger surface
+    # (a43e4adfc) plus the CRS.CategorySLA/CRS.StateSLA scheduler reader
+    # (33dd3f6e4). Avoid `:latest` here — it has previously masked
+    # silent rolls of the running image; explicit short-SHA tags keep the
+    # live container in sync with what's reviewed in source.
+    image: registry.preview.egov.theflywheel.in/egovio/pgr-services-dev:escalation-otel-amd64-crs-sla-7326e9ce1
     depends_on:
       pgbouncer:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Pins `pgr-services` to an explicit short-SHA tag built off `feat/escalation-otel-configurator-designer @ 7326e9ce1`, and drops `:latest` from the base compose.

## Context

The base compose was pinning `pgr-services` to `registry.preview.egov.theflywheel.in/pgr-services-dev:latest`, while the live bomet container had been running an older internal build for the escalation + OTEL + structured-skip-reasons work.

A fresh build at sha `7326e9ce1` had been produced locally on bomet (carrying the CRS-SLA scheduler reader on top of escalation+OTEL), tagged for the VPC registry, but **had never been `docker push`'d**. `docker manifest inspect registry.preview…/egovio/pgr-services-dev:escalation-otel-amd64-crs-sla-7326e9ce1` therefore returned `MANIFEST_UNKNOWN` even though `docker images` on bomet showed the tag — pure local-cache state.

I pushed it from bomet, confirmed it's reachable through the preview proxy from a third-party box (multi-arch OCI index, `amd64` manifest at `sha256:1b3e8b5e…`, multi-arch index at `sha256:955c6021…`).

## What this PR changes

`local-setup/docker-compose.egov-digit.yaml::pgr-services.image`

```diff
-    image: registry.preview.egov.theflywheel.in/pgr-services-dev:latest
+    image: registry.preview.egov.theflywheel.in/egovio/pgr-services-dev:escalation-otel-amd64-crs-sla-7326e9ce1
```

Two things fixed in one move:

1. **No more `:latest`.** Same silent-bypass class as the egov-user case fixed in #772 — a re-tag on the upstream side silently changes what a fresh `docker compose pull` brings in. Explicit short-SHA tags keep the live container in sync with what's reviewed in source.
2. **Brings the live deploy under review.** Bomet was already running a related (older `fallback-a43e4adfc`) internal build that wasn't traceable to anything in source. This pin makes the relationship between source and live image obvious.

## Build provenance

| Field | Value |
|---|---|
| Branch | `feat/escalation-otel-configurator-designer` |
| Commit | `7326e9ce1` — *fix(crs-seed): recovery SQL for x-ref-schema regression on CRS.* schemas* |
| Carries | escalation + OTEL skip-reasons (a43e4adfc); structured `/escalation/_trigger`; CRS.CategorySLA / CRS.StateSLA scheduler (33dd3f6e4) |
| Registry digest | `sha256:955c602120b75da5fbb0e3d7f1cc8e6fc886ee7235cc3fc3aea6368b121e0a46` |
| Public pullable | `registry.preview.egov.theflywheel.in/egovio/pgr-services-dev:escalation-otel-amd64-crs-sla-7326e9ce1` |

## Test plan

- [x] Image pushed to `10.0.0.4:5000` from bomet, mirrors immediately through the preview proxy
- [x] `docker manifest inspect` from a third-party box returns a valid multi-arch index
- [ ] Recreate `digit-pgr-services-1` on bomet from the corrected base compose, verify `/pgr-services/v2/dashboard`, `/escalation/_trigger`, the CRS-SLA scheduler path stay green
- [ ] After merge, fresh `./deploy.sh bomet` from a clean controller picks up the new tag

## Refs

- Related: #772 (same anti-pattern applied to egov-user; merged into develop)
- Sibling concern: same `:latest` pattern exists for `digit-config-service`, `digit-user-preferences-service`, `novu-bridge`, `novu-bridge-endpoint`. Worth a follow-up "ban :latest in the base compose" sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
