### PR TITLE
fix(digit-ui): move MDMS cache to IndexedDB to fix localStorage QuotaExceededError

### DIFF
--- a/digit-ui-esbuild/packages/libraries/src/services/atoms/Utils/Storage.js
+++ b/digit-ui-esbuild/packages/libraries/src/services/atoms/Utils/Storage.js
@@ -21,7 +21,7 @@ const getStorage = (storageClass) => ({
       }
       return item.value;
     } else if (typeof window !== "undefined") {
-      return window?.eGov?.Storage && window.eGov.Storage[k(key)].value;
+      return window?.eGov?.Storage && window.eGov.Storage[k(key)] ? window.eGov.Storage[k(key)].value : null;
     } else {
       return null;
     }
@@ -33,7 +33,17 @@ const getStorage = (storageClass) => ({
       expiry: Date.now() + ttl * 1000,
     };
     if (localStoreSupport()) {
-      storageClass.setItem(k(key), JSON.stringify(item));
+      try {
+        storageClass.setItem(k(key), JSON.stringify(item));
+      } catch (e) {
+        // Never crash on a full/blocked store. Large async-read payloads (MDMS /
+        // ComplaintHierarchy) live in IndexedDB now (idbCache); this guards any
+        // other oversize sync write — skip persisting (the value re-derives on
+        // next load) instead of throwing QuotaExceededError.
+        if (typeof console !== "undefined") {
+          console.warn(`Digit.Storage: "${key}" not persisted (${e && e.name ? e.name : "write failed"}).`);
+        }
+      }
     } else if (typeof window !== "undefined") {
       window.eGov = window.eGov || {};
       window.eGov.Storage = window.eGov.Storage || {};

--- a/digit-ui-esbuild/packages/libraries/src/services/atoms/Utils/idbCache.js
+++ b/digit-ui-esbuild/packages/libraries/src/services/atoms/Utils/idbCache.js
@@ -1,0 +1,147 @@
+// idbCache.js
+//
+// Tiny promise wrapper over IndexedDB for LARGE, asynchronously-read cache
+// payloads — chiefly the transformed MDMS responses (the ComplaintHierarchy tree
+// can be several MB). These used to be written to localStorage via
+// PersistantStorage and blew the ~5 MB quota (QuotaExceededError crashed the
+// inbox). IndexedDB has GB-scale capacity.
+//
+// Scope is deliberately narrow: only data already fetched/read through an async
+// path (MdmsService.getDataByCriteria) moves here. Small, synchronously-read keys
+// (auth, locale, selected city, initData) stay in localStorage via Storage.js —
+// so there is NO sync-tier / boot-hydration machinery to maintain.
+//
+// Key→{value,expiry} with a per-entry TTL (seconds); expired entries are dropped
+// on read. Every method fails soft (null / false) so a missing or blocked
+// IndexedDB never breaks a caller — it just looks like a cache miss → refetch.
+// No external dependency.
+
+const DB_NAME = "digit-ui";
+const STORE_NAME = "mdms_cache";
+const DEFAULT_TTL_SECS = 86400;
+
+let dbPromise = null;
+
+const openDB = () => {
+  if (dbPromise) return dbPromise;
+  dbPromise = new Promise((resolve, reject) => {
+    if (typeof indexedDB === "undefined") {
+      reject(new Error("IndexedDB unavailable"));
+      return;
+    }
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) db.createObjectStore(STORE_NAME);
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  }).catch((e) => {
+    dbPromise = null; // let a later call retry the open
+    throw e;
+  });
+  return dbPromise;
+};
+
+const awaitTx = (tx) =>
+  new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error);
+  });
+
+export const idbCache = {
+  async get(key) {
+    try {
+      const db = await openDB();
+      const entry = await new Promise((resolve, reject) => {
+        const req = db.transaction(STORE_NAME, "readonly").objectStore(STORE_NAME).get(key);
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error);
+      });
+      if (!entry) return null;
+      if (entry.expiry && Date.now() > entry.expiry) {
+        idbCache.remove(key); // fire-and-forget
+        return null;
+      }
+      return entry.value;
+    } catch {
+      return null;
+    }
+  },
+
+  async set(key, value, ttlSecs = DEFAULT_TTL_SECS) {
+    try {
+      // ttl <= 0 means "do not cache" — mirrors the multi-root-tenant path which
+      // passed 0 to force a fresh fetch each time.
+      if (ttlSecs != null && ttlSecs <= 0) {
+        idbCache.remove(key);
+        return false;
+      }
+      const db = await openDB();
+      const tx = db.transaction(STORE_NAME, "readwrite");
+      tx.objectStore(STORE_NAME).put({ value, expiry: Date.now() + ttlSecs * 1000 }, key);
+      await awaitTx(tx);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+
+  async remove(key) {
+    try {
+      const db = await openDB();
+      const tx = db.transaction(STORE_NAME, "readwrite");
+      tx.objectStore(STORE_NAME).delete(key);
+      await awaitTx(tx);
+    } catch {
+      /* best-effort */
+    }
+  },
+
+  async clear() {
+    try {
+      const db = await openDB();
+      const tx = db.transaction(STORE_NAME, "readwrite");
+      tx.objectStore(STORE_NAME).clear();
+      await awaitTx(tx);
+    } catch {
+      /* best-effort */
+    }
+  },
+};
+
+// One-time migration: the MDMS cache used to live in localStorage as
+// "Digit.MDMS.*". Now that getDataByCriteria reads/writes IndexedDB, those
+// entries are orphaned dead weight (this is what tipped localStorage over the
+// quota). Remove them once on first load to reclaim the space. Idempotent —
+// gated by a flag — and order-safe: it frees space *before* writing the flag.
+const cleanupLegacyLocalStorageMdmsCache = () => {
+  try {
+    if (typeof localStorage === "undefined") return;
+    if (localStorage.getItem("Digit.idbCache.migrated")) return;
+    const toRemove = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key && key.startsWith("Digit.MDMS.")) toRemove.push(key);
+    }
+    toRemove.forEach((key) => {
+      try {
+        localStorage.removeItem(key);
+      } catch {
+        /* ignore */
+      }
+    });
+    try {
+      localStorage.setItem("Digit.idbCache.migrated", String(Date.now()));
+    } catch {
+      /* flag is best-effort; worst case we sweep again next load */
+    }
+  } catch {
+    /* best-effort */
+  }
+};
+
+cleanupLegacyLocalStorageMdmsCache();
+
+export default idbCache;

--- a/digit-ui-esbuild/packages/libraries/src/services/elements/MDMS.js
+++ b/digit-ui-esbuild/packages/libraries/src/services/elements/MDMS.js
@@ -3,6 +3,7 @@ import { ApiCacheService } from "../atoms/ApiCacheService";
 import Urls from "../atoms/urls";
 import { Request, ServiceRequest } from "../atoms/Utils/Request";
 import { PersistantStorage } from "../atoms/Utils/Storage";
+import idbCache from "../atoms/Utils/idbCache";
 
 // export const stringReplaceAll = (str = "", searcher = "", replaceWith = "") => {
 //   if (searcher == "") return str;
@@ -1547,14 +1548,17 @@ export const MdmsService = {
   },
   getDataByCriteria: async (tenantId, mdmsDetails, moduleCode) => {
     const key = `MDMS.${tenantId}.${moduleCode}.${mdmsDetails.type}.${JSON.stringify(mdmsDetails.details)}`;
-    const inStoreValue = PersistantStorage.get(key);
+    // Large MDMS payloads (incl. the multi-MB ComplaintHierarchy tree) cache in
+    // IndexedDB, not localStorage — this method is already async + every caller
+    // awaits it, so no sync-read path is affected. Fixes the QuotaExceededError.
+    const inStoreValue = await idbCache.get(key);
     if (inStoreValue) {
       return inStoreValue;
     }
     const { MdmsRes } = await MdmsService.call(tenantId, mdmsDetails.details);
     const responseValue = transformResponse(mdmsDetails.type, MdmsRes, moduleCode.toUpperCase(), tenantId);
     const cacheSetting = getCacheSetting(mdmsDetails.details.moduleDetails[0].moduleName);
-    PersistantStorage.set(key, responseValue, Digit.Utils.getMultiRootTenant() ? 0 : cacheSetting.cacheTimeInSecs);
+    await idbCache.set(key, responseValue, Digit.Utils.getMultiRootTenant() ? 0 : cacheSetting.cacheTimeInSecs);
     return responseValue;
   },
   getServiceDefs: (tenantId, moduleCode) => {


### PR DESCRIPTION
## Summary

Fixes the `QuotaExceededError` that crashes the DIGIT-UI (esbuild) app by moving the MDMS response cache off `localStorage` and into **IndexedDB**, plus a guard so a full/blocked store can never crash the app again.

Closes #961

## Why the QuotaExceededError happens (root cause)

`MdmsService.getDataByCriteria` cached **every** fetched master's transformed response in `localStorage` (keys `Digit.MDMS.*`, via `PersistantStorage`). `localStorage` has a **hard ~5 MB per-origin cap**, and the old `Storage.set` had **no error handling** — so the first write that pushed cumulative usage past the cap threw `QuotaExceededError` synchronously and broke the calling screen (most visibly the PGR inbox and complaint-create flow).

**This is not limited to one master.** The ComplaintHierarchy / ServiceDefs tree (2500+ nodes, several MB) is just the most *visible* offender. The trigger is "whichever write crosses ~5 MB," so **any** sufficiently large MDMS master — or the **aggregate** of many cached masters — can cause it: boundary data, large config masters, and **localization bundles** (many languages × many keys) are all candidates. The fix therefore targets the shared cache mechanism, not one dataset.

## Changes

| File | Change |
|---|---|
| `services/atoms/Utils/idbCache.js` *(new)* | Tiny **no-dependency** IndexedDB KV cache (db `digit-ui`, store `mdms_cache`) with per-entry TTL. Fully **fail-soft**: any IndexedDB error → returns null/false → looks like a cache miss → refetch. Includes a **one-time sweep** of orphaned `Digit.MDMS.*` localStorage keys, gated by a `Digit.idbCache.migrated` flag, to reclaim the space they were holding. |
| `services/elements/MDMS.js` | `getDataByCriteria` now `await`s `idbCache.get/set` instead of `PersistantStorage`. |
| `services/atoms/Utils/Storage.js` | `set()` wrapped in `try/catch` as a backstop — on a full/blocked store it **skips + warns** instead of throwing. Also fixes a latent `.value`-of-undefined throw in the `window.eGov` `get()` branch. |

## Behavior / backward compatibility

- `getDataByCriteria` was **already `async`**, and every caller (the ~60 `MdmsService.getXxx` wrappers, `useMdms`, `ServiceDefinitions`, the PGR hooks) `await`s or returns the promise. The return shape is **identical** to the old `PersistantStorage` path, so no sync-read path is affected.
- **Multi-root tenants** still pass `ttl = 0`; `idbCache.set` treats `ttl <= 0` as do-not-cache (mirrors prior semantics, minus the wasteful write).
- The `Digit.MDMS.*` namespace is exclusive to this cache (other persisted keys use `Digit.cachingService` / `Digit.Locale.*` / auth prefixes), so the sweep removes only orphaned entries and is idempotent + SSR-safe.
- IndexedDB has **GB-scale** capacity, so the large payloads no longer pressure the ~5 MB localStorage cap; small sync-read keys (auth, locale, selected city, initData) stay in localStorage as before.

> Note: this is a deliberately **minimal** approach (no `localforage`, no Hybrid sync-tier/boot-hydration) — the only data that moved is the already-async MDMS cache, which is the dominant offender.

## Testing

Local stack (`http://127.0.0.1/digit-ui/`), hard-refresh with cache disabled:

- ✅ `localStorage.getItem('Digit.idbCache.migrated')` → timestamp (new bundle loaded, sweep ran).
- ✅ `Object.keys(localStorage).filter(k => k.startsWith('Digit.MDMS.')).length` → `0` (legacy bloat swept).
- ✅ After visiting Select Complaint Type / PGR inbox, **DevTools → Application → IndexedDB → `digit-ui` → `mdms_cache`** populates.
- ✅ No `QuotaExceededError` in console even with the large ComplaintHierarchy loaded; inbox + create flows work.
- ✅ Storage guard: artificially filling localStorage near the cap produces a `console.warn` (`Digit.Storage: "<key>" not persisted ...`) instead of a crash.

## Risk

Low. Soft-fail everywhere (private mode / blocked IndexedDB just degrades to refetch — no crash). No API/backend changes; frontend-libraries only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
