### PR TITLE
feat(pgr): add geo-location map field to employee create-complaint (#447)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/Module.js
+++ b/digit-ui-esbuild/products/pgr/src/Module.js
@@ -114,6 +114,14 @@ const componentsToRegister = {
   PGRSelectRating: SelectRating,
   PGRResponseCitzen: ResponseCitizen,
   GeoLocations,
+  // Employee create-complaint map field (egovernments/CCRS#447 item 5).
+  // Same leaflet/Nominatim/resolveWard component the citizen flow uses
+  // ("GeoLocations"); aliased under a PGR-prefixed name so the employee
+  // CreateComplaintConfig can reference it as a `type: "component"` field
+  // without colliding with the citizen flow's `getComponent("GeoLocations")`
+  // lookup. It writes the same `GeoLocationsPoint` form key (lat/lng +
+  // resolved `ward`) that PGRBoundaryComponent's auto-cascade watches.
+  PGRComplaintLocationMap: GeoLocations,
   SelectAddress,
   SelectImages,
   CreatePGRFlow: CreatePGRFlow,

--- a/digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
+++ b/digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
@@ -168,6 +168,34 @@ export const CreateComplaintConfig = {
         {
           head: "CS_COMPLAINT_LOCATION_DETAILS",
           body: [
+            // Pin-location map (egovernments/CCRS#447 item 5). Renders the
+            // same leaflet map the citizen flow uses (registered as
+            // `PGRComplaintLocationMap` → GeoLocations in Module.js). On a
+            // pin drop, GeoLocations.resolveWard() runs point-in-polygon
+            // against the bundled Nairobi-wards GeoJSON and writes
+            // `{ lat, lng, pincode, address, ward:{code,name,...} }` to the
+            // `GeoLocationsPoint` form key. PGRBoundaryComponent below
+            // already watches `formData.GeoLocationsPoint.ward` (CCRS#491)
+            // and auto-fills the County / Sub-County / Ward cascade from
+            // that pin — so dropping a pin populates the boundary picker
+            // for free, with no extra wiring on the employee path.
+            //
+            // Optional: the operator can still file by manually selecting
+            // the boundary cascade without dropping a pin. Leaving it
+            // non-mandatory also avoids forcing a geoLocation onto every
+            // submit (see the null-geoLocation persister risk noted on the
+            // ticket) — the map only contributes a geoLocation when a pin
+            // is actually placed.
+            {
+              isMandatory: false,
+              key: "GeoLocationsPoint",
+              type: "component",
+              component: "PGRComplaintLocationMap",
+              label: "CS_COMPLAINT_DETAILS_PIN_LOCATION",
+              populators: {
+                name: "GeoLocationsPoint",
+              },
+            },
             {
               inline: true,
               label: "CS_COMPLAINT_POSTALCODE__DETAILS",


### PR DESCRIPTION
## What
Adds a pin-location map to the **employee** create-complaint form (item 5 of #447). The citizen flow already had a "Pin location" step; the employee form had only the boundary cascade.

- `digit-ui-esbuild/products/pgr/src/Module.js` — register the existing citizen `GeoLocations` component under the alias `PGRComplaintLocationMap` (additive; citizen lookup name untouched).
- `digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js` — add a non-mandatory `GeoLocationsPoint` component field in the location section, writing the same form key/shape the citizen flow uses.

Because `PGRBoundaryComponent` already watches `formData.GeoLocationsPoint.ward` (CCRS#491), **dropping a pin auto-fills the County/Sub-County/Ward cascade** with no extra wiring.

## Why non-mandatory
So an operator can still file by manually selecting the boundary cascade, and a pin-less submit never sends a null `geoLocation` (avoids the known persister NPE on null geoLocation).

## Validation
Built and run against a live backend: the leaflet map (geocoding search + draggable pin) renders in the employee form above the postal/boundary section; the boundary cascade renders intact below it. No auth/login impact.

## Companion
The new field label key `CS_COMPLAINT_DETAILS_PIN_LOCATION` is seeded in a companion localization PR (default-data-handler rainmaker-pgr). Until that merges the field shows the raw key — purely cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)