### PR TITLE
fix(pgr): auto-dismiss + close button for citizen location toast (#883)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/GeoLocations.js
+++ b/digit-ui-esbuild/products/pgr/src/components/GeoLocations.js
@@ -350,6 +350,14 @@ const GeoLocations = ({ t, config, onSelect, formData }) => {
     setShowToast(null);
   };
 
+  // Auto-dismiss the toast after a few seconds so location/geolocation messages
+  // (e.g. denied permission) don't linger indefinitely. See issue #883.
+  useEffect(() => {
+    if (!showToast) return;
+    const timer = setTimeout(() => setShowToast(null), 5000);
+    return () => clearTimeout(timer);
+  }, [showToast]);
+
   const clearSearch = () => {
     setSearchQuery("");
     setAddress("");
@@ -693,6 +701,7 @@ const GeoLocations = ({ t, config, onSelect, formData }) => {
           error={showToast.key === "error"}
           label={showToast.label}
           onClose={closeToast}
+          isDleteBtn={true}
         />
       )}
     </div>


### PR DESCRIPTION
## Problem
Ref #883 — While filing a complaint (citizen UI), the location toast triggered by the OSM "Current location" button (e.g. when location permission is denied) never clears, and the user cannot manually close it.

## Root cause
In `GeoLocations.js` the toast had no auto-dismiss timer, and the `react-components` `Toast` only renders its close (×) button when `isDleteBtn` is passed — which the error toast did not pass.

## Fix
- Pass `isDleteBtn` so the close icon renders and `onClose` can dismiss it.
- Add a `useEffect` that clears the toast after 5s.

Matches the expected behavior in the issue: clears automatically after a few seconds **and** has a close icon. Same pattern already used in `PGRDetails.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)