### PR TITLE
fix(pgr): make citizen OSM map base theme configurable per tenant (#882)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/ComplaintLocationMap.js
+++ b/digit-ui-esbuild/products/pgr/src/components/ComplaintLocationMap.js
@@ -6,7 +6,7 @@ import { CardLabel } from "@egovernments/digit-ui-react-components";
 import { useTranslation } from "react-i18next";
 import booleanPointInPolygon from "@turf/boolean-point-in-polygon";
 import { point as turfPoint } from "@turf/helpers";
-import useWardHighlightColor from "../hooks/pgr/useWardHighlightColor";
+import useMapConfig from "../hooks/pgr/useMapConfig";
 import useTenantBoundaries from "../hooks/pgr/useTenantBoundaries";
 
 // Fix default icon issue in React builds
@@ -27,9 +27,10 @@ const ComplaintLocationMap = ({ latitude, longitude, address }) => {
   const { t, i18n } = useTranslation();
   const [fetchedAddress, setFetchedAddress] = useState(null);
   const [isLoadingAddress, setIsLoadingAddress] = useState(false);
-  // Resolved from MDMS (RAINMAKER-PGR.MapConfig.wardHighlightColor),
-  // defaults to the legacy orange #FFA74F.
-  const WARD_COLOR = useWardHighlightColor();
+  // Map theming resolved per tenant from MDMS RAINMAKER-PGR.MapConfig:
+  // base tile theme (defaults to the light voyager basemap) + ward-highlight
+  // colour (defaults to the legacy orange #FFA74F).
+  const { tileUrl, tileAttribution, wardHighlightColor: WARD_COLOR } = useMapConfig();
 
   // Nominatim Accept-Language is ISO 639-1; derive from i18n locale (e.g.
   // `sw_KE` → `sw`). Falls back to English (closes egovernments/CCRS#520
@@ -170,10 +171,7 @@ const ComplaintLocationMap = ({ latitude, longitude, address }) => {
             doubleClickZoom={true}
             touchZoom={true}
           >
-            <TileLayer
-              attribution='&copy; <a href="https://carto.com/attributions">CARTO</a> &copy; <a href="https://www.openstreetmap.org/copyright">OSM</a>'
-              url="https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
-            />
+            <TileLayer key={tileUrl} attribution={tileAttribution} url={tileUrl} />
             {tenantBoundaries?.features?.length > 0 && (
               <GeoJSON
                 key={`${matchedWard?.properties?.code || "_"}-${tenantBoundaries.features.length}`}

--- a/digit-ui-esbuild/products/pgr/src/components/GeoLocations.js
+++ b/digit-ui-esbuild/products/pgr/src/components/GeoLocations.js
@@ -7,7 +7,7 @@ import { useTranslation } from "react-i18next";
 import _ from "lodash";
 import booleanPointInPolygon from "@turf/boolean-point-in-polygon";
 import { point as turfPoint } from "@turf/helpers";
-import useWardHighlightColor from "../hooks/pgr/useWardHighlightColor";
+import useMapConfig from "../hooks/pgr/useMapConfig";
 import useTenantBoundaries from "../hooks/pgr/useTenantBoundaries";
 
 // Fix default icon issue in React builds
@@ -71,7 +71,7 @@ const resolveWard = (lat, lng, wardCollection) => {
 };
 
 // Ward polygon style, lifted from wardwise-whispers-resolver.
-// WARD_COLOR is resolved at runtime from MDMS (useWardHighlightColor),
+// WARD_COLOR is resolved at runtime from MDMS (useMapConfig),
 // defaulting to the legacy orange — threaded in per render.
 const wardStyleFor = (WARD_COLOR, selectedCode, hoveredCode) => (feature) => {
   const code = feature?.properties?.code;
@@ -123,7 +123,9 @@ const GeoLocations = ({ t, config, onSelect, formData }) => {
     return v || "#F47738";
   }, []);
 
-  const wardColor = useWardHighlightColor();
+  // Map theming (base tile theme + ward highlight) resolved per tenant from
+  // MDMS RAINMAKER-PGR.MapConfig; defaults to the light voyager basemap.
+  const { tileUrl, tileAttribution, wardHighlightColor: wardColor } = useMapConfig();
   const wardStyle = useMemo(() => wardStyleFor(wardColor, selectedWard, hoveredWard), [wardColor, selectedWard, hoveredWard]);
   const onEachWard = useCallback((feature, layer) => {
     const code = feature?.properties?.code;
@@ -394,10 +396,7 @@ const GeoLocations = ({ t, config, onSelect, formData }) => {
           >
             <MapRefSetter mapRef={mapRef} />
             <MapClickHandler onClick={handleMapClick} />
-            <TileLayer
-              attribution='&copy; <a href="https://carto.com/attributions">CARTO</a> &copy; <a href="https://www.openstreetmap.org/copyright">OSM</a>'
-              url="https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
-            />
+            <TileLayer key={tileUrl} attribution={tileAttribution} url={tileUrl} />
             {tenantBoundaries?.features?.length > 0 && (
               <GeoJSON
                 key={`${selectedWard || "_"}-${hoveredWard || "_"}-${tenantBoundaries.features.length}`}

--- a/digit-ui-esbuild/products/pgr/src/hooks/pgr/useMapConfig.js
+++ b/digit-ui-esbuild/products/pgr/src/hooks/pgr/useMapConfig.js
@@ -1,0 +1,101 @@
+import { useMemo } from "react";
+
+// Default = the legacy hardcoded ward-highlight orange. Anything without
+// an MDMS MapConfig record keeps the exact original behaviour.
+export const DEFAULT_WARD_HIGHLIGHT_COLOR = "#FFA74F";
+
+// Named base-map presets. The complaint-location maps used to hardcode the
+// CARTO `dark_all` raster theme, which renders as a black background on
+// tenants that expect a light map (egovernments/CCRS#882). The base theme is
+// now resolved per tenant from MDMS so operators can switch it without a code
+// change; `voyager` (a light, labelled basemap) is the default.
+export const BASE_MAP_THEMES = {
+  voyager: {
+    tileUrl: "https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png",
+    tileAttribution: '&copy; <a href="https://carto.com/attributions">CARTO</a> &copy; <a href="https://www.openstreetmap.org/copyright">OSM</a>',
+  },
+  light: {
+    tileUrl: "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png",
+    tileAttribution: '&copy; <a href="https://carto.com/attributions">CARTO</a> &copy; <a href="https://www.openstreetmap.org/copyright">OSM</a>',
+  },
+  dark: {
+    tileUrl: "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png",
+    tileAttribution: '&copy; <a href="https://carto.com/attributions">CARTO</a> &copy; <a href="https://www.openstreetmap.org/copyright">OSM</a>',
+  },
+  osm: {
+    tileUrl: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+    tileAttribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+  },
+};
+
+export const DEFAULT_BASE_MAP_THEME = "voyager";
+
+const HEX = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+
+// Resolves the complaint-location maps' theming from MDMS so it can be set
+// per tenant without a code change. Reads `RAINMAKER-PGR.MapConfig[0]` and
+// returns a normalised `{ tileUrl, tileAttribution, wardHighlightColor }`.
+//
+// Supported MapConfig fields (all optional):
+//   baseMapTheme       one of BASE_MAP_THEMES keys ("voyager" | "light" |
+//                      "dark" | "osm"). Picks a known tile URL + attribution.
+//                      Defaults to "voyager" (light) so the map never falls
+//                      back to the legacy black `dark_all` theme.
+//   tileUrl            raw Leaflet tile-URL template ({s}/{z}/{x}/{y}). When
+//                      present it overrides baseMapTheme, letting an operator
+//                      point at any provider.
+//   tileAttribution    HTML attribution string paired with a raw tileUrl.
+//   wardHighlightColor hex colour for the ward overlay (legacy field).
+//
+// MDMS errors (master not registered for this tenant) must not break the map
+// — they are swallowed and every field falls through to its default.
+//
+// FOLLOW-UP: expose these fields in the DIGIT Studio configurator so operators
+// can set them from the UI instead of seeding MDMS by hand.
+const useMapConfig = () => {
+  const tenantId =
+    Digit?.SessionStorage?.get?.("CITIZEN.COMMON.HOME.CITY")?.code ||
+    Digit?.ULBService?.getCurrentTenantId?.();
+
+  const { data } = Digit.Hooks.useCustomMDMS(
+    tenantId,
+    "RAINMAKER-PGR",
+    [{ name: "MapConfig" }],
+    {
+      cacheTime: Infinity,
+      retry: false,
+      enabled: !!tenantId,
+      select: (d) => d?.["RAINMAKER-PGR"]?.MapConfig,
+    },
+    { schemaCode: "RAINMAKER-PGR.MapConfig" }
+  );
+
+  return useMemo(() => {
+    const cfg = Array.isArray(data) ? data[0] : undefined;
+
+    // Ward highlight colour (back-compat with useWardHighlightColor).
+    const rawWard = cfg?.wardHighlightColor;
+    const wardHighlightColor =
+      typeof rawWard === "string" && HEX.test(rawWard.trim())
+        ? rawWard.trim()
+        : DEFAULT_WARD_HIGHLIGHT_COLOR;
+
+    // Base tile theme. A raw tileUrl always wins; otherwise resolve the named
+    // preset, defaulting to voyager when the value is missing or unknown.
+    const themeKey =
+      typeof cfg?.baseMapTheme === "string" && BASE_MAP_THEMES[cfg.baseMapTheme.trim()]
+        ? cfg.baseMapTheme.trim()
+        : DEFAULT_BASE_MAP_THEME;
+    const preset = BASE_MAP_THEMES[themeKey];
+
+    const rawUrl = typeof cfg?.tileUrl === "string" ? cfg.tileUrl.trim() : "";
+    const tileUrl = rawUrl || preset.tileUrl;
+    const rawAttr = typeof cfg?.tileAttribution === "string" ? cfg.tileAttribution.trim() : "";
+    // Pair a custom attribution with a raw URL; named presets carry their own.
+    const tileAttribution = rawUrl ? rawAttr || preset.tileAttribution : preset.tileAttribution;
+
+    return { tileUrl, tileAttribution, wardHighlightColor };
+  }, [data]);
+};
+
+export default useMapConfig;

--- a/digit-ui-esbuild/products/pgr/src/hooks/pgr/useWardHighlightColor.js
+++ b/digit-ui-esbuild/products/pgr/src/hooks/pgr/useWardHighlightColor.js
@@ -1,47 +1,10 @@
-import { useMemo } from "react";
+import useMapConfig, { DEFAULT_WARD_HIGHLIGHT_COLOR } from "./useMapConfig";
 
-// Default = the legacy hardcoded ward-highlight orange. Anything without
-// an MDMS MapConfig record keeps the exact original behaviour.
-export const DEFAULT_WARD_HIGHLIGHT_COLOR = "#FFA74F";
+export { DEFAULT_WARD_HIGHLIGHT_COLOR };
 
-const HEX = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
-
-// Resolves the complaint-location map's ward-highlight colour from MDMS so
-// it can be themed per tenant without a code change. Reads
-// `RAINMAKER-PGR.MapConfig[0].wardHighlightColor`; falls back to the
-// legacy orange while loading, when the master is absent, on error, or
-// when the value isn't a valid hex.
-//
-// FOLLOW-UP: expose `wardHighlightColor` (and likely the broader map
-// theming) as a field in the DIGIT Studio configurator so operators can
-// set it from the UI instead of seeding MDMS by hand. Tracked as a
-// digit-ui-esbuild issue (see PR description).
-const useWardHighlightColor = () => {
-  const tenantId =
-    Digit?.SessionStorage?.get?.("CITIZEN.COMMON.HOME.CITY")?.code ||
-    Digit?.ULBService?.getCurrentTenantId?.();
-
-  const { data } = Digit.Hooks.useCustomMDMS(
-    tenantId,
-    "RAINMAKER-PGR",
-    [{ name: "MapConfig" }],
-    {
-      cacheTime: Infinity,
-      // MDMS errors (master not registered for this tenant) must not
-      // break the map — swallow and fall through to the default.
-      retry: false,
-      enabled: !!tenantId,
-      select: (d) => d?.["RAINMAKER-PGR"]?.MapConfig,
-    },
-    { schemaCode: "RAINMAKER-PGR.MapConfig" }
-  );
-
-  return useMemo(() => {
-    const c = Array.isArray(data) ? data[0]?.wardHighlightColor : undefined;
-    return typeof c === "string" && HEX.test(c.trim())
-      ? c.trim()
-      : DEFAULT_WARD_HIGHLIGHT_COLOR;
-  }, [data]);
-};
+// Back-compat wrapper. Map theming (tile theme + ward highlight) now lives in
+// useMapConfig, which reads the whole `RAINMAKER-PGR.MapConfig` master. Existing
+// callers that only need the ward-highlight colour keep working unchanged.
+const useWardHighlightColor = () => useMapConfig().wardHighlightColor;
 
 export default useWardHighlightColor;


### PR DESCRIPTION
## What & why

Closes part of #882. The original "no outlined counties" is already resolved on `develop` (boundaries are now tenant-driven via `useTenantBoundaries` + `MAP_TENANT`). This PR fixes the **remaining** report on that issue — the **black map background** on Bomet (https://bometfeedbackhub.digit.org/), raised in [this comment](https://github.com/egovernments/Citizen-Complaint-Resolution-System/issues/882#issuecomment-4748920906).

Both citizen complaint-location maps hardcoded the CARTO `dark_all` raster tile theme:

```js
url="https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
```

…which renders as a black background on tenants that expect a light basemap.

## Approach

This extends the **existing** per-tenant map-theming pattern (`useWardHighlightColor` already read `RAINMAKER-PGR.MapConfig.wardHighlightColor` from MDMS — its own code even flagged "the broader map theming" as a follow-up). No new code constants; the value lives in MDMS per tenant.

- `useWardHighlightColor` → generalised to **`useMapConfig`**, returning `{ tileUrl, tileAttribution, wardHighlightColor }` from `RAINMAKER-PGR.MapConfig[0]`. `useWardHighlightColor` stays as a thin back-compat wrapper.
- Both `GeoLocations.js` (pin-drop) and `ComplaintLocationMap.js` (display) read the resolved tile URL/attribution from the hook.

### New `RAINMAKER-PGR.MapConfig` fields (all optional)

| field | meaning |
|---|---|
| `baseMapTheme` | `"voyager"` \| `"light"` \| `"dark"` \| `"osm"` — resolved by the hook to a known tile URL + attribution. **Defaults to `voyager`** (light), so the map no longer falls back to the black `dark_all`. |
| `tileUrl` | raw Leaflet tile-URL template (`{s}/{z}/{x}/{y}`). Overrides `baseMapTheme` — point at any provider. |
| `tileAttribution` | attribution HTML paired with a raw `tileUrl`. |
| `wardHighlightColor` | existing ward-overlay colour (unchanged). |

Example seed value:

```json
{ "baseMapTheme": "voyager", "wardHighlightColor": "#FFA74F" }
```

## Behaviour change

Tenants **without** a `MapConfig` record keep every value at its default — the only visible change is the base theme flipping from black (`dark_all`) to the light `voyager` basemap, which is the desired fix. Tenants wanting dark can set `baseMapTheme: "dark"`.

## Validation

- `esbuild` transform-check passes on all changed files (no syntax/JSX errors).
- Change is config-read only; no deployment-specific constants.

## Follow-up

Expose these `MapConfig` fields in the DIGIT Studio configurator so operators set them from the UI instead of seeding MDMS by hand (noted in the hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)