### PR TITLE
fix(onboarding): boundary localization + cascade + Phase-4 mobile validation (#852–#855)

### DIFF
--- a/configurator/src/api/services/localization.ts
+++ b/configurator/src/api/services/localization.ts
@@ -194,10 +194,20 @@ export const localizationService = {
   },
 
   // Create localization for a boundary.
-  // Emits two keys per boundary, both in module rainmaker-boundary-{hierarchyType}:
+  // Emits two keys per boundary, both in module rainmaker-boundary-{hierarchyType.toLowerCase()}:
   //   1. Bare code (e.g. "PB_AMR") — used by the PGR create-complaint dropdown via t(boundary.code)
   //   2. Prefixed i18nkey (e.g. "MZ_MAPUTO_maputo_hierarchy_type_PB_AMR") — used by BPr/map components
   // Deduped in case code is already uppercase-prefixed and both forms are identical.
+  //
+  // The module name is LOWER-CASED to match the PGR reader, which is the
+  // established convention on the consuming side: both digit-ui-esbuild
+  // (products/pgr/src/Module.js:39) and frontend/micro-ui
+  // (.../pgr/src/Module.js:57) build the module as
+  // `boundary-${hierarchyType.toLowerCase()}`. Without lower-casing here, a
+  // mixed-case hierarchy ("BOMET-Hierarchy") lands under
+  // `rainmaker-boundary-BOMET-Hierarchy` while the UI requests
+  // `rainmaker-boundary-bomet-hierarchy` → 0 hits → every boundary dropdown
+  // (Country/County/Ward) renders the raw code instead of the name.
   buildBoundaryLocalizations(
     tenantId: string,
     code: string,
@@ -205,7 +215,7 @@ export const localizationService = {
     hierarchyType: string,
     locale: string = 'en_IN'
   ): LocalizationMessage[] {
-    const module = `rainmaker-boundary-${hierarchyType}`;
+    const module = `rainmaker-boundary-${hierarchyType.toLowerCase()}`;
     const tenantPrefix = tenantId.toUpperCase().replace(/\./g, '_');
     const prefixedCode = `${tenantPrefix}_${hierarchyType}_${code}`;
     const messages: LocalizationMessage[] = [{ code, message: name, module, locale }];

--- a/configurator/src/api/services/mdms.ts
+++ b/configurator/src/api/services/mdms.ts
@@ -272,7 +272,7 @@ export const mdmsService = {
   },
 
   // ============================================
-  // Validation Rules (ValidationConfigs.mobileNumberValidation)
+  // Mobile validation rule (common-masters.UserValidation, fieldType "mobile")
   // ============================================
 
   async getMobileValidation(tenantId: string): Promise<{
@@ -281,21 +281,43 @@ export const mdmsService = {
     maxLength: number;
     errorMessage: string;
     prefix?: string;
+    allowedStartingCharacters?: string[];
   } | null> {
+    // The mobile rule lives in common-masters.UserValidation — NOT
+    // ValidationConfigs.mobileNumberValidation, which is never seeded in this
+    // stack (so the old query always returned null and Phase 4 fell back to a
+    // lenient ^\d{9,10}$ that accepts any 9-10 digit number). This is the same
+    // master egov-user enforces at create time, so the sheet check now matches
+    // what the backend will actually accept.
+    //
+    // Records are keyed by uniqueIdentifier == data.zone (e.g. "mobile",
+    // "India"); mobile rules carry fieldType:"mobile" and the active one has
+    // default:true. pattern / minLength / maxLength / errorMessage are nested
+    // under data.rules; the dialling prefix under data.attributes.prefix.
     const results = await this.search<Record<string, unknown>>(
       tenantId,
-      'ValidationConfigs.mobileNumberValidation'
+      'common-masters.UserValidation'
     );
+    const mobileRecords = results.filter((r) => r.fieldType === 'mobile');
+    // Pick the rule flagged as the active default — both data.default === true
+    // AND data.isActive === true (the "mobile"/default rule carries both; other
+    // country rules like "India" carry neither). Fall back to any active rule,
+    // then the first mobile rule, so we never silently drop to the lenient path.
     const preferred =
-      results.find((r) => r.validationName === 'defaultMobileValidation') ??
-      results[0];
+      mobileRecords.find((r) => r['default'] === true && r.isActive === true) ??
+      mobileRecords.find((r) => r.isActive === true) ??
+      mobileRecords[0];
     if (!preferred) return null;
     const rules = (preferred.rules as Record<string, unknown> | undefined) ?? {};
+    const attributes = (preferred.attributes as Record<string, unknown> | undefined) ?? {};
     return {
       pattern: typeof rules.pattern === 'string' ? rules.pattern : '^\\d{10}$',
       minLength: typeof rules.minLength === 'number' ? rules.minLength : 10,
       maxLength: typeof rules.maxLength === 'number' ? rules.maxLength : 10,
-      prefix: typeof rules.prefix === 'string' ? rules.prefix : undefined,
+      prefix: typeof attributes.prefix === 'string' ? attributes.prefix : undefined,
+      allowedStartingCharacters: Array.isArray(rules.allowedStartingCharacters)
+        ? (rules.allowedStartingCharacters as string[])
+        : undefined,
       errorMessage:
         typeof rules.errorMessage === 'string' && rules.errorMessage
           ? rules.errorMessage

--- a/configurator/src/pages/Phase2Page.tsx
+++ b/configurator/src/pages/Phase2Page.tsx
@@ -307,11 +307,12 @@ export default function Phase2Page() {
 
       await localizationService.cacheBust().catch(e => console.warn('cache-bust failed', e));
 
-      // Clear ancestralmaterializedpath so boundary-service includeChildren=true
-      // doesn't combine two overlapping queries and return each node twice in the
-      // citizen create-complaint dropdown. Fire-and-forget: if the MCP REST shim
-      // isn't deployed, Phase 2 still completes and an operator can run
-      // fix_boundary_paths via the MCP tool manually.
+      // Populate ancestralmaterializedpath (the '|'-joined ancestor chain) for the
+      // relationships just created. boundary-service builds the includeChildren=true
+      // nested tree FROM this path, so if it's empty the citizen create-complaint
+      // dropdown shows only the root with no cascade (County/Sub-County/Ward never
+      // appear). Fire-and-forget: if the MCP REST shim isn't deployed, Phase 2 still
+      // completes and an operator can run fix_boundary_paths via the MCP tool manually.
       try {
         const { token } = apiClient.getAuth();
         const ac = new AbortController();

--- a/configurator/src/pages/Phase4Page.tsx
+++ b/configurator/src/pages/Phase4Page.tsx
@@ -69,7 +69,7 @@ export default function Phase4Page() {
   const [designations, setDesignations] = useState<Designation[]>([]);
   const [boundaries, setBoundaries] = useState<Boundary[]>([]);
   const [roles, setRoles] = useState<{ code: string; name: string; description?: string }[]>([]);
-  const [mobileRules, setMobileRules] = useState<{ pattern: string; minLength: number; maxLength: number; errorMessage: string } | null>(null);
+  const [mobileRules, setMobileRules] = useState<{ pattern: string; minLength: number; maxLength: number; errorMessage: string; prefix?: string; allowedStartingCharacters?: string[] } | null>(null);
   const [loadingRefs, setLoadingRefs] = useState(false);
 
   // Parsed employee data
@@ -479,7 +479,21 @@ export default function Phase4Page() {
                 • <strong>name</strong> - Employee full name
               </li>
               <li>
-                • <strong>mobileNumber</strong> - 10-digit mobile number
+                • <strong>mobileNumber</strong> -{' '}
+                {mobileRules
+                  ? [
+                      mobileRules.minLength === mobileRules.maxLength
+                        ? `${mobileRules.minLength}-digit`
+                        : `${mobileRules.minLength}-${mobileRules.maxLength} digit`,
+                      'mobile number',
+                      mobileRules.allowedStartingCharacters?.length
+                        ? `starting with ${mobileRules.allowedStartingCharacters.join(' / ')}`
+                        : null,
+                      mobileRules.prefix ? `(${mobileRules.prefix})` : null,
+                    ]
+                      .filter(Boolean)
+                      .join(' ')
+                  : 'mobile number (validated against the tenant rule)'}
               </li>
               <li>
                 • <strong>dob</strong> - Date of birth (YYYY-MM-DD)

--- a/digit-mcp/src/tools/boundary.ts
+++ b/digit-mcp/src/tools/boundary.ts
@@ -9,18 +9,22 @@ export function registerBoundaryTools(registry: ToolRegistry): void {
     category: 'boundary-mgmt',
     risk: 'write',
     description:
-      'Clears the ancestralmaterializedpath column for all boundary relationships of a tenant. ' +
-      'Required after Phase 2 boundary creation to prevent the boundary-service includeChildren=true ' +
-      'query from returning each node twice (the service combines a parent= query and an ' +
-      'array-overlap query on ancestralmaterializedpath; emptying the column disables the second ' +
-      'query so the citizen create-complaint dropdown shows each boundary exactly once).',
+      'Recomputes the ancestralmaterializedpath column (the pipe-separated chain of ANCESTOR ' +
+      'codes, root→parent, excluding self; root rows are empty) for every boundary_relationship ' +
+      'row of a tenant by walking the parent links. boundary-service builds the ' +
+      'includeChildren=true nested tree FROM this path, so when it is empty the citizen ' +
+      'create-complaint dropdown shows only the root with no cascade. Run after Phase 2 boundary ' +
+      'creation to repair rows the wizard left with an empty path. Idempotent — safe to re-run. ' +
+      'NOTE: this tool previously CLEARED the column to suppress a suspected duplicate-node bug; ' +
+      'that broke the cascade, and populated paths are in fact the working norm (ke.citya / ' +
+      'ke.nairobi carry them and render each boundary exactly once).',
     inputSchema: {
       type: 'object' as const,
       required: ['tenant_id'],
       properties: {
         tenant_id: {
           type: 'string',
-          description: 'Tenant ID whose boundary_relationship rows should be cleared (e.g. mz.maputo)',
+          description: 'Tenant ID whose boundary_relationship paths should be recomputed (e.g. ke.bomet)',
         },
       },
     },
@@ -30,8 +34,31 @@ export function registerBoundaryTools(registry: ToolRegistry): void {
 
       await digitDb.initialize();
 
+      // Walk each tenant+hierarchy tree from its root(s) and set every node's path to
+      // its ancestor chain (parent's path + parent's code, '|'-joined). Matches the
+      // format boundary-service writes when relationships are created strictly
+      // top-down — see ke.citya: B1_ADMIN_BLOCK => 'PG_CITYA_ADMIN_CITY|Z1_ADMIN_ZONE'.
       const rowsAffected = await digitDb.execute(
-        `UPDATE boundary_relationship SET ancestralmaterializedpath = '' WHERE tenantid = $1`,
+        `WITH RECURSIVE chain AS (
+           SELECT tenantid, hierarchytype, code, ''::text AS path
+           FROM boundary_relationship
+           WHERE tenantid = $1 AND (parent IS NULL OR parent = '')
+           UNION ALL
+           SELECT r.tenantid, r.hierarchytype, r.code,
+                  CASE WHEN c.path = '' THEN c.code ELSE c.path || '|' || c.code END
+           FROM boundary_relationship r
+           JOIN chain c
+             ON r.parent = c.code
+            AND r.tenantid = c.tenantid
+            AND r.hierarchytype = c.hierarchytype
+           WHERE r.tenantid = $1
+         )
+         UPDATE boundary_relationship b
+         SET ancestralmaterializedpath = chain.path
+         FROM chain
+         WHERE b.tenantid = chain.tenantid
+           AND b.hierarchytype = chain.hierarchytype
+           AND b.code = chain.code`,
         [tenantId]
       );
 
@@ -39,7 +66,7 @@ export function registerBoundaryTools(registry: ToolRegistry): void {
         success: true,
         tenant_id: tenantId,
         rowsAffected,
-        message: `Cleared ancestralmaterializedpath for ${rowsAffected} boundary relationship row(s) in tenant ${tenantId}.`,
+        message: `Recomputed ancestralmaterializedpath for ${rowsAffected} boundary relationship row(s) in tenant ${tenantId}.`,
       }, null, 2);
     },
   } satisfies ToolMetadata);

--- a/digit-mcp/src/utils/xlsx-reader.ts
+++ b/digit-mcp/src/utils/xlsx-reader.ts
@@ -496,6 +496,20 @@ export function readComplaintTypes(
         module: 'rainmaker-pgr',
         locale: 'en_IN',
       });
+      // Department-qualified key: the employee Create-Complaint sub-type
+      // dropdown looks services up as `SERVICEDEFS.<CODE_UPPER>.<DEPT>`
+      // (digit-ui-esbuild useServiceDefs builds the key with the raw,
+      // un-cased department code). Without this the dropdown renders the
+      // raw key. Mirrors the configurator's buildComplaintTypeLocalizations
+      // key #3 — keep both onboarding paths in sync (CCRS#539).
+      if (deptCode) {
+        localizations.push({
+          code: `SERVICEDEFS.${serviceCode.toUpperCase()}.${deptCode}`,
+          message: parentName,
+          module: 'rainmaker-pgr',
+          locale: 'en_IN',
+        });
+      }
     } else if (childName && currentParent) {
       // This is a child row — inherits from current parent
       const serviceCode = nameToPascalCode(`${currentParent.name} ${childName}`);
@@ -519,6 +533,16 @@ export function readComplaintTypes(
         module: 'rainmaker-pgr',
         locale: 'en_IN',
       });
+      // Department-qualified key for the employee sub-type dropdown — see
+      // the parent-row note above. Uses the child's resolved department.
+      if (childDeptCode) {
+        localizations.push({
+          code: `SERVICEDEFS.${serviceCode.toUpperCase()}.${childDeptCode}`,
+          message: childName,
+          module: 'rainmaker-pgr',
+          locale: 'en_IN',
+        });
+      }
     }
   }
 
@@ -596,6 +620,20 @@ function readComplaintTypesFlat(
       module: 'rainmaker-pgr',
       locale: 'en_IN',
     });
+    // Department-qualified key: the employee Create-Complaint sub-type
+    // dropdown looks services up as `SERVICEDEFS.<CODE_UPPER>.<DEPT>`
+    // (digit-ui-esbuild useServiceDefs builds the key with the raw,
+    // un-cased department code). Without this the dropdown renders the
+    // raw key. Mirrors the configurator's buildComplaintTypeLocalizations
+    // key #3 — keep both onboarding paths in sync (CCRS#539).
+    if (deptCode) {
+      localizations.push({
+        code: `SERVICEDEFS.${serviceCode.toUpperCase()}.${deptCode}`,
+        message: name,
+        module: 'rainmaker-pgr',
+        locale: 'en_IN',
+      });
+    }
 
     if (menuName && !seenMenuPaths.has(menuPath)) {
       seenMenuPaths.add(menuPath);


### PR DESCRIPTION
Four independent onboarding bug fixes, isolated onto a `develop`-based branch. Each maps 1:1 to a ticket.

| Ticket | Fix | Files |
|---|---|---|
| #852 | Lower-case the boundary localization module so the PGR UI resolves names | `configurator/.../localization.ts` |
| #853 | Phase 4 reads the mobile rule from `common-masters.UserValidation` (+ dynamic hint) | `configurator/.../mdms.ts`, `Phase4Page.tsx` |
| #854 | `fix_boundary_paths` populates the ancestor path instead of clearing it | `digit-mcp/.../boundary.ts`, `configurator/.../Phase2Page.tsx` |
| #855 | Emit department-qualified `SERVICEDEFS` key for the employee dropdown | `digit-mcp/.../xlsx-reader.ts` |

## Details

**#852 — Boundary dropdowns show raw codes.** `buildBoundaryLocalizations` wrote `rainmaker-boundary-<hierarchyType>` verbatim, but the PGR UI (`Module.js`) reads `rainmaker-boundary-<hierarchyType.toLowerCase()>`. Mismatch ⇒ names never found ⇒ Country/County/Ward show `COUNTRY_001`. Now lower-cased to match both PGR readers.

**#853 — Phase 4 mobile validation reads wrong master.** `getMobileValidation` queried `ValidationConfigs.mobileNumberValidation` (never seeded) ⇒ `null` ⇒ lenient `^\d{9,10}$` accepted any number. Now reads `common-masters.UserValidation` (`fieldType:"mobile"`, `default`+`isActive`) — the same rule egov-user enforces — and the hint is derived from the rule, not hardcoded "10-digit".

**#854 — Boundary cascade missing.** `fix_boundary_paths` *cleared* `ancestralmaterializedpath`, but boundary-service builds the `includeChildren` tree **from** that path, so clearing it left only the root after a restart (an in-memory cache masked it until then). Now recomputes the `|`-joined ancestor chain from the parent links.

**#855 — Raw SERVICEDEFS key in employee dropdown.** The sub-type dropdown looks up `SERVICEDEFS.<CODE_UPPER>.<DEPT>`, but the XLSX loaders only emitted `SERVICEDEFS.<CODE>`/`<MENUPATH>`. Now emits the department-qualified variant in both readers.

## Caveats
- TS changes — **configurator** + **digit-mcp** images must be rebuilt to take effect at runtime.
- #853 follow-up: tenant mobile config (e.g. `bomet.yml`) must carry the correct country rule for the strict check to accept the right numbers.

Relates to #852, #853, #854, #855.

🤖 Generated with [Claude Code](https://claude.com/claude-code)