### PR TITLE
feat(theme): runtime theme config for digit-ui (Phase 1)

### DIFF
--- a/frontend/micro-ui/web/package.json
+++ b/frontend/micro-ui/web/package.json
@@ -21,6 +21,7 @@
     "@egovernments/digit-ui-components": "0.2.0-beta.45",
     "@egovernments/digit-ui-module-workbench": "1.0.28",
     "@egovernments/digit-ui-module-hrms": "1.9.2",
+    "ajv": "^8.12.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "jsonpath": "^1.1.1",

--- a/frontend/micro-ui/web/src/index.js
+++ b/frontend/micro-ui/web/src/index.js
@@ -3,6 +3,20 @@ import ReactDOM from 'react-dom';
 import { initLibraries } from "@egovernments/digit-ui-libraries";
 import "./index.css";
 import App from './App';
+import { applyTheme } from "./theme/applyTheme";
+import defaultTheme from "./theme/default.json";
+
+// Phase 1: apply the bundled default theme before the libraries init so
+// every component renders against the active palette from first paint.
+// Phase 2 (future): fetch MDMS `common-masters.ThemeConfig` per tenant
+// once the user/tenant is resolved and re-apply on top of these defaults.
+applyTheme(defaultTheme);
+
+if (process.env.NODE_ENV === "development") {
+  // Dev-only: tweak the live palette from the console.
+  //   window.__applyTheme({ version: "1", colors: { primary: { main: "#10cdda" } } })
+  window.__applyTheme = applyTheme;
+}
 
 
 initLibraries();

--- a/frontend/micro-ui/web/src/theme/applyTheme.js
+++ b/frontend/micro-ui/web/src/theme/applyTheme.js
@@ -1,0 +1,48 @@
+// Theme loader. Walks a nested color config (validated against schema.json),
+// flattens each leaf path into a --color-<path-joined-by-dashes> CSS custom
+// property, and writes it to document.documentElement.
+//
+// Phase 1: called with a bundled default.json at app bootstrap.
+// Phase 2 (future): called with the MDMS response keyed by tenantId once the
+// tenant is resolved. If validation fails or no config is passed, :root
+// defaults prepended to the vendored CSS render the shipped palette.
+
+const Ajv = require("ajv");
+const schema = require("./schema.json");
+
+const ajv = new Ajv({ allErrors: true, strict: false });
+const validate = ajv.compile(schema);
+
+function flatten(obj, prefix, out) {
+  for (const key of Object.keys(obj)) {
+    const value = obj[key];
+    const next = prefix ? `${prefix}-${key}` : key;
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      flatten(value, next, out);
+    } else {
+      out[`--color-${next}`] = value;
+    }
+  }
+}
+
+function applyTheme(config) {
+  if (!config || typeof config !== "object" || Array.isArray(config)) {
+    console.warn("[theme] config must be an object, skipping apply");
+    return;
+  }
+  if (!validate(config)) {
+    console.warn("[theme] invalid config, skipping apply", validate.errors);
+    return;
+  }
+  if (!config.colors) return;
+
+  const vars = {};
+  flatten(config.colors, "", vars);
+  const root = document.documentElement;
+  for (const name of Object.keys(vars)) {
+    root.style.setProperty(name, vars[name]);
+  }
+  console.log(`[theme] applied ${Object.keys(vars).length} variables`);
+}
+
+module.exports = { applyTheme };

--- a/frontend/micro-ui/web/src/theme/applyTheme.test.js
+++ b/frontend/micro-ui/web/src/theme/applyTheme.test.js
@@ -1,0 +1,72 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+function stubDocument() {
+  const props = {};
+  global.document = {
+    documentElement: {
+      style: {
+        setProperty(name, value) { props[name] = value; },
+      },
+    },
+  };
+  const origWarn = console.warn;
+  const origLog = console.log;
+  console.warn = () => {};
+  console.log = () => {};
+  return { props, restore: () => { console.warn = origWarn; console.log = origLog; } };
+}
+
+function freshApply() {
+  delete require.cache[require.resolve("./applyTheme.js")];
+  return require("./applyTheme.js").applyTheme;
+}
+
+test("valid config: writes all flattened variables", () => {
+  const { props, restore } = stubDocument();
+  try {
+    const applyTheme = freshApply();
+    applyTheme({
+      version: "1",
+      colors: {
+        primary: { main: "#ff0000", light: "#ff8080", dark: "#800000" },
+        secondary: "#00ff00",
+      },
+    });
+    assert.equal(props["--color-primary-main"], "#ff0000");
+    assert.equal(props["--color-primary-light"], "#ff8080");
+    assert.equal(props["--color-primary-dark"], "#800000");
+    assert.equal(props["--color-secondary"], "#00ff00");
+  } finally { restore(); }
+});
+
+test("missing colors key: valid config shape, no-op", () => {
+  const { props, restore } = stubDocument();
+  try {
+    const applyTheme = freshApply();
+    applyTheme({ version: "1" });
+    assert.deepEqual(props, {});
+  } finally { restore(); }
+});
+
+test("invalid value shape (not a hex): no-op", () => {
+  const { props, restore } = stubDocument();
+  try {
+    const applyTheme = freshApply();
+    applyTheme({ version: "1", colors: { primary: { main: "not-a-color" } } });
+    assert.deepEqual(props, {});
+  } finally { restore(); }
+});
+
+test("null / undefined / non-object config: no-op", () => {
+  const { props, restore } = stubDocument();
+  try {
+    const applyTheme = freshApply();
+    applyTheme(null);
+    applyTheme(undefined);
+    applyTheme(42);
+    applyTheme("theme");
+    applyTheme([1, 2]);
+    assert.deepEqual(props, {});
+  } finally { restore(); }
+});

--- a/frontend/micro-ui/web/src/theme/default.json
+++ b/frontend/micro-ui/web/src/theme/default.json
@@ -1,0 +1,29 @@
+{
+  "version": "1",
+  "name": "default",
+  "colors": {
+    "primary": { "light": "#F18F5E", "main": "#c84c0e", "dark": "#C8602B" },
+    "secondary": "#22394D",
+    "text": { "primary": "#0B0C0C", "secondary": "#505A5F" },
+    "link": { "normal": "#1D70B8", "hover": "#003078" },
+    "border": "#D6D5D4",
+    "input-border": "#464646",
+    "error": "#D4351C",
+    "success": "#00703C",
+    "grey": { "dark": "#9E9E9E", "mid": "#EEEEEE", "light": "#FAFAFA", "bg": "#E3E3E3" },
+    "digitv2": {
+      "text-color-disabled": "#B1B4B6",
+      "header-sidenav": "#0B4B66",
+      "primary-bg": "#FEEFE7",
+      "alert-error-bg": "#EFC7C1",
+      "alert-success-bg": "#BAD6C9",
+      "alert-info": "#3498DB",
+      "alert-info-bg": "#C7E0F1",
+      "chart-1": "#048BD0",
+      "chart-2": "#FBC02D",
+      "chart-3": "#8E29BF",
+      "chart-4": "#EA8A3B",
+      "chart-5": "#0BABDE"
+    }
+  }
+}

--- a/frontend/micro-ui/web/src/theme/schema.json
+++ b/frontend/micro-ui/web/src/theme/schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DIGIT UI Theme Config",
+  "type": "object",
+  "required": ["version", "colors"],
+  "additionalProperties": false,
+  "properties": {
+    "version": { "const": "1" },
+    "name": { "type": "string" },
+    "colors": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "primary": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "light": { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$", "default": "#F18F5E" },
+            "main":  { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$", "default": "#c84c0e" },
+            "dark":  { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$", "default": "#C8602B" }
+          }
+        },
+        "secondary": { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$", "default": "#22394D" },
+        "text": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "primary":   { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$", "default": "#0B0C0C" },
+            "secondary": { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$", "default": "#505A5F" }
+          }
+        },
+        "link": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "normal": { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$", "default": "#1D70B8" },
+            "hover":  { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$", "default": "#003078" }
+          }
+        },
+        "border":       { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$", "default": "#D6D5D4" },
+        "input-border": { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$", "default": "#464646" },
+        "error":        { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$", "default": "#D4351C" },
+        "success":      { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$", "default": "#00703C" },
+        "grey": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "dark":  { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$", "default": "#9E9E9E" },
+            "mid":   { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$", "default": "#EEEEEE" },
+            "light": { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$", "default": "#FAFAFA" },
+            "bg":    { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$", "default": "#E3E3E3" }
+          }
+        },
+        "digitv2": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "text-color-disabled": { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$", "default": "#B1B4B6" },
+            "header-sidenav":      { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$", "default": "#0B4B66" },
+            "primary-bg":          { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$", "default": "#FEEFE7" },
+            "alert-error-bg":      { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$", "default": "#EFC7C1" },
+            "alert-success-bg":    { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$", "default": "#BAD6C9" },
+            "alert-info":          { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$", "default": "#3498DB" },
+            "alert-info-bg":       { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$", "default": "#C7E0F1" },
+            "chart-1":             { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$", "default": "#048BD0" },
+            "chart-2":             { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$", "default": "#FBC02D" },
+            "chart-3":             { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$", "default": "#8E29BF" },
+            "chart-4":             { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$", "default": "#EA8A3B" },
+            "chart-5":             { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$", "default": "#0BABDE" }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Ports the Phase 1 runtime-theme work (originally `theflywheel/digit-ui-esbuild#10`, closed unmerged because the bundler stack diverged) into the CCRS `micro-ui-internals` source tree.

Provides the foundation for tenant-scoped runtime theming: every UI surface paints from `--color-<path>` CSS custom properties, fed from a JSON config at bootstrap (Phase 1) and from MDMS per tenant (Phase 2, stubbed).

## What lands in this PR

| File | What |
|---|---|
| `src/theme/applyTheme.js` | ajv-validated loader; flattens a nested color config into `--color-<path>` CSS vars on `documentElement` |
| `src/theme/default.json` | Bundled default palette — 28 tokens covering `primary`/`secondary`/`text`/`link`/`border`/`error`/`success`/`grey`/`digitv2.*` |
| `src/theme/schema.json` | JSON-schema draft-07 validation for the config shape (version + colors required) |
| `src/theme/applyTheme.test.js` | 4 `node:test` unit cases (valid config, missing colors, invalid schema, non-object input) — zero jest dependency, runnable via `node --test` |
| `src/index.js` | Calls `applyTheme(defaultTheme)` before `initLibraries()` so first paint uses the live palette; dev-only `window.__applyTheme` hook for console tweaks |
| `package.json` | Adds `ajv ^8.12.0` dependency |

## What is intentionally NOT ported from #10

- **esbuild bundler config** — CCRS uses `react-scripts` (CRA), not esbuild. Bundler changes belong upstream on `theflywheel/digit-ui-esbuild` only.
- **`public/vendor/digit-ui-css.css` vendoring + transform-css scripts** — CCRS consumes DIGIT UI CSS via `@egovernments/*` npm packages, not via a vendored snapshot.
- **`tests/theme.spec.js` Playwright integration test** — separate test-infra decision; can land later as part of the existing CCRS e2e suite.

## Phase 2 hook

`src/index.js` stubs the Phase 2 site:

```js
// Phase 2 (future): fetch MDMS `common-masters.ThemeConfig` per tenant
// once the user/tenant is resolved and re-apply on top of these defaults.
applyTheme(defaultTheme);
```

Phase 2 will resolve the tenant, fetch `common-masters.ThemeConfig` from MDMS `_search`, and call `applyTheme(mdmsConfig)` on top of the defaults.

## Test plan

- [x] All JSON parses (`default.json`, `schema.json`, `package.json`)
- [x] `applyTheme.js` + `applyTheme.test.js` parse via `node --check`
- [x] All 4 unit tests pass via `node --test` against `ajv ^8`
- [ ] Run `yarn build:libraries && yarn build` in `frontend/micro-ui/web/` to confirm CRA bundle includes the new module
- [ ] Open a tenant in dev, confirm `[theme] applied 28 variables` in console and `--color-primary-main: #c84c0e` is set on `<html>`
- [ ] In Phase 2, swap `applyTheme(defaultTheme)` for an MDMS-driven config and confirm a custom palette flips the UI

## Related

- Upstream (closed): theflywheel/digit-ui-esbuild#10 (Runtime theme config Phase 1)
- Follow-up: theflywheel/digit-ui-esbuild#124 (`fix(theme): bridge MDMS palette into v2-scope tailwind tokens`) — the same Phase 2 bridge work for v2-scope tailwind components

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a theming system with a default color palette that applies at startup
  * Theme configuration is validated and converted to CSS custom properties for consistent styling

* **Tests**
  * Added comprehensive test coverage for theme application and validation

* **Chores**
  * Added `ajv` package dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->