### PR TITLE
Added notification enhancements for Complaints 

### DIFF
--- a/docs/superpowers/specs/workflow-notification/2026-06-20-moz_007-design-and-implementation.md
+++ b/docs/superpowers/specs/workflow-notification/2026-06-20-moz_007-design-and-implementation.md
@@ -1,0 +1,1137 @@
+# MOZ_007 — Workflow Notification Routing: Design + Implementation
+
+**Date:** 2026-06-20
+**Owner:** Priyanshu / Hari / Pradeep
+**Target ship:** 2026-06-30
+**Audience:** Engineers implementing this end-to-end (platform service + PGR adoption + upstream fixes)
+**Companions:**
+- `workflow-extension-service.openapi.yaml` (in this folder) — OpenAPI 3.0.3 spec for the new service
+- `notification-flow-sequence.puml` (in this folder) — standalone PlantUML of the end-to-end flow
+- `2026-06-20-novu-adapter-design-vs-implementation-reconciliation.md` (in this folder) — full gap analysis between Novu Adapter LLD/HLD and live `novu-bridge` code (this doc pulls in only the Bucket A items that are MOZ_007 prerequisites)
+
+**Supersedes:** `2026-06-19-moz_007-workflow-extension-service-design.md` and `2026-06-20-moz_007-workflow-hardcoding-removal.md` (both absorbed here).
+
+---
+
+## 1. Context & goals
+
+PGR-services hardcodes **who** is notified on each workflow transition. The decision lives in two places today:
+
+- The legacy SMS-direct path: `NotificationService.java:86-116` with 11 hand-written `if (state.eq(…) && action.eq(…))` branches that route SMS to the citizen, the assignee, both, or neither.
+- The newer domain-event path: `ComplaintDomainEventService.java:39-62` publishes a `ComplaintsDomainEvent` to the `complaints.domain.events` Kafka topic, with a `stakeholders[]` list built using the same kind of hardcoded transition-to-audience logic. `novu-bridge` consumes this event and handles WhatsApp / email via Novu.
+
+SMS template bodies also live in the wrong place: `egov-localization` keys constructed in code as `PGR_<ROLE>_<ACTION>_<STATUS>_SMS_MESSAGE` (`NotificationUtil.getCustomizedMsg()` lines 89-107). To add a new locale (Mozambique pt_MZ), state, or recipient policy today, you change code, not config.
+
+**The goal of this work** is to make both decisions data-driven:
+
+1. **Audience routing** — for any workflow transition, who should be notified — moves from hardcoded if-chains into a new platform service (`workflow-extension-service`) backed by an MDMS master (`Workflow.BusinessServiceExtension`).
+2. **SMS template bodies** — move from `egov-localization` into `egov-config-service` `TemplateBinding` entries with an inline `body` field. PGR resolves and renders locally, then pushes pre-rendered text to `egov.core.notification.sms`.
+
+Email and WhatsApp keep flowing via the existing `complaints.domain.events` → `novu-bridge` path. The only PGR-side change for those channels is that `stakeholders[]` is now driven by the workflow extension, not hardcoded.
+
+Mozambique is the immediate driver — IGE and IGSAE sub-tenants need different recipient policies on the same transitions, plus pt_MZ SMS bodies.
+
+---
+
+## 2. Scope
+
+### In scope
+
+- **`workflow-extension-service`** — new platform microservice, scaffolded from `backend/digit-config-service/`.
+- **PGR adoption**:
+  - new `WorkflowExtensionClient` and `ConfigServiceClient` classes;
+  - refactor `ComplaintDomainEventService.buildEvent` to populate `stakeholders[]` from the extension;
+  - refactor `NotificationUtil.getCustomizedMsg` and `NotificationService` SMS loop to resolve template bodies from config-service.
+- **`egov-config-service` schema bump**: `TemplateBinding` gains `audience` (selector), `workflowState` (optional selector), `body` (optional inline body).
+- **`novu-bridge` adoption**: `ConfigServiceClient.resolveTemplate` passes `audience` + `workflowState`; `DispatchPipelineService.process` iterates `stakeholders[]`; `nb_dispatch_log` uniqueness constraint and `transactionId` composition updated to support per-stakeholder fan-out.
+- **Migration of ~30 PGR `PGR_<ROLE>_<ACTION>_<STATUS>_SMS_MESSAGE` localization keys** into config-service entries, plus net-new pt_MZ translations.
+- **Mozambique seed data**: extension entry for `(mz, PGR)`, plus the migrated SMS template entries.
+- **Per-tenant feature flags** in `RAINMAKER-PGR.PGRConfiguration` and `novu.bridge.criteria.extended.enabled` in novu-bridge config.
+
+### Out of scope (explicit non-goals)
+
+- `DashboardQueryBuilder.CLOSED_STATUSES` — stays hardcoded.
+- `EscalationScheduler.java:75` — escalation is a separate track.
+- `ServiceRequestValidator.validateReOpen` — per-state reopen rules untouched.
+- Configurator `WorkflowActionSelect.tsx` + `StatusChip.tsx` UI labels / colors — separate track (localization).
+- `NotificationService.java:86-116` legacy SMS-direct dispatch chain — stays as the fallback when feature flags are off.
+- TL / FireNOC adoption of the workflow extension — schema is built to fit them later.
+- ConfigSets / versioned activation — separate epic (see Reconciliation doc row 15).
+- Other deviations from the Reconciliation doc not listed in §5 below — file separately.
+
+### Hard dependencies
+
+- **GitHub issue #905** ("TemplateBinding: add `audience` selector + `body` field") covers the schema bump and the novu-bridge code change. See §5 — the full content is included here for engineering context.
+
+---
+
+## 3. Architecture
+
+```plantuml
+@startuml moz_007-architecture
+!theme plain
+title MOZ_007 — Component view
+
+cloud "MDMS" as MDMS
+
+package "workflow-extension-service\n(NEW)" #LightBlue {
+    component "REST API\n/v1/extension/_search\n/_validate /_create /_update /_delete" as WFExtAPI
+    component "ExtensionValidator\n(cross-ref BusinessService)" as Validator
+    component "MdmsClient\n(read + write)" as WFExtMdms
+    component "WorkflowServiceClient" as WFExtWf
+}
+
+package "egov-workflow-v2\n(Digit-Core, untouched)" #LightGray {
+    component "BusinessService API" as WFAPI
+}
+
+package "egov-config-service\n(schema bump per issue #905)" #LightYellow {
+    component "ConfigEntry API\n_resolve /_create /_search" as CfgAPI
+    component "TemplateBinding\n(now keyed by audience\n+ workflowState\n+ optional body field for SMS)" as TplBinding
+}
+
+package "novu-bridge\n(criteria + per-stakeholder loop)" #LightPink {
+    component "DispatchPipelineService\n(iterates stakeholders[])" as Dispatcher
+    component "ConfigServiceClient\n(criteria includes audience)" as NovuCfg
+    component "NovuClient\n(per-stakeholder transactionId)" as NovuTrigger
+}
+
+package "pgr-services\n(MODIFIED)" #LightGreen {
+    component "WorkflowExtensionClient\n(new, TTL cache)" as PGRClient
+    component "ConfigServiceClient\n(new, TTL cache)" as PGRCfgClient
+    component "ComplaintDomainEventService\n(buildEvent → stakeholders[]\nfrom extension)" as CDE
+    component "NotificationService /\nNotificationUtil\n(SMS template from config)" as NotifSvc
+    component "PGRConfiguration\n(useWorkflowExtension flag)" as PGRCfg
+}
+
+queue "complaints.\ndomain.events" as KEvents
+queue "egov.core.\nnotification.sms" as KSms
+
+participant "Novu API" as Novu
+participant "egov-notification-sms" as SmsSvc
+
+WFExtAPI --> WFExtMdms
+WFExtAPI --> WFExtWf --> WFAPI
+WFExtMdms --> MDMS
+WFAPI --> MDMS
+
+PGRClient --> WFExtAPI
+PGRCfgClient --> CfgAPI
+CfgAPI --> MDMS
+TplBinding --> CfgAPI
+
+CDE --> PGRClient
+NotifSvc --> PGRCfgClient
+CDE --> KEvents
+NotifSvc --> KSms
+
+KEvents --> Dispatcher
+Dispatcher --> NovuCfg --> CfgAPI
+Dispatcher --> NovuTrigger --> Novu
+KSms --> SmsSvc
+
+@enduml
+```
+
+### Design rules
+
+- The Digit-Core workflow service in `/Users/subha/Code/Digit-Core/core-services/` is not modified.
+- `Workflow.BusinessService.json` is not modified by this work.
+- `PGRConstants.java` stays in place as a fallback when the per-tenant flag is off or extension lookup yields nothing.
+- The extension service is the **single integrity authority** for `Workflow.BusinessServiceExtension`. All writes flow through it.
+- Both new pgr-services clients (`WorkflowExtensionClient` and `ConfigServiceClient`) use per-replica TTL caches with last-known-good fallback. Same pattern as the existing `MDMSUtils.serviceCodeToSlaCache`.
+- All novu-bridge behavior changes are gated by `novu.bridge.criteria.extended.enabled` (default `false`).
+
+---
+
+## 4. workflow-extension-service (the new platform service)
+
+### 4.1 Module structure
+
+Scaffolded from `backend/digit-config-service/` (most recent stateless-platform-microservice precedent). New directory at the same level:
+
+```
+backend/workflow-extension-service/
+├── pom.xml                                                (~90 lines, Spring Boot 3.2.4)
+├── Dockerfile
+├── README.md
+├── src/main/java/org/egov/workflow/extension/
+│   ├── WorkflowExtensionApplication.java
+│   ├── config/
+│   │   ├── ApplicationConfig.java
+│   │   └── MultiStateInstanceConfig.java
+│   ├── controller/
+│   │   └── ExtensionController.java                       (REST surface)
+│   ├── service/
+│   │   ├── ExtensionService.java                          (orchestration)
+│   │   └── ExtensionValidator.java                        (cross-ref check)
+│   ├── client/
+│   │   ├── MdmsClient.java                                (read + write)
+│   │   └── WorkflowServiceClient.java                     (BusinessService read for validation cross-ref)
+│   └── web/models/
+│       ├── BusinessServiceExtension.java
+│       ├── TransitionExtension.java
+│       ├── ExtensionSearchRequest.java
+│       ├── ExtensionSearchResponse.java
+│       ├── ExtensionValidateRequest.java
+│       ├── ExtensionValidateResponse.java
+│       ├── ExtensionCreateRequest.java
+│       ├── ExtensionUpdateRequest.java
+│       ├── ExtensionDeleteRequest.java
+│       ├── ValidationResult.java
+│       ├── ValidationError.java
+│       └── ValidationWarning.java
+├── src/main/resources/
+│   ├── application.properties
+│   └── schema/
+│       └── Workflow.BusinessServiceExtension.json         (JSON Schema registration for MDMS)
+└── src/test/java/...
+```
+
+### 4.2 MDMS master — `Workflow.BusinessServiceExtension`
+
+Sibling to `Workflow.BusinessService.json` under the existing `Workflow` MDMS namespace. Schema registered as a new file `utilities/default-data-handler/src/main/resources/schema/Workflow.BusinessServiceExtension.json`.
+
+**Schema definition:**
+
+```json
+[
+  {
+    "tenantId": "{tenantid}",
+    "code": "Workflow.BusinessServiceExtension",
+    "description": "Per-workflow-transition audience routing. Tells consuming modules which stakeholder role codes to notify when a transition fires.",
+    "definition": {
+      "type": "object",
+      "title": "BusinessServiceExtension",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "required": ["tenantId", "businessService", "transitions"],
+      "x-unique": ["tenantId", "businessService"],
+      "properties": {
+        "tenantId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256,
+          "description": "Tenant scope. State-level / sub-tenant resolution via MultiStateInstanceUtil; an extension at `mz` is visible to all `mz.*` sub-tenants unless a more specific entry exists."
+        },
+        "businessService": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "description": "Joins to `Workflow.BusinessService.businessService`. Validated cross-ref."
+        },
+        "transitions": {
+          "type": "array",
+          "minItems": 0,
+          "items": {
+            "type": "object",
+            "required": ["action", "notifyRoles"],
+            "properties": {
+              "fromState": {
+                "type": ["string", "null"],
+                "maxLength": 128,
+                "description": "State the transition fires from. `null` matches the workflow start state (the implicit pre-APPLY position). Joins to `BusinessService.states[].state`."
+              },
+              "action": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 64,
+                "description": "Workflow action name. Joins to `BusinessService.states[fromState].actions[].action`."
+              },
+              "notifyRoles": {
+                "type": "array",
+                "minItems": 0,
+                "items": { "type": "string" },
+                "description": "Audience codes for the notification fired when this transition occurs. Each entry must be a role present in the corresponding BusinessService JSON's `states[].actions[].roles[]`. The consuming module translates each code to actual recipients while building the outbound domain event's `stakeholders[]`. Per-channel template selection, user channel preferences, and template rendering are all downstream of this contract."
+              }
+            }
+          }
+        },
+        "auditDetails": {
+          "type": "object",
+          "properties": {
+            "createdBy": { "type": "string" },
+            "createdTime": { "type": "integer" },
+            "lastModifiedBy": { "type": "string" },
+            "lastModifiedTime": { "type": "integer" }
+          }
+        }
+      }
+    },
+    "isActive": true
+  }
+]
+```
+
+**Attributes:**
+
+| Attribute | Type | Required | Validated against | Notes |
+|---|---|---|---|---|
+| `tenantId` | string | yes | state-level fallback resolution | MultiStateInstanceUtil-aware |
+| `businessService` | string | yes | `Workflow.BusinessService.businessService` | rejected if no matching BusinessService |
+| `transitions[]` | array | yes | — | empty array permitted |
+| `transitions[].fromState` | string \| null | no | `BusinessService.states[].state` | `null` = workflow start state |
+| `transitions[].action` | string | yes | `BusinessService.states[fromState].actions[].action` | rejected if action not defined for the state |
+| `transitions[].notifyRoles[]` | array of string | yes | union of `BusinessService.states[].actions[].roles[]` | rejected if a role is not present anywhere in the BusinessService |
+
+**Uniqueness:** `(tenantId, businessService)`. Exactly one extension document per tenant per businessService.
+
+### 4.3 REST API surface
+
+See `workflow-extension-service.openapi.yaml` in this folder for the full spec. Summary:
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/workflow-extension/v1/extension/_search` | List extensions for `(tenantId, businessService?)` |
+| POST | `/workflow-extension/v1/extension/_validate` | Validate a candidate document; returns 200 with ValidationResult |
+| POST | `/workflow-extension/v1/extension/_create` | Validate + persist; 201 on success, 409 on duplicate, 400 on validation failure |
+| POST | `/workflow-extension/v1/extension/_update` | Validate + replace; 200 on success, 404 if missing |
+| POST | `/workflow-extension/v1/extension/_delete` | Remove by `(tenantId, businessService)` |
+| GET  | `/health` | Spring Actuator |
+
+All payloads use standard DIGIT `RequestInfo` / `ResponseInfo` envelopes.
+
+### 4.4 Validation rules
+
+Enforced on every `_validate`, `_create`, `_update`:
+
+| Code | Severity | Rule |
+|---|---|---|
+| `UNKNOWN_TRANSITION` | error | every `transitions[].(fromState, action)` must exist as `BusinessService.states[fromState].actions[].action` |
+| `INVALID_NOTIFY_ROLE` | error | every entry in `notifyRoles[]` must be from the union of all roles present in the BusinessService JSON |
+| `DUPLICATE_TRANSITION_EXTENSION` | error | at most one entry per `(fromState, action)` |
+| `BUSINESS_SERVICE_NOT_FOUND` | error | no matching BusinessService entry exists for `(tenantId, businessService)` |
+| `MISSING_TRANSITION_COVERAGE` | warning | every transition in BusinessService should have an extension entry — non-blocking |
+
+### 4.5 No service DB
+
+Stateless. Persistence is MDMS via `MdmsClient`. No service-owned PostgreSQL schema; no migrations under `src/main/resources/db/migration/`.
+
+### 4.6 Helm chart
+
+Mirror `Devops/deploy-as-code/charts/core-services/digit-config-service/`. Container resources: `requests: {cpu: 100m, memory: 256Mi}; limits: {cpu: 500m, memory: 512Mi}`. No persistent volume, no Postgres dependency.
+
+### 4.7 Client cache behavior
+
+The service itself does NOT cache. Each consumer (pgr-services in v1) maintains a per-replica TTL cache via its `WorkflowExtensionClient`. Default TTL 10 minutes; configurable. Cache miss + service unreachable → return last-known-good if any; else `Optional.empty()`.
+
+---
+
+## 5. Required upstream fixes (egov-config-service + novu-bridge)
+
+These changes are not part of the workflow-extension-service itself, but they're hard prerequisites for MOZ_007 to work end-to-end. Tracked as **GitHub issue #905**. Reproduced here so engineers see the full picture without flipping to the reconciliation doc.
+
+All novu-bridge changes are gated by `novu.bridge.criteria.extended.enabled` (default `false`). Schema and migration changes are forward-compatible.
+
+### 5.1 TemplateBinding schema bump
+
+**File:** `utilities/default-data-handler/src/main/resources/schema/TemplateBinding.json` (canonical; downstream stale copies at `backend/novu-bridge/schemas/` and `local-setup/db/notif-mdms-seed/schemas/` cleaned up in a separate ticket)
+
+```diff
+ "required": ["eventName", "channel", "templateId", "locale"],
+ "x-unique": [
+   "eventName",
+   "channel",
+-  "locale"
++  "locale",
++  "audience",
++  "workflowState"
+ ],
+ "properties": {
+   ...
++  "audience": {
++    "type": "string",
++    "description": "Stakeholder type the template targets (CITIZEN, EMPLOYEE, SUPERVISOR, …). Resolved per (event, channel, locale, audience, workflowState). Required by convention; left non-required in JSON Schema until backfill across all environments is confirmed."
++  },
++  "workflowState": {
++    "type": "string",
++    "description": "Optional application status the workflow has transitioned into. When absent, the binding matches any state for the given (event, channel, locale, audience)."
++  },
++  "body": {
++    "type": "string",
++    "maxLength": 4000,
++    "description": "Inline template body, used when the channel does not go through Novu (e.g., SMS via egov-notification-sms). Placeholder format: {variableName}. When present, the consuming module renders locally and pushes pre-rendered text. When absent, templateId is the canonical reference and rendering happens in Novu."
++  }
+ }
+```
+
+### 5.2 Seed update (default-data-handler)
+
+**File:** `utilities/default-data-handler/src/main/resources/configData/TemplateBinding.json`
+
+For each of the 4 existing entries (APPLY, ASSIGN, RESOLVE, REJECT for WhatsApp), add `"audience": "CITIZEN"`. All current bodies are citizen-facing.
+
+### 5.3 Backfill migration (egov-config-service)
+
+**File (new):** `backend/digit-config-service/src/main/resources/db/migration/main/V20260620120000__backfill_templatebinding_audience.sql`
+
+```sql
+-- Idempotent: stamps audience="CITIZEN" on any existing TemplateBinding row that lacks it.
+UPDATE eg_config_data
+   SET data = jsonb_set(data, '{audience}', '"CITIZEN"', true),
+       lastmodifiedtime = (extract(epoch from now()) * 1000)::bigint,
+       lastmodifiedby = 'system-migration-V20260620120000'
+ WHERE schemacode = 'TemplateBinding'
+   AND data->>'audience' IS NULL;
+```
+
+No new indexes — the existing `idx_eg_config_data_data_gin` GIN index on `data` supports the new JSONB containment criteria automatically.
+
+### 5.4 ConfigServiceClient — flag + two-attempt resolve
+
+**File:** `backend/novu-bridge/src/main/java/org/egov/novubridge/service/ConfigServiceClient.java`
+
+```java
+public ResolvedTemplate resolveTemplate(DerivedContext context, String eventName, String module, String tenantId) {
+    if (config.isExtendedCriteriaEnabled()) {
+        ResolvedTemplate t = doResolve(context, eventName, tenantId, /*includeWorkflowState=*/ true);
+        if (t != null) return t;
+        if (context.getWorkflowState() != null) {
+            t = doResolve(context, eventName, tenantId, /*includeWorkflowState=*/ false);
+            if (t != null) return t;
+        }
+    }
+    return doResolveLegacy(context, eventName, tenantId);
+}
+
+private ResolvedTemplate doResolve(DerivedContext context, String eventName, String tenantId, boolean includeWorkflowState) {
+    Map<String, Object> criteria = new HashMap<>();
+    criteria.put("eventName", eventName);
+    criteria.put("channel", context.getChannel());
+    criteria.put("locale", context.getLocale());
+    criteria.put("audience", context.getAudience());
+    if (includeWorkflowState && context.getWorkflowState() != null) {
+        criteria.put("workflowState", context.getWorkflowState());
+    }
+    // ... existing POST shape, factored into a helper
+}
+```
+
+The existing locale fallback (lines 59-66 — retries with hardcoded `en_IN` on miss) stays in v1. Replacing it with a `LANGUAGE_STRATEGY` config is a separate ticket (Reconciliation row 13).
+
+### 5.5 DispatchPipelineService — per-stakeholder loop
+
+**File:** `backend/novu-bridge/src/main/java/org/egov/novubridge/service/DispatchPipelineService.java`
+
+Today: `deriveContext` picks the first stakeholder and dispatches once. New: when flag on, iterate `event.stakeholders[]` and dispatch per stakeholder.
+
+```java
+public DispatchOutcome process(ComplaintsDomainEvent event, boolean send, DryRunRequest dryRun) {
+    if (!config.isExtendedCriteriaEnabled()) {
+        return processLegacy(event, send, dryRun);    // existing single-stakeholder path
+    }
+    if (CollectionUtils.isEmpty(event.getStakeholders())) {
+        return DispatchOutcome.skipped("NO_STAKEHOLDERS");
+    }
+    List<DispatchOutcome> outcomes = new ArrayList<>();
+    for (Stakeholder s : event.getStakeholders()) {
+        DerivedContext ctx = deriveContextFor(event, s);
+        try {
+            ResolvedTemplate t = configServiceClient.resolveTemplate(
+                ctx, event.getEventName(), event.getModule(), event.getTenantId());
+            outcomes.add(dispatchOne(event, ctx, t, send));
+        } catch (Exception e) {
+            log.error("dispatch failed for event={} stakeholder={}: {}",
+                event.getEventId(), s.getType(), e.getMessage());
+            outcomes.add(DispatchOutcome.failed(e.getMessage()));
+        }
+    }
+    return DispatchOutcome.aggregate(outcomes);
+}
+```
+
+`deriveContextFor(event, stakeholder)` is the existing `deriveContext` parameterized to take a specific stakeholder. `dispatchOne` is the existing per-stakeholder block (Novu trigger + dispatch-log write) factored out.
+
+### 5.6 nb_dispatch_log uniqueness migration
+
+**File (new):** `backend/novu-bridge/src/main/resources/db/migration/main/V20260620130000__per_recipient_dispatch_uniqueness.sql`
+
+```sql
+-- Per-stakeholder fan-out requires N rows for (event_id, channel) — one per recipient.
+-- Original constraint from V20260217124000 was (event_id, channel) which blocks this.
+ALTER TABLE nb_dispatch_log
+    DROP CONSTRAINT IF EXISTS uk_nb_dispatch_event_channel;
+
+ALTER TABLE nb_dispatch_log
+    ADD CONSTRAINT uk_nb_dispatch_event_channel_recipient
+    UNIQUE (event_id, channel, recipient_value);
+```
+
+### 5.7 transactionId composition
+
+**File:** wherever the Novu trigger payload is built (likely in `dispatchOne` or `NovuClient` — verify during implementation).
+
+Today: `.transactionId(event.getEventId())`. After: `.transactionId(String.format("%s:%s:%s", event.getEventId(), context.getChannel(), context.getRecipientMobile()))`.
+
+Matches WhatsAppDesign §3.3 spec. Without this change, Novu's dedup logic silently drops the second stakeholder's trigger because two triggers with the same `transactionId` are duplicates. Gated by the same flag as 5.4–5.6.
+
+---
+
+## 6. PGR adoption
+
+### 6.1 New: `WorkflowExtensionClient.java`
+
+**Path:** `backend/pgr-services/src/main/java/org/egov/pgr/client/WorkflowExtensionClient.java`
+
+```java
+@Component
+@Slf4j
+public class WorkflowExtensionClient {
+
+    private final ServiceRequestRepository repository;
+    private final PGRConfiguration config;
+    private final ObjectMapper mapper;
+    private final ConcurrentHashMap<CacheKey, CachedExtension> cache = new ConcurrentHashMap<>();
+
+    public Optional<TransitionExtension> getTransition(
+            RequestInfo requestInfo, String tenantId, String businessService,
+            String fromState, String action) {
+        BusinessServiceExtension ext = fetchOrCache(requestInfo, tenantId, businessService);
+        if (ext == null || ext.getTransitions() == null) return Optional.empty();
+        return ext.getTransitions().stream()
+                .filter(t -> equalsNullable(t.getFromState(), fromState)
+                          && action.equalsIgnoreCase(t.getAction()))
+                .findFirst();
+    }
+
+    private BusinessServiceExtension fetchOrCache(
+            RequestInfo requestInfo, String tenantId, String businessService) {
+        CacheKey key = new CacheKey(tenantId, businessService);
+        CachedExtension cached = cache.get(key);
+        if (cached != null && !cached.isExpired()) return cached.value();
+        try {
+            BusinessServiceExtension fresh = doFetch(requestInfo, tenantId, businessService);
+            cache.put(key, new CachedExtension(fresh,
+                    System.currentTimeMillis() + config.getExtensionCacheTtlMs()));
+            return fresh;
+        } catch (Exception e) {
+            log.warn("Failed to fetch workflow extension for tenant={}, businessService={} — serving last-known-good",
+                    tenantId, businessService, e);
+            return cached != null ? cached.value() : null;
+        }
+    }
+
+    private BusinessServiceExtension doFetch(
+            RequestInfo requestInfo, String tenantId, String businessService) {
+        String url = config.getWorkflowExtensionHost() + config.getWorkflowExtensionSearchEndpoint();
+        ExtensionSearchRequest body = ExtensionSearchRequest.builder()
+                .requestInfo(requestInfo)
+                .criteria(ExtensionSearchCriteria.builder()
+                        .tenantId(tenantId)
+                        .businessService(businessService)
+                        .build())
+                .build();
+        Object response = repository.fetchResult(new StringBuilder(url), body);
+        ExtensionSearchResponse parsed = mapper.convertValue(response, ExtensionSearchResponse.class);
+        if (parsed.getExtensions() == null || parsed.getExtensions().isEmpty()) return null;
+        return parsed.getExtensions().get(0);
+    }
+
+    private static boolean equalsNullable(String a, String b) {
+        return a == null ? b == null : a.equalsIgnoreCase(b);
+    }
+}
+```
+
+### 6.2 New: `ConfigServiceClient.java`
+
+**Path:** `backend/pgr-services/src/main/java/org/egov/pgr/client/ConfigServiceClient.java`
+
+```java
+@Component
+@Slf4j
+public class ConfigServiceClient {
+
+    private final ServiceRequestRepository repository;
+    private final PGRConfiguration config;
+    private final ObjectMapper mapper;
+    private final ConcurrentHashMap<CacheKey, CachedTemplate> cache = new ConcurrentHashMap<>();
+
+    public Optional<String> resolveSmsBody(
+            RequestInfo requestInfo, String tenantId, String eventName,
+            String audience, String workflowState, String locale) {
+        CacheKey key = new CacheKey(tenantId, eventName, audience, workflowState, locale);
+        CachedTemplate cached = cache.get(key);
+        if (cached != null && !cached.isExpired()) return Optional.ofNullable(cached.body());
+        try {
+            String body = doResolve(requestInfo, tenantId, eventName, audience, workflowState, locale);
+            cache.put(key, new CachedTemplate(body,
+                    System.currentTimeMillis() + config.getConfigCacheTtlMs()));
+            return Optional.ofNullable(body);
+        } catch (Exception e) {
+            log.warn("Failed to resolve SMS template tenant={}, event={}, audience={}, state={}, locale={}",
+                    tenantId, eventName, audience, workflowState, locale, e);
+            return cached != null ? Optional.ofNullable(cached.body()) : Optional.empty();
+        }
+    }
+
+    private String doResolve(RequestInfo requestInfo, String tenantId, String eventName,
+                             String audience, String workflowState, String locale) {
+        String url = config.getConfigServiceHost() + config.getConfigServiceResolveEndpoint();
+        Map<String, Object> criteria = new HashMap<>();
+        criteria.put("eventName", eventName);
+        criteria.put("audience", audience);
+        criteria.put("channel", "sms");
+        criteria.put("locale", locale);
+        if (workflowState != null) criteria.put("workflowState", workflowState);
+        Map<String, Object> resolveRequest = new HashMap<>();
+        resolveRequest.put("schemaCode", "TemplateBinding");
+        resolveRequest.put("tenantId", tenantId);
+        resolveRequest.put("criteria", criteria);
+        Map<String, Object> body = new HashMap<>();
+        body.put("RequestInfo", requestInfo);
+        body.put("resolveRequest", resolveRequest);
+        Object response = repository.fetchResult(new StringBuilder(url), body);
+        TemplateResolveResponse parsed = mapper.convertValue(response, TemplateResolveResponse.class);
+        return parsed.getConfigData() != null
+            ? (String) parsed.getConfigData().getData().get("body")
+            : null;
+    }
+}
+```
+
+### 6.3 Refactor: `ComplaintDomainEventService.buildEvent`
+
+**Path:** `backend/pgr-services/src/main/java/org/egov/pgr/service/ComplaintDomainEventService.java`
+
+Replace the hardcoded `stakeholders[]` construction with an extension lookup:
+
+```java
+@Autowired private WorkflowExtensionClient extensionClient;
+
+// In buildEvent(ServiceRequest request, String fromState, String action) at line ~70
+List<Map<String, Object>> stakeholders;
+if (config.getUseWorkflowExtension(tenantId)) {
+    Optional<TransitionExtension> tx = extensionClient.getTransition(
+        request.getRequestInfo(), tenantId, "PGR", fromState, action);
+    if (tx.isPresent()) {
+        stakeholders = resolveStakeholders(tx.get().getNotifyRoles(), request);
+    } else {
+        log.warn("workflow extension has no transition entry for tenant={}, fromState={}, action={} — falling back to legacy",
+                tenantId, fromState, action);
+        stakeholders = legacyBuildStakeholders(fromState, action, request);
+    }
+} else {
+    stakeholders = legacyBuildStakeholders(fromState, action, request);
+}
+event.put("stakeholders", stakeholders);
+```
+
+`resolveStakeholders(List<String> notifyRoles, ServiceRequest request)` translates role codes to stakeholder entries:
+
+| Role code | Resolution |
+|---|---|
+| `CITIZEN` | `request.service.accountId` → User Service lookup |
+| `ASSIGNEE` | `ProcessInstance.assignes[]` for the current state |
+| `CREATOR` | `request.service.auditDetails.createdBy` → User Service lookup |
+| `SUPERVISOR` | HRMS `reportingTo` of `ASSIGNEE` |
+| `PREVIOUS_ASSIGNEE` | `ProcessInstance` history, one step back |
+| any other role (workflow role from BusinessService) | HRMS lookup of users with the role for the tenant; log and skip if none |
+
+Each resolution returns a `Stakeholder{type, userId, mobile, locale}` ready for the outbound event payload.
+
+### 6.4 Refactor: `NotificationUtil.getCustomizedMsg`
+
+**Path:** `backend/pgr-services/src/main/java/org/egov/pgr/util/NotificationUtil.java`
+
+Replace the localization-key construction with a config-service resolve:
+
+```java
+public String getCustomizedMsg(RequestInfo requestInfo, String tenantId,
+                                String action, String applicationStatus,
+                                String roles, String locale,
+                                String legacyLocalizationMessage) {
+    if (config.getUseConfigServiceTemplates(tenantId)) {
+        Optional<String> body = configServiceClient.resolveSmsBody(
+                requestInfo, tenantId,
+                "COMPLAINTS.WORKFLOW." + action.toUpperCase(),
+                roles.toUpperCase(),
+                applicationStatus.toUpperCase(),
+                locale);
+        if (body.isPresent()) return body.get();
+        log.warn("config-service returned no SMS body for tenant={}, event=COMPLAINTS.WORKFLOW.{}, audience={}, state={}, locale={} — falling back to localization",
+                tenantId, action, roles, applicationStatus, locale);
+    }
+    return legacyGetCustomizedMsg(action, applicationStatus, roles, legacyLocalizationMessage);
+}
+```
+
+### 6.5 Refactor: `NotificationService` SMS loop
+
+**Path:** `backend/pgr-services/src/main/java/org/egov/pgr/service/NotificationService.java`
+
+The SMS loop needs per-audience template lookups now that templates are keyed by `audience`. Inside the existing `process()` method:
+
+```java
+List<String> notifyRoles = resolveNotifyRolesFromExtension(...);
+for (String role : notifyRoles) {
+    String mobile = resolveMobileForRole(role, serviceWrapper, requestInfo);
+    if (mobile == null) continue;
+
+    String body = notificationUtil.getCustomizedMsg(
+            requestInfo, tenantId, action, applicationStatus,
+            role, locale, legacyLocalizationMessage);
+    if (body == null) continue;
+
+    body = substitutePlaceholders(body, serviceWrapper, requestInfo);
+
+    SMSRequest sms = SMSRequest.builder()
+            .mobileNumber(mobile)
+            .message(body)
+            .build();
+    notificationUtil.sendSMS(tenantId, Collections.singletonList(sms));
+}
+```
+
+Placeholder substitution (`{complaint_type}`, `{id}`, `{emp_name}`, etc.) is unchanged — same logic that exists today, just applied to the body string regardless of where it came from.
+
+### 6.6 PGRConfiguration additions
+
+**Path:** `backend/pgr-services/src/main/java/org/egov/pgr/config/PGRConfiguration.java`
+
+```java
+@Value("${pgr.use.workflow.extension:false}")
+private Boolean defaultUseWorkflowExtension;
+
+@Value("${pgr.use.config.service.templates:false}")
+private Boolean defaultUseConfigServiceTemplates;
+
+@Value("${pgr.workflow.extension.host}")
+private String workflowExtensionHost;
+
+@Value("${pgr.workflow.extension.search.endpoint:/workflow-extension/v1/extension/_search}")
+private String workflowExtensionSearchEndpoint;
+
+@Value("${pgr.workflow.extension.cache.ttl.ms:600000}")
+private Long extensionCacheTtlMs;
+
+@Value("${pgr.config.service.host}")
+private String configServiceHost;
+
+@Value("${pgr.config.service.resolve.endpoint:/config/v1/entry/_resolve}")
+private String configServiceResolveEndpoint;
+
+@Value("${pgr.config.cache.ttl.ms:600000}")
+private Long configCacheTtlMs;
+
+// Per-tenant overrides from RAINMAKER-PGR.PGRConfiguration MDMS master:
+public Boolean getUseWorkflowExtension(String tenantId) { ... }
+public Boolean getUseConfigServiceTemplates(String tenantId) { ... }
+```
+
+### 6.7 Fallback semantics
+
+| Condition | stakeholders[] source | SMS body source |
+|---|---|---|
+| Both flags off | Legacy hardcoded logic | egov-localization |
+| `useWorkflowExtension=true`, extension reachable, transition found | Extension's `notifyRoles[]` | (per `useConfigServiceTemplates`) |
+| `useWorkflowExtension=true`, extension reachable, transition not found | Legacy hardcoded logic | (per `useConfigServiceTemplates`) |
+| `useWorkflowExtension=true`, extension service unreachable, cache has last-known-good | Cached extension | (per `useConfigServiceTemplates`) |
+| `useWorkflowExtension=true`, extension service unreachable, no cache | Legacy hardcoded logic | (per `useConfigServiceTemplates`) |
+| `useConfigServiceTemplates=true`, config reachable, binding found | (per `useWorkflowExtension`) | config-service `body` |
+| `useConfigServiceTemplates=true`, config reachable, binding not found | (per `useWorkflowExtension`) | egov-localization fallback |
+| `useConfigServiceTemplates=true`, config unreachable, cache has last-known-good | (per `useWorkflowExtension`) | Cached body |
+| `useConfigServiceTemplates=true`, config unreachable, no cache | (per `useWorkflowExtension`) | egov-localization fallback |
+
+Metrics emitted on each fallback path: `pgr.workflow_extension.missing_entry`, `pgr.workflow_extension.fetch_failed`, `pgr.config_service.missing_template`, `pgr.config_service.fetch_failed`. Tag with `(tenantId, event, audience, state)`.
+
+### 6.8 PGRConstants stays
+
+`PGRConstants.java` is not deleted. New code path simply prefers extension values when the flag is on and the lookup succeeds; everything else stays on the legacy code path.
+
+### 6.9 Configurator write path (TS client only)
+
+**`configurator/src/api/services/workflowExtension.ts`** (new). Typed client wrapping the workflow-extension-service's REST surface, mirroring `mdms.ts` in shape. Used by whatever notification-config admin UI exists today (or is added in a separate track) to author `transitions[]` entries against the service rather than writing MDMS directly.
+
+`WorkflowActionSelect.tsx` and `StatusChip.tsx` are **untouched** in v1. Their hardcoded label/color constants stay; localization addresses them out-of-band if at all.
+
+Effort: ~0.5 dev-day for the new TS client.
+
+---
+
+## 7. Data: schemas, seed, migration
+
+### 7.1 Workflow.BusinessServiceExtension — see §4.2
+
+### 7.2 TemplateBinding extended schema — see §5.1
+
+### 7.3 Mozambique seed data
+
+**Workflow extension** — `utilities/default-data-handler/src/main/resources/mdmsData-dev/Workflow/Workflow.BusinessServiceExtension.json`:
+
+```json
+[
+  {
+    "tenantId": "mz",
+    "businessService": "PGR",
+    "transitions": [
+      { "fromState": null,                       "action": "APPLY",    "notifyRoles": ["CITIZEN"] },
+      { "fromState": "PENDINGFORASSIGNMENT",     "action": "ASSIGN",   "notifyRoles": ["CITIZEN", "ASSIGNEE"] },
+      { "fromState": "PENDINGATLME",             "action": "RESOLVE",  "notifyRoles": ["CITIZEN", "ASSIGNEE"] },
+      { "fromState": "PENDINGATLME",             "action": "REASSIGN", "notifyRoles": ["CITIZEN", "ASSIGNEE"] },
+      { "fromState": "PENDINGFORREASSIGNMENT",   "action": "REASSIGN", "notifyRoles": ["CITIZEN", "ASSIGNEE"] },
+      { "fromState": "PENDINGFORASSIGNMENT",     "action": "REJECT",   "notifyRoles": ["CITIZEN"] },
+      { "fromState": "RESOLVED",                 "action": "REOPEN",   "notifyRoles": ["CITIZEN", "PREVIOUS_ASSIGNEE"] },
+      { "fromState": "REJECTED",                 "action": "REOPEN",   "notifyRoles": ["CITIZEN", "PREVIOUS_ASSIGNEE"] },
+      { "fromState": "RESOLVED",                 "action": "RATE",     "notifyRoles": ["PREVIOUS_ASSIGNEE"] },
+      { "fromState": "REJECTED",                 "action": "RATE",     "notifyRoles": ["PREVIOUS_ASSIGNEE"] }
+    ]
+  }
+]
+```
+
+**SMS templates for `mz`** — `utilities/default-data-handler/src/main/resources/configData/TemplateBinding.pgr-sms.mz.json`:
+
+```json
+[
+  {
+    "tenantId": "mz", "eventName": "COMPLAINTS.WORKFLOW.APPLY",
+    "audience": "CITIZEN", "channel": "sms",
+    "locale": "en_IN", "workflowState": "PENDINGFORASSIGNMENT",
+    "templateId": "sms-inline",
+    "body": "Dear Citizen, your complaint for {complaint_type} with ID {id} submitted on {date} has been received. Track at {download_link}."
+  },
+  {
+    "tenantId": "mz", "eventName": "COMPLAINTS.WORKFLOW.APPLY",
+    "audience": "CITIZEN", "channel": "sms",
+    "locale": "pt_MZ", "workflowState": "PENDINGFORASSIGNMENT",
+    "templateId": "sms-inline",
+    "body": "Caro cidadão, a sua reclamação para {complaint_type} com ID {id} submetida em {date} foi recebida. Acompanhe em {download_link}."
+  },
+  {
+    "tenantId": "mz", "eventName": "COMPLAINTS.WORKFLOW.ASSIGN",
+    "audience": "CITIZEN", "channel": "sms",
+    "locale": "en_IN", "workflowState": "PENDINGATLME",
+    "templateId": "sms-inline",
+    "body": "Dear Citizen, your complaint {id} has been assigned to {emp_name}, {emp_designation}, {emp_department}."
+  },
+  {
+    "tenantId": "mz", "eventName": "COMPLAINTS.WORKFLOW.ASSIGN",
+    "audience": "EMPLOYEE", "channel": "sms",
+    "locale": "en_IN", "workflowState": "PENDINGATLME",
+    "templateId": "sms-inline",
+    "body": "{emp_name}, complaint {id} ({complaint_type}) has been assigned to you for action. Please respond by {sla_date}."
+  }
+  // … full set: ~30 en_IN + ~30 pt_MZ ≈ 60 entries total
+]
+```
+
+Portuguese (pt_MZ) bodies are net-new copywriting — assign to Hari or a translator before flag-flip in Mozambique.
+
+### 7.4 PGRConfiguration update — Mozambique flag
+
+`utilities/default-data-handler/src/main/resources/mdmsData-dev/RAINMAKER-PGR/RAINMAKER-PGR.PGRConfiguration.json`:
+
+```json
+[
+  {
+    "tenantId": "mz",
+    "useWorkflowExtension": true,
+    "useConfigServiceTemplates": true,
+    "complainMaxIdleTime": 432000000
+  }
+]
+```
+
+Other tenants: no entry → defaults to `false` → legacy behavior preserved.
+
+### 7.5 Localization → config-service migration mapping
+
+Inventory of PGR localization keys (`utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json`):
+
+| Legacy localization key | Becomes TemplateBinding entry |
+|---|---|
+| `PGR_CITIZEN_APPLY_PENDINGFORASSIGNMENT_SMS_MESSAGE` | `(eventName=COMPLAINTS.WORKFLOW.APPLY, audience=CITIZEN, workflowState=PENDINGFORASSIGNMENT, channel=sms, locale=en_IN)` |
+| `PGR_CITIZEN_ASSIGN_PENDINGATLME_SMS_MESSAGE` | `(eventName=COMPLAINTS.WORKFLOW.ASSIGN, audience=CITIZEN, workflowState=PENDINGATLME, channel=sms, locale=en_IN)` |
+| `PGR_EMPLOYEE_ASSIGN_PENDINGATLME_SMS_MESSAGE` | `(eventName=COMPLAINTS.WORKFLOW.ASSIGN, audience=EMPLOYEE, workflowState=PENDINGATLME, channel=sms, locale=en_IN)` |
+| `PGR_CITIZEN_RESOLVE_RESOLVED_SMS_MESSAGE` | `(eventName=COMPLAINTS.WORKFLOW.RESOLVE, audience=CITIZEN, workflowState=RESOLVED, channel=sms, locale=en_IN)` |
+| … | … (full inventory in the migration script) |
+
+**Migration rule:**
+- `eventName` = `COMPLAINTS.WORKFLOW.` + uppercase(`<ACTION>`).
+- `audience` = uppercase(`<ROLE>`).
+- `workflowState` = uppercase(`<STATUS>`).
+- `channel` = `"sms"`.
+- `locale` = file's locale (`en_IN`).
+- `body` = the localized message string verbatim. Placeholders preserved.
+
+**Script:** add as `utilities/default-data-handler/src/main/java/.../migration/PgrSmsLocalizationMigrator.java`. Reads the localization JSON, emits a config-service seed JSON. Run once per locale.
+
+---
+
+## 8. End-to-end sequence diagram
+
+```plantuml
+@startuml moz_007-e2e-sequence
+!theme plain
+title MOZ_007 — end-to-end notification flow
+autonumber
+
+actor       "Citizen /\nEmployee"            as User
+participant "pgr-services"                    as PGR
+participant "egov-workflow-v2"                as WF
+participant "workflow-extension-\nservice"    as WFExt
+participant "egov-config-\nservice"           as Config
+database    "MDMS"                            as MDMS
+queue       "complaints.\ndomain.events"      as KEvents
+queue       "egov.core.\nnotification.sms"    as KSms
+participant "novu-bridge"                     as Novu
+participant "egov-\nnotification-sms"         as SmsSvc
+
+== 1. Inbound action ==
+User -> PGR : POST /pgr-services/v2/request/_update\n(action=RESOLVE)
+activate PGR
+PGR -> PGR : validate request
+
+== 2. Workflow transition ==
+PGR -> WF : POST /egov-wf/process/_transition
+activate WF
+WF -> MDMS : _search Workflow.BusinessService (on cache miss)
+MDMS --> WF : BusinessService
+WF -> WF : validate transition + role gating
+WF --> PGR : ProcessInstance{state=RESOLVED, assignes[…]}
+deactivate WF
+PGR -> PGR : enrich Service\n(applicationStatus=RESOLVED,\n fromState=PENDINGATLME)
+
+== 3. Resolve audience via workflow extension ==
+PGR -> WFExt : POST /workflow-extension/v1/extension/_search\n(tenantId=mz, businessService=PGR)
+activate WFExt
+alt extension not cached
+    WFExt -> MDMS : _search Workflow.BusinessServiceExtension
+    MDMS --> WFExt : BusinessServiceExtension (transitions[])
+end
+WFExt --> PGR : BusinessServiceExtension
+deactivate WFExt
+note over PGR
+  Find transition for (fromState=PENDINGATLME, action=RESOLVE):
+    notifyRoles = [CITIZEN, ASSIGNEE]
+end note
+
+== 4. Build domain event stakeholders ==
+PGR -> PGR : translate each role to Stakeholder\n(CITIZEN ⇒ service.accountId,\n ASSIGNEE ⇒ ProcessInstance.assignes[])
+PGR -> KEvents : produce ComplaintsDomainEvent\n{eventName=COMPLAINTS.WORKFLOW.RESOLVE,\n stakeholders[CITIZEN, ASSIGNEE], data, context}
+
+== 5. Per-audience SMS dispatch (PGR side) ==
+loop for each notifyRole (CITIZEN, ASSIGNEE)
+    PGR -> Config : POST /config/v1/entry/_resolve\n(schemaCode=TemplateBinding,\n criteria={eventName=COMPLAINTS.WORKFLOW.RESOLVE,\n  channel=sms, locale=pt_MZ,\n  audience=<role>, workflowState=RESOLVED})
+    activate Config
+    alt template found
+        Config --> PGR : { body, paramOrder[], requiredVars[] }
+    else not found
+        Config -> Config : retry without workflowState\nthen with locale fallback
+        Config --> PGR : { body, … }
+    end
+    deactivate Config
+    PGR -> PGR : substitute placeholders ({id}, {complaint_type},\n {emp_name}, {date}, {download_link})
+    PGR -> KSms : produce SMSRequest\n{mobile, message}
+end
+
+PGR --> User : 200 OK
+deactivate PGR
+
+== 6. Asynchronous downstream dispatch ==
+KEvents -> Novu : consume ComplaintsDomainEvent
+activate Novu
+loop for each stakeholder
+    Novu -> Config : _resolve TemplateBinding\n(channel=whatsapp, audience=<type>)
+    Config --> Novu : { templateId, contentSid, … }
+    Novu -> Novu : trigger Novu (Twilio / SendGrid)\nwith transactionId=eventId:channel:recipient
+end
+deactivate Novu
+
+KSms -> SmsSvc : consume SMSRequest
+activate SmsSvc
+SmsSvc -> SmsSvc : dispatch via SMS provider
+deactivate SmsSvc
+
+@enduml
+```
+
+---
+
+## 9. DB schema and indexes
+
+### 9.1 pgr-services DB
+**No changes.** All MOZ_007-introduced state is in MDMS or config-service.
+
+### 9.2 workflow-extension-service DB
+**None.** MDMS is the persistence layer.
+
+### 9.3 egov-config-service DB
+
+Existing indexes from `V20260302000000__create_eg_config_data.sql` are sufficient. The new resolve criteria (`audience`, `workflowState`) flow through the existing `idx_eg_config_data_data_gin` GIN index on the `data` JSONB column via PostgreSQL's `@>` containment operator (used in `ConfigDataQueryBuilder.appendJsonbFilter`).
+
+Verify the index is present (it is per migration inspection):
+```sql
+-- Composite index on tenant + schema (heavy hitter for the resolve path)
+SELECT 1 FROM pg_indexes WHERE indexname = 'idx_eg_config_data_schemacode';
+SELECT 1 FROM pg_indexes WHERE indexname = 'idx_eg_config_data_tenantid';
+SELECT 1 FROM pg_indexes WHERE indexname = 'idx_eg_config_data_data_gin';
+```
+
+### 9.4 novu-bridge DB — `nb_dispatch_log` uniqueness migration
+
+See §5.6. New migration `V20260620130000__per_recipient_dispatch_uniqueness.sql` replaces `(event_id, channel)` uniqueness with `(event_id, channel, recipient_value)` to support per-stakeholder fan-out.
+
+### 9.5 MDMS
+
+Existing `(module, master, tenantId)` index pattern covers `Workflow.BusinessServiceExtension` lookups. No change.
+
+### 9.6 Consolidated DDL summary
+
+| File | Owner DB | Purpose |
+|---|---|---|
+| `V20260620120000__backfill_templatebinding_audience.sql` | egov-config-service | Backfill `audience='CITIZEN'` on existing TemplateBinding rows |
+| `V20260620130000__per_recipient_dispatch_uniqueness.sql` | novu-bridge | Drop `(event_id, channel)` uniqueness; add `(event_id, channel, recipient_value)` |
+| (none new) | pgr-services | — |
+| (none new) | workflow-extension-service | No DB |
+| (none new) | MDMS | — |
+
+---
+
+## 10. Testing strategy
+
+### 10.1 workflow-extension-service
+- Unit: `ExtensionValidator` covering each rule in §4.4 (positive + negative).
+- Integration: containerized MDMS instance (testcontainers); create → search → validate → update → delete cycle.
+- Contract: a known-bad extension document produces the expected validation errors with correct codes.
+
+### 10.2 pgr-services
+- Unit: `WorkflowExtensionClient` cache behavior — cold load, warm load, TTL expiry, service-unreachable fallback to last-known-good, no-cache returns `Optional.empty()`.
+- Unit: `ConfigServiceClient.resolveSmsBody` — same matrix; verify per-audience and per-locale lookups return distinct bodies.
+- Integration: `ComplaintDomainEventService.buildEvent` with extension on + transition found → stakeholders[] contains CITIZEN + ASSIGNEE entries with resolved mobiles; with extension off → legacy stakeholders.
+- Integration: `NotificationService` end-to-end with config-service backed templates → produces one `SMSRequest` per audience with the audience-specific body; with config off → original localization-backed body.
+- Contract: published `ComplaintsDomainEvent` payload still matches `ComplaintsDomainEvent.class` in novu-bridge (round-trip JSON test).
+- Regression: with both flags off, all existing notification behavior unchanged (golden-output diff).
+
+### 10.3 egov-config-service
+- Migration applies cleanly on a populated DB; idempotent re-run.
+
+### 10.4 novu-bridge
+- Unit: `ConfigServiceClient.resolveTemplate` — flag off uses 3 keys; flag on adds audience and (conditionally) workflowState; two-attempt precedence retries without workflowState on miss; locale-fallback path retained.
+- Integration: `DispatchPipelineService.process()` with flag on + 2 stakeholders → 2 dispatches, 2 nb_dispatch_log rows, 2 distinct transactionIds; with flag off → single-stakeholder regression.
+- Integration: per-stakeholder failure isolation — stakeholder 1's template missing; stakeholder 2 still dispatches; nb_dispatch_log records both outcomes.
+
+### 10.5 Drift detection (CI)
+- JUnit in `default-data-handler` that loads committed `Workflow.BusinessServiceExtension.json` + `Workflow.BusinessService.json` and asserts every validation rule passes. Blocks PR merges with invalid seed data.
+- JUnit that loads committed `TemplateBinding.pgr-sms.*.json` and asserts every `audience` matches a role present in the corresponding BusinessService, every `eventName` is `COMPLAINTS.WORKFLOW.<known-action>`, every `workflowState` is a known state.
+
+### 10.6 Manual verification
+- Mozambique sub-tenant smoke test: file a complaint as IGE citizen → flip ASSIGN → verify both citizen and employee receive distinct pt_MZ SMS bodies.
+
+---
+
+## 11. Rollout
+
+1. **Day 1–2:** Land #905 (TemplateBinding schema + ConfigServiceClient criteria + per-stakeholder loop + nb_dispatch_log migration + transactionId composition) in novu-bridge. Schema + backfill in default-data-handler / config-service. Verify WhatsApp dispatch still works with flag off (regression).
+2. **Day 3–4:** Ship `workflow-extension-service` scaffold to dev. Smoke-test API surface with empty extension + valid extension.
+3. **Day 4–5:** Ship `WorkflowExtensionClient` + `ConfigServiceClient` to dev pgr-services with both flags off for all tenants. Verify no behavior change (regression baseline).
+4. **Day 5–6:** Seed `Workflow.BusinessServiceExtension.json` for `mz`. Run the localization → config-service migration script for the ~30 PGR SMS keys in en_IN. Add pt_MZ entries (translation work).
+5. **Day 6–7:** Flip `useWorkflowExtension=true` + `useConfigServiceTemplates=true` for `mz` in dev. Flip `novu.bridge.criteria.extended.enabled=true` in novu-bridge dev env. Run smoke test (§10.6).
+6. **Promote service + pgr-services to staging.** Repeat smoke test.
+7. **Production:** deploy services. Deploy pgr-services with both flags off. Seed extension + TemplateBindings. Flip flags for `mz`. Flip novu-bridge flag. Monitor metrics for 48 hours. Done.
+
+No big-bang switchover. All other tenants stay on legacy behavior indefinitely until they opt in via the per-tenant flags.
+
+---
+
+## 12. Effort estimate
+
+| Item | Owner | Dev | Test | Total |
+|---|---|---|---|---|
+| #905 — TemplateBinding schema bump + ConfigServiceClient criteria + per-stakeholder loop + nb_dispatch_log uniqueness + transactionId | novu-bridge maintainer | 3 | 1.5 | 4.5 |
+| workflow-extension-service scaffold + CRUD + validation | Priyanshu | 2 | 1 | 3 |
+| `WorkflowExtensionClient.java` in pgr-services + tests | Priyanshu | 0.75 | 0.5 | 1.25 |
+| `ConfigServiceClient.java` in pgr-services + tests | Priyanshu | 0.75 | 0.5 | 1.25 |
+| `ComplaintDomainEventService.buildEvent` refactor (stakeholders[]) | Priyanshu | 1 | 0.75 | 1.75 |
+| `NotificationUtil` + `NotificationService` SMS-loop refactor | Priyanshu | 1 | 0.75 | 1.75 |
+| Localization → config-service migration script + en_IN seed | Hari | 0.5 | 0.25 | 0.75 |
+| Mozambique pt_MZ translation + seed entries | Hari + translator | 0.75 | 0.25 | 1 |
+| Configurator `workflowExtension.ts` typed client | Hari | 0.5 | 0.25 | 0.75 |
+| PGRConfiguration + per-tenant flag wiring | Hari | 0.25 | 0.25 | 0.5 |
+| Helm chart + deployment scaffolding | Pradeep | 0.5 | 0.25 | 0.75 |
+| Drift CI tests | Priyanshu | 0.5 | 0.25 | 0.75 |
+| **Total** | | **11.5** | **6.5** | **18** |
+
+**Calendar fit:** Target 2026-06-30. From 2026-06-22 (Mon) through 2026-06-30 (Tue): 7 working days. 18 person-days across four owners needs aggressive parallelization. Critical path: #905 (novu-bridge maintainer, days 1–3) → workflow-extension-service scaffold (Priyanshu, days 1–3, in parallel) → pgr-services adoption (Priyanshu, days 4–7) ≈ 7 calendar days. Hari and Pradeep parallelize from day 1.
+
+**Slip mitigation:**
+- If #905 slips, MOZ_007 can ship workflow-extension + ComplaintDomainEventService refactor without the SMS template migration; per-tenant flag stays off for SMS until #905 lands.
+- If pt_MZ translations slip, ship Mozambique with en_IN bodies first; pt_MZ as hotfix.
+- If pgr-services critical path slips, defer the configurator TS client to v1.1 (not deployment-blocking).
+
+---
+
+## 13. Risk register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| #905 slips and blocks per-audience SMS | Medium | High | Two-phase flag flip: extension flag first, templates flag second |
+| Extension service down → stakeholders[] resolution fails | Low | Medium | Last-known-good cache + fallback to legacy hardcoded logic |
+| Config-service down → SMS body resolution fails | Low | Medium | Last-known-good cache + fallback to legacy localization lookup |
+| pt_MZ translation copywriting drags | Medium | Low | Ship en_IN first; pt_MZ as hotfix |
+| novu-bridge regression from schema bump (#905) | Low | High | Schema is forward-compatible (new fields are optional in JSON Schema); regression test WhatsApp dispatch before merging |
+| Per-tenant flag confusion (extension on, templates off, etc.) | Medium | Low | Document 9 fallback states in §6.7; integration tests cover each combination |
+| Configurator write path migration drags | Low | Low | TS client is small; ops can author extension data via curl in the gap |
+| Critical path (Priyanshu) slips | Medium | High | Scaffold workflow-extension-service first so Hari has a real artifact to integrate against |
+| Multi-stakeholder fan-out causes duplicate SMS to the same recipient | Low | Medium | Per-stakeholder dedup via `(event_id, channel, recipient_value)` uniqueness constraint; test §10.4 covers it |
+
+---
+
+## 14. Open questions
+
+- **#905 ownership** — who in the novu-bridge team owns the schema bump + ConfigServiceClient + DispatchPipelineService changes? Must be assigned before this work starts.
+- **pt_MZ translator** — Hari, an external translator, or AI-generated reviewed by Hari? Affects schedule.
+- **`body` field length cap** — 4000 chars in the proposed schema. Are any PGR SMS templates longer? Audit en_IN bodies before locking the cap.
+- **TemplateBinding `templateId` required-ness** — when the SMS path stores a `body`, the `templateId` field is meaningless. Either relax `templateId` to optional, OR use the sentinel `"sms-inline"` for SMS-only bindings. Decide before schema seed.
+
+---
+
+## 15. File-level change inventory
+
+### Created
+- `backend/workflow-extension-service/` — new module (~1500 LOC, mirrors `backend/digit-config-service/` scaffold)
+- `backend/pgr-services/src/main/java/org/egov/pgr/client/WorkflowExtensionClient.java` + model classes
+- `backend/pgr-services/src/main/java/org/egov/pgr/client/ConfigServiceClient.java` + model classes
+- `utilities/default-data-handler/src/main/resources/schema/Workflow.BusinessServiceExtension.json`
+- `utilities/default-data-handler/src/main/resources/mdmsData-dev/Workflow/Workflow.BusinessServiceExtension.json`
+- `utilities/default-data-handler/src/main/resources/configData/TemplateBinding.pgr-sms.json` (en_IN baseline)
+- `utilities/default-data-handler/src/main/resources/configData/TemplateBinding.pgr-sms.mz.json` (Mozambique en_IN + pt_MZ)
+- `utilities/default-data-handler/src/test/java/.../WorkflowExtensionSeedDriftTest.java`
+- `utilities/default-data-handler/src/test/java/.../TemplateBindingSeedDriftTest.java`
+- `utilities/default-data-handler/src/main/java/.../migration/PgrSmsLocalizationMigrator.java`
+- `backend/digit-config-service/src/main/resources/db/migration/main/V20260620120000__backfill_templatebinding_audience.sql`
+- `backend/novu-bridge/src/main/resources/db/migration/main/V20260620130000__per_recipient_dispatch_uniqueness.sql`
+- `backend/novu-bridge/src/test/java/.../ConfigServiceClientTest.java`
+- `backend/novu-bridge/src/test/java/.../DispatchPipelineServiceTest.java`
+- `configurator/src/api/services/workflowExtension.ts`
+- `Devops/deploy-as-code/charts/core-services/workflow-extension-service/` (Helm chart)
+
+### Modified
+- `utilities/default-data-handler/src/main/resources/schema/TemplateBinding.json` (add `audience`, `workflowState`, `body`)
+- `utilities/default-data-handler/src/main/resources/configData/TemplateBinding.json` (add `audience: "CITIZEN"` to 4 existing entries)
+- `backend/novu-bridge/src/main/java/org/egov/novubridge/config/NovuBridgeConfiguration.java` (add `extendedCriteriaEnabled` flag)
+- `backend/novu-bridge/src/main/java/org/egov/novubridge/service/ConfigServiceClient.java` (flag + two-attempt resolve)
+- `backend/novu-bridge/src/main/java/org/egov/novubridge/service/DispatchPipelineService.java` (per-stakeholder loop)
+- `backend/novu-bridge/src/main/java/org/egov/novubridge/service/NovuClient.java` (transactionId composition)
+- `backend/novu-bridge/src/main/resources/application.properties` (document new env key)
+- `backend/pgr-services/src/main/java/org/egov/pgr/service/ComplaintDomainEventService.java` (`buildEvent` stakeholders[])
+- `backend/pgr-services/src/main/java/org/egov/pgr/util/NotificationUtil.java` (`getCustomizedMsg` template source swap)
+- `backend/pgr-services/src/main/java/org/egov/pgr/service/NotificationService.java` (per-audience SMS loop)
+- `backend/pgr-services/src/main/java/org/egov/pgr/config/PGRConfiguration.java` (new flag getters + URL/TTL config)
+- `backend/pgr-services/src/main/resources/application.properties` (URLs + TTLs)
+- `utilities/default-data-handler/src/main/resources/mdmsData-dev/RAINMAKER-PGR/RAINMAKER-PGR.PGRConfiguration.json` (mz tenant entry)
+
+### Untouched (explicit non-goals)
+- `/Users/subha/Code/Digit-Core/core-services/` — Digit-Core workflow service and notification services (egov-notification-sms / -mail / -user-event)
+- `backend/pgr-services/.../util/PGRConstants.java` — stays as fallback
+- `backend/pgr-services/.../service/MigrationService.java` — v1→v2 mapping preserved
+- `backend/pgr-services/.../service/EscalationScheduler.java` — escalation is out of scope
+- `backend/pgr-services/.../repository/rowmapper/DashboardQueryBuilder.java` — `CLOSED_STATUSES` stays hardcoded
+- `backend/pgr-services/.../validator/ServiceRequestValidator.java` — reopen rules unchanged
+- `configurator/src/admin/WorkflowActionSelect.tsx` and `StatusChip.tsx` — UI labels and colors stay hardcoded
+- `Workflow.BusinessService.json` — source of truth for state machine, unchanged
+- `egov-localization` PGR entries — left in place as fallback; not deleted until all tenants are on `useConfigServiceTemplates=true`
+
+---
+
+**End of design + implementation spec.**

--- a/docs/superpowers/specs/workflow-notification/2026-06-20-novu-adapter-design-vs-implementation-reconciliation.md
+++ b/docs/superpowers/specs/workflow-notification/2026-06-20-novu-adapter-design-vs-implementation-reconciliation.md
@@ -1,0 +1,673 @@
+# Novu Adapter — Design vs Implementation Reconciliation
+
+**Date:** 2026-06-20
+**Status:** Reference; informs MOZ_007 engineering work
+**Audience:** Engineers fixing Bucket A (blocks MOZ_007), tech leads triaging Bucket B and C
+**Source docs reviewed:**
+- `docs/Novu_Adapter/NovuAdapter_LLD.md`
+- `docs/WhatsApp_Bidirectional/HLD.md`
+- `docs/WhatsApp_Bidirectional/WhatsAppDesign.md`
+- `docs/HLD.md` (Config Service)
+
+**Code surveyed:**
+- `backend/novu-bridge/src/main/java/org/egov/novubridge/**`
+- `utilities/default-data-handler/src/main/resources/schema/TemplateBinding.json`
+- `utilities/default-data-handler/src/main/resources/configData/TemplateBinding.json`
+- `backend/novu-bridge/src/main/resources/db/migration/main/V20260217124000__create_nb_dispatch_log.sql`
+- `backend/novu-bridge/src/main/resources/db/migration/main/V20260325120000__add_reference_number.sql`
+- `backend/novu-bridge/config/Novu-Bootstrap.postman_collection.json`
+
+---
+
+## 1. Purpose
+
+This document compares what the Novu Adapter LLD, the WhatsApp Bidirectional HLD, and the WhatsAppDesign companion specify against what's actually shipping in `novu-bridge` today. It identifies which deviations block MOZ_007, which are documentation drift, and which are unbuilt features the design promised. For deviations that need fixing it provides JSON-Schema diffs, code change locations, DB / index DDL, and PlantUML diagrams of current vs target flows.
+
+This is reference material. The MOZ_007 engineering spec (`2026-06-20-moz_007-workflow-hardcoding-removal.md`) depends on Bucket A from this document being completed before its own ship date.
+
+---
+
+## 2. Percent deviation (executive summary)
+
+| Area | Designed | Implemented | Match |
+|---|---|---|---|
+| Architecture (services to build) | novu-bridge + user-preferences-service + config-service | all three exist | **~100%** |
+| Runtime pipeline (consume → resolve → trigger → log) | full path | full path | **~90%** |
+| Recipient + preference resolution | spec'd | matches | **~100%** |
+| Persistence (`nb_dispatch_log`) | columns enumerated | matches + 1 extra column | **~95%** |
+| Resolve selectors | 4 (`eventName, audience, workflowState, channel`) | 3 passed (`eventName, channel, locale`); only 1 overlaps the spec | **~25%** |
+| Template storage model | Config Service is source-of-truth | Novu is source-of-truth; Config Service holds reference only | **~25%** |
+| Scope guardrails | WhatsApp-only; Novu for delivery only | Schema accepts SMS / email; Novu owns bodies | **~0%** |
+| Policy catalog (event-channels, classification, rate-limits, quiet-hours, retry, language-strategy, consent, keyword-actions, feature-flags) | 11 config types | 2 of 11 built (`TemplateBinding`, `ProviderDetail`) | **~20%** |
+| ConfigSets / versioned activation | required | not built | **0%** |
+| MDMS vocabulary modules | 2 modules, 7 masters | none seeded | **0%** |
+| Observability (metrics list) | 7 metrics enumerated | partial | **~60%** |
+| Naming / conventions (transactionId, workflow-id format, field names) | spec'd | drift across the board | **~40%** |
+
+**Unweighted average across rows: 51%. Weighted by impact-on-runtime: 60–70%.**
+
+**Most honest one-liner:** the MVP runtime path is ~90% built. The policy / governance / content-management layer is ~15% built. Overall ≈ 50%, concentrated in the governance/policy layer.
+
+---
+
+## 3. The deviation table
+
+22 rows. Severity reflects impact on MOZ_007 and on production correctness.
+
+| # | Area | HLD / LLD specifies | Impl does | Severity |
+|---|---|---|---|---|
+| 1 | Channel scope | HLD: WhatsApp outbound only; "No SMS/email delivery via Novu" (§Non-Goals). LLD §2.1: WhatsApp only Phase-1 | `TemplateBinding.json:30` schema accepts `whatsapp, sms, email`; seed bindings exist for SMS too | Medium |
+| 2 | Template ownership | WhatsAppDesign §1.3: "Canonical templates live in DIGIT Config Service, not in MDMS and not as primary source in Novu" | Bodies live in **Novu** (configured via `Novu-Bootstrap.postman_collection.json`); config-service holds only `templateId` references | High |
+| 3 | Two-tier template model | WhatsAppDesign §5.3.A: split into `OOTB_TEMPLATES` (`{templateCode, locale}` → body) and `OOTB_TEMPLATE_BINDINGS` (`{eventType, channel}` → templateCode) | Single `TemplateBinding` schema collapses both | High |
+| 4 | Resolve selectors — `audience` | LLD §6: selectors are `(eventName, audience, workflowState, channel)` | `ConfigServiceClient.java:36-40` passes only `(eventName, channel, locale)`. `audience` is derived in `DerivedContext.java:14` and `DispatchPipelineService.java:296` but never used in resolve | **High — blocks MOZ_007 Option B** |
+| 5 | Resolve selectors — `workflowState` | LLD §6: include `workflowState` | Derived (`DispatchPipelineService.java:297`) but never used in resolve | Medium |
+| 6 | Config payload field naming | LLD §6: `templateKey, templateVersion, requiredVars[], optionalVars[], paramOrder[], fallbackTemplateKey, fallbackTemplateVersion` | Schema has `templateId, contentSid, paramOrder, requiredVars, novuApiKey, isActive`. Missing: `templateVersion`, `optionalVars`, `fallbackTemplateKey`, `fallbackTemplateVersion`. Extra: `contentSid`, `novuApiKey` per binding | Medium |
+| 7 | Provider model | LLD: implicit in Novu. HLD: not mentioned | Explicit `ProviderDetail` schema + `resolveProvider` / `resolveProvidersByChannel` calls (`ConfigServiceClient.java:108-234`) | Low |
+| 8 | Policy catalog: `EVENT_CHANNELS` | WhatsAppDesign §5.3.B: `event-channel-enablement` config | Not implemented | Medium |
+| 9 | Policy catalog: `EVENT_CATEGORY_MAP` | §5.3.B: `event-classification` (TRANSACTIONAL / CAMPAIGN) | Not implemented | Medium |
+| 10 | Policy catalog: `QUIET_HOURS` | §5.3.C: `quiet-hours-policy` | Not implemented | Low |
+| 11 | Policy catalog: `RATE_LIMITS` | §5.3.C: `rate-limit-policy` per `{channel?, category?, eventType?}` | Not implemented | Medium |
+| 12 | Policy catalog: `RETRY_POLICIES` | §5.3.C: `retry-policy` per channel | LLD §8.2 values are inline constants in code; not config-driven | Low |
+| 13 | Policy catalog: `LANGUAGE_STRATEGY` | §5.3.D: `language-strategy` (precedence + fallback) | Hardcoded fallback to `en_IN` (`ConfigServiceClient.java:59-66`); LLD says "fallback to tenant default" | **Medium — blocks Mozambique pt_MZ** |
+| 14 | Policy catalog: `CONSENT_POLICY` / `KEYWORD_ACTIONS` / `FEATURE_FLAGS` | §5.3.D, §5.3.E | Not implemented (FEATURE_FLAGS partially via env vars, not config) | Low–Medium |
+| 15 | ConfigSets / activation model | WhatsAppDesign §5.1: "ConfigSets are used to activate a coherent set of config versions" | Not implemented; entries are live as soon as written | Medium |
+| 16 | MDMS vocabulary modules | WhatsAppDesign §4: `DIGIT-Notification` (Channel, EventCategory, BackoffType, Locale, FeatureFlagName), `DIGIT-UserPreferences` (ConsentScope, KeywordAction) | None seeded; vocabulary lives ad-hoc in schemas and code | Low |
+| 17 | Novu workflow identifier convention | WhatsAppDesign §3.1: "Workflow identifier = DIGIT eventType (e.g., `PGR_CREATED`, `PGR_STATUS_CHANGED`)" | Uses dot-form `COMPLAINTS.WORKFLOW.APPLY` slugified to `complaints-workflow-apply` to satisfy Novu's id constraints | Low |
+| 18 | `transactionId` convention | WhatsAppDesign §3.3: `<eventId>:<channel>:<recipient>` | Impl uses `eventId` alone | Low |
+| 19 | Subscriber strategy | WhatsAppDesign §3.2: DIGIT user UUID preferred, E.164 phone fallback | `UserServiceClient.resolveUserUuid` exists and is used; falls back to mobile | OK |
+| 20 | Preference gating | LLD §5 step 5; HLD step 3 | `PreferenceServiceClient` called in `DispatchPipelineService` | OK |
+| 21 | `nb_dispatch_log` schema | LLD §9 lists columns | `V20260217124000__create_nb_dispatch_log.sql` matches; `V20260325120000__add_reference_number.sql` adds a `reference_number` column not in the LLD | Low |
+| 22 | Bootstrap-collection-as-config-as-code | Not mentioned in HLD or LLD | `novu-bridge/config/Novu-Bootstrap.postman_collection.json` is the de-facto source-of-truth for Novu template bodies | Medium |
+
+---
+
+## 4. Fix plan — three buckets
+
+### Bucket A — must fix before MOZ_007 ships
+
+| # | Title |
+|---|---|
+| 4 | Add `audience` to TemplateBinding selectors and to ConfigServiceClient.resolveTemplate call |
+| 5 | Add `workflowState` to TemplateBinding selectors and to ConfigServiceClient.resolveTemplate call |
+| 13 | Replace hardcoded `en_IN` fallback in ConfigServiceClient with a `LANGUAGE_STRATEGY` config lookup |
+
+Detail in §5 below.
+
+### Bucket B — design vs impl reconciliation
+
+| # | Title | Resolution direction |
+|---|---|---|
+| 1 | Channel scope in TemplateBinding | Update HLD to allow SMS / email; or remove from schema |
+| 2 | Template ownership | Update HLD to acknowledge Novu owns bodies; or build OOTB_TEMPLATES in config-service |
+| 3 | Two-tier template model | Tied to #2 |
+| 6 | Field naming reconciliation | Update LLD; code names win |
+| 7 | ProviderDetail schema not in design | Document in LLD as the per-channel provider-credential registry |
+| 16 | MDMS vocabulary modules | Either seed per HLD or remove from HLD |
+| 17 | Workflow id format | Document slugification rule in HLD |
+| 18 | transactionId composition | Code fix — switch to `eventId:channel:recipient` to prevent retry+fan-out collisions |
+| 21 | `reference_number` column undocumented | Add to LLD §9 |
+| 22 | Postman bootstrap is the deployment artifact | Document in HLD; or replace with in-process bootstrap |
+
+Detail in §7.
+
+### Bucket C — un-built policy catalog (separate epics)
+
+| # | Title | Recommendation |
+|---|---|---|
+| 8 | EVENT_CHANNELS | Build before second producer module adopts notifications |
+| 9 | EVENT_CATEGORY_MAP | Build alongside QUIET_HOURS / RATE_LIMITS |
+| 10 | QUIET_HOURS | Defer unless campaigns ship |
+| 11 | RATE_LIMITS | Build before scaling — real production risk |
+| 12 | RETRY_POLICIES | Move inline constants to config |
+| 14 | CONSENT_POLICY / KEYWORD_ACTIONS / FEATURE_FLAGS | Defer; track as a single user-preferences-v2 epic |
+| 15 | ConfigSets / activation model | Major architectural addition; needs its own design pass |
+
+Detail in §8.
+
+---
+
+## 5. Bucket A — implementation detail
+
+### 5.1 Add `audience` and `workflowState` as resolve selectors (rows 4, 5)
+
+#### 5.1.1 Schema change — `TemplateBinding`
+
+**File:** `utilities/default-data-handler/src/main/resources/schema/TemplateBinding.json`
+
+Diff:
+
+```diff
+ {
+   "type": "object",
+   "title": "TemplateBinding",
+   "$schema": "http://json-schema.org/draft-07/schema#",
+   "required": [
+     "eventName",
+     "channel",
+     "templateId",
+-    "locale"
++    "locale",
++    "audience"
+   ],
+   "x-unique": [
+     "eventName",
+     "channel",
+-    "locale"
++    "locale",
++    "audience",
++    "workflowState"
+   ],
+   "properties": {
+     "locale": { ... },
+     "channel": { ... },
++    "audience": {
++      "type": "string",
++      "description": "Stakeholder type the template targets (CITIZEN, EMPLOYEE, SUPERVISOR, …). Required; binding is resolved per (event, channel, locale, audience, workflowState)."
++    },
++    "workflowState": {
++      "type": "string",
++      "description": "Application status the workflow has transitioned into. Optional; when absent, the binding matches any state for the given (event, channel, locale, audience)."
++    },
+     "isActive": { ... },
+     "eventName": { ... },
+     ...
+   }
+ }
+```
+
+`audience` is required; `workflowState` is optional so existing entries can continue to match without modification. Uniqueness is the 5-tuple `(eventName, channel, locale, audience, workflowState)` — entries with `workflowState=null` and entries with explicit states coexist; the resolver picks the more specific match (see §5.1.4).
+
+#### 5.1.2 Code change — `ConfigServiceClient.resolveTemplate`
+
+**File:** `backend/novu-bridge/src/main/java/org/egov/novubridge/service/ConfigServiceClient.java:32-40`
+
+Diff:
+
+```diff
+ public ResolvedTemplate resolveTemplate(DerivedContext context, String eventName, String module, String tenantId) {
+     Map<String, Object> resolveRequest = new HashMap<>();
+     resolveRequest.put("schemaCode", "TemplateBinding");
+     resolveRequest.put("tenantId", tenantId);
+-    resolveRequest.put("criteria", Map.of(
+-        "eventName", eventName,
+-        "channel", context.getChannel(),
+-        "locale", context.getLocale()
+-    ));
++    Map<String, Object> criteria = new HashMap<>();
++    criteria.put("eventName", eventName);
++    criteria.put("channel", context.getChannel());
++    criteria.put("locale", context.getLocale());
++    criteria.put("audience", context.getAudience());
++    if (context.getWorkflowState() != null) {
++        criteria.put("workflowState", context.getWorkflowState());
++    }
++    resolveRequest.put("criteria", criteria);
+     ...
+ }
+```
+
+`audience` and `workflowState` are already populated in `DerivedContext` at `DispatchPipelineService.java:296-297` — this is the single code change to start using them.
+
+#### 5.1.3 Resolve precedence
+
+When multiple TemplateBinding entries match the same `(eventName, channel, locale, audience)` — one with a specific `workflowState`, one without — the resolver MUST prefer the more specific entry. Add to `ConfigServiceClient.resolveTemplate`:
+
+1. First attempt: full criteria including `workflowState`.
+2. On miss: retry without `workflowState`.
+3. On miss: retry with default locale `en_IN` (existing behavior at lines 59-66; will be replaced by Bucket A row 13).
+
+Returns first matching entry. Logs the resolution path at INFO for traceability.
+
+#### 5.1.4 Migration of existing TemplateBinding entries
+
+Every entry already in `Workflow.BusinessServiceExtension` and seed files needs an `audience` value. Two-step migration:
+
+**Step 1.** Backfill: for every existing entry, set `audience = "CITIZEN"` (current implicit default — most existing entries are citizen-facing; verify by inspection).
+
+```sql
+-- Run against config-service DB; adapt to the actual table name.
+UPDATE config_entries
+   SET data = jsonb_set(data, '{audience}', '"CITIZEN"', true)
+ WHERE schema_code = 'TemplateBinding'
+   AND data->>'audience' IS NULL;
+```
+
+**Step 2.** Add EMPLOYEE-targeted entries for transitions that need both audiences. Seed file update — one new entry per `(eventName, channel, locale)` where employee SMS is expected. See MOZ_007 engineering spec §5.4 for the Mozambique list.
+
+#### 5.1.5 DB / index implications
+
+Config-service resolves entries by `(tenant_id, schema_code, criteria)` where `criteria` is a JSON object. With `audience` and `workflowState` joining the criteria, the existing index strategy may need a touch:
+
+```sql
+-- If not already present: composite index on tenant + schema (heavy hitter for the resolve path)
+CREATE INDEX IF NOT EXISTS idx_config_entries_tenant_schema
+  ON config_entries (tenant_id, schema_code)
+  WHERE is_active = true;
+
+-- GIN index for JSON containment filters on criteria
+CREATE INDEX IF NOT EXISTS idx_config_entries_criteria_gin
+  ON config_entries USING GIN (criteria jsonb_path_ops);
+```
+
+If config-service stores `data` (entry body) and `criteria` (selector) separately, the GIN index goes on `criteria`. If they're merged, the index goes on the merged JSON. Verify against the live schema at `backend/digit-config-service/src/main/resources/db/migration/main/*.sql` before applying.
+
+#### 5.1.6 Tests
+
+- Unit: `ConfigServiceClient.resolveTemplate` with `audience=CITIZEN` vs `audience=EMPLOYEE` returns different bindings.
+- Unit: precedence — entry with explicit `workflowState` wins over entry without.
+- Unit: locale fallback still works (until row 13 replaces it).
+- Integration: end-to-end dispatch test with two stakeholders of different audiences fetches two distinct templates.
+
+---
+
+### 5.2 Replace hardcoded `en_IN` fallback with `LANGUAGE_STRATEGY` (row 13)
+
+#### 5.2.1 New config schema — `LanguageStrategy`
+
+**File:** `utilities/default-data-handler/src/main/resources/schema/LanguageStrategy.json` (new)
+
+```json
+[
+  {
+    "tenantId": "{tenantid}",
+    "code": "LanguageStrategy",
+    "description": "Per-tenant locale precedence + fallback for notification template resolution",
+    "definition": {
+      "type": "object",
+      "title": "LanguageStrategy",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "required": ["tenantId", "precedence", "fallback"],
+      "x-unique": ["tenantId"],
+      "properties": {
+        "tenantId": { "type": "string" },
+        "precedence": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Ordered list of locale codes to try in order. First match wins. Example: [\"user.preferredLocale\", \"event.context.locale\", \"tenant.defaultLocale\"]"
+        },
+        "fallback": {
+          "type": "string",
+          "pattern": "^[a-z]{2}_[A-Z]{2}$",
+          "description": "Final fallback locale if every precedence entry yields no template match. Tenant default; not hardcoded."
+        }
+      }
+    },
+    "isActive": true
+  }
+]
+```
+
+#### 5.2.2 Seed data — Mozambique
+
+**File:** `utilities/default-data-handler/src/main/resources/configData/LanguageStrategy.json` (new)
+
+```json
+[
+  {
+    "tenantId": "mz",
+    "precedence": ["user.preferredLocale", "event.context.locale"],
+    "fallback": "pt_MZ"
+  },
+  {
+    "tenantId": "pb.amritsar",
+    "precedence": ["user.preferredLocale", "event.context.locale"],
+    "fallback": "en_IN"
+  }
+]
+```
+
+#### 5.2.3 Code change — `ConfigServiceClient`
+
+Replace the hardcoded retry at `ConfigServiceClient.java:59-66`:
+
+```diff
+- log.warn("No config found for locale={}, attempting fallback to en_IN", context.getLocale());
+-
+- resolveRequest.put("criteria", Map.of(
+-     "eventName", eventName,
+-     "channel", context.getChannel(),
+-     "locale", "en_IN"
+- ));
++ String fallbackLocale = languageStrategyClient.getFallbackLocale(tenantId);
++ log.warn("No config found for locale={}, attempting fallback to {}", context.getLocale(), fallbackLocale);
++
++ resolveRequest.put("criteria", Map.of(
++     "eventName", eventName,
++     "channel", context.getChannel(),
++     "locale", fallbackLocale
++ ));
+```
+
+New helper `LanguageStrategyClient.getFallbackLocale(tenantId)` resolves the `LanguageStrategy` config entry for the tenant and returns `fallback`. TTL-cached client-side, same shape as the existing config clients.
+
+#### 5.2.4 Tests
+
+- Unit: `LanguageStrategyClient` resolves `mz` → `pt_MZ`, `pb.amritsar` → `en_IN`.
+- Unit: missing `LanguageStrategy` entry for a tenant falls back to global default `en_IN` (graceful degradation matches today's behavior).
+- Integration: Mozambique dispatch with a complaint context `locale=pt_PT` falls back to `pt_MZ`, not `en_IN`.
+
+---
+
+## 6. Sequence diagrams
+
+### 6.1 Current state — as built today
+
+```plantuml
+@startuml novu-bridge-current
+!theme plain
+title novu-bridge dispatch — current state
+autonumber
+
+queue       "complaints.\ndomain.events" as Kafka
+participant "novu-bridge" as Novu
+participant "user-preferences-\nservice" as Prefs
+participant "egov-config-\nservice" as Config
+participant "Novu API" as NovuAPI
+participant "Twilio / etc." as Provider
+
+Kafka -> Novu : ComplaintsDomainEvent
+activate Novu
+
+loop for each stakeholder
+    Novu -> Prefs : channel preference
+    Prefs --> Novu : [WHATSAPP, ...]
+
+    note over Novu
+      DerivedContext built:
+        channel, audience, workflowState, locale
+      ** but only channel + locale used below **
+    end note
+
+    Novu -> Config : _resolve schemaCode=TemplateBinding\ncriteria={eventName, channel, locale}
+    Config --> Novu : { templateId, contentSid, paramOrder, ... }
+
+    Novu -> Config : _resolve schemaCode=ProviderDetail\ncriteria={channel, priority=1}
+    Config --> Novu : { providerName, credentials, ... }
+
+    Novu -> NovuAPI : triggerWithProviderConfig(\n  templateId, subscriberId,\n  recipientPhone, contentVariables,\n  providerConfig)
+    NovuAPI -> Provider : send
+    Provider --> NovuAPI : status
+    NovuAPI --> Novu : trigger response
+end
+deactivate Novu
+@enduml
+```
+
+### 6.2 Target state — after Bucket A fixes
+
+```plantuml
+@startuml novu-bridge-target
+!theme plain
+title novu-bridge dispatch — target state after Bucket A
+autonumber
+
+queue       "complaints.\ndomain.events" as Kafka
+participant "novu-bridge" as Novu
+participant "user-preferences-\nservice" as Prefs
+participant "egov-config-\nservice" as Config
+participant "Novu API" as NovuAPI
+participant "Twilio / etc." as Provider
+
+Kafka -> Novu : ComplaintsDomainEvent
+activate Novu
+
+Novu -> Config : _resolve schemaCode=LanguageStrategy\ncriteria={tenantId}
+Config --> Novu : { precedence, fallback }
+
+loop for each stakeholder
+    Novu -> Prefs : channel + locale preference
+    Prefs --> Novu : { channels[], preferredLocale }
+
+    note over Novu
+      DerivedContext built:
+        channel, audience, workflowState, locale
+      (locale chosen via precedence above)
+    end note
+
+    Novu -> Config : _resolve schemaCode=TemplateBinding\ncriteria={\n  eventName, channel, locale,\n  audience, workflowState\n}
+    alt match
+        Config --> Novu : { templateId, contentSid, paramOrder, ... }
+    else no match
+        Novu -> Config : retry without workflowState
+        Config --> Novu : { templateId, ... }
+    end
+
+    Novu -> Config : _resolve schemaCode=ProviderDetail\ncriteria={channel, priority=1}
+    Config --> Novu : { providerName, credentials, ... }
+
+    Novu -> NovuAPI : triggerWithProviderConfig(...)
+    NovuAPI -> Provider : send
+    Provider --> NovuAPI : status
+    NovuAPI --> Novu : trigger response
+end
+deactivate Novu
+@enduml
+```
+
+Differences (1) `LanguageStrategy` lookup once per event (cached); (2) `TemplateBinding` resolve criteria now includes `audience` + `workflowState`; (3) on miss, retry without `workflowState` to honor precedence rules in §5.1.3.
+
+---
+
+## 7. Bucket B — doc / impl reconciliation prescriptions
+
+### Row 1 — Channel scope in TemplateBinding accepts SMS / email
+**What:** TemplateBinding's `channel` enum includes `whatsapp, sms, email`; HLD says Novu is WhatsApp-only.
+**Resolution:** Update HLD §Non-Goals — remove "No SMS/email delivery via Novu" wording, OR delete `sms` / `email` from the schema and the SMS seed entry. Recommendation: update HLD to legitimize the impl; SMS via Novu is a real product capability the team has built.
+
+### Row 2 — Template bodies live in Novu, not Config Service
+**What:** HLD says canonical templates live in Config Service. Reality: bodies live in Novu; Config Service holds `templateId` references.
+**Resolution:** Update WhatsAppDesign §1.3. New wording: "For WhatsApp delivered via Novu, template bodies live in Novu; Config Service holds bindings (`templateId`) and provider routing." For non-Novu channels (SMS via egov-notification-sms), bodies live in Config Service inline — see MOZ_007 engineering spec.
+
+### Row 3 — Two-tier template model collapsed into single TemplateBinding
+**What:** WhatsAppDesign §5.3.A specifies separate `OOTB_TEMPLATES` and `OOTB_TEMPLATE_BINDINGS`. Impl has one combined `TemplateBinding`.
+**Resolution:** Tied to row 2. If template bodies stay in Novu, the OOTB_TEMPLATES schema is moot — delete from the design doc. If bodies move into Config Service (MOZ_007 SMS path), `OOTB_TEMPLATES` and `OOTB_TEMPLATE_BINDINGS` can be sibling schemas there.
+
+### Row 6 — Field naming reconciliation
+**What:** LLD says `templateKey`; code says `templateId`. Several other fields missing or renamed.
+**Resolution:** Update LLD §6 to match code:
+- `templateKey` → `templateId`
+- Remove `templateVersion`, `optionalVars`, `fallbackTemplateKey`, `fallbackTemplateVersion` (not built; track as future enhancements if needed).
+- Add `contentSid`, `novuApiKey` (impl-only fields).
+
+### Row 7 — `ProviderDetail` not in LLD
+**What:** Impl has a `ProviderDetail` schema for per-channel provider credentials, used by `resolveProvider` / `resolveProvidersByChannel`. Not in LLD.
+**Resolution:** Add §6.5 to LLD documenting `ProviderDetail`: schema, resolve criteria `{providerName, channel, priority, tenantId}`, payload `{credentials, novuApiKey, isActive, senderNumber}`. Explain rationale (Twilio credentials, per-tenant Novu API keys, multi-provider routing per channel).
+
+### Row 16 — MDMS vocabulary modules
+**What:** WhatsAppDesign §4 specifies `DIGIT-Notification` and `DIGIT-UserPreferences` MDMS modules with 7 enum masters. None exist.
+**Resolution:** Either seed them (low effort: ~7 small JSON files) for vocabulary governance, OR delete §4 from the design doc and let the schemas enumerate values inline (current state).
+
+### Row 17 — Workflow id format
+**What:** Design says `PGR_CREATED`, `PGR_STATUS_CHANGED`. Code uses `complaints-workflow-apply` (dot-form then slugified for Novu's id constraints).
+**Resolution:** Update WhatsAppDesign §3.1 with the slugification rule and the dot-form source: "Workflow identifier source = `COMPLAINTS.WORKFLOW.<ACTION>`; slugified by replacing `.` and `_` with `-` and lowercasing to satisfy Novu's `^[a-z0-9-]+$` id constraint."
+
+### Row 18 — `transactionId` composition
+**What:** Design says `<eventId>:<channel>:<recipient>`. Code uses `eventId` alone.
+**Resolution:** Code fix. In `WhatsappNotifierService` (or wherever `transactionId` is built before the Novu trigger), change to `String.format("%s:%s:%s", event.getEventId(), channel, recipientPhone)`. Critical for idempotency when one event fans out to multiple recipients on the same channel — today, retries on stakeholder 2 collide with stakeholder 1 because Novu dedupes by `transactionId`.
+
+### Row 21 — `reference_number` column undocumented
+**What:** `V20260325120000__add_reference_number.sql` added a column not in LLD §9.
+**Resolution:** Update LLD §9. Add: `reference_number varchar(64) — provider-assigned tracking id (e.g., Twilio messageSid; populated post-trigger).`
+
+### Row 22 — Postman bootstrap is the config-as-code source for Novu workflows
+**What:** Template bodies and Novu workflow definitions live in `novu-bridge/config/Novu-Bootstrap.postman_collection.json`, run as one-time provisioning. Not in any design doc.
+**Resolution:** Document in HLD as the deployment-time bootstrap mechanism. Long-term: replace with an in-process bootstrap call from novu-bridge on startup OR a Helm pre-install hook. Either is fine; the Postman collection is fragile (manual, undiscoverable, no diff history).
+
+---
+
+## 8. Bucket C — un-built policy catalog epics
+
+Each is a separate epic; estimates are rough. None should be conflated with MOZ_007.
+
+### Row 8 — `EVENT_CHANNELS` enablement config
+
+**Schema:**
+```json
+{
+  "eventName": "string",
+  "tenantId": "string",
+  "enabledChannels": ["whatsapp", "sms", "email"],
+  "disabledChannels": []
+}
+```
+**Selectors:** `(eventName, tenantId)`.
+**Effort:** ~2 dev-days (schema + client + bridge-side gate before dispatch).
+**Acceptance:** dispatching an event with no enabled channels for the tenant short-circuits with a `SKIPPED_NO_CHANNEL` outcome in `nb_dispatch_log`.
+
+### Row 9 — `EVENT_CATEGORY_MAP`
+
+**Schema:**
+```json
+{
+  "eventName": "string",
+  "category": "TRANSACTIONAL | CAMPAIGN"
+}
+```
+**Selectors:** `(eventName)` global; tenant override optional.
+**Effort:** ~1 dev-day.
+**Acceptance:** every event consumed by novu-bridge is classified; quiet-hours and rate-limit policies use the classification.
+
+### Row 10 — `QUIET_HOURS`
+
+**Schema:**
+```json
+{
+  "tenantId": "string",
+  "windows": [{ "start": "22:00", "end": "06:00", "timezone": "Africa/Maputo" }],
+  "exemptions": ["TRANSACTIONAL"]
+}
+```
+**Selectors:** `(tenantId)`; per-channel override optional.
+**Effort:** ~3 dev-days (windows + timezone arithmetic + tests).
+**Acceptance:** non-exempt events dispatched during quiet hours are deferred to the next window start.
+
+### Row 11 — `RATE_LIMITS` (production-critical)
+
+**Schema:**
+```json
+{
+  "scope": { "tenantId": "string", "channel": "string?", "eventName": "string?" },
+  "threshold": 100,
+  "burst": 20,
+  "windowSeconds": 60,
+  "action": "DROP | DEFER"
+}
+```
+**Selectors:** ordered precedence — `(tenantId, eventName, channel)` > `(tenantId, channel)` > `(tenantId)`.
+**Effort:** ~5 dev-days (config + Redis-backed token bucket + bridge integration + metrics).
+**Acceptance:** sustained dispatch above threshold for any scope triggers the configured action; outcome recorded in `nb_dispatch_log` as `RATE_LIMITED`.
+
+### Row 12 — `RETRY_POLICIES`
+
+**Schema:**
+```json
+{
+  "channel": "string",
+  "maxRetries": 3,
+  "backoff": { "type": "EXPONENTIAL", "initialMs": 30000, "multiplier": 4 },
+  "dlqTopic": "novu-bridge-dlq"
+}
+```
+**Selectors:** `(channel)`.
+**Effort:** ~1 dev-day (move LLD §8.2 inline constants to config; no behavior change).
+**Acceptance:** retry behavior identical to today, but tunable per channel via config.
+
+### Row 14 — `CONSENT_POLICY` / `KEYWORD_ACTIONS` / `FEATURE_FLAGS`
+
+Bundle into one epic — user-preferences-v2 hardening. Estimate ~10 dev-days. Defer until consent gains a second-channel scope or campaigns ship.
+
+### Row 15 — ConfigSets / versioned activation
+
+**This is an architectural change to config-service**, not a config addition. Out of scope for novu-bridge alone; needs its own design pass that covers:
+- ConfigSet entity (a named, versioned collection of `(configCode, selectors)` → entry pointers).
+- Activation API (atomic switch of "active" pointer from one ConfigSet to another).
+- Rollback API.
+- Resolver behavior — resolve goes through the active ConfigSet, not raw entries.
+
+Effort: ~15 dev-days minimum. File as a separate epic owned by the config-service team.
+
+---
+
+## 9. `nb_dispatch_log` column reconciliation
+
+Current schema (live):
+
+| Column | Type | Source |
+|---|---|---|
+| `id` | uuid PK | `V20260217124000` |
+| `event_id` | varchar(64) NOT NULL | `V20260217124000` |
+| `module` | varchar(128) NOT NULL | `V20260217124000` |
+| `event_name` | varchar(256) NOT NULL | `V20260217124000` |
+| `tenant_id` | varchar(256) NOT NULL | `V20260217124000` |
+| `channel` | varchar(64) NOT NULL | `V20260217124000` |
+| `recipient_value` | varchar(256) NOT NULL | `V20260217124000` |
+| `template_key` | varchar(256) | `V20260217124000` |
+| `template_version` | varchar(64) | `V20260217124000` |
+| `status` | varchar(32) NOT NULL | `V20260217124000` |
+| `attempt_count` | int NOT NULL DEFAULT 0 | `V20260217124000` |
+| `last_error_code` | varchar(128) | `V20260217124000` |
+| `last_error_message` | text | `V20260217124000` |
+| `provider_response_jsonb` | jsonb | `V20260217124000` |
+| `created_time` | bigint NOT NULL | `V20260217124000` |
+| `last_modified_time` | bigint NOT NULL | `V20260217124000` |
+| `reference_number` | varchar(64) | `V20260325120000` (not in LLD) |
+
+Status enum values implemented: `RECEIVED`, `SKIPPED`, `FAILED`, `SENT`, `RETRYING`, `DLQ` — matches LLD §9.
+
+**Documentation fix (LLD §9 update):**
+
+```diff
+ - `provider_response_jsonb` jsonb
+ - `created_time` bigint not null
+ - `last_modified_time` bigint not null
++- `reference_number` varchar(64) — provider-assigned tracking id (e.g., Twilio messageSid; populated post-trigger)
+```
+
+**Index inventory (live, verify against migrations):**
+
+| Index | Columns | Source |
+|---|---|---|
+| `uk_nb_dispatch_event_channel` | `(event_id, channel)` UNIQUE | LLD §9 spec |
+| `idx_nb_dispatch_status_lmt` | `(status, last_modified_time)` | LLD §9 spec |
+| `idx_nb_dispatch_tenant_event` | `(tenant_id, event_name)` | LLD §9 spec |
+
+**Recommended addition** for retry / DLQ queries:
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_nb_dispatch_status_attempt
+  ON nb_dispatch_log (status, attempt_count, last_modified_time)
+  WHERE status IN ('RETRYING', 'FAILED');
+```
+
+This narrows the index to the rows the retry worker actually scans.
+
+**Uniqueness fix (Bucket B row 18):** once `transactionId` becomes `<eventId>:<channel>:<recipient>`, the `(event_id, channel)` uniqueness constraint is no longer sufficient — needs `(event_id, channel, recipient_value)`. Migration:
+
+```sql
+ALTER TABLE nb_dispatch_log DROP CONSTRAINT IF EXISTS uk_nb_dispatch_event_channel;
+ALTER TABLE nb_dispatch_log
+  ADD CONSTRAINT uk_nb_dispatch_event_channel_recipient
+  UNIQUE (event_id, channel, recipient_value);
+```
+
+---
+
+## 10. Effort summary
+
+| Bucket | Items | Total effort | Owner suggestion |
+|---|---|---|---|
+| A (blocks MOZ_007) | rows 4, 5, 13 | ~3 dev-days + 1 test-day | novu-bridge maintainer |
+| B (reconciliation) | rows 1, 2, 3, 6, 7, 16, 17, 18, 21, 22 | ~2 dev-days (mostly doc updates) + 1 dev-day for transactionId fix + uniqueness migration | docs owner + bridge maintainer |
+| C (un-built policy catalog) | rows 8–15 | ~35+ dev-days across multiple epics | platform team backlog |
+
+---
+
+## 11. Open questions
+
+- **Row 1 (channel scope):** does the platform team commit to keeping SMS via Novu, or is novu-bridge-via-egov-notification-sms the long-term path for SMS? This affects rows 2, 3 and the MOZ_007 SMS template architecture.
+- **Row 7 (ProviderDetail):** is this an intentional design evolution or accidental drift? Needs sign-off before documenting in LLD.
+- **Row 15 (ConfigSets):** is versioned activation still on the roadmap, or has the team accepted "live-on-write" as the operating model?
+
+---
+
+**End of reconciliation document.**

--- a/docs/superpowers/specs/workflow-notification/notification-flow-sequence.puml
+++ b/docs/superpowers/specs/workflow-notification/notification-flow-sequence.puml
@@ -1,0 +1,97 @@
+@startuml workflow-notification-flow
+!theme plain
+title PGR Notification Dispatch via Workflow Extension Service (MOZ_007)
+autonumber
+
+actor       "Citizen /\nEmployee"          as User
+participant "pgr-services"                  as PGR
+participant "egov-workflow-v2\n(Digit-Core)" as WF
+participant "workflow-\nextension-service"  as WFExt
+database    "MDMS"                          as MDMS
+queue       "complaints.\ndomain.events\n(Kafka)" as Kafka
+participant "novu-bridge"                   as Novu
+participant "egov-config-\nservice"         as Config
+participant "user-preferences\nservice"     as Prefs
+participant "Novu API\n(SMS / WhatsApp /\nemail provider)" as Provider
+
+== 1. Inbound action on a complaint ==
+
+User -> PGR : POST /pgr-services/v2/request/_update\n(serviceRequest, workflow.action=RESOLVE)
+activate PGR
+
+PGR -> PGR : validate request\n(ServiceRequestValidator)
+
+== 2. Workflow transition ==
+
+PGR -> WF : POST /egov-wf/process/_transition\n(tenantId=mz, businessId=PGR,\n action=RESOLVE, assignes=[…])
+activate WF
+
+alt BusinessService not in WF cache
+    WF -> MDMS : POST /mdms-v2/v1/_search\n(Workflow.BusinessService)
+    MDMS --> WF : BusinessService\n(states[], actions[], roles[])
+end
+
+WF -> WF : validate transition\n+ role gating against BusinessService
+
+WF --> PGR : ProcessInstance\n{state=RESOLVED,\n assignes[], action=RESOLVE}
+deactivate WF
+
+PGR -> PGR : enrich Service\n(applicationStatus=RESOLVED,\n fromState=PENDINGATLME)
+
+== 3. Resolve audience via workflow extension ==
+
+PGR -> WFExt : POST /workflow-extension/v1/extension/_search\n(tenantId=mz, businessService=PGR)
+activate WFExt
+
+alt extension not in pgr-side TTL cache **AND** not in WFExt cache
+    WFExt -> MDMS : POST /mdms-v2/v1/_search\n(Workflow.BusinessServiceExtension)
+    MDMS --> WFExt : BusinessServiceExtension\n(transitions[])
+end
+
+WFExt --> PGR : BusinessServiceExtension\n(transitions[])
+deactivate WFExt
+
+note over PGR
+  Locate transition matching
+  (fromState=PENDINGATLME, action=RESOLVE):
+
+    notifyRoles = [CITIZEN, ASSIGNEE]
+
+  No template / channel info here —
+  those are novu-bridge's job.
+end note
+
+PGR -> PGR : resolve each role to actual identity\n(CITIZEN ⇒ service.accountId,\n ASSIGNEE ⇒ ProcessInstance.assignes[])\nbuild stakeholders[]
+
+== 4. Publish domain event ==
+
+PGR -> Kafka : produce ComplaintsDomainEvent\n{eventName=COMPLAINTS.WORKFLOW.RESOLVE,\n tenantId, entityId, workflow,\n stakeholders[], data, context}
+
+PGR --> User : 200 OK\n(serviceRequest with enriched workflow)
+deactivate PGR
+
+== 5. Asynchronous downstream dispatch (per stakeholder × channel) ==
+
+Kafka -> Novu : consume ComplaintsDomainEvent
+activate Novu
+
+loop for each stakeholder
+    Novu -> Prefs : GET preferred channel(s)\n(userId, tenantId)
+    Prefs --> Novu : [SMS, WHATSAPP, …]
+
+    loop for each enabled channel
+        Novu -> Config : POST /config/v1/entry/_resolve\n(configCode=NOTIF_TEMPLATE_MAP,\n selectors={eventName, channel, locale, tenantId})
+        activate Config
+        Config --> Novu : { templateKey, contentSid,\n  paramOrder[], requiredVars[] }
+        deactivate Config
+
+        Novu -> Novu : validate required vars\nagainst event.data
+
+        Novu -> Provider : trigger(templateKey,\n subscriberId, recipientPhone,\n contentVariables)
+        Provider --> Novu : message id / status
+    end
+end
+
+deactivate Novu
+
+@enduml

--- a/docs/superpowers/specs/workflow-notification/workflow-extension-service.openapi.yaml
+++ b/docs/superpowers/specs/workflow-notification/workflow-extension-service.openapi.yaml
@@ -1,0 +1,619 @@
+openapi: 3.0.3
+info:
+  title: DIGIT Workflow Extension Service API
+  description: |
+    Workflow Extension Service provides extra-workflow metadata that modules
+    layer on top of the canonical `Workflow.BusinessService` definition served
+    by `egov-workflow-v2`.
+
+    Each extension document is keyed by `(tenantId, businessService)` and
+    carries a list of transitions. For each `(fromState, action)` it names
+    the audience codes (`notifyRoles[]`) that should receive a notification
+    when the transition fires. The consuming module translates each audience
+    code into actual recipients while building the outbound domain event's
+    `stakeholders[]`.
+
+    The service is the **single integrity authority** for the
+    `Workflow.BusinessServiceExtension` MDMS master. All writes flow through
+    it; on every write the candidate document is validated against the matching
+    `Workflow.BusinessService` entry before being persisted to MDMS.
+
+    Out of scope for v1:
+      - Per-channel template selection, template bodies, and rendering — all
+        handled downstream by `novu-bridge` via `egov-config-service`.
+      - User channel preferences — handled by `novu-bridge`'s preference
+        client.
+      - State-level metadata (display labels, colors, terminal-state
+        classification, escalation eligibility) — handled by localization and
+        the consumer module's own logic.
+
+    Companions:
+      - Design doc: `2026-06-19-moz_007-workflow-extension-service-design.md`
+      - MDMS shape: `Workflow.BusinessServiceExtension.json`
+      - First consumer: `pgr-services` via `WorkflowExtensionClient.java`.
+  version: 0.1.0
+  contact:
+    name: DIGIT Platform Team
+servers:
+  - url: https://{host}/workflow-extension
+    variables:
+      host:
+        default: workflow-extension.example.org
+
+security:
+  - bearerAuth: []
+
+tags:
+  - name: Extension
+    description: |
+      CRUD + validation for `BusinessServiceExtension` documents.
+
+paths:
+
+  /v1/extension/_search:
+    post:
+      tags: [Extension]
+      summary: Search BusinessService extensions
+      description: |
+        Returns the extension documents matching the criteria. Empty `extensions`
+        array when no match. Use `tenantId` alone to list all extensions for a
+        tenant; add `businessService` to retrieve one specific extension.
+
+        RBAC: requires role `WORKFLOW_EXTENSION_VIEWER` or higher.
+      operationId: searchExtensions
+      requestBody:
+        required: true
+        content:
+          "*/*":
+            schema:
+              $ref: "#/components/schemas/ExtensionSearchRequest"
+      responses:
+        "200":
+          description: Search result.
+          content:
+            "*/*":
+              schema:
+                $ref: "#/components/schemas/ExtensionSearchResponse"
+        "400":
+          description: Malformed input.
+          content:
+            "*/*":
+              schema:
+                $ref: "https://raw.githubusercontent.com/egovernments/DIGIT-OSS/master/core-services/docs/common-contract_v1-1.yml#/components/schemas/ErrorRes"
+        "401":
+          description: Unauthorized.
+          content:
+            "*/*":
+              schema:
+                $ref: "https://raw.githubusercontent.com/egovernments/DIGIT-OSS/master/core-services/docs/common-contract_v1-1.yml#/components/schemas/ErrorRes"
+
+  /v1/extension/_validate:
+    post:
+      tags: [Extension]
+      summary: Validate an extension candidate without persisting
+      description: |
+        Validates a candidate extension document against the corresponding
+        `Workflow.BusinessService` entry. Always returns HTTP 200 with a
+        `ValidationResult` body. The `valid` field is `false` when one or
+        more rule violations are present in `errors[]`. Warnings are advisory
+        and do not flip `valid` to `false`.
+
+        HTTP 400 is reserved for malformed JSON or missing required fields,
+        not for validation failures.
+
+        RBAC: requires role `WORKFLOW_EXTENSION_VIEWER` or higher.
+      operationId: validateExtension
+      requestBody:
+        required: true
+        content:
+          "*/*":
+            schema:
+              $ref: "#/components/schemas/ExtensionValidateRequest"
+      responses:
+        "200":
+          description: Validation result.
+          content:
+            "*/*":
+              schema:
+                $ref: "#/components/schemas/ExtensionValidateResponse"
+        "400":
+          description: Malformed input.
+          content:
+            "*/*":
+              schema:
+                $ref: "https://raw.githubusercontent.com/egovernments/DIGIT-OSS/master/core-services/docs/common-contract_v1-1.yml#/components/schemas/ErrorRes"
+        "401":
+          description: Unauthorized.
+          content:
+            "*/*":
+              schema:
+                $ref: "https://raw.githubusercontent.com/egovernments/DIGIT-OSS/master/core-services/docs/common-contract_v1-1.yml#/components/schemas/ErrorRes"
+
+  /v1/extension/_create:
+    post:
+      tags: [Extension]
+      summary: Create a new BusinessService extension
+      description: |
+        Validates the candidate document, then persists it to MDMS under
+        `Workflow.BusinessServiceExtension`. Validation failures return HTTP
+        400 with a structured `ErrorRes` body whose `Errors[]` array carries
+        the rule violations using the same `code` taxonomy as
+        `/v1/extension/_validate`. A duplicate `(tenantId, businessService)`
+        returns HTTP 409.
+
+        RBAC: requires role `WORKFLOW_EXTENSION_EDITOR`.
+      operationId: createExtension
+      requestBody:
+        required: true
+        content:
+          "*/*":
+            schema:
+              $ref: "#/components/schemas/ExtensionCreateRequest"
+      responses:
+        "201":
+          description: Extension created.
+          content:
+            "*/*":
+              schema:
+                $ref: "#/components/schemas/ExtensionResponse"
+        "400":
+          description: Malformed input or validation failure.
+          content:
+            "*/*":
+              schema:
+                $ref: "https://raw.githubusercontent.com/egovernments/DIGIT-OSS/master/core-services/docs/common-contract_v1-1.yml#/components/schemas/ErrorRes"
+        "401":
+          description: Unauthorized.
+          content:
+            "*/*":
+              schema:
+                $ref: "https://raw.githubusercontent.com/egovernments/DIGIT-OSS/master/core-services/docs/common-contract_v1-1.yml#/components/schemas/ErrorRes"
+        "409":
+          description: Extension already exists for `(tenantId, businessService)`.
+          content:
+            "*/*":
+              schema:
+                $ref: "https://raw.githubusercontent.com/egovernments/DIGIT-OSS/master/core-services/docs/common-contract_v1-1.yml#/components/schemas/ErrorRes"
+
+  /v1/extension/_update:
+    post:
+      tags: [Extension]
+      summary: Update an existing BusinessService extension
+      description: |
+        Full document replacement (no patch semantics). Validates the candidate
+        before persisting. Validation failures return HTTP 400; missing target
+        returns HTTP 404.
+
+        RBAC: requires role `WORKFLOW_EXTENSION_EDITOR`.
+      operationId: updateExtension
+      requestBody:
+        required: true
+        content:
+          "*/*":
+            schema:
+              $ref: "#/components/schemas/ExtensionUpdateRequest"
+      responses:
+        "200":
+          description: Extension updated.
+          content:
+            "*/*":
+              schema:
+                $ref: "#/components/schemas/ExtensionResponse"
+        "400":
+          description: Malformed input or validation failure.
+          content:
+            "*/*":
+              schema:
+                $ref: "https://raw.githubusercontent.com/egovernments/DIGIT-OSS/master/core-services/docs/common-contract_v1-1.yml#/components/schemas/ErrorRes"
+        "401":
+          description: Unauthorized.
+          content:
+            "*/*":
+              schema:
+                $ref: "https://raw.githubusercontent.com/egovernments/DIGIT-OSS/master/core-services/docs/common-contract_v1-1.yml#/components/schemas/ErrorRes"
+        "404":
+          description: No extension exists for the supplied `(tenantId, businessService)`.
+          content:
+            "*/*":
+              schema:
+                $ref: "https://raw.githubusercontent.com/egovernments/DIGIT-OSS/master/core-services/docs/common-contract_v1-1.yml#/components/schemas/ErrorRes"
+
+  /v1/extension/_delete:
+    post:
+      tags: [Extension]
+      summary: Delete a BusinessService extension
+      description: |
+        Removes the extension entry for `(tenantId, businessService)`. Consumers
+        for that tenant subsequently fall back to legacy hardcoded behavior
+        (as if the per-tenant flag were off).
+
+        RBAC: requires role `WORKFLOW_EXTENSION_EDITOR`.
+      operationId: deleteExtension
+      requestBody:
+        required: true
+        content:
+          "*/*":
+            schema:
+              $ref: "#/components/schemas/ExtensionDeleteRequest"
+      responses:
+        "200":
+          description: Extension deleted.
+          content:
+            "*/*":
+              schema:
+                $ref: "#/components/schemas/ExtensionDeleteResponse"
+        "400":
+          description: Malformed input.
+          content:
+            "*/*":
+              schema:
+                $ref: "https://raw.githubusercontent.com/egovernments/DIGIT-OSS/master/core-services/docs/common-contract_v1-1.yml#/components/schemas/ErrorRes"
+        "401":
+          description: Unauthorized.
+          content:
+            "*/*":
+              schema:
+                $ref: "https://raw.githubusercontent.com/egovernments/DIGIT-OSS/master/core-services/docs/common-contract_v1-1.yml#/components/schemas/ErrorRes"
+        "404":
+          description: No extension exists for the supplied `(tenantId, businessService)`.
+          content:
+            "*/*":
+              schema:
+                $ref: "https://raw.githubusercontent.com/egovernments/DIGIT-OSS/master/core-services/docs/common-contract_v1-1.yml#/components/schemas/ErrorRes"
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  schemas:
+
+    # ─── Enums ───────────────────────────────────────────────────────────
+
+    NotifyRole:
+      type: string
+      description: |
+        Logical recipient of a notification on a workflow transition.
+        The consuming module resolves each role to actual identities:
+          - CITIZEN: the citizen on `Service.accountId`.
+          - ASSIGNEE: current `ProcessInstance.assignes`.
+          - CREATOR: `Service.auditDetails.createdBy`.
+          - SUPERVISOR: HRMS reportingTo of ASSIGNEE.
+          - PREVIOUS_ASSIGNEE: ProcessInstance history, one step back.
+      enum:
+        - CITIZEN
+        - ASSIGNEE
+        - CREATOR
+        - SUPERVISOR
+        - PREVIOUS_ASSIGNEE
+
+    ValidationErrorCode:
+      type: string
+      description: |
+        Stable codes for validation rule violations. See the design doc §4.3
+        for full semantics.
+      enum:
+        - UNKNOWN_TRANSITION
+        - INVALID_NOTIFY_ROLE
+        - DUPLICATE_TRANSITION_EXTENSION
+        - BUSINESS_SERVICE_NOT_FOUND
+
+    ValidationWarningCode:
+      type: string
+      description: |
+        Non-blocking advisory codes. Returned alongside successful validation
+        when the candidate document is incomplete relative to the BusinessService.
+      enum:
+        - MISSING_TRANSITION_COVERAGE
+
+    # ─── Core domain models ──────────────────────────────────────────────
+
+    TransitionExtension:
+      type: object
+      required:
+        - action
+        - notifyRoles
+      properties:
+        fromState:
+          type: string
+          nullable: true
+          description: |
+            State the transition fires from. `null` matches the workflow
+            start state (the implicit pre-APPLY position).
+            Joins to `BusinessService.states[].state`.
+          maxLength: 128
+          example: PENDINGATLME
+        action:
+          type: string
+          description: |
+            Workflow action name. Joins to
+            `BusinessService.states[fromState].actions[].action`.
+          minLength: 1
+          maxLength: 64
+          example: RESOLVE
+        notifyRoles:
+          type: array
+          description: |
+            Audience codes for the notification fired when this transition
+            occurs. The consuming module translates each code to actual
+            recipients while building the outbound domain event's
+            `stakeholders[]`. Order is irrelevant; duplicates are
+            deduplicated by the consumer.
+
+            Per-channel template selection, user channel preferences, and
+            template rendering are all downstream of this contract
+            (handled by `novu-bridge` via `egov-config-service`).
+          minItems: 0
+          items:
+            $ref: "#/components/schemas/NotifyRole"
+          example: ["CITIZEN", "ASSIGNEE"]
+
+    BusinessServiceExtension:
+      type: object
+      required:
+        - tenantId
+        - businessService
+        - transitions
+      properties:
+        tenantId:
+          type: string
+          description: |
+            Tenant identifier. Supports the standard DIGIT
+            state-level / city-level convention: an extension at `mz` is
+            visible to all `mz.*` sub-tenants unless overridden at the
+            sub-tenant level.
+          minLength: 1
+          maxLength: 256
+          example: mz
+        businessService:
+          type: string
+          description: |
+            BusinessService name. Joins to
+            `Workflow.BusinessService.businessService`.
+          minLength: 1
+          maxLength: 128
+          example: PGR
+        transitions:
+          type: array
+          description: |
+            One entry per (fromState, action) pair for which a notification
+            should fire. A transition not present in this list is treated as
+            "no notification configured" by consumers, which fall back to
+            their legacy behavior under the per-tenant flag.
+            Each entry must correspond to a defined action in the BusinessService.
+          items:
+            $ref: "#/components/schemas/TransitionExtension"
+        auditDetails:
+          $ref: "#/components/schemas/AuditDetails"
+
+    AuditDetails:
+      type: object
+      description: Standard DIGIT audit envelope. Populated by the server.
+      properties:
+        createdBy:
+          type: string
+        createdTime:
+          type: integer
+          format: int64
+        lastModifiedBy:
+          type: string
+        lastModifiedTime:
+          type: integer
+          format: int64
+
+    # ─── Validation result models ────────────────────────────────────────
+
+    ValidationError:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          $ref: "#/components/schemas/ValidationErrorCode"
+        state:
+          type: string
+          nullable: true
+          description: State this error pertains to, when applicable.
+        fromState:
+          type: string
+          nullable: true
+          description: For transition-scoped errors.
+        action:
+          type: string
+          nullable: true
+          description: For transition-scoped errors.
+        message:
+          type: string
+          description: Human-readable description of the violation.
+
+    ValidationWarning:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          $ref: "#/components/schemas/ValidationWarningCode"
+        state:
+          type: string
+          nullable: true
+        fromState:
+          type: string
+          nullable: true
+        action:
+          type: string
+          nullable: true
+        message:
+          type: string
+
+    ValidationResult:
+      type: object
+      required:
+        - valid
+      properties:
+        valid:
+          type: boolean
+          description: |
+            `true` iff no `errors[]` entries. Warnings do not flip this.
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ValidationError"
+        warnings:
+          type: array
+          items:
+            $ref: "#/components/schemas/ValidationWarning"
+
+    # ─── Search criteria ─────────────────────────────────────────────────
+
+    ExtensionSearchCriteria:
+      type: object
+      required:
+        - tenantId
+      properties:
+        tenantId:
+          type: string
+          minLength: 1
+          maxLength: 256
+          example: mz
+        businessService:
+          type: string
+          description: |
+            When omitted, returns all extensions for the tenant.
+          minLength: 1
+          maxLength: 128
+          example: PGR
+        limit:
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 200
+          default: 50
+        offset:
+          type: integer
+          format: int32
+          minimum: 0
+          default: 0
+
+    # ─── Request envelopes ───────────────────────────────────────────────
+
+    ExtensionSearchRequest:
+      type: object
+      required:
+        - requestInfo
+        - criteria
+      properties:
+        requestInfo:
+          $ref: "https://raw.githubusercontent.com/egovernments/egov-services/master/docs/common/contracts/v1-0-0.yml#/definitions/RequestInfo"
+        criteria:
+          $ref: "#/components/schemas/ExtensionSearchCriteria"
+
+    ExtensionValidateRequest:
+      type: object
+      required:
+        - requestInfo
+        - extension
+      properties:
+        requestInfo:
+          $ref: "https://raw.githubusercontent.com/egovernments/egov-services/master/docs/common/contracts/v1-0-0.yml#/definitions/RequestInfo"
+        extension:
+          $ref: "#/components/schemas/BusinessServiceExtension"
+
+    ExtensionCreateRequest:
+      type: object
+      required:
+        - requestInfo
+        - extension
+      properties:
+        requestInfo:
+          $ref: "https://raw.githubusercontent.com/egovernments/egov-services/master/docs/common/contracts/v1-0-0.yml#/definitions/RequestInfo"
+        extension:
+          $ref: "#/components/schemas/BusinessServiceExtension"
+
+    ExtensionUpdateRequest:
+      type: object
+      required:
+        - requestInfo
+        - extension
+      properties:
+        requestInfo:
+          $ref: "https://raw.githubusercontent.com/egovernments/egov-services/master/docs/common/contracts/v1-0-0.yml#/definitions/RequestInfo"
+        extension:
+          $ref: "#/components/schemas/BusinessServiceExtension"
+
+    ExtensionDeleteRequest:
+      type: object
+      required:
+        - requestInfo
+        - tenantId
+        - businessService
+      properties:
+        requestInfo:
+          $ref: "https://raw.githubusercontent.com/egovernments/egov-services/master/docs/common/contracts/v1-0-0.yml#/definitions/RequestInfo"
+        tenantId:
+          type: string
+          minLength: 1
+          maxLength: 256
+          example: mz
+        businessService:
+          type: string
+          minLength: 1
+          maxLength: 128
+          example: PGR
+
+    # ─── Response envelopes ──────────────────────────────────────────────
+
+    ExtensionSearchResponse:
+      type: object
+      required:
+        - responseInfo
+        - extensions
+      properties:
+        responseInfo:
+          $ref: "https://raw.githubusercontent.com/egovernments/egov-services/master/docs/common/contracts/v1-0-0.yml#/definitions/ResponseInfo"
+        extensions:
+          type: array
+          items:
+            $ref: "#/components/schemas/BusinessServiceExtension"
+        pagination:
+          $ref: "https://raw.githubusercontent.com/egovernments/DIGIT-OSS/master/core-services/docs/common-contract_v1-1.yml#/components/schemas/Pagination"
+
+    ExtensionValidateResponse:
+      type: object
+      required:
+        - responseInfo
+        - result
+      properties:
+        responseInfo:
+          $ref: "https://raw.githubusercontent.com/egovernments/egov-services/master/docs/common/contracts/v1-0-0.yml#/definitions/ResponseInfo"
+        result:
+          $ref: "#/components/schemas/ValidationResult"
+
+    ExtensionResponse:
+      type: object
+      required:
+        - responseInfo
+        - extension
+      properties:
+        responseInfo:
+          $ref: "https://raw.githubusercontent.com/egovernments/egov-services/master/docs/common/contracts/v1-0-0.yml#/definitions/ResponseInfo"
+        extension:
+          $ref: "#/components/schemas/BusinessServiceExtension"
+
+    ExtensionDeleteResponse:
+      type: object
+      required:
+        - responseInfo
+      properties:
+        responseInfo:
+          $ref: "https://raw.githubusercontent.com/egovernments/egov-services/master/docs/common/contracts/v1-0-0.yml#/definitions/ResponseInfo"
+        deleted:
+          type: object
+          properties:
+            tenantId:
+              type: string
+            businessService:
+              type: string


### PR DESCRIPTION
This PR contains the following:

- A summary of what was originally designed for WhatsApp notifications vs what was implemented. Refer to designs below:

> - [ ] [Novu Adapter Design](https://github.com/egovernments/Citizen-Complaint-Resolution-System/blob/develop/docs/Novu_Adapter/NovuAdapter_LLD.md)
> - [ ] [WhatsApp BiDirectional Design](https://github.com/egovernments/Citizen-Complaint-Resolution-System/tree/develop/docs/WhatsApp_Bidirectional)

- Enhancements to be done to make notifications based on Workflow states dynamic (instead of hardcoded)

**Decisions to be made:**

- Store the default OOTB templates for SMS, whatsapp, e-mail in config-service or MDMS (instead of localization). Currently WhatsApp templates reside inside Novu. 
- Do we enhance the BusinessService.json to add who gets notified during a transition? Easiest path. egov-workflow-v2 will ignore it. PGR will read this, assemble the payload and fire an event to Kafka. Novu bridge continues to read user preferences and fire off notifications to Novu. Changes to Novu adapter will be required in this case. Make it more pass through and retain all biz logic inside PGR itself.
- What do we do if a notification needs to happen outside of workflow transition?  This is not covered in the business logic right now. 