### PR TITLE
fix(dashboard): refresh V2 analytics grains + daily snapshot in scheduler

### DIFF
--- a/backend/pgr-services/src/main/java/org/egov/pgr/service/DashboardRefreshScheduler.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/service/DashboardRefreshScheduler.java
@@ -7,6 +7,26 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+/**
+ * Keeps the analytics grains that back the CCRS dashboard fresh.
+ *
+ * <p>The catalog-driven dashboard reads three V2 grains:
+ * <ul>
+ *   <li>{@code complaint_events} — one row per workflow transition (materialized view)</li>
+ *   <li>{@code complaint_facts}  — one row per complaint, current state (materialized view,
+ *       built FROM complaint_events)</li>
+ *   <li>{@code complaint_open_state_daily} — append-only daily backlog snapshot (a table, one row
+ *       per still-open complaint per day)</li>
+ * </ul>
+ *
+ * <p>Materialized views are refreshed in dependency order (events before facts) with
+ * {@code CONCURRENTLY} so dashboard reads are never blocked (both grains carry the unique index
+ * that CONCURRENTLY requires). After facts is fresh, today's open backlog is captured into
+ * {@code complaint_open_state_daily} with an idempotent upsert, so the trend/time-series KPIs
+ * accumulate one point per day.
+ *
+ * <p>The legacy {@code pgr_mv_*} KPI views are still refreshed for back-compat.
+ */
 @Component
 @Slf4j
 public class DashboardRefreshScheduler {
@@ -14,9 +34,30 @@ public class DashboardRefreshScheduler {
     private final JdbcTemplate jdbcTemplate;
     private final PGRConfiguration config;
 
-    private static final String[] MV_NAMES = {
+    // V2 grains the dashboard actually queries. Order matters: complaint_facts is built FROM
+    // complaint_events, so events must be refreshed first for facts to see the latest transitions.
+    private static final String[] V2_GRAIN_MVS = {
+        "complaint_events", "complaint_facts"
+    };
+
+    // Legacy KPI materialized views (superseded by the V2 grains; kept refreshed for back-compat).
+    private static final String[] LEGACY_MV_NAMES = {
         "pgr_mv_kpi", "pgr_mv_monthly", "pgr_mv_monthly_source", "pgr_mv_dimension"
     };
+
+    // Daily backlog snapshot: one row per still-open complaint per day. Runs AFTER complaint_facts
+    // is refreshed. ON CONFLICT keeps the first snapshot captured for each (day, complaint), so
+    // re-running within the same day is a no-op — the day's backlog is fixed at its first capture.
+    private static final String DAILY_SNAPSHOT_UPSERT =
+            "INSERT INTO complaint_open_state_daily "
+          + "(snapshot_date, service_request_id, tenant_id, is_open, sla_breached, sla_status_bucket, "
+          + " aging_bucket, boundary_path, ward_code, zone_code, service_code, current_assignee_uuid, "
+          + " department_code, account_id) "
+          + "SELECT CURRENT_DATE, service_request_id, tenant_id, is_open, sla_breached, sla_status_bucket, "
+          + "       aging_bucket, boundary_path, ward_code, zone_code, service_code, current_assignee_uuid, "
+          + "       department_code, account_id "
+          + "FROM complaint_facts WHERE is_open "
+          + "ON CONFLICT (snapshot_date, service_request_id) DO NOTHING";
 
     @Autowired
     public DashboardRefreshScheduler(JdbcTemplate jdbcTemplate, PGRConfiguration config) {
@@ -31,13 +72,35 @@ public class DashboardRefreshScheduler {
         }
 
         long start = System.currentTimeMillis();
-        for (String mv : MV_NAMES) {
-            try {
-                jdbcTemplate.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY " + mv);
-            } catch (Exception e) {
-                log.warn("Failed to refresh {}: {}", mv, e.getMessage());
-            }
+
+        // 1. V2 grains, in dependency order (events -> facts). These back every dashboard KPI.
+        for (String mv : V2_GRAIN_MVS) {
+            refreshConcurrently(mv);
         }
-        log.info("Dashboard MVs refreshed in {}ms", System.currentTimeMillis() - start);
+
+        // 2. Capture today's open backlog once facts is fresh (idempotent per day+complaint).
+        try {
+            int rows = jdbcTemplate.update(DAILY_SNAPSHOT_UPSERT);
+            if (rows > 0) {
+                log.info("complaint_open_state_daily: captured {} open complaints for today", rows);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to upsert complaint_open_state_daily snapshot: {}", e.getMessage());
+        }
+
+        // 3. Legacy KPI MVs (back-compat).
+        for (String mv : LEGACY_MV_NAMES) {
+            refreshConcurrently(mv);
+        }
+
+        log.info("Dashboard grains + MVs refreshed in {}ms", System.currentTimeMillis() - start);
+    }
+
+    private void refreshConcurrently(String mv) {
+        try {
+            jdbcTemplate.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY " + mv);
+        } catch (Exception e) {
+            log.warn("Failed to refresh {}: {}", mv, e.getMessage());
+        }
     }
 }


### PR DESCRIPTION
## Problem

The dashboard's analytics grains go stale. `DashboardRefreshScheduler` refreshes only the legacy `pgr_mv_*` materialized views — which the catalog-driven dashboard no longer queries. The **V2 grains it actually reads were never wired into the scheduler**:

| Grain | Type | Refresh before this PR | Observed on bomet (2026-07-01) |
|---|---|---|---|
| `complaint_events` | matview | deploy/migration only | — |
| `complaint_facts` | matview | deploy/migration only | 262 open vs **326 live** in source |
| `complaint_open_state_daily` | table (daily snapshot) | **no job at all** | **frozen at a single seed date, 2026-06-07** (~3.5 weeks stale) |

So point-in-time KPIs drift between deploys, and every time-series / trend KPI has been showing one stale day.

## Fix

Extend `DashboardRefreshScheduler.refreshMaterializedViews()` to:

1. `REFRESH MATERIALIZED VIEW CONCURRENTLY complaint_events` then `complaint_facts` — **dependency order** (facts is built `FROM complaint_events`). Both grains carry the unique index `CONCURRENTLY` requires (`ux_complaint_events`, `ux_complaint_facts`), so dashboard reads are never blocked.
2. Upsert today's open backlog into `complaint_open_state_daily` once facts is fresh:
   `INSERT … SELECT … FROM complaint_facts WHERE is_open ON CONFLICT (snapshot_date, service_request_id) DO NOTHING` — **exactly the recurring job the grain migration's own comment already specified**. Idempotent per day.
3. Keep the legacy `pgr_mv_*` refresh for back-compat.

Runs on the existing 5-minute schedule, enabled by default (`pgr.dashboard.refresh.enabled=true`) — **no config or migration change**. Redeploys identically on any tenant.

## Validation

- The daily upsert was **dry-run (`BEGIN`/`ROLLBACK`) against bomet's live DB** — it type-checks and would capture 262 open complaints for today.
- Both V2 grains confirmed to carry the unique index required by `REFRESH … CONCURRENTLY`.

## Note

`complaint_open_state_daily` accumulates **forward** from when this ships. Historical daily backlog before go-live can't be reconstructed from a current-state materialized view, so the trend series will have a gap between its seed date and deploy — expected.

Part of #664 (Decision Support & Analytics), #631 (CCRS SaaS: Dashboard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
