### PR TITLE
fix(micro-ui): resolve and transpile .jsx in the production webpack build

### DIFF
--- a/frontend/micro-ui/web/webpack.config.js
+++ b/frontend/micro-ui/web/webpack.config.js
@@ -7,6 +7,9 @@ module.exports = {
   // mode: 'development',
   entry: "./src/index.js",
   devtool: "none",
+  // src/ mixes .js and .jsx (dashboard/); webpack's default resolve list has no .jsx,
+  // so extensionless imports of .jsx files only worked on the dev server.
+  resolve: { extensions: [".js", ".jsx", ".json"] },
   module: {
     rules: [
       {
@@ -20,7 +23,7 @@ module.exports = {
         }
       },
       {
-        test: /\.(js)$/,
+        test: /\.(js|jsx)$/,
         exclude: /node_modules/,
         use: {
           loader: "babel-loader",


### PR DESCRIPTION
## Problem
`yarn build:webpack` (and therefore the nightly `digit-ui` image build) fails on develop:

```
ERROR in ./src/App.js
Module not found: Error: Can't resolve './dashboard/AdminDashboard' in '/app/web/src'
```

5ec74f31 (supervisor demo dashboard, #16) added `src/dashboard/*.jsx` and an extensionless import of `./dashboard/AdminDashboard`. The dev server resolves `.jsx`, but the production config never did:
- `webpack.config.js` has no `resolve.extensions`, so webpack falls back to defaults (`.js`, `.json`, `.mjs`, `.wasm`) — no `.jsx`
- the babel-loader rule matches only `test: /\.(js)$/`, so `.jsx` files wouldn't transpile even if resolved

## Fix
Add `resolve: { extensions: ['.js', '.jsx', '.json'] }` and widen the babel rule to `/\.(js|jsx)$/`.

## Validation
Applied on bomet and re-ran the nightly build driver:

```
[nightly-build] DONE — OK: digit-ui | FAILED: none
```

`digit-ui:nightly-develop` + `develop-20260612` now build and push cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)