### PR TITLE
feat(novu-bridge): per-tenant channel enable/disable, multi-channel dispatch + retry (#547)

### DIFF
--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/config/NovuBridgeConfiguration.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/config/NovuBridgeConfiguration.java
@@ -63,6 +63,12 @@ public class NovuBridgeConfiguration {
     @Value("${novu.bridge.max.retries:3}")
     private Integer maxRetries;
 
+    // Fixed backoff applied before reprocessing a message consumed from the retry topic, so a brief
+    // downstream outage (e.g. config-service) gets spacing between attempts instead of burning all
+    // retries instantly. Bounded by maxRetries. 0 disables the wait (used in tests).
+    @Value("${novu.bridge.retry.delay.ms:5000}")
+    private Integer retryDelayMs;
+
     @Value("${novu.bridge.preference.enabled:true}")
     private Boolean preferenceEnabled;
 

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/config/NovuBridgeConfiguration.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/config/NovuBridgeConfiguration.java
@@ -7,7 +7,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Component;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.TimeZone;
+import java.util.stream.Collectors;
 
 @Component
 @Data
@@ -26,12 +30,32 @@ public class NovuBridgeConfiguration {
     @Value("${novu.bridge.kafka.dlq.topic:novu-bridge.dlq}")
     private String dlqTopic;
 
-    // Default channel for dispatch. SMS is the safer default — works
-    // with any Twilio SMS-capable sender out of the box. WhatsApp
-    // requires a pre-approved Twilio Programmable WhatsApp sender
-    // (sandbox or production). Override via NOVU_BRIDGE_CHANNEL env.
-    @Value("${novu.bridge.channel:SMS}")
+    // Global channel allow-list for dispatch, as a comma-separated value
+    // (e.g. "whatsapp" or "whatsapp,sms"). This is the deployment-wide guard:
+    // a tenant can only dispatch on a channel that is BOTH enabled in its
+    // NotificationChannel config AND present here. Lets ops keep a channel
+    // globally paused (e.g. SMS pending Twilio A2P) regardless of tenant
+    // toggles. Override via NOVU_BRIDGE_CHANNEL env.
+    @Value("${novu.bridge.channel:whatsapp}")
     private String channel;
+
+    /**
+     * The {@link #channel} CSV parsed into a normalised (lowercase, de-duped) allow-list.
+     * Channel codes are compared lowercase everywhere so they match the lowercase
+     * channel values used in ProviderDetail/TemplateBinding seed data and the
+     * lowercased NotificationChannel.code values.
+     */
+    public List<String> getAllowedChannels() {
+        if (channel == null) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(channel.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(s -> s.toLowerCase())
+                .distinct()
+                .collect(Collectors.toList());
+    }
 
     @Value("${novu.bridge.default.locale:en_IN}")
     private String defaultLocale;

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/consumer/DomainEventConsumer.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/consumer/DomainEventConsumer.java
@@ -8,8 +8,6 @@ import org.egov.novubridge.service.DispatchPipelineService;
 import org.egov.novubridge.web.models.ComplaintsDomainEvent;
 import org.egov.tracer.model.CustomException;
 import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.kafka.support.KafkaHeaders;
-import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
@@ -34,21 +32,27 @@ public class DomainEventConsumer {
         this.config = config;
     }
 
-    @KafkaListener(topics = {"${novu.bridge.kafka.input.topic}", "${novu.bridge.kafka.retry.topic}"})
-    public void listen(final HashMap<String, Object> record, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
-        boolean fromRetry = topic != null && topic.equals(config.getRetryTopic());
+    /** Live events: raw domain event, attempt 0. */
+    @KafkaListener(topics = "${novu.bridge.kafka.input.topic}")
+    public void listenInput(final HashMap<String, Object> record) {
+        process(mapper.convertValue(record, ComplaintsDomainEvent.class), 0);
+    }
 
-        // Retry-topic messages are wrapped { event, attempt, ... }; input-topic messages are the raw event.
-        ComplaintsDomainEvent event = fromRetry
-                ? mapper.convertValue(record.get("event"), ComplaintsDomainEvent.class)
-                : mapper.convertValue(record, ComplaintsDomainEvent.class);
-        int attempt = fromRetry ? asInt(record.get("attempt")) : 0;
+    /**
+     * Retries: a separate listener from the input topic so the backoff sleep can never head-of-line
+     * block live notifications. Capped at one record per poll so a full retry backlog (each sleeping
+     * retryDelayMs) cannot exceed max.poll.interval.ms and trigger a rebalance.
+     * Retry messages are the wrapper { event, attempt, ... }.
+     */
+    @KafkaListener(topics = "${novu.bridge.kafka.retry.topic}", properties = {"max.poll.records=1"})
+    public void listenRetry(final HashMap<String, Object> record) {
+        ComplaintsDomainEvent event = mapper.convertValue(record.get("event"), ComplaintsDomainEvent.class);
+        int attempt = asInt(record.get("attempt"));
+        backoff(); // space out retries so a brief downstream outage isn't burned through instantly
+        process(event, attempt);
+    }
 
-        // Space out retries so a brief downstream outage isn't burned through instantly.
-        if (fromRetry) {
-            backoff();
-        }
-
+    private void process(ComplaintsDomainEvent event, int attempt) {
         try {
             dispatchPipelineService.processEnabledChannels(event, true, null);
         } catch (CustomException ce) {

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/consumer/DomainEventConsumer.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/consumer/DomainEventConsumer.java
@@ -36,16 +36,67 @@ public class DomainEventConsumer {
 
     @KafkaListener(topics = {"${novu.bridge.kafka.input.topic}", "${novu.bridge.kafka.retry.topic}"})
     public void listen(final HashMap<String, Object> record, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
-        ComplaintsDomainEvent event = mapper.convertValue(record, ComplaintsDomainEvent.class);
+        boolean fromRetry = topic != null && topic.equals(config.getRetryTopic());
+
+        // Retry-topic messages are wrapped { event, attempt, ... }; input-topic messages are the raw event.
+        ComplaintsDomainEvent event = fromRetry
+                ? mapper.convertValue(record.get("event"), ComplaintsDomainEvent.class)
+                : mapper.convertValue(record, ComplaintsDomainEvent.class);
+        int attempt = fromRetry ? asInt(record.get("attempt")) : 0;
+
+        // Space out retries so a brief downstream outage isn't burned through instantly.
+        if (fromRetry) {
+            backoff();
+        }
+
         try {
             dispatchPipelineService.processEnabledChannels(event, true, null);
         } catch (CustomException ce) {
-            log.error("Domain event processing failed for eventId={} code={}", event.getEventId(), ce.getCode(), ce);
-            publishDlq(event, ce.getCode(), ce.getMessage());
+            handleFailure(event, attempt, ce.getCode(), ce.getMessage(), ce);
         } catch (Exception e) {
-            log.error("Domain event processing failed for eventId={} topic={}", event.getEventId(), topic, e);
-            publishDlq(event, "NB_PROCESSING_ERROR", e.getMessage());
+            handleFailure(event, attempt, "NB_PROCESSING_ERROR", e.getMessage(), e);
         }
+    }
+
+    /**
+     * Bounded automatic retry: re-queue the event on the retry topic (incrementing the attempt count)
+     * until maxRetries is exhausted, then route it to the DLQ. Recovers from transient downstream
+     * failures (e.g. a brief config-service blip) without a manual replay, while still bounding the
+     * work and never silently dropping the event.
+     */
+    private void handleFailure(ComplaintsDomainEvent event, int attempt, String code, String message, Exception cause) {
+        int maxRetries = config.getMaxRetries() != null ? config.getMaxRetries() : 0;
+        int nextAttempt = attempt + 1;
+        if (nextAttempt <= maxRetries) {
+            log.warn("Processing failed for eventId={} code={}; scheduling retry {}/{}",
+                    event.getEventId(), code, nextAttempt, maxRetries, cause);
+            Map<String, Object> retry = new HashMap<>();
+            retry.put("event", event);
+            retry.put("attempt", nextAttempt);
+            retry.put("lastErrorCode", code);
+            retry.put("lastErrorMessage", message);
+            producer.push(event.getTenantId(), config.getRetryTopic(), retry);
+        } else {
+            log.error("Processing failed for eventId={} code={}; retries exhausted ({}), routing to DLQ",
+                    event.getEventId(), code, maxRetries, cause);
+            publishDlq(event, code, message);
+        }
+    }
+
+    private void backoff() {
+        int delay = config.getRetryDelayMs() != null ? config.getRetryDelayMs() : 0;
+        if (delay <= 0) {
+            return;
+        }
+        try {
+            Thread.sleep(delay);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static int asInt(Object value) {
+        return (value instanceof Number n) ? n.intValue() : 0;
     }
 
     private void publishDlq(ComplaintsDomainEvent event, String errorCode, String errorMessage) {

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/consumer/DomainEventConsumer.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/consumer/DomainEventConsumer.java
@@ -38,7 +38,7 @@ public class DomainEventConsumer {
     public void listen(final HashMap<String, Object> record, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
         ComplaintsDomainEvent event = mapper.convertValue(record, ComplaintsDomainEvent.class);
         try {
-            dispatchPipelineService.process(event, true, null);
+            dispatchPipelineService.processEnabledChannels(event, true, null);
         } catch (CustomException ce) {
             log.error("Domain event processing failed for eventId={} code={}", event.getEventId(), ce.getCode(), ce);
             publishDlq(event, ce.getCode(), ce.getMessage());

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/service/ConfigServiceClient.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/service/ConfigServiceClient.java
@@ -255,6 +255,11 @@ public class ConfigServiceClient {
         Map<String, Object> searchCriteria = new HashMap<>();
         searchCriteria.put("schemaCode", "NotificationChannel");
         searchCriteria.put("tenantId", tenantId);
+        // Only ACTIVE records. config-service _search returns inactive (soft-deleted) rows unless
+        // filtered, but _resolve (the runtime path) already ignores them — so a deactivated channel
+        // record must not count as "configured" here, else it would wrongly suppress the legacy
+        // fallback. Matching _resolve keeps the gate consistent with the rest of config-service.
+        searchCriteria.put("isActive", true);
 
         Map<String, Object> payload = new HashMap<>();
         payload.put("RequestInfo", new HashMap<>());

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/service/ConfigServiceClient.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/service/ConfigServiceClient.java
@@ -235,63 +235,24 @@ public class ConfigServiceClient {
     }
 
     /**
-     * Tenant-level channel toggle. Resolves the NotificationChannel config for the given
-     * tenant + channel and reports whether it is enabled.
+     * Returns the tenant's NotificationChannel configuration, distinguishing "unconfigured" from
+     * "configured but disabled" so the caller can stay backward-compatible:
      *
-     * Defaults to DISABLED (returns false) when no record exists or the lookup fails, so a
-     * channel is only ever dispatched when a tenant has explicitly opted in. NotificationChannel.code
-     * is the uppercase enum (WHATSAPP/SMS/EMAIL); the dispatch channel is lowercase, so we normalise.
-     */
-    public boolean isChannelEnabled(String tenantId, String channel) {
-        String code = channel == null ? "" : channel.toUpperCase();
-        Map<String, Object> resolveRequest = new HashMap<>();
-        resolveRequest.put("schemaCode", "NotificationChannel");
-        resolveRequest.put("tenantId", tenantId);
-        resolveRequest.put("criteria", Map.of("code", code));
-
-        Map<String, Object> payload = new HashMap<>();
-        payload.put("RequestInfo", new HashMap<>());
-        payload.put("resolveRequest", resolveRequest);
-
-        try {
-            String url = config.getConfigHost() + config.getConfigResolvePath();
-            log.info("Channel-enabled check: url={}, schemaCode=NotificationChannel, code={}, tenantId={}",
-                    url, code, tenantId);
-
-            ResponseEntity<Map> response = restTemplate.exchange(url, HttpMethod.POST, new HttpEntity<>(payload), Map.class);
-            if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
-                log.warn("Channel-enabled check returned non-success for tenant={} channel={}; treating as DISABLED",
-                        tenantId, channel);
-                return false;
-            }
-
-            Map<String, Object> configData = (Map<String, Object>) response.getBody().get("configData");
-            if (configData == null) {
-                // No NotificationChannel record for this tenant+channel -> default OFF.
-                return false;
-            }
-
-            Map<String, Object> data = (Map<String, Object>) configData.get("data");
-            boolean enabled = data != null && Boolean.TRUE.equals(data.get("enabled"));
-            log.info("Channel-enabled result: tenantId={}, channel={}, enabled={}", tenantId, channel, enabled);
-            return enabled;
-        } catch (Exception e) {
-            // Fail closed: config-service hiccups must never silently start sending on a channel.
-            log.warn("Channel-enabled check failed for tenant={} channel={}; treating as DISABLED", tenantId, channel, e);
-            return false;
-        }
-    }
-
-    /**
-     * Returns the lowercased channel codes the tenant has explicitly enabled (NotificationChannel
-     * records with enabled=true). Defaults to an empty list (nothing enabled) when no records exist
-     * or the lookup fails, so dispatch never fans out to a channel without an explicit opt-in.
+     *   null            -> the tenant has NO NotificationChannel records (unconfigured). The caller
+     *                      should fall back to legacy behaviour (dispatch on the global allow-list),
+     *                      so existing tenants keep working without a backfill.
+     *   list (lowercased)-> the channel codes the tenant has ENABLED (may be empty if every record
+     *                      is explicitly disabled -> nothing dispatched).
+     *
+     * On a lookup error we also return null (legacy fallback) to favour delivery over silently
+     * dropping notifications; per-recipient consent and the global allow-list still apply.
+     * NotificationChannel.code is the uppercase enum (WHATSAPP/SMS/EMAIL); we normalise to lowercase
+     * to match the channel values used elsewhere (ProviderDetail/TemplateBinding, the allow-list).
      */
     public List<String> getEnabledChannels(String tenantId) {
         Map<String, Object> searchCriteria = new HashMap<>();
         searchCriteria.put("schemaCode", "NotificationChannel");
         searchCriteria.put("tenantId", tenantId);
-        searchCriteria.put("criteria", Map.of("enabled", true));
 
         Map<String, Object> payload = new HashMap<>();
         payload.put("RequestInfo", new HashMap<>());
@@ -299,17 +260,19 @@ public class ConfigServiceClient {
 
         try {
             String url = config.getConfigHost() + config.getConfigSearchPath();
-            log.info("Enabled-channels search: url={}, schemaCode=NotificationChannel, tenantId={}", url, tenantId);
+            log.info("Channel-config search: url={}, schemaCode=NotificationChannel, tenantId={}", url, tenantId);
 
             ResponseEntity<Map> response = restTemplate.exchange(url, HttpMethod.POST, new HttpEntity<>(payload), Map.class);
             if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
-                log.warn("Enabled-channels search returned non-success for tenant={}; treating as none enabled", tenantId);
-                return Collections.emptyList();
+                log.warn("Channel-config search returned non-success for tenant={}; falling back to legacy allow-list", tenantId);
+                return null;
             }
 
             List<Map<String, Object>> configDataList = (List<Map<String, Object>>) response.getBody().get("configData");
-            if (configDataList == null) {
-                return Collections.emptyList();
+            if (configDataList == null || configDataList.isEmpty()) {
+                // Unconfigured tenant -> legacy fallback (no backfill needed for existing tenants).
+                log.info("No NotificationChannel config for tenant={}; falling back to legacy allow-list", tenantId);
+                return null;
             }
 
             List<String> channels = new ArrayList<>();
@@ -323,12 +286,12 @@ public class ConfigServiceClient {
                     channels.add(String.valueOf(code).toLowerCase());
                 }
             }
-            log.info("Enabled-channels result: tenantId={}, channels={}", tenantId, channels);
+            log.info("Channel-config result: tenantId={}, enabledChannels={}", tenantId, channels);
             return channels;
         } catch (Exception e) {
-            // Fail closed: never fan out to channels we could not confirm are enabled.
-            log.warn("Enabled-channels search failed for tenant={}; treating as none enabled", tenantId, e);
-            return Collections.emptyList();
+            // Favour delivery on a transient error: fall back to legacy behaviour rather than drop.
+            log.warn("Channel-config search failed for tenant={}; falling back to legacy allow-list", tenantId, e);
+            return null;
         }
     }
 }

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/service/ConfigServiceClient.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/service/ConfigServiceClient.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -278,6 +279,56 @@ public class ConfigServiceClient {
             // Fail closed: config-service hiccups must never silently start sending on a channel.
             log.warn("Channel-enabled check failed for tenant={} channel={}; treating as DISABLED", tenantId, channel, e);
             return false;
+        }
+    }
+
+    /**
+     * Returns the lowercased channel codes the tenant has explicitly enabled (NotificationChannel
+     * records with enabled=true). Defaults to an empty list (nothing enabled) when no records exist
+     * or the lookup fails, so dispatch never fans out to a channel without an explicit opt-in.
+     */
+    public List<String> getEnabledChannels(String tenantId) {
+        Map<String, Object> searchCriteria = new HashMap<>();
+        searchCriteria.put("schemaCode", "NotificationChannel");
+        searchCriteria.put("tenantId", tenantId);
+        searchCriteria.put("criteria", Map.of("enabled", true));
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("RequestInfo", new HashMap<>());
+        payload.put("criteria", searchCriteria);
+
+        try {
+            String url = config.getConfigHost() + config.getConfigSearchPath();
+            log.info("Enabled-channels search: url={}, schemaCode=NotificationChannel, tenantId={}", url, tenantId);
+
+            ResponseEntity<Map> response = restTemplate.exchange(url, HttpMethod.POST, new HttpEntity<>(payload), Map.class);
+            if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+                log.warn("Enabled-channels search returned non-success for tenant={}; treating as none enabled", tenantId);
+                return Collections.emptyList();
+            }
+
+            List<Map<String, Object>> configDataList = (List<Map<String, Object>>) response.getBody().get("configData");
+            if (configDataList == null) {
+                return Collections.emptyList();
+            }
+
+            List<String> channels = new ArrayList<>();
+            for (Map<String, Object> configItem : configDataList) {
+                Map<String, Object> data = (Map<String, Object>) configItem.get("data");
+                if (data == null || !Boolean.TRUE.equals(data.get("enabled"))) {
+                    continue;
+                }
+                Object code = data.get("code");
+                if (code != null) {
+                    channels.add(String.valueOf(code).toLowerCase());
+                }
+            }
+            log.info("Enabled-channels result: tenantId={}, channels={}", tenantId, channels);
+            return channels;
+        } catch (Exception e) {
+            // Fail closed: never fan out to channels we could not confirm are enabled.
+            log.warn("Enabled-channels search failed for tenant={}; treating as none enabled", tenantId, e);
+            return Collections.emptyList();
         }
     }
 }

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/service/ConfigServiceClient.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/service/ConfigServiceClient.java
@@ -238,14 +238,16 @@ public class ConfigServiceClient {
      * Returns the tenant's NotificationChannel configuration, distinguishing "unconfigured" from
      * "configured but disabled" so the caller can stay backward-compatible:
      *
-     *   null            -> the tenant has NO NotificationChannel records (unconfigured). The caller
-     *                      should fall back to legacy behaviour (dispatch on the global allow-list),
-     *                      so existing tenants keep working without a backfill.
+     *   null            -> the tenant genuinely has NO NotificationChannel records (unconfigured).
+     *                      The caller should fall back to legacy behaviour (dispatch on the global
+     *                      allow-list), so existing tenants keep working without a backfill.
      *   list (lowercased)-> the channel codes the tenant has ENABLED (may be empty if every record
      *                      is explicitly disabled -> nothing dispatched).
      *
-     * On a lookup error we also return null (legacy fallback) to favour delivery over silently
-     * dropping notifications; per-recipient consent and the global allow-list still apply.
+     * On a hard lookup error (non-2xx / unreachable / unparseable) we THROW rather than guess: a
+     * transient config-service failure must not be confused with "unconfigured" (which would ignore
+     * an explicit disable) nor silently drop the event. Throwing routes the event to the consumer's
+     * retry/DLQ path so it is reprocessed once config-service recovers.
      * NotificationChannel.code is the uppercase enum (WHATSAPP/SMS/EMAIL); we normalise to lowercase
      * to match the channel values used elsewhere (ProviderDetail/TemplateBinding, the allow-list).
      */
@@ -264,13 +266,13 @@ public class ConfigServiceClient {
 
             ResponseEntity<Map> response = restTemplate.exchange(url, HttpMethod.POST, new HttpEntity<>(payload), Map.class);
             if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
-                log.warn("Channel-config search returned non-success for tenant={}; falling back to legacy allow-list", tenantId);
-                return null;
+                throw new CustomException("NB_CHANNEL_CONFIG_SEARCH_FAILED",
+                        "NotificationChannel search returned non-success response");
             }
 
             List<Map<String, Object>> configDataList = (List<Map<String, Object>>) response.getBody().get("configData");
             if (configDataList == null || configDataList.isEmpty()) {
-                // Unconfigured tenant -> legacy fallback (no backfill needed for existing tenants).
+                // Genuinely unconfigured tenant -> legacy fallback (no backfill needed for existing tenants).
                 log.info("No NotificationChannel config for tenant={}; falling back to legacy allow-list", tenantId);
                 return null;
             }
@@ -288,10 +290,12 @@ public class ConfigServiceClient {
             }
             log.info("Channel-config result: tenantId={}, enabledChannels={}", tenantId, channels);
             return channels;
+        } catch (CustomException e) {
+            throw e;
         } catch (Exception e) {
-            // Favour delivery on a transient error: fall back to legacy behaviour rather than drop.
-            log.warn("Channel-config search failed for tenant={}; falling back to legacy allow-list", tenantId, e);
-            return null;
+            // Don't guess on a transient failure — propagate so the event is retried/DLQ'd.
+            log.error("Channel-config search failed for tenant={}; propagating for retry/DLQ", tenantId, e);
+            throw new CustomException("NB_CHANNEL_CONFIG_SEARCH_FAILED", "Failed searching NotificationChannel config");
         }
     }
 }

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/service/ConfigServiceClient.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/service/ConfigServiceClient.java
@@ -232,4 +232,52 @@ public class ConfigServiceClient {
             throw new CustomException("NB_PROVIDER_SEARCH_FAILED", "Failed searching provider configs");
         }
     }
+
+    /**
+     * Tenant-level channel toggle. Resolves the NotificationChannel config for the given
+     * tenant + channel and reports whether it is enabled.
+     *
+     * Defaults to DISABLED (returns false) when no record exists or the lookup fails, so a
+     * channel is only ever dispatched when a tenant has explicitly opted in. NotificationChannel.code
+     * is the uppercase enum (WHATSAPP/SMS/EMAIL); the dispatch channel is lowercase, so we normalise.
+     */
+    public boolean isChannelEnabled(String tenantId, String channel) {
+        String code = channel == null ? "" : channel.toUpperCase();
+        Map<String, Object> resolveRequest = new HashMap<>();
+        resolveRequest.put("schemaCode", "NotificationChannel");
+        resolveRequest.put("tenantId", tenantId);
+        resolveRequest.put("criteria", Map.of("code", code));
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("RequestInfo", new HashMap<>());
+        payload.put("resolveRequest", resolveRequest);
+
+        try {
+            String url = config.getConfigHost() + config.getConfigResolvePath();
+            log.info("Channel-enabled check: url={}, schemaCode=NotificationChannel, code={}, tenantId={}",
+                    url, code, tenantId);
+
+            ResponseEntity<Map> response = restTemplate.exchange(url, HttpMethod.POST, new HttpEntity<>(payload), Map.class);
+            if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+                log.warn("Channel-enabled check returned non-success for tenant={} channel={}; treating as DISABLED",
+                        tenantId, channel);
+                return false;
+            }
+
+            Map<String, Object> configData = (Map<String, Object>) response.getBody().get("configData");
+            if (configData == null) {
+                // No NotificationChannel record for this tenant+channel -> default OFF.
+                return false;
+            }
+
+            Map<String, Object> data = (Map<String, Object>) configData.get("data");
+            boolean enabled = data != null && Boolean.TRUE.equals(data.get("enabled"));
+            log.info("Channel-enabled result: tenantId={}, channel={}, enabled={}", tenantId, channel, enabled);
+            return enabled;
+        } catch (Exception e) {
+            // Fail closed: config-service hiccups must never silently start sending on a channel.
+            log.warn("Channel-enabled check failed for tenant={} channel={}; treating as DISABLED", tenantId, channel, e);
+            return false;
+        }
+    }
 }

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/service/DispatchPipelineService.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/service/DispatchPipelineService.java
@@ -55,6 +55,21 @@ public class DispatchPipelineService {
         log.info("Derived context: eventId={}, audience={}, recipientMobile={}, recipientUserId={}, locale={}",
                 event.getEventId(), context.getAudience(), context.getRecipientMobile(),
                 context.getRecipientUserId(), context.getLocale());
+
+        // Tenant-level channel gate (default OFF). A channel is dispatched only when the tenant
+        // has an enabled NotificationChannel config; otherwise skip cleanly before any further work.
+        if (!configServiceClient.isChannelEnabled(event.getTenantId(), context.getChannel())) {
+            persist(event, context, null, "SKIPPED", "NB_CHANNEL_DISABLED",
+                    context.getChannel() + " channel disabled for tenant " + event.getTenantId(), null, 1);
+            return DispatchResult.builder()
+                    .valid(true)
+                    .preferenceAllowed(false)
+                    .derivedContext(context)
+                    .novuTriggered(false)
+                    .diagnostics(Collections.singletonList("Channel disabled for tenant"))
+                    .build();
+        }
+
         String recipientUuid = userServiceClient.resolveUserUuid(
                 event.getTenantId(), context.getAudience(), context.getRecipientUserId(), context.getRecipientMobile());
         if (!StringUtils.hasText(recipientUuid)) {

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/service/DispatchPipelineService.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/service/DispatchPipelineService.java
@@ -45,22 +45,64 @@ public class DispatchPipelineService {
         this.mdmsServiceClient = mdmsServiceClient;
     }
 
-    public DispatchResult process(ComplaintsDomainEvent event, boolean send, RequestInfo requestInfo) {
-        log.info("Processing domain event: eventId={}, eventName={}, tenant={}, module={}, send={}",
+    /**
+     * Multi-channel entry point used by the Kafka consumer. Resolves the channels the tenant has
+     * enabled (intersected with the global allow-list) and dispatches the event on each, isolating
+     * per-channel failures so one misconfigured channel never blocks the others. Returns one
+     * DispatchResult per channel (empty list when the tenant has no enabled+allowed channels).
+     */
+    public List<DispatchResult> processEnabledChannels(ComplaintsDomainEvent event, boolean send, RequestInfo requestInfo) {
+        log.info("Processing domain event (multi-channel): eventId={}, eventName={}, tenant={}, module={}, send={}",
                 event.getEventId(), event.getEventName(), event.getTenantId(), event.getModule(), send);
 
         envelopeValidator.validate(event);
 
+        List<String> allowed = config.getAllowedChannels();
+        List<String> enabled = configServiceClient.getEnabledChannels(event.getTenantId());
+        List<String> effective = enabled.stream()
+                .filter(allowed::contains)
+                .distinct()
+                .collect(java.util.stream.Collectors.toList());
+        if (effective.isEmpty()) {
+            log.info("No enabled+allowed channels for tenant={}, eventId={} (enabled={}, allowed={}); nothing dispatched",
+                    event.getTenantId(), event.getEventId(), enabled, allowed);
+            return Collections.emptyList();
+        }
+
+        DerivedContext base = deriveContext(event);
+        String subscriberId = prepareRecipient(event, base);
+
+        log.info("Dispatching eventId={} on channels={}", event.getEventId(), effective);
+        List<DispatchResult> results = new ArrayList<>();
+        for (String channel : effective) {
+            DerivedContext context = base.toBuilder().channel(channel).build();
+            results.add(dispatchForChannel(event, context, subscriberId, send, requestInfo));
+        }
+        return results;
+    }
+
+    /**
+     * Single-channel entry point used by the diagnostic controller endpoints (_validate / _dry-run).
+     * Targets the primary allowed channel and keeps the tenant-level enable gate (default OFF).
+     */
+    public DispatchResult process(ComplaintsDomainEvent event, boolean send, RequestInfo requestInfo) {
+        log.info("Processing domain event (single-channel): eventId={}, eventName={}, tenant={}, module={}, send={}",
+                event.getEventId(), event.getEventName(), event.getTenantId(), event.getModule(), send);
+
+        envelopeValidator.validate(event);
+
+        String channel = primaryChannel();
         DerivedContext context = deriveContext(event);
-        log.info("Derived context: eventId={}, audience={}, recipientMobile={}, recipientUserId={}, locale={}",
-                event.getEventId(), context.getAudience(), context.getRecipientMobile(),
+        context.setChannel(channel);
+        log.info("Derived context: eventId={}, channel={}, audience={}, recipientMobile={}, recipientUserId={}, locale={}",
+                event.getEventId(), channel, context.getAudience(), context.getRecipientMobile(),
                 context.getRecipientUserId(), context.getLocale());
 
         // Tenant-level channel gate (default OFF). A channel is dispatched only when the tenant
         // has an enabled NotificationChannel config; otherwise skip cleanly before any further work.
-        if (!configServiceClient.isChannelEnabled(event.getTenantId(), context.getChannel())) {
+        if (!configServiceClient.isChannelEnabled(event.getTenantId(), channel)) {
             persist(event, context, null, "SKIPPED", "NB_CHANNEL_DISABLED",
-                    context.getChannel() + " channel disabled for tenant " + event.getTenantId(), null, 1);
+                    channel + " channel disabled for tenant " + event.getTenantId(), null, 1);
             return DispatchResult.builder()
                     .valid(true)
                     .preferenceAllowed(false)
@@ -70,6 +112,16 @@ public class DispatchPipelineService {
                     .build();
         }
 
+        String subscriberId = prepareRecipient(event, context);
+        return dispatchForChannel(event, context, subscriberId, send, requestInfo);
+    }
+
+    /**
+     * Channel-independent recipient + locale resolution. Mutates the given context with the resolved
+     * recipient uuid and preferred locale, and returns the Novu subscriberId. Throws (propagating to
+     * the consumer's DLQ path) when the recipient cannot be resolved — this is fatal for all channels.
+     */
+    private String prepareRecipient(ComplaintsDomainEvent event, DerivedContext context) {
         String recipientUuid = userServiceClient.resolveUserUuid(
                 event.getTenantId(), context.getAudience(), context.getRecipientUserId(), context.getRecipientMobile());
         if (!StringUtils.hasText(recipientUuid)) {
@@ -78,61 +130,123 @@ public class DispatchPipelineService {
         context.setRecipientUserId(recipientUuid);
         String subscriberId = event.getTenantId() + ":" + recipientUuid;
 
-        // Get user's preferred locale from preferences and update context
         String userPreferredLocale = preferenceServiceClient.getUserPreferredLocale(event.getTenantId(), recipientUuid, context.getLocale());
         context.setLocale(userPreferredLocale);
-        log.info("Updated context locale from user preferences: eventId={}, userId={}, locale={}", 
-                event.getEventId(), recipientUuid, userPreferredLocale);
+        log.info("Recipient prepared: eventId={}, userId={}, locale={}", event.getEventId(), recipientUuid, userPreferredLocale);
+        return subscriberId;
+    }
 
-        boolean preferenceAllowed = preferenceServiceClient.isChannelAllowed(event.getTenantId(), recipientUuid, context.getRecipientMobile(), context.getChannel());
-        if (!preferenceAllowed) {
-            persist(event, context, null, "SKIPPED", "NB_PREFERENCE_DENIED", context.getChannel() + " preference denied", null, 1);
-            return DispatchResult.builder()
-                    .valid(true)
-                    .preferenceAllowed(false)
-                    .derivedContext(context)
-                    .novuTriggered(false)
-                    .diagnostics(Collections.singletonList("Preference denied"))
-                    .build();
-        }
+    /**
+     * Dispatches a single channel for an event whose recipient/locale have already been resolved on
+     * {@code context}. Per-channel failures are caught and recorded as FAILED so a misconfigured
+     * channel never aborts sibling channels; only unexpected (non-CustomException) errors bubble up.
+     */
+    private DispatchResult dispatchForChannel(ComplaintsDomainEvent event, DerivedContext context,
+                                              String subscriberId, boolean send, RequestInfo requestInfo) {
+        String channel = context.getChannel();
+        try {
+            boolean preferenceAllowed = preferenceServiceClient.isChannelAllowed(
+                    event.getTenantId(), context.getRecipientUserId(), context.getRecipientMobile(), channel);
+            if (!preferenceAllowed) {
+                persist(event, context, null, "SKIPPED", "NB_PREFERENCE_DENIED", channel + " preference denied", null, 1);
+                return DispatchResult.builder()
+                        .valid(true)
+                        .preferenceAllowed(false)
+                        .derivedContext(context)
+                        .novuTriggered(false)
+                        .diagnostics(Collections.singletonList("Preference denied"))
+                        .build();
+            }
 
-        ResolvedTemplate resolvedTemplate = configServiceClient.resolveTemplate(context, event.getEventName(), event.getModule(), event.getTenantId());
-        log.info("Resolved template: eventId={}, templateKey={}, contentSid={}, requiredVars={}, paramOrder={}",
-                event.getEventId(), resolvedTemplate.getTemplateKey(), resolvedTemplate.getContentSid(),
-                resolvedTemplate.getRequiredVars(), resolvedTemplate.getParamOrder());
-        validateTemplateConfig(resolvedTemplate);
-        
-        // Resolve providers by channel with priority=1, pick the first one
-        List<ResolvedProvider> availableProviders = configServiceClient.resolveProvidersByChannel(event.getTenantId(), context.getChannel());
-        if (availableProviders.isEmpty()) {
-            throw new CustomException("NB_NO_ACTIVE_PROVIDER",
-                    "No provider found with priority 1 for tenant=" + event.getTenantId() + " channel=" + context.getChannel());
-        }
-        ResolvedProvider resolvedProvider = availableProviders.get(0);
+            ResolvedTemplate resolvedTemplate = configServiceClient.resolveTemplate(context, event.getEventName(), event.getModule(), event.getTenantId());
+            log.info("Resolved template: eventId={}, channel={}, templateKey={}, contentSid={}, requiredVars={}, paramOrder={}",
+                    event.getEventId(), channel, resolvedTemplate.getTemplateKey(), resolvedTemplate.getContentSid(),
+                    resolvedTemplate.getRequiredVars(), resolvedTemplate.getParamOrder());
+            validateTemplateConfig(resolvedTemplate);
 
-        log.info("Resolved provider: eventId={}, provider={}, channel={}, isActive={}, priority={}, credentialKeys={}, senderNumber={}, availableCount={}",
-                event.getEventId(), resolvedProvider.getProviderName(), resolvedProvider.getChannel(),
-                resolvedProvider.getIsActive(), resolvedProvider.getPriority(),
-                resolvedProvider.getCredentials() != null ? resolvedProvider.getCredentials().keySet() : "null",
-                resolvedProvider.getSenderNumber(), availableProviders.size());
-        
-        List<String> missingVars = findMissingRequiredVars(resolvedTemplate, event.getData());
-        if (!missingVars.isEmpty()) {
-            persist(event, context, resolvedTemplate, "FAILED", "NB_REQUIRED_VARS_MISSING", "Missing required vars", null, 1);
-            return DispatchResult.builder()
-                    .valid(false)
-                    .preferenceAllowed(true)
-                    .derivedContext(context)
-                    .resolvedTemplate(ResolvedTemplateResponse.fromInternal(resolvedTemplate))
-                    .resolvedProvider(ResolvedProviderResponse.fromInternal(resolvedProvider))
-                    .missingRequiredVars(missingVars)
-                    .novuTriggered(false)
-                    .diagnostics(Collections.singletonList("Missing required vars"))
-                    .build();
-        }
+            // Resolve providers by channel with priority=1, pick the first one
+            List<ResolvedProvider> availableProviders = configServiceClient.resolveProvidersByChannel(event.getTenantId(), channel);
+            if (availableProviders.isEmpty()) {
+                throw new CustomException("NB_NO_ACTIVE_PROVIDER",
+                        "No provider found with priority 1 for tenant=" + event.getTenantId() + " channel=" + channel);
+            }
+            ResolvedProvider resolvedProvider = availableProviders.get(0);
 
-        if (!send) {
-            persist(event, context, resolvedTemplate, "RECEIVED", null, null, null, 1);
+            log.info("Resolved provider: eventId={}, channel={}, provider={}, isActive={}, priority={}, credentialKeys={}, senderNumber={}, availableCount={}",
+                    event.getEventId(), channel, resolvedProvider.getProviderName(),
+                    resolvedProvider.getIsActive(), resolvedProvider.getPriority(),
+                    resolvedProvider.getCredentials() != null ? resolvedProvider.getCredentials().keySet() : "null",
+                    resolvedProvider.getSenderNumber(), availableProviders.size());
+
+            List<String> missingVars = findMissingRequiredVars(resolvedTemplate, event.getData());
+            if (!missingVars.isEmpty()) {
+                persist(event, context, resolvedTemplate, "FAILED", "NB_REQUIRED_VARS_MISSING", "Missing required vars", null, 1);
+                return DispatchResult.builder()
+                        .valid(false)
+                        .preferenceAllowed(true)
+                        .derivedContext(context)
+                        .resolvedTemplate(ResolvedTemplateResponse.fromInternal(resolvedTemplate))
+                        .resolvedProvider(ResolvedProviderResponse.fromInternal(resolvedProvider))
+                        .missingRequiredVars(missingVars)
+                        .novuTriggered(false)
+                        .diagnostics(Collections.singletonList("Missing required vars"))
+                        .build();
+            }
+
+            if (!send) {
+                persist(event, context, resolvedTemplate, "RECEIVED", null, null, null, 1);
+                return DispatchResult.builder()
+                        .valid(true)
+                        .preferenceAllowed(true)
+                        .derivedContext(context)
+                        .resolvedTemplate(ResolvedTemplateResponse.fromInternal(resolvedTemplate))
+                        .resolvedProvider(ResolvedProviderResponse.fromInternal(resolvedProvider))
+                        .missingRequiredVars(Collections.emptyList())
+                        .novuTriggered(false)
+                        .diagnostics(Collections.singletonList("Validation only mode"))
+                        .build();
+            }
+
+            String recipientPhone = formatRecipientPhone(context.getRecipientMobile(), event.getTenantId(), channel, requestInfo);
+
+            log.info("Dispatching notification: eventId={}, eventName={}, tenant={}, channel={}, complaintNo={}, " +
+                     "templateKey={}, subscriberId={}, provider={}, senderNumber={}",
+                    event.getEventId(), event.getEventName(), event.getTenantId(), channel,
+                    event.getData() != null ? event.getData().get("complaintNo") : "N/A",
+                    resolvedTemplate.getTemplateKey(), subscriberId,
+                    resolvedProvider.getProviderName(), resolvedProvider.getSenderNumber());
+            log.info("Novu trigger payload: paramOrder={}, novuBaseUrl={}, providerCredentials={}",
+                    resolvedTemplate.getParamOrder(), config.getNovuBaseUrl(),
+                    resolvedProvider.getCredentials() != null ? "[REDACTED]" : "null");
+
+            // Use provider-specific Novu API key if available and not blank, otherwise use template-specific key
+            String novuApiKey = StringUtils.hasText(resolvedProvider.getNovuApiKey()) ?
+                    resolvedProvider.getNovuApiKey() : resolvedTemplate.getNovuApiKey();
+
+            // Build ordered content variables for template if paramOrder is configured
+            Map<String, String> contentVariables = null;
+            if (!CollectionUtils.isEmpty(resolvedTemplate.getParamOrder()) &&
+                StringUtils.hasText(resolvedTemplate.getContentSid())) {
+                contentVariables = buildOrderedContentVariables(resolvedTemplate, event.getData());
+                log.info("Built ordered content variables from paramOrder: {}", contentVariables);
+            }
+
+            // Use provider-agnostic notification dispatch with automatic strategy selection
+            NovuClient.NovuResponse novuResponse = novuClient.triggerWithProviderConfig(
+                    resolvedTemplate.getTemplateKey(),
+                    subscriberId,
+                    recipientPhone,
+                    event.getData(),
+                    event.getEventId(),
+                    resolvedProvider,
+                    resolvedTemplate,
+                    contentVariables,
+                    novuApiKey);
+
+            log.info("Novu trigger response: eventId={}, channel={}, statusCode={}, response={}",
+                    event.getEventId(), channel, novuResponse.getStatusCode(), novuResponse.getResponse());
+
+            persist(event, context, resolvedTemplate, "SENT", null, null, novuResponse.getResponse(), 1);
             return DispatchResult.builder()
                     .valid(true)
                     .preferenceAllowed(true)
@@ -140,64 +254,28 @@ public class DispatchPipelineService {
                     .resolvedTemplate(ResolvedTemplateResponse.fromInternal(resolvedTemplate))
                     .resolvedProvider(ResolvedProviderResponse.fromInternal(resolvedProvider))
                     .missingRequiredVars(Collections.emptyList())
+                    .novuTriggered(true)
+                    .novuStatusCode(novuResponse.getStatusCode())
+                    .novuResponse(novuResponse.getResponse())
+                    .diagnostics(Collections.singletonList("Dispatch successful"))
+                    .build();
+        } catch (CustomException e) {
+            // Isolate per-channel failures: record FAILED and let sibling channels proceed.
+            log.error("Dispatch failed for eventId={} channel={} code={}", event.getEventId(), channel, e.getCode(), e);
+            persist(event, context, null, "FAILED", e.getCode(), e.getMessage(), null, 1);
+            return DispatchResult.builder()
+                    .valid(false)
+                    .preferenceAllowed(true)
+                    .derivedContext(context)
                     .novuTriggered(false)
-                    .diagnostics(Collections.singletonList("Validation only mode"))
+                    .diagnostics(Collections.singletonList(channel + " failed: " + e.getCode()))
                     .build();
         }
+    }
 
-        String recipientPhone = formatRecipientPhone(context.getRecipientMobile(), event.getTenantId(), context.getChannel(), requestInfo);
-
-        log.info("Dispatching notification: eventId={}, eventName={}, tenant={}, complaintNo={}, " +
-                 "templateKey={}, subscriberId={}, provider={}, channel={}, senderNumber={}",
-                event.getEventId(), event.getEventName(), event.getTenantId(),
-                event.getData() != null ? event.getData().get("complaintNo") : "N/A",
-                resolvedTemplate.getTemplateKey(), subscriberId,
-                resolvedProvider.getProviderName(), resolvedProvider.getChannel(),
-                resolvedProvider.getSenderNumber());
-        log.info("Novu trigger payload: paramOrder={}, novuBaseUrl={}, providerCredentials={}",
-                resolvedTemplate.getParamOrder(), config.getNovuBaseUrl(), 
-                resolvedProvider.getCredentials() != null ? "[REDACTED]" : "null");
-
-        // Use provider-specific Novu API key if available and not blank, otherwise use template-specific key
-        String novuApiKey = StringUtils.hasText(resolvedProvider.getNovuApiKey()) ? 
-                resolvedProvider.getNovuApiKey() : resolvedTemplate.getNovuApiKey();
-
-        // Build ordered content variables for template if paramOrder is configured
-        Map<String, String> contentVariables = null;
-        if (!CollectionUtils.isEmpty(resolvedTemplate.getParamOrder()) && 
-            StringUtils.hasText(resolvedTemplate.getContentSid())) {
-            contentVariables = buildOrderedContentVariables(resolvedTemplate, event.getData());
-            log.info("Built ordered content variables from paramOrder: {}", contentVariables);
-        }
-
-        // Use provider-agnostic notification dispatch with automatic strategy selection
-        NovuClient.NovuResponse novuResponse = novuClient.triggerWithProviderConfig(
-                resolvedTemplate.getTemplateKey(),
-                subscriberId,
-                recipientPhone,
-                event.getData(),
-                event.getEventId(),
-                resolvedProvider,
-                resolvedTemplate,
-                contentVariables,
-                novuApiKey);
-
-        log.info("Novu trigger response: eventId={}, statusCode={}, response={}",
-                event.getEventId(), novuResponse.getStatusCode(), novuResponse.getResponse());
-
-        persist(event, context, resolvedTemplate, "SENT", null, null, novuResponse.getResponse(), 1);
-        return DispatchResult.builder()
-                .valid(true)
-                .preferenceAllowed(true)
-                .derivedContext(context)
-                .resolvedTemplate(ResolvedTemplateResponse.fromInternal(resolvedTemplate))
-                .resolvedProvider(ResolvedProviderResponse.fromInternal(resolvedProvider))
-                .missingRequiredVars(Collections.emptyList())
-                .novuTriggered(true)
-                .novuStatusCode(novuResponse.getStatusCode())
-                .novuResponse(novuResponse.getResponse())
-                .diagnostics(Collections.singletonList("Dispatch successful"))
-                .build();
+    private String primaryChannel() {
+        List<String> allowed = config.getAllowedChannels();
+        return allowed.isEmpty() ? config.getChannel() : allowed.get(0);
     }
 
     public NovuClient.NovuResponse testTrigger(String templateKey, String subscriberId, String phone,
@@ -207,7 +285,7 @@ public class DispatchPipelineService {
         return novuClient.trigger(
                 templateKey,
                 subscriberId,
-                formatRecipientPhone(phone, null, config.getChannel(), requestInfo),
+                formatRecipientPhone(phone, null, primaryChannel(), requestInfo),
                 payload,
                 transactionId,
                 buildTemplateOverrides(contentSid, contentVariables));
@@ -306,8 +384,9 @@ public class DispatchPipelineService {
                     .orElse(event.getStakeholders().get(0));
         }
 
+        // Channel is intentionally left unset here; it is assigned per dispatch
+        // (single channel in process(), one per enabled channel in processEnabledChannels()).
         return DerivedContext.builder()
-                .channel(config.getChannel())
                 .audience(stakeholder != null ? stakeholder.getType() : null)
                 .workflowState(event.getWorkflow() != null ? event.getWorkflow().getToState() : null)
                 .locale(event.getContext() != null && StringUtils.hasText(event.getContext().getLocale()) ? event.getContext().getLocale() : config.getDefaultLocale())

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/service/DispatchPipelineService.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/service/DispatchPipelineService.java
@@ -94,11 +94,27 @@ public class DispatchPipelineService {
                 context.getRecipientUserId(), context.getLocale());
 
         // Tenant-level channel gate. The channel is dispatched when the tenant has enabled it, or when
-        // the tenant has no NotificationChannel config at all (legacy fallback, see effectiveChannels);
-        // otherwise skip cleanly before any further work.
-        if (!effectiveChannels(event.getTenantId()).contains(channel)) {
-            persist(event, context, null, "SKIPPED", "NB_CHANNEL_DISABLED",
-                    channel + " channel not enabled for tenant " + event.getTenantId(), null, 1);
+        // the tenant has no NotificationChannel config at all (legacy fallback, see effectiveChannels).
+        // This is also the diagnostic path (_validate/_dry-run): a config-service failure must not 500
+        // the endpoint, so report it as a diagnostic result instead of letting it throw.
+        List<String> effective;
+        try {
+            effective = effectiveChannels(event.getTenantId());
+        } catch (CustomException e) {
+            return DispatchResult.builder()
+                    .valid(false)
+                    .preferenceAllowed(false)
+                    .derivedContext(context)
+                    .novuTriggered(false)
+                    .diagnostics(Collections.singletonList("Channel config unavailable: " + e.getCode()))
+                    .build();
+        }
+        if (!effective.contains(channel)) {
+            // Only record a SKIPPED dispatch-log row when actually sending; _validate must be side-effect-free.
+            if (send) {
+                persist(event, context, null, "SKIPPED", "NB_CHANNEL_DISABLED",
+                        channel + " channel not enabled for tenant " + event.getTenantId(), null, 1);
+            }
             return DispatchResult.builder()
                     .valid(true)
                     .preferenceAllowed(false)
@@ -255,16 +271,19 @@ public class DispatchPipelineService {
                     .novuResponse(novuResponse.getResponse())
                     .diagnostics(Collections.singletonList("Dispatch successful"))
                     .build();
-        } catch (CustomException e) {
-            // Isolate per-channel failures: record FAILED and let sibling channels proceed.
-            log.error("Dispatch failed for eventId={} channel={} code={}", event.getEventId(), channel, e.getCode(), e);
-            persist(event, context, null, "FAILED", e.getCode(), e.getMessage(), null, 1);
+        } catch (Exception e) {
+            // Isolate ALL per-channel failures (not just CustomException): record FAILED and let sibling
+            // channels proceed. Catching broadly is deliberate — letting an unexpected error bubble would
+            // re-queue the whole event for retry and re-send channels that already succeeded (duplicates).
+            String code = (e instanceof CustomException) ? ((CustomException) e).getCode() : "NB_DISPATCH_ERROR";
+            log.error("Dispatch failed for eventId={} channel={} code={}", event.getEventId(), channel, code, e);
+            persist(event, context, null, "FAILED", code, e.getMessage(), null, 1);
             return DispatchResult.builder()
                     .valid(false)
                     .preferenceAllowed(true)
                     .derivedContext(context)
                     .novuTriggered(false)
-                    .diagnostics(Collections.singletonList(channel + " failed: " + e.getCode()))
+                    .diagnostics(Collections.singletonList(channel + " failed: " + code))
                     .build();
         }
     }

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/service/DispatchPipelineService.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/service/DispatchPipelineService.java
@@ -57,15 +57,10 @@ public class DispatchPipelineService {
 
         envelopeValidator.validate(event);
 
-        List<String> allowed = config.getAllowedChannels();
-        List<String> enabled = configServiceClient.getEnabledChannels(event.getTenantId());
-        List<String> effective = enabled.stream()
-                .filter(allowed::contains)
-                .distinct()
-                .collect(java.util.stream.Collectors.toList());
+        List<String> effective = effectiveChannels(event.getTenantId());
         if (effective.isEmpty()) {
-            log.info("No enabled+allowed channels for tenant={}, eventId={} (enabled={}, allowed={}); nothing dispatched",
-                    event.getTenantId(), event.getEventId(), enabled, allowed);
+            log.info("No effective channels for tenant={}, eventId={}; nothing dispatched",
+                    event.getTenantId(), event.getEventId());
             return Collections.emptyList();
         }
 
@@ -98,17 +93,18 @@ public class DispatchPipelineService {
                 event.getEventId(), channel, context.getAudience(), context.getRecipientMobile(),
                 context.getRecipientUserId(), context.getLocale());
 
-        // Tenant-level channel gate (default OFF). A channel is dispatched only when the tenant
-        // has an enabled NotificationChannel config; otherwise skip cleanly before any further work.
-        if (!configServiceClient.isChannelEnabled(event.getTenantId(), channel)) {
+        // Tenant-level channel gate. The channel is dispatched when the tenant has enabled it, or when
+        // the tenant has no NotificationChannel config at all (legacy fallback, see effectiveChannels);
+        // otherwise skip cleanly before any further work.
+        if (!effectiveChannels(event.getTenantId()).contains(channel)) {
             persist(event, context, null, "SKIPPED", "NB_CHANNEL_DISABLED",
-                    channel + " channel disabled for tenant " + event.getTenantId(), null, 1);
+                    channel + " channel not enabled for tenant " + event.getTenantId(), null, 1);
             return DispatchResult.builder()
                     .valid(true)
                     .preferenceAllowed(false)
                     .derivedContext(context)
                     .novuTriggered(false)
-                    .diagnostics(Collections.singletonList("Channel disabled for tenant"))
+                    .diagnostics(Collections.singletonList("Channel not enabled for tenant"))
                     .build();
         }
 
@@ -276,6 +272,24 @@ public class DispatchPipelineService {
     private String primaryChannel() {
         List<String> allowed = config.getAllowedChannels();
         return allowed.isEmpty() ? config.getChannel() : allowed.get(0);
+    }
+
+    /**
+     * The channels to dispatch on for a tenant: the explicitly-enabled NotificationChannel codes
+     * intersected with the global allow-list, OR — when the tenant has no NotificationChannel config
+     * at all — the full allow-list (legacy back-compat, so existing tenants keep working with no
+     * backfill). A tenant that has config but has disabled everything dispatches on nothing.
+     */
+    private List<String> effectiveChannels(String tenantId) {
+        List<String> allowed = config.getAllowedChannels();
+        List<String> configured = configServiceClient.getEnabledChannels(tenantId); // null => unconfigured
+        if (configured == null) {
+            return allowed;
+        }
+        return configured.stream()
+                .filter(allowed::contains)
+                .distinct()
+                .collect(java.util.stream.Collectors.toList());
     }
 
     public NovuClient.NovuResponse testTrigger(String templateKey, String subscriberId, String phone,

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/web/models/DerivedContext.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/web/models/DerivedContext.java
@@ -6,7 +6,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 public class DerivedContext {

--- a/backend/novu-bridge/src/main/resources/application.properties
+++ b/backend/novu-bridge/src/main/resources/application.properties
@@ -19,6 +19,7 @@ novu.bridge.kafka.input.topic=${NOVU_BRIDGE_KAFKA_INPUT_TOPIC:complaints.domain.
 novu.bridge.kafka.retry.topic=${NOVU_BRIDGE_KAFKA_RETRY_TOPIC:novu-bridge.retry}
 novu.bridge.kafka.dlq.topic=${NOVU_BRIDGE_KAFKA_DLQ_TOPIC:novu-bridge.dlq}
 novu.bridge.max.retries=${NOVU_BRIDGE_MAX_RETRIES:3}
+novu.bridge.retry.delay.ms=${NOVU_BRIDGE_RETRY_DELAY_MS:5000}
 # CSV global allow-list; whatsapp is the live channel. Deploys override via NOVU_BRIDGE_CHANNEL.
 novu.bridge.channel=${NOVU_BRIDGE_CHANNEL:whatsapp}
 novu.bridge.default.locale=${NOVU_BRIDGE_DEFAULT_LOCALE:en_IN}

--- a/backend/novu-bridge/src/main/resources/application.properties
+++ b/backend/novu-bridge/src/main/resources/application.properties
@@ -19,7 +19,8 @@ novu.bridge.kafka.input.topic=${NOVU_BRIDGE_KAFKA_INPUT_TOPIC:complaints.domain.
 novu.bridge.kafka.retry.topic=${NOVU_BRIDGE_KAFKA_RETRY_TOPIC:novu-bridge.retry}
 novu.bridge.kafka.dlq.topic=${NOVU_BRIDGE_KAFKA_DLQ_TOPIC:novu-bridge.dlq}
 novu.bridge.max.retries=${NOVU_BRIDGE_MAX_RETRIES:3}
-novu.bridge.channel=${NOVU_BRIDGE_CHANNEL:SMS}
+# CSV global allow-list; whatsapp is the live channel. Deploys override via NOVU_BRIDGE_CHANNEL.
+novu.bridge.channel=${NOVU_BRIDGE_CHANNEL:whatsapp}
 novu.bridge.default.locale=${NOVU_BRIDGE_DEFAULT_LOCALE:en_IN}
 
 # External dependencies

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/consumer/DomainEventConsumerTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/consumer/DomainEventConsumerTest.java
@@ -1,0 +1,119 @@
+package org.egov.novubridge.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.egov.novubridge.config.NovuBridgeConfiguration;
+import org.egov.novubridge.producer.Producer;
+import org.egov.novubridge.service.DispatchPipelineService;
+import org.egov.novubridge.web.models.ComplaintsDomainEvent;
+import org.egov.tracer.model.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies the bounded retry -> DLQ wiring in the Kafka consumer: success goes nowhere, a failure is
+ * re-queued on the retry topic with an incremented attempt, and once attempts are exhausted it lands
+ * in the DLQ. (Backoff disabled via retryDelayMs=0 so the test doesn't sleep.)
+ */
+public class DomainEventConsumerTest {
+
+    private static final String INPUT = "complaints.domain.events";
+    private static final String RETRY = "novu-bridge.retry";
+    private static final String DLQ = "novu-bridge.dlq";
+    private static final String TENANT = "pb.amritsar";
+
+    @Mock private DispatchPipelineService dispatch;
+    @Mock private Producer producer;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private NovuBridgeConfiguration config;
+    private DomainEventConsumer consumer;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        config = new NovuBridgeConfiguration();
+        config.setRetryTopic(RETRY);
+        config.setDlqTopic(DLQ);
+        config.setMaxRetries(3);
+        config.setRetryDelayMs(0);   // no sleeping in tests
+        consumer = new DomainEventConsumer(mapper, dispatch, producer, config);
+    }
+
+    private ComplaintsDomainEvent event() {
+        return ComplaintsDomainEvent.builder()
+                .eventId("evt-1").tenantId(TENANT).eventName("complaint-resolved").build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private HashMap<String, Object> asInputRecord(ComplaintsDomainEvent e) {
+        return mapper.convertValue(e, HashMap.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private HashMap<String, Object> asRetryRecord(ComplaintsDomainEvent e, int attempt) {
+        HashMap<String, Object> r = new HashMap<>();
+        r.put("event", mapper.convertValue(e, Map.class));
+        r.put("attempt", attempt);
+        return r;
+    }
+
+    private void failProcessing() {
+        when(dispatch.processEnabledChannels(any(ComplaintsDomainEvent.class), anyBoolean(), any()))
+                .thenThrow(new CustomException("NB_CHANNEL_CONFIG_SEARCH_FAILED", "config-service down"));
+    }
+
+    @Test
+    void success_neitherRetriesNorDlqs() {
+        consumer.listen(asInputRecord(event()), INPUT);
+        verifyNoInteractions(producer);
+    }
+
+    @Test
+    void inputFailure_requeuedToRetryWithAttemptOne() {
+        failProcessing();
+
+        consumer.listen(asInputRecord(event()), INPUT);
+
+        ArgumentCaptor<Object> payload = ArgumentCaptor.forClass(Object.class);
+        verify(producer).push(eq(TENANT), eq(RETRY), payload.capture());
+        verify(producer, never()).push(eq(TENANT), eq(DLQ), any());
+        assertEquals(1, ((Map<String, Object>) payload.getValue()).get("attempt"));
+    }
+
+    @Test
+    void retryFailureBelowMax_requeuedWithIncrementedAttempt() {
+        failProcessing();
+
+        consumer.listen(asRetryRecord(event(), 1), RETRY);
+
+        ArgumentCaptor<Object> payload = ArgumentCaptor.forClass(Object.class);
+        verify(producer).push(eq(TENANT), eq(RETRY), payload.capture());
+        assertEquals(2, ((Map<String, Object>) payload.getValue()).get("attempt"));
+    }
+
+    @Test
+    void retryFailureAtMax_routedToDlq() {
+        failProcessing();
+
+        // attempt 3 == maxRetries -> next would be 4 (> 3) -> DLQ, not another retry
+        consumer.listen(asRetryRecord(event(), 3), RETRY);
+
+        verify(producer).push(eq(TENANT), eq(DLQ), any());
+        verify(producer, never()).push(eq(TENANT), eq(RETRY), any());
+    }
+}

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/consumer/DomainEventConsumerTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/consumer/DomainEventConsumerTest.java
@@ -80,7 +80,7 @@ public class DomainEventConsumerTest {
 
     @Test
     void success_neitherRetriesNorDlqs() {
-        consumer.listen(asInputRecord(event()), INPUT);
+        consumer.listenInput(asInputRecord(event()));
         verifyNoInteractions(producer);
     }
 
@@ -88,7 +88,7 @@ public class DomainEventConsumerTest {
     void inputFailure_requeuedToRetryWithAttemptOne() {
         failProcessing();
 
-        consumer.listen(asInputRecord(event()), INPUT);
+        consumer.listenInput(asInputRecord(event()));
 
         ArgumentCaptor<Object> payload = ArgumentCaptor.forClass(Object.class);
         verify(producer).push(eq(TENANT), eq(RETRY), payload.capture());
@@ -100,7 +100,7 @@ public class DomainEventConsumerTest {
     void retryFailureBelowMax_requeuedWithIncrementedAttempt() {
         failProcessing();
 
-        consumer.listen(asRetryRecord(event(), 1), RETRY);
+        consumer.listenRetry(asRetryRecord(event(), 1));
 
         ArgumentCaptor<Object> payload = ArgumentCaptor.forClass(Object.class);
         verify(producer).push(eq(TENANT), eq(RETRY), payload.capture());
@@ -112,7 +112,7 @@ public class DomainEventConsumerTest {
         failProcessing();
 
         // attempt 3 == maxRetries -> next would be 4 (> 3) -> DLQ, not another retry
-        consumer.listen(asRetryRecord(event(), 3), RETRY);
+        consumer.listenRetry(asRetryRecord(event(), 3));
 
         verify(producer).push(eq(TENANT), eq(DLQ), any());
         verify(producer, never()).push(eq(TENANT), eq(RETRY), any());
@@ -124,7 +124,7 @@ public class DomainEventConsumerTest {
         failProcessing();
 
         // 1) input failure -> capture the exact payload pushed to the retry topic
-        consumer.listen(asInputRecord(event()), INPUT);
+        consumer.listenInput(asInputRecord(event()));
         ArgumentCaptor<Object> pushed = ArgumentCaptor.forClass(Object.class);
         verify(producer).push(eq(TENANT), eq(RETRY), pushed.capture());
 
@@ -134,7 +134,7 @@ public class DomainEventConsumerTest {
         HashMap<String, Object> reconsumed = mapper.readValue(onTheWire, HashMap.class);
 
         // 3) re-consume from the retry topic (still failing)
-        consumer.listen(reconsumed, RETRY);
+        consumer.listenRetry(reconsumed);
 
         // the wrapped event survived the round trip (eventId intact) and reached the pipeline again
         ArgumentCaptor<ComplaintsDomainEvent> dispatched = ArgumentCaptor.forClass(ComplaintsDomainEvent.class);

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/consumer/DomainEventConsumerTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/consumer/DomainEventConsumerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -115,5 +116,34 @@ public class DomainEventConsumerTest {
 
         verify(producer).push(eq(TENANT), eq(DLQ), any());
         verify(producer, never()).push(eq(TENANT), eq(RETRY), any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void retryPayload_survivesJsonRoundTripAndReconsumes() throws Exception {
+        failProcessing();
+
+        // 1) input failure -> capture the exact payload pushed to the retry topic
+        consumer.listen(asInputRecord(event()), INPUT);
+        ArgumentCaptor<Object> pushed = ArgumentCaptor.forClass(Object.class);
+        verify(producer).push(eq(TENANT), eq(RETRY), pushed.capture());
+
+        // 2) simulate Kafka: serialize the pushed value and deserialize it back to a HashMap,
+        //    exactly as the JsonSerializer/consumer would when the message comes off the retry topic.
+        String onTheWire = mapper.writeValueAsString(pushed.getValue());
+        HashMap<String, Object> reconsumed = mapper.readValue(onTheWire, HashMap.class);
+
+        // 3) re-consume from the retry topic (still failing)
+        consumer.listen(reconsumed, RETRY);
+
+        // the wrapped event survived the round trip (eventId intact) and reached the pipeline again
+        ArgumentCaptor<ComplaintsDomainEvent> dispatched = ArgumentCaptor.forClass(ComplaintsDomainEvent.class);
+        verify(dispatch, times(2)).processEnabledChannels(dispatched.capture(), anyBoolean(), any());
+        assertEquals("evt-1", dispatched.getAllValues().get(1).getEventId());
+
+        // and the attempt advanced 1 -> 2 across the round trip
+        ArgumentCaptor<Object> rePushed = ArgumentCaptor.forClass(Object.class);
+        verify(producer, times(2)).push(eq(TENANT), eq(RETRY), rePushed.capture());
+        assertEquals(2, ((Map<String, Object>) rePushed.getAllValues().get(1)).get("attempt"));
     }
 }

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/service/ConfigServiceClientContractTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/service/ConfigServiceClientContractTest.java
@@ -1,0 +1,135 @@
+package org.egov.novubridge.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpServer;
+import org.egov.novubridge.config.NovuBridgeConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * On-the-wire contract test for the NotificationChannel calls. Runs the REAL ConfigServiceClient
+ * (real RestTemplate, real JSON serialization, real HTTP) against a local stub that mimics
+ * digit-config-service's _resolve / _search contract. Catches request-shape / parsing drift that
+ * the RestTemplate-mocked unit tests can't see.
+ *
+ * Contract mirrored from config-service models:
+ *   _resolve request : { RequestInfo, resolveRequest:{ schemaCode, tenantId, criteria } }
+ *   _resolve response: { configData:{ ..., data:{...} } }
+ *   _search request  : { RequestInfo, criteria:{ schemaCode, tenantId, criteria } }
+ *   _search response : { configData:[ { data:{...} }, ... ] }
+ */
+public class ConfigServiceClientContractTest {
+
+    private static final String RESOLVE_PATH = "/config-service/config/v1/_resolve";
+    private static final String SEARCH_PATH = "/config-service/config/v1/_search";
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private HttpServer server;
+    private ConfigServiceClient client;
+
+    private final AtomicReference<String> resolveBody = new AtomicReference<>();
+    private final AtomicReference<String> searchBody = new AtomicReference<>();
+    private final AtomicReference<String> resolveResponse = new AtomicReference<>("{\"configData\":null}");
+    private final AtomicReference<String> searchResponse = new AtomicReference<>("{\"configData\":[]}");
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext(RESOLVE_PATH, exchange -> {
+            resolveBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+            byte[] out = resolveResponse.get().getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, out.length);
+            exchange.getResponseBody().write(out);
+            exchange.close();
+        });
+        server.createContext(SEARCH_PATH, exchange -> {
+            searchBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+            byte[] out = searchResponse.get().getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, out.length);
+            exchange.getResponseBody().write(out);
+            exchange.close();
+        });
+        server.start();
+
+        int port = server.getAddress().getPort();
+        NovuBridgeConfiguration config = new NovuBridgeConfiguration();
+        config.setConfigHost("http://127.0.0.1:" + port);
+        config.setConfigResolvePath(RESOLVE_PATH);
+        config.setConfigSearchPath(SEARCH_PATH);
+        client = new ConfigServiceClient(new RestTemplate(), config);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) server.stop(0);
+    }
+
+    @Test
+    void isChannelEnabled_sendsResolveContract_andParsesEnabled() throws Exception {
+        resolveResponse.set("{\"ResponseInfo\":{},\"configData\":{\"tenantId\":\"pb.amritsar\","
+                + "\"schemaCode\":\"NotificationChannel\",\"data\":{\"code\":\"WHATSAPP\",\"name\":\"WhatsApp\",\"enabled\":true}}}");
+
+        boolean enabled = client.isChannelEnabled("pb.amritsar", "whatsapp");
+
+        assertTrue(enabled);
+        // Verify the exact request the bridge put on the wire matches config-service's _resolve contract.
+        JsonNode req = mapper.readTree(resolveBody.get());
+        assertTrue(req.has("RequestInfo"));
+        JsonNode rr = req.get("resolveRequest");
+        assertEquals("NotificationChannel", rr.get("schemaCode").asText());
+        assertEquals("pb.amritsar", rr.get("tenantId").asText());
+        assertEquals("WHATSAPP", rr.get("criteria").get("code").asText()); // lowercased channel -> uppercase code
+    }
+
+    @Test
+    void isChannelEnabled_disabledRecord_parsesFalse() {
+        resolveResponse.set("{\"configData\":{\"data\":{\"code\":\"WHATSAPP\",\"enabled\":false}}}");
+        assertFalse(client.isChannelEnabled("pb.amritsar", "whatsapp"));
+    }
+
+    @Test
+    void isChannelEnabled_noRecord_defaultsOff() {
+        resolveResponse.set("{\"configData\":null}");
+        assertFalse(client.isChannelEnabled("pb.amritsar", "whatsapp"));
+    }
+
+    @Test
+    void getEnabledChannels_sendsSearchContract_andParsesLowercasedCodes() throws Exception {
+        searchResponse.set("{\"configData\":["
+                + "{\"data\":{\"code\":\"WHATSAPP\",\"enabled\":true}},"
+                + "{\"data\":{\"code\":\"EMAIL\",\"enabled\":true}},"
+                + "{\"data\":{\"code\":\"SMS\",\"enabled\":false}}]}");
+
+        List<String> channels = client.getEnabledChannels("pb.amritsar");
+
+        assertEquals(List.of("whatsapp", "email"), channels);
+        // Verify the _search request matches config-service's ConfigDataSearchRequest contract.
+        JsonNode req = mapper.readTree(searchBody.get());
+        assertTrue(req.has("RequestInfo"));
+        JsonNode criteria = req.get("criteria");
+        assertEquals("NotificationChannel", criteria.get("schemaCode").asText());
+        assertEquals("pb.amritsar", criteria.get("tenantId").asText());
+        assertTrue(criteria.get("criteria").get("enabled").asBoolean());
+    }
+
+    @Test
+    void getEnabledChannels_noRecords_returnsEmpty() {
+        searchResponse.set("{\"configData\":[]}");
+        assertTrue(client.getEnabledChannels("pb.amritsar").isEmpty());
+    }
+}

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/service/ConfigServiceClientContractTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/service/ConfigServiceClientContractTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * legacy-fallback semantics, which the RestTemplate-mocked unit tests can't see.
  *
  * Contract mirrored from config-service models:
- *   _search request  : { RequestInfo, criteria:{ schemaCode, tenantId } }   (all records, no enabled filter)
+ *   _search request  : { RequestInfo, criteria:{ schemaCode, tenantId, isActive:true } }  (active records, no enabled filter)
  *   _search response : { configData:[ { data:{ code, enabled } }, ... ] }
  */
 public class ConfigServiceClientContractTest {
@@ -87,6 +87,7 @@ public class ConfigServiceClientContractTest {
         JsonNode criteria = req.get("criteria");
         assertEquals("NotificationChannel", criteria.get("schemaCode").asText());
         assertEquals("pb.amritsar", criteria.get("tenantId").asText());
+        assertTrue(criteria.get("isActive").asBoolean());   // active records only (matches _resolve)
         assertFalse(criteria.has("criteria"));
     }
 

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/service/ConfigServiceClientContractTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/service/ConfigServiceClientContractTest.java
@@ -17,45 +17,33 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * On-the-wire contract test for the NotificationChannel calls. Runs the REAL ConfigServiceClient
- * (real RestTemplate, real JSON serialization, real HTTP) against a local stub that mimics
- * digit-config-service's _resolve / _search contract. Catches request-shape / parsing drift that
- * the RestTemplate-mocked unit tests can't see.
+ * On-the-wire contract test for the NotificationChannel lookup. Runs the REAL ConfigServiceClient
+ * (real RestTemplate, real JSON, real HTTP) against a local stub that mimics digit-config-service's
+ * _search contract — verifying the request shape the bridge emits and its response parsing /
+ * legacy-fallback semantics, which the RestTemplate-mocked unit tests can't see.
  *
  * Contract mirrored from config-service models:
- *   _resolve request : { RequestInfo, resolveRequest:{ schemaCode, tenantId, criteria } }
- *   _resolve response: { configData:{ ..., data:{...} } }
- *   _search request  : { RequestInfo, criteria:{ schemaCode, tenantId, criteria } }
- *   _search response : { configData:[ { data:{...} }, ... ] }
+ *   _search request  : { RequestInfo, criteria:{ schemaCode, tenantId } }   (all records, no enabled filter)
+ *   _search response : { configData:[ { data:{ code, enabled } }, ... ] }
  */
 public class ConfigServiceClientContractTest {
 
-    private static final String RESOLVE_PATH = "/config-service/config/v1/_resolve";
     private static final String SEARCH_PATH = "/config-service/config/v1/_search";
 
     private final ObjectMapper mapper = new ObjectMapper();
     private HttpServer server;
     private ConfigServiceClient client;
 
-    private final AtomicReference<String> resolveBody = new AtomicReference<>();
     private final AtomicReference<String> searchBody = new AtomicReference<>();
-    private final AtomicReference<String> resolveResponse = new AtomicReference<>("{\"configData\":null}");
     private final AtomicReference<String> searchResponse = new AtomicReference<>("{\"configData\":[]}");
 
     @BeforeEach
     void setUp() throws IOException {
         server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
-        server.createContext(RESOLVE_PATH, exchange -> {
-            resolveBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
-            byte[] out = resolveResponse.get().getBytes(StandardCharsets.UTF_8);
-            exchange.getResponseHeaders().set("Content-Type", "application/json");
-            exchange.sendResponseHeaders(200, out.length);
-            exchange.getResponseBody().write(out);
-            exchange.close();
-        });
         server.createContext(SEARCH_PATH, exchange -> {
             searchBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
             byte[] out = searchResponse.get().getBytes(StandardCharsets.UTF_8);
@@ -69,7 +57,6 @@ public class ConfigServiceClientContractTest {
         int port = server.getAddress().getPort();
         NovuBridgeConfiguration config = new NovuBridgeConfiguration();
         config.setConfigHost("http://127.0.0.1:" + port);
-        config.setConfigResolvePath(RESOLVE_PATH);
         config.setConfigSearchPath(SEARCH_PATH);
         client = new ConfigServiceClient(new RestTemplate(), config);
     }
@@ -80,37 +67,8 @@ public class ConfigServiceClientContractTest {
     }
 
     @Test
-    void isChannelEnabled_sendsResolveContract_andParsesEnabled() throws Exception {
-        resolveResponse.set("{\"ResponseInfo\":{},\"configData\":{\"tenantId\":\"pb.amritsar\","
-                + "\"schemaCode\":\"NotificationChannel\",\"data\":{\"code\":\"WHATSAPP\",\"name\":\"WhatsApp\",\"enabled\":true}}}");
-
-        boolean enabled = client.isChannelEnabled("pb.amritsar", "whatsapp");
-
-        assertTrue(enabled);
-        // Verify the exact request the bridge put on the wire matches config-service's _resolve contract.
-        JsonNode req = mapper.readTree(resolveBody.get());
-        assertTrue(req.has("RequestInfo"));
-        JsonNode rr = req.get("resolveRequest");
-        assertEquals("NotificationChannel", rr.get("schemaCode").asText());
-        assertEquals("pb.amritsar", rr.get("tenantId").asText());
-        assertEquals("WHATSAPP", rr.get("criteria").get("code").asText()); // lowercased channel -> uppercase code
-    }
-
-    @Test
-    void isChannelEnabled_disabledRecord_parsesFalse() {
-        resolveResponse.set("{\"configData\":{\"data\":{\"code\":\"WHATSAPP\",\"enabled\":false}}}");
-        assertFalse(client.isChannelEnabled("pb.amritsar", "whatsapp"));
-    }
-
-    @Test
-    void isChannelEnabled_noRecord_defaultsOff() {
-        resolveResponse.set("{\"configData\":null}");
-        assertFalse(client.isChannelEnabled("pb.amritsar", "whatsapp"));
-    }
-
-    @Test
-    void getEnabledChannels_sendsSearchContract_andParsesLowercasedCodes() throws Exception {
-        searchResponse.set("{\"configData\":["
+    void getEnabledChannels_sendsSearchContract_andParsesEnabledLowercased() throws Exception {
+        searchResponse.set("{\"ResponseInfo\":{},\"configData\":["
                 + "{\"data\":{\"code\":\"WHATSAPP\",\"enabled\":true}},"
                 + "{\"data\":{\"code\":\"EMAIL\",\"enabled\":true}},"
                 + "{\"data\":{\"code\":\"SMS\",\"enabled\":false}}]}");
@@ -118,18 +76,25 @@ public class ConfigServiceClientContractTest {
         List<String> channels = client.getEnabledChannels("pb.amritsar");
 
         assertEquals(List.of("whatsapp", "email"), channels);
-        // Verify the _search request matches config-service's ConfigDataSearchRequest contract.
+        // Verify the _search request matches config-service's ConfigDataSearchRequest contract,
+        // fetching ALL records (no enabled filter) so the caller can detect "unconfigured".
         JsonNode req = mapper.readTree(searchBody.get());
         assertTrue(req.has("RequestInfo"));
         JsonNode criteria = req.get("criteria");
         assertEquals("NotificationChannel", criteria.get("schemaCode").asText());
         assertEquals("pb.amritsar", criteria.get("tenantId").asText());
-        assertTrue(criteria.get("criteria").get("enabled").asBoolean());
+        assertFalse(criteria.has("criteria"));
     }
 
     @Test
-    void getEnabledChannels_noRecords_returnsEmpty() {
+    void getEnabledChannels_noRecords_returnsNullForLegacyFallback() {
         searchResponse.set("{\"configData\":[]}");
+        assertNull(client.getEnabledChannels("pb.amritsar"));
+    }
+
+    @Test
+    void getEnabledChannels_configuredButAllDisabled_returnsEmptyList() {
+        searchResponse.set("{\"configData\":[{\"data\":{\"code\":\"WHATSAPP\",\"enabled\":false}}]}");
         assertTrue(client.getEnabledChannels("pb.amritsar").isEmpty());
     }
 }

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/service/ConfigServiceClientContractTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/service/ConfigServiceClientContractTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.HttpServer;
 import org.egov.novubridge.config.NovuBridgeConfiguration;
+import org.egov.tracer.model.CustomException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,11 +14,13 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -40,6 +43,7 @@ public class ConfigServiceClientContractTest {
 
     private final AtomicReference<String> searchBody = new AtomicReference<>();
     private final AtomicReference<String> searchResponse = new AtomicReference<>("{\"configData\":[]}");
+    private final AtomicInteger searchStatus = new AtomicInteger(200);
 
     @BeforeEach
     void setUp() throws IOException {
@@ -48,7 +52,7 @@ public class ConfigServiceClientContractTest {
             searchBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
             byte[] out = searchResponse.get().getBytes(StandardCharsets.UTF_8);
             exchange.getResponseHeaders().set("Content-Type", "application/json");
-            exchange.sendResponseHeaders(200, out.length);
+            exchange.sendResponseHeaders(searchStatus.get(), out.length);
             exchange.getResponseBody().write(out);
             exchange.close();
         });
@@ -96,5 +100,13 @@ public class ConfigServiceClientContractTest {
     void getEnabledChannels_configuredButAllDisabled_returnsEmptyList() {
         searchResponse.set("{\"configData\":[{\"data\":{\"code\":\"WHATSAPP\",\"enabled\":false}}]}");
         assertTrue(client.getEnabledChannels("pb.amritsar").isEmpty());
+    }
+
+    @Test
+    void getEnabledChannels_serverError_throwsForRetry() {
+        // A real 5xx from config-service must propagate (retry/DLQ), not be read as "unconfigured".
+        searchStatus.set(500);
+        searchResponse.set("{\"error\":\"boom\"}");
+        assertThrows(CustomException.class, () -> client.getEnabledChannels("pb.amritsar"));
     }
 }

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/service/ConfigServiceClientTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/service/ConfigServiceClientTest.java
@@ -1,0 +1,95 @@
+package org.egov.novubridge.service;
+
+import org.egov.novubridge.config.NovuBridgeConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the tenant-level channel toggle ({@link ConfigServiceClient#isChannelEnabled}).
+ * Verifies the default-OFF / fail-closed contract that gates dispatch.
+ */
+public class ConfigServiceClientTest {
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    private NovuBridgeConfiguration config;
+    private ConfigServiceClient client;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        config = new NovuBridgeConfiguration();
+        config.setConfigHost("http://config-service");
+        config.setConfigResolvePath("/config-service/config/v1/_resolve");
+        client = new ConfigServiceClient(restTemplate, config);
+    }
+
+    private void stubResolve(ResponseEntity<Map> response) {
+        when(restTemplate.exchange(any(String.class), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(response);
+    }
+
+    @Test
+    void enabledRecord_returnsTrue() {
+        Map<String, Object> body = Map.of("configData", Map.of("data", Map.of("code", "WHATSAPP", "enabled", true)));
+        stubResolve(new ResponseEntity<>(body, HttpStatus.OK));
+
+        assertTrue(client.isChannelEnabled("pb.amritsar", "whatsapp"));
+    }
+
+    @Test
+    void disabledRecord_returnsFalse() {
+        Map<String, Object> body = Map.of("configData", Map.of("data", Map.of("code", "WHATSAPP", "enabled", false)));
+        stubResolve(new ResponseEntity<>(body, HttpStatus.OK));
+
+        assertFalse(client.isChannelEnabled("pb.amritsar", "whatsapp"));
+    }
+
+    @Test
+    void noRecord_defaultsOff() {
+        // config-service returns 200 with no configData -> tenant never opted in
+        stubResolve(new ResponseEntity<>(Map.of(), HttpStatus.OK));
+
+        assertFalse(client.isChannelEnabled("pb.amritsar", "whatsapp"));
+    }
+
+    @Test
+    void lookupThrows_failsClosed() {
+        when(restTemplate.exchange(any(String.class), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class)))
+                .thenThrow(new RuntimeException("config-service unreachable"));
+
+        assertFalse(client.isChannelEnabled("pb.amritsar", "whatsapp"));
+    }
+
+    @Test
+    void normalisesLowercaseChannelToUppercaseCode() {
+        Map<String, Object> body = Map.of("configData", Map.of("data", Map.of("code", "WHATSAPP", "enabled", true)));
+        ArgumentCaptor<HttpEntity> captor = ArgumentCaptor.forClass(HttpEntity.class);
+        when(restTemplate.exchange(any(String.class), eq(HttpMethod.POST), captor.capture(), eq(Map.class)))
+                .thenReturn(new ResponseEntity<>(body, HttpStatus.OK));
+
+        client.isChannelEnabled("pb.amritsar", "whatsapp");
+
+        Map<String, Object> sent = (Map<String, Object>) captor.getValue().getBody();
+        Map<String, Object> resolveRequest = (Map<String, Object>) sent.get("resolveRequest");
+        Map<String, Object> criteria = (Map<String, Object>) resolveRequest.get("criteria");
+        assertTrue("WHATSAPP".equals(criteria.get("code")));
+    }
+}

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/service/ConfigServiceClientTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/service/ConfigServiceClientTest.java
@@ -12,18 +12,21 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 /**
- * Unit tests for the tenant-level channel toggle ({@link ConfigServiceClient#isChannelEnabled}).
- * Verifies the default-OFF / fail-closed contract that gates dispatch.
+ * Unit tests for the tenant channel config lookup ({@link ConfigServiceClient#getEnabledChannels}).
+ * Verifies the legacy-fallback contract: null = unconfigured (caller falls back to the allow-list),
+ * list = the enabled codes (empty when everything is explicitly disabled).
  */
 public class ConfigServiceClientTest {
 
@@ -43,83 +46,65 @@ public class ConfigServiceClientTest {
         client = new ConfigServiceClient(restTemplate, config);
     }
 
-    private void stubResolve(ResponseEntity<Map> response) {
+    private void stubSearch(ResponseEntity<Map> response) {
         when(restTemplate.exchange(any(String.class), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class)))
                 .thenReturn(response);
     }
 
     @Test
-    void enabledRecord_returnsTrue() {
-        Map<String, Object> body = Map.of("configData", Map.of("data", Map.of("code", "WHATSAPP", "enabled", true)));
-        stubResolve(new ResponseEntity<>(body, HttpStatus.OK));
+    void getEnabledChannels_returnsEnabledCodesLowercased() {
+        Map<String, Object> body = Map.of("configData", List.of(
+                Map.of("data", Map.of("code", "WHATSAPP", "enabled", true)),
+                Map.of("data", Map.of("code", "SMS", "enabled", false)),     // filtered out
+                Map.of("data", Map.of("code", "EMAIL", "enabled", true))));
+        stubSearch(new ResponseEntity<>(body, HttpStatus.OK));
 
-        assertTrue(client.isChannelEnabled("pb.amritsar", "whatsapp"));
+        assertEquals(List.of("whatsapp", "email"), client.getEnabledChannels("pb.amritsar"));
     }
 
     @Test
-    void disabledRecord_returnsFalse() {
-        Map<String, Object> body = Map.of("configData", Map.of("data", Map.of("code", "WHATSAPP", "enabled", false)));
-        stubResolve(new ResponseEntity<>(body, HttpStatus.OK));
+    void getEnabledChannels_configuredButAllDisabled_returnsEmptyList() {
+        Map<String, Object> body = Map.of("configData", List.of(
+                Map.of("data", Map.of("code", "WHATSAPP", "enabled", false))));
+        stubSearch(new ResponseEntity<>(body, HttpStatus.OK));
 
-        assertFalse(client.isChannelEnabled("pb.amritsar", "whatsapp"));
+        // Configured (records exist) but nothing enabled -> empty list, NOT null (no legacy fallback).
+        assertTrue(client.getEnabledChannels("pb.amritsar").isEmpty());
     }
 
     @Test
-    void noRecord_defaultsOff() {
-        // config-service returns 200 with no configData -> tenant never opted in
-        stubResolve(new ResponseEntity<>(Map.of(), HttpStatus.OK));
+    void getEnabledChannels_noRecords_returnsNullForLegacyFallback() {
+        stubSearch(new ResponseEntity<>(Map.of(), HttpStatus.OK));         // no configData
+        assertNull(client.getEnabledChannels("pb.amritsar"));
 
-        assertFalse(client.isChannelEnabled("pb.amritsar", "whatsapp"));
+        stubSearch(new ResponseEntity<>(Map.of("configData", List.of()), HttpStatus.OK)); // empty list
+        assertNull(client.getEnabledChannels("pb.amritsar"));
     }
 
     @Test
-    void lookupThrows_failsClosed() {
+    void getEnabledChannels_lookupThrows_returnsNullForLegacyFallback() {
         when(restTemplate.exchange(any(String.class), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class)))
                 .thenThrow(new RuntimeException("config-service unreachable"));
 
-        assertFalse(client.isChannelEnabled("pb.amritsar", "whatsapp"));
+        // Favour delivery on a transient error: fall back to legacy (null), not drop.
+        assertNull(client.getEnabledChannels("pb.amritsar"));
     }
 
     @Test
-    void normalisesLowercaseChannelToUppercaseCode() {
-        Map<String, Object> body = Map.of("configData", Map.of("data", Map.of("code", "WHATSAPP", "enabled", true)));
+    void getEnabledChannels_searchRequestHasNoEnabledFilter() {
+        Map<String, Object> body = Map.of("configData", List.of(
+                Map.of("data", Map.of("code", "WHATSAPP", "enabled", true))));
         ArgumentCaptor<HttpEntity> captor = ArgumentCaptor.forClass(HttpEntity.class);
         when(restTemplate.exchange(any(String.class), eq(HttpMethod.POST), captor.capture(), eq(Map.class)))
                 .thenReturn(new ResponseEntity<>(body, HttpStatus.OK));
 
-        client.isChannelEnabled("pb.amritsar", "whatsapp");
+        client.getEnabledChannels("pb.amritsar");
 
         Map<String, Object> sent = (Map<String, Object>) captor.getValue().getBody();
-        Map<String, Object> resolveRequest = (Map<String, Object>) sent.get("resolveRequest");
-        Map<String, Object> criteria = (Map<String, Object>) resolveRequest.get("criteria");
-        assertTrue("WHATSAPP".equals(criteria.get("code")));
-    }
-
-    @Test
-    void getEnabledChannels_returnsEnabledCodesLowercased() {
-        Map<String, Object> body = Map.of("configData", java.util.List.of(
-                Map.of("data", Map.of("code", "WHATSAPP", "enabled", true)),
-                Map.of("data", Map.of("code", "SMS", "enabled", false)),   // filtered out
-                Map.of("data", Map.of("code", "EMAIL", "enabled", true))));
-        stubResolve(new ResponseEntity<>(body, HttpStatus.OK));
-
-        java.util.List<String> channels = client.getEnabledChannels("pb.amritsar");
-
-        assertEquals(java.util.List.of("whatsapp", "email"), channels);
-    }
-
-    @Test
-    void getEnabledChannels_noRecords_returnsEmpty() {
-        stubResolve(new ResponseEntity<>(Map.of(), HttpStatus.OK));
-
-        assertTrue(client.getEnabledChannels("pb.amritsar").isEmpty());
-    }
-
-    @Test
-    void getEnabledChannels_lookupThrows_failsClosed() {
-        when(restTemplate.exchange(any(String.class), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class)))
-                .thenThrow(new RuntimeException("config-service unreachable"));
-
-        assertTrue(client.getEnabledChannels("pb.amritsar").isEmpty());
+        Map<String, Object> criteria = (Map<String, Object>) sent.get("criteria");
+        assertEquals("NotificationChannel", criteria.get("schemaCode"));
+        assertEquals("pb.amritsar", criteria.get("tenantId"));
+        // We fetch ALL records (to detect "unconfigured"), so no enabled filter is sent.
+        assertFalse(criteria.containsKey("criteria"));
     }
 }

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/service/ConfigServiceClientTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/service/ConfigServiceClientTest.java
@@ -1,6 +1,7 @@
 package org.egov.novubridge.service;
 
 import org.egov.novubridge.config.NovuBridgeConfiguration;
+import org.egov.tracer.model.CustomException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -18,6 +19,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -82,12 +84,19 @@ public class ConfigServiceClientTest {
     }
 
     @Test
-    void getEnabledChannels_lookupThrows_returnsNullForLegacyFallback() {
+    void getEnabledChannels_lookupThrows_propagatesForRetry() {
         when(restTemplate.exchange(any(String.class), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class)))
                 .thenThrow(new RuntimeException("config-service unreachable"));
 
-        // Favour delivery on a transient error: fall back to legacy (null), not drop.
-        assertNull(client.getEnabledChannels("pb.amritsar"));
+        // A hard error must NOT be confused with "unconfigured": throw so the event is retried/DLQ'd
+        // rather than silently falling back (which would ignore an explicit disable) or dropping.
+        assertThrows(CustomException.class, () -> client.getEnabledChannels("pb.amritsar"));
+    }
+
+    @Test
+    void getEnabledChannels_nonSuccessResponse_throws() {
+        stubSearch(new ResponseEntity<>(Map.of(), HttpStatus.INTERNAL_SERVER_ERROR));
+        assertThrows(CustomException.class, () -> client.getEnabledChannels("pb.amritsar"));
     }
 
     @Test

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/service/ConfigServiceClientTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/service/ConfigServiceClientTest.java
@@ -100,7 +100,7 @@ public class ConfigServiceClientTest {
     }
 
     @Test
-    void getEnabledChannels_searchRequestHasNoEnabledFilter() {
+    void getEnabledChannels_searchRequestFiltersActiveOnly_noEnabledFilter() {
         Map<String, Object> body = Map.of("configData", List.of(
                 Map.of("data", Map.of("code", "WHATSAPP", "enabled", true))));
         ArgumentCaptor<HttpEntity> captor = ArgumentCaptor.forClass(HttpEntity.class);
@@ -113,7 +113,9 @@ public class ConfigServiceClientTest {
         Map<String, Object> criteria = (Map<String, Object>) sent.get("criteria");
         assertEquals("NotificationChannel", criteria.get("schemaCode"));
         assertEquals("pb.amritsar", criteria.get("tenantId"));
-        // We fetch ALL records (to detect "unconfigured"), so no enabled filter is sent.
+        // Filters to ACTIVE records (so soft-deleted rows don't count as "configured"),
+        // but still no enabled filter (we need all active records to detect "all disabled").
+        assertEquals(Boolean.TRUE, criteria.get("isActive"));
         assertFalse(criteria.containsKey("criteria"));
     }
 }

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/service/ConfigServiceClientTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/service/ConfigServiceClientTest.java
@@ -14,6 +14,7 @@ import org.springframework.web.client.RestTemplate;
 
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -38,6 +39,7 @@ public class ConfigServiceClientTest {
         config = new NovuBridgeConfiguration();
         config.setConfigHost("http://config-service");
         config.setConfigResolvePath("/config-service/config/v1/_resolve");
+        config.setConfigSearchPath("/config-service/config/v1/_search");
         client = new ConfigServiceClient(restTemplate, config);
     }
 
@@ -91,5 +93,33 @@ public class ConfigServiceClientTest {
         Map<String, Object> resolveRequest = (Map<String, Object>) sent.get("resolveRequest");
         Map<String, Object> criteria = (Map<String, Object>) resolveRequest.get("criteria");
         assertTrue("WHATSAPP".equals(criteria.get("code")));
+    }
+
+    @Test
+    void getEnabledChannels_returnsEnabledCodesLowercased() {
+        Map<String, Object> body = Map.of("configData", java.util.List.of(
+                Map.of("data", Map.of("code", "WHATSAPP", "enabled", true)),
+                Map.of("data", Map.of("code", "SMS", "enabled", false)),   // filtered out
+                Map.of("data", Map.of("code", "EMAIL", "enabled", true))));
+        stubResolve(new ResponseEntity<>(body, HttpStatus.OK));
+
+        java.util.List<String> channels = client.getEnabledChannels("pb.amritsar");
+
+        assertEquals(java.util.List.of("whatsapp", "email"), channels);
+    }
+
+    @Test
+    void getEnabledChannels_noRecords_returnsEmpty() {
+        stubResolve(new ResponseEntity<>(Map.of(), HttpStatus.OK));
+
+        assertTrue(client.getEnabledChannels("pb.amritsar").isEmpty());
+    }
+
+    @Test
+    void getEnabledChannels_lookupThrows_failsClosed() {
+        when(restTemplate.exchange(any(String.class), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class)))
+                .thenThrow(new RuntimeException("config-service unreachable"));
+
+        assertTrue(client.getEnabledChannels("pb.amritsar").isEmpty());
     }
 }

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/service/DispatchPipelineServiceMultiChannelTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/service/DispatchPipelineServiceMultiChannelTest.java
@@ -1,0 +1,121 @@
+package org.egov.novubridge.service;
+
+import org.egov.novubridge.config.NovuBridgeConfiguration;
+import org.egov.novubridge.repository.DispatchLogRepository;
+import org.egov.novubridge.web.models.ComplaintsDomainEvent;
+import org.egov.novubridge.web.models.DispatchResult;
+import org.egov.novubridge.web.models.ResolvedProvider;
+import org.egov.novubridge.web.models.ResolvedTemplate;
+import org.egov.novubridge.web.models.Stakeholder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Multi-channel dispatch behaviour ({@link DispatchPipelineService#processEnabledChannels}):
+ * per-channel isolation, the global allow-list guard, and the default-off outcome.
+ */
+public class DispatchPipelineServiceMultiChannelTest {
+
+    @Mock private EnvelopeValidator envelopeValidator;
+    @Mock private PreferenceServiceClient preferenceServiceClient;
+    @Mock private UserServiceClient userServiceClient;
+    @Mock private ConfigServiceClient configServiceClient;
+    @Mock private NovuClient novuClient;
+    @Mock private DispatchLogRepository dispatchLogRepository;
+    @Mock private MdmsServiceClient mdmsServiceClient;
+
+    private NovuBridgeConfiguration config;
+    private DispatchPipelineService service;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        config = new NovuBridgeConfiguration();
+        config.setChannel("whatsapp,sms");     // both channels globally allowed by default
+        config.setDefaultLocale("en_IN");
+        service = new DispatchPipelineService(envelopeValidator, preferenceServiceClient, userServiceClient,
+                configServiceClient, novuClient, dispatchLogRepository, config, mdmsServiceClient);
+    }
+
+    private ComplaintsDomainEvent event() {
+        return ComplaintsDomainEvent.builder()
+                .eventId("evt-1").eventName("complaint-resolved").tenantId("pb.amritsar").module("PGR")
+                // mobile is already E.164 so formatRecipientPhone needs no MDMS lookup
+                .stakeholders(List.of(Stakeholder.builder().type("CITIZEN").userId("u1").mobile("+254700000000").build()))
+                .data(Map.of("complaintNo", "PGR-1"))
+                .build();
+    }
+
+    private void stubHappyRecipient() {
+        when(userServiceClient.resolveUserUuid(any(), any(), any(), any())).thenReturn("uuid-1");
+        when(preferenceServiceClient.getUserPreferredLocale(any(), any(), any())).thenReturn("en_IN");
+        when(preferenceServiceClient.isChannelAllowed(any(), any(), any(), any())).thenReturn(true);
+        when(configServiceClient.resolveTemplate(any(), any(), any(), any()))
+                .thenReturn(ResolvedTemplate.builder().templateKey("tk").build());
+    }
+
+    @Test
+    void oneChannelFailing_doesNotBlockTheOther() {
+        when(configServiceClient.getEnabledChannels("pb.amritsar")).thenReturn(List.of("whatsapp", "sms"));
+        stubHappyRecipient();
+
+        // whatsapp has a provider; sms has none -> NB_NO_ACTIVE_PROVIDER, caught per channel
+        when(configServiceClient.resolveProvidersByChannel("pb.amritsar", "whatsapp"))
+                .thenReturn(List.of(ResolvedProvider.builder().providerName("twilio").channel("whatsapp").build()));
+        when(configServiceClient.resolveProvidersByChannel("pb.amritsar", "sms"))
+                .thenReturn(List.of());
+        when(novuClient.triggerWithProviderConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(NovuClient.NovuResponse.builder().statusCode(201).response(Map.of("ok", true)).build());
+
+        List<DispatchResult> results = service.processEnabledChannels(event(), true, null);
+
+        assertEquals(2, results.size());
+        DispatchResult whatsapp = results.get(0);
+        DispatchResult sms = results.get(1);
+        assertEquals(Boolean.TRUE, whatsapp.getNovuTriggered(), "whatsapp should have dispatched");
+        assertEquals(Boolean.FALSE, sms.getNovuTriggered(), "sms should not have dispatched");
+        assertEquals(Boolean.FALSE, sms.getValid(), "sms should be marked failed");
+        // exactly one Novu trigger fired (whatsapp); sms never reached Novu
+        verify(novuClient, times(1)).triggerWithProviderConfig(any(), any(), any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void noEnabledChannels_dispatchesNothing() {
+        when(configServiceClient.getEnabledChannels("pb.amritsar")).thenReturn(List.of());
+
+        List<DispatchResult> results = service.processEnabledChannels(event(), true, null);
+
+        assertTrue(results.isEmpty());
+        verifyNoInteractions(novuClient);
+    }
+
+    @Test
+    void globalAllowList_excludesChannelNotAllowed() {
+        config.setChannel("whatsapp");   // sms NOT globally allowed, even though tenant enabled it
+        when(configServiceClient.getEnabledChannels("pb.amritsar")).thenReturn(List.of("whatsapp", "sms"));
+        stubHappyRecipient();
+        when(configServiceClient.resolveProvidersByChannel("pb.amritsar", "whatsapp"))
+                .thenReturn(List.of(ResolvedProvider.builder().providerName("twilio").channel("whatsapp").build()));
+        when(novuClient.triggerWithProviderConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(NovuClient.NovuResponse.builder().statusCode(201).response(Map.of()).build());
+
+        List<DispatchResult> results = service.processEnabledChannels(event(), true, null);
+
+        assertEquals(1, results.size());   // only whatsapp dispatched
+        verify(configServiceClient, never()).resolveProvidersByChannel("pb.amritsar", "sms");
+    }
+}

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/service/DispatchPipelineServiceMultiChannelTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/service/DispatchPipelineServiceMultiChannelTest.java
@@ -94,13 +94,32 @@ public class DispatchPipelineServiceMultiChannelTest {
     }
 
     @Test
-    void noEnabledChannels_dispatchesNothing() {
+    void configuredButAllDisabled_dispatchesNothing() {
+        // Empty list (not null) = the tenant has config but every channel is disabled -> no fallback.
         when(configServiceClient.getEnabledChannels("pb.amritsar")).thenReturn(List.of());
 
         List<DispatchResult> results = service.processEnabledChannels(event(), true, null);
 
         assertTrue(results.isEmpty());
         verifyNoInteractions(novuClient);
+    }
+
+    @Test
+    void unconfiguredTenant_fallsBackToAllowList() {
+        config.setChannel("whatsapp");   // global allow-list
+        // null = the tenant has NO NotificationChannel config -> legacy fallback to the allow-list.
+        when(configServiceClient.getEnabledChannels("pb.amritsar")).thenReturn(null);
+        stubHappyRecipient();
+        when(configServiceClient.resolveProvidersByChannel("pb.amritsar", "whatsapp"))
+                .thenReturn(List.of(ResolvedProvider.builder().providerName("twilio").channel("whatsapp").build()));
+        when(novuClient.triggerWithProviderConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(NovuClient.NovuResponse.builder().statusCode(201).response(Map.of()).build());
+
+        List<DispatchResult> results = service.processEnabledChannels(event(), true, null);
+
+        assertEquals(1, results.size());
+        assertEquals(Boolean.TRUE, results.get(0).getNovuTriggered(), "unconfigured tenant should dispatch on the allow-list");
+        verify(configServiceClient).resolveProvidersByChannel("pb.amritsar", "whatsapp");
     }
 
     @Test

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/service/DispatchPipelineServiceMultiChannelTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/service/DispatchPipelineServiceMultiChannelTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -68,6 +69,27 @@ public class DispatchPipelineServiceMultiChannelTest {
         when(preferenceServiceClient.isChannelAllowed(any(), any(), any(), any())).thenReturn(true);
         when(configServiceClient.resolveTemplate(any(), any(), any(), any()))
                 .thenReturn(ResolvedTemplate.builder().templateKey("tk").build());
+    }
+
+    @Test
+    void unexpectedErrorOnOneChannel_isIsolatedNotBubbled() {
+        // An UNEXPECTED (non-CustomException) error on one channel must be caught per-channel (FAILED),
+        // not bubble out and re-queue the whole event — which would re-send the channel that succeeded.
+        when(configServiceClient.getEnabledChannels("pb.amritsar")).thenReturn(List.of("whatsapp", "sms"));
+        stubHappyRecipient();
+        when(configServiceClient.resolveProvidersByChannel(eq("pb.amritsar"), any()))
+                .thenReturn(List.of(ResolvedProvider.builder().providerName("twilio").build()));
+        // first channel (whatsapp) succeeds, second (sms) throws an unexpected runtime error
+        when(novuClient.triggerWithProviderConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(NovuClient.NovuResponse.builder().statusCode(201).response(Map.of()).build())
+                .thenThrow(new RuntimeException("twilio SDK blew up"));
+
+        // must NOT throw out of processEnabledChannels
+        List<DispatchResult> results = service.processEnabledChannels(event(), true, null);
+
+        assertEquals(2, results.size());
+        assertEquals(Boolean.TRUE, results.get(0).getNovuTriggered(), "whatsapp should have dispatched");
+        assertEquals(Boolean.FALSE, results.get(1).getValid(), "sms should be isolated as failed");
     }
 
     @Test

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/service/DispatchPipelineServiceMultiChannelTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/service/DispatchPipelineServiceMultiChannelTest.java
@@ -7,6 +7,7 @@ import org.egov.novubridge.web.models.DispatchResult;
 import org.egov.novubridge.web.models.ResolvedProvider;
 import org.egov.novubridge.web.models.ResolvedTemplate;
 import org.egov.novubridge.web.models.Stakeholder;
+import org.egov.tracer.model.CustomException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -16,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -101,6 +103,17 @@ public class DispatchPipelineServiceMultiChannelTest {
         List<DispatchResult> results = service.processEnabledChannels(event(), true, null);
 
         assertTrue(results.isEmpty());
+        verifyNoInteractions(novuClient);
+    }
+
+    @Test
+    void configLookupError_propagatesToDlq() {
+        // A hard config-service error throws (not null/legacy), so the event hits the consumer's DLQ
+        // path instead of being silently dropped or wrongly falling back over an explicit disable.
+        when(configServiceClient.getEnabledChannels("pb.amritsar"))
+                .thenThrow(new CustomException("NB_CHANNEL_CONFIG_SEARCH_FAILED", "down"));
+
+        assertThrows(CustomException.class, () -> service.processEnabledChannels(event(), true, null));
         verifyNoInteractions(novuClient);
     }
 

--- a/local-setup/db/notif-mdms-seed/schemas/NotificationChannel.json
+++ b/local-setup/db/notif-mdms-seed/schemas/NotificationChannel.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "NotificationChannel",
+  "description": "Available notification channels and their tenant-level configuration",
+  "required": [
+    "code",
+    "name",
+    "enabled"
+  ],
+  "x-unique": [
+    "code"
+  ],
+  "properties": {
+    "code": {
+      "type": "string",
+      "enum": [
+        "WHATSAPP",
+        "SMS",
+        "EMAIL"
+      ],
+      "description": "Channel identifier"
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-readable channel name"
+    },
+    "enabled": {
+      "type": "boolean",
+      "description": "Whether this channel is active for the tenant"
+    },
+    "providerName": {
+      "type": "string",
+      "description": "Provider handling this channel (links to ProviderDetail)"
+    },
+    "priority": {
+      "type": "integer",
+      "description": "Dispatch priority (lower = higher priority)"
+    }
+  },
+  "additionalProperties": true
+}

--- a/local-setup/db/notif-mdms-seed/seed.sh
+++ b/local-setup/db/notif-mdms-seed/seed.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-# Seeds notification MDMS schemas + per-tenant TemplateBinding /
-# ProviderDetail records into a running DIGIT.
+# Seeds notification MDMS schemas (TemplateBinding, ProviderDetail,
+# NotificationChannel) + per-tenant TemplateBinding / ProviderDetail
+# records into a running DIGIT. NotificationChannel registers the schema
+# only — channel enable/disable is set per tenant (default OFF) via the
+# onboarding UI, not seeded here.
 #
 # Architectural note: novu-bridge resolves templates by calling
 # digit-config-service, which has its OWN postgres table
@@ -68,7 +71,7 @@ echo "    got userInfo: ${USERINFO_JSON:0:60}..."
 # config-service validates against the schema registered here on
 # every `_create`. The schemas are tenant-agnostic — register at
 # root only.
-for schema in TemplateBinding ProviderDetail; do
+for schema in TemplateBinding ProviderDetail NotificationChannel; do
   echo "==> Registering schema: $schema"
   body="$(jq -cn \
     --arg code "$schema" \

--- a/local-setup/db/notif-mdms-seed/seed.sh
+++ b/local-setup/db/notif-mdms-seed/seed.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 # Seeds notification MDMS schemas (TemplateBinding, ProviderDetail,
 # NotificationChannel) + per-tenant TemplateBinding / ProviderDetail
-# records into a running DIGIT. NotificationChannel registers the schema
-# only — channel enable/disable is set per tenant (default OFF) via the
-# onboarding UI, not seeded here.
+# records into a running DIGIT. NotificationChannel registers the SCHEMA
+# only — no per-tenant channel records are seeded here, so a tenant seeded
+# via this script has NO NotificationChannel config and the bridge falls
+# back to legacy behaviour (dispatch on the NOVU_BRIDGE_CHANNEL allow-list).
+# Set explicit per-channel enable/disable via the onboarding/Management UI
+# (tenants provisioned through default-data-handler get a disabled default).
 #
 # Architectural note: novu-bridge resolves templates by calling
 # digit-config-service, which has its OWN postgres table

--- a/utilities/default-data-handler/src/main/resources/configData/NotificationChannel.json
+++ b/utilities/default-data-handler/src/main/resources/configData/NotificationChannel.json
@@ -2,7 +2,7 @@
   {
     "code": "WHATSAPP",
     "name": "WhatsApp",
-    "enabled": true,
+    "enabled": false,
     "providerName": "twilio",
     "priority": 1
   }


### PR DESCRIPTION
Backend for **SaaS Comms Infra Setup** (#547). Makes the per-tenant `NotificationChannel` enable/disable real in `novu-bridge`, end to end. Pairs with the configurator UI in **#919** (which is inert until this ships).

## Problem
`NotificationChannel` config existed in `digit-config-service` but **nothing read it** — the bridge dispatched on a single deploy-time channel (`NOVU_BRIDGE_CHANNEL`) regardless. There was no per-tenant way to turn channels on/off.

## What this does
- **Per-tenant gate.** Dispatch resolves a tenant's enabled `NotificationChannel` codes from config-service and only sends on those.
- **Legacy fallback — no backfill needed.** Three distinct states:
  - *no records* → fall back to the deploy allow-list (`NOVU_BRIDGE_CHANNEL`) = pre-change behaviour, so **existing tenants keep working untouched**;
  - *records, all disabled* → dispatch nothing;
  - *config-service hard error* → throw → retry/DLQ (never a silent wrong-send or drop).
- **Multi-channel dispatch.** Fans out over `enabled ∩ allow-list`; a per-channel failure is isolated (recorded `FAILED`) so it never blocks sibling channels or re-sends ones that already succeeded.
- **Bounded retry + backoff before DLQ.** Transient failures re-queue on a **separate** retry `@KafkaListener` (`max.poll.records=1`, fixed backoff) up to `maxRetries`, then DLQ — so a brief config-service blip self-recovers without a manual replay, and the backoff never head-of-line-blocks live notifications.
- **Schema + default-off for new tenants.** `default-data-handler` registers the `NotificationChannel` schema per tenant and seeds a **disabled** default; `notif-mdms-seed` registers the schema for the local path (records not seeded → legacy fallback).

## Notable design decisions
- `null` (unconfigured) vs empty (all-disabled) vs throw (error) are kept strictly distinct so an outage can't be mistaken for "off".
- Diagnostic endpoints (`_validate`/`_dry-run`) are side-effect-free and don't 5xx on a config-service blip.
- Channel codes normalised lowercase end to end (schema enum is uppercase; provider/template channels are lowercase).

## Tests & build
- novu-bridge suite **23 green**: unit (gate states, multi-channel, per-channel isolation incl. unexpected-error), a **real-HTTP contract test** against config-service's `_resolve`/`_search`, and a Kafka retry **round-trip** test.
- `mvn package` produces deployable jars for `novu-bridge` and `default-data-handler` (NotificationChannel config + schema bundled).
- An independent adversarial review was applied — see PR comments (diagnostic side-effects, per-channel isolation, retry-listener safety, seed comment).

## Deploy / merge notes
- **#919 is inert until this is deployed** — the configurator toggles only take effect once the bridge honours them.
- The `NotificationChannel` schema registration ships here (via `default-data-handler`).
- Still environment-gated (post-merge): a live end-to-end (UI → config-service → event → `nb_dispatch_log`) and confirming the configurator user has config-service write permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)