### PR TITLE
fix(login): render readable error toast instead of raw localization key (#443)

### DIFF
--- a/digit-ui-esbuild/packages/modules/core/src/pages/employee/Login/login.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/employee/Login/login.js
@@ -500,7 +500,12 @@ const Login = ({ config: propsConfig, t, isDisabled, loginOTPBased }) => {
         </div>
       </V2Card>
       {showToast ? (
-        <Toast type="error" label={t(showToast)} onClose={() => setShowToast(null)} />
+        // #443.8: route the toast label through the same key→fallback helper
+        // the labels use (tr), so an unseeded localization key renders a
+        // readable string instead of the raw key. Many toast values here are
+        // already human-readable (e.g. server error_description), so fall back
+        // to the value itself rather than to the key.
+        <Toast type="error" label={tr(showToast, showToast)} onClose={() => setShowToast(null)} />
       ) : null}
     </V2LoginShell>
   );


### PR DESCRIPTION
## What
On the employee login screen (`digit-ui-esbuild/packages/modules/core/src/pages/employee/Login/login.js`), the error `Toast` rendered `t(showToast)` directly. When the key isn't seeded, the user saw the **raw localization key** instead of a message. This routes it through the same `tr()` key→fallback helper the form labels already use: `label={tr(showToast, showToast)}` — a missing key now falls back to a readable string (many toast values are already human-readable server `error_description`s). Addresses #443 (item 8).

## Validation
Triggered a failed login against a live backend — the toast renders the readable message ("Invalid login credentials"), not a raw key.

## Login-safety
**Display-only.** The single changed line affects only the text of an already-displayed error toast. It does **not** touch the oauth/token call, credential validation, the submit handler, button gating, or redirects — the authentication flow is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)