### PR TITLE
fix(profile): fall back to original URL for profile image thumbnail (#445)

### DIFF
--- a/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Home/UserProfile.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Home/UserProfile.js
@@ -781,7 +781,11 @@ const UserProfile = ({ stateCode, userType, cityDetails }) => {
     const res = await Digit.UploadServices.Filefetch(ids, tenantId);
     if (res.data.fileStoreIds && res.data.fileStoreIds.length !== 0) {
       return {
-        thumbs: res.data.fileStoreIds.map((o) => o.url.split(",")[3]),
+        // #445: the *-profile filestore module generates no resize variants,
+        // so `o.url` is a single URL and split(",")[3] is undefined -> blank
+        // avatar. Fall back to the original URL, matching WorkFlow.js / the
+        // load path at line ~396.
+        thumbs: res.data.fileStoreIds.map((o) => o.url.split(",")[3] || o.url.split(",")[0]),
         images: res.data.fileStoreIds.map((o) => Digit.Utils.getFileUrl(o.url)),
       };
     } else {


### PR DESCRIPTION
## What
Addresses #445 — Edit Profile image upload appears not to work. The upload POST succeeds; the **preview** never renders. In `packages/modules/core/src/pages/citizen/Home/UserProfile.js` (shared employee + citizen profile page), the post-upload resolver took only the 4th URL variant:
```js
thumbs: res.data.fileStoreIds.map((o) => o.url.split(",")[3]),
```
When the filestore response is a **single URL** (no resize variants generated), `[3]` is `undefined` → `setProfileImg(undefined)` → blank avatar. Fix adds the fallback that every other upload path already uses:
```js
thumbs: ...map((o) => o.url.split(",")[3] || o.url.split(",")[0]),
```
(mirrors `WorkFlow.js:11`, `useComplaintDetails.js:7`, and this file's own load path ~line 396). FE-only, shared component, tenant-agnostic. **Not** the file-size limit (already 5 MB in develop).

## Validation — please QA on a variant-less deployment
⚠️ Honest caveat: I could **not reproduce the blank-avatar symptom on the test backend (bomet)** because its filestore generates 4 resize variants for *every* image module, so `[3]` (the `_small` URL) is always valid there. Confirmed via API: upload to `employee-profile` returns `url1,url1_large,url1_medium,url1_small`.

So this fix is verified to be **correct and harmless** where variants exist (the `|| [0]` is a no-op), and it resolves the documented failure mode on deployments that return a **single** URL. The original report likely comes from such an environment. Recommend QA confirm on the reporting deployment.

If the reporting environment *does* generate variants, the "upload doesn't work" symptom is instead likely a **profile-photo persistence** issue (egov-user `/user/profile/_update` not saving `photo`) — a separate backend concern, not this FE change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)