### PR TITLE
fix(pgr): auto-dismiss + close button on file-upload error toast (#923)

### DIFF
--- a/digit-ui-esbuild/packages/react-components/src/atoms/ImageUploadHandler.js
+++ b/digit-ui-esbuild/packages/react-components/src/atoms/ImageUploadHandler.js
@@ -43,6 +43,15 @@ export const ImageUploadHandler = (props) => {
     }
   }, [imageFile]);
 
+  // Auto-dismiss the upload error toast so a rejected file (too large /
+  // unsupported) doesn't leave a banner stuck on screen forever (CCRS#923).
+  // The toast also gets a manual close button (isDleteBtn below).
+  useEffect(() => {
+    if (!error) return undefined;
+    const timer = setTimeout(() => setError(null), 5000);
+    return () => clearTimeout(timer);
+  }, [error]);
+
   const addUploadedImageIds = useCallback(
     (imageIdData) => {
       if (uploadedImagesIds === null) {
@@ -118,7 +127,7 @@ export const ImageUploadHandler = (props) => {
 
   return (
     <React.Fragment>
-      {error && <Toast error={true} label={error} onClose={() => setError(null)} />}
+      {error && <Toast error={true} label={error} isDleteBtn={true} onClose={() => setError(null)} />}
       <UploadImages onUpload={getImage} onDelete={deleteImage} thumbnails={uploadedImagesThumbs ? uploadedImagesThumbs.map((o) => o.image) : []} />
     </React.Fragment>
   );


### PR DESCRIPTION
Fixes #923.

## Problem
On **citizen → Create Complaint → upload an image that's too large / unsupported**, the error toast ("file too large") stayed on screen permanently — it didn't auto-dismiss and had no close icon, so the user couldn't get rid of it.

## Root cause
The upload widget is `ImageUploadHandler` (citizen create reuses it via the registered `SelectImages`; Reopen-complaint uses it too). It renders the shared `Toast` atom for the error, but:
- The `Toast` **error variant only renders the close button when `isDleteBtn` is set** — `ImageUploadHandler` didn't pass it ⇒ **no close icon**.
- The atom has **no auto-dismiss timer**, and the caller never cleared the error on a timeout ⇒ **the banner persisted forever**.

## Fix (`ImageUploadHandler.js`)
- Pass `isDleteBtn` so the error toast shows a **manual close button**.
- **Auto-dismiss** the error after 5s.

## Scope note
The **employee** Create-Complaint form has no image-upload field (only text/dropdown/location components), so the persistent-toast case doesn't arise there; its other toasts already auto-dismiss (3s) and its document uploads use inline validation errors that clear on re-upload/delete. The reported repro is citizen-only.

## Verification
- `npm run build` passes.
- Manual QA: rejected-file toast now shows a close (×) and disappears on its own after a few seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)