### PR TITLE
fix(tests): flush partial report.json before timeout SIGKILL (#907)

### DIFF
--- a/tests/integration-tests/runner/run-cycle.sh
+++ b/tests/integration-tests/runner/run-cycle.sh
@@ -51,8 +51,13 @@ rm -rf playwright-report test-results report.json
 
 # ---- run ---- (nice'd so the live DIGIT stack on this box keeps priority)
 phase "running"
+# --global-timeout fires BEFORE the shell `timeout` SIGKILL, so Playwright's json
+# reporter still flushes report.json (written at onEnd) with the partial results
+# gathered so far. A slow run then degrades to a partial dashboard update instead
+# of blanking it entirely (#907). Keep it comfortably under the shell timeout.
 timeout 90m nice -n 10 npx playwright test \
-  || echo "[run-cycle] playwright exited non-zero (some tests failed); continuing to catalog"
+  --global-timeout="${PW_GLOBAL_TIMEOUT_MS:-4800000}" \
+  || echo "[run-cycle] playwright exited non-zero (failures or global-timeout reached); continuing to catalog"
 
 # ---- catalog ----
 phase "catalog"


### PR DESCRIPTION
Closes #907 (hardening half).

## Problem

`tests/integration-tests/runner/run-cycle.sh` runs Playwright under `timeout 90m`. The nightly run now exceeds 90 min (per #907: `mdms-v2`/`user` `/_search` return `400 JsonMappingException`, so many specs burn their full per-test timeout — `(3.2m)`, `(4.2m)` each — instead of passing fast). `timeout` then **SIGKILLs Playwright before its `json` reporter writes `report.json`** (only emitted at `onEnd`).

Result: `run-cycle.sh` finds no report → `exit 6` / `failed-no-report` → nothing is cataloged → the `/tests` dashboard has been **frozen since 2026-06-15**. Confirmed on bomet: nightly runs 06-19/20/21 all end `failed-no-report` after crashing in the onboarding block ~test 219/244.

## Fix (hardening)

Add Playwright `--global-timeout` (default **80m**, overridable via `PW_GLOBAL_TIMEOUT_MS`), set **below** the shell `timeout 90m`. When the global timeout is reached Playwright stops gracefully and **still runs reporter `onEnd`**, flushing a partial `report.json` + `test-results/`. So a slow run degrades to a *partial* dashboard update instead of blanking it.

`run-cycle.sh` is the shared vendored runner — both the nightly (invoked by `bomet-redeploy.sh`) and the RUN-button daemon use it — so this reaches both paths once develop is pulled on the nightly redeploy.

## Scope / not in this PR

- **Primary root cause** — the `/_search` 400 `JsonMappingException` (likely a `:nightly-develop` image bump tightening `_search` deserialization) — is tracked separately in #907 §Fix(1). That's what makes specs slow; this PR only stops a slow run from *blanking the dashboard*.
- The cosmetic `integration-tests-runner` systemd "bad unit file setting" ansible warning (#907 §"Not the cause") is untouched.

## Test plan

- [ ] On bomet, run `PW_GLOBAL_TIMEOUT_MS=120000 bash tests/integration-tests/runner/run-cycle.sh` (2-min global cap) → confirm Playwright self-stops, `report.json` is written, and the run **publishes a partial result** (catalog/history update) rather than `failed-no-report`.
- [ ] Confirm a normal full run (under 80m) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>