### PR TITLE
Polish supervisor dashboard: tables, charts, KPI inventory, and layout

### DIFF
--- a/frontend/micro-ui/web/src/dashboard/AdminDashboard.jsx
+++ b/frontend/micro-ui/web/src/dashboard/AdminDashboard.jsx
@@ -119,6 +119,7 @@ const AdminDashboard = () => {
       onClearFilters={clearFilters}
       filterOptions={filterOptions}
       filterOptionsLoading={loading}
+      kpiCardData={kpiCardData}
     >
       {error && (
         <div className="tw-mb-4 tw-flex tw-items-center tw-justify-between tw-rounded-md tw-border tw-border-[color-mix(in_srgb,var(--destructive)_30%,transparent)] tw-bg-status-breach-bg tw-px-4 tw-py-3 tw-text-sm tw-text-destructive">

--- a/frontend/micro-ui/web/src/dashboard/components/AddKpiDropdown.jsx
+++ b/frontend/micro-ui/web/src/dashboard/components/AddKpiDropdown.jsx
@@ -4,6 +4,7 @@ import {
   INVENTORY_CHART_WIDGETS,
   INVENTORY_KPI_METRICS,
 } from "../config/supervisorMetrics";
+import AddKpiPreview from "./AddKpiPreview";
 
 const PANEL_WIDTH_PX = 320; // ~tw-w-80
 
@@ -85,9 +86,12 @@ const AddKpiDropdown = ({
   open,
   onOpenChange,
   containerRef,
+  kpiCardData,
 }) => {
   const panelRef = useRef(null);
   const [panelPosition, setPanelPosition] = useState(null);
+  const [hoveredItem, setHoveredItem] = useState(null);
+  const [hoverRect, setHoverRect] = useState(null);
 
   const availableItems = useMemo(() => {
     const metrics = INVENTORY_KPI_METRICS.filter(
@@ -108,6 +112,8 @@ const AddKpiDropdown = ({
   useLayoutEffect(() => {
     if (!open) {
       setPanelPosition(null);
+      setHoveredItem(null);
+      setHoverRect(null);
       return undefined;
     }
 
@@ -151,6 +157,8 @@ const AddKpiDropdown = ({
   }, [open, onOpenChange, containerRef]);
 
   const handleDragStart = (event, widgetId) => {
+    setHoveredItem(null);
+    setHoverRect(null);
     event.dataTransfer.setData("text/plain", widgetId);
     event.dataTransfer.effectAllowed = "copy";
     onDragWidgetStart?.(widgetId);
@@ -194,26 +202,38 @@ const AddKpiDropdown = ({
                 draggable
                 onDragStart={(event) => handleDragStart(event, item.id)}
                 onDragEnd={handleDragEnd}
-                className="dashboard-add-kpi-item tw-flex tw-cursor-grab tw-select-none tw-items-center tw-gap-2.5 tw-px-4 tw-py-2.5 active:tw-cursor-grabbing"
+                onMouseEnter={(event) => {
+                  setHoveredItem(item);
+                  setHoverRect(event.currentTarget.getBoundingClientRect());
+                }}
+                onMouseLeave={() => {
+                  setHoveredItem(null);
+                  setHoverRect(null);
+                }}
+                className={`dashboard-add-kpi-item${
+                  hoveredItem?.id === item.id ? " dashboard-add-kpi-item--hover" : ""
+                }`}
               >
-                <MetricIcon kind={iconKind(item)} />
-                <span className="dashboard-add-kpi-item-label tw-min-w-0 tw-flex-1 tw-truncate">
-                  {item.metric}
-                </span>
-                <span className="dashboard-add-kpi-type">{itemTypeLabel(item)}</span>
-                <button
-                  type="button"
-                  draggable={false}
-                  onMouseDown={(event) => event.stopPropagation()}
-                  onClick={() => {
-                    onAddWidget(item.id);
-                    onOpenChange(false);
-                  }}
-                  className="dashboard-add-kpi-add-btn"
-                  aria-label={`Add ${item.metric}`}
-                >
-                  +
-                </button>
+                <div className="dashboard-add-kpi-item-main">
+                  <MetricIcon kind={iconKind(item)} />
+                  <span className="dashboard-add-kpi-item-label">{item.metric}</span>
+                </div>
+                <div className="dashboard-add-kpi-item-aside">
+                  <span className="dashboard-add-kpi-type">{itemTypeLabel(item)}</span>
+                  <button
+                    type="button"
+                    draggable={false}
+                    onMouseDown={(event) => event.stopPropagation()}
+                    onClick={() => {
+                      onAddWidget(item.id);
+                      onOpenChange(false);
+                    }}
+                    className="dashboard-add-kpi-add-btn"
+                    aria-label={`Add ${item.metric}`}
+                  >
+                    +
+                  </button>
+                </div>
               </div>
             </li>
           ))
@@ -222,7 +242,17 @@ const AddKpiDropdown = ({
     </div>
   );
 
-  return createPortal(panel, document.body);
+  return (
+    <>
+      {createPortal(panel, document.body)}
+      <AddKpiPreview
+        item={hoveredItem}
+        anchorRect={hoverRect}
+        panelLeft={panelPosition?.left}
+        kpiCardData={kpiCardData}
+      />
+    </>
+  );
 };
 
 export default AddKpiDropdown;

--- a/frontend/micro-ui/web/src/dashboard/components/AddKpiPreview.jsx
+++ b/frontend/micro-ui/web/src/dashboard/components/AddKpiPreview.jsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { createPortal } from "react-dom";
+import {
+  ADD_KPI_PREVIEW_GAP_PX,
+  ADD_KPI_PREVIEW_WIDTH_PX,
+  buildAddKpiPreviewContent,
+} from "../config/addKpiPreviewPresentation";
+
+const AddKpiPreview = ({ item, anchorRect, panelLeft, kpiCardData }) => {
+  const content = buildAddKpiPreviewContent(item, { kpiCardData });
+  if (!content || !anchorRect || panelLeft == null) return null;
+
+  const left = Math.max(8, panelLeft - ADD_KPI_PREVIEW_WIDTH_PX - ADD_KPI_PREVIEW_GAP_PX);
+  const top = Math.max(8, anchorRect.top - 4);
+
+  return createPortal(
+    <div
+      className="dashboard-add-kpi-preview dashboard-root"
+      style={{
+        position: "fixed",
+        top,
+        left,
+        width: ADD_KPI_PREVIEW_WIDTH_PX,
+        zIndex: 10000,
+      }}
+      role="tooltip"
+    >
+      <div className="dashboard-add-kpi-preview-card">
+        <div className="dashboard-add-kpi-preview-title">{content.title}</div>
+        {content.value ? (
+          <div className="dashboard-add-kpi-preview-value">{content.value}</div>
+        ) : null}
+        {content.target ? (
+          <div className="dashboard-add-kpi-preview-target">{content.target}</div>
+        ) : null}
+      </div>
+      {content.description ? (
+        <p className="dashboard-add-kpi-preview-desc">{content.description}</p>
+      ) : null}
+    </div>,
+    document.body
+  );
+};
+
+export default AddKpiPreview;

--- a/frontend/micro-ui/web/src/dashboard/components/ComplaintsAtRiskTable.jsx
+++ b/frontend/micro-ui/web/src/dashboard/components/ComplaintsAtRiskTable.jsx
@@ -18,7 +18,7 @@ const COLUMNS = [
   { id: "ownerRole", label: "Owner role", align: "left" },
   { id: "statusLabel", label: "Status", align: "left" },
   { id: "slaLabel", label: "SLA status", align: "left" },
-  { id: "breachDurationMs", label: "Breach duration", align: "right" },
+  { id: "breachDurationMs", label: "Breach duration", align: "left" },
 ];
 
 function compareRows(left, right, key) {
@@ -58,7 +58,14 @@ const ComplaintsAtRiskTable = ({ rows = [] }) => {
   };
 
   return (
-    <table className={tableStyles.table}>
+    <table
+      className={`${tableStyles.table} ${tableStyles.tableEqualCols} ${slaStyles.table}`}
+    >
+      <colgroup>
+        {COLUMNS.map((col) => (
+          <col key={col.id} style={{ width: `${100 / COLUMNS.length}%` }} />
+        ))}
+      </colgroup>
       <thead>
         <tr>
           {COLUMNS.map((col) => {
@@ -82,7 +89,14 @@ const ComplaintsAtRiskTable = ({ rows = [] }) => {
         </tr>
       </thead>
       <tbody>
-        {sortedRows.map((row) => (
+        {sortedRows.length === 0 ? (
+          <tr>
+            <td colSpan={COLUMNS.length} className={tableStyles.empty}>
+              No complaints at risk
+            </td>
+          </tr>
+        ) : (
+          sortedRows.map((row) => (
           <tr key={row.id}>
             <td className={getDataTableTdClass()}>
               <a href={complaintDetailHref(row.id)} className={slaStyles.link}>
@@ -108,15 +122,22 @@ const ComplaintsAtRiskTable = ({ rows = [] }) => {
                 {row.slaLabel}
               </span>
             </td>
-            <td className={getDataTableTdClass("right")}>
+            <td className={getDataTableTdClass()}>
               {row.breachDurationLabel ? (
-                <span className={slaStyles.overdue}>{row.breachDurationLabel}</span>
+                <span
+                  className={
+                    row.slaLevel === "breached" ? slaStyles.overdue : tableStyles.muted
+                  }
+                >
+                  {row.breachDurationLabel}
+                </span>
               ) : (
                 <span className={tableStyles.muted}>—</span>
               )}
             </td>
           </tr>
-        ))}
+          ))
+        )}
       </tbody>
     </table>
   );

--- a/frontend/micro-ui/web/src/dashboard/components/DashboardFilters.jsx
+++ b/frontend/micro-ui/web/src/dashboard/components/DashboardFilters.jsx
@@ -129,15 +129,15 @@ const DashboardFilters = ({
           </select>
         </div>
 
-        {canClear ? (
-          <button
-            type="button"
-            onClick={onClearFilters}
-            className="dashboard-filters-clear-inline"
-          >
-            Clear
-          </button>
-        ) : null}
+        <button
+          type="button"
+          onClick={onClearFilters}
+          disabled={!canClear}
+          className="dashboard-filters-clear-inline"
+          aria-disabled={!canClear}
+        >
+          Clear
+        </button>
         </div>
       </div>
     </div>

--- a/frontend/micro-ui/web/src/dashboard/components/DashboardGrid.jsx
+++ b/frontend/micro-ui/web/src/dashboard/components/DashboardGrid.jsx
@@ -8,9 +8,9 @@ import {
   GRID_COLS,
   KPI_ROW_HEIGHT,
   WIDGETS,
+  getDropPreviewSize,
+  getDroppingItem,
   getSizeConstraints,
-  getDefaultChartItem,
-  getDefaultKpiLayoutItem,
   getResizeHandles,
   isChartWidget,
   isKpiWidget,
@@ -121,16 +121,6 @@ function gridItemClassName(widgetId) {
   return undefined;
 }
 
-function getDropPreviewSize(widgetId) {
-  if (isKpiWidget(widgetId)) {
-    const defaults = getDefaultKpiLayoutItem(widgetId);
-    return { w: defaults.w, h: defaults.h };
-  }
-  const defaults = getDefaultChartItem(widgetId);
-  if (defaults) return { w: defaults.w, h: defaults.h };
-  return { w: DROPPING_ITEM.w, h: DROPPING_ITEM.h };
-}
-
 function pixelToGridPosition(containerWidth, clientX, clientY, gridRect, widgetId) {
   const { w, h } = getDropPreviewSize(widgetId);
   const colWidth = (containerWidth - GRID_MARGIN[0] * (GRID_COLS + 1)) / GRID_COLS;
@@ -161,7 +151,12 @@ const DashboardGrid = ({
 }) => {
   const gridWrapRef = useRef(null);
   const externalDropLockRef = useRef(false);
-  const isExternalDrag = Boolean(draggingWidgetIdRef?.current ?? draggingWidgetId);
+  const activeDragWidgetId = draggingWidgetIdRef?.current ?? draggingWidgetId;
+  const isExternalDrag = Boolean(activeDragWidgetId);
+  const droppingItem = useMemo(
+    () => (activeDragWidgetId ? getDroppingItem(activeDragWidgetId) : DROPPING_ITEM),
+    [activeDragWidgetId]
+  );
   const isSearchActive = Boolean(searchQuery?.trim());
 
   // Stamp the load time once. Swap for the API's data-as-of timestamp once a
@@ -321,7 +316,6 @@ const DashboardGrid = ({
 
     const rows = chartData[config.dataKey] || [];
     if (loading && !rows.length) return <ChartPlaceholder message="Loading…" />;
-    if (!rows.length) return <ChartPlaceholder message="No data" />;
 
     return <DashboardTable columns={config.columns} rows={rows} />;
   };
@@ -331,7 +325,6 @@ const DashboardGrid = ({
 
     const rows = chartData.complaintsAtRisk || [];
     if (loading && !rows.length) return <ChartPlaceholder message="Loading…" />;
-    if (!rows.length) return <ChartPlaceholder message="No data" />;
 
     return <ComplaintsAtRiskTable rows={rows} />;
   };
@@ -459,9 +452,9 @@ const DashboardGrid = ({
       if (!dropPosition) return;
 
       externalDropLockRef.current = true;
-      onExternalDragEnd?.();
       requestAnimationFrame(() => {
         onDropWidget(activeId, dropPosition);
+        onExternalDragEnd?.();
         externalDropLockRef.current = false;
       });
     },
@@ -562,7 +555,7 @@ const DashboardGrid = ({
           allowOverlap
           isResizable
           isDroppable
-          droppingItem={DROPPING_ITEM}
+          droppingItem={droppingItem}
           onDrop={handleDrop}
           onDropDragOver={handleDropDragOver}
         >

--- a/frontend/micro-ui/web/src/dashboard/components/DashboardHeader.jsx
+++ b/frontend/micro-ui/web/src/dashboard/components/DashboardHeader.jsx
@@ -51,6 +51,7 @@ const DashboardHeader = ({
   onExport,
   filters,
   filterOptions,
+  kpiCardData,
 }) => {
   const [addKpiOpen, setAddKpiOpen] = useState(false);
   const addKpiRef = useRef(null);
@@ -108,6 +109,7 @@ const DashboardHeader = ({
               open={addKpiOpen}
               onOpenChange={setAddKpiOpen}
               containerRef={addKpiRef}
+              kpiCardData={kpiCardData}
             />
           </div>
 

--- a/frontend/micro-ui/web/src/dashboard/components/DashboardLayout.jsx
+++ b/frontend/micro-ui/web/src/dashboard/components/DashboardLayout.jsx
@@ -19,6 +19,7 @@ const DashboardLayout = ({
   onClearFilters,
   filterOptions,
   filterOptionsLoading,
+  kpiCardData,
 }) => {
   const brandStyle = useMemo(() => {
     const theme = getBrandTheme();
@@ -47,6 +48,7 @@ const DashboardLayout = ({
           onExport={onExport}
           filters={filters}
           filterOptions={filterOptions}
+          kpiCardData={kpiCardData}
         />
         <main className="tw-flex-1 tw-overflow-auto tw-bg-background tw-p-4 lg:tw-p-6">
           <DashboardFilters

--- a/frontend/micro-ui/web/src/dashboard/components/DashboardTable.jsx
+++ b/frontend/micro-ui/web/src/dashboard/components/DashboardTable.jsx
@@ -3,7 +3,6 @@ import {
   DATA_TABLE_STYLES,
   getDataTableTdClass,
   getDataTableThClass,
-  getSlaRiskStatusPillClass,
 } from "../config/visualizationStyles";
 
 const TrendCell = ({ value }) => {
@@ -76,43 +75,57 @@ const CELL_RENDERERS = {
   tags: (value) => value,
 };
 
-function resolveCellToneClass(tone, styles) {
-  if (tone === "breach") return styles.thresholdCell;
-  if (tone === "watch") return styles.thresholdWatch;
-  if (tone === "good") return styles.thresholdGood;
+function resolveToneClass(tone, styles) {
+  if (tone === "breach") return styles.cellToneBreach;
+  if (tone === "watch") return styles.cellToneWatch;
   return undefined;
 }
 
-function renderStatusTags(tags, styles) {
-  const items = Array.isArray(tags) ? tags : [];
+function resolveToneTextClass(tone, styles) {
+  if (tone === "breach") return styles.thresholdCell;
+  if (tone === "watch") return styles.thresholdWatch;
+  return undefined;
+}
+
+function resolveStatusTagClass(tone, styles) {
+  if (tone === "breach") return `${styles.statusTag} ${styles.statusTagBreach}`;
+  if (tone === "watch") return `${styles.statusTag} ${styles.statusTagWatch}`;
+  return undefined;
+}
+
+function renderStatusTags(row, styles) {
+  const items = row.statusTagItems?.length
+    ? row.statusTagItems
+    : (Array.isArray(row.statusTags) ? row.statusTags : []).map((label) => ({
+        label,
+        tone: String(label).toLowerCase().includes("on track") ? "good" : "watch",
+      }));
+
   if (!items.length) return <span className={styles.muted}>—</span>;
 
   return (
     <span className="tw-flex tw-flex-wrap tw-gap-1">
-      {items.map((tag) => {
-        const normalized = String(tag).toLowerCase();
-        const pillClass =
-          normalized === "on track"
-            ? getSlaRiskStatusPillClass("open")
-            : normalized.includes("high") || normalized.includes("low")
-              ? getSlaRiskStatusPillClass("reopened")
-              : getSlaRiskStatusPillClass("assigned");
-        return (
-          <span key={tag} className={pillClass}>
-            {tag}
+      {items.map((item) =>
+        item.tone ? (
+          <span
+            key={item.label}
+            className={resolveStatusTagClass(item.tone, styles)}
+          >
+            {item.label}
           </span>
-        );
-      })}
+        ) : (
+          <span key={item.label} className={styles.muted}>
+            {item.label}
+          </span>
+        )
+      )}
     </span>
   );
 }
 
-const DashboardTable = ({ columns, rows }) => {
+const DashboardTable = ({ columns, rows, emptyMessage = "No data" }) => {
   const styles = DATA_TABLE_STYLES;
-
-  if (!rows?.length) {
-    return <p className={styles.empty}>No data</p>;
-  }
+  const safeRows = rows ?? [];
 
   return (
     <table className={styles.table}>
@@ -135,7 +148,14 @@ const DashboardTable = ({ columns, rows }) => {
         </tr>
       </thead>
       <tbody>
-        {rows.map((row, rowIndex) => (
+        {safeRows.length === 0 ? (
+          <tr>
+            <td colSpan={columns.length} className={styles.empty}>
+              {emptyMessage}
+            </td>
+          </tr>
+        ) : (
+          safeRows.map((row, rowIndex) => (
           <tr
             key={row.id ?? rowIndex}
             className={row.highlight ? styles.rowHighlight : undefined}
@@ -147,17 +167,25 @@ const DashboardTable = ({ columns, rows }) => {
               const render = CELL_RENDERERS[col.type] ?? CELL_RENDERERS.text;
               const content =
                 col.type === "tags"
-                  ? renderStatusTags(raw, styles)
+                  ? renderStatusTags(row, styles)
                   : col.type === "trend"
                     ? render(raw)
                     : render(raw);
               const labelText = typeof raw === "string" ? raw : String(raw ?? "");
               const toneKey = col.thresholdKey ?? col.id;
-              const toneClass = resolveCellToneClass(row.cellTones?.[toneKey], styles);
-              const isThresholdCell = row.cellHighlights?.[col.id];
+              const tone = row.cellTones?.[toneKey];
+              const cellToneClass = resolveToneClass(tone, styles);
+              const textToneClass = resolveToneTextClass(tone, styles);
+              const legacyHighlight =
+                !tone && row.cellHighlights?.[col.id] ? styles.cellToneBreach : undefined;
 
               return (
-                <td key={col.id} className={getDataTableTdClass(col.align)}>
+                <td
+                  key={col.id}
+                  className={`${getDataTableTdClass(col.align)} ${
+                    cellToneClass ?? legacyHighlight ?? ""
+                  }`.trim()}
+                >
                   {isLabel ? (
                     <span className={styles.primary} title={labelText}>
                       <span className={styles.label}>{content}</span>
@@ -166,15 +194,14 @@ const DashboardTable = ({ columns, rows }) => {
                       ) : null}
                     </span>
                   ) : (
-                    <span className={toneClass ?? (isThresholdCell ? styles.thresholdCell : undefined)}>
-                      {content}
-                    </span>
+                    <span className={textToneClass}>{content}</span>
                   )}
                 </td>
               );
             })}
           </tr>
-        ))}
+          ))
+        )}
       </tbody>
     </table>
   );

--- a/frontend/micro-ui/web/src/dashboard/components/DashboardTable.jsx
+++ b/frontend/micro-ui/web/src/dashboard/components/DashboardTable.jsx
@@ -4,6 +4,7 @@ import {
   getDataTableTdClass,
   getDataTableThClass,
 } from "../config/visualizationStyles";
+import { buildRedSeverityStyle } from "../config/tablePresentation";
 
 const TrendCell = ({ value }) => {
   const { muted, trendUp, trendDown } = DATA_TABLE_STYLES;
@@ -159,6 +160,15 @@ const DashboardTable = ({ columns, rows, emptyMessage = "No data" }) => {
           <tr
             key={row.id ?? rowIndex}
             className={row.highlight ? styles.rowHighlight : undefined}
+            style={
+              row.highlight
+                ? {
+                    "--row-sla-severity": String(
+                      row.highlightSeverity != null ? row.highlightSeverity : 1
+                    ),
+                  }
+                : undefined
+            }
           >
             {columns.map((col) => {
               const raw = row[col.id];
@@ -174,10 +184,22 @@ const DashboardTable = ({ columns, rows, emptyMessage = "No data" }) => {
               const labelText = typeof raw === "string" ? raw : String(raw ?? "");
               const toneKey = col.thresholdKey ?? col.id;
               const tone = row.cellTones?.[toneKey];
-              const cellToneClass = resolveToneClass(tone, styles);
-              const textToneClass = resolveToneTextClass(tone, styles);
+              const severity = row.cellToneSeverity?.[toneKey];
+              const severityStyle =
+                severity != null ? buildRedSeverityStyle(severity) : undefined;
+              const usesSeverity = severityStyle != null;
+              const suppressCellBackground = Boolean(row.highlight);
+              const cellToneClass =
+                suppressCellBackground || usesSeverity
+                  ? undefined
+                  : resolveToneClass(tone, styles);
+              const textToneClass = usesSeverity
+                ? styles.slaOverrun
+                : resolveToneTextClass(tone, styles);
               const legacyHighlight =
-                !tone && row.cellHighlights?.[col.id] ? styles.cellToneBreach : undefined;
+                !tone && !usesSeverity && !suppressCellBackground && row.cellHighlights?.[col.id]
+                  ? styles.cellToneBreach
+                  : undefined;
 
               return (
                 <td
@@ -194,7 +216,9 @@ const DashboardTable = ({ columns, rows, emptyMessage = "No data" }) => {
                       ) : null}
                     </span>
                   ) : (
-                    <span className={textToneClass}>{content}</span>
+                    <span className={textToneClass} style={usesSeverity ? severityStyle : undefined}>
+                      {content}
+                    </span>
                   )}
                 </td>
               );

--- a/frontend/micro-ui/web/src/dashboard/components/GeographyChoroplethMap.jsx
+++ b/frontend/micro-ui/web/src/dashboard/components/GeographyChoroplethMap.jsx
@@ -7,7 +7,7 @@ import {
   getGeographyMapLegendFooter,
   getGeographyMapLegendTitle,
 } from "../config/geographyMapPresentation";
-import { buildMapHoverTooltipHtml } from "../config/mapHoverPresentation";
+import { buildMapHoverTooltipHtml, buildComplaintPinTooltipHtml } from "../config/mapHoverPresentation";
 import { fetchBoundariesByCodes } from "../services/boundaryService";
 import { useMapResize } from "../hooks/useMapResize";
 import {
@@ -18,6 +18,9 @@ import {
   getMapCityLabel,
   getMapZoomTier,
   joinWardMapData,
+  MAP_COMPLAINT_PIN_MIN_ZOOM,
+  MAP_COMPLAINT_PIN_MAX_ZOOM,
+  MAP_WARD_UNCLUSTER_ZOOM,
   markerRadiusForZoom,
   wowPctToFillStyle,
 } from "../utils/mapGeoUtils";
@@ -42,6 +45,7 @@ function bindFeatureInteractions({
   map,
   resetView,
   setFocusedCode,
+  zoomLevel,
 }) {
   const code = feature?.properties?.code;
   const props = feature?.properties ?? {};
@@ -49,7 +53,7 @@ function bindFeatureInteractions({
   layer.bindTooltip(buildMapHoverTooltipHtml(props, { geoLevel }), HOVER_TOOLTIP_OPTIONS);
 
   layer.on("mouseover", () => {
-    const style = resolveFeatureStyle(feature, layerMode, focusedCode);
+    const style = resolveFeatureStyle(feature, layerMode, focusedCode, zoomLevel);
     layer.setStyle({
       ...style,
       weight: 2,
@@ -59,13 +63,13 @@ function bindFeatureInteractions({
   });
 
   layer.on("mouseout", () => {
-    layer.setStyle(resolveFeatureStyle(feature, layerMode, focusedCode));
+    layer.setStyle(resolveFeatureStyle(feature, layerMode, focusedCode, zoomLevel));
   });
 
   layer.on("click", () => {
-    const props = feature?.properties ?? {};
+    const clickProps = feature?.properties ?? {};
 
-    if (props.isCluster && feature.memberFeatures?.length > 1) {
+    if (clickProps.isCluster && feature.memberFeatures?.length > 1) {
       const group = L.featureGroup();
       L.geoJSON(
         { type: "FeatureCollection", features: feature.memberFeatures },
@@ -79,7 +83,7 @@ function bindFeatureInteractions({
       if (bounds?.isValid()) {
         map.fitBounds(bounds.pad(0.18), {
           animate: true,
-          maxZoom: Math.min(map.getZoom() + 2, 15),
+          maxZoom: Math.min(map.getZoom() + 2, MAP_COMPLAINT_PIN_MAX_ZOOM),
         });
       }
       return;
@@ -91,14 +95,17 @@ function bindFeatureInteractions({
         return null;
       }
       if (layer.getBounds?.().isValid()) {
-        map.fitBounds(layer.getBounds().pad(0.2), { animate: true, maxZoom: 14 });
+        map.fitBounds(layer.getBounds().pad(0.2), {
+          animate: true,
+          maxZoom: MAP_COMPLAINT_PIN_MAX_ZOOM,
+        });
       }
       return code;
     });
   });
 }
 
-function resolveFeatureStyle(feature, layerMode, focusedCode) {
+function resolveFeatureStyle(feature, layerMode, focusedCode, zoomLevel = 0) {
   const props = feature?.properties ?? {};
   const isFocused = focusedCode && props.code === focusedCode;
   const base =
@@ -106,13 +113,26 @@ function resolveFeatureStyle(feature, layerMode, focusedCode) {
       ? breachShareToFillStyle(props.breachSharePct)
       : wowPctToFillStyle(props.wowPct);
 
+  const dimChoropleth = zoomLevel >= MAP_COMPLAINT_PIN_MIN_ZOOM;
+
   return {
     fillColor: base.fillColor,
     color: isFocused ? "#111827" : base.strokeColor,
     weight: isFocused ? 2.5 : 1.5,
     opacity: 1,
-    fillOpacity: isFocused ? Math.min(base.fillOpacity + 0.08, 0.88) : base.fillOpacity,
+    fillOpacity: dimChoropleth
+      ? Math.min(base.fillOpacity, 0.28)
+      : isFocused
+        ? Math.min(base.fillOpacity + 0.08, 0.88)
+        : base.fillOpacity,
   };
+}
+
+function buildComplaintPinPopup(pin) {
+  const root = document.createElement("div");
+  root.className = "dashboard-map-pin-popup";
+  root.innerHTML = buildComplaintPinTooltipHtml(pin);
+  return root;
 }
 
 const HomeIcon = () => (
@@ -148,6 +168,7 @@ const FullscreenIcon = ({ active }) => (
 
 const GeographyChoroplethMap = ({
   wardCounts = [],
+  complaintPins = [],
   layerMode = "wow_change",
   onLayerModeChange,
   layerOptions = [],
@@ -159,6 +180,7 @@ const GeographyChoroplethMap = ({
   const mapRef = useRef(null);
   const choroplethRef = useRef(null);
   const markersRef = useRef(null);
+  const complaintPinsRef = useRef(null);
   const layerByCodeRef = useRef({});
   const defaultViewRef = useRef({ center: getMapCenter(), zoom: DEFAULT_ZOOM });
 
@@ -174,11 +196,13 @@ const GeographyChoroplethMap = ({
   const zoomTier = getMapZoomTier(zoomLevel);
   const geoLevel = focusedCode
     ? "Ward"
-    : zoomTier === "city"
-      ? "City"
-      : zoomTier === "locality"
-        ? "Locality"
-        : layerMeta?.zoomLevelLabel ?? "Ward";
+    : zoomTier === "complaint"
+      ? "Complaint"
+      : zoomTier === "city"
+        ? "City"
+        : zoomTier === "locality"
+          ? "Locality"
+          : layerMeta?.zoomLevelLabel ?? "Ward";
   const zoomLevelLabel = geoLevel;
 
   const { resizeToken } = useMapResize(mapRef, frameRef);
@@ -231,8 +255,8 @@ const GeographyChoroplethMap = ({
   );
 
   const displayLayers = useMemo(
-    () => buildMapDisplayLayers(joined, zoomLevel),
-    [joined, zoomLevel]
+    () => buildMapDisplayLayers(joined, zoomLevel, complaintPins),
+    [joined, zoomLevel, complaintPins]
   );
 
   useEffect(() => {
@@ -295,7 +319,7 @@ const GeographyChoroplethMap = ({
   useEffect(() => {
     if (!elRef.current || mapRef.current) return;
     const map = L.map(elRef.current, {
-      scrollWheelZoom: false,
+      scrollWheelZoom: true,
       zoomControl: false,
     }).setView(getMapCenter(), DEFAULT_ZOOM);
 
@@ -305,22 +329,35 @@ const GeographyChoroplethMap = ({
       maxZoom: 19,
     }).addTo(map);
 
+    if (!map.getPane("complaintPins")) {
+      map.createPane("complaintPins");
+      map.getPane("complaintPins").style.zIndex = 650;
+    }
+
     choroplethRef.current = L.layerGroup().addTo(map);
     markersRef.current = L.layerGroup().addTo(map);
+    complaintPinsRef.current = L.layerGroup().addTo(map);
     mapRef.current = map;
     defaultViewRef.current = { center: getMapCenter(), zoom: DEFAULT_ZOOM };
 
-    const syncZoom = () => setZoomLevel(map.getZoom());
-    map.on("zoomend", syncZoom);
-    syncZoom();
+    const syncMapView = () => {
+      setZoomLevel(map.getZoom());
+    };
+    map.on("zoom", syncMapView);
+    map.on("zoomend", syncMapView);
+    map.on("moveend", syncMapView);
+    syncMapView();
 
     setTimeout(() => map.invalidateSize(), 150);
     return () => {
-      map.off("zoomend", syncZoom);
+      map.off("zoom", syncMapView);
+      map.off("zoomend", syncMapView);
+      map.off("moveend", syncMapView);
       map.remove();
       mapRef.current = null;
       choroplethRef.current = null;
       markersRef.current = null;
+      complaintPinsRef.current = null;
       layerByCodeRef.current = {};
     };
   }, []);
@@ -329,17 +366,21 @@ const GeographyChoroplethMap = ({
     const map = mapRef.current;
     const choroplethLayer = choroplethRef.current;
     const markerLayer = markersRef.current;
-    if (!map || !choroplethLayer || !markerLayer) return;
+    const complaintPinLayer = complaintPinsRef.current;
+    if (!map || !choroplethLayer || !markerLayer || !complaintPinLayer) return;
 
     choroplethLayer.clearLayers();
     markerLayer.clearLayers();
+    complaintPinLayer.clearLayers();
     layerByCodeRef.current = {};
 
-    const { geoFeatures, pointMarkers } = displayLayers;
+    const { geoFeatures, pointMarkers, complaintPins: visiblePins } = displayLayers;
+
+    const showComplaintPins = zoomLevel >= MAP_COMPLAINT_PIN_MIN_ZOOM;
 
     if (geoFeatures?.features?.length) {
       L.geoJSON(geoFeatures, {
-        style: (feature) => resolveFeatureStyle(feature, layerMode, focusedCode),
+        style: (feature) => resolveFeatureStyle(feature, layerMode, focusedCode, zoomLevel),
         onEachFeature: (feature, layer) => {
           layer.feature = feature;
           const code = feature?.properties?.code;
@@ -353,48 +394,77 @@ const GeographyChoroplethMap = ({
             map,
             resetView,
             setFocusedCode,
+            zoomLevel,
           });
         },
       }).addTo(choroplethLayer);
     }
 
-    pointMarkers.forEach((marker) => {
-      const style =
-        layerMode === "sla_breach"
-          ? breachShareToFillStyle(marker.breachSharePct)
-          : wowPctToFillStyle(marker.wowPct);
-      const isFocused = focusedCode && marker.code === focusedCode;
-      const markerFeature = { properties: { ...marker, code: marker.code } };
-      const circle = L.circleMarker([marker.lat, marker.lng], {
-        radius: markerRadiusForZoom(zoomLevel, isFocused),
-        color: isFocused ? "#111827" : style.strokeColor,
-        weight: isFocused ? 2 : 1,
-        fillColor: style.fillColor,
-        fillOpacity: style.fillOpacity,
+    if (!showComplaintPins) {
+      pointMarkers.forEach((marker) => {
+        const style =
+          layerMode === "sla_breach"
+            ? breachShareToFillStyle(marker.breachSharePct)
+            : wowPctToFillStyle(marker.wowPct);
+        const isFocused = focusedCode && marker.code === focusedCode;
+        const markerFeature = { properties: { ...marker, code: marker.code } };
+        const circle = L.circleMarker([marker.lat, marker.lng], {
+          radius: markerRadiusForZoom(zoomLevel, isFocused),
+          color: isFocused ? "#111827" : style.strokeColor,
+          weight: isFocused ? 2 : 1,
+          fillColor: style.fillColor,
+          fillOpacity: style.fillOpacity,
+        });
+        circle.feature = markerFeature;
+        bindFeatureInteractions({
+          layer: circle,
+          feature: markerFeature,
+          layerMode,
+          focusedCode,
+          geoLevel,
+          map,
+          resetView,
+          setFocusedCode: (updater) => {
+            setFocusedCode((prev) => {
+              const next = typeof updater === "function" ? updater(prev) : updater;
+              if (next === marker.code && prev !== marker.code) {
+                map.flyTo([marker.lat, marker.lng], Math.max(map.getZoom(), MAP_WARD_UNCLUSTER_ZOOM));
+              } else if (next === null && prev === marker.code) {
+                resetView();
+              }
+              return next;
+            });
+          },
+          zoomLevel,
+        });
+        circle.addTo(markerLayer);
       });
-      circle.feature = markerFeature;
-      bindFeatureInteractions({
-        layer: circle,
-        feature: markerFeature,
-        layerMode,
-        focusedCode,
-        geoLevel,
-        map,
-        resetView,
-        setFocusedCode: (updater) => {
-          setFocusedCode((prev) => {
-            const next = typeof updater === "function" ? updater(prev) : updater;
-            if (next === marker.code && prev !== marker.code) {
-              map.flyTo([marker.lat, marker.lng], Math.max(map.getZoom(), 13));
-            } else if (next === null && prev === marker.code) {
-              resetView();
-            }
-            return next;
-          });
-        },
+    }
+
+    visiblePins.forEach((pin) => {
+      const circle = L.circleMarker([pin.lat, pin.lng], {
+        pane: "complaintPins",
+        radius: markerRadiusForZoom(zoomLevel, false, { complaint: true }),
+        color: "#0f766e",
+        weight: 2,
+        fillColor: "#14b8a6",
+        fillOpacity: 0.95,
       });
-      circle.addTo(markerLayer);
+      circle.bindTooltip(buildComplaintPinTooltipHtml(pin), HOVER_TOOLTIP_OPTIONS);
+      circle.on("mouseover", () => {
+        circle.setStyle({ weight: 3, fillOpacity: 1 });
+        circle.bringToFront?.();
+      });
+      circle.on("mouseout", () => {
+        circle.setStyle({ weight: 2, fillOpacity: 0.95 });
+      });
+      circle.bindPopup(buildComplaintPinPopup(pin));
+      circle.addTo(complaintPinLayer);
     });
+
+    if (visiblePins.length) {
+      complaintPinLayer.bringToFront?.();
+    }
   }, [displayLayers, focusedCode, geoLevel, layerMode, resetView, zoomLevel]);
 
   useEffect(() => {
@@ -434,9 +504,9 @@ const GeographyChoroplethMap = ({
     Object.entries(layerByCodeRef.current).forEach(([, layer]) => {
       const feature = layer.feature;
       if (!feature) return;
-      layer.setStyle(resolveFeatureStyle(feature, layerMode, focusedCode));
+      layer.setStyle(resolveFeatureStyle(feature, layerMode, focusedCode, zoomLevel));
     });
-  }, [focusedCode, layerMode]);
+  }, [focusedCode, layerMode, zoomLevel]);
 
   const showEmpty =
     !boundariesLoading && !wardCounts.length && !boundariesError;

--- a/frontend/micro-ui/web/src/dashboard/components/HorizontalBarChart.jsx
+++ b/frontend/micro-ui/web/src/dashboard/components/HorizontalBarChart.jsx
@@ -97,7 +97,7 @@ const HorizontalBarChart = ({ data = [], breakEven = 1, scrollKey }) => {
           horizontal: true,
           borderRadius: 4,
           borderRadiusApplication: "end",
-          barHeight: "68%",
+          barHeight: "58%",
           dataLabels: {
             total: {
               enabled: true,

--- a/frontend/micro-ui/web/src/dashboard/components/HorizontalBarChart.jsx
+++ b/frontend/micro-ui/web/src/dashboard/components/HorizontalBarChart.jsx
@@ -20,13 +20,13 @@ function formatRatio(value) {
   return n.toFixed(2);
 }
 
-function splitAtBreakEven(value, breakEven) {
+function breakEvenSeriesValues(value, breakEven) {
   const v = Math.max(0, Number(value) || 0);
   const threshold = Math.max(0, Number(breakEven) || 0);
-  return {
-    below: Math.min(v, threshold),
-    above: Math.max(0, v - threshold),
-  };
+  if (v >= threshold) {
+    return { below: 0, above: v };
+  }
+  return { below: v, above: 0 };
 }
 
 const HorizontalBarChart = ({ data = [], breakEven = 1, scrollKey }) => {
@@ -69,7 +69,7 @@ const HorizontalBarChart = ({ data = [], breakEven = 1, scrollKey }) => {
     const below = [];
     const above = [];
     for (const value of values) {
-      const split = splitAtBreakEven(value, breakEven);
+      const split = breakEvenSeriesValues(value, breakEven);
       below.push(split.below);
       above.push(split.above);
     }

--- a/frontend/micro-ui/web/src/dashboard/components/OpenComplaintsByGeographyWidget.jsx
+++ b/frontend/micro-ui/web/src/dashboard/components/OpenComplaintsByGeographyWidget.jsx
@@ -38,6 +38,7 @@ const OpenComplaintsByGeographyWidget = ({ layers, loading = false }) => {
       </header>
       <GeographyChoroplethMap
         wardCounts={wardCounts}
+        complaintPins={layers?.complaintPins ?? []}
         layerMode={resolvedLayer}
         onLayerModeChange={setActiveLayer}
         layerOptions={GEOGRAPHY_MAP_LAYERS}

--- a/frontend/micro-ui/web/src/dashboard/components/StackedBarChart.jsx
+++ b/frontend/micro-ui/web/src/dashboard/components/StackedBarChart.jsx
@@ -2,12 +2,9 @@ import React, { useMemo } from "react";
 import Chart from "react-apexcharts";
 import { DASHBOARD_FONT_FAMILY } from "../config/dashboardConfig";
 import {
-  resolveVerticalCategorySlotWidth,
-  resolveVerticalXAxisLabelHeight,
-} from "../config/chartAxisLabels";
-import {
   buildApexSeriesHoverTooltip,
 } from "../config/chartTooltipPresentation";
+import { BAR_CHART_XAXIS_RESERVED_HEIGHT_PX } from "../config/barChartPresentation";
 import {
   buildStackedBarAnnotations,
   buildStackedBarDataLabels,
@@ -51,14 +48,9 @@ const StackedBarChart = ({
     [colors]
   );
 
-  const verticalXAxisLabelHeight = useMemo(() => {
-    if (horizontal) return 4;
-    const slotWidthPx = resolveVerticalCategorySlotWidth(categories.length, containerWidth);
-    return resolveVerticalXAxisLabelHeight(categories, slotWidthPx, {
-      minHeightPx: 22,
-      maxHeightPx: 72,
-    });
-  }, [categories, containerWidth, horizontal]);
+  const verticalXAxisLabelHeight = horizontal
+    ? 4
+    : BAR_CHART_XAXIS_RESERVED_HEIGHT_PX;
 
   const options = useMemo(
     () => ({
@@ -76,7 +68,7 @@ const StackedBarChart = ({
         containerWidth,
         categoryCount: categories.length,
       }),
-      dataLabels: buildStackedBarDataLabels({ valueFormat }),
+      dataLabels: buildStackedBarDataLabels({ valueFormat, horizontal }),
       xaxis: buildStackedBarXAxis({ horizontal, categories, containerWidth }),
       yaxis: horizontal
         ? [buildStackedBarYAxis({ horizontal, categories, containerWidth, valueFormat })]

--- a/frontend/micro-ui/web/src/dashboard/config/addKpiPreviewPresentation.js
+++ b/frontend/micro-ui/web/src/dashboard/config/addKpiPreviewPresentation.js
@@ -1,0 +1,56 @@
+/**
+ * Hover preview content for the header “Add KPI” inventory list.
+ */
+
+import { getKpiDisplayConfig, getKpiDisplayTitle } from "./kpiDisplay";
+import { getSubMetricDef } from "./supervisorMetrics";
+
+function formatPreviewTarget(metricId) {
+  const threshold = getKpiDisplayConfig(metricId).threshold;
+  if (!threshold) return null;
+
+  const { kind, onTrack } = threshold;
+  if (kind === "percent") return `Target: ${onTrack}%`;
+  if (kind === "rating") return `Target: ${onTrack}/5`;
+  if (kind === "count") {
+    if (metricId === "cl-metric-oldest-open") return `Target: ${onTrack} days`;
+    return `Target: ${onTrack}`;
+  }
+  return null;
+}
+
+function resolvePreviewDescription(item) {
+  if (item.itemType === "kpi") {
+    const sub = getSubMetricDef(item, item.defaultSubMetricId);
+    return sub?.label || item.metric;
+  }
+  return item.subMetric || item.outputFormat || null;
+}
+
+function isDisplayableValue(value) {
+  return value != null && value !== "—" && value !== "…";
+}
+
+export function buildAddKpiPreviewContent(item, { kpiCardData } = {}) {
+  if (!item) return null;
+
+  if (item.itemType === "kpi") {
+    const card = kpiCardData?.[item.id];
+    return {
+      title: getKpiDisplayTitle(item),
+      value: isDisplayableValue(card?.value) ? card.value : null,
+      target: formatPreviewTarget(item.id),
+      description: resolvePreviewDescription(item),
+    };
+  }
+
+  return {
+    title: item.metric,
+    value: null,
+    target: null,
+    description: resolvePreviewDescription(item),
+  };
+}
+
+export const ADD_KPI_PREVIEW_WIDTH_PX = 228;
+export const ADD_KPI_PREVIEW_GAP_PX = 12;

--- a/frontend/micro-ui/web/src/dashboard/config/barChartPresentation.js
+++ b/frontend/micro-ui/web/src/dashboard/config/barChartPresentation.js
@@ -22,8 +22,8 @@ export const BAR_CHART_XAXIS_LABEL_HEIGHT_COMPACT_PX = 18;
 /** Fixed bottom reserve for normal vertical bar charts (2 wrapped label lines). */
 export const BAR_CHART_XAXIS_RESERVED_HEIGHT_PX = 28;
 /** Room above the plot for value labels on bar tops (pairs with data label offsetY). */
-export const BAR_CHART_GRID_TOP_PAD = 6;
-export const BAR_CHART_DATA_LABEL_OFFSET_Y = -16;
+export const BAR_CHART_GRID_TOP_PAD = 8;
+export const BAR_CHART_DATA_LABEL_OFFSET_Y = -20;
 /** Bar thickness as a fraction of each category slot — same on every vertical bar chart. */
 export const BAR_COLUMN_WIDTH_RATIO = 0.88;
 export const BAR_COLUMN_MAX_WIDTH_PX = 56;
@@ -39,19 +39,13 @@ export function resolveBarChartYAxisMax(seriesMax, { percent = false } = {}) {
   const peak = Math.max(Number(seriesMax) || 0, 0);
   if (peak === 0) return percent ? 10 : 1;
 
-  if (percent) {
-    const headroom = Math.max(
-      1,
-      Math.ceil(peak * BAR_CHART_YAXIS_HEADROOM_RATIO * 10) / 10
-    );
-    return Math.min(100, Math.ceil((peak + headroom) * 10) / 10);
-  }
-
   const headroom = Math.max(
     BAR_CHART_YAXIS_MIN_HEADROOM,
     Math.ceil(peak * BAR_CHART_YAXIS_HEADROOM_RATIO)
   );
-  return peak + headroom;
+
+  const axisMax = peak + headroom;
+  return percent ? Math.ceil(axisMax * 10) / 10 : axisMax;
 }
 
 export function resolveBarChartColumnWidth(slotWidthPx) {

--- a/frontend/micro-ui/web/src/dashboard/config/chartAxisLabels.js
+++ b/frontend/micro-ui/web/src/dashboard/config/chartAxisLabels.js
@@ -9,8 +9,12 @@ import {
   formatWrappedChartLabel,
   wrapChartLabelToLines,
 } from "../utils/chartLabelWrap";
+import { DASHBOARD_FONT_FAMILY } from "./dashboardConfig";
 
-const VERTICAL_LABEL_STYLE = { fontSize: `${CHART_AXIS_LABEL_FONT_SIZE_PX}px` };
+const VERTICAL_LABEL_STYLE = {
+  fontSize: `${CHART_AXIS_LABEL_FONT_SIZE_PX}px`,
+  fontFamily: DASHBOARD_FONT_FAMILY,
+};
 
 export function resolveVerticalCategorySlotWidth(categoryCount, containerWidth, gutterPx = 8) {
   if (!categoryCount || !containerWidth) return 0;

--- a/frontend/micro-ui/web/src/dashboard/config/citizenExperienceLandscape.js
+++ b/frontend/micro-ui/web/src/dashboard/config/citizenExperienceLandscape.js
@@ -8,31 +8,6 @@ export const CITIZEN_EXPERIENCE_SECTION = "Citizen experience";
 /** @type {Array<{id:string, metric:string, accent:string, defaultSubMetricId:string, subMetrics:object[]}>} */
 export const CITIZEN_EXPERIENCE_METRICS = [
   {
-    id: "ce-metric-csat",
-    metric: "CSAT / post-resolution rating",
-    accent: "teal",
-    vizType: "number-tile-sparkline",
-    defaultSubMetricId: "avg_rating_week",
-    subMetrics: [
-      {
-        id: "avg_rating_week",
-        label: "Avg. rating (zone, this week)",
-        outputFormat: "Decimal (1 place, out of 5)",
-        format: "decimalOne",
-        measureKey: "avg",
-        queryKey: "ce_csat_avg_week",
-      },
-      {
-        id: "response_rate",
-        label: "% rated (response rate)",
-        outputFormat: "% (round to nearest integer)",
-        format: "percentInteger",
-        measureKey: "pct",
-        queryKey: "ce_response_rate",
-      },
-    ],
-  },
-  {
     id: "ce-metric-reopen-rate",
     metric: "Reopen rate at zone level",
     accent: "amber",

--- a/frontend/micro-ui/web/src/dashboard/config/complaintLandscape.js
+++ b/frontend/micro-ui/web/src/dashboard/config/complaintLandscape.js
@@ -130,7 +130,7 @@ export const LANDSCAPE_METRICS = [
   },
   {
     id: "cl-metric-csat",
-    metric: "CSAT",
+    metric: "Citizen satisfaction",
     accent: "teal",
     vizType: "number-tile-delta",
     defaultSubMetricId: "avg",

--- a/frontend/micro-ui/web/src/dashboard/config/complaintTypeDetailsTablePresentation.js
+++ b/frontend/micro-ui/web/src/dashboard/config/complaintTypeDetailsTablePresentation.js
@@ -22,15 +22,16 @@ function resolutionTableValue(ms) {
   return Math.round((ms / MS_PER_DAY) * 10) / 10 * 24;
 }
 
-function toneForResolutionVsSla(avgMs, slaMs) {
+/** Same gate as OVER SLA; severity = (avgMs − slaMs) / slaMs in raw time. */
+function resolutionOverSlaSeverity(avgMs, slaMs) {
+  if (!Number.isFinite(avgMs) || !Number.isFinite(slaMs)) return null;
   const avg = resolutionTableValue(avgMs);
   const sla = resolutionTableValue(slaMs);
   if (avg == null || sla == null || avg <= sla) return null;
-  if (sla === 0) return "breach";
-  const ratio = avg / sla;
-  if (ratio > 1.15) return "breach";
-  if (ratio > 1) return "watch";
-  return null;
+
+  const overrunMs = avgMs - slaMs;
+  const scaleMs = slaMs > 0 ? slaMs : MS_PER_DAY;
+  return Math.min(1, overrunMs / scaleMs);
 }
 
 function isOverSla(avgMs, slaMs) {
@@ -44,10 +45,11 @@ export function annotateComplaintTypeDetailsRows(rows) {
 
   return rows.map((row) => {
     const cellTones = {};
+    const cellToneSeverity = {};
 
-    const resolutionTone = toneForResolutionVsSla(row.avgResolutionMs, row.idealSlaMs);
-    if (resolutionTone) {
-      cellTones.avgResolutionMs = resolutionTone;
+    const resolutionSeverity = resolutionOverSlaSeverity(row.avgResolutionMs, row.idealSlaMs);
+    if (resolutionSeverity != null) {
+      cellToneSeverity.avgResolutionMs = resolutionSeverity;
     }
 
     for (const [key, config] of Object.entries(COMPLAINT_TYPE_DETAILS_THRESHOLDS)) {
@@ -59,7 +61,9 @@ export function annotateComplaintTypeDetailsRows(rows) {
     return {
       ...row,
       cellTones,
+      cellToneSeverity,
       highlight: overSla,
+      highlightSeverity: resolutionSeverity,
       badge: overSla ? "OVER SLA" : null,
     };
   });

--- a/frontend/micro-ui/web/src/dashboard/config/complaintTypeDetailsTablePresentation.js
+++ b/frontend/micro-ui/web/src/dashboard/config/complaintTypeDetailsTablePresentation.js
@@ -1,0 +1,66 @@
+/**
+ * Per-cell threshold coloring for the complaint type details table.
+ */
+
+import { evaluateMetricTone, storeCellTone } from "./tablePresentation";
+
+const MS_PER_HOUR = 3600000;
+const MS_PER_DAY = 86400000;
+
+export const COMPLAINT_TYPE_DETAILS_THRESHOLDS = {
+  reopenRate: { higherIsBetter: false, watch: 0.1, breach: 0.25 },
+  ontimeRate: { higherIsBetter: true, watch: 0.85, breach: 0.6 },
+  avgCsat: { higherIsBetter: true, watch: 4, breach: 3 },
+  oldestOpenMs: { higherIsBetter: false, watch: 7 * MS_PER_DAY, breach: 30 * MS_PER_DAY },
+};
+
+/** Same rounding as `formatHoursDays` in DashboardTable — compare what the user sees. */
+function resolutionTableValue(ms) {
+  if (!Number.isFinite(ms)) return null;
+  const hours = ms / MS_PER_HOUR;
+  if (hours < 48) return Math.round(hours * 10) / 10;
+  return Math.round((ms / MS_PER_DAY) * 10) / 10 * 24;
+}
+
+function toneForResolutionVsSla(avgMs, slaMs) {
+  const avg = resolutionTableValue(avgMs);
+  const sla = resolutionTableValue(slaMs);
+  if (avg == null || sla == null || avg <= sla) return null;
+  if (sla === 0) return "breach";
+  const ratio = avg / sla;
+  if (ratio > 1.15) return "breach";
+  if (ratio > 1) return "watch";
+  return null;
+}
+
+function isOverSla(avgMs, slaMs) {
+  const avg = resolutionTableValue(avgMs);
+  const sla = resolutionTableValue(slaMs);
+  return avg != null && sla != null && avg > sla;
+}
+
+export function annotateComplaintTypeDetailsRows(rows) {
+  if (!rows?.length) return rows;
+
+  return rows.map((row) => {
+    const cellTones = {};
+
+    const resolutionTone = toneForResolutionVsSla(row.avgResolutionMs, row.idealSlaMs);
+    if (resolutionTone) {
+      cellTones.avgResolutionMs = resolutionTone;
+    }
+
+    for (const [key, config] of Object.entries(COMPLAINT_TYPE_DETAILS_THRESHOLDS)) {
+      storeCellTone(cellTones, key, evaluateMetricTone(row[key], config));
+    }
+
+    const overSla = isOverSla(row.avgResolutionMs, row.idealSlaMs);
+
+    return {
+      ...row,
+      cellTones,
+      highlight: overSla,
+      badge: overSla ? "OVER SLA" : null,
+    };
+  });
+}

--- a/frontend/micro-ui/web/src/dashboard/config/complaintsAtRiskPresentation.js
+++ b/frontend/micro-ui/web/src/dashboard/config/complaintsAtRiskPresentation.js
@@ -3,8 +3,18 @@ const MS_PER_DAY = 86400000;
 
 export const SLA_STATUS_LABELS = {
   breached: "Breached",
-  approaching: "Nearing breach",
+  nearing: "Nearing breach",
 };
+
+export const WORKFLOW_STATUS_LABELS = {
+  reopened: "Reopened",
+  in_progress: "In progress",
+  assigned: "Assigned",
+  open: "Open",
+};
+
+const OPEN_STATUS_KEYS = new Set(["PENDINGFORASSIGNMENT", "OPEN"]);
+const ASSIGNED_STATUS_KEYS = new Set(["PENDINGATLME", "ASSIGNED"]);
 
 export function formatBreachDurationCompact(ms) {
   const n = Number(ms);
@@ -24,7 +34,7 @@ export function formatBreachDurationCompact(ms) {
 export function resolveSlaRiskPresentation(bucket) {
   const normalized = String(bucket ?? "").toLowerCase();
   if (normalized === "approaching") {
-    return { slaLabel: SLA_STATUS_LABELS.approaching, slaLevel: "nearing" };
+    return { slaLabel: SLA_STATUS_LABELS.nearing, slaLevel: "nearing" };
   }
   return { slaLabel: SLA_STATUS_LABELS.breached, slaLevel: "breached" };
 }
@@ -44,15 +54,30 @@ export function complaintDetailHref(serviceRequestId) {
 }
 
 export function formatWorkflowStatusLabel(status) {
-  return String(status ?? "—")
-    .replace(/_/g, " ")
-    .replace(/\b\w/g, (c) => c.toUpperCase());
+  const key = normalizeWorkflowStatusKey(status);
+  return WORKFLOW_STATUS_LABELS[key] ?? WORKFLOW_STATUS_LABELS.in_progress;
 }
 
 export function normalizeWorkflowStatusKey(status) {
-  const normalized = String(status ?? "").toLowerCase();
-  if (normalized.includes("reopen")) return "reopened";
-  if (normalized.includes("assign")) return "assigned";
-  if (normalized.includes("open") || normalized.includes("pending")) return "open";
+  const key = String(status ?? "")
+    .trim()
+    .toUpperCase()
+    .replace(/[\s_-]+/g, "");
+
+  if (!key) return "in_progress";
+  if (key.includes("REOPEN")) return "reopened";
+  if (ASSIGNED_STATUS_KEYS.has(key) || (key.includes("ASSIGN") && !key.includes("PENDINGFORASSIGNMENT"))) {
+    return "assigned";
+  }
+  if (OPEN_STATUS_KEYS.has(key) || key === "PENDINGFORASSIGNMENT") return "open";
+  if (key.includes("INPROGRESS") || key.includes("PROGRESS")) return "in_progress";
+  if (
+    key.includes("PENDING") ||
+    key.includes("SUPERVISOR") ||
+    key.includes("REASSIGN") ||
+    key.includes("ESCALAT")
+  ) {
+    return "in_progress";
+  }
   return "in_progress";
 }

--- a/frontend/micro-ui/web/src/dashboard/config/dashboardConfig.js
+++ b/frontend/micro-ui/web/src/dashboard/config/dashboardConfig.js
@@ -52,7 +52,7 @@ export function getSystemTitle() {
 }
 
 export function getLayoutStorageKey() {
-  return `${getTenantId()}-supervisor-dashboard-layout-v30`;
+  return `${getTenantId()}-supervisor-dashboard-layout-v31`;
 }
 
 export function getSubMetricStorageKey() {

--- a/frontend/micro-ui/web/src/dashboard/config/dashboardFilters.js
+++ b/frontend/micro-ui/web/src/dashboard/config/dashboardFilters.js
@@ -38,7 +38,7 @@ export function loadDashboardFilters() {
     /* fall through */
   }
 
-  return { timeWindow: migrateTimeWindowFromLegacy() };
+  return sanitizeFilters({ timeWindow: migrateTimeWindowFromLegacy() });
 }
 
 export function clearDashboardFilters() {

--- a/frontend/micro-ui/web/src/dashboard/config/dashboardTables.js
+++ b/frontend/micro-ui/web/src/dashboard/config/dashboardTables.js
@@ -62,15 +62,30 @@ export const COMPLAINT_TYPE_DETAILS_COLUMNS = [
     align: "right",
     type: "hoursDays",
     width: "13%",
+    thresholdKey: "avgResolutionMs",
   },
-  { id: "idealSlaMs", label: "Ideal (SLA)", align: "right", type: "hoursDays", width: "11%" },
-  { id: "reopenRate", label: "Reopen rate", align: "right", type: "percent", width: "10%" },
+  {
+    id: "idealSlaMs",
+    label: "SLA",
+    align: "right",
+    type: "hoursDays",
+    width: "11%",
+  },
+  {
+    id: "reopenRate",
+    label: "Reopen rate",
+    align: "right",
+    type: "percent",
+    width: "10%",
+    thresholdKey: "reopenRate",
+  },
   {
     id: "oldestOpenMs",
     label: "Oldest complaint",
     align: "right",
     type: "hoursDays",
     width: "13%",
+    thresholdKey: "oldestOpenMs",
   },
   {
     id: "ontimeRate",
@@ -78,8 +93,16 @@ export const COMPLAINT_TYPE_DETAILS_COLUMNS = [
     align: "right",
     type: "percent",
     width: "13%",
+    thresholdKey: "ontimeRate",
   },
-  { id: "avgCsat", label: "CSAT", align: "right", type: "rating", width: "8%" },
+  {
+    id: "avgCsat",
+    label: "CSAT",
+    align: "right",
+    type: "rating",
+    width: "8%",
+    thresholdKey: "avgCsat",
+  },
 ];
 
 export const TABLE_WIDGET_CONFIG = {

--- a/frontend/micro-ui/web/src/dashboard/config/employeePerformanceTablePresentation.js
+++ b/frontend/micro-ui/web/src/dashboard/config/employeePerformanceTablePresentation.js
@@ -2,7 +2,7 @@
  * Threshold coloring and status tags for the employee performance table.
  */
 
-/** @typedef {'breach' | 'watch' | 'good'} MetricTone */
+import { evaluateMetricTone, storeCellTone } from "./tablePresentation";
 
 export const EMPLOYEE_PERFORMANCE_METRIC_THRESHOLDS = {
   open: { higherIsBetter: false, watch: 8, breach: 15 },
@@ -18,29 +18,14 @@ const TAG_LABELS = {
   escalationRate: { breach: "High escalation", watch: "Escalation risk" },
 };
 
-export function evaluateEmployeeMetricTone(value, config) {
-  if (!Number.isFinite(value) || !config) return null;
-  const { higherIsBetter, watch, breach } = config;
-
-  if (higherIsBetter) {
-    if (value < breach) return "breach";
-    if (value < watch) return "watch";
-    return "good";
-  }
-
-  if (value > breach) return "breach";
-  if (value > watch) return "watch";
-  return "good";
-}
-
-function buildStatusTags(cellTones) {
-  const tags = [];
+function buildStatusTagItems(cellTones) {
+  const items = [];
   for (const [metricKey, tone] of Object.entries(cellTones ?? {})) {
-    if (tone === "good" || tone == null) continue;
     const label = TAG_LABELS[metricKey]?.[tone];
-    if (label) tags.push(label);
+    if (label) items.push({ label, tone });
   }
-  return tags.length ? tags : ["On track"];
+  if (!items.length) return [{ label: "On track", tone: null }];
+  return items;
 }
 
 export function annotateEmployeePerformanceRows(rows) {
@@ -49,14 +34,16 @@ export function annotateEmployeePerformanceRows(rows) {
   return rows.map((row) => {
     const cellTones = {};
     for (const [metricKey, config] of Object.entries(EMPLOYEE_PERFORMANCE_METRIC_THRESHOLDS)) {
-      const tone = evaluateEmployeeMetricTone(row[metricKey], config);
-      if (tone) cellTones[metricKey] = tone;
+      storeCellTone(cellTones, metricKey, evaluateMetricTone(row[metricKey], config));
     }
+
+    const statusTagItems = buildStatusTagItems(cellTones);
 
     return {
       ...row,
       cellTones,
-      statusTags: buildStatusTags(cellTones),
+      statusTagItems,
+      statusTags: statusTagItems.map((item) => item.label),
     };
   });
 }

--- a/frontend/micro-ui/web/src/dashboard/config/geographyMapPresentation.js
+++ b/frontend/micro-ui/web/src/dashboard/config/geographyMapPresentation.js
@@ -56,9 +56,11 @@ export function getGeographyMapLegendTitle(layerId) {
 }
 
 export function getGeographyMapLegendFooter(layerId) {
-  return layerId === "wow_change"
-    ? "Click a locality to focus · click again to clear"
-    : "Click a ward to focus · click again to clear";
+  const focusHint =
+    layerId === "wow_change"
+      ? "Click a locality to focus · click again to clear"
+      : "Click a ward to focus · click again to clear";
+  return `${focusHint} · Zoom to level 10+ to see complaint pins (hover for details)`;
 }
 
 export function getWowChangeBucket(wowPct) {

--- a/frontend/micro-ui/web/src/dashboard/config/globalFilterGroups.js
+++ b/frontend/micro-ui/web/src/dashboard/config/globalFilterGroups.js
@@ -51,11 +51,18 @@ export function buildDefaultFilters() {
 
 export function hasActiveFilters(filters) {
   if (!filters) return false;
-  if (filters.dateRangeActive) return true;
   const defaults = buildDefaultFilters();
+  const geography = filters.geography ?? defaults.geography;
+  const complaintType = filters.complaintType ?? defaults.complaintType;
+  const dateFrom = filters.dateFrom ?? defaults.dateFrom;
+  const dateTo = filters.dateTo ?? defaults.dateTo;
+
   return (
-    filters.geography !== defaults.geography ||
-    filters.complaintType !== defaults.complaintType
+    filters.dateRangeActive === true ||
+    geography !== defaults.geography ||
+    complaintType !== defaults.complaintType ||
+    dateFrom !== defaults.dateFrom ||
+    dateTo !== defaults.dateTo
   );
 }
 

--- a/frontend/micro-ui/web/src/dashboard/config/inventoryAllowlist.js
+++ b/frontend/micro-ui/web/src/dashboard/config/inventoryAllowlist.js
@@ -26,7 +26,7 @@ export const DEFAULT_VIEW_KPI_IDS = new Set([
   "rs-metric-breach-count",
   "cl-metric-total-resolved",
   "cl-metric-reopen-rate",
-  "ce-metric-csat",
+  "cl-metric-csat",
 ]);
 
 /**

--- a/frontend/micro-ui/web/src/dashboard/config/kpiDisplay.js
+++ b/frontend/micro-ui/web/src/dashboard/config/kpiDisplay.js
@@ -45,7 +45,7 @@ export const KPI_DISPLAY = {
     threshold: { kind: "percent", higherIsBetter: false, onTrack: 10, breaching: 25 },
   },
   "cl-metric-csat": {
-    displayTitle: "CSAT",
+    displayTitle: "Citizen satisfaction",
     threshold: { kind: "rating", higherIsBetter: true, onTrack: 4, breaching: 3 },
   },
   "cl-metric-first-assignment-rate": {
@@ -55,12 +55,10 @@ export const KPI_DISPLAY = {
   "cl-metric-sla-compliance-rate": {
     displayTitle: "SLA compliance rate",
     threshold: { kind: "percent", higherIsBetter: true, onTrack: 85, breaching: 60 },
-    deltaColorMode: "value",
   },
   "cl-metric-sla-non-compliance-rate": {
     displayTitle: "SLA non-compliance rate",
     threshold: { kind: "percent", higherIsBetter: false, onTrack: 15, breaching: 40 },
-    deltaColorMode: "value",
   },
   "cl-metric-resolved-on-time-rate": {
     displayTitle: "Resolved on time rate",
@@ -77,11 +75,6 @@ export const KPI_DISPLAY = {
     displayTitle: "Reopen rate",
     threshold: { kind: "percent", higherIsBetter: false, onTrack: 10, breaching: 25 },
     context: { type: "csatSnapshot" },
-  },
-  "ce-metric-csat": {
-    displayTitle: "Citizen satisfaction",
-    threshold: { kind: "rating", higherIsBetter: true, onTrack: 4, breaching: 3 },
-    context: { type: "acrossResolved" },
   },
 };
 
@@ -129,6 +122,7 @@ export function resolveThresholdStatus(metricId, displayValue) {
   return KPI_STATUS.NORMAL;
 }
 
+/** On track → green, breaching → red, normal → black. */
 export function getStatusValueClass(status) {
   switch (status) {
     case KPI_STATUS.ON_TRACK:
@@ -140,6 +134,26 @@ export function getStatusValueClass(status) {
   }
 }
 
+/** Delta text — same threshold mapping via dashboard delta color tokens. */
+export function getNumberTileDeltaClass(status, { unavailable = false } = {}) {
+  const {
+    deltaMuted,
+    deltaNeutral,
+    deltaPositive,
+    deltaNegative,
+  } = VISUALIZATION_STYLES[VIZ_TYPE.NUMBER_TILE_DELTA];
+
+  if (unavailable) return deltaMuted;
+  switch (status) {
+    case KPI_STATUS.ON_TRACK:
+      return deltaPositive;
+    case KPI_STATUS.BREACHING:
+      return deltaNegative;
+    default:
+      return deltaNeutral;
+  }
+}
+
 /** Value color for number tiles — threshold-driven, shared by every metric card. */
 export function getNumberTileValueClass(status, { unavailable = false } = {}) {
   const styles = VISUALIZATION_STYLES[VIZ_TYPE.NUMBER_TILE_DELTA];
@@ -147,37 +161,13 @@ export function getNumberTileValueClass(status, { unavailable = false } = {}) {
   return getStatusValueClass(status);
 }
 
-/** Delta color for KPI tiles — threshold-aligned or trend-based per metric config. */
-export function resolveKpiDeltaClass(metricId, deltaPercent, displayValue) {
-  const config = getKpiDisplayConfig(metricId);
+/** Delta color for KPI tiles — matches the main value (threshold-driven). */
+export function resolveKpiDeltaClass(metricId, _deltaPercent, displayValue) {
   const unavailable =
     displayValue == null || displayValue === "—" || displayValue === "…";
-  if (config.deltaColorMode === "value") {
-    return getNumberTileValueClass(resolveThresholdStatus(metricId, displayValue), {
-      unavailable,
-    });
-  }
-  return getSparklineDeltaClass(deltaPercent, metricId);
-}
-
-/** Delta arrow color — uses metric threshold when set, else treats volume increases as negative. */
-export function getSparklineDeltaClass(deltaPercent, metricId) {
-  const {
-    deltaMuted,
-    deltaNeutral,
-    deltaPositive,
-    deltaNegative,
-  } = VISUALIZATION_STYLES[VIZ_TYPE.NUMBER_TILE_SPARKLINE];
-
-  if (deltaPercent == null || !Number.isFinite(deltaPercent)) {
-    return deltaMuted;
-  }
-  if (deltaPercent === 0) return deltaNeutral;
-
-  const threshold = getKpiDisplayConfig(metricId).threshold;
-  const higherIsBetter = threshold?.higherIsBetter ?? false;
-  const improving = higherIsBetter ? deltaPercent > 0 : deltaPercent < 0;
-  return improving ? deltaPositive : deltaNegative;
+  return getNumberTileDeltaClass(resolveThresholdStatus(metricId, displayValue), {
+    unavailable,
+  });
 }
 
 export function statusValueToCssColor(statusClass) {

--- a/frontend/micro-ui/web/src/dashboard/config/kpiQueries.js
+++ b/frontend/micro-ui/web/src/dashboard/config/kpiQueries.js
@@ -615,6 +615,20 @@ export const BATCH_QUERIES = {
     measures: [{ name: "total", agg: "count" }],
     limit: 600,
   },
+  cl_map_complaint_pins: {
+    grain: "facts",
+    filters: { is_open: true },
+    dimensions: [
+      "service_request_id",
+      "latitude",
+      "longitude",
+      "ward_code",
+      "service_code",
+      "application_status",
+    ],
+    measures: [{ name: "total", agg: "count" }],
+    limit: 2000,
+  },
   cl_chart_status_week: {
     grain: "facts",
     window: { name: "last_28d", timeRole: "filed_at" },
@@ -1574,6 +1588,53 @@ function priorPeriodCreatedAtFilter(bounds) {
   return { gte: bounds.fromMs - duration, lt: bounds.fromMs };
 }
 
+/** Complaints filed in the 7 days immediately before the rolling last-7d window. */
+function priorRolling7dCreatedAtFilter() {
+  const now = Date.now();
+  return { gte: now - 14 * MS_PER_DAY, lt: now - 7 * MS_PER_DAY };
+}
+
+function applyMapWowQueries(queries, dashboardFilters, apiFilters, dateRangeBounds) {
+  const currentKey = "cl_map_ward_wow_current";
+  const priorKey = "cl_map_ward_wow_prior";
+  const baseCurrent = BATCH_QUERIES[currentKey];
+  const basePrior = BATCH_QUERIES[priorKey];
+  if (!baseCurrent || !basePrior) return;
+
+  const { __dateRange, ...dimensionFilters } = apiFilters || {};
+
+  if (dashboardFilters?.dateRangeActive && dateRangeBounds) {
+    queries[currentKey] = applySelectedDateRangeToQuery(
+      { ...baseCurrent },
+      dashboardFilters,
+      apiFilters
+    );
+    const priorFilters = { ...(basePrior.filters || {}) };
+    delete priorFilters.created_at;
+    queries[priorKey] = {
+      ...basePrior,
+      filters: mergeQueryFilters(priorFilters, {
+        ...dimensionFilters,
+        created_at: priorPeriodCreatedAtFilter(dateRangeBounds),
+      }),
+    };
+    delete queries[priorKey].window;
+    return;
+  }
+
+  queries[currentKey] = applyDashboardFiltersToQuery({ ...baseCurrent }, dimensionFilters);
+  const priorFilters = { ...(basePrior.filters || {}) };
+  delete priorFilters.created_at;
+  queries[priorKey] = {
+    ...basePrior,
+    filters: mergeQueryFilters(priorFilters, {
+      ...dimensionFilters,
+      created_at: priorRolling7dCreatedAtFilter(),
+    }),
+  };
+  delete queries[priorKey].window;
+}
+
 function applySelectedDateRangeToQuery(query, dashboardFilters, apiFilters) {
   const bounds = selectedDateRangeBounds(dashboardFilters, apiFilters);
   if (!bounds) return query;
@@ -1912,7 +1973,7 @@ export function buildBatchQueries(dashboardFilters) {
   if (!apiFilters.__dateRange) {
     const priorWeekFilter = { created_at: priorWeekCreatedAtFilter() };
     const priorWeekResolvedFilter = { resolved_at: priorWeekCreatedAtFilter() };
-    for (const key of ["cl_reg_prior_week", "cl_open_prior_week", "rs_breach_prior_week", "cl_map_ward_wow_prior"]) {
+    for (const key of ["cl_reg_prior_week", "cl_open_prior_week", "rs_breach_prior_week"]) {
       if (queries[key]) {
         queries[key] = {
           ...queries[key],
@@ -1956,6 +2017,7 @@ export function buildBatchQueries(dashboardFilters) {
   }
 
   applyTodayKpiQueries(queries, apiFilters);
+  applyMapWowQueries(queries, dashboardFilters, apiFilters, dateRangeBounds);
 
   return queries;
 }
@@ -2604,11 +2666,7 @@ export function buildKpiCardData(
 
   if (!isSparkline && !isDeltaTile) return base;
 
-  const deltaClass = resolveKpiDeltaClass(
-    deltaExtras.delta,
-    metric.id,
-    value
-  );
+  const deltaClass = resolveKpiDeltaClass(metric.id, deltaExtras.delta, value);
 
   if (!isSparkline) {
     return {
@@ -2908,6 +2966,33 @@ export function parseGeographyMapLayers(
   return { wow_change, sla_breach, wardDetails };
 }
 
+/** Open complaints for the map — one row per service_request_id. */
+export function parseComplaintMapPins(result) {
+  if (!result?.rows?.length) return [];
+
+  return result.rows
+    .map((row, index) => {
+      const lat = Number(row.latitude);
+      const lng = Number(row.longitude);
+      const serviceCode = String(row.service_code ?? "").trim();
+      const wardCode = String(row.ward_code ?? "").trim();
+      const serviceRequestId = String(row.service_request_id ?? "").trim();
+      const count = Number(row.total) || 1;
+
+      return {
+        id: serviceRequestId || `pin-${index}`,
+        serviceRequestId,
+        wardCode,
+        lat: Number.isFinite(lat) ? lat : null,
+        lng: Number.isFinite(lng) ? lng : null,
+        count,
+        serviceCode: serviceCode ? formatDimensionLabel(serviceCode) : "Complaint",
+        status: formatWorkflowStatusLabel(row.application_status),
+      };
+    })
+    .filter((pin) => pin.wardCode || (pin.lat != null && pin.lng != null));
+}
+
 export function parseDepartmentFlowRatioBarChart(result, { maxDepartments = 12 } = {}) {
   if (!result?.rows?.length) return [];
 
@@ -2938,7 +3023,7 @@ export function parseDepartmentFlowRatioBarChart(result, { maxDepartments = 12 }
     }))
     .filter((row) => row.created > 0)
     .sort((a, b) => {
-      const ratioDiff = b.value - a.value;
+      const ratioDiff = a.value - b.value;
       if (Math.abs(ratioDiff) > 0.0001) return ratioDiff;
       return a.label.localeCompare(b.label);
     })
@@ -3681,11 +3766,6 @@ export function parseComplaintTypeDetailsTable(result, limit = 30) {
     const typeKey = String(row.service_group ?? "").trim();
     const avgResolutionMs = Number(row.avg_resolution_ms);
     const idealSlaMs = Number(row.ideal_sla_ms);
-    const overSla =
-      Number.isFinite(avgResolutionMs) &&
-      Number.isFinite(idealSlaMs) &&
-      idealSlaMs > 0 &&
-      avgResolutionMs > idealSlaMs;
 
     return {
       id: `type-details-${index}-${subtypeKey}`,
@@ -3699,9 +3779,6 @@ export function parseComplaintTypeDetailsTable(result, limit = 30) {
         : null,
       ontimeRate: Number(row.ontime_rate),
       avgCsat: Number.isFinite(Number(row.avg_csat)) ? Number(row.avg_csat) : null,
-      highlight: overSla,
-      badge: overSla ? "OVER SLA" : null,
-      cellHighlights: overSla ? { avgResolutionMs: true, idealSlaMs: true } : undefined,
     };
   });
 }

--- a/frontend/micro-ui/web/src/dashboard/config/kpiSparkline.js
+++ b/frontend/micro-ui/web/src/dashboard/config/kpiSparkline.js
@@ -14,7 +14,6 @@ export const SPARKLINE_KPI_IDS = new Set([
   "rs-metric-sla-compliance",
   "rs-metric-breach-count",
   "ce-metric-reopen-rate",
-  "ce-metric-csat",
 ]);
 
 /**
@@ -122,14 +121,6 @@ export const SPARKLINE_KPI_QUERIES = {
     deltaLabel: "WoW",
     measureKey: "pct",
     sparklineMeasureKey: "pct",
-  },
-  "ce-metric-csat": {
-    sparklineQueryKey: "ce_csat_sparkline_7d",
-    currentQueryKey: "ce_csat_avg_week",
-    priorQueryKey: "ce_csat_prior_week",
-    deltaLabel: "WoW",
-    measureKey: "avg",
-    sparklineMeasureKey: "avg",
   },
   "cl-metric-oldest-open": {
     currentQueryKey: "cl_oldest_open_age",

--- a/frontend/micro-ui/web/src/dashboard/config/mapHoverPresentation.js
+++ b/frontend/micro-ui/web/src/dashboard/config/mapHoverPresentation.js
@@ -1,3 +1,5 @@
+import { formatDimensionLabel } from "./kpiQueries";
+
 function formatWowPct(wowPct) {
   if (!Number.isFinite(wowPct)) return "new spike";
   const rounded = Math.round(wowPct);
@@ -46,6 +48,27 @@ export function buildMapHoverTooltipHtml(ward = {}, { geoLevel = "Locality" } = 
         ${slaPill("dashboard-map-hover-dot--breaching", breaching, "breaching")}
         ${slaPill("dashboard-map-hover-dot--breached", breached, "breached")}
       </div>
+    </div>
+  `;
+}
+
+/** Hover card for an individual complaint pin. */
+export function buildComplaintPinTooltipHtml(pin = {}) {
+  const title = pin.serviceCode || "Complaint";
+  const status = pin.status || "—";
+  const ward = pin.wardCode ? formatDimensionLabel(pin.wardCode) : null;
+
+  return `
+    <div class="dashboard-map-hover-card dashboard-map-hover-card--pin">
+      <div class="dashboard-map-hover-title">${escapeHtml(title)}</div>
+      ${metricRow("Status", status)}
+      ${ward ? metricRow("Ward", ward) : ""}
+      ${pin.serviceRequestId ? metricRow("ID", pin.serviceRequestId) : ""}
+      ${
+        pin.approximate
+          ? '<div class="dashboard-map-hover-note">Approximate location (ward centroid)</div>'
+          : ""
+      }
     </div>
   `;
 }

--- a/frontend/micro-ui/web/src/dashboard/config/stackedBarPresentation.js
+++ b/frontend/micro-ui/web/src/dashboard/config/stackedBarPresentation.js
@@ -13,6 +13,7 @@ import {
   resolveBarCategorySlotWidth,
   resolveBarChartColumnWidth,
 } from "./barChartPresentation";
+import { CHART_AXIS_WRAPPED_LABEL_MAX_LINES } from "../utils/chartLabelWrap";
 
 export const STACKED_BAR_LEGEND = {
   position: "top",
@@ -47,7 +48,7 @@ export const HORIZONTAL_BAR_LABEL_LAYOUT = {
   min: 40,
   maxCap: 140,
   ratio: 0.28,
-  maxLines: 2,
+  maxLines: CHART_AXIS_WRAPPED_LABEL_MAX_LINES,
 };
 
 export const HORIZONTAL_BAR_GRID_PADDING = {
@@ -57,7 +58,8 @@ export const HORIZONTAL_BAR_GRID_PADDING = {
   bottom: 4,
 };
 
-export const HORIZONTAL_STACKED_BAR_HEIGHT = "82%";
+/** Thinner bars leave more vertical room between category rows. */
+export const HORIZONTAL_STACKED_BAR_HEIGHT = "62%";
 
 export function buildHorizontalCategoryYAxis(categories, containerWidth) {
   return buildHorizontalBarYAxisItem(categories, containerWidth, {

--- a/frontend/micro-ui/web/src/dashboard/config/stackedBarPresentation.js
+++ b/frontend/micro-ui/web/src/dashboard/config/stackedBarPresentation.js
@@ -5,11 +5,11 @@
 import {
   buildHorizontalBarYAxisItem,
   buildWrappedVerticalXAxisLabels,
-  resolveVerticalCategorySlotWidth,
-  resolveVerticalXAxisLabelHeight,
 } from "./chartAxisLabels";
 import { resolveDashboardCssColor } from "./chartColors";
 import {
+  BAR_CHART_XAXIS_RESERVED_HEIGHT_PX,
+  buildBarChartGrid,
   resolveBarCategorySlotWidth,
   resolveBarChartColumnWidth,
 } from "./barChartPresentation";
@@ -33,7 +33,7 @@ export function buildStackedBarLegend({ horizontal = false } = {}) {
   return {
     ...STACKED_BAR_LEGEND,
     horizontalAlign: horizontal ? "center" : STACKED_BAR_LEGEND.horizontalAlign,
-    offsetY: horizontal ? 8 : STACKED_BAR_LEGEND.offsetY,
+    offsetY: horizontal ? 8 : 6,
   };
 }
 
@@ -68,13 +68,20 @@ export function buildHorizontalCategoryYAxis(categories, containerWidth) {
 }
 
 export function buildStackedBarGrid({ horizontal = false, bottomPadding } = {}) {
+  if (!horizontal) {
+    return buildBarChartGrid({
+      left: 2,
+      right: 2,
+      top: 0,
+      bottom: bottomPadding ?? BAR_CHART_XAXIS_RESERVED_HEIGHT_PX,
+    });
+  }
+
   return {
     show: false,
     padding: {
       ...HORIZONTAL_BAR_GRID_PADDING,
-      top: horizontal ? -6 : HORIZONTAL_BAR_GRID_PADDING.top,
-      left: horizontal ? HORIZONTAL_BAR_GRID_PADDING.left : 4,
-      right: horizontal ? HORIZONTAL_BAR_GRID_PADDING.right : 4,
+      top: -6,
       bottom: bottomPadding ?? HORIZONTAL_BAR_GRID_PADDING.bottom,
     },
   };
@@ -150,6 +157,106 @@ export function formatStackedBarHours(value) {
   return `${n.toFixed(1)}h`;
 }
 
+const STACKED_BAR_LABEL_CHAR_WIDTH_PX = 7;
+const STACKED_BAR_LABEL_HEIGHT_PX = 14;
+const STACKED_BAR_LABEL_PADDING_PX = 4;
+/** Extra vertical room — Apex centers with +height/2, which clips the bottom of glyphs. */
+const STACKED_BAR_LABEL_VERTICAL_INSET_PX = 8;
+const STACKED_BAR_SEGMENT_LABEL_OFFSET_Y = 7;
+
+function formatStackedBarSegmentValue(value, valueFormat) {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return "";
+  return valueFormat === "hours" ? formatStackedBarHours(n) : String(Math.round(n));
+}
+
+function readStackTotal(opts) {
+  const idx = opts.dataPointIndex;
+  const series = opts.w?.config?.series ?? [];
+  return series.reduce((sum, entry) => sum + (Number(entry.data?.[idx]) || 0), 0);
+}
+
+function labelBoxForText(text) {
+  return {
+    width: text.length * STACKED_BAR_LABEL_CHAR_WIDTH_PX + STACKED_BAR_LABEL_PADDING_PX,
+    height: STACKED_BAR_LABEL_HEIGHT_PX + STACKED_BAR_LABEL_PADDING_PX,
+  };
+}
+
+/** Hide segment labels that cannot fit — show full value or nothing. */
+export function shouldShowStackedSegmentLabel(value, opts, { horizontal, valueFormat } = {}) {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return false;
+
+  const text = formatStackedBarSegmentValue(n, valueFormat);
+  if (!text) return false;
+
+  const stackTotal = readStackTotal(opts);
+  if (stackTotal <= 0) return false;
+
+  const { width: labelW, height: labelH } = labelBoxForText(text);
+  const globals = opts.w?.globals ?? {};
+  const idx = opts.dataPointIndex;
+
+  if (horizontal) {
+    const niceMax = Number(globals.xAxisScale?.niceMax);
+    const gridWidth = Number(globals.gridWidth) || 0;
+    const barH = Number(globals.barHeight?.[idx]) || 0;
+    if (niceMax > 0 && gridWidth > 0 && barH > 0) {
+      const segmentW = (n / niceMax) * gridWidth;
+      return segmentW >= labelW && barH >= labelH;
+    }
+    return n / stackTotal >= 0.14;
+  }
+
+  const barH = Number(globals.barHeight?.[idx]) || 0;
+  if (barH > 0) {
+    const segmentH = (n / stackTotal) * barH;
+    const categories = Math.max(1, globals.labels?.length ?? 1);
+    const barW =
+      Number(globals.barWidth?.[idx]) ||
+      (Number(globals.gridWidth) || 0) / categories;
+    const minSegmentH = labelH + STACKED_BAR_LABEL_VERTICAL_INSET_PX * 2;
+    return segmentH >= minSegmentH && barW >= labelW;
+  }
+
+  return n / stackTotal >= 0.11;
+}
+
+function shouldShowStackedTotalLabel(total, opts, { horizontal, valueFormat } = {}) {
+  const n = Number(total);
+  if (!Number.isFinite(n) || n <= 0) return false;
+
+  const text = formatStackedBarSegmentValue(n, valueFormat);
+  if (!text) return false;
+
+  const { width: labelW, height: labelH } = labelBoxForText(text);
+  const globals = opts.w?.globals ?? {};
+  const idx = opts.dataPointIndex;
+
+  if (horizontal) {
+    const niceMax = Number(globals.xAxisScale?.niceMax);
+    const gridWidth = Number(globals.gridWidth) || 0;
+    const barH = Number(globals.barHeight?.[idx]) || 0;
+    if (niceMax > 0 && gridWidth > 0 && barH > 0) {
+      const barW = (n / niceMax) * gridWidth;
+      const roomAfterBar = Math.max(0, gridWidth - barW - 6);
+      return roomAfterBar >= labelW && barH >= labelH;
+    }
+    return true;
+  }
+
+  const niceMax = Number(globals.yAxisScale?.[0]?.niceMax ?? globals.maxY);
+  const gridHeight = Number(globals.gridHeight) || 0;
+  const barH = Number(globals.barHeight?.[idx]) || 0;
+  if (niceMax > 0 && gridHeight > 0 && barH > 0) {
+    const headroom = gridHeight - (n / niceMax) * gridHeight;
+    return headroom >= labelH + 8;
+  }
+
+  return true;
+}
+
 export function buildStackedBarPlotOptions({
   horizontal = false,
   valueFormat,
@@ -157,14 +264,15 @@ export function buildStackedBarPlotOptions({
   categoryCount = 0,
 } = {}) {
   const totalLabelColor = resolveDashboardCssColor("var(--foreground)");
-  const formatTotal =
-    valueFormat === "hours"
-      ? formatStackedBarHours
-      : (value) => {
-          const n = Number(value);
-          if (!Number.isFinite(n) || n <= 0) return "";
-          return String(Math.round(n));
-        };
+  const formatTotal = (value, opts) => {
+    if (
+      opts &&
+      !shouldShowStackedTotalLabel(value, opts, { horizontal, valueFormat })
+    ) {
+      return "";
+    }
+    return formatStackedBarSegmentValue(value, valueFormat);
+  };
 
   const slotWidth = horizontal
     ? 0
@@ -179,8 +287,12 @@ export function buildStackedBarPlotOptions({
       columnWidth,
       barHeight: horizontal ? HORIZONTAL_STACKED_BAR_HEIGHT : undefined,
       dataLabels: {
+        hideOverflowingLabels: true,
+        position: "center",
+        orientation: "horizontal",
         total: {
           enabled: true,
+          hideOverflowingLabels: true,
           offsetX: horizontal ? 6 : 0,
           offsetY: horizontal ? 0 : -8,
           style: {
@@ -195,21 +307,13 @@ export function buildStackedBarPlotOptions({
   };
 }
 
-export function buildStackedBarDataLabels({ valueFormat } = {}) {
-  const formatter =
-    valueFormat === "hours"
-      ? formatStackedBarHours
-      : (value) => {
-          const n = Number(value);
-          if (!Number.isFinite(n) || n <= 0) return "";
-          return String(Math.round(n));
-        };
-
+export function buildStackedBarDataLabels({ valueFormat, horizontal = false } = {}) {
   return {
     enabled: true,
+    hideOverflowingLabels: true,
     textAnchor: "middle",
     offsetX: 0,
-    offsetY: 0,
+    offsetY: horizontal ? 0 : STACKED_BAR_SEGMENT_LABEL_OFFSET_Y,
     style: {
       fontSize: "11px",
       fontWeight: 600,
@@ -218,7 +322,12 @@ export function buildStackedBarDataLabels({ valueFormat } = {}) {
     background: {
       enabled: false,
     },
-    formatter,
+    formatter(value, opts) {
+      if (!shouldShowStackedSegmentLabel(value, opts, { horizontal, valueFormat })) {
+        return "";
+      }
+      return formatStackedBarSegmentValue(value, valueFormat);
+    },
   };
 }
 
@@ -236,16 +345,13 @@ export function buildStackedBarXAxis({
     };
   }
 
-  const slotWidthPx = resolveVerticalCategorySlotWidth(categories.length, containerWidth);
-  const labelHeight = resolveVerticalXAxisLabelHeight(categories, slotWidthPx, {
-    minHeightPx: 22,
-    maxHeightPx: 72,
-  });
+  const slotWidthPx = resolveBarCategorySlotWidth(categories.length, containerWidth);
+  const labelHeight = BAR_CHART_XAXIS_RESERVED_HEIGHT_PX;
 
   return {
     categories,
     labels: {
-      ...buildWrappedVerticalXAxisLabels(slotWidthPx),
+      ...buildWrappedVerticalXAxisLabels(slotWidthPx, { maxLines: 2 }),
       maxHeight: labelHeight,
     },
     axisBorder: { show: false },

--- a/frontend/micro-ui/web/src/dashboard/config/tablePresentation.js
+++ b/frontend/micro-ui/web/src/dashboard/config/tablePresentation.js
@@ -2,7 +2,36 @@
  * Shared table presentation — threshold highlighting for dashboard data tables.
  */
 
+/** @typedef {'breach' | 'watch' | 'good'} MetricTone */
+/** @typedef {{ higherIsBetter: boolean, watch: number, breach: number }} MetricThresholdConfig */
 /** @typedef {{ column: string, extremum?: 'min' | 'max', badge?: string }} TableThresholdConfig */
+
+export function evaluateMetricTone(value, config) {
+  if (!Number.isFinite(value) || !config) return null;
+  const { higherIsBetter, watch, breach } = config;
+
+  let v = value;
+  if (watch <= 1 && breach <= 1 && v > 1 && v <= 100) {
+    v = v / 100;
+  }
+
+  if (higherIsBetter) {
+    if (v < breach) return "breach";
+    if (v < watch) return "watch";
+    return "good";
+  }
+
+  if (v > breach) return "breach";
+  if (v > watch) return "watch";
+  return "good";
+}
+
+/** Breach and watch tones are stored; only breach is surfaced as cell/row chrome. */
+export function storeCellTone(cellTones, key, tone) {
+  if (tone === "breach" || tone === "watch") {
+    cellTones[key] = tone;
+  }
+}
 
 export const TABLE_THRESHOLDS = {
   "cl-table-workflow-stages": {
@@ -32,7 +61,8 @@ export function getTableThreshold(widgetId) {
 }
 
 /**
- * Highlight the row at the min or max of `column` (needs at least 2 finite values).
+ * Highlight a single row at the min or max of `column` (needs at least 2 finite values).
+ * When multiple rows tie, only the first extremum row is flagged.
  */
 export function annotateTableThresholds(rows, threshold) {
   if (!threshold || !rows?.length || rows.length < 2) return rows;
@@ -46,13 +76,13 @@ export function annotateTableThresholds(rows, threshold) {
   const target =
     extremum === "min" ? Math.min(...values) : Math.max(...values);
 
-  return rows.map((row) => {
-    const value = row[column];
-    const isExtremum = Number.isFinite(value) && value === target;
-    return {
-      ...row,
-      highlight: isExtremum,
-      badge: isExtremum && badge ? badge : null,
-    };
-  });
+  const highlightIndex = rows.findIndex(
+    (row) => Number.isFinite(row[column]) && row[column] === target
+  );
+
+  return rows.map((row, index) => ({
+    ...row,
+    highlight: index === highlightIndex,
+    badge: index === highlightIndex && badge ? badge : null,
+  }));
 }

--- a/frontend/micro-ui/web/src/dashboard/config/tablePresentation.js
+++ b/frontend/micro-ui/web/src/dashboard/config/tablePresentation.js
@@ -33,6 +33,42 @@ export function storeCellTone(cellTones, key, tone) {
   }
 }
 
+/**
+ * Red text/background scaled by severity (0–1), linear — no artificial floor.
+ */
+export function buildRedSeverityStyle(severity) {
+  const s = Math.min(1, Math.max(0, severity));
+  if (s <= 0) return null;
+  return {
+    "--sla-overrun-severity": String(s),
+  };
+}
+
+/**
+ * How far past a breach threshold a value is (0–1). Null when not in breach.
+ */
+export function breachSeverity(value, config) {
+  if (!Number.isFinite(value) || !config) return null;
+  const tone = evaluateMetricTone(value, config);
+  if (tone !== "breach") return null;
+
+  const { higherIsBetter, watch, breach } = config;
+  let v = value;
+  if (watch <= 1 && breach <= 1 && v > 1 && v <= 100) {
+    v = v / 100;
+  }
+
+  if (higherIsBetter) {
+    const floor = Math.max(0, breach - (watch - breach));
+    const span = breach - floor || 1;
+    return Math.min(1, (breach - v) / span);
+  }
+
+  const ceiling = breach + (breach - watch);
+  const span = ceiling - breach || 1;
+  return Math.min(1, (v - breach) / span);
+}
+
 export const TABLE_THRESHOLDS = {
   "cl-table-workflow-stages": {
     column: "avgDwellMs",

--- a/frontend/micro-ui/web/src/dashboard/config/visualizationStyles.js
+++ b/frontend/micro-ui/web/src/dashboard/config/visualizationStyles.js
@@ -62,6 +62,7 @@ const DATA_TABLE_STYLES = {
   subtitle: SHARED_CHROME.dragHandleSubtitle,
   scroll: "dashboard-table-scroll",
   table: "dashboard-table",
+  tableEqualCols: "dashboard-table--equal-cols",
   th: "dashboard-table-th",
   thRight: "dashboard-table-th-right",
   td: "dashboard-table-td",
@@ -81,6 +82,13 @@ const DATA_TABLE_STYLES = {
   thresholdCell: "dashboard-table-threshold-cell",
   thresholdWatch: "dashboard-table-threshold-watch",
   thresholdGood: "dashboard-table-threshold-good",
+  cellToneBreach: "dashboard-table-cell-tone--breach",
+  cellToneWatch: "dashboard-table-cell-tone--watch",
+  cellToneGood: "dashboard-table-cell-tone--good",
+  statusTag: "dashboard-table-status-tag",
+  statusTagBreach: "dashboard-table-status-tag--breach",
+  statusTagWatch: "dashboard-table-status-tag--watch",
+  statusTagGood: "dashboard-table-status-tag--good",
 };
 
 /**
@@ -145,6 +153,7 @@ export const VISUALIZATION_STYLES = {
   },
   [VIZ_TYPE.DATA_TABLE]: DATA_TABLE_STYLES,
   [VIZ_TYPE.SLA_RISK_TABLE]: {
+    table: "dashboard-sla-risk-table",
     link: "dashboard-sla-link",
     linkButton: "dashboard-sla-link dashboard-sla-link--button",
     breachPill: "dashboard-sla-breach-pill",

--- a/frontend/micro-ui/web/src/dashboard/config/visualizationStyles.js
+++ b/frontend/micro-ui/web/src/dashboard/config/visualizationStyles.js
@@ -85,6 +85,7 @@ const DATA_TABLE_STYLES = {
   cellToneBreach: "dashboard-table-cell-tone--breach",
   cellToneWatch: "dashboard-table-cell-tone--watch",
   cellToneGood: "dashboard-table-cell-tone--good",
+  slaOverrun: "dashboard-table-sla-overrun",
   statusTag: "dashboard-table-status-tag",
   statusTagBreach: "dashboard-table-status-tag--breach",
   statusTagWatch: "dashboard-table-status-tag--watch",

--- a/frontend/micro-ui/web/src/dashboard/constants/layoutConfig.js
+++ b/frontend/micro-ui/web/src/dashboard/constants/layoutConfig.js
@@ -287,25 +287,63 @@ export function getDroppingItem(widgetId) {
 }
 
 /** Next open slot on the bottom row when adding without an explicit drop position. */
-export function computeNextOpenPosition(layout) {
-  if (!layout.length) return { x: 0, y: 0 };
-  const maxY = Math.max(...layout.map((item) => item.y + item.h));
+function rectsOverlap(a, b) {
+  return (
+    a.x < b.x + b.w &&
+    a.x + a.w > b.x &&
+    a.y < b.y + b.h &&
+    a.y + a.h > b.y
+  );
+}
+
+function collidesAt(x, y, w, h, layout) {
+  const candidate = { x, y, w, h };
+  return layout.some((other) => rectsOverlap(candidate, other));
+}
+
+/** First grid slot (reading order) that fits w×h without overlapping any item. */
+export function findFirstOpenPosition(layout, w, h, cols = GRID_COLS) {
+  const maxY = layout.length
+    ? Math.max(...layout.map((item) => item.y + item.h))
+    : 0;
+  const yLimit = maxY + h + 12;
+
+  for (let y = 0; y <= yLimit; y += 1) {
+    for (let x = 0; x <= cols - w; x += 1) {
+      if (!collidesAt(x, y, w, h, layout)) {
+        return { x, y };
+      }
+    }
+  }
+
   return { x: 0, y: maxY };
 }
 
+export function computeNextOpenPosition(layout, w = 2, h = 2) {
+  return findFirstOpenPosition(layout, w, h);
+}
+
 /** Next KPI tile position when adding via inventory click (not drag-drop). */
-export function computeNextKpiPosition(layout) {
+export function computeNextKpiPosition(layout, widgetId) {
+  const defaults = getDefaultKpiLayoutItem(widgetId);
+  const w = defaults?.w ?? DEFAULT_KPI_LAYOUT_ITEM.w;
+  const h = defaults?.h ?? DEFAULT_KPI_LAYOUT_ITEM.h;
+
   const kpiItems = layout.filter((item) => isKpiWidget(item.i));
-  if (kpiItems.length === 0) return { x: 0, y: 0 };
+  if (kpiItems.length === 0) {
+    return findFirstOpenPosition(layout, w, h);
+  }
 
   const maxY = Math.max(...kpiItems.map((item) => item.y + item.h));
   const bottomRow = kpiItems.filter((item) => item.y + item.h === maxY);
-  const usedWidth = bottomRow.reduce((sum, item) => sum + item.w, 0);
+  const nextX = bottomRow.reduce((max, item) => Math.max(max, item.x + item.w), 0);
+  const rowY = bottomRow[0].y;
 
-  if (usedWidth + DEFAULT_KPI_LAYOUT_ITEM.w <= GRID_COLS) {
-    return { x: usedWidth, y: bottomRow[0].y };
+  if (nextX + w <= GRID_COLS && !collidesAt(nextX, rowY, w, h, layout)) {
+    return { x: nextX, y: rowY };
   }
-  return { x: 0, y: maxY };
+
+  return findFirstOpenPosition(layout, w, h);
 }
 
 /**
@@ -363,9 +401,12 @@ export function buildNewLayoutItem(widgetId, position, existingLayout = []) {
   const defaults = getDefaultLayoutItem(widgetId);
   if (!defaults) return null;
 
+  const w = defaults.w;
+  const h = defaults.h;
+
   const fallback = isKpiWidget(widgetId)
-    ? computeNextKpiPosition(existingLayout)
-    : computeNextOpenPosition(existingLayout);
+    ? computeNextKpiPosition(existingLayout, widgetId)
+    : computeNextOpenPosition(existingLayout, w, h);
 
   const x = position?.x ?? fallback.x;
   const y = position?.y ?? fallback.y;

--- a/frontend/micro-ui/web/src/dashboard/constants/layoutConfig.js
+++ b/frontend/micro-ui/web/src/dashboard/constants/layoutConfig.js
@@ -8,7 +8,17 @@ export const GRID_MARGIN_Y = 16;
 
 export const RANKED_LIST_WIDGET_ID = "cl-table-complaint-type-details";
 
-/** Default grid size for data-table cards (header + rows + updated stamp). */
+/** Default grid size for full-width data tables (header + rows + updated stamp). */
+export const FULL_WIDTH_TABLE_GRID = {
+  w: 12,
+  h: 6,
+  minW: 6,
+  minH: 4,
+  maxW: 12,
+  maxH: 14,
+};
+
+/** Default grid size for compact ranked-list table cards. */
 export const TABLE_CARD_GRID = {
   h: 3,
   minH: 3,
@@ -145,10 +155,10 @@ export const MAP_SIZE_CONSTRAINTS = {
 
 export const CHART_TYPE_SIZE_CONSTRAINTS = {
   "data-table": {
-    minW: TABLE_CARD_GRID.minW,
-    minH: TABLE_CARD_GRID.minH,
-    maxW: TABLE_CARD_GRID.maxW,
-    maxH: TABLE_CARD_GRID.maxH,
+    minW: FULL_WIDTH_TABLE_GRID.minW,
+    minH: FULL_WIDTH_TABLE_GRID.minH,
+    maxW: FULL_WIDTH_TABLE_GRID.maxW,
+    maxH: FULL_WIDTH_TABLE_GRID.maxH,
   },
   "bar-chart": UNIFORM_CHART_SIZE_CONSTRAINTS,
   "histogram": UNIFORM_CHART_SIZE_CONSTRAINTS,
@@ -159,10 +169,10 @@ export const CHART_TYPE_SIZE_CONSTRAINTS = {
   "sla-toggle": UNIFORM_CHART_SIZE_CONSTRAINTS,
   "map": MAP_SIZE_CONSTRAINTS,
   "sla-risk-table": {
-    minW: 6,
-    minH: 4,
-    maxW: 12,
-    maxH: 14,
+    minW: FULL_WIDTH_TABLE_GRID.minW,
+    minH: FULL_WIDTH_TABLE_GRID.minH,
+    maxW: FULL_WIDTH_TABLE_GRID.maxW,
+    maxH: FULL_WIDTH_TABLE_GRID.maxH,
   },
   "gauge": GAUGE_SIZE_CONSTRAINTS,
 };
@@ -172,9 +182,9 @@ export function getChartTypeSizeConstraints(type) {
 }
 
 const RAW_DEFAULT_CHART_LAYOUT = {
-  "cl-table-complaint-type-details": { x: 0, w: 12, ...TABLE_CARD_GRID },
-  "cl-table-complaints-at-risk": { x: 0, w: 12, h: 5, minW: 6, minH: 4, maxW: 12, maxH: 14 },
-  "ep-table-employee-performance": { x: 0, w: 12, h: 6, minW: 6, minH: 4, maxW: 12, maxH: 12 },
+  "cl-table-complaint-type-details": { x: 0, ...FULL_WIDTH_TABLE_GRID },
+  "cl-table-complaints-at-risk": { x: 0, ...FULL_WIDTH_TABLE_GRID },
+  "ep-table-employee-performance": { x: 0, ...FULL_WIDTH_TABLE_GRID },
   "cl-chart-complaints-by-type": { x: 0, w: 6, h: 6, minW: 4, minH: 4, maxW: 12, maxH: 10 },
   "cl-chart-departments": { x: 6, w: 6, h: 6, minW: 4, minH: 4, maxW: 12, maxH: 10 },
   "cl-chart-department-resolution-rate": { x: 0, w: 6, h: 6, minW: 4, minH: 4, maxW: 12, maxH: 10 },
@@ -192,7 +202,17 @@ export const DEFAULT_CHART_LAYOUT = Object.fromEntries(
   Object.entries(RAW_DEFAULT_CHART_LAYOUT).map(([widgetId, layout]) => {
     const type = WIDGETS[widgetId]?.type;
     if (!type) return [widgetId, layout];
-    return [widgetId, { ...layout, ...getChartTypeSizeConstraints(type) }];
+    const typeConstraints = getChartTypeSizeConstraints(type);
+    return [
+      widgetId,
+      {
+        ...layout,
+        minW: layout.minW ?? typeConstraints.minW,
+        minH: layout.minH ?? typeConstraints.minH,
+        maxW: layout.maxW ?? typeConstraints.maxW,
+        maxH: layout.maxH ?? typeConstraints.maxH,
+      },
+    ];
   })
 );
 
@@ -203,13 +223,13 @@ export const DEFAULT_LAYOUT = [
   { i: "rs-metric-breach-count", x: 2, y: 0, w: 2, h: 2, minW: 2, minH: 2, maxH: 6, moved: false, static: false, resizeHandles: ["se"] },
   { i: "cl-metric-total-resolved", x: 4, y: 0, w: 2, h: 2, minW: 2, minH: 2, maxH: 6, moved: false, static: false, resizeHandles: ["se"] },
   { i: "cl-metric-reopen-rate", x: 6, y: 0, w: 2, h: 2, minW: 2, minH: 2, maxH: 6, moved: false, static: false, resizeHandles: ["se"] },
-  { i: "ce-metric-csat", x: 8, y: 0, w: 2, h: 2, minW: 2, minH: 2, maxH: 6, moved: true, static: false, resizeHandles: ["se"] },
+  { i: "cl-metric-csat", x: 8, y: 0, w: 2, h: 2, minW: 2, minH: 2, maxH: 6, moved: true, static: false, resizeHandles: ["se"] },
   { i: "cl-chart-officer-sla", x: 0, y: 2, w: 8, h: 6, minW: 4, minH: 4, maxW: 12, maxH: 10, moved: false, static: false, resizeHandles: ["se"] },
   { i: "cl-chart-resolution-subtype", x: 8, y: 2, w: 4, h: 6, minW: 4, minH: 4, maxW: 12, maxH: 10, moved: false, static: false, resizeHandles: ["se"] },
   { i: "cl-map-geography-choropleth", x: 0, y: 8, w: 8, h: 6, minW: 4, minH: 5, maxW: 12, maxH: 14, moved: false, static: false, resizeHandles: ["se"] },
   { i: "cl-chart-department-flow-ratio", x: 8, y: 8, w: 4, h: 6, minW: 4, minH: 4, maxW: 12, maxH: 10, moved: false, static: false, resizeHandles: ["se"] },
   { i: "cl-chart-over-time", x: 0, y: 14, w: 12, h: 6, minW: 4, minH: 4, maxW: 12, maxH: 10, moved: false, static: false, resizeHandles: ["se"] },
-  { i: "cl-table-complaints-at-risk", x: 0, y: 20, w: 12, h: 5, minW: 6, minH: 4, maxW: 12, maxH: 14, moved: false, static: false, resizeHandles: ["se"] },
+  { i: "cl-table-complaints-at-risk", x: 0, y: 20, w: 12, h: 6, minW: 6, minH: 4, maxW: 12, maxH: 14, moved: false, static: false, resizeHandles: ["se"] },
 ].map((item) => {
   const type = WIDGETS[item.i]?.type;
   if (!type || type === "kpi") return item;
@@ -236,6 +256,128 @@ export function getDefaultChartItem(widgetId) {
   const defaults = DEFAULT_CHART_LAYOUT[widgetId];
   if (!defaults) return null;
   return { i: widgetId, ...defaults };
+}
+
+/** Full default grid item (KPI or chart/table) from catalog config. */
+export function getDefaultLayoutItem(widgetId) {
+  if (isKpiWidget(widgetId)) {
+    return { i: widgetId, ...getDefaultKpiLayoutItem(widgetId) };
+  }
+  return getDefaultChartItem(widgetId);
+}
+
+/** Default w/h for external drag preview and drop placeholder sizing. */
+export function getDropPreviewSize(widgetId) {
+  const defaults = getDefaultLayoutItem(widgetId);
+  if (!defaults?.w || !defaults?.h) {
+    return { w: DROPPING_ITEM.w, h: DROPPING_ITEM.h };
+  }
+  return { w: defaults.w, h: defaults.h };
+}
+
+/** react-grid-layout dropping placeholder — sized per dragged widget. */
+export function getDroppingItem(widgetId) {
+  const { w, h } = getDropPreviewSize(widgetId);
+  return {
+    i: DROPPING_ITEM_ID,
+    w,
+    h,
+    ...getSizeConstraints(widgetId),
+  };
+}
+
+/** Next open slot on the bottom row when adding without an explicit drop position. */
+export function computeNextOpenPosition(layout) {
+  if (!layout.length) return { x: 0, y: 0 };
+  const maxY = Math.max(...layout.map((item) => item.y + item.h));
+  return { x: 0, y: maxY };
+}
+
+/** Next KPI tile position when adding via inventory click (not drag-drop). */
+export function computeNextKpiPosition(layout) {
+  const kpiItems = layout.filter((item) => isKpiWidget(item.i));
+  if (kpiItems.length === 0) return { x: 0, y: 0 };
+
+  const maxY = Math.max(...kpiItems.map((item) => item.y + item.h));
+  const bottomRow = kpiItems.filter((item) => item.y + item.h === maxY);
+  const usedWidth = bottomRow.reduce((sum, item) => sum + item.w, 0);
+
+  if (usedWidth + DEFAULT_KPI_LAYOUT_ITEM.w <= GRID_COLS) {
+    return { x: usedWidth, y: bottomRow[0].y };
+  }
+  return { x: 0, y: maxY };
+}
+
+/**
+ * Pin catalog w/h and size constraints onto a layout item.
+ * Position (x/y) is preserved; dimensions always come from config.
+ */
+export function applyCatalogDimensions(item) {
+  const defaults = getDefaultLayoutItem(item.i);
+  if (!defaults) return item;
+
+  const heightLocked = isHeightLockedChart(item.i);
+  return {
+    ...item,
+    w: defaults.w,
+    h: defaults.h,
+    minW: defaults.minW,
+    minH: defaults.minH,
+    maxW: defaults.maxW,
+    maxH: defaults.maxH,
+    ...(heightLocked ? { h: defaults.h } : {}),
+  };
+}
+
+/** Repair widgets saved with the 2×2 KPI drop placeholder or legacy table heights. */
+export function reconcileInventoryWidgetDimensions(item) {
+  if (isKpiWidget(item.i)) return item;
+
+  const defaults = getDefaultLayoutItem(item.i);
+  if (!defaults?.w || !defaults?.h) return item;
+
+  const widgetType = WIDGETS[item.i]?.type;
+  const isTableWidget =
+    widgetType === "data-table" || widgetType === "sla-risk-table";
+
+  const savedWithKpiPlaceholder =
+    item.w === DEFAULT_KPI_LAYOUT_ITEM.w &&
+    item.h === DEFAULT_KPI_LAYOUT_ITEM.h &&
+    (defaults.w !== item.w || defaults.h !== item.h);
+
+  const savedWithLegacyTableHeight =
+    isTableWidget &&
+    item.w === defaults.w &&
+    (item.h === 3 || item.h === 5) &&
+    defaults.h === FULL_WIDTH_TABLE_GRID.h;
+
+  if (!savedWithKpiPlaceholder && !savedWithLegacyTableHeight) return item;
+  return applyCatalogDimensions(item);
+}
+
+/**
+ * Build a layout item for a widget newly added from inventory (drop or click).
+ * Always uses catalog default w/h; only x/y come from the drop position or fallback.
+ */
+export function buildNewLayoutItem(widgetId, position, existingLayout = []) {
+  const defaults = getDefaultLayoutItem(widgetId);
+  if (!defaults) return null;
+
+  const fallback = isKpiWidget(widgetId)
+    ? computeNextKpiPosition(existingLayout)
+    : computeNextOpenPosition(existingLayout);
+
+  const x = position?.x ?? fallback.x;
+  const y = position?.y ?? fallback.y;
+
+  return applyCatalogDimensions({
+    i: widgetId,
+    x,
+    y,
+    static: false,
+    moved: false,
+    resizeHandles: getResizeHandles(widgetId),
+  });
 }
 
 /** Charts with a fixed grid height (width still resizes). */

--- a/frontend/micro-ui/web/src/dashboard/hooks/useDashboardData.js
+++ b/frontend/micro-ui/web/src/dashboard/hooks/useDashboardData.js
@@ -14,6 +14,7 @@ import {
   parseDowChart,
   parseFilterOptions,
   parseGeographyMapLayers,
+  parseComplaintMapPins,
   parseLocalityTable,
   parseOpenComplaintsByTypeStackedChart,
   parseOpenComplaintsByChannelPieChart,
@@ -26,6 +27,7 @@ import {
   parseWorkflowStageTable,
 } from "../config/kpiQueries";
 import { annotateTableThresholds, TABLE_THRESHOLDS } from "../config/tablePresentation";
+import { annotateComplaintTypeDetailsRows } from "../config/complaintTypeDetailsTablePresentation";
 import { annotateEmployeePerformanceRows } from "../config/employeePerformanceTablePresentation";
 import { COMPLAINT_TYPE_OPTIONS, GEOGRAPHY_OPTIONS } from "../config/globalFilterGroups";
 import { hasAuth, runBatchQueries } from "../services/analyticsService";
@@ -60,7 +62,7 @@ const EMPTY_CHART_DATA = {
   complaintTypeDetails: [],
   employeePerformance: [],
   complaintsAtRisk: [],
-  geographyMap: { wow_change: [], sla_breach: [], wardDetails: {} },
+  geographyMap: { wow_change: [], sla_breach: [], wardDetails: {}, complaintPins: [] },
   complaintsOverTime: null,
 };
 
@@ -128,8 +130,8 @@ function buildChartData(results, dashboardFilters) {
       "cl-table-workflow-stages",
       parseWorkflowStageTable(results?.ev_table_stage_dwell)
     ),
-    complaintTypeDetails: parseComplaintTypeDetailsTable(
-      results?.cl_table_complaint_type_details
+    complaintTypeDetails: annotateComplaintTypeDetailsRows(
+      parseComplaintTypeDetailsTable(results?.cl_table_complaint_type_details)
     ),
     employeePerformance: annotateEmployeePerformanceRows(
       parseEmployeePerformanceTable(
@@ -139,13 +141,16 @@ function buildChartData(results, dashboardFilters) {
       )
     ),
     complaintsAtRisk: parseComplaintsAtRiskTable(results?.cl_table_complaints_at_risk),
-    geographyMap: parseGeographyMapLayers(
-      results?.cl_map_ward_wow_current,
-      results?.cl_map_ward_wow_prior,
-      results?.cl_map_ward_sla_breach,
-      results?.cl_map_ward_open,
-      results?.cl_map_ward_sla_buckets
-    ),
+    geographyMap: {
+      ...parseGeographyMapLayers(
+        results?.cl_map_ward_wow_current,
+        results?.cl_map_ward_wow_prior,
+        results?.cl_map_ward_sla_breach,
+        results?.cl_map_ward_open,
+        results?.cl_map_ward_sla_buckets
+      ),
+      complaintPins: parseComplaintMapPins(results?.cl_map_complaint_pins),
+    },
   };
 }
 

--- a/frontend/micro-ui/web/src/dashboard/hooks/useDashboardLayout.js
+++ b/frontend/micro-ui/web/src/dashboard/hooks/useDashboardLayout.js
@@ -4,6 +4,7 @@ import {
   DEFAULT_LAYOUT,
   WIDGETS,
   buildNewLayoutItem,
+  findFirstOpenPosition,
   getDefaultKpiLayoutItem,
   getChartTypeSizeConstraints,
   isHeightLockedChart,
@@ -425,11 +426,31 @@ function loadLayout() {
   }
 }
 
-/** Same post-drop pipeline as onDragStop: swap with overlapped card, then compact. */
+function collidesWithAny(item, layout) {
+  return layout.some(
+    (other) =>
+      item.x < other.x + other.w &&
+      item.x + item.w > other.x &&
+      item.y < other.y + other.h &&
+      item.y + item.h > other.y
+  );
+}
+
+/**
+ * Insert a newly-added widget WITHOUT relocating any existing card.
+ *
+ * Existing cards stay exactly where react-grid-layout already renders them, so
+ * there is nothing for RGL to "fail to re-sync" — a render overlap is therefore
+ * impossible. If the requested drop position collides with anything, the new
+ * card is moved to the first grid slot that fits it; every other card is left
+ * untouched. (Drag/resize of existing cards still uses swap + compaction.)
+ */
 function placeNewItemInLayout(prev, newItem) {
-  const origin = { x: newItem.x, y: newItem.y };
-  const swapped = swapOnDrop([...prev, newItem], newItem.i, origin);
-  return compactVertically(swapped);
+  if (!collidesWithAny(newItem, prev)) {
+    return [...prev, newItem];
+  }
+  const slot = findFirstOpenPosition(prev, newItem.w, newItem.h);
+  return [...prev, { ...newItem, x: slot.x, y: slot.y }];
 }
 
 /* -------------------------------------------------------------------------- */
@@ -575,13 +596,13 @@ export function useDashboardLayout() {
     (widgetId, position) => {
       if (!WIDGETS[widgetId]) return;
 
-      const dropPosition =
-        position != null && (position.x != null || position.y != null)
-          ? { x: position.x, y: position.y }
-          : undefined;
-
       setLayout((prev) => {
         if (prev.some((item) => item.i === widgetId)) return prev;
+
+        const dropPosition =
+          position != null && (position.x != null || position.y != null)
+            ? { x: position.x, y: position.y }
+            : undefined;
 
         const newItem = buildNewLayoutItem(widgetId, dropPosition, prev);
         if (!newItem) return prev;

--- a/frontend/micro-ui/web/src/dashboard/hooks/useDashboardLayout.js
+++ b/frontend/micro-ui/web/src/dashboard/hooks/useDashboardLayout.js
@@ -1,16 +1,16 @@
 import { useCallback, useRef, useState } from "react";
 import { getLayoutStorageKey } from "../config/dashboardConfig";
 import {
-  DEFAULT_KPI_LAYOUT_ITEM,
   DEFAULT_LAYOUT,
-  GRID_COLS,
   WIDGETS,
-  getDefaultChartItem,
+  buildNewLayoutItem,
   getDefaultKpiLayoutItem,
   getChartTypeSizeConstraints,
   isHeightLockedChart,
   isKpiWidget,
   DEFAULT_CHART_LAYOUT,
+  applyCatalogDimensions,
+  reconcileInventoryWidgetDimensions,
 } from "../constants/layoutConfig";
 import { isSparklineKpi } from "../config/kpiSparkline";
 
@@ -27,6 +27,8 @@ const LEGACY_GEOGRAPHY_MAP_WIDGET_ID = "demo-viz-map";
 const LIVE_GEOGRAPHY_MAP_WIDGET_ID = "cl-map-geography-choropleth";
 const DEFAULT_REOPEN_RATE_KPI_ID = "cl-metric-reopen-rate";
 const LEGACY_ZONE_REOPEN_RATE_KPI_ID = "ce-metric-reopen-rate";
+const DEFAULT_CSAT_KPI_ID = "cl-metric-csat";
+const LEGACY_ZONE_CSAT_KPI_ID = "ce-metric-csat";
 const DEFAULT_RESOLUTION_RATE_KPI_ID = "cl-metric-resolution-rate";
 const LEGACY_ON_TIME_SLA_KPI_ID = "rs-metric-sla-compliance";
 const LEGACY_RESOLVED_ON_TIME_RATE_KPI_ID = "cl-metric-resolved-on-time-rate";
@@ -44,7 +46,7 @@ function migratePieChannelWidget(layout) {
     if (hasLivePie) return next;
 
     const defaults = DEFAULT_CHART_LAYOUT[LIVE_PIE_WIDGET_ID] ?? {};
-    next.push({ ...defaults, ...item, i: LIVE_PIE_WIDGET_ID });
+    next.push(applyCatalogDimensions({ ...item, i: LIVE_PIE_WIDGET_ID }));
     return next;
   }, []);
 }
@@ -61,8 +63,7 @@ function migrateSlaRiskWidget(layout) {
 
     if (hasLive) return next;
 
-    const defaults = DEFAULT_CHART_LAYOUT[LIVE_SLA_RISK_WIDGET_ID] ?? {};
-    next.push({ ...defaults, ...item, i: LIVE_SLA_RISK_WIDGET_ID });
+    next.push(applyCatalogDimensions({ ...item, i: LIVE_SLA_RISK_WIDGET_ID }));
     return next;
   }, []);
 }
@@ -79,8 +80,7 @@ function migrateFlowRatioWidget(layout) {
 
     if (hasLive) return next;
 
-    const defaults = DEFAULT_CHART_LAYOUT[LIVE_FLOW_RATIO_WIDGET_ID] ?? {};
-    next.push({ ...defaults, ...item, i: LIVE_FLOW_RATIO_WIDGET_ID });
+    next.push(applyCatalogDimensions({ ...item, i: LIVE_FLOW_RATIO_WIDGET_ID }));
     return next;
   }, []);
 }
@@ -97,8 +97,7 @@ function migrateDemoStackedToOfficerSla(layout) {
 
     if (hasLive) return next;
 
-    const defaults = DEFAULT_CHART_LAYOUT[LIVE_OFFICER_SLA_WIDGET_ID] ?? {};
-    next.push({ ...defaults, ...item, i: LIVE_OFFICER_SLA_WIDGET_ID });
+    next.push(applyCatalogDimensions({ ...item, i: LIVE_OFFICER_SLA_WIDGET_ID }));
     return next;
   }, []);
 }
@@ -115,8 +114,24 @@ function migrateGeographyMapWidget(layout) {
 
     if (hasLive) return next;
 
-    const defaults = DEFAULT_CHART_LAYOUT[LIVE_GEOGRAPHY_MAP_WIDGET_ID] ?? {};
-    next.push({ ...defaults, ...item, i: LIVE_GEOGRAPHY_MAP_WIDGET_ID });
+    next.push(applyCatalogDimensions({ ...item, i: LIVE_GEOGRAPHY_MAP_WIDGET_ID }));
+    return next;
+  }, []);
+}
+
+/** Use complaint-landscape CSAT tile in place of the zone sparkline CSAT KPI. */
+function migrateDefaultCsatKpi(layout) {
+  const hasLive = layout.some((item) => item.i === DEFAULT_CSAT_KPI_ID);
+
+  return layout.reduce((next, item) => {
+    if (item.i !== LEGACY_ZONE_CSAT_KPI_ID) {
+      next.push(item);
+      return next;
+    }
+
+    if (hasLive) return next;
+
+    next.push({ ...item, i: DEFAULT_CSAT_KPI_ID });
     return next;
   }, []);
 }
@@ -141,6 +156,7 @@ function migrateDefaultReopenRateKpi(layout) {
 const LEGACY_REMOVED_KPI_IDS = new Set([
   "rs-metric-sla-compliance",
   "ce-metric-reopen-rate",
+  "ce-metric-csat",
 ]);
 
 function purgeRemovedKpis(layout) {
@@ -178,6 +194,7 @@ function migrateDefaultResolutionRateKpi(layout) {
 function migrateSavedLayoutWidgets(layout) {
   return purgeRemovedKpis(
     migrateDefaultResolutionRateKpi(
+      migrateDefaultCsatKpi(
       migrateDefaultReopenRateKpi(
         migrateGeographyMapWidget(
           migrateFlowRatioWidget(
@@ -186,6 +203,7 @@ function migrateSavedLayoutWidgets(layout) {
             )
           )
         )
+      )
       )
     )
   );
@@ -292,41 +310,11 @@ export function swapOnDrop(layout, activeId, origin) {
 }
 
 /* -------------------------------------------------------------------------- */
-/* Item normalization (only for newly added widgets)                          */
-/* -------------------------------------------------------------------------- */
-
-function normalizeKpiItem(item) {
-  const defaults = getDefaultKpiLayoutItem(item.i);
-  return {
-    ...defaults,
-    ...item,
-    minW: item.minW ?? defaults.minW,
-    minH: Math.max(item.minH ?? defaults.minH, defaults.minH),
-    maxH: defaults.maxH ?? item.maxH ?? DEFAULT_KPI_LAYOUT_ITEM.maxH,
-  };
-}
-
-function normalizeChartItem(item) {
-  const defaults = DEFAULT_CHART_LAYOUT[item.i];
-  if (!defaults) return item;
-  const heightLocked = isHeightLockedChart(item.i);
-  return {
-    ...defaults,
-    ...item,
-    ...(heightLocked ? { h: defaults.h } : {}),
-    minW: item.minW ?? defaults.minW,
-    minH: heightLocked ? defaults.minH : (item.minH ?? defaults.minH),
-    maxW: defaults.maxW ?? item.maxW,
-    maxH: heightLocked ? defaults.maxH : (defaults.maxH ?? item.maxH),
-  };
-}
-
-/* -------------------------------------------------------------------------- */
 /* localStorage persistence                                                    */
 /* -------------------------------------------------------------------------- */
 
 const LEGACY_LAYOUT_VERSIONS = [
-  "v29", "v28", "v27", "v20", "v19", "v18", "v17", "v16", "v15", "v14", "v13", "v12", "v11", "v10", "v9",
+  "v30", "v29", "v28", "v27", "v20", "v19", "v18", "v17", "v16", "v15", "v14", "v13", "v12", "v11", "v10", "v9",
 ];
 
 function getAllLayoutStorageKeys() {
@@ -409,7 +397,7 @@ function loadLayout() {
           maxW: constraints.maxW ?? defaults?.maxW ?? item.maxW,
         };
       }
-      return item;
+      return reconcileInventoryWidgetDimensions(item);
     });
 
     if (hasOverlaps(normalized)) {
@@ -420,11 +408,12 @@ function loadLayout() {
     }
 
     const withTeamSla = mergeDefaultTeamSlaWidget(normalized);
+    const dimensionsRepaired = normalized.some((item, i) => item !== migrated[i]);
     const layoutChanged =
       withTeamSla.length > normalized.length ||
       migrated.some((item, i) => item.i !== valid[i]?.i);
 
-    if (layoutChanged) {
+    if (layoutChanged || dimensionsRepaired) {
       persistLayout(withTeamSla);
     } else if (normalized.some((item, i) => item !== valid[i])) {
       persistLayout(normalized);
@@ -434,24 +423,6 @@ function loadLayout() {
   } catch {
     return DEFAULT_LAYOUT;
   }
-}
-
-/* -------------------------------------------------------------------------- */
-/* Positioning for newly added KPI cards                                       */
-/* -------------------------------------------------------------------------- */
-
-function nextKpiPosition(layout) {
-  const kpiItems = layout.filter((item) => isKpiWidget(item.i));
-  if (kpiItems.length === 0) return { x: 0, y: 0 };
-
-  const maxY = Math.max(...kpiItems.map((item) => item.y + item.h));
-  const bottomRow = kpiItems.filter((item) => item.y + item.h === maxY);
-  const usedWidth = bottomRow.reduce((sum, item) => sum + item.w, 0);
-
-  if (usedWidth + DEFAULT_KPI_LAYOUT_ITEM.w <= GRID_COLS) {
-    return { x: usedWidth, y: bottomRow[0].y };
-  }
-  return { x: 0, y: maxY };
 }
 
 /** Same post-drop pipeline as onDragStop: swap with overlapped card, then compact. */
@@ -600,18 +571,20 @@ export function useDashboardLayout() {
     [stampSync]
   );
 
-  const addKpiToLayout = useCallback(
+  const addWidgetToLayout = useCallback(
     (widgetId, position) => {
-      if (!isKpiWidget(widgetId)) return;
+      if (!WIDGETS[widgetId]) return;
+
+      const dropPosition =
+        position != null && (position.x != null || position.y != null)
+          ? { x: position.x, y: position.y }
+          : undefined;
+
       setLayout((prev) => {
         if (prev.some((item) => item.i === widgetId)) return prev;
 
-        const fallback = nextKpiPosition(prev);
-        const newItem = normalizeKpiItem({
-          i: widgetId,
-          x: position?.x ?? fallback.x,
-          y: position?.y ?? fallback.y,
-        });
+        const newItem = buildNewLayoutItem(widgetId, dropPosition, prev);
+        if (!newItem) return prev;
 
         const next = placeNewItemInLayout(prev, newItem);
         persistLayout(next);
@@ -621,32 +594,12 @@ export function useDashboardLayout() {
     [stampSync]
   );
 
-  const addWidgetToLayout = useCallback(
+  const addKpiToLayout = useCallback(
     (widgetId, position) => {
-      if (!WIDGETS[widgetId]) return;
-
-      if (isKpiWidget(widgetId)) {
-        addKpiToLayout(widgetId, position);
-        return;
-      }
-
-      setLayout((prev) => {
-        if (prev.some((item) => item.i === widgetId)) return prev;
-
-        const defaultItem = getDefaultChartItem(widgetId);
-        if (!defaultItem) return prev;
-
-        const newItem = normalizeChartItem({
-          ...defaultItem,
-          ...(position && { x: position.x, y: position.y }),
-        });
-
-        const next = placeNewItemInLayout(prev, newItem);
-        persistLayout(next);
-        return stampSync(next);
-      });
+      if (!isKpiWidget(widgetId)) return;
+      addWidgetToLayout(widgetId, position);
     },
-    [addKpiToLayout, stampSync]
+    [addWidgetToLayout]
   );
 
   const visibleLayoutIds = layout.map((item) => item.i);

--- a/frontend/micro-ui/web/src/dashboard/styles/dashboard.css
+++ b/frontend/micro-ui/web/src/dashboard/styles/dashboard.css
@@ -587,7 +587,6 @@
 }
 
 .dashboard-add-kpi-list {
-  scrollbar-gutter: stable;
   -webkit-overflow-scrolling: touch;
   background-color: #ffffff;
   list-style: none;
@@ -3079,6 +3078,20 @@
   transition-property: transform;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
+}
+
+/* Scroll works; scrollbar thumbs/tracks are hidden across the dashboard. */
+
+.dashboard-root,
+.dashboard-root * {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.dashboard-root *::-webkit-scrollbar {
+  display: none;
+  width: 0;
+  height: 0;
 }
 
 /* Beat global digit-ui Roboto rules on bare form/table elements */

--- a/frontend/micro-ui/web/src/dashboard/styles/dashboard.css
+++ b/frontend/micro-ui/web/src/dashboard/styles/dashboard.css
@@ -1456,6 +1456,11 @@
   overflow: visible;
 }
 
+.dashboard-widget-surface .apexcharts-xaxis-label tspan:not(:first-child),
+  .dashboard-widget-surface .apexcharts-yaxis-label tspan:not(:first-child) {
+  dy: 9px;
+}
+
 /* Viz type: horizontal-bar — ranked / ratio bars */
 
 .dashboard-horizontal-bar {
@@ -1502,7 +1507,6 @@
   text-anchor: start;
   transform-box: fill-box;
   transform-origin: left center;
-  transform: scaleY(0.82);
 }
 
 .dashboard-horizontal-bar .apexcharts-legend,

--- a/frontend/micro-ui/web/src/dashboard/styles/dashboard.css
+++ b/frontend/micro-ui/web/src/dashboard/styles/dashboard.css
@@ -150,6 +150,8 @@
   --status-assigned-bg: lab(94.4979% -9.48459 -3.96528);
   --status-progress: lab(41.816% 17.1944 63.4163);
   --status-progress-bg: lab(95.4544% 2.6814 15.3591);
+  --status-nearing: var(--status-progress);
+  --status-nearing-bg: var(--status-progress-bg);
   --status-resolved: lab(36.3321% -35.6256 3.05576);
   --status-resolved-bg: lab(94.7185% -13.6163 1.20147);
   --status-rejected: lab(36.1728% -1.98329 -7.04196);
@@ -891,12 +893,24 @@
   min-height: 1.75rem;
 }
 
+.\!layout .react-grid-item.dashboard-grid-item-kpi {
+  overflow: hidden !important;
+}
+
 .layout .react-grid-item.dashboard-grid-item-kpi {
   overflow: hidden;
 }
 
+.\!layout .react-grid-item.dashboard-grid-item-chart-visible {
+  overflow: visible !important;
+}
+
 .layout .react-grid-item.dashboard-grid-item-chart-visible {
   overflow: visible;
+}
+
+.\!layout .react-grid-item.dashboard-grid-item-chart-clipped {
+  overflow: hidden !important;
 }
 
 .layout .react-grid-item.dashboard-grid-item-chart-clipped {
@@ -1019,6 +1033,17 @@
   overflow: visible;
 }
 
+.dashboard-root table.dashboard-table.dashboard-table--equal-cols {
+  table-layout: fixed;
+}
+
+.dashboard-root table.dashboard-table.dashboard-table--equal-cols th.dashboard-table-th,
+  .dashboard-root table.dashboard-table.dashboard-table--equal-cols td.dashboard-table-td {
+  width: 1% !important;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .dashboard-root table.dashboard-table thead tr {
   text-align: left;
   color: var(--dashboard-muted-foreground, #6b6860);
@@ -1104,16 +1129,23 @@
 .dashboard-table-primary{
   display: flex;
   min-width: 0px;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 0.25rem;
+  column-gap: 0.25rem;
+  row-gap: 0.125rem;
+  overflow: hidden;
 }
 
 .dashboard-table-label{
   min-width: 0px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .dashboard-table-badge{
   flex-shrink: 0;
+  flex-basis: 100%;
   font-size: 8px;
   font-weight: 700;
   text-transform: uppercase;
@@ -1131,12 +1163,51 @@
   color: var(--status-nearing);
 }
 
-.dashboard-table-threshold-good {
+.dashboard-table-threshold-good{
+  font-weight: 600;
+  color: var(--status-resolved);
+}
+
+.dashboard-table-cell-tone--breach {
+  background-color: color-mix(in srgb, var(--status-breach) 14%, transparent);
+}
+
+.dashboard-table-cell-tone--watch {
+  background-color: color-mix(in srgb, var(--status-nearing) 14%, transparent);
+}
+
+.dashboard-table-cell-tone--good {
+  background-color: color-mix(in srgb, var(--status-resolved) 10%, transparent);
+}
+
+.dashboard-table-status-tag {
+  display: inline-block;
+  border-radius: 9999px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  line-height: 1.3;
+  padding: 2px 8px;
+  text-transform: uppercase;
+}
+
+.dashboard-table-status-tag--breach {
+  background-color: color-mix(in srgb, var(--status-breach) 16%, transparent);
+  color: var(--status-breach);
+}
+
+.dashboard-table-status-tag--watch {
+  background-color: color-mix(in srgb, var(--status-nearing) 16%, transparent);
+  color: var(--status-nearing);
+}
+
+.dashboard-table-status-tag--good {
+  background-color: color-mix(in srgb, var(--status-resolved) 14%, transparent);
   color: var(--status-resolved);
 }
 
 .dashboard-table-row-highlight {
-  background-color: color-mix(in srgb, var(--status-breach) 3%, transparent);
+  background-color: color-mix(in srgb, var(--status-breach) 6%, transparent);
 }
 
 .dashboard-table-trend-up{
@@ -1461,19 +1532,20 @@
   padding-right: 0.5rem;
   padding-top: 0px;
   margin-top: -6px;
-  padding-bottom: 1.125rem;
+  padding-bottom: 0.125rem;
 }
 
 .dashboard-stacked-bar-body:has(.dashboard-stacked-bar--horizontal){
   padding-left: 0.375rem;
   padding-right: 0.375rem;
+  padding-bottom: 1.125rem;
 }
 
 .dashboard-stacked-bar-header{
   border-bottom-width: 0px;
   padding-left: 0.75rem;
   padding-right: 0.75rem;
-  padding-bottom: 0px;
+  padding-bottom: 0.25rem;
   padding-top: 0.375rem;
 }
 
@@ -1498,7 +1570,16 @@
 
 .dashboard-stacked-bar .apexcharts-legend {
   padding-bottom: 0 !important;
-  margin-bottom: -6px !important;
+  margin-bottom: 0 !important;
+}
+
+/* Apex column labels sit low in the segment rect; keep glyphs inside the fill. */
+
+.dashboard-stacked-bar:not(.dashboard-stacked-bar--horizontal)
+    .apexcharts-bar-series
+    .apexcharts-datalabels
+    text {
+  dominant-baseline: central;
 }
 
 .dashboard-stacked-bar--horizontal .apexcharts-legend {
@@ -1766,13 +1847,30 @@
   z-index: 1000;
 }
 
+.\!layout .react-grid-item.dashboard-grid-item-map > .react-resizable-handle {
+  z-index: 1200 !important;
+  pointer-events: auto !important;
+}
+
 .layout .react-grid-item.dashboard-grid-item-map > .react-resizable-handle {
   z-index: 1200;
   pointer-events: auto;
 }
 
+.\!layout .react-grid-item.dashboard-grid-item-map:hover > .react-resizable-handle {
+  opacity: 1 !important;
+}
+
 .layout .react-grid-item.dashboard-grid-item-map:hover > .react-resizable-handle {
   opacity: 1;
+}
+
+.\!layout .react-grid-item.dashboard-grid-item-map > .react-resizable-handle.react-resizable-handle-s {
+  bottom: 0 !important;
+  left: 0 !important;
+  width: 100% !important;
+  height: 12px !important;
+  cursor: s-resize !important;
 }
 
 .layout .react-grid-item.dashboard-grid-item-map > .react-resizable-handle.react-resizable-handle-s {
@@ -1781,6 +1879,15 @@
   width: 100%;
   height: 12px;
   cursor: s-resize;
+}
+
+.\!layout .react-grid-item.dashboard-grid-item-map > .react-resizable-handle.react-resizable-handle-e {
+  top: 0 !important;
+  right: 0 !important;
+  width: 12px !important;
+  height: 100% !important;
+  margin-top: 0 !important;
+  cursor: e-resize !important;
 }
 
 .layout .react-grid-item.dashboard-grid-item-map > .react-resizable-handle.react-resizable-handle-e {
@@ -1977,9 +2084,19 @@
   cursor: default;
 }
 
+.\!layout .react-grid-item > .react-resizable-handle::after {
+  content: none !important;
+  border: 0 !important;
+}
+
 .layout .react-grid-item > .react-resizable-handle::after {
   content: none;
   border: 0;
+}
+
+.\!layout .react-grid-item > .react-resizable-handle {
+  background: transparent !important;
+  opacity: 0 !important;
 }
 
 .layout .react-grid-item > .react-resizable-handle {
@@ -1987,10 +2104,31 @@
   opacity: 0;
 }
 
+.\!layout .react-grid-item:hover > .react-resizable-handle.react-resizable-handle-se,
+  .\!layout .react-grid-item:hover > .react-resizable-handle.react-resizable-handle-e,
+  .\!layout .react-grid-item:hover > .react-resizable-handle.react-resizable-handle-s {
+  opacity: 1 !important;
+}
+
 .layout .react-grid-item:hover > .react-resizable-handle.react-resizable-handle-se,
   .layout .react-grid-item:hover > .react-resizable-handle.react-resizable-handle-e,
   .layout .react-grid-item:hover > .react-resizable-handle.react-resizable-handle-s {
   opacity: 1;
+}
+
+.\!layout .react-grid-item:hover > .react-resizable-handle.react-resizable-handle-se,
+  .\!layout .react-grid-item:hover > .react-resizable-handle.react-resizable-handle-e,
+  .\!layout .react-grid-item:hover > .react-resizable-handle.react-resizable-handle-s {
+  opacity: 1 !important;
+}
+
+.\!layout .react-grid-item > .react-resizable-handle.react-resizable-handle-se {
+  bottom: 0 !important;
+  right: 0 !important;
+  width: 18px !important;
+  height: 18px !important;
+  cursor: se-resize !important;
+  z-index: 3 !important;
 }
 
 .layout .react-grid-item > .react-resizable-handle.react-resizable-handle-se {
@@ -2000,6 +2138,16 @@
   height: 18px;
   cursor: se-resize;
   z-index: 3;
+}
+
+.\!layout .react-grid-item > .react-resizable-handle.react-resizable-handle-e {
+  top: 50% !important;
+  right: 0 !important;
+  width: 18px !important;
+  height: 18px !important;
+  margin-top: -9px !important;
+  cursor: e-resize !important;
+  z-index: 3 !important;
 }
 
 .layout .react-grid-item > .react-resizable-handle.react-resizable-handle-e {
@@ -2012,6 +2160,15 @@
   z-index: 3;
 }
 
+.\!layout .react-grid-item > .react-resizable-handle.react-resizable-handle-s {
+  bottom: 0 !important;
+  left: 0 !important;
+  width: 100% !important;
+  height: 12px !important;
+  cursor: s-resize !important;
+  z-index: 3 !important;
+}
+
 .layout .react-grid-item > .react-resizable-handle.react-resizable-handle-s {
   bottom: 0;
   left: 0;
@@ -2019,6 +2176,12 @@
   height: 12px;
   cursor: s-resize;
   z-index: 3;
+}
+
+.\!layout .react-grid-placeholder {
+  background: transparent !important;
+  opacity: 0 !important;
+  border: 0 !important;
 }
 
 .layout .react-grid-placeholder {
@@ -2046,6 +2209,12 @@
   border-width: 0px;
   background-color: transparent;
   padding: 0px;
+}
+
+.dashboard-root table.dashboard-table.dashboard-sla-risk-table th.dashboard-table-th,
+  .dashboard-root table.dashboard-table.dashboard-sla-risk-table td.dashboard-table-td {
+  padding-left: 0.5rem !important;
+  padding-right: 0.5rem !important;
 }
 
 .dashboard-sla-breach-pill {

--- a/frontend/micro-ui/web/src/dashboard/styles/dashboard.css
+++ b/frontend/micro-ui/web/src/dashboard/styles/dashboard.css
@@ -590,14 +590,56 @@
   scrollbar-gutter: stable;
   -webkit-overflow-scrolling: touch;
   background-color: #ffffff;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  text-align: left;
 }
 
 .dashboard-add-kpi-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding-top: 0.625rem;
+  padding-bottom: 0.625rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  cursor: grab;
+  user-select: none;
   font-weight: 400;
   background-color: #ffffff;
 }
 
+.dashboard-add-kpi-item:active{
+  cursor: grabbing;
+}
+
+.dashboard-add-kpi-item-main{
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  align-items: center;
+  gap: 0.5rem;
+  justify-content: flex-start;
+  text-align: left;
+}
+
+.dashboard-add-kpi-item-aside{
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  margin-left: 0.75rem;
+}
+
 .dashboard-add-kpi-item-label{
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: left;
   font-size: 13px;
   line-height: 1.375;
   font-weight: 400;
@@ -609,6 +651,7 @@
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.025em;
+  text-align: right;
   font-weight: 400;
   color: var(--muted-foreground, #6b6860);
 }
@@ -639,8 +682,60 @@
   color: var(--foreground, #1a1917);
 }
 
-.dashboard-add-kpi-item:hover {
+.dashboard-add-kpi-item:hover,
+  .dashboard-add-kpi-item--hover {
   background-color: var(--muted, #f5f4f1);
+}
+
+.dashboard-add-kpi-preview {
+  border: 1px solid var(--border, #e5e2db);
+  border-radius: 8px;
+  background-color: #ffffff;
+  box-shadow:
+    0 10px 24px -8px rgb(0 0 0 / 0.12),
+    0 4px 8px -4px rgb(0 0 0 / 0.08);
+  padding: 0.75rem;
+  pointer-events: none;
+}
+
+.dashboard-add-kpi-preview-card {
+  border: 1px solid var(--border, #e5e2db);
+  border-radius: 6px;
+  background-color: #ffffff;
+  padding: 0.625rem 0.75rem;
+}
+
+.dashboard-add-kpi-preview-title{
+  font-size: 10px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted-foreground, #6b6860);
+  line-height: 1.3;
+}
+
+.dashboard-add-kpi-preview-value{
+  margin-top: 0.25rem;
+  font-size: 22px;
+  font-weight: 600;
+  line-height: 1.25;
+  color: var(--foreground, #1a1917);
+  font-variant-numeric: tabular-nums;
+}
+
+.dashboard-add-kpi-preview-target{
+  margin-top: 0.125rem;
+  font-size: 11px;
+  line-height: 1.375;
+  color: var(--muted-foreground, #6b6860);
+}
+
+.dashboard-add-kpi-preview-desc{
+  margin-top: 0.625rem;
+  margin-bottom: 0px;
+  font-size: 11px;
+  line-height: 1.375;
+  color: var(--muted-foreground, #6b6860);
 }
 
 .dashboard-filters-card{
@@ -833,6 +928,12 @@
 
 .dashboard-filters-clear-inline:hover{
   color: var(--foreground);
+}
+
+.dashboard-filters-clear-inline:disabled{
+  opacity: 0.4;
+  cursor: default;
+  pointer-events: none;
 }
 
 .dashboard-widget-surface {

--- a/frontend/micro-ui/web/src/dashboard/styles/dashboard.css
+++ b/frontend/micro-ui/web/src/dashboard/styles/dashboard.css
@@ -601,21 +601,19 @@
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
-  padding-top: 0.625rem;
-  padding-bottom: 0.625rem;
-  padding-left: 1rem;
-  padding-right: 1rem;
+  padding: 0.625rem 1rem;
   cursor: grab;
-  user-select: none;
+  -webkit-user-select: none;
+          user-select: none;
   font-weight: 400;
   background-color: #ffffff;
 }
 
-.dashboard-add-kpi-item:active{
+.dashboard-add-kpi-item:active {
   cursor: grabbing;
 }
 
-.dashboard-add-kpi-item-main{
+.dashboard-add-kpi-item-main {
   display: flex;
   min-width: 0;
   flex: 1 1 auto;
@@ -625,7 +623,7 @@
   text-align: left;
 }
 
-.dashboard-add-kpi-item-aside{
+.dashboard-add-kpi-item-aside {
   display: flex;
   flex-shrink: 0;
   align-items: center;
@@ -634,7 +632,7 @@
   margin-left: 0.75rem;
 }
 
-.dashboard-add-kpi-item-label{
+.dashboard-add-kpi-item-label {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -692,8 +690,8 @@
   border-radius: 8px;
   background-color: #ffffff;
   box-shadow:
-    0 10px 24px -8px rgb(0 0 0 / 0.12),
-    0 4px 8px -4px rgb(0 0 0 / 0.08);
+      0 10px 24px -8px rgb(0 0 0 / 0.12),
+      0 4px 8px -4px rgb(0 0 0 / 0.08);
   padding: 0.75rem;
   pointer-events: none;
 }
@@ -731,8 +729,8 @@
 }
 
 .dashboard-add-kpi-preview-desc{
-  margin-top: 0.625rem;
   margin-bottom: 0px;
+  margin-top: 0.625rem;
   font-size: 11px;
   line-height: 1.375;
   color: var(--muted-foreground, #6b6860);
@@ -930,7 +928,7 @@
   color: var(--foreground);
 }
 
-.dashboard-filters-clear-inline:disabled{
+.dashboard-filters-clear-inline:disabled {
   opacity: 0.4;
   cursor: default;
   pointer-events: none;
@@ -1220,7 +1218,20 @@
 }
 
 .dashboard-root table.dashboard-table tbody tr.dashboard-table-row-highlight td.dashboard-table-td {
-  background-color: color-mix(in srgb, var(--status-breach) 3%, transparent) !important;
+  background-color: color-mix(
+      in srgb,
+      var(--status-breach) calc(var(--row-sla-severity, 1) * 14%),
+      transparent
+    ) !important;
+}
+
+.dashboard-table-sla-overrun {
+  font-weight: 600;
+  color: color-mix(
+      in srgb,
+      var(--status-breach) calc(var(--sla-overrun-severity, 1) * 100%),
+      var(--foreground)
+    );
 }
 
 .dashboard-root table.dashboard-table col.dashboard-table-col-fixed {
@@ -2591,11 +2602,6 @@
   cursor: grab;
 }
 
-.tw-select-none{
-  -webkit-user-select: none;
-          user-select: none;
-}
-
 .tw-list-none{
   list-style-type: none;
 }
@@ -2634,10 +2640,6 @@
 
 .tw-gap-2{
   gap: 0.5rem;
-}
-
-.tw-gap-2\.5{
-  gap: 0.625rem;
 }
 
 .tw-gap-3{
@@ -2867,11 +2869,6 @@
 .tw-py-2{
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
-}
-
-.tw-py-2\.5{
-  padding-top: 0.625rem;
-  padding-bottom: 0.625rem;
 }
 
 .tw-py-3{

--- a/frontend/micro-ui/web/src/dashboard/styles/input.css
+++ b/frontend/micro-ui/web/src/dashboard/styles/input.css
@@ -802,7 +802,20 @@
   }
 
   .dashboard-root table.dashboard-table tbody tr.dashboard-table-row-highlight td.dashboard-table-td {
-    background-color: color-mix(in srgb, var(--status-breach) 3%, transparent) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--status-breach) calc(var(--row-sla-severity, 1) * 14%),
+      transparent
+    ) !important;
+  }
+
+  .dashboard-table-sla-overrun {
+    font-weight: 600;
+    color: color-mix(
+      in srgb,
+      var(--status-breach) calc(var(--sla-overrun-severity, 1) * 100%),
+      var(--foreground)
+    );
   }
 
   .dashboard-root table.dashboard-table col.dashboard-table-col-fixed {

--- a/frontend/micro-ui/web/src/dashboard/styles/input.css
+++ b/frontend/micro-ui/web/src/dashboard/styles/input.css
@@ -367,7 +367,6 @@
   }
 
   .dashboard-add-kpi-list {
-    scrollbar-gutter: stable;
     -webkit-overflow-scrolling: touch;
     background-color: #ffffff;
     list-style: none;
@@ -1657,6 +1656,19 @@
     outline: none;
     box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary) 25%, transparent);
   }
+}
+
+/* Scroll works; scrollbar thumbs/tracks are hidden across the dashboard. */
+.dashboard-root,
+.dashboard-root * {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.dashboard-root *::-webkit-scrollbar {
+  display: none;
+  width: 0;
+  height: 0;
 }
 
 /* Beat global digit-ui Roboto rules on bare form/table elements */

--- a/frontend/micro-ui/web/src/dashboard/styles/input.css
+++ b/frontend/micro-ui/web/src/dashboard/styles/input.css
@@ -370,14 +370,53 @@
     scrollbar-gutter: stable;
     -webkit-overflow-scrolling: touch;
     background-color: #ffffff;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    text-align: left;
   }
 
   .dashboard-add-kpi-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.625rem 1rem;
+    cursor: grab;
+    user-select: none;
     font-weight: 400;
     background-color: #ffffff;
   }
 
+  .dashboard-add-kpi-item:active {
+    cursor: grabbing;
+  }
+
+  .dashboard-add-kpi-item-main {
+    display: flex;
+    min-width: 0;
+    flex: 1 1 auto;
+    align-items: center;
+    gap: 0.5rem;
+    justify-content: flex-start;
+    text-align: left;
+  }
+
+  .dashboard-add-kpi-item-aside {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    gap: 0.5rem;
+    justify-content: flex-end;
+    margin-left: 0.75rem;
+  }
+
   .dashboard-add-kpi-item-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    text-align: left;
     @apply tw-text-[13px] tw-leading-snug;
     font-weight: 400;
     color: var(--foreground, #1a1917);
@@ -385,6 +424,7 @@
 
   .dashboard-add-kpi-type {
     @apply tw-shrink-0 tw-text-[10px] tw-uppercase tw-tracking-wide;
+    text-align: right;
     font-weight: 400;
     color: var(--muted-foreground, #6b6860);
   }
@@ -402,8 +442,49 @@
     color: var(--foreground, #1a1917);
   }
 
-  .dashboard-add-kpi-item:hover {
+  .dashboard-add-kpi-item:hover,
+  .dashboard-add-kpi-item--hover {
     background-color: var(--muted, #f5f4f1);
+  }
+
+  .dashboard-add-kpi-preview {
+    border: 1px solid var(--border, #e5e2db);
+    border-radius: 8px;
+    background-color: #ffffff;
+    box-shadow:
+      0 10px 24px -8px rgb(0 0 0 / 0.12),
+      0 4px 8px -4px rgb(0 0 0 / 0.08);
+    padding: 0.75rem;
+    pointer-events: none;
+  }
+
+  .dashboard-add-kpi-preview-card {
+    border: 1px solid var(--border, #e5e2db);
+    border-radius: 6px;
+    background-color: #ffffff;
+    padding: 0.625rem 0.75rem;
+  }
+
+  .dashboard-add-kpi-preview-title {
+    @apply tw-text-[10px] tw-font-medium tw-uppercase tw-tracking-wider;
+    color: var(--muted-foreground, #6b6860);
+    line-height: 1.3;
+  }
+
+  .dashboard-add-kpi-preview-value {
+    @apply tw-mt-1 tw-text-[22px] tw-font-semibold tw-leading-tight;
+    color: var(--foreground, #1a1917);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .dashboard-add-kpi-preview-target {
+    @apply tw-mt-0.5 tw-text-[11px] tw-leading-snug;
+    color: var(--muted-foreground, #6b6860);
+  }
+
+  .dashboard-add-kpi-preview-desc {
+    @apply tw-mb-0 tw-mt-2.5 tw-text-[11px] tw-leading-snug;
+    color: var(--muted-foreground, #6b6860);
   }
 
   .dashboard-filters-card {
@@ -483,6 +564,12 @@
 
   .dashboard-filters-clear-inline {
     @apply tw-box-border tw-m-0 tw-inline-flex tw-h-7 tw-shrink-0 tw-items-center tw-self-center tw-rounded-sm tw-border-0 tw-bg-transparent tw-px-2 tw-py-0 tw-text-[11px] tw-font-medium tw-leading-none tw-text-muted-foreground hover:tw-text-foreground;
+  }
+
+  .dashboard-filters-clear-inline:disabled {
+    opacity: 0.4;
+    cursor: default;
+    pointer-events: none;
   }
 
   .dashboard-widget-surface {

--- a/frontend/micro-ui/web/src/dashboard/styles/input.css
+++ b/frontend/micro-ui/web/src/dashboard/styles/input.css
@@ -964,6 +964,11 @@
     overflow: visible;
   }
 
+  .dashboard-widget-surface .apexcharts-xaxis-label tspan:not(:first-child),
+  .dashboard-widget-surface .apexcharts-yaxis-label tspan:not(:first-child) {
+    dy: 9px;
+  }
+
   /* Viz type: horizontal-bar — ranked / ratio bars */
   .dashboard-horizontal-bar {
     min-height: 0;
@@ -998,7 +1003,6 @@
     text-anchor: start;
     transform-box: fill-box;
     transform-origin: left center;
-    transform: scaleY(0.82);
   }
 
   .dashboard-horizontal-bar .apexcharts-legend,

--- a/frontend/micro-ui/web/src/dashboard/styles/input.css
+++ b/frontend/micro-ui/web/src/dashboard/styles/input.css
@@ -52,6 +52,8 @@
     --status-assigned-bg: lab(94.4979% -9.48459 -3.96528);
     --status-progress: lab(41.816% 17.1944 63.4163);
     --status-progress-bg: lab(95.4544% 2.6814 15.3591);
+    --status-nearing: var(--status-progress);
+    --status-nearing-bg: var(--status-progress-bg);
     --status-resolved: lab(36.3321% -35.6256 3.05576);
     --status-resolved-bg: lab(94.7185% -13.6163 1.20147);
     --status-rejected: lab(36.1728% -1.98329 -7.04196);
@@ -636,6 +638,17 @@
     overflow: visible;
   }
 
+  .dashboard-root table.dashboard-table.dashboard-table--equal-cols {
+    table-layout: fixed;
+  }
+
+  .dashboard-root table.dashboard-table.dashboard-table--equal-cols th.dashboard-table-th,
+  .dashboard-root table.dashboard-table.dashboard-table--equal-cols td.dashboard-table-td {
+    width: 1% !important;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
   .dashboard-root table.dashboard-table thead tr {
     text-align: left;
     color: var(--dashboard-muted-foreground, #6b6860);
@@ -710,15 +723,15 @@
   }
 
   .dashboard-table-primary {
-    @apply tw-flex tw-min-w-0 tw-items-center tw-gap-1;
+    @apply tw-flex tw-min-w-0 tw-flex-wrap tw-items-center tw-gap-x-1 tw-gap-y-0.5 tw-overflow-hidden;
   }
 
   .dashboard-table-label {
-    @apply tw-min-w-0;
+    @apply tw-min-w-0 tw-truncate;
   }
 
   .dashboard-table-badge {
-    @apply tw-shrink-0 tw-text-[8px] tw-font-bold tw-uppercase tw-tracking-wide;
+    @apply tw-shrink-0 tw-basis-full tw-text-[8px] tw-font-bold tw-uppercase tw-tracking-wide;
     color: var(--status-breach);
   }
 
@@ -733,11 +746,50 @@
   }
 
   .dashboard-table-threshold-good {
+    @apply tw-font-semibold;
+    color: var(--status-resolved);
+  }
+
+  .dashboard-table-cell-tone--breach {
+    background-color: color-mix(in srgb, var(--status-breach) 14%, transparent);
+  }
+
+  .dashboard-table-cell-tone--watch {
+    background-color: color-mix(in srgb, var(--status-nearing) 14%, transparent);
+  }
+
+  .dashboard-table-cell-tone--good {
+    background-color: color-mix(in srgb, var(--status-resolved) 10%, transparent);
+  }
+
+  .dashboard-table-status-tag {
+    display: inline-block;
+    border-radius: 9999px;
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.03em;
+    line-height: 1.3;
+    padding: 2px 8px;
+    text-transform: uppercase;
+  }
+
+  .dashboard-table-status-tag--breach {
+    background-color: color-mix(in srgb, var(--status-breach) 16%, transparent);
+    color: var(--status-breach);
+  }
+
+  .dashboard-table-status-tag--watch {
+    background-color: color-mix(in srgb, var(--status-nearing) 16%, transparent);
+    color: var(--status-nearing);
+  }
+
+  .dashboard-table-status-tag--good {
+    background-color: color-mix(in srgb, var(--status-resolved) 14%, transparent);
     color: var(--status-resolved);
   }
 
   .dashboard-table-row-highlight {
-    background-color: color-mix(in srgb, var(--status-breach) 3%, transparent);
+    background-color: color-mix(in srgb, var(--status-breach) 6%, transparent);
   }
 
   .dashboard-table-trend-up {
@@ -968,15 +1020,16 @@
   .dashboard-stacked-bar-body {
     @apply tw-flex tw-min-h-0 tw-flex-1 tw-flex-col tw-overflow-hidden tw-px-2 tw-pt-0;
     margin-top: -6px;
-    padding-bottom: 1.125rem;
+    padding-bottom: 0.125rem;
   }
 
   .dashboard-stacked-bar-body:has(.dashboard-stacked-bar--horizontal) {
     @apply tw-pl-1.5 tw-pr-1.5;
+    padding-bottom: 1.125rem;
   }
 
   .dashboard-stacked-bar-header {
-    @apply tw-border-b-0 tw-px-3 tw-pb-0 tw-pt-1.5;
+    @apply tw-border-b-0 tw-px-3 tw-pb-1 tw-pt-1.5;
   }
 
   .dashboard-stacked-bar-header .dashboard-drag-handle-title {
@@ -999,7 +1052,15 @@
 
   .dashboard-stacked-bar .apexcharts-legend {
     padding-bottom: 0 !important;
-    margin-bottom: -6px !important;
+    margin-bottom: 0 !important;
+  }
+
+  /* Apex column labels sit low in the segment rect; keep glyphs inside the fill. */
+  .dashboard-stacked-bar:not(.dashboard-stacked-bar--horizontal)
+    .apexcharts-bar-series
+    .apexcharts-datalabels
+    text {
+    dominant-baseline: central;
   }
 
   .dashboard-stacked-bar--horizontal .apexcharts-legend {
@@ -1401,6 +1462,12 @@
 
   .dashboard-sla-link--button {
     @apply tw-border-0 tw-bg-transparent tw-p-0;
+  }
+
+  .dashboard-root table.dashboard-table.dashboard-sla-risk-table th.dashboard-table-th,
+  .dashboard-root table.dashboard-table.dashboard-sla-risk-table td.dashboard-table-td {
+    padding-left: 0.5rem !important;
+    padding-right: 0.5rem !important;
   }
 
   .dashboard-sla-breach-pill {

--- a/frontend/micro-ui/web/src/dashboard/utils/chartLabelWrap.js
+++ b/frontend/micro-ui/web/src/dashboard/utils/chartLabelWrap.js
@@ -1,7 +1,25 @@
 /** Approximate monospace width per character at 10px axis labels. */
 export const CHART_LABEL_CHAR_WIDTH_PX = 6.5;
 export const CHART_AXIS_LABEL_FONT_SIZE_PX = 10;
-export const CHART_AXIS_LABEL_LINE_HEIGHT_PX = 12;
+/** Vertical gap between wrapped lines of the same category label. */
+export const CHART_AXIS_LABEL_LINE_HEIGHT_PX = 9;
+/** Minimum clear gap between adjacent category labels (horizontal bar rows). */
+export const CHART_AXIS_CATEGORY_GAP_PX = 16;
+export const CHART_AXIS_WRAPPED_LABEL_MAX_LINES = 2;
+
+const HORIZONTAL_BAR_BAND_PX = 14;
+
+/** Smallest row height that keeps wrapped labels readable and separated. */
+export function resolveMinHorizontalBarRowHeight(
+  maxLabelLines = CHART_AXIS_WRAPPED_LABEL_MAX_LINES
+) {
+  const lines = Math.max(1, maxLabelLines);
+  return (
+    lines * CHART_AXIS_LABEL_LINE_HEIGHT_PX +
+    CHART_AXIS_CATEGORY_GAP_PX +
+    HORIZONTAL_BAR_BAND_PX
+  );
+}
 
 export function wrapChartLabelToLines(
   text,

--- a/frontend/micro-ui/web/src/dashboard/utils/chartScrollBaseline.js
+++ b/frontend/micro-ui/web/src/dashboard/utils/chartScrollBaseline.js
@@ -4,6 +4,7 @@ import {
   GRID_MARGIN_Y,
   KPI_ROW_HEIGHT,
 } from "../constants/layoutConfig";
+import { resolveMinHorizontalBarRowHeight } from "./chartLabelWrap";
 
 const STORAGE_PREFIX = "dashboard-chart-baseline:v2:";
 const GRID_MARGIN_X = 16;
@@ -12,6 +13,8 @@ const WIDGET_BODY_PADDING_X_PX = 16;
 
 /** Bars visible in the viewport before horizontal scroll is required. */
 export const BAR_CHART_VISIBLE_SLOTS_WITHOUT_SCROLL = 5;
+/** Horizontal bar charts use taller rows so category labels do not run together. */
+export const HORIZONTAL_BAR_VISIBLE_SLOTS_WITHOUT_SCROLL = 4;
 
 export function chartScrollStorageKey(scrollKey) {
   return scrollKey ? `${STORAGE_PREFIX}${scrollKey}` : null;
@@ -165,7 +168,9 @@ export function resolveHorizontalBarRowHeight(
     120,
     Number(minChartHeight) || Number(viewportHeight) || 0
   );
-  return referenceHeight / BAR_CHART_VISIBLE_SLOTS_WITHOUT_SCROLL;
+  const slotFromViewport =
+    referenceHeight / HORIZONTAL_BAR_VISIBLE_SLOTS_WITHOUT_SCROLL;
+  return Math.max(slotFromViewport, resolveMinHorizontalBarRowHeight());
 }
 
 export function resolveHorizontalBarVisibleSlots(
@@ -174,7 +179,7 @@ export function resolveHorizontalBarVisibleSlots(
 ) {
   const viewport = Math.max(0, Number(viewportHeight) || 0);
   const row = Math.max(0, Number(rowHeight) || 0);
-  if (viewport <= 0 || row <= 0) return BAR_CHART_VISIBLE_SLOTS_WITHOUT_SCROLL;
+  if (viewport <= 0 || row <= 0) return HORIZONTAL_BAR_VISIBLE_SLOTS_WITHOUT_SCROLL;
   return Math.max(1, Math.floor(viewport / row));
 }
 

--- a/frontend/micro-ui/web/src/dashboard/utils/mapGeoUtils.js
+++ b/frontend/micro-ui/web/src/dashboard/utils/mapGeoUtils.js
@@ -191,18 +191,120 @@ export function resolveJoinedMapBounds(joined) {
   return bounds?.isValid() ? bounds : null;
 }
 
+/** Zoom at which ward polygons stop merging into clusters. */
+export const MAP_WARD_UNCLUSTER_ZOOM = 12;
+
+/** Zoom at which individual complaint location pins appear. */
+export const MAP_COMPLAINT_PIN_MIN_ZOOM = 10;
+
+/** Fit bounds padding when zooming to complaint pins. */
+export const MAP_COMPLAINT_PIN_MAX_ZOOM = 17;
+
 /** Zoom tier shown in the toolbar badge. */
 export function getMapZoomTier(zoom) {
-  if (zoom >= 13) return "ward";
-  if (zoom >= 11) return "locality";
+  if (zoom >= MAP_COMPLAINT_PIN_MIN_ZOOM) return "complaint";
+  if (zoom >= MAP_WARD_UNCLUSTER_ZOOM) return "ward";
+  if (zoom >= 8) return "locality";
   return "city";
 }
 
-/** Grid cell size (degrees) — smaller zoom ⇒ larger cells ⇒ fewer merged clusters. */
+/** Grid cell size (degrees) — larger cells at low zoom, none once wards are unclustered. */
 function getClusterCellSize(zoom) {
-  if (zoom >= 13) return null;
-  if (zoom >= 11) return 0.022;
-  return 0.055;
+  if (zoom >= MAP_WARD_UNCLUSTER_ZOOM) return null;
+  if (zoom >= 10) return 0.016;
+  return 0.048;
+}
+
+export function filterPinsInBounds(pins, bounds, { padRatio = 0.12 } = {}) {
+  if (!bounds?.isValid?.()) return pins;
+  const padded = padRatio > 0 ? bounds.pad(padRatio) : bounds;
+  return pins.filter((pin) => padded.contains([pin.lat, pin.lng]));
+}
+
+function hashSeed(value) {
+  const str = String(value ?? "");
+  let hash = 0;
+  for (let i = 0; i < str.length; i += 1) {
+    hash = (hash * 31 + str.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash);
+}
+
+function jitterAroundCentroid(centroid, seed, slot) {
+  const angle = ((hashSeed(seed) + slot * 47) % 360) * (Math.PI / 180);
+  const dist = 0.0008 + (hashSeed(`${seed}-${slot}`) % 5) * 0.00025;
+  return {
+    lat: centroid.lat + Math.sin(angle) * dist,
+    lng: centroid.lng + Math.cos(angle) * dist,
+  };
+}
+
+function isNearMapCenter(lat, lng) {
+  const [centerLat, centerLng] = getMapCenter();
+  return Math.abs(lat - centerLat) < 1.5 && Math.abs(lng - centerLng) < 1.5;
+}
+
+function hasUsableGeoPin(pin) {
+  if (pin?.lat == null || pin?.lng == null) return false;
+  if (Math.abs(pin.lat) < 0.0001 && Math.abs(pin.lng) < 0.0001) return false;
+  return isNearMapCenter(pin.lat, pin.lng);
+}
+
+/** Ward/locality centroids keyed by boundary code. */
+export function buildWardCentroidIndex(joined) {
+  const index = {};
+  const { geoFeatures, markers } = joined ?? {};
+
+  for (const feature of geoFeatures?.features ?? []) {
+    const code = String(feature?.properties?.code ?? "").trim();
+    const centroid = geometryCentroid(feature.geometry);
+    if (code && centroid) index[code] = centroid;
+  }
+
+  for (const marker of markers ?? []) {
+    const code = String(marker.code ?? "").trim();
+    if (code) index[code] = { lat: marker.lat, lng: marker.lng };
+  }
+
+  return index;
+}
+
+/**
+ * Place each open complaint on the map using geo coordinates when valid,
+ * otherwise ward centroid with a small jitter so stacked complaints separate.
+ */
+export function resolveComplaintPinPositions(pins = [], joined) {
+  const wardCentroids = buildWardCentroidIndex(joined);
+  const wardSlot = new Map();
+
+  return pins
+    .map((pin, index) => {
+      if (hasUsableGeoPin(pin)) {
+        return { ...pin, lat: pin.lat, lng: pin.lng, approximate: false };
+      }
+
+      const wardCode = pin.wardCode;
+      if (!wardCode) return null;
+
+      const centroid = wardCentroids[wardCode];
+      if (!centroid) return null;
+
+      const slot = wardSlot.get(wardCode) ?? 0;
+      wardSlot.set(wardCode, slot + 1);
+      const jittered = jitterAroundCentroid(
+        centroid,
+        pin.id || pin.serviceRequestId || String(index),
+        slot
+      );
+
+      return {
+        ...pin,
+        lat: jittered.lat,
+        lng: jittered.lng,
+        approximate: true,
+      };
+    })
+    .filter(Boolean);
 }
 
 function crossProduct(origin, a, b) {
@@ -375,20 +477,33 @@ function clusterGeoFeatures(features, zoom) {
 /**
  * Build choropleth + point layers for the current zoom.
  * Low zoom merges adjacent wards into cluster polygons; zooming in splits them apart.
+ * At MAP_COMPLAINT_PIN_MIN_ZOOM+, individual complaint pins are included.
  */
-export function buildMapDisplayLayers(joined, zoom) {
+export function buildMapDisplayLayers(joined, zoom, complaintPins = []) {
   const { geoFeatures, markers } = joined ?? {};
   const rawFeatures = geoFeatures?.features ?? [];
   const displayFeatures = clusterGeoFeatures(rawFeatures, zoom);
 
+  let visibleComplaintPins = [];
+  if (zoom >= MAP_COMPLAINT_PIN_MIN_ZOOM && complaintPins.length) {
+    visibleComplaintPins = resolveComplaintPinPositions(complaintPins, joined);
+  }
+
   return {
     geoFeatures: { type: "FeatureCollection", features: displayFeatures },
     pointMarkers: markers ?? [],
+    complaintPins: visibleComplaintPins,
   };
 }
 
-/** Point-only wards: tiny markers when zoomed out, slightly larger when zoomed in. */
-export function markerRadiusForZoom(zoom, isFocused = false) {
+/** Ward centroid markers and complaint pins scale with zoom. */
+export function markerRadiusForZoom(zoom, isFocused = false, { complaint = false } = {}) {
+  if (complaint) {
+    if (zoom >= 16) return isFocused ? 8 : 6;
+    if (zoom >= 13) return isFocused ? 7 : 5;
+    if (zoom >= MAP_COMPLAINT_PIN_MIN_ZOOM) return isFocused ? 6 : 4;
+    return 3;
+  }
   if (zoom <= 10) return isFocused ? 4 : 2;
   if (zoom <= 12) return isFocused ? 5 : 3;
   return isFocused ? 6 : 4;


### PR DESCRIPTION
## Summary

Follow-up polish on the supervisor demo dashboard (`feature/demo-dashboard`), building on the earlier dashboard work merged in #866.

- **Charts** — Horizontal bar label typography and category spacing; bar/stacked chart presentation tweaks; general chart and map polish.
- **Tables** — Complaint type details: OVER SLA row highlighting with proportional severity (uniform row tint, red intensity scales with overrun); complaints-at-risk table styling (status/SLA pills, alignment, padding).
- **KPI inventory** — Add KPI list layout; hover previews (title, value, target, description); fix Clear filters button staying visible (disabled when nothing to clear).
- **Layout** — Fix inventory add (click/drop) so new KPI/chart/table cards never overlap existing cards; drag-and-drop behavior unchanged.
- **Chrome** — Hide scrollbar indicators across the dashboard while keeping scroll (wheel, trackpad, touch).

