### PR TITLE
fix(theme): read sidebar-hover from ThemeConfig instead of hardcoding it (#562)

### DIFF
--- a/digit-ui-esbuild/public/vendor/digit-ui-css.css
+++ b/digit-ui-esbuild/public/vendor/digit-ui-css.css
@@ -92,8 +92,15 @@
   --color-sidebar-bg: #0B4B66;
   --color-sidebar-text-active: #FFFFFF;
   --color-sidebar-text-default: #D1D5DB;
-  --color-sidebar-hover-text: #FFFFFF;
-  --color-sidebar-hover-bg: #FBEEE8;
+  /* #562: sidebar-hover-{bg,text} are intentionally NOT hardcoded here.
+   * Theming values belong in the MDMS ThemeConfig; the UI only reads them.
+   * The old hardcoded pair (--color-sidebar-hover-bg: #FBEEE8 light peach +
+   * --color-sidebar-hover-text: #FFFFFF white) was white-on-light and, worse,
+   * shadowed the config — a tenant that set neither got the broken pair.
+   * With no :root default, the sidebar rules' existing var() chain resolves
+   * to an explicit ThemeConfig value if present, else the config-driven
+   * --color-primary-selected-bg (light tint) + --color-primary-1 (dark) —
+   * a readable pair from the tenant's own colors. */
   --color-sidebar-icon-active: #FFFFFF;
   --color-sidebar-selected-bg: #c84c0e;
   --color-sidebar-selected-text: #FFFFFF;

--- a/digit-ui-esbuild/scripts/vendor-digit-ui-css.js
+++ b/digit-ui-esbuild/scripts/vendor-digit-ui-css.js
@@ -183,8 +183,15 @@ const ROOT_BLOCK = `:root {
   --color-sidebar-bg: #0B4B66;
   --color-sidebar-text-active: #FFFFFF;
   --color-sidebar-text-default: #D1D5DB;
-  --color-sidebar-hover-text: #FFFFFF;
-  --color-sidebar-hover-bg: #FBEEE8;
+  /* #562: sidebar-hover-{bg,text} are intentionally NOT hardcoded here.
+   * Theming values belong in the MDMS ThemeConfig; the UI only reads them.
+   * The old hardcoded pair (--color-sidebar-hover-bg: #FBEEE8 light peach +
+   * --color-sidebar-hover-text: #FFFFFF white) was white-on-light and, worse,
+   * shadowed the config — a tenant that set neither got the broken pair.
+   * With no :root default, the sidebar rules' existing var() chain resolves
+   * to an explicit ThemeConfig value if present, else the config-driven
+   * --color-primary-selected-bg (light tint) + --color-primary-1 (dark) —
+   * a readable pair from the tenant's own colors. */
   --color-sidebar-icon-active: #FFFFFF;
   --color-sidebar-selected-bg: #c84c0e;
   --color-sidebar-selected-text: #FFFFFF;


### PR DESCRIPTION
## What
Fixes #562 (employee sidebar Home item unreadable on hover — white text on a light background).

Root cause was an **architecture violation, not a color choice**: the vendored CSS `:root` *hardcoded* a sidebar-hover pair —
```
--color-sidebar-hover-bg:  #FBEEE8;  /* light peach */
--color-sidebar-hover-text: #FFFFFF; /* white      */
```
That pair is white-on-light by itself, and — worse — it **shadowed the theme config**: a tenant whose MDMS `ThemeConfig` set neither key got this broken hardcoded pair instead of anything theme-driven.

Theming values belong in the **MDMS ThemeConfig**; the UI should only **read** them. So this removes the two hardcoded `:root` defaults. The sidebar rules' existing `var()` chain then resolves, in order:
- an explicit `ThemeConfig.colors.sidebar-hover-bg` / `-text` (wins), else
- the config-driven `--color-primary-selected-bg` (light tint) + `--color-primary-1` (dark) — a readable pair derived from the tenant's own colors.

No hardcoded theming value remains for sidebar-hover.

## Files
- `scripts/vendor-digit-ui-css.js` — the generator (source of truth)
- `public/vendor/digit-ui-css.css` — regenerated output

## Validation (live tenant, Bomet)
- With `ThemeConfig` providing `sidebar-hover-*`: UI reads it (e.g. `#145C7D` + white) — readable.
- With it omitted: hover resolves to `--color-primary-selected-bg` (`#E3F0FA`) + `--color-primary-1` (`#1565A8`) — dark-blue text on light-blue, readable — **not** the old white-on-peach.

No build-time color logic; pure removal of a hardcoded shadow so the config read takes effect. The per-tenant value itself is set in MDMS ThemeConfig (data), separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)