### PR TITLE
chore(deploy): drop dead /egov-rainmaker nginx passthrough + flag

### DIFF
--- a/local-setup/ansible/README.md
+++ b/local-setup/ansible/README.md
@@ -141,8 +141,8 @@ files trigger restarts.
 
 Some production tenants have hand-crafted `/etc/nginx/sites-enabled/<domain>`
 files with routing the templated `nginx-site.conf.j2` doesn't render
-(e.g. Bomet's `/egov-rainmaker/` filestore passthrough, `/novu/`+`/novu-api/`,
-the `/digit-ui/` host-alias). Set `nginx_preserve_vhost: true` in their
+(e.g. Bomet's `/novu/`+`/novu-api/` routing and the `/digit-ui/` host-alias).
+Set `nginx_preserve_vhost: true` in their
 host_vars and the playbook will still install nginx, but will skip
 rendering/symlinking the site file — your hand-managed vhost is left
 ## Per-tenant overrides
@@ -185,8 +185,8 @@ so deploys on tenants without an overlay are unaffected.
 
 Set in host_vars when the tenant's `/etc/nginx/sites-enabled/<domain>`
 has routing the templated `nginx-site.conf.j2` doesn't render (Bomet's
-`/egov-rainmaker/` filestore passthrough, `/novu/`+`/novu-api/`, the
-`/digit-ui/` host-alias). The playbook still installs nginx, but skips
+`/novu/`+`/novu-api/` routing and the `/digit-ui/` host-alias). The
+playbook still installs nginx, but skips
 templating + symlinking the site file — your hand-managed vhost is left
 alone across every redeploy.
 

--- a/local-setup/ansible/inventory/host_vars/_example.yml
+++ b/local-setup/ansible/inventory/host_vars/_example.yml
@@ -374,9 +374,8 @@ nginx_features:
 # nginx still gets installed (apt task is unconditional) but the operator's
 # hand-managed vhost is left as-is. Use for tenants whose production vhost
 # has hand-crafted routing the template can't (yet) render — e.g. Bomet's
-# /egov-rainmaker/ filestore passthrough, /novu/+/novu-api/ routing, the
-# /digit-ui/ host-alias. Default false so new tenants get the standard
-# templated vhost.
+# /novu/+/novu-api/ routing and the /digit-ui/ host-alias. Default false so
+# new tenants get the standard templated vhost.
 nginx_preserve_vhost: false
 
 # ────────── OpenBao (per-tenant secrets backend) ──────────

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -1744,8 +1744,8 @@
       # `nginx_preserve_vhost: true` in host_vars makes the next three tasks
       # (render / enable / remove-default) no-op. Use it for tenants whose
       # production vhost has hand-crafted routing the template can't (yet)
-      # render — e.g. Bomet's /egov-rainmaker/ filestore passthrough,
-      # /novu/+/novu-api/ routing, and the /digit-ui/ host-alias. The nginx
+      # render — e.g. Bomet's /novu/+/novu-api/ routing and the /digit-ui/
+      # host-alias. The nginx
       # install task above still runs (idempotent), so the package is
       # always present; only the site file is left alone.
 

--- a/local-setup/ansible/templates/nginx-site.conf.j2
+++ b/local-setup/ansible/templates/nginx-site.conf.j2
@@ -418,25 +418,6 @@ server {
     proxy_buffering off;
   }
 
-{% if nginx_features.minio_egov_rainmaker_alias | default(false) %}
-  # Legacy /egov-rainmaker/ MinIO passthrough. Used when egov-filestore
-  # signs presigned URLs with the public domain (MINIO_URL=https://<domain>)
-  # under the `egov-rainmaker` bucket instead of the internal minio:9000.
-  # Host is preserved so the AWS4 signature ($host) keeps validating.
-  # ^~ prefix beats the Kong catch-all below.
-  location ^~ /egov-rainmaker/ {
-    proxy_pass http://{{ nginx_upstream_host | default('127.0.0.1') }}:{{ upstream_minio_port | default(19000) }};
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_buffering off;
-    proxy_request_buffering off;
-    client_max_body_size 100m;
-    proxy_read_timeout 120s;
-  }
-{% endif %}
-
 {% if nginx_features.root_to_digit_ui | default(false) %}
   # Bare domain -> citizen app login. Lands users in the digit-ui SPA
   # instead of Kong's default response. Exact match (=), so the catch-all


### PR DESCRIPTION
**TL;DR:** the template has two nginx blocks doing the same job — serving MinIO attachment URLs to browsers. This deletes the redundant one (`/egov-rainmaker/`, Approach B) in favor of the canonical one from #856 by @Lokendra-egov (`/file-store/` + `/filestore/`, Approach A). Dead code on every live box — deploy-time no-op.

## What

Removes the `minio_egov_rainmaker_alias` feature flag and its `/egov-rainmaker/` nginx location block from `templates/nginx-site.conf.j2`, plus the now-stale doc references to it.

## Why — two mechanisms, same problem

egov-filestore returns presigned URLs pointing at the internal `http://minio:9000`, which browsers can't resolve. The template grew two independent fixes for this:

- **Approach A — canonical, from #856 (@Lokendra-egov), the template default.** filestore keeps `MINIO_URL=http://minio:9000`; nginx rewrites the host in the JSON body via `sub_filter` and the `/file-store/` passthrough re-sets `Host: minio:9000` so the AWS4 signature still validates. Hostname-portable (uses `$host` since #856), no per-tenant config.
- **Approach B — this block, being removed.** Reproduced Bomet's original (2026-05-18) hand-fix: filestore signs against the *public domain* (`MINIO_URL=https://<domain>`), served via a host-preserving `/egov-rainmaker/` passthrough + a TLS-hairpin `extra_hosts` entry. Hostname-locked, needs per-tenant `MINIO_URL`, depends on the docker gateway IP + public cert.

Both solve the identical problem; A is strictly better and is what everything runs on. Keeping B is a second way to do the same thing — a footgun, not a feature.

## Safety — deploy-time no-op, verified live

Both live tenants that ever ran Approach B are already fully on A. Config verified on each box:

| Tenant | filestore `MINIO_URL` | `ExtraHosts` | `/egov-rainmaker/` in live vhost |
|--------|----------------------|--------------|----------------------------------|
| bometfeedbackhub.digit.org | `http://minio:9000` | `[]` | none |
| naipepea | `http://minio:9000` | `[]` | none |

And verified **functionally** on bomet — resolved a real citizen attachment through the public gateway:
- returned URL → `https://bometfeedbackhub.digit.org/file-store/…?X-Amz-Signature=…` (public domain via Approach A, no `localhost`/`minio:9000`)
- fetching it → `HTTP 200`, `image/png`, valid PNG bytes.

No committed host_var enables `minio_egov_rainmaker_alias`, so removing it changes no rendered output on any box.

## Related

- Follows #856 (`fix(deploy): rewrite filestore presigned URLs with runtime $host`) — the fix we're standardizing on.
- Closes the original attachment bug's cleanup; tracked under #913 (bomet→develop convergence).
