### PR TITLE
fix(deploy): keycloak-readiness before the dependent compose-up (converge no longer aborts)

### DIFF
--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -634,6 +634,107 @@
       when:
         - build_digit_ui | default(false)
 
+    # ---- Keycloak readiness BEFORE the dependent compose-up (converge-abort fix) ----
+    # The compose-up below waits on keycloak: service_healthy, but the keycloak DB
+    # secret is otherwise written to .env only AFTER it (the OpenBao block further
+    # down). So the first compose-up runs keycloak with the compose-default
+    # password, recreates keycloak/keycloak-postgres when .env later changes,
+    # keycloak races its DB / fails the healthcheck inside compose's dependency
+    # wait, and the whole play ABORTS — silently skipping every post-compose-up
+    # task (configurator build, overpass, etc.). Bring up OpenBao +
+    # keycloak-postgres, unseal, write the keycloak secrets to .env, and align the
+    # DB-user password HERE so the compose-up finds keycloak able to start healthy
+    # and the play runs to completion. All gated on enable_keycloak; idempotent.
+    - name: "Keycloak prep — bring up OpenBao + keycloak-postgres first"
+      ansible.builtin.shell: COMPOSE_PROFILES={{ compose_profiles }} docker compose {{ compose_files }} up -d openbao keycloak-postgres
+      args:
+        chdir: "{{ digit_dir }}"
+      changed_when: true
+      when: enable_keycloak | default(false)
+
+    - name: "Keycloak prep — wait for OpenBao to bind 18200"
+      ansible.builtin.wait_for:
+        host: 127.0.0.1
+        port: 18200
+        timeout: 120
+      when: enable_keycloak | default(false)
+
+    - name: "Keycloak prep — load OpenBao init state"
+      ansible.builtin.slurp:
+        src: "{{ digit_dir }}/.openbao/init.json"
+      register: kcprep_init
+      no_log: true
+      when: enable_keycloak | default(false)
+
+    - name: "Keycloak prep — parse OpenBao init state"
+      ansible.builtin.set_fact:
+        kcprep_unseal_key: "{{ (kcprep_init.content | b64decode | from_json).keys_base64[0] }}"
+        kcprep_root_token: "{{ (kcprep_init.content | b64decode | from_json).root_token }}"
+      no_log: true
+      when:
+        - enable_keycloak | default(false)
+        - kcprep_init.content is defined
+
+    - name: "Keycloak prep — read OpenBao seal status"
+      ansible.builtin.uri:
+        url: http://127.0.0.1:18200/v1/sys/seal-status
+        status_code: [200]
+      register: kcprep_seal
+      when:
+        - enable_keycloak | default(false)
+        - kcprep_root_token is defined
+
+    - name: "Keycloak prep — unseal OpenBao if sealed"
+      ansible.builtin.uri:
+        url: http://127.0.0.1:18200/v1/sys/unseal
+        method: POST
+        body_format: json
+        body:
+          key: "{{ kcprep_unseal_key }}"
+        status_code: [200]
+      no_log: true
+      when:
+        - enable_keycloak | default(false)
+        - kcprep_seal.json.sealed | default(false)
+
+    - name: "Keycloak prep — read secrets from OpenBao"
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:18200/v1/{{ secrets_path | regex_replace('^kv/', 'kv/data/') }}"
+        headers:
+          X-Vault-Token: "{{ kcprep_root_token }}"
+        status_code: [200]
+      register: kcprep_secrets
+      no_log: true
+      when:
+        - enable_keycloak | default(false)
+        - kcprep_root_token is defined
+
+    - name: "Keycloak prep — write KEYCLOAK SECRETS into .env BEFORE compose-up"
+      ansible.builtin.blockinfile:
+        path: "{{ digit_dir }}/.env"
+        block: |
+          KC_ADMIN_PASSWORD={{ kcprep_secrets.json.data.data.keycloak_admin_password | default('') }}
+          KC_DB_PASSWORD={{ kcprep_secrets.json.data.data.keycloak_db_password | default('') }}
+          TOKEN_EXCHANGE_SYSTEM_PASSWORD={{ kcprep_secrets.json.data.data.token_exchange_system_password | default('eGov@123') }}
+        marker: "# {mark} KEYCLOAK SECRETS"
+        create: false
+        mode: '0600'
+      no_log: true
+      when:
+        - enable_keycloak | default(false)
+        - kcprep_secrets.json is defined
+
+    - name: "Keycloak prep — align keycloak DB-user password to OpenBao value"
+      ansible.builtin.shell: >-
+        docker exec keycloak-postgres psql -U keycloak -d keycloak -c
+        "ALTER USER keycloak WITH PASSWORD '{{ kcprep_secrets.json.data.data.keycloak_db_password }}';"
+      no_log: true
+      changed_when: true
+      failed_when: false
+      when:
+        - enable_keycloak | default(false)
+        - kcprep_secrets.json.data.data.keycloak_db_password | default('') | length > 0
+
     - name: Pull all images from VPC registry
       shell: COMPOSE_PROFILES={{ compose_profiles }} docker compose {{ compose_files }} pull --ignore-pull-failures
       args:


### PR DESCRIPTION
## Problem

On tenants with `enable_keycloak`, the converge's first compose-up ("Start DIGIT stack") waits on `keycloak: condition: service_healthy`. But the keycloak DB secret (`KC_DB_PASSWORD`) is written to `.env` only **after** that — in the OpenBao block ~480 lines later. So:

1. The first compose-up starts keycloak with the compose-default password.
2. When `.env` later changes (the OpenBao block writes the real secret), keycloak + keycloak-postgres get **recreated**; keycloak races its DB and fails the healthcheck inside compose's dependency-wait.
3. The whole play **aborts** (`dependency failed to start: container keycloak is unhealthy`), silently **skipping every post-compose-up task** — configurator build, overpass, lay-digit-ui, etc.

Net effect on a real deployment: nightly converges only ever rebuilt **digit-ui** (a *pre*-compose-up task). **Configurator and overpass/turbopass never auto-rebuilt** — they stayed as whatever was last built by hand.

## Fix

Add a gated, idempotent **"Keycloak prep"** block immediately before the compose-up that:
- brings up OpenBao + keycloak-postgres,
- unseals OpenBao,
- writes the `KEYCLOAK SECRETS` block to `.env`,
- aligns the keycloak DB-user password to the OpenBao value,

so the dependent compose-up finds keycloak able to start healthy and the play runs to completion. Reuses the same OpenBao tasks/patterns already in the playbook; all gated on `enable_keycloak | default(false)` so keycloak-free tenants are unaffected.

## Validation (bomet reference box)

- Before: play aborted at the keycloak compose-up (~`ok=40`); configurator stuck at a stale build, overpass/turbopass not recreated.
- After: play reached `ok=89`; **configurator rebuilt from develop**, **overpass + turbopass recreated** (first time), **keycloak stayed healthy (no recreate)**, smoke green.

The durable counterpart to the on-box `bomet-redeploy.sh` heal that was papering over this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)