### PR TITLE
fix(digit-mcp): tenant-bootstrap mobile-rule tsc fix + public ghcr image

### DIFF
--- a/digit-mcp/src/tools/mdms-tenant.ts
+++ b/digit-mcp/src/tools/mdms-tenant.ts
@@ -984,10 +984,11 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
           const mob = (uv || []).find(
             (r: any) => (r && r.data && r.data.fieldType === 'mobile') || (r && r.uniqueIdentifier === 'mobile'),
           );
-          if (mob && mob.data && mob.data.rules && mob.data.rules.pattern) {
-            (args as any).mobile_regex = mob.data.rules.pattern;
-            if (!args.mobile_length && mob.data.rules.minLength) {
-              (args as any).mobile_length = mob.data.rules.minLength;
+          const rules = (mob && mob.data && (mob.data as any).rules) as any;
+          if (rules && rules.pattern) {
+            (args as any).mobile_regex = rules.pattern;
+            if (!args.mobile_length && rules.minLength) {
+              (args as any).mobile_length = rules.minLength;
             }
           }
         } catch (e) {

--- a/local-setup/.gitignore
+++ b/local-setup/.gitignore
@@ -17,6 +17,10 @@
 build/
 dist/
 
+# Playwright e2e run artifacts (outputDir in tests/e2e/playwright.config.ts)
+tests/e2e/test-results/
+tests/e2e/playwright-report/
+
 # Dependencies
 node_modules/
 

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -1477,8 +1477,10 @@ services:
       - egov-network
 
   # ==================== DIGIT MCP Server ====================
-  # The MCP image is built off CCRS and lives in a private VPC registry
-  # (10.0.0.4:5000). Hosts outside the Hetzner egov VPC can't pull it.
+  # The MCP image is built off CCRS. Deploys inside the Hetzner egov VPC
+  # pull it from the private registry (10.0.0.4:5000); standalone/public
+  # boxes fall back to the pinned public build on ghcr.io (see the
+  # digit-mcp `image:` line below).
   # Both services are tagged `mcp` so they only start when the operator
   # explicitly opts in (`COMPOSE_PROFILES=mcp docker compose up`). On a
   # fresh public-internet box, the default deploy skips them entirely —
@@ -1507,10 +1509,11 @@ services:
     # MCP image source resolved at deploy time. The Ansible playbook
     # writes MCP_IMAGE={{ docker_registry }}/digit-mcp:latest into the
     # .env it generates per tenant (so compose picks it up here).
-    # When running compose directly without the playbook, export
-    # MCP_IMAGE yourself — there's no built-in fallback because the
-    # right registry depends on the operator's network.
-    image: ${MCP_IMAGE}
+    # When running compose directly without the playbook, the fallback
+    # below pulls a public, pinned build from ghcr.io — no VPC access or
+    # insecure-registries trust required. Override MCP_IMAGE to use a
+    # different registry/tag.
+    image: ${MCP_IMAGE:-ghcr.io/subhashini-egov/digit-mcp:2026-06-10}
     container_name: digit-mcp
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
## Summary
- **fix(digit-mcp):** read the MDMS mobile validation record's `rules` via a single cast instead of chaining typed property access on `mob.data` (the data-provider type shape doesn't declare `rules`), so `tsc` compiles cleanly. Same regex/length inheritance behaviour as before.
- **compose:** pin a public ghcr.io fallback for the `digit-mcp` service so standalone/public boxes can pull a fixed build without VPC access — `image: ${MCP_IMAGE:-ghcr.io/subhashini-egov/digit-mcp:2026-06-10}` (the `MCP_IMAGE` override still wins for in-VPC deploys). Stale "can't pull outside the VPC" comment corrected.
- **chore:** gitignore Playwright e2e run artifacts (`tests/e2e/test-results/`, `playwright-report/`).

## Image
Built from this branch's source and published publicly:
- `ghcr.io/subhashini-egov/digit-mcp:2026-06-10` and `:latest` (digest `sha256:9cb76718878ed57d2194cd75e2c2561e88dc34957eebd23e335f401a6c6708c6`)
- Package visibility **public**; verified anonymously pullable (anon registry token → manifest HTTP 200). The compose pin references the matching `:2026-06-10` tag.

## Verification
- `npm run build` in `digit-mcp/` → clean tsc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)