### PR TITLE
feat(configurator): backend-driven i18n for all UI chrome (en/hi/fr/pt)

### DIFF
--- a/configurator/src/admin/DigitDashboard.tsx
+++ b/configurator/src/admin/DigitDashboard.tsx
@@ -1,7 +1,8 @@
-import { useGetList } from 'ra-core';
+import { useGetList, useTranslate } from 'ra-core';
 import { DigitCard } from '@/components/digit/DigitCard';
 import { useNavigate } from 'react-router-dom';
-import { getDedicatedResources, getResourceLabel } from '@/providers/bridge';
+import { getDedicatedResources } from '@/providers/bridge';
+import { useResourceLabel } from '@/providers/useResourceLabel';
 import {
   Building2,
   MapPin,
@@ -36,7 +37,8 @@ function ResourceCard({ resource }: { resource: string }) {
   });
 
   const navigate = useNavigate();
-  const label = getResourceLabel(resource);
+  const resourceLabel = useResourceLabel();
+  const label = resourceLabel(resource);
   const Icon = ICONS[resource] ?? Briefcase;
 
   return (
@@ -62,6 +64,7 @@ function ResourceCard({ resource }: { resource: string }) {
 }
 
 export function DigitDashboard() {
+  const translate = useTranslate();
   const dedicatedMap = getDedicatedResources();
   const resources = Object.keys(dedicatedMap).filter(
     (r) => ICONS[r] // only show resources that have icons
@@ -70,7 +73,7 @@ export function DigitDashboard() {
   return (
     <div className="space-y-6">
       <h1 className="text-2xl sm:text-3xl font-bold font-condensed text-foreground">
-        DIGIT Management Studio
+        {translate('app.header.title')}
       </h1>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
         {resources.map((resource) => (

--- a/configurator/src/admin/DigitLayout.tsx
+++ b/configurator/src/admin/DigitLayout.tsx
@@ -141,7 +141,7 @@ export function DigitLayout({ children }: { children?: ReactNode }) {
             <div>
               <span className="font-condensed font-bold text-foreground">DIGIT</span>
               <span className="font-condensed font-medium text-muted-foreground ml-1">
-                Complaints Management
+                {translate('app.header.brand', { _: 'Complaints Management' })}
               </span>
             </div>
           )}
@@ -184,10 +184,10 @@ export function DigitLayout({ children }: { children?: ReactNode }) {
                   ? 'bg-primary/10 text-primary border-l-2 border-primary'
                   : 'text-muted-foreground hover:bg-muted hover:text-foreground'}
               `}
-              title={sidebarCollapsed ? 'PGR Dashboard' : undefined}
+              title={sidebarCollapsed ? translate('app.nav.pgr_dashboard') : undefined}
             >
               <BarChart3 className="w-5 h-5 flex-shrink-0" />
-              {!sidebarCollapsed && <span className="text-sm font-medium">PGR Dashboard</span>}
+              {!sidebarCollapsed && <span className="text-sm font-medium">{translate('app.nav.pgr_dashboard')}</span>}
             </button>
           </div>
 
@@ -290,7 +290,9 @@ export function DigitLayout({ children }: { children?: ReactNode }) {
                       `}
                     >
                       <span className="w-1.5 h-1.5 rounded-full bg-current opacity-40 flex-shrink-0" />
-                      <span className="text-xs font-medium truncate">{item.name}</span>
+                      <span className="text-xs font-medium truncate">
+                        {translate(`app.resources.${item.id.replace(/-/g, '_')}`, { _: item.name })}
+                      </span>
                     </button>
                   );
                 })}

--- a/configurator/src/admin/MdmsResourceCreate.tsx
+++ b/configurator/src/admin/MdmsResourceCreate.tsx
@@ -3,7 +3,8 @@ import { DigitCreate } from './DigitCreate';
 import { DigitFormInput } from './DigitFormInput';
 import { WidgetForFieldSpec } from './widgets';
 import { useResourceContext, useInput, required } from 'ra-core';
-import { getResourceConfig, getResourceLabel } from '@/providers/bridge';
+import { getResourceConfig } from '@/providers/bridge';
+import { useResourceLabel } from '@/providers/useResourceLabel';
 import { useSchemaDefinition } from '@/hooks/useSchemaDefinition';
 import { orderFields, formatFieldLabel } from './schemaUtils';
 import { Label } from '@/components/ui/label';
@@ -102,7 +103,7 @@ function MdmsCreateFields({
 export function MdmsResourceCreate() {
   const resource = useResourceContext() ?? '';
   const config = getResourceConfig(resource);
-  const label = getResourceLabel(resource);
+  const label = useResourceLabel()(resource);
   const { definition } = useSchemaDefinition(config?.schema);
   const descriptor = getDescriptor(config?.schema);
 

--- a/configurator/src/admin/MdmsResourceShow.tsx
+++ b/configurator/src/admin/MdmsResourceShow.tsx
@@ -3,7 +3,8 @@ import { FieldSection, FieldRow, StatusChip, JsonViewer } from './fields';
 import { EntityLink } from '@/components/ui/EntityLink';
 import { ReverseReferenceList } from './fields/ReverseReferenceList';
 import { useShowController, useResourceContext } from 'ra-core';
-import { getResourceConfig, getResourceLabel, getResourceBySchema } from '@/providers/bridge';
+import { getResourceConfig, getResourceBySchema } from '@/providers/bridge';
+import { useResourceLabel } from '@/providers/useResourceLabel';
 import { useSchemaDefinition } from '@/hooks/useSchemaDefinition';
 import { useReverseRefs } from '@/hooks/useReverseRefs';
 import { groupShowFields, getRefMap, formatFieldLabel } from './schemaUtils';
@@ -13,7 +14,7 @@ import type { ReverseRef } from '@/hooks/useReverseRefs';
 export function MdmsResourceShow() {
   const resource = useResourceContext() ?? '';
   const config = getResourceConfig(resource);
-  const label = getResourceLabel(resource);
+  const label = useResourceLabel()(resource);
   const { record } = useShowController();
 
   // Fetch schema definition and reverse refs

--- a/configurator/src/pages/PgrDashboard.tsx
+++ b/configurator/src/pages/PgrDashboard.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from 'react';
+import { useTranslate } from 'ra-core';
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -171,6 +172,7 @@ function BreakdownTable({ rows }: { rows: BreakdownRow[] }) {
 // -- Main Dashboard ---------------------------------------------------------
 
 export default function PgrDashboard() {
+  const translate = useTranslate();
   const [datePreset, setDatePreset] = useState<DatePreset>('all');
   const dateRange = useMemo(() => dateRangeFromPreset(datePreset), [datePreset]);
   const { stats, isLoading, error } = usePgrDashboardData(dateRange);
@@ -320,7 +322,7 @@ export default function PgrDashboard() {
       <div className="flex items-start justify-between flex-wrap gap-2">
         <div>
           <h1 className="text-2xl sm:text-3xl font-bold font-condensed text-foreground">
-            PGR Dashboard
+            {translate('app.nav.pgr_dashboard')}
           </h1>
           <p className="text-sm text-muted-foreground mt-1">
             {isLoading
@@ -367,7 +369,7 @@ export default function PgrDashboard() {
                 : 'bg-muted text-muted-foreground hover:bg-muted/80'
             }`}
           >
-            {p.label}
+            {translate(`app.dashboard.date.${p.value}`, { _: p.label })}
           </button>
         ))}
         {isLoading && <Loader2 className="w-3 h-3 animate-spin text-muted-foreground ml-2" />}

--- a/configurator/src/providers/i18nProvider.ts
+++ b/configurator/src/providers/i18nProvider.ts
@@ -2,16 +2,20 @@
  * i18n provider bridging react-admin's polyglot with DIGIT's localization API.
  *
  * Architecture:
- * - English is the ONLY fully-bundled locale (needed synchronously on boot).
- * - All `app.*` translations for non-English locales are fetched from DIGIT's
- *   localization API on demand (module: "configurator-ui").
+ * - `app.*` translations for ALL locales (English included) are fetched from
+ *   DIGIT's localization API (module: "configurator-ui") and are the source of
+ *   truth — so edits made in the configurator's own Localization UI take effect
+ *   without a code change. The bundled English `app.*` below is only a
+ *   boot/offline fallback (the default locale must render synchronously before
+ *   the network responds).
  * - `ra.*` framework strings (react-admin internals) are bundled per-locale
  *   since they're not stored in DIGIT. These are compact — just action/page/
  *   navigation/validation strings.
- * - API translations are deep-merged on top of the bundled base, so the DIGIT
- *   backend is the source of truth for all `app.*` keys.
- * - To add a new language: seed it in DIGIT via localization_upsert, add its
- *   `ra.*` bundle below, and add an entry to AVAILABLE_LOCALES.
+ * - API translations are deep-merged on top of the bundled base.
+ * - To add a new language: seed its `app.*` keys in DIGIT under module
+ *   "configurator-ui" (committed bundle at
+ *   local-setup/ansible/files/configurator-localization/, seeded by the deploy
+ *   playbook), add its `ra.*` bundle below, and add an entry to AVAILABLE_LOCALES.
  */
 import polyglotI18nProvider from 'ra-i18n-polyglot';
 import englishMessages from 'ra-language-english';
@@ -57,10 +61,22 @@ const customEnglishMessages: TranslationMessages = {
       boundaries: 'Boundaries',
       advanced: 'Advanced',
       switch_to_onboarding: 'Switch to Onboarding',
+      pgr_dashboard: 'PGR Dashboard',
     },
     header: {
       management_mode: 'Management Mode',
       title: 'DIGIT Management Studio',
+      brand: 'Complaints Management',
+    },
+    dashboard: {
+      date: {
+        all: 'All Time',
+        today: 'Today',
+        yesterday: 'Yesterday',
+        week: 'This Week',
+        month: 'This Month',
+        '3months': '3 Months',
+      },
     },
     resources: {
       complaint_types: 'Complaint Types',
@@ -528,10 +544,37 @@ async function getMessagesAsync(locale: string): Promise<TranslationMessages> {
   return result;
 }
 
+/**
+ * Build the message tree synchronously from the bundled base plus any backend
+ * app.* strings already sitting in the localStorage cache. Used only for the
+ * default locale's first render, where we cannot await the network.
+ */
+function buildSyncMessages(locale: string): TranslationMessages {
+  const base = JSON.parse(JSON.stringify(customEnglishMessages)) as Record<string, unknown>;
+  const raBundle = RA_BUNDLES[locale];
+  if (raBundle) {
+    deepMerge(base, raBundle);
+  }
+  const cachedFlat = readLocalStorageCache(locale);
+  if (cachedFlat && Object.keys(cachedFlat).length > 0) {
+    deepMerge(base, dotToNested(cachedFlat));
+  }
+  return base as TranslationMessages;
+}
+
 function getMessages(locale: string): TranslationMessages | Promise<TranslationMessages> {
-  // Default locale (en_IN) must return synchronously for polyglot init
+  // The default locale (en_IN) must resolve synchronously for polyglot's first
+  // render, so we can't await the network here. Instead we serve the bundled
+  // base immediately — overlaid with any backend app.* strings already in the
+  // localStorage cache — and kick off a background refresh so the next render
+  // (or locale switch) picks up edits made in the Localization UI. English is
+  // no longer a hardcoded-only locale: its app.* strings live in the
+  // `configurator-ui` backend module like every other locale, and the bundle
+  // is only a boot/offline fallback.
   if (locale === 'en_IN' || locale === 'en') {
-    return customEnglishMessages;
+    const sync = memoryCache.get(locale) ?? buildSyncMessages(locale);
+    void getMessagesAsync(locale);
+    return sync;
   }
   return getMessagesAsync(locale);
 }

--- a/configurator/src/providers/useResourceLabel.ts
+++ b/configurator/src/providers/useResourceLabel.ts
@@ -1,0 +1,18 @@
+import { useTranslate } from 'ra-core';
+import { getResourceLabel } from '@/providers/bridge';
+
+/**
+ * Returns a function that resolves a resource's display label via the
+ * `app.resources.<id>` localization key (e.g. `app.resources.state_info`),
+ * falling back to the registry's hardcoded English label when the key isn't
+ * seeded. Hyphens in resource ids are normalised to underscores so the codes
+ * are valid nested keys. This is the single point that makes every resource
+ * label — dedicated and generic MDMS alike — backend-driven and translatable.
+ */
+export function useResourceLabel(): (resource: string) => string {
+  const translate = useTranslate();
+  return (resource: string) =>
+    translate(`app.resources.${resource.replace(/-/g, '_')}`, {
+      _: getResourceLabel(resource),
+    });
+}

--- a/local-setup/ansible/files/configurator-localization/configurator-ui.json
+++ b/local-setup/ansible/files/configurator-localization/configurator-ui.json
@@ -1,0 +1,3410 @@
+[
+  {
+    "code": "app.nav.dashboard",
+    "message": "Dashboard",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.nav.tenant_management",
+    "message": "Tenant Management",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.nav.tenants",
+    "message": "Tenants",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.nav.departments",
+    "message": "Departments",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.nav.designations",
+    "message": "Designations",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.nav.hierarchies",
+    "message": "Hierarchies",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.nav.complaint_management",
+    "message": "Complaint Management",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.nav.complaint_hierarchies",
+    "message": "Complaint Hierarchies",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.nav.complaint_types",
+    "message": "Complaint Types",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.nav.complaints",
+    "message": "Complaints",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.nav.localization",
+    "message": "Localization",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.nav.people",
+    "message": "People",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.nav.employees",
+    "message": "Employees",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.nav.users",
+    "message": "Users",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.nav.system",
+    "message": "System",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.nav.access_roles",
+    "message": "Access Roles",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.nav.workflows",
+    "message": "Workflows",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.nav.processes",
+    "message": "Processes",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.nav.mdms_schemas",
+    "message": "MDMS Schemas",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.nav.boundaries",
+    "message": "Boundaries",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.nav.advanced",
+    "message": "Advanced",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.nav.switch_to_onboarding",
+    "message": "Switch to Onboarding",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.header.management_mode",
+    "message": "Management Mode",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.header.title",
+    "message": "DIGIT Management Studio",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.complaint_types",
+    "message": "Complaint Types",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.departments",
+    "message": "Departments",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.designations",
+    "message": "Designations",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.tenants",
+    "message": "Tenants",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.employees",
+    "message": "Employees",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.users",
+    "message": "Users",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.complaints",
+    "message": "Complaints",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.boundaries",
+    "message": "Boundaries",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.localization",
+    "message": "Localization Messages",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.access_roles",
+    "message": "Access Roles",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.access_actions",
+    "message": "Access Actions",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.role_actions",
+    "message": "Role Actions",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.workflow_services",
+    "message": "Business Services",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.workflow_processes",
+    "message": "Workflow Processes",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.mdms_schemas",
+    "message": "MDMS Schemas",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.boundary_hierarchies",
+    "message": "Boundary Hierarchies",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.code",
+    "message": "Code",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.name",
+    "message": "Name",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.description",
+    "message": "Description",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.status",
+    "message": "Status",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.active",
+    "message": "Active",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.service_code",
+    "message": "Service Code",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.department",
+    "message": "Department",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.sla_hours",
+    "message": "SLA (hrs)",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.menu_path",
+    "message": "Complaint Type",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.parent",
+    "message": "Parent",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.city",
+    "message": "City",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.district",
+    "message": "District",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.mobile",
+    "message": "Mobile",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.designation",
+    "message": "Designation",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.username",
+    "message": "Username",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.type",
+    "message": "Type",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.roles",
+    "message": "Roles",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.boundary_type",
+    "message": "Boundary Type",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.tenant",
+    "message": "Tenant",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.message",
+    "message": "Message",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.module",
+    "message": "Module",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.locale",
+    "message": "Locale",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.url",
+    "message": "URL",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.service",
+    "message": "Service",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.enabled",
+    "message": "Enabled",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.role_code",
+    "message": "Role Code",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.action_id",
+    "message": "Action ID",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.action_code",
+    "message": "Action Code",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.business_service",
+    "message": "Business Service",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.business",
+    "message": "Business",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.sla",
+    "message": "SLA",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.business_id",
+    "message": "Business ID",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.action",
+    "message": "Action",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.state",
+    "message": "State",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.created",
+    "message": "Created",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.hierarchy_type",
+    "message": "Hierarchy Type",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.request_id",
+    "message": "Request ID",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.citizen",
+    "message": "Citizen",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.locality",
+    "message": "Locality",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.list.refresh",
+    "message": "Refresh",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.list.create",
+    "message": "Create",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.list.search",
+    "message": "Search...",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.list.loading",
+    "message": "Loading...",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.list.error_loading",
+    "message": "Error loading data",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.list.error_unexpected",
+    "message": "An unexpected error occurred",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.list.try_again",
+    "message": "Try again",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.list.no_records",
+    "message": "No records found",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.list.adjust_search",
+    "message": "Try adjusting your search query",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.list.showing",
+    "message": "Showing %{start}-%{end} of %{total}",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.list.previous",
+    "message": "Previous",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.list.next",
+    "message": "Next",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.list.page_info",
+    "message": "Page %{page} of %{totalPages}",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.list.actions",
+    "message": "Actions",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.list.columns",
+    "message": "Columns",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.list.show_columns",
+    "message": "Show columns",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.list.reset",
+    "message": "Reset",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.list.rows_per_page",
+    "message": "Rows per page:",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.complaint_hierarchy",
+    "message": "Complaint Types",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.workflow_business_services",
+    "message": "Workflow Business Services",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.complaint_hierarchies",
+    "message": "Complaint Hierarchies",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.state_info",
+    "message": "State Info",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.city_modules",
+    "message": "City Modules",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.id_formats",
+    "message": "ID Formats",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.workflow_config",
+    "message": "Workflow Config",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.auto_escalation",
+    "message": "Auto Escalation",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.sla_config",
+    "message": "SLA Config",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.roles",
+    "message": "Roles",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.action_mappings",
+    "message": "Action Mappings",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.encryption_policy",
+    "message": "Encryption Policy",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.decryption_abac",
+    "message": "Decryption ABAC",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.masking_patterns",
+    "message": "Masking Patterns",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.security_policy",
+    "message": "Security Policy",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.inbox_config",
+    "message": "Inbox Config",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.deactivation_reasons",
+    "message": "Deactivation Reasons",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.degrees",
+    "message": "Degrees",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.employment_tests",
+    "message": "Employment Tests",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.specializations",
+    "message": "Specializations",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.gender_types",
+    "message": "Gender Types",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.employee_status",
+    "message": "Employee Status",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.employee_type",
+    "message": "Employee Type",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.cron_jobs",
+    "message": "Cron Jobs",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.ui_homepage",
+    "message": "UI Homepage",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.theme_config",
+    "message": "Theme Config",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.user_validation",
+    "message": "User Field Validation",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.mobile_validation",
+    "message": "Mobile Number Validation",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.tenant_boundary",
+    "message": "Tenant Boundary (HRMS)",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.auto_escalation_ignore",
+    "message": "Auto-Escalation Ignored",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.workflow_bs_master",
+    "message": "Workflow BS Master",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.pgr_ui_constants",
+    "message": "PGR UI Constants",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.header.brand",
+    "message": "Complaints Management",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.nav.pgr_dashboard",
+    "message": "PGR Dashboard",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.nav.notifications",
+    "message": "Notifications",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.dashboard.date.all",
+    "message": "All Time",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.dashboard.date.today",
+    "message": "Today",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.dashboard.date.yesterday",
+    "message": "Yesterday",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.dashboard.date.week",
+    "message": "This Week",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.dashboard.date.month",
+    "message": "This Month",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.nav.notification_routing",
+    "message": "Notification Routing",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.nav.notification_templates",
+    "message": "Notification Templates",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.notification_routing",
+    "message": "PGR Notification Routing",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.resources.notification_template",
+    "message": "PGR Notification Templates",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.dashboard.date.3months",
+    "message": "3 Months",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.nav.dashboard",
+    "message": "डैशबोर्ड",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.nav.tenant_management",
+    "message": "टेनेंट प्रबंधन",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.nav.tenants",
+    "message": "टेनेंट",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.nav.departments",
+    "message": "विभाग",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.nav.designations",
+    "message": "पदनाम",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.nav.hierarchies",
+    "message": "पदानुक्रम",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.nav.complaint_management",
+    "message": "शिकायत प्रबंधन",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.nav.complaint_hierarchies",
+    "message": "शिकायत पदानुक्रम",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.nav.complaint_types",
+    "message": "शिकायत प्रकार",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.nav.complaints",
+    "message": "शिकायतें",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.nav.localization",
+    "message": "स्थानीयकरण",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.nav.people",
+    "message": "लोग",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.nav.employees",
+    "message": "कर्मचारी",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.nav.users",
+    "message": "उपयोगकर्ता",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.nav.system",
+    "message": "सिस्टम",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.nav.access_roles",
+    "message": "एक्सेस भूमिकाएं",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.nav.workflows",
+    "message": "वर्कफ़्लो",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.nav.processes",
+    "message": "प्रक्रियाएं",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.nav.mdms_schemas",
+    "message": "MDMS स्कीमा",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.nav.boundaries",
+    "message": "सीमाएं",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.nav.advanced",
+    "message": "उन्नत",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.nav.switch_to_onboarding",
+    "message": "ऑनबोर्डिंग पर जाएं",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.header.management_mode",
+    "message": "प्रबंधन मोड",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.header.title",
+    "message": "DIGIT Management Studio",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.complaint_types",
+    "message": "शिकायत प्रकार",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.departments",
+    "message": "विभाग",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.designations",
+    "message": "पदनाम",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.tenants",
+    "message": "टेनेंट",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.employees",
+    "message": "कर्मचारी",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.users",
+    "message": "उपयोगकर्ता",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.complaints",
+    "message": "शिकायतें",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.boundaries",
+    "message": "सीमाएं",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.localization",
+    "message": "स्थानीयकरण संदेश",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.access_roles",
+    "message": "एक्सेस भूमिकाएं",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.access_actions",
+    "message": "एक्सेस क्रियाएं",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.role_actions",
+    "message": "भूमिका क्रियाएं",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.workflow_services",
+    "message": "व्यापार सेवाएं",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.workflow_processes",
+    "message": "वर्कफ़्लो प्रक्रियाएं",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.mdms_schemas",
+    "message": "MDMS स्कीमा",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.boundary_hierarchies",
+    "message": "सीमा पदानुक्रम",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.code",
+    "message": "कोड",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.name",
+    "message": "नाम",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.description",
+    "message": "विवरण",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.status",
+    "message": "स्थिति",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.active",
+    "message": "सक्रिय",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.service_code",
+    "message": "सेवा कोड",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.department",
+    "message": "विभाग",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.sla_hours",
+    "message": "SLA (घंटे)",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.menu_path",
+    "message": "शिकायत प्रकार",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.parent",
+    "message": "मूल",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.city",
+    "message": "शहर",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.district",
+    "message": "जिला",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.mobile",
+    "message": "मोबाइल",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.designation",
+    "message": "पदनाम",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.username",
+    "message": "उपयोगकर्ता नाम",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.type",
+    "message": "प्रकार",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.roles",
+    "message": "भूमिकाएं",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.boundary_type",
+    "message": "सीमा प्रकार",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.tenant",
+    "message": "टेनेंट",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.message",
+    "message": "संदेश",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.module",
+    "message": "मॉड्यूल",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.locale",
+    "message": "लोकेल",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.url",
+    "message": "URL",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.service",
+    "message": "सेवा",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.enabled",
+    "message": "सक्षम",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.role_code",
+    "message": "भूमिका कोड",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.action_id",
+    "message": "क्रिया ID",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.action_code",
+    "message": "क्रिया कोड",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.business_service",
+    "message": "व्यापार सेवा",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.business",
+    "message": "व्यापार",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.sla",
+    "message": "SLA",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.business_id",
+    "message": "व्यापार ID",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.action",
+    "message": "क्रिया",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.state",
+    "message": "राज्य",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.created",
+    "message": "निर्मित",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.hierarchy_type",
+    "message": "पदानुक्रम प्रकार",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.request_id",
+    "message": "अनुरोध ID",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.citizen",
+    "message": "नागरिक",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.locality",
+    "message": "इलाका",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.list.refresh",
+    "message": "ताज़ा करें",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.list.create",
+    "message": "बनाएं",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.list.search",
+    "message": "खोजें...",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.list.loading",
+    "message": "लोड हो रहा है...",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.list.error_loading",
+    "message": "डेटा लोड करने में त्रुटि",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.list.error_unexpected",
+    "message": "एक अप्रत्याशित त्रुटि हुई",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.list.try_again",
+    "message": "पुनः प्रयास करें",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.list.no_records",
+    "message": "कोई रिकॉर्ड नहीं मिला",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.list.adjust_search",
+    "message": "अपनी खोज को समायोजित करने का प्रयास करें",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.list.showing",
+    "message": "%{total} में से %{start}-%{end} दिखा रहे हैं",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.list.previous",
+    "message": "पिछला",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.list.next",
+    "message": "अगला",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.list.page_info",
+    "message": "%{totalPages} में से पृष्ठ %{page}",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.list.actions",
+    "message": "क्रियाएं",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.list.columns",
+    "message": "कॉलम",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.list.show_columns",
+    "message": "कॉलम दिखाएं",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.list.reset",
+    "message": "रीसेट",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.list.rows_per_page",
+    "message": "प्रति पृष्ठ पंक्तियाँ:",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.complaint_hierarchy",
+    "message": "शिकायत प्रकार",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.workflow_business_services",
+    "message": "वर्कफ़्लो व्यापार सेवाएं",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.complaint_hierarchies",
+    "message": "शिकायत पदानुक्रम",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.state_info",
+    "message": "राज्य जानकारी",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.city_modules",
+    "message": "शहर मॉड्यूल",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.id_formats",
+    "message": "ID प्रारूप",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.workflow_config",
+    "message": "वर्कफ़्लो कॉन्फ़िग",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.auto_escalation",
+    "message": "स्वचालित वृद्धि",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.sla_config",
+    "message": "SLA कॉन्फ़िग",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.roles",
+    "message": "भूमिकाएं",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.action_mappings",
+    "message": "क्रिया मैपिंग",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.encryption_policy",
+    "message": "एन्क्रिप्शन नीति",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.decryption_abac",
+    "message": "डिक्रिप्शन ABAC",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.masking_patterns",
+    "message": "मास्किंग पैटर्न",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.security_policy",
+    "message": "सुरक्षा नीति",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.inbox_config",
+    "message": "इनबॉक्स कॉन्फ़िग",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.deactivation_reasons",
+    "message": "निष्क्रियकरण कारण",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.degrees",
+    "message": "डिग्रियां",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.employment_tests",
+    "message": "रोजगार परीक्षण",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.specializations",
+    "message": "विशेषज्ञताएं",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.gender_types",
+    "message": "लिंग प्रकार",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.employee_status",
+    "message": "कर्मचारी स्थिति",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.employee_type",
+    "message": "कर्मचारी प्रकार",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.cron_jobs",
+    "message": "क्रॉन जॉब्स",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.ui_homepage",
+    "message": "UI होमपेज",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.theme_config",
+    "message": "थीम कॉन्फ़िग",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.user_validation",
+    "message": "उपयोगकर्ता फ़ील्ड सत्यापन",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.mobile_validation",
+    "message": "मोबाइल नंबर सत्यापन",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.tenant_boundary",
+    "message": "टेनेंट सीमा (HRMS)",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.auto_escalation_ignore",
+    "message": "स्वतः-वृद्धि अनदेखी",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.workflow_bs_master",
+    "message": "वर्कफ़्लो BS मास्टर",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.pgr_ui_constants",
+    "message": "PGR UI स्थिरांक",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.header.brand",
+    "message": "शिकायत प्रबंधन",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.nav.pgr_dashboard",
+    "message": "PGR डैशबोर्ड",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.nav.notifications",
+    "message": "सूचनाएं",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.dashboard.date.all",
+    "message": "सभी समय",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.dashboard.date.today",
+    "message": "आज",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.dashboard.date.yesterday",
+    "message": "कल",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.dashboard.date.week",
+    "message": "इस सप्ताह",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.dashboard.date.month",
+    "message": "इस महीने",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.nav.notification_routing",
+    "message": "अधिसूचना रूटिंग",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.nav.notification_templates",
+    "message": "अधिसूचना टेम्पलेट",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.notification_routing",
+    "message": "PGR अधिसूचना रूटिंग",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.resources.notification_template",
+    "message": "PGR अधिसूचना टेम्पलेट",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.dashboard.date.3months",
+    "message": "3 महीने",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.nav.dashboard",
+    "message": "Tableau de bord",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.nav.tenant_management",
+    "message": "Gestion des entités",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.nav.tenants",
+    "message": "Entités",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.nav.departments",
+    "message": "Départements",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.nav.designations",
+    "message": "Fonctions",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.nav.hierarchies",
+    "message": "Hiérarchies",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.nav.complaint_management",
+    "message": "Gestion des plaintes",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.nav.complaint_hierarchies",
+    "message": "Hiérarchies de plaintes",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.nav.complaint_types",
+    "message": "Types de plaintes",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.nav.complaints",
+    "message": "Plaintes",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.nav.localization",
+    "message": "Localisation",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.nav.people",
+    "message": "Personnes",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.nav.employees",
+    "message": "Employés",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.nav.users",
+    "message": "Utilisateurs",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.nav.system",
+    "message": "Système",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.nav.access_roles",
+    "message": "Rôles d'accès",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.nav.workflows",
+    "message": "Flux de travail",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.nav.processes",
+    "message": "Processus",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.nav.mdms_schemas",
+    "message": "Schémas MDMS",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.nav.boundaries",
+    "message": "Limites",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.nav.advanced",
+    "message": "Avancé",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.nav.switch_to_onboarding",
+    "message": "Passer à l'intégration",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.header.management_mode",
+    "message": "Mode gestion",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.header.title",
+    "message": "DIGIT Management Studio",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.complaint_types",
+    "message": "Types de plaintes",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.departments",
+    "message": "Départements",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.designations",
+    "message": "Fonctions",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.tenants",
+    "message": "Entités",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.employees",
+    "message": "Employés",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.users",
+    "message": "Utilisateurs",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.complaints",
+    "message": "Plaintes",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.boundaries",
+    "message": "Limites",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.localization",
+    "message": "Messages de localisation",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.access_roles",
+    "message": "Rôles d'accès",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.access_actions",
+    "message": "Actions d'accès",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.role_actions",
+    "message": "Actions de rôle",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.workflow_services",
+    "message": "Services métier",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.workflow_processes",
+    "message": "Processus de flux",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.mdms_schemas",
+    "message": "Schémas MDMS",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.boundary_hierarchies",
+    "message": "Hiérarchies de limites",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.code",
+    "message": "Code",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.name",
+    "message": "Nom",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.description",
+    "message": "Description",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.status",
+    "message": "Statut",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.active",
+    "message": "Actif",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.service_code",
+    "message": "Code de service",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.department",
+    "message": "Département",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.sla_hours",
+    "message": "SLA (h)",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.menu_path",
+    "message": "Type de plainte",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.parent",
+    "message": "Parent",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.city",
+    "message": "Ville",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.district",
+    "message": "District",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.mobile",
+    "message": "Mobile",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.designation",
+    "message": "Fonction",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.username",
+    "message": "Nom d'utilisateur",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.type",
+    "message": "Type",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.roles",
+    "message": "Rôles",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.boundary_type",
+    "message": "Type de limite",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.tenant",
+    "message": "Entité",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.message",
+    "message": "Message",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.module",
+    "message": "Module",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.locale",
+    "message": "Langue",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.url",
+    "message": "URL",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.service",
+    "message": "Service",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.enabled",
+    "message": "Activé",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.role_code",
+    "message": "Code de rôle",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.action_id",
+    "message": "ID d'action",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.action_code",
+    "message": "Code d'action",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.business_service",
+    "message": "Service métier",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.business",
+    "message": "Métier",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.sla",
+    "message": "SLA",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.business_id",
+    "message": "ID métier",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.action",
+    "message": "Action",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.state",
+    "message": "État",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.created",
+    "message": "Créé",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.hierarchy_type",
+    "message": "Type de hiérarchie",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.request_id",
+    "message": "ID de demande",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.citizen",
+    "message": "Citoyen",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.locality",
+    "message": "Localité",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.list.refresh",
+    "message": "Actualiser",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.list.create",
+    "message": "Créer",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.list.search",
+    "message": "Rechercher...",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.list.loading",
+    "message": "Chargement...",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.list.error_loading",
+    "message": "Erreur lors du chargement des données",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.list.error_unexpected",
+    "message": "Une erreur inattendue est survenue",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.list.try_again",
+    "message": "Réessayer",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.list.no_records",
+    "message": "Aucun enregistrement trouvé",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.list.adjust_search",
+    "message": "Essayez d'ajuster votre recherche",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.list.showing",
+    "message": "Affichage de %{start} à %{end} sur %{total}",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.list.previous",
+    "message": "Précédent",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.list.next",
+    "message": "Suivant",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.list.page_info",
+    "message": "Page %{page} sur %{totalPages}",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.list.actions",
+    "message": "Actions",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.list.columns",
+    "message": "Colonnes",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.list.show_columns",
+    "message": "Afficher les colonnes",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.list.reset",
+    "message": "Réinitialiser",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.list.rows_per_page",
+    "message": "Lignes par page :",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.complaint_hierarchy",
+    "message": "Types de plaintes",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.workflow_business_services",
+    "message": "Services métier de flux",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.complaint_hierarchies",
+    "message": "Hiérarchies de plaintes",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.state_info",
+    "message": "Infos sur l'État",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.city_modules",
+    "message": "Modules de ville",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.id_formats",
+    "message": "Formats d'identifiant",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.workflow_config",
+    "message": "Configuration des flux",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.auto_escalation",
+    "message": "Escalade automatique",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.sla_config",
+    "message": "Configuration SLA",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.roles",
+    "message": "Rôles",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.action_mappings",
+    "message": "Mappages d'actions",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.encryption_policy",
+    "message": "Politique de chiffrement",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.decryption_abac",
+    "message": "Déchiffrement ABAC",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.masking_patterns",
+    "message": "Modèles de masquage",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.security_policy",
+    "message": "Politique de sécurité",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.inbox_config",
+    "message": "Configuration de la boîte de réception",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.deactivation_reasons",
+    "message": "Motifs de désactivation",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.degrees",
+    "message": "Diplômes",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.employment_tests",
+    "message": "Tests d'emploi",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.specializations",
+    "message": "Spécialisations",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.gender_types",
+    "message": "Types de genre",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.employee_status",
+    "message": "Statut de l'employé",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.employee_type",
+    "message": "Type d'employé",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.cron_jobs",
+    "message": "Tâches Cron",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.ui_homepage",
+    "message": "Page d'accueil UI",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.theme_config",
+    "message": "Configuration du thème",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.user_validation",
+    "message": "Validation des champs utilisateur",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.mobile_validation",
+    "message": "Validation du numéro de mobile",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.tenant_boundary",
+    "message": "Limite d'entité (HRMS)",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.auto_escalation_ignore",
+    "message": "Auto-escalade ignorée",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.workflow_bs_master",
+    "message": "Maître BS de flux",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.pgr_ui_constants",
+    "message": "Constantes UI PGR",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.header.brand",
+    "message": "Gestion des plaintes",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.nav.pgr_dashboard",
+    "message": "Tableau de bord PGR",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.nav.notifications",
+    "message": "Notifications",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.dashboard.date.all",
+    "message": "Tout",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.dashboard.date.today",
+    "message": "Aujourd'hui",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.dashboard.date.yesterday",
+    "message": "Hier",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.dashboard.date.week",
+    "message": "Cette semaine",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.dashboard.date.month",
+    "message": "Ce mois-ci",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.nav.notification_routing",
+    "message": "Routage des notifications",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.nav.notification_templates",
+    "message": "Modèles de notification",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.notification_routing",
+    "message": "Routage des notifications PGR",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.resources.notification_template",
+    "message": "Modèles de notification PGR",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.dashboard.date.3months",
+    "message": "3 mois",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.nav.dashboard",
+    "message": "Painel",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.nav.tenant_management",
+    "message": "Gestão de entidades",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.nav.tenants",
+    "message": "Entidades",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.nav.departments",
+    "message": "Departamentos",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.nav.designations",
+    "message": "Cargos",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.nav.hierarchies",
+    "message": "Hierarquias",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.nav.complaint_management",
+    "message": "Gestão de reclamações",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.nav.complaint_hierarchies",
+    "message": "Hierarquias de reclamações",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.nav.complaint_types",
+    "message": "Tipos de reclamação",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.nav.complaints",
+    "message": "Reclamações",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.nav.localization",
+    "message": "Localização",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.nav.people",
+    "message": "Pessoas",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.nav.employees",
+    "message": "Funcionários",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.nav.users",
+    "message": "Usuários",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.nav.system",
+    "message": "Sistema",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.nav.access_roles",
+    "message": "Funções de acesso",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.nav.workflows",
+    "message": "Fluxos de trabalho",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.nav.processes",
+    "message": "Processos",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.nav.mdms_schemas",
+    "message": "Esquemas MDMS",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.nav.boundaries",
+    "message": "Limites",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.nav.advanced",
+    "message": "Avançado",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.nav.switch_to_onboarding",
+    "message": "Mudar para integração",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.header.management_mode",
+    "message": "Modo de gestão",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.header.title",
+    "message": "DIGIT Management Studio",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.complaint_types",
+    "message": "Tipos de reclamação",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.departments",
+    "message": "Departamentos",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.designations",
+    "message": "Cargos",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.tenants",
+    "message": "Entidades",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.employees",
+    "message": "Funcionários",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.users",
+    "message": "Usuários",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.complaints",
+    "message": "Reclamações",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.boundaries",
+    "message": "Limites",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.localization",
+    "message": "Mensagens de localização",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.access_roles",
+    "message": "Funções de acesso",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.access_actions",
+    "message": "Ações de acesso",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.role_actions",
+    "message": "Ações de função",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.workflow_services",
+    "message": "Serviços de negócio",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.workflow_processes",
+    "message": "Processos de fluxo",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.mdms_schemas",
+    "message": "Esquemas MDMS",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.boundary_hierarchies",
+    "message": "Hierarquias de limites",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.code",
+    "message": "Código",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.name",
+    "message": "Nome",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.description",
+    "message": "Descrição",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.status",
+    "message": "Status",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.active",
+    "message": "Ativo",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.service_code",
+    "message": "Código de serviço",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.department",
+    "message": "Departamento",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.sla_hours",
+    "message": "SLA (h)",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.menu_path",
+    "message": "Tipo de reclamação",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.parent",
+    "message": "Pai",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.city",
+    "message": "Cidade",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.district",
+    "message": "Distrito",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.mobile",
+    "message": "Celular",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.designation",
+    "message": "Cargo",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.username",
+    "message": "Nome de usuário",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.type",
+    "message": "Tipo",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.roles",
+    "message": "Funções",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.boundary_type",
+    "message": "Tipo de limite",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.tenant",
+    "message": "Entidade",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.message",
+    "message": "Mensagem",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.module",
+    "message": "Módulo",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.locale",
+    "message": "Idioma",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.url",
+    "message": "URL",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.service",
+    "message": "Serviço",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.enabled",
+    "message": "Habilitado",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.role_code",
+    "message": "Código de função",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.action_id",
+    "message": "ID da ação",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.action_code",
+    "message": "Código da ação",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.business_service",
+    "message": "Serviço de negócio",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.business",
+    "message": "Negócio",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.sla",
+    "message": "SLA",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.business_id",
+    "message": "ID de negócio",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.action",
+    "message": "Ação",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.state",
+    "message": "Estado",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.created",
+    "message": "Criado",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.hierarchy_type",
+    "message": "Tipo de hierarquia",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.request_id",
+    "message": "ID da solicitação",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.citizen",
+    "message": "Cidadão",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.locality",
+    "message": "Localidade",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.list.refresh",
+    "message": "Atualizar",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.list.create",
+    "message": "Criar",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.list.search",
+    "message": "Pesquisar...",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.list.loading",
+    "message": "Carregando...",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.list.error_loading",
+    "message": "Erro ao carregar dados",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.list.error_unexpected",
+    "message": "Ocorreu um erro inesperado",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.list.try_again",
+    "message": "Tentar novamente",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.list.no_records",
+    "message": "Nenhum registro encontrado",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.list.adjust_search",
+    "message": "Tente ajustar sua pesquisa",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.list.showing",
+    "message": "Mostrando %{start}-%{end} de %{total}",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.list.previous",
+    "message": "Anterior",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.list.next",
+    "message": "Próximo",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.list.page_info",
+    "message": "Página %{page} de %{totalPages}",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.list.actions",
+    "message": "Ações",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.list.columns",
+    "message": "Colunas",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.list.show_columns",
+    "message": "Mostrar colunas",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.list.reset",
+    "message": "Redefinir",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.list.rows_per_page",
+    "message": "Linhas por página:",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.complaint_hierarchy",
+    "message": "Tipos de reclamação",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.workflow_business_services",
+    "message": "Serviços de negócio de fluxo",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.complaint_hierarchies",
+    "message": "Hierarquias de reclamações",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.state_info",
+    "message": "Informações do estado",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.city_modules",
+    "message": "Módulos da cidade",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.id_formats",
+    "message": "Formatos de ID",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.workflow_config",
+    "message": "Configuração de fluxo",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.auto_escalation",
+    "message": "Escalonamento automático",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.sla_config",
+    "message": "Configuração de SLA",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.roles",
+    "message": "Funções",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.action_mappings",
+    "message": "Mapeamentos de ações",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.encryption_policy",
+    "message": "Política de criptografia",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.decryption_abac",
+    "message": "Descriptografia ABAC",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.masking_patterns",
+    "message": "Padrões de máscara",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.security_policy",
+    "message": "Política de segurança",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.inbox_config",
+    "message": "Configuração da caixa de entrada",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.deactivation_reasons",
+    "message": "Motivos de desativação",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.degrees",
+    "message": "Graus",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.employment_tests",
+    "message": "Testes de emprego",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.specializations",
+    "message": "Especializações",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.gender_types",
+    "message": "Tipos de gênero",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.employee_status",
+    "message": "Status do funcionário",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.employee_type",
+    "message": "Tipo de funcionário",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.cron_jobs",
+    "message": "Tarefas Cron",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.ui_homepage",
+    "message": "Página inicial da UI",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.theme_config",
+    "message": "Configuração de tema",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.user_validation",
+    "message": "Validação de campos do usuário",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.mobile_validation",
+    "message": "Validação de número de celular",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.tenant_boundary",
+    "message": "Limite de entidade (HRMS)",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.auto_escalation_ignore",
+    "message": "Escalonamento automático ignorado",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.workflow_bs_master",
+    "message": "Mestre BS de fluxo",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.pgr_ui_constants",
+    "message": "Constantes de UI PGR",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.header.brand",
+    "message": "Gestão de reclamações",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.nav.pgr_dashboard",
+    "message": "Painel PGR",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.nav.notifications",
+    "message": "Notificações",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.dashboard.date.all",
+    "message": "Todo o período",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.dashboard.date.today",
+    "message": "Hoje",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.dashboard.date.yesterday",
+    "message": "Ontem",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.dashboard.date.week",
+    "message": "Esta semana",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.dashboard.date.month",
+    "message": "Este mês",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.nav.notification_routing",
+    "message": "Roteamento de notificações",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.nav.notification_templates",
+    "message": "Modelos de notificação",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.notification_routing",
+    "message": "Roteamento de notificações PGR",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.resources.notification_template",
+    "message": "Modelos de notificação PGR",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.dashboard.date.3months",
+    "message": "3 meses",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  }
+]

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -2307,6 +2307,69 @@
       when: state_root != 'pg'
 
     # ────────────────────────────────────────────────────────────────
+    # Configurator UI localization seed. The configurator's own chrome —
+    # nav, field labels, resource names, dashboard strings — for every
+    # supported locale lives in the `configurator-ui` localization module
+    # so it renders from the backend and is editable in the configurator's
+    # own Localization screen (no rebuild to change a label or add a
+    # language). Seed/refresh it from the committed bundle so the strings
+    # survive redeploys (which rewrite server-side state) and every new
+    # tenant gets all languages on day 1. Idempotent: _upsert overwrites
+    # by (tenant, locale, module, code).
+    # ────────────────────────────────────────────────────────────────
+    - name: "configurator-i18n — mint ADMIN token at state_root for localization upsert"
+      ansible.builtin.uri:
+        url: "{{ 'https://' + domain if (tls_enabled | default(true)) else 'http://127.0.0.1' }}/user/oauth/token"
+        method: POST
+        headers: >-
+          {{
+            {'Authorization': 'Basic ZWdvdi11c2VyLWNsaWVudDo=',
+             'Content-Type': 'application/x-www-form-urlencoded'}
+            | combine({'Host': domain} if not (tls_enabled | default(true)) else {})
+          }}
+        body_format: form-urlencoded
+        body:
+          grant_type: password
+          username: "{{ bootstrap_user | default('ADMIN') }}"
+          password: "{{ bootstrap_password | default('eGov@123') }}"
+          scope: read
+          tenantId: "{{ state_root }}"
+          userType: EMPLOYEE
+        status_code: [200]
+        timeout: 15
+        validate_certs: "{{ tls_enabled | default(true) }}"
+      register: cfg_i18n_auth
+      retries: 6
+      delay: 10
+      until: cfg_i18n_auth.status == 200
+      no_log: true
+      when: state_root != 'pg'
+
+    - name: "configurator-i18n — upsert configurator-ui bundle (per locale)"
+      ansible.builtin.uri:
+        url: "{{ 'https://' + domain if (tls_enabled | default(true)) else 'http://127.0.0.1' }}/localization/messages/v1/_upsert"
+        method: POST
+        headers: "{{ {'Content-Type': 'application/json'} | combine({'Host': domain} if not (tls_enabled | default(true)) else {}) }}"
+        body_format: json
+        body:
+          RequestInfo:
+            apiId: emp
+            ver: ".01"
+            action: create
+            authToken: "{{ cfg_i18n_auth.json.access_token }}"
+            userInfo: "{{ cfg_i18n_auth.json.UserRequest }}"
+          tenantId: "{{ state_root }}"
+          locale: "{{ item }}"
+          messages: "{{ configurator_i18n_bundle | selectattr('locale', 'equalto', item) | list }}"
+        status_code: [200, 201]
+        timeout: 60
+        validate_certs: "{{ tls_enabled | default(true) }}"
+      vars:
+        configurator_i18n_bundle: "{{ lookup('file', playbook_dir ~ '/files/configurator-localization/configurator-ui.json') | from_json }}"
+      loop: "{{ configurator_i18n_bundle | map(attribute='locale') | unique | list }}"
+      when: state_root != 'pg'
+
+    # ────────────────────────────────────────────────────────────────
     # Novu Twilio bootstrap. Runs only when:
     #   1. enable_novu is true (the notifications profile is active)
     #   2. The operator has filled in novu_api_key + twilio_* in host_vars


### PR DESCRIPTION
## What

Makes the **configurator's own UI** fully localizable from the backend, and ships **English, Hindi, French, Portuguese** for it.

Previously only *part* of the configurator chrome was translatable:
- English `app.*` and react-admin `ra.*` strings were hardcoded in the JS bundle.
- Only **non-English** `app.*` came from the backend (`configurator-ui` module).
- Generic MDMS resource labels (State Info, City Modules, Theme Config, …), the dashboard count-cards, the header brand and the PGR dashboard chrome were **hardcoded English**, never passed through `translate()`.

## Changes

**Code (`configurator/`)**
- `i18nProvider.ts` — English `app.*` now hydrates from the `configurator-ui` backend module like every other locale; the bundled English is kept only as a synchronous boot/offline fallback. Edits made in the configurator's own **Localization** screen now take effect with no code change.
- `useResourceLabel.ts` (new hook) — resolves a resource's label via `app.resources.<id>`, falling back to the registry's English label. Single point that makes every resource label backend-driven.
- Wired the hook into the dashboard cards (`DigitDashboard`), the Advanced/generic-MDMS nav (`DigitLayout`) and the MDMS show/create page titles — all previously raw `getResourceLabel()` English.
- Header brand, PGR Dashboard title/nav item and the dashboard date-filter presets now go through `translate()`.

**Data + deploy**
- Committed localization bundle: `local-setup/ansible/files/configurator-localization/configurator-ui.json` — **142 codes × 4 locales (en_IN, hi_IN, fr_FR, pt_BR)** for module `configurator-ui`.
- New playbook task seeds/refreshes this bundle into `configurator-ui` at the state-root tenant on every deploy (idempotent `_upsert`), so it survives redeploys (which rewrite server-side state) and every new tenant gets all languages on day 1.

## Notes
- `ra.*` (react-admin framework strings) stay bundled per-locale — they're library internals, not editable content.
- The bundle is a forward-compatible **superset**: it includes the notification-routing labels so it stays in sync with tenants running ahead of `develop`. Those keys are inert until the notification-routing resources exist.
- Adding a new language is now: add its strings to the bundle + a `ra.*` bundle + an `AVAILABLE_LOCALES` entry.

## Verification
- Configurator builds clean (vite, 3379 modules).
- Bundle seeded + verified on Bomet (`ke`): 142 rows per locale across en/hi/fr/pt; Portuguese spot-checks correct (`Painel PGR`, `Gestão de reclamações`, `Informações do estado`, `Configuração de tema`, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)