### PR TITLE
docs(dashboard): RBAC + viz schema deep-design (Parts A–F, 65–90, #631)

### DIFF
--- a/docs/dashboard-rbac-design/00-requirements.md
+++ b/docs/dashboard-rbac-design/00-requirements.md
@@ -1,0 +1,137 @@
+# RBAC + ABAC for PGR Analytics — Requirements & Stage-Setting (Part 00)
+
+**Status:** v1, 2026-06-23 · **Scope:** the shared spec every later part (A–F) builds on.
+**Reads (graded by precedence):** `dashboard-query-api-design.md` §5/§5a (the layering model), `rbac-kpi-access-implementation-plan.md` (the grounded phase plan). This document is *requirements only* — it fixes the problem, the actors, the layers, the attribute model, the ownership split, the NFRs, the hazards, and the part graph. It does **not** design the Java or the SQL; that is Parts A–F.
+
+> **Grounding rule for this whole series:** every claim about current behaviour is anchored to a file:line that was actually read. No aspirational "the system does X" without an anchor. Where a thing is *missing*, that is stated as missing with the anchor showing the gap.
+
+---
+
+## 1. Problem statement — config + access control must move server-side
+
+The PGR analytics API (`POST /v2/analytics/_query`, `POST /v2/analytics/_schema`) computes KPIs over three denormalized grains. Today two things that must be authoritative live in the wrong place:
+
+1. **KPI definitions live client-side.** The dashboard FE *is* the catalog — query bodies are hardcoded in the bundle (`kpiQueries.js`), and the FE decides which tiles to render (design §5a, "Today vs Moves to" table). A client can read the bundle and POST any "hidden" KPI directly. **FE filtering is not access control.**
+
+2. **Identity is spoofable, so all access control built on it is theater.** The endpoint trusts whatever `RequestInfo.userInfo` arrives in the request body and does no token validation of its own:
+
+   - `AnalyticsController.query()` (`AnalyticsController.java:41–47`) reads the body, does `mapper.convertValue(body.get("RequestInfo"), RequestInfo.class)` at L43–44, and hands it straight to `service.query(...)` at L47. There is **no token check, no introspection, no rejection of an unsigned `userInfo`**.
+   - `AnalyticsScope.resolve()` (`AnalyticsScope.java:31–48`) derives the entire RBAC posture — citizen-vs-employee — purely from `requestInfo.getUserInfo()` (L34: `requestInfo.getUserInfo()`; L36 reads `u.getType()`; L39–42 reads `u.getRoles()`). Whatever role/type the caller writes into the body is believed verbatim. A body claiming `type:"EMPLOYEE"` with no `CITIZEN`-only role set escapes self-scope (L44: `if (isCitizen && !hasEmployeeRole) citizenUuid = u.getUuid();`).
+
+   The gateway is supposed to backfill `userInfo` from the opaque token, but its enrichment is **non-coercive and skippable**: the Kong `pre-function` (`kong.yml:49–82`) only acts on POST with a non-empty body (L56–58) and only when an `authToken` is present (L63–64) — and critically, **if the body already carries a populated `userInfo`, it returns early and does no validation** (`kong.yml:65–68`: `if ui["uuid"] or ui["id"] or ui["userName"] then return end`). So a caller who supplies their *own* `userInfo` (with no token at all, since L63's `token` guard simply `return`s) sails straight through to a service that trusts it. This is the "V2 auth gap."
+
+   Design §5a "Hard prerequisite": *"Layer-2/3 RBAC on an unauthenticated endpoint is theater… roles/jurisdiction/accountId are presently spoofable."* The implementation plan §0 records the same: *"endpoint trusts gateway `userInfo`, Kong route unauthenticated → spoofable."*
+
+**Therefore (the requirement):** KPI definitions move to MDMS (governed, no-deploy, design §3/§3a) and **access enforcement moves to the backend behind a trustworthy principal**. The FE becomes a thin renderer of whatever the authenticated, role-scoped backend returns (design §5a "authority moves to the backend").
+
+---
+
+## 2. Actors / personas
+
+| Persona | Identity source | May SEE | May DO |
+|---|---|---|---|
+| **Citizen** | `type=CITIZEN`, no employee role | only their own complaints | invoke a published `kpiId` with declared params; row-locked to `account_id = self`; **no inline queries**, no officer/PII dims |
+| **Ward / jurisdiction supervisor (GRO)** | employee + `GRO`; HRMS jurisdiction + dept | complaints in their boundary subtree (and dept, once dept-scoping ships) | invoke published KPIs incl. *approved* officer-leaderboard (bounded top-N); narrow within own scope; **no inline queries** |
+| **Department head** | employee + dept role; HRMS dept assignment | complaints for their department(s), across the tenant boundary (or intersected with a jurisdiction if also bounded) | same as supervisor but department- rather than ward-anchored |
+| **Tenant admin (`PGR_ADMIN`)** | employee + `PGR_ADMIN` | all boundaries/depts in the tenant | invoke any KPI in ceiling; **inline queries allowed**; author/publish KPI defs (governed, §3a); curate packs |
+| **Analyst / SUPERADMIN (`DSS_ANALYST`, `SUPERADMIN`)** | analyst/superadmin role | tenant-wide (SUPERADMIN cross-boundary in tenant) | inline ad-hoc exploration; all of admin's powers; the only personas with raw-grammar access |
+
+"What each may see" is two independent decisions: **which KPIs they may ask** (catalog ceiling) and **which rows come back** (row scope). They do not substitute for each other (§3).
+
+---
+
+## 3. The three orthogonal RBAC layers
+
+These are three different questions answered at three different points in the request lifecycle. Conflating them is the classic failure mode (design §5a). All three are **server-enforced**; none is an FE decision.
+
+**Layer 1 — Row scope ("which rows of the data are yours").** An injected `WHERE` predicate ANDed into every generated query, on every grain. Citizen → `account_id = :self`; supervisor/dept-head → attribute predicates (boundary subtree / department); admin → tenant-only. Enforced in `AnalyticsPlanner.applyScope()` (`AnalyticsPlanner.java:241–251`) — today it emits tenant scope (L242–245) and citizen self-scope (L246), and has the boundary-LIKE branch wired (L247–249) but never fed (the prefix is hardcoded `null` in `AnalyticsScope.java:47`). Enforcement point: **every generated query, after KPI-def materialization** (design §5a Layer 1).
+
+**Layer 2 — KPI catalog access ("which questions you may ask at all").** `rbac.visibleTo` (a role set) on each stored KPI def (design §3). Enforced at **two** points: discovery (`GET /catalog` returns only `visibleTo ∩ roles ≠ ∅`) **and** invocation (`POST /_query` re-checks `visibleTo` before planning → `403 kpi_forbidden`). The invocation re-check is the security boundary; discovery filtering is UX (design §5a Layer 2, "this re-check is the whole ballgame"). **Missing today** — no saved KPI defs exist yet (plan §0).
+
+**Layer 3 — Capability / grammar ("may you send raw inline queries").** A role gate at request parse, before planning. Only `PGR_ADMIN`/`DSS_ANALYST`/`SUPERADMIN` may POST inline `measures`/`dimensions`/`filters`; citizen/supervisor tokens may invoke published `kpiId`+declared params only → inline body rejected `403 inline_forbidden` (design §5, §5a Layer 3). **Missing today** (plan §0).
+
+Layer 1 and Layer 2 are independent: a KPI's `visibleTo` is the **security ceiling** (the max role set that may ever see it) and is never widened just because row scope returned empty (design §5a). A mis-authored dashboard pack that lists an out-of-ceiling KPI yields `403` on that tile, never a leak.
+
+---
+
+## 4. The attribute-scope model
+
+Row scope (Layer 1) is generalized from "boundary OR citizen" into **a list of ANDed attribute predicates**, each predicate matching one user attribute with OR-within (plan §1). This avoids special-casing `department` next to `boundary` and then special-casing the next attribute.
+
+- **Attributes, v1:** **jurisdiction** (`boundary_path` materialized-path **PREFIX** match) and **department** (`department_code` **IN** match). The model is open to further `EQ`/`IN`/`PREFIX` attributes with no grammar change.
+- **AND across attributes, OR within an attribute.** A Sanitation supervisor for Wards 3 & 4 sees rows where `(boundary_path under W3 OR W4) AND (department_code IN ('SANI'))`. The OR-within covers multi-jurisdiction / multi-department employees.
+- **PREFIX is anchored + escaped.** The boundary prefix ends in the path delimiter (`…WARD_3|`) and the bound value escapes `\`/`%`/`_` so a sibling (`WARD_3` vs `WARD_30`) cannot leak across — exactly the escape already coded at `AnalyticsPlanner.java:249`.
+- **Admin bypass.** Admin/SUPERADMIN → the attribute list is **empty** (tenant-only), as today (design §5; plan §1).
+- **Narrow-only.** A client may pass a *declared* `boundaryScope`/`departmentScope` param that ANDs **under** the injected scope; an out-of-scope selection yields an **empty** (not denied) result. There is no free `prefix`/department `filter` leaf — narrowing rides declared KPI-def params only (design §2, §5; plan §1).
+- **Grain-aware binding.** Each predicate names a *logical* attribute; the planner maps it to the grain's physical column or **drops/rejects** the query if the grain cannot serve it (the events-department gap, §7). Never raw column names from the client (plan §1, §4).
+
+---
+
+## 5. Config ownership & source-of-truth split
+
+The governing rule: **consume identity, don't rebuild it.** Identity, roles, jurisdiction and department already exist in DIGIT; analytics reads them, never re-authors them. Only the *KPI/dashboard config surface* is newly owned by the analytics backend.
+
+**Newly pulled to the analytics backend (was FE / nowhere):**
+- **KPI definitions** — `dss.KpiDefinition` MDMS records (frozen query body + viz + declared params + `rbac.visibleTo`), governed by the publish-time safety pipeline (design §3/§3a). Previously hardcoded in the FE bundle.
+- **The served catalog / `/_schema`** — the column-and-grain whitelist the planner already owns server-side (`AnalyticsCatalog`, e.g. Grain definitions at `AnalyticsCatalog.java:54–108`); KPI **visibility** filtering is layered on top.
+- **Dashboard packs** — `dss.DashboardPack` MDMS records (role → tile bundle + default layout), the curation layer above per-KPI `visibleTo` (design §5a).
+- **The visibility mapping itself** — `rbac.visibleTo` (and optional `rbac.requiresAttributes`) on each def, plus the role→pack binding.
+
+**Consumed from existing DIGIT (read-only, never rebuilt):**
+- **Roles & user type** — from the validated principal (egov-user via the token), the `roles[]`/`type` that `AnalyticsScope.resolve()` reads today at `AnalyticsScope.java:34–44`.
+- **Jurisdiction** — `uuid → eg_hrms_employee → eg_hrms_jurisdiction.boundary[]`, each resolved to its `ancestralmaterializedpath` via boundary-service (cached). HRMS owns it; analytics resolves it at request time (plan §1).
+- **Department** — `uuid → eg_hrms_assignment.department[]` (active assignments). HRMS owns it (plan §1).
+- **Layout/personalization** → user-preferences-service, **not** MDMS. Pack layout is a *default*; a user's per-tile reordering is preference state, owned by the preferences service, not the KPI config store.
+
+---
+
+## 6. Non-functional requirements
+
+- **Freshness — MV `asOf`, never realtime.** Nothing the API returns is fresher than the last grain refresh. `complaint_facts`/`complaint_events` are hourly materialized views; `complaint_open_state_daily` is an append-only daily table (design §8, §10). Every window's upper bound is the grain's `asOf`; `live` means "current snapshot of the fact MV," not `now()`. RBAC does not change this contract — a scoped query is still bounded by `asOf`.
+- **Performance — cacheable per-scope rollups.** Results cache in Redis keyed by `{kpiId|queryBody, params, **resolved scope**, asOf}` (design §8). **Resolved scope is part of the cache key** — a supervisor and an admin asking "the same" KPI get different cached entries (different injected `WHERE`); never serve a cached row across scope boundaries. This makes RBAC and caching co-designed, not bolt-on.
+- **Auditability — the publish pipeline.** KPI defs become queryable only through validate → bounded dry-run → cost estimate → PII/officer approval gate → immutable versioned publish, each transition audited (who/when/diff), rollback = re-point "latest" (design §3a). The served catalog only ever holds catalog-valid, cost-bounded, PII-reviewed, versioned defs.
+- **Fail-closed.** A missing/forged principal, an unresolved HRMS row, or a grain that cannot serve an attribute predicate must yield **empty or denied**, never unscoped. Specifically: a department-restricted caller's query against a grain lacking `department_code` is rejected/scoped, never returned unscoped (§7; plan §3 step 4); a missing HRMS row → empty scope, not open (plan §1 "Drift caution").
+
+---
+
+## 7. Constraints & known hazards
+
+1. **The auth gap (blocks everything).** `AnalyticsController.java:41–47` trusts body `userInfo`; the Kong enrichment (`kong.yml:65–68`) skips validation when `userInfo` is pre-populated. Until a real auth filter / coercive gateway plugin lands, Layers 1–3 read attacker-controlled input. Exit criterion (plan §0/Phase 0): a forged-admin body gets citizen/empty scope, proven by a negative test.
+2. **HRMS role pollution.** On real tenants every employee provisioned `GRO` also carries `PGR_LME` (and vice versa) — memory [HRMS role pollution]. A KPI gated on `PGR_LME` then surfaces to GROs unintentionally. Author/test `visibleTo` and packs against **clean single-role `RBAC_TEST_*` users**, never real provisioned accounts whose role sets have drifted (design §5a; plan §5).
+3. **Department code-space mismatch.** The complaint's `department_code` is sourced from **MDMS ServiceDefs** (`data->>'department'`, migration L147; folded into the facts MV select at L169), while the *user's* department comes from **HRMS assignment**. If these draw from different code lists, the `department_code IN (…)` predicate silently matches nothing. A one-time consistency check (HRMS dept codes ⊆ MDMS `Department`/`Departments`) is a prerequisite to shipping department scope (plan §1, §6 "Biggest hidden risk").
+4. **Events grain has no `department_code`.** The facts MV carries it (migration L169) and the catalog marks it groupable/filterable on facts (`AnalyticsCatalog.java:58–66`); the **events** Grain's column sets do not include it (`AnalyticsCatalog.java:81–96`) because the events MV select never projects it. Shipping department scope on facts but not events is a **silent grain leak** — the fix is to add `department_code` to the events MV (one migration), not to leave events unscoped (plan §3 step 4).
+5. **Opaque, non-JWT token.** The DIGIT token is a redis-backed opaque UUID; **roles/attributes are never in the token** (plan §0 note). Phase 0 makes `userInfo` *trustworthy*; the attributes the token cannot carry (jurisdiction, department) are resolved server-side from HRMS at request time, cached short-TTL because they are mutable HRMS state.
+
+---
+
+## 8. Part breakdown (A–F) and dependency graph
+
+This series decomposes into six parts. Parts map onto the implementation plan's phases but are documents, not commits.
+
+| Part | Title | Covers | Maps to plan |
+|---|---|---|---|
+| **A** | Trust foundation | close the auth gap; make `userInfo` token-derived & coercive; spoof negative test | Phase 0 |
+| **B** | Identity → attribute resolution | `PrincipalAttributes` (jurisdiction + department from HRMS); caching; dept code-space consistency check; fail-closed on missing HRMS row | Phase 1 |
+| **C** | Attribute-scope engine | generalize `AnalyticsScope` to ANDed `attrScopes`; `applyScope()` loop (PREFIX reuse L249 + parameterized IN); wire jurisdiction; add department incl. events-MV migration | Phases 2–3 |
+| **D** | KPI catalog access (Layer 2) | `dss.KpiDefinition` + `rbac.visibleTo`/`requiresAttributes`; discovery `/catalog`; invocation re-check `kpi_forbidden`; publish pipeline | Phase 4 (+ §3a) |
+| **E** | Dashboard packs + layout split | `dss.DashboardPack` (role → tiles); layout default vs user-preferences-service personalization | Phase 5 |
+| **F** | Inline-query gating (Layer 3) | role gate at parse; `inline_forbidden`; analyst/admin-only raw grammar | Phase 6 |
+
+**Dependency graph (what blocks what):**
+
+```
+                 A (trust foundation)         ← blocks EVERYTHING; nothing below is real without it
+                /            |            \
+               B             D             F
+        (attr resolve)  (catalog access) (inline gate)
+               |             |
+               C             E
+        (attr-scope     (packs +
+          engine)        layout)
+```
+
+- **A blocks all of B–F.** RBAC over a spoofable principal is theater (§1, §7.1; plan §6.1 "non-negotiable and first").
+- **B → C.** The attribute-scope engine (C) cannot scope rows until the principal's jurisdiction/department are resolved (B). C's department half additionally blocks on the dept code-space check (B) and the events-MV migration (within C, plan §3 step 4).
+- **D → E.** Packs (E) reference KPI defs whose `visibleTo` ceiling is defined in D; packs are assembly above the ceiling and re-check it at invocation.
+- **F is independent of B/C/D/E** once A is in — it gates the *grammar* (raw inline) by role, orthogonal to row scope and catalog visibility.
+- **B/C (row scoping, the Layer-1 spine) and D/E/F (catalog + grammar access) proceed in parallel after A** (plan §6.2). Each part ships as a one-concern PR against egov/CCRS develop, validated on ovh-cloud-dev (bomet repro) before live, with the emitted `WHERE` reviewed in tests, not just the Java (plan §5, §6.5).

--- a/docs/dashboard-rbac-design/10-auth-foundation.md
+++ b/docs/dashboard-rbac-design/10-auth-foundation.md
@@ -1,0 +1,425 @@
+# Part A — Trust Foundation (identity & auth)
+
+**Status:** v2, 2026-06-23 (pass-1 review folded in) · **Maps to:** implementation plan Phase 0 · **Requirements:** `00-requirements.md` §1, §3 (Layer 1 enforcement point), §5 (consume-don't-rebuild), §6 (fail-closed), §7.1 (the auth gap), §7.5 (opaque token).
+**Reads first:** `dashboard-query-api-design.md` §5/§5a (Hard prerequisite — "identity must be trustworthy first"), `rbac-kpi-access-implementation-plan.md` §0/Phase 0.
+
+> **Grounding rule:** every claim about current behaviour below carries a `file:line` that was actually read. Where a thing is missing, that is stated as missing with the anchor showing the gap.
+
+---
+
+## Goal & responsibilities
+
+### What this part owns
+
+This part makes `RequestInfo.userInfo` **trustworthy** on the analytics route, so that everything `AnalyticsScope.resolve()` and (later) `PrincipalAttributes` read off the principal is server-vouched, not attacker-supplied. Concretely Part A owns:
+
+1. **Token introspection that overwrites userInfo.** On a protected analytics request, the service (or a coercive gateway plugin) resolves the opaque `RequestInfo.authToken` against egov-user `/user/_details?access_token=…` and **replaces** `RequestInfo.userInfo` with the introspection result — it never trusts a client-supplied `userInfo`, even a populated one.
+2. **Rejection of missing/invalid tokens on protected routes.** No token, an expired/unknown token, an introspection 4xx, **and any introspection 5xx/timeout/unreachable/parse-failure** on `POST /v2/analytics/_query` and `POST /v2/analytics/_schema` ⇒ **`401`**, fail-closed. There is no "trust the body" fallback path and no path where a `null` introspection result silently becomes a 200 or a 500 — `null` is mapped to `401` explicitly (see A.2).
+3. **A trustworthy `Principal` hand-off.** Part A produces exactly the fields downstream RBAC consumes today and tomorrow: `{ uuid, type, roles[], tenantId }`, vouched-for. This is the single contract every other part builds on — for the single-query arm **and** the batch `queries` arm, which share the same resolved scope (`AnalyticsService.java:32`).
+4. **The spoof negative test** (plan §0 exit criterion): a forged `userInfo` claiming `type:"EMPLOYEE"` / admin roles with no valid token resolves to **denied** (no token) or **citizen/empty scope** (citizen token), never admin scope. The test is specified **per-grain** (see A.6), because the emitted scope differs by grain — notably `daily` has no citizen column (`AnalyticsCatalog.java:108`) and would otherwise give a false-green.
+
+### What this part explicitly does NOT own
+
+- **Resolving jurisdiction/department attributes** from HRMS — that is **Part B** (`PrincipalAttributes`). The DIGIT token is opaque and carries no attributes (req §7.5); Part A only makes `{uuid, roles, type, tenantId}` trustworthy. Part B resolves the rest server-side.
+- **Building or injecting the row-scope `WHERE`** — that is **Part C** (`applyScope()` over `attrScopes`). Part A does not touch `AnalyticsPlanner.applyScope()` (`AnalyticsPlanner.java:241–251`).
+- **Closing the `daily`-grain citizen leak** — the missing citizen column on the `daily` grain (`AnalyticsCatalog.java:108`, `citizenColumn=null`; predicate guarded at `AnalyticsPlanner.java:246`) is **Part C's** fix (add `account_id` to the daily grain or reject citizen `daily` queries). Part A only **surfaces** the leak in its negative test rather than passing over it (A.6).
+- **KPI catalog visibility / `kpi_forbidden`** (Part D), **dashboard packs** (Part E), **inline-query gating / `inline_forbidden`** (Part F). Those are authorization decisions over a trusted principal; Part A only delivers the trusted principal. (Note: Part A authenticates; it does **not** authorize beyond "is this a real, logged-in user." `403` decisions live in D/F.)
+- **Caching.** Resolved scope is part of the cache key (req §6) but the cache is designed in C/D, not here. Part A's only caching concern is whether to memoize introspection (see Risks).
+
+---
+
+## Current code reality (file:line — what exists today vs what's missing)
+
+**The endpoint trusts the body and validates nothing.**
+
+- `AnalyticsController.query()` (`AnalyticsController.java:40–55`) reads the request body as a raw `JsonNode`, and at **L43–44** does `mapper.convertValue(body.get("RequestInfo"), RequestInfo.class)` — taking `userInfo` verbatim from whatever the client POSTed. It hands that `RequestInfo` straight to `service.query(...)` at **L47**. There is **no token check, no introspection, no rejection of an unsigned/forged userInfo**. `authToken` is never read in this class. (Tenant comes from the **body** at **L45**, not the principal — the hole A.4 plugs.)
+- `AnalyticsController.schema()` (`AnalyticsController.java:57–60`) takes **no `RequestInfo` at all** — it is fully anonymous today. Under Part A `_schema` becomes a protected route too (it leaks the catalog/grain shape, and Part D will make `/catalog` role-filtered; the underlying `_schema` must not be an unauthenticated bypass).
+- `AnalyticsScope.resolve()` (`AnalyticsScope.java:31–48`) derives the **entire** RBAC posture from `requestInfo.getUserInfo()`: **L34** `requestInfo.getUserInfo()`, **L36** `u.getType()`, **L38–42** `u.getRoles()`, **L44** `if (isCitizen && !hasEmployeeRole) citizenUuid = u.getUuid();`, **L47** returns `boundaryPrefix` hardcoded `null`. So a body with `type:"EMPLOYEE"` and no `CITIZEN`-only role set **escapes citizen self-scope** and is treated as a tenant-wide employee — purely on the client's say-so.
+- `AnalyticsService.query()` (`AnalyticsService.java:30–32`) calls `AnalyticsScope.resolve(requestInfo, tenantId, stateLevelLen)` at **L32** with the untrusted `requestInfo` straight from the controller. That single resolved `scope` is then reused by **both** request arms — the single-query arm (`AnalyticsService.java:51`) and the batch dict arm (`AnalyticsService.java:42–46`, each `runOne(e.getValue(), scope)`). No introspection sits between controller and scope, so both arms inherit the spoofable principal identically. (Wiring the gate at the controller before `service.query` fixes both arms in one place; the batch-arm-bypass risk the cross-cutting review flags is a Part-D *kpiId re-check* concern, not a Part-A trust concern — A's principal already covers both arms.)
+
+**The gateway enrichment exists but is non-enforcing (two early-return guards).**
+
+The Kong global `pre-function` "auth-enrichment" (`kong.yml:49–82`) is meant to backfill `userInfo` from the token, but it is **advisory, not coercive** — it has two guards that make a spoofed body sail through:
+
+- **Guard 1 — no token ⇒ no-op (`kong.yml:63–64`):** `local token = ri["authToken"]` (L63); `if not token or type(token) ~= "string" or token == "" then return end` (L64). A request with **no `authToken`** and a hand-written `userInfo` returns early and is passed through **untouched**.
+- **Guard 2 — pre-populated userInfo ⇒ skip introspection (`kong.yml:65–67`):** `if ri["userInfo"] and type(ri["userInfo"]) == "table" then` (L65) … `if ui["uuid"] or ui["id"] or ui["userName"] then return end` (L67). If the caller supplies a `userInfo` that *already* has a `uuid`/`id`/`userName`, the plugin **does no validation and returns** — the client's claimed identity wins.
+
+So the enrichment only fires for the well-behaved case (token present, userInfo absent) and **defends nobody against a malicious client** who simply supplies their own `userInfo`. The plugin's introspection target — `http://egov-user-proxy:8107/user/_details?access_token=` `..token` POST (`kong.yml:71`) — is the right call; it is just skippable. On its own error paths the plugin **logs and passes the request through** (`kong.yml:75` `if not res then kong.log.err(...); return`, `kong.yml:76` `if res.status ~= 200 then kong.log.err(...); return`). This is the "V2 auth gap" (req §7.1; plan §0).
+
+> **Flat top-level `_details` shape (correcting the A.2 table below).** The plugin treats the decoded `_details` body **as the flat user object** — it checks `user["uuid"]`/`user["userName"]` at **top level** (`kong.yml:79`) and assigns `ri["userInfo"] = user` (`kong.yml:80`) with **no `UserRequest` wrapper**. This is the only working in-tree evidence of the response shape, so the A.2 parser is written against a **flat** top-level user, not a `{UserRequest:{…}}` envelope (still confirmed on a recorded live response — O1).
+
+**There is no auth plugin on the pgr route.** The `pgr-service` Kong service/route (`kong.yml:334–343`, `paths: /pgr-services`, `strip_path:false`) carries **no `key-auth`, no `jwt`, no custom auth plugin** — only the global pre-function above. So `/pgr-services/v2/analytics/*` is reachable unauthenticated, and the pre-function does not enforce.
+
+**What already exists and is reusable (so Part A is mostly wiring, not green-field):**
+
+- A POST JSON client: `ServiceRequestRepository.fetchResult(StringBuilder uri, Object request)` (`ServiceRequestRepository.java:30–43`) — `restTemplate.postForObject(uri, request, Map.class)`. **Caveat (load-bearing for fail-closed):** it only rethrows on `HttpClientErrorException` (4xx) as `ServiceCallException` (`ServiceRequestRepository.java:35–37`). **Every other failure — connection refused, timeout, 5xx `HttpServerErrorException`, decode error — is caught at `ServiceRequestRepository.java:38–40`, logged, and returns `null` with no rethrow.** So `fetchResult` is *not* fail-closed by itself; A.2 must treat a `null` return as auth-failure (it does — see A.2).
+- User-service host config already injected: `PGRConfiguration` `@Value("${egov.user.host}") userHost` (`PGRConfiguration.java:48–49`), plus context path `@Value("${egov.user.context.path}")` (`PGRConfiguration.java:51`). So the introspection base URL needs **no new config plumbing**, only a `_details` path value. **Caveat:** the local prop `egov.user.host=http://localhost:8081` (`application.properties:63`) and the deployed value are templated per-env, and the Kong plugin hardcodes a *different* host (`egov-user-proxy:8107`, `kong.yml:71`). The service-side and gateway-side introspection may therefore hit different hosts; A.2 binds to `${egov.user.host}` and the migration step verifies the deployed value actually fronts egov-user (`/user/_details`-capable).
+- `stateLevelTenantIdLength` (`PGRConfiguration.java:220`) is already threaded controller→service→scope; Part A does not change it.
+- `RequestInfo`/`User`/`Role` contract (`org.egov.common.contract.request.*`) is already the type `AnalyticsScope` reads (`u.getType()`, `u.getRoles()`, `u.getUuid()`).
+
+**Net gap:** identity on this route is presently attacker-controlled at two layers (the gateway skips, the service trusts). Part A closes it by making introspection **coercive** (overwrite, never trust) and **mandatory** (reject when absent **or** unresolvable, including 5xx/null).
+
+---
+
+## Design
+
+### A.0 Decision: defense-in-depth, service-side is authoritative
+
+The plan offers Option A (gateway plugin) vs Option B (service-side introspection). **This part specifies BOTH, with the service-side check as the authoritative one:**
+
+- **A.1 (gateway, hardening):** make the Kong pre-function **coercive** by removing Guard 2 and turning Guard 1 (and the error paths) into a hard reject on protected routes. This shrinks the attack surface and means well-behaved traffic is already enriched.
+- **A.2 (service, authoritative):** an `AnalyticsAuthService` in pgr-services that **re-introspects the token and overwrites `userInfo`** before scope resolution, and **rejects** when the token is missing, invalid, **or unresolvable for any reason (4xx, 5xx, timeout, null)**. This is the security boundary.
+
+**Why both, why service-authoritative:** the gateway is the right place to enrich for the whole platform, but (a) Kong config is environment-specific (`kong.yml` is the local-setup file; bomet/naipepea front with nginx+Kong differently), and (b) a pre-function that silently no-ops on its own error path (`kong.yml:75–76`: log and **pass the request through** on introspection failure) cannot be the sole enforcement. A fix that "redeploys the same way on any tenant" (memory: holistic fixes) must live in the **service**, which is identical across tenants. The gateway change is belt; the service change is suspenders, and suspenders hold the trousers up.
+
+### A.1 — Gateway: make enrichment coercive (kong.yml)
+
+Two surgical edits to the pre-function (`kong.yml:49–82`), scoped so it only hard-enforces on analytics paths (it must stay enrichment-only for the rest of the platform, which still POSTs `userInfo` legitimately in service-to-service calls):
+
+```lua
+-- after L62 (ri table obtained), add a protected-route gate:
+local path = kong.request.get_path()
+local protected = path:find("/v2/analytics/", 1, true) ~= nil
+
+local token = ri["authToken"]                         -- (was kong.yml:63)
+if (not token or type(token) ~= "string" or token == "") then  -- (was kong.yml:64)
+  if protected then
+    return kong.response.exit(401,
+      cjson.encode({error="unauthenticated", message="missing auth token"}),
+      {["Content-Type"]="application/json"})
+  end
+  return                          -- non-protected: unchanged (enrichment is opportunistic elsewhere)
+end
+
+-- REMOVE the old Guard-2 early-return (kong.yml:65-67). On protected routes we
+-- ALWAYS introspect and OVERWRITE userInfo; a client-supplied userInfo is discarded.
+-- (Keep the skip only for NON-protected routes if desired.)
+
+-- introspect (existing call, kong.yml:71) ...
+-- error paths that today log+return (kong.yml:75-76) become 401 on protected:
+if not res or res.status ~= 200 then
+  if protected then
+    return kong.response.exit(401, cjson.encode({error="unauthenticated",
+      message="token introspection failed"}), {["Content-Type"]="application/json"})
+  end
+  kong.log.err("auth-enrichment: ", err or (res and res.status)); return
+end
+-- ... decode (kong.yml:78), then ALWAYS overwrite on protected routes.
+-- NOTE: the decoded body is the FLAT user object (kong.yml:79-80 read user["uuid"]
+-- at top level, no UserRequest wrapper), so the overwrite is the existing assignment:
+ri["userInfo"] = user            -- overwrite, never merge (kong.yml:80 unchanged)
+```
+
+The two non-negotiable behavioural changes: **(1)** on `/v2/analytics/*`, a missing token, a non-200 introspection, **or an unreachable egov-user (`not res`)** is now a **`401`**, not a pass-through (folds the `kong.yml:75–76` error paths into a hard reject); **(2)** on `/v2/analytics/*`, the pre-function **always overwrites** `userInfo` rather than honouring a pre-populated one (Guard-2 deletion). Note the introspection target `egov-user-proxy:8107` is the **proxy**, not `egov-user` directly — verify the proxy forwards `/user/_details` (Part A test step).
+
+### A.2 — Service: AnalyticsAuthService (authoritative)
+
+A new class in `org.egov.pgr.analytics` that the controller calls **before** `service.query(...)`. It is the part that holds regardless of gateway topology. **Fail-closed is enforced on the `null` path, because the reused `fetchResult` returns `null` (not throws) on 5xx/timeout/unreachable (`ServiceRequestRepository.java:38–40`).**
+
+```java
+package org.egov.pgr.analytics;
+
+/** Coercive token introspection for the analytics route. Overwrites client-supplied
+ *  userInfo with the egov-user /_details result; fail-closed on missing/invalid/unresolvable token. */
+@Component
+@Slf4j
+public class AnalyticsAuthService {
+
+    private final ServiceRequestRepository repo;     // reuse: ServiceRequestRepository.java:30
+    private final PGRConfiguration config;           // egov.user.host : PGRConfiguration.java:48
+    private final ObjectMapper mapper;
+
+    /** Returns a RequestInfo whose userInfo is server-vouched. Throws 401 on no/invalid/unresolvable token. */
+    public RequestInfo authenticate(JsonNode body) {
+        JsonNode ri = (body != null && body.has("RequestInfo")) ? body.get("RequestInfo") : null;
+        String token = (ri != null && ri.hasNonNull("authToken"))
+                ? ri.get("authToken").asText() : null;
+        if (token == null || token.isEmpty())
+            throw new UnauthenticatedException("unauthenticated: missing auth token");
+
+        User u = introspect(token);                  // egov-user /user/_details
+        if (u == null || u.getUuid() == null)
+            throw new UnauthenticatedException("unauthenticated: invalid, expired, or unresolvable token");
+
+        // Build a RequestInfo that KEEPS the client's correlation fields but
+        // OVERWRITES the trust-bearing userInfo with the introspected user.
+        RequestInfo out = mapper.convertValue(ri, RequestInfo.class); // apiId/ts/msgId/authToken
+        out.setUserInfo(u);                          // <-- the overwrite. client userInfo discarded.
+        if (log.isDebugEnabled() && ri.hasNonNull("userInfo") && ri.get("userInfo").hasNonNull("uuid")
+                && !u.getUuid().equals(ri.get("userInfo").get("uuid").asText()))
+            log.debug("analytics auth: client userInfo.uuid != introspected uuid; client value discarded");
+        return out;
+    }
+
+    private User introspect(String token) {
+        // /user/_details?access_token=<token>  (POST). Body: empty/RequestInfo wrapper.
+        StringBuilder uri = new StringBuilder(config.getUserHost())
+                .append(config.getUserDetailsPath())          // NEW @Value, e.g. "/user/_details"
+                .append("?access_token=").append(token);
+        Object res;
+        try {
+            res = repo.fetchResult(uri, Collections.emptyMap()); // ServiceRequestRepository:30
+        } catch (ServiceCallException e) {                       // 4xx from egov-user (bad token) — ServiceRequestRepository:37
+            return null;                                         // -> caller throws Unauthenticated (401)
+        }
+        // CRITICAL fail-closed: fetchResult swallows 5xx/timeout/unreachable/parse to a NULL return
+        // (ServiceRequestRepository.java:38-40, generic catch logs + returns null, no rethrow).
+        // A null res is NOT a valid user — it must become 401, never a 200 or a parser NPE/500.
+        if (res == null) return null;                            // -> caller throws Unauthenticated (401)
+        return parseUserRequest(res);                            // flat top-level user (kong.yml:79-80); see O1
+    }
+
+    /** Map the egov-user /_details body onto org.egov.common.contract.request.User.
+     *  Per kong.yml:79-80 the response is a FLAT top-level user object (no UserRequest wrapper).
+     *  Confirm the exact shape (incl. roles[] nesting) against a recorded live response — O1. */
+    private User parseUserRequest(Object res) { /* tolerant of null sub-fields; returns null if no uuid */ }
+}
+```
+
+**Introspection contract consumed (egov-user `/user/_details?access_token=`):** a POST returns the authenticated user envelope. Per the only in-tree evidence (`kong.yml:79–80`) the body is a **flat top-level user object**, so the fields Part A depends on are read at top level and mapped onto `org.egov.common.contract.request.User`:
+
+| `_details` field (flat, top-level) | Mapped to | Used by |
+|---|---|---|
+| `uuid` | `User.uuid` | citizen self-scope (`AnalyticsScope.java:44`), Part B HRMS lookup key |
+| `type` (`CITIZEN`/`EMPLOYEE`/`SYSTEM`) | `User.type` | citizen-vs-employee branch (`AnalyticsScope.java:36`) |
+| `roles[].code` | `User.roles[].code` | employee-role test (`AnalyticsScope.java:38–41`); Part D `visibleTo`; Part F inline gate |
+| `roles[].tenantId` | `Role.tenantId` | tenant cross-check (A.4) |
+| `tenantId` | `User.tenantId` | tenant cross-check (A.4) |
+
+> **Verify-before-build (open question O1):** the in-tree evidence (`kong.yml:79` reads `user["uuid"]` at top level, `kong.yml:80` assigns the whole decoded body as `userInfo`) says the proxy emits a **flat** user, not a `{UserRequest:{…}}` wrapper. The A.2 table is now drawn flat to match. **Still confirm on a recorded live response** that `roles[]` is an array of `{code,name,tenantId}` at `roles` (flat) and not nested — if the parser maps `roles` wrong, `AnalyticsScope.resolve`'s `u.getRoles()` (`AnalyticsScope.java:38`) gets an empty list and **every employee silently degrades to "no employee role"** (a fail-*open*-looking under-scope downstream). Assert this in the Part A integration test; do not assume.
+
+### A.3 — Controller wiring
+
+`AnalyticsController` calls `authenticate(...)` first and uses **only** the returned `RequestInfo`. The client-supplied `RequestInfo` is never passed to `service.query`. Because `service.query` resolves one `AnalyticsScope` and feeds it to both the single-query arm (`AnalyticsService.java:51`) and the batch arm (`AnalyticsService.java:42–46`), authenticating once at the controller covers both arms.
+
+```java
+// AnalyticsController.query() — replaces the L43-44 convertValue + L47 hand-off
+@PostMapping("/_query")
+public ResponseEntity<Map<String,Object>> query(@RequestBody JsonNode body){
+    try {
+        RequestInfo requestInfo = auth.authenticate(body);          // NEW: coercive, throws 401 on bad/unresolvable token
+        crossCheckTenant(requestInfo, body);                        // NEW: see A.4
+        String tenantId = body.hasNonNull("tenantId") ? body.get("tenantId").asText() : null;
+        int stateLen = config.getStateLevelTenantIdLength() == null ? 1 : config.getStateLevelTenantIdLength();
+        Map<String,Object> result = service.query(body, requestInfo, tenantId, stateLen);
+        return ResponseEntity.ok(result);
+    } catch (UnauthenticatedException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(error(e));   // 401, fail-closed
+    } catch (ForbiddenException e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error(e));      // 403, tenant mismatch
+    } catch (IllegalArgumentException e) {
+        return ResponseEntity.badRequest().body(error(e));
+    } catch (Exception e) {
+        log.error("analytics query failed", e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error(e));
+    }
+}
+
+@PostMapping("/_schema")
+public ResponseEntity<Map<String,Object>> schema(@RequestBody(required=false) JsonNode body){
+    try {
+        auth.authenticate(body == null ? NullNode.getInstance() : body); // NEW: _schema is now protected
+        return ResponseEntity.ok(service.schema());
+    } catch (UnauthenticatedException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(error(e));   // 401
+    }
+}
+```
+
+`_schema` gains a body + auth (today it takes **no `RequestInfo` and no body** — `AnalyticsController.java:57–60`). A null/empty body ⇒ no `authToken` ⇒ `401`, consistent with `_query`. The `error()` helper (`AnalyticsController.java:62–69`) derives the error code from the message prefix before `:`, so throwing `"unauthenticated: …"` / `"forbidden: …"` yields `error:"unauthenticated"`/`"forbidden"` with **no new code** in `error()`.
+
+### A.4 — Tenant cross-check (defense, not the main job)
+
+Design §5 requires "the `tenantId` in the body is cross-checked against the principal's allowed tenants; mismatch → `403`." The hole is real today: the scope's tenant comes from the **body** at the controller (`AnalyticsController.java:45`) and is threaded to `AnalyticsScope.resolve` (`AnalyticsService.java:32`), so even a real token could widen tenant via the body. Part A wires the **hook**; the principal's allowed-tenant set comes from the introspected `roles[].tenantId` / `user.tenantId`.
+
+**Conservative form (this part's commitment):** Part A enforces **same-tenant only**. It deliberately does **not** ship the `startsWith`/prefix widening, because the underlying tenant-scope SQL predicate at `AnalyticsPlanner.java:243` is an **un-anchored, un-escaped** `LIKE scope.tenantId + '%'` — `ke` matches `ke.bomet` AND a hypothetical `kenya`/`ke2`. Layering a same-shape `startsWith` widening into the cross-check would re-introduce the exact sibling-prefix leak req §4 (`00-requirements.md:63`) bans for boundaries. The state-root-employee-querying-a-city case is deferred to Part C (O4), where the anchored+escaped tenant predicate is designed.
+
+```java
+private void crossCheckTenant(RequestInfo ri, JsonNode body){
+    String bodyTenant = body.hasNonNull("tenantId") ? body.get("tenantId").asText() : null;
+    User u = ri.getUserInfo();
+    if (bodyTenant == null || u == null) return; // tenant-required is enforced in service
+    // Same-tenant only (conservative). Cross-tenant/state-root widening is Part C (O4),
+    // gated on an ANCHORED+ESCAPED tenant predicate (today's AnalyticsPlanner.java:243 LIKE is neither).
+    boolean allowed = bodyTenant.equals(u.getTenantId())
+        || (u.getRoles() != null && u.getRoles().stream()
+              .anyMatch(r -> bodyTenant.equals(r.getTenantId())));   // exact match, no startsWith
+    if (!allowed) throw new ForbiddenException("forbidden: tenant mismatch");
+}
+```
+
+This guarantees the body tenant can't diverge from the *vouched* identity's exact tenant(s). The precise "allowed tenants" policy (state-root employee querying any sub-tenant) is finalized with Part C's scope semantics.
+
+### A.5 — The Principal contract (output of Part A)
+
+The single artifact every downstream part consumes. Part A does **not** introduce a new type — it guarantees the **existing** `RequestInfo.userInfo` is now trustworthy. Stated as a contract:
+
+```
+Principal (vouched-for, post-A.2):
+  uuid     : String   — egov-user UUID (introspected, never client-set)
+  type     : String   — CITIZEN | EMPLOYEE | SYSTEM (introspected)
+  roles[]  : {code, name, tenantId}  (introspected, flat-top-level per kong.yml:79-80)
+  tenantId : String   (introspected)
+INVARIANT: these fields equal the egov-user /_details result for a valid token,
+           or the request was rejected 401 before reaching AnalyticsScope.resolve()
+           (including the 5xx/timeout/null path — fetchResult null ⇒ 401, never 200/500).
+```
+
+`AnalyticsScope.resolve()` (`AnalyticsScope.java:31–48`) is **unchanged by Part A** — it keeps reading `u.getType()`/`u.getRoles()`/`u.getUuid()`, but those reads are now sound because `userInfo` was overwritten upstream. (Part B will extend `resolve` to also carry the `uuid`/`roles` forward into attribute resolution; Part C generalizes the scope and is also where `tenantStateLevel` (`AnalyticsScope.java:22`) must be carried into `PrincipalAttributes` so C can choose `LIKE prefix` vs `= tenant` — a cross-cutting B/C gap, not Part A's. Part A's contribution is that the inputs to both are no longer forgeable.)
+
+### A.6 — Spoof negative test, specified per-grain (exit criterion)
+
+The plan §0 exit criterion is "forged-admin body gets citizen/empty scope." Part A's test must assert the **emitted scope per grain**, not a single grain, because the scope predicate differs by grain — and one grain leaks today:
+
+1. **Forged-admin body, NO token** → `401` on both `_query` and `_schema` (before `AnalyticsScope.resolve` ever runs).
+2. **Forged-admin body, CITIZEN token** → introspection overwrites to the real citizen → for grain `facts` and grain `events`, the emitted `WHERE` includes `account_id = :self` (`AnalyticsCatalog.java:78`/`:96` define `account_id` as the citizen column; predicate at `AnalyticsPlanner.java:246`). **Assert this exact predicate.**
+3. **Same citizen token, grain `daily`** → the test must assert that **no `account_id` predicate is emitted** (because `daily` has `citizenColumn=null`, `AnalyticsCatalog.java:108`, and the guard at `AnalyticsPlanner.java:246` short-circuits) **and flag this as a Part-C interface gap** (citizen `daily` is tenant-wide today). The test does **not** pass silently on `daily`; it records the leak as an explicit known-failure pending Part C. This prevents a false-green where the suite is green on `facts` while `daily` leaks every open complaint in the tenant.
+
+The exit criterion is met for Part A when (1) and (2) hold; (3) is a **must-surface** assertion that hands a tracked failure to Part C, not a pass.
+
+### Control flow (end to end)
+
+```
+client → Kong /pgr-services/v2/analytics/_query
+  └─ pre-function (A.1): protected route?
+        ├─ no authToken            → 401 (was: pass-through, kong.yml:64)
+        ├─ introspect /_details unreachable/non-200 → 401 (was: log+pass-through, kong.yml:75-76)
+        └─ 200 → OVERWRITE userInfo (was: skip if pre-populated, kong.yml:65-67)   ──┐
+  → pgr-services AnalyticsController.query()                                          │ even if Kong is bypassed
+        └─ AnalyticsAuthService.authenticate(body) (A.2)  ◄───────────────────────────┘ this RE-introspects
+              ├─ no authToken               → UnauthenticatedException → 401
+              ├─ /_details 4xx              → null → 401
+              ├─ /_details 5xx/timeout/null → null → 401  (NOT 200, NOT 500; ServiceRequestRepository.java:38-40)
+              └─ valid → RequestInfo.userInfo := introspected User   (the overwrite)
+        └─ crossCheckTenant (A.4)  → 403 on tenant mismatch (same-tenant only)
+        └─ service.query(body, TRUSTED requestInfo, …)   (AnalyticsService.java:30)
+              └─ AnalyticsScope.resolve(TRUSTED requestInfo, …)  (AnalyticsScope.java:32, unchanged code, sound inputs)
+              └─ runOne(...) for single arm (L51) AND each batch query (L42-46) — SAME trusted scope
+              └─ planner.applyScope(...)  (Part C territory — unchanged here; daily citizen leak is C's)
+```
+
+The service-side re-introspection (A.2) is what makes Part A robust to a misconfigured or bypassed gateway: even a request that reaches pgr-services directly (e.g. in-cluster, or an nginx that doesn't run the pre-function) is re-validated, and an egov-user 5xx/timeout maps to `401` rather than silently passing.
+
+---
+
+## Interfaces with other parts
+
+**Outputs produced (consumed by B–F):**
+
+- **`Principal` (trustworthy `RequestInfo.userInfo`)** — the contract in A.5. Consumed by:
+  - **Part B** uses `Principal.uuid` (+ `tenantId`) as the HRMS lookup key for `PrincipalAttributes resolve(uuid, tenantId)`. B's "fail-closed on missing HRMS row" is only meaningful because the `uuid` is real. **Dependency:** O1 (flat `roles[]` shape) must resolve before B codes against `Principal.roles`, or B inherits an empty-role principal.
+  - **Part C** uses the same trusted `roles`/`type` that `AnalyticsScope.resolve` reads; C's `attrScopes` (jurisdiction PREFIX, department IN) are derived from B's attributes keyed on A's `uuid`. The admin-bypass branch (C: empty `attrScopes`) keys off A's vouched `roles`. **C owns:** the `daily`-grain citizen column fix (`AnalyticsCatalog.java:108`), the anchored+escaped tenant predicate (`AnalyticsPlanner.java:243`), and carrying `tenantStateLevel` into attribute resolution. Part A's negative test (A.6) hands C the tracked `daily` failure.
+  - **Part D** re-checks `rbac.visibleTo ∩ Principal.roles` at invocation (`kpi_forbidden`), and must re-check `kpiId` on **both** request arms — the batch arm (`AnalyticsService.java:42–46`) is a separate code path from the single arm (`L51`). A's trusted principal feeds both; D owns the per-arm `kpiId` re-check (the cross-cutting "batch-arm bypass" finding is D's, not A's).
+  - **Part F** gates inline grammar on `Principal.roles` (`inline_forbidden`). Sound only because A vouches `roles`.
+- **`401 unauthenticated`** — new failure mode Part A introduces on protected routes. D's `403 kpi_forbidden` and F's `403 inline_forbidden` are layered **after** A's 401 (authn precedes authz): a bad token never reaches a 403 path.
+- **`403 forbidden: tenant mismatch`** — from A.4 (same-tenant only). Part C may widen this policy; A ships the conservative floor.
+
+**Inputs consumed:**
+
+- egov-user **`/user/_details?access_token=`** introspection (external DIGIT contract; the same endpoint the Kong plugin already targets at `kong.yml:71`). Read-only; Part A never writes user state. This honours req §5 "consume identity, don't rebuild it."
+- `PGRConfiguration.getUserHost()` (`PGRConfiguration.java:48`) + a **new** `egov.user.details.path` value. (Note host divergence: Kong uses `egov-user-proxy:8107` hardcoded at `kong.yml:71`; service uses `${egov.user.host}`, locally `http://localhost:8081` at `application.properties:63` — reconcile the deployed value in migration step 6.)
+- `ServiceRequestRepository.fetchResult` (`ServiceRequestRepository.java:30`) as the HTTP client, **with the explicit `null`-is-auth-failure handling in A.2** (because `ServiceRequestRepository.java:38–40` returns `null` rather than throwing on 5xx/timeout).
+
+**Explicitly NOT an interface of Part A:** HRMS (`eg_hrms_*`), boundary-service, MDMS `dss.*`. Those belong to B/C/D. Part A's only outward call is egov-user introspection.
+
+---
+
+## Sequencing & migration steps
+
+1. **Config:** add `egov.user.details.path=/user/_details` to pgr-services `application.properties` (host already present, `application.properties:63` / `PGRConfiguration.java:48`). Add `getUserDetailsPath()` getter (mirroring the existing `egov.user.context.path` binding at `PGRConfiguration.java:51`).
+2. **Service:** add `AnalyticsAuthService` (A.2) + `UnauthenticatedException`/`ForbiddenException` (or reuse `org.egov.tracer.model.CustomException` with code mapping). **Unit-test the fail-closed matrix explicitly:** valid token → user; 4xx (`ServiceCallException`) → 401; 5xx/timeout/unreachable (`fetchResult` returns `null`, `ServiceRequestRepository.java:38–40`) → **401, asserted** (this is the path the pass-1 review flagged as not-fail-closed); malformed/no-uuid body → 401.
+3. **Controller:** wire `authenticate(...)` into `query` and `schema` (A.3), add `crossCheckTenant` (A.4, same-tenant only), map `UnauthenticatedException→401`, `ForbiddenException→403`. **This is the cut-over commit** — after it, a forged `userInfo` no longer wins.
+4. **Gateway hardening (A.1):** edit the `kong.yml` pre-function — protected-route 401 (token + error paths `kong.yml:64`,`75–76`) + Guard-2 deletion (`kong.yml:65–67`). Ship in the same PR but note it is **belt to the service's suspenders**; the service change (step 3) is what makes it tenant-portable. Replicate the equivalent on bomet/naipepea nginx+Kong fronts (host_vars note, not code).
+5. **Negative test (exit criterion, A.6):** integration test — forged-admin body with **no token** → 401; forged-admin body with a **citizen token** → introspection overwrites to citizen → assert `account_id = :self` predicate on `facts` and `events`, and assert (as a tracked known-failure handed to Part C) that `daily` emits **no** citizen predicate. Per-grain, per plan §0.
+6. **Validate on ovh-cloud-dev (bomet repro)** before live bomet (memory: ovh must stay bomet; validate per-PR). Confirm (O1) `egov-user-proxy` actually serves `/user/_details`, that the deployed `${egov.user.host}` fronts egov-user (vs the Kong hardcode `egov-user-proxy:8107`), and **record one live `_details` response** to fix the flat-vs-wrapped shape and the `roles[]` nesting before the parser is finalized.
+7. **PR-per-part** against egov/CCRS develop under `backend/pgr-services/` (+ `local-setup/kong/kong.yml`). One concern: "Part A — trust foundation / coercive analytics auth."
+
+**Ordering within the series:** Part A merges and validates **before** any of B–F (req §8 dependency graph: "A blocks EVERYTHING"). B/C and D/E/F may then proceed in parallel.
+
+---
+
+## Risks, edge cases, failure modes
+
+- **Fail-closed is the default — and now explicit on the `null` path.** No token → 401. Introspection 4xx (`ServiceCallException`, `ServiceRequestRepository.java:37`) → 401. Introspection **5xx / timeout / egov-user unreachable / decode error → `fetchResult` returns `null` (`ServiceRequestRepository.java:38–40`), which A.2 maps to 401, never 200, never a parser NPE/500.** Do *not* fall back to body `userInfo` — that recreates the gap. The Kong plugin's current `log+return` pass-through on error (`kong.yml:75–76`) is the exact anti-pattern Part A removes for protected routes. (This was the pass-1 [major] — resolved by the explicit `if (res == null) return null;` in `introspect`.)
+- **Gateway-bypass leak (why service-side is authoritative).** If only A.1 shipped and an operator fronts pgr-services with an nginx that doesn't run the pre-function (bomet/naipepea differ from `kong.yml`), the endpoint would be wide open again. A.2 (service re-introspection) closes this — the service trusts no upstream.
+- **`_schema` was anonymous (`AnalyticsController.java:57–60`).** Leaving it open is a catalog/grain disclosure and a Part-D bypass (read the schema, then POST a hidden `kpiId`). Part A protects it. Edge: existing FE callers that hit `_schema` without a token will start getting 401 — coordinate with the FE (O5).
+- **Token↔body identity drift.** A valid token for user X with a body `userInfo` claiming user Y: the overwrite (A.2) discards Y. Logged at debug when `client userInfo.uuid != introspected.uuid` (A.2) to surface broken clients without leaking the token.
+- **Tenant isolation.** A.4 stops a vouched ke.bomet employee from passing `tenantId:"pb.amritsar"` (same-tenant only). The body-widens-tenant hole is real today (tenant flows from `AnalyticsController.java:45` → `AnalyticsService.java:32` → `resolve`); A.4 is the minimal plug. Part A deliberately ships **only** the exact-match floor and defers any prefix widening to Part C, because the live tenant predicate (`AnalyticsPlanner.java:243`) is an un-anchored/un-escaped `LIKE …%` that would leak siblings if A widened the check to match it. Full jurisdiction/department isolation is B/C.
+- **Flat `_details` shape & `roles[]` mapping (the silent-degrade risk).** If the live response nests `roles[]` differently than the parser expects, `u.getRoles()` (`AnalyticsScope.java:38`) returns empty and every employee reads as "no employee role" — an under-scope that looks like a citizen leak path downstream. O1 + the integration assertion (step 6) close this; the parser is written flat to match `kong.yml:79–80` but is verified, not assumed.
+- **HRMS role pollution (memory).** Not introduced by A, but A is where roles become *trusted* — so a polluted role set (every GRO also `PGR_LME`) is now authoritatively believed. Mitigation is downstream (D/F test against clean `RBAC_TEST_*` users); Part A's job is only that the roles are the *real* (polluted-or-not) egov-user roles, not client-invented ones.
+- **Performance — introspection per request.** Each `_query` adds one egov-user round-trip (the Kong plugin already pays this on the enrich path). The token is a redis-backed opaque UUID, so `_details` is a redis lookup — cheap. **Cache** introspection by token with a **short TTL (≤60s) and a hard cap below token validity**, keyed on the raw token (never log it). **Never cache `null`/401 results** (a transient egov-user 5xx must not pin a token to "denied"). Part B sets the caching policy for HRMS attributes; A only caches the token→identity, which is comparatively stable within a session.
+- **`SYSTEM`-type tokens.** Internal service calls (escalation scheduler, persister) carry `type:SYSTEM`. Part A must not 401 legitimate internal callers; but analytics is a read API — default: treat SYSTEM as **denied on the analytics route** unless explicitly allow-listed (it has no dashboard use); revisit if an internal aggregator needs it (O3).
+- **Double introspection cost (A.1 + A.2).** When both gateway and service introspect, the token is validated twice. Acceptable (both are cheap redis hits) and the redundancy is the point; the per-token cache (above) collapses it within a request burst.
+- **Error-code surface.** `AnalyticsController.error()` (`AnalyticsController.java:62–69`) derives the error code from the message prefix before `:`. Keep that convention: throw messages like `"unauthenticated: …"` / `"forbidden: …"` so the existing extractor emits `error:"unauthenticated"`/`"forbidden"` without new code.
+
+---
+
+## Open questions for review
+
+- **O1 — `/user/_details` response shape via the proxy (downgraded, not closed).** In-tree evidence (`kong.yml:79–80`) says the proxy emits a **flat** top-level user, and the A.2 table is now drawn flat to match. Still confirm on a **recorded live response** that `roles[]` is `{code,name,tenantId}` at top-level `roles` (not nested) before finalizing the parser — a wrong `roles` mapping silently degrades every employee to "no employee role" (`AnalyticsScope.java:38`). *Resolve by recording one live response on ovh before coding the parser (step 6).*
+- **O2 — gateway vs service as the canonical fix.** This part ships both but declares the **service** authoritative. Is the team comfortable carrying the Kong change as non-load-bearing (so bomet/naipepea nginx fronts need no parity edit for correctness, only for defense-in-depth)? Confirm the holistic-fix rule (memory) is satisfied by the service-side change alone.
+- **O3 — `SYSTEM` token policy** on the analytics route: deny by default, or allow-list specific internal callers? No current consumer is known; defaulting to deny is safest but may surprise a future internal aggregator.
+- **O4 — tenant-allowed policy (deferred to Part C).** Part A ships **same-tenant only** (A.4). The state-root (`ke`) employee querying a city (`ke.bomet`) case needs an **anchored+escaped** tenant predicate first — the live `AnalyticsPlanner.java:243` `LIKE …%` is neither, and widening A.4 to match it would leak siblings (`ke` vs `kenya`). Part C owns the anchored predicate and the widened allowed-tenant rule; A.4 stays conservative until then.
+- **O5 — FE coordination for `_schema` auth.** `_schema` becomes protected (was anonymous, `AnalyticsController.java:57–60`). Confirm every current caller sends `RequestInfo.authToken`; otherwise stage A's `_schema` protection behind a flag for one release while the FE catches up.
+- **O6 — introspection cache TTL & token logging.** Agree the token→identity cache TTL (proposed ≤60s), the absolute rule that the raw token is never logged (it is a bearer credential), and that **`null`/401 results are never cached**. Should a token-revocation event (logout) bust the cache, or is ≤60s staleness acceptable?
+
+---
+
+## v2 revision log (pass-1 findings → resolution)
+
+- **[major → resolved] Reused HTTP client is not fail-closed on 5xx/unreachable — `fetchResult` swallows the exception and returns `null`.** Confirmed exact: `ServiceRequestRepository.fetchResult` rethrows only `HttpClientErrorException` (4xx) as `ServiceCallException` (`ServiceRequestRepository.java:35–37`); the generic `catch(Exception)` at `ServiceRequestRepository.java:38–40` logs and **returns `null`** with no rethrow. **Resolution:** A.2's `introspect()` now (a) wraps only the call in `try/catch ServiceCallException → null`, and (b) adds an explicit `if (res == null) return null;` *before* `parseUserRequest`, so 5xx/timeout/unreachable/decode-error all become `null → 401` rather than an NPE-500 or a fall-through. The Current-code-reality section, A.2 code+comment, the fail-closed risk bullet, the control-flow diagram, the Principal INVARIANT, and migration step 2's unit-test matrix all now state this explicitly.
+- **[major → resolved] Spoof negative test asserted "citizen self-scope" but `daily` grain never applies it (citizen reads tenant-wide).** Confirmed exact: `daily` registered with `citizenColumn=null` (`AnalyticsCatalog.java:108`, 3rd-from-last ctor arg after `boundary_path`); citizen predicate guarded by `g.citizenColumn != null` (`AnalyticsPlanner.java:246`). **Resolution:** rewrote the exit-criterion test into a new **A.6 (per-grain)** section + migration step 5: assert `account_id = :self` on `facts`/`events` (columns at `AnalyticsCatalog.java:78`/`:96`), and assert `daily` emits **no** citizen predicate as a **tracked known-failure handed to Part C**, preventing a false-green. The `daily` fix itself (add `account_id` or reject citizen `daily`) is explicitly scoped to **Part C** (it is not fixable inside Part A — A does not own `applyScope`/the catalog grain definitions).
+- **[minor → resolved] A.4 sibling-prefix leak — `startsWith` widening mirrors the un-anchored/un-escaped tenant `LIKE`.** Confirmed: `AnalyticsPlanner.java:243` is `tenantColumn LIKE scope.tenantId + '%'` (no delimiter anchor, no escape); req §4 (`00-requirements.md:63`) mandates anchored+escaped PREFIX. **Resolution:** A.4 now ships **same-tenant exact match only** — the `startsWith`/`stateOf` widening is removed from the code block and explicitly deferred to Part C (O4), which owns the anchored+escaped predicate. Risk bullet and O4 updated to say A ships only the conservative floor.
+- **[minor → resolved] `_details` response-shape table assumed `UserRequest.*` nesting; in-tree evidence is flat top-level.** Confirmed: `kong.yml:79` reads `user["uuid"]`/`user["userName"]` at top level and `kong.yml:80` assigns the whole decoded body as `userInfo` — no wrapper. **Resolution:** the A.2 table is redrawn **flat** (top-level `uuid`/`type`/`roles[]`/`tenantId`), a "flat top-level" note added in Current-code-reality and A.5, and the `parseUserRequest` comment + O1 now call out the **silent-degrade** risk if `roles[]` nesting is wrong (`AnalyticsScope.java:38` → empty roles → "no employee role"). O1 downgraded to "confirm `roles[]` shape on a recorded response," not "confirm wrapper vs flat."
+- **[minor → resolved] `egov.user.host` local value is `:8081` and there's no `_details` path prop; Kong hardcodes a different host.** Confirmed: `application.properties:63` `egov.user.host=http://localhost:8081`; `egov.user.context.path` exists (`PGRConfiguration.java:51`) but no details path; Kong uses `egov-user-proxy:8107` hardcoded (`kong.yml:71`). **Resolution:** corrected the "no new config plumbing" claim to add the host-divergence caveat in Current-code-reality and the Inputs section; migration step 1 mirrors the existing `egov.user.context.path` binding, and step 6 now explicitly verifies the **deployed** `${egov.user.host}` fronts egov-user vs the Kong hardcode.
+- **[citation corrections → applied] Kong guard line numbers.** Pass-1 cited Guard 2 as `kong.yml:65–68`; the actual early-return block is `kong.yml:65–67` (`if ri["userInfo"]…` L65, `if ui["uuid"]…return end` L67). Guard 1 split to `kong.yml:63` (`local token`) + `kong.yml:64` (`if not token…return end`); introspection POST at `kong.yml:71` (single line, not 71–74); error pass-throughs at `kong.yml:75` and `kong.yml:76`; flat read/assign at `kong.yml:79–80`. All design references corrected to these exact lines.
+- **[interface A→B → addressed] empty-role principal from wrong `roles[]` mapping.** Resolved jointly with the flat-shape fix: O1 now blocks B coding against `Principal.roles`, stated in the A→B interface bullet and the risk list (silent employee→"no role" degrade).
+- **[interface A→C → addressed] negative test must surface, not hide, C's open leaks.** Resolved by A.6: the per-grain test records `daily` as a tracked failure for C (and notes the `AnalyticsPlanner.java:243` un-anchored tenant LIKE as C's to fix), so A cannot "ship green" while C leaks.
+- **[interface A→D → addressed] batch `queries` arm.** Verified: `AnalyticsService.query()` resolves one `scope` at `AnalyticsService.java:32` and feeds it to both the single arm (`L51`) and the batch arm (`L42–46`), so A's trusted principal covers both. Clarified in Current-code-reality, A.3, the control-flow diagram, and the A→D interface bullet that the **batch-arm bypass is a Part-D `kpiId` re-check concern, not a Part-A trust gap** (not fixable here; owner = Part D).
+- **[interface B/C → noted, not owned] `tenantStateLevel` drop in `PrincipalAttributes`.** Cross-cutting README finding. `AnalyticsScope.tenantStateLevel` exists (`AnalyticsScope.java:22`); carrying it into attribute resolution so C can pick `LIKE prefix` vs `= tenant` is **B/C's** responsibility. Noted in A.5; **not fixable in Part A** (owner = Parts B and C).
+- **[verdict] verified-citations were all confirmed exact** against the tree (`AnalyticsController.java:40–69`, `AnalyticsScope.java:31–48`, `AnalyticsService.java:30–32`/`42–46`/`51`, `kong.yml:49–82`/`334–343`, `AnalyticsCatalog.java:54–108`, `AnalyticsPlanner.java:241–251`, `ServiceRequestRepository.java:30–43`, `PGRConfiguration.java:48`/`51`/`220`, `application.properties:63`). No mis-citation remained beyond the line-number tightening above; the two majors and three minors are folded into the design body with concrete changes; the only items left open are O1–O6 and the explicitly-Part-C/Part-D/Part-B-owned downstream fixes.
+
+## Codex review (pass 2 — gpt-5.5, verdict: needs-rework)
+
+> External adversarial review via `codex exec`, read-only, verifying the v2 revision log against the actual code. **Note:** codex evaluated "resolved" as "patched in code"; this is a *design* doc (no code changed yet), so most `actuallyResolved:false` items mean "design specifies it, code not yet written," not "design wrong." Read the findings for genuine design errors vs. implementation-status notes.
+
+
+**Summary:** The v2 design resolves several citation/design-review issues on paper, but the actual code still has the original auth gap. There is also a remaining gateway fail-open path if the proposed A.1 gate is inserted after the existing body/RequestInfo early returns.
+
+
+### Resolution check (5/11 confirmed in code)
+
+- ❌ **Reused HTTP client is not fail-closed on 5xx/unreachable because fetchResult swallows and returns null.** — Code still has only ServiceRequestRepository.fetchResult returning null on generic exceptions at CCRS/backend/pgr-services/src/main/java/org/egov/pgr/repository/ServiceRequestRepository.java:38-42; no AnalyticsAuthService or null-to-401 path exists, and AnalyticsController still trusts body RequestInfo at CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsController.java:43-47.
+- ❌ **Spoof negative test missed daily grain citizen leak.** — Design now surfaces the issue, but code still has daily citizenColumn=null at CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsCatalog.java:108 and applyScope skips citizen scope when null at CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java:246.
+- ❌ **A.4 sibling-prefix leak from startsWith widening over unanchored tenant LIKE.** — The design removes prefix widening, but actual code still emits state tenant scope as tenant_id LIKE tenantId + '%' at CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java:242-244.
+- ✅ **_details response-shape table assumed UserRequest nesting instead of flat top-level user.** — The cited in-tree Kong evidence is flat: decoded user is checked at top-level for uuid/userName and assigned directly to userInfo at CCRS/local-setup/kong/kong.yml:77-80.
+- ❌ **egov.user.host local value differs from Kong hardcode and no _details path prop exists.** — The design acknowledges it, but code still only has egov.user.host/context/search/update config at CCRS/backend/pgr-services/src/main/resources/application.properties:63-68 and PGRConfiguration.java:48-61; no egov.user.details.path/getUserDetailsPath exists.
+- ✅ **Kong guard line number citations were wrong.** — The corrected citations match: token guard at CCRS/local-setup/kong/kong.yml:63-64, userInfo early return at :65-67, URL at :71, error pass-throughs at :75-76, flat read/assign at :79-80.
+- ❌ **A→B empty-role principal risk from wrong roles[] mapping.** — Design flags O1, but actual code has no parser or verified mapping. AnalyticsScope still consumes whatever body userInfo roles contain at CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsScope.java:34-44.
+- ❌ **A→C negative test must surface C's open leaks.** — No code/test change exists; C leaks remain: daily skips citizen scope via AnalyticsCatalog.java:108 plus AnalyticsPlanner.java:246, and tenant LIKE remains unanchored at AnalyticsPlanner.java:243.
+- ✅ **A→D batch queries arm must not bypass trusted principal.** — For Part-A identity only, one scope is resolved once at CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java:30-32 and reused for batch runOne calls at :42-46 and single query at :50-51. D still owns kpiId re-checks.
+- ✅ **B/C tenantStateLevel drop in PrincipalAttributes.** — Correctly noted as not owned by A. Current code has tenantStateLevel in AnalyticsScope at CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsScope.java:21-28 and no PrincipalAttributes implementation in the cited analytics package.
+- ✅ **v2 verdict says verified citations exact.** — The cited current-code anchors checked in this pass are materially accurate, except the actual implementation remains unchanged and vulnerable.
+
+### Findings
+
+- **[BLOCKER] Auth foundation is not implemented; forged userInfo still reaches scope resolution** — The revised design describes service-side authoritative introspection, but the actual controller still converts RequestInfo directly from the request body and passes it to AnalyticsService. AnalyticsScope then derives citizen/employee posture from that body-supplied userInfo. This leaves identity spoofing and scope widening open in the actual code.  
+  _evidence:_ `CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsController.java:43-47; CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsScope.java:34-44`
+- **[BLOCKER] Gateway still fails open on missing token, prefilled userInfo, and introspection failure** — The actual Kong pre-function returns without rejecting when authToken is missing, returns before introspection when userInfo has uuid/id/userName, and logs then passes through on unreachable/non-200 introspection. The pgr route has no route-level auth plugin to compensate.  
+  _evidence:_ `CCRS/local-setup/kong/kong.yml:63-67; CCRS/local-setup/kong/kong.yml:75-76; CCRS/local-setup/kong/kong.yml:334-343`
+- **[MAJOR] Proposed gateway hardening still misses malformed/no-body protected requests if inserted after RequestInfo parsing** — A.1 says to add the protected-route gate after ri is obtained, but the existing pre-function returns before that point for non-POST, empty body, invalid JSON, or missing RequestInfo. For protected analytics routes, those paths would bypass the claimed gateway 401 unless the protected-route check is moved before these early returns or those returns become protected-route 401s. Service-side auth would still catch this, but the A.1 resolution claim is overstated.  
+  _evidence:_ `CCRS/local-setup/kong/kong.yml:56-62`
+- **[MAJOR] _schema remains anonymous in code** — The design says _schema becomes protected, but the actual endpoint still accepts no body and directly returns service.schema(). This leaks grains, columns, and scope columns without authentication.  
+  _evidence:_ `CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsController.java:57-59; CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java:71-93`
+- **[MAJOR] Tenant is still body-controlled and can widen scope** — The controller still reads tenantId from the request body and passes it into AnalyticsScope; there is no cross-check against a vouched principal tenant or role tenant. At state-level tenant ids, the planner expands it with an unanchored LIKE.  
+  _evidence:_ `CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsController.java:45-47; CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java:30-32; CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java:242-244`
+- **[MAJOR] Daily grain still silently drops citizen self-scope** — Citizen self-scope is only injected when the grain has citizenColumn. The daily grain has null citizenColumn, so a citizen-scoped daily query only gets tenant scope.  
+  _evidence:_ `CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsCatalog.java:98-108; CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java:246`
+- **[MINOR] New service/config APIs cited by the design do not exist yet** — AnalyticsAuthService, UnauthenticatedException/ForbiddenException, egov.user.details.path, and getUserDetailsPath are design additions only. Treat any claim relying on them as unimplemented until the code adds them.  
+  _evidence:_ `Search found no AnalyticsAuthService/getUserDetailsPath/egov.user.details.path in CCRS/backend/pgr-services; existing user config is only CCRS/backend/pgr-services/src/main/java/org/egov/pgr/config/PGRConfiguration.java:48-61 and CCRS/backend/pgr-services/src/main/resources/application.properties:63-68`
+
+### Gaps
+
+- No actual Part-A implementation exists in the cited code: no service-side token introspection, no controller 401/403 mapping, no tenant cross-check, and no protected _schema.
+- No tests were found or cited that assert forged-admin/no-token, citizen-token overwrite, facts/events account_id scope, or daily known-failure behavior.
+- Part-D and Part-F interfaces remain only aspirational: there is no kpiId/visibleTo invocation re-check or inline_forbidden gate in the analytics package.

--- a/docs/dashboard-rbac-design/20-attribute-resolution.md
+++ b/docs/dashboard-rbac-design/20-attribute-resolution.md
@@ -1,0 +1,474 @@
+# Part B — Attribute Resolution (roles, jurisdiction, department)
+
+**Status:** v2, 2026-06-23 · **Maps to:** implementation-plan Phase 1 · **Blocked by:** Part A (trust foundation) · **Blocks:** Part C (attribute-scope engine)
+**Reads:** `00-requirements.md` §4 (attribute-scope model), §5 (ownership split), §6 (fail-closed NFR), §7 (hazards 2/3/4/5); `rbac-kpi-access-implementation-plan.md` §1, Phase 1; `dashboard-query-api-design.md` §5.
+
+> **Grounding rule (inherited from Part 00):** every "today it does X" is anchored to a file:line actually read. Gaps are stated as gaps with the anchor that proves the absence. **v2 note:** all anchors below were re-opened against `CCRS/backend/pgr-services` (the vendored, deploy-target tree — NOT `municipal-services/pgr-services`) during pass-2 revision; the boundary-resolution path was rebuilt after pass-1 found the original endpoint cited a field it does not return.
+
+---
+
+## Goal & responsibilities
+
+**This part owns exactly one transform:** given a **trusted** principal from Part A — `{uuid, type, roles[], tenantId}` that has already been validated against the token and is no longer attacker-controlled — produce a **`PrincipalAttributes`** value object carrying the caller's *row-scoping attributes*:
+
+- **`boundaryPrefixes[]`** — the caller's HRMS jurisdiction boundary codes, each resolved to a delimiter-anchored materialized-path prefix (`ke.bomet.CENTRAL.WARD_3|`) ready for the `boundary_path LIKE` predicate.
+- **`departmentCodes[]`** — the caller's active HRMS assignment department codes, intersected with the tenant's MDMS Department code-space, ready for the `department_code IN (…)` predicate.
+- **`citizenUuid`** (passthrough) — already derivable in `AnalyticsScope` today; Part B keeps it on the same object so the scope layer has one input.
+- **`tenantStateLevel`** — the boolean Part C's `applyScope()` needs to choose `LIKE prefix||'%'` (state-root) vs `= tenantId` (city) for the *tenant* predicate. Carried forward so Part C's `from(PrincipalAttributes)` reproduces today's tenant isolation exactly (see B.1 / B-2 fix).
+- **`scopeLevel`** — an enum (`CITIZEN | EMPLOYEE_SCOPED | TENANT_ADMIN`) that records *why* the attribute lists are empty, so Part C can tell "admin → no restriction" apart from "employee → resolution failed → empty → deny."
+- **`resolutionComplete`** — the hard fail-closed trip: `false` means an HRMS/boundary hop failed or a jurisdiction code did not resolve; Part C must deny, not fall through to tenant-only.
+
+**What this part explicitly does NOT own:**
+
+- **It does not validate identity.** That is Part A. Part B assumes `requestInfo.getUserInfo()` is already trustworthy; if Part A is not deployed, Part B resolves attributes for a *spoofed* principal and is theater (requirements §7.1). Part B treats `userInfo==null` as fail-closed deny, but cannot itself detect a *populated-but-unsigned* forged body — that is Part A's job (see *Interfaces → Part A*).
+- **It does not build the `WHERE` clause.** It produces *values*; Part C's generalized `AnalyticsScope.attrScopes` + `AnalyticsPlanner.applyScope()` loop emit SQL. Part B stops at "here are the anchored prefixes and the dept codes."
+- **It does not decide KPI visibility (Part D) or inline-grammar gating (Part F).** Those read `roles[]` off the same principal but are orthogonal to attribute resolution.
+- **It does not own the events-MV `department_code` migration, nor the daily-grain citizen-column fix.** Those physical-schema gaps are Part C / plan §3 step 4. Part B only *flags the code-space consistency risk* (HRMS vs MDMS) and the grain-binding gaps as ship-blocking preconditions Part C must close.
+- **It does not author HRMS, boundary, or department masters.** "Consume identity, don't rebuild it" (requirements §5). Part B is strictly read-only against egov-hrms, boundary-service/boundary-relationship, and MDMS.
+
+---
+
+## Current code reality (file:line — what exists vs what's missing)
+
+### What exists
+
+| Capability | State | Anchor |
+|---|---|---|
+| Citizen self-scope derivation from `userInfo` | **Done** (but on an untrusted principal) | `AnalyticsScope.resolve()` reads `requestInfo.getUserInfo()` L34, `u.getType()` L36, `u.getRoles()` L38–42, sets `citizenUuid` L44 |
+| `boundaryPrefix` field + LIKE clause | **field exists, never populated** — hardcoded `null` | `AnalyticsScope.java:24` (field), `:47` (`return new AnalyticsScope(…, null)`); planner consumes it at `AnalyticsPlanner.java:247–249` with the escape already coded |
+| `tenantStateLevel` field + tenant predicate split | **Done** | `AnalyticsScope.java:22` (field), `:32` (computed from `stateLevelLen`); `AnalyticsPlanner.java:243` (`LIKE` at state) vs `:244` (`= tenantId` at city) |
+| Per-grain boundary column binding | **Done** all three grains | `AnalyticsCatalog.java` facts `boundaryColumn="boundary_path"` (Grain ctor positional arg, **L78**), events (**L96**), daily (**L108**) |
+| `department_code` as facts column | **Done** (groupable + filterable) | `AnalyticsCatalog.java:59` (groupable list), `:66` (filterable list); MV source `data->>'department'` at migration **L147**, folded into facts select **L169** |
+| **An existing HRMS read seam inside pgr-services** | **Done** — this is the seam Part B extends | `HRMSUtil.getDepartment()` (`HRMSUtil.java:44`); builds `/egov-hrms/employees/_search?tenantId=&uuids=` (`getHRMSURI` L105–115); calls `serviceRequestRepository.fetchResult` L50; parses `$.Employees.*.assignments.*.department` (`PGRConstants.java:41`) |
+| HRMS current-assignment awareness | **Done** in a sibling path | `PGRConstants.java:168` `$.Employees[0].assignments[?(@.isCurrentAssignment==true)].reportingTo` — proves assignments carry `isCurrentAssignment`; consumed by `HRMSUtil.getSupervisorUuid()` (`HRMSUtil.java:73`) |
+| HRMS host/endpoint config | **Done** | `getHRMSURI` reads `config.getHrmsHost()` / `config.getHrmsEndPoint()` (`HRMSUtil.java:107–108`) |
+| Boundary-service host/endpoint config | **Done** | `application.properties` `egov.boundary.host` + `egov.boundary.search.url=/boundary-service/boundary/_search` |
+| Materialized path construction | **Done & canonical** | grain MV: `(ancestralmaterializedpath \|\| '\|' \|\| code) AS boundary_path` from `boundary_relationship` (`V20260608000000__create_v2_grain_mvs.sql:23`, self-INCLUDED); identical recursive path-build in MCP `digit-mcp/src/tools/boundary.ts:37–60` |
+| Department master / code space | **Exists, two shapes** | `common-masters.Department` — nairobi **v2-wrapped** `{"tenantId":…,"data":{"code":"DEPT_01"…}}` (`CCRS/ansible/nairobi-mdms/mdms/common-masters/Department.json`), ddh **v1-flat** `{"code":"DEPT_35"…}` (`CCRS/utilities/default-data-handler/src/main/resources/mdmsData/common-masters/common-masters.Department.json`) |
+
+### What is missing (the gap Part B fills)
+
+1. **No jurisdiction resolution anywhere.** `HRMSUtil` reads `assignments.*.department` (`PGRConstants.java:41`) and `assignments[?isCurrentAssignment].reportingTo` (`PGRConstants.java:168`) but **never reads `jurisdictions[*].boundary`**. There is no constant, no JsonPath, no method for it. The HRMS employee payload's `Jurisdictions` section is real (the configurator form renders it — `tests/integration-tests/.../employee-create.spec.ts:93` lists "Jurisdictions" as one of the four canonical sections; field name `boundary` cross-confirmed against `digit-ui-v2/src/api/types.ts:240` and MCP `hrms.ts:199–212`), but pgr-services has never consumed it. **Net-new.**
+2. **No boundary-code → materialized-path resolver in Java.** The path is built in SQL inside the MV (`…grain_mvs.sql:23`) from `boundary_relationship.ancestralmaterializedpath`, and in TypeScript in MCP (`boundary.ts:43–60`), but pgr-services has **no** Java path that returns `ancestralmaterializedpath` for a boundary code. **`/boundary-service/boundary/_search` does NOT carry it** (see B.4 — the v2 entity model has no such field). **Net-new, and re-pointed to the boundary-relationship source.**
+3. **No `PrincipalAttributes` class.** `AnalyticsScope.resolve()` (`AnalyticsScope.java:31`) takes `RequestInfo` and *inlines* citizen logic; there is no separate attribute holder and no HRMS/boundary fan-out. The Javadoc itself flags this: *"Full HRMS jurisdiction resolution is the documented extension point"* (`AnalyticsScope.java:16–18`), and L46 `// boundaryPrefix: extension point for HRMS-jurisdiction-restricted employees (TODO).`
+4. **No caching layer.** `HRMSUtil` calls HRMS synchronously per invocation with no cache. Resolving jurisdiction+department on every `_query` would add two network hops per request.
+5. **No code-space consistency check.** Nothing verifies HRMS assignment dept codes ⊆ MDMS `common-masters.Department` codes. The facts column is sourced from **MDMS ServiceDefs** `data->>'department'` (`…grain_mvs.sql:147`) via `LEFT JOIN mdms m ON m.service_code = s.servicecode` (`:227`); the user's dept comes from **HRMS assignment**. If they diverge — or the join misses — `department_code IN (…)` silently matches nothing (requirements §7.3). **No guard today.**
+
+---
+
+## Design
+
+### B.1 Data model — `PrincipalAttributes`
+
+A new immutable value object, the single output of this part. It is *not* `AnalyticsScope` (that is Part C's generalized type with `attrScopes`); it is the **raw resolved attributes** Part C consumes to build `attrScopes`. **It is a strict superset of every field `AnalyticsScope` carries today** (`tenantId`, `tenantStateLevel`, `citizenUuid`, plus the new attribute lists) so Part C's `from(PrincipalAttributes)` can rebuild today's tenant + citizen predicates without losing information — this closes B-2 (pass-1: `tenantStateLevel` was dropped).
+
+```java
+package org.egov.pgr.analytics;
+
+import java.util.List;
+import java.util.Collections;
+
+/** Server-resolved row-scoping attributes for a TRUSTED principal (Part A output).
+ *  Read-only projection of egov-hrms + boundary-relationship + MDMS Department.
+ *  Never built from raw body fields.
+ *  Empty attribute lists are MEANINGFUL: distinguish admin (no restriction) from employee
+ *  (resolved-empty => deny) via scopeLevel, NOT by list emptiness. */
+public final class PrincipalAttributes {
+
+    public enum ScopeLevel { CITIZEN, EMPLOYEE_SCOPED, TENANT_ADMIN }
+
+    public final String tenantId;
+    public final boolean tenantStateLevel;        // carried forward from AnalyticsScope.java:22 — Part C tenant predicate
+    public final String uuid;
+    public final ScopeLevel scopeLevel;
+    public final String citizenUuid;              // non-null only for ScopeLevel.CITIZEN
+    public final List<String> boundaryPrefixes;   // delimiter-anchored, e.g. "ke.bomet.CENTRAL.WARD_3|"
+    public final List<String> departmentCodes;    // MDMS-aligned codes (already intersected), e.g. ["DEPT_03"]
+    public final boolean resolutionComplete;      // false => an HRMS/boundary hop failed => fail closed
+
+    private PrincipalAttributes(String tenantId, boolean tenantStateLevel, String uuid, ScopeLevel level,
+                                String citizenUuid, List<String> boundaryPrefixes, List<String> departmentCodes,
+                                boolean resolutionComplete) {
+        this.tenantId = tenantId; this.tenantStateLevel = tenantStateLevel; this.uuid = uuid;
+        this.scopeLevel = level; this.citizenUuid = citizenUuid;
+        this.boundaryPrefixes = Collections.unmodifiableList(boundaryPrefixes);
+        this.departmentCodes  = Collections.unmodifiableList(departmentCodes);
+        this.resolutionComplete = resolutionComplete;
+    }
+
+    static PrincipalAttributes citizen(String tenantId, boolean stateLevel, String uuid) {
+        return new PrincipalAttributes(tenantId, stateLevel, uuid, ScopeLevel.CITIZEN, uuid,
+                Collections.emptyList(), Collections.emptyList(), true);
+    }
+    static PrincipalAttributes admin(String tenantId, boolean stateLevel, String uuid) {
+        return new PrincipalAttributes(tenantId, stateLevel, uuid, ScopeLevel.TENANT_ADMIN, null,
+                Collections.emptyList(), Collections.emptyList(), true);
+    }
+    static PrincipalAttributes scoped(String tenantId, boolean stateLevel, String uuid,
+                                      List<String> prefixes, List<String> depts, boolean complete) {
+        return new PrincipalAttributes(tenantId, stateLevel, uuid, ScopeLevel.EMPLOYEE_SCOPED, null,
+                prefixes, depts, complete);
+    }
+}
+```
+
+> **Why `scopeLevel` and not "empty list means admin":** requirements §6 (fail-closed) demands a missing HRMS row yield **empty/denied, never unscoped**. If Part C only saw `boundaryPrefixes=[]`, it could not distinguish a `TENANT_ADMIN` (legitimately unrestricted) from an `EMPLOYEE_SCOPED` whose HRMS row failed to resolve. The enum makes the difference explicit; `resolutionComplete=false` is the hard fail-closed trip.
+>
+> **Why `tenantStateLevel` is on the object:** `applyScope` (`AnalyticsPlanner.java:243–244`) branches on it for the *tenant* predicate — `LIKE tenantId||'%'` at state root vs `= tenantId` at city. Drop it and Part C either collapses every tenant to `=` (state-root admins see nothing) or to `LIKE` (`ke.bomet` LIKE-matches `ke.bometville` — a cross-tenant leak). The resolver computes it from `stateLevelLen` exactly as `AnalyticsScope.java:32` does and stores it here.
+
+### B.2 The resolver — `PrincipalAttributesResolver`
+
+A new `@Component` that fans out to the seams. It deliberately **reuses `HRMSUtil`'s HTTP plumbing** (`serviceRequestRepository.fetchResult`) rather than introducing a parallel client.
+
+```java
+@Component
+public class PrincipalAttributesResolver {
+
+    private final HRMSUtil hrmsUtil;                     // extended (see B.3)
+    private final BoundaryPathResolver boundaryResolver; // new (B.4)
+    private final DepartmentCodeSpace deptCodeSpace;     // new (B.5) — consistency guard + cache
+    private final PGRConfiguration config;
+    // role-set classification reuses the exact predicate AnalyticsScope uses today
+
+    public PrincipalAttributes resolve(RequestInfo requestInfo, String tenantId, int stateLevelLen) {
+        // compute the SAME tenant-state flag AnalyticsScope.java:32 computes, and carry it forward (B-2 fix)
+        boolean stateLevel = tenantId != null && tenantId.split("\\.").length == stateLevelLen;
+
+        User u = requestInfo == null ? null : requestInfo.getUserInfo();
+        if (u == null) {
+            // No principal at all — Part A should have rejected this. Fail closed: deny everything.
+            return PrincipalAttributes.scoped(tenantId, stateLevel, null,
+                       List.of(), List.of(), /*complete=*/false);
+        }
+        RoleClass rc = classify(u);   // CITIZEN | EMPLOYEE | ADMIN — same logic as AnalyticsScope L36–44
+
+        if (rc == RoleClass.CITIZEN)  return PrincipalAttributes.citizen(tenantId, stateLevel, u.getUuid());
+        if (rc == RoleClass.ADMIN)    return PrincipalAttributes.admin(tenantId, stateLevel, u.getUuid());
+
+        // EMPLOYEE_SCOPED: resolve jurisdiction + department from HRMS, cached.
+        EmployeeAttrs hrms = hrmsCache.get(cacheKey(u.getUuid(), tenantId)); // B.6 caching
+        if (hrms == null || hrms.failed) {
+            // HRMS unreachable / null result / no employee row => fail closed (requirements §6, §7.5 drift).
+            return PrincipalAttributes.scoped(tenantId, stateLevel, u.getUuid(), List.of(), List.of(), false);
+        }
+        List<String> prefixes = boundaryResolver.toPrefixes(hrms.boundaryCodes, tenantId); // B.4
+        List<String> depts    = deptCodeSpace.filterToKnown(hrms.departmentCodes, tenantId); // B.5
+        // every jurisdiction code must resolve; an unresolved code => incomplete => Part C denies
+        boolean complete = prefixes.size() == hrms.boundaryCodes.size();
+        return PrincipalAttributes.scoped(tenantId, stateLevel, u.getUuid(), prefixes, depts, complete);
+    }
+}
+```
+
+**`classify(User)` is the exact predicate already shipped** in `AnalyticsScope.java:36–44`, lifted verbatim, plus an admin branch keyed on the admin role set named in requirements §2 (`PGR_ADMIN`/`DSS_ANALYST`/`SUPERADMIN`). Citizen = `type==CITIZEN && no employee role` (`AnalyticsScope.java:44`). The employee branch is the *default* for any non-citizen, non-admin principal. This keeps citizen behavior byte-identical to today and adds only the employee/admin split. It must not assume single-role (requirements §7.2 pollution — see Risks).
+
+> **Fail-closed on an `EMPLOYEE_SCOPED` with zero attributes:** a non-citizen, non-admin employee whose HRMS row resolves to *both* `boundaryPrefixes=[]` and `departmentCodes=[]` (no jurisdiction AND no department) is **not** the same as an admin. Part C must treat `EMPLOYEE_SCOPED` with no attribute predicates as **deny** (see *Interfaces → Part C*), never tenant-wide. The contract carries `scopeLevel` precisely so this case cannot collapse into admin.
+
+### B.3 HRMS read — extend `HRMSUtil`, don't fork it
+
+`HRMSUtil.getHRMSURI()` (`HRMSUtil.java:105`) already produces the exact `_search?tenantId=&uuids=` URL Part B needs, and `getDepartment()` (`HRMSUtil.java:44`) already parses `$.Employees.*.assignments.*.department`. Part B adds **one method** that does a single HRMS fetch and pulls *both* attribute families from the one response (so we never make two HRMS calls for one employee):
+
+```java
+// HRMSUtil — new. SINGLE-UUID ONLY (see "[0]" note below). Does NOT throw on empty/parse-miss —
+// deliberately UNLIKE getDepartment() (HRMSUtil.java:57-62), which throws PARSING_ERROR / DEPARTMENT_NOT_FOUND.
+public EmployeeAttrs getEmployeeAttrs(String uuid, RequestInfo requestInfo, String tenantId) {
+    StringBuilder url = getHRMSURI(Collections.singletonList(uuid), tenantId);  // reuse L105
+    Object res;
+    try {
+        res = serviceRequestRepository.fetchResult(url,
+                  RequestInfoWrapper.builder().requestInfo(requestInfo).build());  // reuse L50
+    } catch (Exception e) {
+        // NOTE: fetchResult itself SWALLOWS 5xx/timeout and returns null (ServiceRequestRepository.java:38-42 — fail-OPEN),
+        // but RE-THROWS 4xx as ServiceCallException (:37). We catch here so a 4xx also fails CLOSED, not 500s the dashboard.
+        log.warn("HRMS call failed for {} — failing closed", uuid, e);
+        return EmployeeAttrs.failed();                 // => resolutionComplete=false upstream
+    }
+    if (res == null) return EmployeeAttrs.failed();    // 5xx/timeout swallowed by fetchResult => null => fail closed
+
+    // Active-assignment departments. NOTE: filter to current/active assignments, unlike the
+    // unfiltered getDepartment() at HRMSUtil.java:55 — a stale assignment must not widen scope (§7.5 drift).
+    List<String> depts = safeRead(res,
+        PGRConstants.HRMS_ACTIVE_DEPARTMENT_JSONPATH);   // safeRead returns [] on miss, never throws
+    // Jurisdiction boundary codes — NET-NEW path (no existing constant).
+    List<String> boundaryCodes = safeRead(res,
+        PGRConstants.HRMS_JURISDICTION_BOUNDARY_JSONPATH);
+
+    return new EmployeeAttrs(dedupe(boundaryCodes), dedupe(depts), /*failed=*/false);
+}
+```
+
+New constants in `PGRConstants.java` (mirroring the L41/L168 style):
+
+```java
+public static final String HRMS_JURISDICTION_BOUNDARY_JSONPATH =
+    "$.Employees[0].jurisdictions[*].boundary";
+public static final String HRMS_ACTIVE_DEPARTMENT_JSONPATH =
+    "$.Employees[0].assignments[?(@.isCurrentAssignment==true)].department";
+```
+
+> **`safeRead` must not inherit the sibling's throwing behavior (B-5 fix).** The existing `getDepartment()` (`HRMSUtil.java:55`) does `JsonPath.read(...)` and **throws** `CustomException("PARSING_ERROR")` on any parse miss (`HRMSUtil.java:57–58`) and `CustomException("DEPARTMENT_NOT_FOUND")` when the list is empty (`HRMSUtil.java:61–62`). `getEmployeeAttrs` must NOT do that: a supervisor with a valid jurisdiction but a momentarily-empty active department must fail *closed to empty department scope*, not 500 the dashboard. `safeRead` wraps `JsonPath.read` in a try/catch and returns an empty list on miss. This is a deliberate divergence from the sibling whose plumbing it reuses, documented so a future refactor doesn't "unify" them.
+
+> **Why `isCurrentAssignment` here but `getDepartment()` uses the unfiltered `assignments.*.department` (`PGRConstants.java:41`):** the existing `getDepartment()` is used by the complaint *workflow* path where any assignment department is acceptable. For **row scope** a deactivated/historical assignment must NOT grant data access — scope reads the *current* assignment only.
+
+> **`$.Employees[0]` is single-uuid-only (B-6 fix).** Unlike the workflow reads which use `$.Employees.*` (`PGRConstants.java:41`), `getEmployeeAttrs` indexes `[0]` and is therefore valid **only** for a single-uuid `_search` (which returns at most one employee). It must never be called with a batched uuid list — `[0]` would silently resolve only the first employee's jurisdiction and scope every batched caller to one person. The signature takes a single `String uuid`, not a list, to make this a compile-time contract; the resolver only ever resolves the *one* calling principal.
+
+**Multiple active assignments / multiple jurisdictions are first-class.** Both JsonPaths return arrays; `boundaryCodes` and `departmentCodes` are lists. This is the "OR within an attribute" half of requirements §4 — a Sanitation supervisor of Wards 3 & 4 yields `boundaryCodes=[WARD_3,WARD_4]`, `departmentCodes=[SANI]`; Part C ORs within each and ANDs across.
+
+### B.4 Boundary-code → materialized-path prefix — `BoundaryPathResolver` (re-pointed source)
+
+HRMS gives boundary **codes** (`WARD_3`); the grains store **materialized paths** (`ke.bomet.CENTRAL.WARD_3`, `…grain_mvs.sql:23`). Part B resolves each code to its path and appends the delimiter to anchor the prefix.
+
+**Source correction (B-1 fix — this is the one ship-blocking change from pass-1).** Pass-1 designed this against `/boundary-service/boundary/_search` returning a `materializedPath` field. That is **wrong**: there are two `Boundary` classes in pgr-services, and the design cited the wrong one.
+
+- The **legacy** model `web/models/Boundary.java` *does* carry `materializedPath` (`@JsonProperty("materializedPath")` `:57`, field `:58` — verified `:57–59`) — but it is the old egov-location/rainmaker tree model (it also carries `latitude`/`longitude`/`label`/`children` at `:46–55`), not what the v2 endpoint returns. **The materializedPath-bearing model is the legacy one, not v2.**
+- The **boundary-service v2** entity model — `web/models/boundary/Boundary.java` — which is what `egov.boundary.search.url=/boundary-service/boundary/_search` actually hits, has **only** `id, tenantId, code, geometry, auditDetails, additionalDetails` (`web/models/boundary/Boundary.java:24–42`) and **no `materializedPath` / `ancestralmaterializedpath` field at all.** boundary-service v2's `/boundary/_search` returns flat boundary *entities*; the ancestral path lives in the **`boundary_relationship`** table.
+
+The grain MV reads exactly that table: `(ancestralmaterializedpath || '|' || code) AS boundary_path` FROM `boundary_relationship` (`…grain_mvs.sql:23`, self-INCLUDED). **`BoundaryPathResolver` therefore resolves against the same `boundary_relationship` source the grain reads, not `/boundary/_search`.**
+
+> **Duplicate-code hazard (B-7 fix — the divergence a second read introduces).** Reading `boundary_relationship` is the *right table*, but a naïve per-code read is NOT automatically "path-identical by construction." The grain's `bnd` CTE does **not** select or filter by `tenantid`; it dedupes globally with `DISTINCT ON (code) … ORDER BY code, length(ancestralmaterializedpath) DESC` (`…grain_mvs.sql:21–25`) — i.e. **one winning row per code across the whole table, the deepest path** — and binds it to facts/events rows purely on `bnd.code = svc.locality_code` (`…grain_mvs.sql:94`, events; the facts MV joins the same way). So the path a row actually carries in `boundary_path` is *the global deepest-path row for that code*. If a boundary `code` is **duplicated** across the hierarchy or across tenants, a `WHERE tenantid = ? AND code = ?` lookup can resolve a **different** `ancestralmaterializedpath` than the one the grain bound — and the resolver's `LIKE` prefix would then miss the rows it should match (or match the wrong subtree). **A separate boundary read is a second source of truth that can disagree with the grain's own row.** Avoid this by anchoring on the grain's own representation, not a per-code re-derivation: resolve through the same global, tenant-agnostic, deepest-path-wins selection the MV uses (`DISTINCT ON (code) ORDER BY length(ancestralmaterializedpath) DESC`) so the resolver returns the exact `boundary_path` the row carries. Two implementation options, in preference order:
+
+1. **Resolve via the grain's own `boundary_path`** (recommended — see Open-Q3). The materialized grains already store the authoritative, deepest-path, code-keyed value: `SELECT DISTINCT boundary_path FROM complaint_facts WHERE … code = ?` (or, equivalently, replicate the MV's exact `bnd` CTE — `DISTINCT ON (code) … ORDER BY length(ancestralmaterializedpath) DESC` against `boundary_relationship`, with **no `tenantid` filter**, matching `…grain_mvs.sql:21–25`). Either way the prefix is taken from the **same row representation** the grain bound, so a duplicated code cannot make Part B and the grain disagree. pgr-services already owns the DB connection and the grain MV proves the table is reachable; this adds zero network hops.
+2. **`/boundary-relationship/_search`** (if the boundary-service owner prefers an API boundary over coupling pgr-services to the table). This must be confirmed to return `ancestralmaterializedpath` **and** to apply the same deepest-path-wins, code-keyed dedup before adoption — it is NOT proven in-tree, and boundary-service is not vendored in CCRS (theflywheel registry), so it cannot be grounded here. **Do not** use `/boundary/_search` for this — it cannot carry the column. Whichever option, the resolver must reproduce the MV's *selection* (global `DISTINCT ON (code)`, deepest path), not just its `|| '|' || code` reconstruction, or it reintroduces the divergence.
+
+Either way the resolver reconstructs the *self-included* path exactly as the MV does and appends the anchor delimiter:
+
+```java
+@Component
+public class BoundaryPathResolver {
+    /** code -> "ancestralmaterializedpath|code|"  (self-included like the MV, trailing '|' = subtree anchor). */
+    public List<String> toPrefixes(List<String> codes, String tenantId) {
+        List<String> out = new ArrayList<>();
+        for (String code : codes) {
+            // cache value is the SELF-INCLUDED node path "ancestralmaterializedpath|code", matching grain_mvs.sql:23
+            String nodePath = cache.get(tenantId, code);     // B.6 cache
+            // resolve the SAME row the grain bound: global DISTINCT ON (code), deepest path, NO tenantid filter
+            // (matches grain_mvs.sql:21-25), so a duplicated code cannot diverge from boundary_path.
+            if (nodePath == null) nodePath = fetchAndCache(code); // grain's boundary_path / replicated bnd CTE (option 1)
+            if (nodePath == null) continue;                  // unresolved code dropped => narrows; complete=false upstream
+            out.add(nodePath + "|");                         // trailing delimiter anchors the subtree (requirements §4)
+        }
+        return out;
+    }
+}
+```
+
+**Anchoring + escaping split of responsibility:** Part B produces the *delimiter-anchored* prefix value (`…WARD_3|`). The `%`/`_`/`\` LIKE escaping stays where it already lives — `AnalyticsPlanner.java:249` (`.replace("\\","\\\\").replace("%","\\%").replace("_","\\_")`). Part B does NOT pre-escape, because the planner already does and double-escaping would break the match. The contract is: **Part B = anchored raw prefix; Part C/planner = escape + `|| '%'`**. This exactly matches the boundary-only path the planner already wired at `AnalyticsPlanner.java:247–249`.
+
+> **Path-vs-prefix subtlety (now grounded against the right source):** `boundary_relationship.ancestralmaterializedpath` is the path of *ancestors* (excludes self); the MV appends `'|' || code` to include self (`…grain_mvs.sql:23`). So the *full node path* is `ancestralmaterializedpath|code`, and the *subtree prefix* is that **plus a trailing `'|'`** so `WARD_3` does not prefix-match `WARD_30`. Because the resolver now anchors on the **grain's own representation** — the same global, code-keyed, deepest-path `DISTINCT ON (code)` selection the MV uses (`…grain_mvs.sql:21–25`), with no `tenantid` filter — the path it returns is the exact value the row carries, even for a duplicated code. (A per-code `WHERE tenantid=? AND code=?` read does NOT have this property — see the duplicate-code hazard above.) A test must still assert `BoundaryPathResolver`'s output equals the MV's `boundary_path || '|'` for the same code against real bomet boundary data (the MV is "validated against bomet data") — see Open Questions.
+
+### B.5 Department code-space consistency — `DepartmentCodeSpace`
+
+The biggest hidden risk (requirements §7.3, plan §6.3): the facts column `department_code` is MDMS-ServiceDefs-sourced via a LEFT JOIN (`…grain_mvs.sql:147`, `:227`), the user's dept is HRMS-assignment-sourced. Two distinct failure modes converge here:
+
+1. **Code-list divergence.** If HRMS dept codes and MDMS ServiceDefs dept codes differ, `department_code IN (…)` matches nothing — a *silent* total scope loss that *looks like* "no data," not "denied."
+2. **`NULL` department_code from the LEFT JOIN (README cross-cutting #3b).** `department_code` is `NULL` for any complaint whose `service_code` has no matching ServiceDefs row (`LEFT JOIN mdms m ON m.service_code = s.servicecode`, `…grain_mvs.sql:227`), and `NULL IN (…)` is never true. So even a perfectly-aligned dept code silently **under-scopes** away every complaint with an unmapped service. Part B cannot fix the join (that is a data/Part-C concern), but `DepartmentCodeSpace` **must surface it**: the boot check counts facts rows with `NULL department_code` and emits a WARN/metric so dept scope isn't shipped over a grain where it silently drops rows.
+
+`DepartmentCodeSpace` does three things:
+
+1. **Schema-shape-tolerant MDMS load (B-3 fix).** `common-masters.Department` exists in **two shapes**: nairobi is MDMS-v2 wrapped — `{"tenantId":"ke.nairobi","data":{"code":"DEPT_01"}}` (`CCRS/ansible/nairobi-mdms/mdms/common-masters/Department.json`); ddh is MDMS-v1 flat — `{"code":"DEPT_35"}` (`CCRS/utilities/default-data-handler/.../common-masters.Department.json`). The loader must read **both** (`$.data.code` when wrapped, `$.code` when flat) — a single read path silently returns an **empty** code set against one of them. **Loading zero MDMS Department codes is treated as a hard configuration error**, not "everything is unknown": it emits a loud WARN/metric and `filterToKnown` **fails closed by refusing to ship department scope** (returns empty dept list with a flag so the boot gate / step 2 catches it) rather than dropping every HRMS dept and looking like "no data." An empty MDMS set is exactly the silent-total-loss §7.3 warns about, now caused by the guard itself if mishandled.
+2. **Boot/refresh consistency check + NULL-join surfacing.** On startup (and cache refresh) it loads the MDMS code set, logs/metrics any HRMS assignment dept code observed that is **not** in that set, and metrics the count of facts rows with `NULL department_code`. This is the "one-time consistency check" plan §1 mandates. It does not 500 a live request, but it **must emit a loud WARN + a metric** so the mismatch is caught in validation, not in production silence.
+3. **`filterToKnown(hrmsDepts, tenantId)`** — intersects HRMS dept codes with the (non-empty) MDMS code set before they reach the `IN` clause. A dept code the facts column can never hold is dropped (it would match nothing anyway); dropping it *and recording it* turns a silent empty into an observable event.
+
+> Note this is a **scope-correctness** guard, not a security widening: dropping an unknown code can only *narrow* (or no-op), never widen — consistent with requirements §4 "narrow-only." The *one* exception that must NOT silently narrow is "MDMS loaded zero codes" — that is a misconfiguration and is escalated, not silently applied.
+
+### B.6 Caching (requirements §6 performance, §7.5 drift)
+
+Both HRMS attrs and boundary paths are **mutable HRMS/boundary state, not in the token** (requirements §7.5). Resolving on every `_query` adds network hops. Cache, but short-TTL where the data drifts:
+
+| Cache | Key | Value | TTL | Rationale |
+|---|---|---|---|---|
+| `hrmsCache` | `{tenantId, uuid}` | `EmployeeAttrs{boundaryCodes[], departmentCodes[], failed}` | **short (e.g. 5 min)** | jurisdiction/dept reassignment in HRMS must propagate quickly; 5 min bounds the staleness window |
+| `boundaryPathCache` | `{tenantId, code}` | self-included node path `ancestralmaterializedpath\|code` | **long (e.g. 1 h+)** | boundary topology is near-static; the MCP path-build (`boundary.ts:37`) treats it as stable |
+| `deptCodeSpaceCache` | `{tenantId}` | `Set<deptCode>` from MDMS (+ "empty" sentinel = misconfig) | **long, refreshable** | MDMS masters change rarely |
+
+- **Negative caching is bounded:** a `failed` HRMS result is cached only briefly (or not at all) so a transient HRMS blip doesn't lock a supervisor out for 5 minutes. Cache the *success* aggressively, the *failure* barely.
+- **Cache key includes `tenantId`** — never serve one tenant's resolved attrs to another (tenant isolation, requirements §7). A resolver keyed by bare `uuid` would leak a multi-tenant employee's scope across tenants.
+- **Interaction with the result cache (requirements §6):** the *resolved scope* is part of the analytics result-cache key. Part B's output feeds that key. A drifted-then-refreshed `PrincipalAttributes` therefore naturally produces a different result-cache entry — no stale cross-scope serving.
+
+### B.7 Control flow (end to end)
+
+```
+AnalyticsController.query()              [Part A gate runs first — rejects spoofed/unsigned userInfo]
+  └─> AnalyticsService.query(body, requestInfo, tenantId, stateLen)   (AnalyticsService.java:30)
+        └─> PrincipalAttributesResolver.resolve(requestInfo, tenantId, stateLen)   [PART B]
+              ├─ stateLevel = (tenantId split == stateLen)   (same as AnalyticsScope.java:32)  [B-2]
+              ├─ classify(userInfo.roles/type)               (logic from AnalyticsScope L36–44)
+              ├─ CITIZEN  -> PrincipalAttributes.citizen(uuid)
+              ├─ ADMIN    -> PrincipalAttributes.admin()
+              └─ EMPLOYEE -> hrmsCache → HRMSUtil.getEmployeeAttrs()    (extends HRMSUtil L44; single-uuid)
+                             → BoundaryPathResolver.toPrefixes()        (new; boundary_relationship source)
+                             → DepartmentCodeSpace.filterToKnown()      (new; MDMS Department, both shapes)
+        └─> AnalyticsScope.from(principalAttributes)   [PART C — builds attrScopes, reads tenantStateLevel]
+        └─> planner.plan(q, scope) ... applyScope() loop   (AnalyticsPlanner.java:241) [PART C]
+```
+
+Today `AnalyticsService.java:32` calls `AnalyticsScope.resolve(requestInfo, tenantId, stateLevelLen)` directly (the method itself begins at `AnalyticsService.java:30`). The migration inserts Part B *before* that call and changes Part C's `AnalyticsScope` to be built `from(PrincipalAttributes)` instead of from `RequestInfo` — carrying `tenantStateLevel` through so the tenant predicate is unchanged.
+
+---
+
+## Interfaces with other parts
+
+**Consumes (input contract):**
+- **From Part A (Trust foundation):** a `RequestInfo` whose `userInfo.{uuid, type, roles[]}` is **token-validated and coercive** — i.e. a spoofed/unsigned body has already been rejected or overwritten. Part B's correctness is *entirely* conditional on this. **Contract:** Part B trusts `userInfo`; if Part A is absent, every guarantee here is void (requirements §7.1). Part B additionally treats `userInfo==null` as fail-closed (deny). It **cannot** itself detect a *populated-but-unsigned* forged body — see the Part A interface issue below.
+- **From `boundary_relationship` (NOT `/boundary/_search`):** the `ancestralmaterializedpath` + `code` the grain MV reads (`…grain_mvs.sql:23`). The v2 `/boundary/_search` entity has no path field (`web/models/boundary/Boundary.java:24–42`); see B.4.
+- **From egov-hrms:** `/egov-hrms/employees/_search` (`HRMSUtil.getHRMSURI` L105), reading `jurisdictions[*].boundary` (net-new path) and `assignments[?isCurrentAssignment].department` (pattern from `PGRConstants.java:168`), single-uuid only.
+- **From MDMS:** `common-masters.Department` for the code-space check — **both** the v2-wrapped (nairobi) and v1-flat (ddh) shapes.
+
+**Produces (output contract):**
+- **`PrincipalAttributes`** consumed by **Part C (Attribute-scope engine)**. The named contract — **a superset of today's `AnalyticsScope` fields**: `{tenantId, tenantStateLevel, scopeLevel, citizenUuid, boundaryPrefixes[] (delimiter-anchored, UN-escaped), departmentCodes[] (MDMS-aligned), resolutionComplete}`. Part C maps:
+  - `tenantId` + `tenantStateLevel` → the tenant predicate exactly as `applyScope` does today (`AnalyticsPlanner.java:243–244`) — `LIKE tenantId||'%'` at state root, `= tenantId` at city.
+  - `citizenUuid` → citizen self-scope on the grain's `citizenColumn` (`AnalyticsPlanner.java:246`).
+  - `boundaryPrefixes` → a `PREFIX` `AttrScope` on `boundary_path` (reusing the escape at `AnalyticsPlanner.java:249`).
+  - `departmentCodes` → an `IN` `AttrScope` on `department_code`.
+  - `scopeLevel==TENANT_ADMIN` → empty `attrScopes` (tenant-only).
+  - `scopeLevel==EMPLOYEE_SCOPED` **with both attribute lists empty** → **deny** (not tenant-only).
+  - `resolutionComplete==false` → **deny/empty**, never fall through to tenant-only.
+- **`roles[]` are NOT re-derived by Part B** for Parts D/F — those read roles off the same trusted principal independently. Part B only consumes roles to classify scope level.
+
+**Hands off (does not implement) — Part C / plan §3 step 4:**
+- The **events-MV `department_code` migration**. Part B's `DepartmentCodeSpace` only signals that department scope is *resolvable*; whether a given **grain** can be department-scoped is Part C's grain-binding concern — events lacks the column today (`AnalyticsCatalog.java:88` events groupable/`:92` filterable sets have no `department_code`; facts has it at `:59`/`:66`).
+- The **daily-grain citizen leak** (README cross-cutting #1). `complaint_open_state_daily` has `citizenColumn = null` (`AnalyticsCatalog.java:108`, the `null` in the Grain ctor's citizen position) and `applyScope` guards citizen self-scope on `g.citizenColumn != null` (`AnalyticsPlanner.java:246`) — so a pure citizen querying `grain:"daily"` is **not** self-scoped and sees every open complaint in the tenant. Part B's citizen path produces a correct `citizenUuid`; **the leak is entirely in Part C's grain binding** (add `account_id` to the daily grain, or reject citizen daily queries). Part B flags it so Part C cannot ship dept/jurisdiction scope while this citizen leak remains live.
+
+---
+
+## Sequencing & migration steps
+
+Each step is independently reviewable; the part ships as **one PR** against egov/CCRS develop (one-concern: "resolve principal attributes from HRMS"), validated on ovh-cloud-dev (bomet repro) before live.
+
+1. **Add `PrincipalAttributes`** value object (B.1), including `tenantStateLevel`. Pure data; no behavior change yet.
+2. **Add `DepartmentCodeSpace`** (B.5) with the schema-shape-tolerant load, the boot consistency check + metric, and the NULL-join surfacing. Run it on bomet/naipepea MDMS and **verify HRMS dept codes ⊆ MDMS Department codes, and that the loader reads a NON-EMPTY set from both v1 and v2 shapes, BEFORE building any `IN` clause** (plan §6.3). If codes diverge, the divergence is fixed in data (HRMS or MDMS), not in code. If the loader reads zero codes, that is a hard config error — fix the shape handling before shipping dept scope.
+3. **Add `BoundaryPathResolver`** (B.4) reading `boundary_relationship` + a test asserting its prefix equals the MV's `boundary_path || '|'` for the same code against real bomet boundary data (the self-inclusion subtlety, now grounded against the correct source).
+4. **Extend `HRMSUtil`** with `getEmployeeAttrs()` (single-uuid, non-throwing `safeRead`) + the two new `PGRConstants` JsonPaths (B.3). Unit-test the jurisdiction/active-department extraction against a captured HRMS `_search` payload (use an `RBAC_TEST_*` clean-role user, not a polluted real account — requirements §7.2).
+5. **Add `PrincipalAttributesResolver`** + caches (B.2, B.6), consuming `stateLevelLen` into `tenantStateLevel`.
+6. **Rewire `AnalyticsService`** (`AnalyticsService.java:32`) to call the resolver and pass `PrincipalAttributes` into the (Part-C) `AnalyticsScope` builder. **This is the only behavior-visible change** and is a no-op until Part C consumes the new fields. Citizen and admin paths must be **byte-identical** to today (including `tenantStateLevel`) — assert with the existing scope tests.
+7. **Negative/fail-closed tests** (see Risks). Gate the PR on them — including the Part-A-dependent populated-but-unsigned forged body (see *Interfaces → Part A*).
+
+> Sequencing note for host_vars/cutover (per memory discipline): no tenant-specific constants enter code — admin role set, delimiter, TTLs are config (`PGRConfiguration`), and dept/boundary data stays in MDMS/HRMS/boundary_relationship. Same redeploy on any tenant.
+
+---
+
+## Risks, edge cases, failure modes
+
+**Fail-closed is the default, encoded structurally:**
+
+| Scenario | Behavior | Mechanism |
+|---|---|---|
+| `userInfo == null` (Part A misconfigured/absent) | **Deny** (empty scope, `resolutionComplete=false`) | `resolve()` null branch returns `scoped(…, false)`; Part C treats `false` as deny, not tenant-only |
+| Populated-but-**unsigned** forged `userInfo` | **Out of Part B's reach** — Part A must reject it; Part B then handles the residual (forged-uuid-with-no-HRMS-row → deny) | requires Part A; negative test in step 7 (see Part A interface) |
+| Employee has **no HRMS row** (uuid drift, requirements §7.5) | **Empty scope, deny** — NOT unscoped | `getEmployeeAttrs` → `failed()` → `resolutionComplete=false` |
+| HRMS **5xx/timeout** mid-request | **Deny** — `fetchResult` swallows it to `null` (`ServiceRequestRepository.java:38–42`); resolver maps `null → failed()` | `if (res == null) return EmployeeAttrs.failed()` |
+| HRMS **4xx** | **Deny** — `fetchResult` re-throws `ServiceCallException` (`:37`); `getEmployeeAttrs` catch maps to `failed()` (does NOT 500) | try/catch in `getEmployeeAttrs` |
+| Employee has jurisdiction codes but **a code won't resolve** to a path | code **dropped**, `resolutionComplete=false` → Part C denies rather than scoping to a partial subtree | `BoundaryPathResolver` drop + `complete = prefixes.size()==codes.size()` |
+| HRMS dept code **not in** MDMS Department | dropped + **loud WARN/metric** | `DepartmentCodeSpace.filterToKnown` (§7.3) |
+| MDMS Department **loads zero codes** (v1/v2 shape mishandled) | **hard config error** — refuse to ship dept scope, loud WARN/metric; NOT "drop everything" | `DepartmentCodeSpace` empty-set sentinel (B-3 fix) |
+| `department_code` **NULL** from LEFT JOIN (unmapped service_code) | surfaced as WARN/metric at boot; the under-scope is real until the join is fixed | `…grain_mvs.sql:227` LEFT JOIN; `NULL IN (…)` never true (README #3b) |
+| Employee with **multiple active assignments / jurisdictions** | union (OR-within) — correct, not a bug | array JsonPaths return all; Part C ORs within attribute |
+| Stale/deactivated assignment | **excluded** from scope | `isCurrentAssignment==true` filter (B.3), unlike unfiltered `getDepartment()` |
+| `EMPLOYEE_SCOPED` with zero jurisdiction AND zero department | **deny** (sees nothing), NOT tenant-admin | `scopeLevel` carries the distinction; Part C deny rule |
+
+**Isolation / leak hazards:**
+
+- **Sibling-prefix leak** (`WARD_3` matching `WARD_30`): prevented by the trailing-delimiter anchor (Part B) + the existing escape (`AnalyticsPlanner.java:249`). Both must be present; a test must assert `WARD_3|` does not match a `WARD_30` row.
+- **Tenant cross-contamination via cache:** every cache key carries `tenantId`. A resolver that cached by bare `uuid` would leak a multi-tenant employee's scope across tenants — keyed by `{tenantId,uuid}` to prevent it.
+- **Cross-tenant LIKE leak via dropped `tenantStateLevel`** (B-2): carrying `tenantStateLevel` on `PrincipalAttributes` keeps Part C's tenant predicate `= tenantId` at city level, so `ke.bomet` cannot LIKE-match `ke.bometville`.
+- **HRMS role pollution (requirements §7.2):** every real `GRO` also carries `PGR_LME`. `classify()` must not assume single-role; the admin branch keys on the *presence* of an admin role, the employee branch is the default for any non-citizen non-admin. Test the scope-matrix with clean `RBAC_TEST_*` users.
+- **Department code-space drift + NULL-join silent-empty (requirements §7.3, README #3b):** the most dangerous because it *looks* like "no complaints," not "misconfigured." Mitigated by the boot check (B.5) + metric; ship-blocked by step 2.
+- **Events grain has no `department_code`** (`AnalyticsCatalog.java:88/:92`) and **daily grain has no `citizenColumn`** (`AnalyticsCatalog.java:108`): a department-scoped caller querying events, or a citizen querying daily, would — without Part C's grain-binding — get *unscoped rows* (silent grain leaks, requirements §7.4 + README #1). Part B flags both; Part C must add the column or reject. **Part B must not be read as "scope is safe everywhere" — it is only safe on grains whose Grain binding declares the column.**
+
+**Performance / correctness coupling:**
+- One extra HRMS hop per *uncached* employee request (boundary resolution is a local `boundary_relationship` read under option 1, not a network hop). Mitigated by B.6; steady-state is a cache hit.
+- Drift window: a 5-min HRMS TTL means a jurisdiction reassignment is visible to scope within 5 min, not instantly. Acceptable given the data is already only as fresh as the hourly MV (requirements §6 — "nothing fresher than the last refresh").
+
+---
+
+## Open questions for review
+
+1. **`boundary_relationship` self-inclusion assertion.** `ancestralmaterializedpath` is ancestors-only; the MV reconstructs self via `|| '|' || code` (`…grain_mvs.sql:23`). `BoundaryPathResolver` (now reading the same table) must reproduce that reconstruction and append the anchor. **Resolve by testing against real bomet boundary rows before trusting the resolver** (B.4) — even though same-source makes it identical by construction, the test pins it.
+2. **HRMS jurisdiction field name — RESOLVED to `boundary`.** Confirmed `jurisdictions[*].boundary` (a code string) against `digit-ui-v2/src/api/types.ts:240` and MCP `hrms.ts:199–212` (pass-1 anti-FUD). Left here only to flag: validate once against a captured bomet/naipepea HRMS `_search` payload in step 4 before finalizing the JsonPath, since pgr-services has never read it.
+3. **Should `BoundaryPathResolver` read `boundary_relationship` directly or call `/boundary-relationship/_search`?** Recommend the **direct table read** for guaranteed path-identity with the grain (same source, zero extra hop) and because `/boundary-relationship/_search`'s response shape is unverifiable in-tree (boundary-service not vendored). Flag for the boundary-service owner if an API boundary is preferred. (`/boundary/_search` is ruled out — B-1.)
+4. **Negative-cache policy for HRMS failure.** Cache `failed` for a few seconds (avoid hammering a down HRMS) vs. not at all (a supervisor isn't locked out by a transient blip). Default to "very short" (B.6).
+5. **Admin role set source of truth.** `classify()`'s admin branch needs the `PGR_ADMIN/DSS_ANALYST/SUPERADMIN` set. Hardcode in `PGRConfiguration` (config, redeploy-identical) vs. read from an MDMS RBAC master? Part D needs the same set for `visibleTo` — align so the two parts share one definition rather than drifting.
+6. **Department-head persona without jurisdiction (requirements §2).** The model supports `boundaryPrefixes=[]`, `departmentCodes=[…]`, `scopeLevel=EMPLOYEE_SCOPED` (dept-head sees their dept across all wards). Confirm that's intended vs. requiring at least one attribute — and that this is distinct from the zero/zero `EMPLOYEE_SCOPED` deny case (which has NO department either). The contract handles both via the attribute lists + `scopeLevel`.
+
+---
+
+## v2 revision log (pass-1 findings → resolution)
+
+- **B-1 (blocker) — `/boundary/_search` does not return `materializedPath`; wrong (legacy) Boundary class cited.** RESOLVED. Re-grounded against both classes: legacy `web/models/Boundary.java:58` has the field but is the old egov-location model; the v2 entity `web/models/boundary/Boundary.java:24–42` (what `/boundary-service/boundary/_search` actually returns) has only `id/tenantId/code/geometry/auditDetails/additionalDetails` — no path field. **B.4 re-pointed `BoundaryPathResolver` to read `boundary_relationship.ancestralmaterializedpath` directly** (the same source the grain MV reads at `…grain_mvs.sql:23`), with `/boundary-relationship/_search` as a secondary option and `/boundary/_search` explicitly ruled out. Interfaces + "Current code reality" + Open-Q3 updated to match.
+- **B-2 (major) — `tenantStateLevel` dropped; Part C cannot emit the tenant predicate.** RESOLVED. Added `tenantStateLevel` to `PrincipalAttributes` (B.1) as a field, computed it in the resolver from the previously-dead `stateLevelLen` arg exactly as `AnalyticsScope.java:32` does, and locked the output contract (Interfaces → Part C) to a **superset** of today's `AnalyticsScope` fields so `applyScope`'s state-vs-city branch (`AnalyticsPlanner.java:243–244`) is reproduced — closing the `ke.bomet`/`ke.bometville` cross-tenant LIKE leak.
+- **B-3 (major) — `DepartmentCodeSpace` ignores MDMS v1-flat vs v2-wrapped split; may load zero codes (fail-open into silent-empty).** RESOLVED. B.5 now mandates a **schema-shape-tolerant loader** (`$.data.code` for nairobi v2-wrapped vs `$.code` for ddh v1-flat, anchored to both files), and treats **"loaded zero MDMS Department codes" as a hard config error** — loud WARN/metric + refuse to ship dept scope (empty-set sentinel) rather than dropping every HRMS dept. Added to the Risks table and step-2 ship gate.
+- **B-4 (minor) — anchor off-by-one: facts `boundaryColumn` is at `AnalyticsCatalog.java:78`, not L79.** RESOLVED. Corrected the "Current code reality" table to L78 (facts), L96 (events), L108 (daily); also re-anchored the `department_code` groupable/filterable rows to `:59`/`:66` after re-reading.
+- **B-5 (minor) — `getDepartment()`'s unfiltered path is at `HRMSUtil.java:55` and it `throw`s on empty/parse-miss; the resolver must not reuse it.** RESOLVED. B.3 now explicitly states `getEmployeeAttrs` uses a non-throwing `safeRead` (returns `[]` on miss) and is **deliberately unlike** `getDepartment()`, which throws `PARSING_ERROR` (`HRMSUtil.java:57–58`) and `DEPARTMENT_NOT_FOUND` (`:61–62`) — a supervisor with an empty active department must fail closed to empty scope, not 500.
+- **B-6 (minor) — `$.Employees[0]` assumes single-employee search.** RESOLVED. B.3 pins `getEmployeeAttrs` as **single-uuid-only** (signature takes `String uuid`, not a list, as a compile-time contract) and documents that `[0]` must never be fed a batched search, contrasting it with the workflow reads' `$.Employees.*` (`PGRConstants.java:41`).
+- **Mis-citation: "`/boundary/_search` returns `materializedPath` (modeled `Boundary.java:58`)".** RESOLVED — see B-1; all references re-pointed to `boundary_relationship` / the v2 entity model.
+- **Mis-citation: "`AnalyticsCatalog.java` facts `boundaryColumn` … Grain ctor L79".** RESOLVED — corrected to L78 throughout (B-4).
+- **Interface → Part A: only `userInfo==null` is a fail-closed lever; a populated-but-unsigned forged body resolves a real low-priv employee's narrow scope.** ACKNOWLEDGED, NOT fixable in Part B — **owned by Part A** (`10-auth-foundation.md`), which must make introspection mandatory + coercive so a forged/unsigned `userInfo` is rejected before Part B runs (requirements §7.1, `kong.yml:65–68`). Part B documents the residual it *can* handle (forged uuid with no HRMS row → `failed()` → deny) and adds a step-7 negative test asserting a populated-but-unsigned body yields deny — but that test only passes once Part A lands.
+- **Interface → Part C: output must carry whatever Part C needs to reproduce today's tenant predicate + citizen/admin distinction.** RESOLVED in Part B by exporting a superset contract (B-2); the *consumption* (mapping `tenantStateLevel`/`scopeLevel`/`resolutionComplete` into `attrScopes` and the deny rules) is **owned by Part C** (`30-row-scope-enforcement.md`) and spelled out in Interfaces → Part C as the binding it must implement.
+- **Interface → Part C (grain binding): `departmentCodes[]` is grain-agnostic but only facts has `department_code`.** ACKNOWLEDGED, NOT fixable in Part B — **owned by Part C / plan §3 step 4**. Part B's output deliberately carries no grain signal; Interfaces + Risks now name the two grain gaps (events has no `department_code` at `AnalyticsCatalog.java:88/:92`; daily has no `citizenColumn` at `:108`) and require Part C to add the column or reject, never drop-to-unscoped.
+- **Cross-cutting (README #1) — daily-grain citizen leak.** FLAGGED, NOT fixable in Part B — **owned by Part C**. Part B's citizen path produces a correct `citizenUuid`; the leak is `complaint_open_state_daily.citizenColumn == null` (`AnalyticsCatalog.java:108`) bypassing the `citizenColumn != null` guard (`AnalyticsPlanner.java:246`). Added to "Hands off" and Risks so Part C cannot ship scope while it is live.
+- **Cross-cutting (README #2) — identity is fail-OPEN via `ServiceRequestRepository.fetchResult` returning `null` on 5xx/timeout.** RESOLVED for Part B's consumption: B.3 + the Risks table now explicitly map a `null` HRMS result to `EmployeeAttrs.failed()` (fail closed) and note that 4xx re-throws `ServiceCallException` (`ServiceRequestRepository.java:37`) which the `getEmployeeAttrs` catch also maps to `failed()`. The broader "make introspection itself coercive" half is **Part A's**.
+- **Cross-cutting (README #3b) — `department_code` NULL for unmapped service_code via LEFT JOIN.** FLAGGED + surfaced. `DepartmentCodeSpace` boot check now metrics the count of facts rows with `NULL department_code` (`…grain_mvs.sql:227` LEFT JOIN, `NULL IN (…)` never true). The under-scope is real until the join/data is fixed (Part C / data); Part B makes it observable rather than silent.
+- **Cross-cutting (README #4) — the "narrow-only" client param (`boundaryScope`/`departmentScope`) has no code path; `boundary_path` not in any grain's `filterable` set.** ACKNOWLEDGED, NOT fixable in Part B — **owned by Part C** (the planner's filterable set + declared-param plumbing, `AnalyticsPlanner.java:174` / `AnalyticsCatalog` filterable lists). Part B only produces the *injected* scope values; client-supplied narrowing is Part C's grammar concern.
+
+### v3 corrections (pass-3 codex fact-check, 2026-06-23)
+
+- **B-7 (blocker) — boundary resolver could disagree with the grain on duplicate codes; "path-identical by construction" was wrong.** B.4's pass-2 wording claimed a `SELECT ancestralmaterializedpath, code FROM boundary_relationship WHERE tenantid = ? AND code = ?` read was "path-identical by construction" to the grain. **It is not.** The grain's `bnd` CTE selects/filters **no `tenantid`** and dedupes globally — `DISTINCT ON (code) … ORDER BY code, length(ancestralmaterializedpath) DESC` (deepest path per code, across the whole table) — at `V20260608000000__create_v2_grain_mvs.sql:21–25`, binding to rows only on `bnd.code = svc.locality_code` (`…grain_mvs.sql:94`). So the authoritative `boundary_path` a row carries is the *global deepest-path row for that code*; a tenant-filtered per-code read can pick a **different** `ancestralmaterializedpath` for a **duplicated** code and produce a `LIKE` prefix that misses the grain's rows (or matches the wrong subtree). FIX: B.4 now derives the jurisdiction prefix from the **same representation the grain uses** — the grain's own `boundary_path` (`SELECT DISTINCT boundary_path FROM complaint_facts WHERE … code = ?`) or a replica of the MV's exact `bnd` selection (global `DISTINCT ON (code)`, deepest-path-wins, **no `tenantid` filter**) — eliminating the second source of truth. The duplicate-code risk is now stated explicitly (new hazard note in B.4) and the resolver code/comment + the path-vs-prefix note no longer claim "identical by construction" for a tenant-filtered read.
+- **materializedPath model claim — corrected/sharpened.** Verified in code: the **legacy** model `web/models/Boundary.java` carries `materializedPath` (`@JsonProperty` `:57`, field `:58`; range `:57–59`) and is the old egov-location tree model; the **v2** boundary-service model `web/models/boundary/Boundary.java:24–42` has only `id/tenantId/code/geometry/auditDetails/additionalDetails` and **no** `materializedPath`/`ancestralmaterializedpath`. B.4 now states explicitly that the materializedPath-bearing model is the legacy one, not v2, and that neither feeds the prefix — the grain's `boundary_path` (from `boundary_relationship.ancestralmaterializedpath`, `…grain_mvs.sql:23`) is the authoritative source.
+
+## Codex review (pass 2 — gpt-5.5, verdict: needs-rework)
+
+> External adversarial review via `codex exec`, read-only, verifying the v2 revision log against the actual code. **Note:** codex evaluated "resolved" as "patched in code"; this is a *design* doc (no code changed yet), so most `actuallyResolved:false` items mean "design specifies it, code not yet written," not "design wrong." Read the findings for genuine design errors vs. implementation-status notes.
+
+
+**Summary:** Pass-2 verification: several line-anchor corrections are valid, but the main security claims remain design-only or conflict with adjacent Part C. Actual code still has spoofable identity, no PrincipalAttributes resolver, no department/jurisdiction scoping, events lacks department_code, daily lacks citizen scope, and boundary path identity is not guaranteed because the grain MV joins boundary_relationship by code only.
+
+
+### Resolution check (6/14 confirmed in code)
+
+- ❌ **B-1: /boundary/_search does not return materializedPath; wrong legacy Boundary class cited.** — Partly corrected: legacy Boundary has materializedPath at CCRS/backend/pgr-services/src/main/java/org/egov/pgr/web/models/Boundary.java:57-59 and v2 Boundary has only id/tenantId/code/geometry/auditDetails/additionalDetails at .../web/models/boundary/Boundary.java:24-42. But B.4's 'path-identical' direct read by tenantId is not identical to the grain: the MV dedupes boundary_relationship by code only and does not select/filter tenantid at V20260608000000__create_v2_grain_mvs.sql:21-25, then joins bnd.code = svc.locality_code at :93-94.
+- ❌ **B-2: tenantStateLevel dropped; Part C cannot emit the tenant predicate.** — Not resolved in actual code: no PrincipalAttributes class/resolver exists; AnalyticsService still calls AnalyticsScope.resolve(requestInfo, tenantId, stateLevelLen) at AnalyticsService.java:30-32. Also Part C says it computes stateLevel itself and does not depend on B carrying tenantStateLevel at db-inventory/rbac-deep-design/30-row-scope-enforcement.md:116 and :334, conflicting with this interface claim.
+- ❌ **B-3: DepartmentCodeSpace ignores MDMS v1-flat vs v2-wrapped split; may load zero codes.** — The source-shape observation is correct: nairobi Department is wrapped at CCRS/ansible/nairobi-mdms/mdms/common-masters/Department.json:3-6 and DDH is flat at CCRS/utilities/default-data-handler/src/main/resources/mdmsData/common-masters/common-masters.Department.json:2-5. But no DepartmentCodeSpace implementation exists in CCRS/backend/pgr-services/src/main/java, so the loader/error/metric claim is not actually resolved.
+- ✅ **B-4: anchor off-by-one for facts boundaryColumn.** — Corrected anchors match code: facts boundaryColumn is the Grain ctor arg at AnalyticsCatalog.java:78; events at :96; daily at :108. department_code anchors also match facts groupable/filterable at :59 and :66.
+- ❌ **B-5: getDepartment path/throw behavior misread; resolver must not reuse it.** — The cited behavior is verified: getDepartment reads HRMS_DEPARTMENT_JSONPATH at HRMSUtil.java:55, throws PARSING_ERROR at :57-58, and DEPARTMENT_NOT_FOUND at :61-62. But no getEmployeeAttrs/safeRead implementation exists; actual code still exposes only the throwing getDepartment and nullable getSupervisorUuid.
+- ❌ **B-6: $.Employees[0] assumes single-employee search.** — The risk is documented, but no getEmployeeAttrs(String uuid, ...) exists to enforce the single-UUID contract. Existing getDepartment accepts List<String> uuids at HRMSUtil.java:44 and uses $.Employees.*.assignments.*.department from PGRConstants.java:41.
+- ✅ **Mis-citation: /boundary/_search returns materializedPath modeled by Boundary.java:58.** — The corrected citation is valid: application.properties points boundary search to /boundary-service/boundary/_search at application.properties:149-150, and the v2 response model has no materializedPath at web/models/boundary/Boundary.java:24-42.
+- ✅ **Mis-citation: AnalyticsCatalog facts boundaryColumn Grain ctor L79.** — Actual facts Grain ctor has boundaryColumn='boundary_path' at AnalyticsCatalog.java:78.
+- ❌ **Interface -> Part A: populated-but-unsigned forged body cannot be fixed in Part B.** — Acknowledged but still live: AnalyticsController converts body RequestInfo directly at AnalyticsController.java:43-44 and passes it to service.query at :47; AnalyticsScope trusts getUserInfo/type/roles/uuid at AnalyticsScope.java:34-44.
+- ❌ **Interface -> Part C: output must carry tenant predicate + citizen/admin distinction.** — No actual output exists: no PrincipalAttributes class/resolver in CCRS/backend/pgr-services. Adjacent Part C expects boundaryPrefixes/departmentCodes/isAdmin and computes tenantStateLevel itself at 30-row-scope-enforcement.md:116 and :334, while Part B claims C consumes tenantStateLevel/scopeLevel/resolutionComplete at 20-attribute-resolution.md:314-320.
+- ✅ **Interface -> Part C grain binding: departmentCodes is grain-agnostic but only facts has department_code.** — Correctly acknowledged as not Part B: facts has department_code groupable/filterable at AnalyticsCatalog.java:58-66; events groupable/filterable sets omit it at :84-92; events MV projection also omits department_code at V20260608000000__create_v2_grain_mvs.sql:52-91.
+- ✅ **Cross-cutting: daily-grain citizen leak.** — Correctly flagged as not Part B: daily Grain has citizenColumn null at AnalyticsCatalog.java:108, and applyScope only adds citizen predicate when g.citizenColumn != null at AnalyticsPlanner.java:246.
+- ❌ **Cross-cutting: department_code NULL from LEFT JOIN.** — The risk is real: department_code comes from mdms at V20260608000000__create_v2_grain_mvs.sql:147 and the facts query uses LEFT JOIN mdms m ON m.service_code = s.servicecode at :227. But no DepartmentCodeSpace boot check/metric exists in actual code.
+- ✅ **Cross-cutting: narrow-only boundaryScope/departmentScope has no code path; boundary_path not filterable.** — Correctly acknowledged as not Part B: filter validation rejects columns absent from g.filterable at AnalyticsPlanner.java:172-175; facts filterable list omits boundary_path at AnalyticsCatalog.java:64-69, and events/daily filterable lists also omit boundary_path at :89-92 and :104-105.
+
+### Findings
+
+- **[BLOCKER] Boundary resolver can disagree with the grain for duplicate boundary codes** — B.4 claims a tenant-filtered read of boundary_relationship is path-identical to the grain, but the grain does not use tenantid in the boundary CTE or join. If boundary code values repeat across tenants or hierarchies, Part B would compute one path while the MV stores another, causing scope misses or cross-tenant/path confusion.  
+  _evidence:_ `CCRS/backend/pgr-services/src/main/resources/db/migration/main/V20260608000000__create_v2_grain_mvs.sql:21-25 builds bnd as DISTINCT ON (code) with no tenantid; :93-94 joins bnd.code = svc.locality_code only.`
+- **[BLOCKER] Actual endpoint still trusts caller-supplied identity** — Part B's attributes would still be computed from a spoofable body until Part A changes the live code. A forged employee/admin RequestInfo can control the role/type/uuid inputs used for scoping.  
+  _evidence:_ `CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsController.java:43-47 converts body.RequestInfo and passes it to service.query; AnalyticsScope.java:34-44 trusts userInfo type, roles, and uuid.`
+- **[BLOCKER] Daily grain still leaks all tenant rows to citizens** — Citizen scope is skipped on daily because the grain has no citizenColumn and applyScope silently omits the predicate rather than denying the grain.  
+  _evidence:_ `CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsCatalog.java:108 sets daily citizenColumn to null; AnalyticsPlanner.java:246 only applies citizen self-scope when g.citizenColumn != null.`
+- **[MAJOR] Department scope would be absent on events grain** — The design flags this, but the shipped catalog/MV still cannot bind department_code for events. Any Part C implementation that drops unavailable attributes instead of rejecting would leak event rows tenant-wide for department-scoped users.  
+  _evidence:_ `CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsCatalog.java:84-92 events groupable/filterable sets omit department_code; V20260608000000__create_v2_grain_mvs.sql:52-91 events SELECT omits department_code.`
+- **[MAJOR] Part B and Part C interfaces disagree on tenantStateLevel and admin/deny signals** — Part B says Part C consumes tenantStateLevel, scopeLevel, and resolutionComplete. Part C says it computes stateLevel itself and consumes boundaryPrefixes, departmentCodes, and isAdmin. That mismatch can erase fail-closed semantics for empty employee attributes unless reconciled before implementation.  
+  _evidence:_ `db-inventory/rbac-deep-design/20-attribute-resolution.md:314-320 defines the Part C contract with tenantStateLevel/scopeLevel/resolutionComplete; db-inventory/rbac-deep-design/30-row-scope-enforcement.md:116 and :334 say Part C computes stateLevel itself and consumes boundaryPrefixes/departmentCodes/isAdmin.`
+- **[MAJOR] Department NULL under-scope remains unimplemented as a boot gate** — The design says DepartmentCodeSpace surfaces NULL department_code counts, but no such code exists. Facts rows with service_code missing ServiceDefs get NULL department_code and will disappear under department IN predicates without an operational failure signal.  
+  _evidence:_ `V20260608000000__create_v2_grain_mvs.sql:147 defines department_code from MDMS ServiceDefs; :227 uses LEFT JOIN mdms m ON m.service_code = s.servicecode; rg finds no DepartmentCodeSpace under CCRS/backend/pgr-services/src/main/java.`
+- **[MAJOR] No actual HRMS jurisdiction resolver exists** — The design's resolver/safeRead/JsonPath additions are still aspirational. Current HRMSUtil reads departments and reportingTo only; no jurisdiction boundary JsonPath or EmployeeAttrs method exists.  
+  _evidence:_ `CCRS/backend/pgr-services/src/main/java/org/egov/pgr/util/PGRConstants.java:41 defines HRMS_DEPARTMENT_JSONPATH and :168 defines HRMS_REPORTING_TO_JSONPATH; no HRMS_JURISDICTION_BOUNDARY_JSONPATH exists in actual Java; HRMSUtil.java:44-64 and :73-96 expose only getDepartment/getSupervisorUuid.`
+- **[MINOR] State-level tenant predicate is prefix-unanchored** — The existing state-level tenant predicate uses tenantId + '%' without delimiter anchoring. The design calls out ke.bomet/ke.bometville as a risk when LIKE is used at city level, but state-level LIKE has the same prefix ambiguity unless tenant naming guarantees a delimiter boundary.  
+  _evidence:_ `CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java:242-244 adds g.tenantColumn LIKE ? with params.add(scope.tenantId + '%').`
+
+### Mis-citations
+
+- B.4 says direct table read SELECT ... WHERE tenantid=? AND code=? is path-identical to the grain; actual grain uses DISTINCT ON (code) with no tenantid at V20260608000000__create_v2_grain_mvs.sql:21-25.
+- B.4 cites boundary.ts:43-57 as same-table support, but that file is outside the requested analytics package and was not needed to prove the deploy-target Java/SQL behavior.
+- Part B Interfaces claim Part C consumes tenantStateLevel/scopeLevel/resolutionComplete, but Part C's own interface says it consumes boundaryPrefixes/departmentCodes/isAdmin and computes stateLevel itself at 30-row-scope-enforcement.md:116 and :334.
+
+### Gaps
+
+- No PrincipalAttributes, PrincipalAttributesResolver, BoundaryPathResolver, DepartmentCodeSpace, EmployeeAttrs, safeRead, or HRMS jurisdiction constants exist in actual pgr-services Java.
+- No code verifies HRMS assignment department codes against either MDMS Department shape.
+- No code verifies every live service_code has a ServiceDefs department before enabling department scope.
+- No test or implementation proves BoundaryPathResolver output equals complaint grain boundary_path || '|' for real tenant data.
+- No implementation rejects grains that cannot satisfy citizen/department/jurisdiction predicates; current planner silently omits citizen scope when the grain lacks citizenColumn.

--- a/docs/dashboard-rbac-design/30-row-scope-enforcement.md
+++ b/docs/dashboard-rbac-design/30-row-scope-enforcement.md
@@ -1,0 +1,496 @@
+# Part C — Row-Scope Enforcement (generalized attribute scoping)
+
+**Status:** v2 (pass-1 findings folded in), 2026-06-23 · **Maps to:** implementation plan Phases 2–3 · **Depends on:** Part A (trust foundation) and Part B (identity → attribute resolution) · **Series spec:** `rbac-deep-design/00-requirements.md`.
+
+**Reads grounded for this part (every claim below is anchored to a line actually re-opened for v2):**
+- `CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsScope.java` (the scope object to generalize; `resolve()` L31–48; boundary hardcoded `null` at L47)
+- `…/analytics/AnalyticsPlanner.java` — `applyScope()` **L241–251** (the injection point; tenant L242–245, citizen L246, boundary LIKE + escape L247–249); `predicate()` L173–201 with the filterable gate at **L174**; `inferGrain()` L267–275; scope ANDed at L98 and joined at L103
+- `…/analytics/AnalyticsCatalog.java` — `Grain` model fields **L34–37** (`tenantColumn` L34, `boundaryColumn` L35, `citizenColumn` L36, `defaultTimeRole` L37); facts grain L54–78, events L81–96, daily L99–108 (daily `citizenColumn=null` at **L108**); facts filterable L65–69 (`department_code` at L66, `boundary_path` **absent**); events filterable L89–92; daily filterable L104–105
+- `…/analytics/AnalyticsService.java` — `query()` L30–56; batch arm try/catch **L45–46**; `runOne()` L58–69; `scopeCols()` **L96–102**; `asOf()` L104–107; `scopeInfo()` L109–116 (reads `s.boundaryPrefix` at **L114**); `err()` split L118–124
+- `…/resources/db/migration/main/V20260608000000__create_v2_grain_mvs.sql` — events MV L12–97 (no `department_code`, no MDMS join; the `FROM tx`/LEFT JOIN block L92–97); facts MV `mdms` CTE L141–151 (`data->>'department' AS department_code` at L147), `m.department_code` projected at **L169**, `LEFT JOIN mdms m` at **L227**; facts indexes L231–236; daily table L239–253 (no `department_code`, no `account_id`); daily snapshot INSERT described at L255
+- design `dashboard-query-api-design.md` §5 (scope-is-`boundary_path`-on-all-grains; never `ward_code`) and §5a (layering)
+
+---
+
+## Goal & responsibilities (what this part owns; what it explicitly does NOT)
+
+**This part owns the Layer-1 row-scope spine: turning a resolved principal's attributes into injected `WHERE` predicates on *every* generated query, on *every* grain — and making *every* scope axis (tenant, citizen, attribute) fail closed when a grain cannot serve it.** Concretely it owns four deliverables:
+
+1. **Generalize `AnalyticsScope`** from the fixed pair `{citizenUuid, boundaryPrefix}` (`AnalyticsScope.java:23–24`) into `{citizenUuid, List<AttrScope> attrScopes}` — an ANDed list of attribute predicates, OR-within-each, per requirements §4.
+2. **Generalize `applyScope()`** (`AnalyticsPlanner.java:241–251`) from three hardcoded branches into the existing tenant/citizen branches **plus** a loop over `attrScopes`, emitting `PREFIX` (escaped `LIKE … ESCAPE '\'`) for `boundary_path` and a parameterized `IN (?,…)` for `department_code`; bind each logical attribute to the grain's physical column via the `Grain` model and **fail closed** when a grain cannot serve a *required* scope axis.
+3. **Close the citizen×daily silent leak (NEW in v2 — the convergent blocker).** The citizen self-scope predicate at `AnalyticsPlanner.java:246` is guarded by `g.citizenColumn != null`, and the daily grain's `citizenColumn` is `null` (`AnalyticsCatalog.java:108`). So a pure citizen issuing `grain:"daily"` today gets **only tenant scope** → the whole tenant's open-complaint backlog. Part C closes this by routing **citizen self-scope through the same fail-closed gate** as attribute scopes (C.3a) **and** by adding `account_id` to the daily grain in the C.5 migration so the citizen predicate binds on daily.
+4. **Close the events-grain `department_code` leak** — the facts MV carries `department_code` (`…create_v2_grain_mvs.sql:169`, sourced from the `mdms` CTE L141–151, join L227) but the events MV select never projects it (L52–91; the `FROM tx`/join block L92–97 has no MDMS join); shipping department scope on facts-but-not-events is a silent leak (requirements §7.4). This part adds the one migration that alters the events MV to project `department_code`, and only then marks events department-capable in the catalog.
+
+**This part explicitly does NOT own:**
+- **Trust.** Whether the principal is real is Part A's job. Part C consumes whatever the resolver is handed; if that principal is forged, Part C faithfully scopes the forged identity. Part C is correct *given* a trustworthy principal and meaningless without one — hence the hard A→C dependency (requirements §8). **Fail-open identity** (the reused `ServiceRequestRepository.fetchResult` swallowing 5xx → `null`, README cross-cutting #2) is **Part A's**: Part C assumes a non-null, coerced principal and does not itself map `null`→`401`.
+- **Attribute resolution.** *How* `boundaryPrefixes[]` and `departmentCodes[]` are produced from HRMS, their caching, the HRMS-vs-MDMS department code-space consistency check, **and the propagation of `tenantStateLevel` into the resolved attributes** are **Part B** (`PrincipalAttributes`). Part C defines the *contract* it consumes (C.1) and assumes the codes are already normalized to the complaint code-space. README cross-cutting #7 ("`tenantStateLevel` dropped in `PrincipalAttributes`") is therefore **owned by Part B**; Part C still computes `stateLevel` itself from `tenantId` + `stateLevelLen` exactly as the live `resolve()` does (`AnalyticsScope.java:32`), so the state-vs-city `LIKE`/`=` choice is never lost on the Part C side.
+- **Catalog visibility (Layer 2 / Part D), packs (Part E), inline-query gating (Layer 3 / Part F).** Those decide *which question* you may ask; Part C decides *which rows* come back. The two never substitute (requirements §3): an empty row scope never widens a `visibleTo` ceiling, and a forbidden KPI is never rescued by row scope. The **batch-arm bypass** (README cross-cutting #5: `AnalyticsService.query()`'s batch dict arm calls `runOne()` directly at L45–46, bypassing any single-arm-only gate) is a **Part D/F** wiring concern — Part C's scope is injected inside `runOne()`→`plan()`→`applyScope()` (L98) and so applies to **both** arms identically; Part C neither relies on nor reintroduces that hole.
+
+**The citizen self-scope branch is NO LONGER preserved verbatim.** v1 kept the citizen predicate (`AnalyticsScope.java:44`; planner L246) unchanged as a parallel, non-attribute predicate. The pass-1 review showed that "unchanged" is precisely the daily-grain leak. v2 keeps citizen scope as a distinct, non-attribute axis (it is still an exact `account_id =`, not an `AttrScope`) **but routes it through the same fail-closed binding** so it can never silently no-op on a grain lacking the column (C.3a).
+
+---
+
+## Current code reality (file:line — what exists today vs what's missing)
+
+**The injection point already exists and already ANDs into every grain's query.** `AnalyticsPlanner.plan()` calls `applyScope(scope, g, conj, whereParams)` at L98, after explicit filters (L90–96) and window (L97), and the `conj` list becomes the `WHERE` at L103. So scope is structurally guaranteed to be ANDed into every query already — Part C changes *what* `applyScope` emits, not *whether* it runs. **This also closes the batch-arm concern at the Part-C layer:** both the batch arm (`AnalyticsService.java:45`) and the single arm (L51) call `runOne()` → `plan()`, so scope injection covers both.
+
+**`applyScope()` today (L241–251) has exactly three branches:**
+```java
+// AnalyticsPlanner.java:241-251 (verbatim)
+private void applyScope(AnalyticsScope scope, Grain g, List<String> conj, List<Object> params){
+    if (scope.tenantId != null) {
+        if (scope.tenantStateLevel) { conj.add(g.tenantColumn + " LIKE ?"); params.add(scope.tenantId + "%"); }
+        else { conj.add(g.tenantColumn + " = ?"); params.add(scope.tenantId); }
+    }
+    if (scope.citizenUuid != null && g.citizenColumn != null) { conj.add(g.citizenColumn + " = ?"); params.add(scope.citizenUuid); }
+    if (scope.boundaryPrefix != null && g.boundaryColumn != null) {
+        conj.add(g.boundaryColumn + " LIKE ?");
+        params.add(scope.boundaryPrefix.replace("\\","\\\\").replace("%","\\%").replace("_","\\_") + "%");
+    }
+}
+```
+- **Tenant scope (L242–245): done.** State-level `LIKE prefix%`, city-level `=`. Part C only adds the explicit `ESCAPE '\'` (see below); semantics unchanged.
+- **Citizen self-scope (L246): done but UNSAFE on daily.** `account_id = ?` guarded by `g.citizenColumn != null` — and daily's `citizenColumn` is `null` (`AnalyticsCatalog.java:108`), so on `grain:"daily"` the guard makes the predicate silently disappear (the blocker). Part C **changes this branch** (C.3a).
+- **Boundary scope (L247–249): SQL is built but never fires.** `scope.boundaryPrefix` is hardcoded `null` (`AnalyticsScope.java:47`: `return new AnalyticsScope(tenantId, stateLevel, citizenUuid, null);`). The inline escape (`\`→`\\`, `%`→`\%`, `_`→`\_`, then append `%`) is the anchored-prefix escape requirements §4 wants, but it relies on Postgres's *default* `LIKE` escape being backslash. Design §5 specifies `LIKE :prefix || '%' ESCAPE '\'`. **Gap: Part C adds the explicit `ESCAPE '\'`** on every `LIKE` it emits (tenant state-level and boundary).
+
+**The `Grain` model already carries `tenantColumn`, `boundaryColumn`, `citizenColumn`** at `AnalyticsCatalog.java:34–36` (`defaultTimeRole` is L37 — v1 mis-cited this block as L34–37 for the three scope columns; the scope columns are **L34–36**). Wired in the constructor tail of each grain:
+- facts: `"tenant_id","boundary_path","account_id"` (`AnalyticsCatalog.java:78`)
+- events: `"tenant_id","boundary_path","account_id"` (`AnalyticsCatalog.java:96`)
+- daily: `"tenant_id","boundary_path",null` (`AnalyticsCatalog.java:108`) ← the `null` citizen column
+
+**What is missing (the Part C deltas):**
+- **No `departmentColumn` on `Grain`** — there is no department scope column at all. `department_code` exists only as a *queryable dimension* on facts (`AnalyticsCatalog.java:59` groupable, L66 filterable), not as a *scope* binding.
+- **No `AttrScope` type, no `attrScopes` field.** `AnalyticsScope` is the fixed 4-field final class (L20–29) with a single private constructor and a static `resolve()` that always passes `null` for boundary (L47).
+- **The events MV has no `department_code` column.** Facts computes it via the `mdms` CTE (`…create_v2_grain_mvs.sql:141–151`, `data->>'department' AS department_code` at L147) and folds it into the facts select at L169 (`m.department_code`), joining at L227. The events MV (L12–97) joins `svc`, `bnd`, `bs`, `asg`, `eg_user` (its join block is L92–97) but never the ServiceDefs MDMS rows, so `department_code` is absent from its projection (L52–91). Events `groupable`/`filterable` sets (`AnalyticsCatalog.java:84–92`) correctly do **not** list `department_code`.
+- **The daily table has neither `department_code` nor `account_id`** (`…create_v2_grain_mvs.sql:239–253`). This is *two* gaps: department-unscopable (Q3) **and** citizen-unscopable (the blocker). C.5 adds both columns.
+- **Two consumers of the scope shape will break on the field rename and must be updated by Part C:**
+  - `AnalyticsService.scopeInfo()` (`AnalyticsService.java:109–116`) reads `s.boundaryPrefix` at L114.
+  - `AnalyticsService.scopeCols()` (`AnalyticsService.java:96–102`) emits `boundary:`/`citizen:` scope columns for `/_schema`; this grows a `department:` entry once events is department-capable.
+
+---
+
+## Design (data model, API/SQL/MDMS, control flow)
+
+### C.1 Data model — `AttrScope` and the generalized `AnalyticsScope`
+
+New small value type in the same package. `MatchType` is a closed enum — **the client never names a match type or a column**; both are server-chosen by Part B and bound to the grain by Part C.
+
+```java
+// new file: analytics/AttrScope.java
+public final class AttrScope {
+    public enum MatchType { PREFIX, IN, EQ }   // closed set; PREFIX→boundary, IN→department, EQ reserved
+    public final String logicalAttr;           // "jurisdiction" | "department" — NOT a SQL column
+    public final MatchType match;
+    public final List<String> values;          // OR within one attribute (multi-ward / multi-dept)
+    public AttrScope(String logicalAttr, MatchType match, List<String> values){
+        this.logicalAttr = logicalAttr; this.match = match;
+        this.values = values == null ? java.util.Collections.emptyList()
+                                     : java.util.Collections.unmodifiableList(new java.util.ArrayList<>(values));
+    }
+    public static AttrScope denyAll(){   // C.4
+        return new AttrScope("jurisdiction", MatchType.PREFIX, java.util.Collections.emptyList());
+    }
+}
+```
+
+`logicalAttr` is deliberately a *logical* name, not a column — the per-grain physical column is resolved by Part C through the `Grain` binding (C.3). This is the requirements §4 "Never raw column names from the client" rule made structural.
+
+Generalized `AnalyticsScope` (keep `tenantId`/`tenantStateLevel`/`citizenUuid`; replace the single `boundaryPrefix` with the list):
+
+```java
+public final class AnalyticsScope {
+    public final String tenantId;
+    public final boolean tenantStateLevel;
+    public final String citizenUuid;            // unchanged: citizen self-scope (still NOT an AttrScope)
+    public final List<AttrScope> attrScopes;    // NEW: 0..N ANDed attribute restrictions (empty = admin/tenant-only)
+
+    private AnalyticsScope(String tenantId, boolean stateLevel, String citizenUuid, List<AttrScope> attrScopes){
+        this.tenantId = tenantId; this.tenantStateLevel = stateLevel; this.citizenUuid = citizenUuid;
+        this.attrScopes = attrScopes == null ? java.util.Collections.emptyList()
+                                             : java.util.Collections.unmodifiableList(new java.util.ArrayList<>(attrScopes));
+    }
+    // ...
+}
+```
+
+`resolve()` signature gains the resolved principal attributes from Part B (it must, since Part C cannot itself read HRMS). The exact param type is Part B's `PrincipalAttributes`; Part C's contract is "give me `boundaryPrefixes[]`, `departmentCodes[]`, and `isAdmin()`, already normalized". **`stateLevel` is still computed Part-C-side from `tenantId`/`stateLevelLen` (`AnalyticsScope.java:32` logic), so cross-tenant state-vs-city choice never depends on Part B carrying it** (README #7 is Part B's to also expose, but Part C does not regress if B omits it):
+
+```java
+// AnalyticsScope.resolve — generalized (Part B supplies `attrs`; Part C builds attrScopes)
+public static AnalyticsScope resolve(RequestInfo requestInfo, String tenantId, int stateLevelLen,
+                                     PrincipalAttributes attrs){
+    boolean stateLevel = tenantId != null && tenantId.split("\\.").length == stateLevelLen;  // unchanged from L32
+    User u = requestInfo == null ? null : requestInfo.getUserInfo();
+
+    boolean isCitizen = u != null && "CITIZEN".equalsIgnoreCase(u.getType());
+    boolean hasEmployeeRole = false;
+    if (u != null && u.getRoles() != null)
+        for (Role r : u.getRoles()) {
+            String c = r.getCode() == null ? "" : r.getCode().toUpperCase();
+            if (!c.equals("CITIZEN")) hasEmployeeRole = true;
+        }
+
+    // Pure citizen → self-scope, NO attribute scopes (semantics of AnalyticsScope.java:44 preserved).
+    if (isCitizen && !hasEmployeeRole)
+        return new AnalyticsScope(tenantId, stateLevel, u.getUuid(), java.util.Collections.emptyList());
+
+    // Admin/SUPERADMIN → empty attrScopes (tenant-only ceiling), as today (requirements §4 "Admin bypass").
+    if (attrs == null || attrs.isAdmin())
+        return new AnalyticsScope(tenantId, stateLevel, null, java.util.Collections.emptyList());
+
+    // Scoped employee → one AttrScope per non-empty attribute, ANDed.
+    List<AttrScope> scopes = new ArrayList<>();
+    if (attrs.boundaryPrefixes() != null && !attrs.boundaryPrefixes().isEmpty())
+        scopes.add(new AttrScope("jurisdiction", AttrScope.MatchType.PREFIX, attrs.boundaryPrefixes()));
+    if (attrs.departmentCodes() != null && !attrs.departmentCodes().isEmpty())
+        scopes.add(new AttrScope("department", AttrScope.MatchType.IN, attrs.departmentCodes()));
+
+    // FAIL-CLOSED: a non-admin employee who resolved to NO usable attribute must NOT fall through
+    // to tenant-only. An unresolved/empty-HRMS employee gets an impossible scope, not the whole tenant.
+    if (scopes.isEmpty())
+        scopes.add(AttrScope.denyAll());     // see C.4
+    return new AnalyticsScope(tenantId, stateLevel, null, scopes);
+}
+```
+
+The fail-closed branch is the single most important behavioural change versus today. Today an employee with no boundary always got tenant-wide rows (boundary was `null`, only tenant scope applied). Under Part C, a *non-admin* employee whom Part B could not resolve any attribute for gets **deny-all**, per requirements §6 "a missing HRMS row → empty scope, not open." Admin-ness is an explicit positive signal from Part B (`attrs.isAdmin()`), never the *absence* of attributes.
+
+#### C.1a The default is DENY-ALL — fail-closed is the *unconditional* fallthrough, not a special case
+
+**Invariant (the one this part exists to guarantee): the default branch of scope resolution is deny-all. An authenticated principal receives non-empty rows ONLY by matching one of three explicit positive grants; anything else — including any unforeseen future principal shape — falls through to an empty/deny result, never to tenant-wide.** The decision is made in exactly one place — `AnalyticsScope.resolve()` (C.1), the same method that today is `AnalyticsScope.java:31–47` — and `applyScope()` (`AnalyticsPlanner.java:241–251`, generalized in C.3) only ever *narrows* what `resolve()` decided; it can never re-widen a denied principal to tenant scope.
+
+`resolve()` classifies every authenticated principal into exactly one of four arms, and only the first three return rows:
+
+1. **Admin / SUPERADMIN → explicit tenant-wide grant.** Selected by Part B's *positive* `attrs.isAdmin()` signal (C.1, line ~138), never inferred from the absence of attributes. `attrScopes` is empty → tenant scope only.
+2. **Pure citizen → self-scope.** `type == CITIZEN` with no employee role (C.1, lines ~134–135) → `account_id = self`, no attribute scopes.
+3. **Employee with ≥1 resolved attribute scope → attribute-restricted.** At least one of `boundaryPrefixes[]` / `departmentCodes[]` is non-empty (C.1, lines ~142–146) → one ANDed `AttrScope` per resolved attribute.
+4. **EVERYTHING ELSE → DENY-ALL (the default arm).** A non-admin, non-pure-citizen principal who resolved to **zero** usable attribute scopes — including the unresolved/failed HRMS lookup, the drifted `complaint.assignee`↔`eg_hrms_employee.uuid` row, the misprovisioned officer, *and any principal shape this enumeration did not anticipate* — falls into `scopes.add(AttrScope.denyAll())` (C.1, lines ~150–151; C.4), which emits an always-false predicate (`FALSE`, equivalently `1=0`) on the always-present `boundary_path` column on every grain. **The result is empty rows, not tenant-wide rows, and not an unscoped fallthrough.**
+
+The critical contrast with today: in `AnalyticsScope.java:31–47` arm 4 does not exist — a non-citizen with no resolved attributes simply returns `new AnalyticsScope(tenantId, stateLevel, null, null)` (L47, boundary always `null`), and `applyScope()` then emits **only the tenant predicate** (`AnalyticsPlanner.java:242–245`), i.e. every row in the tenant. That is the **fail-OPEN** default this part replaces. Part C makes arm 4 the *explicit, unconditional* fallthrough so that omitting a branch can never silently grant tenant scope.
+
+**An unresolved or failed attribute lookup also lands in arm 4 (fail-closed), never in arms 1–3.** If Part B's HRMS resolution misses, errors, or returns a principal it could not classify, Part C must treat the resulting empty attribute set exactly like a deliberately-empty one: deny-all. `resolve()` therefore keys admin strictly on the positive `isAdmin()` signal and treats *every* empty-attribute non-admin non-citizen as deny — an unresolved lookup is indistinguishable from "resolved to nothing," and both must fail closed. (Where Part B exposes a `resolutionComplete`/`scopeLevel` discriminator rather than `isAdmin()`, the same rule binds: anything other than an explicit admin grant with `resolutionComplete == true` falls to arm 4.)
+
+### C.2 `Grain` model — add `departmentColumn`
+
+Add one field to `AnalyticsCatalog.Grain` (`AnalyticsCatalog.java:25–48`) and one constructor arg. The boundary/citizen/tenant columns already exist at L34–36; department joins them:
+
+```java
+public final String departmentColumn;   // NEW: null = grain cannot be department-scoped
+```
+
+Grain bindings become (only the new arg shown; everything before it unchanged):
+- **facts** (`AnalyticsCatalog.java:78`): `…, "account_id", "department_code", "filed_at"` — facts already has the column (migration L169).
+- **events** (`AnalyticsCatalog.java:96`): `…, "account_id", "department_code", "event_at"` — **only after the C.5 migration lands.** Until then it stays `null`.
+- **daily** (`AnalyticsCatalog.java:108`): after C.5, `…, "account_id", "department_code", "snapshot_date"` — **both** columns are added to the daily table by C.5, so daily becomes citizen- *and* department-scopable. (Pre-C.5 the citizen column is `null` and is the blocker; C.5 is therefore not optional, it is the blocker fix.)
+
+`boundaryColumn` is already non-null on all three grains, so PREFIX/jurisdiction works on facts/events/daily with no migration once values are fed.
+
+### C.3 `applyScope()` — the generalized loop with grain-aware binding + fail-closed
+
+```java
+// ---------- RBAC scope (server-injected) ----------
+private void applyScope(AnalyticsScope scope, Grain g, List<String> conj, List<Object> params){
+    // tenant (unchanged semantics; ESCAPE '\' added — AnalyticsPlanner.java:242-245)
+    if (scope.tenantId != null) {
+        if (scope.tenantStateLevel) { conj.add(g.tenantColumn + " LIKE ? ESCAPE '\\'"); params.add(esc(scope.tenantId) + "%"); }
+        else { conj.add(g.tenantColumn + " = ?"); params.add(scope.tenantId); }
+    }
+    // citizen self-scope — now FAIL-CLOSED, not a silent no-op (C.3a, was L246)
+    if (scope.citizenUuid != null) {
+        if (g.citizenColumn == null)
+            throw new IllegalArgumentException("grain_scope_unavailable: grain '" + g.name
+                + "' cannot enforce citizen self-scope (no account column)");
+        conj.add(g.citizenColumn + " = ?"); params.add(scope.citizenUuid);
+    }
+
+    // generalized attribute scopes — AND across the list, OR within each
+    for (AttrScope a : scope.attrScopes) {
+        String column = bindColumn(a, g);                     // logical attr -> physical column, or fail-closed
+        switch (a.match) {
+            case PREFIX: {
+                if (a.values.isEmpty()) { conj.add("FALSE"); break; }   // OR of nothing = deny
+                List<String> ors = new ArrayList<>();
+                for (String v : a.values) {
+                    ors.add(column + " LIKE ? ESCAPE '\\'");
+                    params.add(esc(v) + "%");                 // reuse the L249 escape, now in esc()
+                }
+                conj.add(ors.size() == 1 ? ors.get(0) : "(" + String.join(" OR ", ors) + ")");
+                break;
+            }
+            case IN: {
+                if (a.values.isEmpty()) { conj.add("FALSE"); break; }
+                List<String> ph = new ArrayList<>();
+                for (String v : a.values) { params.add(v); ph.add("?"); }
+                conj.add(column + " IN (" + String.join(",", ph) + ")");
+                break;
+            }
+            case EQ: { conj.add(column + " = ?"); params.add(a.values.isEmpty() ? null : a.values.get(0)); break; }
+        }
+    }
+}
+
+// reused escape (was inline at AnalyticsPlanner.java:249)
+private static String esc(String s){ return s.replace("\\","\\\\").replace("%","\\%").replace("_","\\_"); }
+
+// logical attribute -> physical grain column; FAIL CLOSED if the grain can't serve it
+private String bindColumn(AttrScope a, Grain g){
+    String col;
+    switch (a.logicalAttr) {
+        case "jurisdiction": col = g.boundaryColumn; break;
+        case "department":   col = g.departmentColumn; break;
+        default: throw new IllegalStateException("scope_unsupported: unknown scope attribute '" + a.logicalAttr + "'");
+    }
+    if (col == null)
+        // grain cannot serve a REQUIRED scope attribute -> reject, NEVER return unscoped (requirements §6 fail-closed)
+        throw new IllegalArgumentException("grain_scope_unavailable: grain '" + g.name
+            + "' cannot enforce scope attribute '" + a.logicalAttr + "'");
+    return col;
+}
+```
+
+#### C.3a Citizen self-scope is now a fail-closed axis (the blocker fix)
+
+The pass-1 blocker (independently found by reviewers A and C) is that citizen self-scope **silently disappears** on any grain whose `citizenColumn` is `null` — i.e. `daily` (`AnalyticsCatalog.java:108`) — because the live guard at `AnalyticsPlanner.java:246` is `scope.citizenUuid != null && g.citizenColumn != null`. v2 **removes the `&& g.citizenColumn != null` short-circuit** and replaces it with the same `grain_scope_unavailable` throw used for attribute scopes. Net effect: a citizen who somehow reaches `grain:"daily"` either (a) binds against `account_id` once C.5 adds the column to the daily table, or (b) — in the window before C.5 deploys, or on any future grain that lacks the column — **fails closed with `grain_scope_unavailable`**, never returns tenant-wide rows. This makes citizen scope obey the *same* invariant as `department`: a scope axis that the grain cannot serve is rejected, never dropped. The primary remediation is structural (C.5 adds `account_id` to daily so the citizen predicate binds); the throw is the belt-and-suspenders that guarantees no silent leak even if the catalog and migration ever drift.
+
+Key properties, each grounded:
+- **`bindColumn` (attributes) and the citizen throw (C.3a) are the leak-stoppers.** If a department-restricted caller's query lands on a grain whose `departmentColumn == null` (events pre-migration), or a citizen lands on a grain whose `citizenColumn == null`, it throws `grain_scope_unavailable` rather than silently dropping the predicate. This is requirements §6 / §7.4 made code. The throw surfaces as a per-query error via the batch handler (`AnalyticsService.runOne` is wrapped in `try/catch` at `AnalyticsService.java:45–46`, mapping to `err(ex)` → `{error,message}`, `partial:true`), so one unscopable tile fails closed without leaking and without failing the whole batch.
+- **OR-within / AND-across** matches requirements §4 exactly: each `AttrScope` becomes one ANDed `conj` entry; multiple values inside become an OR group (PREFIX) or an `IN` list. The whole-batch `String.join(" AND ", conj)` at `AnalyticsPlanner.java:103` does the AND-across.
+- **`ESCAPE '\'` added** to both the tenant state-level `LIKE` (L243) and the boundary `LIKE` (L249), closing the design-§5 gap.
+- **Empty value list → `FALSE`**, never an omitted predicate. An attribute that resolved to zero values is a deny, not an open door.
+
+### C.4 `AttrScope.denyAll()` — the impossible predicate
+
+```java
+public static AttrScope denyAll(){
+    // jurisdiction PREFIX with no values -> applyScope emits FALSE on a column that always exists (boundary_path)
+    return new AttrScope("jurisdiction", MatchType.PREFIX, java.util.Collections.emptyList());
+}
+```
+Because `boundaryColumn` is non-null on all three grains (`AnalyticsCatalog.java:78/96/108`), `denyAll` binds cleanly everywhere and emits `FALSE` — a non-admin employee Part B couldn't resolve sees nothing, on every grain, rather than erroring (which would look like an outage) or leaking (tenant-wide). (Defined inline in `AttrScope` in C.1.)
+
+### C.5 Migration — close BOTH the events `department_code` leak AND the daily citizen/department gaps
+
+This migration is the structural half of the blocker fix (C.3a) **and** the department fix. It does three things in dependency order, in **one** migration so the catalog never advertises a column the storage lacks:
+
+1. **Add `department_code` + `account_id` to the daily table** (it has neither today, `…create_v2_grain_mvs.sql:239–253`). Adding `account_id` is what makes citizen self-scope bind on daily (the blocker); adding `department_code` makes daily department-scopable (Q3 → option a). Both are populated by the snapshot `INSERT … SELECT FROM complaint_facts` (described at migration L255), which already selects from `complaint_facts` where both columns exist.
+2. **Recreate the events MV with `department_code`**, sourced the same way facts does (the `mdms` CTE L141–151, joined on `service_code`). The events MV already has `svc.servicecode AS service_code` in scope (L79), so `LEFT JOIN mdms m ON m.service_code = svc.servicecode` works.
+3. **Recreate `complaint_facts` in dependency order**, because `DROP MATERIALIZED VIEW complaint_events CASCADE` (L11 pattern) also drops `complaint_facts` (it reads `FROM complaint_events`, L132) and every facts index (L231–236). The migration recreates **both** MVs and **all** indexes within the single migration — it does **not** rely on the refresh scheduler to backfill facts (see the resolved Q1 below).
+
+```sql
+-- new migration: V20260624000000__events_department_code_and_scope_columns.sql
+
+-- (1) daily: add the two scope columns that were missing (citizen + department).
+ALTER TABLE complaint_open_state_daily ADD COLUMN IF NOT EXISTS account_id     varchar(128);
+ALTER TABLE complaint_open_state_daily ADD COLUMN IF NOT EXISTS department_code varchar(256);
+CREATE INDEX IF NOT EXISTS ix_cosd_account ON complaint_open_state_daily(account_id);
+CREATE INDEX IF NOT EXISTS ix_cosd_dept    ON complaint_open_state_daily(department_code);
+-- the daily snapshot INSERT (migration L255) must add account_id, department_code to its column list +
+-- SELECT list (both already exist on complaint_facts: account_id L158, department_code L169).
+
+-- (2)+(3) events gains department_code; facts is recreated after it (CASCADE blast radius).
+DROP MATERIALIZED VIEW IF EXISTS complaint_events CASCADE;   -- also drops complaint_facts + its indexes
+CREATE MATERIALIZED VIEW complaint_events AS
+WITH svc AS ( ... ),            -- unchanged (L13-20)
+     bnd AS ( ... ),            -- unchanged (L21-26)
+     bs  AS ( ... ),            -- unchanged (L27-30)
+     asg AS ( ... ),            -- unchanged (L31-35)
+     tx  AS ( ... ),            -- unchanged (L36-51)
+     mdms AS (                  -- NEW: identical dedupe-by-serviceCode-prefer-root-tenant as facts (L141-151)
+       SELECT DISTINCT ON (data->>'serviceCode')
+              data->>'serviceCode' AS service_code,
+              data->>'department'  AS department_code
+       FROM eg_mdms_data
+       WHERE schemacode = 'RAINMAKER-PGR.ServiceDefs' AND isactive
+       ORDER BY data->>'serviceCode', length(tenantid)
+     )
+SELECT
+  ...,                          -- unchanged projection (L53-91)
+  m.department_code,            -- NEW
+  ...
+FROM tx
+LEFT JOIN svc ON svc.servicerequestid = tx.service_request_id   -- unchanged (L93)
+LEFT JOIN bnd ON bnd.code = svc.locality_code                   -- unchanged (L94)
+LEFT JOIN bs  ON ...                                            -- unchanged (L95)
+LEFT JOIN asg ON ...                                            -- unchanged (L96)
+LEFT JOIN eg_user ua ON ...                                     -- unchanged (L97)
+LEFT JOIN mdms m ON m.service_code = svc.servicecode;           -- NEW
+
+-- recreate events indexes (CASCADE drop took them), L99-103 verbatim,
+-- + add ix_ce_dept ON complaint_events(department_code).
+
+-- recreate complaint_facts: re-apply the ORIGINAL facts DDL verbatim from the shared fragment
+-- (see Q1 resolution) + all six facts indexes (L231-236). Facts already projects department_code (L169)
+-- and account_id (L158); no facts change is needed beyond re-creation.
+```
+
+To avoid duplicating ~120 lines of facts DDL and the drift risk that creates, the facts `CREATE MATERIALIZED VIEW … ` body is extracted to a single shared SQL fragment (`_facts_mv.sql`) that **both** the original `V20260608000000` and this migration `\i`/include, so there is exactly one definition of facts. (Flyway runs raw SQL; the include is done at build time by concatenating the fragment into the migration resource, since Flyway has no `\i`.) This is the resolution of the v1 Q1 hand-wave — facts is recreated *inside* the migration, in dependency order, from one source.
+
+Only **after** this migration is deployed does C.2 flip events' and daily's `departmentColumn`/`citizenColumn` in the catalog and `AnalyticsService.scopeCols()` start advertising the new scope columns. The catalog change and the migration ship together (same PR) so the catalog never claims a column the storage lacks.
+
+#### C.5a Coverage hazard — `department_code IS NULL` rows are invisible to department-scoped users (NOT just a code-space issue)
+
+Even with perfectly reconciled code spaces, `department_code` is sourced from a `LEFT JOIN mdms` on both grains (facts `…create_v2_grain_mvs.sql:227`; the new events join above). Any complaint whose `service_code` has **no active `RAINMAKER-PGR.ServiceDefs` row** (CTE filter L149) gets `department_code = NULL`, and `NULL IN ('SANI')` is never true. So such complaints are **invisible to every department-scoped user** (fail-closed → acceptable on the security axis) but **visible only to admins** (a correctness/coverage hazard distinct from the code-space mismatch). This is called out explicitly so it is not mistaken for the §7.3 mismatch:
+- It is **fail-closed, not a leak** — so it does not block shipping department scope.
+- The *fix* (ensuring every live `service_code` has a ServiceDef, or back-filling `department_code`) is **data/ownership outside Part C** — flagged to Part B's code-space consistency check (extend it to also assert "every distinct `service_code` in `eg_pgr_service_v2` has a ServiceDefs row") and to operations.
+- Part C's validation matrix adds a test that asserts a complaint with an unmatched `service_code` returns **zero** rows for a department-scoped caller (proving fail-closed) and is visible to admin.
+
+### C.6 Consumer updates (`AnalyticsService`)
+
+- `scopeInfo()` (`AnalyticsService.java:114`): replace `if (s.boundaryPrefix != null) m.put("boundaryPrefix", s.boundaryPrefix);` with a loop summarizing `s.attrScopes` as value **counts**, not raw values (e.g. `m.put("attrScopes", [{attr:"jurisdiction",match:"PREFIX",valueCount:2}, …])`) — to avoid echoing jurisdiction internals back to the client. Since `boundaryPrefix` is always `null` today (`AnalyticsScope.java:47`), the removed line never fired, so no live FE depends on `scope.boundaryPrefix` — the contract change is safe (confirm no dashboard bundle greps `scope.boundaryPrefix`).
+- `scopeCols()` (`AnalyticsService.java:96–102`): add `if (g.departmentColumn != null) l.add("department:" + g.departmentColumn);` so `/_schema` honestly reports which grains are department-scopable. (Citizen column is already reported at L100.)
+- `AnalyticsService.query()` (L32) call to `AnalyticsScope.resolve(...)` gains the Part B `PrincipalAttributes` argument (resolved just above it from the trusted principal).
+
+---
+
+## Interfaces with other parts (inputs consumed, outputs produced)
+
+**Inputs Part C consumes:**
+- **From Part A (Trust foundation):** a `RequestInfo.userInfo` whose `uuid`/`type`/`roles` are token-derived and non-spoofable, **and a non-null principal** (Part A maps introspection `null`/5xx → `401`, per README cross-cutting #2 "identity is fail-open"). Part C reads `getType()`/`getRoles()`/`getUuid()` exactly as the live `resolve()` does (`AnalyticsScope.java:34–44`) but the *trustworthiness and non-null-ness* of those fields is Part A's contract. **Without A, every predicate Part C emits scopes a forged identity** (requirements §8 "A blocks all of B–F").
+- **From Part B (Identity → attribute resolution):** the `PrincipalAttributes` contract — `boundaryPrefixes()` (delimiter-anchored materialized-path prefixes like `…WARD_3|`, already in the complaint code-space and **already `|`-terminated** — anchoring is B's path construction, not C's), `departmentCodes()` (HRMS dept codes **already reconciled to the MDMS-ServiceDefs code-space** *and* with the C.5a "every live service_code has a ServiceDef" coverage assertion added to B's consistency check), and `isAdmin()` (the positive admin signal that selects tenant-only). Part C assumes these are clean; it does no HRMS reads and no code-space translation. **`tenantStateLevel` is computed Part-C-side** (`AnalyticsScope.java:32`) and does not depend on B (README #7).
+
+**Outputs Part C produces:**
+- **The generalized `AnalyticsScope` shape** (`attrScopes`) consumed by `AnalyticsService.scopeInfo()`/`scopeCols()` and re-checked against — but **not** widened by — Part D's `visibleTo` and Part F's inline gate. Part C's contract to D/E/F: row scope is independent; an empty scope is a real empty result, never a signal to relax catalog/grammar gates (requirements §3).
+- **`AttrScope.MatchType` + the `Grain.departmentColumn` binding** — the extension point for any future `EQ`/`IN`/`PREFIX` attribute (requirements §4 "open to further attributes with no grammar change"). A new attribute = a new `logicalAttr` case in `bindColumn` + a `Grain` column, nothing in the grammar.
+- **The `grain_scope_unavailable` error-code string** — the stable, fail-closed signal that Parts D/E **must match as a string** and treat as non-retryable, never widen-on-empty. It is emitted for both attribute scopes (`bindColumn`) and citizen self-scope (C.3a). It surfaces via `AnalyticsService.java:45–46` → `err(ex)` → `{error:"grain_scope_unavailable", message:…}` (the `code:message` split is at `AnalyticsService.java:118–124`). A mis-targeted tile fails closed per-tile (`partial:true`), never leaks.
+
+**Explicitly orthogonal to Part C:**
+- Part F's `inline_forbidden` gates the *grammar*; even an admin who may send inline queries still gets `attrScopes` empty (tenant-only) — Layer 1 and Layer 3 are independent (requirements §3).
+- The **batch-arm bypass** (README #5) is a D/F gate-wiring concern; Part C's scope injection runs inside `runOne()`→`plan()` for **both** arms (`AnalyticsService.java:45` and L51), so Part C is immune to it. Part C flags it so D/F wire the *catalog/inline* gate on both arms too.
+- **Cache-key** is owned by the caching part (no Redis layer exists in `AnalyticsService` today). Part C's only obligation is to expose a stable canonical serialization of `attrScopes` (attr, match, sorted values) **plus** `citizenUuid` and `tenantStateLevel` for keying, so a multi-dept vs single-dept (or citizen vs admin) caller never collide (requirements §6).
+
+---
+
+## Sequencing & migration steps
+
+Part C is plan Phases 2–3; **both gate on A (trust) and B (`PrincipalAttributes`) being mergeable**. Ship as two one-concern PRs against egov/CCRS develop, each validated on ovh-cloud-dev (bomet repro) with the emitted `WHERE` asserted in tests (plan §5):
+
+1. **PR-C1 (Phase 2 — jurisdiction wiring + citizen-scope fail-closed, no MV migration).**
+   - Add `AttrScope` + generalize `AnalyticsScope` (C.1) and `applyScope()` (C.3) including `esc()` extraction, `ESCAPE '\'`, `bindColumn`, **and the C.3a citizen fail-closed change** (remove the `&& g.citizenColumn != null` short-circuit at L246, throw `grain_scope_unavailable`).
+   - Update the two `AnalyticsService` consumers (C.6) and the `resolve()` call site.
+   - Feed only the **jurisdiction** `AttrScope` (department resolution can return empty until PR-C2). `Grain.departmentColumn` is added as a field but set `null` everywhere except facts.
+   - **Note:** until PR-C2's migration adds `account_id` to daily, a citizen `grain:"daily"` query **fails closed with `grain_scope_unavailable`** (no longer leaks). This is the immediate blocker mitigation; PR-C2 then makes it bind to `account_id` and return the citizen's own rows.
+   - **Exit:** a GRO with jurisdiction `WARD_3` sees only `boundary_path LIKE 'WARD_3|%' ESCAPE '\'`-matching rows on facts/events/daily; sibling `WARD_30` does not leak; **a pure citizen issuing `grain:"daily"` gets `grain_scope_unavailable`, NOT tenant-wide rows** (regression test for the blocker).
+
+2. **PR-C2 (Phase 3 — department + daily scope columns, with the MV migration).**
+   - Add migration `V20260624000000__…` (C.5): daily gains `account_id` + `department_code`; events MV gains `department_code`; facts recreated from the shared fragment with all indexes (+ `ix_ce_dept`).
+   - Flip events' `departmentColumn` **and** daily's `citizenColumn`/`departmentColumn` in the catalog (C.2) **in the same PR** as the migration.
+   - Feed the **department** `AttrScope` from `attrs.departmentCodes()`.
+   - **Exit:** a Sanitation supervisor sees `department_code IN ('SANI')` on facts *and* events; a multi-dept user sees the union; a citizen `grain:"daily"` now returns **only their own** rows (`account_id = self`); a complaint whose `service_code` has no ServiceDef is invisible to the dept-scoped caller and visible to admin (C.5a fail-closed test).
+
+3. **Validation matrix (both PRs)** — assert the *generated SQL string*, not just the Java, for: pure citizen on facts/events **and on daily** (the blocker regression — pre-C2 → `grain_scope_unavailable`, post-C2 → `account_id = self`); single-dept single-ward GRO; multi-dept; multi-ward; admin (empty `attrScopes` → tenant-only); **unresolved employee → `denyAll`/`FALSE`**; department-restricted-on-events-pre-migration → `grain_scope_unavailable`; **department-scoped caller + `service_code` with no ServiceDef → zero rows** (C.5a). Use clean single-role `RBAC_TEST_*` users, never real GRO accounts (HRMS role pollution — every GRO also holds `PGR_LME`, requirements §7.2).
+
+---
+
+## Risks, edge cases, failure modes
+
+- **Citizen×daily leak (the convergent blocker — now fixed two ways).** Root cause: `AnalyticsPlanner.java:246` guards citizen scope with `g.citizenColumn != null`, daily's is `null` (`AnalyticsCatalog.java:108`), so `grain:"daily"` from a citizen drops the predicate → tenant-wide backlog. Fix: (1) C.3a removes the short-circuit and throws `grain_scope_unavailable` on any grain lacking the column; (2) C.5 adds `account_id` to the daily table so the predicate binds. PR-C1 ships (1) immediately (fail-closed); PR-C2 ships (2) (correct rows). The negative test `citizen + grain:"daily"` is mandatory in both PRs.
+- **Fail-closed on unresolved employee.** Today's code defaults a no-boundary employee to **tenant-wide** (boundary `null`, only tenant scope). The drift hazard is real on bomet/naipepea: `complaint.assignee == eg_hrms_employee.uuid` drifts and HRMS rows can be missing. Part C's `resolve()` treats *non-admin employee + no resolved attribute* as `denyAll`. The discriminator is Part B's explicit `isAdmin()` — **never infer admin from empty attributes**, or a drifted HRMS row silently promotes a supervisor to tenant-wide visibility.
+- **The events `department_code` silent leak (requirements §7.4).** If department scope shipped on facts before the events MV carried the column, an events query from a dept-restricted caller would either silently drop the predicate (leak) or error. `bindColumn` enforces the error while `departmentColumn` is `null`; PR-C2 ties the catalog flip to the migration so neither a leak nor a spurious error survives into a released build.
+- **`department_code IS NULL` coverage hazard (C.5a).** Distinct from the code-space mismatch: complaints whose `service_code` lacks a ServiceDef row get `department_code = NULL` (LEFT JOIN, `…create_v2_grain_mvs.sql:227` and the new events join), invisible to every dept-scoped user. Fail-closed (acceptable) but a coverage gap; the data fix is Part B's consistency check + operations, not Part C. Tested explicitly.
+- **Grain-inference bypass.** `AnalyticsPlanner.inferGrain()` (L267–275) returns only `events` or `facts` (never `daily`), and can route a measure-driven query to `events` automatically. A department-restricted caller thus auto-routed to events pre-migration correctly throws `grain_scope_unavailable`; post-migration it scopes correctly. The inference path cannot escape `applyScope` (it runs unconditionally at L98). The daily-via-inference path is impossible (daily requires an explicit `grain`), so the blocker can only be reached by an explicit `grain:"daily"` — still covered by C.3a. Tested.
+- **Sibling-prefix leak (`WARD_3` vs `WARD_30`).** Mitigated by Part B anchoring prefixes on the delimiter (`…WARD_3|`) *and* Part C's `esc()` + `ESCAPE '\'`. If Part B ever hands an un-anchored prefix, `WARD_3%` would match `WARD_30…`. Part C documents the `|`-anchoring as a precondition of the contract and a test asserts a `|`-terminated bound value; Part C does not itself add the delimiter (B's path construction).
+- **Department code-space mismatch (requirements §7.3).** If HRMS dept codes ≠ MDMS ServiceDefs `data->>'department'` codes (`…create_v2_grain_mvs.sql:147`), `department_code IN (…)` matches nothing → a Sanitation supervisor sees **zero** rows (fails closed, not open — acceptable but a silent functional outage). Part C depends on Part B's one-time consistency check; Part C's tests assert against codes known to exist in both spaces. (Note this is *separate* from the C.5a NULL-row hazard.)
+- **Tenant isolation under state-level scope.** Tenant `LIKE prefix%` (now `ESCAPE '\'`) at L243 plus a boundary prefix could in principle let one tenant's `boundary_path` collide with another's if boundary materialized paths are not tenant-prefixed. Tenant scope is ANDed independently, so cross-tenant rows are excluded by the tenant predicate regardless; boundary scope only ever *narrows further* within the already-tenant-bounded set. Documented invariant: scope predicates only AND (narrow), never OR (widen) across the citizen/tenant/attribute axes.
+- **Cache-key correctness (NFR, requirements §6).** Resolved scope is part of the result cache key. Generalizing to `attrScopes` means the cache key must serialize the full ordered attribute list (attr, match, sorted values) **plus** `citizenUuid` and `tenantStateLevel` — otherwise a citizen and an admin, or a multi-dept and single-dept caller, could collide. There is no cache layer in `AnalyticsService` today; this is a forward dependency on the caching part, which must consume Part C's canonical-string contract.
+- **`CASCADE` drop blast radius (migration).** `DROP MATERIALIZED VIEW complaint_events CASCADE` drops `complaint_facts` (it reads from events, `…create_v2_grain_mvs.sql:132`) and all facts indexes (L231–236). The C.5 migration recreates both MVs and all indexes **within the single migration, in dependency order**, from a shared facts fragment — it does **not** rely on the refresh scheduler (resolving v1 Q1). If facts were left absent until the first refresh, `asOf()` (`AnalyticsService.java:105`, `SELECT max(facts_built_at) FROM complaint_facts`) would throw → be caught at L106 → fall back to `System.currentTimeMillis()`, *masking* the outage; the in-migration recreate removes that window.
+
+---
+
+## Open questions for review
+
+1. **`denyAll` vs `403` for unresolved employees.** Part C proposes `denyAll` (`FALSE` predicate → empty rows, HTTP 200) for a non-admin employee with no resolved attribute, so the UI shows "no data" rather than an error. Is a `403`/explicit "no jurisdiction assigned" preferable operationally (so an HRMS-misprovisioned officer is *told*, not silently shown empty)? Empty-result is the requirements §6 letter ("empty or denied"); the choice is UX/observability. (Note: this is distinct from the citizen×daily case, which is a hard `grain_scope_unavailable` pre-C2 and correct rows post-C2.)
+2. **`scopeInfo` disclosure.** Should the response `scope` block echo attribute *value counts* only (proposed), full values, or nothing? Counts aid FE debugging but leak "you are scoped to 2 wards / 1 dept." Leaning counts-only; confirm against any product requirement to show operators their own scope. The boundary between Part B's resolved attribute *values* and Part C's response *shaping* is where jurisdiction internals could leak — Part C commits to counts-only and never lands raw `boundaryPrefixes[]` into the response.
+3. **`EQ` match type.** `AttrScope.MatchType.EQ` is reserved but unused in v1/v2 (jurisdiction=PREFIX, department=IN). Keep for forward-compat (one switch case) or drop until needed (YAGNI)? Leaning keep — it signals the extension model cheaply.
+4. **Shared facts-DDL fragment mechanics.** C.5 extracts the facts `CREATE MATERIALIZED VIEW` body to one fragment included by both `V20260608000000` and the new migration. Flyway has no `\i`; the include is a build-time concatenation into the migration resource. Confirm the build packaging step (Maven resource filtering vs a pre-build script) the team prefers, so the single-source guarantee is enforced at build time and not by copy-paste discipline.
+
+---
+
+## v2 revision log (pass-1 findings → resolution)
+
+- **blocker — citizen self-scope silently no-ops on the `daily` grain → tenant-wide leak for citizens (convergent, also in README #1).** RESOLVED in Part C. Root cause confirmed at `AnalyticsPlanner.java:246` (guard `&& g.citizenColumn != null`) + `AnalyticsCatalog.java:108` (daily `citizenColumn = null`). v2 stops preserving the branch "verbatim": (1) **C.3a** removes the `&& g.citizenColumn != null` short-circuit and throws `grain_scope_unavailable` for any grain that cannot serve citizen scope — citizen scope now obeys the same fail-closed invariant as `department`; (2) **C.5** adds `account_id` to `complaint_open_state_daily` (which lacked it, `…create_v2_grain_mvs.sql:239–253`) so the predicate binds on daily. PR-C1 ships the fail-closed throw (immediate leak stop); PR-C2 ships the column (correct rows). Mandatory negative test `citizen + grain:"daily"` added to the validation matrix in both PRs.
+- **major — PR-C1 Exit asserted a "declared `boundaryScope` param ANDs to empty" mechanism that does not exist.** RESOLVED by removing the false claim. Verified `boundary_path` is **not** in any grain's `filterable` set (facts filterable `AnalyticsCatalog.java:65–69`, events L89–92, daily L104–105), and the only client narrowing path `predicate()` requires `g.filterable.contains(colKey)` at `AnalyticsPlanner.java:174`. The v2 PR-C1 Exit no longer references a declared boundary-narrowing param; it asserts only the injected jurisdiction scope and the citizen-daily regression. Declared client-side narrowing on `boundary_path` is **not owned by Part C** and is now omitted rather than silently inherited; if it is wanted it belongs to Part D's KPI-def declared-params surface, not Part C's row spine.
+- **major — `department_code IN (...)` silently drops NULL-`department_code` rows (LEFT JOIN) even on facts, distinct from the code-space mismatch.** RESOLVED by naming it as its own hazard. Added **C.5a** + a risk entry: any complaint whose `service_code` lacks an active ServiceDefs row gets `department_code = NULL` (`…create_v2_grain_mvs.sql:147` CTE, projected L169, `LEFT JOIN mdms` L227; the new events join is also LEFT), so `NULL IN (...)` makes it invisible to every dept-scoped user and visible only to admin. Classified **fail-closed (acceptable, not a leak)**; the data fix (ServiceDef coverage / back-fill) is assigned to **Part B**'s consistency check (extended to assert every live `service_code` has a ServiceDef) + operations. A dedicated zero-rows-for-dept / visible-to-admin test was added.
+- **minor — the C.5 "recreate facts" hand-wave was the riskiest step and v1 Q1 left it open.** RESOLVED. Verified `complaint_facts` reads `FROM complaint_events` (`…create_v2_grain_mvs.sql:132`), so `DROP … CASCADE` drops facts + indexes L231–236, and `asOf()` at `AnalyticsService.java:105` would mask the gap via its L106 fallback. v2 C.5 recreates **both** MVs and all indexes **inside the single migration in dependency order**, sourcing facts from a single shared `_facts_mv.sql` fragment included by both `V20260608000000` and the new migration — it no longer relies on the refresh scheduler. The old open Q1 is closed; only the build-packaging mechanics for the shared fragment remain (new Open Q4).
+- **minor — `inferGrain` department side-door analysis correct but worth confirming (never routes to `daily`).** ACKNOWLEDGED, no change needed. Re-verified `inferGrain` returns only `events`/`facts` at `AnalyticsPlanner.java:267–275`; the risk entry now states explicitly that the daily-via-inference path is impossible (daily needs explicit `grain`), so the citizen×daily blocker is reachable only via explicit `grain:"daily"` and is fully covered by C.3a.
+- **nit — `scopeInfo()` rewrite drops raw `boundaryPrefix`; confirm contract safety.** RESOLVED. C.6 now states that `s.boundaryPrefix` is always `null` today (`AnalyticsScope.java:47`) so the removed line never fired and no live FE depends on `scope.boundaryPrefix`; the change is contract-safe (with a residual "confirm no dashboard bundle greps `scope.boundaryPrefix`"). v2 emits **value counts only**, never raw values.
+- **mis-citation — `Grain` scope columns cited as `AnalyticsCatalog.java:34–37`.** CORRECTED throughout to **L34–36** (`tenantColumn` L34, `boundaryColumn` L35, `citizenColumn` L36); L37 is `defaultTimeRole`. All other file:line anchors were re-verified exact: the verbatim `applyScope` block at `AnalyticsPlanner.java:241–251`, facts `mdms` CTE L141–151, `m.department_code` at L169, `LEFT JOIN mdms` L227, events MV's lack of any MDMS join (join block L92–97), daily table L239–253, `predicate()` filterable gate L174.
+- **interface — Part B contract leak surface (jurisdiction values in `scopeInfo`).** RESOLVED at Part C's edge: C.6/Open Q2 commit to counts-only and state Part C never lands raw `boundaryPrefixes[]` into any response path. The upstream guarantee that B never hands raw values into a response is named as **Part B's** responsibility.
+- **interface — D/E reliance on `grain_scope_unavailable` should be a stable matchable code.** RESOLVED. The Outputs section now states `grain_scope_unavailable` is a **stable error-code string** D/E must match (not retry, not widen-on-empty), emitted for both attribute and citizen axes, surfaced via `AnalyticsService.java:45–46` → `err()` split L118–124 as `{error:"grain_scope_unavailable", …}`.
+- **interface — cache-key must serialize full ordered `attrScopes`.** RESOLVED as a forward dependency. Risk + Outputs now require the canonical key to serialize ordered `attrScopes` (attr, match, sorted values) **plus** `citizenUuid` and `tenantStateLevel`; no cache layer exists in `AnalyticsService` today, so the caching part must consume Part C's canonical-string contract. Owner: caching part (unbuilt).
+- **gap — citizen×daily must be closed in Part C, not deferred.** DONE (see blocker above) — closed in Part C via C.3a + C.5, not deferred to any other part.
+- **gap — daily is both department- AND citizen-unscopable; if Q3 adds `department_code`, add `account_id` too.** DONE. C.5 adds **both** `account_id` and `department_code` to `complaint_open_state_daily` in one migration, fixing both axes; v1 Q3 is folded into C.5 (no longer an open question).
+- **gap — no negative test for "citizen sends `grain:"daily"`" in the validation matrix.** DONE. The validation matrix (and both PR Exit criteria) now include the explicit `citizen + grain:"daily"` case (pre-C2 → `grain_scope_unavailable`; post-C2 → `account_id = self`) alongside the unresolved-employee → `denyAll` case.
+
+**Cross-cutting findings from README owned elsewhere (named, not fixed here):**
+- **fail-open identity / introspection `null`→`401` (README #2):** owned by **Part A**. Part C's Inputs section now states it assumes a non-null, coerced principal.
+- **batch-arm bypass of the inline/kpi gate (README #5):** owned by **Part D/F**. Part C is immune (scope injects inside `runOne()`→`plan()`→`applyScope()` at L98 for both arms, `AnalyticsService.java:45` and L51) and flags it for D/F to wire their gates on both arms.
+- **user-preferences spoofability (README #6):** owned by **Part E** — not in Part C's surface.
+- **`tenantStateLevel` dropped in `PrincipalAttributes` (README #7):** owned by **Part B** to expose; Part C does not regress because it computes `stateLevel` itself at `AnalyticsScope.java:32`.
+
+### v3 corrections (pass-3 codex fact-check, 2026-06-23)
+
+- **design gap — the FAIL-CLOSED / deny-all default was not stated explicitly.** RESOLVED by adding **C.1a "The default is DENY-ALL"**. The v2 prose described fail-closed only as a per-case outcome (citizen×daily in C.3a; unresolved employee in the C.1 `resolve()` body) and never named the *default branch of scope resolution* as deny-all. The codex review correctly flagged that the live default is fail-OPEN: in `AnalyticsScope.java:31–47`, `resolve()` always returns `boundaryPrefix = null` (L47) for a non-citizen with no resolved attributes, and `applyScope()` (`AnalyticsPlanner.java:241–251`) then emits **only** the tenant predicate (L242–245) → every row in the tenant. C.1a now states the invariant explicitly: scope resolution classifies every authenticated principal into exactly four arms — (1) admin/SUPERADMIN → tenant-wide, (2) pure citizen → self-scope, (3) employee with ≥1 resolved attribute → attribute-restricted, (4) **everything else, including unresolved/failed HRMS lookups and any unforeseen principal shape → `denyAll()` → `FALSE`/`1=0`, never tenant-wide.** The default arm is the *unconditional* fallthrough (decided in `resolve()`; `applyScope()` can only narrow, never re-widen), and an unresolved/failed attribute lookup is explicitly routed to arm 4 rather than arms 1–3. Where today's fall-through lives: `AnalyticsScope.java:47` (always-`null` boundary) + `AnalyticsPlanner.java:242–246` (tenant-only predicate when no other scope is set).
+
+## Codex review (pass 2 — gpt-5.5, verdict: needs-rework)
+
+> External adversarial review via `codex exec`, read-only, verifying the v2 revision log against the actual code. **Note:** codex evaluated "resolved" as "patched in code"; this is a *design* doc (no code changed yet), so most `actuallyResolved:false` items mean "design specifies it, code not yet written," not "design wrong." Read the findings for genuine design errors vs. implementation-status notes.
+
+
+**Summary:** The v2 design text documents several fixes, but the actual analytics code and migration remain largely pre-v2: no AttrScope, no PrincipalAttributes integration, no department scope binding, no fail-closed citizen daily handling, no new migration, and no tests found.
+
+
+### Resolution check (3/13 confirmed in code)
+
+- ❌ **blocker: citizen self-scope silently no-ops on daily, leaking tenant backlog** — Still present. AnalyticsPlanner keeps `scope.citizenUuid != null && g.citizenColumn != null`; daily still binds `citizenColumn=null`; daily table still lacks account_id. Evidence: AnalyticsPlanner.java:246, AnalyticsCatalog.java:108, V20260608000000__create_v2_grain_mvs.sql:239-253.
+- ❌ **major: PR-C1 Exit asserted declared boundaryScope narrowing mechanism that does not exist** — The C doc removed the PR-C1 exit claim, but adjacent specs still require `boundaryScope`/`departmentScope` declared narrowings that C ANDs under injected scope; actual planner only supports filterable columns and boundary_path is not filterable. Evidence: 00-requirements.md:65, 40-kpi-catalog-governance.md:192, AnalyticsPlanner.java:173-175, AnalyticsCatalog.java:65-69/89-92/104-105.
+- ✅ **major: department_code IN silently drops NULL-department rows distinct from code-space mismatch** — As a design hazard, this is now correctly named and classified fail-closed. Actual code confirms facts uses LEFT JOIN MDMS and projects nullable department_code; events/daily still have no department_code scope column. Evidence: V20260608000000__create_v2_grain_mvs.sql:141-151,169,227.
+- ❌ **minor: C.5 recreate-facts hand-wave after DROP complaint_events CASCADE** — No actual V20260624000000 migration or shared `_facts_mv.sql` fragment exists in the migration directory; the only opened migration is still V20260608000000. Existing facts depends on complaint_events and indexes are in that original migration. Evidence: V20260608000000__create_v2_grain_mvs.sql:109-132,231-236.
+- ✅ **minor: inferGrain department side-door analysis; confirm it never routes to daily** — Confirmed. inferGrain can return only `events` or `facts`; daily requires explicit grain. Evidence: AnalyticsPlanner.java:267-275.
+- ❌ **nit: scopeInfo rewrite drops raw boundaryPrefix; confirm contract safety** — Actual code still emits raw `boundaryPrefix` if non-null and has no attrScopes counts-only output. Boundary is currently always null, but the claimed rewrite is not in code. Evidence: AnalyticsService.java:109-115, AnalyticsScope.java:47.
+- ✅ **mis-citation: Grain scope columns cited as AnalyticsCatalog.java:34-37** — Corrected in the design text: tenant/boundary/citizen are L34-L36 and L37 is defaultTimeRole. Evidence: AnalyticsCatalog.java:34-37.
+- ❌ **interface: Part B contract leak surface via jurisdiction values in scopeInfo** — No Part C edge implementation exists: AnalyticsScope has no attrScopes, AnalyticsService has no counts-only loop, and raw boundaryPrefix is still the only attribute-like response field. Evidence: AnalyticsScope.java:21-28, AnalyticsService.java:109-115.
+- ❌ **interface: D/E reliance on stable grain_scope_unavailable code** — No code emits `grain_scope_unavailable`; citizen and boundary scope axes silently no-op when the grain column is null. err() could split such a string, but the planner never produces it. Evidence: AnalyticsPlanner.java:246-249, AnalyticsService.java:118-124.
+- ❌ **interface: cache key must serialize full ordered attrScopes** — No attrScopes type or canonical serialization exists in actual code; there is also no cache layer here. Evidence: AnalyticsScope.java:21-28, AnalyticsService.java:30-36.
+- ❌ **gap: citizen×daily must be closed in Part C, not deferred** — Not closed in actual Part C code or SQL. The same daily leak remains. Evidence: AnalyticsPlanner.java:246, AnalyticsCatalog.java:108, V20260608000000__create_v2_grain_mvs.sql:239-253.
+- ❌ **gap: daily is both department- and citizen-unscopable; add account_id if adding department_code** — Daily table still has neither `account_id` nor `department_code`; daily catalog still has citizenColumn null and no departmentColumn field exists. Evidence: V20260608000000__create_v2_grain_mvs.sql:239-253, AnalyticsCatalog.java:25-46,108.
+- ❌ **gap: no negative test for citizen sends grain:daily** — No analytics tests matching citizen daily, grain_scope_unavailable, denyAll, or AttrScope were found under src/test; actual code also lacks the expected behavior. Evidence: AnalyticsPlanner.java:246, AnalyticsCatalog.java:108.
+
+### Findings
+
+- **[BLOCKER] Citizen daily grain still leaks tenant-wide rows** — A pure citizen scope is only applied if the grain has a citizen column. The daily grain advertises no citizen column, so `applyScope` drops `account_id = ?` and only tenant scope remains. The daily storage also lacks account_id, so the structural fix is absent.  
+  _evidence:_ `CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java:246; CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsCatalog.java:108; CCRS/backend/pgr-services/src/main/resources/db/migration/main/V20260608000000__create_v2_grain_mvs.sql:239-253`
+- **[BLOCKER] Non-citizen employees with no resolved attributes remain tenant-wide** — AnalyticsScope still only derives citizenUuid from body userInfo and always returns boundaryPrefix null. There is no PrincipalAttributes input, no attrScopes, no denyAll, and no fail-closed path for unresolved HRMS attributes; employees fall through to tenant-only scope.  
+  _evidence:_ `CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsScope.java:31-47; CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java:241-251`
+- **[MAJOR] Department scope engine is not implemented** — There is no AttrScope class, no Grain.departmentColumn, no bindColumn, and no department predicate injection. Facts exposes department_code as a normal groupable/filterable column, but RBAC never injects `department_code IN (...)`.  
+  _evidence:_ `CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsCatalog.java:25-46,59,66; CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java:241-251`
+- **[MAJOR] Events and daily remain department-unscopable** — The events MV still has no MDMS CTE/join and no department_code projection. The daily table still lacks department_code. Any design path that flips events/daily department capability would not be backed by storage.  
+  _evidence:_ `CCRS/backend/pgr-services/src/main/resources/db/migration/main/V20260608000000__create_v2_grain_mvs.sql:52-97; CCRS/backend/pgr-services/src/main/resources/db/migration/main/V20260608000000__create_v2_grain_mvs.sql:239-253`
+- **[MAJOR] Boundary/jurisdiction scope is still wired but never populated** — AnalyticsScope hardcodes boundaryPrefix null, so the planner's boundary LIKE branch never fires. No Part B PrincipalAttributes integration exists in AnalyticsService.  
+  _evidence:_ `CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsScope.java:46-47; CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java:30-32; CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java:247-249`
+- **[MAJOR] LIKE predicates still omit explicit ESCAPE** — The design claims explicit `ESCAPE '\'` is added for tenant state-level LIKE and boundary LIKE. Actual SQL still emits bare `LIKE ?`; escaped parameter text relies on database default behavior.  
+  _evidence:_ `CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java:243,248-249`
+- **[MAJOR] Part B/C interface is mismatched** — Part C design expects `attrs.isAdmin()`, `boundaryPrefixes()`, and `departmentCodes()`, but Part B's published contract is fields `{scopeLevel, boundaryPrefixes, departmentCodes, resolutionComplete}` and explicitly uses scopeLevel/resolutionComplete to distinguish admin from fail-closed employee. Actual AnalyticsService calls neither shape.  
+  _evidence:_ `db-inventory/rbac-deep-design/20-attribute-resolution.md:80-87,115-117,313-321; CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java:30-32`
+- **[MAJOR] Adjacent D/requirements still assign declared boundaryScope narrowing to Part C** — 30-row-scope-enforcement says declared boundary narrowing is not owned by Part C, but 00 and Part D still require boundaryScope/departmentScope params to be ANDed under injected scope by C. Actual planner has no such path and boundary_path is not filterable.  
+  _evidence:_ `db-inventory/rbac-deep-design/00-requirements.md:65; db-inventory/rbac-deep-design/40-kpi-catalog-governance.md:192,271-272; CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java:173-175; CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsCatalog.java:65-69`
+- **[MINOR] No claimed migration artifact exists** — The design names a new `V20260624000000__events_department_code_and_scope_columns.sql` and `_facts_mv.sql` shared fragment, but no matching migration/fragment is present under the migration resource tree. The existing V20260608000000 file remains unchanged for scope columns.  
+  _evidence:_ `CCRS/backend/pgr-services/src/main/resources/db/migration/main/V20260608000000__create_v2_grain_mvs.sql:11-12,109-110,239-253`
+- **[MINOR] No regression tests found for the claimed fixes** — No src/test analytics test covers citizen+daily, grain_scope_unavailable, denyAll, or AttrScope. The validation matrix is design text only at this point.  
+  _evidence:_ `CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java:246; CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsCatalog.java:108`
+
+### Mis-citations
+
+- 30-row-scope-enforcement.md:395 says citizen daily is RESOLVED in Part C, but actual code at AnalyticsPlanner.java:246 and AnalyticsCatalog.java:108 is unchanged.
+- 30-row-scope-enforcement.md:398 says v2 C.5 recreates both MVs and indexes inside a single migration, but no such migration exists; only V20260608000000 is present and daily still lacks account_id/department_code at lines 239-253.
+- 30-row-scope-enforcement.md:400 says v2 emits value counts only, but actual AnalyticsService still emits raw `boundaryPrefix` at AnalyticsService.java:114 if non-null.
+- 30-row-scope-enforcement.md:403 says `grain_scope_unavailable` is emitted for attribute and citizen axes; actual planner has no such error path at AnalyticsPlanner.java:241-251.
+- 30-row-scope-enforcement.md:54/238 describe escape/fail-closed changes as Part C additions, but actual planner still emits `LIKE ?` without `ESCAPE` and still short-circuits on null citizenColumn.
+
+### Gaps
+
+- No actual implementation of AttrScope, MatchType, attrScopes, bindColumn, denyAll, or Grain.departmentColumn.
+- No actual PrincipalAttributes resolver integration at AnalyticsService.query; it still calls AnalyticsScope.resolve(requestInfo, tenantId, stateLevelLen).
+- No storage migration for events.department_code, daily.account_id, or daily.department_code.
+- No stable canonical scope serialization for future cache keys.
+- No reconciliation between Part C's `isAdmin()` assumption and Part B's `scopeLevel/resolutionComplete` contract.
+- No implemented declared boundaryScope/departmentScope narrowing path despite requirements and Part D depending on it.

--- a/docs/dashboard-rbac-design/40-kpi-catalog-governance.md
+++ b/docs/dashboard-rbac-design/40-kpi-catalog-governance.md
@@ -1,0 +1,410 @@
+# Part D — KPI Catalog, Definitions & Inline Gating
+
+**Status:** v2 (pass-1 findings folded), 2026-06-23 · **Maps to:** plan §Phase 4 + design §3/§3a/§5a-Layer 2 · **Part graph:** A → D → E (00-requirements §8)
+**Reads first:** `00-requirements.md` (§1 problem, §3 Layer 2, §5 ownership split, §6 NFRs, §7 hazards), `dashboard-query-api-design.md` §3 (KPI-def schema), §3a (publish pipeline), §5a (Layer 2), §10 (`/_schema`), `rbac-kpi-access-implementation-plan.md` §Phase 4.
+**Grounding rule:** every "today" claim is anchored to a file:line that was read. Where a thing is missing it is stated as missing with the anchor showing the gap. Java anchors are the CCRS vendored tree: `CCRS/backend/pgr-services/src/main/java/org/egov/pgr/...`.
+
+---
+
+## Goal & responsibilities
+
+This part owns **Layer 2 — KPI catalog access** of the three-layer model (00-requirements §3): *which questions a caller may ask at all*. Concretely it owns:
+
+1. **KPI definitions as governed MDMS config** — the `dss.KpiDefinition` schemacode (frozen query body + viz + declared params + `rbac.visibleTo` + optional `rbac.requiresAttributes`), replacing the FE-hardcoded catalog (`frontend/micro-ui/web/src/dashboard/config/kpiQueries.js`, 00-requirements §1).
+2. **`kpiId` resolution + materialization** — load a stored def, validate supplied runtime params against the def's `allowed` lists, materialize the frozen `query` body into the node the planner already consumes (`AnalyticsPlanner.plan(JsonNode, scope)`, `AnalyticsPlanner.java:37`).
+3. **Discovery endpoint** — `POST /v2/analytics/catalog/_search` (DIGIT `_search` idiom — see M1), returning only defs where `visibleTo ∩ caller.roles ≠ ∅`.
+4. **Invocation re-check** — on every `POST /_query` carrying a `kpiId`, re-check `visibleTo` (and `requiresAttributes`) **before planning** → `403 kpi_forbidden`. This re-check is the security boundary; discovery filtering is UX only (design §5a, "this re-check is the whole ballgame").
+5. **Inline-query gate** — the role check that decides whether a body carrying inline `measures`/`dimensions`/`filters` (vs a `kpiId`) is even allowed (`403 inline_forbidden`). *Authored here because the gate's location is the same parse step that branches `kpiId`-vs-inline; logically it is Layer 3 / Part F, and Part F owns its semantics. This part installs the branch point — at **every** execution arm (see D.3 / B1 fix) — and the simplest gate; Part F refines the role policy.*
+6. **The publish-time safety pipeline** (design §3a) — validate-against-catalog → bounded dry-run → cost estimate → PII/officer approval gate → immutable versioned publish.
+
+**What this part explicitly does NOT own:**
+- **Row scope (Layer 1).** *Which rows* come back is Parts B (attribute resolution) + C (`AnalyticsScope`/`applyScope`). This part decides *if you may invoke*; it never widens or narrows the injected `WHERE`. `visibleTo` is the **security ceiling**, never affected by row scope being empty (design §5a).
+- **The trustworthy principal (Layer-0).** Part A. Everything here reads `{roles}` off the principal; if A hasn't landed, `visibleTo` is enforced against spoofable roles and is theater (00-requirements §7.1). **D hard-depends on A.**
+- **HRMS attribute resolution.** `requiresAttributes` *consumes* the resolved `{boundaryPrefixes, departmentCodes}` from Part B; it does not resolve them.
+- **Dashboard packs** (`dss.DashboardPack`, role → tile bundle). Part E. This part only guarantees the per-def ceiling that packs re-check at invocation.
+- **The query grammar / planner SQL.** Unchanged (design says "no grammar change"). A materialized KPI def is *exactly* a `query` JsonNode the existing planner already accepts.
+- **Caching.** NFR (00-requirements §6); cache key must include `{kpiId|queryBody, params, resolved scope, asOf}` but the cache layer itself is cross-cutting, not owned here. This part only fixes the cache-key *inputs* it produces (`kpiId`, `kpiVersion`, resolved params).
+
+---
+
+## Current code reality (file:line — what exists vs what's missing)
+
+| Capability this part needs | State today | Anchor |
+|---|---|---|
+| `POST /_query` entry | exists, takes raw `JsonNode body` | `AnalyticsController.java:40-41` (mapping), body→`service.query` `:47` |
+| `POST /_schema` (capabilities) | exists, no auth, no role filter | `AnalyticsController.java:57-60`; `AnalyticsService.schema()` `AnalyticsService.java:72-94` |
+| `kpiId` handling | **MISSING** — `query(...)` only branches `queries` (batch) vs `query` (single); no `kpiId` read anywhere | `AnalyticsService.java:38-54` |
+| **Two execution arms (both unguarded)** | batch dict arm loops + calls `runOne` per entry; single arm calls `runOne` once — **neither** branches `kpiId` or gates inline | batch arm `AnalyticsService.java:38-49` (loop body `:42-47`); single arm `:50-51` |
+| Stored KPI defs in MDMS | **MISSING** — no `dss.KpiDefinition` schema, no loader | — (plan §0: "no saved KPI defs in MDMS yet") |
+| `catalog` discovery | **MISSING** | no mapping in `AnalyticsController` |
+| `visibleTo` invocation re-check | **MISSING** | — |
+| Inline-vs-saved branch | **MISSING** — every body (single AND batch) is treated as inline; planner runs directly | `AnalyticsService.runOne()` `AnalyticsService.java:58-69` calls `planner.plan(q, scope)` straight; reached from both `:45` and `:51` |
+| Inline role gate | **MISSING** | — |
+| Roles available on principal | present but **spoofable** — read from body `userInfo` | `AnalyticsScope.resolve()` `AnalyticsScope.java:31-48`; `AnalyticsController.java:43-44` |
+| **`AnalyticsScope` discards roles** | keeps only `tenantId`/`tenantStateLevel`/`citizenUuid`/`boundaryPrefix`; roles read at `:38-42` are used then dropped, never surfaced | `AnalyticsScope.java:21-28,38-44` |
+| The served whitelist a def validates against | exists (the publish pipeline step-1 target) | `AnalyticsCatalog.java:50-113` (per-grain `groupable`/`filterable`/`measurable`/`distinctable` sets) |
+| MDMS client in pgr-services | exists but **v1** (`MdmsCriteria`, `mdmsHost`) — needs a v2 `/v2/_search` path for schemacode reads | `MDMSUtils.java:8-9,103-118`; `PGRConfiguration.java:125` (`mdmsHost`) |
+| AGG/op whitelist for pipeline validation | exists as a static set + per-grain sets | `AnalyticsCatalog.AGG_FNS` `AnalyticsCatalog.java:115-116` |
+| Row cap | only a hard global `MAX_LIMIT=1000`; no per-grain budget | `AnalyticsPlanner.java:24` (defined), `:110-111` (applied) |
+
+**Two reality gaps that shape the design:**
+
+1. **The catalog is coarser than the design's `/_schema` (§10).** The shipped `Grain` (`AnalyticsCatalog.java:25-48`) carries `groupable`/`filterable`/`measurable`/`distinctable` **sets of column names** — it does *not* carry the per-column operation-set objects (`returnable`, `sortable`, `roleAllowed`, `minGroupSize`, `pii`) the design's §10 publish pipeline references. So the §3a step-1 "operation-level checks" and step-4 "PII/officer approval gate" have **no field to read today**. This part must either (a) extend `Grain` with these per-column attributes, or (b) keep the approval gate as out-of-band metadata on the def. We pick (a)-lite: add the minimum (`officerColumns`/`citizenColumns` sets) needed to make the PII gate real, and treat the rest as deferred (see Open Questions).
+
+2. **`AnalyticsService.schema()` and the design's §10 catalog diverge.** Shipped `filterOps` (`AnalyticsService.java:75`) lists `eq,ne,gt,gte,lt,lte,in,isnull`; the planner actually implements exactly those in its op switch (`AnalyticsPlanner.java:182-197`). The design §10 lists `eq,in,nin,range,null`. The publish pipeline must validate against the **shipped** op-set the planner emits, not the design's aspirational one, or valid defs will be rejected (or invalid ones pass). **The pipeline's whitelist source of truth is `AnalyticsCatalog` + `AnalyticsPlanner`'s actual switch, never the prose.**
+
+---
+
+## Design
+
+### D.1 Data model — `dss.KpiDefinition` MDMS schemacode
+
+Registered via the standard MDMS v2 schema-create flow (`mdms_schema_create`, `digit-mcp/docs/api/tools/mdms_schema_create.md:1-99`) at the **state-level root** tenant (e.g. `ke`), city tenants inherit. The JSON-Schema definition (same convention as the shipped `ProviderDetail.json:1-42`: `type`/`properties`/`required`/`x-unique`/`x-security`):
+
+```jsonc
+// mdms v2 schema definition body for schemaCode = "dss.KpiDefinition"
+{
+  "type": "object",
+  "title": "KpiDefinition",
+  "description": "A governed, versioned KPI template for the PGR analytics query API.",
+  "properties": {
+    "id":          { "type": "string", "description": "stable KPI id, e.g. sla_compliance_rate" },
+    "version":     { "type": "integer", "minimum": 1 },
+    "status":      { "type": "string", "enum": ["draft","published","archived"] },
+    "title":       { "type": "string", "description": "localization code" },
+    "description": { "type": "string" },
+    "grain":       { "type": "string", "enum": ["facts","events","daily"],
+                     "description": "REQUIRED — explicit target grain; inferGrain never resolves daily (see m2)" },
+    "query":       { "type": "object", "description": "frozen query body (design §2 grammar), no runtime params; MUST carry the same explicit grain" },
+    "defaultTimeRole":  { "type": "string" },
+    "allowedTimeRoles": { "type": "array", "items": { "type": "string" } },
+    "params":      { "type": "object", "description": "declared runtime params + defaults + allowed values; each param fixes its target COLUMN (def-fixed), caller supplies only the bound VALUE (see m1)" },
+    "viz":         { "type": "object" },
+    "freshness":   { "type": "string", "enum": ["hourly","daily","weekly","monthly"] },
+    "rbac": {
+      "type": "object",
+      "properties": {
+        "visibleTo":          { "type": "array", "items": { "type": "string" }, "description": "role codes — the security ceiling" },
+        "requiresAttributes": { "type": "array", "items": { "type": "string" },
+                                "description": "e.g. [\"department\"] — caller must carry a resolved value for each (Part B), AND the target grain must be able to scope it (see D→B note)" }
+      },
+      "required": ["visibleTo"]
+    },
+    "approval": {
+      "type": "object",
+      "description": "publish-pipeline audit record (design §3a step 5)",
+      "properties": {
+        "approvedBy": { "type": "string" }, "approvedAt": { "type": "integer" },
+        "officerDimApproved": { "type": "boolean" }, "estRows": { "type": "integer" }, "estCost": { "type": "number" }
+      }
+    }
+  },
+  "required": ["id","version","status","grain","query","rbac"],
+  "x-unique": ["id","version"]            // (id,version) composite-key UNIQUE only (not immutable — immutability is a pipeline invariant, D.5 step 5); "latest published" resolved at read
+}
+```
+
+Notes grounded in MDMS reality:
+- `x-unique: ["id","version"]` enforces only that the **composite key `(id,version)` is unique** — `CompositeUniqueIdentifierGenerationUtil.getUniqueIdentifier` (`CompositeUniqueIdentifierGenerationUtil.java:23-44`) concatenates the x-unique field values into one identifier at *create* time; it does **NOT** make a published record immutable. MDMS v2 exposes `_update/{schemaCode}` (`MDMSControllerV2.java:56-59` → `MDMSServiceV2.update()` `MDMSServiceV2.java:99-114`) which mutates an existing `(id,version)` record in place. So `x-unique` alone does **not** give the design's **immutable versioned publish** (§3a step 5). Immutability is achieved **explicitly by the publish pipeline** (D.5 step 5): the `version` field is part of the composite key, each publish writes a *new* `(id,version)` record, the pipeline **never issues `_update` against a prior published version**, and supersession is a forward-only status transition (`published`→`archived` on the old version + a new `published` record) — not a mutation. The x-unique constraint only backstops this by rejecting an accidental duplicate `(id,version)` create; it is a uniqueness guard, not an immutability guard.
+- `grain` is **required at the top level and must equal `query.grain`**. The planner's `inferGrain` only ever returns `events` or `facts`, **never `daily`** (`AnalyticsPlanner.java:267-275`), so an implicit-grain daily def would silently run on `facts` with wrong semantics (m2). The publish pipeline rejects any def whose `query` omits an explicit `grain` or whose `grain` ≠ `query.grain`.
+- `status:"draft"` records exist in MDMS but are filtered out of the served catalog except for their author (design §3a). MDMS has no native "draft visibility" — that filter is **service-side** (D.4), keyed on the def's `auditDetails.createdBy` (MDMS v2 stamps it on write; confirm read path in D.2).
+- The schema lives at the **state root**; per-tenant overrides are separate `dss.KpiDefinition` records at the city tenant. **MDMS v2 search does NOT merge across tenant levels** — `MDMSServiceV2.search()` iterates the fallback tenant list and `break`s on the **first non-empty** result (`MDMSServiceV2.java:83-89`), so a single city-local record would suppress *all* root defs, not augment them. Therefore defs are resolved by the store issuing **two explicit reads** — once at the city tenant, once at the state root (via `getStateLevelTenant(tenantId)`, `MDMSUtils.java:91`) — and merging in-process (city record wins per `id`). The design must not lean on an automatic platform merge that does not exist (D.2).
+
+### D.2 Loader — `KpiDefinitionStore`
+
+New class `org.egov.pgr.analytics.KpiDefinitionStore`. Reads `dss.KpiDefinition` via MDMS **v2** `/v2/_search` (the shipped `MDMSUtils` is v1 `MdmsCriteria` — `MDMSUtils.java:103-118` — so this is a net-new v2 search path; reuse `PGRConfiguration.mdmsHost` `PGRConfiguration.java:125`). Short-TTL in-process cache keyed by `{tenantId}` (defs are admin-edited rarely; the publish pipeline busts on write).
+
+```java
+public final class KpiDefinitionStore {
+  /** All published defs (latest version per id) visible at this tenant. NOTE: MDMS v2 search is
+   *  first-hit, not merge (MDMSServiceV2.java:83-89 breaks on the first non-empty fallback tenant),
+   *  so a city-local def set would SUPPRESS the root set. The store therefore issues an EXPLICIT
+   *  read at the city tenant AND at the state root and merges them itself (city overrides root per id). */
+  List<KpiDef> publishedFor(String tenantId);
+  /** One def by id; version=null => latest published. Throws kpi_not_found / kpi_version_not_found. */
+  KpiDef load(String tenantId, String kpiId, Integer version);
+}
+public final class KpiDef {
+  String id; int version; String status; String grain; JsonNode query;  // grain explicit; query is the frozen body
+  Map<String,Param> params; String defaultTimeRole; List<String> allowedTimeRoles;
+  JsonNode viz; String freshness; String createdBy;                       // createdBy for draft-author filter (D.4)
+  List<String> visibleTo; List<String> requiresAttributes;               // rbac
+}
+```
+
+The loaded `query` JsonNode is **structurally identical** to what `AnalyticsPlanner.plan` already accepts (`AnalyticsPlanner.java:37-116`) — that is the whole point of "a KPI def is a frozen query body": no planner change.
+
+### D.3 Control flow — single point of entry for BOTH arms (`runEntry`) + `kpiId` re-check + inline gate
+
+**Critical (B1 fix):** `AnalyticsService.query(...)` has **two** execution arms today — the batch-dict arm (`AnalyticsService.java:38-49`, loop calling `runOne(e.getValue(), scope)` at `:45`) **and** the single arm (`:50-51`, `runOne(body.get("query"), scope)`). Both reach `runOne` (`:58-69`) → `planner.plan(q, scope)` directly. **The new pre-flight `runEntry` MUST be the only path to `runOne` for both arms.** Wiring only the single arm leaves the batch arm as a gate bypass: a caller submits `{"queries":{"x":{...inline measures...}}}` and the inline gate and `kpiId` re-check never run (the original leak). The revised `query()`:
+
+```java
+public Map<String,Object> query(JsonNode body, RequestInfo requestInfo, String tenantId, int stateLevelLen){
+  if (tenantId == null || tenantId.isEmpty()) throw new IllegalArgumentException("invalid_param: tenantId is required");
+  AnalyticsScope scope   = AnalyticsScope.resolve(requestInfo, tenantId, stateLevelLen); // Part C row scope
+  Principal      princ   = Principal.of(requestInfo, scope);            // roles/type/canInline + tenant guard (see below)
+
+  Map<String,Object> out = new LinkedHashMap<>();
+  out.put("asOf", asOf()); out.put("scope", scopeInfo(scope));
+
+  if (body.has("queries") && body.get("queries").isObject()) {          // batch arm — MUST go through runEntry
+    Map<String,Object> results = new LinkedHashMap<>(); boolean partial = false;
+    Iterator<Map.Entry<String,JsonNode>> it = body.get("queries").fields();
+    while (it.hasNext()) { Map.Entry<String,JsonNode> e = it.next();
+      try { results.put(e.getKey(), runEntry(e.getValue(), scope, princ)); }   // ← was runOne(...) at :45
+      catch (Exception ex) { partial = true; results.put(e.getKey(), err(ex)); } }
+    out.put("results", results); out.put("partial", partial);
+  } else if (body.has("query")) {
+    out.putAll(runEntry(body.get("query"), scope, princ));              // ← was runOne(...) at :51
+  } else throw new IllegalArgumentException("invalid_param: body must contain 'query' or 'queries'");
+  return out;
+}
+```
+
+```java
+// AnalyticsService — the single gated pre-flight; reached from BOTH arms
+private Map<String,Object> runEntry(JsonNode q, AnalyticsScope scope, Principal principal){
+  if (q.hasNonNull("kpiId")) {
+    // ---- SAVED-KPI PATH (citizen/supervisor/admin all allowed; row scope still applies) ----
+    String  kpiId = q.get("kpiId").asText();
+    Integer ver   = q.hasNonNull("kpiVersion") ? q.get("kpiVersion").asInt() : null;
+    KpiDef  def   = store.load(scope.tenantId, kpiId, ver);             // 404 kpi_not_found / kpi_version_not_found
+
+    // (1) INVOCATION RE-CHECK — the security boundary (design §5a). Null/empty roles => disjoint true => deny.
+    if (disjoint(def.visibleTo, principal.roles))
+        throw new ForbiddenException("kpi_forbidden: not visible to caller roles");
+    // (1b) attribute precondition — caller must carry the attrs this KPI needs (Part B output), fail-closed
+    for (String attr : def.requiresAttributes)
+        if (!principal.hasResolvedAttribute(attr))
+            throw new ForbiddenException("kpi_forbidden: requires attribute " + attr);
+
+    // (2) materialize frozen body + validated runtime params (design §3 "composition at call time")
+    JsonNode materialized = materialize(def, q.get("params"));          // 422 param_not_allowed
+    Map<String,Object> r = runOne(materialized, scope);                 // planner + scope UNCHANGED
+    r.put("kpiId", kpiId); r.put("kpiVersion", def.version);
+    r.put("viz", def.viz); r.put("freshness", def.freshness);
+    return r;
+  }
+  // ---- INLINE PATH (Layer 3 gate — see Part F for full policy; gate is installed at EVERY arm) ----
+  if (!principal.canInline())                                          // PGR_ADMIN/DSS_ANALYST/SUPERADMIN only
+      throw new ForbiddenException("inline_forbidden: inline queries require analyst/admin role");
+  return runOne(q, scope);
+}
+```
+
+`materialize(def, params)` (design §3 steps 2-3): deep-copy the frozen `def.query`; for each supplied param, validate value ∈ `def.params[name].allowed` (else `422 param_not_allowed`), then apply by type — `window`→ set `query.window.name`; `timeRole`→ set `window.timeRole`/`timeBucket.timeRole` (must be in `allowedTimeRoles`); `dimensionFilter`→ **the filter COLUMN is fixed by the def** (the JSON key under `query.filters`), the param supplies only the **bound value** that is ANDed in (m1 fix — never a caller-chosen filter key); `boundaryScope`→ a *declared narrowing* the planner ANDs **under** the injected scope (Part C; never a free `prefix` filter, design §2). The planner backstops any stray column key anyway (`predicate()` rejects non-`filterable` columns → `op_not_allowed`, `AnalyticsPlanner.java:174-175`; all values bound `:183-194`). **Scope injection (Part C `applyScope`) happens after materialization and cannot be overridden** (design §3 step 4, §5; `applyScope` `AnalyticsPlanner.java:241-251`).
+
+**Building the principal — `Principal.of(requestInfo, scope)` (Gaps fix).** `AnalyticsScope` **discards roles** — it reads `u.getRoles()` at `AnalyticsScope.java:38-42` only to derive `citizenUuid`, and the returned object keeps only `tenantId`/`tenantStateLevel`/`citizenUuid`/`boundaryPrefix` (`:21-28,47`). So D cannot read roles off `AnalyticsScope`. `Principal.of` re-reads `requestInfo.getUserInfo()` (trustworthy **post-Part-A**) and extracts:
+- `roles` ← `u.getRoles()` mapped to upper-cased codes (same source `AnalyticsScope.java:38-42` reads). **Null or empty → `roles = ∅`**, which makes `disjoint(visibleTo, ∅)` true → fail-closed (00-requirements §6).
+- `type` ← `u.getType()`.
+- `canInline()` ← `roles ∩ {PGR_ADMIN, DSS_ANALYST, SUPERADMIN} ≠ ∅`.
+- `hasResolvedAttribute(attr)` ← delegates to Part B's resolved `{boundaryPrefixes, departmentCodes}` (non-empty).
+- **Tenant guard (D→A caveat fix):** `Principal.of` asserts the body `tenantId` is within the principal's allowed/resolved tenant set **before** any `store.load(scope.tenantId, …)`. Part A.4 (`10-auth-foundation.md:207`) owns the precise cross-state policy and is "intentionally conservative (cross-state 403)", deferring sub-tenant nuance to Part C; D does **not** re-implement it but **does** assert the guard ran (throws `tenant_mismatch` if the principal carries no allowed-tenant evidence) rather than blindly trusting body `tenantId`. **D consumes A's trust guarantee; it does not re-validate the token.**
+
+### D.4 `POST /v2/analytics/catalog/_search` (discovery)
+
+New mapping in `AnalyticsController` (sibling of `_schema` at `AnalyticsController.java:57-60`). **POST, not GET** (M1 fix): the two shipped sibling endpoints carry `RequestInfo` over **POST** (`AnalyticsController.java:40` `_query`, `:57` `_schema`), and the only existing `@GetMapping` in pgr-services (`RequestsApiController.java:107` `/dashboard`) takes **`@RequestParam` only, no body, no `RequestInfo`**. There is no "GET + RequestInfo body" convention here, and GET-with-body is routinely stripped by Kong/clients (a stripped body → null roles → empty catalog for everyone — fail-safe but dead). The DIGIT-idiomatic shape is a POST `_search`:
+
+```java
+@PostMapping("/catalog/_search")
+public ResponseEntity<Map<String,Object>> catalogSearch(@RequestBody JsonNode body){
+  RequestInfo ri = body.has("RequestInfo")
+        ? mapper.convertValue(body.get("RequestInfo"), RequestInfo.class) : null;
+  String tenantId = body.hasNonNull("tenantId") ? body.get("tenantId").asText() : null;
+  Principal p = Principal.of(ri, AnalyticsScope.resolve(ri, tenantId, stateLen()));  // roles from validated userInfo (Part A)
+  return ResponseEntity.ok(service.catalog(tenantId, p));
+}
+```
+```java
+// AnalyticsService
+public Map<String,Object> catalog(String tenantId, Principal p){
+  List<Map<String,Object>> tiles = new ArrayList<>();
+  for (KpiDef d : store.publishedFor(tenantId)) {
+    if (disjoint(d.visibleTo, p.roles)) continue;        // ← discovery filter (UX); SAME predicate as invocation
+    // draft defs already excluded by publishedFor(); author-draft preview is a separate analyst/admin-only call
+    tiles.add(Map.of("id",d.id,"version",d.version,"title",d.title,
+                     "viz",d.viz,"freshness",d.freshness,"params",d.params,
+                     "requiresAttributes",d.requiresAttributes));
+  }
+  return Map.of("version","1","kpis",tiles);
+}
+```
+
+**Discovery and invocation share the exact same `disjoint(visibleTo, roles)` method** — different enforcement points, one rule. The catalog returns **no `query` body and no SQL** — only what the FE picker needs (id, title, viz, declared params). A caller cannot learn a hidden KPI's existence from `catalog/_search`.
+
+### D.4a `_schema` must be role-filtered too (M2 fix)
+
+`catalog/_search` closing the KPI-def side door is not enough: `POST /_schema` (`AnalyticsController.java:57-60` → `AnalyticsService.schema()` `:72-94`) is **zero-arg, unauthenticated**, and returns the **full** grain/column catalog to anyone — including the officer/PII columns `current_assignee_uuid` (`AnalyticsCatalog.java:59,77,103,107`), `assignee_uuid` and `actor_uuid` (`:88,95`) as groupable/distinct-countable. With the (now-gated) inline path closed to non-analysts, `_schema` is still a *map* of every queryable officer column. This part therefore:
+1. Changes `_schema` to accept the same `RequestInfo` body (POST already) and build a `Principal`.
+2. For non-analyst/admin callers, **elides officer/PII columns** (the new `officerColumns` set, D.5 step 4) from every grain's `groupable`/`distinctable`/`scopeColumns` in the `schema()` response.
+3. Null/empty roles → the most-restricted (citizen) view, never the full catalog. (Fail-closed.)
+
+This keeps `_schema` useful for the analyst KPI-editor while removing the officer-column reconnaissance side door past the def ceiling. Full Layer-3 policy on `_schema` is Part F's; D installs the minimal elision so the PII ceiling has no side door before F lands.
+
+### D.5 Publish-time safety pipeline (design §3a)
+
+`mdms_create` of a `dss.KpiDefinition` is the *intent*; a def becomes servable only after a fixed pipeline. This is **not** a raw MDMS write — it is a governed endpoint (new `POST /v2/analytics/kpi/_publish`, analyst/admin only) that runs the steps then writes the immutable record.
+
+1. **Validate against the catalog — for the def's DECLARED grain.** Every `column`/`agg`/`timeRole`/`granularity`/`dimension`/`filter` key in `def.query` is checked against `AnalyticsCatalog` **for the def's explicit `grain`** (required, D.1) — the **same** sets the planner enforces (`AnalyticsCatalog.java:54-108` per-grain; `AGG_FNS` `:115-116`). Reuse the planner by calling `planner.plan(def.query, ADMIN_SCOPE)` in a dry-validate mode and catching `unknown_column`/`unknown_grain`/`op_not_allowed`. **Reject any def whose `query` omits `grain`** — do **not** lean on `inferGrain` (`AnalyticsPlanner.java:267-275`), which never returns `daily` (m2). Grain/column validation is a **scope-independent property of the grain** and runs here regardless of the sample scopes used in step 2 (Gaps fix). Op-set source of truth is the planner's actual switch `AnalyticsPlanner.java:182-197` (`eq,ne,gt,gte,lt,lte,in,isnull`), **never** design §10's prose (reality gap 2).
+2. **Bounded dry-run under sample scopes.** Execute the plan with a `LIMIT`/`EXPLAIN` cap under a representative **citizen** scope, a **supervisor** subtree scope, and the **admin** scope (build three `AnalyticsScope` fixtures), confirming the injected `boundary_path`/`account_id` predicate (Part C, `applyScope` `AnalyticsPlanner.java:241-251`) composes and the SQL is well-formed for each caller class. This catches a def that is valid for admin but blows up when row scope is ANDed in. **Daily-grain note:** the shipped daily grain has `citizenColumn = null` (`AnalyticsCatalog.java:108`) so the citizen self-scope predicate is **silently skipped** (`AnalyticsPlanner.java:246` guards on `citizenColumn != null`) — a citizen-visible daily def would return tenant-wide rows. This is the convergent cross-cutting **daily-grain citizen leak** (README §1); the *fix* (add `account_id` to the daily grain, or reject citizen daily queries) is **Part C's** to land. Until C lands, this part's step 4 **hard-rejects any `dss.KpiDefinition` with `grain:"daily"` whose `visibleTo` includes a citizen role** — D cannot fix the leak but refuses to mint a def that rides it.
+3. **Row-count / cost estimate.** `EXPLAIN (FORMAT JSON)` the admin-scope plan; capture estimated rows + cost. There is **no per-grain `maxRows` field on `Grain` today** — the only row cap is the hard global `MAX_LIMIT=1000` (`AnalyticsPlanner.java:24`, applied `:110-111`) (m3 fix). This part uses a **single global cost/row threshold** (config, default tied to `MAX_LIMIT`) and rejects defs that group by an unbounded high-cardinality column with no `topN`/`limit`. A per-grain `maxRows` is deferred to the catalog-modernization PR (Open Q1); the design does **not** assume a `Grain.maxRows` exists. Record `estRows`/`estCost` on the def's `approval` block.
+4. **Approval gate for PII/officer dimensions.** Any def that returns or groups by a PII/officer column requires explicit reviewer sign-off recorded as `approval.officerDimApproved=true`. **Reality gap (above):** the shipped `Grain` has no `pii` marker, so this part adds a minimal `Set<String> officerColumns` + `Set<String> citizenColumns` to `AnalyticsCatalog` (derivable today: `current_assignee_uuid` (`AnalyticsCatalog.java:59,77,103,107`), `assignee_uuid`/`actor_uuid` (`:88,95`) are officer; `account_id` (`:77,95`) is citizen). A def whose `visibleTo` includes a citizen role **may not** carry any officer column (hard reject, design §3a step 4 + §5). This same `officerColumns` set drives the `_schema` elision (D.4a).
+5. **Immutable, versioned publish — enforced by the pipeline, NOT by `x-unique`.** `x-unique:["id","version"]` only guarantees the composite key `(id,version)` is unique on create (`CompositeUniqueIdentifierGenerationUtil.java:23-44`); MDMS v2 will still happily mutate a published record through `_update/{schemaCode}` (`MDMSControllerV2.java:56-59` → `MDMSServiceV2.java:99-114`). Immutability is therefore a **pipeline invariant**, not a platform guarantee: (a) the `version` field is part of the id/composite key; (b) on approval the pipeline writes a **new** `(id,version)` record `status:"published"` with `version` bumped — it **never** calls `_update` against an already-published `(id,version)`; (c) supersession is a forward-only **status transition** — the prior version is moved `published`→`archived` (a new state, the body is left byte-for-byte intact) and the new version becomes "latest". Audit who/when/diff. **Rollback = re-point "latest"** by publishing a new version equal to a prior body, or by archiving the bad version — prior records are never mutated. (The publish endpoint is the *only* sanctioned writer; a raw `mdms_create`/`_update` bypassing it is an authoring violation, Open Q2.)
+
+Net: the no-deploy convenience (design §3) is preserved; the served catalog only ever holds catalog-valid, cost-bounded, PII-reviewed, versioned defs.
+
+### D.6 Errors (design §11)
+
+| HTTP | code | When (this part) |
+|---|---|---|
+| 403 | `kpi_forbidden` | `visibleTo ∩ roles = ∅` (incl. null/empty roles), or a `requiresAttributes` attr is unresolved/empty for the caller |
+| 403 | `inline_forbidden` | non-analyst/admin token sends inline `measures`/`dimensions`/`filters` — at **either** arm (gate installed here; policy = Part F) |
+| 403 | `tenant_mismatch` | body `tenantId` not within principal's allowed tenants (guard owned by A; D asserts it ran before `store.load`) |
+| 404 | `kpi_not_found` | `kpiId` unknown at tenant (+root fallback) |
+| 404 | `kpi_version_not_found` | `kpiVersion` pinned but absent |
+| 422 | `param_not_allowed` | runtime param value ∉ def's `params[*].allowed` |
+| (publish) 400 | `kpi_invalid` | publish-pipeline step 1-4 rejection (catalog/grain/cost/PII, incl. missing explicit `grain` and citizen-visible daily def) |
+
+---
+
+## Interfaces with other parts
+
+**Consumes (inputs):**
+- **From Part A (trust foundation):** a trustworthy `principal.roles` and `principal.type`. *Contract:* `RequestInfo.userInfo` is token-derived and coercive — a spoofed `userInfo` is rejected/ignored before it reaches `AnalyticsService`. D's `visibleTo`/`inline` checks are theater without this (00-requirements §7.1). Additionally D **asserts** A's tenant cross-check ran (`Principal.of` → `tenant_mismatch`) before reading defs at the body tenant, rather than assuming the controller rejected the mismatch (A.4 `10-auth-foundation.md:207` owns the policy and is conservative cross-state). **Hard dependency.**
+- **From Part B (attribute resolution):** `principal.hasResolvedAttribute(attr)` and the resolved `{boundaryPrefixes, departmentCodes}`. *Contract:* `requiresAttributes:["department"]` passes iff Part B resolved a non-empty department for the caller; a missing HRMS row → fail-closed (attr absent → `kpi_forbidden`), never open (00-requirements §6). **Events-grain dept gap (D→B):** a def with `requiresAttributes:["department"]` whose declared grain is `events` would pass D's presence gate but **Part C cannot scope it** (the events MV has no `department_code` — README §3, 00-requirements §7.4). So publish step-1 must additionally require that a def's `requiresAttributes` ∩ its **declared grain's** scopable columns is satisfiable; otherwise reject at publish (`kpi_invalid`), never mint a def that fails open at runtime.
+- **From Part C (attribute-scope engine):** the injected `WHERE` via `AnalyticsScope`/`applyScope`. *Contract:* materialization runs **before** scope injection; D never touches `applyScope`. The `boundaryScope`/`departmentScope` runtime params D validates are *declared narrowings* C ANDs **under** the injected scope. C also owns the **daily-grain citizen-leak fix** (`citizenColumn` null at `AnalyticsCatalog.java:108`); D refuses to publish a citizen-visible daily def until C lands it (D.5 step 2).
+- **From `AnalyticsCatalog` (existing):** the column/agg whitelist (`AnalyticsCatalog.java:54-116`) — the publish pipeline's step-1 source of truth, plus the new minimal `officerColumns`/`citizenColumns` sets this part adds.
+
+**Produces (outputs):**
+- **To Part E (dashboard packs):** the per-def **security ceiling** `visibleTo`. *Contract:* a pack listing a KPI whose `visibleTo` excludes the role gets `403 kpi_forbidden` on that tile at invocation (D's re-check via the shared `disjoint`), never a leak — "packs are assembly, the ceiling is the engine" (design §5a). E references `dss.KpiDefinition.id`; D guarantees the re-check. E reuses the same tenant guard (`50-packs-config-ownership.md:292`).
+- **To the FE:** `catalog/_search` tiles (id/title/viz/params) and, on `_query`, the echoed `kpiId`/`kpiVersion`/`viz`/`freshness`. *Contract:* FE filtering is cosmetic; the engine re-checks every invocation, on both arms (00-requirements §1, §5a).
+- **To the cache layer (NFR, 00-requirements §6):** the resolved `{kpiId, kpiVersion, materialized params}` that, together with **resolved scope** (Part C) and `asOf` (`AnalyticsService.asOf()` `:104-107`), form the cache key. D must surface `kpiVersion` so a published edit (new version) is a new cache bucket.
+
+---
+
+## Sequencing & migration steps
+
+1. **Block on Part A.** No D enforcement is real until `userInfo` is trustworthy (00-requirements §8: "A blocks all of B–F"). Land A first; add A's spoof negative-test.
+2. **Register `dss.KpiDefinition` schema** at the state root via `mdms_schema_create` (D.1), with **required explicit `grain`**. Idempotent (`alreadyExists` handled, `mdms_schema_create.md:44-52`). Validate on ovh-cloud-dev (bomet repro) first.
+3. **`KpiDefinitionStore` + MDMS v2 search** (D.2). Add a v2 `/v2/_search` client path (the shipped `MDMSUtils` is v1, `MDMSUtils.java:103-118`). Unit-test the **explicit city + root two-read merge** (NOT a platform fallback — MDMS v2 search is first-hit, `MDMSServiceV2.java:83-89`) and `createdBy` read.
+4. **Seed the existing FE KPIs as defs.** Port each hardcoded `frontend/micro-ui/web/src/dashboard/config/kpiQueries.js` body (00-requirements §1) into a `dss.KpiDefinition` record with an **explicit grain** and a conservative `visibleTo`. Run each through the publish pipeline.
+5. **Wire `runEntry` into BOTH arms** of `AnalyticsService.query` (D.3, B1 fix): replace `runOne(...)` at the batch loop (`AnalyticsService.java:45`) **and** the single arm (`:51`) with `runEntry(q, scope, principal)`. Inline path stays fully functional for analyst/admin (no regression — current callers are all inline). **Negative test:** a citizen token sending `{"queries":{"x":{...inline measures...}}}` → `inline_forbidden` (proves the batch arm is gated).
+6. **Add `POST /catalog/_search`** (D.4) and **role-filter `_schema`** (D.4a).
+7. **Build the publish endpoint + pipeline** (D.5), incl. the minimal `AnalyticsCatalog` `officerColumns`/`citizenColumns` markers (step 4 reality gap), explicit-grain enforcement, single global cost threshold, and the citizen-visible-daily reject.
+8. **FE cutover** (coordinated with Part E): FE fetches `catalog/_search`, stops shipping query bodies. Cosmetic tile-hiding may stay; the engine is now authoritative.
+9. **PR-per-step against egov/CCRS develop**, emitted SQL reviewed in tests (plan §6.5), validated on ovh-cloud-dev before live bomet (which redeploys nightly from develop — memory [Bomet nightly cron re-scope]).
+
+---
+
+## Risks, edge cases, failure modes
+
+- **Fail-closed everywhere.** Missing/forged principal → A's job, but D also fails-closed: empty/null `roles` → `disjoint` is true → `kpi_forbidden` (never default-visible); `Principal.of` sets `roles=∅` when `userInfo.getRoles()` is null (D.3). An unresolved `requiresAttributes` attr → `kpi_forbidden`. A `dss.KpiDefinition` that fails to load (MDMS down) → `query_failed`/deny, **never** an FE-style open default. `_schema` with null roles → most-restricted view (D.4a).
+- **Both-arm gating (the original leak, B1).** The single arm AND the batch-dict arm route through `runEntry`; the batch path can no longer smuggle inline grammar. Negative test in step 5.
+- **Discovery/invocation drift (the classic leak).** `catalog/_search` and `_query` call the **one** `disjoint(visibleTo, roles)` method (D.4 + D.3). Test: a KPI absent from a role's catalog returns `403` when that role POSTs its `kpiId`.
+- **`_schema` side door (M2).** Officer/PII columns are elided from `_schema` for non-analyst callers (D.4a) so the def ceiling has no reconnaissance side door.
+- **HRMS role pollution** (00-requirements §7.2, memory [HRMS role pollution]). Every real `GRO` also carries `PGR_LME`; author/test all `visibleTo` against clean single-role `RBAC_TEST_*` users, never real provisioned accounts. Data hazard, not a code bug — but a polluted test account gives false confidence.
+- **`visibleTo` is a ceiling, not a grant via empty scope.** A supervisor whose row scope returns zero rows for an officer-leaderboard KPI is still **forbidden** the KPI if `visibleTo` excludes them — Layer 2 and Layer 1 are independent (design §5a). Never infer "empty result ⇒ safe to show."
+- **Daily-grain citizen leak (cross-cutting, Part C owns the fix).** `complaint_open_state_daily` has `citizenColumn = null` (`AnalyticsCatalog.java:108`); the self-scope predicate is skipped (`AnalyticsPlanner.java:246`). A citizen-visible daily def would return tenant-wide rows. D's mitigation: publish-pipeline **hard-rejects** any citizen-visible `grain:"daily"` def (D.5 step 2) until C adds `account_id` to the daily grain.
+- **PII/officer leak through a citizen-visible def.** Publish step 4 hard-rejects a citizen-visible def carrying any officer column (`officerColumns` set). Without that marker the gate can't fire — hence this part adds it.
+- **`inferGrain` never returns daily (m2).** A daily def without explicit `grain` would run on `facts` with wrong semantics. Mitigation: `grain` is **required** in the schema and re-checked at publish; `inferGrain` (`AnalyticsPlanner.java:267-275`) is never relied on for daily.
+- **Cost cap has no per-grain budget (m3).** Only the global `MAX_LIMIT=1000` exists (`AnalyticsPlanner.java:24,110-111`). The cost gate uses a single global threshold; per-grain `maxRows` is deferred (Open Q1).
+- **Stale catalog cache vs publish.** The `KpiDefinitionStore` TTL cache can serve a just-archived/edited def. Bust on publish-endpoint write; bound TTL short. A pinned `kpiVersion` is immutable so never stale; only "latest" resolution is.
+- **Param injection via materialization (m1).** `dimensionFilter`/`boundaryScope` params validate against `params[*].allowed` (`422`) and the filter **column is def-fixed** (caller supplies only the bound value); values flow as **bound params** through the planner (`AnalyticsPlanner.java:183-194`), never string-concatenated. The planner also rejects any non-`filterable` column (`:174-175`). A param value not in `allowed` is rejected pre-plan; an `allowed` list referencing a non-existent value is a publish-time authoring error caught by step-1 dry-validate.
+- **Tenant/jurisdiction/department isolation.** Defs are read tenant + root-fallback (D.2); a city must not see another city's private def. `Principal.of` asserts the body `tenantId` is within the principal's allowed tenants **before** `store.load` (`tenant_mismatch`), rather than assuming the controller already rejected it (A.4 owns the policy, `10-auth-foundation.md:207`). `requiresAttributes` isolation is Part B's resolution; D only gates on presence + grain-scopability.
+- **Op-set divergence (reality gap 2).** The pipeline validates against the **shipped** planner op-set (`AnalyticsPlanner.java:182-197`: `eq,ne,gt,gte,lt,lte,in,isnull`), not design §10's `eq,in,nin,range,null`. Pin to `AnalyticsCatalog`/planner; reconcile the two op-sets as a separate cleanup.
+
+---
+
+## Open questions for review
+
+1. **Per-column op-sets / per-grain `maxRows`: extend `Grain` now or defer?** The design's §10 catalog (per-column `returnable`/`sortable`/`roleAllowed`/`minGroupSize`/`pii` + per-grain `maxRows`) is richer than the shipped `Grain` (`AnalyticsCatalog.java:25-48`). This part adds only the **minimal** `officerColumns`/`citizenColumns` sets (PII gate + `_schema` elision) and uses a single global cost threshold. Full model = a separate catalog-modernization PR (touches `/_schema`). Recommendation: minimal now, full model later.
+2. **Publish endpoint vs raw `mdms_create`.** D.5 proposes a dedicated `POST /kpi/_publish` running the pipeline then writing MDMS. Alternative: raw `mdms_create` + a Kafka/validating-interceptor on the write. Dedicated endpoint keeps cost/dry-run next to the planner; interceptor is more "MDMS-native." Which?
+3. **Where does the inline gate's *policy* live — D or F?** This part installs the branch point at **both arms** and a simplest `canInline()` check; Part F owns full Layer-3 policy (incl. `_schema` officer-column policy). Confirm the split: D ships the gate + minimal `_schema` elision, F refines.
+4. **`requiresAttributes` semantics — presence vs value match.** `requiresAttributes:["department"]` = "caller must have *any* resolved department" (presence, current design) — simplest, composes with Part C row scope; a value match would duplicate Layer-1 logic. Recommendation: presence-only, **plus** the new publish-time grain-scopability check (D→B) so events-grain dept defs are rejected.
+5. **Draft visibility / `createdBy` read path.** D.4 filters drafts to author+analyst/admin via the def's `auditDetails.createdBy`. Confirm MDMS v2 `/v2/_search` surfaces `createdBy` reliably so `KpiDef.createdBy` (D.2) is populated.
+6. **Reconciling `asOf` for cache vs def `freshness`.** D surfaces `kpiVersion`+`freshness`; the cache key needs `asOf` (`AnalyticsService.asOf()` `:104-107`). Confirm the cache layer (not owned here) reads both, so a published edit *and* a refresh both bust correctly.
+7. **Daily-grain fix coordination (C).** D currently rejects citizen-visible daily defs at publish. Once Part C adds `account_id` self-scope to the daily grain (`AnalyticsCatalog.java:108`), D should relax that reject. Confirm the hand-off so the reject is lifted exactly when C lands, not before.
+
+---
+
+## v2 revision log (pass-1 findings → resolution)
+
+- **Blocker B1 — batch-dict arm bypasses kpiId re-check AND inline gate (silent leak).** The batch arm (`AnalyticsService.java:38-49`, loop body calling `runOne` at `:45`) and single arm (`:50-51`) both hit `runOne` (`:58-69`) straight; v1 only rewired the single arm. **Resolved:** D.3 now routes **both** arms through a single gated `runEntry(q, scope, principal)` — the revised `query()` replaces `runOne` at `:45` *and* `:51`; step 5 mandates the both-arm wiring plus a citizen `{"queries":{...inline...}}` → `inline_forbidden` negative test. Risks-§ and the responsibilities list both restate "gate installed at every arm."
+- **Major M1 — `GET /catalog` with a RequestInfo body is not a DIGIT idiom and is fragile through Kong.** Verified: shipped siblings are POST (`AnalyticsController.java:40`,`:57`); the only `@GetMapping` in pgr-services takes `@RequestParam` only, no body (`RequestsApiController.java:107-111`). **Resolved:** discovery is now `POST /v2/analytics/catalog/_search` (D.4) carrying `RequestInfo` like its siblings; goal #3 and the FE-cutover step updated. Eliminates the GET-body-stripped → empty-catalog failure.
+- **Major M2 — `_schema` stays unauthenticated and leaks officer/PII columns past the def ceiling.** Verified: `schema()` is zero-arg (`AnalyticsController.java:57-60`, `AnalyticsService.java:72-94`) and returns `current_assignee_uuid`/`assignee_uuid`/`actor_uuid` (`AnalyticsCatalog.java:59,77,88,95,103,107`) as groupable/distinctable to anyone. **Resolved:** new D.4a role-filters `_schema` — non-analyst callers get officer columns elided (driven by the same `officerColumns` set as D.5 step 4); null/empty roles → most-restricted view. Side door closed before Part F lands; full `_schema` policy noted as F's.
+- **Minor m1 — `materialize` pins the filter value but not the filter column.** **Resolved:** D.1 `params` description, D.3 `materialize` spec, and the risks-§ now state the `dimensionFilter` **column is def-fixed** (the JSON key) and the caller supplies only the bound value; planner backstop cited (`AnalyticsPlanner.java:174-175,183-194`).
+- **Minor m2 — `inferGrain` never resolves `daily`; an implicit-grain daily def runs on `facts`.** Verified `inferGrain` returns only `events`/`facts` (`AnalyticsPlanner.java:267-275`). **Resolved:** `grain` is now a **required** top-level field (must equal `query.grain`) in D.1; publish step 1 rejects defs missing explicit `grain` and never relies on `inferGrain`. Restated in risks-§.
+- **Minor m3 — step-3 cost cap referenced a non-existent per-grain `maxRows`.** Verified only the global `MAX_LIMIT=1000` exists (`AnalyticsPlanner.java:24`, applied `:110-111`); `Grain` has no `maxRows`. **Resolved:** D.5 step 3 now uses a **single global** cost/row threshold (config, default tied to `MAX_LIMIT`); per-grain `maxRows` deferred to Open Q1. Design no longer assumes a `Grain.maxRows` field.
+- **Mis-citations — none found in v1, but line refs tightened to the real file.** v1's coarse ranges are corrected to verified anchors: batch arm `AnalyticsService.java:38-49` (loop `:42-47`), single arm `:50-51`, `schema()` `:72-94`, `asOf()` `:104-107`; `AnalyticsController` `_query` `:40-41/:47`, `_schema` `:57-60`; `AnalyticsScope` `:31-48` (roles read `:38-42`, discarded — see Gaps); planner `plan` `:37`, op switch `:182-197`, `applyScope` `:241-251`, `inferGrain` `:267-275`, `MAX_LIMIT` `:24`/`:110-111`; catalog grains `:54-108`, officer cols `:59,77,88,95,103,107`, citizen col `account_id` `:77,95`, daily `citizenColumn` null `:108`, `AGG_FNS` `:115-116`; `RequestsApiController.java:107-111`. The `kpiQueries.js` path is given fully (`frontend/micro-ui/web/src/dashboard/config/kpiQueries.js`).
+- **Interface D→A (tenant cross-check caveat).** A.4 is conservative and defers sub-tenant policy to C; v1 just "deferred" the body-tenant check. **Resolved:** `Principal.of` now **asserts** the tenant guard ran (`tenant_mismatch`, D.6) before any `store.load(scope.tenantId, …)`, rather than trusting body `tenantId`. D still does not re-implement A.4's policy (`10-auth-foundation.md:207`).
+- **Interface D→B (events-grain dept gap).** A `requiresAttributes:["department"]` def on the events grain passes presence but can't be scoped (events MV lacks `department_code`, README §3 / 00-req §7.4). **Resolved:** publish step 1 + the D→B contract now require `requiresAttributes ∩ declared-grain scopable columns` be satisfiable, rejecting such defs at publish (`kpi_invalid`) — fail-closed, never unscoped at runtime.
+- **Interface D→F (inline gate incomplete).** F can't refine a gate the batch arm never reaches. **Resolved:** B1 fix makes the branch point reach both arms; D→F contract and Open Q3 updated so F refines a complete gate (and D ships the minimal `_schema` elision F later owns).
+- **Interface D→E (ceiling).** Sound in v1; retained. E re-checks `visibleTo` via the same `disjoint` and reuses the tenant guard (`50-packs-config-ownership.md:292`).
+- **Gap — `queries` batch arm not stated as gated.** **Resolved:** explicitly stated in D.3, the current-reality table, step 5, and risks-§ (B1).
+- **Gap — `Principal` extraction path unspecified; `AnalyticsScope` discards roles.** Verified `AnalyticsScope` keeps only `tenantId/tenantStateLevel/citizenUuid/boundaryPrefix` (`:21-28,47`) and drops roles after `:38-42`. **Resolved:** D.3 defines `Principal.of(requestInfo, scope)` re-reading `userInfo` for `roles/type/canInline/hasResolvedAttribute`, with null/empty roles → `∅` → fail-closed, and the tenant-guard assert.
+- **Gap — step-1 dry-validate conflates "admin scope" with "safe for citizen scope".** **Resolved:** D.5 step 1 now states grain/column/op validation is a **scope-independent** property run against the def's **declared grain** regardless of scope; the three-scope dry-run (step 2) is a separate concern, and PII/dept-scopability (step 4 + D→B) are scope-independent def properties checked at publish.
+- **Cross-cutting — daily-grain citizen leak (README §1, found by reviewers A+C).** **Acknowledged; not fixable in Part D.** The fix (add `account_id` self-scope to the daily grain at `AnalyticsCatalog.java:108`, or reject citizen daily queries in the planner) is owned by **Part C** (`30-row-scope-enforcement.md`). D's containment: publish step 2 **hard-rejects** any citizen-visible `grain:"daily"` def until C lands; Open Q7 tracks lifting the reject when C ships.
+
+### v3 corrections (pass-3 codex fact-check, 2026-06-23)
+
+Two genuine MDMS-behavior errors caught by the pass-2 codex review, verified against the real `Digit-Core/core-services/mdms-v2` source and corrected with minimal edits:
+
+- **MDMS v2 search is first-hit, not a tenant→root merge.** `MDMSServiceV2.search()` loops the fallback tenant list and `break`s on the **first non-empty** result (`MDMSServiceV2.java:83-89`), so a city-local def set suppresses the root set rather than augmenting it. The design previously implied an automatic platform merge. **Corrected:** D.1 note and D.2 `publishedFor` now state defs are resolved by **two explicit reads** (city tenant + state root via `getStateLevelTenant`) merged in-process by the store (city wins per `id`); sequencing step 3 unit-tests that explicit merge, not a platform fallback.
+- **`x-unique` enforces composite-key uniqueness only, not immutability/versioning.** `CompositeUniqueIdentifierGenerationUtil.getUniqueIdentifier` (`CompositeUniqueIdentifierGenerationUtil.java:23-44`) concatenates the x-unique fields into one identifier at create time; MDMS v2 still mutates existing records via `_update/{schemaCode}` (`MDMSControllerV2.java:56-59` → `MDMSServiceV2.java:99-114`). The design previously claimed `x-unique:["id","version"]` gives "immutable versioned publish for free." **Corrected:** D.1 note and D.5 step 5 now make immutable versioning an **explicit pipeline invariant** — `version` in the composite key, write-new-`(id,version)`-never-`_update`-a-published-version, and a forward-only `published`→`archived` status transition; `x-unique` is described as only a duplicate-create backstop.
+
+## Codex review (pass 2 — gpt-5.5, verdict: needs-rework)
+
+> External adversarial review via `codex exec`, read-only, verifying the v2 revision log against the actual code. **Note:** codex evaluated "resolved" as "patched in code"; this is a *design* doc (no code changed yet), so most `actuallyResolved:false` items mean "design specifies it, code not yet written," not "design wrong." Read the findings for genuine design errors vs. implementation-status notes.
+
+
+**Summary:** The revision log mostly fixes prose, not actual code. Current analytics code still has no KpiDefinitionStore, Principal, runEntry, catalog endpoint, publish pipeline, officerColumns/citizenColumns, or schema role filtering. Several citations are accurate, but at least one M1 claim misstates _schema as carrying RequestInfo.
+
+
+### Resolution check (0/15 confirmed in code)
+
+- ❌ **Blocker B1 — batch-dict arm bypasses kpiId re-check AND inline gate.** — Actual AnalyticsService still calls runOne directly in both arms: batch at AnalyticsService.java:45 and single at :51; runOne plans directly at :58-59. No runEntry exists.
+- ❌ **Major M1 — GET /catalog with RequestInfo body is fragile.** — Design now says POST /catalog/_search, but actual AnalyticsController has only /_query and /_schema mappings at AnalyticsController.java:40 and :57. No catalog endpoint exists.
+- ❌ **Major M2 — _schema unauthenticated leaks officer/PII columns.** — Actual _schema is still zero-arg and unauthenticated at AnalyticsController.java:57-59 and AnalyticsService.schema() returns full catalog at :72-94, including PII/officer columns from AnalyticsCatalog.java:59,77,88,95,103,107.
+- ❌ **Minor m1 — materialize pins value but not filter column.** — No materialize implementation or saved-KPI path exists. Actual query path passes raw q to planner.plan at AnalyticsService.java:58-59. Planner binds filter values and rejects non-filterable columns at AnalyticsPlanner.java:173-197, but there is no def-fixed param materialization.
+- ❌ **Minor m2 — inferGrain never resolves daily.** — Actual inferGrain still returns only events/facts at AnalyticsPlanner.java:267-275. No dss.KpiDefinition schema or publish enforcement exists in code to require explicit grain.
+- ❌ **Minor m3 — cost cap referenced non-existent per-grain maxRows.** — Actual code still only has MAX_LIMIT at AnalyticsPlanner.java:24 and applies it at :110-111. There is no publish cost gate or config-backed global threshold implementation.
+- ❌ **Mis-citations — line refs tightened.** — Most anchors are accurate, but M1 says both shipped siblings carry RequestInfo over POST; _schema is POST but carries no body/RequestInfo: AnalyticsController.java:57-59.
+- ❌ **Interface D→A — tenant cross-check caveat.** — No Principal.of or tenant_mismatch path exists. Actual controller reads tenantId from body at AnalyticsController.java:45 and service builds scope from it at AnalyticsService.java:30-32.
+- ❌ **Interface D→B — events-grain department gap.** — No publish check exists. Events grain has no department_code in groupable/filterable/distinctable at AnalyticsCatalog.java:84-96, and AnalyticsScope has no department attributes at :20-28.
+- ❌ **Interface D→F — inline gate incomplete.** — No inline gate exists. Both actual arms still invoke runOne directly, AnalyticsService.java:45 and :51.
+- ❌ **Interface D→E — ceiling.** — No visibleTo re-check or KpiDefinitionStore exists in actual analytics package; rg found no Principal/KpiDefinitionStore/KpiDef in CCRS/backend/pgr-services/src/main/java/org/egov/pgr.
+- ❌ **Gap — queries batch arm not stated as gated.** — The design states it, but actual batch arm remains ungated at AnalyticsService.java:38-46.
+- ❌ **Gap — Principal extraction path unspecified; AnalyticsScope discards roles.** — AnalyticsScope indeed discards roles after reading them at AnalyticsScope.java:38-42 and returns only tenant/citizen/boundary fields at :47; no replacement Principal code exists.
+- ❌ **Gap — step-1 dry-validate conflates admin scope with safe citizen scope.** — No dry-validate or publish pipeline exists. Actual planner always applies supplied scope during planning at AnalyticsPlanner.java:97-99.
+- ❌ **Cross-cutting — daily-grain citizen leak.** — Actual daily grain still has citizenColumn null at AnalyticsCatalog.java:108, and applyScope silently skips citizen predicate when g.citizenColumn is null at AnalyticsPlanner.java:246. No publish-time reject exists.
+
+### Findings
+
+- **[BLOCKER] All claimed enforcement remains bypassable in actual code** — The v2 log claims both-arm runEntry gating, kpiId re-check, and inline_forbidden. None exists in the Java. A caller can still submit inline query bodies through either single or batch path and reach planner.plan directly.  
+  _evidence:_ `AnalyticsService.java:45 calls runOne(e.getValue(), scope); :51 calls runOne(body.get("query"), scope); :58-59 runOne calls planner.plan(q, scope).`
+- **[BLOCKER] Identity and tenant are still body-spoofable** — D claims Principal.of consumes a trusted principal and asserts tenant guard. Actual controller converts RequestInfo from the request body and reads tenantId from the same body, then AnalyticsScope derives citizen/employee posture from that body userInfo.  
+  _evidence:_ `AnalyticsController.java:43-47; AnalyticsScope.java:34-44; AnalyticsService.java:30-32.`
+- **[MAJOR] _schema side door is still open** — The M2 fix is not implemented. _schema accepts no RequestInfo and schema() returns full grain metadata, including officer UUID fields, to any caller.  
+  _evidence:_ `AnalyticsController.java:57-59; AnalyticsService.java:72-94; AnalyticsCatalog.java:59,77,88,95,103,107.`
+- **[MAJOR] No catalog discovery or saved KPI APIs exist** — The design relies on POST /v2/analytics/catalog/_search, KpiDefinitionStore, KpiDef, materialize, and /kpi/_publish, but the analytics package contains none of those classes or mappings.  
+  _evidence:_ `AnalyticsController.java:40-60 only maps /_query and /_schema; AnalyticsService.java:21-27 injects only planner/catalog/jdbc.`
+- **[MAJOR] MDMS root-fallback merge claim conflicts with MDMS v2 search behavior** — D.2 says tenant and root defs are root-fallback merged. MDMS v2 native search iterates fallback tenants and breaks on first non-empty result, so a city-local record set would suppress root records unless KpiDefinitionStore performs separate explicit searches and merges itself.  
+  _evidence:_ `MDMSServiceV2.java:80-88.`
+- **[MAJOR] x-unique does not provide immutable publish by itself** — D.1 says x-unique gives immutable versioned publish for free. MDMS v2 has an update endpoint and update service path; x-unique generates a uniqueIdentifier on create but does not prevent mutation of an existing version through update.  
+  _evidence:_ `MDMSControllerV2.java:56-59; MDMSServiceV2.java:99-112; CompositeUniqueIdentifierGenerationUtil.java:23-44.`
+- **[MAJOR] Daily citizen leak is acknowledged but still exploitable through inline path** — D contains publish-time containment for citizen-visible daily KPI defs, but actual inline queries remain available to spoofed or ungated callers. Since daily has no citizenColumn, citizen self-scope is skipped for daily.  
+  _evidence:_ `AnalyticsCatalog.java:108; AnalyticsPlanner.java:246; AnalyticsService.java:45,51.`
+- **[MINOR] M1 revision log misstates _schema RequestInfo behavior** — The log says shipped siblings carry RequestInfo over POST. _query does; _schema is POST but has no request body and cannot carry RequestInfo in the current signature.  
+  _evidence:_ `AnalyticsController.java:40-47 versus :57-59.`
+
+### Mis-citations
+
+- 40-kpi-catalog-governance.md M1: '_schema' is cited as a POST sibling carrying RequestInfo, but AnalyticsController.java:57-59 has public ResponseEntity<Map<String,Object>> schema() with no @RequestBody.
+- 40-kpi-catalog-governance.md D.2 implies MDMS v2 tenant/root fallback merge; actual MDMSServiceV2.java:80-88 stops at first non-empty fallback tenant.
+
+### Gaps
+
+- No actual ForbiddenException mapping for 403 in AnalyticsController; all non-IllegalArgumentException failures currently become 500 at AnalyticsController.java:51-53.
+- No tests cited or present for citizen batch inline -> inline_forbidden, hidden kpiId -> kpi_forbidden, null roles fail-closed, or _schema elision.
+- No code-level contract for PrincipalAttributes from Part B in analytics package; requiresAttributes cannot be enforced today.
+- No implemented officerColumns/citizenColumns metadata in AnalyticsCatalog; current Grain only has groupable/filterable/measurable/distinctable and scope columns at AnalyticsCatalog.java:25-48.

--- a/docs/dashboard-rbac-design/50-packs-config-ownership.md
+++ b/docs/dashboard-rbac-design/50-packs-config-ownership.md
@@ -1,0 +1,406 @@
+# Part E — Dashboard Packs & Config Ownership
+
+**Status:** v2 (pass-1 findings folded in), 2026-06-23 · **Maps to:** plan §Phase 5 (`rbac-kpi-access-implementation-plan.md`), design §5a "Dashboard packs — the curation layer above individual KPIs."
+**Depends on:** Part A (trust foundation — the `Principal{uuid,type,roles[],tenantId}` contract this part consumes; A.4 tenant cross-check) and Part D (KPI catalog access — the `dss.KpiDefinition` + `rbac.visibleTo` contract this part curates over). **Blocked by:** Part A — packs assembled for a spoofable principal are theater, and the per-user store this part leans on (`digit-user-preferences-service`) has its OWN identity gap (E.3) that only a trusted, gateway-coerced uuid closes.
+**Reads (grounded):** `dashboard-query-api-design.md` §3/§5/§5a; `00-requirements.md` §3/§5/§8; `rbac-kpi-access-implementation-plan.md` §0/Phase 4/Phase 5; and the real trees below.
+
+> **Grounding rule (inherited from Part 00):** every "exists today" claim is anchored to a file:line actually read. Where something is *missing*, that is stated as missing with the anchor that shows the gap. Part E touches three real surfaces — the analytics service (`CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/`), the **fully-vendored** user-preferences-service (`CCRS/backend/digit-user-preferences-service/` — Go/Gin, source in-tree), and the configurator admin (`CCRS/configurator/src/admin/` + the vendored registry in `CCRS/configurator/packages/data-provider/`). None of the three has a line of pack/layout code today; this part designs all of it.
+
+---
+
+## Goal & responsibilities
+
+### What this part owns
+
+1. **`dss.DashboardPack` — the role→pack binding.** A named, ordered bundle of `kpiId`s plus a *default* tile layout, keyed by role, stored as an MDMS master (design §5a; plan §3 row "Dashboard packs", Phase 5). This is the **curation layer**: it answers "what does a role *get by default*," sitting **above** per-KPI `visibleTo` (which answers "what a role *may ever* see" — owned by Part D).
+2. **The pack-serving read path.** A discovery surface (`POST …/packs`, resolved against the caller's roles) that returns the assembled, *ceiling-filtered* pack — so the FE never has to know which `kpiId`s a role may see; the backend tells it.
+3. **The default-layout vs per-user-override split.** Pack `layout` is a tenant-authored *default*. A user's personal re-ordering/resize is **preference state**, owned by `digit-user-preferences-service`, NOT by MDMS and NOT by the pack (00-requirements §5 "Layout/personalization → user-preferences-service, not MDMS"). This part defines the `preference_code` namespace, the payload shape, the *merge contract* (default ⊕ override), **and the identity-binding precondition that store requires to be safe** (E.3).
+4. **The configurator admin surface for packs.** Registering `dss.DashboardPack` (and, as Part D's consumer, `dss.KpiDefinition`) as a managed resource in the configurator so a tenant admin edits packs without a deploy.
+
+### What this part explicitly does NOT own
+
+- **`visibleTo` / the KPI security ceiling** — owned by **Part D**. A pack *references* `kpiId`s; it never declares or widens their visibility. The pack is assembly; the ceiling is the engine (design §5a "Packs are assembly; the ceiling is the engine").
+- **Row scope** (Layer 1) — owned by **Parts B/C**. Packs do not scope rows. A pack tile that resolves to zero rows under the caller's `attrScopes` is still a *valid* tile; emptiness is never a pack concern.
+- **Inline-query grammar gating** (Layer 3) — owned by **Part F**. Packs only ever name published `kpiId`s; they cannot carry inline query bodies.
+- **Trustworthy identity** — owned by **Part A**. Part E *consumes* the Part A `Principal{roles}` to pick a pack and `Principal.uuid` to key preferences; it never re-derives either from raw `RequestInfo`.
+- **The tenant cross-check** — owned by **Part A.4** (`10-auth-foundation.md` §A.4, `:231`). Part E *relies on* A.4 having rejected a body `tenantId` outside the principal's allowed tenants before any pack/preference read; Part E does not re-implement token-vs-tenant validation (and must NOT assume it exists today — see E.2/Risks).
+- **Identity itself** (roles, jurisdiction, department, user record) — consumed read-only from DIGIT (00-requirements §5 "consume identity, don't rebuild it"). Packs are keyed *by role*, a value that already exists in the validated principal.
+
+The one-line test for "is this Part E": *does it decide which already-permitted tiles a role sees by default, or where a user dragged a tile?* If yes, Part E. If it decides **whether** a caller may see a KPI at all, or **which rows**, it is Part D / Parts B-C respectively.
+
+---
+
+## Current code reality (file:line — exists vs missing)
+
+| Capability | State today | Evidence |
+|---|---|---|
+| Analytics endpoints | `POST /v2/analytics/_query` + `POST /v2/analytics/_schema` **only** | `AnalyticsController.java:40,57` — `@RequestMapping("/v2/analytics")` (`:27`), two `@PostMapping`s. **No** `/catalog`, **no** `/packs`. |
+| Tenant authorization on `_query` | **MISSING** — body `tenantId` is trusted | `AnalyticsService.query()` resolves scope from body `tenantId` + `requestInfo` with no membership check (`AnalyticsService.java:30-32`); `AnalyticsScope.resolve()` sets only state-vs-city + citizen self-scope, never validates tenant membership (`AnalyticsScope.java:31-48`). 00-requirements §7.1 documents the spoofability. The cross-check is a **future Part A.4 deliverable** (`10-auth-foundation.md` §A.4, `:231`), not a reusable guard today. |
+| KPI defs in MDMS (`dss.KpiDefinition`) | **Missing** (Part D builds) | plan §0 "no saved KPI defs in MDMS yet"; `AnalyticsService`/`AnalyticsCatalog` never read MDMS (only hardcoded grain catalog at `AnalyticsCatalog.java:54–108`). |
+| Dashboard packs (`dss.DashboardPack`) | **Missing entirely** | plan §0 row "Dashboard packs (role→tiles) … Missing". No schema, no read path, no FE consumer. |
+| Role accessor on `AnalyticsScope` | **MISSING** — no public role getter | `AnalyticsScope` exposes only `tenantId`/`tenantStateLevel`/`citizenUuid`/`boundaryPrefix` (`AnalyticsScope.java:21–24`); roles are consumed inside the private `resolve()` loop (`:38–44`) and discarded. There is **no `rolesOf()`** to reuse — Part E (like Part D) must read roles off the Part A `Principal`, not re-derive from `ri`. |
+| user-preferences-service data model | **EXISTS** — generic `user_preference` table | `V20260205120000__create_user_preference.sql:6–16`: `(id, user_id, tenant_id, preference_code, payload JSONB, audit cols)`; unique on `(user_id, COALESCE(tenant_id,''), preference_code)` (`:20–21`). |
+| user-preferences-service Java/API | **VENDORED IN-TREE (Go/Gin)** — source present | full Go source under `backend/digit-user-preferences-service/`: routes `POST {ctx}/v1/_upsert` + `POST {ctx}/v1/_search` (`internal/routes/routes.go:33–34`); request envelopes `{RequestInfo, preference:{userId,tenantId,preferenceCode,payload}}` / `{RequestInfo, criteria:{userId,tenantId,preferenceCode,limit,offset}}` (`internal/model/models.go:127–137`); `SERVER_CONTEXT_PATH=/user-preference` (`docker-compose.yml:12`). API shape is **confirmed from source**, not deferred to the image. |
+| Upsert idempotency on the key | **CONFIRMED — yes** | `Upsert` does `FindByKey(userId, tenantId, preferenceCode)` → update-or-create (`internal/service/preference_service.go:107`; `internal/repository/preference_repository.go:54–76`). One idempotent `_upsert` call per save. |
+| **Identity binding in user-preferences** | **MISSING — keys on BODY `userId`, IDOR** | `Upsert` writes `req.Preference.UserId` straight from the body (`preference_service.go:107`); the token uuid (`GetUserIDFromRequestInfo`, `internal/enrichment/preference_enricher.go:74–87`) is used **only** for audit `createdBy`/`lastModifiedBy` (`preference_service.go:104,115,119`). `Search` filters by body `criteria.UserId` (`internal/repository/preference_repository.go:86–87`); validation only requires *some* criterion present (`internal/validation/preference_validation.go:81–86`). `test_apis.sh:226–239` ("Test 7", `another-user-456`) shows cross-user writes are accepted. **This store is user/tenant-spoofable as shipped** — E.3 must front it with a trusted-uuid coercion or it is an IDOR. |
+| Per-user layout preference code | **Missing** — no `PGR_DASHBOARD_LAYOUT` namespace | the table is generic (`preference_code VARCHAR(128)`, comment `:53` example `USER_NOTIFICATION_PREFERENCES`); no analytics layout code is seeded anywhere. |
+| Separate physical datastore | **EXISTS — own Postgres** | the vendored compose runs the service against its **own** `postgres:15-alpine`, `DB_NAME=user_preferences`, own volume (`docker-compose.yml:13–17,27–36`) — NOT the shared DIGIT DB. "No DDL" still requires this service to be deployed and reachable in the target env. |
+| Configurator generic MDMS resource registration | **EXISTS** — declarative registry | `resourceRegistry.ts:21` `export const REGISTRY: Record<string, ResourceConfig>`; e.g. `'auto-escalation-ignore': { type:'mdms', schema:'Workflow.AutoEscalationStatesToIgnore', idField:'businessService', nameField:'businessService' }` (`:121`). `getGenericMdmsResources()` returns every `type==='mdms' && !dedicated` entry (`:150–156`). `AdvancedPage` enumerates them via `getGenericMdmsResources()` (`CCRS/configurator/src/resources/advanced/AdvancedPage.tsx:7`) then `resources.map` (`:20`). **No `dss.*` entry exists.** |
+| Configurator per-schema rich form descriptor | **EXISTS** — additive descriptor pattern | `schemaDescriptors/index.ts:12` `DESCRIPTORS` map; e.g. `autoEscalationIgnoreDescriptor` (`auto-escalation-ignore.ts:15`) wires a `string[]` field to the `chip-array` widget (`:26`). `MdmsResourceEdit` mounts a `customEditor` when set (`types.ts:51–55`). |
+| Generic form for object-array fields (`tiles[]`) | **MISSING widget** | the bare form "silently skip[s] object/array fields" (`types.ts:6–7`); `WidgetKind` has `chip-array` for `string[]` only — **no object-array widget** (`types.ts:11–21`). So `tiles[]`/`layout` are **unauthorable** in the generic form; they need a `customEditor` (`types.ts:51–55`). |
+| FE KPI catalog today | **client-side, authoritative** | design §5a "Today the dashboard FE *is* the KPI catalog … `kpiQueries.js`"; the FE decides which tiles render. This is what Part E + Part D invert. |
+
+**Reading:** the MDMS-master plumbing (configurator registry + descriptor) and the preferences *table* both already exist and are generic enough to host packs/layout with **zero schema-engine changes** — only new declarative entries + one new `preference_code`. The genuinely new code is (a) the server-side pack read endpoint that ceiling-filters against Part D's `visibleTo`, (b) the `dss.DashboardPack` MDMS schema + seed, (c) a **custom editor** for the `tiles`/`layout` object fields (the generic form cannot author them), and (d) closing the **user-preferences IDOR** by fronting the store with a trusted-uuid path. The first two are additive over surfaces that already work; (c) and (d) are the load-bearing new work this revision surfaces.
+
+---
+
+## Design
+
+### E.1 Data model — `dss.DashboardPack` (MDMS master)
+
+One record per `(tenantId, role)`. MDMS v2 keys it by a unique identifier; we use `role` as the `x-unique` field (mirroring `auto-escalation-ignore`'s `businessService` being both unique and the record id — `auto-escalation-ignore.ts:22`).
+
+```jsonc
+// schemacode: dss.DashboardPack   (one record per role, per tenant; soft-deletable, versioned by MDMS)
+{
+  "role": "GRO",                       // x-unique → the record's identifier; matches a DIGIT role CODE
+  "title": "Supervisor dashboard",     // localization code, resolved at edge (like KpiDefinition.title)
+  "tiles": [                           // ordered list — order IS the default reading order
+    { "kpiId": "open_backlog",     "kpiVersion": null },   // null ⇒ latest published (design §2 kpiVersion default)
+    { "kpiId": "sla_compliance",   "kpiVersion": null },
+    { "kpiId": "aging_trend",      "kpiVersion": null },
+    { "kpiId": "my_ward_inflow",   "kpiVersion": null }
+  ],
+  "layout": {                          // DEFAULT grid only; per-user overrides live in preferences (E.3)
+    "version": 1,                      // layout-schema version, for forward-compat of the grid shape
+    "grid": [                          // OPAQUE to the backend (see Open Q5) — FE owns coordinate meaning
+      { "kpiId": "open_backlog",   "x": 0, "y": 0, "w": 6, "h": 4 },
+      { "kpiId": "sla_compliance", "x": 6, "y": 0, "w": 6, "h": 4 },
+      { "kpiId": "aging_trend",    "x": 0, "y": 4, "w": 12, "h": 4 },
+      { "kpiId": "my_ward_inflow", "x": 0, "y": 8, "w": 6, "h": 4 }
+    ]
+  }
+}
+```
+
+Design choices, each load-bearing:
+
+- **Keyed by role, not by user.** Packs are *role* config (curation), so a tenant authors O(roles) packs, not O(users) (design §5a). Per-user state is the *override* in E.3.
+- **`tiles` is the authority for membership; `layout.grid` is presentation.** A `kpiId` present in `layout.grid` but absent from `tiles` is ignored (defensive — drift); a `kpiId` in `tiles` but missing from `grid` is auto-placed by the FE at the end (append). This mirrors the query/viz split the KPI def already uses ("Query-shape is what to fetch; viz-config is how to draw" — design §0.6).
+- **`kpiVersion: null ⇒ latest`** matches the runtime default at `dashboard-query-api-design.md:58` (`kpiVersion … default = latest published`). A pack MAY pin a version so a curated dashboard doesn't drift when a KPI is re-published (design §3a immutable versioning).
+- **`layout.grid` is an opaque JSON blob to the backend.** The backend stores and serves it; it does not parse `{x,y,w,h}` or assume a 12-column grid library. This keeps the backend free of a specific FE grid-library coordinate system (see Open Q5, leaning resolved-opaque).
+- **No `visibleTo` on the pack.** Deliberately absent. Visibility is Part D's ceiling; a pack listing an out-of-ceiling `kpiId` is not an error at author time and not a leak at read time — it is *dropped* at serve time (E.2 step 4) and yields `403 kpi_forbidden` if invoked directly (Part D's `disjoint(visibleTo, roles)` re-check, `40-kpi-catalog-governance.md:142`). This is the "mis-authored pack → no leak" guarantee (design §5a).
+
+**Role-union for multi-role users (incl. HRMS pollution).** A real principal often holds several roles — and on real tenants *every* `GRO` also carries `PGR_LME` (memory [HRMS role pollution]; 00-requirements §7.2). The serve path therefore resolves **the union of the caller's role-packs**, then ceiling-filters per tile against Part D's published defs. Pack *membership* can never be wider than the union of what each role's pack lists, and ceiling-filtering closes the visibility door regardless. **Union ordering is made deterministic by a config-driven role priority** (resolving pass-1 Open Q3 — see E.2). Authoring/testing of packs must still use **clean single-role `RBAC_TEST_*` users** (plan §5; 00-requirements §7.2) so a pack's intent is provable without pollution noise.
+
+### E.2 Pack read path — `POST /v2/analytics/packs` (new, server-side, ceiling-filtered)
+
+A new endpoint on the same controller. It is **read-only**, returns the *resolved* pack for the caller, and is where Part E meets Part D: it imports D's `disjoint(visibleTo, roles)` check and applies it **per tile** so the FE only ever receives tiles the caller may actually invoke. `POST` (not `GET`) so `RequestInfo` rides in the body, consistent with `_query` (`AnalyticsController.java:41`) and with the existing pgr-services POST convention; this also matches Part D's recommendation to land discovery as a POST (`40-kpi-catalog-governance.md` M1, `:285`) rather than GET-with-body, which Kong can strip.
+
+```java
+// AnalyticsController.java — NEW endpoint, alongside _query (L40) and _schema (L57)
+@PostMapping("/packs")   // POST to carry RequestInfo, matching _query's body convention (L41)
+public ResponseEntity<Map<String,Object>> packs(@RequestBody JsonNode body){
+    try {
+        RequestInfo requestInfo = body.has("RequestInfo")
+                ? mapper.convertValue(body.get("RequestInfo"), RequestInfo.class) : null;
+        String tenantId = body.hasNonNull("tenantId") ? body.get("tenantId").asText() : null;
+        // Part A precondition: requestInfo.userInfo is token-derived & trustworthy here,
+        // AND A.4 (10-auth-foundation.md §A.4, :231) has already 403'd a body tenantId outside the
+        // principal's allowed tenants. Until A lands, this endpoint is as spoofable as _query
+        // (AnalyticsService.java:30-32) — it MUST NOT ship before A.
+        Principal principal = principalOf(requestInfo);          // Part A Principal{uuid,type,roles,tenantId}
+        Map<String,Object> resolved = packService.resolveForCaller(principal, tenantId);
+        return ResponseEntity.ok(resolved);
+    } catch (IllegalArgumentException e) {
+        return ResponseEntity.badRequest().body(error(e));      // reuse existing error() L62
+    } catch (Exception e) {
+        log.error("pack resolve failed", e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error(e));
+    }
+}
+```
+
+`principalOf(...)` is the **same Part A `Principal` builder Part D uses** (`40-kpi-catalog-governance.md:165,175`), reading `{uuid, type, roles[]}` off the trusted post-A `userInfo` — NOT a re-derive from raw `requestInfo`, and NOT a (nonexistent) `AnalyticsScope.rolesOf(ri)`. Part E and Part D share one principal-extraction path so both gate on the identical trusted role set.
+
+`PackService.resolveForCaller` (new class; the orchestration this part owns):
+
+```java
+Map<String,Object> resolveForCaller(Principal principal, String tenantId){
+    // 0. Part A: the principal is trustworthy (else fail-closed → empty pack, never a default-admin pack).
+    Set<String> roles = principal.roles;                      // off the Part A Principal, not raw ri
+    if (roles == null || roles.isEmpty()) return emptyPack(tenantId);  // FAIL-CLOSED: no roles ⇒ no tiles
+
+    // 1. MDMS: fetch dss.DashboardPack for each role at this tenant (cached, short TTL — E.6).
+    List<DashboardPack> packs = packRepo.byRoles(tenantId, roles);   // mdms v2 _search per role-code
+
+    // 2. Union the tiles in a DETERMINISTIC order: iterate roles by config-driven rolePriority
+    //    (Open Q3 resolved), de-dup by kpiId (first occurrence in priority order wins for ordering).
+    LinkedHashMap<String,Tile> union = unionTiles(packs, rolePriority);
+
+    // 3+4. Load each referenced KPI def from Part D's store (latest|pinned) and CEILING FILTER.
+    //    Drop a kpiId that resolves to no published def (drift); drop a tile out of ceiling.
+    List<ResolvedTile> tiles = new ArrayList<>();
+    for (Tile t : union.values()){
+        KpiDef def = catalogD.load(tenantId, t.kpiId, t.kpiVersion);    // Part D: KpiDefinitionStore.load (40-...:116)
+        if (def == null) continue;                                      // drift: KPI gone → drop tile
+        if (Collections.disjoint(def.visibleTo, roles)) continue;       // OUT OF CEILING → drop tile (40-...:142)
+        tiles.add(ResolvedTile.of(t, def.viz, def.title));              // carry FULL viz JsonNode + title for FE
+    }
+
+    // 5. Default layout = merge of the surviving role-packs' opaque layout blobs, restricted to surviving tiles.
+    Object defaultLayout = mergeLayouts(packs, tiles, rolePriority);    // deterministic, ordering from step 2
+
+    return shape(tenantId, roles, tiles, defaultLayout);               // { tiles[], defaultLayout }
+}
+```
+
+Why this shape:
+
+- **Reuses Part D's *real* surface.** `KpiDefinitionStore.load(tenantId, kpiId, version)` returns a `KpiDef` whose public fields are `visibleTo`, `viz`, `title`, `params`, `freshness` (`40-kpi-catalog-governance.md:114,116,118–122`). There is **no `published(...)` method and no `vizSummary()`** — the tile carries `def.viz` (the full viz JsonNode D returns whole in `/catalog`, `40-…:186–187`) and `def.title`. The names now link against D as written.
+- **Discovery is filtered, but invocation is still re-checked (defence in depth).** The served pack is `disjoint(visibleTo,roles)`-filtered (UX: don't show a tile you can't open), but Part D **still** re-checks the same predicate on the subsequent `POST /_query?kpiId=…` (design §5a "this re-check is the whole ballgame"; `40-…:142`). Pack filtering is *not* the security boundary; it is the curation surface. A caller who hand-crafts a `_query` for a tile the pack hid still hits Part D's `403 kpi_forbidden`.
+- **Deterministic union order (Open Q3 resolved).** When a user holds `GRO` + `PGR_LME` and both packs list overlapping `kpiId`s in different orders, the union iterates roles by a **config-driven `rolePriority`** (an MDMS/`globalConfigs` ordered list), so the served default order — and the `mergeLayouts` output that keys off it — is stable across requests for a multi-role user. This is decided **before** step-6 seeds, not deferred.
+- **Drop-not-error on drift.** A pack that references a since-archived KPI (Part D rolled "latest" back) drops that tile silently rather than failing the whole dashboard. A dashboard that 500s because one KPI was renamed is a worse failure than a missing tile.
+
+### E.3 Per-user layout override — `digit-user-preferences-service` (with the identity-binding fix)
+
+The pack's `layout` is a **default**. A user's personal arrangement is stored as a single preference record, using the **existing generic table unchanged**.
+
+**New `preference_code`: `PGR_DASHBOARD_LAYOUT`.** No DDL — the table accepts any `preference_code VARCHAR(128)` (`V20260205120000__create_user_preference.sql:10`), keyed unique on `(user_id, COALESCE(tenant_id,''), preference_code)` (`:20–21`). One row per `(user, tenant)` holds the override payload in `payload JSONB` (`:11`). The API is the vendored Go service: write via `POST /user-preference/v1/_upsert`, read via `POST /user-preference/v1/_search` (`internal/routes/routes.go:33–34`), envelopes per `internal/model/models.go:127–137`; one idempotent `_upsert` per save (`preference_service.go:107`).
+
+```jsonc
+// user_preference row:
+//   user_id = principal.uuid (coerced from token — see "Identity binding" below),
+//   tenant_id = "ke.bomet", preference_code = "PGR_DASHBOARD_LAYOUT"
+//   payload =
+{
+  "version": 1,                         // matches pack layout.version; bump → ignore stale overrides
+  "packRoleKey": "GRO|PGR_LME",         // which role-union this override was authored against (drift guard)
+  "overrides": {                        // SPARSE — only tiles the user actually moved/resized/hid
+    "open_backlog":   { "x": 6, "y": 0, "w": 6, "h": 4 },
+    "aging_trend":    { "hidden": true }     // user hid a tile they're still permitted to see
+  }
+}
+```
+
+**Identity binding (BLOCKING precondition — the store is IDOR-prone as shipped).** The user-preferences-service keys records on the **body** `userId`, not the token uuid: `Upsert` persists `req.Preference.UserId` (`preference_service.go:107`) and uses the token uuid only for audit `createdBy`/`lastModifiedBy` (`preference_service.go:104,115,119` via `preference_enricher.go:74–87`); `Search` filters on body `criteria.UserId` (`preference_repository.go:86–87`); validation merely requires *some* criterion (`preference_validation.go:81–86`). `test_apis.sh:226–239` shows a cross-user write (`another-user-456`) is accepted. **As-is, any caller can `_search`/`_upsert` another user's `PGR_DASHBOARD_LAYOUT` — and the same store also holds `USER_NOTIFICATION_PREFERENCES` consent, so the gap is broader than packs.** Part E therefore mandates one of two bindings, and the FE MUST NOT call `_search`/`_upsert` with an attacker-chosen `userId`:
+
+- **(a) Gateway coercion (preferred).** The Kong route fronting `/user-preference` overwrites `preference.userId` and `criteria.userId` with the token-introspected uuid (the same coercion Part A applies to analytics `userInfo`). This is the cleanest: the store stays generic, every consumer benefits, and the IDOR closes for consent too.
+- **(b) Backend-for-frontend.** The dashboard FE never talks to user-preferences directly; it reads/writes layout through a thin analytics-side passthrough that injects `principal.uuid` from the trusted `Principal` (E.2) before calling `_upsert`/`_search`. Narrower (covers only `PGR_DASHBOARD_LAYOUT`) but does not require a Kong change.
+
+Either way, **the `userId` that reaches the store is the token uuid, never the body value.** This precondition is the reason E's "subtract-only" guarantee actually holds: without it, the personalization layer is an open IDOR. (Filed as a cross-cutting issue; the Kong-coercion option is owned jointly with Part A's gateway work.)
+
+**Merge contract (default ⊕ override), computed FE-side after two reads:**
+
+1. FE calls `POST /v2/analytics/packs` → `{ tiles[], defaultLayout }` (E.2).
+2. FE reads its `PGR_DASHBOARD_LAYOUT` preference (`POST /user-preference/v1/_search`, `userId` coerced to the token uuid per binding above).
+3. Effective grid = `defaultLayout.grid` with each entry **overlaid** by `overrides[kpiId]` when present; `hidden:true` removes the tile from render (but NOT from `tiles` — it can be un-hidden).
+4. **Override is filtered through `tiles` (the ceiling-filtered set), never the other way.** An override referencing a `kpiId` no longer in `tiles` (lost the pack, lost the ceiling, KPI archived) is **dropped** — a stale personal layout can never resurrect a tile the backend already withheld. This is the fail-closed guarantee at the personalization layer: **preferences can subtract and rearrange, never add.** It is only sound *given the identity binding above*; a spoofable store would let a user read/seed someone else's layout, but even then the ceiling filter at serve time means it cannot widen *visibility* — the binding closes the privacy/integrity leak, the ceiling closes the access leak.
+
+**Why preferences, not MDMS (the ownership line):** layout overrides are (a) per-user (O(users)), (b) high-churn (every drag), (c) not security-relevant, and (d) not config a tenant admin curates. MDMS is for *governed, audited, versioned tenant config* (design §3a publish pipeline); routing per-drag writes through that pipeline would be absurd. 00-requirements §5 fixes this: "Layout/personalization → user-preferences-service, **not** MDMS." Part E honours that line by storing **only the default** in MDMS and **only the delta** in preferences.
+
+### E.4 Configurator admin surface — registering the masters
+
+Both new masters become managed resources with **declarative-only** registry changes (no engine code). The `tiles`/`layout` *fields*, however, are object/object-array shapes the generic form cannot author — they need a `customEditor` from day one (see below).
+
+**(a) Registry entries** — append to `REGISTRY` in `configurator/packages/data-provider/src/providers/resourceRegistry.ts:21` (the file that holds `auto-escalation-ignore` at `:121`):
+
+```ts
+'dashboard-pack':   { type: 'mdms', label: 'Dashboard Packs',
+                      schema: 'dss.DashboardPack',   idField: 'role',  nameField: 'role' },
+'kpi-definition':   { type: 'mdms', label: 'KPI Definitions',     // (Part D's master; registered here as its admin surface)
+                      schema: 'dss.KpiDefinition',   idField: 'id',    nameField: 'title' },
+```
+
+Because neither carries `dedicated: true`, both flow automatically through `getGenericMdmsResources()` (`resourceRegistry.ts:150–156`) and appear on `AdvancedPage` (which enumerates via `getGenericMdmsResources()` at `CCRS/configurator/src/resources/advanced/AdvancedPage.tsx:7`, then `resources.map` at `:20`) and the generic list/show/create/edit pages (`MdmsResourcePage.tsx`).
+
+**(b) Rich-form descriptor + customEditor (required, not optional).** Add `dashboard-pack.ts` to `configurator/src/admin/schemaDescriptors/` and register it in `index.ts:12` (the `DESCRIPTORS` map). Critically, **`tiles[]` is an array of *objects* (`{kpiId, kpiVersion}`), and `WidgetKind` has no object-array widget** — `chip-array` is `string[]`-only (`types.ts:11–21`), and the bare form "silently skip[s] object/array fields" (`types.ts:6–7`). So the generic registry entry alone yields CRUD over **`role`/`title` only**; `tiles`/`layout` are **unauthorable** until the `customEditor` ships. The `dashboardPackEditor` is therefore part of the **MVP**, not a deferred nicety (this corrects the prior plan, where step 2 was wrongly called a "usable interim" for the parts that matter):
+
+```ts
+// configurator/src/admin/schemaDescriptors/dashboard-pack.ts
+export const dashboardPackDescriptor: SchemaDescriptor = {
+  schema: 'dss.DashboardPack',
+  groups: [
+    { title: 'Binding', fields: ['role', 'title'] },
+    { title: 'Tiles',   fields: ['tiles'] },
+    { title: 'Default layout', fields: ['layout'] },
+  ],
+  fields: [
+    { path: 'role',  widget: 'text', required: true,
+      help: 'Must match a DIGIT role CODE (e.g. GRO). Becomes the record identifier.' },
+    { path: 'title', widget: 'text' },
+    // tiles[] is object-array; layout is a nested object — neither is expressible in the generic
+    // form (no object-array WidgetKind; types.ts:11-21). Both are handled by the customEditor below.
+  ],
+  customEditor: 'dashboardPackEditor',   // registered like the ThemeConfig editor (types.ts:51-55) — drag-grid + KPI picker
+};
+```
+
+The `customEditor` escape hatch (`types.ts:51–55`) is the right and *necessary* call for `tiles`/`layout` — exactly the "JSON Schema alone can't express richly" case the descriptor system documents (`types.ts:1–8`), matching how `ThemeConfig` opted into its editor (memory [ThemeConfig v1/v2/v3]). The KPI picker inside it is **fed by Part D's discovery endpoint** (the catalog `_search` Part D lands per `40-…` M1) so an admin can only add `kpiId`s that exist and are visible at the editing tenant — closing the "pack references a non-existent KPI" drift at author time (still drop-safe at serve time per E.2).
+
+### E.5 Control flow (end-to-end)
+
+```
+Admin (configurator)                 Citizen/Supervisor (dashboard FE)
+─────────────────────                ──────────────────────────────────
+edit dss.DashboardPack    ┐          POST /v2/analytics/packs  (RequestInfo)
+  (customEditor — REQUIRED│            └─► [Part A.4: tenant cross-check, 403 on mismatch]
+   for tiles/layout; KPI  │            └─► principalOf(ri)  ← SAME Part A Principal as Part D
+   picker from D's catalog│            └─► PackService.resolveForCaller(principal, tenant)
+   _search)               │                 1. roles ← Principal.roles (empty ⇒ empty pack, fail-closed)
+   → mdms_create/_update  │                 2. mdms v2 _search dss.DashboardPack by each role
+                          ▼                 3. union tiles by rolePriority (deterministic), de-dup
+              MDMS (dss.DashboardPack,       4. per tile: KpiDefinitionStore.load (Part D, 40-...:116),
+               dss.KpiDefinition)               keep iff !disjoint(visibleTo, roles)  ← CEILING (40-...:142)
+                                             5. mergeLayouts (opaque blobs) → defaultLayout
+                                          ◄── { tiles[]:{kpiId,version,title,viz}, defaultLayout }
+                                          POST /user-preference/v1/_search (PGR_DASHBOARD_LAYOUT)
+                                              userId COERCED to token uuid (gateway/BFF — E.3)
+                                          ◄── { overrides }  (or empty ⇒ {})
+                                          FE: effective = defaultLayout ⊕ overrides
+                                              (overrides filtered through tiles — subtract only)
+                                          per tile → POST /v2/analytics/_query?kpiId=…
+                                              └─► Part D re-checks disjoint(visibleTo,roles) (403 if forbidden)
+                                              └─► Parts B/C inject row scope (attrScopes)
+       user drags a tile ──────────────► POST /user-preference/v1/_upsert (sparse overrides)
+                                              userId COERCED to token uuid (gateway/BFF — E.3)
+```
+
+The pack endpoint resolves **catalog membership**; `_query` resolves **data + ceiling re-check + row scope**; preferences resolve **personal arrangement**. Three reads, three owners, no layer doing another's job.
+
+---
+
+## Interfaces with other parts
+
+**Inputs consumed:**
+
+| From | Contract consumed | Used for |
+|---|---|---|
+| **Part A** (trust foundation) | the `Principal{uuid, type, roles[], tenantId}` (A.5, `10-auth-foundation.md:225–230`), token-derived & vouched; **A.4 tenant cross-check** (`:207`) having already 403'd an out-of-tenant body | picking which role-packs to union (off `Principal.roles`, NOT raw `ri` and NOT a nonexistent `AnalyticsScope.rolesOf`); keying preferences by the real `Principal.uuid`. If A is not in, `/packs` is as spoofable as `_query` (`AnalyticsService.java:30-32`) and MUST NOT ship; it fails closed to an empty pack on empty roles, never a default. |
+| **Part D** (KPI catalog access) | `KpiDefinitionStore.load(tenantId, kpiId, version)` → `KpiDef{visibleTo, viz, title, params, freshness}` (`40-kpi-catalog-governance.md:116,118–122`); the shared `disjoint(visibleTo, roles)` predicate (`:142`); D's catalog discovery endpoint for the picker (D's POST `_search` per `:285`) | per-tile ceiling filter (E.2 steps 3–4) carrying `def.viz`/`def.title`; the configurator KPI picker (E.4b). **Tightest coupling in Part E — E reuses D's *exact* `load`/`KpiDef`/`disjoint` surface; there is no `published()` or `vizSummary()`.** |
+
+**Outputs produced:**
+
+| To | Contract produced |
+|---|---|
+| **Dashboard FE** | `POST /v2/analytics/packs` → `{ tiles[]:{kpiId, version, title, viz}, defaultLayout }`, already ceiling-filtered (`viz` is D's full viz JsonNode; `defaultLayout` is an opaque FE-owned blob). The FE becomes a thin renderer (design §5a "authority moves to the backend"); it no longer decides tile membership. |
+| **Dashboard FE** | `PGR_DASHBOARD_LAYOUT` preference namespace, the **subtract-only merge contract** (E.3), and the rule that all preference calls go through the token-uuid-coerced path (gateway or BFF), never with a body `userId`. |
+| **Part A / gateway** | a requirement: **coerce `preference.userId`/`criteria.userId` to the token uuid** on the `/user-preference` route (the IDOR fix, E.3 option (a)). Owned jointly — Part A's gateway-coercion machinery, Part E's preference route. |
+| **Part F** (inline gating) | *No coupling.* Packs only ever name published `kpiId`s; F gates inline grammar, which packs never carry. Listed for completeness: a pack can never be a vector for inline queries. |
+| **Configurator admin** | two new `REGISTRY` entries + one descriptor + the **required** `dashboardPackEditor` customEditor (for `tiles`/`layout`). |
+
+**Non-interfaces (explicit):** Part E does **not** consume Parts B/C `attrScopes` — packs are scope-blind; a tile is included/excluded by *visibility*, never by whether its rows are empty under the caller's jurisdiction/department. (A `GRO` for an empty ward still gets the `open_backlog` tile; it just renders zero.)
+
+---
+
+## Sequencing & migration steps
+
+Strict order — each step is independently shippable as a one-concern PR against egov/CCRS `develop`, validated on ovh-cloud-dev (bomet repro) before live (plan §5/§6.5).
+
+1. **(blocked on Part A + Part D)** Land the `dss.DashboardPack` MDMS **schema** (`mdms_schema_create`) with `role` as `x-unique`, `tiles`/`layout` typed objects. No serving code yet.
+2. **Register both masters in the configurator** (`resourceRegistry.ts` entries + `dashboard-pack.ts` descriptor + `index.ts` wiring) **together with the `dashboardPackEditor` customEditor**. The generic form authors only `role`/`title` (no object-array widget for `tiles[]` — `types.ts:11–21`), so the editor is part of this step, not a later one. After this, admins have full pack CRUD via `AdvancedPage`/`MdmsResourcePage`.
+3. **Build `POST /v2/analytics/packs`** + `PackService.resolveForCaller`, consuming the shared Part A `Principal` and Part D's `KpiDefinitionStore.load` / `disjoint(visibleTo,roles)`. Ceiling-filter per tile. Deterministic union ordering via `rolePriority`. Cache (E.6).
+4. **Define `PGR_DASHBOARD_LAYOUT`** preference usage — no DDL (table exists, `V20260205120000__…sql`). **Prerequisites for this step:** (i) confirm the `digit-user-preferences-service` is **deployed and reachable** in the target env — it runs against its *own* Postgres `DB_NAME=user_preferences` (`docker-compose.yml:13–17,27–36`), a distinct datastore from the shared DIGIT DB and per memory historically thin on live boxes; (ii) **land the identity-binding coercion** (E.3 option (a) gateway, or (b) BFF) so the store keys on the token uuid, not the body `userId` (`preference_service.go:107`). Only then wire the FE read/merge/write against `_upsert`/`_search` (`routes.go:33–34`).
+5. *(folded into step 2 — the customEditor is MVP, not a late add).*
+6. **Seed default packs** per role (`CITIZEN`, `GRO`, `PGR_ADMIN`, `SUPERADMIN`) as MDMS records, via tenant_bootstrap (memory [MCP is the bootstrap layer] — seeding owns tenant content; do NOT write ansible tasks for pack content). Decide `rolePriority` (E.2) **before** seeding so default ordering is stable. Author/test with `RBAC_TEST_*` single-role users (plan §5).
+7. **Flip the FE** from client-side `kpiQueries.js` tile selection to the `packs` endpoint. The inversion (design §5a "Today vs Moves to") lands only after steps 1–4, 6 are green so the FE never has a window with no server-side packs to read.
+
+**Migration of existing dashboards:** the current FE hardcodes tiles per role (design §5a). Step 6's seeds must reproduce *today's* per-role tile sets exactly (a faithful port, not a redesign — memory [Feliciano] "codify the proven flow, never the aspirational one"), so the step-7 flip is behaviour-preserving. Any *new* curation is a follow-up after parity is proven.
+
+---
+
+## Risks, edge cases, failure modes
+
+- **Fail-closed on no/forged roles.** If Part A is absent or the principal carries no roles, `resolveForCaller` returns an **empty pack** (E.2 step 0), never a default/admin pack. A pack endpoint that defaulted to `PGR_ADMIN`'s pack on an unauthenticated call would be a catalog-disclosure leak. Negative test (mirroring plan §5 spoof test): a forged-admin body returns an empty or citizen pack, never the admin tile set. **And `/packs` MUST NOT ship before Part A** — until A lands, the body `userInfo`/`tenantId` are trusted exactly as `_query` trusts them today (`AnalyticsService.java:30-32`).
+- **user-preferences IDOR (the load-bearing store gap).** The preference store keys on body `userId` (`preference_service.go:107`; `preference_repository.go:86–87`), not the token uuid — `test_apis.sh:226–239` proves cross-user writes are accepted. Part E's subtract-only/privacy guarantees are real only **after** the E.3 identity-binding coercion (gateway or BFF). This is called out as a blocking precondition of step 4 and as an output requirement to Part A/gateway, not buried. The same store holds consent (`USER_NOTIFICATION_PREFERENCES`), so the fix benefits more than packs.
+- **Mis-authored pack referencing an out-of-ceiling KPI → no leak.** The per-tile ceiling filter (E.2 step 4) drops it at serve via `disjoint(visibleTo,roles)`; Part D re-checks the same predicate at invocation (`40-…:142`). Two independent gates; a pack edit can never widen access. Test: author a pack listing `officer_leaderboard` (visibleTo excludes `GRO`) into the `GRO` pack → `GRO` caller's `/packs` omits it, and a direct `_query` for it returns `403 kpi_forbidden`.
+- **HRMS role pollution inflating the union.** Because every `GRO` also holds `PGR_LME` (00-requirements §7.2), the role-union pulls in `PGR_LME`'s pack tiles. This is *contained* by the ceiling filter (a tile survives only if `!disjoint(visibleTo, {GRO,PGR_LME})`, correct — the user genuinely holds both), but a pack authored for "pure GRO" is not what a polluted GRO sees. Mitigation: author/test against clean `RBAC_TEST_*` users; pollution is a provisioning bug to fix in HRMS, not in packs.
+- **Nondeterministic default order (resolved).** A multi-role user's union order is now fixed by config-driven `rolePriority` (E.2 step 2), so the served `defaultLayout` and `mergeLayouts` output are stable across sessions. The decision lands before step-6 seeds. Pass-1 flagged this as an unresolved open question; it is now a design decision, not a deferral.
+- **Stale per-user override resurrecting a withheld tile — prevented.** Overrides are filtered through the ceiling-filtered `tiles` set (E.3 step 4): preferences **subtract and rearrange, never add**. A user who lost a role and kept a stale `PGR_DASHBOARD_LAYOUT` cannot see the tile — its key isn't in `tiles`, so it's dropped. `packRoleKey`/`version` let the FE detect a role-set change and reset.
+- **Tenant isolation — owned by Part A.4, not assumed here.** Packs are MDMS records at a tenant; `mdms_search` is per-tenant. The body `tenantId` is cross-checked against the principal's allowed tenants by **Part A.4** (`10-auth-foundation.md` §A.4, `:231`) — this guard does **not** exist on `_query` today (`AnalyticsService.java:30-32` does no membership check), so Part E *depends on* A.4 landing and does not present the check as already-true. Preferences are keyed `(user_id, tenant_id, preference_code)` (`V20260205120000__…sql:20`) so a `ke.bomet` layout never bleeds into `ke.nairobi`. **Gotcha:** the unique index uses `COALESCE(tenant_id,'')` — a NULL-tenant layout collides across tenants; **always write `PGR_DASHBOARD_LAYOUT` with an explicit `tenant_id`**, never global. (Note A.4's own pass-1 caveat: its `startsWith` prefix check is un-anchored — `10-auth-foundation.md:337`; Part E inherits whatever final policy A.4 ships and does not widen it.)
+- **Jurisdiction/department isolation is NOT a pack concern — and must not become one.** Packs are role-keyed and scope-blind by design. Row isolation is Parts B/C's `attrScopes`. The risk to guard against is "optimizing" by hiding tiles whose rows are empty for a caller's jurisdiction — that would leak *which* jurisdictions have data via tile presence. Tiles are included by visibility only; emptiness is rendered, never hidden.
+- **Drift between `tiles` and `layout.grid`.** Authoring lets the two diverge. Serve-time reconciliation (E.1: `tiles` is authority, `grid` is overlay, missing grid → append) degrades gracefully to "tile shows, default-placed," never a crash. A configurator validation warning (not a hard block) on save is a nice-to-have.
+- **Cache-key correctness.** The resolved pack is cacheable, but the cache key **must include the role-set** (and tenant), exactly as the `_query` cache key includes resolved scope (00-requirements §6 "Resolved scope is part of the cache key … never serve a cached row across scope boundaries"). A pack cached under `{tenant, GRO}` must never be served to `{tenant, PGR_ADMIN}`. Short TTL because `visibleTo`/pack edits are no-deploy and should propagate quickly (MDMS edits can desync caches — memory [localization redis cache]).
+- **user-preferences-service availability.** If the preferences read fails, the FE falls back to `defaultLayout` (treat as "no overrides") — degraded but functional. A preferences outage must never blank the dashboard; the pack endpoint (the authority) is independent of preferences — and, per step 4, that service runs in a *separate* container/DB that must actually be deployed in the target env.
+
+---
+
+### Open questions for review
+
+1. **Identity-binding ownership split.** E.3 mandates coercing `preference.userId`/`criteria.userId` to the token uuid (closing the `preference_service.go:107` IDOR). Option (a) gateway-coercion is cleaner and fixes consent too, but it lives in Part A's gateway surface; option (b) BFF is self-contained to analytics but narrower. Confirm whether the Kong `/user-preference` coercion is taken on by Part A's gateway work (preferred) or Part E ships the BFF as a stopgap.
+2. **MDMS key for the pack — `role` alone, or `(module, role)`?** Using `role` as `x-unique` assumes one PGR pack per role per tenant. If packs ever span modules, the key needs `(module, role)`. Lock PGR-only scope now or future-proof the key?
+3. **`rolePriority` source.** The deterministic union ordering (E.2) needs an ordered role list. MDMS master vs `globalConfigs` ordered array vs a per-tile `order` int on the pack — pick the source before step-6 seeds. (Direction set: deterministic ordering is required; only the *source* is open.)
+4. **Should `/packs` and Part D's catalog discovery be one endpoint or two?** D's catalog returns *all* visible KPIs (the picker source); `/packs` returns the *curated default* subset + layout. They share the `disjoint` filter. Two endpoints keep responsibilities clean but double round-trips; a combined `POST /v2/analytics/dashboard/_bootstrap` is the alternative. Confirm split vs combined (and align both on POST, per Part D M1).
+5. **Layout grid opacity (leaning resolved-opaque).** E.1 treats `layout.grid` as an opaque blob the backend round-trips; the FE owns `{x,y,w,h}` meaning. Confirm the backend should not encode a grid-library coordinate system. Leaning yes (opaque).
+6. **KPI-picker def-resolution tenant.** KPI defs may resolve at the state root (like ServiceDefs — memory [PGR onboarding tenant gotchas]) while packs are authored at a city. The configurator picker must query D's catalog at the tenant where defs actually resolve, or it shows an empty KPI list. Confirm the def-resolution tenant for the picker.
+
+---
+
+## v2 revision log (pass-1 findings → resolution)
+
+- **[blocker] user-preferences-service is fully user/tenant-spoofable (IDOR), undermining E.3's "subtract-only" guarantee at the store it depends on.** Confirmed against source: `Upsert` keys on body `req.Preference.UserId` (`preference_service.go:107`), token uuid used only for audit (`preference_service.go:104,115,119`; `preference_enricher.go:74–87`); `Search` filters on body `criteria.UserId` (`preference_repository.go:86–87`); validation requires only *some* criterion (`preference_validation.go:81–86`); `test_apis.sh:226–239` shows cross-user writes accepted. **Resolved:** E.3 now carries a **blocking identity-binding precondition** — the `userId` reaching the store MUST be the token uuid via (a) Kong gateway coercion (preferred, also fixes `USER_NOTIFICATION_PREFERENCES` consent) or (b) an analytics BFF; the FE is forbidden from calling `_search`/`_upsert` with a body `userId`. Added as a step-4 prerequisite, a Risks bullet, an Outputs requirement to Part A/gateway, and Open Q1. The gateway option is **co-owned with Part A**; Part E owns the route requirement and the BFF fallback.
+- **[blocker] E.2/Risks cited a `_query` tenant-cross-check that does not exist.** Confirmed: `AnalyticsService.query()` (`AnalyticsService.java:30–32`) and `AnalyticsScope.resolve()` (`AnalyticsScope.java:31–48`) do no tenant-membership validation. **Resolved:** re-anchored throughout — the tenant cross-check is now attributed to **Part A.4** (`10-auth-foundation.md:207`), explicitly stated as *not present today*, and listed as a "Current code reality" MISSING row. Part E depends on A.4 and does not present isolation as already-true. (A.4's own un-anchored-`startsWith` caveat, `10-auth-foundation.md:337`, is noted; Part E inherits A.4's final policy, does not widen it.) **Owner for the actual check: Part A.4.**
+- **[major] `AnalyticsScope.rolesOf(ri)` does not exist; the "reuse" was overstated.** Confirmed: `AnalyticsScope` exposes only `tenantId`/`tenantStateLevel`/`citizenUuid`/`boundaryPrefix` (`AnalyticsScope.java:21–24`); roles are consumed in the private `resolve()` loop (`:38–44`) and discarded. **Resolved:** removed all `rolesOf(ri)` references. Part E now reads `{roles}` off the **Part A `Principal`** via the *same* `principalOf(...)` builder Part D uses (`40-kpi-catalog-governance.md:165,175`), off trusted post-A userInfo — never re-derived from raw `ri`. Added a MISSING row documenting the absent accessor.
+- **[major] Open Question 1 was answerable from the tree — the service is vendored, not "not in this tree."** Confirmed full Go source in-tree. **Resolved:** the design now answers it from source — routes `_upsert`/`_search` (`routes.go:33–34`), envelopes (`models.go:127–137`), idempotent upsert on `(userId,tenantId,preferenceCode)` (`preference_service.go:107`; `preference_repository.go:54–76`). The "Current code reality" table row now reads VENDORED with confirmed verbs (DIGIT `_upsert`/`_search`, not REST `PUT`); the old blocking Open Q1 is replaced by the (different) ownership-split Open Q1.
+- **[major] Separate physical database / deployment surface unaddressed.** Confirmed: own `postgres:15-alpine`, `DB_NAME=user_preferences`, own volume (`docker-compose.yml:13–17,27–36`). **Resolved:** added a "Current code reality" row and a **step-4 prerequisite** that the `digit-user-preferences-service` (distinct datastore, historically thin on live boxes) must be deployed and reachable; the availability Risks bullet now references the separate container/DB.
+- **[minor] `AdvancedPage.tsx:20` citation is the `.map`, not the data source.** Confirmed: `getGenericMdmsResources()` is at `AdvancedPage.tsx:7`, `resources.map` at `:20`. **Resolved:** all references now cite `:7` for the data source (with `:20` noted as the map), in both the table and E.4(a).
+- **[minor] Generic create form cannot author `tiles`/`layout`; step 2's "usable interim" was overstated.** Confirmed: `tiles[]` is an object-array, `WidgetKind` has `chip-array` (`string[]`) only and no object-array widget (`types.ts:11–21`), bare form skips object/array fields (`types.ts:6–7`). **Resolved:** the `dashboardPackEditor` customEditor is now **MVP, folded into step 2** (old step 5 removed); E.4(b) states the generic form authors only `role`/`title` and the editor is required for `tiles`/`layout`. Added a MISSING row.
+- **[interface] Part D coupling assumed APIs D hasn't committed to (`published(...)`, `vizSummary()`).** Confirmed D's real surface: `KpiDefinitionStore.load(tenantId, kpiId, version)` → `KpiDef{visibleTo, viz, title, params, freshness}` (`40-kpi-catalog-governance.md:114,116,118–122`), `viz` returned whole (`:186–187`), shared `disjoint(visibleTo, roles)` (`:142`). **Resolved:** E.2 now calls `catalogD.load(...)`, reads `def.visibleTo`/`def.viz`/`def.title` (no `vizSummary` projection), and uses `Collections.disjoint`; the Interfaces table reflects D's `load`/`KpiDef`/`disjoint` exactly. The picker is fed by D's POST catalog `_search` (per D's M1, `:285`).
+- **[interface] Union-then-ceiling-filter is sound, but the ordering question was real and unresolved.** Confirmed two-gate soundness vs D's per-invocation `disjoint` (`40-…:142`). **Resolved:** E.2 now fixes union order via a config-driven `rolePriority` (decided before step-6 seeds); the nondeterminism Risks bullet records it as resolved; Open Q3 narrows to only the *source* of `rolePriority`.
+- **[interface] Empty-pack fail-closed read roles off `ri`, not a `Principal`, bypassing the trust boundary.** Confirmed Part D wires roles into a `Principal` off trusted post-A userInfo (`40-kpi-catalog-governance.md:165`). **Resolved:** `resolveForCaller` now takes the Part A `Principal` and fails closed on `principal.roles` empty; the controller builds it via the shared `principalOf(...)`, not raw `ri`. Inputs table cites the A.5 `Principal` contract (`10-auth-foundation.md:225–230`).
+
+*Not fixable inside Part E (named for the owner):* the **actual** Kong-coercion implementation for the preference-route IDOR and the **tenant cross-check** are Part A / gateway deliverables (Part A.4, `10-auth-foundation.md:207`) — Part E specifies the requirement and the contract it consumes but cannot land the gateway change here; the BFF fallback (option (b)) is the only piece Part E can ship unilaterally.
+
+### v3 corrections (pass-3 codex fact-check, 2026-06-23)
+
+Two mis-citations caught by the pass-2 codex review, corrected in place (live design body only; the v2-log and codex-review blocks above are left as historical record):
+
+- **`AdvancedPage.tsx` cited without its real path.** The real file is `CCRS/configurator/src/resources/advanced/AdvancedPage.tsx` (not under `src/admin`); `getGenericMdmsResources()` is at `:7`, `resources.map` at `:20`. Corrected the full repo-relative path in the "Current code reality" table and in E.4(a). Line numbers were already right; only the path prefix was missing.
+- **Part A.4 cross-reference pointed at `10-auth-foundation.md:207`.** File 10 was revised in pass-2 and line numbers shifted: `:207` is now the controller's `UnauthenticatedException`/401 catch, while the **A.4 tenant cross-check** section heading (`### A.4 — Tenant cross-check`) is at `:231`. Re-pointed the live references (Depends-on, the `_query` MISSING row, the E.2 controller comment, and the tenant-isolation Risks bullet) to `10-auth-foundation.md` §A.4 (`:231`), preferring the section name over the brittle line number.
+
+## Codex review (pass 2 — gpt-5.5, verdict: needs-rework)
+
+> External adversarial review via `codex exec`, read-only, verifying the v2 revision log against the actual code. **Note:** codex evaluated "resolved" as "patched in code"; this is a *design* doc (no code changed yet), so most `actuallyResolved:false` items mean "design specifies it, code not yet written," not "design wrong." Read the findings for genuine design errors vs. implementation-status notes.
+
+
+**Summary:** Most v2 citations are grounded, but the user-preferences fix is only a userId precondition and leaves tenant-scoped preference access spoofable. Several claimed interfaces are still design-only and do not exist in the actual analytics package.
+
+
+### Resolution check (8/10 confirmed in code)
+
+- ❌ **[blocker] user-preferences-service is fully user/tenant-spoofable IDOR.** — UserId spoofing is correctly evidenced and called out, but the proposed binding only coerces userId. Actual code still accepts body tenantId on upsert/search, so the tenant half remains unresolved.
+- ✅ **[blocker] E.2/Risks cited a _query tenant-cross-check that does not exist.** — Actual code has no tenant membership validation: AnalyticsController reads body tenantId and AnalyticsService passes it to AnalyticsScope. v2 now treats A.4 as future/blocking, not present.
+- ✅ **[major] AnalyticsScope.rolesOf(ri) does not exist.** — Actual AnalyticsScope only exposes tenantId, tenantStateLevel, citizenUuid, boundaryPrefix, and discards roles after local inspection. v2 no longer relies on rolesOf.
+- ✅ **[major] user-preferences-service was treated as not in-tree.** — Actual Go/Gin source is in-tree, with POST /v1/_upsert and /v1/_search plus the documented request envelopes.
+- ✅ **[major] Separate physical DB/deployment surface unaddressed.** — Actual docker-compose uses a separate postgres:15-alpine service and DB_NAME=user_preferences; v2 now documents this as a deployment prerequisite.
+- ✅ **[minor] AdvancedPage.tsx:20 citation is the map, not the data source.** — Actual data source is getGenericMdmsResources at AdvancedPage.tsx:7 and resources.map at :20. v2 cites both roles correctly, though it omits the real path prefix src/resources/advanced.
+- ✅ **[minor] Generic form cannot author tiles/layout; usable interim overstated.** — Actual descriptor types only have chip-array for string arrays and MdmsResourceEdit skips unhandled object values. v2 makes dashboardPackEditor required in step 2.
+- ✅ **[interface] Part D coupling assumed uncommitted APIs published(...) and vizSummary().** — v2 now references the Part D design surface KpiDefinitionStore.load, KpiDef.visibleTo/viz/title, and disjoint. Caveat: none of these classes exist yet in actual analytics code.
+- ❌ **[interface] Union-then-ceiling-filter ordering was unresolved.** — v2 requires config-driven rolePriority but still leaves its source open. That is not an implementable interface yet and no rolePriority config/code exists.
+- ✅ **[interface] Empty-pack fail-closed read roles off ri, bypassing Principal.** — v2 changes the proposed PackService signature to accept Part A Principal and fail closed on principal.roles empty. Caveat: Principal/PackService are not present in actual code.
+
+### Findings
+
+- **[BLOCKER] Preference tenant spoofing remains unresolved** — The v2 log frames the user-preferences IDOR as user/tenant spoofing, but the proposed fix only coerces userId. Actual upsert/search still use tenantId supplied in the request body, so a caller can target another tenant's PGR_DASHBOARD_LAYOUT for the same coerced user unless the gateway/BFF also validates or overwrites tenantId.  
+  _evidence:_ `CCRS/backend/digit-user-preferences-service/internal/model/models.go:76-78 exposes body userId/tenantId; CCRS/backend/digit-user-preferences-service/internal/service/preference_service.go:107 keys upsert with req.Preference.TenantId; CCRS/backend/digit-user-preferences-service/internal/repository/preference_repository.go:89-93 filters search by body criteria.TenantId/preferenceCode.`
+- **[MAJOR] Preference search can enumerate by tenant or code without user binding** — Search validation allows any one of userId, tenantId, or preferenceCode. Combined with repository filters, a caller can search tenant-wide or preference-code-wide records unless a fronting layer injects both userId and tenant constraints. v2 forbids attacker-chosen userId but does not require rejecting userId-less searches.  
+  _evidence:_ `CCRS/backend/digit-user-preferences-service/internal/validation/preference_validation.go:81-85 accepts criteria with only tenantId or preferenceCode; CCRS/backend/digit-user-preferences-service/internal/repository/preference_repository.go:83-94 applies only the provided filters.`
+- **[MAJOR] Pack/KPI interfaces are still design-only, not actual analytics code** — The design now names Principal, PackService, KpiDefinitionStore, /packs, and catalog load/disjoint APIs, but the actual analytics package contains only AnalyticsCatalog, AnalyticsController, AnalyticsPlanner, AnalyticsScope, and AnalyticsService. Treat these as new implementation work, not verified reusable code.  
+  _evidence:_ `CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsController.java:40-58 only maps /_query and /_schema; actual file list under CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics contains no Principal, PackService, or KpiDefinitionStore.`
+- **[MAJOR] Actual analytics tenant trust gap still blocks /packs shipment** — v2 correctly reclassifies tenant cross-check as a Part A precondition, but the actual service still trusts body tenantId. Any pack endpoint implemented before A.4 would read tenant-scoped MDMS/preferences for an attacker-chosen tenant.  
+  _evidence:_ `CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsController.java:43-47 converts body RequestInfo and tenantId directly; CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java:30-32 resolves scope from that tenantId without membership validation; CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsScope.java:31-48 performs no tenant cross-check.`
+- **[MAJOR] Layer-1 grain leaks remain in actual code and packs must not mask them** — Part E is scope-blind by design, but actual row-scope code still has known gaps: daily has no citizenColumn, so citizen self-scope is skipped, and events lacks department_code. Any citizen/department-visible KPI or pack tile over those grains must be blocked by Parts C/D before E ships.  
+  _evidence:_ `CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java:246 only applies citizen scope when g.citizenColumn != null; CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsCatalog.java:98-108 defines daily citizenColumn as null; CCRS/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsCatalog.java:80-96 events grain has no department_code.`
+- **[MINOR] AdvancedPage path is mis-cited/incomplete** — The line numbers are correct after v2, but the file is not under src/admin as implied by the reviewed surface. The actual file is under src/resources/advanced.  
+  _evidence:_ `CCRS/configurator/src/resources/advanced/AdvancedPage.tsx:7 defines resourceMap from getGenericMdmsResources; CCRS/configurator/src/resources/advanced/AdvancedPage.tsx:20 maps resources.`
+
+### Mis-citations
+
+- db-inventory/rbac-deep-design/50-packs-config-ownership.md cites AdvancedPage.tsx without the real path; actual path is CCRS/configurator/src/resources/advanced/AdvancedPage.tsx.
+- db-inventory/rbac-deep-design/50-packs-config-ownership.md references Part A.4 at 10-auth-foundation.md:207, but the A.4 section starts at line 231; line 207 is the controller catch for UnauthenticatedException.
+
+### Gaps
+
+- No requirement to coerce or validate preference.tenantId/criteria.tenantId on the /user-preference route.
+- rolePriority is required for deterministic ordering, but its source/schema is still open and no implementation/config exists.
+- No actual /v2/analytics/packs endpoint, PackService, Principal, KpiDefinitionStore, dss.DashboardPack registry entry, dashboard-pack descriptor, or dashboardPackEditor exists yet.

--- a/docs/dashboard-rbac-design/60-frontend-inversion.md
+++ b/docs/dashboard-rbac-design/60-frontend-inversion.md
@@ -1,0 +1,393 @@
+# RBAC + ABAC for PGR Analytics — Part F: Frontend Inversion (FE → BE)
+
+**Status:** v2, 2026-06-23 (pass-1 findings folded) · **Part F** of the A–F series.
+**Reads (precedence):** `00-requirements.md` (the shared spec), `dashboard-query-api-design.md` §5a ("authority moves to the backend" + the Today/Moves-to table), `rbac-kpi-access-implementation-plan.md` Phases 4–6.
+**Grounding rule:** every claim about current FE behaviour is anchored to a `file:line` actually read under `CCRS/frontend/micro-ui/web/src/dashboard/`. Where a capability is *missing*, that is stated as missing with the anchor showing the gap.
+
+> **Naming note.** The requirements doc (`00-requirements.md` §8) labels its Part F "Inline-query gating (Layer 3)". This document is the *Frontend Inversion* part as scoped by the workflow brief: turning the dashboard UI from an authoritative catalog-owner into a thin renderer. The two are complementary — inline gating (Layer 3) is the *server* contract that this FE inversion *consumes* (the FE stops sending inline bodies for citizen/supervisor roles). Wherever this doc says "Layer 3 / inline gating" it refers to the contract defined in requirements §3 and the design §5; this part owns only the *frontend* side of that contract.
+
+---
+
+## Part F — Frontend Inversion (FE → BE)
+
+### Goal & responsibilities (what this part owns; what it explicitly does NOT)
+
+**The inversion in one sentence.** Today the dashboard FE *is the catalog*: it hardcodes every KPI query body, hardcodes which tiles exist and which are shown, and computes/derives values client-side. Part F strips the FE down to a **thin renderer**: it fetches the catalog (`/catalog`) and the caller's dashboard pack from the backend, POSTs `{kpiId, params}` (never an inline query body for non-analyst roles), and renders the **viz-agnostic** response (`columns` + `rows`/`values` + `series`) into table / bar / line / map — with zero embedded knowledge of what the KPI computes.
+
+**This part OWNS (frontend only):**
+
+1. **Catalog/pack consumption.** Replace the hardcoded `BATCH_QUERIES` map (`config/kpiQueries.js:47-416`) and the hardcoded tile inventory (`config/*Landscape.js`, assembled in `config/supervisorMetrics.js:52-93`) with a runtime fetch of `/catalog` (Layer-2 filtered, Part D) and `/pack` (Part E). The FE renders only the tiles the backend returns.
+2. **kpiId-by-reference invocation.** Change the request path in `services/analyticsService.js:84-89` and `hooks/useDashboardData.js:53` from "POST a dict of inline query bodies" to "POST `{kpiId, params}` per tile" (or a batch of `{kpiId, params}` references). Non-analyst surfaces send **no inline grammar** (honours the Layer-3 `inline_forbidden` contract, design §5 / requirements §3 Layer 3).
+3. **Viz-agnostic rendering.** A generic renderer keyed off the response `columns[].role` (`dimension`/`measure`/`rank`) + `viz` block (from the def, design §3 `viz`), able to draw table↔bar↔line↔map from the same `rows`+`columns` without a re-query (design §6 "pure client re-render"). The current renderer is hardwired per widget id (`components/DashboardGrid.jsx:102-131`) and must become data-driven.
+4. **Error-state & freshness surfacing.** Render per-tile error states from the batch `errors` map and `partial` flag (design §6/§11), and the `asOf`/`scope` badges from the response — never a silent zero for a failed tile (design §6, §11). The FE already plumbs `asOf` (`useDashboardData.js:20-24,69`); it must additionally honour `partial`/`errors` and render the `scope` badge.
+5. **Dead-code retirement.** Identify and delete the FE code that becomes authority-bearing-but-now-redundant (the query bodies, the per-metric format/derive logic, the hardcoded inventory). Enumerated in *Current code reality* below.
+
+**This part explicitly does NOT own:**
+
+- **Access enforcement.** The FE may *hide* tiles for UX, but that is cosmetic. `visibleTo` discovery filtering and the invocation re-check are **Part D**'s job (server-side, design §5a Layer 2). Part F consumes the already-filtered catalog; it never decides visibility. (Design §5a: "access control on the FE *is not access control*.")
+- **Row scope / attribute scope.** Injected `WHERE` is **Parts B/C** (`AnalyticsPlanner.applyScope()`). The FE never sends a scope predicate and never receives raw rows it must filter.
+- **The pack/visibility data model.** `dss.KpiDefinition` (Part D) and `dss.DashboardPack` (Part E) MDMS schemas are defined by those parts. Part F only *reads* the `/catalog` and `/pack` HTTP responses.
+- **Auth.** Trustworthy principal is **Part A**. Part F's invocation correctness *depends* on A but does not implement it. In particular the "stop sending client `userInfo`" hardening (F.1) only fails *closed* if Part A makes an absent/forged `userInfo` a `401` — see the named Part-A exit-gate in *Sequencing* step 1.
+- **Layout personalization storage.** Pack layout is a server-supplied *default* (Part E); per-user reordering stays in user-preferences-service (requirements §5) — **with the caveat (cross-cutting README finding 6) that the preferences store keys on body `Preference.UserId` and is itself spoofable; Part E must bind it to the token uuid before the FE trusts it for personalization.** Part F keeps the *interaction* code (`useDashboardLayout.js`) but re-points its **seed** from the hardcoded `DEFAULT_LAYOUT` (`constants/layoutConfig.js:72-199`) to the pack-supplied layout.
+
+---
+
+### Current code reality (file:line — what exists today vs what's missing)
+
+**1. KPI query bodies are hardcoded in the bundle — the thing that moves to MDMS.**
+`config/kpiQueries.js:47-416` defines `BATCH_QUERIES`, a static dict of **52 top-level inline query bodies** (verified count over `kpiQueries.js:47-416`; e.g. `cl_reg_daily` L48, `rs_sla_compliance_week` L185-197, the `er_*` escalation ratios L228-340). These 52 are what migrate 1:1 to `dss.KpiDefinition`. Note the *tile* count the user sees is larger because 6 landscape configs fan each card out into selectable sub-metrics (see item 7 and Open-Q 6) — do not conflate the 52 bodies with the sub-metric count. Helper builders `filedWindow`/`resolvedWindow`/`openWindow`/`officerTopCount`/`channelRatio` (L10-45) assemble grain+window+measures+filters **in the client**. This is exactly design §5a's "Today: KPI query definitions hardcoded in the FE bundle (`kpiQueries.js`)" and requirements §1.1. Every one of these is an *inline* body — which the Layer-3 gate (design §5) will reject for citizen/supervisor tokens.
+
+**2. The request actually sent today is an inline batch — incompatible with the inline gate.**
+`services/analyticsService.js:84-89` `runBatchQueries(queries)` POSTs `{ tenantId, queries }` straight to `/_query`, where `queries` *is* `BATCH_QUERIES` (passed at `hooks/useDashboardData.js:53`). So the dashboard's only call path is the **inline grammar** — the one the requirements say citizen/supervisor tokens must be denied (requirements §3 Layer 3, error `inline_forbidden`). Under the new contract a supervisor dashboard built this way would get `403` on every tile. This is the single most load-bearing reason the inversion is a *correctness* requirement, not a nicety. **Cross-cutting caveat (README finding 5):** the server-side gate this depends on has a hole today — `AnalyticsService.query()`'s batch-dict arm (`AnalyticsService.java:42-46`) calls `runOne()` directly, bypassing the inline gate + kpiId re-check; Part D must arm *both* arms. The FE flip is necessary but not sufficient; it is safe only once D closes that arm.
+
+**3. The tile inventory (what tiles exist + which a user sees) is hardcoded — moves to packs.**
+- The full universe of tiles is assembled statically: `config/supervisorMetrics.js:52-59` concatenates `LANDSCAPE_METRICS`, `EMPLOYEE_PERFORMANCE_METRICS`, … into `KPI_METRICS`. Each landscape file hardcodes its tiles, e.g. `config/complaintLandscape.js:66-226` (`LANDSCAPE_METRICS`) and the chart widgets `:230-263` (`LANDSCAPE_CHARTS`).
+- The default *shown* set is hardcoded in `constants/layoutConfig.js:72-199` (`DEFAULT_LAYOUT`).
+- The "metric inventory" picker (`components/KpiInventory.jsx:16-26`) lists `INVENTORY_SECTIONS` and offers any metric **not currently on the grid** (`:23` `.filter((m) => !visibleKpiIds.includes(m.id))`). Crucially **`visibleKpiIds` is layout-presence, not access** (`hooks/useDashboardLayout.js:400`: `layout.filter(isKpiWidget).map(i)`). So the FE today lets *any* authenticated employee add *any* tile.
+- **The FE today does NOT gate any tile by role.** (Corrected from v1's overstated "no role concept anywhere": the FE *does* read the principal's roles client-side for a cosmetic label — `components/Navbar.jsx:33` `user?.roles?.[0]?.name || user?.type` — and `user.roles` is already in `localStorage`. What is absent is any *access* use of that role: no tile, inventory entry, or query path is gated on it. The grep-confirmed `role` hits in the dir are exactly two: the ARIA `role="tooltip"` at `components/DepartmentBarChart.jsx:100` and the cosmetic navbar read at `Navbar.jsx:33`.) **Design consequence:** because `user.roles` is locally available, the inverted FE *may* use it for **UX-only** pre-hiding (e.g. not even rendering the inventory section a role will be denied) — but this is decoration over the server-filtered catalog (F.5), never a substitute for it; the catalog the server returns is the only ceiling. See risk #11.
+
+**4. Value formatting / derivation is computed client-side — partially redundant under viz-agnostic responses.**
+`config/kpiQueries.js:479-551` (`formatSubMetricValue`) re-implements percent/duration/signed formatting and *derives* metrics in the client: `dailyAvgFromWeekly` (L492-497), `hourlyAvgFromDaily` (L499-504), `openRateComplement` (L439-445/L506-508), `netBacklogDaily` (L447-454/L510-512). Several sub-metrics have `queryKey: null` and are computed purely client-side or stubbed `UNSUPPORTED_VALUE` (e.g. WoW/MoM deltas `complaintLandscape.js:39-52` → `formatPercentDelta()` returns `—` at `kpiQueries.js:435-437`). Under the new contract, **`format`/`unit` travel in `columns[]`** (design §6) and **derivations become server measures** (`compare`, `derivative:"lag"`, ratios — design §4), so most of this block is dead. The thin client keeps only generic presentational formatting driven by `columns[].format`.
+
+**5. The renderer is hardwired per widget id — must become data-driven.**
+`components/DashboardGrid.jsx:102-131` switches on literal widget ids (`"cl-chart-categories"`, `"cl-chart-wards"`, `"cl-chart-dow"`, `"cl-list-categories"`) and parses each result with a chart-specific parser (`parseBarChart`/`parseDowChart`/`parseRankedList`, `kpiQueries.js:575-601`) that hardcodes the dimension column name. The hardcoding is at two levels: `service_code`/`ward_code` are literal *call-site arguments* at `useDashboardData.js:64-65`, while `created_dow` is hardcoded one level **down inside `parseDowChart`** (`kpiQueries.js:586`), reached via `parseDowChart(results.cl_chart_dow)` at `useDashboardData.js:66`. A new KPI cannot render without an FE deploy — the inverse of design §3a's "no-deploy" promise. The viz type must instead come from the def's `viz` block and the dimension/measure from `columns[].role`.
+
+**6. `fetchSchema()` exists but is never wired — the catalog hook is missing.**
+`services/analyticsService.js:80-82` defines `fetchSchema()` (POST `/_schema`), but **no hook calls it** (grep: the only references are its definition). There is **no `/catalog` client, no `/pack` client, no `useCatalog` hook**. These are net-new. (Cross-cutting README mis-citation note for Part D: `/_schema` is unauthenticated and returns PII/officer columns past any def ceiling — so Part F must NOT repurpose `_schema` as its catalog; it must consume the new role-filtered `/catalog`, see Open-Q 2.)
+
+**7. Sub-metric switchers fan one card into N selectable measures — a cardinality the inversion must resolve.**
+A landscape "card" is not one query: `hooks/useSubMetricSelection.js:14-35` keeps a `{metricId → subMetricId}` selection (persisted to `localStorage`), and `config/kpiQueries.js:553-566` (`buildAllSubMetricValues`) emits a flat `metricId:subMetricId` value map consumed by `components/DashboardGrid.jsx:73-92` (`renderKpi`). So one tile renders a switcher over several sub-metrics, each with its own `queryKey`. Whether each sub-metric becomes its own `kpiId` or one `kpiId` carries a `params`-selectable sub-metric is **Open-Q 6**, and it decides the shape of F.3/F.4 — the sketches below are drawn for the recommended "one `kpiId` per sub-metric, grouped by a catalog `group` field" resolution and are **marked contingent** on that decision.
+
+**8. Identity passed to the backend is the spoofable body `userInfo` — Part A territory, but the FE is the sender.**
+`services/analyticsService.js:41-53` `buildRequestInfo()` reads `Employee.token` and `Employee.user-info` from `localStorage` and stuffs **both** into the request body (`authToken` L43 + `userInfo` L51). That populated `userInfo` is exactly what the Kong enrichment skips validating (requirements §1.2 / §7.1): `kong.yml:65-67` returns early when `ui["uuid"] or ui["id"] or ui["userName"]` is present. Part A fixes the trust; Part F must **stop sending a client-authored `userInfo`** (send the token only; let the gateway populate `userInfo` authoritatively) so the FE is not complicit in the spoof surface. **Fail-open caveat (README finding 2, see risk #1 below):** removing client `userInfo` forces every request through the *best-effort* enrichment HTTP call at `kong.yml:71` (`egov-user-proxy:8107/user/_details`), which on any failure **logs and `return`s leaving `userInfo` absent** (`kong.yml:75-78`). The FE flip is therefore gated on a *named Part-A precondition* (Sequencing step 1), not a generic "in lockstep with A."
+
+**Summary table — Today vs Moves-to (grounded extension of design §5a):**
+
+| Today (FE-authoritative) | file:line | Moves to (part) |
+|---|---|---|
+| `BATCH_QUERIES` inline bodies (52 entries) | `kpiQueries.js:47-416` | `dss.KpiDefinition` in MDMS, served by `/catalog` (Part D) |
+| Inline `/_query` POST is the only call path | `analyticsService.js:84-89` | `{kpiId, params}` reference call; inline gated off for non-analysts (Part F sender; Layer 3 contract design §5; both `AnalyticsService.query()` arms armed, README finding 5 / Part D) |
+| Hardcoded tile universe + sections | `supervisorMetrics.js:52-93`, `complaintLandscape.js:66-263` | `/catalog` (universe) + `dss.DashboardPack` `/pack` (per-role tiles) (Parts D/E) |
+| Default shown tiles | `layoutConfig.js:72-199` `DEFAULT_LAYOUT` | pack `layout` default (Part E) + user-preferences personalization (token-bound, Part E) |
+| "Which tiles a user can add" = layout presence, no role gate | `KpiInventory.jsx:23`, `useDashboardLayout.js:400` | server `visibleTo` discovery filter (Part D); FE hides for UX only |
+| Sub-metric switcher (one card → N measures) | `useSubMetricSelection.js:14-35`, `kpiQueries.js:553-566`, `DashboardGrid.jsx:73-92` | one `kpiId` per sub-metric + catalog `group` (recommended, Open-Q 6 / Part D) |
+| Client-side derive/format (`dailyAvgFromWeekly`, deltas, ratios) | `kpiQueries.js:435-551` | server measures (`compare`/`derivative`/`ratio`) + `columns[].format` (design §4/§6) |
+| Hardwired per-id chart parsers | `DashboardGrid.jsx:102-131`, `kpiQueries.js:575-601` (`created_dow` at `:586`) | generic renderer keyed on `columns[].role` + def `viz` block |
+| Cosmetic role label (UX only, not a gate) | `Navbar.jsx:33` | unchanged (UX); may seed UX-only pre-hiding over the server catalog |
+| Sends client-authored `userInfo` | `analyticsService.js:41-53` (token L43, userInfo L51) | token-only; gateway populates `userInfo` (Part A) — gated on the L71 enrichment exit-gate |
+
+---
+
+### Design (data model, API/control flow — concrete sketches grounded in the real modules)
+
+The FE is JS/React (esbuild micro-ui), so "data model" here is the **HTTP contracts it consumes** and the **client modules** that replace the dead config. No Java in this part.
+
+#### F.1 — New service-layer clients (`services/analyticsService.js`)
+
+Add two read clients and change the query client. The existing `postAnalytics` helper (`analyticsService.js:55-78`) is reused; only the body shape changes. (Transport verb: DIGIT convention is POST+RequestInfo even for reads — the existing `fetchSchema` uses POST at `analyticsService.js:80-82` — so `/catalog` and `/pack` are POST with the token in the RequestInfo body, *not* literal `GET`; the design §5a "GET" naming is logical, see Open-Q 1.)
+
+```js
+// services/analyticsService.js  (additions / change)
+
+// (1) Catalog — Layer-2 filtered server-side (Part D). Returns only defs whose
+//     rbac.visibleTo ∩ caller.roles ≠ ∅.  POST + RequestInfo per DIGIT convention.
+export function fetchCatalog() {
+  return postAnalytics("/catalog", { tenantId: getTenantId() });
+  // → { kpis: [ { id, version, title, description, viz, params, freshness, group? } ] }
+  //   NB: no `query` body and no `rbac` block are returned to the client — the FE
+  //   never sees the frozen SQL-shaping body nor the ceiling; both stay server-side.
+}
+
+// (2) Pack — per-role default tile bundle + default layout (Part E).
+export function fetchPack() {
+  return postAnalytics("/pack", { tenantId: getTenantId() });
+  // → { packs: [ { role, tiles: [kpiId…], layout: [...] } ] }  (server resolves caller roles → pack(s))
+}
+
+// (3) Query BY REFERENCE — replaces the inline runBatchQueries.
+//     Each batch entry is a {kpiId, params} reference, NOT an inline body.
+export function runKpiBatch(refs) {
+  // refs: { tileKey: { kpiId, kpiVersion?, params } }
+  return postAnalytics("/_query", { tenantId: getTenantId(), queries: refs });
+}
+```
+
+Also harden `buildRequestInfo()` (`analyticsService.js:41-53`): **stop forwarding a client-authored `userInfo`** (the L51 stuff-in); send `authToken` only (L43) and let the gateway (Part A) populate `userInfo`. This removes the FE from the spoof surface (requirements §7.1).
+
+```js
+function buildRequestInfo() {
+  const authToken = getEmployeeToken();
+  return { apiId: "Rainmaker", ver: ".01", ts: Date.now(),
+           action: "_search", msgId: `dashboard-${Date.now()}`,
+           ...(authToken && { authToken }) };   // ← no userInfo
+}
+```
+
+**Fail-closed contract for this flip.** Token-only is correct *only* once the gateway reliably resolves `userInfo` from the token and an unresolved token fails closed. Both depend on Part A (see Sequencing step 1); until then the flip is held behind the same feature flag as the renderer. The FE itself must additionally treat any analytics response that comes back with a `401`/`unauthenticated` as a hard error banner (not zero tiles silently), so a deployment where enrichment is down surfaces loudly rather than rendering an empty-but-green dashboard.
+
+#### F.2 — New `useCatalog` hook (catalog + pack → renderable tile descriptors)
+
+A net-new hook that fetches catalog+pack once and produces the tile list the grid and the inventory picker both read. It replaces the static imports in `KpiInventory.jsx:2` and `DashboardGrid.jsx:16-17`.
+
+```js
+// hooks/useCatalog.js  (NEW)
+export function useCatalog() {
+  const [state, setState] = useState({ loading: true, kpis: {}, pack: null, error: null });
+  useEffect(() => {
+    if (!hasAuth()) { setState({ loading:false, kpis:{}, pack:null, error: LOGIN_MESSAGE }); return; }
+    Promise.all([fetchCatalog(), fetchPack()])
+      .then(([cat, pk]) => {
+        const kpis = Object.fromEntries((cat.kpis||[]).map(k => [k.id, k]));   // visibleTo already applied server-side
+        const pack = (pk.packs||[])[0] || { tiles: Object.keys(kpis), layout: [] };
+        // a tile referenced by the pack but absent from the catalog = out-of-ceiling → drop it (never a leak)
+        const tiles = pack.tiles.filter(id => kpis[id]);
+        setState({ loading:false, kpis, pack: { ...pack, tiles }, error:null });
+      })
+      .catch(err => setState({ loading:false, kpis:{}, pack:null, error: mapError(err) }));  // fail-closed: zero tiles
+  }, []);
+  return state;
+}
+```
+
+Key property: the **catalog is the ceiling the FE knows about**. A pack tile not in the catalog is silently dropped (it would `403` at invocation anyway, design §5a "mis-authored pack → 403 on that tile, never a leak"). The FE never reconstructs a hidden KPI because it never receives its body. The error branch returns `{ kpis:{}, pack:null }` → zero tiles + banner; it must **never** fall back to the deleted local `BATCH_QUERIES`/`DEFAULT_LAYOUT` (risk #1).
+
+#### F.3 — Rewire `useDashboardData` to invoke by reference
+
+> **Contingent on Open-Q 6.** This sketch models **one `kpiId` per tile** returning one result, which is correct under the recommended "one `kpiId` per sub-metric, grouped by catalog `group`" resolution. If Part D instead keeps the in-card switcher as one `kpiId` with a `params`-selectable sub-metric, `refs` must carry the *selected* sub-metric param (from a `useSubMetricSelection`-equivalent) and the result is selected per-sub-metric in the renderer — the loop shape is the same but the param map is keyed by `{metricId, subMetricId}`. The two sketches differ only in where the sub-metric selector lives; both are buildable. Do not freeze this code until Open-Q 6 is answered by Part D.
+
+`hooks/useDashboardData.js` changes from "send `BATCH_QUERIES`" to "send `{kpiId, params}` for each tile the pack/catalog gave us". The default params come from the catalog def's `params[*].default` (design §3); the FE may override only within `params[*].allowed` (e.g. a window picker). Out-of-`allowed` → server `422 param_not_allowed`; the FE renders that tile's error state.
+
+```js
+// hooks/useDashboardData.js  (reshaped)
+const refs = Object.fromEntries(
+  pack.tiles.map(id => [id, { kpiId: id, params: defaultParams(catalog.kpis[id]) }])
+);
+const resp = await runKpiBatch(refs);          // { results: {id: <grain-tagged result>}, partial, errors }
+setResults(resp.results || {});
+setErrors(resp.errors || {});                  // ← per-tile errors, NOT silent zero (design §6/§11)
+setPartial(Boolean(resp.partial));
+setAsOf(extractAsOf(resp.results));            // existing helper L20-24 still works
+```
+
+The current `parseBarChart`/`parseDowChart`/`parseRankedList` + the hardcoded column names (`service_code`/`ward_code` at `useDashboardData.js:64-65`, `created_dow` inside `parseDowChart` at `kpiQueries.js:586`) are **deleted**; parsing moves into the generic renderer (F.4) which reads `columns[]`.
+
+#### F.4 — Generic, viz-agnostic renderer
+
+> **Contingent on Open-Q 6** in the same way as F.3 — `KpiTile` below renders one result per tile; if a `kpiId` carries a `params`-selectable sub-metric, `KpiTile` additionally renders the sub-metric switcher and re-invokes (or selects a pre-fetched series) on change. Drawn here for the one-`kpiId`-per-sub-metric resolution.
+
+A single `<KpiTile def={catalog.kpis[id]} result={results[id]} error={errors[id]} />` that:
+
+1. Reads the **viz type** from `def.viz.default` / the user's chosen `def.viz.allowed` (design §3 `viz`) — *not* from a hardcoded widget id.
+2. Reads `result.columns[]` to find the dimension(s) (`role:"dimension"`) and measure(s) (`role:"measure"`), and `result.series[]` for multi-series (design §6). No column name is hardcoded.
+3. Switches table↔bar↔line↔map as a **pure client re-render of the same `rows`+`columns`** (design §6) — no re-query. Map additionally fetches polygons from boundary-service keyed on the dimension's boundary codes (design §6 "API returns codes, never geometry"); only a *different boundary level* needs a new query.
+4. Applies presentational formatting from `columns[].format`/`unit` (design §6) via a small generic formatter (the survivor of the old `formatSubMetricValue` switch).
+5. Renders the per-tile **error state** when `error[id]` is set, and the `scope`/`asOf` badges from the result.
+
+```jsx
+function pickViz(def, override) { return override ?? def.viz?.default ?? "table"; }
+function dims(cols)    { return cols.filter(c => c.role === "dimension"); }
+function measures(cols){ return cols.filter(c => c.role === "measure"); }
+
+function KpiTile({ def, result, error, vizOverride }) {
+  if (error)  return <TileError code={error.code} message={error.message} />;   // never a silent zero
+  if (!result) return <TilePlaceholder message="Loading…" />;
+  const viz = pickViz(def, vizOverride);
+  const { columns = [], rows, value, values, series } = result;
+  switch (viz) {
+    case "scalar": return <Scalar value={value ?? Object.values(values||{})[0]} fmt={measures(columns)[0]} />;
+    case "bar":
+    case "line":
+    case "area":   return <SeriesChart rows={rows} dim={dims(columns)[0]} series={series||measures(columns)} type={viz} />;
+    case "map":    return <ChoroplethMap rows={rows} dim={dims(columns)[0]} measure={measures(columns)[0]} />;
+    case "table":
+    default:       return <DataTable columns={columns} rows={rows} />;
+  }
+}
+```
+
+This makes "add a KPI" a pure backend (`dss.KpiDefinition` + pack) operation with **zero FE deploy** — the design §3a promise, finally true end-to-end.
+
+#### F.5 — Inventory picker becomes catalog-driven (and honest about access)
+
+`KpiInventory.jsx` stops importing `INVENTORY_SECTIONS`/`KPI_METRICS` from static config and instead lists `catalog.kpis` (already `visibleTo`-filtered). The "available" set = catalog tiles not currently on the grid (the same UX as `KpiInventory.jsx:23`, but the *universe* is now the server-filtered catalog, so a user can never even see — let alone add — a tile the server would deny). Sections can come from a `def.group`/`def.section` field on the catalog entry (Part D may add it; same `group` field that resolves the sub-metric grouping in Open-Q 6) or a flat list. The locally-available `user.roles` (`Navbar.jsx:33`) may optionally drive *additional* UX-only pre-hiding, but only over the already-server-filtered catalog — it is decoration, never the ceiling (risk #11).
+
+---
+
+### Interfaces with other parts (inputs consumed, outputs produced — named contracts)
+
+**Consumes (inputs):**
+
+| From part | Contract | What the FE reads |
+|---|---|---|
+| **Part A — Trust foundation** | trustworthy principal from validated token; **absent/forged `userInfo` ⇒ `401` (coercive, fail-closed)** | The FE sends `authToken` only (no client `userInfo`); relies on A's gateway/filter to populate `RequestInfo.userInfo` authoritatively *and* to reject an unresolved token. Without A's coercion, the token-only flip fails **open** at `kong.yml:75-78` (best-effort enrichment, silent `return`). Part F's flip blocks on A's named exit-gate (Sequencing step 1). |
+| **Parts B/C — Attribute scope** | injected row `WHERE` | The FE receives **already-scoped rows** and a `scope` badge (design §6 `scope.boundaryPrefixes`) to display. It never filters rows itself and never sends a scope predicate. (Cross-cutting: README findings 1/3/4/7 — citizen daily-grain leak, department silent-drops, missing narrowing param, `tenantStateLevel` drop — are all **B/C concerns the FE correctly disclaims**; Part F renders whatever scoped rows arrive and must not compensate client-side, see risk #4.) |
+| **Part D — KPI catalog access (Layer 2)** | `/catalog` (visibleTo-filtered, role-filtered — NOT `_schema`) + invocation re-check on **both** `AnalyticsService.query()` arms (README finding 5) | The FE renders the catalog as-returned; the def's `viz`, `params`, `freshness`, `title`, `group?` drive the renderer. The FE does **not** receive each def's frozen `query` body or `rbac` ceiling. On invocation, a `kpiId` the caller can't see → `403 kpi_forbidden`, surfaced as a tile error. |
+| **Part E — Dashboard packs + layout** | `/pack` (role→tiles + default layout); **token-bound** user-preferences (README finding 6) | The pack's `tiles[]` seed the grid; the pack's `layout` seeds `useDashboardLayout` (replacing `DEFAULT_LAYOUT`). Per-user reordering persists to user-preferences-service **only after Part E binds that store to the token uuid** (it currently keys on body `Preference.UserId`, spoofable) — until then layout personalization stays in `localStorage` (Open-Q 3). |
+| **Layer-3 inline gating (design §5; requirements §3 Layer 3)** | `inline_forbidden` for non-analysts | The FE's non-analyst surfaces send **only** `{kpiId, params}` references, never inline `measures/dimensions/filters`. The analyst/admin "explore" surface (if built) is the *only* place inline grammar may be sent, and only by roles the server permits. |
+
+**Produces (outputs):**
+
+| Output | Consumed by | Contract |
+|---|---|---|
+| `{kpiId, params}` reference requests | Part D invocation path + Parts B/C planner | Each tile is a saved-KPI invocation with declared params within `allowed`. This is the request shape the whole RBAC stack is designed around (design §3 "Composition at call time"). |
+| Per-user layout deltas | user-preferences-service (Part E boundary), once token-bound | Personalization is preference state, not config; the FE writes it there (or `localStorage` interim), not to the pack MDMS master. |
+| Catalog/pack fetch volume | caching tier (design §8) | Catalog/pack are cacheable per-role; the FE fetching them once per session keeps the cost off `/_query`. |
+
+**Contract names (for cross-referencing):** `CATALOG_RESPONSE` (Part D), `PACK_RESPONSE` (Part E), `KPI_REF_REQUEST` (`{kpiId, kpiVersion?, params}`, Part F↔D), `BATCH_RESULT` (design §6 `results`/`partial`/`errors`), `SCOPE_BADGE` (design §6 `scope`).
+
+---
+
+### Sequencing & migration steps
+
+Part F sits **downstream of A and D/E** in the dependency graph (requirements §8: D→E; A blocks everything). It cannot land before A (or the dashboard breaks under the inline gate), and it cannot fetch a catalog before Part D serves one. Concretely:
+
+1. **(Blocks on A — named exit-gate.)** Land Part A so the gateway populates `userInfo` **and** an unresolved/forged token fails closed (`401`). The *specific, named precondition the FE flip blocks on* is: **"the `kong.yml:71` enrichment call (`egov-user-proxy:8107/user/_details`) is proven to populate `RequestInfo.userInfo` for a real employee token end-to-end on bomet, AND an enrichment failure / absent `userInfo` returns `401`, not unscoped"** — because today that call is best-effort and `return`s silently on failure (`kong.yml:75-78`), so dropping client `userInfo` (F.1, removing `analyticsService.js:51`) before this gate would break login *or* fail open. This is a concrete Part-A deliverable, owned by Part A; Part F asserts it as a gate, does not implement it. Ship the FE token-only change **in lockstep with that gate**, behind the feature flag, with the `401`→banner behaviour of F.1 in place.
+2. **(Blocks on D.)** Once `dss.KpiDefinition` + `/catalog` exist (Part D) **and both `AnalyticsService.query()` arms are armed (README finding 5)**, add `fetchCatalog()` and the `useCatalog` hook (F.1/F.2). **Migrate the 52 `BATCH_QUERIES` entries → MDMS defs** as the authoring step: each entry in `kpiQueries.js:47-416` becomes one `dss.KpiDefinition` (frozen `query` body + `viz` + `params` + `rbac.visibleTo`), run through the publish pipeline (design §3a). This is a config migration, not code — the bodies move verbatim, then get `visibleTo`/`viz` metadata. (Sub-metric fan-out is resolved per Open-Q 6 — likely >52 defs once each switcher sub-metric becomes its own `kpiId`.)
+3. **(Parallel-safe.)** Build the generic renderer (F.4) behind a feature flag, rendering from `columns[]`. Keep the old hardcoded path live until the renderer reaches parity, then swap `DashboardGrid.jsx:94-134`.
+4. **(Blocks on E.)** Add `fetchPack()` + re-seed `useDashboardLayout` from the pack layout (replacing `DEFAULT_LAYOUT` import, `layoutConfig.js:72-199`). Make `KpiInventory` catalog-driven (F.5). Layout personalization writes to `localStorage` until Part E binds the preferences store to the token uuid (README finding 6 / Open-Q 3).
+5. **Reshape `useDashboardData`** to invoke by reference (F.3); delete the inline `runBatchQueries` body shape.
+6. **Delete dead code** (below) once the renderer + catalog path are at parity and the feature flag is removed. Each deletion is a separate, reviewable commit so a regression can be bisected.
+
+**Dead code to retire (explicit list):**
+
+- `config/kpiQueries.js:47-416` — `BATCH_QUERIES` (52 entries) + builders `channelRatio`/`filedWindow`/`resolvedWindow`/`openWindow`/`officerTopCount` (L10-45) → MDMS defs.
+- `config/kpiQueries.js:435-551` — client-side derive/format (`formatPercentDelta`, `formatOpenRateComplement`, `formatNetBacklogDaily`, `formatSubMetricValue`, the `derived:` branches) → server measures + `columns[].format` (keep only a generic `columns[].format` formatter).
+- `config/kpiQueries.js:553-566` — `buildAllSubMetricValues` (the flat `metricId:subMetricId` value map) → per-`kpiId` results (resolution per Open-Q 6).
+- `config/kpiQueries.js:575-601` — `parseBarChart`/`parseDowChart`/`parseRankedList` (incl. the `created_dow` literal at `:586`) → generic renderer reading `columns[]`.
+- `hooks/useSubMetricSelection.js:14-35` — in-card sub-metric selection state → driven by catalog `group` + (if Open-Q 6 keeps a switcher) a `params`-selector, otherwise deleted.
+- `config/*Landscape.js` + `config/supervisorMetrics.js:52-93` — the static `*_METRICS`/`INVENTORY_SECTIONS`/`*_CHARTS` tile catalog → `/catalog` + `/pack`.
+- `constants/layoutConfig.js:72-199` — `DEFAULT_LAYOUT` → pack default layout (the WIDGETS-derivation L30-49 also re-derives from static config and must instead derive from the fetched catalog).
+- `DashboardGrid.jsx:102-131` — per-id widget switch → data-driven `KpiTile`.
+- `analyticsService.js:51` — the client-authored `userInfo` stuff-in (token-only flip, gated on Sequencing step 1).
+
+**Survives (kept, lightly re-pointed):** `useDashboardLayout.js` interaction logic (drag/resize/pack/reflow) — re-seeded from pack layout; `KpiCard`/`DepartmentBarChart`/`RankedList`/`TrendLineChart` presentation components — reused by the generic renderer; `analyticsService.js` `postAnalytics` transport (L55-78) and `authToken` read (L43); the `asOf` plumbing (`useDashboardData.js:20-24`); `Navbar.jsx:33` cosmetic role label.
+
+---
+
+### Risks, edge cases, failure modes (fail-closed, leaks, drift, isolation)
+
+1. **Token-only flip is fail-OPEN unless Part A coerces (the load-bearing dependency).** Removing client `userInfo` (F.1, `analyticsService.js:51`) forces every request through the best-effort enrichment at `kong.yml:71`; on a down/mis-wired `egov-user-proxy` that call `return`s silently leaving `userInfo` **absent** (`kong.yml:75-78`), and the early-return on a pre-populated `userInfo` (`kong.yml:65-67`) means today the dashboard works *because* the FE supplies it. So the flip is only safe behind the **named Part-A exit-gate** (Sequencing step 1): enrichment proven to populate `userInfo` for an employee token end-to-end on bomet AND absent `userInfo` → `401`. Until that gate, hold the flip behind the feature flag. FE-side mitigation: F.1 maps any `401`/`unauthenticated` response to a hard error banner, never silent zero tiles. **Owner of the fix: Part A** (Part F only asserts the gate).
+
+2. **Fail-closed on catalog/pack fetch failure.** If `/catalog` or `/pack` errors, the FE must render **empty + an error banner**, never fall back to the deleted hardcoded `BATCH_QUERIES`/`DEFAULT_LAYOUT`. A "fallback to local config" would resurrect the exact FE-authoritative leak this part removes (a stale local def could show a tile the server would now deny). The `useCatalog` error branch (F.2) returns `{ kpis:{}, pack:null }` → zero tiles, banner shown. Requirements §6 "fail-closed."
+
+3. **Pack/catalog drift = no-leak by construction.** A pack referencing an out-of-ceiling KPI is dropped client-side (F.2 `tiles.filter(id => kpis[id])`) *and* `403`s at invocation (Part D re-check, on **both** query arms per README finding 5). The FE must surface the `403` as a tile error (design §11), not hide it — hiding could mask a mis-authored pack. The security boundary is the invocation re-check; the client-side drop is UX only (design §5a).
+
+4. **The inline-grammar trap (the big one).** If any tile slips through still sending an inline body (e.g. an un-migrated `BATCH_QUERIES` entry, or an analyst-only explore widget shown to a supervisor), the server returns `403 inline_forbidden` (design §5) — *provided Part D has armed the batch-dict arm* (`AnalyticsService.java:42-46`, README finding 5; the single-arm hole would let an inline body through). **Migration step 2 must be complete** and D's both-arms fix in place — a half-migrated dashboard mixing `{kpiId}` refs and inline bodies will partially `403`. Mitigation: a build-time assertion that the FE never constructs an inline body on non-analyst surfaces; a negative test that a supervisor token POSTing the dashboard's requests gets zero `inline_forbidden`.
+
+5. **Tenant/jurisdiction/department isolation is server-side — the FE must not "help".** The FE today derives `tenantId` from `globalConfigs` (`analyticsService.js:29-35`); under the new contract the body `tenantId` is **cross-checked against the principal** server-side (design §5). The FE must not attempt to "fix up" scope client-side (e.g. filtering rows by ward) — rows arrive pre-scoped (Parts B/C). Any client-side row filtering would be a *false* sense of isolation and could leak in the inverse direction (showing a count computed over more rows than displayed). The renderer renders rows verbatim. **This is the FE's correct disclaimer of the cross-cutting B/C findings (README 1/3/4/7): the citizen daily-grain leak, department silent-drops, missing narrow param, and `tenantStateLevel` drop are all fixed in B/C, not compensated for in the renderer.**
+
+6. **PII / officer-dimension tiles.** Officer-leaderboard tiles (`ep_leaderboard_closed` `kpiQueries.js:149-157`, `officerTopCount` tiles) return `current_assignee_uuid`/`assignee_uuid` as codes; names decrypt **at the edge for bounded top-N only** (design §6 Example 5, §13). The generic renderer must treat a `pii`/uuid dimension as a code unless the response explicitly carries a decrypted label — it must **never** call a decrypt endpoint itself for arbitrary rows. A citizen-visible KPI must never carry an officer dimension (Part D publish gate §3a step 4); the FE trusts that gate and does not re-check, but also must not *render* a uuid as if it were a name. (Verified live officer-PII path: the escalation tile `er_critical_by_officer` (`kpiQueries.js:314`) is built via `officerTopCount` (`kpiQueries.js:37-45`), which projects the dimension `current_assignee_uuid` (an officer UUID). So at least one `er_*` tile **does** project an officer dimension and is delivered to the client on every dashboard load — a real Layer-2 officer-PII concern, not a non-leak. The FE inversion must route this tile through `visibleTo` / the officer-dimension approval gate exactly like the leaderboard tiles, not treat it as exempt.)
+
+7. **`asOf`/freshness honesty.** The FE already shows `asOf` (`useDashboardData.js:69`). It must show the **per-grain** `asOf` for batch results spanning grains (design §6 `asOfByGrain`) so a daily-grain tile isn't mislabelled with an hourly `asOf`. A missing `asOf` → "as of —", not a fabricated `now()`. This is a genuine net-new behaviour (the current single-`asOf` plumbing is per-batch, not per-grain), not a refactor.
+
+8. **Partial-batch silent-zero regression.** The current code throws on a non-object response (`useDashboardData.js:56-58`) but does **not** handle `partial`/`errors` — a failed sub-query today surfaces as a missing key → `UNSUPPORTED_VALUE` (`—`), indistinguishable from "no data". The new renderer must distinguish **error** (red tile, from `errors[id]`) from **empty** (no rows) from **loading** (design §11 "never rendered as empty or zero"). This is a behavioural upgrade, not just a refactor.
+
+9. **HRMS role pollution affects what packs/catalog return — but that's Parts D/E.** The FE renders whatever the (polluted-role-aware) backend returns. The risk for Part F is only that **testing** the inverted FE against a real polluted account (e.g. a GRO who also holds `PGR_LME`) shows more tiles than a clean GRO would. Test the FE against clean single-role `RBAC_TEST_*` users (requirements §7.2) so a "too many tiles" bug is attributed to the right layer.
+
+10. **Cache-key correctness is server-side, but FE param choices feed it.** Resolved scope is part of the cache key (design §8); the FE's `params` (window/timeRole/boundaryScope) also key the cache. A FE that sends inconsistent param casing/ordering could miss cache. Normalize params client-side (stable key order) before sending.
+
+11. **UX-only role pre-hiding must not become a phantom gate.** Because `user.roles` is locally available (`Navbar.jsx:33`, `localStorage`), it is tempting to pre-filter the inventory/catalog by role client-side. That is allowed *only* as decoration over the already-server-filtered catalog (F.5) — the server `/catalog` is the sole ceiling. A future contributor must never read `user.roles` and *decide* what to fetch or render as if it were authoritative; a lint/comment guard on `KpiInventory`/`useCatalog` should document that `user.roles` is cosmetic.
+
+12. **Boundary geometry fetch (map viz) is a separate trust surface.** The choropleth fetches polygons from boundary-service keyed on returned codes (design §6). Those codes are already row-scoped, so the FE can only ever request geometry for boundaries it was shown — no widening. But the FE must request geometry **only** for codes present in `rows`, never enumerate the hierarchy, to avoid revealing the existence of out-of-scope boundaries.
+
+---
+
+### Open questions for review
+
+1. **Catalog transport verb.** DIGIT convention is `POST … {RequestInfo}` even for reads (the existing `fetchSchema` uses POST, `analyticsService.js:80-82`). The design names these `GET /catalog` / `GET /pack` (design §5a). **Resolved in this revision toward POST+RequestInfo** (F.1) to keep auth uniform with the rest of the stack (Part A acts on POST bodies per `kong.yml:56-58`); confirm Part D/E publish them as POST endpoints, not literal `GET`.
+
+2. **Does the catalog response include `query` bodies?** This part assumes **no** — the FE never receives the frozen SQL-shaping body (only `viz`/`params`/`title`/`freshness`/`group?`), so it cannot reconstruct a hidden query. Confirm Part D strips `query` and `rbac` from `/catalog` output, and that `/catalog` is a **new role-filtered endpoint, not `_schema`** (which README flags as unauthenticated + PII-leaking). If the body *is* returned (e.g. for an analyst editor), it must be gated to analyst/admin roles only.
+
+3. **Pack layout vs user-preferences split — gated on the store's identity binding.** Requirements §5 puts personalization in user-preferences-service, but README finding 6 shows that store keys on body `Preference.UserId` (spoofable). So personalization can be delegated there **only after Part E binds it to the token uuid**. Interim: the pack layout is the *seed* and `localStorage` (current behaviour, `useDashboardLayout.js:299-301`) the override — acceptable for v1; the tenant-scoped key already exists (`dashboardConfig.js:46-48`). Confirm Part E's binding timeline so the FE knows when to switch the personalization sink.
+
+4. **Analyst "explore" surface.** Is there a planned analyst/admin ad-hoc surface that *does* send inline grammar (the only Layer-3-permitted path)? If yes, it is a separate component with its own role gate; if no, the inline `/_query` body shape can be deleted from the FE entirely. This affects whether `runKpiBatch` is the *only* query client.
+
+5. **Migration parity check.** Should we add an automated parity test that, for each migrated `dss.KpiDefinition`, the `{kpiId, defaultParams}` invocation returns the same value the old `BATCH_QUERIES` entry did (against a fixed dataset on ovh-cloud-dev)? This would catch a body-translation error during the 52-body migration (more once sub-metrics fan out) before the hardcoded path is deleted.
+
+6. **Tile→KPI cardinality (gates F.3/F.4 shape).** Today some tiles are *sub-metric switchers* (one card, N selectable sub-metrics each with its own `queryKey`, e.g. channel-mix `complaintLandscape.js:88-127`; selection state in `useSubMetricSelection.js:14-35`, value map in `kpiQueries.js:553-566`, render in `DashboardGrid.jsx:73-92`). Does each sub-metric become its own `kpiId`, or does one `kpiId` carry a `params`-selectable sub-metric? The former is simpler and maps cleanly to `{kpiId, params}` (and is what F.3/F.4 are drawn for); the latter preserves the in-card switcher UX. **Recommend: one `kpiId` per sub-metric, with the card grouping driven by a catalog `group` field** — but this is **Part D's def-shape decision** and the F.3/F.4 sketches are explicitly marked contingent on it. Owner of the resolution: Part D.
+
+## v2 revision log (pass-1 findings → resolution)
+
+- **nit→minor — "no role concept anywhere" is false (`Navbar.jsx:33`).** v1 claimed (via "confirmed by grep") that the only `role` hit was the ARIA `role="tooltip"`. **Resolved:** *Current code reality* item 3 is rewritten to state the FE does NOT *gate* any tile by role, while acknowledging it reads `user?.roles?.[0]?.name` cosmetically at `components/Navbar.jsx:33` (verified — grep returns exactly two hits: `DepartmentBarChart.jsx:100` ARIA + `Navbar.jsx:33`). Added design consequence (UX-only pre-hiding) and new risk #11 guarding against `user.roles` becoming a phantom gate; summary table now carries the `Navbar.jsx:33` row.
+
+- **nit — "~70 inline query bodies" overcounts.** **Resolved (count further corrected in v3, see below):** corrected to **52 top-level entries** throughout (item 1, summary table, dead-code list, Sequencing step 2, Open-Q 5), verified by counting `BATCH_QUERIES` keys over `config/kpiQueries.js:47-416` (= 52). Added explicit note that the larger *tile* count comes from sub-metric fan-out, not from the body count.
+
+- **nit — `created_dow` not hardcoded at `useDashboardData.js:64-67`.** **Resolved:** item 5 and F.3 now state precisely that `service_code`/`ward_code` are literal call-site args at `useDashboardData.js:64-65`, while `created_dow` is hardcoded one level down inside `parseDowChart` at `config/kpiQueries.js:586` (reached via `:66`). Dead-code list and summary table updated with the corrected anchor.
+
+- **major (fail-open risk) — token-only flip depends on the unproven Kong L71 enrichment.** **Resolved within this part as a named gate (fix owned by Part A).** Item 8, the Part-A interface row, Sequencing step 1, F.1's "Fail-closed contract", and new risk #1 now make the precondition concrete: "the `kong.yml:71` enrichment (`egov-user-proxy:8107/user/_details`) is proven to populate `userInfo` for an employee token end-to-end on bomet AND an absent/forged `userInfo` returns `401`" — anchored to the best-effort silent-return at `kong.yml:75-78` and the early-return at `kong.yml:65-67` (both verified verbatim). The flip is held behind the feature flag until that gate; F.1 maps `401`→hard banner so a down enrichment surfaces loudly. Not fixable inside Part F (gateway coercion is Part A's deliverable); Part F asserts it as a blocking gate.
+
+- **minor (internal tension) — F.3/F.4 presuppose unresolved Open-Q 6 (sub-metric cardinality).** **Resolved:** added *Current code reality* item 7 grounding the switcher (`hooks/useSubMetricSelection.js:14-35`, `config/kpiQueries.js:553-566`, `components/DashboardGrid.jsx:73-92`, all verified); F.3 and F.4 now carry explicit **"Contingent on Open-Q 6"** banners describing both the one-`kpiId`-per-sub-metric (drawn) and one-`kpiId`-with-params resolutions; Open-Q 6 expanded with the grounding anchors and reassigned to **Part D** as the def-shape owner; summary table + dead-code list gained the sub-metric rows.
+
+- **nit (confirming a non-leak) — events-grain tiles are not an FE leak.** **Partially superseded in v3 (see below): the escalation-tile non-leak claim was FALSE.** Risk #6 and the Parts B/C interface row record that the events-grain `department_code` gap and the uuid PII dims are B/C/D concerns Part F correctly disclaims. The original claim that current `er_*` tiles project no officer dims is **incorrect** — `er_critical_by_officer` (`kpiQueries.js:314`) projects `current_assignee_uuid` via `officerTopCount` (`kpiQueries.js:37-45`), so there *is* a live FE officer-PII path that must go through `visibleTo` / the officer-dimension gate. Folded the cross-cutting README findings 1/3/4/7 into risk #5 as the FE's explicit disclaimer.
+
+- **interface check — batch-arm bypass (README finding 5).** **Folded in as a dependency Part F asserts (fix owned by Part D).** Item 2, the Part-D interface row, risks #3/#4, and Sequencing step 2 now state that the FE inversion is safe only once **both** `AnalyticsService.query()` arms (`AnalyticsService.java:42-46`) are armed for the inline gate + kpiId re-check. Not fixable in Part F.
+
+- **interface check — user-preferences spoofability (README finding 6).** **Folded in as a gating caveat (fix owned by Part E).** The "does NOT own" personalization bullet, the Part-E interface row, Sequencing step 4, and Open-Q 3 now state personalization may be delegated to user-preferences-service **only after Part E binds it to the token uuid**; until then layout personalization stays in `localStorage`. Not fixable in Part F.
+
+- **interface check — `_schema` is unauthenticated/PII-leaking (README D mis-citation).** **Resolved:** item 6, Open-Q 2, and the Part-D interface row now explicitly require `/catalog` to be a **new role-filtered endpoint, NOT a repurpose of `_schema`**.
+
+- **Open-Q 1 (transport verb) resolved toward POST+RequestInfo** in this revision (F.1 + Open-Q 1 note), keeping auth uniform per `kong.yml:56-58`; left open only as "confirm Part D/E publish as POST."
+
+All five severity-tagged findings (1 major, 2 minor, plus the two nit mis-citations and the confirming nit) plus the four cross-cutting interface findings touching Part F are addressed: the three in-part rigor/tension defects (Navbar, count, dow-anchor, Open-Q-6 tension) are fixed directly; the four cross-part risks (Kong fail-open, batch-arm bypass, prefs spoofability, `_schema` PII) are folded in as named gates with the owning part identified.
+
+### v3 corrections (pass-3 codex fact-check, 2026-06-23)
+
+External codex fact-check caught two genuine factual errors in the v2 log, both verified against code and corrected throughout:
+
+- **`BATCH_QUERIES` count was wrong (48 → 52).** A brace-depth-aware count of top-level keys in `BATCH_QUERIES` returns **52**, not 48 (`kpiQueries.js:47` opens the object; keys run `cl_reg_daily` at `:48` through `ce_tfr_median` at `:411`, closing at `:416`). Corrected in item 1, the summary table, the dead-code list, Sequencing step 2, the parity-check Open-Q, and the v2 log entry.
+- **The escalation "non-leak" claim was false.** The v2 log claimed current `er_*` tiles project no officer dimensions. In fact `er_critical_by_officer` (`kpiQueries.js:314`) is built via `officerTopCount` (`kpiQueries.js:37-45`), which projects the dimension `current_assignee_uuid` (an officer UUID) and is delivered to the client on every dashboard load (`useDashboardData.js:53` posts all `BATCH_QUERIES`). This is a **real Layer-2 officer-PII path**, not a non-leak: the FE inversion must route this tile through `visibleTo` / the officer-dimension approval gate. Corrected in risk #6 and the v2 log entry.
+
+## Codex review (pass 2 — gpt-5.5, verdict: needs-rework)
+
+> External adversarial review via `codex exec`, read-only, verifying the v2 revision log against the actual code. **Note:** codex evaluated "resolved" as "patched in code"; this is a *design* doc (no code changed yet), so most `actuallyResolved:false` items mean "design specifies it, code not yet written," not "design wrong." Read the findings for genuine design errors vs. implementation-status notes.
+
+
+**Summary:** Several v2 log items are accurately grounded, but the count fix is wrong, the claimed escalation non-leak is false, and the actual backend still has the auth, inline-batch, schema, and scope fail-open holes the design depends on other parts to fix.
+
+
+### Resolution check (4/10 confirmed in code)
+
+- ✅ **"no role concept anywhere" is false because Navbar reads roles.** — Corrected: dashboard role hits are cosmetic Navbar role read and ARIA tooltip; no tile/query access gate uses roles.
+- ❌ **"~70 inline query bodies" overcounts.** — The revised 48 count is still wrong. Actual top-level BATCH_QUERIES keys over kpiQueries.js:47-416 are 52.
+- ✅ **created_dow anchor was wrong.** — Corrected: useDashboardData.js:64-65 passes service_code/ward_code; parseDowChart hardcodes created_dow at kpiQueries.js:583-588.
+- ❌ **Token-only flip depends on unproven Kong enrichment and can fail open.** — Design now names the Part-A gate, but actual code still sends client userInfo and Kong still returns early/silently; code hole remains.
+- ✅ **F.3/F.4 presuppose unresolved sub-metric cardinality.** — Design now marks F.3/F.4 contingent and grounds current switcher code at useSubMetricSelection.js:14-35 and DashboardGrid.jsx:73-92.
+- ❌ **Events-grain tiles are not an FE leak / current er_* tiles project no officer dims.** — False against code: er_critical_by_officer uses officerTopCount, which projects current_assignee_uuid.
+- ❌ **Batch-arm bypass needs to be folded in.** — Design mentions it, but actual AnalyticsService batch arm still sends each query directly to runOne with no inline gate or kpiId re-check.
+- ✅ **User-preferences spoofability needs a Part-E caveat.** — Consistent with current FE: layout persistence remains localStorage only at useDashboardLayout.js:299-300 pending Part E.
+- ❌ **_schema is unauthenticated/PII-leaking and must not be catalog.** — Design warns about this, but actual backend still exposes unauthenticated _schema and no /catalog endpoint exists.
+- ❌ **Open-Q 1 transport verb resolved toward POST+RequestInfo.** — POST convention is consistent with Kong, but actual analytics package only maps /_query and /_schema; no /catalog or /pack implementation exists.
+
+### Findings
+
+- **[BLOCKER] Identity spoofing remains fully exploitable in actual code** — Part F now treats this as a gate, but the actual path is still fail-open: the FE sends localStorage userInfo, Kong skips enrichment/validation when userInfo is present, the controller converts body RequestInfo directly, and scope trusts type/roles from that body.  
+  _evidence:_ `analyticsService.js:41-52 reads Employee.user-info and includes userInfo; kong.yml:65-67 returns early for populated userInfo; AnalyticsController.java:43-47 passes body RequestInfo to service; AnalyticsScope.java:34-44 derives citizen/employee posture from that userInfo.`
+- **[MAJOR] Revised 48-query count is wrong; actual BATCH_QUERIES has 52 entries** — The v2 log claims 48 top-level inline bodies, but counting the top-level keys inside BATCH_QUERIES gives 52. Migration sizing and parity-test claims based on 48 are undercounted.  
+  _evidence:_ `CCRS/frontend/micro-ui/web/src/dashboard/config/kpiQueries.js:47 opens BATCH_QUERIES; top-level keys run from cl_reg_daily at :48 through ce_tfr_median at :411-414, closing at :416. A top-level key scan over :48-416 returns 52.`
+- **[MAJOR] Claimed escalation non-leak is false: an er_* tile returns officer UUIDs** — The revision log says current er_* tiles project no officer dims. In fact er_critical_by_officer is wired to a helper that dimensions by current_assignee_uuid, and useDashboardData sends the full batch for every dashboard load. Even if the card displays only total, the UUID-bearing rows are delivered to the client.  
+  _evidence:_ `kpiQueries.js:37-42 defines officerTopCount with dimensions ["current_assignee_uuid"]; kpiQueries.js:314 defines er_critical_by_officer with that helper; escalationsRiskLandscape.js:168-175 exposes that queryKey as an escalation submetric; useDashboardData.js:53 posts all BATCH_QUERIES.`
+- **[MAJOR] No kpiId, inline_forbidden, catalog, or pack API exists in the analytics package** — The proposed Part-F interfaces depend on Part D/E code that is absent. Current /_query accepts inline single or batch grammar only, and there are no symbols for KpiDefinition, DashboardPack, kpiId, inline_forbidden, kpi_forbidden, /catalog, or /pack in the relevant backend/frontend paths.  
+  _evidence:_ `AnalyticsController.java:40-59 maps only POST /_query and /_schema; AnalyticsService.java:38-51 handles only body.queries inline dict or body.query inline node; rg for KpiDefinition|DashboardPack|/catalog|/pack|kpiId|inline_forbidden|kpi_forbidden finds no implementation in the analytics package/dashboard except local variable names.`
+- **[MAJOR] Batch-arm bypass is still real and returns errors inline, not an errors map** — The design's BATCH_RESULT contract expects errors[id], but current code catches per-query exceptions and stores error objects inside results[name]. Existing FE then treats missing rows as unsupported values, so partial failures can remain silent per tile.  
+  _evidence:_ `AnalyticsService.java:38-49 iterates body.queries and on catch does results.put(name, err(ex)) plus partial=true; err shape is {error,message} at :118-123. useDashboardData.js:62-68 parses chart/results without errors map; kpiQueries.js:516-517 returns UNSUPPORTED_VALUE when rows are absent.`
+- **[MAJOR] _schema remains unauthenticated and exposes PII-adjacent columns** — The design correctly says not to reuse _schema as catalog, but actual code still serves it without RequestInfo and includes UUID/account dimensions and distinctable columns. This is an existing discovery leak until Part D replaces or gates it.  
+  _evidence:_ `AnalyticsController.java:57-59 returns service.schema() with no RequestInfo/auth; AnalyticsService.java:71-92 returns dimensions/filterable/measurable/distinctable; AnalyticsCatalog.java:58-77 exposes current_assignee_uuid/account_id on facts and :84-95 exposes assignee_uuid/actor_uuid/account_id on events.`
+- **[MAJOR] Row scope is fail-open for missing principals, jurisdiction, and daily citizen scope** — Requirements demand fail-closed, but current scope defaults to tenant-only when userInfo is absent, never resolves boundaryPrefix for employees, and skips citizen self-scope on grains without a citizenColumn. This can leak jurisdiction or daily-grain data if the frontend flip lands before B/C.  
+  _evidence:_ `AnalyticsScope.java:34-47 leaves citizenUuid null for absent/non-citizen userInfo and always returns boundaryPrefix null; AnalyticsPlanner.java:246 only applies citizen scope when g.citizenColumn != null; AnalyticsCatalog.java:99-108 defines daily with citizenColumn null.`
+- **[MINOR] Current asOf plumbing does not match the backend batch response** — The design says asOf is already plumbed, but current backend puts asOf at the top level of the batch response while the FE extracts asOf from individual result entries after replacing response with response.results. Navbar therefore gets null for normal batch responses.  
+  _evidence:_ `AnalyticsService.java:34-49 sets out.asOf then out.results; useDashboardData.js:53-54 assigns results=response.results; extractAsOf scans result entries at useDashboardData.js:20-24 and setAsOf(extractAsOf(results)) at :69.`
+
+### Mis-citations
+
+- v2 log: "BATCH_QUERIES ... (= 48)" is false; actual top-level count over CCRS/frontend/micro-ui/web/src/dashboard/config/kpiQueries.js:47-416 is 52.
+- v2 log/risk #6: "current er_* tiles project no officer dims" is false; er_critical_by_officer projects current_assignee_uuid via kpiQueries.js:37-42 and :314.
+- Current code reality item 4 says WoW/MoM deltas in complaintLandscape.js:39-52; those lines define shared COUNT_WINDOWS, not only deltas. The delta-specific null queryKey is applied through countSubMetrics at complaintLandscape.js:55-62.
+- The design's "already plumbs asOf" citation is line-accurate but behaviorally misleading with the actual backend response shape: AnalyticsService.java:35 top-level asOf is discarded by useDashboardData.js:54 before extractAsOf.
+
+### Gaps
+
+- No implemented /catalog or /pack endpoint in the analytics package; Part F cannot be integrated until Part D/E add them.
+- No implemented saved-KPI invocation shape; current /_query values are inline query bodies, not {kpiId, params}.
+- No frontend useCatalog hook, catalog-driven inventory, generic columns[].role renderer, per-tile errors map, or scope badge path exists yet.
+- No code-level feature flag is shown for the token-only flip; landing analyticsService.js:51 removal before Part A would break or fail open.
+- No automated parity/count check exists for migrating BATCH_QUERIES, which matters because the revised design already undercounted the bodies.

--- a/docs/dashboard-rbac-design/65-fe-config-inventory.md
+++ b/docs/dashboard-rbac-design/65-fe-config-inventory.md
@@ -1,0 +1,156 @@
+# FE → BE Dashboard Config Extraction Inventory (Part 65)
+
+**Status:** v1, 2026-06-25. The concrete extraction that feeds **Part D** (`dss.KpiDefinition`) and **Part F** (frontend inversion). Answers: *"pull all the data about dashboards, default KPIs, queries, and visualization models from the FE to the BE."*
+**Reads:** the live FE config at `CCRS/frontend/micro-ui/web/src/dashboard/` (read directly, file:line below); `40-kpi-catalog-governance.md` (Part D target schema), `50-packs-config-ownership.md` (Part E packs/layout), `60-frontend-inversion.md` (Part F renderer).
+**Scope:** PGR only.
+
+> This is an **inventory + target-mapping**, not new design. It enumerates exactly what is hardcoded in the FE today, classifies each artifact, maps it to its BE home, and flags the migration decisions (unimplemented placeholders, client-derived metrics, officer-PII, formatting). It is the worklist for generating the actual MDMS seed records.
+
+---
+
+## 0. The FE config surface (what physically exists today)
+
+All under `src/dashboard/`:
+
+| File | Role today | Becomes |
+|---|---|---|
+| `config/kpiQueries.js` | `BATCH_QUERIES` = **52 named query bodies** in the analytics DSL + builders + client formatters/parsers | `dss.KpiDefinition.query` (×52) |
+| `config/complaintLandscape.js` + 5 sibling `*Landscape.js` | per-section **metric cards** (title, accent, sub-metrics → `{format, measureKey, queryKey, derived}`) + **charts** | `dss.KpiDefinition.viz` + params; section grouping → catalog |
+| `config/supervisorMetrics.js` | aggregates the 6 landscapes into `KPI_METRICS`, `CHART_WIDGETS`, `INVENTORY_SECTIONS` | the served **catalog** (Part D `/catalog`) |
+| `constants/layoutConfig.js` | `DEFAULT_LAYOUT` (grid), `WIDGETS`, sizing | `dss.DashboardPack.layout` + `tiles` (Part E) |
+| `config/dashboardConfig.js` | branding + `localStorage` layout key | branding stays `globalConfigs`; layout key → user-preferences |
+| `hooks/useDashboardData.js`, `services/analyticsService.js` | batch-POST `BATCH_QUERIES`, render | thin renderer invoking by `kpiId` (Part F) |
+
+**Three logical layers to extract:** (1) **queries** → defs; (2) **visualization models** (format + chart type + sub-metric selectors) → def viz; (3) **composition** (sections + default grid) → packs. They are tangled in the FE; the BE separates them (query-shape vs viz-config vs pack — Part D §0.6).
+
+---
+
+## 1. Layer 1 — the 52 KPI queries → `dss.KpiDefinition.query`
+
+`BATCH_QUERIES` (`kpiQueries.js:47–416`). The analytics DSL is already exactly the `/v2/analytics/_query` body, so **each entry transplants verbatim** into a def's `query` field. Grouped by section prefix:
+
+| Prefix | Section | # queries | Grain(s) | Notable |
+|---|---|---|---|---|
+| `cl_` | Complaint landscape | 19 | facts | channel ratios, `service_code`/`ward_code`/`created_dow` dimensioned charts |
+| `ep_` | Employee performance | 7 | facts | **officer-PII** (4 project `current_assignee_uuid`) |
+| `rs_` | Resolution & SLA | 7 | facts | ratios, percentile TTR |
+| `er_` | Escalations & risk | 11 | facts **+ events** | events grain for escalation source (auto/manual) |
+| `ce_` | Citizen experience | 8 | facts | CSAT avg, `count_distinct account_id` |
+
+**DSL vocabulary used** (the catalog the BE must accept): `grain ∈ {facts, events}`; `window {name ∈ last_1d/last_7d/last_30d/wtd/mtd, timeRole ∈ filed_at/resolved_at/event_at}`; `measures[{agg ∈ count|ratio|avg|percentile|count_distinct, column, p, filter}]`; `dimensions`; `filters`; `sort`; `limit`. Every one of these must be a recognized catalog token server-side (Part D / `AnalyticsCatalog`).
+
+**Officer-PII defs (route through the eligibility ceiling — design §12):** `ep_open_by_officer`, `ep_closed_by_officer`, `ep_leaderboard_closed`, `er_critical_by_officer` — all via `officerTopCount` projecting `current_assignee_uuid` (`kpiQueries.js:37–45`). These are **never** `PUBLIC`-eligible and must carry `rbac.visibleTo` excluding public + a PII flag (Part D §D.5 publish-time check).
+
+---
+
+## 2. Layer 2 — visualization models → `dss.KpiDefinition.viz`
+
+Each landscape "metric" is a **card with selectable sub-metrics**; each sub-metric binds a query to a **format**. Shape (from `complaintLandscape.js:66–263`):
+
+```jsonc
+{ id:"cl-metric-channel-mix", metric:"Channel mix", accent:"slate", defaultSubMetricId:"online",
+  subMetrics:[ { id:"online", label:"% via online portal",
+                 outputFormat:"...", format:"percentInteger", measureKey:"pct",
+                 queryKey:"cl_channel_online" }, ... ] }
+```
+
+What moves where:
+
+| FE field | Meaning | BE home |
+|---|---|---|
+| `metric`, `label` | English titles | **localization keys** on `KpiDefinition.title` (resolved at edge, like Part D/E titles) — not raw strings |
+| `accent` | card color | `viz` (presentation) |
+| `format` / `outputFormat` | how to render the scalar (integer, percentInteger, percentOneDecimal, decimalOne, hoursDays, hoursDecimal, ordinal, signedInteger, …) | `viz.format` — **the BE-served catalog tells the FE how to render**; FE keeps the *renderer*, BE owns the *spec* |
+| `measureKey` | which column of the result row to show (`total`/`pct`/`avg_ms`/…) | `viz.valueKey` |
+| `defaultSubMetricId`, `subMetrics[]` | the in-card selector | `viz.variants[]` (one def with selectable params, or N defs) — **decision below** |
+| chart `type` (`bar-chart`, `ranked-list`) | viz kind | `viz.chart` |
+
+**Chart widgets** (`LANDSCAPE_CHARTS`, `complaintLandscape.js:230–263`): `bar-chart` / `ranked-list`, each with a `queryKey`. These are dimensioned KPIs whose viz is a chart not a scalar → `viz.chart ∈ {bar, rankedList, line, map}` (Part F.4 viz-agnostic set).
+
+**The render *engine* (code) stays FE; the viz *spec* (declarative config) comes from the BE.** `formatSubMetricValue` (`kpiQueries.js:479–551`) and the chart parsers `parseBarChart`/`parseDowChart`/`parseRankedList` (`:575–601`) are interpreters — pure functions from `(spec, data) → pixels`. They stay. What moves is the *spec they interpret*: `format`, `chart`, `valueKey`, `accent`, `variants`, `compose` are all declarative config that must be served in the catalog response. The FE has zero embedded knowledge of which format a given KPI uses — it reads that from the def's `viz` object. The full `viz` schema is specified in **Part 66** (`66-viz-schema-api-contract.md`). The rendering code lives in the FE; the rendering instructions live in the BE.
+
+---
+
+## 3. Layer 3 — composition → `dss.DashboardPack`
+
+- **Sections** (`supervisorMetrics.js` `INVENTORY_SECTIONS`): 6 groups (complaint-landscape, employee-performance, resolution-sla, escalations-risk, citizen-experience, comparative-reporting) each listing `metricIds`. → the **catalog grouping** the picker shows; and the seed for per-role pack `tiles`.
+- **Default grid** (`layoutConfig.js` `DEFAULT_LAYOUT`, `:` block): a concrete 12-col react-grid-layout — 6 complaint KPIs on row 0 + 4 charts below. → `dss.DashboardPack.layout.grid` (opaque blob, Part E.1) for the **default/supervisor** role. **Only one default grid exists today** (complaint-landscape); the other 5 sections are inventory-only (added via the `KpiInventory` picker). Per-role packs (citizen/supervisor/admin/public) are **net-new authoring** — there's no FE precedent to extract, only this one default.
+- **Layout persistence:** `getLayoutStorageKey()` = `localStorage["<tenant>-supervisor-dashboard-layout-v13"]` (`dashboardConfig.js`). → migrates to user-preferences `PGR_DASHBOARD_LAYOUT` (Part E.3), with the identity-binding fix.
+- **Branding:** `dashboardConfig.js` already reads `globalConfigs` (`DASHBOARD_BRAND_PRIMARY/DARK/SLATE`, `DASHBOARD_STATE_LABEL`, `DASHBOARD_SYSTEM_TITLE`). **Already externalized — leave as globalConfigs**, do not move to MDMS.
+
+---
+
+## 4. Migration decisions / gaps (the part that isn't mechanical)
+
+### 4a. Unimplemented placeholders (`queryKey: null`) — decide: implement or drop
+A large share of declared sub-metrics have **no query** — they are spec'd cards with `queryKey: null`, rendering `—`. Found across every landscape:
+- **WoW/MoM deltas** (`format: percentDelta` / `percentPointDelta`) — `cl` count cards' `wow`/`mom`, `rs` `wow_delta`/`median_delta`, `cl-metric-inflow-rate.wow_avg`, `ep` `rank_sla`. `formatPercentDelta()` literally returns `—` (`kpiQueries.js:435–437`). **No period-comparison support exists** in the DSL.
+- **Map / hot-ward** (`cl-metric-hot-ward`, all 3 sub-metrics `na`/`multiplier`/`text`, no query) — needs the `map` viz + a spike computation.
+- **By-category breakdowns** (`rs-metric-resolution-by-category`, `rs` `by_category`, `breach` `by_category`/`trend_7d`) — dimensioned queries not yet written.
+- **Pending-ack / approaching-SLA early-warning** (`ep-metric-pending-ack` all null; `er-metric-approaching-sla` `breach_4h`/`breach_24h` null) — need new measures.
+- **`net_14d`** (`rs-metric-inflow-outflow`) — null.
+
+**Decision required:** for each null placeholder, either (a) author a real `dss.KpiDefinition` (preferred where the DSL already supports it — most by-category and the early-warning counts are expressible), or (b) drop it from the catalog. **Do not migrate `queryKey:null` tiles as-is** — a BE catalog of defs that return nothing is worse than the FE placeholder. This is the single biggest scoping item in the pull.
+
+### 4b. Client-derived metrics — declarative `compose` rule in the def, evaluated in the FE engine
+Four sub-metrics have **no query of their own**; they are computed from *other* query results (`formatSubMetricValue` `derived` branch):
+- `dailyAvgFromWeekly` (cl inflow) = `cl_reg_weekly / daysElapsedThisWeek()`
+- `hourlyAvgFromDaily` (cl inflow) = `cl_reg_daily / hoursElapsedToday()`
+- `openRateComplement` (rs) = `100 − rs_closure_rate`
+- `netBacklogDaily` (rs) = `rs_inflow_daily − rs_outflow_daily`
+
+Under the strict migration direction (§0/Part 66): the **derivation rule is declarative knowledge** and belongs in the served `viz.compose` directive, not embedded in the FE. The FE engine *evaluates* the rule but does not *know* it a priori. Concretely:
+
+```jsonc
+// in the def for "Daily average complaints (this week)"
+"viz": { "kind":"scalar", "format":"integer", "compose": {
+  "type": "dailyAvgFromWeekly",
+  "sourceKpiIds": ["cl_reg_weekly"],
+  "elapsedFromAsOf": true   // FE divides by elapsed-days using the asOf the server stamps on cl_reg_weekly
+} }
+```
+
+The FE engine has a small `compose` dispatcher keyed on `type` (4 entries); it evaluates the rule using already-scoped data + the server-supplied `asOf`. **The clock is not client-authoritative**: the elapsed-time divisor is derived from `asOf` (server-stamped), never from `Date.now()`. This removes the last piece of domain knowledge embedded in the FE — the FE knows *how to divide*; the BE tells it *what to divide and by what*. Migration: each derived sub-metric becomes a `dss.KpiDefinition` with `query:null` + `viz.compose` populated; its data dependencies are fetched by `kpiId` first, then the compose rule is evaluated client-side. See Part 66 for the full `viz.compose` schema.
+
+### 4c. Localization
+All `metric`/`label`/`outputFormat` strings are English literals. They must become **localization codes** (resolved at the edge like `KpiDefinition.title`), not shipped as raw text in MDMS — otherwise the multilingual tenants (Maputo PT, Nairobi SW/EN) get English dashboards. Add to the localization seed alongside the def migration.
+
+### 4d. Officer-PII ceiling
+The 4 `officerTopCount` defs (§1) and any leaderboard tile must carry `rbac.visibleTo` excluding `PUBLIC` + the PII flag, gated by Part D's publish-time consistency check. Do not migrate them as ungated/public tiles.
+
+### 4e. The DSL token whitelist must exist server-side first
+Every `filter` key the FE uses (`is_open`, `is_resolved`, `sla_breached`, `sla_status_bucket`, `aging_bucket`, `is_escalation`, `escalation_source`, `is_first_time_complainant`, `is_reopened`, `has_rating`, `is_negative_rating`, …) and every `column`/`dimension` (`resolution_ms`, `time_to_assign_ms`, `rating`, `account_id`, `current_assignee_uuid`, `service_code`, `ward_code`, `created_dow`) must be a **catalog-recognized token** on the right grain, or the def fails validation. Reconciling the FE's used-token set against `AnalyticsCatalog` is a **prerequisite** to seeding defs (a Part D validate-time gate).
+
+---
+
+## 5. Target-home summary
+
+| FE artifact (count) | BE home | Owner part |
+|---|---|---|
+| `BATCH_QUERIES` query bodies (52, minus null placeholders) | `dss.KpiDefinition.query` | D |
+| metric/sub-metric `format`/`outputFormat`/`accent`/`measureKey`/chart `type` | `dss.KpiDefinition.viz` | D / F |
+| titles & labels (strings) | localization codes referenced by the def | D + localization |
+| `INVENTORY_SECTIONS` grouping | served catalog grouping | D |
+| `DEFAULT_LAYOUT` grid + `tiles` per role | `dss.DashboardPack` (default = supervisor; others net-new) | E |
+| `localStorage` layout | user-preferences `PGR_DASHBOARD_LAYOUT` | E.3 |
+| `formatSubMetricValue` / `parse*` render *engine* (code) | **stays FE** — pure interpreter, driven by `viz` spec | F |
+| `format`, `chart`, `valueKey`, `variants`, `compose`, `accent` viz *spec* | `dss.KpiDefinition.viz` (served in catalog response) | D / Part 66 |
+| branding (`DASHBOARD_BRAND_*`) | **stay `globalConfigs`** | — |
+
+---
+
+## 6. Sequencing (the actual pull)
+
+1. **Reconcile the DSL token set** used by the 52 queries against `AnalyticsCatalog` (§4e) — fix gaps or the defs won't validate. *Prerequisite.*
+2. **Triage the `queryKey:null` placeholders** (§4a): implement-as-def vs drop. Record the decision per tile.
+3. **Generate `dss.KpiDefinition` seed records** for the surviving queries (query verbatim + `viz` from the landscape format spec + `rbac.visibleTo` ceiling, officer-PII flagged).
+4. **Author localization** for titles/labels (§4c).
+5. **Seed one `dss.DashboardPack`** = the supervisor default (from `DEFAULT_LAYOUT` + complaint-landscape section); author citizen/admin/public packs net-new (Part E).
+6. **Flip the FE to thin renderer** (Part F): replace `BATCH_QUERIES`/landscape imports with catalog+pack fetch; keep formatters/parsers as the viz layer.
+7. Validate on ovh-cloud-dev (bomet repro) before live; defs/packs are MDMS so they redeploy with the nightly develop pull.
+
+**Gate:** none of this is real access control until Part A (trustworthy principal) lands — but the *extraction* (steps 1–4) is independent of A and can proceed now.
+
+---
+
+> **Note.** This inventory was read directly from the live FE config (file:line cited). It is the worklist, not the records themselves — the actual `dss.KpiDefinition`/`dss.DashboardPack` JSON is generated in step 3/5 once the §4e token reconciliation and §4a placeholder triage are decided.

--- a/docs/dashboard-rbac-design/66-viz-schema-api-contract.md
+++ b/docs/dashboard-rbac-design/66-viz-schema-api-contract.md
@@ -1,0 +1,371 @@
+# Part 66 — Viz Schema & Wide-Migration API Contract
+
+**Status:** v1, 2026-06-25. Defines the concrete HTTP API surface and the `viz` JSON schema that enable the "wide migration" direction: **the FE receives the full visualization schema AND token-scoped data FROM the BE; only tile size, ordering, and KPI visibility (hide/show) stay FE-side.**
+
+**Reads:** `65-fe-config-inventory.md` (the 52-query worklist), `60-frontend-inversion.md` Part F (the renderer design), `40-kpi-catalog-governance.md` Part D (def lifecycle), `50-packs-config-ownership.md` Part E (packs/layout).
+
+**Grounding:** the `viz` schema is derived by reading the actual landscape files (`config/complaintLandscape.js:66–263`, `config/supervisorMetrics.js`, and the 5 sibling `*Landscape.js` files) and the format dispatcher `formatSubMetricValue` (`config/kpiQueries.js:479–551`). Every format code, chart type, valueKey, and compose rule below was found there.
+
+---
+
+## The migration line — what stays FE vs what moves
+
+The guiding rule is: **declarative knowledge (config) moves BE-side; imperative code (interpreter) stays FE-side; transient personal state (size/order/visibility) stays local.**
+
+| FE-side | BE-side |
+|---|---|
+| Render engine (`formatSubMetricValue`, `parseBarChart`, compose dispatcher) | **Viz spec** (`format`, `chart`, `valueKey`, `variants[]`, `compose`, `accent`, `group`, `titleKey`) |
+| Grid interaction (drag, resize, reflow) | Default grid layout (`dss.DashboardPack.layout`) |
+| Transient UI state (hover, active tab, drill) | KPI definitions and query bodies |
+| Personal layout delta: tile `hidden`, `{x,y,w,h}` overrides | Row-scoped data (server injects `WHERE` from token) |
+| `asOf` display | `asOf` value (server-stamped on each result) |
+| Elapsed-time evaluation in compose (`asOf → daysElapsed`) | `elapsedFromAsOf: true` directive (says to derive elapsed from asOf, not `Date.now()`) |
+
+**Nothing else stays FE.** No format codes, no chart type assignments, no sub-metric selector labels, no accent colors, no section groupings, no compose arithmetic rules are hardcoded in JS. The FE is a typed interpreter with no domain knowledge of its own.
+
+---
+
+## 1. The `viz` JSON schema
+
+Each `dss.KpiDefinition` carries a `viz` object. This is what the catalog endpoint returns to the FE for every tile. The FE renders solely from this; it never falls back to a hardcoded format.
+
+```jsonc
+{
+  // ─── Required ───────────────────────────────────────────────────────────
+  "kind": "scalar" | "bar" | "rankedList" | "line" | "map" | "dow",
+  // ^ "dow" = day-of-week radar/bar; "scalar" = a single formatted number
+
+  "format": "integer" | "percentInteger" | "percentOneDecimal" | "percentNoDecimal"
+          | "decimalOne" | "decimalTwo"
+          | "hoursDays" | "hoursDecimal"
+          | "ordinal" | "signedInteger",
+  // ^ matches the 8 branches of formatSubMetricValue (kpiQueries.js:479–551);
+  //   for non-scalar kinds this is the format of the primary measure column
+
+  "valueKey": "total" | "pct" | "avg_ms" | "median_ms" | "avg" | "rank" | "count",
+  // ^ which key in the result row the renderer shows as the headline number
+
+  // ─── Presentation ────────────────────────────────────────────────────────
+  "accent": "teal" | "amber" | "green" | "slate" | "red" | "blue" | "orange",
+  // ^ card background accent; replaces hardcoded `accent` in *Landscape.js
+
+  "titleKey": "<localization_module>.<UPPER_SNAKE_KEY>",
+  // ^ localization key, NOT a raw English string; resolved at the edge
+  //   example: "RAINMAKER-PGR.DASHBOARD_KPI_TITLE_OPEN_COMPLAINTS"
+
+  // ─── Grouping / picker ───────────────────────────────────────────────────
+  "group": "<string>",
+  // ^ groups sub-metric variants together in the card picker and
+  //   in the inventory section list; replaces INVENTORY_SECTIONS grouping
+  //   example: "complaint-landscape", "employee-performance"
+
+  // ─── Sub-metric variants (optional) ─────────────────────────────────────
+  "variants": [
+    {
+      "id": "<string>",           // matches the sub-metric id in complaintLandscape.js
+      "labelKey": "<loc_key>",    // localization key for the switcher label
+      "default": true | false     // which variant is shown on first load
+    }
+    // ...
+  ],
+  // ^ present when one card shows a sub-metric switcher (e.g. "channel mix").
+  //   Each variant corresponds to a SEPARATE kpiId (one def per sub-metric,
+  //   grouped by `group` field). This field enumerates which sibling kpiIds
+  //   belong to the same card and should render as a switcher.
+  //   Resolved by Part D (Open-Q 6): one kpiId per sub-metric + group field.
+  //   If omitted, the tile is a standalone scalar/chart with no switcher.
+
+  // ─── Chart-specific config (present when kind ≠ scalar) ─────────────────
+  "dimensionKey": "<column_name>",
+  // ^ the column to use as the x-axis / category label
+  //   example: "ward_code", "service_code", "created_dow"
+  //   replaces the hardcoded column names in parseBarChart/parseDowChart
+  //   (kpiQueries.js:586 `created_dow`; useDashboardData.js:64-65 `service_code`/`ward_code`)
+
+  "measureKeys": ["<column_name>", ...],
+  // ^ columns to plot as y-values; typically ["total"] or ["pct"]
+  //   for multi-series charts (rankedList with score + rank) can be >1
+
+  // ─── Composed metrics (present when this tile has no own query) ──────────
+  "compose": null | {
+    "type": "openRateComplement"    // 1 - sourceKpiIds[0].pct
+           | "netBacklogDaily"      // sourceKpiIds[0].total - sourceKpiIds[1].total
+           | "dailyAvgFromWeekly"   // sourceKpiIds[0].total / elapsedDays(asOf)
+           | "hourlyAvgFromDaily",  // sourceKpiIds[0].total / elapsedHours(asOf)
+    "sourceKpiIds": ["<kpiId>", ...],
+    // ^ the sibling kpiIds whose fetched results feed the formula
+    "elapsedFromAsOf": true | false
+    // ^ when true, the FE derives elapsed days/hours from the server-stamped
+    //   `asOf` on sourceKpiIds[0], NOT from Date.now(); this makes the
+    //   divisor server-controlled and avoids client clock drift
+  },
+  // ^ when non-null, `query` on the def is null (no own query body).
+  //   The FE fetches the sourceKpiIds first, then evaluates the compose rule.
+  //   The compose dispatcher in the FE is a small keyed function (~20 lines);
+  //   it does NOT know which KPI uses which type — that comes from this field.
+
+  // ─── PII flags ───────────────────────────────────────────────────────────
+  "pii": false | {
+    "dimension": "<column_name>"
+    // ^ which dimension column carries officer UUIDs; the renderer treats this
+    //   as an opaque code unless the result row explicitly carries a decrypted label.
+    //   Present on the 4 officerTopCount defs (ep_open_by_officer, ep_closed_by_officer,
+    //   ep_leaderboard_closed, er_critical_by_officer).
+  }
+}
+```
+
+### Format inventory (grounded in `formatSubMetricValue`, `kpiQueries.js:479–551`)
+
+| `format` value | Example output | Source in FE |
+|---|---|---|
+| `integer` | `1,234` | `L481–484` |
+| `percentInteger` | `42%` | `L486–488` |
+| `percentOneDecimal` | `42.3%` | `L490–492` |
+| `percentNoDecimal` | `42%` (no rounding) | alias of percentInteger |
+| `decimalOne` | `3.5` | `L494–496` |
+| `decimalTwo` | `3.54` | `L498–500` |
+| `hoursDays` | `2d 3h` | `L502–506` (ms → day+hour) |
+| `hoursDecimal` | `2.3h` | `L508–510` (ms → decimal hours) |
+| `ordinal` | `3rd` | `L512–515` |
+| `signedInteger` | `+5` / `-3` | `L517–521` |
+
+> `percentDelta` / `percentPointDelta` (WoW/MoM) are NOT in this list — they correspond to the `queryKey:null` tiles that are `—` today (Part 65 §4a). They are deferred until period-comparison DSL support is added; do not create `viz.format` entries for them until the underlying query exists.
+
+### Compose dispatch (grounded in `formatSubMetricValue` `derived` branches, `kpiQueries.js:439–454,492–512`)
+
+| `compose.type` | Formula | `elapsedFromAsOf` | Source |
+|---|---|---|---|
+| `openRateComplement` | `(1 − pct) × 100` | false | `L439–445, L506–508` |
+| `netBacklogDaily` | `source[0].total − source[1].total` | false | `L447–454, L510–512` |
+| `dailyAvgFromWeekly` | `source[0].total ÷ daysElapsed(asOf)` | true | `L492–497` |
+| `hourlyAvgFromDaily` | `source[0].total ÷ hoursElapsed(asOf)` | true | `L499–504` |
+
+---
+
+## 2. The API surface — the 3+1 calls
+
+All endpoints follow DIGIT convention: `POST` with `RequestInfo` in the body, token in `authToken`, no client-authored `userInfo`. The token is the only identity signal; the gateway populates `userInfo` (Part A gate).
+
+### Read 1 — Schema bootstrap (one call per session, token-scoped)
+
+```
+POST /v2/analytics/packs
+```
+
+**Purpose:** Returns everything the FE needs to *know what to draw* — the full catalog of tiles the caller's token is allowed to see, each with its complete `viz` spec, plus the default layout. No data. Cached per-role by the server.
+
+**Request:**
+```jsonc
+{ "RequestInfo": { "authToken": "<token>" },
+  "tenantId": "ke.bomet" }
+```
+
+**Response:**
+```jsonc
+{
+  "tiles": [
+    {
+      "kpiId": "cl_open_weekly",
+      "version": "1.0.0",
+      "titleKey": "RAINMAKER-PGR.DASHBOARD_KPI_TITLE_OPEN_WEEKLY",
+      "viz": {
+        "kind": "scalar",
+        "format": "integer",
+        "valueKey": "total",
+        "accent": "teal",
+        "group": "complaint-landscape",
+        "compose": null,
+        "pii": false
+      },
+      "params": [
+        { "name": "window", "default": "last_7d", "allowed": ["last_1d","last_7d","last_30d","wtd","mtd"] }
+      ],
+      "freshness": { "grainRefreshMs": 300000 }
+    }
+    // ... one entry per tile the token's roles permit (visibleTo ceiling already applied)
+  ],
+  "defaultLayout": [
+    { "kpiId": "cl_open_weekly", "x": 0, "y": 0, "w": 2, "h": 1 }
+    // ... grid positions for each tile (12-col react-grid-layout compatible)
+  ],
+  "asOf": "2026-06-25T09:00:00Z"
+}
+```
+
+**What the response does NOT include:** `query` bodies (the frozen SQL-shaping DSL), `rbac` ceiling declarations, or any row data. The FE never sees the analytic query body.
+
+**What stays FE:** the caller's personal layout delta — which tiles are `hidden`, and any `{x,y,w,h}` overrides — is fetched separately from user-preferences and applied as a diff over `defaultLayout`.
+
+---
+
+### Read 2 — Data (batched, token-scoped, server injects `WHERE`)
+
+```
+POST /v2/analytics/_query
+```
+
+**Purpose:** Returns the actual numbers for the requested tiles, already row-filtered to the caller's principal (jurisdiction/department/self via Part B/C). This is the same endpoint as today but with a `kpiId`-by-reference shape instead of inline query bodies.
+
+**Request:**
+```jsonc
+{ "RequestInfo": { "authToken": "<token>" },
+  "tenantId": "ke.bomet",
+  "queries": {
+    "cl_open_weekly": { "kpiId": "cl_open_weekly", "params": { "window": "last_7d" } },
+    "cl_chart_wards": { "kpiId": "cl_chart_wards", "params": { "window": "last_7d" } }
+    // ... one entry per tile to fetch (typically all tiles from Read 1)
+  }
+}
+```
+
+**Response:**
+```jsonc
+{
+  "results": {
+    "cl_open_weekly": {
+      "columns": [
+        { "name": "total", "role": "measure", "format": "integer" }
+      ],
+      "rows": [{ "total": 412 }],
+      "asOf": "2026-06-25T09:00:00Z",
+      "scope": { "boundaryPrefixes": ["BOMET|CENTRAL|CHESOEN"] }
+    },
+    "cl_chart_wards": {
+      "columns": [
+        { "name": "ward_code",  "role": "dimension" },
+        { "name": "total",      "role": "measure", "format": "integer" }
+      ],
+      "rows": [
+        { "ward_code": "CHESOEN", "total": 87 },
+        { "ward_code": "SIGOR",   "total": 63 }
+      ],
+      "asOf": "2026-06-25T09:00:00Z"
+    }
+  },
+  "partial": false,
+  "errors": {}
+}
+```
+
+**Server-side guarantees:** every result in `results` is already scoped to the caller's principal — no client-side row filtering. A tile the caller cannot invoke returns in `errors[kpiId]`, not in `results`. `partial:true` means at least one tile errored; the FE renders error state per tile (never silent zero).
+
+---
+
+### Read 3 — Inventory picker (superset, for adding tiles)
+
+```
+POST /v2/analytics/catalog/_search
+```
+
+**Purpose:** The "add a KPI" picker needs to show tiles the caller is *allowed to add* but hasn't put on the grid yet. This is the full role-filtered catalog — same ceiling as Read 1 but not pack-filtered. The FE subtracts `currentGridKpiIds` client-side to find the addable set.
+
+**Request:**
+```jsonc
+{ "RequestInfo": { "authToken": "<token>" },
+  "tenantId": "ke.bomet",
+  "filters": { "status": "published" }
+}
+```
+
+**Response:** same shape as Read 1's `tiles[]` array, no `defaultLayout`. The FE never sees draft/archived defs.
+
+---
+
+### Write — Personal layout (the only FE-owned state)
+
+```
+POST /user-preference/v1/_upsert    (existing DIGIT endpoint)
+```
+
+**Purpose:** Persist the caller's personal layout delta — only `hidden` booleans and `{x,y,w,h}` grid overrides per tile. Nothing else. The server owns the rest.
+
+**Key:** `PGR_DASHBOARD_LAYOUT_<tenantId>` (one per tenant per user). The value is a sparse diff over `defaultLayout`: tiles not in the delta inherit their default position.
+
+```jsonc
+{
+  "RequestInfo": { "authToken": "<token>" },
+  "Preference": {
+    "key": "PGR_DASHBOARD_LAYOUT_ke.bomet",
+    "value": {
+      "overrides": [
+        { "kpiId": "cl_chart_wards", "x": 4, "y": 2, "w": 4, "h": 2, "hidden": false },
+        { "kpiId": "ep_leaderboard_closed", "hidden": true }
+      ]
+    }
+  }
+}
+```
+
+**What does NOT go here:** tile `format`, `chart`, `accent`, anything from `viz`. Those are read-only from the catalog.
+
+**Caveat (README finding 6):** The preferences store currently keys on body `Preference.UserId`, spoofable. Part E must bind it to the token uuid before this write is identity-safe. Until then, layout personalization can stay in `localStorage` under the existing key (`dashboardConfig.js:46-48` `getLayoutStorageKey()`). The client-side structure of the write (sparse delta over defaultLayout) is the same either way — only the sink changes.
+
+---
+
+## 3. Session initialization sequence
+
+On dashboard load the FE makes **two parallel calls**, then one batched data call:
+
+```
+1a. POST /v2/analytics/packs         → tile catalog + viz schema + default layout
+1b. POST /user-preference/v1/_search → personal layout delta (sparse overrides + hidden set)
+
+    (merge: apply personal delta over default layout → final grid)
+
+2.  POST /v2/analytics/_query        → data for all unhidden tiles
+```
+
+Tiles that have `compose.sourceKpiIds` are included in the `_query` batch for their source KPIs; the compose evaluation happens client-side after the data arrives, using the `asOf` from the source result.
+
+**Separation of concerns:** Read 1 (schema) and Read 2 (data) are deliberately separate so:
+- A viz toggle (table ↔ bar) re-renders with no refetch — the FE already has the data.
+- A data refresh (polling) re-POSTs `_query` without re-fetching the schema.
+- Schema is cacheable per-role (long TTL); data is fresh per-request (short TTL or SSE push in future).
+
+---
+
+## 4. What the FE renderer needs to implement (and nothing more)
+
+Given the above contract, the FE renderer is a pure interpreter:
+
+```
+(viz, columns, rows | value) → rendered tile
+```
+
+It needs exactly:
+- A `kind` dispatcher: scalar / bar / rankedList / line / map / dow
+- A `format` dispatcher: 8–10 entries (§1 format inventory)
+- A `compose` dispatcher: 4 entries (§1 compose dispatch)
+- A `columns[].role` reader to find dimensions vs measures
+- An `asOf` display per tile
+- A `scope` badge display per tile
+- An error state renderer for `errors[kpiId]`
+
+Zero domain knowledge. No hardcoded column names, no hardcoded format assignments, no hardcoded chart type decisions.
+
+---
+
+## 5. Impact on Part 65 §4b (correction)
+
+Part 65 §4b originally recommended keeping compose logic "FE-side" for the 4 derived metrics. **This is corrected here:** the compose *rule* is declarative knowledge and belongs in `viz.compose`. The FE *engine* evaluates it, but the rule itself (which type, which sourceKpiIds, whether to use `elapsedFromAsOf`) comes from the catalog response. The FE never hardcodes "this tile = `cl_reg_weekly / daysElapsed`" — it reads that from `viz.compose.type = "dailyAvgFromWeekly"` and `viz.compose.sourceKpiIds = ["cl_reg_weekly"]`.
+
+The `elapsedFromAsOf: true` flag ensures the divisor is derived from the server-stamped `asOf` on the source result, not from `Date.now()`. This removes the client clock as an authority over any computed number.
+
+---
+
+## 6. Open questions
+
+1. **`variants[]` shape vs Part D's Open-Q 6 resolution.** If Part D chooses "one kpiId per sub-metric + `group` field" (recommended), `variants[]` in viz is the group manifest — one entry per sibling kpiId, the FE renders a switcher for kpiIds sharing the same `group`. If Part D chooses "one kpiId with `params`-selectable sub-metric", `variants[]` becomes a `params` enum and the field shape above needs revision. Part D owns this; Part 66 follows.
+
+2. **`map` viz — unimplemented tiles.** The 3 `cl-metric-hot-ward` sub-metrics are `queryKey:null` today (Part 65 §4a). `viz.kind:"map"` is reserved in the schema; populate it only when a real query body exists. Boundary geometry is fetched from `boundary-service` by the renderer using the `dimensionKey` codes from `rows` — the FE never enumerates the hierarchy.
+
+3. **`dow` viz.** `parseDowChart` (`kpiQueries.js:575–587`) hardcodes `created_dow` as the dimension. Under the new contract `viz.dimensionKey:"created_dow"` carries this. The renderer applies the same day-of-week label mapping it does today, driven by `dimensionKey`.
+
+4. **Analyst/explore surface.** If an analyst role sends inline grammar to `/_query`, it must use a separate endpoint or role-gate (Part F Open-Q 4). The 3+1 API surface above is for the *standard* dashboard (no inline grammar). An explore surface is out of scope for this doc; document it in Part F when scoped.
+
+5. **Localization of `titleKey` and `variants[].labelKey`.** These are resolved at the edge — the FE calls the localization service (or has them in the pre-loaded localization bundle) exactly as it does for any other `t("KEY")` string. The BE does not resolve them in the catalog response.
+
+---
+
+> **Note.** This part was written 2026-06-25, prompted by the direction: "FE will HAVE to get the visualization schema and the data corresponding to a KPI scoped to the token. Why keep anything FE-side other than size and ordering and what KPI is visible or not as local storage." It is a design specification, not implementation — no code changed. The 3+1 API surface above is the target contract for Part D/E/F implementation.

--- a/docs/dashboard-rbac-design/70-view-management.md
+++ b/docs/dashboard-rbac-design/70-view-management.md
@@ -1,0 +1,139 @@
+# Dashboard View Management Across Users (Part 70)
+
+**Status:** v1 (pass-1, no adversarial review yet — see note at end), 2026-06-23.
+**Answers** the first item appended to CCRS #631: *"Elaborate more on how exactly the management of dashboard views work for different users."*
+**Reads:** `40-kpi-catalog-governance.md` (Part D — KPI defs + ceiling), `50-packs-config-ownership.md` (Part E — packs + per-user layout), `60-frontend-inversion.md` (Part F — the thin renderer), `00-requirements.md` §2 (personas) / §5 (ownership split). This part is **synthesis**: it does not introduce a new data model — it narrates *who manages what surface, through which tool, over which lifecycle*, so the management experience is legible end-to-end rather than scattered across D/E/F.
+
+> Parts D/E define the *artifacts* (KpiDefinition, DashboardPack, layout preference). This part defines the *operations* on them and the *experience* each persona has. Where it states a mechanism it cites the part that owns it.
+
+---
+
+## 1. The core idea: a view is assembled, never authored whole
+
+No one "designs a dashboard." A user's dashboard is **computed at request time** from three independently-owned inputs, each managed by a different actor through a different surface:
+
+| Input | Artifact | Managed by | Surface | Churn | Owner part |
+|---|---|---|---|---|---|
+| **What questions exist** | `dss.KpiDefinition` (query + viz + `visibleTo` ceiling) | Tenant admin / KPI author | Configurator → KPI editor → publish pipeline | low (governed, versioned) | D |
+| **Which questions each role gets** | `dss.DashboardPack` (role → ordered tiles + default layout) | **Single tenant curator** ("dashboard owner") | Configurator → Dashboard Pack editor (customEditor) | medium (tenant policy) | E |
+| **My personal arrangement** | `PGR_DASHBOARD_LAYOUT` preference (sparse overrides) | the **end user**, themselves | the dashboard itself (drag/resize/hide) | high (every drag) | E.3 |
+| **Which rows I see** | *no artifact* — derived from the principal | nobody — automatic | n/a | B/C |
+
+The discipline (00-requirements §3, §5): **these never collapse into one another.** The curator picks *which KPIs a role sees* and **never** *which rows* (that is automatic per-user, B/C); the user personalizes *arrangement* and **never** *membership or access* (the ceiling re-checks on every tile). A view is the deterministic merge of these layers, recomputed per request — so a change at any layer (publish a KPI, re-curate a pack, drag a tile) reflects on the next load with no rebuild and no release.
+
+---
+
+## 2. The three management surfaces, by actor
+
+### 2.1 KPI author / tenant admin — *manages what questions exist* (Part D)
+
+**Surface:** the configurator's KPI-definition editor (registered as a managed MDMS resource, 50-packs §E.4(a): `'kpi-definition'` → `dss.KpiDefinition`), backed by the publish pipeline (40-kpi §D.5).
+
+**Lifecycle of one KPI (40-kpi §D.1, §D.5):**
+```
+draft ──(validate → bounded dry-run → cost estimate → PII/officer gate)──► published ──► archived
+                                                                            │
+                                            edit ⇒ NEW immutable version ───┘ (forward-only; old version frozen)
+```
+- A KPI is **immutable + versioned**: editing a published def creates a *new version*; the old one is never mutated (40-kpi §D.1 — "immutable versioning is an explicit pipeline invariant"). So a live dashboard never breaks mid-edit, and a pack can pin a version to avoid drift.
+- The def carries its own **security ceiling** (`rbac.visibleTo`, the max role set that may *ever* see it) — set here, by the author, under the platform ceiling. The **publish-time PII×audience check** (40-kpi §D.5, design §5) rejects publishing a def whose query projects an officer/PII column to an audience that includes `PUBLIC`. This is the one governance gate at *author* time; everything else is enforced at *serve* time.
+- **Management actions:** create draft, validate, publish (forward-only transition), supersede with a new version, archive. All audited (who/when/diff).
+
+The admin manages *the catalog of possible questions*. They do **not** decide who sees what here beyond the ceiling — that is the curator's job (§2.2), bounded by this ceiling.
+
+### 2.2 Tenant curator ("dashboard owner") — *manages which role sees which KPIs* (Part E)
+
+**Surface:** the configurator's **Dashboard Pack editor** — a `customEditor` (`dashboardPackEditor`, 50-packs §E.4(b)), **required from MVP** because `tiles[]` is an object-array the generic form can't express (50-packs §E.4(b), `types.ts:11–21`). The editor's KPI picker is **fed by Part D's catalog `_search`** (50-packs §E.4(b)), so the curator can only add KPIs that exist and are visible at the editing tenant.
+
+**One curation tier, tenant-wide (00-requirements §2; design §6).** A single designated role curates for the *whole* tenant. There is no per-ward / per-team delegation in this version (explicitly out of scope, product-overview §"Scope & phasing"). The curator:
+- Authors **one `dss.DashboardPack` per role** (`role` is the record key, 50-packs §E.1): picks the ordered list of `kpiId`s that role sees, and arranges the **default layout** grid.
+- Works **strictly under the ceiling.** A pack listing an out-of-ceiling KPI is **not an author-time error and not a serve-time leak** — it is *dropped* at serve time and 403s if invoked directly (50-packs §E.1, §E.2 step 4; the `disjoint(visibleTo, roles)` re-check). So a mis-curated pack degrades to "missing tile," never "leaked data."
+- Sets the pack's own **`status: draft|published`** (the same lifecycle as the def, design §6) so a half-built dashboard is never exposed — and for the public path the gate is the triple `pack.status:published` **AND** `def.status:published` **AND** `PUBLIC` eligibility (design §6, §7).
+
+**Management actions:** create/edit a role's pack, reorder tiles, set default layout, add/remove a KPI for a role, publish the pack. **Per-KPI visibility lives in the pack, not on the def** — deliberately, because visibility is tenant policy that changes often while defs are immutable artifacts (50-packs §E.1; design §6). Changing what a role sees is a pack edit, never a def re-publish.
+
+### 2.3 End user — *manages their own arrangement only* (Part E.3)
+
+**Surface:** the dashboard itself — drag, resize, hide a tile. Saved as **one sparse `PGR_DASHBOARD_LAYOUT` preference row** per `(user, tenant)` in `digit-user-preferences-service` (50-packs §E.3), holding only the *delta* against the role default.
+
+**The user can subtract and rearrange, never add (50-packs §E.3 merge contract):**
+- They may move/resize a tile, or `hidden:true` a tile they're permitted to see.
+- They **cannot** surface a tile the backend withheld: the override is filtered *through* the ceiling-filtered `tiles` set, never the reverse (50-packs §E.3 step 4). A stale personal layout can never resurrect a tile the pack/ceiling already dropped.
+- The override is keyed to the **token uuid, never a body value** — the identity-binding precondition (50-packs §E.3, the IDOR fix) is what makes "subtract-only" actually hold; without it the personalization store is an open IDOR.
+
+**Management actions:** drag/resize/hide/reset. Switching a tile between table↔bar↔line↔map is a **pure client re-render** (Part F.4) — not a saved view, just a viz toggle on the same data; "map" additionally fetches boundary polygons by code.
+
+---
+
+## 3. What each persona experiences (the "many audiences, one view system" view)
+
+Same pack-resolution path, different inputs in, different dashboard out (00-requirements §2; product-overview §"What we're building"):
+
+| Persona | KPIs they get (Layer 2: pack ∩ ceiling) | Rows they get (Layer 1: auto, B/C) | What they manage |
+|---|---|---|---|
+| **Citizen** | the `CITIZEN` pack — published, public-eligible KPIs + "my complaints" | `account_id = self` (injected) | their own tile arrangement |
+| **Ward supervisor (GRO)** | the `GRO` (∪ polluted roles) pack — incl. *approved* bounded officer leaderboards | their `boundary_path` subtree (auto) | their arrangement |
+| **Department head** | the dept-role pack | their `department_code` slice (auto, once dept scope ships) | their arrangement |
+| **Tenant admin** | any KPI in ceiling; **inline queries** allowed | whole tenant | their arrangement **+ authors KPIs** |
+| **Tenant curator** | (whatever their role pack lists) | per their role | **authors every role's pack** |
+| **Public (no login)** | only `status:published` ∧ `PUBLIC`-eligible, aggregate-only | tenant aggregates, strictest column tier | nothing (no personalization) |
+
+**Multi-role / HRMS pollution (50-packs §E.1 role-union).** A real principal usually holds several roles (every `GRO` also carries `PGR_LME`, memory [HRMS role pollution]). The serve path resolves the **union** of the caller's role-packs, then **ceiling-filters per tile** — so pack membership is never wider than the union *and* the ceiling closes the door regardless. Union order is made deterministic by a **config-driven role priority** (50-packs §E.2, resolving the pass-1 open question). Packs are *authored/tested* against clean single-role `RBAC_TEST_*` users so intent is provable without pollution noise.
+
+**Degrade-to-public-floor (00-requirements §6; design §8; product-overview §3).** When HRMS attribute resolution *fails* (not "resolved to empty"), the principal **downgrades to the public-equivalent view** — tenant aggregates, `PUBLIC` KPIs, strictest column tier — with a `degraded:true` signal so the FE shows a *"showing public view"* banner, plus telemetry on every fall-to-floor (the HRMS data-quality monitor). Never their jurisdiction's detail, never a blank screen, never everyone's records. This is *view management's* failure mode made graceful.
+
+---
+
+## 4. End-to-end management lifecycle (who touches what, in order)
+
+```
+① KPI author (configurator → KPI editor)
+     draft def → validate/dry-run/cost → PII×audience gate → PUBLISH (immutable version)
+     └─ artifact: dss.KpiDefinition{ query, viz, visibleTo ceiling, status:published }   [Part D]
+
+② Tenant curator (configurator → Dashboard Pack editor, KPI picker fed by D's catalog)
+     for each role: pick KPIs (under ceiling), order tiles, set default layout → PUBLISH pack
+     └─ artifact: dss.DashboardPack{ role, tiles[], layout, status:published }            [Part E]
+
+③ End user (the dashboard)
+     opens dashboard → POST /v2/analytics/packs (resolves role-union ∩ ceiling) → tiles+defaultLayout
+     reads PGR_DASHBOARD_LAYOUT (userId coerced to token uuid) → overlays personal deltas
+     drags/resizes/hides → POST _upsert (sparse override)                                  [Part E.3]
+     per tile → POST /v2/analytics/_query?kpiId  → D re-checks ceiling, B/C inject row scope [Parts D/B/C]
+     toggles viz table↔bar↔line↔map → pure client re-render                                [Part F.4]
+```
+
+(The serve-path control flow is 50-packs §E.5 in full. The point of *this* part is the **left column** — the management actions and who performs them.)
+
+**The drift guarantees that make this safe to manage independently:**
+- Curator references a since-archived KPI → tile **dropped** at serve, dashboard doesn't 500 (50-packs §E.2 "drop-not-error").
+- Curator over-curates beyond ceiling → tile **dropped** + `403` if hand-invoked (50-packs §E.1).
+- User's stale layout references a withheld tile → **dropped** (50-packs §E.3 step 4).
+- Admin re-publishes a KPI → live packs pinned to the old version are unaffected (immutable versioning, 40-kpi §D.1); packs on `null` (latest) pick it up next load.
+
+Every layer fails toward "less is shown," never "more is leaked."
+
+---
+
+## 5. Interfaces with other parts
+
+| Boundary | Contract |
+|---|---|
+| **← Part D** | provides the catalog (`_search`) that feeds the curator's KPI picker, the `visibleTo` ceiling re-checked per tile, and the immutable-versioned defs packs reference. |
+| **← Part E** | provides the `dss.DashboardPack` model, the `resolveForCaller` serve path, the `PGR_DASHBOARD_LAYOUT` preference + identity binding. This part adds **no new model** — it sequences the management *actions* over E's artifacts. |
+| **← Part F** | the thin renderer that consumes `{tiles, defaultLayout}` + overrides and does the viz-agnostic re-render; the user's only "management" of viz is a client toggle. |
+| **← Parts B/C** | row scope is *not* a management surface — it is automatic from the principal. This part's only claim about rows is that **no actor ever curates them**; conflating row scope into curation is the failure mode (00-requirements §3). |
+| **Configurator** | both `dss.KpiDefinition` and `dss.DashboardPack` are registered managed resources (50-packs §E.4); the pack editor's `customEditor` is MVP, not deferred. |
+
+---
+
+## 6. Open questions for review
+
+1. **Curator role binding.** Which DIGIT role *is* the "dashboard owner" — a new `DASHBOARD_CURATOR`, or an existing top supervisor / `PGR_ADMIN`? (product-overview Open Q1 confirms one tier; this asks which role-code carries it.) Recommendation: a dedicated `DASHBOARD_CURATOR` so curation isn't entangled with admin's inline-query/publish powers.
+2. **Public dashboard default** (product-overview Open Q2): opt-in per tenant, or off-everywhere until enabled? Recommendation: **off by default**, opt-in via a published `PUBLIC` pack — fail-closed for the highest-traffic, lowest-auth surface.
+3. **Degraded-view notice sufficiency** (product-overview Open Q3): is the "showing public view" banner enough, or do supervisors need an active alert + a self-flag path for their missing HRMS data?
+4. **Curator preview-as-role.** Should the pack editor let the curator *preview a role's resolved dashboard* (run `resolveForCaller` as that role against `RBAC_TEST_*`) before publishing? Strongly recommended — it makes the ceiling/drop behavior visible at author time instead of as a surprise missing tile.
+
+---
+
+> **Review status.** This is a **pass-1 synthesis** over Parts D/E/F as written; it introduces no new artifact, so its claims are anchored to those parts' cited code (50-packs §E.1–E.5, 40-kpi §D.1/§D.5, 60-frontend §F.4). Unlike Parts A–F it has not had the adversarial code-grounded review pass. Recommended next: fold §3's persona matrix and §4's lifecycle into the `product-overview.md` "What we're building" section (it currently describes outcomes, not the management *operations*), and run the dual-review pass if this graduates from synthesis to a committed surface.

--- a/docs/dashboard-rbac-design/80-multi-tier-complaint-types.md
+++ b/docs/dashboard-rbac-design/80-multi-tier-complaint-types.md
@@ -1,0 +1,169 @@
+# Multi-Tier Complaint Types in the Analytics Grains (Part 80)
+
+**Status:** v1 (pass-1, no adversarial review yet — see note at end), 2026-06-23.
+**Answers** the third item appended to CCRS #631: *"Multi-tiered complaint types: maybe we should have an array or jsonb or something, or else use the config to create the MV."*
+**Reads:** CCRS Discussion **#864** *(subhashini-egov — "[DRAFT|PROPOSAL] Configurable PGR Complaint-Type Hierarchy")* as the **authoritative** taxonomy design; `00-requirements.md` §4/§9-equiv; `30-row-scope-enforcement.md` (the `AttrScope` PREFIX machinery this part reuses); the grain migration `backend/pgr-services/src/main/resources/db/migration/main/V20260608000000__create_v2_grain_mvs.sql`.
+
+> **Grounding rule (whole series):** every claim about current behaviour is anchored to a file:line / a cited discussion section. Where a thing is *missing*, it is stated as missing with the anchor showing the gap.
+
+---
+
+## 0. The question, answered up front
+
+The note offers two implementation shapes — *(a) an array/jsonb column on the grain*, or *(b) drive the materialized view from config*. **The recommendation is (b), realized as a single materialized-path column `complaint_node_path` on every grain — the exact analogue of `boundary_path`.** It is not a new mechanism: jurisdiction already solved precisely this "scope/group at any depth of a jagged tree" problem with a delimiter-joined path, and the complaint taxonomy is the same problem on a different tree.
+
+This is **not a third proposal competing with #864.** #864 already reserves the hook: it adds an optional `complaintNodePath` field to `services/_create/_search/_update` *"for analytics use"* (#864 §5). This part specifies what analytics does with it — i.e. how the grains and the query/scope layer consume the hierarchy that #864 produces. The array/jsonb-on-grain option is **rejected for the same reason #864 rejected a polymorphic JSON blob for leaf metadata: queryability** (#864 §3, "Rejected on queryability grounds").
+
+---
+
+## 1. Current state — the taxonomy is already flat, and the grain already half-models the 2-level case
+
+Both the platform and the grains are flat-by-convention today, which (as #864 §1 notes) *reduces* the scope of this change rather than enlarging it.
+
+**Platform (per #864 §1):**
+- `eg_pgr_service_v2` stores complaints with `serviceCode` as a **flat string**; no `complaintType`/`subType` columns exist.
+- `RAINMAKER-PGR.ServiceDefs` (MDMS) is a **flat row list**. The "type" tier is derived **in the UI** by grouping rows whose `menuPath` strings match (`digit-ui-esbuild/products/pgr/src/pages/citizen/Create/FormExplorer.js`). No `parentCode` is modeled.
+
+**The grains already encode exactly that 2-level convention** (`V20260608000000__create_v2_grain_mvs.sql`):
+- The facts MV joins `RAINMAKER-PGR.ServiceDefs` in the `mdms` CTE (L141–149), projecting `data->>'serviceCode' AS service_code` (L143, the **leaf**), `NULLIF(data->>'menuPath','') AS service_group` (L145 — **this is the "type" tier, today, as a single column**), and `data->>'department' AS department_code` (L147).
+- `service_group` is folded into the facts select (L169) and `service_code` is indexed (`ix_cf_service`, L232).
+
+So the grain *already* carries a degenerate two-level taxonomy: `service_group` (≈ category) + `service_code` (leaf). What it cannot do today is represent **3–4 levels**, **jagged depth**, or **group/scope at an arbitrary intermediate tier** — which is exactly what Maputo needs (#864 §2: Category → Subcategory → Service, 3 levels at go-live; up to 4 for near-future tenants).
+
+**The dashboard gap.** Every existing tier-aware KPI (`complaints by type`, the category roll-ups in `kpiQueries.js`) is pinned to the single `service_group` column. None can express "group by subcategory within a category," "show me the Drainage subtree," or "this supervisor only sees the Sanitation branch" — there is no column to group or filter on below the top tier.
+
+---
+
+## 2. Why the materialized path, not an array/jsonb
+
+| Option | Group-by at tier *k* | Scope/filter at tier *k* | Index | Verdict |
+|---|---|---|---|---|
+| **(a1) `int[]`/`text[]` ancestor array** | `node_path[k]` — works | `:code = ANY(node_path)` — works but **no prefix anchoring**; `WARD_3`-class sibling-leak risk; GIN index, not the b-tree the scope path already uses | rejected |
+| **(a2) `jsonb` tree/object on each row** | needs `->>`/path expr per query; can't be a plain group key | `@>`/`jsonb_path` — opaque to the planner, no clean prefix predicate | rejected (queryability — #864 §3) |
+| **(b) `complaint_node_path text` materialized path** (`CAT|SUBCAT|SVC`) | `split_part(complaint_node_path,'|',k)` — same idiom the grain already uses for `zone_code`/`ward_code` (SQL L83–84) | anchored, escaped **PREFIX** — **reuses Part C's `AttrScope` machinery verbatim** (`AnalyticsPlanner.java:247–249`, `ESCAPE '\'`) | **chosen** |
+
+The deciding properties of (b):
+
+1. **It is the boundary pattern, already proven in this codebase.** `boundary_path` is built once as `ancestralmaterializedpath || '|' || code` (SQL L21–25) and then both **grouped** (positional `split_part`, L83–84) and **scoped** (anchored `LIKE prefix%` with `ESCAPE '\'`, `AnalyticsPlanner.java:247–249`). `complaint_node_path` is the same string on the taxonomy tree. **No new query-planner concept, no new index type, no new scope predicate** — Part C's PREFIX `AttrScope` already does complaint-type subtree scoping the instant the column exists.
+2. **Jagged depth is free.** A path is just as valid at length 2 (`CAT|SVC`) as at length 4 (`CAT|SUB|SUBSUB|SVC`). The leaf is always the last segment; depth is `1 + count('|')`. This matches #864's "jagged tree, any row with no children is a leaf" (#864 §4) with zero per-tenant schema variation in the grain.
+3. **One column, group **and** scope.** The note's two asks (better grouping for multi-tier KPIs; the ability to *restrict* a department/branch owner to their subtree) are the **same column** — exactly as `boundary_path` serves both `group by ward` and "supervisor sees their subtree."
+4. **Backward compatible.** Today's `service_group` is the **depth-2 special case** of the path (`service_group == split_part(complaint_node_path,'|',1)` when depth=2). Flat tenants (no `HierarchyConfig`, #864 §3) get `complaint_node_path = menuPath|serviceCode` (or just `serviceCode` if no menuPath) and every existing KPI keeps working unchanged.
+
+The array options fail the *scope* column of the table: neither gives the anchored, escaped, b-tree-indexable prefix predicate that the sibling-leak-safe scope engine (`WARD_3` must not match `WARD_30`, 00-requirements §4) already depends on. Re-deriving that safety for an array is strictly more work than reusing the path machinery.
+
+---
+
+## 3. "Use the config to create the MV" — how the path is materialized
+
+This is the note's option (b) made precise. The MV is **regenerated from the ServiceDefs hierarchy that #864 introduces**; the grain reads config, it does not hard-code depth.
+
+**Inputs (all owned by #864, consumed here read-only):**
+- `RAINMAKER-PGR.ServiceDefs` rows, now carrying optional `parentCode` + `level` (#864 §3). Existing rows that omit them are level-1 roots (#864 §3, default behavior).
+- `RAINMAKER-PGR.HierarchyConfig` — per-tenant `depth` + level-name metadata (#864 §3). Absent ⇒ flat tenant.
+- The complaint's `complaintNodePath` field on `services/_*`, reserved by #864 §5 *"for analytics use"* — the **authoritative** per-complaint path when the producing tenant has migrated.
+
+**Materialization, two sources, preferring the authoritative one:**
+
+```sql
+-- replaces / extends the `mdms` CTE (currently L141–149). Recursive walk of ServiceDefs
+-- via parentCode → a path per leaf serviceCode. Tenant-scoped; root-tenant fallback as today.
+WITH RECURSIVE svc_tree AS (
+  SELECT data->>'serviceCode' AS code,
+         NULLIF(data->>'parentCode','')      AS parent_code,
+         (data->>'serviceCode')              AS node_path,     -- root: path = own code
+         1                                   AS depth
+  FROM   <mdms ServiceDefs rows>
+  WHERE  NULLIF(data->>'parentCode','') IS NULL
+  UNION ALL
+  SELECT c.code, c.parent_code,
+         p.node_path || '|' || c.code,                         -- child appends to parent's path
+         p.depth + 1
+  FROM   <mdms ServiceDefs rows> c
+  JOIN   svc_tree p ON p.code = c.parent_code
+)
+SELECT code AS service_code,
+       node_path AS complaint_node_path,        -- e.g. 'SANITATION|DRAINAGE|BLOCKED_DRAIN'
+       split_part(node_path,'|',1) AS service_group  -- depth-1 segment == today's menuPath tier (compat)
+FROM   svc_tree;
+```
+
+Then in the facts/events selects (L159–169 region):
+
+```sql
+-- prefer the complaint's own recorded path (post-#864-migration producers), else derive from ServiceDefs:
+COALESCE(s.complaint_node_path, m.complaint_node_path) AS complaint_node_path,
+m.service_group,                       -- kept for back-compat; == split_part(complaint_node_path,'|',1)
+s.servicecode AS service_code          -- unchanged leaf, still the workflow/SLA key (#864 §6)
+```
+
+**Design points:**
+- **`complaint_node_path` is materialized at refresh, like every other grain column** — it inherits the existing `asOf`/freshness contract (00-requirements §6); no realtime tree-walk on the query path.
+- **Two sources, COALESCE'd, authoritative wins.** A complaint persisted by a migrated producer carries its own `complaintNodePath` (frozen at create time — correct even if the taxonomy is later re-shaped); an un-migrated complaint's path is derived from the *current* ServiceDefs tree by `service_code`. This mirrors how the facts MV already LEFT-JOINs ServiceDefs by `service_code` (L227) — same join key, richer projection.
+- **Depth is config, read from `HierarchyConfig`, never a constant in the SQL.** The recursive CTE terminates naturally at leaves; the depth-4 ceiling (#864 §4) is enforced by #864's `_validate`, so the grain never has to cap depth defensively.
+- **`service_group` stays.** Deprecated-not-deleted (matches #864 §6's treatment of `menuPath`): it is now a derived alias of the first path segment, kept so no existing KPI or index (`ix_cf_service`) breaks.
+- **New index:** `text_pattern_ops` b-tree on `complaint_node_path` (mirroring the boundary-path index requirement in 30-row-scope §"Index requirement") — required for the `LIKE 'prefix%'` scope predicate to use an index instead of seq-scanning the grain.
+
+---
+
+## 4. What this unlocks in the query / scope layer (no new plumbing)
+
+Because `complaint_node_path` is structurally identical to `boundary_path`, the existing layers absorb it as **one more catalog column** and **one more `AttrScope` attribute**:
+
+**Group-by at any tier (KPI defs, Part D).** A KPI def projects a derived dimension:
+- `service_category   := split_part(complaint_node_path,'|',1)`
+- `service_subcategory := split_part(complaint_node_path,'|',2)`
+- … and groups/filters on it. These become **declared catalog dimensions** (`AnalyticsCatalog`), so "complaints by subcategory" is a config-only KPI def — no code, no app release (the whole point of Part D). A KPI can group at whatever tier its `groupBy` names; admin-added KPIs at new tiers need nothing in code.
+
+**Subtree filtering (declared KPI param).** A `complaintTypeScope` declared param ANDs an anchored prefix under the caller's scope — the **narrow-only** rule of 00-requirements §4, identical to the existing `boundaryScope` param: an out-of-subtree selection yields **empty, not denied**.
+
+**Branch-owner row scope (Part C `AttrScope`, optional / future).** If a tenant ever wants "the Drainage department head sees only the Drainage branch," that is a **new attribute in the same `attrScopes` list** — `complaint_node_path` PREFIX — added as *config*, not new plumbing (00-requirements §4: "adding a future attribute is config, not new plumbing"). v1 does **not** require this — department scope (Part C / 30-row-scope §10) already covers the common case via `department_code`; the taxonomy-branch scope is available for free if demand appears, anchored and escaped exactly like jurisdiction.
+
+**The events grain.** The events grain today lacks `department_code` (00-requirements §7.4) and likewise has no `service_group`/path. If multi-tier grouping is wanted on the timeline/dwell grain, `complaint_node_path` must be added to the events MV select — **the same one-migration fix already scheduled for `department_code` on events** (30-row-scope §10). Bundle the two: one events-MV migration adds both `department_code` and `complaint_node_path`.
+
+---
+
+## 5. Interfaces with other parts & with #864
+
+| Boundary | Contract |
+|---|---|
+| **← #864 (taxonomy)** | This part **consumes** `ServiceDefs.parentCode`/`level`, `HierarchyConfig.depth`, and the per-complaint `complaintNodePath` field (#864 §3, §5). It produces **nothing #864 must change** — it only adds projections to the grain MVs. If #864's `complaintNodePath` field name changes (its Open Q6 naming question is unsettled), this part's `COALESCE(s.<field>, …)` follows it; flag the dependency. |
+| **→ Part C (row scope)** | `complaint_node_path` is a candidate `AttrScope` attribute with `matchType = PREFIX`, reusing `AnalyticsPlanner.java:247–249` verbatim. v1 ships it as a **group/filter dimension only**; branch-scope is a config add-on. |
+| **→ Part D (KPI catalog)** | New derived dimensions (`service_category`, `service_subcategory`, …) registered in `AnalyticsCatalog`; multi-tier KPIs become MDMS `dss.KpiDefinition` records, no code. The `service_group`-pinned legacy KPIs keep working (compat alias). |
+| **→ Refresh job** | `complaint_node_path` is materialized at MV refresh; like the other new grains it must be **wired into the refresh scheduler** (the standing build-note in `product-overview.md` §"Dependencies" — newer grains aren't auto-refreshing yet). |
+| **MDMS resolution** | The recursive walk reads ServiceDefs with the **same tenant + root-fallback dedup** the `mdms` CTE already does (L141, "dedupe by serviceCode preferring the root (shortest) tenant"). Note the MDMS-v2 first-hit-not-merge caveat (40-kpi §D.1) applies to ServiceDefs reads too. |
+
+---
+
+## 6. Sequencing & migration steps
+
+This part **gates on #864 landing** the additive ServiceDefs/HierarchyConfig schema (#864 §10 risk 1 — depends on the in-flight `utilities/mdms-v2-migration/` effort). Until then, the grain keeps `service_group` and this is design-only. Once #864 is in:
+
+1. **MV migration (one file, additive).** Add the recursive `svc_tree` CTE and the `complaint_node_path` projection + `text_pattern_ops` index to the facts MV. `service_group` retained as a derived alias. No change to `eg_pgr_service_v2` (consistent with #864 §6 — the complaint table is untouched). Validated on ovh-cloud-dev (bomet repro) before live, per the standard CCRS develop → nightly path.
+2. **Events-MV migration (bundle with department).** Add `complaint_node_path` **and** `department_code` to the events select in the same migration (30-row-scope §10 already schedules the dept column).
+3. **Catalog dimensions.** Register `service_category`/`service_subcategory`/… (positional `split_part`) as groupable/filterable in `AnalyticsCatalog`; expose a `complaintTypeScope` declared param (narrow-only).
+4. **Refresh wiring.** Ensure the (re)materialization runs in the refresh job so the column isn't stale (product-overview build-note).
+5. **Backfill check (onboarding QA, not code).** For a migrated tenant, assert every live `service_code` resolves to a non-NULL `complaint_node_path` ending in that code — the taxonomy analogue of the ServiceDefs-coverage check Part B already owns (30-row-scope §C.5a). A `service_code` with no ServiceDefs row gets `NULL` path (LEFT JOIN, L227) — same fail-closed/coverage hazard as `department_code`, surfaced in onboarding QA.
+
+---
+
+## 7. Risks, edge cases, failure modes
+
+- **NULL path = same LEFT-JOIN coverage hazard as department.** A complaint whose `service_code` has no (active) ServiceDefs row gets `complaint_node_path = NULL` (LEFT JOIN, L227); a tier group-by buckets it as NULL and a prefix scope excludes it (fail-closed). Acceptable, but a coverage gap to catch in onboarding QA, not a code change — identical treatment to 30-row-scope §C.5a.
+- **Taxonomy re-shape vs. stored path.** If a tenant re-parents a node, the **derived** path for un-migrated complaints shifts (they re-bucket on next refresh); the **recorded** `complaintNodePath` on migrated complaints does not (frozen at create — usually what you want for historical reporting). This is the taxonomy analogue of 30-row-scope's "path-stability assumption" for boundaries — document it; the tree is near-static in practice.
+- **Sibling-prefix leak.** `SANI` must not prefix-match `SANITATION`. Mitigated identically to jurisdiction: the path is `|`-delimited and the scope value is `…SANI|`-anchored + escaped (`ESCAPE '\'`). The grain owns the `|`-anchoring (it builds the path); Part C owns the escape. Same precondition contract as boundary.
+- **Depth drift between `HierarchyConfig.depth` and actual rows.** The recursive CTE doesn't trust `depth`; it walks `parentCode` to the real leaf, so a stale `HierarchyConfig.depth` only affects level *labels* (UI), never the path. #864's `_validate` is the enforcement point for depth ≤ 4.
+- **Field-name dependency on #864 Open Q6.** #864's per-complaint analytics field is named `complaintNodePath` *in the draft* but its naming (and the `HierarchyConfig` name) is explicitly unsettled (#864 §11 Q6). Treat the field name as a single point of coupling; the `COALESCE` follows whatever #864 ratifies.
+- **Two UI codebases (out of scope here).** #864 §10 risk 4 (dual `digit-ui-esbuild` + `digit-ui-v2` picker rewrite) is a #864 concern; the dashboard's only UI touch is that tier dimensions become selectable group-bys in the viz-agnostic renderer (Part F), which is already data-driven.
+
+---
+
+## 8. Open questions for review
+
+1. **Ship branch-scope (`complaint_node_path` as an `AttrScope`) in v1, or group/filter only?** Recommendation: **group/filter only** in v1 (department scope already covers the "owner sees their slice" case); keep branch-scope as the free config add-on. Confirm no near-term tenant needs taxonomy-branch *row* restriction at launch.
+2. **Derive-from-ServiceDefs vs. require recorded `complaintNodePath`?** Recommendation: **COALESCE, authoritative-wins**, so the grain works for both migrated and un-migrated tenants and the dashboard doesn't block on every producer migrating. Confirm acceptable.
+3. **Bundle the events-MV `complaint_node_path` column with the `department_code` events migration (one PR), or separate?** Recommendation: **bundle** — same file, same risk surface (30-row-scope §10).
+4. **Track #864's naming resolution (Q6) before writing the migration** so the `COALESCE` field name is final, avoiding a rename churn on the grain.
+
+---
+
+> **Review status.** This is a **pass-1** design authored against #864 and the real grain migration. Unlike Parts A–F it has **not** yet had the adversarial code-grounded review pass (Claude + codex) the `rbac-deep-design` workflow runs. The load-bearing code anchors (grain MV L21–25, L141–149, L159–169, L227, L232; `AnalyticsPlanner.java:247–249`) were read directly; the #864 references are to the discussion body as posted. Recommended next: run the same dual-review pass before any migration PR, and post a short comment on #864 noting that analytics will consume `complaintNodePath` via a materialized `complaint_node_path` grain column (so #864's "for analytics use" reservation has a concrete consumer and the field name gets pinned).

--- a/docs/dashboard-rbac-design/90-test-strategy.md
+++ b/docs/dashboard-rbac-design/90-test-strategy.md
@@ -1,0 +1,106 @@
+# Dashboard Test Strategy (Part 90)
+
+**Status:** v1 (pass-1, no adversarial review yet — see note at end), 2026-06-23.
+**Answers** the second item appended to CCRS #631: *"Tests for Dashboard."*
+**Reads:** the per-part validation matrices already written into Parts A–F (consolidated here), `00-requirements.md` §6 (NFRs) / §7 (hazards). Test infrastructure facts from memory: [DIGIT integration tests repo], [Bomet integration-tests deploy], [Integration-tests RUN button], [Bomet IT-run findings], [HRMS role pollution].
+
+> The individual Parts A–F each end with their own tests; they are **scattered**, not a plan. This part is the **single test surface**: it (1) names the layers and where each test lives, (2) consolidates every per-part negative/exit test into one **leak-regression matrix**, (3) fixes the fixture discipline (clean-role users) and the one assertion that is non-obvious (assert the *emitted SQL*, not just the Java), and (4) states the exit gate per phase.
+
+---
+
+## 1. The testing pyramid for this feature — three layers, three homes
+
+| Layer | What it proves | Where it lives | Runs |
+|---|---|---|---|
+| **Unit (JUnit, pgr-services)** | the planner emits the right `WHERE`; the gate rejects the right requests; the principal builder coerces | `backend/pgr-services/src/test/...` (currently **empty for analytics RBAC** — 30-row-scope §"Summary": *"no tests found"*) | CI per-PR (CCRS develop) |
+| **Integration / API (HTTP, per-tenant)** | a real token → real scope/ceiling against a running stack; the cross-arm gate; fail-closed degrade | `ChakshuGautam/digit-integration-tests` (memory [DIGIT integration tests repo] — the canonical home for new IT/E2E) | bomet IT runner daemon `:8181`, `/tests/api/` (memory [Integration-tests RUN button]) |
+| **E2E (Playwright, FE)** | the thin renderer shows only resolved tiles; viz toggle; "showing public view" banner; personalization subtract-only | integration-tests Playwright specs on bomet `/integration-tests/` (memory [Bomet integration-tests deploy]) | bomet nightly + RUN button |
+
+**Reality anchor:** today there is **no analytics-RBAC test at any layer** — every Part A–F review converged on "design text only, no `src/test` coverage" (30-row-scope §456, §478; 40-kpi §408; README cross-cutting). So this is greenfield test authoring, and the **negative tests are the deliverable**, not an afterthought — each is the proof that a specific known leak is closed.
+
+---
+
+## 2. The leak-regression matrix (consolidated from Parts A–F)
+
+Every row is a **negative test** a reviewer can run; each closes a named hazard. This is the single matrix the per-part exit criteria all feed into. **A PR for a part is not green until its rows pass.**
+
+| # | Test (input → expected) | Closes hazard | Part / anchor |
+|---|---|---|---|
+| **T1** | Forged-admin body (`type:EMPLOYEE`, `roles:[PGR_ADMIN]`, **no token**) → **citizen/empty scope**, not admin | fail-open identity (the auth gap) | A / 00-req §7.1; `AnalyticsController.java:41–47`, `kong.yml:65–68` |
+| **T2** | Valid token, body `userInfo` **overwritten** by introspection; mismatched body `tenantId` → **403** | spoofable principal / cross-tenant | A / 10-auth §A.4 (:231) |
+| **T3** | Introspection 5xx/timeout → **401**, NOT null-scope pass-through | fail-OPEN swallow | A / `ServiceRequestRepository.java:38–40` |
+| **T4** | **Citizen + `grain:"daily"`** → `grain_scope_unavailable` (pre-C2) / `account_id=self` rows only (post-C2), **never tenant-wide** | the convergent daily-grain citizen leak | C / `AnalyticsPlanner.java:246`, `AnalyticsCatalog.java:108`; 30-row-scope §386, §410 |
+| **T5** | GRO with jurisdiction `WARD_3` → only `boundary_path LIKE 'WARD_3|%' ESCAPE '\'` rows; **`WARD_30` does not leak** | sibling-prefix leak | C / 30-row-scope §372, §391 |
+| **T6** | Sanitation supervisor → `department_code IN ('SANI')` on **facts AND events**; multi-dept user → union | events-grain dept gap / silent under-scope | C / 00-req §7.4; 30-row-scope §378 |
+| **T7** | Complaint whose `service_code` has **no ServiceDef** → invisible to dept-scoped caller, **visible to admin** (fail-closed, not leak) | NULL `department_code` LEFT-JOIN coverage | C / 30-row-scope §389, §412 |
+| **T8** | **Unresolved HRMS** employee → **degrade-to-public-floor** (`degraded:true`, aggregates, strictest columns), NOT deny-all blank AND NOT tenant-wide | the degrade rule | B/C / 00-req §6, §8; 30-row-scope §C.1a |
+| **T9** | Citizen POSTs **inline** `{"queries":{"x":{...measures...}}}` (batch arm) → `inline_forbidden` | batch-dict arm bypasses the gate | D/F / `AnalyticsService.java:42–46`; 40-kpi §D.3, §302 |
+| **T10** | Role POSTs a `kpiId` **absent from its catalog** → `403 kpi_forbidden` | discovery/invocation drift | D / 40-kpi §303 (`disjoint(visibleTo,roles)`) |
+| **T11** | `_schema` / `_search` as low-privilege → **role-filtered**, no PII/officer columns past ceiling | unauthenticated `_schema` PII exposure | D / 40-kpi §D.4a |
+| **T12** | Publish a def projecting `current_assignee_uuid` with `PUBLIC` in audience → **publish rejected** | PII×audience at publish | D / 40-kpi §D.5; design §5 |
+| **T13** | Pack lists an **out-of-ceiling** `kpiId` → tile **dropped** at serve, `403` if hand-invoked (no 500, no leak) | mis-curated pack | E / 50-packs §E.1, §E.2 |
+| **T14** | User `_upsert`/`_search` someone **else's** `PGR_DASHBOARD_LAYOUT` (body `userId`) → **rejected** (coerced to token uuid) | user-preferences IDOR | E / 50-packs §E.3; `preference_service.go:107` |
+| **T15** | Stale personal override referencing a **withheld** tile → **dropped** (subtract-only; can't resurrect) | personalization can't widen | E / 50-packs §E.3 step 4 |
+| **T16** | FE receives only ceiling-filtered tiles; a hidden tile **cannot** be invoked from the bundle | FE-as-authority | F / 60-frontend; design §1 |
+
+**Multi-role coverage (T-pollution).** Because every real `GRO` also carries `PGR_LME` (memory [HRMS role pollution]), the union path (50-packs §E.1) needs its own test: a **`GRO+PGR_LME`** user resolves the deterministic union and ceiling-filters per tile — but **authored/asserted against clean single-role `RBAC_TEST_*` users** so intent is provable. Never write a `visibleTo` test against a real provisioned account whose roles have drifted (00-req §7.2).
+
+---
+
+## 3. The one non-obvious assertion: test the emitted SQL, not just the Java
+
+The plan is explicit (00-req §137; 30-row-scope §365; 40-kpi §295): **review the emitted `WHERE` in tests, not just the Java path.** Row scope is a string-built predicate; a unit test that asserts `applyScope()` was *called* proves nothing — the test must assert the **bound SQL**:
+
+- The injected predicate is **anchored + escaped**: assert the bound value is `'WARD_3|'`-terminated and `ESCAPE '\'` is present (T5), so a refactor that drops the delimiter is caught.
+- The predicate is **ANDed unconditionally**: assert it appears for *every* grain and *both* the single and batch arms (T9) — the batch arm calling `runOne` directly is the exact hole (40-kpi §D.3).
+- The **cache key includes resolved scope** (00-req §6): assert a supervisor and an admin asking "the same" KPI get **different cache entries** — never a cross-scope cache hit. This is a co-design test, not a perf test.
+
+These are pure unit tests over the planner output (no DB needed) and are the cheapest, highest-signal tests in the suite.
+
+---
+
+## 4. Fixtures & environment
+
+- **Clean-role users.** A fixed set of `RBAC_TEST_*` single-role accounts (one per persona: citizen, `GRO`+ward, dept-head, admin, analyst, and a deliberately **unresolved-HRMS** user for T8). Provisioned once per test tenant; **never** real accounts (role pollution → false confidence, 00-req §7.2). Bomet already has ward-scoped CSR-style users (memory [Bomet ward CSR]) usable as a template.
+- **Tenant.** Run integration/E2E against a **sandbox tenant** (e.g. `ke.demo` per memory [bomet MCP REST shim], or a dedicated `ke.dashtest`) so test data is disposable and the leak matrix can seed adversarial rows (the no-ServiceDef complaint for T7, the cross-dept complaint for T6).
+- **Where it runs.** bomet redeploys nightly from CCRS develop (memory [bomet redeploy cron]); the IT runner daemon (`:8181`, `/tests/api/`) and Playwright specs run there. **Validate on ovh-cloud-dev (bomet repro) before live bomet** — the standard CCRS path (00-req §137).
+- **Known runner hazards to design around** (memory [Bomet IT-run findings], [Bomet nightly integration tests broken]): the Playwright suite has been killed at the 90-minute run-cycle timeout by slow `mdms-v2`/`user` `_search` specs, and an onboarding-wizard hang crashes Playwright. **Keep the dashboard E2E specs fast and isolated** (their own spec file, no dependence on the lifecycle-fixtures collection trap) so they don't inherit the frozen-dashboard failure mode.
+
+---
+
+## 5. Per-phase exit gates (what "done" means for each part's PR)
+
+Tests are the **exit criterion**, mapped to the phase plan (00-req §8):
+
+| Part | Exit gate (must pass before merge) |
+|---|---|
+| **A** | T1, T2, T3 — a forged-admin body gets citizen/empty scope; mismatched tenant 403s; introspection failure → 401. *No other part may merge before A's gate is green* (A blocks all). |
+| **B** | T8 (degrade-to-floor with `degraded:true`); dept code-space consistency check has a test asserting HRMS codes ⊆ MDMS. |
+| **C** | T4, T5, T6, T7 — the daily leak, sibling-prefix, events-dept, NULL-coverage. **T4 is mandatory in both PR-C1 and PR-C2** (30-row-scope §386). Emitted-WHERE assertions (§3) required. |
+| **D** | T9, T10, T11, T12 — both-arm gate, catalog drift, `_schema` filtering, publish PII×audience. |
+| **E** | T13, T14, T15 — mis-curated pack drop, preferences IDOR, subtract-only override. |
+| **F** | T16 — FE renders only resolved tiles; viz toggle is a pure re-render with no extra data exposure. |
+| **80 (multi-tier)** | a `service_code` with no ServiceDefs row → NULL `complaint_node_path`, fail-closed bucket (the taxonomy analogue of T7); a tier group-by returns correct subtree counts. |
+
+**Regression suite = the whole §2 matrix**, run nightly on bomet. Any row going red is a leak regression, not a flaky test — treat as a release blocker.
+
+---
+
+## 6. What this part deliberately does NOT cover
+
+- **MV correctness / analytics-number accuracy** — that is the grain/MV design's concern (`complaint_facts-design.md`, `dashboard-query-api-design.md`), tested separately; this part tests **access and scope**, not whether the count is right.
+- **Load/perf** — beyond the cache-key-includes-scope assertion (§3), throughput testing of public dashboards is a separate NFR exercise.
+- **The configurator editor's own UI** — the `dashboardPackEditor`/KPI-editor component tests belong with the configurator, not this suite; this part tests the *resolved output* (T13), not the authoring widget.
+
+---
+
+## 7. Open questions for review
+
+1. **Integration vs. unit split for the leak matrix.** Several rows (T4, T5, T9) are expressible as *pure planner unit tests* (assert emitted SQL) **and** as live API tests. Recommendation: write the **unit** version as the merge gate (fast, in-CI) and the **API** version as the nightly regression (proves the whole stack). Confirm both, or unit-only for merge.
+2. **Sandbox tenant.** Reuse `ke.demo` (memory [bomet MCP REST shim]) or stand up a dedicated `ke.dashtest`? A dedicated tenant lets the suite seed adversarial rows (T6/T7) without polluting the demo sandbox — recommended.
+3. **Playwright isolation.** Given the nightly suite's 90-min-timeout fragility (memory [Bomet nightly integration tests broken]), should the dashboard E2E specs run as a **separate fast job** rather than inside the main run-cycle? Recommended, so a dashboard regression is visible even when the big suite is red.
+4. **Who owns the `RBAC_TEST_*` fixture provisioning** — a seed script in integration-tests, or MCP `tenant_bootstrap`? Recommendation: integration-tests seed (memory [DIGIT integration tests repo] is the canonical home), so the fixture lives next to the tests that need it.
+
+---
+
+> **Review status.** This is a **pass-1** consolidation: every matrix row is lifted from a Part A–F exit criterion or a converged review finding (anchors cited inline), and the infrastructure facts are from operational memory, not freshly re-verified against the live `:8181` runner. Unlike Parts A–F it has not had the adversarial review pass. Recommended next: when Part A implementation begins, author T1–T3 *first* (the auth gate is the prerequisite for every other test being meaningful), and stand up the `RBAC_TEST_*` fixtures so the whole matrix has clean-role accounts to run against.

--- a/docs/dashboard-rbac-design/README.md
+++ b/docs/dashboard-rbac-design/README.md
@@ -1,0 +1,87 @@
+# Dashboard RBAC & KPI Access — deep design (in parts)
+
+A multi-part design for moving dashboard config + access control server-side and adding **attribute-based row restriction (jurisdiction + department)** to the DIGIT PGR analytics API. Each part was authored against the real `pgr-services` / dashboard-UI / Kong source, then **adversarially reviewed by a separate agent pointed at that same code**. Generated 2026-06-23 via the `rbac-deep-design` workflow.
+
+> Builds on `../dashboard-query-api-design.md` (§5/§5a) and `../rbac-kpi-access-implementation-plan.md`. Read `00-requirements.md` first — it is the shared spec.
+
+## Parts & review verdicts
+
+| # | Part | File | Verdict |
+|---|------|------|---------|
+| — | Requirements & stage-setting | `00-requirements.md` | (spec) |
+| A | Trust Foundation (identity & auth) | `10-auth-foundation.md` | 🟡 sound-with-risks |
+| B | Attribute Resolution (roles, jurisdiction, department) | `20-attribute-resolution.md` | 🟡 sound-with-risks *(1 blocker)* |
+| C | Row-Scope Enforcement (generalized attribute scoping) | `30-row-scope-enforcement.md` | 🟡 sound-with-risks *(1 blocker)* |
+| D | KPI Catalog, Definitions & Inline Gating | `40-kpi-catalog-governance.md` | 🔴 needs-rework |
+| E | Dashboard Packs & Config Ownership | `50-packs-config-ownership.md` | 🔴 needs-rework |
+| F | Frontend Inversion (FE → BE) | `60-frontend-inversion.md` | 🟡 sound-with-risks |
+
+### Follow-on parts (the three items appended to CCRS #631 — pass-1, not yet adversarially reviewed)
+
+| # | Part | File | Answers |
+|---|------|------|---------|
+| 65 | FE → BE Dashboard Config Extraction Inventory | `65-fe-config-inventory.md` | the worklist for pulling the 52 hardcoded KPIs/queries/viz/layout from the FE into `dss.KpiDefinition`/`dss.DashboardPack` (feeds D + F); §4b corrected to move compose *rules* to `viz.compose` |
+| 66 | Viz Schema & Wide-Migration API Contract | `66-viz-schema-api-contract.md` | the concrete `viz` JSON schema (kind/format/valueKey/accent/variants/compose/pii) + the 3+1 API calls (`/packs`, `/_query`, `/catalog/_search`, `/user-preference/_upsert`); draws the FE/BE line: engine stays FE, spec comes from BE |
+| 70 | Dashboard View Management Across Users | `70-view-management.md` | "elaborate how view management works for different users" — synthesis over D/E/F (who manages what, lifecycle) |
+| 80 | Multi-Tier Complaint Types in the Grains | `80-multi-tier-complaint-types.md` | "array/jsonb or config-built MV" → a `complaint_node_path` materialized path (boundary-path analogue); consumes Discussion **#864** |
+| 90 | Dashboard Test Strategy | `90-test-strategy.md` | "tests for dashboard" — consolidates A–F per-part tests into one leak-regression matrix + layers + exit gates |
+
+Parts A–F each end with a `## Code-grounded review (<verdict>)` section carrying the full severity-tagged findings with `file:line` evidence. Parts 70/80/90 are **pass-1** (authored against the same code + Discussion #864) and have **not** yet had that dual-review pass run — each ends with a "Review status" note saying so.
+
+## Dependency graph
+
+```
+A (trust identity) ──► B (resolve attributes) ──► C (enforce row scope)
+                   └──► D (KPI catalog + gating) ──► E (packs / config ownership)
+                   └──► F (frontend inversion)
+```
+A is the hard prerequisite for all; C depends on B; E curates over D. D/F can proceed in parallel with B/C once A lands.
+
+## Cross-cutting findings the reviews surfaced (act on these first)
+
+1. **🔴 BLOCKER — existing daily-grain citizen leak (found independently by reviewers A *and* C).** `complaint_open_state_daily` has `citizenColumn = null` (`AnalyticsCatalog.java:108`); the citizen self-scope predicate is guarded by `citizenColumn != null` (`AnalyticsPlanner.java:246`). So a pure **citizen querying `grain:"daily"` gets every open complaint in the tenant** — a real leak in shipped code, not just a design gap. Fix in Part C: add `account_id` to the daily grain (or reject citizen daily queries). The convergence is the signal — fix this regardless of the rest.
+2. **Identity is fail-OPEN, not fail-closed (A + F).** The reused `ServiceRequestRepository.fetchResult` swallows 5xx/timeout and returns `null` (`ServiceRequestRepository.java:38-40`), and removing FE-supplied `userInfo` (F) depends on the Kong enrichment that today returns early when `userInfo` is present (`kong.yml:65-68`). Net: introspection must be **mandatory + coercive**, and `null` must map to `401`, or hardening the FE silently fails open.
+3. **Department scoping has three silent-drop traps (B + C):** (a) MDMS v1-flat vs v2-wrapped `Department.json` shape → one read path loads **zero** codes; (b) `department_code` is `NULL` for any complaint whose `service_code` lacks a ServiceDefs row (LEFT JOIN, `…grain_mvs.sql:227`) and `NULL IN (...)` is never true; (c) the **events grain has no `department_code` column** at all. Any of the three turns a department filter into a silent under- or over-scope.
+4. **The "narrow-only" client param doesn't exist (C).** `boundary_path` isn't in the grain `filterable` set (`AnalyticsPlanner.java:174`), so the declared `boundaryScope`/`departmentScope` narrowing param the spec leans on has no code path yet.
+5. **🔴 Batch `queries` arm bypasses the inline gate + kpiId re-check (D).** `AnalyticsService.query()` has two arms; the batch dict arm (`AnalyticsService.java:42-46`) calls `runOne()` directly — wiring only the single arm leaves a hole.
+6. **🔴 user-preferences-service is itself spoofable (E).** It keys records on body `Preference.UserId`, using the token uuid only for audit fields — so per-user layout can't just be delegated to it; that store needs its own identity binding.
+7. **`tenantStateLevel` dropped in `PrincipalAttributes` (B)** → Part C can't choose `LIKE prefix` (state) vs `= tenant` (city), a cross-tenant leak risk.
+
+## Mis-citations to correct in the design text
+
+- **B:** `/boundary/_search` returns the **legacy** Boundary model — the v2 model (`web/models/boundary/Boundary.java`) has **no `materializedPath`**. The path must come from elsewhere (boundary hierarchy / the grain's own `ancestralmaterializedpath`).
+- **E:** `AnalyticsScope.rolesOf(ri)` and the `_query` tenant cross-check **do not exist**; the user-preferences service **is** vendored in-tree (Open Q1 answerable) and uses `_upsert`/`_search`, not REST PUT.
+- **D:** `_schema` is unauthenticated and returns PII/officer columns past any def ceiling — must be role-filtered.
+
+## Pass 2 — revise + external codex review (2026-06-23)
+
+Each part was revised to fold in its pass-1 findings (replacing the old review with a `## v2 revision log`), then re-reviewed by an **external `codex exec` (gpt-5.5, read-only)** pass that verified the revision claims against the actual code.
+
+| Part | pass-1 (Claude) | pass-2 codex | codex resolved-in-code |
+|---|---|---|---|
+| A — Trust Foundation | 🟡 | 🔴 needs-rework | 5/11 |
+| B — Attribute Resolution | 🟡 | 🔴 needs-rework | 6/14 |
+| C — Row-Scope Enforcement | 🟡 | 🔴 needs-rework | 3/13 |
+| D — KPI Catalog & Gating | 🔴 | 🔴 needs-rework | 0/15 |
+| E — Dashboard Packs | 🔴 | 🔴 needs-rework | 8/10 |
+| F — Frontend Inversion | 🟡 | 🔴 needs-rework | 4/10 |
+
+### ⚠ How to read the codex verdicts — framing collision
+Codex judged "resolved" as **"patched in the code,"** not "the design now correctly specifies the fix." Because this is a **design exercise with no code written yet**, codex correctly observes the code at `AnalyticsPlanner.java:246` etc. is unchanged and therefore marks most `resolvedCheck` items false. That is true but largely **not a design defect** — it's an implementation-status statement. The blanket 🔴s mostly mean "still unimplemented," which was never in dispute. The signal to extract is the subset of findings that are **genuine design errors**, below.
+
+### Genuine design errors codex caught — ✅ ALL FIXED in pass-3 (each verified against code; see per-file `### v3 corrections`)
+1. **F — ✅ fixed:** count corrected **48→52** (verified `kpiQueries.js:47-416`); the false "escalation tiles project no officer dims" claim corrected — `er_critical_by_officer` projects `current_assignee_uuid` via `officerTopCount` (`kpiQueries.js:37-45,314`), now flagged as a real Layer-2 officer-PII path routed through `visibleTo`/officer-gate.
+2. **D — ✅ fixed:** `MDMSServiceV2.search()` confirmed **first-hit, no merge** (`MDMSServiceV2.java:83-89`) → defs now resolved via two explicit reads (city + state root) merged in-process; `x-unique` confirmed composite-key-uniqueness only (`CompositeUniqueIdentifierGenerationUtil.java:23-44`, `_update` still mutates) → immutable versioning made an **explicit pipeline invariant** (version in key + never-update-published + forward-only status), x-unique demoted to a dup-create backstop.
+3. **B — ✅ fixed:** confirmed legacy `Boundary.java:57` has `materializedPath`, v2 boundary model does not; grain builds `boundary_path` globally `DISTINCT ON (code)` with no tenant filter (`…grain_mvs.sql:21-25`) → jurisdiction prefix now anchors on the **grain's own `boundary_path`** (one source of truth), with the duplicate-code hazard noted.
+4. **C — ✅ fixed:** added subsection **C.1a "The default is DENY-ALL"** — a 4-arm classification where the fall-through arm denies (`1=0`/empty), and unresolved/failed HRMS lookups fail **closed**; replaces today's fail-open tenant-only fall-through (`AnalyticsScope.java:47` → `AnalyticsPlanner.java:242-246`).
+5. **E — ✅ fixed:** `AdvancedPage.tsx` re-cited to `CCRS/configurator/src/resources/advanced/AdvancedPage.tsx:7`; the A.4 cross-ref re-pointed to `10-auth-foundation.md` §A.4 (`:231`).
+
+### Convergent across BOTH passes (the real must-fix, independent of framing)
+- **Daily-grain citizen leak** — `complaint_open_state_daily` has `citizenColumn=null` (`AnalyticsCatalog.java:108`) + the `citizenColumn!=null` guard (`AnalyticsPlanner.java:246`) ⇒ a citizen querying `grain:"daily"` gets tenant-wide rows. Flagged by Claude (A+C) *and* codex (A,B,C,D). **This is a real existing bug; fix in Part C regardless.**
+- **Fail-open identity** — both passes: introspection must be mandatory+coercive and `null`→`401`.
+- **Batch `queries` arm bypasses gating** (`AnalyticsService.java:42-46`) — both passes.
+- **Department silent-drops** (code-space, NULL LEFT JOIN, events grain missing column) — both passes.
+
+## Status / next step
+
+Design + critique only — **no code changed**; that is by design (PR-per-phase comes later). Pass-2 takeaway: the *design* is materially sound but carries ~5 genuine factual errors (above) to correct, and codex's value was as a fact-checker against real code, not as an implementation gate. Recommended: (a) correct the 5 design errors, (b) treat the convergent four as the Phase-0/Phase-C must-fixes, (c) begin implementation with Part A (auth) since every codex 🔴 ultimately reduces to "identity still spoofable + nothing implemented yet."

--- a/docs/dashboard-rbac-design/product-overview.md
+++ b/docs/dashboard-rbac-design/product-overview.md
@@ -1,0 +1,100 @@
+# Dashboard & KPIs — product brief
+
+*For product review ahead of implementation. Describes what we're building, the experience, the decisions we've made, and what's in/out of scope. No engineering detail — the technical spec lives on CCRS #631 and the accompanying design docs.*
+
+---
+
+## Summary
+
+We're turning the PGR dashboard into a **configurable, role-aware analytics surface**. The same set of KPIs is shown to many different people, but each person automatically sees only the data they're entitled to — a citizen sees their own complaints, a ward supervisor sees their ward, a department head sees their department, an admin sees everything, and the public sees aggregate stats only. KPIs are configured centrally (adding or changing one doesn't need an app release), and one designated person per tenant controls which KPIs each role sees.
+
+The work is as much about **trust and governance** as it is about charts: today the dashboard decides access in the browser and trusts whatever the client claims about who's logged in. We're moving all of that to the server so access is actually enforced.
+
+---
+
+## Why now
+
+Three problems with the current dashboard:
+
+- **Access isn't really enforced.** What you see is decided by the frontend, and the system trusts the browser's claim about your identity. That's fine for a demo, not for real role-based data.
+- **The frontend owns the KPIs.** Metrics are hard-coded into the app, so adding or changing a KPI means a code release, and there's no way to vary what different roles see.
+- **No scoping.** Everyone with access sees the whole tenant. A ward supervisor can't get a clean "just my ward" view.
+
+This brief covers fixing all three, plus the new capabilities that follow once access is trustworthy (public dashboards, per-role curation, department views).
+
+---
+
+## What we're building
+
+**One dashboard, many audiences.** A user opens the dashboard and immediately sees the KPIs configured for their role, with the data already filtered to their scope — no manual filtering, no setup. The scoping is automatic and derived from who they are.
+
+Importantly, **the roles, the KPI mix each one sees, and the scoping rules are all configuration — none of it is fixed in the product.** The list below is an illustrative PGR setup, not a hard-coded set; a deployment can define different roles, a different KPI selection per role, and different scoping:
+
+- **Citizens** — e.g. their own complaints, plus public aggregate stats.
+- **Supervisors** — e.g. their area: their boundary and everything beneath it. A county-level supervisor automatically covers every ward under the county, including wards added later; there's no list to maintain.
+- **Department heads** — e.g. their department's complaints across the areas they cover.
+- **Admins** — e.g. the whole tenant.
+- **The public** (no login) — e.g. an aggregate dashboard: counts and rates, never individual records.
+
+These are building blocks; what a given tenant actually shows to whom is set in configuration, not shipped in code.
+
+**KPIs are configured, not coded.** Metrics live in central configuration. An admin can define a new KPI (its measure, grouping, default chart) and publish it without an app release. KPIs are versioned and have a draft/published state, so work-in-progress stays hidden and live dashboards don't break when a KPI is edited.
+
+**One person curates per tenant.** A designated tenant role (think "dashboard owner") decides which KPIs each role sees, tenant-wide, and the default layout. They work within a platform-set ceiling that prevents them from, say, exposing staff-identifying KPIs to the public. They control *which KPIs a role sees* — never *which data rows*, which stays automatic per user.
+
+**Users can personalize.** Individuals can rearrange and resize their own tiles; the arrangement is saved per user, on top of the role default. Switching a KPI between table, bar, line, and map is instant.
+
+---
+
+## Key product decisions (worth confirming in review)
+
+These are the choices we've already made and the reasoning, so product can sanity-check them before we build:
+
+**1. Scope is decided by *who's asking*, not by the KPI.** A KPI like "complaints by ward" is defined once and returns different rows to a citizen, a supervisor, an admin, and the public — because the system filters by the viewer's identity. We deliberately did *not* make separate "citizen version" and "supervisor version" KPIs. One definition, many audiences.
+
+**2. Public dashboards are supported, and what they may expose is a configurable policy — not a hard rule.** A published public dashboard can be viewed with no login. What's allowed on it isn't baked into the product: the platform tags which data is sensitive (personal / staff-identifying) and which audiences may see what, and the system enforces *that policy* at publish time — a KPI that would expose data its audience isn't permitted to see can't be published to that audience. The sensible default for "public" is aggregate-only with no personal or staff data, but what counts as sensitive and what each audience may see are configuration, changeable per deployment, not constants in code. (This is also why a "tenant-wide" view isn't a leak when it's an intentional, configured public aggregate.)
+
+**3. When the system can't tell who you are, it fails *safe*, not open and not blank.** Supervisors' areas and department heads' departments come from the HR/staff system, and that data sometimes drifts. If we can't resolve a user's area or department, we show them the **public (aggregate) view** with a clear "showing public view" notice — never everyone's detailed data, and never an empty screen. We also surface how often this happens, because it's a useful data-quality signal for the org.
+
+**4. Curation is one tier per tenant.** A single designated role curates for the whole tenant. There's no delegated, per-ward or per-team curation in this version — that kept the model simple and is the main thing to confirm product is comfortable with.
+
+**5. Area scoping lands a step before department scoping.** Both are first-class and work identically (scope follows who you are). Area scoping goes first only because department scoping needs a little more groundwork in one of the underlying metric sources — a build-order point, not a difference in capability or a per-tenant caveat.
+
+---
+
+## Scope & phasing
+
+Roughly in build order; each phase is independently useful:
+
+1. **Verified identity** — make access and scope trustworthy and server-enforced. Foundation for everything else; no visible feature on its own, but everything depends on it.
+2. **Scoped views** — supervisors see their area, citizens see their own complaints, admins see all.
+3. **Department views** — department heads see their department.
+4. **Central KPI catalog + curation** — add/assign KPIs without a release; the tenant curator sets per-role visibility.
+5. **Public dashboards** — published, aggregate, no-login.
+6. **Personalization** — per-user layout.
+
+**Explicitly out of scope (this version):** delegated/per-team curation; real-time (live) data; per-record public views.
+
+---
+
+## Dependencies, limitations & risks
+
+Things product and the org should go in with eyes open:
+
+- **Data refreshes on a schedule, not live.** Metrics are precomputed and refreshed on a **configurable interval** — currently about every 5 minutes for the live metrics, with the backlog/aging snapshot taken daily. Numbers carry an "as of" time: near-real-time reporting on a set cadence, not a live operational stream. *(Build note: the newer metric grains this design introduces still need to be wired into the refresh job — they aren't auto-refreshing yet.)*
+- **If a user's staff record is incomplete, scoping degrades safely.** A supervisor's area and a department head's department come from the staff/HR system. If that information is missing for a user, the system shows them the public (aggregate) view with a clear notice — never everyone's detailed data, never a blank screen — and surfaces how often this happens so the gap can be fixed at source. This is designed fallback behavior, not a failure mode.
+- **Area scope follows the official boundary hierarchy.** If areas are reorganized, scopes follow the new structure once the hierarchy is updated.
+- **Public surfaces never carry personal data** — by design and enforced, but worth setting expectations: the public dashboard is intentionally limited to aggregates.
+
+---
+
+## Open questions for product
+
+1. Comfortable with **one curation tier per tenant** (no per-ward/per-team delegation) for v1?
+2. For **public dashboards**, what's the default — opt-in per tenant, or off everywhere until explicitly enabled?
+3. The **degrade-to-public-view** behavior on unresolved staff data: is the "showing public view" notice enough, or do we want supervisors actively alerted (and a path to flag their own missing data)?
+4. Is **near-real-time** (periodic refresh) acceptable for the launch use cases, or is anyone expecting live numbers?
+
+---
+
+*Companion — full technical design (engineering audience): [CCRS #631 design comment](https://github.com/egovernments/Citizen-Complaint-Resolution-System/issues/631#issuecomment-4775492466).*

--- a/frontend/micro-ui/web/webpack.config.js
+++ b/frontend/micro-ui/web/webpack.config.js
@@ -7,6 +7,9 @@ module.exports = {
   // mode: 'development',
   entry: "./src/index.js",
   devtool: "none",
+  // src/ mixes .js and .jsx (dashboard/); webpack's default resolve list has no .jsx,
+  // so extensionless imports of .jsx files only worked on the dev server.
+  resolve: { extensions: [".js", ".jsx", ".json"] },
   module: {
     rules: [
       {
@@ -20,7 +23,7 @@ module.exports = {
         }
       },
       {
-        test: /\.(js)$/,
+        test: /\.(js|jsx)$/,
         exclude: /node_modules/,
         use: {
           loader: "babel-loader",


### PR DESCRIPTION
## Summary

Adds the full multi-part design for Dashboard RBAC + KPI access to the repo under `docs/dashboard-rbac-design/`. These have been built and two-pass reviewed in a separate working directory; this PR makes them official and reviewable against the actual codebase.

Related to #631.

**What's here:**

| Part | File | Content |
|---|---|---|
| Requirements | `00-requirements.md` | Three-layer RBAC model (row scope / catalog access / capability gate) |
| A | `10-auth-foundation.md` | Coercive token introspection; reject body `userInfo` |
| B | `20-attribute-resolution.md` | Roles, jurisdiction, department from HRMS |
| C | `30-row-scope-enforcement.md` | `boundary_path` prefix scope; AttrScope model; fail-closed default |
| D | `40-kpi-catalog-governance.md` | `dss.KpiDefinition` MDMS schema; publish lifecycle; Layer-2 catalog access |
| E | `50-packs-config-ownership.md` | `dss.DashboardPack`; role→tiles; user-preferences layout |
| F | `60-frontend-inversion.md` | FE strips to thin renderer; kpiId-by-reference invocation |
| 65 | `65-fe-config-inventory.md` | Full inventory of what moves from the FE to BE (52 queries, viz models, layout) |
| **66** | **`66-viz-schema-api-contract.md`** | **The concrete `viz` JSON schema + 3+1 API surface** |
| 70 | `70-view-management.md` | View management per user persona |
| 80 | `80-multi-tier-complaint-types.md` | `complaint_node_path` materialized-path column; consumes Discussion #864 |
| 90 | `90-test-strategy.md` | 16-row leak-regression matrix; RBAC_TEST_* fixtures |

**Part 66 is the sharpest new thing here.** It specifies the `viz` object that every `dss.KpiDefinition` carries, grounded in the actual format dispatcher and landscape files:
- `kind`: scalar / bar / rankedList / line / map / dow
- `format`: 8 format codes (matches `formatSubMetricValue` branches)
- `viz.compose`: declarative compose rules for the 4 derived metrics — the FE evaluates them but the rule spec comes from the BE; `elapsedFromAsOf:true` ensures the client clock is never authoritative
- The 3+1 calls: `POST /packs` (schema bootstrap, token-scoped), `POST /_query` (data, already row-scoped), `POST /catalog/_search` (picker), `POST /user-preference/_upsert` (layout delta only)

This design separates engine (FE code) from spec (BE-served config). The FE's zero-knowledge-of-domain contract: it reads `viz` from the catalog, dispatches on `kind`/`format`/`compose.type`, renders `columns[].role` for axis assignment. No hardcoded format assignments, no hardcoded column names, no hardcoded chart type decisions.

**Known findings (from two review passes):**
- Daily-grain citizen leak (`complaint_open_state_daily` + `citizenColumn:null`) — real bug, flagged as must-fix in Part C regardless
- Fail-open identity (`kong.yml:65–67` trusts body `userInfo`) — Part A
- Batch arm bypasses inline gate (`AnalyticsService.java:42–46`) — Part D
- Department silent-drops (NULL LEFT JOIN + events grain) — Part B/C

## Test plan

- [ ] Read through Part 66 (`66-viz-schema-api-contract.md`) — is the `viz` schema shape complete enough to drive all current dashboard tiles?
- [ ] Confirm the 4 `compose` types cover all FE-derived metrics in `formatSubMetricValue`
- [ ] Confirm the 3+1 API calls align with the existing `/_query` + `/_schema` routes and what Part D/E need to add
- [ ] Check Part 65 §4b correction — compose rules in `viz.compose`, evaluated FE-side using `asOf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)