### PR TITLE
feat(cms): CMS roles + workflow seeded by default on fresh setups; CMS=1 migration for existing envs

### DIFF
--- a/docs/migration/seed-pgr-masters.cjs
+++ b/docs/migration/seed-pgr-masters.cjs
@@ -15,6 +15,16 @@
  *
  * USAGE
  *   LOCAL:  BASE_URL=http://localhost:18000 TENANT=mz node docs/migration/seed-pgr-masters.cjs
+ *
+ *   CMS multi-tier workflow (optional): add CMS=1 to ALSO seed the CMS_* roles,
+ *   any missing actions-test catalog entries, their role→action grants (all at the
+ *   state tenant) and the CMS PGR BusinessService (at the CITY tenant). Source of
+ *   truth = the default-data-handler resources (same files fresh setups use).
+ *     BASE_URL=http://localhost:18000 TENANT=mz.igsae CMS=1 node docs/migration/seed-pgr-masters.cjs
+ *   With CMS=1, TENANT must be the CITY tenant (or pass CMS_TENANT=<state.city>).
+ *   UPDATE_WF=1 additionally applies in-place workflow role/nextState/flag changes
+ *   when the live BusinessService differs. After a workflow create/update, restart
+ *   egov-workflow-v2 (it caches BusinessServices).
  *   PROD :  BASE_URL=http://<host> TENANT=mz OAUTH_USER=<admin> OAUTH_PASS=<pass> \
  *             PGPASSWORD=<egov-db-pass> node docs/migration/seed-pgr-masters.cjs   (run on the VM)
  *
@@ -44,11 +54,23 @@ let TOKEN = process.env.TOKEN || "";
 const DB_CONTAINER = process.env.DB_CONTAINER || "docker-postgres";
 const NO_DB_FIX = process.env.NO_DB_FIX === "1";
 const RESEED = process.env.RESEED === "1"; // drop old schema defs + data for these masters first (use when the master SHAPE changed)
+const CMS = process.env.CMS === "1";       // also seed the CMS multi-tier workflow (roles/actions/grants/BusinessService)
+const CMS_TENANT = process.env.CMS_TENANT || (TENANT.includes(".") ? TENANT : ""); // city tenant for the workflow
+const UPDATE_WF = process.env.UPDATE_WF === "1";
 
 const SCHEMA_FILE = path.join(
   __dirname, "..", "..",
   "utilities", "default-data-handler", "src", "main", "resources", "schema", "RAINMAKER-PGR.json"
 );
+const CMS_ROLES = ["CMS_RECEPTION_OFFICER", "CMS_SCREENING_OFFICER", "CMS_SUPERVISOR", "CMS_CASE_MANAGER", "CMS_VIEWER"];
+const DDH_RES = path.join(__dirname, "..", "..", "utilities", "default-data-handler", "src", "main", "resources");
+const CMS_FILES = {
+  roles: path.join(DDH_RES, "mdmsData", "ACCESSCONTROL-ROLE", "ACCESSCONTROL-ROLES.roles.json"),
+  roleactions: path.join(DDH_RES, "mdmsData", "ACCESSCONTROL-ROLEACTIONS", "ACCESSCONTROL-ROLEACTIONS.roleactions.json"),
+  actions: path.join(DDH_RES, "mdmsData", "ACCESSCONTROL-ACTIONS-TEST", "ACCESSCONTROL-ACTIONS-TEST.actions-test.json"),
+  workflow: path.join(DDH_RES, "CmsPgrWorkflowConfig.json"),
+};
+
 const MASTERS = [
   { code: "RAINMAKER-PGR.ComplaintRelatedToMap", file: path.join(__dirname, "seed", "ComplaintRelatedToMap.json"), uid: "code" },
   { code: "RAINMAKER-PGR.ComplaintTemplateType", file: path.join(__dirname, "seed", "ComplaintTemplateType.json"), uid: "caseRelatedTo" },
@@ -58,6 +80,9 @@ const MASTERS = [
 function die(msg) { console.error("\n✗ " + msg + "\n"); process.exit(1); }
 if (!BASE || !TENANT) {
   die("Set BASE_URL and TENANT.\n    e.g. BASE_URL=http://localhost:18000 TENANT=mz node docs/migration/seed-pgr-masters.cjs");
+}
+if (CMS && !CMS_TENANT) {
+  die("CMS=1 needs the CITY tenant for the workflow — set TENANT=<state.city> (e.g. mz.igsae) or CMS_TENANT=<state.city>.");
 }
 
 function req(method, p, body, headers) {
@@ -218,6 +243,171 @@ async function verify() {
   return allOk;
 }
 
+
+/* ══════════════════ CMS multi-tier workflow (CMS=1) ══════════════════
+ * Back-fills envs bootstrapped before the CMS defaults existed in the
+ * default-data-handler image. Reads the SAME DDH resource files a fresh
+ * setup uses — no data is duplicated here. All phases idempotent.       */
+
+// Workflow _create/_update stamps auditDetails from RequestInfo.userInfo.
+const cmsRI = () => Object.assign({}, RI, {
+  userInfo: { id: 1, uuid: "cms-migration", userName: OAUTH_USER, type: "EMPLOYEE", tenantId: STATE, roles: [{ code: "SUPERUSER", name: "Super User", tenantId: STATE }] },
+});
+
+async function cmsSearchAll(schemaCode) {
+  const out = [];
+  for (let offset = 0; ; offset += 100) {
+    const r = await req("POST", "/mdms-v2/v2/_search", { MdmsCriteria: { tenantId: STATE, schemaCode, limit: 100, offset }, RequestInfo: cmsRI() });
+    let rows = [];
+    try { rows = JSON.parse(r.body).mdms || []; } catch { }
+    out.push(...rows);
+    if (rows.length < 100) return out;
+  }
+}
+
+// create-one; DUPLICATE_RECORD counts as "already present" (v2 search pages have
+// no stable order, so the pre-scan can miss rows — the server check is the truth).
+async function cmsCreate(schemaCode, uniqueIdentifier, data) {
+  const r = await req("POST", "/mdms-v2/v2/_create/" + schemaCode, {
+    Mdms: { tenantId: STATE, schemaCode, uniqueIdentifier, data, isActive: true },
+    RequestInfo: cmsRI(),
+  });
+  if (r.code >= 200 && r.code < 300) return "created";
+  if (/DUPLICATE_RECORD|already|exist/i.test(r.body)) return "present";
+  die(schemaCode + " create failed for " + uniqueIdentifier + ": " + (r.body || "").slice(0, 220));
+}
+
+async function cmsSeedRoles() {
+  const want = JSON.parse(fs.readFileSync(CMS_FILES.roles, "utf8")).filter((x) => CMS_ROLES.includes(x.code));
+  if (want.length !== CMS_ROLES.length) die("DDH roles file is missing CMS roles — expected 5, found " + want.length);
+  const have = new Set((await cmsSearchAll("ACCESSCONTROL-ROLES.roles")).map((m) => m.data && m.data.code));
+  for (const row of want) {
+    const st = have.has(row.code) ? "present" : await cmsCreate("ACCESSCONTROL-ROLES.roles", row.code, row);
+    console.log("  " + (st === "created" ? "✓ role " + row.code + " created" : "• role " + row.code + " already present"));
+  }
+}
+
+// roleactions x-ref-validate actionid against the actions-test catalog; older envs
+// miss recently-added catalog entries — create those first.
+async function cmsSeedActions() {
+  const grants = JSON.parse(fs.readFileSync(CMS_FILES.roleactions, "utf8")).filter((x) => CMS_ROLES.includes(x.rolecode));
+  const needed = [...new Set(grants.map((g) => g.actionid))];
+  const catalog = {};
+  for (const a of JSON.parse(fs.readFileSync(CMS_FILES.actions, "utf8"))) catalog[a.id] = a;
+  const have = new Set((await cmsSearchAll("ACCESSCONTROL-ACTIONS-TEST.actions-test")).map((m) => m.data && Number(m.data.id)));
+  let created = 0;
+  for (const id of needed) {
+    if (have.has(id)) continue;
+    const row = catalog[id];
+    if (!row) die("actionid " + id + " referenced by CMS grants but absent from the actions-test catalog file");
+    if (await cmsCreate("ACCESSCONTROL-ACTIONS-TEST.actions-test", String(id), Object.assign({}, row, { tenantId: STATE })) === "created") {
+      console.log("  ✓ action " + id + " (" + (row.displayName || row.name) + ") created");
+      created++;
+    }
+  }
+  if (!created) console.log("  • all " + needed.length + " referenced actions already present");
+}
+
+async function cmsSeedRoleactions() {
+  const want = JSON.parse(fs.readFileSync(CMS_FILES.roleactions, "utf8")).filter((x) => CMS_ROLES.includes(x.rolecode));
+  const have = new Set((await cmsSearchAll("ACCESSCONTROL-ROLEACTIONS.roleactions"))
+    .map((m) => m.uniqueIdentifier || (m.data && m.data.rolecode + "." + m.data.actionid)));
+  let created = 0, present = 0;
+  for (const row of want) {
+    const key = row.rolecode + "." + row.actionid;
+    if (have.has(key)) { present++; continue; }
+    const st = await cmsCreate("ACCESSCONTROL-ROLEACTIONS.roleactions", key, Object.assign({}, row, { tenantId: STATE }));
+    if (st === "created") created++; else present++;
+  }
+  console.log("  roleactions: " + created + " created, " + present + " already present (of " + want.length + ")");
+}
+
+// canonical view of a BusinessService: state -> {flags, actions{name -> {next, roles}}}
+function cmsCanon(bs, nameByUuid) {
+  const out = {};
+  for (const s of bs.states) {
+    const actions = {};
+    for (const a of s.actions || []) {
+      const next = nameByUuid ? (nameByUuid[a.nextState] || a.nextState) : a.nextState;
+      actions[a.action] = { next, roles: (a.roles || []).slice().sort() };
+    }
+    out[s.state || "<START>"] = { appStatus: s.applicationStatus || null, doc: !!s.docUploadRequired, term: !!s.isTerminateState, sla: s.sla == null ? null : s.sla, actions };
+  }
+  return out;
+}
+function cmsDiff(wantC, liveC) {
+  const diffs = [];
+  for (const st of new Set([...Object.keys(wantC), ...Object.keys(liveC)])) {
+    if (!liveC[st]) { diffs.push("state " + st + " missing in live"); continue; }
+    if (!wantC[st]) { diffs.push("state " + st + " extra in live"); continue; }
+    const w = wantC[st], l = liveC[st];
+    for (const f of ["appStatus", "doc", "term", "sla"])
+      if (JSON.stringify(w[f]) !== JSON.stringify(l[f])) diffs.push(st + "." + f + ": want " + JSON.stringify(w[f]) + " live " + JSON.stringify(l[f]));
+    for (const act of new Set([...Object.keys(w.actions), ...Object.keys(l.actions)])) {
+      const wa = w.actions[act], la = l.actions[act];
+      if (!la) { diffs.push(st + "." + act + " missing in live"); continue; }
+      if (!wa) { diffs.push(st + "." + act + " extra in live"); continue; }
+      if (wa.next !== la.next) diffs.push(st + "." + act + ".nextState: want " + wa.next + " live " + la.next);
+      if (JSON.stringify(wa.roles) !== JSON.stringify(la.roles)) diffs.push(st + "." + act + ".roles: want " + wa.roles + " live " + la.roles);
+    }
+  }
+  return diffs;
+}
+
+async function cmsSeedWorkflow() {
+  const want = JSON.parse(fs.readFileSync(CMS_FILES.workflow, "utf8").split("{tenantid}").join(CMS_TENANT)).BusinessServices[0];
+  const r = await req("POST", "/egov-workflow-v2/egov-wf/businessservice/_search?tenantId=" + CMS_TENANT + "&businessServices=PGR", { RequestInfo: cmsRI() });
+  let live = null;
+  try { live = (JSON.parse(r.body).BusinessServices || [])[0] || null; } catch { }
+
+  if (!live) {
+    const c = await req("POST", "/egov-workflow-v2/egov-wf/businessservice/_create", { RequestInfo: cmsRI(), BusinessServices: [want] });
+    if (c.code < 200 || c.code >= 300) die("workflow create failed: " + (c.body || "").slice(0, 300));
+    console.log("  ✓ CMS PGR workflow CREATED at " + CMS_TENANT + " (" + want.states.length + " states)");
+    return "created";
+  }
+
+  const nameByUuid = {}; for (const s of live.states) nameByUuid[s.uuid] = s.state || "<START>";
+  const diffs = cmsDiff(cmsCanon(want), cmsCanon(live, nameByUuid));
+  if (!diffs.length) { console.log("  • workflow already present and matches (" + live.states.length + " states)"); return "present"; }
+
+  console.log("  ! workflow present but DIFFERS:");
+  diffs.forEach((d) => console.log("      - " + d));
+  if (!UPDATE_WF) { console.log("  → re-run with UPDATE_WF=1 to apply role/nextState/flag changes in place."); return "differs"; }
+  if (diffs.some((d) => d.includes("missing in live") || d.includes("extra in live")))
+    die("UPDATE_WF can only patch existing states/actions (roles, nextState, flags). State/action add/remove needs a manual _update.");
+
+  const uuidByName = {}; for (const s of live.states) uuidByName[s.state || "<START>"] = s.uuid;
+  const wantC = cmsCanon(want);
+  for (const s of live.states) {
+    const w = wantC[s.state || "<START>"];
+    s.applicationStatus = w.appStatus; s.docUploadRequired = w.doc; s.isTerminateState = w.term; s.sla = w.sla;
+    for (const a of s.actions || []) { const wa = w.actions[a.action]; a.roles = wa.roles; a.nextState = uuidByName[wa.next] || a.nextState; }
+  }
+  const u = await req("POST", "/egov-workflow-v2/egov-wf/businessservice/_update", { RequestInfo: cmsRI(), BusinessServices: [live] });
+  if (u.code < 200 || u.code >= 300) die("workflow update failed: " + (u.body || "").slice(0, 300));
+  console.log("  ✓ workflow UPDATED in place (" + diffs.length + " differences applied)");
+  return "updated";
+}
+
+async function cmsRun() {
+  console.log("[CMS 1/4] Roles @ " + STATE + " …");
+  await cmsSeedRoles();
+  console.log("\n[CMS 2/4] Actions catalog (referenced by CMS grants) @ " + STATE + " …");
+  await cmsSeedActions();
+  console.log("\n[CMS 3/4] Role→action mappings @ " + STATE + " …");
+  await cmsSeedRoleactions();
+  console.log("\n[CMS 4/4] CMS PGR workflow @ " + CMS_TENANT + " …");
+  const wf = await cmsSeedWorkflow();
+  const roles = new Set((await cmsSearchAll("ACCESSCONTROL-ROLES.roles")).map((m) => m.data && m.data.code));
+  const missing = CMS_ROLES.filter((c) => !roles.has(c));
+  if (missing.length) die("CMS verify failed — roles still missing: " + missing);
+  console.log("\n  ✓ all 5 CMS roles present @ " + STATE);
+  if (wf === "created" || wf === "updated")
+    console.log("  ⚠ RESTART egov-workflow-v2 now (it caches BusinessServices): docker restart digit-egov-workflow-v2-1");
+  console.log("  Employees: assign the CMS_* roles to real staff via HRMS/configurator (not created here).");
+}
+
 (async () => {
   console.log("PGR dynamic-fields masters → state tenant '" + STATE + "' @ " + BASE + "\n");
 
@@ -248,10 +438,16 @@ async function verify() {
   const ok = await verify();
   console.log();
 
-  if (ok) {
-    console.log("✅ DONE — all masters present at '" + STATE + "'. Sub-tenants inherit them via state-fallback.");
-    console.log("   Final check in the UI: <host>/digit-ui/citizen → File a Complaint (hard-refresh).");
-    process.exit(0);
+  if (!ok) die("Some masters have 0 rows — see ✗ above.");
+
+  if (CMS) {
+    console.log("── CMS multi-tier workflow (CMS=1) ──\n");
+    await cmsRun();
+    console.log();
   }
-  die("Some masters have 0 rows — see ✗ above.");
+
+  console.log("✅ DONE — all masters present at '" + STATE + "'. Sub-tenants inherit them via state-fallback."
+    + (CMS ? " CMS roles/grants @ '" + STATE + "', workflow @ '" + CMS_TENANT + "'." : ""));
+  console.log("   Final check in the UI: <host>/digit-ui/citizen → File a Complaint (hard-refresh).");
+  process.exit(0);
 })();

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -935,6 +935,9 @@ services:
     environment:
       SPRING_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       KAFKA_CONFIG_BOOTSTRAP_SERVER_CONFIG: redpanda:9092
+      # New tenants get the multi-tier CMS PGR workflow (CmsPgrWorkflowConfig.json).
+      # Set to "standard" for the classic GRO/LME single-tier workflow.
+      PGR_WORKFLOW_VARIANT: ${PGR_WORKFLOW_VARIANT:-cms}
       EGOV_MDMS_HOST: http://mdms-backend:8094/
       EGOV_LOCALIZATION_HOST: http://egov-localization:8096/
       EGOV_USER_HOST: http://egov-user-proxy:8107/

--- a/utilities/default-data-handler/src/main/java/org/egov/handler/service/DataHandlerService.java
+++ b/utilities/default-data-handler/src/main/java/org/egov/handler/service/DataHandlerService.java
@@ -57,6 +57,12 @@ public class DataHandlerService {
 
     private final RestTemplate restTemplate;
 
+    // Which PGR workflow a new tenant gets: "standard" (GRO/LME single-tier) or
+    // "cms" (multi-tier CMS_* officer chain). Deploy-level switch — a tenant has
+    // exactly one PGR BusinessService, so the variant is chosen per deployment.
+    @org.springframework.beans.factory.annotation.Value("${pgr.workflow.variant:standard}")
+    private String pgrWorkflowVariant;
+
     @Autowired
     public DataHandlerService(MdmsV2Util mdmsV2Util, HrmsUtil hrmsUtil, LocalizationUtil localizationUtil, TenantManagementUtil tenantManagementUtil, ServiceConfiguration serviceConfig, ObjectMapper objectMapper, ResourceLoader resourceLoader, WorkflowUtil workflowUtil, CustomKafkaTemplate producer, MdmsBulkLoader mdmsBulkLoader, RestTemplate restTemplate) {
         this.mdmsV2Util = mdmsV2Util;
@@ -476,8 +482,12 @@ public class DataHandlerService {
     }
 
     public void createPgrWorkflowConfig(String targetTenantId) {
-        // Load the JSON file
-        Resource resource = resourceLoader.getResource("classpath:PgrWorkflowConfig.json");
+        // Load the JSON file for the configured workflow variant
+        String wfConfigFile = "cms".equalsIgnoreCase(pgrWorkflowVariant)
+                ? "classpath:CmsPgrWorkflowConfig.json"
+                : "classpath:PgrWorkflowConfig.json";
+        log.info("Creating PGR workflow for tenant {} from {} (variant={})", targetTenantId, wfConfigFile, pgrWorkflowVariant);
+        Resource resource = resourceLoader.getResource(wfConfigFile);
         try (InputStream inputStream = resource.getInputStream()) {
             BusinessServiceRequest businessServiceRequest = objectMapper.readValue(inputStream, BusinessServiceRequest.class);
             businessServiceRequest.getBusinessServices().forEach(service -> service.setTenantId(targetTenantId));

--- a/utilities/default-data-handler/src/main/resources/CmsPgrWorkflowConfig.json
+++ b/utilities/default-data-handler/src/main/resources/CmsPgrWorkflowConfig.json
@@ -1,0 +1,367 @@
+{
+  "RequestInfo": {
+    "apiId": "Rainmaker",
+    "action": "",
+    "did": 1,
+    "key": "",
+    "msgId": "20170310130900|en_IN",
+    "requesterId": "",
+    "ts": 1513579888683,
+    "ver": ".01",
+    "userInfo": {
+      "id": 73,
+      "userName": null,
+      "name": null,
+      "type": "EMPLOYEE",
+      "mobileNumber": null,
+      "emailId": null,
+      "roles": [
+        {
+          "id": 2,
+          "name": "Customer Support Representative",
+          "code": null,
+          "tenantId": null
+        }
+      ],
+      "tenantId": null,
+      "uuid": "uuid"
+    }
+  },
+  "BusinessServices": [
+    {
+      "tenantId": "{tenantid}",
+      "businessService": "PGR",
+      "business": "pgr-services",
+      "businessServiceSla": 432000000,
+      "states": [
+        {
+          "tenantId": "{tenantid}",
+          "sla": null,
+          "state": null,
+          "applicationStatus": null,
+          "docUploadRequired": false,
+          "isStartState": true,
+          "isTerminateState": false,
+          "isStateUpdatable": true,
+          "actions": [
+            {
+              "tenantId": "{tenantid}",
+              "currentState": "ce08d758-1788-4b56-b1ec-91db449d41a4",
+              "action": "APPLY",
+              "nextState": "PENDINGFORASSIGNMENT",
+              "roles": [
+                "CITIZEN",
+                "CMS_RECEPTION_OFFICER"
+              ],
+              "active": true
+            }
+          ]
+        },
+        {
+          "tenantId": "{tenantid}",
+          "sla": null,
+          "state": "PENDINGFORASSIGNMENT",
+          "applicationStatus": "PENDINGFORASSIGNMENT",
+          "docUploadRequired": false,
+          "isStartState": false,
+          "isTerminateState": false,
+          "isStateUpdatable": false,
+          "actions": [
+            {
+              "tenantId": "{tenantid}",
+              "currentState": "PENDINGFORASSIGNMENT",
+              "action": "ASSIGN",
+              "nextState": "REFERRED",
+              "roles": [
+                "CMS_SCREENING_OFFICER",
+                "CMS_VIEWER"
+              ],
+              "active": true
+            },
+            {
+              "tenantId": "{tenantid}",
+              "currentState": "PENDINGFORASSIGNMENT",
+              "action": "REJECT",
+              "nextState": "REJECTED",
+              "roles": [
+                "CMS_SCREENING_OFFICER",
+                "CMS_VIEWER"
+              ],
+              "active": true
+            }
+          ]
+        },
+        {
+          "tenantId": "{tenantid}",
+          "sla": null,
+          "state": "REFERRED",
+          "applicationStatus": "REFERRED",
+          "docUploadRequired": false,
+          "isStartState": false,
+          "isTerminateState": false,
+          "isStateUpdatable": false,
+          "actions": [
+            {
+              "tenantId": "{tenantid}",
+              "currentState": "REFERRED",
+              "action": "ASSIGN",
+              "nextState": "INVESTIGATION",
+              "roles": [
+                "CMS_SUPERVISOR",
+                "CMS_VIEWER"
+              ],
+              "active": true
+            },
+            {
+              "tenantId": "{tenantid}",
+              "currentState": "REFERRED",
+              "action": "REJECT",
+              "nextState": "REJECTED",
+              "roles": [
+                "CMS_SUPERVISOR",
+                "CMS_VIEWER"
+              ],
+              "active": true
+            },
+            {
+              "tenantId": "{tenantid}",
+              "currentState": "REFERRED",
+              "action": "REASSIGN",
+              "nextState": "PENDINGFORREASSIGNMENT",
+              "roles": [
+                "CMS_SUPERVISOR",
+                "CMS_VIEWER"
+              ],
+              "active": true
+            }
+          ]
+        },
+        {
+          "tenantId": "{tenantid}",
+          "sla": 300000,
+          "state": "INVESTIGATION",
+          "applicationStatus": "INVESTIGATION",
+          "docUploadRequired": false,
+          "isStartState": false,
+          "isTerminateState": false,
+          "isStateUpdatable": false,
+          "actions": [
+            {
+              "tenantId": "{tenantid}",
+              "currentState": "INVESTIGATION",
+              "action": "AWAITINGINFORMATION",
+              "nextState": "INFOFROMCITIZEN",
+              "roles": [
+                "CMS_CASE_MANAGER",
+                "CMS_VIEWER"
+              ],
+              "active": true
+            },
+            {
+              "tenantId": "{tenantid}",
+              "currentState": "INVESTIGATION",
+              "action": "REJECT",
+              "nextState": "REJECTED",
+              "roles": [
+                "CMS_CASE_MANAGER",
+                "CMS_VIEWER"
+              ],
+              "active": true
+            },
+            {
+              "tenantId": "{tenantid}",
+              "currentState": "INVESTIGATION",
+              "action": "RESOLVE",
+              "nextState": "RESOLVED",
+              "roles": [
+                "CMS_CASE_MANAGER",
+                "CMS_VIEWER"
+              ],
+              "active": true
+            }
+          ]
+        },
+        {
+          "tenantId": "{tenantid}",
+          "sla": 300000,
+          "state": "INFOFROMCITIZEN",
+          "applicationStatus": "AWAITINGINFORMATION",
+          "docUploadRequired": true,
+          "isStartState": false,
+          "isTerminateState": false,
+          "isStateUpdatable": false,
+          "actions": [
+            {
+              "tenantId": "{tenantid}",
+              "currentState": "INFOFROMCITIZEN",
+              "action": "COMMENT",
+              "nextState": "INVESTIGATION",
+              "roles": [
+                "CMS_CASE_MANAGER",
+                "CMS_RECEPTION_OFFICER"
+              ],
+              "active": true
+            }
+          ]
+        },
+        {
+          "tenantId": "{tenantid}",
+          "sla": 300000,
+          "state": "PENDINGFORREASSIGNMENT",
+          "applicationStatus": "REASSIGND",
+          "docUploadRequired": false,
+          "isStartState": false,
+          "isTerminateState": false,
+          "isStateUpdatable": false,
+          "actions": [
+            {
+              "tenantId": "{tenantid}",
+              "currentState": "PENDINGFORREASSIGNMENT",
+              "action": "REJECT",
+              "nextState": "REJECTED",
+              "roles": [
+                "CMS_SCREENING_OFFICER",
+                "CMS_VIEWER"
+              ],
+              "active": true
+            },
+            {
+              "tenantId": "{tenantid}",
+              "currentState": "PENDINGFORREASSIGNMENT",
+              "action": "ASSIGN",
+              "nextState": "REFERRED",
+              "roles": [
+                "CMS_SCREENING_OFFICER",
+                "CMS_VIEWER"
+              ],
+              "active": true
+            }
+          ]
+        },
+        {
+          "tenantId": "{tenantid}",
+          "sla": 300000,
+          "state": "REJECTED",
+          "applicationStatus": "REJECTED",
+          "docUploadRequired": false,
+          "isStartState": false,
+          "isTerminateState": true,
+          "isStateUpdatable": false,
+          "actions": [
+            {
+              "tenantId": "{tenantid}",
+              "currentState": "REJECTED",
+              "action": "COMMENT",
+              "nextState": "REJECTED",
+              "roles": [
+                "CITIZEN"
+              ],
+              "active": true
+            },
+            {
+              "tenantId": "{tenantid}",
+              "currentState": "REJECTED",
+              "action": "REOPEN",
+              "nextState": "REFERRED",
+              "roles": [
+                "CITIZEN",
+                "CMS_RECEPTION_OFFICER",
+                "CMS_VIEWER"
+              ],
+              "active": true
+            },
+            {
+              "tenantId": "{tenantid}",
+              "currentState": "REJECTED",
+              "action": "RATE",
+              "nextState": "CLOSEDAFTERREJECTION",
+              "roles": [
+                "CMS_RECEPTION_OFFICER",
+                "CITIZEN"
+              ],
+              "active": true
+            }
+          ]
+        },
+        {
+          "tenantId": "{tenantid}",
+          "sla": 300000,
+          "state": "RESOLVED",
+          "applicationStatus": "RESOLVED",
+          "docUploadRequired": false,
+          "isStartState": false,
+          "isTerminateState": true,
+          "isStateUpdatable": false,
+          "actions": [
+            {
+              "tenantId": "{tenantid}",
+              "currentState": "RESOLVED",
+              "action": "RATE",
+              "nextState": "CLOSEDAFTERRESOLUTION",
+              "roles": [
+                "CMS_RECEPTION_OFFICER",
+                "CITIZEN"
+              ],
+              "active": true
+            },
+            {
+              "tenantId": "{tenantid}",
+              "currentState": "RESOLVED",
+              "action": "REOPEN",
+              "nextState": "PENDINGFORASSIGNMENT",
+              "roles": [
+                "CMS_RECEPTION_OFFICER",
+                "CITIZEN",
+                "CMS_VIEWER"
+              ],
+              "active": true
+            },
+            {
+              "tenantId": "{tenantid}",
+              "currentState": "RESOLVED",
+              "action": "COMMENT",
+              "nextState": "RESOLVED",
+              "roles": [
+                "CITIZEN"
+              ],
+              "active": true
+            }
+          ]
+        },
+        {
+          "tenantId": "{tenantid}",
+          "sla": null,
+          "state": "CLOSEDAFTERREJECTION",
+          "applicationStatus": "CLOSEDAFTERREJECTION",
+          "docUploadRequired": false,
+          "isStartState": false,
+          "isTerminateState": true,
+          "isStateUpdatable": false,
+          "actions": null
+        },
+        {
+          "tenantId": "{tenantid}",
+          "sla": null,
+          "state": "CLOSEDAFTERRESOLUTION",
+          "applicationStatus": "CLOSEDAFTERRESOLUTION",
+          "docUploadRequired": false,
+          "isStartState": false,
+          "isTerminateState": true,
+          "isStateUpdatable": false,
+          "actions": null
+        },
+        {
+          "tenantId": "{tenantid}",
+          "sla": null,
+          "state": "CANCELLED",
+          "applicationStatus": "CANCELLED",
+          "docUploadRequired": false,
+          "isStartState": false,
+          "isTerminateState": true,
+          "isStateUpdatable": false,
+          "actions": null
+        }
+      ]
+    }
+  ]
+}

--- a/utilities/default-data-handler/src/main/resources/mdmsData/ACCESSCONTROL-ROLE/ACCESSCONTROL-ROLES.roles.json
+++ b/utilities/default-data-handler/src/main/resources/mdmsData/ACCESSCONTROL-ROLE/ACCESSCONTROL-ROLES.roles.json
@@ -140,6 +140,11 @@
     "description": "System administrator; manages master data, categories, and system configuration"
   },
   {
+    "code": "CMS_VIEWER",
+    "name": "CMS Viewer",
+    "description": "Oversight role for the CMS complaint workflow; can view and act on complaints per the workflow definition"
+  },
+  {
     "code": "CENTRAL_USER",
     "name": "Central User",
     "description": "Scope role: user belongs to the central IGE/IGSAE unit and can see complaints across all tenants"

--- a/utilities/default-data-handler/src/main/resources/mdmsData/ACCESSCONTROL-ROLEACTIONS/ACCESSCONTROL-ROLEACTIONS.roleactions.json
+++ b/utilities/default-data-handler/src/main/resources/mdmsData/ACCESSCONTROL-ROLEACTIONS/ACCESSCONTROL-ROLEACTIONS.roleactions.json
@@ -4626,5 +4626,264 @@
     "rolecode": "CMS_ADMIN",
     "actionid": 2557,
     "tenantId": "{tenantid}"
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 2553,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 1985
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 2568,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 1986
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 2567,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 1987
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 2560,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 1988
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 2562,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 1989
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 2564,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 1990
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 2557,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 1991
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 2556,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 1992
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 604,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 1993
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 2317,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 1994
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 2156,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 1995
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 1743,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 1996
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 2021,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 1997
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 2020,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 1998
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 2018,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 1999
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 2015,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 2000
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 2026,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 2001
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 2009,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 2002
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 2008,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 2003
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 2007,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 2004
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 2006,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 2005
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 1775,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 2006
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 1752,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 2007
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 1730,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 2008
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 1729,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 2009
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 1556,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 2010
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 870,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 2011
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 1557,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 2012
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 700,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 2013
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 699,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 2014
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 695,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 2015
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 698,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 2016
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 701,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 2017
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 1531,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 2018
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 1530,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 2019
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 1529,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 2020
+  },
+  {
+    "rolecode": "CMS_VIEWER",
+    "actionid": 1528,
+    "actioncode": "",
+    "tenantId": "{tenantid}",
+    "id": 2021
   }
 ]


### PR DESCRIPTION
## Problem
Fresh deployments show **no CMS roles** (verified on 20.40.49.209: 22 roles at `mz.bomet`, zero CMS). Root cause: environments are provisioned from the **default-data-handler image**, and the deployed registry tag (`crs_dataseeder-084b7cc`, Jan 2026) predates the CMS role data (added Jun 2026). Data in the repo never reaches a deployment whose image was built before it.

## Changes (role/seeding only)

**default-data-handler**
- Add `CMS_VIEWER` role + 37 role→action grants (the workflow references `CMS_VIEWER`; only `CMS_DASHBOARD_VIEWER` was productized)
- New `CmsPgrWorkflowConfig.json` — the multi-tier CMS PGR BusinessService (11 states / 18 actions, `REJECTED.REOPEN → REFERRED`)
- `pgr.workflow.variant` property (`standard` default / `cms`, env `PGR_WORKFLOW_VARIANT`) selects which PGR workflow `createPgrWorkflowConfig` seeds for new tenants
- local-setup compose sets `PGR_WORKFLOW_VARIANT=cms` for this product's deploys

**docs/migration/seed-pgr-masters.cjs** — extended (no new script): `CMS=1` back-fills existing environments.

## Steps

**Fresh setup — automatic.** Deploy with a DDH image built from this branch (`build_default_data_handler: true`, already set in host_vars). On tenant create, DDH seeds roles + grants at the state root (cities inherit via MDMS fallback) and creates the CMS workflow.

**Existing environment — one command:**
```bash
BASE_URL=http://<host> TENANT=<state.city> CMS=1 \
OAUTH_USER=<admin> OAUTH_PASS=<pass> \
node docs/migration/seed-pgr-masters.cjs
# then restart egov-workflow-v2 if the workflow was created/updated
```
Idempotent — re-runs report "already present". Without `CMS=1` the script is byte-identical to its previous behavior.

**Registry deploys:** CI must publish a new `default-data-handler:crs_dataseeder-<sha>` tag and the compose tag bumped, or images predating this PR keep seeding without CMS roles.

## Testing
- DDH image builds clean; jar verified to contain the new resources
- Script run against a fully-seeded local env: both modes green, all phases idempotent (5 roles / 38 catalog actions / 181 grants / workflow "present and matches")
- Live prod check documented the missing-roles state this fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)