### PR TITLE
feat(pgr): show extendedAttributes on citizen + employee complaint detail pages

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/PgrExtendedAttributesView.js
+++ b/digit-ui-esbuild/products/pgr/src/components/PgrExtendedAttributesView.js
@@ -1,0 +1,54 @@
+// Read-only display helper for the PGR "extended attributes" on the complaint
+// DETAIL pages (citizen + employee).
+//
+// The frontend only FETCHES service.extendedAttributes and SHOWS it — the
+// backend handles everything else: confidentiality masking returns the values
+// already as "****", decryption, viewer-role checks, etc. So this is a pure
+// value -> row mapper: NO schema fetch, NO masking logic, NO translation of the
+// values themselves.
+
+import { prettifyKey } from "../utils/extendedAttributes";
+
+// Internal / control keys that are not user-facing data rows: the discriminator,
+// the confidentiality flag, the schema version, the hierarchy breadcrumbs (which
+// already render as the complaint type / sub-type), and the user-service-bound
+// contact fields. Everything else in extendedAttributes is shown verbatim.
+const SKIP_KEYS = new Set([
+  "caseRelatedTo",
+  "isConfidential",
+  "schemaVersion",
+  "hierarchyLevel1",
+  "hierarchyLevel2",
+  "complainantAddress",
+  "email",
+]);
+
+function formatValue(v) {
+  if (v === null || v === undefined || v === "") return "NA";
+  if (typeof v === "boolean") return v ? "Yes" : "No";
+  if (Array.isArray(v)) {
+    return (
+      v
+        .map((x) => (x && typeof x === "object" ? x.code ?? x.name ?? "" : x))
+        .filter((x) => x !== "" && x !== null && x !== undefined)
+        .join(", ") || "NA"
+    );
+  }
+  if (typeof v === "object") return String(v.code ?? v.name ?? "") || "NA";
+  // Strings — including the backend-masked "****" — pass through unchanged.
+  return String(v);
+}
+
+// Map a flat service.extendedAttributes object to ordered { fieldKey, label,
+// value } rows. Returns [] when there is nothing to show, so callers render
+// nothing (graceful gating — safe before the backend read side ships).
+export function buildExtendedAttributeRows(extendedAttributes) {
+  if (!extendedAttributes || typeof extendedAttributes !== "object") return [];
+  return Object.keys(extendedAttributes)
+    .filter((k) => !SKIP_KEYS.has(k))
+    .map((k) => ({
+      fieldKey: k,
+      label: prettifyKey(k),
+      value: formatValue(extendedAttributes[k]),
+    }));
+}

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintDetails.js
@@ -22,6 +22,7 @@ import { buildComplaintPath } from "../../utils/complaintHierarchyPath";
 import TimeLine from "../../components/TimeLine";
 import ComplaintPhotos from "../../components/ComplaintPhotos";
 import ComplaintLocationMap from "../../components/ComplaintLocationMap";
+import { buildExtendedAttributeRows } from "../../components/PgrExtendedAttributesView";
 
 const CLOSED_STATUSES = ["RESOLVED", "REJECTED", "CLOSEDAFTERREJECTION", "CLOSEDAFTERRESOLUTION"];
 const REJECTED_STATUSES = ["REJECTED", "CLOSEDAFTERREJECTION"];
@@ -354,6 +355,22 @@ const ComplaintDetailsPage = () => {
                 </div>
               ) : null}
             </Card>
+
+            {(() => {
+              // Read-only "Additional Details" — just fetch service.extendedAttributes
+              // and show it; the backend already returns masked ("****") values.
+              const extAttrRows = buildExtendedAttributeRows(complaintDetails?.service?.extendedAttributes);
+              return extAttrRows.length > 0 ? (
+                <Card style={{ padding: "20px 24px", display: "flex", flexDirection: "column", gap: "12px" }}>
+                  <SectionTitle>{tr("CS_COMPLAINT_DETAILS_ADDITIONAL_DETAILS", "Additional Details")}</SectionTitle>
+                  <div>
+                    {extAttrRows.map((r) => (
+                      <DetailRow key={r.fieldKey} label={r.label} value={r.value} />
+                    ))}
+                  </div>
+                </Card>
+              ) : null;
+            })()}
 
             {Number.isFinite(geoLocation?.latitude) && Number.isFinite(geoLocation?.longitude) ? (
               <Card style={{ padding: "20px 24px", display: "flex", flexDirection: "column", gap: "12px" }}>

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
@@ -10,6 +10,7 @@ import PGRWorkflowModal from "../../components/PGRWorkflowModal";
 import ComplaintLocationMap from "../../components/ComplaintLocationMap";
 import Urls from "../../utils/urls";
 import ComplaintPhotos from "../../components/ComplaintPhotos";
+import { buildExtendedAttributeRows } from "../../components/PgrExtendedAttributesView";
 import { buildComplaintPath } from "../../utils/complaintHierarchyPath";
 import { selectServiceDefsFromComplaintHierarchy } from "../../utils";
 
@@ -636,6 +637,22 @@ const PGRDetails = () => {
                   },
                 ],
               },
+              // Read-only "Additional Details" — fetch service.extendedAttributes
+              // and show it as label:value rows; backend returns masked ("****")
+              // values. Renders nothing when there are no extended attributes.
+              ...(buildExtendedAttributeRows(pgrData?.ServiceWrappers?.[0]?.service?.extendedAttributes).length > 0
+                ? [{
+                  cardType: "primary",
+                  header: t("CS_COMPLAINT_DETAILS_ADDITIONAL_DETAILS"),
+                  fieldPairs: buildExtendedAttributeRows(pgrData?.ServiceWrappers?.[0]?.service?.extendedAttributes).map((r) => ({
+                    inline: true,
+                    label: r.label,
+                    type: "text",
+                    value: r.value,
+                  })),
+                }]
+                : []
+              ),
               ...(pgrData?.ServiceWrappers[0]?.workflow?.verificationDocuments?.length > 0
                 ? [{
                   cardType: "primary",


### PR DESCRIPTION
## Summary
View-side counterpart to the extended-attributes **capture** (merged in #991): renders the per-category
extended attributes as a read-only **"Additional Details"** section on **both** the citizen and employee
complaint detail pages.

## Approach (per requirement)
The frontend **only fetches `service.extendedAttributes` and shows it** — the backend owns everything else:
confidentiality **masking** (returns values already as `****`), decryption, viewer-role checks, and routing
`complainantAddress`/`email` to the User Service. So: **no schema fetch, no FE masking, no value translation.**

## Changes
- **`PgrExtendedAttributesView.js`** (new): pure `buildExtendedAttributeRows()` — iterates the flat
  `extendedAttributes` object, skips control/internal keys (`caseRelatedTo`, `isConfidential`,
  `schemaVersion`, `hierarchyLevel1/2`, `complainantAddress`, `email`), labels via `prettifyKey`, values
  verbatim (a masked `****` passes straight through). Returns `[]` when empty.
- **`ComplaintDetails.js`** (citizen): an "Additional Details" `Card` before the location section.
- **`PGRDetails.js`** (employee): an "Additional Details" `SummaryCard` section before attachments.

## Behavior
- Verified against a live `_search` response — renders Witness Name/Note, Institute Name, Witness Address;
  skips the control fields and the `null` `complainantAddress`/`email` (the backend stripped those to the
  user record).
- **Gated / additive**: the section renders only when `service.extendedAttributes` is present — safe before
  the backend read side ships, and a no-op for legacy / non-category complaints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)