### PR TITLE
fix(configurator): server-side pagination for MDMS list views

### DIFF
--- a/configurator/packages/data-provider/src/providers/dataProvider.ts
+++ b/configurator/packages/data-provider/src/providers/dataProvider.ts
@@ -586,6 +586,26 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
         return { data: records, total };
       }
 
+      // MDMS resources without the leaf-adapter (all schemas except
+      // complaint-hierarchy): push limit/offset to the server when no
+      // client-side filter is active so the API is called with the actual
+      // page size instead of a fixed 500. MDMS v2 does not return a total
+      // count, so we use a heuristic: a full page means "there may be more"
+      // (next button enabled), a partial page means "last page".
+      if (config.type === 'mdms' && !config.leafServiceDefAdapter) {
+        const filter = (params.filter ?? {}) as Record<string, unknown>;
+        const hasClientFilter = Object.keys(filter).some((k) => k !== TENANT_OVERRIDE_KEY);
+        if (!hasClientFilter) {
+          const tenant = pickTenant(tenantId, filter);
+          const offset = (page - 1) * perPage;
+          const raw = await client.mdmsSearch(tenant, config.schema!, { limit: perPage, offset });
+          const data = raw.filter((r) => r.isActive).map((r) => normalizeMdmsRecord(r, config));
+          const sorted = clientSort(data, field, order);
+          const total = raw.length >= perPage ? offset + perPage + 1 : offset + data.length;
+          return { data: sorted, total };
+        }
+      }
+
       const all = await fetchAll(resource, params.filter);
       const filtered = clientFilter(all, params.filter);
       const sorted = clientSort(filtered, field, order);


### PR DESCRIPTION
## Summary

- Every MDMS list page was calling `mdmsSearch` with a hardcoded `limit: 500, offset: 0` regardless of which page the user viewed — the server always returned 500 records and the client sliced them locally
- `getList` in `dataProvider.ts` now passes the actual `perPage` and `offset` to the MDMS API for all resources that don't use `leafServiceDefAdapter`
- Since MDMS v2 has no `totalCount` in its response, pagination uses a heuristic: a full-page response enables the Next button; a partial page signals the last page (no total record count displayed)
- Resources with `leafServiceDefAdapter` (`complaint-hierarchy`) are unchanged — they still fetch all records because `adaptHierarchyLeaves` needs the complete tree to resolve parent names and detect terminal nodes

## Affected resources

All MDMS-backed list pages: departments, designations, tenants, complaint-hierarchies, roles, action-mappings, and all generic MDMS schemas.

## Test plan

- [ ] Open any MDMS list page (e.g. `/manage/departments`) — network tab should show `limit: <perPage>, offset: 0` on first load
- [ ] Navigate to page 2 — request should show `offset: <perPage>`
- [ ] Next button is disabled on the last page (server returned fewer records than `perPage`)
- [ ] Search filter active: falls back to fetch-all (existing behaviour)
- [ ] `complaint-hierarchy` list still fetches all records (limit: 500)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)