### PR TITLE
fix(877): mobile number validation schema update + DB dump cleanup

### DIFF
--- a/digit-mcp/src/tools/mdms-tenant.ts
+++ b/digit-mcp/src/tools/mdms-tenant.ts
@@ -39,17 +39,16 @@ export function isDuplicateError(msg: string): boolean {
 /**
  * Evict egov-user's Redis-backed ValidationRulesCache entry for a tenant.
  *
- * egov-user caches UserValidation rules in a Redis hash:
+ * egov-user caches MobileNumberValidation rules in a Redis hash:
  *   key: validationRules   field: validation:<tenantId>
  *
- * The default-data-handler seeds India UserValidation for the target tenant
- * at stack startup (before bootstrap). egov-user's first mz request (from
- * the data-handler's own MDMS calls which carry mz in the JWT userInfo)
- * triggers a Cache MISS → reads India from MDMS → caches India in Redis with
+ * The default-data-handler seeds the MobileNumberValidation record for the
+ * target tenant at stack startup (before bootstrap). egov-user's first mz
+ * request triggers a Cache MISS → reads from MDMS → caches in Redis with
  * TTL=3600s. MCP bootstrap then corrects MDMS to the country pattern but
- * Redis still holds India. Evicting the key forces egov-user to re-read from
- * MDMS on the next _createnovalidate call and find the correct pattern.
- * Non-fatal — bootstrap continues if Redis is unreachable.
+ * Redis still holds the stale record. Evicting the key forces egov-user to
+ * re-read from MDMS on the next _createnovalidate call and find the correct
+ * pattern. Non-fatal — bootstrap continues if Redis is unreachable.
  */
 async function evictValidationCache(tenantId: string): Promise<void> {
   const host = process.env.EGOV_REDIS_HOST || 'redis';
@@ -972,50 +971,39 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
         mobile_regex: {
           type: 'string',
           description:
-            'Mobile-number regex for the synthesized common-masters.UserValidation "mobile" rule ' +
-            '(citizen register). Source tenants (pg/statea) ship no UserValidation, so it must ' +
-            'be synthesized, not copied. Default "^[6-9][0-9]{9}$" (India 10-digit). ' +
+            'Mobile-number regex stored as mobileNumberRegex in the synthesized ' +
+            'common-masters.MobileNumberValidation record. Inherited from the source tenant\'s ' +
+            'MobileNumberValidation when omitted. Default "^[6-9][0-9]{9}$" (India 10-digit). ' +
             'Kenya: "^[17][0-9]{8}$". Mozambique: "^8[0-9]{8}$".',
         },
         mobile_length: {
           type: 'integer',
           description:
-            'Mobile-number length (min=max) for the back-compat "mobile" UserValidation rule. ' +
-            'Default 10 (India). Kenya/Mozambique: 9. Ignored when user_validation is supplied.',
+            'Mobile-number length used to generate a conforming ADMIN mobile number when ' +
+            'admin_mobile is not supplied. Default 10 (India). Kenya/Mozambique: 9. ' +
+            'Ignored when user_validation is supplied.',
         },
         mobile_prefix: {
           type: 'string',
           description:
-            'Country dialling prefix for the "mobile" UserValidation rule (e.g. "+258" for ' +
-            'Mozambique, "+254" for Kenya). Stored in attributes.prefix so useMobileValidation.js ' +
-            'can read it via mdmsConfig?.attributes?.prefix. Ignored when user_validation is supplied.',
-        },
-        mobile_allowed_starting_characters: {
-          type: 'array',
-          items: { type: 'string' },
-          description:
-            'Allowed leading digit(s) for the mobile field (e.g. ["8"] for Mozambique, ' +
-            '["1","7"] for Kenya). Stored in rules.allowedStartingCharacters on the MDMS record. ' +
+            'Country dialling prefix (e.g. "+258" for Mozambique, "+254" for Kenya). ' +
+            'Used as the countryCode field and x-unique key in the MobileNumberValidation record. ' +
+            'Inherited from the source tenant\'s MobileNumberValidation when omitted. ' +
             'Ignored when user_validation is supplied.',
-        },
-        mobile_error_message: {
-          type: 'string',
-          description: 'Error message (or localization key) for the back-compat "mobile" rule.',
         },
         mobile_zone: {
           type: 'string',
           description:
-            'Zone/country label for the new UserValidation record (e.g. "Mozambique", "Kenya"). ' +
-            'Stored in the "zone" field so the country-specific record coexists with the India ' +
-            'record (pg) without violating x-unique:[\'zone\']. Defaults to the state-level tenant id.',
+            'Deprecated — superseded by mobile_prefix. Accepted for backwards compatibility ' +
+            'but ignored when mobile_prefix is also provided.',
         },
         admin_mobile: {
           type: 'string',
           description:
             'Mobile number for the provisioned ADMIN user on the target tenant. Optional — ' +
             'if omitted, a value conforming to mobile_regex is generated (the source country\'s ' +
-            'mobile would fail the target tenant\'s UserValidation, e.g. India 10-digit vs ' +
-            'Mozambique ^8[0-9]{8}$). Set it to pin a specific number.',
+            'mobile would fail the target tenant\'s MobileNumberValidation pattern). ' +
+            'Set it to pin a specific number.',
         },
         pincode_allowlist: {
           type: 'array',
@@ -1031,22 +1019,17 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
         user_validation: {
           type: 'array',
           description:
-            'Config-driven user-field validation rules — one entry per field. Fully declarative: ' +
-            'a new country/field is config, not code. Each entry maps to a common-masters.UserValidation ' +
-            'record (egov-user ValidationData). When supplied, supersedes mobile_regex/mobile_length.',
+            'Mobile validation rules — one entry per country. Each entry maps to a ' +
+            'common-masters.MobileNumberValidation record (x-unique: countryCode). ' +
+            'When supplied, supersedes mobile_regex/mobile_prefix.',
           items: {
             type: 'object',
             properties: {
-              fieldType: { type: 'string', description: 'e.g. "mobile", "userName", "email", "name"' },
-              zone: { type: 'string', description: 'Country/zone label (e.g. "Mozambique"). Used as x-unique key so records with different zones coexist. Defaults to state-level tenant id.' },
-              prefix: { type: 'string', description: 'Country dialling prefix (e.g. "+258"). Stored in attributes.prefix on the MDMS record.' },
-              allowedStartingCharacters: { type: 'array', items: { type: 'string' }, description: 'Allowed leading digits (e.g. ["8"]). Stored in rules.allowedStartingCharacters.' },
-              pattern: { type: 'string', description: 'regex the field value must match' },
-              minLength: { type: 'integer' },
-              maxLength: { type: 'integer' },
-              errorMessage: { type: 'string', description: 'message or localization key' },
+              countryCode: { type: 'string', description: 'Country dialling prefix, used as x-unique key (e.g. "+254" for Kenya, "+258" for Mozambique, "+91" for India).' },
+              mobileNumberRegex: { type: 'string', description: 'regex the mobile number must match (e.g. "^[17][0-9]{8}$")' },
+              default: { type: 'boolean', description: 'Whether this is the default validation rule for the tenant (default: true).' },
             },
-            required: ['fieldType', 'pattern'],
+            required: ['countryCode', 'mobileNumberRegex'],
           },
         },
       },
@@ -1060,27 +1043,24 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
 
       const target = args.target_tenant as string;
       const source = (args.source_tenant as string) || 'pg';
-      if (!args.mobile_regex) {
-        // When no explicit regex is passed (e.g. the bootstrap wizard, which
-        // only sends target_tenant + source_tenant), inherit the SOURCE
-        // tenant's own mobile rule from common-masters.UserValidation so the
-        // derived ADMIN mobile validates against the same egov-user rule the
-        // target inherits (e.g. Kenya ^0?[17][0-9]{8}$) instead of a hardcoded
-        // India default. Tenant-specific values stay in MDMS, not in code.
+      if (!args.mobile_regex || !args.mobile_prefix) {
+        // When regex or prefix are not explicit (e.g. the bootstrap wizard only
+        // sends target_tenant + source_tenant), inherit from the SOURCE tenant's
+        // common-masters.MobileNumberValidation so the derived ADMIN mobile and
+        // the seeded rule match what the target will enforce.
         try {
-          const uv = await digitApi.mdmsV2SearchRaw(source, 'common-masters.UserValidation', { limit: 50 });
-          const mob = (uv || []).find(
-            (r: any) => (r && r.data && r.data.fieldType === 'mobile') || (r && r.uniqueIdentifier === 'mobile'),
-          );
-          const rules = (mob && mob.data && (mob.data as any).rules) as any;
-          if (rules && rules.pattern) {
-            (args as any).mobile_regex = rules.pattern;
-            if (!args.mobile_length && rules.minLength) {
-              (args as any).mobile_length = rules.minLength;
+          const mnv = await digitApi.mdmsV2SearchRaw(source, 'common-masters.MobileNumberValidation', { limit: 50 });
+          const defaultRecord = (mnv || []).find((r: any) => r?.data?.default === true) || (mnv || [])[0];
+          if (defaultRecord?.data) {
+            if (!args.mobile_regex && (defaultRecord.data as any).mobileNumberRegex) {
+              (args as any).mobile_regex = (defaultRecord.data as any).mobileNumberRegex;
+            }
+            if (!args.mobile_prefix && (defaultRecord.data as any).countryCode) {
+              (args as any).mobile_prefix = (defaultRecord.data as any).countryCode;
             }
           }
         } catch (e) {
-          /* no UserValidation at source -> fall through to the generic default */
+          /* no MobileNumberValidation at source -> fall through to the generic default */
         }
       }
       const mobileRegex = (args.mobile_regex as string) || '^[6-9][0-9]{9}$';
@@ -1544,32 +1524,21 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
         }
       }
 
-      // ── Step 3b: INSERT country-specific common-masters.UserValidation ──────
-      // Schema + India record (zone:'India') are seeded by default-data-handler
-      // at pg and copied to new root tenants via TenantConsumer. MCP only INSERTs
-      // the country-specific record identified by zone. x-unique:['zone'] allows
-      // both records to coexist; egov-user fetches all active mobile rules.
-      //
-      // FULLY CONFIG-DRIVEN: the caller passes `user_validation` — a list of
-      // { fieldType, zone, pattern, minLength, maxLength, errorMessage } — so a
-      // new country/field is pure config, no code. `mobile_regex`/`mobile_length`/
-      // `mobile_zone` are a back-compat shorthand that builds a single entry.
-      const stateRoot = (target as string).includes('.') ? (target as string).split('.')[0] : (target as string);
-      const mobileZone = (args.mobile_zone as string) || 'mobile';
-      const validationRules: Array<{ fieldType: string; zone: string; prefix?: string; allowedStartingCharacters?: string[]; pattern: string; minLength?: number; maxLength?: number; errorMessage?: string }> =
+      // ── Step 3b: INSERT country-specific common-masters.MobileNumberValidation ──
+      // Schema is seeded by default-data-handler at pg and copied to new root tenants
+      // via TenantConsumer. MCP INSERTs the target-country record identified by
+      // countryCode (the x-unique key). `mobile_regex`/`mobile_prefix` are a
+      // back-compat shorthand; `user_validation` is the fully declarative form.
+      const mobileCountryCode = (args.mobile_prefix as string) || '+91';
+      const validationRules: Array<{ countryCode: string; mobileNumberRegex: string; default?: boolean }> =
         Array.isArray(args.user_validation) && (args.user_validation as unknown[]).length > 0
           ? (args.user_validation as typeof validationRules)
           : [{
-              fieldType: 'mobile',
-              zone: mobileZone,
-              prefix: (args.mobile_prefix as string) || undefined,
-              allowedStartingCharacters: (args.mobile_allowed_starting_characters as string[]) || undefined,
-              pattern: mobileRegex,
-              minLength: Number(args.mobile_length) || 10,
-              maxLength: Number(args.mobile_length) || 10,
-              errorMessage: (args.mobile_error_message as string) || undefined,
+              countryCode: mobileCountryCode,
+              mobileNumberRegex: mobileRegex,
+              default: true,
             }];
-      emitProgress({ phase: 'uservalidation:start', message: `Synthesizing ${validationRules.length} UserValidation rule(s)`, pct: 76 });
+      emitProgress({ phase: 'mobilevalidation:start', message: `Synthesizing ${validationRules.length} MobileNumberValidation rule(s)`, pct: 76 });
       let uvNewlySeeded = false;
       try {
         // data-handler seeds the schema at pg and TenantConsumer copies it to the
@@ -1580,55 +1549,46 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
           const schemaMaxAttempts = 20; // up to 60 s
           let schemaReady = false;
           for (let i = 0; i < schemaMaxAttempts; i++) {
-            const schemas = await digitApi.mdmsSchemaSearch(target, ['common-masters.UserValidation']).catch(() => []);
+            const schemas = await digitApi.mdmsSchemaSearch(target, ['common-masters.MobileNumberValidation']).catch(() => []);
             if (schemas && schemas.length > 0) { schemaReady = true; break; }
-            emitProgress({ phase: 'uservalidation:wait', message: `Waiting for common-masters.UserValidation schema at "${target}" (attempt ${i + 1}/${schemaMaxAttempts})…` });
+            emitProgress({ phase: 'mobilevalidation:wait', message: `Waiting for common-masters.MobileNumberValidation schema at "${target}" (attempt ${i + 1}/${schemaMaxAttempts})…` });
             await new Promise(res => setTimeout(res, schemaWaitMs));
           }
           if (!schemaReady) {
-            throw new Error(`common-masters.UserValidation schema not found at "${target}" after ${schemaMaxAttempts * schemaWaitMs / 1000}s — default-data-handler may not have seeded it yet`);
+            throw new Error(`common-masters.MobileNumberValidation schema not found at "${target}" after ${schemaMaxAttempts * schemaWaitMs / 1000}s — default-data-handler may not have seeded it yet`);
           }
         }
         // mdms-v2 search is HIERARCHICAL — filter to exact-tenant rows only,
-        // keyed by zone (the x-unique field).
-        const existingUVraw = await digitApi.mdmsV2SearchRaw(target, 'common-masters.UserValidation', { limit: 50 });
-        const getExistingByZone = (zone: string) => existingUVraw.find(
+        // keyed by countryCode (the x-unique field).
+        const existingUVraw = await digitApi.mdmsV2SearchRaw(target, 'common-masters.MobileNumberValidation', { limit: 50 });
+        const getExistingByCountryCode = (countryCode: string) => existingUVraw.find(
           (r) => (r as { tenantId?: string }).tenantId === target
-            && (r as { data?: { zone?: string } }).data?.zone === zone,
+            && (r as { data?: { countryCode?: string } }).data?.countryCode === countryCode,
         );
         for (const rule of validationRules) {
-          if (getExistingByZone(rule.zone)) {
-            results.data.skipped.push(`common-masters.UserValidation/${rule.zone}`);
+          if (getExistingByCountryCode(rule.countryCode)) {
+            results.data.skipped.push(`common-masters.MobileNumberValidation/${rule.countryCode}`);
             continue;
           }
           try {
-            await mdmsCreateWithSchemaWait(target, 'common-masters.UserValidation', rule.zone, {
-              fieldType: rule.fieldType,
-              zone: rule.zone,
-              isActive: true,
-              default: true,
-              ...(rule.prefix ? { attributes: { prefix: rule.prefix } } : {}),
-              rules: {
-                pattern: rule.pattern,
-                minLength: rule.minLength ?? undefined,
-                maxLength: rule.maxLength ?? undefined,
-                ...(rule.allowedStartingCharacters ? { allowedStartingCharacters: rule.allowedStartingCharacters } : {}),
-                errorMessage: rule.errorMessage ?? `Invalid ${rule.fieldType}`,
-              },
+            await mdmsCreateWithSchemaWait(target, 'common-masters.MobileNumberValidation', rule.countryCode, {
+              countryCode: rule.countryCode,
+              mobileNumberRegex: rule.mobileNumberRegex,
+              default: rule.default ?? true,
             });
           } catch (e) {
             const m = e instanceof Error ? e.message : String(e);
             if (isDuplicateError(m)) {
-              results.data.skipped.push(`common-masters.UserValidation/${rule.zone} (already exists)`);
+              results.data.skipped.push(`common-masters.MobileNumberValidation/${rule.countryCode} (already exists)`);
               continue;
             }
             throw e;
           }
-          results.data.copied.push(`common-masters.UserValidation/${rule.zone} (inserted, pattern=${rule.pattern})`);
+          results.data.copied.push(`common-masters.MobileNumberValidation/${rule.countryCode} (inserted, pattern=${rule.mobileNumberRegex})`);
           uvNewlySeeded = true;
         }
       } catch (e) {
-        results.data.failed.push(`common-masters.UserValidation: ${e instanceof Error ? e.message : String(e)}`);
+        results.data.failed.push(`common-masters.MobileNumberValidation: ${e instanceof Error ? e.message : String(e)}`);
       }
 
       // Poll until the inserted record is readable before Step 4 creates the ADMIN user.
@@ -1638,12 +1598,12 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
         let uvReady = false;
         for (let attempt = 0; attempt < maxAttempts; attempt++) {
           try {
-            const uvRows = await digitApi.mdmsV2SearchRaw(target, 'common-masters.UserValidation', { limit: 10 });
+            const uvRows = await digitApi.mdmsV2SearchRaw(target, 'common-masters.MobileNumberValidation', { limit: 10 });
             const allCorrect = validationRules.every(rule =>
               uvRows.some(r =>
                 (r as { tenantId?: string }).tenantId === target &&
-                (r as { data?: { zone?: string } }).data?.zone === rule.zone &&
-                (r as { data?: { rules?: { pattern?: string } } }).data?.rules?.pattern === rule.pattern,
+                (r as { data?: { countryCode?: string } }).data?.countryCode === rule.countryCode &&
+                (r as { data?: { mobileNumberRegex?: string } }).data?.mobileNumberRegex === rule.mobileNumberRegex,
               ),
             );
             if (allCorrect) { uvReady = true; break; }
@@ -1651,7 +1611,7 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
           await new Promise(res => setTimeout(res, pollIntervalMs));
         }
         if (!uvReady) {
-          console.warn(`[tenant_bootstrap] UserValidation not yet readable on "${target}" after ${maxAttempts * pollIntervalMs / 1000}s — proceeding anyway`);
+          console.warn(`[tenant_bootstrap] MobileNumberValidation not yet readable on "${target}" after ${maxAttempts * pollIntervalMs / 1000}s — proceeding anyway`);
         }
       }
 
@@ -3358,7 +3318,7 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
           type: 'string',
           description: 'Tenant ID the record lives on (must match record.tenantId exactly — inherited records cannot be updated from a child tenant).',
         },
-        schema_code: { type: 'string', description: 'MDMS schema code, e.g. "common-masters.UserValidation".' },
+        schema_code: { type: 'string', description: 'MDMS schema code, e.g. "common-masters.MobileNumberValidation".' },
         unique_identifier: { type: 'string', description: 'The record\'s uniqueIdentifier.' },
         data: { type: 'object', description: 'Optional. Full replacement for the record\'s `data` block. Mutually exclusive with `patch`.' },
         patch: { type: 'object', description: 'Optional. Top-level keys to merge into existing data. Mutually exclusive with `data`.' },

--- a/local-setup/tests/e2e/common/mdms-mobile.ts
+++ b/local-setup/tests/e2e/common/mdms-mobile.ts
@@ -1,7 +1,7 @@
 /**
  * Mobile-number validation rule, sourced from MDMS.
  *
- * Reads the rule under MDMS schema `ValidationConfigs.mobileNumberValidation`
+ * Reads the rule under MDMS schema `common-masters.MobileNumberValidation`
  * for the active tenant — the same rule the citizen + employee login forms
  * use. Lets specs stay tenant-agnostic: the same test passes against an
  * Ethiopia tenant (9-digit starting with 1/7), a Kenya tenant (9-digit),
@@ -42,14 +42,36 @@ export interface MobileRuleOptions {
 }
 
 /**
+ * Derive min/max digit counts from a mobile-number regex.
+ * Tries every (lead, fill) digit combo at lengths 5–15 and records which
+ * lengths produce a match. Falls back to {min:10, max:10} if the regex
+ * is invalid or no length matches.
+ */
+function deriveMobileLengths(regex: string): { min: number; max: number } {
+  let re: RegExp | null = null;
+  try { re = new RegExp(regex); } catch { return { min: 10, max: 10 }; }
+  let min = 16, max = 0;
+  for (const f of '0123456789') {
+    for (const d of '0123456789') {
+      for (let len = 5; len <= 15; len++) {
+        if (re.test(f + d.repeat(len - 1))) {
+          if (len < min) min = len;
+          if (len > max) max = len;
+        }
+      }
+    }
+  }
+  return max > 0 ? { min, max } : { min: 10, max: 10 };
+}
+
+/**
  * Fetch the live mobile-validation rule for `tenant` from MDMS.
  *
  * Authenticates against `rootTenant` (defaults to env ROOT_TENANT or the
  * supplied tenant) with admin credentials, then queries MDMS v2 for the
- * `ValidationConfigs.mobileNumberValidation` schema scoped to `tenant`.
- * Returns the record whose `uniqueIdentifier === 'defaultMobileValidation'`
- * if present, otherwise the first record. Falls back to a 10-digit numeric
- * rule on any failure.
+ * `common-masters.MobileNumberValidation` schema scoped to `tenant`.
+ * Returns the record whose `data.default === true` if present, otherwise
+ * the first record. Falls back to a 10-digit numeric rule on any failure.
  */
 export async function getMobileValidationRule(
   tenant: string,
@@ -83,29 +105,26 @@ export async function getMobileValidationRule(
         RequestInfo: ri,
         MdmsCriteria: {
           tenantId: tenant,
-          schemaCode: 'ValidationConfigs.mobileNumberValidation',
+          schemaCode: 'common-masters.MobileNumberValidation',
         },
       }),
     });
     if (!resp.ok) return FALLBACK;
     const json = (await resp.json()) as {
-      mdms?: Array<{ uniqueIdentifier?: string; data?: { rules?: Partial<MobileRule> } }>;
+      mdms?: Array<{ data?: { countryCode?: string; mobileNumberRegex?: string; default?: boolean } }>;
     };
     const records = json.mdms ?? [];
-    const preferred =
-      records.find((r) => r.uniqueIdentifier === 'defaultMobileValidation') ?? records[0];
-    const rules = preferred?.data?.rules;
-    if (!rules) return FALLBACK;
+    const preferred = records.find((r) => r.data?.default === true) ?? records[0];
+    const data = preferred?.data;
+    if (!data?.mobileNumberRegex) return FALLBACK;
+    const lengths = deriveMobileLengths(data.mobileNumberRegex);
     return {
-      prefix: typeof rules.prefix === 'string' ? rules.prefix : undefined,
-      pattern: typeof rules.pattern === 'string' ? rules.pattern : FALLBACK.pattern,
-      minLength: typeof rules.minLength === 'number' ? rules.minLength : FALLBACK.minLength,
-      maxLength: typeof rules.maxLength === 'number' ? rules.maxLength : FALLBACK.maxLength,
-      errorMessage:
-        typeof rules.errorMessage === 'string' ? rules.errorMessage : FALLBACK.errorMessage,
-      allowedStartingDigits: Array.isArray(rules.allowedStartingDigits)
-        ? (rules.allowedStartingDigits as string[])
-        : undefined,
+      prefix: typeof data.countryCode === 'string' ? data.countryCode : undefined,
+      pattern: data.mobileNumberRegex,
+      minLength: lengths.min,
+      maxLength: lengths.max,
+      errorMessage: `Please enter a valid ${lengths.max}-digit mobile number`,
+      allowedStartingDigits: derivedStartingDigits(data.mobileNumberRegex) ?? undefined,
     };
   } catch {
     return FALLBACK;

--- a/local-setup/tests/e2e/specs/citizen/citizen-pgr-complaint-api.spec.ts
+++ b/local-setup/tests/e2e/specs/citizen/citizen-pgr-complaint-api.spec.ts
@@ -45,7 +45,7 @@ test.describe.serial('Citizen PGR complaint — full lifecycle', () => {
   let complaintCreated = false;
   let complaintAssigned = false;
   // Tenant-aware fixtures sourced from the live deployment at setup time.
-  // - mobile rule comes from MDMS ValidationConfigs.mobileNumberValidation
+  // - mobile rule comes from MDMS common-masters.MobileNumberValidation
   // - locality is a RANDOMLY-picked leaf from the boundary tree (egov-location)
   // Random picking is deliberate: it forces the test to exercise different
   // wards across runs instead of pinning a single happy path.

--- a/local-setup/tests/static/mobile-rules.test.ts
+++ b/local-setup/tests/static/mobile-rules.test.ts
@@ -1,7 +1,7 @@
 /**
  * Unit tests for utils/mobile.ts — tenant-aware test mobile numbers.
  *
- * egov-user enforces the tenant's UserValidation mobile rule even on
+ * egov-user enforces the tenant's MobileNumberValidation mobile rule even on
  * _createnovalidate (ethiopia: ^[17][0-9]{8}$ → INVALID_MOBILE_FORMAT
  * for the old hardcoded 10-digit numbers), so the generators must
  * follow CITIZEN_MOBILE_LENGTH / CITIZEN_MOBILE_PREFIX and default to
@@ -104,7 +104,7 @@ describe('tenant-rule self-assert (CITIZEN_MOBILE_PATTERN)', () => {
     expect(uniqueMobile()).toMatch(/^0?[17][0-9]{8}$/);
   });
 
-  test('no pattern set → no assertion (pg/statea ship no UserValidation)', () => {
+  test('no pattern set → no assertion (pg/statea ship no MobileNumberValidation)', () => {
     process.env.CITIZEN_MOBILE_LENGTH = '10';
     process.env.CITIZEN_MOBILE_PREFIX = '9';
     expect(() => uniqueMobile()).not.toThrow();

--- a/tests/integration-tests/tests/citizen/login-mobile.spec.ts
+++ b/tests/integration-tests/tests/citizen/login-mobile.spec.ts
@@ -5,10 +5,10 @@
  * error with no indication of what a valid number looks like. Three
  * things had to change (PR #28, 3b7c917):
  *
- * 1. The citizen login now reads `ValidationConfigs.mobileNumberValidation`
+ * 1. The citizen login now reads `common-masters.MobileNumberValidation`
  *    from MDMS rather than the hardcoded Indian 10-digit regex. On
- *    naipepea this resolves to the Kenya rule (`^0?[17][0-9]{8}$`) with
- *    its own `errorMessage`.
+ *    naipepea this resolves to the Kenya rule (`^0?[17][0-9]{8}$`) driven
+ *    by the countryCode/mobileNumberRegex fields.
  * 2. A helper hint renders under the field even in the idle state, so the
  *    citizen knows what length to type before they type anything.
  * 3. The error renders inline under the input, not just as a toast.

--- a/tests/integration-tests/tests/specs/debug-mdms-api.spec.ts
+++ b/tests/integration-tests/tests/specs/debug-mdms-api.spec.ts
@@ -3,12 +3,12 @@ import { test } from '@playwright/test';
 test('capture MDMS calls from login page', {
   annotation: {
     type: 'description',
-    description: `Diagnostic spec used to inspect what the citizen login page actually requests from MDMS — specifically which tenant it uses and which validation modules it queries (UserValidation, ValidationConfigs, mobileNumberValidation). The test attaches request/response listeners, navigates to the login page, and prints every relevant MDMS POST it sees plus the STATE_LEVEL_TENANT_ID the UI resolved.
+    description: `Diagnostic spec used to inspect what the citizen login page actually requests from MDMS — specifically which tenant it uses and which validation modules it queries (MobileNumberValidation, ValidationConfigs). The test attaches request/response listeners, navigates to the login page, and prints every relevant MDMS POST it sees plus the STATE_LEVEL_TENANT_ID the UI resolved.
 
 Steps:
 1. Attach listeners to capture every POST that hits an mdms URL plus its JSON response.
 2. Navigate to https://naipepea.digit.org/digit-ui/citizen/login and wait 10s for the page to settle.
-3. Walk the captured calls and print URL/tenant/modules/response for any whose body mentions mobileNumberValidation, UserValidation, or ValidationConfigs.
+3. Walk the captured calls and print URL/tenant/modules/response for any whose body mentions MobileNumberValidation or ValidationConfigs.
 4. Print the total MDMS POST count and read STATE_LEVEL_TENANT_ID off window.globalConfigs.
 
 This is a diagnostic, not an assertion-driven test — it has no expect() calls and exists to surface what's going over the wire when mobile validation looks wrong.`,
@@ -44,7 +44,7 @@ This is a diagnostic, not an assertion-driven test — it has no expect() calls 
   // Print all MDMS calls that mentioned mobile/Validation
   for (const c of mdmsCalls) {
     const body = c.body || '';
-    if (body.includes('mobileNumberValidation') || body.includes('UserValidation') || body.includes('ValidationConfigs')) {
+    if (body.includes('MobileNumberValidation') || body.includes('mobileNumberValidation') || body.includes('ValidationConfigs')) {
       console.log('=== MDMS CALL ===');
       console.log('URL:', c.url);
       try {
@@ -55,8 +55,8 @@ This is a diagnostic, not an assertion-driven test — it has no expect() calls 
         console.log('Body (raw):', body.slice(0, 300));
       }
       if (c.response) {
-        const tc = c.response?.MdmsRes?.ValidationConfigs?.mobileNumberValidation;
-        console.log('Returned mobileNumberValidation:', JSON.stringify(tc));
+        const tc = c.response?.mdms;
+        console.log('Returned MobileNumberValidation records:', JSON.stringify(tc));
       }
     }
   }

--- a/tests/integration-tests/tests/specs/verify-mobile-validation.spec.ts
+++ b/tests/integration-tests/tests/specs/verify-mobile-validation.spec.ts
@@ -5,7 +5,7 @@ import { getMobileValidationRule, generateValidMobile } from '../utils/mdms-mobi
 test('mobile validation reflects the deployment MDMS rule', {
   annotation: {
     type: 'description',
-    description: `End-to-end verification that the citizen login page reflects the deployment's MDMS UserValidation rule (originally pinned to the 9-digit-only CCRS Kenya rollout, now parameterized). The page must hard-cap input length at rule.maxLength, the visible counter must read x/<maxLength>, and typing a too-long number must truncate to <= maxLength — confirming the MDMS rule made it through the validationRules Redis cache and into the UI.
+    description: `End-to-end verification that the citizen login page reflects the deployment's MDMS MobileNumberValidation rule (originally pinned to the 9-digit-only CCRS Kenya rollout, now parameterized). The page must hard-cap input length at rule.maxLength, the visible counter must read x/<maxLength>, and typing a too-long number must truncate to <= maxLength — confirming the MDMS rule made it through the validationRules Redis cache and into the UI.
 
 Steps:
 1. Fetch the live mobile-validation rule from MDMS for TENANT.

--- a/tests/integration-tests/tests/utils/mdms-mobile.ts
+++ b/tests/integration-tests/tests/utils/mdms-mobile.ts
@@ -2,13 +2,11 @@
  * Mobile-number validation rule, sourced from MDMS.
  *
  * The citizen + employee login forms validate against the rule stored
- * under MDMS schema `ValidationConfigs.mobileNumberValidation` for the
+ * under MDMS schema `common-masters.MobileNumberValidation` for the
  * active tenant. The rule controls:
  *   - prefix     (country code shown to the user, e.g. "+254")
- *   - pattern    (regex applied to the entered number)
- *   - minLength / maxLength
- *   - errorMessage  (the human-readable string the UI surfaces inline)
- *   - allowedStartingDigits
+ *   - pattern    (mobileNumberRegex applied to the entered number)
+ *   - minLength / maxLength (derived from the regex)
  *
  * Reading the rule here lets specs stay tenant-agnostic — the same test
  * passes against ke.nairobi (9-digit starting with 1/7) and a 10-digit
@@ -40,6 +38,55 @@ const ADMIN_USER = process.env.ADMIN_USER || 'ADMIN';
 const ADMIN_PASS = process.env.ADMIN_PASSWORD || 'eGov@123';
 
 /**
+ * Derive min/max digit counts from a mobile-number regex.
+ * Tries every (lead, fill) digit combo at lengths 5–15 and records which
+ * lengths produce a match. Falls back to {min:10, max:10} if the regex
+ * is invalid or no length matches.
+ */
+function deriveMobileLengths(regex: string): { min: number; max: number } {
+  let re: RegExp | null = null;
+  try { re = new RegExp(regex); } catch { return { min: 10, max: 10 }; }
+  let min = 16, max = 0;
+  for (const f of '0123456789') {
+    for (const d of '0123456789') {
+      for (let len = 5; len <= 15; len++) {
+        if (re.test(f + d.repeat(len - 1))) {
+          if (len < min) min = len;
+          if (len > max) max = len;
+        }
+      }
+    }
+  }
+  return max > 0 ? { min, max } : { min: 10, max: 10 };
+}
+
+/**
+ * If the rule's regex starts with a character class like `^[17]` or
+ * `^[6-9]`, extract the allowed starting digits from it.
+ */
+function derivedStartingDigits(pattern: string): string[] | null {
+  const m = pattern.match(/^\^?\[([0-9\-]+)\]/);
+  if (!m) return null;
+  const body = m[1];
+  const set = new Set<string>();
+  let i = 0;
+  while (i < body.length) {
+    if (i + 2 < body.length && body[i + 1] === '-') {
+      const start = parseInt(body[i], 10);
+      const end = parseInt(body[i + 2], 10);
+      if (Number.isInteger(start) && Number.isInteger(end)) {
+        for (let c = start; c <= end; c++) set.add(String(c));
+      }
+      i += 3;
+    } else {
+      set.add(body[i]);
+      i++;
+    }
+  }
+  return [...set];
+}
+
+/**
  * Fetch the live mobile-validation rule for `tenant` from MDMS. Falls
  * back to a 10-digit-numeric default if the schema search fails — this
  * is the same shape the configurator's UI uses for new tenants that
@@ -57,27 +104,25 @@ export async function getMobileValidationRule(tenant: string): Promise<MobileRul
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         RequestInfo: ri,
-        MdmsCriteria: { tenantId: tenant, schemaCode: 'ValidationConfigs.mobileNumberValidation' },
+        MdmsCriteria: { tenantId: tenant, schemaCode: 'common-masters.MobileNumberValidation' },
       }),
     });
     if (!resp.ok) return FALLBACK;
     const json = (await resp.json()) as {
-      mdms?: Array<{ uniqueIdentifier?: string; data?: { rules?: Partial<MobileRule> } }>;
+      mdms?: Array<{ data?: { countryCode?: string; mobileNumberRegex?: string; default?: boolean } }>;
     };
     const records = json.mdms ?? [];
-    const preferred =
-      records.find((r) => r.uniqueIdentifier === 'defaultMobileValidation') ?? records[0];
-    const rules = preferred?.data?.rules;
-    if (!rules) return FALLBACK;
+    const preferred = records.find((r) => r.data?.default === true) ?? records[0];
+    const data = preferred?.data;
+    if (!data?.mobileNumberRegex) return FALLBACK;
+    const lengths = deriveMobileLengths(data.mobileNumberRegex);
     return {
-      prefix: typeof rules.prefix === 'string' ? rules.prefix : undefined,
-      pattern: typeof rules.pattern === 'string' ? rules.pattern : FALLBACK.pattern,
-      minLength: typeof rules.minLength === 'number' ? rules.minLength : FALLBACK.minLength,
-      maxLength: typeof rules.maxLength === 'number' ? rules.maxLength : FALLBACK.maxLength,
-      errorMessage: typeof rules.errorMessage === 'string' ? rules.errorMessage : FALLBACK.errorMessage,
-      allowedStartingDigits: Array.isArray(rules.allowedStartingDigits)
-        ? (rules.allowedStartingDigits as string[])
-        : undefined,
+      prefix: typeof data.countryCode === 'string' ? data.countryCode : undefined,
+      pattern: data.mobileNumberRegex,
+      minLength: lengths.min,
+      maxLength: lengths.max,
+      errorMessage: `Please enter a valid ${lengths.max}-digit mobile number`,
+      allowedStartingDigits: derivedStartingDigits(data.mobileNumberRegex) ?? undefined,
     };
   } catch {
     return FALLBACK;


### PR DESCRIPTION
## Summary
- Migrates `tenant_bootstrap` and related tests from the legacy `UserValidation` schema to `MobileNumberValidation` (MDMS-driven mobile validation per tenant)
- Cleans up `local-setup/db/full-dump.sql` (removes 141 stale lines): Corrected the Security policy master data not matching as per schema and updated data as per schema definition.

## Test plan
- [ ] Verify citizen login mobile validation reads from `common-masters.MobileNumberValidation` for the target tenant
- [ ] Bootstrap a new tenant from `pg` and confirm no `INVALID_REQUEST_TYPE1/2` errors for `DataSecurity.SecurityPolicy`
- [ ] Confirm `full-dump.sql` applies cleanly on a fresh local setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)