### PR TITLE
fix(hrms): pin egov-hrms image to 800-preview (clears user-enrichment regression)

### DIFF
--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -1092,12 +1092,24 @@ services:
   # HRMS Service - Employee management
   # ===========================================================================
   egov-hrms:
-    # digit-common-boundary: fixes CCRS#482 (custom password on employee
-    # create) + CCRS#484 (null tenantId on User object breaking MDMS
-    # mobile validation). EGOV_HRMS_DEV_MODE=true must be set so
-    # enrichUser() respects the password supplied in the request instead
-    # of overwriting with the default/auto-generated one.
-    image: registry.preview.egov.theflywheel.in/egovio/egov-hrms:digit-common-boundary-uuidlink
+    # 800-preview: adds the user-enrichment tenant fix (DIGIT-Common#70 /
+    # CCRS#800) on top of digit-common-boundary-uuidlink. With the prior
+    # image, /egov-hrms/employees/_search returned `"user": null` for
+    # every employee on multi-tenant deploys — HRMS was sending the
+    # state-stripped tenant (`ke`) to egov-user while EMPLOYEE rows
+    # actually live at the city tenant (`ke.bomet`), so the SQL WHERE
+    # missed every row. Drop this back to a canonical
+    # `digit-common-boundary-uuidlink-<post-fix>` tag once DIGIT-Common#70
+    # merges and a follow-up build is published.
+    #
+    # Previous lineage notes (still in this image):
+    # - CCRS#482: custom password on employee create
+    # - CCRS#484: null tenantId on User object breaking MDMS mobile
+    #   validation
+    # EGOV_HRMS_DEV_MODE=true must be set so enrichUser() respects the
+    # password supplied in the request instead of overwriting with the
+    # default/auto-generated one.
+    image: registry.preview.egov.theflywheel.in/egovio/egov-hrms:800-preview
     container_name: egov-hrms
     depends_on:
       pgbouncer:


### PR DESCRIPTION
## Summary

Pins `egov-hrms` to `registry.preview.egov.theflywheel.in/egovio/egov-hrms:800-preview` to clear the user-enrichment regression that's blanking Name/Mobile in the Configurator's Employee Management list (#800).

## Why

The previous image (`digit-common-boundary-uuidlink`) carries a regression introduced in `cb666091 fix(hrms): null-safety for employee create and search user join` (2026-02-27): `EmployeeService.search` switched the user-enrichment search from `criteria.getTenantId()` to `stateLevelTenantId`, sending the *state-stripped* tenant (`ke`) to egov-user. But `UserUtils.getStateLevelTenantForCitizen` only strips for CITIZEN — EMPLOYEE rows live at the *city* tenant (`ke.bomet`, `mz.maputo`). So egov-user's `WHERE userdata.tenantid = 'ke'` matches nothing, HRMS gets an empty user list, and stamps `user: null` on every employee.

Live repro from bomet logs:
```
HRMS log: uuid is available {tenantId=ke, uuid=[49b9571a-...]}
direct /user/_search tenantId=ke,       uuid=[...] → 0 users
direct /user/_search tenantId=ke.bomet, uuid=[...] → 1 user (full payload, "Chakshu-02")
```

## What's in `800-preview`

Two deltas over the previously-deployed `digit-common-boundary-uuidlink`:

1. **`b56c3d67` (fix #800)** — captures the original city tenant in a local before the `criteria.setTenantId(null)` mutation, uses it at the user-enrichment search step. Three-line behavior change. Upstream PR: egovernments/DIGIT-Common#70.
2. **`01e5e2d5` (uuid-link)** — feature that landed 26 minutes after the previous image was built: HRMS short-circuits to "link to existing user" when the caller supplies `employee.user.uuid`, instead of trying to create a fresh user (which would trip `DuplicateUserName` and cascade into PGR `DEPARTMENT_NOT_FOUND`).

No mobile-validation change — the `@Pattern` removal (`399be63b`) is already in both images; HRMS continues to delegate format validation to egov-user/MDMS.

## Test plan

- [x] Image built on egov-ci, pushed to `10.0.0.4:5000/egovio/egov-hrms:800-preview`, publicly pullable through the preview proxy
- [x] Live bomet `/egov-hrms/employees/_search` repro confirmed: every employee `user: null` on the previous image
- [ ] After deploy: `_search` returns each employee's full `user` object (name, mobile, roles, etc.)
- [ ] PGR `assign` dropdown re-populates with employee names
- [ ] Existing create / search / update flows stay green
- [ ] After merge: next clean `./deploy.sh bomet` pulls `800-preview` directly from upstream

## Refs

- Fixes #800 (P0 blocker — Configurator Employee Management list)
- Upstream HRMS code change: egovernments/DIGIT-Common#70

🤖 Generated with [Claude Code](https://claude.com/claude-code)
