### PR TITLE
fix(pgr-webview): open file chooser + surface geolocation errors in WebView

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/GeoLocations.js
+++ b/digit-ui-esbuild/products/pgr/src/components/GeoLocations.js
@@ -337,8 +337,27 @@ const GeoLocations = ({ t, config, onSelect, formData }) => {
           setIsSearching(false);
         },
         (error) => {
-          console.error("Error getting location:", error);
-          setShowToast({ key: "error", label: t("CS_GEOLOCATION_ERROR") });
+          // Surface the specific GeolocationPositionError instead of one opaque
+          // toast — a permission denial, an insecure-origin block (code 1,
+          // "Only secure origins are allowed"), a missing GPS fix and a timeout
+          // are otherwise indistinguishable. code: 1=PERMISSION_DENIED,
+          // 2=POSITION_UNAVAILABLE, 3=TIMEOUT.
+          console.error("Error getting location:", error?.code, error?.message, error);
+          const KEY_BY_CODE = {
+            1: "CS_GEOLOCATION_PERMISSION_DENIED",
+            2: "CS_GEOLOCATION_UNAVAILABLE",
+            3: "CS_GEOLOCATION_TIMEOUT",
+          };
+          const specificKey = KEY_BY_CODE[error?.code];
+          const specific = specificKey ? t(specificKey) : null;
+          // Use the per-code message when it is localised; otherwise fall back
+          // to the generic label + the raw message so the cause is visible
+          // on-device even before the new keys are uploaded.
+          const label =
+            specific && specific !== specificKey
+              ? specific
+              : `${t("CS_GEOLOCATION_ERROR")}${error?.message ? ` (${error.message})` : ""}`;
+          setShowToast({ key: "error", label });
           setIsSearching(false);
         },
         {

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
@@ -1300,7 +1300,22 @@ function PgrFileUpload({
         accept="image/*"
         multiple
         onChange={onInputChange}
-        style={{ display: "none" }}
+        // Do NOT use display:none. Some Android WebViews refuse to fire the file
+        // chooser (WebChromeClient.onShowFileChooser) for a programmatic .click()
+        // on a display:none input — the tap silently does nothing. Keep the input
+        // rendered but visually hidden so the chooser opens inside the WebView.
+        style={{
+          position: "absolute",
+          width: 1,
+          height: 1,
+          opacity: 0,
+          overflow: "hidden",
+          border: 0,
+          padding: 0,
+          margin: -1,
+          clip: "rect(0 0 0 0)",
+          pointerEvents: "none",
+        }}
         aria-hidden="true"
         tabIndex={-1}
       />


### PR DESCRIPTION
## Summary
Front-end fixes for the DIGIT SPA running inside the **CMS-App Flutter WebView**, where **photo upload was "not clickable"** and **location fetching failed** with an opaque error.

## Changes
- **Upload (`CreatePGRFlowV2.tsx` / PgrFileUpload):** the hidden `<input type="file">` was `display:none`. Some Android WebViews won't fire the file chooser for a programmatic `.click()` on a `display:none` input, so tapping "Choose files" did nothing (works in a normal browser, fails in the WebView). Changed to visually-hidden (absolute / opacity:0 / clip) so `onShowFileChooser` fires and the picker opens.
- **Location (`GeoLocations.js`):** the error handler showed one opaque `CS_GEOLOCATION_ERROR` for every failure and discarded `error.code`/`error.message`. It now logs + shows the specific code/message (per-code keys + raw-message fallback), so the real cause — permission denied vs insecure-origin block vs GPS unavailable vs timeout — is visible on-device.

## ⚠️ Build note
These take effect only after the SPA bundle is rebuilt. The base branch has a **pre-existing build break** in `CreatePGRFlowV2.tsx` (a `SectionHeader`/`StepShell` merge tangle — duplicated `<GeoLocations>` block + unclosed `StepShell`) that must be resolved for `esbuild.build.js` to compile. Not fixed here (it touches the complaint-hierarchy feature); flagging so it's resolved before/with deploy.

## Testing (after rebuild + redeploy)
- Citizen complaint → upload step → tap "Choose files": the native file/gallery chooser opens inside the WebView.
- Map → "Locate Me": the toast now names the exact failure (e.g. `… (User denied Geolocation)` / `(Only secure origins are allowed)` / timeout), pinpointing the location root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
