### PR TITLE
fix(theme): bridge MDMS palette into v2-scope tokens + backfill v3 for v1/v2 records

### DIFF
--- a/digit-ui-esbuild/src/theme/applyTheme.js
+++ b/digit-ui-esbuild/src/theme/applyTheme.js
@@ -246,6 +246,71 @@ function flatten(obj, prefix, out) {
   }
 }
 
+// ── v2-scope (Tailwind/shadcn) bridge ───────────────────────────────────────
+// The v2 component library (packages/digit-ui-components-v2) paints from
+// `--v2-*` HSL-triplet tokens defined ON the `.v2-scope` element by its
+// bundled tokens.css — e.g. `.bg-primary { background: hsl(var(--v2-primary)/…) }`.
+// Because the scope element carries its own definition, custom properties set
+// inline on <html> never reach those rules: the scope's stylesheet value
+// shadows the inherited one. Net effect before this bridge: MDMS themes
+// painted every legacy `--color-*` surface but v2 surfaces (login page,
+// citizen flows) stayed on the baked-in defaults.
+//
+// Bridge: after applying the palette, inject a `.v2-scope { … }` rule into
+// <head> with HSL triplets derived from the applied hex values. Same
+// specificity as tokens.css, later source order — so it wins, and removing
+// the MDMS record cleanly falls back to defaults on next load.
+const V2_BRIDGE_STYLE_ID = "mdms-theme-v2-bridge";
+
+function hexToHslTriplet(hex) {
+  if (typeof hex !== "string") return null;
+  const m = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(hex.trim());
+  if (!m) return null;
+  const h6 = m[1].length === 3 ? [...m[1]].map((c) => c + c).join("") : m[1];
+  const r = parseInt(h6.slice(0, 2), 16) / 255;
+  const g = parseInt(h6.slice(2, 4), 16) / 255;
+  const b = parseInt(h6.slice(4, 6), 16) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  let h = 0;
+  let s = 0;
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    if (max === r) h = (g - b) / d + (g < b ? 6 : 0);
+    else if (max === g) h = (b - r) / d + 2;
+    else h = (r - g) / d + 4;
+    h /= 6;
+  }
+  return `${Math.round(h * 360)} ${Math.round(s * 100)}% ${Math.round(l * 100)}%`;
+}
+
+// vars already encodes record precedence (v3 > v2 > v1), so reading from it
+// keeps the bridge consistent with whatever won for the legacy surfaces.
+function injectV2Bridge(vars) {
+  if (typeof document.createElement !== "function" || !document.head) return 0;
+  const primaryHex =
+    vars["--color-button-primary-bg-default"] || vars["--color-primary-main"];
+  const fgHex = vars["--color-button-primary-text"];
+
+  const decls = [];
+  const primary = hexToHslTriplet(primaryHex);
+  if (primary) decls.push(`--v2-primary: ${primary}`, `--v2-ring: ${primary}`);
+  const fg = hexToHslTriplet(fgHex);
+  if (fg) decls.push(`--v2-primary-foreground: ${fg}`);
+  if (decls.length === 0) return 0;
+
+  let el = document.getElementById(V2_BRIDGE_STYLE_ID);
+  if (!el) {
+    el = document.createElement("style");
+    el.id = V2_BRIDGE_STYLE_ID;
+    document.head.appendChild(el);
+  }
+  el.textContent = `.v2-scope { ${decls.join("; ")}; }`;
+  return decls.length;
+}
+
 function applyTheme(config) {
   if (!config || typeof config !== "object" || Array.isArray(config)) {
     console.warn("[theme] config must be an object, skipping apply");
@@ -302,10 +367,37 @@ function applyTheme(config) {
     }
   }
 
+  // Pass 4: v3 backfill for v1/v2 records. Newer components consume v3
+  // tokens directly (often via inline style, e.g. the login button's
+  // `background: var(--color-button-primary-bg-default, var(--color-primary-2, …))`),
+  // and the vendored :root defaults for those tokens are DIGIT-orange. A
+  // tenant with a v1/v2-shaped record would theme every legacy surface while
+  // v3-consuming components silently stayed on defaults. Derive the v3
+  // basics from the resolved palette so older records paint consistently.
+  // Real v3 records are left untouched.
+  if (!v3Active) {
+    const primaryMain = vars["--color-primary-main"];
+    const primaryDark = vars["--color-primary-dark"];
+    const backfill = {
+      "--color-primary-1": primaryDark || primaryMain,
+      "--color-primary-2": primaryMain,
+      "--color-button-primary-bg-default": primaryMain,
+      "--color-button-primary-bg-hover": primaryDark || primaryMain,
+      "--color-button-primary-bg-pressed": primaryDark || primaryMain,
+    };
+    for (const [name, value] of Object.entries(backfill)) {
+      if (typeof value === "string" && !(name in vars)) vars[name] = value;
+    }
+  }
+
   for (const name of Object.keys(vars)) {
     root.style.setProperty(name, vars[name]);
   }
-  console.log(`[theme] applied ${Object.keys(vars).length} variables`);
+  const bridged = injectV2Bridge(vars);
+  console.log(
+    `[theme] applied ${Object.keys(vars).length} variables` +
+      (bridged ? ` (+${bridged} v2-scope tokens)` : ""),
+  );
 }
 
-module.exports = { applyTheme, SEMANTIC_EXPANSION, V3_EXPANSION };
+module.exports = { applyTheme, SEMANTIC_EXPANSION, V3_EXPANSION, hexToHslTriplet };

--- a/digit-ui-esbuild/src/theme/applyTheme.test.js
+++ b/digit-ui-esbuild/src/theme/applyTheme.test.js
@@ -3,18 +3,29 @@ const assert = require("node:assert/strict");
 
 function stubDocument() {
   const props = {};
+  // Minimal element + head stub so the v2-scope bridge (createElement +
+  // appendChild + getElementById) can run under node:test.
+  const elements = {};
+  const head = { children: [], appendChild(el) { this.children.push(el); } };
   global.document = {
     documentElement: {
       style: {
         setProperty(name, value) { props[name] = value; },
       },
     },
+    head,
+    createElement(tag) {
+      return { tagName: tag.toUpperCase(), id: "", textContent: "" };
+    },
+    getElementById(id) {
+      return head.children.find((el) => el.id === id) || elements[id] || null;
+    },
   };
   const origWarn = console.warn;
   const origLog = console.log;
   console.warn = () => {};
   console.log = () => {};
-  return { props, restore: () => { console.warn = origWarn; console.log = origLog; } };
+  return { props, head, restore: () => { console.warn = origWarn; console.log = origLog; } };
 }
 
 function freshApply() {
@@ -358,5 +369,125 @@ test("v3 not active without `primary-1` marker — v1/v2-only records keep their
     assert.equal(props["--color-button-primary-bg-hover"], "#E6B800");
     // But primary-1-derived vars should be absent.
     assert.equal(props["--color-primary-1"], undefined);
+  } finally { restore(); }
+});
+
+// ── v2-scope bridge ──────────────────────────────────────────────────────────
+
+const { hexToHslTriplet } = require("./applyTheme.js");
+
+test("hexToHslTriplet: known conversions + invalid input", () => {
+  assert.equal(hexToHslTriplet("#1B85D2"), "205 77% 46%");
+  assert.equal(hexToHslTriplet("#ffffff"), "0 0% 100%");
+  assert.equal(hexToHslTriplet("#fff"), "0 0% 100%");
+  assert.equal(hexToHslTriplet("ff0000"), "0 100% 50%"); // bare hex tolerated
+  assert.equal(hexToHslTriplet("not-a-color"), null);
+  assert.equal(hexToHslTriplet(undefined), null);
+  assert.equal(hexToHslTriplet("rgb(1,2,3)"), null);
+});
+
+test("v2 bridge: primary.main drives .v2-scope --v2-primary HSL triplet", () => {
+  const { head, restore } = stubDocument();
+  try {
+    const applyTheme = freshApply();
+    applyTheme({
+      version: "1",
+      colors: { primary: { main: "#10cdda" } },
+    });
+    const bridge = head.children.find((el) => el.id === "mdms-theme-v2-bridge");
+    assert.ok(bridge, "bridge <style> should be appended to head");
+    assert.match(bridge.textContent, /\.v2-scope \{/);
+    assert.match(bridge.textContent, /--v2-primary: 184 86% 46%/);
+    assert.match(bridge.textContent, /--v2-ring: 184 86% 46%/);
+  } finally { restore(); }
+});
+
+test("v2 bridge: v3 button-primary-bg-default wins over primary.main", () => {
+  const { head, restore } = stubDocument();
+  try {
+    const applyTheme = freshApply();
+    applyTheme({
+      version: "1",
+      colors: {
+        "primary-1": "#204F37", // v3 marker
+        "button-primary-bg-default": "#FEC931",
+        "button-primary-text": "#1D2433",
+        primary: { main: "#10cdda" },
+      },
+    });
+    const bridge = head.children.find((el) => el.id === "mdms-theme-v2-bridge");
+    assert.ok(bridge);
+    // #FEC931 = hsl(44 99% 59%)
+    assert.match(bridge.textContent, /--v2-primary: 44 99% 59%/);
+    assert.match(bridge.textContent, /--v2-primary-foreground: 221 28% 16%/);
+  } finally { restore(); }
+});
+
+test("v2 bridge: no usable color → no style tag injected", () => {
+  const { head, restore } = stubDocument();
+  try {
+    const applyTheme = freshApply();
+    applyTheme({ version: "1", colors: { grey: { bg: "#E6E6E6" } } });
+    const bridge = head.children.find((el) => el.id === "mdms-theme-v2-bridge");
+    assert.equal(bridge, undefined);
+  } finally { restore(); }
+});
+
+test("v2 bridge: re-apply reuses the same style tag (no duplicates)", () => {
+  const { head, restore } = stubDocument();
+  try {
+    const applyTheme = freshApply();
+    applyTheme({ version: "1", colors: { primary: { main: "#10cdda" } } });
+    applyTheme({ version: "1", colors: { primary: { main: "#1B85D2" } } });
+    const bridges = head.children.filter((el) => el.id === "mdms-theme-v2-bridge");
+    assert.equal(bridges.length, 1);
+    assert.match(bridges[0].textContent, /--v2-primary: 205 77% 46%/);
+  } finally { restore(); }
+});
+
+// ── v3 backfill for v1/v2 records ────────────────────────────────────────────
+
+test("v3 backfill: v1 record feeds button + primary-N tokens from palette", () => {
+  const { props, restore } = stubDocument();
+  try {
+    const applyTheme = freshApply();
+    applyTheme({
+      version: "1",
+      colors: { primary: { main: "#FEC931", dark: "#204F37" } },
+    });
+    assert.equal(props["--color-button-primary-bg-default"], "#FEC931");
+    assert.equal(props["--color-button-primary-bg-hover"], "#204F37");
+    assert.equal(props["--color-button-primary-bg-pressed"], "#204F37");
+    assert.equal(props["--color-primary-1"], "#204F37");
+    assert.equal(props["--color-primary-2"], "#FEC931");
+  } finally { restore(); }
+});
+
+test("v3 backfill: skipped entirely for real v3 records", () => {
+  const { props, restore } = stubDocument();
+  try {
+    const applyTheme = freshApply();
+    applyTheme({
+      version: "1",
+      colors: {
+        "primary-1": "#204F37",
+        "button-primary-bg-default": "#E6B800",
+        primary: { main: "#FEC931" },
+      },
+    });
+    // v3 path applied the record's own value, not a backfilled one
+    assert.equal(props["--color-button-primary-bg-default"], "#E6B800");
+    // hover wasn't in the record and must NOT be invented for v3 records
+    assert.equal(props["--color-button-primary-bg-hover"], undefined);
+  } finally { restore(); }
+});
+
+test("v3 backfill: no primary in record → nothing invented", () => {
+  const { props, restore } = stubDocument();
+  try {
+    const applyTheme = freshApply();
+    applyTheme({ version: "1", colors: { grey: { bg: "#E6E6E6" } } });
+    assert.equal(props["--color-button-primary-bg-default"], undefined);
+    assert.equal(props["--color-primary-2"], undefined);
   } finally { restore(); }
 });


### PR DESCRIPTION
## Summary

Port of **theflywheel/digit-ui-esbuild#124** into the monorepo's `digit-ui-esbuild/` tree — per #841's note, this monorepo is the source of truth for digit-ui-esbuild (deployments serve its bundle via `digit_ui_bundle_image`), so the theme fix has to land here to reach deployments.

Fixes "the configurator theme doesn't apply" (reported on `subhadev.digitlab.in` / tenant `ethiopia`): MDMS `ThemeConfig` records themed every legacy `--color-*` surface, but the login page and citizen-flow surfaces silently stayed on baked-in DIGIT-orange defaults.

## Root cause — two layers

1. **v2-scope (tailwind/shadcn) components** paint from `--v2-*` HSL-triplet tokens defined *on* `.v2-scope` by the component library's bundled tokens.css. A scope-level definition shadows anything `applyTheme` sets inline on `<html>` — the MDMS palette could never reach those rules.
2. **Newer components consume v3 tokens via inline style** — the login button's `background: var(--color-button-primary-bg-default, var(--color-primary-2, …))` beats every stylesheet. v1/v2-shaped records never write those tokens, so they resolve to the vendored `:root` orange defaults.

## Fix (both in `applyTheme.js`)

- **v2 bridge**: after applying the palette, inject `<style id="mdms-theme-v2-bridge">.v2-scope { … }</style>` into `<head>` (same specificity as tokens.css, later source order wins) with hex→HSL-converted `--v2-primary` / `--v2-ring` / `--v2-primary-foreground`.
- **v3 backfill**: when a record carries no v3 marker, derive `--color-primary-1/-2` and `--color-button-primary-bg-{default,hover,pressed}` from the resolved palette. v3 > v2 > v1 precedence preserved; real v3 records untouched.

## Validation

- `applyTheme.js` here was **byte-identical to flywheel main pre-fix** — this is a verbatim port, no merge drift.
- 30/30 via `node --test digit-ui-esbuild/src/theme/applyTheme.test.js` (8 new tests).
- Live on subhadev/ethiopia: console `[theme] applied 42 variables (+2 v2-scope tokens)`, login button flips default `#C84C0E` → record's effective primary, post-login UI fully themed.
- End-to-end write-path regression test (configurator Brand edit → MDMS → digit-ui repaint, **including the button pixel**): ChakshuGautam/digit-integration-tests#30 — 2 passed against subhadev.

## Refs

- Upstream twin: theflywheel/digit-ui-esbuild#124 (open — flywheel repo consumers get the same fix there)
- Related: #841 (prebuilt UI bundle serving — the mechanism that makes this tree the deployed source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
