### PR TITLE
fix(configurator): boundary picker fetches all hierarchy types (not just ADMIN)

### DIFF
--- a/configurator/packages/data-provider/src/providers/dataProvider.ts
+++ b/configurator/packages/data-provider/src/providers/dataProvider.ts
@@ -163,9 +163,25 @@ async function boundaryGetList(client: DigitApiClient, config: ResourceConfig, t
     return flat;
   }
 
-  // Always fetch the session tenant's tree first.
-  const rootTrees = await client.boundaryRelationshipSearch(tenantId, 'ADMIN').catch(() => []);
-  const rootFlat = flattenTrees(rootTrees as Record<string, unknown>[]);
+  // Fetch the boundary tree for EVERY hierarchy type defined on the tenant —
+  // not just "ADMIN". Boundaries can be seeded under any hierarchy (e.g. Maputo
+  // uses "Divisão Administrativa", so an "ADMIN"-only query returned an empty
+  // tree and left the Boundary picker blank). Falls back to "ADMIN" when no
+  // hierarchy definitions are found.
+  async function flatForTenant(t: string): Promise<RaRecord[]> {
+    const hierarchies = await client.boundaryHierarchySearch(t).catch(() => []);
+    const hierarchyTypes = (hierarchies as Record<string, unknown>[])
+      .map((h) => (typeof h.hierarchyType === 'string' ? h.hierarchyType : ''))
+      .filter(Boolean);
+    const types = hierarchyTypes.length > 0 ? hierarchyTypes : ['ADMIN'];
+    const treeLists = await Promise.all(
+      types.map((ht) => client.boundaryRelationshipSearch(t, ht).catch(() => [])),
+    );
+    return treeLists.flatMap((trees) => flattenTrees(trees as Record<string, unknown>[]));
+  }
+
+  // Always fetch the session tenant's tree(s) first.
+  const rootFlat = await flatForTenant(tenantId);
 
   // When the session is at state level, aggregate city sub-tenants too — a
   // seeded BOMET tree at `ke` would otherwise hide NAIROBI_CITY at
@@ -178,25 +194,9 @@ async function boundaryGetList(client: DigitApiClient, config: ResourceConfig, t
       .map((r) => String(r.data.code));
 
     if (cityTenants.length > 0) {
-      const hierarchyChecks = await Promise.allSettled(
-        cityTenants.map((ct) => client.boundaryHierarchySearch(ct)),
-      );
-      const tenantsWithHierarchies = cityTenants.filter((_, i) => {
-        const result = hierarchyChecks[i];
-        return result.status === 'fulfilled' && Array.isArray(result.value) && result.value.length > 0;
-      });
-
-      if (tenantsWithHierarchies.length > 0) {
-        const cityResults = await Promise.all(
-          tenantsWithHierarchies.map((ct) =>
-            client.boundaryRelationshipSearch(ct, 'ADMIN').catch(() => []),
-          ),
-        );
-        const cityFlat = cityResults.flatMap((trees) =>
-          flattenTrees(trees as Record<string, unknown>[]),
-        );
-        return [...rootFlat, ...cityFlat];
-      }
+      const cityFlatLists = await Promise.all(cityTenants.map((ct) => flatForTenant(ct)));
+      const cityFlat = cityFlatLists.flat();
+      if (cityFlat.length > 0) return [...rootFlat, ...cityFlat];
     }
   }
 


### PR DESCRIPTION
﻿## What & why
The employee **Jurisdictions → Boundary** dropdown was always empty: `boundaryGetList` hardcoded `hierarchyType = 'ADMIN'` when fetching the boundary-relationship tree, but tenants like Maputo seed boundaries under `Divisão Administrativa` (ADMIN is an empty template) → 0 boundaries.

Closes #801

## Change
`configurator/packages/data-provider/src/providers/dataProvider.ts` — `boundaryGetList` now fetches the relationship tree for **every** hierarchy type the tenant defines (`boundaryHierarchySearch` -> per-hierarchy `boundaryRelationshipSearch`) and flattens them all; falls back to `ADMIN` only when none are defined. Applies to the session tenant and aggregated city sub-tenants.

## Testing
- Maputo (`Divisão Administrativa`): pick Hierarchy -> Boundary Type -> Boundary now populates (Município/Distrito/Bairro).
- ADMIN-only tenants unchanged.

## Deployment
`@digit-mcp/data-provider` is a `file:` package — rebuild `dist` + redeploy. `dist` is gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
