### PR TITLE
fix(bootstrap): re-provision ADMIN user with correct encryption key p…

### DIFF
--- a/digit-mcp/src/tools/mdms-tenant.ts
+++ b/digit-mcp/src/tools/mdms-tenant.ts
@@ -1033,16 +1033,84 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
           },
         },
       },
+        user_only: {
+          type: 'boolean',
+          description:
+            'When true, skip all MDMS copy steps and only re-create the ADMIN user on ' +
+            'target_tenant. Called after post-bootstrap changes STATE_LEVEL_TENANT_ID ' +
+            'from pg to the real state root so the user is stored with the correct enc key.',
+        },
       required: ['target_tenant'],
     },
     handler: async (args) => {
       validateTenantId(args.target_tenant, 'target_tenant');
       if (args.source_tenant) validateTenantId(args.source_tenant, 'source_tenant');
 
-      await ensureAuthenticated();
-
       const target = args.target_tenant as string;
       const source = (args.source_tenant as string) || 'pg';
+
+      if (args.user_only) {
+        const mobileRegex = (args.mobile_regex as string) || '^[6-9][0-9]{9}$';
+        const stateTenantForEviction = target.includes('.') ? target.split('.')[0] : target;
+        await evictValidationCache(stateTenantForEviction);
+
+        let userProvisioned: { username: string; tenantId: string; roles: string[] } | null = null;
+        let userProvisionError: string | null = null;
+        try {
+          const currentUsername = process.env.CRS_USERNAME || 'ADMIN';
+          const currentPassword = process.env.CRS_PASSWORD || 'eGov@123';
+          const mobileNumber = deriveValidMobile(
+            mobileRegex,
+            Number(args.mobile_length) || 10,
+            (args.admin_mobile as string) || undefined,
+          );
+          const standardRoles = [
+            { code: 'EMPLOYEE', name: 'Employee' },
+            { code: 'CITIZEN', name: 'Citizen' },
+            { code: 'CSR', name: 'CSR' },
+            { code: 'GRO', name: 'Grievance Routing Officer' },
+            { code: 'PGR_LME', name: 'PGR Last Mile Employee' },
+            { code: 'DGRO', name: 'Department GRO' },
+            { code: 'SUPERUSER', name: 'Super User' },
+            { code: 'INTERNAL_MICROSERVICE_ROLE', name: 'Internal Microservice Role' },
+          ].map((r) => ({ ...r, tenantId: target }));
+          const newUser = {
+            name: 'Admin',
+            mobileNumber,
+            userName: currentUsername,
+            password: currentPassword,
+            type: 'EMPLOYEE',
+            active: true,
+            roles: standardRoles,
+            tenantId: target,
+          };
+          try {
+            await digitApi.userCreate(newUser, target);
+            userProvisioned = { username: currentUsername, tenantId: target, roles: standardRoles.map((r) => r.code) };
+          } catch (createErr) {
+            const createMsg = createErr instanceof Error ? createErr.message : String(createErr);
+            const isDuplicate =
+              createMsg.includes('DuplicateUserName') ||
+              createMsg.toLowerCase().includes('duplicate');
+            if (isDuplicate) {
+              userProvisioned = { username: currentUsername, tenantId: target, roles: [] };
+            } else {
+              throw createErr;
+            }
+          }
+        } catch (error) {
+          userProvisionError = error instanceof Error ? error.message : String(error);
+        }
+        return JSON.stringify({
+          success: true,
+          user_only: true,
+          admin_user_provisioned: !!userProvisioned,
+          admin_user_provisioned_details: userProvisioned,
+          admin_user_provision_error: userProvisionError || undefined,
+        }, null, 2);
+      }
+
+      await ensureAuthenticated();
       if (!args.mobile_regex || !args.mobile_prefix) {
         // When regex or prefix are not explicit (e.g. the bootstrap wizard only
         // sends target_tenant + source_tenant), inherit from the SOURCE tenant's

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -2307,6 +2307,60 @@
       changed_when: false
       when: state_root != 'pg'
 
+    # egov-user's EncryptionDecryptionUtil.encryptObject() uses stateLevelTenantId
+    # (STATE_LEVEL_TENANT_ID env var) as the enc key — not the user's tenantId.
+    # Bootstrap runs while STATE_LEVEL=pg → ADMIN@mz stored with pg's enc key.
+    # Post-bootstrap restarts egov-user with STATE_LEVEL=mz → login now encrypts
+    # with mz's key → ciphertext mismatch → "Invalid login credentials".
+    # Fix: call bootstrap with user_only=true AFTER STATE_LEVEL=mz is active so
+    # the new ADMIN row is stored with mz's enc key. configurator-i18n login
+    # finds this row and succeeds.
+    - name: "post-bootstrap — re-provision ADMIN with state_root enc key (user_only)"
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:13101/v1/tenant/bootstrap"
+        method: POST
+        headers:
+          Content-Type: application/json
+        body_format: json
+        body:
+          target_tenant: "{{ state_root }}"
+          source_tenant: "pg"
+          user_only: true
+          mobile_regex: "{{ core_mobile_configs.mobileNumberPattern }}"
+          mobile_prefix: "{{ core_mobile_configs.mobilePrefix }}"
+          mobile_length: "{{ core_mobile_configs.mobileNumberLength | int }}"
+        status_code: [200]
+        timeout: 60
+      register: mcp_rekey_root
+      failed_when: >-
+        mcp_rekey_root.status != 200 or
+        not (mcp_rekey_root.json.admin_user_provisioned | default(false))
+      when: state_root != 'pg'
+      no_log: true
+
+    - name: "post-bootstrap — re-provision ADMIN with city enc key (user_only)"
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:13101/v1/tenant/bootstrap"
+        method: POST
+        headers:
+          Content-Type: application/json
+        body_format: json
+        body:
+          target_tenant: "{{ tenant_id }}"
+          source_tenant: "pg"
+          user_only: true
+          mobile_regex: "{{ core_mobile_configs.mobileNumberPattern }}"
+          mobile_prefix: "{{ core_mobile_configs.mobilePrefix }}"
+          mobile_length: "{{ core_mobile_configs.mobileNumberLength | int }}"
+        status_code: [200]
+        timeout: 60
+      register: mcp_rekey_city
+      failed_when: >-
+        mcp_rekey_city.status != 200 or
+        not (mcp_rekey_city.json.admin_user_provisioned | default(false))
+      when: state_root != 'pg' and tenant_id != state_root
+      no_log: true
+
     # ────────────────────────────────────────────────────────────────
     # Configurator UI localization seed. The configurator's own chrome —
     # nav, field labels, resource names, dashboard strings — for every

--- a/utilities/default-data-handler/src/main/resources/mdmsData/common-masters/common-masters.MobileNumberValidation.json
+++ b/utilities/default-data-handler/src/main/resources/mdmsData/common-masters/common-masters.MobileNumberValidation.json
@@ -2,6 +2,6 @@
   {
     "countryCode": "+254",
     "mobileNumberRegex": "^0?[17][0-9]{8}$",
-    "default": true
+    "default": false
   }
 ]


### PR DESCRIPTION
…ost-bootstrap

- Add user_only flag to bootstrap endpoint to skip MDMS copy and only re-create ADMIN user
- Call bootstrap twice post-bootstrap: once for state_root tenant, once for city tenant
- Ensures ADMIN user is encrypted with correct STATE_LEVEL_TENANT_ID after egov-user restart
- Fixes "Invalid login credentials" error caused by encryption key mismatch between bootstrap (STATE_LEVEL=pg) and post-restart (STATE_LEVEL=state_root)
- Update Kenya mobile validation to set default=false for proper routing
- Add detailed comments explaining the encryption lifecycle issue and the two-phase bootstrap solution