### PR TITLE
feat(pgr): add assignee-based search filtering for service requests

### DIFF
--- a/backend/pgr-services/src/main/java/org/egov/pgr/repository/rowmapper/PGRQueryBuilder.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/repository/rowmapper/PGRQueryBuilder.java
@@ -130,6 +130,13 @@ public class PGRQueryBuilder {
             addToPreparedStatement(preparedStmtList, userIds);
         }
 
+        Set<String> serviceRequestIds = criteria.getServiceRequestIds();
+        if (!CollectionUtils.isEmpty(serviceRequestIds)) {
+            addClauseIfRequired(preparedStmtList, builder);
+            builder.append(" ser.serviceRequestId IN (").append(createQuery(serviceRequestIds)).append(")");
+            addToPreparedStatement(preparedStmtList, serviceRequestIds);
+        }
+
 
         Set<String> localities = criteria.getLocality();
         if(!CollectionUtils.isEmpty(localities)){

--- a/backend/pgr-services/src/main/java/org/egov/pgr/service/PGRService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/service/PGRService.java
@@ -118,6 +118,15 @@ public class PGRService {
         if(criteria.getMobileNumber()!=null && CollectionUtils.isEmpty(criteria.getUserIds()))
             return new ArrayList<>();
 
+        if (criteria.getAssignee() != null) {
+            String tenantId = criteria.getTenantId() != null ? criteria.getTenantId() : requestInfo.getUserInfo().getTenantId();
+            Set<String> serviceRequestIds = workflowService.getServiceRequestIdsByAssignee(requestInfo, tenantId, criteria.getAssignee());
+            if (serviceRequestIds.isEmpty()) {
+                return new ArrayList<>();
+            }
+            criteria.setServiceRequestIds(serviceRequestIds);
+        }
+
         criteria.setIsPlainSearch(false);
 
         List<ServiceWrapper> serviceWrappers = repository.getServiceWrappers(criteria);

--- a/backend/pgr-services/src/main/java/org/egov/pgr/service/WorkflowService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/service/WorkflowService.java
@@ -260,5 +260,31 @@ public class WorkflowService {
 
     }
 
+    public Set<String> getServiceRequestIdsByAssignee(RequestInfo requestInfo, String tenantId, String assigneeUuid) {
+        StringBuilder url = new StringBuilder(pgrConfiguration.getWfHost());
+        url.append(pgrConfiguration.getWfProcessInstanceSearchPath());
+        url.append("?tenantId=").append(tenantId);
+        url.append("&businessService=").append(PGR_BUSINESSSERVICE);
+        url.append("&assignee=").append(assigneeUuid);
+
+        RequestInfoWrapper requestInfoWrapper = RequestInfoWrapper.builder().requestInfo(requestInfo).build();
+        Object result = repository.fetchResult(url, requestInfoWrapper);
+
+        ProcessInstanceResponse response;
+        try {
+            response = mapper.convertValue(result, ProcessInstanceResponse.class);
+        } catch (IllegalArgumentException e) {
+            throw new CustomException("PARSING ERROR", "Failed to parse workflow response for assignee search");
+        }
+
+        if (CollectionUtils.isEmpty(response.getProcessInstances())) {
+            return Collections.emptySet();
+        }
+
+        return response.getProcessInstances().stream()
+                .map(ProcessInstance::getBusinessId)
+                .collect(Collectors.toSet());
+    }
+
 
 }

--- a/backend/pgr-services/src/main/java/org/egov/pgr/web/models/RequestSearchCriteria.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/web/models/RequestSearchCriteria.java
@@ -92,9 +92,17 @@ public class RequestSearchCriteria {
     @JsonProperty("accountId")
     private String accountId;
 
+    @SafeHtml
+    @JsonProperty("assignee")
+    private String assignee;
+
+    @JsonIgnore
+    private Set<String> serviceRequestIds;
+
     public boolean isEmpty(){
         return (this.tenantId==null && this.serviceCode==null && this.mobileNumber==null && this.serviceRequestId==null
-        && this.applicationStatus==null && this.ids==null && this.userIds==null && this.locality==null);
+        && this.applicationStatus==null && this.ids==null && this.userIds==null && this.locality==null
+        && this.assignee==null);
     }
 
 }


### PR DESCRIPTION
- Add serviceRequestIds filter to PGRQueryBuilder for querying complaints by assignee
- Implement getServiceRequestIdsByAssignee method in WorkflowService to fetch process instances from workflow engine
- Add assignee parameter to RequestSearchCriteria model with @SafeHtml validation
- Integrate assignee filtering logic in PGRService to resolve assignee UUID to service request IDs before search
- Enable operators to search and filter complaints assigned to specific users via workflow integration