### PR TITLE
fix(deploy): rewrite filestore presigned URLs with runtime $host

### DIFF
--- a/local-setup/ansible/templates/nginx-site.conf.j2
+++ b/local-setup/ansible/templates/nginx-site.conf.j2
@@ -353,6 +353,12 @@ server {
   #   /filestore/  — egov-filestore JSON API. sub_filter rewrites
   #     `http://minio:9000/` in response bodies to the public passthrough
   #     above. Accept-Encoding stripped so sub_filter sees uncompressed JSON.
+  #     The replacement uses runtime $host (not the inventory `domain` var)
+  #     so attachment URLs follow whatever hostname the client actually
+  #     used — a box rendered with `domain: localhost` but served on a real
+  #     domain otherwise hands browsers unresolvable localhost URLs (CCRS#753).
+  #     Safe for the AWS4 signature: /file-store/ re-sets Host to minio:9000,
+  #     so the public hostname never participates in signature validation.
   location /file-store/ {
     proxy_pass http://{{ nginx_upstream_host | default('127.0.0.1') }}:{{ upstream_minio_port | default(19000) }}/;
     proxy_set_header Host minio:9000;
@@ -373,7 +379,7 @@ server {
     proxy_set_header Accept-Encoding "";
     sub_filter_once off;
     sub_filter_types application/json;
-    sub_filter 'http://minio:9000/' '{{ "https://" if (tls_enabled | default(true)) else "http://" }}{{ domain }}/file-store/';
+    sub_filter 'http://minio:9000/' '{{ "https://" if (tls_enabled | default(true)) else "http://" }}$host/file-store/';
     client_max_body_size 25M;
     proxy_buffering off;
   }
@@ -460,7 +466,7 @@ server {
     proxy_set_header Accept-Encoding "";
     sub_filter_once off;
     sub_filter_types application/json;
-    sub_filter 'http://minio:9000/' '{{ "https://" if (tls_enabled | default(true)) else "http://" }}{{ domain }}/file-store/';
+    sub_filter 'http://minio:9000/' '{{ "https://" if (tls_enabled | default(true)) else "http://" }}$host/file-store/';
     client_max_body_size 25M;
     proxy_buffering off;
   }


### PR DESCRIPTION
The /filestore/ sub_filter rewrote the internal minio:9000 host in presigned URLs to the render-time inventory `domain` value. A box deployed with `domain: localhost` but served on a real hostname handed browsers unresolvable http://localhost/file-store/... attachment URLs (egovernments/Citizen-Complaint-Resolution-System#753, observed live on digit.mctd.gov.mz — the object serves fine once the host is corrected, since /file-store/ re-sets Host: minio:9000 and the public hostname never participates in AWS4 signature validation).

Use nginx's runtime $host instead, so attachment URLs follow whatever hostname the client actually used, in both digit_ui_mode branches.