### PR TITLE
fix(profile-avatar): show uploaded photo in employee topbar + citizen desktop sidebar (#997)

### DIFF
--- a/digit-ui-esbuild/packages/modules/core/src/components/TopBarSideBar/SideBar/StaticCitizenSideBar.js
+++ b/digit-ui-esbuild/packages/modules/core/src/components/TopBarSideBar/SideBar/StaticCitizenSideBar.js
@@ -25,16 +25,24 @@ import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 import LogoutDialog from "../../Dialog/LogoutDialog";
 import ChangeCity from "../../ChangeCity";
-import { defaultImage } from "../../utils";
+import { defaultImage, resolveProfilePhoto } from "../../utils";
 import ImageComponent from "../../ImageComponent";
 
 /* 
 Feature :: Citizen Webview sidebar
 */
-const Profile = ({ info, stateName, t }) => (
+const Profile = ({ info, stateName, t, photo }) => (
   <div className="profile-section">
     <div className="imageloader imageloader-loaded">
-      <ImageComponent className="img-responsive img-circle img-Profile" src={defaultImage} alt="Profile Logo" />
+      {/* #997: the desktop citizen sidebar hard-coded src={defaultImage}, so an
+          uploaded profile photo never showed here. Use the resolved photo URL
+          when available, falling back to the default glyph. */}
+      <ImageComponent
+        className="img-responsive img-circle img-Profile"
+        src={photo || defaultImage}
+        style={{ objectFit: "cover", objectPosition: "center" }}
+        alt="Profile Logo"
+      />
     </div>
     {info?.name && info?.name !== info?.mobileNumber && (
       <div id="profile-name" className="label-container name-Profile">
@@ -86,6 +94,28 @@ const StaticCitizenSideBar = ({ linkData, islinkDataLoading }) => {
   const [isEmployee, setisEmployee] = useState(false);
   const [isSidebarOpen, toggleSidebar] = useState(false);
   const [showDialog, setShowDialog] = useState(false);
+  const [profilePic, setProfilePic] = useState(null);
+
+  // #997: fetch + resolve the logged-in user's photo (a bare fileStoreId) so the
+  // sidebar avatar renders the uploaded image instead of always the default.
+  useEffect(() => {
+    let cancelled = false;
+    const fetchProfilePhoto = async () => {
+      const tenant = Digit.ULBService.getCurrentTenantId();
+      const uuid = user?.info?.uuid;
+      if (!uuid) return;
+      const usersResponse = await Digit.UserService.userSearch(tenant, { uuid: [uuid] }, {});
+      const userData = usersResponse?.user?.[0];
+      if (userData?.photo) {
+        const resolved = await resolveProfilePhoto(userData.photo, Digit.ULBService.getStateId());
+        if (!cancelled) setProfilePic(resolved);
+      }
+    };
+    if (!profilePic) fetchProfilePhoto();
+    return () => {
+      cancelled = true;
+    };
+  }, [user?.info?.uuid]);
 
   const handleLogout = () => {
     toggleSidebar(false);
@@ -157,7 +187,7 @@ const StaticCitizenSideBar = ({ linkData, islinkDataLoading }) => {
   let profileItem;
 
   if (isFetched && user && user.access_token && user?.info?.type === "CITIZEN") {
-    profileItem = <Profile info={user?.info} stateName={stateInfo?.name} t={t} />;
+    profileItem = <Profile info={user?.info} stateName={stateInfo?.name} t={t} photo={profilePic} />;
     menuItems = menuItems.filter((item) => item?.id !== "login-btn");
     menuItems = [
       ...menuItems,

--- a/digit-ui-esbuild/packages/modules/core/src/components/TopBarSideBar/TopBar.js
+++ b/digit-ui-esbuild/packages/modules/core/src/components/TopBarSideBar/TopBar.js
@@ -137,7 +137,23 @@ const TopBar = ({
           <Dropdown
             option={userOptions}
             optionKey="name"
-            profilePic={profilePic ? profilePic : userDetails?.info?.name || userDetails?.info?.userInfo?.name || "Employee"}
+            // #997: the Dropdown's `profilePic` prop renders a *string* as
+            // charAt(0) (a text initial) and only renders a picture when handed
+            // a React element. #445 resolved the photo to a URL but passed that
+            // URL string here, so the header showed the first char of the URL
+            // ("h" → "H") instead of the image. Pass an <img> element when a
+            // photo exists; fall back to the name string for the text initial.
+            profilePic={
+              profilePic ? (
+                <ImageComponent
+                  src={profilePic}
+                  alt="Profile"
+                  style={{ width: "100%", height: "100%", objectFit: "cover", objectPosition: "center" }}
+                />
+              ) : (
+                userDetails?.info?.name || userDetails?.info?.userInfo?.name || "Employee"
+              )
+            }
             select={handleUserDropdownSelection}
             showArrow={true}
             menuStyles={{ marginTop: "1rem" }}


### PR DESCRIPTION
## What & why

Closes #997. Profile upload works (#445, now closed), but the uploaded photo still doesn't appear in the avatar chrome. #868 resolved the bare `fileStoreId` to a real URL, yet the two surfaces QA flagged still don't paint it.

**Reproduced live on bomet**: logged in as an employee with a photo → the top-right avatar rendered the letter **"H"**, not the image. Diagnosis ruled out every layer except the final wiring:
- filestore resolves the id → public URL (200), the `_small` variant loads (200, image/jpeg)
- the live TopBar **does** fire `GET /filestore/v1/files/url?...` (200) — `resolveProfilePhoto` runs
- …but the resolved value is plumbed into a prop that renders a text initial, not an image.

## Two gaps, same symptom

### 1. Employee TopBar (`TopBar.js`)
The shared `Dropdown`'s `profilePic` prop (`digit-ui-components/atoms/Dropdown.js:476`) renders a **string** as `profilePic[0].toUpperCase()` and only renders a picture when handed a **React element**. #868 passed the resolved URL **string**, so the header showed `"https…"[0]` → **"H"**. That's also why the initial looked "random" — it tracked the first char of whatever string was passed (name → "C", URL → "H").

**Fix:** pass `<ImageComponent src={url}/>` when a photo exists; keep the name-string fallback so the text initial still works when there's no photo.

### 2. Citizen desktop sidebar (`StaticCitizenSideBar.js`)
The `Profile` avatar hard-coded `src={defaultImage}` and never used the user's photo at all — #868 only wired the mobile `Hamburger` path, not the desktop static sidebar (the left-menu surface QA tested on desktop).

**Fix:** resolve the logged-in user's photo via the same `resolveProfilePhoto` helper and feed it to the avatar, falling back to the default glyph.

## Notes
- No tenant-specific values; both paths degrade to the prior fallback when no photo is set (holistic — redeploys identically on any tenant).
- Frontend-only; both edited files parse clean under esbuild (JSX).

## Validation
- [x] Root cause reproduced live on bomet (employee top-right "H"), Filefetch 200 confirmed, `Dropdown.js` string→charAt(0) contract confirmed in source.
- [ ] Post-build click-through on a live box: employee top-right + citizen desktop left-menu show the uploaded photo and persist on refresh (to confirm after this builds into the bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)