### PR TITLE
fix(configurator): fetch full MDMS masters — bulk-employee false "department not found"

### DIFF
--- a/configurator/src/api/services/mdms.ts
+++ b/configurator/src/api/services/mdms.ts
@@ -57,7 +57,10 @@ export const mdmsService = {
   // ============================================
 
   async getDepartments(tenantId: string): Promise<Department[]> {
-    return this.search<Department>(tenantId, MDMS_SCHEMAS.DEPARTMENT);
+    // Pull the full master, not the search() default page (100). Tenants like
+    // mz.ige have 120+ departments; a partial fetch makes bulk-employee
+    // validation wrongly flag the unloaded ones as "Department not found".
+    return this.search<Department>(tenantId, MDMS_SCHEMAS.DEPARTMENT, { limit: 5000 });
   },
 
   async createDepartment(tenantId: string, department: Department): Promise<MdmsRecord> {
@@ -95,7 +98,9 @@ export const mdmsService = {
   // ============================================
 
   async getDesignations(tenantId: string): Promise<Designation[]> {
-    return this.search<Designation>(tenantId, MDMS_SCHEMAS.DESIGNATION);
+    // Same as getDepartments: fetch the full master so employee-bulk validation
+    // doesn't false-negative on designations beyond the default page.
+    return this.search<Designation>(tenantId, MDMS_SCHEMAS.DESIGNATION, { limit: 5000 });
   },
 
   async createDesignation(tenantId: string, designation: Designation): Promise<MdmsRecord> {
@@ -142,7 +147,8 @@ export const mdmsService = {
   async getComplaintTypes(tenantId: string): Promise<ComplaintType[]> {
     const results = await this.search<Record<string, unknown>>(
       tenantId,
-      MDMS_SCHEMAS.COMPLAINT_HIERARCHY
+      MDMS_SCHEMAS.COMPLAINT_HIERARCHY,
+      { limit: 5000 } // full hierarchy can be thousands of leaves; don't truncate at the 100 default
     );
 
     const isLeaf = (r: Record<string, unknown>) =>


### PR DESCRIPTION
## Problem
On tenants with many master records, the configurator's **bulk-employee** upload wrongly reports `Department "<code>" not found` and skips those rows. On **`mz.ige`** (Mozambique IGE — **120 departments**), **340 of 419** employees were skipped, even though every department exists in MDMS.

## Root cause
`mdmsService.search()` defaults to **`limit: 100`**, and the master getters called it **without** overriding. MDMS therefore returns only the first 100 records, so anything past page 1 (20 of 120 departments) is absent from the validation set and flagged "not found."

Verified against prod MDMS: `limit:100 → 100`, `limit:200 → 120`. It's a **fetch-completeness** bug, not missing data.

## Fix
Pass an explicit high `limit` at the **caller level** (the shared `search()` default is left at 100 — no behavior change for other callers), on the masters that are validated/listed in full:

| Method | Change |
|---|---|
| `getDepartments` | `{ limit: 5000 }` |
| `getDesignations` | `{ limit: 5000 }` |
| `getComplaintTypes` | `{ limit: 5000 }` — the merged N-level `ComplaintHierarchy` can be thousands of leaves |

MDMS natively supports `limit`/`offset`; `5000` returns the full master in one call. (A paginated `offset` loop would be the fully size-agnostic alternative if a tenant ever exceeds 5000 of a single master.)

## Test
- **Before:** `getDepartments(mz.ige)` → 100 of 120 → bulk-employee skips 340.
- **After:** full 120 load → all 419 employees validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
