### PR TITLE
fix(ui): unify toast auto-dismiss + close button, env-configurable timer (#883, #923)

### DIFF
--- a/digit-ui-esbuild/packages/react-components/src/atoms/ImageUploadHandler.js
+++ b/digit-ui-esbuild/packages/react-components/src/atoms/ImageUploadHandler.js
@@ -43,15 +43,6 @@ export const ImageUploadHandler = (props) => {
     }
   }, [imageFile]);
 
-  // Auto-dismiss the upload error toast so a rejected file (too large /
-  // unsupported) doesn't leave a banner stuck on screen forever (CCRS#923).
-  // The toast also gets a manual close button (isDleteBtn below).
-  useEffect(() => {
-    if (!error) return undefined;
-    const timer = setTimeout(() => setError(null), 5000);
-    return () => clearTimeout(timer);
-  }, [error]);
-
   const addUploadedImageIds = useCallback(
     (imageIdData) => {
       if (uploadedImagesIds === null) {
@@ -127,7 +118,7 @@ export const ImageUploadHandler = (props) => {
 
   return (
     <React.Fragment>
-      {error && <Toast error={true} label={error} isDleteBtn={true} onClose={() => setError(null)} />}
+      {error && <Toast error={true} label={error} onClose={() => setError(null)} isDleteBtn={true} autoDismiss={true} />}
       <UploadImages onUpload={getImage} onDelete={deleteImage} thumbnails={uploadedImagesThumbs ? uploadedImagesThumbs.map((o) => o.image) : []} />
     </React.Fragment>
   );

--- a/digit-ui-esbuild/packages/react-components/src/atoms/Toast.js
+++ b/digit-ui-esbuild/packages/react-components/src/atoms/Toast.js
@@ -1,9 +1,34 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import { RoundedCheck, DeleteBtn, ErrorIcon } from "./svgindex";
 import ButtonSelector from "./ButtonSelector";
 
+// Auto-dismiss delay in ms. Configurable per deployment via the runtime config
+// key TOAST_AUTO_DISMISS_MS (window.globalConfigs); falls back to 5000 (5s).
+// A positive `override` (autoDismissTimer prop) wins over the config.
+const resolveAutoDismissMs = (override) => {
+  if (override != null && Number(override) > 0) return Number(override);
+  const fromConfig =
+    (typeof window !== "undefined" && window?.globalConfigs?.getConfig?.("TOAST_AUTO_DISMISS_MS")) || undefined;
+  const ms = Number(fromConfig);
+  return Number.isFinite(ms) && ms > 0 ? ms : 5000;
+};
+
 const Toast = (props) => {
+  // Opt-in auto-dismiss: when `autoDismiss` is set, call onClose after the
+  // configured delay. onClose is read through a ref so a parent passing an
+  // inline handler doesn't reset the timer on every render; the timer resets
+  // when the message (label) changes so a new toast gets the full delay.
+  const onCloseRef = useRef(props.onClose);
+  onCloseRef.current = props.onClose;
+  useEffect(() => {
+    if (!props.autoDismiss) return undefined;
+    const timer = setTimeout(() => {
+      if (typeof onCloseRef.current === "function") onCloseRef.current();
+    }, resolveAutoDismissMs(props.autoDismissTimer));
+    return () => clearTimeout(timer);
+  }, [props.autoDismiss, props.autoDismissTimer, props.label]);
+
   if (props.error) {
     return (
       <div className="toast-success error" style={{ backgroundColor: "red", ...props.style }}>
@@ -52,13 +77,18 @@ const Toast = (props) => {
 Toast.propTypes = {
   label: PropTypes.string,
   onClose: PropTypes.func,
-  isDleteBtn: PropTypes.bool
+  isDleteBtn: PropTypes.bool,
+  // When true, the toast calls onClose after the auto-dismiss delay.
+  autoDismiss: PropTypes.bool,
+  // Optional per-toast override (ms) for the auto-dismiss delay.
+  autoDismissTimer: PropTypes.number
 };
 
 Toast.defaultProps = {
   label: "",
   onClose: undefined,
-  isDleteBtn: false
+  isDleteBtn: false,
+  autoDismiss: false
 };
 
 export default Toast;

--- a/digit-ui-esbuild/products/pgr/src/components/GeoLocations.js
+++ b/digit-ui-esbuild/products/pgr/src/components/GeoLocations.js
@@ -350,14 +350,6 @@ const GeoLocations = ({ t, config, onSelect, formData }) => {
     setShowToast(null);
   };
 
-  // Auto-dismiss the toast after a few seconds so location/geolocation messages
-  // (e.g. denied permission) don't linger indefinitely. See issue #883.
-  useEffect(() => {
-    if (!showToast) return;
-    const timer = setTimeout(() => setShowToast(null), 5000);
-    return () => clearTimeout(timer);
-  }, [showToast]);
-
   const clearSearch = () => {
     setSearchQuery("");
     setAddress("");
@@ -702,6 +694,7 @@ const GeoLocations = ({ t, config, onSelect, formData }) => {
           label={showToast.label}
           onClose={closeToast}
           isDleteBtn={true}
+          autoDismiss={true}
         />
       )}
     </div>

--- a/digit-ui-esbuild/public/vendor/overrides.css
+++ b/digit-ui-esbuild/public/vendor/overrides.css
@@ -1338,6 +1338,16 @@ button[class*="submit-bar"] *,
   fill: #ffffff !important;
   color: #ffffff !important;
 }
+/* ...but paths explicitly marked fill="none" (e.g. the (x) close button and
+ * viewbox-padding shapes) must STAY transparent — otherwise the white fill
+ * above turns them into solid white boxes (#883/#923). */
+.toast-success svg path[fill="none"],
+.digit-toast-success svg path[fill="none"],
+[class*="toast-error"] svg path[fill="none"],
+[class*="toast-warning"] svg path[fill="none"],
+[class*="toast-info"] svg path[fill="none"] {
+  fill: none !important;
+}
 /* Inner chips / boxes inside the toast (the source of the
  * outline mismatch) — make them transparent. */
 .toast-success > div,


### PR DESCRIPTION
## Issues
Fixes **#883** and **#923** — the same class of bug (a toast that won't go away), so they're addressed together:
- **#883** — Citizen UI → File a Complaint → pin location: with browser location access revoked, clicking "Current location" raises an error toast that **never clears and can't be closed manually**.
- **#923** — Citizen/Employee → Create Complaint → upload an image **exceeding the 5 MB limit**: the size-validation toast **never clears and has no close button**.

## Why one PR
Both need the same thing — auto-dismiss + a manual close (×) — and the two original fixes each **duplicated** a `setTimeout` `useEffect` in their parent component. This PR unifies that into the shared `Toast` atom so there is a single implementation.

## Changes
- **`packages/react-components/src/atoms/Toast.js`** — auto-dismiss is now built into the shared Toast, **opt-in** via `autoDismiss` (default **off**, so every existing Toast usage is unchanged). The delay is **configurable per deployment** via runtime config **`TOAST_AUTO_DISMISS_MS`** (`window.globalConfigs`), **defaulting to 5000 ms (5s)**; an optional `autoDismissTimer` prop overrides per toast. `onClose` is read through a ref so a parent passing an inline handler doesn't reset the timer, and the timer resets when the message changes.
- **`products/pgr/src/components/GeoLocations.js`** (#883) and **`packages/react-components/src/atoms/ImageUploadHandler.js`** (#923) — drop the duplicated timer; just pass `isDleteBtn` + `autoDismiss`.
- **`public/vendor/overrides.css`** — keep toast SVG paths marked `fill="none"` transparent so the (×) close button renders correctly instead of a solid white box.

## Verification (live stack)
- #883 geolocation toast: shows a working (×); clicking it closes the toast (before the auto-dismiss fires).
- #923 file-size toast: auto-dismisses at ~5s.
- **ENV timer:** with `TOAST_AUTO_DISMISS_MS=1500` the toast dismissed in **~1.5s** (proving the config is read); default remains 5s.

Supersedes #987 and #988.

Closes #883
Closes #923

🤖 Generated with [Claude Code](https://claude.com/claude-code)
