### PR TITLE
feat(configurator): edit all locales side-by-side in the localization list

### DIFF
--- a/configurator/packages/data-provider/src/providers/dataProvider.ts
+++ b/configurator/packages/data-provider/src/providers/dataProvider.ts
@@ -168,6 +168,11 @@ function clientFilter(records: RaRecord[], filter: Record<string, unknown>): RaR
       // Internal control keys never participate in record-level filtering;
       // they're consumed by fetchers (e.g. mdmsGetList honours __tenantId).
       if (key === TENANT_OVERRIDE_KEY) return true;
+      // Localization fetcher control keys — consumed by localizationGetList to
+      // choose which locales to pivot; they are not record fields, so they must
+      // not participate in record-level filtering (else every pivoted row, which
+      // has msg__<locale> fields but no `locales`/`locale` field, gets dropped).
+      if (key === 'locale' || key === 'locale2' || key === 'locales') return true;
       if (key === 'q' && typeof value === 'string') {
         const q = value.toLowerCase();
         return JSON.stringify(record).toLowerCase().includes(q);

--- a/configurator/packages/data-provider/src/providers/dataProvider.ts
+++ b/configurator/packages/data-provider/src/providers/dataProvider.ts
@@ -352,6 +352,34 @@ async function localizationGetList(client: DigitApiClient, config: ResourceConfi
   // so the right column starts as all-missing rather than defaulting to a
   // hardcoded locale that may not exist on the tenant.
   const module = filter?.module ? String(filter.module) : undefined;
+  // Multi-locale pivot: when the caller passes `locales` (array or CSV) the
+  // grid wants one editable column per locale (msg__<locale>) instead of the
+  // 2-way message/message2 compare — so every language can be edited side by
+  // side. Rows are keyed by code+module; a code present in one locale but not
+  // another still appears (its missing columns stay empty).
+  const localesRaw = filter?.locales;
+  if (localesRaw) {
+    const locales = (Array.isArray(localesRaw) ? localesRaw : String(localesRaw).split(','))
+      .map((l) => String(l).trim()).filter(Boolean);
+    const perLocale = await Promise.all(locales.map((l) => client.localizationSearch(tenantId, l, module)));
+    const pivotN = new Map<string, Record<string, unknown>>();
+    locales.forEach((loc, i) => {
+      for (const m of perLocale[i] as Record<string, unknown>[]) {
+        const code = String(m.code ?? '');
+        const mod = String(m.module ?? '');
+        const key = `${code}__${mod}`;
+        let row = pivotN.get(key);
+        if (!row) {
+          row = { id: key, code, module: mod };
+          for (const L of locales) row[`msg__${L}`] = '';
+          pivotN.set(key, row);
+        }
+        row[`msg__${loc}`] = String(m.message ?? '');
+      }
+    });
+    return Array.from(pivotN.values()).map((r) => normalizeRecord(r, config));
+  }
+
   const localeA = filter?.locale ? String(filter.locale) : 'en_IN';
   const localeB = filter?.locale2 ? String(filter.locale2) : '';
   const [aMsgs, bMsgs] = await Promise.all([
@@ -953,6 +981,23 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
         const prev = (params.previousData ?? {}) as Record<string, unknown>;
         const code = String(data.code || params.id);
         const mod = String(data.module ?? '');
+
+        // Multi-locale grid: an inline edit emits msg__<locale> fields. Upsert
+        // only the locales whose value actually changed.
+        const msgKeys = Object.keys(data).filter((k) => k.startsWith('msg__'));
+        if (msgKeys.length) {
+          const localeWrites: Promise<unknown>[] = [];
+          for (const k of msgKeys) {
+            if (data[k] === prev[k]) continue;
+            const loc = k.slice('msg__'.length);
+            localeWrites.push(client.localizationUpsert(tenantId, loc, [
+              { code, message: String(data[k] ?? ''), module: mod },
+            ]));
+          }
+          await Promise.all(localeWrites);
+          return { data: { ...data, id: String(data.id ?? `${code}__${mod}`) } as RaRecord };
+        }
+
         const localeA = String(data.locale ?? 'en_IN');
         const localeB = String(data.locale2 ?? '');
         const writes: Promise<unknown>[] = [];

--- a/configurator/scripts/loc-multilocale.spec.mjs
+++ b/configurator/scripts/loc-multilocale.spec.mjs
@@ -1,0 +1,69 @@
+import { chromium } from 'playwright';
+
+const BASE = 'https://bometfeedbackhub.digit.org/configurator';
+// Chromium resolves the real domain (valid cert) through the SSH tunnel on :8443.
+const ARGS = ['--host-resolver-rules=MAP bometfeedbackhub.digit.org 127.0.0.1:8443'];
+
+const log = (...a) => console.log(...a);
+
+const browser = await chromium.launch({ args: ARGS });
+const ctx = await browser.newContext({ ignoreHTTPSErrors: true });
+const page = await ctx.newPage();
+const errors = [];
+page.on('console', (m) => { if (m.type() === 'error') errors.push(m.text()); });
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+page.on('response', (r) => { if (r.status() >= 400) errors.push(`${r.status()} ${r.request().method()} ${r.url()}`); });
+
+try {
+  // --- login (Management mode) ---
+  await page.goto(BASE + '/', { waitUntil: 'domcontentloaded', timeout: 30000 });
+  await page.getByRole('button', { name: /Management/ }).click().catch(() => {});
+  await page.fill('#username', 'ADMIN');
+  await page.fill('#password', 'eGov@123');
+  await page.fill('#tenantCode', 'ke');
+  await page.getByRole('button', { name: /Sign In/i }).click();
+  await page.waitForTimeout(4000);
+  log('after login url:', page.url());
+
+  // --- localization list ---
+  await page.goto(BASE + '/manage/localization', { waitUntil: 'domcontentloaded', timeout: 30000 });
+  await page.waitForTimeout(2000);
+
+  // pick Module = Configurator UI. Target the module trigger specifically
+  // (the header also has a Theme combobox) by its current "All modules" text.
+  const moduleTrigger = page.locator('[role=combobox]').filter({ hasText: /All modules/ });
+  await moduleTrigger.click();
+  await page.getByRole('option', { name: /Configurator UI/ }).click();
+
+  // sample row count right away and again after a delay (catch the "poof")
+  await page.waitForTimeout(1500);
+  const early = await page.locator('table tbody tr').count();
+  await page.waitForTimeout(4000);
+  const late = await page.locator('table tbody tr').count();
+  const noRecords = await page.getByText('No records found').count();
+  const headers = await page.locator('table thead th').allInnerTexts();
+
+  await page.screenshot({ path: '/tmp/loc-multilocale.png', fullPage: true });
+
+  log('HEADERS:', JSON.stringify(headers));
+  log('ROWS early:', early, '| ROWS late:', late, '| "No records found":', noRecords);
+
+  // read first row's locale cells to confirm columns are populated
+  const firstRow = page.locator('table tbody tr').first();
+  const cells = await firstRow.locator('td').allInnerTexts().catch(() => []);
+  log('FIRST ROW cells:', JSON.stringify(cells));
+
+  const ok = late > 0 && noRecords === 0
+    && headers.some((h) => /en_IN/.test(h)) && headers.some((h) => /fr_FR/.test(h))
+    && headers.some((h) => /hi_IN/.test(h)) && headers.some((h) => /pt_BR/.test(h));
+  log(ok ? '\n✅ PASS — grid persists with EN/HI/PT/FR columns' : '\n❌ FAIL — see above');
+  log('console errors:', errors.slice(0, 8));
+  await browser.close();
+  process.exit(ok ? 0 : 1);
+} catch (e) {
+  log('THREW:', e.message);
+  await page.screenshot({ path: '/tmp/loc-multilocale-error.png', fullPage: true }).catch(() => {});
+  log('console errors:', errors.slice(0, 8));
+  await browser.close();
+  process.exit(2);
+}

--- a/configurator/src/resources/localization/LocalizationList.tsx
+++ b/configurator/src/resources/localization/LocalizationList.tsx
@@ -3,11 +3,19 @@ import { useListContext } from 'ra-core';
 import { DigitList, DigitDatagrid } from '@/admin';
 import type { DigitColumn } from '@/admin';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { useAvailableLocales, type LocaleOption } from '@/hooks/useAvailableLocales';
+import { AVAILABLE_LOCALES } from '@/providers/i18nProvider';
 import { LocalizationToolbar } from './LocalizationToolbar';
 
-const labelFor = (code: string, locales: LocaleOption[]) =>
-  locales.find((o) => o.value === code)?.label ?? code;
+const truncate = (s: unknown) => {
+  const t = String(s ?? '');
+  return t.length > 80 ? t.slice(0, 80) + '…' : t;
+};
+
+// The configurator's supported locales — one editable column each.
+const LOCALE_CODES = AVAILABLE_LOCALES.map((l) => l.locale);
+const LOCALE_NAME: Record<string, string> = Object.fromEntries(
+  AVAILABLE_LOCALES.map((l) => [l.locale, l.name]),
+);
 
 // Sentinel for the "all modules" option — Radix Select disallows an empty value.
 const ALL_MODULES = '__all__';
@@ -54,98 +62,39 @@ function ModuleSelector() {
   );
 }
 
-const truncate = (s: unknown) => {
-  const t = String(s ?? '');
-  return t.length > 80 ? t.slice(0, 80) + '…' : t;
-};
-
-/** Two-locale picker rendered above the datagrid. Writes to the list filter
- *  state — the data provider reads `locale` (left col) + `locale2` (right
- *  col) and pivots both into one row per (code, module). */
-function LocaleSelector() {
+/** Pins the list to fetch every supported locale so the data provider pivots
+ *  one msg__<locale> column per language. Runs once on mount. */
+function LocalesFilterSetup() {
   const { filterValues, setFilters } = useListContext();
-  const { locales, isLoading } = useAvailableLocales();
-
-  // Defaults: first locale on the left, second locale on the right (or
-  // duplicate when only one is registered). Honors any user choice in URL/state.
-  const fallbackA = locales[0]?.value ?? 'en_IN';
-  const fallbackB = locales[1]?.value ?? locales[0]?.value ?? 'en_IN';
-  const localeA = String(filterValues.locale || fallbackA);
-  const localeB = String(filterValues.locale2 || fallbackB);
-  const update = (key: 'locale' | 'locale2') => (v: string) =>
-    setFilters({ ...filterValues, [key]: v }, undefined, true);
-
-  // Once locales are loaded, write the defaults into filter state so the
-  // data provider receives locale/locale2 on the initial fetch instead of
-  // waiting for the user to manually pick a locale.
   useEffect(() => {
-    if (isLoading || locales.length === 0) return;
-    const needsA = !filterValues.locale;
-    const needsB = !filterValues.locale2;
-    if (needsA || needsB) {
-      setFilters({
-        ...filterValues,
-        ...(needsA ? { locale: fallbackA } : {}),
-        ...(needsB ? { locale2: fallbackB } : {}),
-      }, undefined, true);
+    if (!filterValues.locales) {
+      setFilters({ ...filterValues, locales: LOCALE_CODES }, undefined, true);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoading, fallbackA, fallbackB]);
-
-  return (
-    <div className="flex items-center gap-3 mb-3 flex-wrap">
-      <span className="text-xs font-medium text-muted-foreground">Compare locales:</span>
-      <Select value={localeA} onValueChange={update('locale')} disabled={isLoading}>
-        <SelectTrigger className="w-[200px] h-8 text-xs"><SelectValue placeholder={isLoading ? 'loading…' : 'pick locale'} /></SelectTrigger>
-        <SelectContent>
-          {locales.map((o) => <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>)}
-        </SelectContent>
-      </Select>
-      <span className="text-xs text-muted-foreground">vs</span>
-      <Select value={localeB} onValueChange={update('locale2')} disabled={isLoading}>
-        <SelectTrigger className="w-[200px] h-8 text-xs"><SelectValue placeholder={isLoading ? 'loading…' : 'pick locale'} /></SelectTrigger>
-        <SelectContent>
-          {locales.map((o) => <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>)}
-        </SelectContent>
-      </Select>
-      {localeA === localeB && (
-        <span className="text-xs text-warning-dark">Same locale on both sides — pick different ones to compare.</span>
-      )}
-    </div>
-  );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return null;
 }
 
-/** Datagrid with column labels driven by the locale dropdowns. Rendered
- *  inside DigitList so it shares the ListContextProvider with the selector. */
-function PivotDatagrid() {
-  const { filterValues } = useListContext();
-  const { locales } = useAvailableLocales();
-  const fallbackA = locales[0]?.value ?? 'en_IN';
-  const fallbackB = locales[1]?.value ?? locales[0]?.value ?? 'en_IN';
-  const localeA = String(filterValues.locale || fallbackA);
-  const localeB = String(filterValues.locale2 || fallbackB);
-
+/** One editable column per locale (msg__<locale>) so every language can be
+ *  edited inline, side by side. */
+function MultiLocaleDatagrid() {
   const columns: DigitColumn[] = [
     { source: 'code', label: 'app.fields.code' },
     { source: 'module', label: 'app.fields.module' },
-    {
-      source: 'message',
-      label: `Message · ${labelFor(localeA, locales)}`,
-      editable: true,
-      render: (record) => <span className="block max-w-[300px] truncate">{truncate(record.message)}</span>,
-    },
-    {
-      source: 'message2',
-      label: `Message · ${labelFor(localeB, locales)}`,
-      editable: true,
-      render: (record) => (
-        <span className={`block max-w-[300px] truncate ${record.message2 ? '' : 'italic text-muted-foreground'}`}>
-          {record.message2 ? truncate(record.message2) : '— missing —'}
-        </span>
-      ),
-    },
+    ...LOCALE_CODES.map((loc) => ({
+      source: `msg__${loc}`,
+      label: `${LOCALE_NAME[loc]} (${loc})`,
+      editable: true as const,
+      render: (record: Record<string, unknown>) => {
+        const v = record[`msg__${loc}`];
+        return (
+          <span className={`block max-w-[260px] truncate ${v ? '' : 'italic text-muted-foreground'}`}>
+            {v ? truncate(v) : '— missing —'}
+          </span>
+        );
+      },
+    })),
   ];
-
   return <DigitDatagrid columns={columns} />;
 }
 
@@ -158,8 +107,8 @@ export function LocalizationList() {
       actions={<LocalizationToolbar />}
     >
       <ModuleSelector />
-      <LocaleSelector />
-      <PivotDatagrid />
+      <LocalesFilterSetup />
+      <MultiLocaleDatagrid />
     </DigitList>
   );
 }


### PR DESCRIPTION
## What
The localization list (`/configurator/manage/localization`) was a 2-locale **compare** pivot — you could only ever see two languages (e.g. English vs Default), so editing several languages meant repeatedly switching the dropdown.

This turns it into a **multi-locale editor**: one **editable column per supported locale** (EN / HI / PT / FR, from `AVAILABLE_LOCALES`), so you can edit every language inline, side by side.

## How
- The list pins a `locales` filter (all supported locales).
- `localizationGetList` gains a multi-locale branch: when `locales` is passed it fetches each locale and pivots every code into `msg__<locale>` fields (one row per code+module; a code missing in a locale just shows an empty, editable cell).
- Inline edit emits `msg__<locale>`; the `update` handler upserts **only** the locales whose value actually changed.
- The Module filter is retained — narrow to `configurator-ui` and edit all languages for the configurator's own strings in place.

The original 2-locale `message`/`message2` path is untouched (still used by the Show/Edit record pages).

## Verification
- Configurator + data-provider build clean; deployed to Bomet — list shows Code / Module / EN / HI / PT / FR columns, each editable, and edits persist to the correct locale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)