### PR TITLE
fix(dashboard): date-filter change blanks dashboard on null filterOptions

### DIFF
--- a/frontend/micro-ui/web/src/dashboard/config/dashboardFilters.js
+++ b/frontend/micro-ui/web/src/dashboard/config/dashboardFilters.js
@@ -53,14 +53,18 @@ export function persistDashboardFilters(filters, dynamicOptions) {
 export function reconcileFiltersWithOptions(filters, filterOptions) {
   if (!filterOptions) return filters;
 
-  const next = sanitizeFilters(filters, filterOptions);
+  // `filters` can momentarily be null (e.g. a rapid external change racing the options
+  // effect); sanitizeFilters already tolerates that, but the comparison below dereferences
+  // it — fall back to sane defaults so we never read `.geography` off null.
+  const safe = filters && typeof filters === "object" ? filters : buildDefaultFilters();
+  const next = sanitizeFilters(safe, filterOptions);
   const changed =
-    next.geography !== filters.geography ||
-    next.complaintType !== filters.complaintType ||
-    next.dateFrom !== filters.dateFrom ||
-    next.dateTo !== filters.dateTo;
+    next.geography !== safe.geography ||
+    next.complaintType !== safe.complaintType ||
+    next.dateFrom !== safe.dateFrom ||
+    next.dateTo !== safe.dateTo;
 
-  return changed ? next : filters;
+  return changed ? next : safe;
 }
 
 export function resolveSubMetricId(metric, globalFilters) {

--- a/frontend/micro-ui/web/src/dashboard/config/globalFilterGroups.js
+++ b/frontend/micro-ui/web/src/dashboard/config/globalFilterGroups.js
@@ -92,6 +92,12 @@ export function sanitizeFilters(raw, dynamicOptions = {}) {
     return defaults;
   }
 
+  // The `= {}` default only applies when the arg is `undefined`. Callers such as
+  // persistDashboardFilters(filters, dynamicOptions) can pass `null` explicitly, which
+  // slips past the default and makes `dynamicOptions[field.id]` throw on the first select
+  // field ("geography") — blanking the dashboard on any date-filter change. Normalize it.
+  const options = dynamicOptions && typeof dynamicOptions === "object" ? dynamicOptions : {};
+
   const next = { ...defaults };
 
   for (const field of GLOBAL_FILTER_FIELDS) {
@@ -100,8 +106,8 @@ export function sanitizeFilters(raw, dynamicOptions = {}) {
       next[field.id] = value;
     }
     if (field.type === "select") {
-      const options = dynamicOptions[field.id] ?? field.options;
-      if (options.some((opt) => opt.id === value)) {
+      const fieldOptions = options[field.id] ?? field.options;
+      if (fieldOptions.some((opt) => opt.id === value)) {
         next[field.id] = value;
       }
     }


### PR DESCRIPTION
## Problem
Changing any date in the supervisor dashboard filter bar blanks the whole page with:

```
TypeError: Cannot read properties of null (reading 'geography')
    at sanitizeFilters (globalFilterGroups.js)
    at persistDashboardFilters (dashboardFilters.js)
```

## Root cause
`sanitizeFilters(raw, dynamicOptions = {})` — the `= {}` default only fires when the argument is `undefined`. `persistDashboardFilters(filters, dynamicOptions)` can pass `dynamicOptions` as an explicit `null` (options not yet resolved), which slips past the default. The loop then does `dynamicOptions[field.id]`, and the first `select`-type field is `geography`, so it throws reading `null["geography"]`. (Date fields are checked first and don't touch `dynamicOptions`, which is why the error always names `geography`.)

## Fix
- `globalFilterGroups.sanitizeFilters`: normalize a null / non-object `dynamicOptions` to `{}` before the loop.
- `dashboardFilters.reconcileFiltersWithOptions`: guard the sibling path that dereferences a possibly-null `filters` in its change comparison (same null class, latent).

Both are null-safety guards only — no behavior change on the happy path.

## Verification
Reproduced live on bomet (`/dashboard-ui`): changing the From date threw the error and blanked the page. With the guard applied, the date change updates cleanly and tiles stay rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)