### PR TITLE
feat(deploy): self-hosted Overpass for configurator boundary fetch (opt-in)

### DIFF
--- a/configurator/src/pages/Phase2Page.tsx
+++ b/configurator/src/pages/Phase2Page.tsx
@@ -50,6 +50,13 @@ type BoundaryPath = 'osm' | 'excel' | null;
 // proxies it to the search-api container); override via VITE_TURBOPASS_URL.
 const TURBOPASS_BASE: string = import.meta.env.VITE_TURBOPASS_URL || '/turbopass';
 
+// Overpass endpoint for the boundary-polygon fetch. Defaults to the public
+// instance (zero-config, but rate-limited / 504-prone under load). A deploy
+// that self-hosts Overpass sets VITE_OVERPASS_URL (e.g. same-origin
+// '/overpass/api/interpreter', proxied by nginx to the on-box container behind
+// the enable_overpass gate) at configurator build time.
+const OVERPASS_URL: string = import.meta.env.VITE_OVERPASS_URL || 'https://overpass-api.de/api/interpreter';
+
 // The OSM path always writes the ADMIN hierarchy (the Excel path lets the
 // operator name it).
 const OSM_HIERARCHY_TYPE = 'ADMIN';
@@ -510,7 +517,7 @@ out body;
 >;
 out skel qt;`;
 
-      const res = await fetch('https://overpass-api.de/api/interpreter', {
+      const res = await fetch(OVERPASS_URL, {
         method: 'POST',
         body: query
       });

--- a/local-setup/ansible/inventory/host_vars/_example.yml
+++ b/local-setup/ansible/inventory/host_vars/_example.yml
@@ -210,6 +210,23 @@ enable_mcp: true
 enable_turbopass: false
 # turbopass_port: 13301        # loopback port the search-api publishes on
 
+# ────────── Self-hosted Overpass (boundary-polygon fetch) ──────────
+# The configurator's Phase 2 OSM step fetches admin-boundary polygons from
+# Overpass. The public overpass-api.de is rate-limited / 504-prone; enable this
+# to run a standalone on-box `bomet-overpass` container (loopback 127.0.0.1:12346)
+# fed a boundary-filtered OSM extract, with nginx proxying /overpass/ → it. When
+# on, the configurator build bakes VITE_OVERPASS_URL=/overpass/api/interpreter so
+# Phase 2 uses the on-box instance. Off by default → public Overpass, nginx vhost
+# byte-identical to a pre-overpass deploy.
+# PREPARE THE EXTRACT FIRST (operator-specific country/size): see
+# overpass/README.md + overpass/prepare-extract.sh, then place the result at
+# overpass_planet_file on the target.
+enable_overpass: false
+# overpass_port: 12346                                   # loopback port
+# overpass_data_dir: /opt/overpass/data                  # holds the extract (mounted /data)
+# overpass_db_dir: /opt/overpass/db                      # Overpass DB volume (mounted /db)
+# overpass_planet_file: /opt/overpass/data/boundaries.osm.bz2  # prepared extract
+
 # ────────── Notifications (Novu + Twilio WhatsApp) ──────────
 # Turn on the `notifications` compose profile — adds 8 containers:
 #   digit-config-service, digit-user-preferences-service, novu-bridge,

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -1267,6 +1267,12 @@
         "{{ configurator_repo | default(playbook_dir ~ '/../../configurator') }}"
         "{{ configurator_repo_url | default('-') }}"
         "{{ configurator_ref | default('') }}"
+      # When the box self-hosts Overpass, bake the same-origin endpoint into the
+      # build so Phase 2's boundary fetch hits the on-box container (nginx
+      # /overpass/) instead of the public, rate-limited overpass-api.de. Empty
+      # otherwise → the code default (public Overpass) applies.
+      environment:
+        VITE_OVERPASS_URL: "{{ '/overpass/api/interpreter' if (enable_overpass | default(false)) else '' }}"
       register: configurator_build_run
       changed_when: true
       when:
@@ -1355,6 +1361,68 @@
       register: turbopass_sweep
       changed_when: turbopass_sweep.stdout | length > 0
       when: not (enable_turbopass | default(false))
+
+    # ---- Self-hosted Overpass (opt-in: enable_overpass) ----
+    # The configurator's Phase 2 boundary-polygon fetch hits Overpass. The
+    # public overpass-api.de is rate-limited / 504-prone; a box can self-host
+    # it as a standalone `bomet-overpass` container (loopback only) fed a
+    # boundary-filtered OSM extract, with nginx proxying /overpass/ → it (same
+    # gate). The configurator build above bakes VITE_OVERPASS_URL=/overpass/...
+    # when this flag is on. The extract is operator-prepared (country choice +
+    # size are deployment-specific) — see overpass/README.md + prepare-extract.sh;
+    # the playbook only runs the container against {{ overpass_planet_file }}.
+    - name: "Overpass — ensure data dir on target"
+      ansible.builtin.file:
+        path: "{{ overpass_data_dir | default('/opt/overpass/data') }}"
+        state: directory
+        mode: '0755'
+      when: enable_overpass | default(false)
+
+    - name: "Overpass — check prepared extract exists"
+      ansible.builtin.stat:
+        path: "{{ overpass_planet_file | default('/opt/overpass/data/boundaries.osm.bz2') }}"
+      register: overpass_extract
+      when: enable_overpass | default(false)
+
+    - name: "Overpass — warn if extract missing (container not started)"
+      ansible.builtin.debug:
+        msg: >-
+          enable_overpass is true but {{ overpass_planet_file | default('/opt/overpass/data/boundaries.osm.bz2') }}
+          is missing. Prepare it with overpass/prepare-extract.sh (geofabrik pbf
+          → osmium boundary-filter → .osm.bz2), then re-run. Skipping container.
+      when:
+        - enable_overpass | default(false)
+        - not (overpass_extract.stat.exists | default(false))
+
+    # (re)create the Overpass container. OVERPASS_RULES_LOAD=10 builds the
+    # area[] index the configurator's `area["name"=...]` query needs; META=no
+    # keeps the DB lean. init mode imports on first run; the DB volume persists.
+    - name: "Overpass — (re)create the bomet-overpass container"
+      ansible.builtin.shell: |
+        docker rm -f bomet-overpass >/dev/null 2>&1 || true
+        docker run -d --name bomet-overpass --restart unless-stopped \
+          -e OVERPASS_META=no -e OVERPASS_MODE=init -e OVERPASS_RULES_LOAD=10 \
+          -e OVERPASS_PLANET_URL=file:///data/{{ (overpass_planet_file | default('/opt/overpass/data/boundaries.osm.bz2')) | basename }} \
+          -p 127.0.0.1:{{ overpass_port | default(12346) }}:80 \
+          -v {{ overpass_data_dir | default('/opt/overpass/data') }}:/data \
+          -v {{ overpass_db_dir | default('/opt/overpass/db') }}:/db \
+          wiktorn/overpass-api
+      register: overpass_run
+      changed_when: true
+      when:
+        - enable_overpass | default(false)
+        - overpass_extract.stat.exists | default(false)
+
+    # Flag flipped true → false: sweep the standalone container (not compose-managed).
+    - name: "Overpass — sweep container when flag is OFF"
+      ansible.builtin.shell: |
+        if docker ps -a --filter name=^bomet-overpass$ --format '{{ "{{" }}.Names{{ "}}" }}' | grep -q '^bomet-overpass$'; then
+          docker rm -f bomet-overpass >/dev/null
+          echo "swept bomet-overpass"
+        fi
+      register: overpass_sweep
+      changed_when: overpass_sweep.stdout | length > 0
+      when: not (enable_overpass | default(false))
 
     # ---- digit-integration-tests dashboards (opt-in: enable_integration_tests) ----
     # Builds the react-admin catalog dashboard from the VENDORED in-tree source

--- a/local-setup/ansible/templates/nginx-site.conf.j2
+++ b/local-setup/ansible/templates/nginx-site.conf.j2
@@ -333,6 +333,22 @@ server {
   }
 
 {% endif %}
+{% if enable_overpass | default(false) %}
+  # Self-hosted Overpass — boundary-polygon fetch for the configurator's
+  # Phase 2 OSM step (POST /overpass/api/interpreter). Proxies to the on-box
+  # bomet-overpass container (loopback only; started by the playbook's
+  # "Overpass" tasks behind the same enable_overpass gate). Trailing slash
+  # strips the /overpass prefix so the app sees /api/interpreter.
+  location /overpass/ {
+    proxy_pass http://127.0.0.1:{{ overpass_port | default(12346) }}/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_read_timeout 120s;
+  }
+
+{% endif %}
 {% if digit_ui_mode == "static" %}
   # digit-ui in static mode: host nginx serves the build artifact from
   # /opt/digit-ui-esbuild/build/ directly. Built by the playbook

--- a/overpass/README.md
+++ b/overpass/README.md
@@ -1,0 +1,47 @@
+# Self-hosted Overpass (boundary fetch for configurator Phase 2)
+
+The configurator's Phase 2 OSM step fetches admin-boundary polygons from
+Overpass. The public `overpass-api.de` is rate-limited and frequently returns
+`504 Gateway Timeout` under load. A deployment can self-host Overpass instead.
+
+## How it fits together
+
+- **configurator** — `Phase2Page.tsx` calls `VITE_OVERPASS_URL || https://overpass-api.de/api/interpreter`.
+  The `enable_overpass` deploy bakes `VITE_OVERPASS_URL=/overpass/api/interpreter`
+  at build time, so Phase 2 hits the on-box instance same-origin.
+- **ansible** — host_var `enable_overpass: true` runs a standalone
+  `bomet-overpass` container (`wiktorn/overpass-api`, loopback `127.0.0.1:12346`)
+  and renders an nginx `/overpass/` proxy in front of it. Default-off → nginx
+  renders byte-identical and the configurator uses public Overpass.
+- **data** — operator-prepared, because country choice + size are
+  deployment-specific. Not committed (extracts are large).
+
+## Prepare the data
+
+`prepare-extract.sh` downloads Geofabrik country extracts, filters each to
+`boundary=administrative` (keeps the Overpass DB tiny and area-generation fast),
+merges them, and writes `boundaries.osm.bz2`:
+
+```bash
+./prepare-extract.sh /opt/overpass/data \
+  https://download.geofabrik.de/africa/kenya-latest.osm.pbf \
+  https://download.geofabrik.de/africa/mozambique-latest.osm.pbf
+```
+
+Then in `host_vars/<tenant>.yml`:
+
+```yaml
+enable_overpass: true
+overpass_planet_file: /opt/overpass/data/boundaries.osm.bz2
+```
+
+and deploy. First start imports the extract and builds the area index
+(`OVERPASS_RULES_LOAD=10`) — a few minutes for a country; the DB volume persists.
+
+## Verify
+
+```bash
+curl -s -X POST http://127.0.0.1:12346/api/interpreter --data-urlencode \
+  'data=[out:json];area["name"="Nairobi"]["boundary"="administrative"]->.a;(rel(area.a)["boundary"="administrative"];);out ids;' \
+  | grep -c '"type": "relation"'
+```

--- a/overpass/prepare-extract.sh
+++ b/overpass/prepare-extract.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# prepare-extract.sh — build a boundary-filtered OSM extract for self-hosted
+# Overpass (the configurator Phase 2 boundary fetch). Downloads Geofabrik
+# country extracts, filters each to admin boundaries (tiny → fast Overpass
+# import + area-gen), merges them, and writes a single .osm.bz2 that the
+# enable_overpass deploy feeds to the wiktorn/overpass-api container.
+#
+# osmium runs in a throwaway container (no host install needed). Output goes to
+# the dir the playbook mounts as the Overpass /data volume.
+#
+# Usage:
+#   ./prepare-extract.sh <out-dir> <region-url> [<region-url> ...]
+# Example (Kenya + Mozambique + India):
+#   ./prepare-extract.sh /opt/overpass/data \
+#     https://download.geofabrik.de/africa/kenya-latest.osm.pbf \
+#     https://download.geofabrik.de/africa/mozambique-latest.osm.pbf \
+#     https://download.geofabrik.de/asia/india-latest.osm.pbf
+#
+# Result: <out-dir>/boundaries.osm.bz2  (== overpass_planet_file default)
+set -euo pipefail
+
+OUT_DIR="${1:?usage: prepare-extract.sh <out-dir> <region-url>...}"; shift
+[ "$#" -ge 1 ] || { echo "need at least one geofabrik region URL" >&2; exit 2; }
+mkdir -p "$OUT_DIR"
+OSMIUM="docker run --rm -v ${OUT_DIR}:/data ubuntu:22.04 bash -c"
+RUN_OSMIUM() { docker run --rm -v "${OUT_DIR}:/data" ubuntu:22.04 bash -c "apt-get update -qq >/dev/null && apt-get install -y -qq osmium-tool >/dev/null && $1"; }
+
+FILTERED=()
+for url in "$@"; do
+  name="$(basename "$url" .osm.pbf)"
+  echo ">> $name: downloading"; curl -fSL -o "${OUT_DIR}/${name}.osm.pbf" "$url"
+  echo ">> $name: filtering to admin boundaries"
+  RUN_OSMIUM "osmium tags-filter -o /data/${name}-boundaries.osm.bz2 --overwrite /data/${name}.osm.pbf boundary=administrative"
+  rm -f "${OUT_DIR}/${name}.osm.pbf"
+  FILTERED+=("/data/${name}-boundaries.osm.bz2")
+done
+
+echo ">> merging ${#FILTERED[@]} region(s) → boundaries.osm.bz2"
+RUN_OSMIUM "osmium merge --overwrite -o /data/boundaries.osm.bz2 ${FILTERED[*]}"
+echo "done: ${OUT_DIR}/boundaries.osm.bz2 ($(du -h "${OUT_DIR}/boundaries.osm.bz2" | cut -f1))"
+echo "Set overpass_planet_file: ${OUT_DIR}/boundaries.osm.bz2 and enable_overpass: true, then deploy."


### PR DESCRIPTION
## Why

The configurator's Phase 2 OSM step fetches admin-boundary polygons from Overpass. It was hardcoded to the **public** `overpass-api.de`, which is rate-limited and frequently returns `504 Gateway Timeout` under load (hit during live boundary testing). This adds an **opt-in self-hosted Overpass**, so a deployment can serve the boundary fetch entirely on-box.

This is the last piece of the OSM boundary onboarding work that wasn't yet codified — it had been validated live on bomet but existed only as on-box hot-patches.

## What

Mirrors the existing turbopass pattern (gated, default-off, byte-identical when off):

- **configurator** (`Phase2Page.tsx`): the Overpass endpoint is now `import.meta.env.VITE_OVERPASS_URL || 'https://overpass-api.de/api/interpreter'`. Zero-config still uses the public instance.
- **ansible**: `enable_overpass` host_var (default `false`) runs a standalone `bomet-overpass` container (`wiktorn/overpass-api`, loopback `127.0.0.1:12346`, `OVERPASS_RULES_LOAD=10` for the `area[]` index the query needs) against an operator-prepared boundary extract, renders a gated nginx `/overpass/` proxy, and sweeps the container when flipped off. The configurator build task bakes `VITE_OVERPASS_URL=/overpass/api/interpreter` when the flag is on.
- **overpass/**: `prepare-extract.sh` (Geofabrik pbf → `osmium tags-filter boundary=administrative` → merge → `.osm.bz2`) + README. Extracts are operator-prepared (country/size are deployment-specific) and intentionally not committed.

## Validation

- configurator builds green; default bundle → public Overpass; with `VITE_OVERPASS_URL` set → bakes `/overpass/api/interpreter` (confirmed in the built bundle).
- playbook + `_example.yml` YAML parse; nginx jinja `{% if %}/{% endif %}` balanced — vhost renders byte-identical when `enable_overpass` is off.
- Mechanism proven live on bomet: Mozambique + Kenya + India admin boundaries served via `/overpass`; 504s eliminated (Nairobi 157 / Delhi 1229 / Cidade de Maputo 72 relations).

## Cutover note (bomet)

To make bomet's current on-box Overpass durable: set `enable_overpass: true` + `overpass_planet_file` in its host_vars after this merges (the container + data are already on the box from testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
