### PR TITLE
fix(pgr): make assignee optional in Assign Complaint modal (#1009)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
@@ -29,7 +29,7 @@ const ACTION_CONFIGS = [
           body: [
             {
               type: "component",
-              isMandatory: true,
+              isMandatory: false,
               component: "PGRAssigneeComponent",
               key: "SelectedAssignee",
               label: "CS_COMMON_EMPLOYEE_NAME",


### PR DESCRIPTION
Employee Name was incorrectly required when assigning a complaint, blocking submission unless an assignee was selected. Flip isMandatory to false to match the already-correct frontend/micro-ui copy and the REOPEN/REASSIGN actions in the same config.