### PR TITLE
fix(deploy): raise keycloak healthcheck start_period so the converge stops aborting

### DIFF
--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -2154,7 +2154,17 @@ services:
       interval: 15s
       timeout: 5s
       retries: 10
-      start_period: 60s
+      # `start-dev --import-realm` re-runs the Quarkus augmentation + realm
+      # import on EVERY container start, so cold-start to "Listening on 8180"
+      # is ~120s (measured ~118s on bomet under a full-stack converge). At the
+      # old 60s the container flipped to `unhealthy` mid-startup, and the
+      # converge's `up -d` (services depend_on keycloak: service_healthy) aborted
+      # "dependency failed to start" — which on Linux ends the whole playbook,
+      # silently skipping every later task (configurator build, bootstrap, …).
+      # Keep start_period comfortably above real startup so the container stays
+      # `starting` (not `unhealthy`) until it's actually up. retries×interval
+      # (150s) still catches a genuinely dead keycloak after the grace window.
+      start_period: 180s
     networks:
       - egov-network
 


### PR DESCRIPTION
## Problem

bomet's nightly redeploy has been aborting partway through the ansible play for ~5 nights (`failed=1` on Jun 13/14/15), silently skipping every task after the converge — the **Configurator SPA build/sync**, post-bootstrap, and validation steps. The box still reported green because the redeploy wrapper's heal loop re-ups the containers, so the failure was invisible until the configurator was found frozen at a 5-day-old bundle.

## Root cause

keycloak launches with `start-dev --import-realm`, which re-runs the Quarkus augmentation + realm import on **every** container start. Cold-start to `Listening on 8180` is ~120s (measured **~118s** on bomet during a full-stack converge: recreate 15:33:39 → listening 15:35:37). The healthcheck `start_period` was only **60s** — about half the real startup — so the container flipped to `unhealthy` mid-startup. Other services `depends_on: keycloak: condition: service_healthy`, so the converge's `docker compose up -d` aborted with *"dependency failed to start: container keycloak is unhealthy"* (~67s in, ~50s before keycloak would actually have been ready).

It is **not** the keycloak DB-password ordering issue — keycloak connected to its Postgres cleanly; no JDBC/auth errors. The only defect is `start_period < actual startup` against a dev-mode launch that's slow by design.

## Fix

Raise keycloak's healthcheck `start_period` 60s → **180s** (comfortably above the ~118s startup). During `start_period`, failing probes keep the container in `starting` rather than `unhealthy`, so compose waits through the boot instead of aborting. `retries × interval` (150s) still flags a genuinely dead keycloak after the grace window.

## Validation (on bomet, by running)

Applied to the runtime compose and ran the exact converge that aborts nightly:
- keycloak recreated (exercising the real ~120s slow-start path), came up healthy
- `docker compose up -d` returned **rc=0**, **no "dependency failed to start"**
- `StartPeriod=3m0s` live on the container; **0 unhealthy / 52 containers up**

With this, the play completes instead of aborting, so the back half (configurator build, bootstrap, validation) runs on its own and the heal loop returns to being a true safety net rather than a failure-masker.

## Follow-ups (not in this PR)

- keycloak runs in dev mode (`start-dev`, "DO NOT use this configuration in production"); an optimized/prod build (`kc.sh build` + `start --optimized`) would cut startup to ~10s and remove the dev-mode warning.
- Linux uses a bare `docker compose up -d` while macOS uses the resilient retry-converge (`mac-stack-up.sh`); giving Linux the same loop would make any single slow service non-fatal to the play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
