### PR TITLE
fix(core): resolve profile photo fileStoreId before rendering avatars (#445)

### DIFF
--- a/digit-ui-esbuild/packages/modules/core/src/components/TopBarSideBar/SideBar/CitizenSideBar.js
+++ b/digit-ui-esbuild/packages/modules/core/src/components/TopBarSideBar/SideBar/CitizenSideBar.js
@@ -4,7 +4,7 @@ import React, { useState, Fragment, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 import ChangeCity from "../../ChangeCity";
-import { defaultImage } from "../../utils";
+import { defaultImage, resolveProfilePhoto } from "../../utils";
 import StaticCitizenSideBar from "./StaticCitizenSideBar";
 import { Hamburger } from "@egovernments/digit-ui-components";
 import { LogoutIcon } from "@egovernments/digit-ui-react-components";
@@ -17,26 +17,22 @@ const Profile = ({ info, stateName, t }) => {
   // update (CCRS#556 sub-bug pair fix). Fall back to the per-uuid
   // userSearch lookup only if the session doesn't already carry one
   // (e.g. on first login).
-  const [profilePic, setProfilePic] = React.useState(
-    info?.photo ? info.photo.split(",").at(0) : null,
-  );
+  const [profilePic, setProfilePic] = React.useState(null);
   React.useEffect(() => {
-    if (info?.photo) {
-      setProfilePic(info.photo.split(",").at(0));
-      return;
-    }
-    const uuid = info?.uuid;
-    if (!uuid) return;
     let cancelled = false;
     (async () => {
-      const tenant = Digit.ULBService.getCurrentTenantId();
-      const usersResponse = await Digit.UserService.userSearch(tenant, { uuid: [uuid] }, {});
-      if (cancelled) return;
-      if (usersResponse?.user?.length) {
-        const userDetails = usersResponse.user[0];
-        const thumbs = userDetails?.photo?.split(",");
-        setProfilePic(thumbs?.at(0));
+      const stateId = Digit.ULBService.getStateId();
+      let photo = info?.photo;
+      if (!photo && info?.uuid) {
+        const tenant = Digit.ULBService.getCurrentTenantId();
+        const usersResponse = await Digit.UserService.userSearch(tenant, { uuid: [info.uuid] }, {});
+        if (cancelled) return;
+        photo = usersResponse?.user?.[0]?.photo;
       }
+      // #445: photo may be a bare fileStoreId — resolve to a real URL before
+      // it is used as an <img src>, otherwise the avatar shows the placeholder.
+      const resolved = await resolveProfilePhoto(photo, stateId);
+      if (!cancelled) setProfilePic(resolved);
     })();
     return () => {
       cancelled = true;
@@ -152,8 +148,10 @@ export const CitizenSideBar = ({
         }
         if (usersResponse && usersResponse.user && usersResponse?.user?.length) {
           const userDetails = usersResponse.user[0];
-          const thumbs = userDetails?.photo?.split(",");
-          setProfilePic(thumbs?.at(0));
+          // #445: photo may be a bare fileStoreId — resolve to a real URL so
+          // the sidebar avatar renders instead of falling back to a glyph.
+          const resolved = await resolveProfilePhoto(userDetails?.photo, Digit.ULBService.getStateId());
+          setProfilePic(resolved);
         }
       }
     };

--- a/digit-ui-esbuild/packages/modules/core/src/components/TopBarSideBar/TopBar.js
+++ b/digit-ui-esbuild/packages/modules/core/src/components/TopBarSideBar/TopBar.js
@@ -6,6 +6,7 @@ import ChangeCity from "../ChangeCity";
 import ChangeLanguage from "../ChangeLanguage";
 import { Header as TopBarComponentMain } from "@egovernments/digit-ui-components";
 import ImageComponent from "../ImageComponent";
+import { resolveProfilePhoto } from "../utils";
 
 const DEFAULT_EGOV_LOGO ="https://egov-dev-assets.s3.ap-south-1.amazonaws.com/egov-logo-2025.png";
 const TopBar = ({
@@ -33,8 +34,11 @@ const TopBar = ({
       const usersResponse = await Digit.UserService.userSearch(tenant, { uuid: [uuid] }, {});
       if (usersResponse && usersResponse.user && usersResponse.user.length) {
         const userDetails = usersResponse.user[0];
-        const thumbs = userDetails?.photo?.split(",");
-        setProfilePic(thumbs?.at(0));
+        // #445: photo may be a bare fileStoreId — resolve to a real URL,
+        // otherwise the Dropdown renders charAt(0) of the UUID as a "random"
+        // avatar initial. stateId is the filestore tenant for the lookup.
+        const resolved = await resolveProfilePhoto(userDetails?.photo, Digit.ULBService.getStateId());
+        setProfilePic(resolved);
       }
     }
   }, [profilePic !== null, userDetails?.info?.uuid]);

--- a/digit-ui-esbuild/packages/modules/core/src/components/utils.js
+++ b/digit-ui-esbuild/packages/modules/core/src/components/utils.js
@@ -20,3 +20,37 @@ export const defaultImage =
   "Ue6ilunu8jF8pFwgv1FXp3mUt35OtRbr7eM4u4Gs6vUBXgeuHc5kfE/cbvWZtkROLm1DMtLCy80tzsu2PRj0hTI8fvrQuvsjlJkyutszq+m423wHaLTyniy/XuiGZ84LuT+m5ZfNfRxyGs7L" +
   "XZOvia7VujatUwVTrIt+Q/Csc7Tuhe+BOakT10b4TuoiiJjvgU9emTO42PwEfBa+cuodKkuf42DXr1D3JpXz73Hnn0j10evHKe+nufgfUm+7B84sX9FfdEzXux2DBpWuKokkCqN/5pa/8pmvn" +
   "L+RGKCddCGmatiPyPB/+ekO/M/q/7uvbt22kTt3zEnXPzCV13T3Gel4/6NduDu66xRvlPNkM1RjjxUdv+4WhGx6TftD19Q/dfzpwcHO+rE3fAAAAAElFTkSuQmCC";
+
+// Resolve a user `photo` value to a displayable image URL.
+//
+// `user.photo` arrives in two shapes (see UserProfile.js / CCRS#556):
+//   - a comma-separated list of pre-resolved URLs
+//     ("https://…/full,https://…/medium,https://…/small"), or
+//   - a bare fileStoreId ("07505a88-cae6-…") for fresh uploads persisted
+//     via /user/profile/_update.
+//
+// The avatar widgets (TopBar dropdown, citizen/employee sidebars) historically
+// fed this value straight into an <img src>. That worked for the URL shape but
+// broke for a bare fileStoreId (#445): the citizen avatar fell back to the
+// placeholder, and the employee Dropdown — unable to load the "src" — rendered
+// charAt(0) of the UUID, so the fallback initial appeared to change at random
+// on every upload. Mirror the edit-profile page and resolve the bare-id case
+// through Filefetch. Returns null on absence/failure so callers fall back to
+// their placeholder.
+export const resolveProfilePhoto = async (photo, stateId) => {
+  if (!photo) return null;
+  if (photo.startsWith("http") || photo.includes(",")) {
+    return photo.split(",").at(0);
+  }
+  try {
+    const res = await Digit.UploadServices.Filefetch([photo], stateId);
+    const entry = res?.data?.fileStoreIds?.[0];
+    if (entry?.url) {
+      const urls = entry.url.split(",");
+      return urls.find((u) => /small/i.test(u)) || urls[0];
+    }
+  } catch (e) {
+    // Silent: a stale id must not break the page chrome.
+  }
+  return null;
+};


### PR DESCRIPTION
## What

Profile-image **upload** works (since the 5 MB ceiling + crash fixes on #445), but the uploaded image never shows in the avatar chrome:

- **Citizen UI** — left-menu profile icon stays on the placeholder.
- **Employee UI** — top-right profile icon stays empty, and its fallback **initial letter changes at random on every upload**.

## Root cause

`user.photo` arrives in two shapes:
- a comma-separated list of pre-resolved URLs (`…/full,…/medium,…/small`), or
- a **bare fileStoreId** (`07505a88-…`) for fresh uploads persisted via `/user/profile/_update`.

The edit-profile *page* was already patched to resolve the bare-id case via `Filefetch` (CCRS#556), but the three avatar widgets were not — they fed `user.photo` straight into an `<img src>`. A bare fileStoreId is not a fetchable URL, so:
- the citizen `<img>` fails and falls back to the placeholder, and
- the employee `<Dropdown>`, unable to load the "src", treats the string as a name and renders `charAt(0)` of it — i.e. the **first character of the UUID**, which differs per upload → the "random initial" symptom.

## Fix

Add a shared `resolveProfilePhoto(photo, stateId)` helper in `core/components/utils.js` that mirrors the edit-profile logic (pass URL-shaped values through; resolve a bare id via `Filefetch`, preferring the `small` thumbnail; return `null` on absence/failure). Wire all three render paths to it:

- `TopBarSideBar/TopBar.js` — employee top-right Dropdown
- `TopBarSideBar/SideBar/CitizenSideBar.js` — citizen left-menu `Profile` + employee sidebar

No behavior change for the already-working URL shape; only the bare-fileStoreId case is newly resolved.

## Validate

Employee → Edit Profile → upload a 2–3 MB phone JPEG → save. Top-right avatar shows the photo (not a random letter). Citizen → same flow → left-menu icon shows the photo. Refresh: both persist.

Closes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)