### PR TITLE
fix(pgr-escalation): allow SYSTEM + AUTO_ESCALATE on the ESCALATE workflow action

### DIFF
--- a/utilities/default-data-handler/src/main/resources/PgrWorkflowConfig.json
+++ b/utilities/default-data-handler/src/main/resources/PgrWorkflowConfig.json
@@ -214,7 +214,9 @@
               "nextState": "PENDINGATSUPERVISOR",
               "roles": [
                 "PGR_LME",
-                "PGR_VIEWER"
+                "PGR_VIEWER",
+                "SYSTEM",
+                "AUTO_ESCALATE"
               ],
               "active": true
             }


### PR DESCRIPTION
## Problem

The PGR auto-escalation scheduler (`EscalationScheduler`, shipped in #692) performs the `ESCALATE` workflow transition acting as a **`SYSTEM`** user (`egov.internal.microservice.user.uuid`, role `SYSTEM` tagged at the state tenant).

But the seeded workflow in `PgrWorkflowConfig.json` allows only `["PGR_LME", "PGR_VIEWER"]` on the `PENDINGATLME → PENDINGATSUPERVISOR` `ESCALATE` action. So on a **fresh deploy**, the workflow validator rejects the scheduler's transition (actor role `SYSTEM` ∉ allowed roles) and auto-escalation silently no-ops — the scheduler runs, finds the breach, but the `ESCALATE` is refused.

Live deployments only work because the workflow was **hand-patched on the box** to add `SYSTEM` + `AUTO_ESCALATE` (one of the non-persisted bomet layers tracked under #687). This PR brings the seed (“built”) in line with what’s actually deployed.

## Change

Add `SYSTEM` and `AUTO_ESCALATE` to the `ESCALATE` action roles in `PgrWorkflowConfig.json`:

```diff
   "action": "ESCALATE",
   "nextState": "PENDINGATSUPERVISOR",
   "roles": [
     "PGR_LME",
-    "PGR_VIEWER"
+    "PGR_VIEWER",
+    "SYSTEM",
+    "AUTO_ESCALATE"
   ],
```

## Evidence

On a live deployment (bomet, tenant `ke`) the same transition is configured as `PGR_LME, PGR_VIEWER, SYSTEM, AUTO_ESCALATE`, and auto-escalation was verified end-to-end there 2026-06-17 (filed → assigned → scheduler escalated `PENDINGATLME → PENDINGATSUPERVISOR`, `escalationLevel=1`, performed by the SYSTEM user). With develop's seed missing `SYSTEM`, a fresh deploy would not reproduce that.

Refs #585, #692, #687.

> Note: this only affects the seed used to **create** the workflow on a fresh deploy / re-seed. Existing deployments where the workflow already exists are unaffected (the loader skips existing business services).
