### PR TITLE
fix(pgr): stop citizen map pin jump + auto-fill pincode (partial #920)

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/pgr/src/components/GeoLocations.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/pgr/src/components/GeoLocations.js
@@ -55,6 +55,11 @@ const GeoLocations = ({ t, config, onSelect, formData }) => {
   const mapRef = useRef(null);
   const searchInputRef = useRef(null);
   const hasInitialized = useRef(false);
+  // Monotonic id for reverse-geocode requests. Reverse geocoding is async and
+  // unordered: the mount-time lookup for MAP_CENTER, or an earlier click, can
+  // resolve *after* a newer selection and overwrite it (the pin "jumps back").
+  // Each fetch captures an id and only commits its result if it is still latest.
+  const geocodeSeqRef = useRef(0);
 
   // Initialize with India center location on first load or from Session Storage
   useEffect(() => {
@@ -87,8 +92,18 @@ const GeoLocations = ({ t, config, onSelect, formData }) => {
     if (formData?.[config.key]) {
       const { lat, lng, address: savedAddress } = formData[config.key];
       if (lat && lng) {
-        setCoords({ lat, lng });
-        setMarkerPos([lat, lng]);
+        // formData is react-hook-form's watch() snapshot: it gets a fresh object
+        // identity on every change elsewhere in the form, so this effect re-runs
+        // constantly. Only move the marker when the coordinates actually differ
+        // from what we're already showing — otherwise a re-render that lands while
+        // an async reverse-geocode is in flight snaps the pin back to the previous
+        // value and it appears to "jump" on its own.
+        const samePos =
+          markerPos && Math.abs(markerPos[0] - lat) < 1e-9 && Math.abs(markerPos[1] - lng) < 1e-9;
+        if (!samePos) {
+          setCoords({ lat, lng });
+          setMarkerPos([lat, lng]);
+        }
         // Restore saved address if available
         if (savedAddress) {
           setAddress(savedAddress);
@@ -101,19 +116,26 @@ const GeoLocations = ({ t, config, onSelect, formData }) => {
   }, [formData, config.key]);
 
   const fetchAddress = async (lat, lng) => {
+    const seq = ++geocodeSeqRef.current;
+    // True only if this is still the most recent reverse-geocode request; a
+    // superseded response must not touch state or the form.
+    const isLatest = () => seq === geocodeSeqRef.current;
     try {
       const response = await fetch(
         `https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lng}&zoom=18&addressdetails=1`
       );
       const data = await response.json();
+      if (!isLatest()) return;
       if (data && data.display_name) {
         setAddress(data.display_name);
         setSearchQuery(data.display_name); // Update search bar with fetched address
-        // Extract pincode if available
+        // Extract pincode if available. Prefer the structured postcode Nominatim
+        // returns for most countries; only fall back to scraping display_name.
+        // The fallback is deliberately not hard-coded to 6 digits (India) so
+        // Kenya/other tenants with 4-5 digit postal codes still resolve.
         let pincode = data.address?.postcode;
         if (!pincode && data.display_name) {
-          // Fallback: Try to extract 6-digit pincode from display_name
-          const pincodeMatch = data.display_name.match(/\b\d{6}\b/);
+          const pincodeMatch = data.display_name.match(/\b\d{4,6}\b/);
           if (pincodeMatch) {
             pincode = pincodeMatch[0];
           }
@@ -128,13 +150,19 @@ const GeoLocations = ({ t, config, onSelect, formData }) => {
       }
     } catch (error) {
       console.error("Error fetching address:", error);
-      onSelect(config.key, { lat, lng });
+      if (isLatest()) onSelect(config.key, { lat, lng });
     }
   };
 
   const updateLocation = async (lat, lng) => {
     setCoords({ lat, lng });
     setMarkerPos([lat, lng]);
+    // Commit the coordinates to the form synchronously. fetchAddress only calls
+    // onSelect after its network round-trip, and until then the form still holds
+    // the previous location; any re-render in that window would otherwise reset
+    // the marker via the sync effect above. Writing lat/lng now closes that race;
+    // fetchAddress then enriches the same point with pincode + address.
+    onSelect(config.key, { lat, lng });
     setIsSearching(true);
     await fetchAddress(lat, lng);
     setIsSearching(false);

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/pgr/src/pages/citizen/Create/FormExplorer.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/pgr/src/pages/citizen/Create/FormExplorer.js
@@ -357,10 +357,22 @@ const FormExplorer = () => {
 
 
   const previousMenuPathRef = React.useRef(null);
+  const lastBridgedPincodeRef = React.useRef(null);
 
   const onFormValueChange = (setValue, formData, formState, reset, setError, clearErrors, trigger, getValues) => {
 
-    console.log(`*** LOG formData***`, formData);
+    // Bridge the pincode captured from the map pin (GeoLocationsPoint) into the
+    // postalCode field. This must go through react-hook-form's setValue: the form
+    // is never reset between steps, so mutating defaultValues at render time never
+    // reaches the live field. onFormValueChange fires on every change, so we only
+    // push a value when the *map* pincode actually changes (i.e. a new pin was
+    // dropped) — otherwise we'd overwrite a postalCode the user typed by hand on
+    // every keystroke elsewhere in the form.
+    const mapPincode = formData?.GeoLocationsPoint?.pincode;
+    if (mapPincode && `${mapPincode}` !== `${lastBridgedPincodeRef.current ?? ""}`) {
+      lastBridgedPincodeRef.current = `${mapPincode}`;
+      setValue("postalCode", `${mapPincode}`);
+    }
 
     const complaintType = formData?.SelectComplaintType;
     const currentMenuPath = complaintType?.menuPath;
@@ -412,12 +424,9 @@ const FormExplorer = () => {
     }
   };
 
-  if (formData.GeoLocationsPoint?.pincode) {
-    formData.postalCode = `${formData.GeoLocationsPoint.pincode}`;
-  }
-  else if (formData.postalCode) {
-    formData.postalCode = `${formData.postalCode}`;
-  }
+  // Note: the pincode captured from the map is now propagated into the
+  // postalCode field via setValue() in onFormValueChange, not by mutating
+  // formData here — react-hook-form ignores defaultValues changes after mount.
 
   if (formData.landmark && typeof formData.landmark === "object") {
     formData.landmark = "";

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/pgr/src/pages/citizen/Create/steps-config/locationDetails.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/pgr/src/pages/citizen/Create/steps-config/locationDetails.js
@@ -48,9 +48,11 @@ export const locationDetails = {
       "populators": {
         "name": "postalCode",
         "maxlength": 6,
-        "value":"560001",
         validation: {
-                  pattern: /^[1-9][0-9]{5}$/i,
+                  // Accept 4-6 digit postal codes so non-India tenants (e.g. Kenya)
+                  // aren't blocked, and so a value auto-filled from the map pin
+                  // always satisfies the field's own validation.
+                  pattern: /^[0-9]{4,6}$/i,
                 },
       }
     }


### PR DESCRIPTION
Partially addresses #920 (CMS citizen create-complaint map). This PR fixes **two of the three** reported defects; the third (locality auto-fill) is a separate regression — see below.

## What this fixes

### 1. Pin keeps changing on its own
`GeoLocations` had two competing sources of truth for the marker: local state (set instantly on click) and a `useEffect` that re-syncs from the `formData` prop — which is `FormComposerV2`'s react-hook-form `watch()` snapshot, a **new object identity on every form change**. Two races resulted:
- `updateLocation` committed coordinates to the form only **after** the async Nominatim reverse-geocode, so any re-render in that window re-applied the *stale* form value and snapped the marker back → **commit lat/lng synchronously** on selection + make the sync effect **idempotent** (only move when coords actually differ).
- Reverse-geocode responses are **unordered**: the mount-time lookup for `MAP_CENTER`, or an earlier click, could resolve *after* a newer pin and overwrite it → added a **monotonic request id**; a superseded response is dropped.

### 2. Pincode did not auto-fill
The pincode was bridged into `postalCode` by **mutating `formData` at render time** and passing it as RHF `defaultValues`, which RHF ignores after mount (single form instance, never reset between steps) → **bridge via `setValue()`** in `onFormValueChange`, applied **once per new map pincode** (via a ref) so a value the user typed by hand isn't clobbered. Also removed the hardcoded `value: "560001"` default that masked it, and relaxed the India-only 6-digit pincode extraction + field validation to 4–6 digits so non-India tenants (e.g. Kenya) aren't blocked.

## What this does NOT fix — locality auto-fill (separate regression)
The issue also asks for **locality** to auto-fill. That broke in commit `1b2b7d224` ("Citizen Side Boundary changes", 2026-01-22), which replaced the custom `SelectAddress` component — which **filtered the city/locality dropdowns by the entered pincode** — with a generic manual `type: "boundary"` admin-tree picker (`boundaryComponent`) that ignores pincode entirely. Restoring auto-fill is a design + MDMS-data decision (pincode↔boundary mapping, which many tenants lack), not a mechanical fix, so it is intentionally left for a follow-up. **Do not auto-close #920 on merge.**

## Files
- `components/GeoLocations.js` — sync commit + idempotent marker + request-ordering guard + locale-agnostic pincode extraction
- `pages/citizen/Create/FormExplorer.js` — `setValue` pincode bridge (once per pin); remove dead render-time mutation
- `pages/citizen/Create/steps-config/locationDetails.js` — drop hardcoded `560001`; relax postalCode pattern to 4–6 digits

## Testing
All changed files parse (JSX-aware). Diagnosis independently reviewed with a second tool (codex), which caught the clobber + async-ordering gaps now fixed, and confirmed the locality regression. Manual UI verification (pin select → Next → postalCode populated, pin stable under rapid clicks) still needed by QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)