### PR TITLE
fix(pgr): enable inbox pagination by setting totalCountJsonPath (#916)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/configs/PGRSearchInboxConfig.js
+++ b/digit-ui-esbuild/products/pgr/src/configs/PGRSearchInboxConfig.js
@@ -147,6 +147,7 @@ const PGRSearchInboxConfig = () => {
                     enableGlobalSearch: false,
                     enableColumnSort: true,
                     resultsJsonPath: "items",
+                    totalCountJsonPath: "totalCount",
                 },
                 children: {},
                 show: true


### PR DESCRIPTION
ResultsDataTableWrapper needs totalCountJsonPath to locate the server-side total record count in the hook response. Without it, TotalCount is undefined, data?.[undefined] falls back to filteredData.length/rowsPerPage = 1, and the Next page button is permanently disabled even when >10 complaints exist.

Setting totalCountJsonPath: "totalCount" wires it to the count returned by usePGRInboxSearch (which calls pgr-services/_count in parallel with _search).