### PR TITLE
fix(tests): guard ?.complaints?.terminal_rated against skipped lifecycle fixtures

### DIFF
--- a/tests/integration-tests/tests/citizen/timeline-fixes-2026-04-29.spec.ts
+++ b/tests/integration-tests/tests/citizen/timeline-fixes-2026-04-29.spec.ts
@@ -10,7 +10,7 @@ import { readLifecycleFixtures } from '../utils/lifecycle-fixtures';
 //   3. naipepea historical fallback
 const SR_ID =
   process.env.PINNED_COMPLAINT_SRID
-  || readLifecycleFixtures()?.complaints.terminal_rated
+  || readLifecycleFixtures()?.complaints?.terminal_rated
   || 'NCCG-PGR-2026-04-28-011862';
 
 test.describe('04-citizen-timeline (#473 follow-up)', () => {

--- a/tests/integration-tests/tests/lifecycle/api-smoke-2026-04-29.spec.ts
+++ b/tests/integration-tests/tests/lifecycle/api-smoke-2026-04-29.spec.ts
@@ -9,7 +9,7 @@ import { TENANT } from '../utils/env';
 // SRID and the tenant we search always come from the same source.
 const KNOWN_RESOLVED_SRID =
   process.env.KNOWN_RESOLVED_SRID
-  || readLifecycleFixtures()?.complaints.terminal_rated
+  || readLifecycleFixtures()?.complaints?.terminal_rated
   || 'NCCG-PGR-2026-04-28-011862';
 
 test.describe('00-smoke: API helpers reach the configured deployment', () => {


### PR DESCRIPTION
## Summary

Two integration-test specs read `readLifecycleFixtures()?.complaints.terminal_rated` at **module-load / collection time**. The single optional-chain only guards the fixtures file being *absent* — not the **skip-marker shape** (`{status:"skipped", ...}` with no `complaints` key) that `lifecycle.setup.ts` writes when it can't seed a terminal-rated complaint (e.g. the `DEPARTMENT_NOT_FOUND` workflow-walk failure on bomet `ke`).

When the skip-marker is on disk, `.complaints` is `undefined` and `.terminal_rated` throws during collection → **Playwright aborts the entire run with empty results** (`exit_code 3`). Reproduced on `bometfeedbackhub.digit.org` 2026-06-18 (whole 244-test suite failed to start until the stale `lifecycle-fixtures.json` was removed).

## Fix

One-character guard on each — `?.complaints` → `?.complaints?.terminal_rated`:

- `tests/integration-tests/tests/citizen/timeline-fixes-2026-04-29.spec.ts:13`
- `tests/integration-tests/tests/lifecycle/api-smoke-2026-04-29.spec.ts:12`

Mirrors the identical fix applied to `tests/integration-tests/tests/employee/pgr-details.spec.ts` in #891 — these were the other two specs with the same pattern. With all three guarded, a skipped lifecycle fixture falls through to the fallback SRID instead of crashing collection.

## Test plan

- [x] Confirmed both lines now use `?.complaints?.terminal_rated` and no unguarded occurrence remains.
- [ ] Re-run the full `tests/integration-tests` suite on bomet with a skip-marker `lifecycle-fixtures.json` present — collection should proceed (was: `exit_code 3` empty-results).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>