### PR TITLE
feat(pgr-analytics): expose latitude/longitude as facts dimensions (map support)

### DIFF
--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsCatalog.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsCatalog.java
@@ -59,6 +59,7 @@ public class AnalyticsCatalog {
                   "service_group","department_code","aging_bucket","sla_status_bucket","current_assignee_uuid",
                   "is_open","is_resolved","is_reopened","was_rejected","sla_breached","current_state_sla_breached",
                   "has_rating","is_negative_rating","is_first_time_complainant","has_geo_pin","filed_on_behalf",
+                  "latitude","longitude",   // map pins: group by (lat,long) → one row per complaint location
                   "current_state_seq","created_month","created_week_start","created_year","created_quarter",
                   "created_date","created_dow","created_is_weekend","created_is_business_hr","tenant_id"),
             // filterable (NOTE: UUID columns intentionally absent)


### PR DESCRIPTION
## What

Exposes `latitude`/`longitude` as **dimensions** on the `complaint_facts` grain in the analytics catalog, so the query API can return per-complaint pin locations for a map widget:

```json
{ "grain":"facts", "dimensions":["latitude","longitude","service_code","application_status"],
  "measures":[{"name":"n","agg":"count"}], "filters":{"has_geo_pin":true} }
```

The columns already exist on the `complaint_facts` materialized view (64/66 complaints are pinned) — this 2-line change just adds them to the `groupable` set so `dimensions:[latitude,longitude]` no longer 400s.

## Why
Backs the **complaint map widget** in the dashboard PR (#845). Realizes part of the "map support" the visualization-validator design called out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
