### PR TITLE
fix(pgr-inbox): per-complaint-type SLA ordering/display + working status filter (#432)

### DIFF
--- a/backend/pgr-services/src/main/java/org/egov/pgr/repository/PGRRepository.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/repository/PGRRepository.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import org.egov.pgr.repository.rowmapper.DocumentRowMapper;
 import org.egov.pgr.repository.rowmapper.PGRQueryBuilder;
 import org.egov.pgr.repository.rowmapper.PGRRowMapper;
+import org.egov.pgr.util.MDMSUtils;
 import org.egov.pgr.util.PGRConstants;
 import org.egov.pgr.util.PGRUtils;
 import org.egov.pgr.web.models.Document;
@@ -39,14 +40,28 @@ public class PGRRepository {
 
     private PGRUtils utils;
 
+    private MDMSUtils mdmsUtils;
+
 
     @Autowired
-    public PGRRepository(PGRQueryBuilder queryBuilder, PGRRowMapper rowMapper, DocumentRowMapper documentRowMapper, JdbcTemplate jdbcTemplate, PGRUtils utils) {
+    public PGRRepository(PGRQueryBuilder queryBuilder, PGRRowMapper rowMapper, DocumentRowMapper documentRowMapper, JdbcTemplate jdbcTemplate, PGRUtils utils, MDMSUtils mdmsUtils) {
         this.queryBuilder = queryBuilder;
         this.rowMapper = rowMapper;
         this.documentRowMapper = documentRowMapper;
         this.jdbcTemplate = jdbcTemplate;
         this.utils = utils;
+        this.mdmsUtils = mdmsUtils;
+    }
+
+    /**
+     * Per-complaint-type SLA map (serviceCode -> millis) for SLA ordering, fetched only
+     * when the caller asks to sort by SLA. Null otherwise, so non-SLA searches skip the
+     * MDMS lookup entirely (and the query builder falls back to the uniform SLA).
+     */
+    private Map<String, Long> slaMapFor(RequestSearchCriteria criteria) {
+        if (criteria.getSortBy() != RequestSearchCriteria.SortBy.sla)
+            return null;
+        return mdmsUtils.getServiceCodeToSlaMillis(criteria.getTenantId());
     }
 
 
@@ -79,7 +94,7 @@ public class PGRRepository {
 
         String tenantId = criteria.getTenantId();
         List<Object> preparedStmtList = new ArrayList<>();
-        String query = queryBuilder.getPGRSearchQuery(criteria, preparedStmtList);
+        String query = queryBuilder.getPGRSearchQuery(criteria, preparedStmtList, slaMapFor(criteria));
         try {
             query = utils.replaceSchemaPlaceholder(query, tenantId);
         } catch (Exception e) {
@@ -123,7 +138,7 @@ public class PGRRepository {
 
         String tenantId = criteria.getTenantId();
         List<Object> preparedStmtList = new ArrayList<>();
-        String query = queryBuilder.getCountQuery(criteria, preparedStmtList);
+        String query = queryBuilder.getCountQuery(criteria, preparedStmtList, slaMapFor(criteria));
         try {
             query = utils.replaceSchemaPlaceholder(query, tenantId);
         } catch (Exception e) {

--- a/backend/pgr-services/src/main/java/org/egov/pgr/repository/rowmapper/PGRQueryBuilder.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/repository/rowmapper/PGRQueryBuilder.java
@@ -12,6 +12,7 @@ import java.time.Instant;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 @Repository
@@ -47,6 +48,10 @@ public class PGRQueryBuilder {
 
 
     public String getPGRSearchQuery(RequestSearchCriteria criteria, List<Object> preparedStmtList) {
+        return getPGRSearchQuery(criteria, preparedStmtList, null);
+    }
+
+    public String getPGRSearchQuery(RequestSearchCriteria criteria, List<Object> preparedStmtList, Map<String, Long> serviceCodeToSla) {
 
         StringBuilder builder = new StringBuilder(QUERY);
 
@@ -153,7 +158,7 @@ public class PGRQueryBuilder {
         }
 
 
-        addOrderByClause(builder, criteria, preparedStmtList);
+        addOrderByClause(builder, criteria, preparedStmtList, serviceCodeToSla);
 
         addLimitAndOffset(builder, criteria, preparedStmtList);
 
@@ -162,12 +167,16 @@ public class PGRQueryBuilder {
 
 
     public String getCountQuery(RequestSearchCriteria criteria, List<Object> preparedStmtList){
-        String query = getPGRSearchQuery(criteria, preparedStmtList);
+        return getCountQuery(criteria, preparedStmtList, null);
+    }
+
+    public String getCountQuery(RequestSearchCriteria criteria, List<Object> preparedStmtList, Map<String, Long> serviceCodeToSla){
+        String query = getPGRSearchQuery(criteria, preparedStmtList, serviceCodeToSla);
         String countQuery = COUNT_WRAPPER.replace("{INTERNAL_QUERY}", query);
         return countQuery;
     }
 
-    private void addOrderByClause(StringBuilder builder, RequestSearchCriteria criteria, List<Object> preparedStmtList){
+    private void addOrderByClause(StringBuilder builder, RequestSearchCriteria criteria, List<Object> preparedStmtList, Map<String, Long> serviceCodeToSla){
 
         if(StringUtils.isEmpty(criteria.getSortBy()))
             builder.append( " ORDER BY ser_createdtime ");
@@ -184,24 +193,34 @@ public class PGRQueryBuilder {
         else if(criteria.getSortBy()== RequestSearchCriteria.SortBy.createdTime)
             builder.append(" ORDER BY ser.createdtime ");
 
-        // SLA-remaining ordering. The inbox "SLA days remaining" column is the
-        // SLA budget minus wall-clock elapsed since creation — egov-workflow-v2
-        // computes businesssServiceSla the same way, with no per-state pausing.
-        // Sorting on that expression server-side keeps the order consistent
-        // across the FULL paginated result set; a client-side sortFunction can
-        // only reorder one page at a time, so rows drop in/out of view as page
-        // size changes (issue #432).
+        // SLA-remaining ordering = (SLA budget for this complaint type) − (wall-clock
+        // elapsed since creation). Done server-side so the order is consistent across
+        // the FULL paginated result set; a client-side sortFunction only reorders one
+        // page at a time, so rows dropped in/out of view as page size changed (#432).
         //
-        // The budget is currently a single business-service constant, so today
-        // this is monotonically equivalent to ORDER BY ser.createdtime. SLAs are
-        // expected to become per-complaint-type in future: when that lands, this
-        // is the ONLY spot that changes — replace the single bound budget with a
-        // per-serviceCode budget (e.g. a CASE ser.servicecode ... END built from
-        // the SLA-per-type master). The sortBy=sla API contract and all frontend
-        // code stay untouched, and createdtime ordering is no longer equivalent.
+        // The budget is per complaint type, sourced from MDMS RAINMAKER-PGR.ServiceDefs
+        // (slaHours), matching the inbox's displayed "SLA days remaining". When the map
+        // is available we build a CASE ser.servicecode ...; types not present in the map
+        // (and the empty-map / MDMS-failure case) fall back to the uniform business-level
+        // SLA, which keeps this correct even before per-type slaHours is populated.
         else if(criteria.getSortBy()== RequestSearchCriteria.SortBy.sla){
-            builder.append(" ORDER BY (? - ((extract(epoch FROM NOW())*1000) - ser.createdtime)) ");
-            preparedStmtList.add(config.getBusinessLevelSla());
+            long defaultSla = config.getBusinessLevelSla();
+            StringBuilder slaExpr = new StringBuilder();
+            if (serviceCodeToSla == null || serviceCodeToSla.isEmpty()) {
+                slaExpr.append("?");
+                preparedStmtList.add(defaultSla);
+            } else {
+                slaExpr.append("CASE ser.servicecode");
+                for (Map.Entry<String, Long> entry : serviceCodeToSla.entrySet()) {
+                    slaExpr.append(" WHEN ? THEN ?");
+                    preparedStmtList.add(entry.getKey());
+                    preparedStmtList.add(entry.getValue());
+                }
+                slaExpr.append(" ELSE ? END");
+                preparedStmtList.add(defaultSla);
+            }
+            builder.append(" ORDER BY ((").append(slaExpr)
+                   .append(") - ((extract(epoch FROM NOW())*1000) - ser.createdtime)) ");
         }
 
         if(criteria.getSortOrder()== RequestSearchCriteria.SortOrder.ASC)

--- a/backend/pgr-services/src/main/java/org/egov/pgr/repository/rowmapper/PGRQueryBuilder.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/repository/rowmapper/PGRQueryBuilder.java
@@ -185,14 +185,20 @@ public class PGRQueryBuilder {
             builder.append(" ORDER BY ser.createdtime ");
 
         // SLA-remaining ordering. The inbox "SLA days remaining" column is the
-        // business-service SLA budget minus wall-clock elapsed since creation —
-        // egov-workflow-v2 computes businesssServiceSla the same way, with no
-        // per-state pausing. Sorting on that expression server-side keeps the
-        // order consistent across the FULL paginated result set; a client-side
-        // sortFunction can only reorder one page at a time, so rows drop in/out
-        // of view as page size changes (issue #432). The budget is a single
-        // configured constant, making this monotonically equivalent to ordering
-        // by createdtime today, but it stays correct if the budget changes.
+        // SLA budget minus wall-clock elapsed since creation — egov-workflow-v2
+        // computes businesssServiceSla the same way, with no per-state pausing.
+        // Sorting on that expression server-side keeps the order consistent
+        // across the FULL paginated result set; a client-side sortFunction can
+        // only reorder one page at a time, so rows drop in/out of view as page
+        // size changes (issue #432).
+        //
+        // The budget is currently a single business-service constant, so today
+        // this is monotonically equivalent to ORDER BY ser.createdtime. SLAs are
+        // expected to become per-complaint-type in future: when that lands, this
+        // is the ONLY spot that changes — replace the single bound budget with a
+        // per-serviceCode budget (e.g. a CASE ser.servicecode ... END built from
+        // the SLA-per-type master). The sortBy=sla API contract and all frontend
+        // code stay untouched, and createdtime ordering is no longer equivalent.
         else if(criteria.getSortBy()== RequestSearchCriteria.SortBy.sla){
             builder.append(" ORDER BY (? - ((extract(epoch FROM NOW())*1000) - ser.createdtime)) ");
             preparedStmtList.add(config.getBusinessLevelSla());

--- a/backend/pgr-services/src/main/java/org/egov/pgr/repository/rowmapper/PGRQueryBuilder.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/repository/rowmapper/PGRQueryBuilder.java
@@ -153,7 +153,7 @@ public class PGRQueryBuilder {
         }
 
 
-        addOrderByClause(builder, criteria);
+        addOrderByClause(builder, criteria, preparedStmtList);
 
         addLimitAndOffset(builder, criteria, preparedStmtList);
 
@@ -167,7 +167,7 @@ public class PGRQueryBuilder {
         return countQuery;
     }
 
-    private void addOrderByClause(StringBuilder builder, RequestSearchCriteria criteria){
+    private void addOrderByClause(StringBuilder builder, RequestSearchCriteria criteria, List<Object> preparedStmtList){
 
         if(StringUtils.isEmpty(criteria.getSortBy()))
             builder.append( " ORDER BY ser_createdtime ");
@@ -183,6 +183,20 @@ public class PGRQueryBuilder {
 
         else if(criteria.getSortBy()== RequestSearchCriteria.SortBy.createdTime)
             builder.append(" ORDER BY ser.createdtime ");
+
+        // SLA-remaining ordering. The inbox "SLA days remaining" column is the
+        // business-service SLA budget minus wall-clock elapsed since creation —
+        // egov-workflow-v2 computes businesssServiceSla the same way, with no
+        // per-state pausing. Sorting on that expression server-side keeps the
+        // order consistent across the FULL paginated result set; a client-side
+        // sortFunction can only reorder one page at a time, so rows drop in/out
+        // of view as page size changes (issue #432). The budget is a single
+        // configured constant, making this monotonically equivalent to ordering
+        // by createdtime today, but it stays correct if the budget changes.
+        else if(criteria.getSortBy()== RequestSearchCriteria.SortBy.sla){
+            builder.append(" ORDER BY (? - ((extract(epoch FROM NOW())*1000) - ser.createdtime)) ");
+            preparedStmtList.add(config.getBusinessLevelSla());
+        }
 
         if(criteria.getSortOrder()== RequestSearchCriteria.SortOrder.ASC)
             builder.append(" ASC ");

--- a/backend/pgr-services/src/main/java/org/egov/pgr/util/MDMSUtils.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/util/MDMSUtils.java
@@ -1,5 +1,7 @@
 package org.egov.pgr.util;
 
+import com.jayway.jsonpath.JsonPath;
+import lombok.extern.slf4j.Slf4j;
 import org.egov.common.contract.request.RequestInfo;
 import org.egov.common.utils.MultiStateInstanceUtil;
 import org.egov.mdms.model.MasterDetail;
@@ -13,14 +15,55 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 import static org.egov.pgr.util.PGRConstants.MDMS_MODULE_NAME;
 import static org.egov.pgr.util.PGRConstants.MDMS_SERVICEDEF;
 import static org.egov.pgr.util.PGRConstants.MDMS_COMMON_MASTERS_MODULE_NAME;
 import static org.egov.pgr.util.PGRConstants.MDMS_DEPT_MASTER;
+import static org.egov.pgr.util.PGRConstants.MDMS_DATA_JSONPATH;
+import static org.egov.pgr.util.PGRConstants.MDMS_DATA_SLA_KEYWORD;
+import static org.egov.pgr.util.PGRConstants.MDMS_DATA_SERVICE_CODE_KEYWORD;
 
+@Slf4j
 @Component
 public class MDMSUtils {
+
+    // serviceCode -> SLA millis (from RAINMAKER-PGR.ServiceDefs.slaHours), cached per
+    // state-level tenant. Backs per-complaint-type SLA ordering of the inbox (issue
+    // #432). Cache lives for the process lifetime — slaHours changes in MDMS need a
+    // pgr-services restart to take effect, same staleness window the migration map had.
+    private final Map<String, Map<String, Long>> serviceCodeToSlaCache = new ConcurrentHashMap<>();
+
+    /**
+     * serviceCode -> SLA in millis, derived from MDMS RAINMAKER-PGR.ServiceDefs.slaHours.
+     * Cached per state-level tenant. Returns an empty map (never null) on MDMS failure,
+     * so callers can fall back to the uniform business-level SLA.
+     */
+    public Map<String, Long> getServiceCodeToSlaMillis(String tenantId) {
+        String stateTenant = multiStateInstanceUtil.getStateLevelTenant(tenantId);
+        return serviceCodeToSlaCache.computeIfAbsent(stateTenant, this::fetchServiceCodeToSlaMillis);
+    }
+
+    private Map<String, Long> fetchServiceCodeToSlaMillis(String stateTenant) {
+        Map<String, Long> map = new LinkedHashMap<>();
+        try {
+            MdmsCriteriaReq req = getMDMSRequest(new RequestInfo(), stateTenant);
+            Object result = serviceRequestRepository.fetchResult(getMdmsSearchUrl(), req);
+            List<Map<String, Object>> defs = JsonPath.read(result, MDMS_DATA_JSONPATH);
+            for (Map<String, Object> def : defs) {
+                Object code = def.get(MDMS_DATA_SERVICE_CODE_KEYWORD);
+                Object sla = def.get(MDMS_DATA_SLA_KEYWORD);
+                if (code != null && sla instanceof Number)
+                    map.put(code.toString(), TimeUnit.HOURS.toMillis(((Number) sla).longValue()));
+            }
+        } catch (Exception e) {
+            log.error("Failed to load serviceCode->SLA map for tenant {}; inbox SLA sort will fall back "
+                    + "to the business-level SLA", stateTenant, e);
+        }
+        return map;
+    }
 
 
 

--- a/backend/pgr-services/src/main/java/org/egov/pgr/web/models/RequestSearchCriteria.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/web/models/RequestSearchCriteria.java
@@ -84,7 +84,8 @@ public class RequestSearchCriteria {
         locality,
         applicationStatus,
         serviceRequestId,
-        createdTime
+        createdTime,
+        sla
     }
 
     @SafeHtml

--- a/digit-ui-esbuild/products/pgr/src/configs/PGRSearchInboxConfig.js
+++ b/digit-ui-esbuild/products/pgr/src/configs/PGRSearchInboxConfig.js
@@ -88,12 +88,11 @@ const PGRSearchInboxConfig = () => {
             searchResult: {
                 label: "",
                 uiConfig: {
-                    // Per-column `disableSortBy: true` on every column whose
-                    // backend `sortBy` value isn't accepted by pgr-services'
-                    // `RequestSearchCriteria.SortBy` enum (only
-                    // `applicationStatus` is supported today). Showing a sort
-                    // icon on un-sortable columns implied a working sort and
-                    // confused operators when nothing changed on click.
+                    // Column header sort is client-side react-table, which only
+                    // reorders the CURRENT page while pagination is server-side —
+                    // so it misleads operators (issue #432). Every column sets
+                    // `disableSortBy: true`; ordering is done server-side in
+                    // PGRInboxConfig.preProcess (sortBy=sla, most urgent first).
                     columns: [
                         {
                             label: "CS_COMMON_COMPLAINT_NO",
@@ -118,6 +117,10 @@ const PGRSearchInboxConfig = () => {
                             label: "CS_COMPLAINT_DETAILS_CURRENT_STATUS",
                             jsonPath: "businessObject.service.applicationStatus",
                             additionalCustomization: true,
+                            // Client-side header sort only reorders the current
+                            // page (server pagination), so it misleads operators.
+                            // The inbox is ordered server-side by SLA (#432).
+                            disableSortBy: true,
                         },
                         {
                             label: "WF_INBOX_HEADER_CURRENT_OWNER",
@@ -131,14 +134,14 @@ const PGRSearchInboxConfig = () => {
                             jsonPath: "businessObject.serviceSla",
                             additionalCustomization: true,
                             key: "state",
-                            // #432.2: SLA sort is CLIENT-SIDE via react-data-table's
-                            // sortFunction (pgr-services' SortBy enum doesn't accept
-                            // `sortBy=serviceSla`, so we can't sort server-side).
-                            // NOTE: this only reorders rows on the CURRENT page —
-                            // it does not re-sort across the full paginated result set.
-                            sortFunction: (a, b) =>
-                                (a?.businessObject?.serviceSla ?? -Infinity) -
-                                (b?.businessObject?.serviceSla ?? -Infinity),
+                            // #432.2: the inbox is now ordered by SLA remaining
+                            // server-side (sortBy=sla, ASC — most urgent first;
+                            // see PGRInboxConfig.preProcess + PGRQueryBuilder).
+                            // The previous per-column client sortFunction only
+                            // reordered the CURRENT page, so rows dropped in/out
+                            // of view as page size changed. disableSortBy hides
+                            // the misleading per-page sort icon.
+                            disableSortBy: true,
                         },
                     ],
                     enableGlobalSearch: false,

--- a/digit-ui-esbuild/products/pgr/src/configs/UICustomizations.js
+++ b/digit-ui-esbuild/products/pgr/src/configs/UICustomizations.js
@@ -1580,8 +1580,14 @@ export const UICustomizations = {
         tenantId: Digit.ULBService.getCurrentTenantId(),
         limit: clonedData?.state?.tableForm?.limit || 10,
         offset: clonedData?.state?.tableForm?.offset ?? 0,
-        sortBy: "applicationStatus",
-        sortOrder: "DESC",
+        // Order by SLA remaining (most urgent first) server-side, so the order
+        // is consistent across the FULL paginated result set. The table's
+        // column-header sort is client-side react-table — it only reorders the
+        // current page, so rows appeared to drop in/out as page size changed
+        // (issue #432). pgr-services now supports sortBy=sla; see
+        // PGRQueryBuilder.addOrderByClause.
+        sortBy: "sla",
+        sortOrder: "ASC",
       };
 
       // Search form fields

--- a/digit-ui-esbuild/products/pgr/src/hooks/pgr/usePGRInboxSearch.js
+++ b/digit-ui-esbuild/products/pgr/src/hooks/pgr/usePGRInboxSearch.js
@@ -86,7 +86,14 @@ const usePGRInboxSearch = (reqCriteria) => {
       statusMap = states
         .filter((s) => s.state)
         .map((s) => ({
-          statusid: s.uuid,
+          // WorkflowStatusFilter uses `statusid` as each checkbox's value, and
+          // PGRInboxConfig.preProcess feeds the checked keys straight into the
+          // pgr-services `applicationStatus` filter. pgr-services matches that
+          // against the state CODE (e.g. PENDINGFORASSIGNMENT), not the workflow
+          // state UUID — so emitting `s.uuid` here made every status selection
+          // return zero rows and the inbox list vanished (issue #432). Use the
+          // state code as the identifier so a selection actually filters.
+          statusid: s.state,
           state: s.state,
           businessservice: "PGR",
         }));

--- a/digit-ui-esbuild/products/pgr/src/hooks/pgr/usePGRInboxSearch.js
+++ b/digit-ui-esbuild/products/pgr/src/hooks/pgr/usePGRInboxSearch.js
@@ -101,13 +101,33 @@ const usePGRInboxSearch = (reqCriteria) => {
       console.error("PGR inbox: failed to fetch workflow states", e);
     }
 
+    // Per-complaint-type SLA budget (hours) from MDMS ServiceDefs — the inbox filter
+    // caches these in SessionStorage on mount. Used to show "SLA days remaining" per
+    // type, matching the server-side sortBy=sla ordering (issue #432).
+    const serviceDefs = Digit.SessionStorage.get("serviceDefs") || [];
+    const slaHoursByCode = {};
+    if (Array.isArray(serviceDefs)) {
+      serviceDefs.forEach((d) => {
+        if (d?.serviceCode != null && d?.slaHours != null) slaHoursByCode[d.serviceCode] = Number(d.slaHours);
+      });
+    }
+    const DAY_MS = 24 * 60 * 60 * 1000;
+
     return {
       items: wrappers.map((sw) => {
         const pi = wfMap[sw.service?.serviceRequestId] || {};
-        const slaDays =
-          pi.businesssServiceSla != null
-            ? Math.round(pi.businesssServiceSla / (24 * 60 * 60 * 1000))
-            : null;
+        // SLA days remaining = per-type SLA budget (ServiceDefs.slaHours) − elapsed
+        // since creation. Falls back to the workflow's uniform businesssServiceSla
+        // when slaHours isn't available (serviceDefs not yet cached, or a type with
+        // no slaHours) so the column never goes blank.
+        const slaHours = slaHoursByCode[sw.service?.serviceCode];
+        const createdTime = sw.service?.auditDetails?.createdTime;
+        let slaDays = null;
+        if (slaHours != null && createdTime != null) {
+          slaDays = Math.round((slaHours * 60 * 60 * 1000 - (Date.now() - createdTime)) / DAY_MS);
+        } else if (pi.businesssServiceSla != null) {
+          slaDays = Math.round(pi.businesssServiceSla / DAY_MS);
+        }
         return {
           businessObject: { service: sw.service, serviceSla: slaDays },
           ProcessInstance: pi,


### PR DESCRIPTION
## What & why

Closes the two sub-items QA bounced back to **Todo** on the 2026-06-14 pass for #432 (the other two — hide resolved complaints, full complaint number — landed in #818).

### 1. SLA sort was inconsistent across pagination — now per-complaint-type, server-side
The inbox column-header sort is **client-side react-table**: it only reorders the *current page* while pagination is server-side. So at 10/page the lowest SLA shown was `4`, but at 20/page a different server-ordered window was fetched and those rows vanished (QA's exact repro).

Fixed by ordering **server-side** on SLA remaining. Crucially this is now **per complaint type**, not a uniform budget:

- The per-type SLA already exists in MDMS `RAINMAKER-PGR.ServiceDefs.slaHours` (e.g. Nairobi: 4h–72h) but the live inbox ignored it, showing the uniform 120h workflow SLA. This wires it in.
- **Backend:** `MDMSUtils.getServiceCodeToSlaMillis` (cached per state tenant) builds `serviceCode → SLA millis`; `PGRQueryBuilder` orders `sortBy=sla` by `(CASE ser.servicecode … ELSE <business-level SLA> END) − elapsed-since-creation`. Types missing from the map (or MDMS failure) fall back to the uniform SLA, so it's safe before per-type values are populated. The map is fetched only when `sortBy=sla`.
- **Frontend:** `usePGRInboxSearch` computes the displayed "SLA days remaining" from `ServiceDefs.slaHours` (already cached in SessionStorage by the inbox filter) so the number matches the order; falls back to workflow `businesssServiceSla` if `slaHours` is unavailable.
- The misleading per-page client column sort is disabled.

Why per-type matters: a fresh complaint of a 4h-SLA type is more urgent than an older complaint of a 72h-SLA type. Uniform/createdtime ordering gets that backwards; the per-type CASE gets it right (verified in Postgres).

### 2. Status filter emptied the list
`WorkflowStatusFilter` uses each `statusMap` entry's `statusid` as the checkbox value, and `PGRInboxConfig.preProcess` feeds the checked keys into the pgr-services `applicationStatus` filter — which matches on the state **code**, not the workflow state **UUID**. The hook emitted `s.uuid`, so every selection returned zero rows. Fix: emit `s.state`.

## Changes
- `backend/pgr-services/.../RequestSearchCriteria.java` — `SortBy.sla`
- `backend/pgr-services/.../PGRQueryBuilder.java` — per-type CASE SLA order-by
- `backend/pgr-services/.../MDMSUtils.java` — cached serviceCode→SLA map
- `backend/pgr-services/.../PGRRepository.java` — fetch SLA map when sorting by SLA
- `digit-ui-esbuild/products/pgr/.../usePGRInboxSearch.js` — per-type SLA display + status code
- `digit-ui-esbuild/products/pgr/.../UICustomizations.js` — default server sort = sla ASC
- `digit-ui-esbuild/products/pgr/.../PGRSearchInboxConfig.js` — disable misleading client column sort

## Validation
- pgr-services compiles clean (dockerized Maven, Java 17 / Spring Boot 3.2.2).
- CASE-based SLA ordering verified in Postgres: a fresh 4h-SLA complaint ranks above an older 72h-SLA complaint (createdtime ordering would invert this).
- All edited frontend files parse clean (esbuild).
- End-to-end click-through on a live box to be confirmed post-deploy.

## Notes
- SLA cache is process-lifetime; `slaHours` changes in MDMS take effect on pgr-services restart (same staleness window the migration map already had).
- Escalation SLA is a separate, already-per-type metric (per serviceCode + level, from `lastModifiedTime`); this change does not touch it.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)