### PR TITLE
fix(pgr): citizen complaint-details page crash (dead useMyContext in TimelineWrapper)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/TimeLineWrapper.js
+++ b/digit-ui-esbuild/products/pgr/src/components/TimeLineWrapper.js
@@ -1,11 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from "react-i18next";
 import { PopUp, Timeline, TimelineMolecule, Loader } from '@egovernments/digit-ui-components';
-import { useMyContext } from "../utils/context";
 import { convertEpochFormateToDate } from '../utils';
 
+// NOTE: no useMyContext() here — the citizen route tree has no MyContext
+// provider, and this wrapper renders on BOTH citizen and employee details.
 const TimelineWrapper = ({ businessId, isWorkFlowLoading, workflowData, labelPrefix = "" }) => {
-    const { state } = useMyContext();
     const { t } = useTranslation();
 
     const tenantId = Digit.ULBService.getCurrentTenantId();


### PR DESCRIPTION
## Problem
Opening any complaint from the **citizen** side (`/citizen/pgr/complaints/<id>`) crashes to the error boundary ("Something went wrong"):
```
TypeError: Cannot destructure property 'state' of 'u4r(...)' as it is undefined.
```

## Root cause
`TimelineWrapper` destructured `{ state }` from `useMyContext()` — **and never used it**. Employee pages are wrapped in the `MyContext` provider, so the dead line was harmless there; the citizen route tree has no provider, so the hook returns `undefined` and the destructure throws. Surfaced when #1045 switched the citizen timeline to this shared wrapper.

## Fix
Remove the dead destructure + import (2 lines), with a comment noting the wrapper renders on both citizen and employee trees. No behavior change otherwise.

## Testing
- Rebuilt and deployed locally: citizen details page for `PG-PGR-2026-07-06-001468` renders with the full workflow timeline; employee details page unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)