### PR TITLE
fix(auth): separate citizen/employee auth provider so Keycloak doesn't break employee login (#769)

### DIFF
--- a/digit-ui-esbuild/packages/digit-ui-components/src/atoms/PrivateRoute.js
+++ b/digit-ui-esbuild/packages/digit-ui-components/src/atoms/PrivateRoute.js
@@ -2,8 +2,19 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Route, Redirect } from "react-router-dom";
 
-function isKeycloakAuth() {
-  return window?.globalConfigs?.getConfig("AUTH_PROVIDER") === "keycloak";
+// Keycloak/SSO is resolved per surface: citizen may use Keycloak while the
+// employee surface always stays on DIGIT password auth. Keep in sync with
+// libraries/src/services/auth/authSurface.js (inlined here to avoid a
+// cross-package import).
+function isKeycloakAuth(pathname) {
+  const parts = (pathname || "").split("/").filter(Boolean);
+  const surface = parts[1] === "employee" ? "employee" : "citizen";
+  const cfg = (key) => window?.globalConfigs?.getConfig(key);
+  const provider =
+    surface === "employee"
+      ? cfg("EMPLOYEE_AUTH_PROVIDER") || "digit"
+      : cfg("CITIZEN_AUTH_PROVIDER") || cfg("AUTH_PROVIDER") || "digit";
+  return provider === "keycloak";
 }
 
 export const PrivateRoute = ({ component: Component, roles, ...rest }) => {
@@ -18,7 +29,7 @@ export const PrivateRoute = ({ component: Component, roles, ...rest }) => {
         // `/<contextPath>/employee/...` → employee, anything else → citizen.
         const pathParts = (props.location.pathname || "").split("/").filter(Boolean);
         const pathUserType = pathParts[1] === "employee" ? "employee" : "citizen";
-        const loginPath = isKeycloakAuth()
+        const loginPath = isKeycloakAuth(props.location.pathname)
           ? `/${window?.contextPath}/user/login`
           : (pathUserType === "employee"
             ? `/${window?.contextPath}/employee/user/language-selection`

--- a/digit-ui-esbuild/packages/libraries/src/services/atoms/Utils/Request.js
+++ b/digit-ui-esbuild/packages/libraries/src/services/atoms/Utils/Request.js
@@ -1,8 +1,5 @@
 import Axios from "axios";
-
-function isKeycloakAuth() {
-  return window?.globalConfigs?.getConfig("AUTH_PROVIDER") === "keycloak";
-}
+import { isKeycloakAuth } from "../../auth/authSurface";
 
 function getTokenExchangeUrl() {
   return window?.globalConfigs?.getConfig("TOKEN_EXCHANGE_URL") || "";

--- a/digit-ui-esbuild/packages/libraries/src/services/auth/AuthAdapter.js
+++ b/digit-ui-esbuild/packages/libraries/src/services/auth/AuthAdapter.js
@@ -1,7 +1,9 @@
 /**
  * AuthAdapter interface.
  * All implementations must provide these methods.
- * Active adapter is selected via globalConfigs.getConfig("AUTH_PROVIDER").
+ * The active adapter is selected per surface by getAuthProvider() in
+ * ./authSurface.js (CITIZEN_AUTH_PROVIDER / EMPLOYEE_AUTH_PROVIDER, with the
+ * legacy AUTH_PROVIDER honoured for the citizen surface only).
  */
 
 export class AuthAdapter {

--- a/digit-ui-esbuild/packages/libraries/src/services/auth/authSurface.js
+++ b/digit-ui-esbuild/packages/libraries/src/services/auth/authSurface.js
@@ -1,0 +1,41 @@
+/**
+ * Auth surface + provider resolution.
+ *
+ * DIGIT serves two surfaces from a single bundle: citizen
+ * (`/<contextPath>/citizen/...`) and employee (`/<contextPath>/employee/...`).
+ * They can use DIFFERENT auth providers — e.g. Keycloak/SSO for citizens while
+ * employees stay on DIGIT password auth.
+ *
+ * Config keys (globalConfigs):
+ *   CITIZEN_AUTH_PROVIDER  - provider for the citizen surface
+ *                            (default: AUTH_PROVIDER || "digit")
+ *   EMPLOYEE_AUTH_PROVIDER - provider for the employee surface (default: "digit")
+ *   AUTH_PROVIDER          - legacy/global key; honoured for the CITIZEN surface
+ *                            only, for backward compatibility.
+ *
+ * The employee surface NEVER inherits the global AUTH_PROVIDER. A deployment
+ * that turns on Keycloak for citizens must not silently break employee login
+ * (which has no SSO path): the employee bundle would otherwise run the Keycloak
+ * adapter, time out, and leave the login page wedged. That is exactly the
+ * regression this split fixes.
+ */
+
+export function getAuthSurface(pathname) {
+  const path =
+    pathname || (typeof window !== "undefined" ? window.location.pathname : "");
+  // `/<contextPath>/employee/...` -> employee, anything else -> citizen.
+  const parts = (path || "").split("/").filter(Boolean);
+  return parts[1] === "employee" ? "employee" : "citizen";
+}
+
+export function getAuthProvider(pathname) {
+  const cfg = (key) => window?.globalConfigs?.getConfig(key);
+  if (getAuthSurface(pathname) === "employee") {
+    return cfg("EMPLOYEE_AUTH_PROVIDER") || "digit";
+  }
+  return cfg("CITIZEN_AUTH_PROVIDER") || cfg("AUTH_PROVIDER") || "digit";
+}
+
+export function isKeycloakAuth(pathname) {
+  return getAuthProvider(pathname) === "keycloak";
+}

--- a/digit-ui-esbuild/packages/libraries/src/services/auth/index.js
+++ b/digit-ui-esbuild/packages/libraries/src/services/auth/index.js
@@ -1,4 +1,5 @@
 import { AuthAdapter } from "./AuthAdapter";
+import { getAuthProvider } from "./authSurface";
 
 let _adapter = null;
 
@@ -8,7 +9,9 @@ export function getAuthAdapter() {
 }
 
 export async function initAuthAdapter() {
-  const provider = window?.globalConfigs?.getConfig("AUTH_PROVIDER") || "digit";
+  // Resolve per the current surface so the employee bundle never instantiates
+  // the Keycloak adapter off a global AUTH_PROVIDER flag.
+  const provider = getAuthProvider();
 
   if (provider === "keycloak") {
     const { KeycloakAuthAdapter } = await import("./KeycloakAuthAdapter");

--- a/digit-ui-esbuild/packages/libraries/src/services/elements/User/index.js
+++ b/digit-ui-esbuild/packages/libraries/src/services/elements/User/index.js
@@ -2,10 +2,11 @@ import Urls from "../../atoms/urls";
 import { Request, ServiceRequest } from "../../atoms/Utils/Request";
 import { Storage } from "../../atoms/Utils/Storage";
 import { getAuthAdapter } from "../../auth/index";
+import { isKeycloakAuth } from "../../auth/authSurface";
 
 export const UserService = {
   authenticate: async (details) => {
-    if (window?.globalConfigs?.getConfig("AUTH_PROVIDER") === "keycloak") {
+    if (isKeycloakAuth()) {
       const adapter = getAuthAdapter();
       const result = await adapter.login({
         email: details.username,
@@ -62,7 +63,7 @@ export const UserService = {
     return Digit.SessionStorage.get("User");
   },
   logout: async () => {
-    if (window?.globalConfigs?.getConfig("AUTH_PROVIDER") === "keycloak") {
+    if (isKeycloakAuth()) {
       const adapter = getAuthAdapter();
       return adapter.logout();
     }

--- a/digit-ui-esbuild/packages/modules/core/src/App.js
+++ b/digit-ui-esbuild/packages/modules/core/src/App.js
@@ -11,8 +11,15 @@ import SignUpV2 from "./pages/employee/SignUp-v2";
 import LoginV2 from "./pages/employee/Login-v2";
 import UnifiedLogin from "./pages/common/Login/index";
 
-const isKeycloakAuth = () =>
-  window?.globalConfigs?.getConfig("AUTH_PROVIDER") === "keycloak";
+// The unified `/user/login` + `/user/sign-up` entries (and the contextPath
+// mount below) are the CITIZEN single-sign-on surface. Resolve the citizen
+// provider here (falling back to the legacy global AUTH_PROVIDER). Employees
+// always use DIGIT password auth via `/<contextPath>/employee/...` and are
+// routed by EmployeeApp, independent of this flag.
+const isKeycloakAuth = () => {
+  const cfg = (key) => window?.globalConfigs?.getConfig(key);
+  return (cfg("CITIZEN_AUTH_PROVIDER") || cfg("AUTH_PROVIDER") || "digit") === "keycloak";
+};
 
 export const DigitApp = ({ stateCode, modules, appTenants, logoUrl, logoUrlWhite, initData, defaultLanding = "citizen",allowedUserTypes=["citizen","employee"] }) => {
   const history = useHistory();

--- a/digit-ui-esbuild/packages/react-components/src/atoms/PrivateRoute.js
+++ b/digit-ui-esbuild/packages/react-components/src/atoms/PrivateRoute.js
@@ -1,8 +1,19 @@
 import React from "react";
 import { Route, Redirect } from "react-router-dom";
 
-function isKeycloakAuth() {
-  return window?.globalConfigs?.getConfig("AUTH_PROVIDER") === "keycloak";
+// Keycloak/SSO is resolved per surface: citizen may use Keycloak while the
+// employee surface always stays on DIGIT password auth. Keep in sync with
+// libraries/src/services/auth/authSurface.js (inlined here to avoid a
+// cross-package import).
+function isKeycloakAuth(pathname) {
+  const parts = (pathname || "").split("/").filter(Boolean);
+  const surface = parts[1] === "employee" ? "employee" : "citizen";
+  const cfg = (key) => window?.globalConfigs?.getConfig(key);
+  const provider =
+    surface === "employee"
+      ? cfg("EMPLOYEE_AUTH_PROVIDER") || "digit"
+      : cfg("CITIZEN_AUTH_PROVIDER") || cfg("AUTH_PROVIDER") || "digit";
+  return provider === "keycloak";
 }
 
 export const PrivateRoute = ({ component: Component, roles, ...rest }) => {
@@ -17,7 +28,7 @@ export const PrivateRoute = ({ component: Component, roles, ...rest }) => {
         // `/<contextPath>/employee/...` → employee, anything else → citizen.
         const pathParts = (props.location.pathname || "").split("/").filter(Boolean);
         const pathUserType = pathParts[1] === "employee" ? "employee" : "citizen";
-        const loginPath = isKeycloakAuth()
+        const loginPath = isKeycloakAuth(props.location.pathname)
           ? `/${window?.contextPath}/user/login`
           : (pathUserType === "employee"
             ? `/${window?.contextPath}/employee/user/language-selection`

--- a/digit-ui-esbuild/src/index.js
+++ b/digit-ui-esbuild/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { initLibraries } from "@egovernments/digit-ui-libraries";
+import { isKeycloakAuth } from "../packages/libraries/src/services/auth/authSurface";
 import "./index.css";
 import App from './App';
 import { applyTheme } from "./theme/applyTheme";
@@ -47,9 +48,6 @@ const normalizeLocale = () => {
     window.Digit.StoreData.setCurrentLanguage(DEFAULT_LOCALE);
   }
 };
-
-const isKeycloakAuth = () =>
-  window?.globalConfigs?.getConfig("AUTH_PROVIDER") === "keycloak";
 
 async function bootstrap() {
   if (isKeycloakAuth()) {


### PR DESCRIPTION
## Problem

The employee UI (digit-ui-esbuild) honours a single global `AUTH_PROVIDER` flag for **both** the citizen and employee surfaces. When a deployment turns on Keycloak/SSO for citizens (e.g. "Continue with Google"), that same flag activates the Keycloak adapter on the **employee** surface, which has no SSO login path. The employee bundle then:

1. runs `initAuthAdapter()` at bootstrap → Keycloak init has nothing to authenticate against → **times out after 15s**;
2. leaves the store init unresolved → the login-page tenant query throws `Cannot read properties of null (reading 'tenants')`;
3. the city dropdown renders **"No options"**, so the Login button never enables — and even with a cached tenant list, the token call 200s but the adapter never establishes the session, bouncing the user back to login.

This is what broke employee login on the Bomet deployment (`AUTH_PROVIDER=keycloak` set for citizen Google SSO): see egovernments/Citizen-Complaint-Resolution-System#769. The regression surfaced the moment the AuthAdapter code landed in `develop`'s `digit-ui-esbuild` and the bundle was rebuilt — the pre-existing keycloak flag then activated the adapter for employees.

## Fix — separate auth config per surface

Introduce surface-aware provider resolution so citizen and employee can use different auth providers:

| Config key (globalConfigs) | Applies to | Default |
|---|---|---|
| `CITIZEN_AUTH_PROVIDER` | citizen surface | `AUTH_PROVIDER` ?? `digit` |
| `EMPLOYEE_AUTH_PROVIDER` | employee surface | `digit` |
| `AUTH_PROVIDER` (legacy) | citizen only (back-compat) | — |

Key rule: **the employee surface never inherits the global `AUTH_PROVIDER`.** It defaults to DIGIT password auth and only uses Keycloak if `EMPLOYEE_AUTH_PROVIDER=keycloak` is set explicitly.

Surface is derived from the URL (`/<contextPath>/employee/...` → employee, else citizen) — the same convention already used by `PrivateRoute`.

### Changes
- **New** `packages/libraries/src/services/auth/authSurface.js` — single source of truth: `getAuthSurface()`, `getAuthProvider()`, `isKeycloakAuth()`.
- `src/index.js`, `Request.js`, `elements/User/index.js`, `auth/index.js` — use the shared surface-aware helpers instead of reading `AUTH_PROVIDER` directly.
- both `PrivateRoute.js` (in `react-components` and `digit-ui-components`) — inline surface-aware resolution (kept inline to avoid a new cross-package import; mirrors `authSurface.js`).
- `modules/core/src/App.js` — the unified `/user/login` + `/user/sign-up` routes and the contextPath mount are the **citizen** SSO surface, so they resolve the citizen provider (`CITIZEN_AUTH_PROVIDER` ?? `AUTH_PROVIDER`). Behaviour is unchanged for existing deployments.

### Backward compatibility
Existing deployments are unaffected:
- `AUTH_PROVIDER` unset → both surfaces resolve to `digit` (as before).
- `AUTH_PROVIDER=keycloak` → **citizen** keeps Keycloak; **employee** now correctly falls back to `digit` (this is the fix).

## Validation
- Unit-tested the resolution logic across 6 scenarios (bomet-today, explicit employee KC, plain digit, root path) — all pass.
- `npm run build` of digit-ui-esbuild succeeds with the changes.
- Pending: live verification of employee password login + citizen Google SSO on a keycloak-enabled deployment.

Fixes egovernments/Citizen-Complaint-Resolution-System#769

🤖 Generated with [Claude Code](https://claude.com/claude-code)
