### PR TITLE
fix(configurator): MDMS record identity (UserValidation) + mobile-validation source

### DIFF
--- a/configurator/packages/data-provider/src/providers/dataProvider.ts
+++ b/configurator/packages/data-provider/src/providers/dataProvider.ts
@@ -41,7 +41,13 @@ function normalizeMdmsRecord(mdms: MdmsRecord, config: ResourceConfig): RaRecord
   }
   return {
     ...data,
-    id: extractId(data, config),
+    // Key by the MDMS uniqueIdentifier (genuinely unique per record) rather
+    // than data[idField]. When two records share the idField value (e.g. two
+    // UserValidation rows both fieldType "mobile"), data[idField] collapsed
+    // them to the same react-admin id, so every row opened the first record.
+    // uniqueIdentifier is always distinct; fall back to data[idField] only
+    // for legacy records that lack it.
+    id: mdms.uniqueIdentifier || extractId(data, config),
     _uniqueIdentifier: mdms.uniqueIdentifier,
     _isActive: mdms.isActive,
     _auditDetails: mdms.auditDetails,
@@ -163,9 +169,25 @@ async function boundaryGetList(client: DigitApiClient, config: ResourceConfig, t
     return flat;
   }
 
-  // Always fetch the session tenant's tree first.
-  const rootTrees = await client.boundaryRelationshipSearch(tenantId, 'ADMIN').catch(() => []);
-  const rootFlat = flattenTrees(rootTrees as Record<string, unknown>[]);
+  // Fetch the boundary tree for EVERY hierarchy type defined on the tenant —
+  // not just "ADMIN". Boundaries can be seeded under any hierarchy (e.g. Maputo
+  // uses "Divisão Administrativa", so an "ADMIN"-only query returned an empty
+  // tree and left the Boundary picker blank). Falls back to "ADMIN" when no
+  // hierarchy definitions are found.
+  async function flatForTenant(t: string): Promise<RaRecord[]> {
+    const hierarchies = await client.boundaryHierarchySearch(t).catch(() => []);
+    const hierarchyTypes = (hierarchies as Record<string, unknown>[])
+      .map((h) => (typeof h.hierarchyType === 'string' ? h.hierarchyType : ''))
+      .filter(Boolean);
+    const types = hierarchyTypes.length > 0 ? hierarchyTypes : ['ADMIN'];
+    const treeLists = await Promise.all(
+      types.map((ht) => client.boundaryRelationshipSearch(t, ht).catch(() => [])),
+    );
+    return treeLists.flatMap((trees) => flattenTrees(trees as Record<string, unknown>[]));
+  }
+
+  // Always fetch the session tenant's tree(s) first.
+  const rootFlat = await flatForTenant(tenantId);
 
   // When the session is at state level, aggregate city sub-tenants too — a
   // seeded BOMET tree at `ke` would otherwise hide NAIROBI_CITY at
@@ -178,25 +200,9 @@ async function boundaryGetList(client: DigitApiClient, config: ResourceConfig, t
       .map((r) => String(r.data.code));
 
     if (cityTenants.length > 0) {
-      const hierarchyChecks = await Promise.allSettled(
-        cityTenants.map((ct) => client.boundaryHierarchySearch(ct)),
-      );
-      const tenantsWithHierarchies = cityTenants.filter((_, i) => {
-        const result = hierarchyChecks[i];
-        return result.status === 'fulfilled' && Array.isArray(result.value) && result.value.length > 0;
-      });
-
-      if (tenantsWithHierarchies.length > 0) {
-        const cityResults = await Promise.all(
-          tenantsWithHierarchies.map((ct) =>
-            client.boundaryRelationshipSearch(ct, 'ADMIN').catch(() => []),
-          ),
-        );
-        const cityFlat = cityResults.flatMap((trees) =>
-          flattenTrees(trees as Record<string, unknown>[]),
-        );
-        return [...rootFlat, ...cityFlat];
-      }
+      const cityFlatLists = await Promise.all(cityTenants.map((ct) => flatForTenant(ct)));
+      const cityFlat = cityFlatLists.flat();
+      if (cityFlat.length > 0) return [...rootFlat, ...cityFlat];
     }
   }
 

--- a/configurator/packages/data-provider/src/providers/dataProvider.ts
+++ b/configurator/packages/data-provider/src/providers/dataProvider.ts
@@ -169,25 +169,9 @@ async function boundaryGetList(client: DigitApiClient, config: ResourceConfig, t
     return flat;
   }
 
-  // Fetch the boundary tree for EVERY hierarchy type defined on the tenant —
-  // not just "ADMIN". Boundaries can be seeded under any hierarchy (e.g. Maputo
-  // uses "Divisão Administrativa", so an "ADMIN"-only query returned an empty
-  // tree and left the Boundary picker blank). Falls back to "ADMIN" when no
-  // hierarchy definitions are found.
-  async function flatForTenant(t: string): Promise<RaRecord[]> {
-    const hierarchies = await client.boundaryHierarchySearch(t).catch(() => []);
-    const hierarchyTypes = (hierarchies as Record<string, unknown>[])
-      .map((h) => (typeof h.hierarchyType === 'string' ? h.hierarchyType : ''))
-      .filter(Boolean);
-    const types = hierarchyTypes.length > 0 ? hierarchyTypes : ['ADMIN'];
-    const treeLists = await Promise.all(
-      types.map((ht) => client.boundaryRelationshipSearch(t, ht).catch(() => [])),
-    );
-    return treeLists.flatMap((trees) => flattenTrees(trees as Record<string, unknown>[]));
-  }
-
-  // Always fetch the session tenant's tree(s) first.
-  const rootFlat = await flatForTenant(tenantId);
+  // Always fetch the session tenant's tree first.
+  const rootTrees = await client.boundaryRelationshipSearch(tenantId, 'ADMIN').catch(() => []);
+  const rootFlat = flattenTrees(rootTrees as Record<string, unknown>[]);
 
   // When the session is at state level, aggregate city sub-tenants too — a
   // seeded BOMET tree at `ke` would otherwise hide NAIROBI_CITY at
@@ -200,9 +184,25 @@ async function boundaryGetList(client: DigitApiClient, config: ResourceConfig, t
       .map((r) => String(r.data.code));
 
     if (cityTenants.length > 0) {
-      const cityFlatLists = await Promise.all(cityTenants.map((ct) => flatForTenant(ct)));
-      const cityFlat = cityFlatLists.flat();
-      if (cityFlat.length > 0) return [...rootFlat, ...cityFlat];
+      const hierarchyChecks = await Promise.allSettled(
+        cityTenants.map((ct) => client.boundaryHierarchySearch(ct)),
+      );
+      const tenantsWithHierarchies = cityTenants.filter((_, i) => {
+        const result = hierarchyChecks[i];
+        return result.status === 'fulfilled' && Array.isArray(result.value) && result.value.length > 0;
+      });
+
+      if (tenantsWithHierarchies.length > 0) {
+        const cityResults = await Promise.all(
+          tenantsWithHierarchies.map((ct) =>
+            client.boundaryRelationshipSearch(ct, 'ADMIN').catch(() => []),
+          ),
+        );
+        const cityFlat = cityResults.flatMap((trees) =>
+          flattenTrees(trees as Record<string, unknown>[]),
+        );
+        return [...rootFlat, ...cityFlat];
+      }
     }
   }
 

--- a/configurator/packages/data-provider/src/providers/resourceRegistry.ts
+++ b/configurator/packages/data-provider/src/providers/resourceRegistry.ts
@@ -115,7 +115,7 @@ export const REGISTRY: Record<string, ResourceConfig> = {
   // These get the same generic CRUD as the entries above; richer per-field widgets
   // are layered on later via src/admin/schemaDescriptors/ (Stage 1+).
   'theme-config':           { type: 'mdms', label: 'Theme Config',             schema: 'common-masters.ThemeConfig',               idField: 'code',              nameField: 'name' },
-  'user-validation':        { type: 'mdms', label: 'User Field Validation',    schema: 'common-masters.UserValidation',            idField: 'fieldType',         nameField: 'fieldType' },
+  'user-validation':        { type: 'mdms', label: 'User Field Validation',    schema: 'common-masters.UserValidation',            idField: 'zone',              nameField: 'zone' },
   'mobile-validation':      { type: 'mdms', label: 'Mobile Number Validation', schema: 'ValidationConfigs.mobileNumberValidation', idField: 'validationName',    nameField: 'validationName' },
   'tenant-boundary':        { type: 'mdms', label: 'Tenant Boundary (HRMS)',   schema: 'egov-location.TenantBoundary',             idField: 'hierarchyType.code', nameField: 'hierarchyType.code' },
   'auto-escalation-ignore': { type: 'mdms', label: 'Auto-Escalation Ignored',  schema: 'Workflow.AutoEscalationStatesToIgnore',    idField: 'businessService',   nameField: 'businessService' },

--- a/configurator/src/admin/hrms/useMobileValidator.ts
+++ b/configurator/src/admin/hrms/useMobileValidator.ts
@@ -29,11 +29,19 @@ function parseRules(record: Record<string, unknown> | undefined): MobileRules {
   if (!record) return FALLBACK;
   const raw = record.rules as Record<string, unknown> | undefined;
   if (!raw) return FALLBACK;
+  // common-masters.UserValidation keeps the dial-code under `attributes.prefix`
+  // (ValidationConfigs.mobileNumberValidation kept it under `rules.prefix`),
+  // so read attributes first and fall back to rules for the legacy shape.
+  const attributes = record.attributes as Record<string, unknown> | undefined;
+  const prefix =
+    typeof attributes?.prefix === 'string' ? attributes.prefix
+    : typeof raw.prefix === 'string' ? (raw.prefix as string)
+    : FALLBACK.prefix;
   return {
     pattern: typeof raw.pattern === 'string' ? raw.pattern : FALLBACK.pattern,
     minLength: typeof raw.minLength === 'number' ? raw.minLength : FALLBACK.minLength,
     maxLength: typeof raw.maxLength === 'number' ? raw.maxLength : FALLBACK.maxLength,
-    prefix: typeof raw.prefix === 'string' ? raw.prefix : FALLBACK.prefix,
+    prefix,
     errorMessage:
       typeof raw.errorMessage === 'string' && raw.errorMessage
         ? raw.errorMessage
@@ -48,19 +56,25 @@ export interface UseMobileValidatorResult {
 }
 
 export function useMobileValidator(): UseMobileValidatorResult {
-  const { data, isLoading } = useGetList('mobile-validation', {
-    pagination: { page: 1, perPage: 20 },
-    sort: { field: 'validationName', order: 'ASC' },
+  // Source: common-masters.UserValidation (the `user-validation` resource).
+  // Pick the record whose fieldType === 'mobile' (preferring an active default),
+  // and read its rules.
+  const { data, isLoading } = useGetList('user-validation', {
+    pagination: { page: 1, perPage: 50 },
+    sort: { field: 'fieldType', order: 'ASC' },
   });
 
   const rules = useMemo<MobileRules>(() => {
     if (!data || data.length === 0) return FALLBACK;
+    const mobileRecords = data.filter((r) => {
+      const rec = r as Record<string, unknown>;
+      return rec.fieldType === 'mobile' && rec.isActive !== false;
+    });
     const preferred =
-      data.find(
-        (r) =>
-          (r as Record<string, unknown>).validationName ===
-          'defaultMobileValidation',
-      ) ?? data[0];
+      mobileRecords.find((r) => (r as Record<string, unknown>).default === true) ??
+      mobileRecords[0] ??
+      null;
+    if (!preferred) return FALLBACK;
     return parseRules(preferred as Record<string, unknown>);
   }, [data]);
 

--- a/configurator/src/admin/schemaDescriptors/user-validation.ts
+++ b/configurator/src/admin/schemaDescriptors/user-validation.ts
@@ -16,7 +16,7 @@ import type { SchemaDescriptor } from './types';
 export const userValidationDescriptor: SchemaDescriptor = {
   schema: 'common-masters.UserValidation',
   groups: [
-    { title: 'Field', fields: ['fieldType', 'default', 'isActive'] },
+    { title: 'Field', fields: ['zone', 'fieldType', 'default', 'isActive'] },
     { title: 'Format rules', fields: [
       'attributes.prefix',
       'rules.pattern',
@@ -27,8 +27,10 @@ export const userValidationDescriptor: SchemaDescriptor = {
     ] },
   ],
   fields: [
+    { path: 'zone', widget: 'text', required: true,
+      help: 'Unique identifier for this validation record (e.g. the tenant/zone). This is the record\'s unique key.' },
     { path: 'fieldType', widget: 'text', required: true,
-      help: 'e.g. "mobile", "email". Becomes the record\'s unique identifier.' },
+      help: 'e.g. "mobile", "email". The kind of field this rule applies to (no longer the unique key).' },
     { path: 'default', widget: 'boolean',
       help: 'Mark this rule as the default for its fieldType.' },
     { path: 'isActive', widget: 'boolean' },


### PR DESCRIPTION
## What & why
Two related Configurator fixes around MDMS `common-masters.UserValidation`.

Closes #798

## Changes

### 1. MDMS record identity — "every row opens the first" (User Validation)
`common-masters.UserValidation` rows were keyed by `data[idField]` = `fieldType`; multiple records share `fieldType: "mobile"`, so they collapsed to one react-admin `id`.
- **`dataProvider.ts → normalizeMdmsRecord`**: key by **`mdms.uniqueIdentifier`** (falling back to `data[idField]` for legacy records). Makes rows individually addressable for **all** MDMS resources.
- **`resourceRegistry.ts`**: `user-validation` `idField`/`nameField` → **`zone`**.
- **`user-validation.ts` descriptor**: add the **`zone`** field + group; `fieldType` is no longer the unique key.

### 2. Employee mobile validation source
- **`useMobileValidator.ts`**: read from **`common-masters.UserValidation`** (`fieldType === 'mobile'`, preferring an active `default`), dial-code from `attributes.prefix`. Previously read `ValidationConfigs.mobileNumberValidation`, which was empty → hardcoded **Kenya** fallback that rejected Mozambique numbers.

## Commits
- `0ed0b16b64` — MDMS identity (`uniqueIdentifier`) + `zone` key
- `9a3b07d28a` — mobile validation reads `common-masters.UserValidation`
- `c68cf51a52` — split the boundary multi-hierarchy fetch out to its own PR

## Testing
- User Validation list: each row opens its own record; create/edit shows the **Zone** field.
- Employee Create: mobile field validates against the tenant's `common-masters.UserValidation` rule (no Kenya fallback) given a valid `mobile`/`default` record.

## Data prerequisites (not code)
- One valid `common-masters.UserValidation` `mobile` record with `default: true`, `rules.pattern: "^8[0-9]{8}$"` (min/max 9), `attributes.prefix: "+258"`. (Current `INDIA3`/`matupo` default is broken — flip/fix it.)
- Schema `common-masters.UserValidation`: make `zone` the `x-unique` key + declare `zone`/`default`/`isActive` — tracked in #795.

## Related
- #795 — schema `x-unique` → `zone`
- **#801 / #802 — boundary picker multi-hierarchy fetch (split out of this PR)**

## Deployment
`@digit-mcp/data-provider` is a `file:` package — rebuild its `dist` and redeploy. `dist` is gitignored.

## Not included
Local-dev-only files (`App.tsx` origin/proxy override, `vite.config.ts` proxy target/allowedHosts) are intentionally excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
