### PR TITLE
fix(pgr): fix location dropdown not showing on employee create-compla…

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/BoundaryComponent.js
+++ b/digit-ui-esbuild/products/pgr/src/components/BoundaryComponent.js
@@ -68,10 +68,16 @@ const BoundaryComponent = ({ t, config, onSelect, userType, formData, readOnly }
           return { ...node, children: filteredChildren };
         })
         .filter(Boolean);
-    return rawChildrenData.map((entry) => ({
+    const filtered = rawChildrenData.map((entry) => ({
       ...entry,
       boundary: filterTree(entry.boundary || []),
     }));
+    // If the jurisdiction filter prunes the entire tree (HRMS boundary codes
+    // don't exactly match boundary-service node codes — common with seeding
+    // drift), fall back to the full unfiltered tree so the dropdown renders.
+    // Silently returning empty would black out the picker with no error shown.
+    const hasAny = filtered.some((e) => (e.boundary || []).length > 0);
+    return hasAny ? filtered : rawChildrenData;
   }, [rawChildrenData, allowedRoots]);
 
   // boundaryHierarchyOrder is populated by usePGRInitialization at

--- a/digit-ui-esbuild/products/pgr/src/hooks/boundary/useFetchBoundaries.js
+++ b/digit-ui-esbuild/products/pgr/src/hooks/boundary/useFetchBoundaries.js
@@ -3,7 +3,7 @@ import { useQuery } from "react-query";
 
 const useFetchBoundaries = (tenantId, config = {}) => {
     
-  return useQuery(["FETCH_BOUNDARIES",], () => fetchBoundaries({tenantId}), config);
+  return useQuery(["FETCH_BOUNDARIES", tenantId], () => fetchBoundaries({tenantId}), config);
 };
 
 export default useFetchBoundaries;

--- a/digit-ui-esbuild/products/pgr/src/hooks/project/usePGRInitialization.js
+++ b/digit-ui-esbuild/products/pgr/src/hooks/project/usePGRInitialization.js
@@ -2,7 +2,7 @@ import initializePGRModule from "../../services/PGRInitialization";
 import { useQuery } from "react-query";
 
 const usePGRInitialization = ({tenantId}) => {
-  return useQuery(["PGR_INITIALIZATION",], () => initializePGRModule({tenantId}));
+  return useQuery(["PGR_INITIALIZATION", tenantId], () => initializePGRModule({tenantId}));
 };
 
 export default usePGRInitialization;

--- a/digit-ui-esbuild/products/pgr/src/services/PGRInitialization.js
+++ b/digit-ui-esbuild/products/pgr/src/services/PGRInitialization.js
@@ -53,8 +53,16 @@ const initializePGRModule = async ({ tenantId }) => {
       throw new Error("Couldn't fetch boundary data");
     }
 
-    // Extract the order of boundary types using a depth-first traversal
-    const boundaryHierarchyOrder = getBoundaryTypeOrder(fetchBoundaryData?.TenantBoundary?.[0]?.boundary);
+    // Extract the order of boundary types using a depth-first traversal.
+    // Guard against an empty/unexpected response shape — if boundary is
+    // missing, skip rather than crashing (which would leave
+    // boundaryHierarchyOrder unset and the dropdown silently blank).
+    const rootBoundary = fetchBoundaryData?.TenantBoundary?.[0]?.boundary;
+    if (!Array.isArray(rootBoundary) || rootBoundary.length === 0) {
+      console.warn("PGR init: boundary-relationships returned no boundary nodes for", hierarchyType, tenantId);
+      return;
+    }
+    const boundaryHierarchyOrder = getBoundaryTypeOrder(rootBoundary);
 
     // Store the ordered boundary types in session storage for use in dropdown components
     Digit.SessionStorage.set("boundaryHierarchyOrder", boundaryHierarchyOrder);


### PR DESCRIPTION
…int (#871)

Three code issues caused the boundary cascade to silently disappear:

1. useFetchBoundaries + usePGRInitialization used fixed query keys without tenantId, so React Query would serve stale boundary data from a previous tenant session instead of fetching fresh data for the current tenant.

2. BoundaryComponent's allowedRoots filter (HRMS jurisdiction scoping, #496) could prune the entire boundary tree when jurisdiction boundary codes in HRMS don't exactly match boundary-service node codes. This caused setValue({}) to be called after hrmsData loaded, wiping all rendered dropdowns. Now falls back to the full unfiltered tree when the filter prunes everything.

3. PGRInitialization crashed silently (TypeError: undefined.forEach) when TenantBoundary[0].boundary was unexpectedly null/empty, leaving boundaryHierarchyOrder unset in SessionStorage and boundaryHierarchy=[] in BoundaryComponent, so no dropdowns would render. Now logs a warning and returns cleanly.