### PR TITLE
fix(globalConfigs): per-surface CITIZEN_/EMPLOYEE_AUTH_PROVIDER so legacy citizen login stays OTP under Keycloak (#809)

### DIFF
--- a/local-setup/ansible/inventory/host_vars/_example.yml
+++ b/local-setup/ansible/inventory/host_vars/_example.yml
@@ -254,6 +254,16 @@ enable_keycloak: false
 # verified a successful test login via /auth/realms/<realm>/account.
 auth_provider: ""
 
+# Per-surface override (digit-ui-esbuild resolves these post-#793):
+#   citizen surface  -> citizen_auth_provider  || auth_provider || 'digit'
+#   employee surface -> employee_auth_provider || 'digit'  (never inherits auth_provider)
+# Use these when Keycloak SSO ("Continue with Google") should live ONLY on the
+# separate digit-ui-v2 (/citizen) surface while the legacy esbuild citizen login
+# stays on OTP — e.g. bomet sets `citizen_auth_provider: digit` with
+# `auth_provider: keycloak` (issue #809). Leave unset to inherit the defaults above.
+# citizen_auth_provider: ""
+# employee_auth_provider: ""
+
 # OIDC public client id in the per-tenant realm. The realm template
 # ships `digit-ui`; only change this if you've forked the template
 # and added a different client.

--- a/local-setup/ansible/templates/globalConfigs.js.j2
+++ b/local-setup/ansible/templates/globalConfigs.js.j2
@@ -32,6 +32,15 @@ var globalConfigs = (function () {
   var hrmsContext = {{ hrms_context | to_json }};
   var invalidEmployeeRoles = {{ invalid_employee_roles | to_json }};
   var authProvider = {{ auth_provider | to_json }};
+  // Per-surface auth provider (digit-ui-esbuild reads these post-#793):
+  //   citizen surface  -> CITIZEN_AUTH_PROVIDER || AUTH_PROVIDER || "digit"
+  //   employee surface -> EMPLOYEE_AUTH_PROVIDER || "digit"  (never inherits AUTH_PROVIDER)
+  // Pin `citizen_auth_provider: digit` in host_vars when Keycloak SSO is only
+  // wanted on the separate digit-ui-v2 (/citizen) surface and the legacy
+  // esbuild citizen login must stay on OTP (see issue #809). Defaults preserve
+  // existing behaviour: citizen inherits auth_provider, employee stays digit.
+  var citizenAuthProvider = {{ (citizen_auth_provider | default(auth_provider)) | to_json }};
+  var employeeAuthProvider = {{ (employee_auth_provider | default('digit')) | to_json }};
   var pgrBoundaryHighestLevel = {{ pgr_boundary_highest_level | to_json }};
   var pgrBoundaryLowestLevel = {{ pgr_boundary_lowest_level | to_json }};
   var boundaryType = {{ boundary_type | to_json }};
@@ -95,6 +104,10 @@ var globalConfigs = (function () {
       return hrmsContext;
     } else if (key === "AUTH_PROVIDER") {
       return authProvider;
+    } else if (key === "CITIZEN_AUTH_PROVIDER") {
+      return citizenAuthProvider;
+    } else if (key === "EMPLOYEE_AUTH_PROVIDER") {
+      return employeeAuthProvider;
     } else if (key === "INVALIDROLES") {
       return invalidEmployeeRoles;
     } else if (key === "PGR_BOUNDARY_HIGHEST_LEVEL") {


### PR DESCRIPTION
## Problem

Issue #809: citizens can't log in with the default OTP on bomet's **legacy** UI (`/digit-ui/citizen/login`).

PR #793 taught `digit-ui-esbuild` to resolve auth **per surface**:

- citizen → `CITIZEN_AUTH_PROVIDER || AUTH_PROVIDER || "digit"`
- employee → `EMPLOYEE_AUTH_PROVIDER || "digit"` (never inherits `AUTH_PROVIDER`)

…but the ansible `globalConfigs.js` template was never updated — it still only emits `AUTH_PROVIDER`. So on a Keycloak deployment (bomet: `auth_provider: keycloak`, for the citizen "Continue with Google" flow that lives in the **separate** `digit-ui-v2` `/citizen` surface), the **legacy esbuild citizen** login inherited `authProvider=keycloak` and routed its OTP/oauth calls through the `/kc` token-exchange. That endpoint (KC realm `ke`) currently 500s, so default-OTP login was dead. #793 fixed the employee surface; this completes it on the deploy side for citizen.

## Fix

Render the two per-surface keys from optional host_vars, faithful to the bundle's own defaults so **existing tenants are unaffected**:

- `citizenAuthProvider`  ← `citizen_auth_provider | default(auth_provider)`
- `employeeAuthProvider` ← `employee_auth_provider | default('digit')`

and expose `CITIZEN_AUTH_PROVIDER` / `EMPLOYEE_AUTH_PROVIDER` via `getConfig`.

A tenant wanting Keycloak SSO **only** on the `digit-ui-v2` `/citizen` surface, with the legacy esbuild citizen login on OTP, sets `citizen_auth_provider: digit` alongside `auth_provider: keycloak` — documented in `_example.yml`. This is bomet's config.

Defaults preserve current behaviour: unset → citizen inherits `auth_provider`, employee stays `digit`.

## Validation

Applied the rendered config live on `bometfeedbackhub.digit.org` and logged in through the **UI** with the default OTP (`123456`):

- `POST /user-otp/v1/_send?tenantId=ke` → **200** (direct DIGIT path, not `/kc`)
- `POST /user/oauth/token` → **200**
- lands on `/digit-ui/citizen/all-services` (File a Complaint / My Complaints)

No `/kc/*` routing in the network trace.

Fixes #809

🤖 Generated with [Claude Code](https://claude.com/claude-code)