### PR TITLE
fix(kong): preserve empty JSON arrays in auth-enrichment pre-function

### DIFF
--- a/local-setup/kong/auth-enrichment.lua
+++ b/local-setup/kong/auth-enrichment.lua
@@ -5,7 +5,14 @@
 -- calls egov-user/_details to resolve the token and injects the user object
 -- as RequestInfo.userInfo before forwarding to the upstream service.
 
-local cjson = require("cjson")
+-- Scoped cjson instance with array metatable on decode. Plain lua-cjson cannot tell an empty
+-- array from an empty object (both are empty Lua tables) and re-encodes [] as {}, so the
+-- decode->encode round-trip below would corrupt every EMPTY array in the body (e.g. an MDMS
+-- schema's "x-ref-schema": []). decode_array_with_array_mt(true) tags decoded arrays (incl.
+-- empty ones) so cjson.encode re-emits them as []; genuinely-empty objects stay {}. .new()
+-- keeps the setting off the shared worker cjson.
+local cjson = require("cjson").new()
+cjson.decode_array_with_array_mt(true)
 local http = require("resty.http")
 
 -- Only enrich POST requests

--- a/local-setup/kong/kong.yml
+++ b/local-setup/kong/kong.yml
@@ -51,7 +51,15 @@ plugins:
     access:
       - |
         -- Auth enrichment: resolve authToken → userInfo (mirrors Spring Cloud Gateway AuthCheckFilterHelper)
-        local cjson = require("cjson")
+        -- Scoped cjson instance with array metatable on decode. Plain lua-cjson cannot tell an
+        -- empty array from an empty object (both are empty Lua tables) and re-encodes [] as {},
+        -- so the decode->encode round-trip below would silently corrupt every EMPTY array in the
+        -- body (e.g. MDMS schema "x-ref-schema": []). decode_array_with_array_mt(true) tags
+        -- decoded arrays (incl. empty ones) so cjson.encode re-emits them as []; genuinely-empty
+        -- objects carry no array mt and stay {}. .new() scopes this so it never leaks to the
+        -- shared cjson used by other pre-functions in the worker.
+        local cjson = require("cjson").new()
+        cjson.decode_array_with_array_mt(true)
         local http = require("resty.http")
         if kong.request.get_method() ~= "POST" then return end
         local raw_body = kong.request.get_raw_body()


### PR DESCRIPTION
## TL;DR

The Kong `auth-enrichment` pre-function corrupts **every empty JSON array** in a tokened request body (`[]` → `{}`) before it reaches the upstream service. Root cause is a lua-cjson limitation. One-line-per-file fix, generically validated. This unblocks new state-root tenant onboarding, which currently dies on an `mdms-v2` `ClassCastException`.

---

## What breaks

`local-setup/kong/kong.yml` (and its standalone twin `auth-enrichment.lua`) run a `pre-function` on the access phase of every route. To mirror Spring Cloud Gateway's `AuthCheckFilterHelper`, it resolves `authToken` → `userInfo` and injects it into `RequestInfo`. To do that it **decodes the entire request body and re-encodes it**:

```lua
local cjson = require("cjson")
local ok, body = pcall(cjson.decode, raw_body)   -- decode whole body
... body["RequestInfo"]["userInfo"] = resolved ...
kong.service.request.set_raw_body(cjson.encode(body))   -- re-encode whole body
```

**lua-cjson cannot distinguish an empty array from an empty object** — both decode to an empty Lua table `{}`, and `cjson.encode({})` defaults to `{}`. So the round-trip rewrites:

| In body | After Kong |
|---|---|
| `"x-ref-schema": []` (empty array) | `"x-ref-schema": {}` ❌ |
| `"x-unique": ["code"]` (non-empty array) | `["code"]` ✅ |
| `"attributes": {}` (empty object) | `{}` ✅ |

Only **empty arrays** are corrupted; non-empty arrays and empty objects are fine. This happens to **any** body that carries a token, for every service behind Kong — MDMS is simply the one service strict enough to crash on it.

### How it manifests

Creating a **new state-root tenant** through the onboarding wizard (bare-code root, e.g. `bbbbbb`) seeds ACCESSCONTROL/DataSecurity/etc. schemas at the new root via `mdms-v2 /schema/v1/_create`. Those schema definitions carry `"x-ref-schema": []`. Kong flattens it to `{}`; mdms-v2 stores the `{}` verbatim in `eg_mdms_schema_definition`. Later, seeding data for that schema (`/v2/_create/ACCESSCONTROL-ROLES.roles`) makes mdms-v2 read the schema back and run:

```java
// MdmsDataValidator.validateReference
JSONArray referenceSchema = (JSONArray) schemaObject.get("x-ref-schema"); // {} -> ClassCastException
```

→ `An unhandled exception occurred on the server: class org.json.JSONObject cannot be cast to class org.json.JSONArray`, and onboarding halts.

Tenants provisioned by a **direct DB dump** (`db_fast_path`, e.g. `pg`, `ke`, `np`) are unaffected because the dump writes JSONB straight to Postgres and never traverses Kong — their `x-ref-schema` is a correct `[]`.

---

## How we replicated / proof chain

Every layer was checked; the culprit was isolated by elimination and a decisive bypass test.

1. **Raw DB (bomet)** — `SELECT jsonb_typeof(definition->'x-ref-schema')` on `eg_mdms_schema_definition`:
   - API/wizard-created tenants (`bbbbbb`, `aaaa`) → **`{}` (object)**
   - dump-seeded tenants (`pg`, `ke`, `np`, `statea`, …) → **`[]` (array)**
   So corruption is at write time, not read.

2. **Kafka capture** — consumed `save-mdms-schema-definition` while issuing a fresh `_create` with `"x-ref-schema": []`. The message **mdms-v2 emitted already contained `{}`** → corruption is upstream of persistence.

3. **Ruled out egov-persister** — reproduced its `json-smart parse → Jackson writeValueAsString` round-trip with bomet's exact versions (`json-path 2.9.0`, `json-smart 2.5.2`, `jackson-databind 2.18.6`): empty arrays are **preserved**. Persister is innocent.

4. **Ruled out mdms-v2** — decompiled bomet's actual jars: the Kafka value serializer (`ISTTimeZoneJsonSerializer`) and the tracer `ObjectMapperFactory` are plain `new ObjectMapper().setTimeZone(...)`; the repository pushes the request POJO verbatim; the enricher never touches `definition`. Repro of `readValue → JsonNode → writeValueAsString` is faithful.

5. **Decisive bypass test (bomet)** — same body, two paths:
   - Browser → **Kong** → mdms-v2 → Kafka message `x-ref-schema: {}` ❌
   - redpanda container → **mdms-v2:8094 directly** (Kong skipped) → Kafka message `x-ref-schema: []` ✅
   The only difference is Kong. Confirmed culprit.

6. **Kong source** — `/kong/kong.yml` `pre-function` does the `cjson.decode` → `cjson.encode` round-trip described above.

7. **Generic validation (clean-room, no DIGIT)** — stood up Kong `3.6.1` (bundled lua-cjson `2.1.0.11`) in DB-less mode in front of an echo upstream. Sent `{"RequestInfo":{"authToken":"x"},"a":[],"b":["code"],"c":{"nested":[]},"d":{},"e":[1,2,3]}`:

   | Field | Sent | Unfixed | Fixed |
   |---|---|---|---|
   | `a` empty array | `[]` | `{}` ❌ | `[]` ✅ |
   | `b` non-empty array | `["code"]` | `["code"]` ✅ | `["code"]` ✅ |
   | `c.nested` nested empty array | `[]` | `{}` ❌ | `[]` ✅ |
   | `d` empty object | `{}` | `{}` ✅ | `{}` ✅ (not broken) |
   | `e` non-empty array | `[1,2,3]` | `[1,2,3]` ✅ | `[1,2,3]` ✅ |

   Edge cases (deeply nested empty arrays, `[[],[]]`, empty-obj-alongside-deep-empty-arr) all round-trip faithfully with the fix and all corrupt without it.

---

## The fix

Use a **scoped** cjson instance with the array metatable enabled on decode:

```lua
local cjson = require("cjson").new()
cjson.decode_array_with_array_mt(true)
```

- `decode_array_with_array_mt(true)` tags every decoded JSON array — **including empty ones** — with `cjson.array_mt`, so `cjson.encode` re-emits them as `[]`.
- It only tags things that were **actually arrays** in the input, so a genuinely-empty object `{}` (no array metatable) still re-encodes as `{}`. Verified in the table above.
- `.new()` gives this pre-function its **own** cjson instance, so the setting does not leak to the shared `require("cjson")` used by other pre-functions in the same nginx worker.

Applied to the **auth-enrichment** block only (in both `kong.yml` and the standalone `auth-enrichment.lua`). The second pre-function (boundary-service adapter) forwards `raw_body` verbatim and only decodes the *response*, so it does not corrupt request empty-arrays and is left unchanged.

### Requirements / caveats
- Needs `untrusted_lua = on` (or `cjson` allowlisted in `untrusted_lua_sandbox_requires`) — DIGIT already sets this; the default `sandbox` blocks `require('cjson')`.
- Available in Kong 3.6's bundled cjson (`2.1.0.11`); function presence confirmed at runtime.
- The `pcall`-guarded decode is retained, so non-JSON/empty bodies still pass through untouched.

### Why fix here rather than in mdms-v2
This is the true root cause and fixes empty-array flattening **platform-wide** for every service behind Kong, not just MDMS. (A reader-side tolerance in mdms-v2 was considered but deliberately dropped in favour of the single upstream fix.)

## Deploy note
bomet pulls `develop`, so this applies on the next deploy. Existing already-corrupted `{}` rows on live tenants are not rewritten by this change; they can be normalized separately if needed (`jsonb_set(... '{x-ref-schema}', '[]')`), or simply re-created once the gateway stops corrupting new writes.
