### PR TITLE
feat(i18n): seed CS_COMPLAINT_DETAILS_PIN_LOCATION label (#447)

### DIFF
--- a/utilities/default-data-handler/src/main/resources/localisations/default/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/default/rainmaker-pgr.json
@@ -7060,5 +7060,11 @@
         "message": "Dear Citizen, Your complaint for <complaint_type> has been submitted with ID <id> on <date>. You can track your complaint status on the web portal.",
         "module": "rainmaker-pgr",
         "locale": "default"
+    },
+    {
+        "code": "CS_COMPLAINT_DETAILS_PIN_LOCATION",
+        "message": "Pin Location",
+        "module": "rainmaker-pgr",
+        "locale": "default"
     }
 ]

--- a/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
@@ -6430,5 +6430,11 @@
         "message": "Dear Citizen, Your complaint for <complaint_type> has been submitted with ID <id> on <date>. You can track your complaint status on the web portal.",
         "module": "rainmaker-pgr",
         "locale": "en_IN"
+    },
+    {
+        "code": "CS_COMPLAINT_DETAILS_PIN_LOCATION",
+        "message": "Pin Location",
+        "module": "rainmaker-pgr",
+        "locale": "en_IN"
     }
 ]


### PR DESCRIPTION
## What
Seeds the `rainmaker-pgr` localization key **`CS_COMPLAINT_DETAILS_PIN_LOCATION`** → "Pin Location" (en_IN + default) in `utilities/default-data-handler`. Companion to the employee geo-location map field PR (#820) — without this key the new field renders the raw key string.

## Why a separate, generic PR
The pin-location field lives in the **shared** PGR create-complaint config, so every deployment needs the label → it belongs in the global default-data-handler seed.

The Kenya-specific **City → County** rename (#443) is deliberately **not** included here — that's a per-tenant localization override (seeded to the `ke` tenant), not a global default, per the holistic-fix principle (tenant values don't go in global code/seeds).

## Notes
Data-only seed; no auth/login/UI-behavior impact. Two-line additions, valid JSON verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)