### PR TITLE
fix(pgr-create): never blank the complaint Type/Sub-Type dropdowns (#810)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/employee/CreateComplaint/createComplaintForm.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/CreateComplaint/createComplaintForm.js
@@ -67,6 +67,23 @@ const CreateComplaintForm = ({
     return [...set];
   }, [currentEmployeeData]);
 
+  // Admin-style roles aren't tied to a single department, so they should always
+  // see the full Type/Sub-Type list rather than be scoped to one (or none).
+  const PRIVILEGED_ROLES = ["SUPERUSER", "PGR_ADMIN", "PGR-ADMIN"];
+  const isPrivileged = (user?.info?.roles || []).some((r) => PRIVILEGED_ROLES.includes(r?.code));
+
+  // Department gating is a *refinement*, never a hard block: only scope the
+  // Type/Sub-Type dropdowns to the employee's department(s) when doing so still
+  // leaves something to pick. If the user has no department, a privileged role,
+  // or a department that matches no ServiceDef (HRMS dept codes can diverge from
+  // the ServiceDefs `department`), gating is disabled and every type is shown —
+  // otherwise the dropdowns went blank even though MDMS has the data (issue #810).
+  const departmentGate = useMemo(() => {
+    const scoped = (serviceDefs || []).filter((d) => loggedInUserDepartments.includes(d.department));
+    const enabled = !isPrivileged && loggedInUserDepartments.length > 0 && scoped.length > 0;
+    return { enabled, scoped };
+  }, [serviceDefs, loggedInUserDepartments, isPrivileged]);
+
   useEffect(() => {
     if (toast?.show) {
       const timer = setTimeout(() => {
@@ -147,12 +164,11 @@ const CreateComplaintForm = ({
       return [];
     }
 
-    // Strict gate by the logged-in employee's department(s): only show
-    // sub-types when the user is assigned to the selected Type's department.
-    // Supports multiple departments. If the user isn't assigned to it (or the
-    // assignment hasn't loaded), show nothing — never forward a department the
-    // user isn't assigned to.
-    if (!loggedInUserDepartments.includes(baseItem.department)) {
+    // Gate sub-types by the selected Type's department ONLY when department
+    // gating is active (see departmentGate / issue #810). When it's disabled —
+    // no/mismatched department or a privileged user — skip the gate so sub-types
+    // still appear for the chosen Type.
+    if (departmentGate.enabled && !loggedInUserDepartments.includes(baseItem.department)) {
       return [];
     }
 
@@ -179,14 +195,12 @@ const CreateComplaintForm = ({
 
   const updatedConfig = useMemo(() => {
 
-    // Scope the Complaint Type options strictly to the logged-in employee's
-    // assigned department(s) — a user only sees Types they can act on (e.g. an
-    // "ambiental" user doesn't see the "Water"/DEPT_36 Type). If the user has
-    // no assignment (or it hasn't loaded yet), the list is empty: we never
-    // forward Types for a department the user isn't assigned to.
-    const departmentScopedDefs = (serviceDefs || []).filter((d) =>
-      loggedInUserDepartments.includes(d.department)
-    );
+    // Complaint Type options: scoped to the employee's department(s) when
+    // departmentGate is active (e.g. an "ambiental" user doesn't see the
+    // "Water"/DEPT_36 Type), otherwise the full list. The gate is disabled
+    // rather than yielding an empty list when the user has no/mismatched
+    // department or is privileged (issue #810).
+    const departmentScopedDefs = departmentGate.enabled ? departmentGate.scoped : (serviceDefs || []);
 
     const baseConfig = Digit.Utils.preProcessMDMSConfig(
       t,
@@ -229,7 +243,7 @@ const CreateComplaintForm = ({
     });
 
     return { ...baseConfig, form: updatedForm };
-  }, [createComplaintConfig, serviceDefs, t, disabledFields, subType, loggedInUserDepartments]);
+  }, [createComplaintConfig, serviceDefs, t, disabledFields, subType, loggedInUserDepartments, departmentGate]);
 
 
 


### PR DESCRIPTION
## What & why

Fixes #810 — on **employee → Create Complaint**, the Complaint **Type** and **Sub-Type** dropdowns are empty even though the backend (MDMS `ServiceDefs`) has the data.

**Root cause:** commit `05b51679` scoped the dropdowns to the logged-in employee's HRMS department(s): `serviceDefs.filter(d => loggedInUserDepartments.includes(d.department))`. When that intersection is empty the lists go **completely blank** — there's no fallback. This happens whenever:
- the employee's HRMS department has **no matching `ServiceDef`** (the department code-spaces diverge — on bomet ~53 employees are in DEPT_25 / DEPT_35 / BOMET_MUNICIPALITY / DEPT_2 / ambiental / … which have zero ServiceDefs),
- the user has **no department assignment** (e.g. configurator-created / admin users), or
- the HRMS lookup hasn't resolved / fails.

In all of those, the employee **cannot file a complaint at all** — hence P0.

## Fix

Make department gating a **refinement, not a hard block**. A single `departmentGate.enabled` flag is true only when scoping still leaves something pickable:

```
enabled = !isPrivileged && loggedInUserDepartments.length > 0 && scopedServiceDefs.length > 0
```

- **enabled** → keep today's behaviour (Type/Sub-Type scoped to the user's department).
- **disabled** (no/mismatched department, or a privileged SUPERUSER/PGR_ADMIN) → show **all** types. The Sub-Type department gate is made conditional on the same flag.

So department-scoped users keep their scoped view; everyone else gets the full list instead of an empty one. No tenant-specific values — purely a guard on the existing filter.

## Files
- `digit-ui-esbuild/products/pgr/src/pages/employee/CreateComplaint/createComplaintForm.js`

## Validation
- esbuild parses clean.
- Logic: DEPT_25 employee (no matching ServiceDef) → gate disabled → all types shown; WATER_ENV employee (matches) → gate active → scoped; SUPERUSER / no-HRMS → all types.
- Live click-through to confirm on bomet after deploy (build serves `products/pgr`).

## Follow-up (not in this PR)
The underlying **department code-space mismatch** between HRMS assignments and `ServiceDefs.department` is a data/config issue worth reconciling separately so the *scoping* works as intended for those employees; this PR just guarantees the form is never unusable.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)