### PR TITLE
fix(compose): set DIGIT_GATEWAY_HOST for token-exchange-svc (kong:8000)

### DIFF
--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -2186,6 +2186,14 @@ services:
       # is on the egov-network too, listens on 8107, and forwards to
       # the real egov-user container.
       DIGIT_USER_HOST: http://egov-user-proxy:8107
+      # The DIGIT API gateway that token-exchange-svc forwards authenticated
+      # /kc/* calls to. The keycloak-deploy image defaults DIGIT_GATEWAY_HOST
+      # to the legacy zuul address http://gateway:8080, which does not exist
+      # on a kong-based stack — kong's proxy listens on :8000 and the service
+      # is named `kong`. Without this every /kc/* request 502s with
+      # "getaddrinfo EAI_AGAIN gateway". (CCRS#771-adjacent; the block sets
+      # DIGIT_USER_HOST but historically omitted the gateway host.)
+      DIGIT_GATEWAY_HOST: ${DIGIT_GATEWAY_HOST:-http://kong:8000}
       # Defaults to ADMIN (which user-seed.sh always creates on a
       # fresh DIGIT install). On environments where you have a
       # dedicated INTERNAL_MICROSERVICE_ROLE seeded, override via


### PR DESCRIPTION
## Problem
Every authenticated `/kc/*` API call goes through `token-exchange-svc`, which forwards to the DIGIT API gateway read from `DIGIT_GATEWAY_HOST`. The `token-exchange-svc:keycloak-deploy` image **defaults that to the legacy zuul address `http://gateway:8080`** when the env var is unset (`dist/config.js`).

On a kong-based stack there is no `gateway` host — kong's compose service is named `kong` and its proxy listens on `:8000`. So token-exchange can't resolve the hostname and fails with `getaddrinfo EAI_AGAIN gateway`, and **every `/kc/*` request returns `502 Bad Gateway`**.

The `token-exchange-svc` env block already sets `DIGIT_USER_HOST` but has **always omitted `DIGIT_GATEWAY_HOST`** (it never appears anywhere in git history). So this 502 is **reproducible on every fresh deploy** of the Keycloak surface, on any tenant — not bomet-specific.

## Fix
Add `DIGIT_GATEWAY_HOST: ${DIGIT_GATEWAY_HOST:-http://kong:8000}` to the `token-exchange-svc` environment, next to the existing `DIGIT_USER_HOST`. Overridable via env; defaults to the in-stack kong proxy.

## Validation
Verified live on bomet (`bometfeedbackhub.digit.org`): with the override applied, token-exchange forwards to `http://kong:8000/<svc>` and `/kc/mdms-v2/v1/_search` reaches mdms-v2 (real app response) instead of 502ing. Reproduced the 502 before, confirmed gone after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)