### PR TITLE
fix(micro-ui): handle .jsx in webpack so the digit-ui image builds

### DIFF
--- a/frontend/micro-ui/web/webpack.config.js
+++ b/frontend/micro-ui/web/webpack.config.js
@@ -20,7 +20,10 @@ module.exports = {
         }
       },
       {
-        test: /\.(js)$/,
+        // Match .jsx too: the src/dashboard/* feature is authored in .jsx,
+        // which this rule (preset-react) must transpile — a bare /\.js$/
+        // silently skips them and webpack fails on the JSX syntax.
+        test: /\.(jsx?)$/,
         exclude: /node_modules/,
         use: {
           loader: "babel-loader",
@@ -43,6 +46,12 @@ module.exports = {
         ],
       },
     ],
+  },
+  resolve: {
+    // Without this, extensionless imports like `./dashboard/AdminDashboard`
+    // only resolve .js — webpack's defaults don't include .jsx — so the
+    // .jsx dashboard modules fail to resolve.
+    extensions: [".js", ".jsx", ".json"],
   },
   output: {
     filename: "[name].bundle.js",


### PR DESCRIPTION
## Problem

The nightly `digit-ui` (legacy `frontend/micro-ui`) image build fails on develop:

```
ERROR in ./src/App.js
Module not found: Error: Can't resolve './dashboard/AdminDashboard' in '/app/web/src'
error Command failed with exit code 1.   # yarn build:webpack
```

`web/src/dashboard/` (the admin dashboard feature — `AdminDashboard.jsx` + 9 component `.jsx` files) is authored in **`.jsx`**, but `web/webpack.config.js` never handled `.jsx`:

- the app babel rule matched only `/\.js$/`, so the JSX-syntax files were never run through `@babel/preset-react`;
- there was **no** `resolve.extensions`, so webpack's defaults (which don't include `.jsx`) couldn't resolve the extensionless `import AdminDashboard from "./dashboard/AdminDashboard"`.

So the build has been broken since the dashboard feature landed.

## Fix

`web/webpack.config.js`:
- app babel rule `test: /\.(js)$/` → `/\.(jsx?)$/` (transpile `.jsx` with preset-react)
- add `resolve.extensions: [".js", ".jsx", ".json"]` (resolve extensionless `.jsx` imports)

## Validation

Ran the exact nightly build on bomet:

```
docker build -f frontend/micro-ui/web/docker/Dockerfile frontend/micro-ui/
```

Before: failed at `yarn build:webpack` on the `AdminDashboard` import.
After: webpack compiles clean, image exports, `BUILD_EXIT=0`.

This clears the last `FAILED` entry in the nightly image set (alongside #863 for `digit-ui-esbuild`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
