### PR TITLE
fix(pgr): use full city tenant when fetching complaint attachment URLs (#555)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/ComplaintPhotos.js
+++ b/digit-ui-esbuild/products/pgr/src/components/ComplaintPhotos.js
@@ -12,7 +12,11 @@ const ComplaintPhotos = ({ serviceWrapper }) => {
     const [images, setImages] = useState(null);
     const [imageZoom, setImageZoom] = useState(null);
     const [currentIndex, setCurrentIndex] = useState(0);
-    const tenantId = serviceWrapper?.service?.tenantId?.split(".")[0];
+    // #555: attachments are uploaded under the complaint's CITY tenant
+    // (e.g. ke.bomet), and /filestore/v1/files/url is tenant-scoped, so
+    // stripping to the state root returned no file and the panel rendered
+    // nothing. Use the full tenant, like PGRDetails.js:289 / useComplaintDetails.js:63.
+    const tenantId = serviceWrapper?.service?.tenantId;
 
     useEffect(() => {
         (async () => {


### PR DESCRIPTION
## What
Fixes the remaining root cause of #555 — uploaded attachment thumbnails not visible on the complaint detail page (citizen **and** employee, shared `ComplaintPhotos` component).

`products/pgr/src/components/ComplaintPhotos.js:15` resolved the attachment fileStoreIds with the complaint tenant **stripped to the state root**:
```js
const tenantId = serviceWrapper?.service?.tenantId?.split(".")[0];  // ke.bomet -> ke
```
But attachments are uploaded under the complaint's **city** tenant (`SelectImages.js` → `ImageUploadHandler.js`), and `/filestore/v1/files/url` is **tenant-scoped**, so the root-tenant query returned no file → `thumbs.length === 0` → the panel rendered nothing.

Fix: use the full `service.tenantId` (drop `.split(".")[0]`), matching `PGRDetails.js:289` and `useComplaintDetails.js:63`, which already query at city level.

## Validation (live, multi-level tenant)
A file uploaded under `ke.bomet`:
- `GET /filestore/v1/files/url?tenantId=ke&fileStoreIds=…` → **EMPTY** (the buggy stripped-root query)
- `GET /filestore/v1/files/url?tenantId=ke.bomet&fileStoreIds=…` → **returns the URL** (the fix)

That's the exact failure mechanism and the fix, end to end.

## Scope
FE-only, generic (no tenant-specific values — removes a hard-coded "files live at state root" assumption; works for single-root and multi-root tenants). A prior #555 pass already fixed the response parser; this completes it. No auth/login impact. On a flat single-root tenant the change is a no-op (strip of a dotless tenant returns itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)