### PR TITLE
fix(pgr-inbox): enable SLA sort and show full complaint number (#432)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/configs/PGRSearchInboxConfig.js
+++ b/digit-ui-esbuild/products/pgr/src/configs/PGRSearchInboxConfig.js
@@ -101,6 +101,12 @@ const PGRSearchInboxConfig = () => {
                             key: "complaintNumber",
                             additionalCustomization: true,
                             disableSortBy: true,
+                            // #432.4: react-data-table ellipsis-truncates the
+                            // full serviceRequestId by default. wrap lets the
+                            // complaint number render in full; minWidth keeps
+                            // the column from collapsing too narrow.
+                            wrap: true,
+                            minWidth: "180px",
                         },
                         {
                             label: "WF_INBOX_HEADER_LOCALITY",
@@ -125,10 +131,14 @@ const PGRSearchInboxConfig = () => {
                             jsonPath: "businessObject.serviceSla",
                             additionalCustomization: true,
                             key: "state",
-                            // SLA sort would also need pgr-services to accept
-                            // `sortBy=serviceSla` — currently rejects with
-                            // typeMismatch. Tracked in the issue.
-                            disableSortBy: true,
+                            // #432.2: SLA sort is CLIENT-SIDE via react-data-table's
+                            // sortFunction (pgr-services' SortBy enum doesn't accept
+                            // `sortBy=serviceSla`, so we can't sort server-side).
+                            // NOTE: this only reorders rows on the CURRENT page —
+                            // it does not re-sort across the full paginated result set.
+                            sortFunction: (a, b) =>
+                                (a?.businessObject?.serviceSla ?? -Infinity) -
+                                (b?.businessObject?.serviceSla ?? -Infinity),
                         },
                     ],
                     enableGlobalSearch: false,


### PR DESCRIPTION
## What
Two display fixes in the employee **Search Complaint** inbox (`digit-ui-esbuild/products/pgr/src/configs/PGRSearchInboxConfig.js`), addressing parts of #432:

1. **SLA sort** — the `SLA (Days Remaining)` column was `disableSortBy: true` with no comparator, so clicking it did nothing. Sorting in this table is **client-side** (`react-data-table` `sortFunction`), so the fix removes the flag and adds a null-safe numeric comparator on `businessObject.serviceSla`.
2. **Full complaint number** — the `Complaint No` column had no `wrap`, so the full `serviceRequestId` was ellipsis-truncated. Added `wrap: true` (+ minWidth) so it renders in full.

## Validation
Built from this branch and run against a live PGR backend: the SLA header now shows a sort arrow and rows reorder bidirectionally; complaint numbers display in full (wrap to two lines).

## Scope / notes
- Config-only, no behavior change outside the inbox table. No auth/login impact.
- Does **not** address #432's status-filter item (workflow-state vs `applicationStatus` vocabulary) — that needs live-tenant data and is tracked separately.
- Client sort reorders the current page only (noted in a code comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)