### PR TITLE
fix(integration-tests): keep dashboard catalog in sync with on-disk runs (#907)

### DIFF
--- a/tests/integration-tests/runner/run-cycle.sh
+++ b/tests/integration-tests/runner/run-cycle.sh
@@ -94,8 +94,25 @@ rsync -a --delete --exclude=run.log --exclude=phase \
 rsync -a --delete test-results "$RUN_DIR/" 2>/dev/null \
   || cp -rf test-results "$RUN_DIR/"
 
-# Prune older runs to RUN_LIMIT (newest kept).
-( cd "$WEBROOT/runs" && ls -1t | tail -n +"$((RUN_LIMIT+1))" | xargs -r rm -rf ) || true
+# Prune runs/ to exactly the set the dashboard references — the run ids in the
+# history.json we just published. This keeps runs/ in lockstep with the catalog:
+# a failed-no-report run creates a runs/<id>/ folder but never a catalog entry,
+# and the old mtime-based prune ("newest RUN_LIMIT folders") let those
+# newer-but-reportless folders evict the runs the catalog still pointed at — so
+# the dashboard showed a stale "last run" and 404'd on it (#907 skew).
+# build-catalog already dropped dead ids from history, so honouring that set here
+# converges disk == catalog. Falls back to the recency prune if the ids can't be
+# read (missing/old node, malformed json).
+KEEP_IDS="$(node -e 'const fs=require("fs");try{const h=JSON.parse(fs.readFileSync(process.argv[1],"utf8"));process.stdout.write((h.runs||[]).map(r=>r.id).join("\n"))}catch(e){}' "$WEBROOT/history.json" 2>/dev/null)"
+if [[ -n "$KEEP_IDS" ]]; then
+  ( shopt -s nullglob; cd "$WEBROOT/runs" 2>/dev/null || exit 0
+    for d in */; do
+      id="${d%/}"
+      grep -qxF -- "$id" <<<"$KEEP_IDS" || rm -rf -- "$id"
+    done ) || true
+else
+  ( cd "$WEBROOT/runs" && ls -1t | tail -n +"$((RUN_LIMIT+1))" | xargs -r rm -rf ) || true
+fi
 
 phase "done"
 echo "[run-cycle] done — RUN_ID=$RUN_ID"

--- a/tests/integration-tests/scripts/build-catalog.ts
+++ b/tests/integration-tests/scripts/build-catalog.ts
@@ -363,13 +363,30 @@ function buildCatalog(opts: BuildOptions): { catalog: Catalog; nextHistory: Hist
   const oldHistory = readHistory(opts.publicHistoryPath ?? opts.historyPath);
   const priorCatalog = readPriorCatalog(opts.publicCatalogPath ?? null);
 
-  // Compute the surviving run-id set after this run is published. publish.sh
-  // prunes runs/ on the host to RUN_LIMIT (=HISTORY_LIMIT here, 5). Any
-  // latestRun pointer to a run NOT in this set is about to be unreachable, so
-  // we drop it. Pointers into still-extant runs are preserved.
+  // The runs/ folders on disk are the source of truth for what the dashboard
+  // can actually open. In the local-serve model the published history/catalog
+  // live in the webroot next to runs/, so drop any prior-history run whose
+  // runs/<id>/ folder no longer exists — otherwise a folder that an earlier
+  // cycle pruned (or that a failed-no-report run occupied without ever writing
+  // a report/catalog entry) leaves the catalog pointing at a 404, and the
+  // reportless-but-newer folder that evicted it stays invisible (#907 skew).
+  // Only trust disk when the runs are actually local (the current run's own
+  // folder is present); the CI rsync model publishes runs elsewhere, so there
+  // we keep the old purely-logical window and this stays a no-op.
+  const runsDir = opts.publicHistoryPath
+    ? path.join(path.dirname(opts.publicHistoryPath), 'runs')
+    : null;
+  const runsAreLocal = !!runsDir && fs.existsSync(path.join(runsDir, opts.runId));
+  const runExists = (id: string): boolean =>
+    !runsAreLocal || fs.existsSync(path.join(runsDir!, id));
+  const priorRuns = oldHistory.runs.filter(r => r.id !== opts.runId && runExists(r.id));
+
+  // Surviving run-id set after this run is published: the current run plus the
+  // still-extant prior runs, capped at the rolling window. run-cycle.sh prunes
+  // runs/ to exactly this set, so a latestRun pointer into it is guaranteed
+  // reachable; pointers to anything else are dropped below.
   const survivingRunIds = new Set<string>(
-    [opts.runId, ...oldHistory.runs.map(r => r.id).filter(id => id !== opts.runId)]
-      .slice(0, HISTORY_LIMIT)
+    [opts.runId, ...priorRuns.map(r => r.id)].slice(0, HISTORY_LIMIT)
   );
 
   // Merge: every test from disk → CatalogTest. Tests that ran get latestRun.
@@ -487,7 +504,7 @@ function buildCatalog(opts: BuildOptions): { catalog: Catalog; nextHistory: Hist
     lastRunId: opts.runId,
     tagFacets,
     tests: tests.sort((a, b) => a.id.localeCompare(b.id)),
-    runs: [newRun, ...oldHistory.runs.filter(r => r.id !== opts.runId)].slice(0, HISTORY_LIMIT),
+    runs: [newRun, ...priorRuns].slice(0, HISTORY_LIMIT),
   };
 
   // Persist next history.json.


### PR DESCRIPTION
## What & why

Fixes the bometfeedbackhub dashboard "stale last-run date" bug (part of #907).

The run **catalog** and the **`runs/` folder prune** used two different "keep last 5" rules that could silently drift apart:

- **Catalog** (`build-catalog.ts`) builds its run window by prepending the current run to the *previous* catalog's list, and only runs on a **successful** run.
- **Prune** (`run-cycle.sh`) kept the **newest N folders by mtime** — but *every* run, pass or fail, creates a folder up front.

So a `failed-no-report` run (a folder with no `report.json`) is newer-by-mtime and wins the prune, evicting the folders the catalog still references. Result: the dashboard points at a run whose folder was deleted (404), while the surviving folders are invisible because they never entered the catalog.

## Changes

- **`build-catalog.ts`** — make the on-disk `runs/<id>/` folders the source of truth: drop any prior-history run whose folder no longer exists. Guarded by a `runsAreLocal` check so the CI/rsync publish model (runs published elsewhere) is unaffected.
- **`run-cycle.sh`** — prune `runs/` to exactly the run-ids in the freshly published `history.json`, instead of newest-N-by-mtime, so reportless failed folders can't evict referenced runs. Falls back to the old mtime prune if the id list can't be read.

Together these keep **disk == catalog** after every run; the existing skew self-heals on the next successful run.

## Verification

- Typecheck (`tsc -p tsconfig.json`) clean; `bash -n run-cycle.sh` passes.
- Reproduced the real broken state (stale history listing 12–15 Jun + a disk holding only later runs) and confirmed `build-catalog` now drops the dead refs.
- Confirmed the CI/rsync path is a no-op (old logical window preserved when runs aren't local).
- Confirmed the new prune sweeps the orphaned `failed-no-report` folders and keeps disk in lockstep with the catalog.

Full root-cause write-up is in the comment on #907.
