### PR TITLE
fix(compose): set EGOV_BOUNDARY_HOST for pgr-services

### DIFF
--- a/docker-compose.egov-digit.yaml
+++ b/docker-compose.egov-digit.yaml
@@ -1424,6 +1424,7 @@ services:
       EGOV_LOCALIZATION_HOST: http://egov-localization:8096/
       EGOV_USER_HOST: http://egov-user-proxy:8107/
       EGOV_LOCATION_HOST: http://boundary-service:8081/
+      EGOV_BOUNDARY_HOST: http://boundary-service:8081/
       EGOV_HRMS_HOST: http://egov-hrms:8092/
       EGOV_URL_SHORTNER_HOST: http://egov-url-shortening:8080/
       EGOV_UI_APP_HOST: http://localhost:18080

--- a/local-setup/docker-compose.db-migrations.yml
+++ b/local-setup/docker-compose.db-migrations.yml
@@ -1214,6 +1214,7 @@ services:
       EGOV_LOCALIZATION_HOST: http://egov-localization:8096/
       EGOV_USER_HOST: http://egov-user:8107/
       EGOV_LOCATION_HOST: http://boundary-service:8081/
+      EGOV_BOUNDARY_HOST: http://boundary-service:8081/
       EGOV_HRMS_HOST: http://egov-hrms:8092/
       EGOV_URL_SHORTNER_HOST: http://egov-url-shortening:8080/
       EGOV_UI_APP_HOST: http://localhost:18080

--- a/local-setup/docker-compose.deploy.yaml
+++ b/local-setup/docker-compose.deploy.yaml
@@ -790,6 +790,7 @@ services:
       EGOV_LOCALIZATION_HOST: http://egov-localization:8096/
       EGOV_USER_HOST: http://egov-user:8107/
       EGOV_LOCATION_HOST: http://boundary-service:8081/
+      EGOV_BOUNDARY_HOST: http://boundary-service:8081/
       EGOV_HRMS_HOST: http://egov-hrms:8092/
       EGOV_URL_SHORTNER_HOST: http://egov-url-shortening:8080/
       EGOV_UI_APP_HOST: http://localhost:18080

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -1295,6 +1295,7 @@ services:
       EGOV_LOCALIZATION_HOST: http://egov-localization:8096/
       EGOV_USER_HOST: http://egov-user-proxy:8107/
       EGOV_LOCATION_HOST: http://boundary-service:8081/
+      EGOV_BOUNDARY_HOST: http://boundary-service:8081/
       EGOV_HRMS_HOST: http://egov-hrms:8092/
       EGOV_URL_SHORTNER_HOST: http://egov-url-shortening:8080/
       EGOV_UI_APP_HOST: http://localhost:18080

--- a/local-setup/docker-compose.registry.yml
+++ b/local-setup/docker-compose.registry.yml
@@ -1503,6 +1503,7 @@ services:
       EGOV_LOCALIZATION_HOST: http://egov-localization:8096/
       EGOV_USER_HOST: http://egov-user-proxy:8107/
       EGOV_LOCATION_HOST: http://boundary-service:8081/
+      EGOV_BOUNDARY_HOST: http://boundary-service:8081/
       EGOV_HRMS_HOST: http://egov-hrms:8092/
       EGOV_URL_SHORTNER_HOST: http://egov-url-shortening:8080/
       EGOV_UI_APP_HOST: http://localhost:18080

--- a/local-setup/docker-compose.yml
+++ b/local-setup/docker-compose.yml
@@ -967,6 +967,7 @@ services:
       EGOV_LOCALIZATION_HOST: http://egov-localization:8096/
       EGOV_USER_HOST: http://egov-user:8107/
       EGOV_LOCATION_HOST: http://boundary-service:8081/
+      EGOV_BOUNDARY_HOST: http://boundary-service:8081/
       EGOV_HRMS_HOST: http://egov-hrms:8092/
       EGOV_URL_SHORTNER_HOST: http://egov-url-shortening:8080/
       EGOV_UI_APP_HOST: http://localhost:18080


### PR DESCRIPTION
pgr-services only set the legacy EGOV_LOCATION_HOST, so validateBoundary fell back to the application.properties default
http://boundary-service.egov:8080/ — a Kubernetes-style hostname that doesn't resolve on a compose network. ServiceRequestRepository swallows the resulting connection error and returns null, surfacing to citizens as BOUNDARY_SERVICE_SEARCH_ERROR ("boundarySearchResponse" is null) on complaint creation (egovernments/Citizen-Complaint-Resolution-System#816).