### PR TITLE
fix(digit-ui-esbuild): copy products/ + scripts/ and build via npm run build

### DIFF
--- a/digit-ui-esbuild/docker/Dockerfile
+++ b/digit-ui-esbuild/docker/Dockerfile
@@ -2,11 +2,17 @@ FROM node:20-slim AS build
 WORKDIR /app
 COPY package.json ./
 COPY packages/ packages/
+# products/pgr overrides @egovernments/digit-ui-module-pgr via esbuild alias
+COPY products/ products/
+# scripts/vendor-digit-ui-css.js is the prebuild step npm run build depends on
+COPY scripts/ scripts/
 COPY src/ src/
 COPY public/ public/
 COPY esbuild.build.js ./
 RUN npm install --legacy-peer-deps
-RUN node esbuild.build.js
+# npm run build = prebuild (vendored themeable CSS into public/vendor/) + esbuild;
+# invoking esbuild.build.js directly skips the prebuild and ships a broken-theme bundle
+RUN npm run build
 
 FROM nginx:mainline-alpine
 RUN mkdir -p /var/web/digit-ui


### PR DESCRIPTION
## Problem
The nightly `digit-ui-esbuild` image build fails on develop:

```
ERROR: Could not resolve "/app/products/pgr/src/Module.js" (originally "@egovernments/digit-ui-module-pgr")
```

`docker/Dockerfile` predates the products/pgr module override: `esbuild.build.js` aliases `@egovernments/digit-ui-module-pgr` → `products/pgr/src/Module.js`, but the image never copies `products/`.

It also runs `node esbuild.build.js` directly, skipping the npm `prebuild` step (`scripts/vendor-digit-ui-css.js`) that vendors the themeable CSS into `public/vendor/` — the bundle builds but ships with broken theming (the known regression vs the proven on-box `npm run build` recipe).

## Fix
- `COPY products/ products/` (the esbuild alias target) and `COPY scripts/ scripts/` (the prebuild)
- build with `npm run build` so prebuild + esbuild both run, matching the on-box recipe

## Validation
Applied on bomet and re-ran the nightly build driver:

```
[nightly-build] DONE — OK: digit-ui-esbuild | FAILED: none
```

Image content verified: `/var/web/digit-ui/vendor/` contains all five vendored CSS files and `index.js` is 7.3MB (matches the known-healthy on-box bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)