### PR TITLE
fix(configurator): clear re-login prompt on expired session during boundary create

### DIFF
--- a/configurator/src/App.tsx
+++ b/configurator/src/App.tsx
@@ -158,6 +158,10 @@ function ManagementAdmin() {
 // Storage key for persisting auth state
 const AUTH_STORAGE_KEY = 'crs-auth-state';
 
+// One-shot flag (sessionStorage) set when a request is rejected for an expired
+// session, read by LoginPage to explain why the operator was sent back.
+export const SESSION_EXPIRED_KEY = 'crs-session-expired';
+
 // Helper to restore apiClient from localStorage
 function restoreApiClientFromStorage(): { isAuthenticated: boolean; user: AppState['user']; environment: string; tenant: string; targetTenant: string; mode: AppMode; currentPhase: number; completedPhases: number[] } | null {
   const saved = localStorage.getItem(AUTH_STORAGE_KEY);
@@ -238,6 +242,23 @@ function App() {
       showHelp: false,
     };
   });
+
+  // Drop the session and bounce to /login when any request reports the token
+  // is no longer valid (e.g. it expired while the operator was partway through
+  // a long flow like the Phase 2 OSM boundary fetch). Without this, an expired
+  // token surfaces only on the first write, as a cryptic downstream NPE, with
+  // the UI still pretending to be logged in.
+  useEffect(() => {
+    apiClient.setSessionExpiredHandler(() => {
+      try { sessionStorage.setItem(SESSION_EXPIRED_KEY, '1'); } catch { /* ignore */ }
+      clearUser();
+      localStorage.removeItem(AUTH_STORAGE_KEY);
+      apiClient.logout();
+      digitClient.clearAuth();
+      resetProviders();
+      setState(s => ({ ...s, isAuthenticated: false, user: null }));
+    });
+  }, []);
 
   // Re-sync apiClient on every render if authenticated (handles HMR)
   useEffect(() => {

--- a/configurator/src/api/client.ts
+++ b/configurator/src/api/client.ts
@@ -14,6 +14,16 @@ class DigitApiClient {
   private authToken: string | null = null;
   private userInfo: UserInfo | null = null;
   private tenantId: string = '';
+  // Invoked when a request fails because the session is no longer valid (see
+  // isSessionExpired). The app registers this to drop the dead session and
+  // bounce the operator to the login screen.
+  private onSessionExpired: (() => void) | null = null;
+
+  // Register a callback fired the first time a request is rejected for an
+  // expired/invalid session. Called before the SessionExpiredError is thrown.
+  setSessionExpiredHandler(handler: () => void): void {
+    this.onSessionExpired = handler;
+  }
 
   // Initialize the client with environment URL
   setEnvironment(url: string): void {
@@ -166,6 +176,20 @@ class DigitApiClient {
           description: data.description,
         },
       ];
+
+      // An expired/invalid token surfaces here in a way that's confusing to
+      // operators: read/search endpoints are open at the gateway and keep
+      // working, so the wizard looks fine right up until the first WRITE. The
+      // gateway then can't resolve a user from the dead token (it strips any
+      // client-sent userInfo to prevent identity spoofing, so we can't supply
+      // it ourselves) and a service like boundary-service throws a raw
+      // "UserInfo ... must not be null" NPE instead of a clean 401. Detect that
+      // shape, drop the dead session, and surface an actionable message.
+      if (isSessionExpired(response.status, errors)) {
+        this.onSessionExpired?.();
+        throw new SessionExpiredError(response.status);
+      }
+
       throw new ApiClientError(errors, response.status);
     }
 
@@ -245,6 +269,40 @@ export class ApiClientError extends Error {
   // Get all error messages
   get allErrors(): string[] {
     return this.errors.map((e) => e.message);
+  }
+}
+
+// Friendly message shown whenever the session has expired or the token is
+// otherwise no longer accepted. firstError feeds straight into the existing
+// error banners, so callers need no special handling to get a clear message.
+const SESSION_EXPIRED_MESSAGE =
+  'Your session has expired. Please log in again to continue.';
+
+// Decide whether an error response means "the session is no longer valid"
+// rather than a genuine data/validation problem. Two signals:
+//   - HTTP 401 from the gateway (the clean case, on auth-enforced routes);
+//   - the gateway forwarded a dead token to an open route, so a downstream
+//     service NPEs on the missing userInfo. boundary-service's message is the
+//     canonical example: "UserInfo present inside RequestInfo being sent to
+//     enrichAuditDetails method must not be null".
+function isSessionExpired(status: number, errors: ApiError[]): boolean {
+  if (status === 401) return true;
+  return errors.some(
+    (e) =>
+      /userinfo[\s\S]*must not be null/i.test(e?.message || '') ||
+      /invalid.?access.?token|access token.*(expired|invalid)/i.test(
+        `${e?.code || ''} ${e?.message || ''}`
+      )
+  );
+}
+
+// Thrown when isSessionExpired matches. Extends ApiClientError so existing
+// `instanceof ApiClientError` catches keep working and `firstError` already
+// carries the friendly message.
+export class SessionExpiredError extends ApiClientError {
+  constructor(statusCode: number) {
+    super([{ code: 'SESSION_EXPIRED', message: SESSION_EXPIRED_MESSAGE }], statusCode);
+    this.name = 'SessionExpiredError';
   }
 }
 

--- a/configurator/src/api/index.ts
+++ b/configurator/src/api/index.ts
@@ -1,5 +1,5 @@
 // DIGIT API - Main Export
-export { apiClient, ApiClientError, DigitApiClient } from './client';
+export { apiClient, ApiClientError, SessionExpiredError, DigitApiClient } from './client';
 export { getApiBaseUrl, ENDPOINTS, MDMS_SCHEMAS, OAUTH_CONFIG, DEFAULT_PASSWORD } from './config';
 
 // Services

--- a/configurator/src/pages/LoginPage.tsx
+++ b/configurator/src/pages/LoginPage.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useApp } from '../App';
+import { useApp, SESSION_EXPIRED_KEY } from '../App';
 import { Eye, EyeOff, Loader2, Database, AlertCircle, HelpCircle, Rocket, Settings } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
@@ -24,6 +24,16 @@ export default function LoginPage() {
   const [showPassword, setShowPassword] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Explain the bounce when an expired session sent the operator back here.
+  useEffect(() => {
+    try {
+      if (sessionStorage.getItem(SESSION_EXPIRED_KEY)) {
+        setError('Your session expired. Please log in again to continue.');
+        sessionStorage.removeItem(SESSION_EXPIRED_KEY);
+      }
+    } catch { /* sessionStorage unavailable — skip the banner */ }
+  }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Problem

Operators running the Phase 2 OSM boundary autofill hit a cryptic backend error:

> `UserInfo present inside RequestInfo being sent to enrichAuditDetails method must not be null`

The UI still looked logged in, so the error read like a data/boundary problem.

## Root cause (verified live against boundary-service)

It's an **expired auth token**, not the boundary data:

- Read/search endpoints are open at the gateway, so the wizard's earlier steps (hierarchy search, etc.) keep working and the dead session stays hidden.
- The first **write** — boundary `_create` — is auth-enriched. The Kong gateway **strips any client-sent `userInfo`** (anti-spoofing) and re-injects it from the token. With an expired token it injects nothing, so `boundary-service` NPEs on the null `userInfo` instead of returning a clean 401. The client can't work around it by supplying `userInfo` itself (the gateway discards it).

Reproduced directly:
- valid token → create succeeds, `auditDetails.createdBy` populated by the gateway;
- invalid/expired token → exact `NullCheckException` above, with or without `userInfo` in the body.

## Fix

Detect this condition centrally in the configurator API client (`isSessionExpired`: HTTP 401, the `UserInfo ... must not be null` signature, or invalid-access-token codes), drop the dead session, and bounce the operator to `/login` with a clear banner: **"Your session expired. Please log in again to continue."**

- `client.ts` — `SessionExpiredError` + `setSessionExpiredHandler` hook; mapped in `request()`.
- `App.tsx` — registers the handler: clears `localStorage`/apiClient/digitClient and routes to login, setting a one-shot `sessionStorage` flag.
- `LoginPage.tsx` — reads the flag and shows the banner.

Existing `instanceof ApiClientError` catches keep working (`SessionExpiredError` extends it, and `firstError` carries the friendly message).

## Validation

- `tsc -b --noEmit` clean against the develop tree.
- Root-cause behavior reproduced live (valid vs. expired token) on a running boundary-service.

## Notes / follow-up

Scope is the configurator `apiClient` that owns the boundary flow. The data-provider bridge client (`digitClient`, used by management-mode MDMS) has the same gateway behavior and could get the same treatment in a follow-up if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)