### PR TITLE
feat(configurator): translatable column headers, exhaustive field i18n + localization module filter

### DIFF
--- a/configurator/scripts/.gitignore
+++ b/configurator/scripts/.gitignore
@@ -1,0 +1,1 @@
+i18n-missing.json

--- a/configurator/scripts/i18n-audit.mjs
+++ b/configurator/scripts/i18n-audit.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+/**
+ * Configurator i18n audit — enumerate the EXHAUSTIVE set of translatable
+ * label keys the configurator can render, and diff against the committed
+ * localization bundle so you know exactly what still needs translating.
+ *
+ * Where labels come from (and thus what this enumerates):
+ *   1. app.resources.<id>  — every resource in the data-provider registry
+ *      (dedicated + generic MDMS), rendered via useResourceLabel().
+ *   2. app.fields.<field>  — every SCALAR property of every resource's MDMS
+ *      schema. List column headers (DigitDatagrid) and show/edit field labels
+ *      derive from these via the same snake-case key.
+ *
+ * Usage (run anywhere with network to a DIGIT install):
+ *   DIGIT_BASE=https://bometfeedbackhub.digit.org \
+ *   TENANT=ke ADMIN_USER=ADMIN ADMIN_PASS=eGov@123 \
+ *   BUNDLE=../local-setup/ansible/files/configurator-localization/configurator-ui.json \
+ *   node scripts/i18n-audit.mjs
+ *
+ * Output:
+ *   - prints a summary (total keys, how many already translated, how many missing)
+ *   - writes scripts/i18n-missing.json: { "<code>": {en, hi, fr, pt:""} } for the
+ *     missing keys, pre-filled with the English label — fill in hi/fr/pt, then
+ *     fold into the bundle generator and re-seed.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DIGIT_BASE = process.env.DIGIT_BASE || 'http://localhost:18000';
+const TENANT = process.env.TENANT || 'ke';
+const ADMIN_USER = process.env.ADMIN_USER || 'ADMIN';
+const ADMIN_PASS = process.env.ADMIN_PASS || 'eGov@123';
+const BUNDLE = process.env.BUNDLE
+  || path.resolve(__dirname, '../../local-setup/ansible/files/configurator-localization/configurator-ui.json');
+const LOCALES = ['en_IN', 'hi_IN', 'fr_FR', 'pt_BR'];
+
+// --- helpers replicated from @digit-ui/datagrid + DigitDatagrid (keep in sync) ---
+function formatFieldLabel(fieldName) {
+  return fieldName
+    .replace(/_/g, ' ')
+    .replace(/([A-Z])/g, ' $1')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (s) => s.toUpperCase());
+}
+function fieldKey(source) {
+  return 'app.fields.' + source.replace(/\./g, '_').replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase();
+}
+function resourceKey(id) {
+  return 'app.resources.' + id.replace(/-/g, '_');
+}
+function isComplexType(prop) {
+  if (!prop || typeof prop !== 'object') return true;
+  if (prop.type === 'object' || prop.type === 'array') return true;
+  if ('properties' in prop || 'items' in prop) return true;
+  return false;
+}
+
+async function api(p, body) {
+  const res = await fetch(DIGIT_BASE + p, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`${p} -> ${res.status} ${await res.text()}`);
+  return res.json();
+}
+
+async function mintToken() {
+  const form = new URLSearchParams({
+    username: ADMIN_USER, password: ADMIN_PASS, userType: 'EMPLOYEE',
+    tenantId: TENANT, scope: 'read', grant_type: 'password',
+  });
+  const res = await fetch(DIGIT_BASE + '/user/oauth/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded', Authorization: 'Basic ZWdvdi11c2VyLWNsaWVudDo=' },
+    body: form.toString(),
+  });
+  if (!res.ok) throw new Error(`auth -> ${res.status} ${await res.text()}`);
+  return res.json();
+}
+
+async function main() {
+  // registry (resource -> schema/label) from the built data-provider package
+  const reg = await import(path.resolve(__dirname, '../packages/data-provider/dist/index.js'));
+  const resources = { ...reg.getDedicatedResources(), ...reg.getGenericMdmsResources() };
+
+  const tok = await mintToken();
+  const ri = { apiId: 'Rainmaker', ver: '.01', authToken: tok.access_token, userInfo: tok.UserRequest };
+
+  // pull all schema definitions in one shot
+  const schemaCodes = [...new Set(Object.values(resources).map((r) => r.schema).filter(Boolean))];
+  const schemaResp = await api('/mdms-v2/schema/v1/_search', {
+    RequestInfo: ri,
+    SchemaDefCriteria: { tenantId: TENANT, codes: schemaCodes, limit: 500, offset: 0 },
+  });
+  const byCode = {};
+  for (const s of schemaResp.SchemaDefinitions || []) byCode[s.code] = s.definition;
+
+  // collect the exhaustive key -> English label map
+  const expected = {}; // code -> englishLabel
+  for (const [id, cfg] of Object.entries(resources)) {
+    expected[resourceKey(id)] = reg.getResourceLabel(id);
+    const def = cfg.schema ? byCode[cfg.schema] : null;
+    const props = (def && def.properties) || {};
+    for (const [name, prop] of Object.entries(props)) {
+      if (isComplexType(prop)) continue;
+      expected[fieldKey(name)] = formatFieldLabel(name);
+    }
+  }
+
+  // what the committed bundle already has (per locale)
+  const bundle = JSON.parse(fs.readFileSync(BUNDLE, 'utf8'));
+  const have = {}; // code -> Set(locale)
+  for (const m of bundle) (have[m.code] ||= new Set()).add(m.locale);
+
+  const missing = {};
+  let fullyTranslated = 0;
+  for (const [code, en] of Object.entries(expected)) {
+    const locs = have[code] || new Set();
+    const complete = LOCALES.every((l) => locs.has(l));
+    if (complete) { fullyTranslated++; continue; }
+    missing[code] = { en, hi: '', fr: '', pt: '' };
+  }
+
+  const outPath = path.resolve(__dirname, 'i18n-missing.json');
+  fs.writeFileSync(outPath, JSON.stringify(missing, null, 2) + '\n');
+
+  console.log('=== Configurator i18n audit ===');
+  console.log(`DIGIT_BASE           : ${DIGIT_BASE}  (tenant ${TENANT})`);
+  console.log(`resources            : ${Object.keys(resources).length}`);
+  console.log(`schemas fetched      : ${Object.keys(byCode).length}/${schemaCodes.length}`);
+  console.log(`expected keys (total): ${Object.keys(expected).length}`);
+  console.log(`fully translated     : ${fullyTranslated}`);
+  console.log(`MISSING              : ${Object.keys(missing).length}  -> ${outPath}`);
+  if (Object.keys(missing).length) {
+    console.log('\nMissing codes (English label):');
+    for (const [code, v] of Object.entries(missing)) console.log(`  ${code}  =  ${v.en}`);
+  }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/configurator/src/admin/DigitDatagrid.tsx
+++ b/configurator/src/admin/DigitDatagrid.tsx
@@ -60,6 +60,22 @@ export interface DigitDatagridProps<RecordType extends RaRecord = RaRecord> {
  * Get a nested value from an object using dot notation.
  * e.g. getNestedValue({ a: { b: 'c' } }, 'a.b') => 'c'
  */
+/**
+ * Localization key for a column header, derived from its field source so list
+ * columns are translatable (e.g. `businessService` → `app.fields.business_service`).
+ * The generated English label is passed as the `_` fallback, so an un-seeded
+ * field still shows its humanized English header rather than the raw key.
+ */
+function fieldKey(source: string): string {
+  return (
+    'app.fields.' +
+    source
+      .replace(/\./g, '_')
+      .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+      .toLowerCase()
+  );
+}
+
 function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
   return path.split('.').reduce<unknown>((acc, part) => {
     if (acc && typeof acc === 'object') {
@@ -175,7 +191,7 @@ export function DigitDatagrid<RecordType extends RaRecord = RaRecord>({
                     onClick={() => handleSort(col.source)}
                     className="flex items-center gap-1 font-medium text-muted-foreground hover:text-foreground transition-colors"
                   >
-                    {translate(col.label, { _: col.label })}
+                    {translate(fieldKey(col.source), { _: col.label })}
                     {sort.field === col.source ? (
                       sort.order === 'ASC' ? (
                         <ArrowUp className="w-3.5 h-3.5" />
@@ -188,7 +204,7 @@ export function DigitDatagrid<RecordType extends RaRecord = RaRecord>({
                   </button>
                 ) : (
                   <span className="font-medium text-muted-foreground">
-                    {translate(col.label, { _: col.label })}
+                    {translate(fieldKey(col.source), { _: col.label })}
                   </span>
                 )}
               </TableHead>

--- a/configurator/src/admin/MdmsResourcePage.tsx
+++ b/configurator/src/admin/MdmsResourcePage.tsx
@@ -2,14 +2,15 @@ import { useMemo } from 'react';
 import { DigitList, DigitDatagrid } from '@/admin';
 import type { DigitColumn } from '@/admin';
 import { useListContext, useResourceContext } from 'ra-core';
-import { getResourceConfig, getResourceLabel, getResourceBySchema } from '@/providers/bridge';
+import { getResourceConfig, getResourceBySchema } from '@/providers/bridge';
+import { useResourceLabel } from '@/providers/useResourceLabel';
 import { useSchemaDefinition } from '@/hooks/useSchemaDefinition';
 import { generateColumns, getRefMap, generateFilterElements } from './schemaUtils';
 
 export function MdmsResourcePage() {
   const resource = useResourceContext() ?? '';
   const config = getResourceConfig(resource);
-  const label = getResourceLabel(resource);
+  const label = useResourceLabel()(resource);
   const { definition } = useSchemaDefinition(config?.schema);
 
   // Compute refMap once, reused by columns and filters

--- a/configurator/src/resources/localization/LocalizationList.tsx
+++ b/configurator/src/resources/localization/LocalizationList.tsx
@@ -9,6 +9,51 @@ import { LocalizationToolbar } from './LocalizationToolbar';
 const labelFor = (code: string, locales: LocaleOption[]) =>
   locales.find((o) => o.value === code)?.label ?? code;
 
+// Sentinel for the "all modules" option — Radix Select disallows an empty value.
+const ALL_MODULES = '__all__';
+
+/** Modules worth filtering to. `configurator-ui` (the configurator's own UI
+ *  strings) is first since that's the common reason to come here. The list is
+ *  curated because the localization service has no module-enumeration endpoint;
+ *  any module not listed can still be reached by typing its code in search. */
+const MODULE_OPTIONS: { value: string; label: string }[] = [
+  { value: ALL_MODULES, label: 'All modules' },
+  { value: 'configurator-ui', label: 'Configurator UI (configurator-ui)' },
+  { value: 'rainmaker-common', label: 'rainmaker-common' },
+  { value: 'rainmaker-common-masters', label: 'rainmaker-common-masters' },
+  { value: 'rainmaker-pgr', label: 'rainmaker-pgr' },
+  { value: 'rainmaker-hr', label: 'rainmaker-hr' },
+  { value: 'rainmaker-hrms', label: 'rainmaker-hrms' },
+  { value: 'rainmaker-workbench', label: 'rainmaker-workbench' },
+  { value: 'egov-user', label: 'egov-user' },
+  { value: 'egov-hrms', label: 'egov-hrms' },
+];
+
+/** Module filter. Writes `module` into the list filter state; the localization
+ *  data provider passes it straight to the localization search so the grid
+ *  shows just that module's messages (e.g. the configurator's own strings). */
+function ModuleSelector() {
+  const { filterValues, setFilters } = useListContext();
+  const current = String(filterValues.module ?? '');
+  const onChange = (v: string) => {
+    const next = { ...filterValues };
+    if (v === ALL_MODULES) delete next.module;
+    else next.module = v;
+    setFilters(next, undefined, true);
+  };
+  return (
+    <div className="flex items-center gap-2 mb-3">
+      <span className="text-xs font-medium text-muted-foreground">Module:</span>
+      <Select value={current || ALL_MODULES} onValueChange={onChange}>
+        <SelectTrigger className="w-[280px] h-8 text-xs"><SelectValue /></SelectTrigger>
+        <SelectContent>
+          {MODULE_OPTIONS.map((m) => <SelectItem key={m.value} value={m.value}>{m.label}</SelectItem>)}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
 const truncate = (s: unknown) => {
   const t = String(s ?? '');
   return t.length > 80 ? t.slice(0, 80) + '…' : t;
@@ -112,6 +157,7 @@ export function LocalizationList() {
       sort={{ field: 'code', order: 'ASC' }}
       actions={<LocalizationToolbar />}
     >
+      <ModuleSelector />
       <LocaleSelector />
       <PivotDatagrid />
     </DigitList>

--- a/local-setup/ansible/files/configurator-localization/configurator-ui.json
+++ b/local-setup/ansible/files/configurator-localization/configurator-ui.json
@@ -846,6 +846,30 @@
     "locale": "en_IN"
   },
   {
+    "code": "app.fields.from_state",
+    "message": "From State",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.to_state",
+    "message": "To State",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.audience",
+    "message": "Audience",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.channel",
+    "message": "Channel",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
     "code": "app.dashboard.date.3months",
     "message": "3 Months",
     "module": "configurator-ui",
@@ -1694,6 +1718,30 @@
   {
     "code": "app.resources.notification_template",
     "message": "PGR अधिसूचना टेम्पलेट",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.from_state",
+    "message": "स्रोत स्थिति",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.to_state",
+    "message": "लक्ष्य स्थिति",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.audience",
+    "message": "दर्शक",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.channel",
+    "message": "चैनल",
     "module": "configurator-ui",
     "locale": "hi_IN"
   },
@@ -2550,6 +2598,30 @@
     "locale": "fr_FR"
   },
   {
+    "code": "app.fields.from_state",
+    "message": "État source",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.to_state",
+    "message": "État cible",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.audience",
+    "message": "Public",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.channel",
+    "message": "Canal",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
     "code": "app.dashboard.date.3months",
     "message": "3 mois",
     "module": "configurator-ui",
@@ -3398,6 +3470,30 @@
   {
     "code": "app.resources.notification_template",
     "message": "Modelos de notificação PGR",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.from_state",
+    "message": "Estado de origem",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.to_state",
+    "message": "Estado de destino",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.audience",
+    "message": "Público",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.channel",
+    "message": "Canal",
     "module": "configurator-ui",
     "locale": "pt_BR"
   },

--- a/local-setup/ansible/files/configurator-localization/configurator-ui.json
+++ b/local-setup/ansible/files/configurator-localization/configurator-ui.json
@@ -876,6 +876,324 @@
     "locale": "en_IN"
   },
   {
+    "code": "app.fields.tenant_id",
+    "message": "Tenant ID",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.path",
+    "message": "Path",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.order",
+    "message": "Order",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.keywords",
+    "message": "Keywords",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.level_code",
+    "message": "Level Code",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.parent_code",
+    "message": "Parent Code",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.logo_url",
+    "message": "Logo URL",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.banner_url",
+    "message": "Banner URL",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.qr_code_url",
+    "message": "QR Code URL",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.statelogo",
+    "message": "State Logo",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.logo_url_white",
+    "message": "Logo URL (White)",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.enable_whats_app",
+    "message": "Enable WhatsApp",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.has_localisation",
+    "message": "Has Localisation",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.format",
+    "message": "Format",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.idname",
+    "message": "ID Name",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.uuid",
+    "message": "UUID",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.get_uri",
+    "message": "GET URI",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.post_uri",
+    "message": "POST URI",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.is_state_level",
+    "message": "Is State Level",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.topic",
+    "message": "Topic",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.state_sla",
+    "message": "State SLA",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.business_sla",
+    "message": "Business SLA",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.slot_percentage",
+    "message": "Slot Percentage",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.middle_slab_color",
+    "message": "Middle Slab Color",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.negative_slab_color",
+    "message": "Negative Slab Color",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.positive_slab_color",
+    "message": "Positive Slab Color",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.actionid",
+    "message": "Action ID",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.rolecode",
+    "message": "Role Code",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.actioncode",
+    "message": "Action Code",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.id",
+    "message": "ID",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.left_icon",
+    "message": "Left Icon",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.right_icon",
+    "message": "Right Icon",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.display_name",
+    "message": "Display Name",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.order_number",
+    "message": "Order Number",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.parent_module",
+    "message": "Parent Module",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.navigation_url",
+    "message": "Navigation URL",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.key",
+    "message": "Key",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.pattern",
+    "message": "Pattern",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.pattern_id",
+    "message": "Pattern ID",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.model",
+    "message": "Model",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.index",
+    "message": "Index",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.method",
+    "message": "Method",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.job_name",
+    "message": "Job Name",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.redirect_url",
+    "message": "Redirect URL",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.version",
+    "message": "Version",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.default",
+    "message": "Default",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.is_active",
+    "message": "Is Active",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.field_type",
+    "message": "Field Type",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.validation_name",
+    "message": "Validation Name",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.is_statelevel",
+    "message": "Is State Level",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.reopensla",
+    "message": "Reopen SLA",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.body",
+    "message": "Body",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.subject",
+    "message": "Subject",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
     "code": "app.nav.dashboard",
     "message": "डैशबोर्ड",
     "module": "configurator-ui",
@@ -1748,6 +2066,324 @@
   {
     "code": "app.dashboard.date.3months",
     "message": "3 महीने",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.tenant_id",
+    "message": "टेनेंट आईडी",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.path",
+    "message": "पथ",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.order",
+    "message": "क्रम",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.keywords",
+    "message": "कीवर्ड",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.level_code",
+    "message": "स्तर कोड",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.parent_code",
+    "message": "मूल कोड",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.logo_url",
+    "message": "लोगो URL",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.banner_url",
+    "message": "बैनर URL",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.qr_code_url",
+    "message": "QR कोड URL",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.statelogo",
+    "message": "राज्य लोगो",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.logo_url_white",
+    "message": "लोगो URL (सफ़ेद)",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.enable_whats_app",
+    "message": "WhatsApp सक्षम करें",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.has_localisation",
+    "message": "स्थानीयकरण उपलब्ध",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.format",
+    "message": "प्रारूप",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.idname",
+    "message": "आईडी नाम",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.uuid",
+    "message": "UUID",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.get_uri",
+    "message": "GET URI",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.post_uri",
+    "message": "POST URI",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.is_state_level",
+    "message": "राज्य स्तरीय",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.topic",
+    "message": "विषय",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.state_sla",
+    "message": "राज्य SLA",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.business_sla",
+    "message": "व्यापार SLA",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.slot_percentage",
+    "message": "स्लॉट प्रतिशत",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.middle_slab_color",
+    "message": "मध्य स्लैब रंग",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.negative_slab_color",
+    "message": "नकारात्मक स्लैब रंग",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.positive_slab_color",
+    "message": "सकारात्मक स्लैब रंग",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.actionid",
+    "message": "क्रिया आईडी",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.rolecode",
+    "message": "भूमिका कोड",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.actioncode",
+    "message": "क्रिया कोड",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.id",
+    "message": "आईडी",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.left_icon",
+    "message": "बायां आइकन",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.right_icon",
+    "message": "दायां आइकन",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.display_name",
+    "message": "प्रदर्शित नाम",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.order_number",
+    "message": "क्रम संख्या",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.parent_module",
+    "message": "मूल मॉड्यूल",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.navigation_url",
+    "message": "नेविगेशन URL",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.key",
+    "message": "कुंजी",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.pattern",
+    "message": "पैटर्न",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.pattern_id",
+    "message": "पैटर्न आईडी",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.model",
+    "message": "मॉडल",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.index",
+    "message": "सूचकांक",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.method",
+    "message": "विधि",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.job_name",
+    "message": "जॉब नाम",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.redirect_url",
+    "message": "रीडायरेक्ट URL",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.version",
+    "message": "संस्करण",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.default",
+    "message": "डिफ़ॉल्ट",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.is_active",
+    "message": "सक्रिय है",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.field_type",
+    "message": "फ़ील्ड प्रकार",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.validation_name",
+    "message": "सत्यापन नाम",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.is_statelevel",
+    "message": "राज्य स्तरीय",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.reopensla",
+    "message": "पुनः खोलें SLA",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.body",
+    "message": "मुख्य भाग",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.subject",
+    "message": "विषय",
     "module": "configurator-ui",
     "locale": "hi_IN"
   },
@@ -2628,6 +3264,324 @@
     "locale": "fr_FR"
   },
   {
+    "code": "app.fields.tenant_id",
+    "message": "ID de l'entité",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.path",
+    "message": "Chemin",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.order",
+    "message": "Ordre",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.keywords",
+    "message": "Mots-clés",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.level_code",
+    "message": "Code de niveau",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.parent_code",
+    "message": "Code parent",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.logo_url",
+    "message": "URL du logo",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.banner_url",
+    "message": "URL de la bannière",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.qr_code_url",
+    "message": "URL du code QR",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.statelogo",
+    "message": "Logo de l'État",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.logo_url_white",
+    "message": "URL du logo (blanc)",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.enable_whats_app",
+    "message": "Activer WhatsApp",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.has_localisation",
+    "message": "Localisation disponible",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.format",
+    "message": "Format",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.idname",
+    "message": "Nom de l'ID",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.uuid",
+    "message": "UUID",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.get_uri",
+    "message": "URI GET",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.post_uri",
+    "message": "URI POST",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.is_state_level",
+    "message": "Niveau État",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.topic",
+    "message": "Sujet",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.state_sla",
+    "message": "SLA de l'État",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.business_sla",
+    "message": "SLA métier",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.slot_percentage",
+    "message": "Pourcentage de créneau",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.middle_slab_color",
+    "message": "Couleur du palier intermédiaire",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.negative_slab_color",
+    "message": "Couleur du palier négatif",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.positive_slab_color",
+    "message": "Couleur du palier positif",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.actionid",
+    "message": "ID d'action",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.rolecode",
+    "message": "Code de rôle",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.actioncode",
+    "message": "Code d'action",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.id",
+    "message": "ID",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.left_icon",
+    "message": "Icône de gauche",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.right_icon",
+    "message": "Icône de droite",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.display_name",
+    "message": "Nom affiché",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.order_number",
+    "message": "Numéro d'ordre",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.parent_module",
+    "message": "Module parent",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.navigation_url",
+    "message": "URL de navigation",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.key",
+    "message": "Clé",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.pattern",
+    "message": "Modèle",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.pattern_id",
+    "message": "ID du modèle",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.model",
+    "message": "Modèle",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.index",
+    "message": "Index",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.method",
+    "message": "Méthode",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.job_name",
+    "message": "Nom de la tâche",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.redirect_url",
+    "message": "URL de redirection",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.version",
+    "message": "Version",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.default",
+    "message": "Par défaut",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.is_active",
+    "message": "Actif",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.field_type",
+    "message": "Type de champ",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.validation_name",
+    "message": "Nom de validation",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.is_statelevel",
+    "message": "Niveau État",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.reopensla",
+    "message": "SLA de réouverture",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.body",
+    "message": "Corps",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.subject",
+    "message": "Objet",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
     "code": "app.nav.dashboard",
     "message": "Painel",
     "module": "configurator-ui",
@@ -3500,6 +4454,324 @@
   {
     "code": "app.dashboard.date.3months",
     "message": "3 meses",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.tenant_id",
+    "message": "ID da entidade",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.path",
+    "message": "Caminho",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.order",
+    "message": "Ordem",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.keywords",
+    "message": "Palavras-chave",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.level_code",
+    "message": "Código de nível",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.parent_code",
+    "message": "Código pai",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.logo_url",
+    "message": "URL do logotipo",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.banner_url",
+    "message": "URL do banner",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.qr_code_url",
+    "message": "URL do código QR",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.statelogo",
+    "message": "Logotipo do estado",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.logo_url_white",
+    "message": "URL do logotipo (branco)",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.enable_whats_app",
+    "message": "Ativar WhatsApp",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.has_localisation",
+    "message": "Tem localização",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.format",
+    "message": "Formato",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.idname",
+    "message": "Nome do ID",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.uuid",
+    "message": "UUID",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.get_uri",
+    "message": "URI GET",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.post_uri",
+    "message": "URI POST",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.is_state_level",
+    "message": "Nível estadual",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.topic",
+    "message": "Tópico",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.state_sla",
+    "message": "SLA do estado",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.business_sla",
+    "message": "SLA de negócio",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.slot_percentage",
+    "message": "Percentual de faixa",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.middle_slab_color",
+    "message": "Cor da faixa intermediária",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.negative_slab_color",
+    "message": "Cor da faixa negativa",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.positive_slab_color",
+    "message": "Cor da faixa positiva",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.actionid",
+    "message": "ID da ação",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.rolecode",
+    "message": "Código de função",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.actioncode",
+    "message": "Código da ação",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.id",
+    "message": "ID",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.left_icon",
+    "message": "Ícone esquerdo",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.right_icon",
+    "message": "Ícone direito",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.display_name",
+    "message": "Nome de exibição",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.order_number",
+    "message": "Número de ordem",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.parent_module",
+    "message": "Módulo pai",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.navigation_url",
+    "message": "URL de navegação",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.key",
+    "message": "Chave",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.pattern",
+    "message": "Padrão",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.pattern_id",
+    "message": "ID do padrão",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.model",
+    "message": "Modelo",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.index",
+    "message": "Índice",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.method",
+    "message": "Método",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.job_name",
+    "message": "Nome da tarefa",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.redirect_url",
+    "message": "URL de redirecionamento",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.version",
+    "message": "Versão",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.default",
+    "message": "Padrão",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.is_active",
+    "message": "Ativo",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.field_type",
+    "message": "Tipo de campo",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.validation_name",
+    "message": "Nome da validação",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.is_statelevel",
+    "message": "Nível estadual",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.reopensla",
+    "message": "SLA de reabertura",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.body",
+    "message": "Corpo",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.subject",
+    "message": "Assunto",
     "module": "configurator-ui",
     "locale": "pt_BR"
   }


### PR DESCRIPTION
Follow-up to #975 (which only carried the first commit). This adds the rest of the configurator i18n work.

## What
1. **List column headers are now translatable.** `DigitDatagrid` translated `col.label`, but the label is generated English text so the lookup never matched. It now translates by a key derived from the column's field source (`businessService` → `app.fields.business_service`), keeping the English label as the `_` fallback. The MDMS list **page title** also goes through `useResourceLabel` (was raw English).

2. **Exhaustive field/resource coverage + an audit script.** New `configurator/scripts/i18n-audit.mjs` enumerates every translatable key the configurator can render — `app.resources.<id>` for every registry resource and `app.fields.<field>` for every scalar property of every resource's MDMS schema — diffs against the committed bundle, and writes `i18n-missing.json` (English pre-filled). Running it surfaced 53 untranslated fields; all are now translated (en/hi/fr/pt). Bundle is **199 codes × 4 locales**; audit reports MISSING: 0.

3. **Localization module filter.** The localization list (`/configurator/manage/localization`) now has a Module dropdown (writes `filter.module`, already honored by the data provider) so you can jump to a module's strings — `configurator-ui` is the first option, for editing the configurator's own UI text.

## Notes
- Items 1 & 3 are app-code changes; item 2 is pure localization data (the column wiring from item 1 makes it render).
- `ra.*` framework strings stay bundled. Adding a language is still: bundle + `ra.*` + `AVAILABLE_LOCALES` entry.
- Re-run the audit anytime: `DIGIT_BASE=<url> TENANT=ke BUNDLE=local-setup/ansible/files/configurator-localization/configurator-ui.json node configurator/scripts/i18n-audit.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)