### PR TITLE
feat(ci): incident-derived config gates — preflight rules + infra contracts

### DIFF
--- a/.github/workflows/local-setup-ci.yaml
+++ b/.github/workflows/local-setup-ci.yaml
@@ -16,6 +16,35 @@ defaults:
     working-directory: local-setup
 
 jobs:
+  config-contracts:
+    name: Config combination + infra contracts
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Incident-derived combination rules (rules-as-code, each cites the
+      # incident it encodes). Real tenant host_vars are gitignored, so CI
+      # proves the RULES (self-test + fixtures + the tracked example);
+      # deploy.sh applies the same gate to operators' real configs.
+      - name: preflight — rule self-test
+        run: python3 local-setup/scripts/preflight.py --self-test
+
+      - name: preflight — fixtures (valid must pass, invalid must trip)
+        run: python3 local-setup/scripts/preflight.py --fixtures local-setup/tests/fixtures/host_vars/
+
+      - name: preflight — tracked example must pass
+        run: python3 local-setup/scripts/preflight.py local-setup/ansible/inventory/host_vars/_example.yml
+
+      # Cross-file contracts lint can't see: compose -f stack discipline,
+      # :latest pin freeze, overlay-service existence.
+      - name: infra contract tests
+        working-directory: local-setup/tests
+        run: |
+          npm ci
+          npx jest static/infra-contracts.test.ts
+
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/local-setup/ansible/deploy.sh
+++ b/local-setup/ansible/deploy.sh
@@ -89,6 +89,19 @@ if [[ ! -f "inventory/host_vars/${host}.yml" ]]; then
   exit 1
 fi
 
+# Incident-derived config gate — refuses combinations that have actually
+# burned us (data-wipe fastpath, KC half-wired, inconsistent mobile rules,
+# ...). Runs HERE because real host_vars are gitignored: CI can only ever
+# validate fixtures; this is the only spot that sees the operator's config.
+# Each failure prints the incident it encodes. SKIP_PREFLIGHT=1 to bypass.
+if [[ "${SKIP_PREFLIGHT:-0}" != "1" ]]; then
+  if ! python3 ../scripts/preflight.py "inventory/host_vars/${host}.yml"; then
+    echo "" >&2
+    echo "preflight failed — fix the config or re-run with SKIP_PREFLIGHT=1 if you are CERTAIN." >&2
+    exit 1
+  fi
+fi
+
 shift
 ansible-playbook \
   -i inventory/hosts.yml \

--- a/local-setup/ansible/inventory/host_vars/_example.yml
+++ b/local-setup/ansible/inventory/host_vars/_example.yml
@@ -291,6 +291,10 @@ requires_nairobi_mdms: false
 # volume — the overlay also corrects the named-volume mount path,
 # which forces container recreation and wipes the existing data.
 db_fast_path: true
+# scripts/preflight.py refuses db_fast_path without this explicit ack —
+# it encodes the data-wipe trap above. Set it only after confirming the
+# target box has no anonymous-volume postgres data worth keeping.
+db_fast_path_ack_data_wipe: true
 
 # Run the post-deploy CI suite (XLSX dataloader + Playwright). Requires
 # a sibling `digit-ui-fix/` clone next to this repo on the controller.

--- a/local-setup/scripts/preflight.py
+++ b/local-setup/scripts/preflight.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""Pre-flight gate for tenant deploy configs (host_vars/<tenant>.yml).
+
+Rules-as-code, not rules-as-schema: every rule is a small function with a
+`why` string citing the real incident it encodes. Checks run in deploy.sh on
+the controller — the only place that can see the operator's actual host_vars
+(tenant files are gitignored; CI only ever sees _example.yml and fixtures).
+CI runs the same rules via --self-test (embedded cases) and against
+committed fixtures, proving the rule logic without needing real configs.
+
+Add a rule when an incident bites; don't add speculative ones. A false
+positive here costs operator trust in the whole gate.
+
+Usage:
+  preflight.py inventory/host_vars/mytenant.yml      # gate one config
+  preflight.py --fixtures tests/fixtures/host_vars/  # CI: *.yml in a dir
+  preflight.py --self-test                           # rule unit tests
+  SKIP_PREFLIGHT=1 ./deploy.sh mytenant              # escape hatch
+"""
+
+import argparse
+import glob
+import os
+import re
+import sys
+
+try:
+    import yaml
+except ImportError:  # PyYAML ships with ansible — same machine, same env
+    sys.exit("preflight: PyYAML not importable (it ships with ansible — is ansible installed?)")
+
+# The combined dump's eg_enc_*_keys were sealed with this master password.
+# It is already tracked in _example.yml and docker-compose.egov-digit.yaml;
+# repeating it here adds no exposure.
+DUMP_MASTER_PASSWORD = "asd@#$@$!132123"
+
+FAIL = "FAIL"
+WARN = "WARN"
+
+RULES = []
+
+
+def rule(rule_id, why):
+    def deco(fn):
+        RULES.append((rule_id, why, fn))
+        return fn
+    return deco
+
+
+def get(cfg, path, default=None):
+    cur = cfg
+    for part in path.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return default
+        cur = cur[part]
+    return cur
+
+
+# ── Rules (each cites its incident) ─────────────────────────────────────────
+
+@rule(
+    "fastpath-data-wipe-ack",
+    "db_fast_path corrects the postgres volume mount path, which forces "
+    "container recreation and WIPES data stored in an anonymous volume. "
+    "Bomet/Nairobi production boxes are exactly in that state — flipping the "
+    "flag there destroys live tenant data.",
+)
+def r_fastpath_ack(cfg):
+    if get(cfg, "db_fast_path") is True and get(cfg, "db_fast_path_ack_data_wipe") is not True:
+        yield (FAIL,
+               "db_fast_path: true requires db_fast_path_ack_data_wipe: true — "
+               "confirm the target has NO live data in an anonymous postgres volume.")
+
+
+@rule(
+    "fastpath-master-password",
+    "The dump's eg_enc_symmetric/asymmetric keys were generated with a fixed "
+    "MASTER_PASSWORD. A mismatching elasticsearch_master_password makes "
+    "egov-enc-service throw AEADBadTagException on boot and every encrypted "
+    "row becomes unreadable.",
+)
+def r_fastpath_master_password(cfg):
+    if get(cfg, "db_fast_path") is True:
+        got = get(cfg, "bootstrap_secrets.elasticsearch_master_password")
+        if got != DUMP_MASTER_PASSWORD:
+            yield (FAIL,
+                   "db_fast_path: true requires bootstrap_secrets.elasticsearch_master_password "
+                   "to equal the dump's master password (see _example.yml) — got "
+                   + ("(unset)" if got is None else "a different value") + ".")
+
+
+@rule(
+    "keycloak-combo",
+    "auth_provider: keycloak with enable_keycloak unset deploys a UI that "
+    "redirects to a Keycloak that was never brought up — every login dead-ends. "
+    "Found at validate-time ~30 minutes into a deploy instead of in 2 seconds.",
+)
+def r_keycloak(cfg):
+    if get(cfg, "auth_provider") == "keycloak":
+        if get(cfg, "enable_keycloak") is not True:
+            yield (FAIL, "auth_provider: keycloak requires enable_keycloak: true.")
+        if not get(cfg, "bootstrap_secrets.keycloak_admin_password"):
+            yield (FAIL, "auth_provider: keycloak requires bootstrap_secrets.keycloak_admin_password.")
+
+
+@rule(
+    "digit-ui-v2-combo",
+    "nginx_features.digit_ui_v2 renders /citizen/ location blocks pointing at "
+    "a bundle that nothing builds unless enable_digit_ui_v2 is also on — "
+    "users get 404s; historically also a playbook NPE (fixed in 317ec44d4) "
+    "when the repo/branch vars were missing.",
+)
+def r_digit_ui_v2(cfg):
+    if get(cfg, "nginx_features.digit_ui_v2") is True and get(cfg, "enable_digit_ui_v2") is not True:
+        yield (FAIL, "nginx_features.digit_ui_v2: true requires enable_digit_ui_v2: true.")
+
+
+@rule(
+    "mcp-needs-registry",
+    "digit-mcp images live on the Hetzner-VPC registry (10.0.0.4:5000) which "
+    "is unreachable from public boxes — the pull fails ~20 minutes into the "
+    "run. Fail in seconds instead. (Reachability itself is deliberately not "
+    "probed here: static gate, no network.)",
+)
+def r_mcp_registry(cfg):
+    if get(cfg, "enable_mcp") is True and not get(cfg, "docker_registry"):
+        yield (FAIL, "enable_mcp: true requires docker_registry to be set to a registry the TARGET can reach.")
+
+
+@rule(
+    "mobile-config-consistency",
+    "core_mobile_configs carries one intent in three fields. The pattern is "
+    "what egov-user enforces (synthesized into MDMS UserValidation); length "
+    "and allowed starting characters are what the UI and test suites trust. "
+    "When they disagree, citizens/tests mint numbers the server rejects with "
+    "INVALID_MOBILE_FORMAT (PR #841 discussion).",
+)
+def r_mobile(cfg):
+    mc = get(cfg, "core_mobile_configs")
+    if not isinstance(mc, dict) or not mc:
+        return
+    pattern = mc.get("mobileNumberPattern")
+    length = mc.get("mobileNumberLength")
+    starts = mc.get("mobileNumberAllowedStartingCharacters") or []
+    if not pattern:
+        yield (WARN, "core_mobile_configs has no mobileNumberPattern — egov-user gets no rule to enforce.")
+        return
+    try:
+        rx = re.compile(str(pattern))
+    except re.error as e:
+        yield (FAIL, f"mobileNumberPattern does not compile: {e}")
+        return
+    if length:
+        for start in (starts or ["dummy-skip"]):
+            if start == "dummy-skip":
+                break
+            sample = str(start) + "0" * (int(length) - len(str(start)))
+            if not rx.fullmatch(sample):
+                yield (FAIL,
+                       f"inconsistent core_mobile_configs: a {length}-digit number starting "
+                       f"with '{start}' ({sample}) is rejected by mobileNumberPattern {pattern}.")
+
+
+@rule(
+    "boot-tenant-prefix",
+    "boot_tenant must live under state_tenant_id (e.g. ke.bomet under ke). "
+    "A mismatched pair seeds city data under a root the services never query — "
+    "everything 'succeeds' and nothing is visible.",
+)
+def r_boot_tenant(cfg):
+    boot = get(cfg, "boot_tenant")
+    state = get(cfg, "state_tenant_id")
+    if boot and state and boot != state and not str(boot).startswith(str(state) + "."):
+        yield (FAIL, f"boot_tenant '{boot}' is not under state_tenant_id '{state}'.")
+
+
+@rule(
+    "ci-tests-need-boot-tenant",
+    "run_ci_tests drives the XLSX dataloader + Playwright against boot_tenant; "
+    "it was once silently defaulted to ke.bomet and ran Kenya tests against "
+    "the wrong deployment. The playbook now uses `| mandatory` — this gives "
+    "the answer in 2 seconds instead of mid-run.",
+)
+def r_ci_tests(cfg):
+    if get(cfg, "run_ci_tests") is True and not get(cfg, "boot_tenant"):
+        yield (FAIL, "run_ci_tests: true requires boot_tenant.")
+
+
+@rule(
+    "digit-ui-mode-enum",
+    "digit_ui_mode drives a three-way converge (static|hmr|container) — both "
+    "static and hmr bind port 18080, so a typo'd mode skips the kill-the-other-"
+    "runner step and the deploy fights itself over the port.",
+)
+def r_ui_mode(cfg):
+    mode = get(cfg, "digit_ui_mode")
+    if mode is not None and mode not in ("static", "hmr", "container"):
+        yield (FAIL, f"digit_ui_mode '{mode}' is not one of: static, hmr, container.")
+
+
+@rule(
+    "configurator-build-path",
+    "nginx_features.configurator serves /configurator/ from the rsynced "
+    "configurator_build dist. Unset (or pointing at a missing path on this "
+    "controller) ships an empty or stale UI.",
+)
+def r_configurator(cfg):
+    if get(cfg, "nginx_features.configurator") is True:
+        build = get(cfg, "configurator_build")
+        if not build:
+            yield (WARN, "nginx_features.configurator: true but configurator_build is unset — "
+                         "the existing /var/www/configurator on the target (if any) is served as-is.")
+        elif not os.path.isdir(os.path.expanduser(str(build))):
+            yield (WARN, f"configurator_build '{build}' does not exist on this controller — rsync will fail.")
+
+
+# ── Engine ──────────────────────────────────────────────────────────────────
+
+def load_config(host_vars_path):
+    """host_vars merged over inventory group_vars (all.yml, digit.yml) when
+    they sit in the conventional ../../group_vars relative location."""
+    merged = {}
+    inv_dir = os.path.dirname(os.path.dirname(os.path.abspath(host_vars_path)))
+    for name in ("all.yml", "digit.yml"):
+        gv = os.path.join(inv_dir, "group_vars", name)
+        if os.path.isfile(gv):
+            with open(gv) as f:
+                merged.update(yaml.safe_load(f) or {})
+    with open(host_vars_path) as f:
+        merged.update(yaml.safe_load(f) or {})
+    return merged
+
+
+def run_rules(cfg):
+    findings = []
+    for rule_id, why, fn in RULES:
+        for severity, msg in fn(cfg) or []:
+            findings.append((severity, rule_id, msg, why))
+    return findings
+
+
+def report(path, findings, strict):
+    bad = False
+    for severity, rule_id, msg, why in findings:
+        effective = FAIL if (strict and severity == WARN) else severity
+        print(f"[{effective}] {rule_id}: {msg}")
+        print(f"       why: {why}")
+        if effective == FAIL:
+            bad = True
+    if not findings:
+        print(f"[ OK ] {path}: all {len(RULES)} rules pass")
+    return bad
+
+
+# ── Self-test: each rule gets a firing and a non-firing case ────────────────
+
+SELF_TEST_CASES = [
+    # (description, cfg, expected rule ids that FAIL/WARN)
+    ("fastpath without ack fires", {"db_fast_path": True,
+      "bootstrap_secrets": {"elasticsearch_master_password": DUMP_MASTER_PASSWORD}},
+     {"fastpath-data-wipe-ack"}),
+    ("fastpath with ack + right password is clean", {"db_fast_path": True,
+      "db_fast_path_ack_data_wipe": True,
+      "bootstrap_secrets": {"elasticsearch_master_password": DUMP_MASTER_PASSWORD}},
+     set()),
+    ("fastpath wrong master password fires", {"db_fast_path": True,
+      "db_fast_path_ack_data_wipe": True,
+      "bootstrap_secrets": {"elasticsearch_master_password": "nope"}},
+     {"fastpath-master-password"}),
+    ("keycloak provider without stack fires twice", {"auth_provider": "keycloak"},
+     {"keycloak-combo"}),
+    ("keycloak fully wired is clean", {"auth_provider": "keycloak", "enable_keycloak": True,
+      "bootstrap_secrets": {"keycloak_admin_password": "x"}},
+     set()),
+    ("ui-v2 nginx without enable fires", {"nginx_features": {"digit_ui_v2": True}},
+     {"digit-ui-v2-combo"}),
+    ("mcp without registry fires", {"enable_mcp": True, "docker_registry": ""},
+     {"mcp-needs-registry"}),
+    ("inconsistent mobile combo fires (pattern 9 digits, length 10)",
+     {"core_mobile_configs": {"mobileNumberPattern": "^[17][0-9]{8}$",
+       "mobileNumberLength": 10, "mobileNumberAllowedStartingCharacters": ["1", "7"]}},
+     {"mobile-config-consistency"}),
+    ("consistent kenya-shaped mobile combo is clean",
+     {"core_mobile_configs": {"mobileNumberPattern": "^[17][0-9]{8}$",
+       "mobileNumberLength": 9, "mobileNumberAllowedStartingCharacters": ["1", "7"]}},
+     set()),
+    ("optional-prefix pattern accepts both lengths",
+     {"core_mobile_configs": {"mobileNumberPattern": "^0?[17][0-9]{8}$",
+       "mobileNumberLength": 9, "mobileNumberAllowedStartingCharacters": ["1", "7"]}},
+     set()),
+    ("boot tenant outside state root fires",
+     {"boot_tenant": "mz.maputo", "state_tenant_id": "ke"},
+     {"boot-tenant-prefix"}),
+    ("ci tests without boot tenant fires", {"run_ci_tests": True},
+     {"ci-tests-need-boot-tenant"}),
+    ("bad ui mode fires", {"digit_ui_mode": "docker"},
+     {"digit-ui-mode-enum"}),
+    ("configurator without build warns", {"nginx_features": {"configurator": True}},
+     {"configurator-build-path"}),
+    ("empty config is clean", {}, set()),
+]
+
+
+def self_test():
+    failures = 0
+    for desc, cfg, expected in SELF_TEST_CASES:
+        fired = {rule_id for _, rule_id, _, _ in run_rules(cfg)}
+        if fired != expected:
+            print(f"[self-test FAIL] {desc}: expected {sorted(expected)}, fired {sorted(fired)}")
+            failures += 1
+        else:
+            print(f"[self-test ok ] {desc}")
+    print(f"self-test: {len(SELF_TEST_CASES) - failures}/{len(SELF_TEST_CASES)} cases pass")
+    return failures == 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("config", nargs="*", help="host_vars YAML file(s) to gate")
+    ap.add_argument("--fixtures", help="directory of *.yml fixture configs (CI mode)")
+    ap.add_argument("--self-test", action="store_true", help="run embedded rule unit tests")
+    ap.add_argument("--strict", action="store_true", help="treat WARN as FAIL")
+    args = ap.parse_args()
+
+    if args.self_test:
+        sys.exit(0 if self_test() else 1)
+
+    paths = list(args.config)
+    if args.fixtures:
+        paths += sorted(glob.glob(os.path.join(args.fixtures, "*.yml")))
+    if not paths:
+        ap.error("no config given (file args, --fixtures, or --self-test)")
+
+    any_bad = False
+    for path in paths:
+        print(f"── preflight: {path}")
+        cfg = load_config(path)
+        # Fixture convention: files named invalid-*.yml MUST fire something;
+        # valid-*.yml must be clean. Lets CI assert both directions.
+        findings = run_rules(cfg)
+        base = os.path.basename(path)
+        if base.startswith("invalid-"):
+            if not any(s == FAIL for s, *_ in findings):
+                print(f"[FAIL] fixture {base} was expected to trip a rule and didn't")
+                any_bad = True
+            else:
+                report(path, findings, args.strict)
+                print(f"[ OK ] fixture {base} tripped rules as expected")
+            continue
+        any_bad |= report(path, findings, args.strict)
+
+    sys.exit(1 if any_bad else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/local-setup/tests/fixtures/host_vars/invalid-combo-matrix.yml
+++ b/local-setup/tests/fixtures/host_vars/invalid-combo-matrix.yml
@@ -1,0 +1,18 @@
+# Preflight fixture: every documented bad combination at once — preflight
+# must trip on this file (the CI run asserts invalid-* fixtures fire).
+db_fast_path: true                      # no ack, wrong master password
+auth_provider: keycloak                 # KC stack not enabled, no secret
+nginx_features:
+  digit_ui_v2: true                     # enable_digit_ui_v2 missing
+enable_mcp: true
+docker_registry: ''                     # MCP without a registry
+digit_ui_mode: docker                   # not a valid mode
+run_ci_tests: true                      # no boot_tenant
+state_tenant_id: ke
+boot_tenant: mz.maputo                  # outside the state root
+core_mobile_configs:
+  mobileNumberPattern: ^[17][0-9]{8}$   # 9-digit pattern…
+  mobileNumberLength: 10                # …with a 10-digit length
+  mobileNumberAllowedStartingCharacters: ['1', '7']
+bootstrap_secrets:
+  elasticsearch_master_password: wrong

--- a/local-setup/tests/fixtures/host_vars/valid-kenya-shaped.yml
+++ b/local-setup/tests/fixtures/host_vars/valid-kenya-shaped.yml
@@ -1,0 +1,17 @@
+# Preflight fixture: a realistic Kenya-shaped tenant that must pass all rules.
+ansible_host: 10.0.0.99
+domain: fixture.example.org
+state_tenant_id: ke
+boot_tenant: ke.fixture
+db_fast_path: true
+db_fast_path_ack_data_wipe: true
+digit_ui_mode: static
+run_ci_tests: true
+auth_provider: digit
+core_mobile_configs:
+  mobilePrefix: '+254'
+  mobileNumberPattern: ^[17][0-9]{8}$
+  mobileNumberLength: 9
+  mobileNumberAllowedStartingCharacters: ['1', '7']
+bootstrap_secrets:
+  elasticsearch_master_password: asd@#$@$!132123

--- a/local-setup/tests/static/infra-contracts.test.ts
+++ b/local-setup/tests/static/infra-contracts.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Infra contract tests — cross-file invariants that lint can't see.
+ *
+ * Each describe block encodes a REAL incident, same philosophy as
+ * scripts/preflight.py (which gates operator host_vars at deploy time —
+ * these tests gate the tracked artifacts in CI). Add a contract when an
+ * incident bites; cite it.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const ROOT = path.resolve(__dirname, '..', '..'); // local-setup/
+const PLAYBOOK = fs.readFileSync(path.join(ROOT, 'ansible', 'playbook-deploy.yml'), 'utf8');
+const BASE_COMPOSE = fs.readFileSync(path.join(ROOT, 'docker-compose.egov-digit.yaml'), 'utf8');
+
+describe('compose invocation discipline', () => {
+  /**
+   * Incident: bomet egov-user rollback (2026-06-09). A container was
+   * recreated with `docker compose -f docker-compose.egov-digit.yaml up`
+   * — without the per-tenant overlay in the -f stack — which silently
+   * dropped the tenant's image pin and booted an image with a known
+   * regression (#771). The playbook's protection is that every mutating
+   * invocation goes through the single templated `{{ compose_files }}`
+   * stack; this contract pins that discipline.
+   */
+  const MUTATING = /\b(up|down|restart|rm|stop|start|create|pull)\b/;
+
+  // Read-only or deliberately-scoped invocations, each justified:
+  const ALLOWED_RAW_F = [
+    // `ps` against the base file only — read-only health probe; the
+    // service set is identical across overlays so a partial stack is fine.
+    /docker compose -f \{\{ digit_dir \}\}\/docker-compose\.egov-digit\.yaml ps/,
+  ];
+
+  const invocations = PLAYBOOK.split('\n')
+    .map((line, i) => ({ line: line.trim(), n: i + 1 }))
+    .filter(({ line }) => line.includes('docker compose') && !line.startsWith('#'));
+
+  test('every mutating `docker compose` call uses the templated {{ compose_files }} stack', () => {
+    const offenders = invocations.filter(({ line }) => {
+      if (!MUTATING.test(line)) return false;            // read-only — next test
+      if (line.includes('{{ compose_files }}')) return false; // canonical stack
+      if (!line.includes(' -f ')) return false;          // no file args (e.g. `docker compose version`)
+      return !ALLOWED_RAW_F.some((rx) => rx.test(line));
+    });
+    expect(
+      offenders.map(({ n, line }) => `playbook-deploy.yml:${n}: ${line}`),
+    ).toEqual([]);
+  });
+
+  test('raw -f invocations stay read-only and on the allowlist', () => {
+    const rawF = invocations.filter(
+      ({ line }) => line.includes(' -f ') && !line.includes('{{ compose_files }}'),
+    );
+    for (const { n, line } of rawF) {
+      const allowed = ALLOWED_RAW_F.some((rx) => rx.test(line));
+      const mutating = MUTATING.test(line);
+      expect({
+        where: `playbook-deploy.yml:${n}`,
+        line,
+        verdict: allowed && !mutating ? 'ok' : 'NEW RAW -f INVOCATION — route it through {{ compose_files }} or justify it in ALLOWED_RAW_F',
+      }).toEqual(expect.objectContaining({ verdict: 'ok' }));
+    }
+  });
+});
+
+describe('image pin immutability', () => {
+  /**
+   * Incidents (three in one month): `digit-ui:pgr-fixes` re-tag drift left
+   * two servers running different content under the same tag;
+   * `pgr-services-dev:latest` in the base compose diverged from what the
+   * live container ran; `egov-user` regressions shipped under a reused tag.
+   * Mutable tags make `docker compose pull` a silent deploy of unreviewed
+   * content.
+   *
+   * Policy: no NEW `:latest` pins in the base compose. The existing ones
+   * are frozen below as debt — burn the list down, never grow it. (Exact
+   * known set, so a removal also fails the test until the list is updated:
+   * that's intentional — the list IS the changelog of this debt.)
+   */
+  const FROZEN_LATEST_DEBT = [
+    'edoburu/pgbouncer:latest',
+    'tilt-demo-db-migrations:latest',
+    'curlimages/curl:latest', // appears twice (two gate containers)
+    'pgr-services-dev:latest', // env-overridable fallback — pin when #774-class work lands
+    'twinproduction/gatus:latest',
+    'tilt-demo-jupyter:latest',
+    'openbao/openbao:latest',
+    'egovio/novu-bridge-endpoint:latest',
+    'egovio/digit-config-service:latest',
+    'egovio/digit-user-preferences-service:latest',
+    'egovio/novu-bridge:latest',
+  ];
+
+  test('no :latest image pins beyond the frozen debt list', () => {
+    const pins = [...BASE_COMPOSE.matchAll(/^\s*image:\s*(.+)$/gm)]
+      .map((m) => m[1].trim())
+      .filter((img) => /:latest\b|:latest\}/.test(img));
+
+    const unaccounted = pins.filter(
+      (img) => !FROZEN_LATEST_DEBT.some((debt) => img.includes(debt)),
+    );
+    expect(unaccounted).toEqual([]);
+
+    // Debt may shrink, never grow. 12 = the count at freeze time
+    // (curl appears twice). Update downward as pins get fixed.
+    expect(pins.length).toBeLessThanOrEqual(12);
+  });
+});
+
+describe('per-tenant overlay services exist in the base compose', () => {
+  /**
+   * Incident class: an overlay referencing a service name the base compose
+   * doesn't define is a silent no-op for env overrides — the deploy
+   * "succeeds" and the override never applies.
+   */
+  // Only files layered ONTO the base via -f stacking are overlays. The
+  // standalone compose files (deploy.yaml, db-migrations.yml, registry.yml)
+  // define their own service universes and are exempt. Add new per-tenant
+  // overlays (docker-compose.<inventory_hostname>.yml) here as they land.
+  const overlays = ['docker-compose.bomet.yml', 'docker-compose.fast-path.yml', 'docker-compose.core.yml']
+    .filter((f) => fs.existsSync(path.join(ROOT, f)));
+
+  const baseServices = new Set(
+    [...BASE_COMPOSE.matchAll(/^ {2}([a-z0-9][a-z0-9_-]*):\s*$/gm)].map((m) => m[1]),
+  );
+
+  test.each(overlays)('%s only references base services', (overlay) => {
+    const text = fs.readFileSync(path.join(ROOT, overlay), 'utf8');
+    const inServices = text.match(/^services:\s*$([\s\S]*)/m);
+    if (!inServices) return; // overlay without a services block — nothing to check
+    const overlayServices = [...inServices[1].matchAll(/^ {2}([a-z0-9][a-z0-9_-]*):\s*$/gm)].map(
+      (m) => m[1],
+    );
+    const unknown = overlayServices.filter((s) => !baseServices.has(s));
+    expect(unknown).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Companion to #709, adding the two layers that lint and runtime health checks skip: **config-combination gates** and **cross-file contracts** — the places people actually go wrong. Every rule encodes a documented incident from this repo's history; none are speculative.

## Why not just more lint

The defining constraint: **real tenant host_vars are gitignored.** A GitHub-CI check can never see the config that deploys to production. So:

- the combination gate runs in **`deploy.sh` on the controller**, against the operator's actual `host_vars/<tenant>.yml`, before ansible starts (`SKIP_PREFLIGHT=1` escape hatch)
- **CI proves the rules** — `--self-test` (15 embedded cases), fixtures (`valid-*` must pass, `invalid-*` must trip), and the tracked `_example.yml`

## The rules (each cites its incident)

| Rule | Incident it encodes |
|---|---|
| `fastpath-data-wipe-ack` | db_fast_path's volume-path fix recreates containers and wipes anonymous-volume data (the bomet/nairobi trap) — now needs an explicit ack flag |
| `fastpath-master-password` | wrong `elasticsearch_master_password` + dump → AEADBadTagException, all encrypted rows unreadable |
| `keycloak-combo` | `auth_provider: keycloak` without the KC stack → every login dead-ends, found 30 min into the deploy |
| `digit-ui-v2-combo` | nginx flag without the build flag → /citizen/ 404s; historically a playbook NPE (317ec44d4) |
| `mcp-needs-registry` | VPC-only image on a public box → pull failure 20 minutes in |
| `mobile-config-consistency` | pattern vs length vs starting-chars drift (the #841 thread) → INVALID_MOBILE_FORMAT |
| `boot-tenant-prefix` | city seeded outside the state root — everything "succeeds", nothing visible |
| `ci-tests-need-boot-tenant` | suite once defaulted to ke.bomet and tested the wrong deployment |
| `digit-ui-mode-enum` | typo'd mode skips the kill-other-runner step → port-18080 fight |
| `configurator-build-path` | missing dist on the controller → rsync fails / stale UI (warn) |

## The contracts (CI, tracked files)

| Contract | Incident |
|---|---|
| Every **mutating** `docker compose` call uses the templated `{{ compose_files }}` stack; raw `-f` calls must be read-only + allowlisted | The bomet egov-user rollback: a partial `-f` stack silently dropped the tenant overlay and booted a regressed image (#771) |
| No **new** `:latest` pins in the base compose; the existing 12 are frozen as named debt | `digit-ui:pgr-fixes` / `pgr-services-dev:latest` mutable-tag drift — three incidents in one month |
| Per-tenant overlay services must exist in the base compose | Silent-no-op env overrides |

## Design decisions (from the review discussion)

- **Rules-as-code, not JSON Schema** — conditional cross-field rules in schema become unmaintainable `allOf/if/then` pyramids; a 20-line python function with a `why:` string is reviewable and greppable.
- **Incident-derived only** — a rule is added when something bites. False positives erode operator trust faster than missing rules do.
- **Deliberately no network in the static gate** — registry reachability etc. belongs to the runtime layer (#709's health phase), not preflight.

## Validation

- `preflight.py --self-test`: 15/15
- fixtures: `valid-kenya-shaped.yml` clean, `invalid-combo-matrix.yml` trips 10 findings
- tracked `_example.yml`: passes all 10 rules (gained the documented `db_fast_path_ack_data_wipe: true`)
- `jest static/infra-contracts.test.ts`: 6/6 against develop's tree
- New CI job is additive (parallel to #709's `ansible-lint` job, no file conflicts inside the jobs map beyond clean YAML merge)

## Refs

- Complements #709 (lint + idempotency + runtime health) — together they cover all four layers: lint → contracts → combinations → runtime
- `mobile-config-consistency` is the static half of the #841 mobile-rules discussion

🤖 Generated with [Claude Code](https://claude.com/claude-code)
