### PR TITLE
feat(pgr-inbox): My/All visibility tabs (inbox v2)

### DIFF
--- a/backend/pgr-services/src/main/java/org/egov/pgr/service/PGRService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/service/PGRService.java
@@ -118,14 +118,11 @@ public class PGRService {
         if(criteria.getMobileNumber()!=null && CollectionUtils.isEmpty(criteria.getUserIds()))
             return new ArrayList<>();
 
-        if (criteria.getAssignee() != null) {
-            String tenantId = criteria.getTenantId() != null ? criteria.getTenantId() : requestInfo.getUserInfo().getTenantId();
-            Set<String> serviceRequestIds = workflowService.getServiceRequestIdsByAssignee(requestInfo, tenantId, criteria.getAssignee());
-            if (serviceRequestIds.isEmpty()) {
-                return new ArrayList<>();
-            }
-            criteria.setServiceRequestIds(serviceRequestIds);
-        }
+        // Resolve the assignee filter (uuid -> service request ids via workflow).
+        // Returns false when the assignee owns no complaints, so the search
+        // short-circuits to an empty list instead of falling through to "all".
+        if (!resolveAssigneeFilter(requestInfo, criteria))
+            return new ArrayList<>();
 
         criteria.setIsPlainSearch(false);
 
@@ -188,9 +185,35 @@ public class PGRService {
      * @return
      */
     public Integer count(RequestInfo requestInfo, RequestSearchCriteria criteria){
+        // Apply the same assignee resolution as search() so the count matches
+        // the assignee-scoped result set (e.g. the "My Complaints" tab badge).
+        // Without this the count ignored the assignee and returned the count of
+        // ALL complaints, because an unset serviceRequestIds adds no clause.
+        if (!resolveAssigneeFilter(requestInfo, criteria))
+            return 0;
         criteria.setIsPlainSearch(false);
         Integer count = repository.getCount(criteria);
         return count;
+    }
+
+    /**
+     * Resolves the assignee filter on the criteria. When an assignee uuid is
+     * present, it is translated (via the workflow engine) into the set of
+     * service request ids currently assigned to that user, which is then set on
+     * the criteria for the query builder to constrain on.
+     *
+     * @return true if the search/count should proceed; false if the assignee
+     *         owns no complaints (caller should short-circuit to an empty result)
+     */
+    private boolean resolveAssigneeFilter(RequestInfo requestInfo, RequestSearchCriteria criteria){
+        if (criteria.getAssignee() == null)
+            return true;
+        String tenantId = criteria.getTenantId() != null ? criteria.getTenantId() : requestInfo.getUserInfo().getTenantId();
+        Set<String> serviceRequestIds = workflowService.getServiceRequestIdsByAssignee(requestInfo, tenantId, criteria.getAssignee());
+        if (CollectionUtils.isEmpty(serviceRequestIds))
+            return false;
+        criteria.setServiceRequestIds(serviceRequestIds);
+        return true;
     }
 
 

--- a/digit-ui-esbuild/products/pgr/src/configs/PGRSearchInboxConfig.js
+++ b/digit-ui-esbuild/products/pgr/src/configs/PGRSearchInboxConfig.js
@@ -180,38 +180,17 @@ const PGRSearchInboxConfig = () => {
                     minReqFields: 0,
                     defaultValues: {
                         locality: null,
-                        assignedToMe: {
-                            "code": "ASSIGNED_TO_ALL",
-                            "name": "ASSIGNED_TO_ALL"
-                        },
                         status: null,
                         complaintType: null,
                         serviceCode:null,
 
                     },
+                    // The "Assigned to me / Assigned to all" radio that used to live
+                    // here has been promoted to the two inbox tabs (My Complaints /
+                    // All Complaints) rendered in PGRInbox.js. The active tab drives
+                    // the assignee scope via apiDetails.additionalDetails.assigneeScope
+                    // (read in PGRInboxConfig.preProcess), so the radio is gone.
                     fields: [
-                        {
-                            label: "",
-                            type: "radio",
-                            isMandatory: false,
-                            disable: false,
-                            populators: {
-                                name: "assignedToMe",
-                                options: [
-                                    { code: "ASSIGNED_TO_ME", name: "ASSIGNED_TO_ME" },
-                                    { code: "ASSIGNED_TO_ALL", name: "ASSIGNED_TO_ALL" },
-                                ],
-                                optionsKey: "name",
-                                styles: {
-                                    "gap": "1rem",
-                                    "flexDirection": "column"
-                                },
-                                innerStyles: {
-                                    "display": "flex"
-                                }
-                            },
-
-                        },
                         {
 
                             label: "CS_COMPLAINT_DETAILS_COMPLAINT_SUBTYPE",

--- a/digit-ui-esbuild/products/pgr/src/configs/UICustomizations.js
+++ b/digit-ui-esbuild/products/pgr/src/configs/UICustomizations.js
@@ -1571,7 +1571,10 @@ export const UICustomizations = {
     test: "yes",
   },
   PGRInboxConfig: {
-    preProcess: (data) => {
+    // `additionalDetails` is the 2nd arg InboxSearchComposer passes to
+    // preProcess (configs.additionalDetails). PGRInbox.js puts the active
+    // visibility tab there as { assigneeScope: "MY" | "ALL" }.
+    preProcess: (data, additionalDetails) => {
       const clonedData = _.cloneDeep(data);
       const searchForm = clonedData?.state?.searchForm || {};
       const filterForm = clonedData?.state?.filterForm || {};
@@ -1640,12 +1643,15 @@ export const UICustomizations = {
       const statuses = Object.keys(rawStatuses).filter((key) => rawStatuses[key] === true);
       params.applicationStatus = statuses.length > 0 ? statuses : OPEN_STATES;
 
-      // Filter: assigned to me
-      const assignedFilter = filterForm.assignedToMe;
-      if (assignedFilter?.code === "ASSIGNED_TO_ME") {
+      // Visibility scope from the active inbox tab (My / All). The old
+      // "Assigned to me" radio is gone — the My Complaints tab now drives this.
+      // assignee is a single uuid string (pgr-services RequestSearchCriteria.assignee
+      // is a String; it resolves the uuid -> assigned service-request-ids via
+      // the workflow engine, see PR #942). "All Complaints" sends no assignee.
+      if (additionalDetails?.assigneeScope === "MY") {
         const userInfo = Digit.UserService.getUser()?.info;
         if (userInfo?.uuid) {
-          params.assignee = [userInfo.uuid];
+          params.assignee = userInfo.uuid;
         }
       }
 

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRInbox.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRInbox.js
@@ -1,9 +1,27 @@
 import React, { useMemo, useState, useEffect } from "react";
 import { InboxSearchComposer, HeaderComponent, Toast, Loader } from "@egovernments/digit-ui-components";
+import { Request } from "@egovernments/digit-ui-libraries";
 import { useTranslation } from "react-i18next";
 import _ from "lodash";
 import PGRSearchInboxConfig from "../../configs/PGRSearchInboxConfig";
 import { useLocation } from "react-router-dom";
+
+/**
+ * Inbox v2 visibility tabs. The active tab drives the assignee scope that
+ * PGRInboxConfig.preProcess reads off `configs.additionalDetails.assigneeScope`:
+ *   MY  -> params.assignee = <my uuid> (complaints currently assigned to me)
+ *   ALL -> no assignee filter (every complaint in the tenant)
+ * "My Complaints" is the default, matching the visibility PRD reference image.
+ */
+const INBOX_TABS = [
+  { key: "MY", labelKey: "PGR_INBOX_TAB_MY_COMPLAINTS", fallback: "My Complaints" },
+  { key: "ALL", labelKey: "PGR_INBOX_TAB_ALL_COMPLAINTS", fallback: "All Complaints" },
+];
+
+// Default open / actionable states the inbox shows when no status filter is
+// applied. Kept in sync with PGRInboxConfig.preProcess (UICustomizations.js) so
+// the tab count badges reflect the same rows the list shows.
+const INBOX_OPEN_STATES = ["PENDINGFORASSIGNMENT", "PENDINGFORREASSIGNMENT", "PENDINGATLME", "PENDINGATSUPERVISOR"];
 
 /**
  * PGRSearchInbox - Complaint Search Inbox Screen
@@ -41,6 +59,39 @@ const PGRSearchInbox = () => {
 
   // Used to detect route/location changes to trigger config reset
   const location = useLocation();
+
+  // Active visibility tab (My / All). Drives the assignee scope below.
+  const [activeTab, setActiveTab] = useState("MY");
+
+  // Per-tab count badges. Fetched via pgr-services _count: the My count is
+  // assignee-scoped to the current user (PR #942 + the count() parity fix),
+  // the All count is the unscoped tenant total. Both are constrained to the
+  // same default open states as the list, so the badges match what's shown.
+  const [tabCounts, setTabCounts] = useState({ MY: null, ALL: null });
+
+  useEffect(() => {
+    let cancelled = false;
+    const countUrl = "/pgr-services/v2/request/_count";
+    const uuid = Digit.UserService.getUser()?.info?.uuid;
+    const baseParams = { tenantId, applicationStatus: INBOX_OPEN_STATES };
+    const fetchCounts = async () => {
+      try {
+        const requests = [
+          Request({ url: countUrl, method: "POST", auth: true, userService: true, useCache: false, params: { ...baseParams, ...(uuid ? { assignee: uuid } : {}) } }),
+          Request({ url: countUrl, method: "POST", auth: true, userService: true, useCache: false, params: baseParams }),
+        ];
+        const [myRes, allRes] = await Promise.all(requests);
+        if (!cancelled) setTabCounts({ MY: myRes?.count ?? 0, ALL: allRes?.count ?? 0 });
+      } catch (e) {
+        // Counts are a nicety on the tab labels — never block the inbox on them.
+        console.error("PGR inbox: tab count fetch failed", e);
+      }
+    };
+    fetchCounts();
+    return () => {
+      cancelled = true;
+    };
+  }, [tenantId]);
 
   // Fetch mobile validation config from MDMS
   const { validationRules, isLoading: isValidationLoading, getMinMaxValues } = Digit.Hooks.pgr.useMobileValidation(tenantId);
@@ -161,14 +212,51 @@ const PGRSearchInbox = () => {
     return v === headingKey ? "Complaints" : v;
   })();
 
+  const tabLabel = (tab) => {
+    const v = t(tab.labelKey);
+    return v === tab.labelKey ? tab.fallback : v;
+  };
+
+  // Attach the active tab's scope so PGRInboxConfig.preProcess can read it as
+  // its 2nd arg (configs.additionalDetails). Re-derived per tab/config change.
+  const composerConfig = useMemo(
+    () => (updatedConfig ? { ...updatedConfig, additionalDetails: { ...(updatedConfig.additionalDetails || {}), assigneeScope: activeTab } } : updatedConfig),
+    [updatedConfig, activeTab]
+  );
+
   return (
     <div className="v2-pgr-inbox v2-scope">
       <header className="v2-employee-page-header">
         <h1>{heading}</h1>
       </header>
+
+      {/* Visibility tabs (Inbox v2). Switching tabs swaps the assignee scope and
+          remounts the composer (key={activeTab}) so the search/filter form resets,
+          per the visibility PRD ("if a filter was applied and the tab switched,
+          the filter should reset"). */}
+      <div className="v2-pgr-inbox-tabs" role="tablist">
+        {INBOX_TABS.map((tab) => {
+          const isActive = activeTab === tab.key;
+          const count = tabCounts[tab.key];
+          return (
+            <button
+              key={tab.key}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              className={`v2-pgr-inbox-tab${isActive ? " active" : ""}`}
+              onClick={() => setActiveTab(tab.key)}
+            >
+              <span className="tab-label">{tabLabel(tab)}</span>
+              {count != null && <span className="tab-count">{count}</span>}
+            </button>
+          );
+        })}
+      </div>
+
       {/* Complaint search and filter interface */}
       <div className="digit-inbox-search-wrapper">
-        <InboxSearchComposer configs={updatedConfig} />
+        <InboxSearchComposer key={activeTab} configs={composerConfig} />
       </div>
     </div>
   );

--- a/digit-ui-esbuild/public/vendor/overrides.css
+++ b/digit-ui-esbuild/public/vendor/overrides.css
@@ -2726,6 +2726,57 @@ button[class*="toast-close"] svg,
 }
 
 /* ----------------------------------------------------------------------
+ * PGR Inbox v2 visibility tabs (My Complaints / All Complaints).
+ * Rendered by PGRInbox.js above the InboxSearchComposer. Active tab uses
+ * the v2 primary accent with an underline; the count badge is a pill.
+ * -------------------------------------------------------------------- */
+.v2-pgr-inbox .v2-pgr-inbox-tabs {
+  display: flex;
+  gap: 0.5rem;
+  border-bottom: 1px solid var(--color-divider, #d6d5d4);
+  margin: 0 0 1rem 0;
+}
+.v2-pgr-inbox .v2-pgr-inbox-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1rem;
+  background: none;
+  border: none;
+  border-bottom: 3px solid transparent;
+  margin-bottom: -1px;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text-secondary, #505a5f);
+  cursor: pointer;
+}
+.v2-pgr-inbox .v2-pgr-inbox-tab:hover {
+  color: var(--color-primary-1, var(--color-primary-main, #c84c0e));
+}
+.v2-pgr-inbox .v2-pgr-inbox-tab.active {
+  color: var(--color-primary-1, var(--color-primary-main, #c84c0e));
+  border-bottom-color: var(--color-primary-1, var(--color-primary-main, #c84c0e));
+}
+.v2-pgr-inbox .v2-pgr-inbox-tab .tab-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  padding: 0 0.4rem;
+  border-radius: 999px;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  line-height: 1;
+  background: var(--color-surface-secondary, #eef1f2);
+  color: var(--color-text-secondary, #505a5f);
+}
+.v2-pgr-inbox .v2-pgr-inbox-tab.active .tab-count {
+  background: var(--color-primary-1, var(--color-primary-main, #c84c0e));
+  color: #ffffff;
+}
+
+/* ----------------------------------------------------------------------
  * PGR Employee Complaint Details (`/employee/pgr/complaint-details/<id>`)
  * — wrap is `.v2-pgr-details`. Re-skin the SummaryCard sections so the
  * details page reads at the same v2 chrome as the inbox + create-


### PR DESCRIPTION
## What

Inbox **v2** visibility: replaces the "Assigned to me / Assigned to all" filter-card radio with two **tabs** above the PGR employee inbox, per the CMS visibility PRD (visibility v1 tab) and a first slice toward #903.

| | Before | After |
|---|---|---|
| Scope control | radio inside the filter card | **My Complaints / All Complaints** tabs above the list |
| Default | Assigned to all | **My Complaints** (matches PRD reference image) |
| "My" backing | radio → `assignee` (no-op before #942) | `assignee = <my uuid>`, resolved server-side via #942 |
| Switch behaviour | n/a | form **resets** on tab switch (composer remount) |

## How

- **`PGRInbox.js`** — renders the two tabs with count badges; the active tab is passed to `PGRInboxConfig.preProcess` through the existing 2nd arg (`configs.additionalDetails.assigneeScope`). `key={activeTab}` remounts the `InboxSearchComposer` so the search/filter form resets on switch (the PRD's "if a filter was applied and the tab switched, the filter should reset").
- **`UICustomizations.js`** — `preProcess` reads `assigneeScope`: `MY` → `params.assignee = <my uuid>` (single string, matching the backend `String` field), `ALL` → no assignee filter. Old `filterForm.assignedToMe` block removed.
- **`PGRSearchInboxConfig.js`** — removes the `assignedToMe` radio field + default.
- **`PGRService.count()`** — applies the same assignee resolution as `search()` (extracted into `resolveAssigneeFilter`). Without this the "My" badge counted **all** complaints, since an unset `serviceRequestIds` adds no SQL clause. This is a parity fix for #942.
- **`overrides.css`** — `.v2-pgr-inbox-tabs` styling (active accent + count pill).

## Scope of this increment

✅ Tabs, default-to-My, scope wiring, reset-on-switch, per-tab count badges, count() parity fix.

⏭️ **Deferred** (separate increments):
- PRD badge semantics "unopened" (My) / "new since last opened" (All) + red dot — needs per-user read-state tracking.
- Supervisor **reportee / role N+1** scoping for All Complaints — needs HRMS reportee→assignee resolution.

## Notes
- Tab labels use i18n keys `PGR_INBOX_TAB_MY_COMPLAINTS` / `PGR_INBOX_TAB_ALL_COMPLAINTS` with English fallbacks; seed for other locales.
- **Behaviour change:** employees now land on *My Complaints* by default (was *all*); an employee with nothing assigned sees an empty initial list.
- Validated: full read of the search/count/workflow paths, controller query-param binding for both `_search` and `_count`, and esbuild syntax-check of all three JS files. Not yet run against a live stack — pending e2e on a running tenant.

Relates to #903.

🤖 Generated with [Claude Code](https://claude.com/claude-code)