### PR TITLE
feat(dashboard): POST /packs + /catalog/_search + kpiId-by-reference query arm

### DIFF
--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsController.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsController.java
@@ -4,21 +4,27 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.egov.common.contract.request.RequestInfo;
+import org.egov.common.contract.request.Role;
+import org.egov.common.contract.request.User;
+import org.egov.pgr.analytics.model.DashboardPack;
+import org.egov.pgr.analytics.model.KpiDefinition;
 import org.egov.pgr.config.PGRConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Dynamic analytics query API over the V2 grains (complaint_facts / complaint_events /
  * complaint_open_state_daily).
  *
- *   POST /v2/analytics/_query   — run a single query or a batch dict of named queries
- *   POST /v2/analytics/_schema  — capabilities/catalog so the FE can build the KPI editor
+ *   POST /v2/analytics/_query          — run a single query or a batch dict of named queries
+ *   POST /v2/analytics/_schema         — capabilities/catalog so the FE can build the KPI editor
+ *   POST /v2/analytics/packs           — return best-match DashboardPack + safe tile descriptors
+ *   POST /v2/analytics/catalog/_search — return all visible KpiDefinition tiles (no query/rbac)
  *
  * Body (single):  { "RequestInfo": {...}, "tenantId": "ke", "query": { ...grammar... } }
  * Body (batch):   { "RequestInfo": {...}, "tenantId": "ke", "queries": { "name": {...}, ... } }
@@ -29,12 +35,15 @@ import java.util.Map;
 public class AnalyticsController {
 
     private final AnalyticsService service;
+    private final KpiCatalogService kpiCatalogService;
     private final ObjectMapper mapper;
     private final PGRConfiguration config;
 
     @Autowired
-    public AnalyticsController(AnalyticsService service, ObjectMapper mapper, PGRConfiguration config){
-        this.service = service; this.mapper = mapper; this.config = config;
+    public AnalyticsController(AnalyticsService service, KpiCatalogService kpiCatalogService,
+                               ObjectMapper mapper, PGRConfiguration config){
+        this.service = service; this.kpiCatalogService = kpiCatalogService;
+        this.mapper = mapper; this.config = config;
     }
 
     @PostMapping("/_query")
@@ -57,6 +66,117 @@ public class AnalyticsController {
     @PostMapping("/_schema")
     public ResponseEntity<Map<String,Object>> schema(){
         return ResponseEntity.ok(service.schema());
+    }
+
+    /**
+     * POST /v2/analytics/packs
+     *
+     * Returns the best-matching DashboardPack for the caller plus safe tile descriptors
+     * (viz metadata only — query and rbac are never included in the response).
+     *
+     * Response: { "tiles": [...], "defaultLayout": [...], "asOf": epochMs }
+     */
+    @PostMapping("/packs")
+    public ResponseEntity<Map<String,Object>> getPacks(@RequestBody Map<String,Object> body){
+        try {
+            RequestInfo requestInfo = extractRequestInfo(body);
+            String tenantId = extractTenantId(body);
+            Set<String> callerRoles = extractRoles(requestInfo);
+
+            List<KpiDefinition> visibleDefs = kpiCatalogService.getVisibleDefs(tenantId, callerRoles);
+            Map<String,KpiDefinition> defIndex = visibleDefs.stream()
+                    .collect(Collectors.toMap(KpiDefinition::getId, d -> d));
+
+            Optional<DashboardPack> pack = kpiCatalogService.getBestPack(tenantId, callerRoles, visibleDefs);
+
+            List<Map<String,Object>> tiles = new ArrayList<>();
+            List<String> tileIds = pack.map(DashboardPack::getTiles)
+                    .filter(l -> l != null)
+                    .orElse(visibleDefs.stream().map(KpiDefinition::getId).collect(Collectors.toList()));
+
+            for (String kpiId : tileIds) {
+                KpiDefinition def = defIndex.get(kpiId);
+                if (def != null) tiles.add(safeTile(def));
+            }
+
+            Map<String,Object> out = new LinkedHashMap<>();
+            out.put("tiles", tiles);
+            out.put("defaultLayout", pack.map(DashboardPack::getLayout).orElse(Collections.emptyList()));
+            out.put("asOf", System.currentTimeMillis());
+            return ResponseEntity.ok(out);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(error(e));
+        } catch (Exception e) {
+            log.error("analytics packs failed", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error(e));
+        }
+    }
+
+    /**
+     * POST /v2/analytics/catalog/_search
+     *
+     * Returns all published KpiDefinition tiles visible to the caller (no query/rbac).
+     *
+     * Response: { "tiles": [...], "total": n }
+     */
+    @PostMapping("/catalog/_search")
+    public ResponseEntity<Map<String,Object>> searchCatalog(@RequestBody Map<String,Object> body){
+        try {
+            RequestInfo requestInfo = extractRequestInfo(body);
+            String tenantId = extractTenantId(body);
+            Set<String> callerRoles = extractRoles(requestInfo);
+
+            List<KpiDefinition> visibleDefs = kpiCatalogService.getVisibleDefs(tenantId, callerRoles);
+            List<Map<String,Object>> tiles = visibleDefs.stream()
+                    .map(this::safeTile)
+                    .collect(Collectors.toList());
+
+            Map<String,Object> out = new LinkedHashMap<>();
+            out.put("tiles", tiles);
+            out.put("total", tiles.size());
+            return ResponseEntity.ok(out);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(error(e));
+        } catch (Exception e) {
+            log.error("analytics catalog search failed", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error(e));
+        }
+    }
+
+    // ---- helpers ----
+
+    /** Serializes a KpiDefinition for external consumption: includes viz/params but NEVER query or rbac. */
+    private Map<String,Object> safeTile(KpiDefinition def) {
+        Map<String,Object> t = new LinkedHashMap<>();
+        t.put("kpiId", def.getId());
+        t.put("version", def.getVersion());
+        t.put("titleKey", def.getViz() != null ? def.getViz().getTitleKey() : null);
+        t.put("viz", def.getViz());
+        t.put("params", def.getParams());
+        return t;
+    }
+
+    private RequestInfo extractRequestInfo(Map<String,Object> body) {
+        Object ri = body.get("RequestInfo");
+        if (ri == null) return null;
+        return mapper.convertValue(ri, RequestInfo.class);
+    }
+
+    private String extractTenantId(Map<String,Object> body) {
+        Object t = body.get("tenantId");
+        if (t == null || t.toString().isEmpty())
+            throw new IllegalArgumentException("invalid_param: tenantId is required");
+        return t.toString();
+    }
+
+    private Set<String> extractRoles(RequestInfo requestInfo) {
+        if (requestInfo == null) return Collections.emptySet();
+        User u = requestInfo.getUserInfo();
+        if (u == null || u.getRoles() == null) return Collections.emptySet();
+        return u.getRoles().stream()
+                .filter(r -> r != null && r.getCode() != null)
+                .map(Role::getCode)
+                .collect(Collectors.toSet());
     }
 
     private Map<String,Object> error(Exception e){

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
@@ -3,16 +3,25 @@ package org.egov.pgr.analytics;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.extern.slf4j.Slf4j;
 import org.egov.common.contract.request.RequestInfo;
+import org.egov.common.contract.request.Role;
+import org.egov.common.contract.request.User;
 import org.egov.pgr.analytics.AnalyticsCatalog.Grain;
+import org.egov.pgr.analytics.model.KpiDefinition;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Orchestrates the dynamic analytics query: resolve server-side RBAC scope, plan each query
  * against the catalog, execute parameterized SQL, and shape the response (single or batch dict).
+ *
+ * The batch-query arm supports a kpiId-by-reference shorthand: when a query node contains
+ * {@code "kpiId": "<id>"} instead of an inline grammar, the KPI's query is loaded from MDMS
+ * via {@link KpiCatalogService}. Callers not authorized for the KPI receive a per-entry
+ * {@code kpi_forbidden} error with {@code partial: true}; the rest of the batch continues normally.
  */
 @Service
 @Slf4j
@@ -21,15 +30,19 @@ public class AnalyticsService {
     private final AnalyticsPlanner planner;
     private final AnalyticsCatalog catalog;
     private final JdbcTemplate jdbc;
+    private final KpiCatalogService kpiCatalogService;
 
     @Autowired
-    public AnalyticsService(AnalyticsPlanner planner, AnalyticsCatalog catalog, JdbcTemplate jdbc){
+    public AnalyticsService(AnalyticsPlanner planner, AnalyticsCatalog catalog, JdbcTemplate jdbc,
+                            KpiCatalogService kpiCatalogService){
         this.planner = planner; this.catalog = catalog; this.jdbc = jdbc;
+        this.kpiCatalogService = kpiCatalogService;
     }
 
     public Map<String,Object> query(JsonNode body, RequestInfo requestInfo, String tenantId, int stateLevelLen){
         if (tenantId == null || tenantId.isEmpty()) throw new IllegalArgumentException("invalid_param: tenantId is required");
         AnalyticsScope scope = AnalyticsScope.resolve(requestInfo, tenantId, stateLevelLen);
+        Set<String> callerRoles = extractRoles(requestInfo);
 
         Map<String,Object> out = new LinkedHashMap<>();
         out.put("asOf", asOf());
@@ -42,17 +55,54 @@ public class AnalyticsService {
             Iterator<Map.Entry<String,JsonNode>> it = body.get("queries").fields();
             while (it.hasNext()) {
                 Map.Entry<String,JsonNode> e = it.next();
-                try { results.put(e.getKey(), runOne(e.getValue(), scope)); }
-                catch (Exception ex) { partial = true; results.put(e.getKey(), err(ex)); }
+                String name = e.getKey();
+                JsonNode queryNode = e.getValue();
+                try {
+                    JsonNode actualQueryNode = resolveKpiRef(queryNode, tenantId, callerRoles);
+                    if (actualQueryNode == null) {
+                        partial = true;
+                        results.put(name, Map.of("error", "kpi_forbidden",
+                                "message", "KPI not found or not authorized for role set"));
+                        continue;
+                    }
+                    results.put(name, runOne(actualQueryNode, scope));
+                } catch (Exception ex) {
+                    partial = true;
+                    results.put(name, err(ex));
+                }
             }
             out.put("results", results);
             out.put("partial", partial);
         } else if (body.has("query")) {
-            out.putAll(runOne(body.get("query"), scope));
+            JsonNode queryNode = body.get("query");
+            JsonNode actualQueryNode = resolveKpiRef(queryNode, tenantId, callerRoles);
+            if (actualQueryNode == null)
+                throw new IllegalArgumentException("kpi_forbidden: KPI not found or not authorized");
+            out.putAll(runOne(actualQueryNode, scope));
         } else {
             throw new IllegalArgumentException("invalid_param: body must contain 'query' or 'queries'");
         }
         return out;
+    }
+
+    /**
+     * If the query node has a {@code "kpiId"} field, resolve it to the KPI's stored query
+     * and check authorization. Returns null if forbidden. Returns queryNode unchanged when
+     * there is no {@code "kpiId"} field (inline query path is unchanged).
+     */
+    private JsonNode resolveKpiRef(JsonNode queryNode, String tenantId, Set<String> callerRoles) {
+        if (!queryNode.has("kpiId")) return queryNode;
+
+        String kpiId = queryNode.get("kpiId").asText();
+        Optional<KpiDefinition> def = kpiCatalogService.getDef(kpiId, tenantId);
+        if (def.isEmpty() || !def.get().isPublished() || !def.get().isVisibleTo(callerRoles)) {
+            log.debug("kpiId '{}' not found or not authorized (roles={})", kpiId, callerRoles);
+            return null;
+        }
+        JsonNode storedQuery = def.get().getQuery();
+        if (storedQuery == null || storedQuery.isNull())
+            throw new IllegalArgumentException("invalid_kpi: KPI '" + kpiId + "' has no query defined");
+        return storedQuery;
     }
 
     private Map<String,Object> runOne(JsonNode q, AnalyticsScope scope){
@@ -121,5 +171,16 @@ public class AnalyticsService {
         String code = msg.contains(":") ? msg.substring(0, msg.indexOf(':')) : "query_failed";
         m.put("error", code); m.put("message", msg);
         return m;
+    }
+
+    /** Extract role codes from RequestInfo.userInfo.roles — mirrors AnalyticsScope role extraction. */
+    private Set<String> extractRoles(RequestInfo requestInfo) {
+        if (requestInfo == null) return Collections.emptySet();
+        User u = requestInfo.getUserInfo();
+        if (u == null || u.getRoles() == null) return Collections.emptySet();
+        return u.getRoles().stream()
+                .filter(r -> r != null && r.getCode() != null)
+                .map(Role::getCode)
+                .collect(Collectors.toSet());
     }
 }

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiCatalogService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiCatalogService.java
@@ -1,0 +1,157 @@
+package org.egov.pgr.analytics;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import lombok.extern.slf4j.Slf4j;
+import org.egov.common.contract.request.RequestInfo;
+import org.egov.common.utils.MultiStateInstanceUtil;
+import org.egov.mdms.model.MasterDetail;
+import org.egov.mdms.model.MdmsCriteria;
+import org.egov.mdms.model.MdmsCriteriaReq;
+import org.egov.mdms.model.ModuleDetail;
+import org.egov.pgr.analytics.model.DashboardPack;
+import org.egov.pgr.analytics.model.KpiDefinition;
+import org.egov.pgr.config.PGRConfiguration;
+import org.egov.pgr.repository.ServiceRequestRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Loads KpiDefinition and DashboardPack records from MDMS (dss module) and applies
+ * visibility filtering by status + caller roles.
+ *
+ * Uses the exact same MDMS client pattern as {@link org.egov.pgr.util.MDMSUtils}:
+ * MdmsCriteriaReq built with builder, posted via ServiceRequestRepository.fetchResult,
+ * result parsed with JsonPath.
+ */
+@Service
+@Slf4j
+public class KpiCatalogService {
+
+    private static final String DSS_MODULE = "dss";
+    private static final String MASTER_KPI  = "KpiDefinition";
+    private static final String MASTER_PACK = "DashboardPack";
+
+    private final PGRConfiguration config;
+    private final ServiceRequestRepository serviceRequestRepository;
+    private final MultiStateInstanceUtil multiStateInstanceUtil;
+    private final ObjectMapper mapper;
+
+    @Autowired
+    public KpiCatalogService(PGRConfiguration config,
+                             ServiceRequestRepository serviceRequestRepository,
+                             MultiStateInstanceUtil multiStateInstanceUtil,
+                             ObjectMapper mapper) {
+        this.config = config;
+        this.serviceRequestRepository = serviceRequestRepository;
+        this.multiStateInstanceUtil = multiStateInstanceUtil;
+        this.mapper = mapper;
+    }
+
+    /**
+     * Returns all published KpiDefinitions that are visible to the given caller roles,
+     * scoped to the state-root tenant derived from tenantId.
+     * Returns an empty list (never throws) when the dss module does not exist in MDMS.
+     */
+    public List<KpiDefinition> getVisibleDefs(String tenantId, Set<String> callerRoles) {
+        String stateRoot = multiStateInstanceUtil.getStateLevelTenant(tenantId);
+        List<KpiDefinition> all = fetchDefs(stateRoot);
+        return all.stream()
+                .filter(KpiDefinition::isPublished)
+                .filter(d -> d.isVisibleTo(callerRoles))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns the first DashboardPack whose roles overlap the caller's roles, searching
+     * from MDMS for the state-root tenant. Returns Optional.empty() when none match or
+     * when the dss module does not exist.
+     */
+    public Optional<DashboardPack> getBestPack(String tenantId, Set<String> callerRoles,
+                                               List<KpiDefinition> visibleDefs) {
+        String stateRoot = multiStateInstanceUtil.getStateLevelTenant(tenantId);
+        Set<String> visibleIds = visibleDefs.stream()
+                .map(KpiDefinition::getId)
+                .collect(Collectors.toSet());
+
+        return fetchPacks(stateRoot).stream()
+                .filter(p -> p.matchesRoles(callerRoles))
+                // Filter pack tiles down to only what the caller can actually see
+                .peek(p -> {
+                    if (p.getTiles() != null)
+                        p.setTiles(p.getTiles().stream().filter(visibleIds::contains).collect(Collectors.toList()));
+                    if (p.getLayout() != null)
+                        p.setLayout(p.getLayout().stream()
+                                .filter(e -> visibleIds.contains(e.getKpiId()))
+                                .collect(Collectors.toList()));
+                })
+                .findFirst();
+    }
+
+    /**
+     * Returns a single KpiDefinition by id (no visibility check — the caller must apply
+     * isVisibleTo separately). Returns Optional.empty() when not found or MDMS unavailable.
+     */
+    public Optional<KpiDefinition> getDef(String kpiId, String tenantId) {
+        String stateRoot = multiStateInstanceUtil.getStateLevelTenant(tenantId);
+        return fetchDefs(stateRoot).stream()
+                .filter(d -> kpiId.equals(d.getId()))
+                .findFirst();
+    }
+
+    // ---- private MDMS helpers ----
+
+    private List<KpiDefinition> fetchDefs(String stateRoot) {
+        return fetchMaster(stateRoot, MASTER_KPI, new TypeReference<List<KpiDefinition>>() {});
+    }
+
+    private List<DashboardPack> fetchPacks(String stateRoot) {
+        return fetchMaster(stateRoot, MASTER_PACK, new TypeReference<List<DashboardPack>>() {});
+    }
+
+    private <T> List<T> fetchMaster(String stateRoot, String masterName, TypeReference<List<T>> typeRef) {
+        try {
+            MdmsCriteriaReq req = buildMdmsRequest(new RequestInfo(), stateRoot, masterName);
+            Object result = serviceRequestRepository.fetchResult(getMdmsSearchUrl(), req);
+            if (result == null) return Collections.emptyList();
+
+            String jsonPath = "$.MdmsRes." + DSS_MODULE + "." + masterName;
+            List<Object> raw = JsonPath.read(result, jsonPath);
+            if (raw == null || raw.isEmpty()) return Collections.emptyList();
+
+            return mapper.convertValue(raw, typeRef);
+        } catch (com.jayway.jsonpath.PathNotFoundException e) {
+            // dss module or master not present in MDMS — graceful empty
+            log.debug("MDMS path not found for {}.{} at tenant {}: {}", DSS_MODULE, masterName, stateRoot, e.getMessage());
+            return Collections.emptyList();
+        } catch (Exception e) {
+            log.warn("Failed to load {}.{} from MDMS for tenant {}; returning empty list. Cause: {}",
+                    DSS_MODULE, masterName, stateRoot, e.getMessage());
+            return Collections.emptyList();
+        }
+    }
+
+    private MdmsCriteriaReq buildMdmsRequest(RequestInfo requestInfo, String tenantId, String masterName) {
+        MasterDetail masterDetail = MasterDetail.builder().name(masterName).build();
+        ModuleDetail moduleDetail = ModuleDetail.builder()
+                .moduleName(DSS_MODULE)
+                .masterDetails(Collections.singletonList(masterDetail))
+                .build();
+        MdmsCriteria mdmsCriteria = MdmsCriteria.builder()
+                .tenantId(tenantId)
+                .moduleDetails(Collections.singletonList(moduleDetail))
+                .build();
+        return MdmsCriteriaReq.builder()
+                .requestInfo(requestInfo)
+                .mdmsCriteria(mdmsCriteria)
+                .build();
+    }
+
+    private StringBuilder getMdmsSearchUrl() {
+        return new StringBuilder().append(config.getMdmsHost()).append(config.getMdmsEndPoint());
+    }
+}

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/model/DashboardPack.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/model/DashboardPack.java
@@ -1,0 +1,28 @@
+package org.egov.pgr.analytics.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+import java.util.List;
+import java.util.Set;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DashboardPack {
+    private String id;
+    private String description;
+    private List<String> roles;
+    private List<String> tiles;
+    private List<LayoutEntry> layout;
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class LayoutEntry {
+        private String kpiId;
+        private int x, y, w, h;
+    }
+
+    public boolean matchesRoles(Set<String> callerRoles) {
+        return roles != null && roles.stream().anyMatch(callerRoles::contains);
+    }
+}

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/model/KpiDefinition.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/model/KpiDefinition.java
@@ -1,0 +1,80 @@
+package org.egov.pgr.analytics.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.Data;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KpiDefinition {
+    private String id;
+    private String version;
+    private String status;
+    private JsonNode query;
+    private KpiViz viz;
+    private List<KpiParam> params;
+    private KpiRbac rbac;
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class KpiViz {
+        private String kind;
+        private String format;
+        private String valueKey;
+        private String accent;
+        private String group;
+        private String titleKey;
+        private String dimensionKey;
+        private List<String> measureKeys;
+        private List<KpiVariant> variants;
+        private JsonNode compose;
+        private JsonNode pii;
+    }
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class KpiParam {
+        private String name;
+        private String defaultValue;
+
+        @JsonProperty("default")
+        public String getDefaultValue() { return defaultValue; }
+
+        @JsonProperty("default")
+        public void setDefaultValue(String v) { this.defaultValue = v; }
+
+        private List<String> allowed;
+    }
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class KpiVariant {
+        private String id;
+        private String labelKey;
+        private boolean defaultVariant;
+
+        @JsonProperty("default")
+        public boolean isDefaultVariant() { return defaultVariant; }
+
+        @JsonProperty("default")
+        public void setDefaultVariant(boolean v) { this.defaultVariant = v; }
+    }
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class KpiRbac {
+        private List<String> visibleTo = Collections.emptyList();
+    }
+
+    public boolean isPublished() { return "published".equals(status); }
+
+    public boolean isVisibleTo(Set<String> callerRoles) {
+        if (rbac == null || rbac.getVisibleTo() == null || rbac.getVisibleTo().isEmpty()) return true;
+        return rbac.getVisibleTo().stream().anyMatch(callerRoles::contains);
+    }
+}

--- a/frontend/micro-ui/web/webpack.config.js
+++ b/frontend/micro-ui/web/webpack.config.js
@@ -7,6 +7,9 @@ module.exports = {
   // mode: 'development',
   entry: "./src/index.js",
   devtool: "none",
+  // src/ mixes .js and .jsx (dashboard/); webpack's default resolve list has no .jsx,
+  // so extensionless imports of .jsx files only worked on the dev server.
+  resolve: { extensions: [".js", ".jsx", ".json"] },
   module: {
     rules: [
       {
@@ -20,7 +23,7 @@ module.exports = {
         }
       },
       {
-        test: /\.(js)$/,
+        test: /\.(js|jsx)$/,
         exclude: /node_modules/,
         use: {
           loader: "babel-loader",


### PR DESCRIPTION
## Summary

Adds the backend API surface from the wide-migration design (`docs/dashboard-rbac-design/66-viz-schema-api-contract.md`).

**New files (3):**
- `analytics/model/KpiDefinition.java` — model with `isPublished()` + `isVisibleTo(Set<String>)` helpers; handles the `"default"` Java keyword collision via `@JsonProperty`
- `analytics/model/DashboardPack.java` — model with `matchesRoles()` helper + `LayoutEntry`
- `analytics/KpiCatalogService.java` — loads `dss.KpiDefinition` and `dss.DashboardPack` from MDMS; uses existing `MDMSUtils`/`MultiStateInstanceUtil` pattern; `getBestPack` hard-gates pack tiles against the visible def set (never a leak); `PathNotFoundException` + all errors caught → empty list, never a 500

**Modified (2):**
- `AnalyticsController.java` — `POST /v2/analytics/packs` + `POST /v2/analytics/catalog/_search`; `safeTile()` helper strips `query` and `rbac` from the response (FE never sees those)
- `AnalyticsService.java` — `resolveKpiRef()` arm: when a batch entry has `"kpiId"`, resolves from MDMS, checks `isPublished() && isVisibleTo(callerRoles)`, returns `kpi_forbidden` error if not (with `partial:true`); inline queries without `kpiId` are untouched

Part of #631 / #934.

## Test plan
- [ ] `POST /v2/analytics/packs` returns `{tiles, defaultLayout}` with viz schema, no query body in response
- [ ] `POST /v2/analytics/catalog/_search` returns `{tiles, total}`
- [ ] `POST /v2/analytics/_query` with `{"kpiId":"cl_open_weekly","params":{"window":"last_7d"}}` returns same result as the inline query body
- [ ] A kpiId not in the caller's `visibleTo` returns `errors: {kpi_forbidden}` not data
- [ ] When `dss` module missing in MDMS, endpoints return empty gracefully (no 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)