### PR TITLE
fix(integration-tests): serve dashboards at /tests (match naipepea), align runner API

### DIFF
--- a/local-setup/ansible/files/integration-tests-build.sh
+++ b/local-setup/ansible/files/integration-tests-build.sh
@@ -10,12 +10,12 @@
 #
 # Usage: integration-tests-build.sh <integration_tests_dir> <dashboard_base>
 #   <integration_tests_dir>  absolute path to the vendored tests/integration-tests
-#   <dashboard_base>         vite base for the react-admin build (e.g. /integration-tests-v2/)
+#   <dashboard_base>         vite base for the react-admin build (e.g. /tests-v2/)
 #   prints the integration-tests source dir on the last line (playbook captures it).
 set -uo pipefail
 
 IT_DIR="$1"
-DASHBOARD_BASE="${2:-/integration-tests-v2/}"
+DASHBOARD_BASE="${2:-/tests-v2/}"
 NEED_NODE="20.0.0"
 
 command -v npm >/dev/null 2>&1 || { echo "ERROR: npm not on PATH (need Node >= $NEED_NODE)" >&2; exit 1; }

--- a/local-setup/ansible/inventory/host_vars/_example.yml
+++ b/local-setup/ansible/inventory/host_vars/_example.yml
@@ -154,14 +154,14 @@ digit_ui_v2_branch: "feat/digit-ui-v2-keycloak"
 
 # digit-integration-tests dashboards. Builds the react-admin catalog dashboard
 # from the VENDORED in-tree source (tests/integration-tests/) and serves both
-# the vanilla (/integration-tests/) and react-admin (/integration-tests-v2/)
+# the vanilla (/tests/) and react-admin (/tests-v2/)
 # dashboards from /var/www. The deploy only SERVES them — catalog.json + runs/
 # are produced out-of-band by a test runner (`make publish` from
 # tests/integration-tests/). Pair with `nginx_features.integration_tests: true`
 # below (ignored on hosts with nginx_preserve_vhost — wire those by hand from
 # tests/integration-tests/deploy/nginx-integration-tests.conf).
 enable_integration_tests: false
-integration_tests_dashboard_base: "/integration-tests-v2/"
+integration_tests_dashboard_base: "/tests-v2/"
 integration_tests_basic_auth_user: "digit-tests"
 # Set in vault (never commit a real password). The htpasswd task skips if unset.
 # integration_tests_basic_auth_password: "{{ vault_integration_tests_password }}"
@@ -170,7 +170,7 @@ integration_tests_basic_auth_user: "digit-tests"
 # Playwright run (writes results back into /var/www/integration-tests). Requires
 # enable_integration_tests: true (it serves on the same vhost) AND
 # nginx_features.integration_tests_runner: true below. The API is proxied at
-# /integration-tests/api/ behind the SAME basic-auth as the dashboards.
+# /tests/api/ behind the SAME basic-auth as the dashboards.
 # NOTE: a run is CPU/RAM heavy and shares the box with the live DIGIT stack
 # (it's nice'd, but still). Leave off unless you want in-dashboard runs.
 enable_integration_tests_runner: false
@@ -303,8 +303,8 @@ nginx_features:
   mcp: true                  # /mcp + /v1/* — MCP HTTP transport + REST shim (requires enable_mcp: true)
   keycloak: false            # /auth/ + /token-exchange/ — requires enable_keycloak: true
   digit_ui_v2: false         # /citizen/ — Vite + React 19 SPA (requires enable_digit_ui_v2: true)
-  integration_tests: false   # /integration-tests/ + -v2/ — test dashboards (requires enable_integration_tests: true)
-  integration_tests_runner: false  # /integration-tests/api/ — RUN-button daemon proxy (requires enable_integration_tests_runner: true)
+  integration_tests: false   # /tests/ + -v2/ — test dashboards (requires enable_integration_tests: true)
+  integration_tests_runner: false  # /tests/api/ — RUN-button daemon proxy (requires enable_integration_tests_runner: true)
 
 # If true, the playbook will NOT render `templates/nginx-site.conf.j2` into
 # /etc/nginx/sites-available/ and will NOT touch /etc/nginx/sites-enabled/.

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -1314,7 +1314,7 @@
       ansible.builtin.command: >-
         bash {{ playbook_dir }}/files/integration-tests-build.sh
         "{{ integration_tests_src | default(playbook_dir ~ '/../../tests/integration-tests') }}"
-        "{{ integration_tests_dashboard_base | default('/integration-tests-v2/') }}"
+        "{{ integration_tests_dashboard_base | default('/tests-v2/') }}"
       register: it_build
       changed_when: true
       when: enable_integration_tests | default(false)
@@ -1411,7 +1411,7 @@
 
     # ---- RUN button: on-box test-runner daemon (opt-in: enable_integration_tests_runner) ----
     # Backs the "Run tests" button on the v2 dashboard. Loopback-only Node
-    # service; nginx (/integration-tests/api/, nginx_features.integration_tests_runner)
+    # service; nginx (/tests/api/, nginx_features.integration_tests_runner)
     # is the auth front. Requires the dashboards block above (needs
     # integration_tests_dir). A run is heavy and shares the box with the live
     # stack, so this stays opt-in and nice'd. Linux only.

--- a/local-setup/ansible/templates/integration-tests-runner.service.j2
+++ b/local-setup/ansible/templates/integration-tests-runner.service.j2
@@ -1,6 +1,6 @@
 # test-runner daemon — backs the RUN button on the integration-tests dashboard.
 # Rendered by the playbook when enable_integration_tests_runner: true.
-# Loopback-only; nginx (/integration-tests/api/) is the auth front.
+# Loopback-only; nginx (/tests/api/) is the auth front.
 [Unit]
 Description=DIGIT integration-tests runner (RUN button backend)
 After=network.target

--- a/local-setup/ansible/templates/nginx-site.conf.j2
+++ b/local-setup/ansible/templates/nginx-site.conf.j2
@@ -68,34 +68,34 @@ server {
 {% endif %}
 {% if nginx_features.integration_tests | default(false) %}
   # digit-integration-tests dashboards — vanilla catalog SPA at
-  # /integration-tests/ and the react-admin rebuild at /integration-tests-v2/.
-  # Built from the vendored tests/integration-tests/ source and synced to
-  # /var/www/integration-tests{,-v2}/ by the deploy. Behind basic-auth
-  # (/etc/nginx/.htpasswd-tests, created by the playbook). catalog.json + runs/
-  # are produced out-of-band by a test runner (make publish), not the deploy.
-  location = /integration-tests    { return 301 /integration-tests/; }
-  location = /integration-tests-v2 { return 301 /integration-tests-v2/; }
-  location /integration-tests/ {
+  # /tests/ and the react-admin rebuild at /tests-v2/ (matches naipepea's
+  # route convention). Built from the vendored tests/integration-tests/ source
+  # and synced to /var/www/integration-tests{,-v2}/ by the deploy. Behind
+  # basic-auth (/etc/nginx/.htpasswd-tests, created by the playbook).
+  # catalog.json + runs/ are produced out-of-band by a test runner, not the deploy.
+  location = /tests    { return 301 /tests/; }
+  location = /tests-v2 { return 301 /tests-v2/; }
+  location /tests/ {
     alias /var/www/integration-tests/;
     auth_basic "DIGIT integration tests";
     auth_basic_user_file /etc/nginx/.htpasswd-tests;
     add_header Cache-Control "no-cache, must-revalidate" always;
     try_files $uri $uri/ $uri/index.html =404;
   }
-  location /integration-tests-v2/ {
+  location /tests-v2/ {
     alias /var/www/integration-tests-v2/;
     auth_basic "DIGIT integration tests";
     auth_basic_user_file /etc/nginx/.htpasswd-tests;
     add_header Cache-Control "no-cache, must-revalidate" always;
-    try_files $uri $uri/ /integration-tests-v2/index.html =404;
+    try_files $uri $uri/ /tests-v2/index.html =404;
   }
 {% if nginx_features.integration_tests_runner | default(false) %}
   # RUN button → on-box test-runner daemon (loopback only; nginx is the auth).
   # SAME realm string as the dashboards above so the browser reuses the already-
   # entered basic-auth creds for the API calls. Longest-prefix match means this
-  # wins over /integration-tests/ for /integration-tests/api/*. Long read-timeout
+  # wins over /tests/ for /tests/api/*. Long read-timeout
   # + buffering off so /run/<id>/log can stream a live console.
-  location /integration-tests/api/ {
+  location /tests/api/ {
     auth_basic "DIGIT integration tests";
     auth_basic_user_file /etc/nginx/.htpasswd-tests;
     proxy_pass http://127.0.0.1:{{ integration_tests_runner_port | default(8181) }}/;

--- a/tests/integration-tests/dashboard-react-admin/src/RunButton.tsx
+++ b/tests/integration-tests/dashboard-react-admin/src/RunButton.tsx
@@ -1,6 +1,6 @@
 /**
  * RunButton — triggers an on-box Playwright run via the test-runner daemon and
- * reflects its progress. The daemon sits behind nginx at /integration-tests/api/
+ * reflects its progress. The daemon sits behind nginx at /tests/api/
  * under the SAME basic-auth as the dashboard, so `credentials: 'include'` reuses
  * the creds the browser already has — no separate login.
  *
@@ -16,7 +16,7 @@ import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import HourglassTopIcon from '@mui/icons-material/HourglassTop';
 import { refreshCatalog } from './dataProvider';
 
-const API_BASE = (import.meta.env.VITE_RUNNER_API_BASE as string) || '/integration-tests/api';
+const API_BASE = (import.meta.env.VITE_RUNNER_API_BASE as string) || '/tests/api';
 const POLL_MS = 10_000;
 
 type Current =

--- a/tests/integration-tests/deploy/README.md
+++ b/tests/integration-tests/deploy/README.md
@@ -11,8 +11,8 @@ client against the live API — no in-place changes to bomet's containers.
 
 ```
 /opt/integration-tests/
-├── dist/          # vanilla dashboard + catalog.json + history.json + runs/   → /integration-tests/
-└── dist-v2/       # react-admin build; catalog.json/history.json/runs symlinked to ../dist/ → /integration-tests-v2/
+├── dist/          # vanilla dashboard + catalog.json + history.json + runs/   → /tests/
+└── dist-v2/       # react-admin build; catalog.json/history.json/runs symlinked to ../dist/ → /tests-v2/
 ```
 
 ## One-time box setup
@@ -50,8 +50,8 @@ ssh bomet '
 | `LOCALITY_CODE` | NAIROBI_CITY_VIWANDANI | BOMET_BOMET_CENTRAL_CHESOEN | `bomet.env` |
 | `SERVICE_CODE` | IllegalConstruction | RudeBehavior (exists on bomet) | `bomet.env` |
 | `HOST_DIR` | /var/www/tests | /opt/integration-tests/dist | `bomet.env` |
-| `DASHBOARD_BASE` | /tests-v2/ | /integration-tests-v2/ | `bomet.env` |
-| nginx path | /tests/, /tests-v2/ | /integration-tests/, /integration-tests-v2/ | `nginx-integration-tests.conf` |
+| `DASHBOARD_BASE` | /tests-v2/ | **same** (/tests-v2/) | `bomet.env` |
+| nginx path | /tests/, /tests-v2/ | **same** (/tests/, /tests-v2/) | `nginx-integration-tests.conf` |
 | persona users | BOMET_LME etc. | **same** | already default in `tests/utils/env.ts` |
 
 Specs `enc-key-drift-622` (skipped), `boundary-jurisdiction-496`, and the

--- a/tests/integration-tests/deploy/bomet.env
+++ b/tests/integration-tests/deploy/bomet.env
@@ -42,6 +42,6 @@ export HOST_DIR=/opt/integration-tests/dist          # vanilla dashboard + catal
 export BRANCH=feat/bomet-integration-deploy
 
 # ── React-admin (v2) dashboard build base ─────────────────────────────────────
-# Served at /integration-tests-v2/ on the bomet vhost.
-export DASHBOARD_BASE=/integration-tests-v2/
+# Served at /tests-v2/ on the bomet vhost.
+export DASHBOARD_BASE=/tests-v2/
 export TESTS_PROXY_TARGET=https://bometfeedbackhub.digit.org

--- a/tests/integration-tests/deploy/nginx-integration-tests.conf
+++ b/tests/integration-tests/deploy/nginx-integration-tests.conf
@@ -14,7 +14,7 @@
 #   sudo htpasswd -c /etc/nginx/.htpasswd-tests digit-tests
 
 # Vanilla test catalog dashboard + per-run Playwright reports
-location /integration-tests/ {
+location /tests/ {
   alias /opt/integration-tests/dist/;
   autoindex off;
   auth_basic "DIGIT integration tests";
@@ -24,20 +24,20 @@ location /integration-tests/ {
 }
 
 # React-admin dashboard rebuild (v2) — reads the same catalog.json
-location /integration-tests-v2/ {
+location /tests-v2/ {
   alias /opt/integration-tests/dist-v2/;
   autoindex off;
   auth_basic "DIGIT integration tests";
   auth_basic_user_file /etc/nginx/.htpasswd-tests;
   add_header Cache-Control "no-cache, must-revalidate" always;
-  try_files $uri $uri/ /integration-tests-v2/index.html =404;
+  try_files $uri $uri/ /tests-v2/index.html =404;
 }
 
 # RUN button → on-box test-runner daemon (runner/server.mjs on 127.0.0.1:8181).
 # SAME basic-auth realm as the dashboards so the browser reuses the creds.
-# Longest-prefix match wins over /integration-tests/. Only add this if the
+# Longest-prefix match wins over /tests/. Only add this if the
 # test-runner systemd service is installed on this box.
-location /integration-tests/api/ {
+location /tests/api/ {
   auth_basic "DIGIT integration tests";
   auth_basic_user_file /etc/nginx/.htpasswd-tests;
   proxy_pass http://127.0.0.1:8181/;

--- a/tests/integration-tests/runner/server.mjs
+++ b/tests/integration-tests/runner/server.mjs
@@ -5,12 +5,12 @@
  * The dashboards are static files served by nginx; nothing in the browser can
  * start Playwright or write into the webroot. This tiny HTTP service does, and
  * NOTHING ELSE. It is deliberately dependency-free (Node core only) and bound
- * to loopback — nginx proxies `/integration-tests/api/` to it WITH the existing
+ * to loopback — nginx proxies `/tests/api/` to it WITH the existing
  * basic-auth (digit-tests / .htpasswd-tests), so auth is enforced by nginx, not
  * re-implemented here. The loopback bind + remote-addr guard below make sure the
  * daemon can't be reached around nginx.
  *
- * Endpoints (all relative to the proxied /integration-tests/api/):
+ * Endpoints (all relative to the proxied /tests/api/):
  *   POST /run            → 202 {run_id} | 409 {running, run_id}   (single-flight)
  *   GET  /run/current    → {state, run_id, started_at, phase, exit_code}
  *   GET  /run/:id/log    → text/plain, current contents of that run's run.log


### PR DESCRIPTION
## Why

The integration-tests dashboards + RUN-button runner were canonicalized on `/integration-tests/` when the bomet setup was first codified into ansible (#717). **naipepea — the incumbent deployment — serves them at `/tests/` + `/tests-v2/`.** That divergence is exactly why the route "isn't enabled" on bomet for anyone used to naipepea's URL (e.g. the recent thread hitting `bometfeedbackhub.digit.org/tests` → 404, while `/integration-tests/` → 200).

This reverts the **web-facing route** back to naipepea's convention so all boxes + the ansible canonical agree.

## What changed (URL-only)

| before | after |
|---|---|
| `/integration-tests/` | `/tests/` |
| `/integration-tests-v2/` | `/tests-v2/` |
| `/integration-tests/api/` (runner) | `/tests/api/` |

**Deliberately unchanged** (nginx `alias` decouples URL from dir, so the rename is surgical):
- vendored source dir `tests/integration-tests/`
- on-box install/webroot dirs `/opt/integration-tests/*`, `/var/www/integration-tests*`
- ansible var/unit names (`enable_integration_tests`, `nginx_features.integration_tests`, `integration-tests-runner.service`)

## Runner placement

The `/tests/api/` nginx block keeps the trailing-slash `proxy_pass` (strips the prefix to the loopback daemon), and `RunButton.tsx`'s `API_BASE` default tracks the new path — so the RUN button, the nginx proxy, and the daemon stay consistent.

## Files
`nginx-site.conf.j2`, `deploy/nginx-integration-tests.conf`, playbook `dashboard_base` default, `integration-tests-build.sh` default, `_example.yml` (base + docs), `bomet.env`, `RunButton.tsx`, `runner/server.mjs` docs, `runner.service.j2` doc, `deploy/README.md`.

## Validation
- [ ] ovh: deploy with `enable_integration_tests: true` + `nginx_features.integration_tests: true`; confirm `/tests/` + `/tests-v2/` serve 200 (basic-auth) and `/integration-tests/` no longer routes.
- [ ] With the runner enabled, confirm `/tests/api/run` → 202 and the RUN button drives a run.

## Notes
- This standardizes the **code** on `/tests`; naipepea's live box already matches. bomet's live serving (hand-wired at `/integration-tests/` since June 1) will switch to `/tests/` on the next converge once its host_vars + hand-wired vhost are updated — tracked separately.
- The #713 acceptance-criteria text says `/digit-integration-tests`; I'll update the issue to `/tests` to match reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)