### PR TITLE
fix(hrms): always set reActivateEmployee to avoid _update NullPointer…

### DIFF
--- a/digit-ui-esbuild/packages/modules/hrms/src/components/EmployeeAction.js
+++ b/digit-ui-esbuild/packages/modules/hrms/src/components/EmployeeAction.js
@@ -131,6 +131,7 @@ const EmployeeAction = ({ t, action, tenantId, closeModal, submitAction, applica
       set(Employees[0], 'deactivationDetails[0].remarks', data?.remarks);
 
       Employees[0].isActive = false;
+      Employees[0].reActivateEmployee = false;
       mutationUpdate.mutate(
         {
           Employees: Employees,
@@ -163,6 +164,7 @@ const EmployeeAction = ({ t, action, tenantId, closeModal, submitAction, applica
       set(Employees[0], 'reactivationDetails[0].reasonForDeactivation', data?.reasonForDeactivation);
       set(Employees[0], 'reactivationDetails[0].remarks', data?.remarks);
       Employees[0].isActive = true;
+      Employees[0].reActivateEmployee = true;
 
       mutationUpdate.mutate(
         {

--- a/digit-ui-esbuild/packages/modules/hrms/src/pages/EditEmployee/EditForm.js
+++ b/digit-ui-esbuild/packages/modules/hrms/src/pages/EditEmployee/EditForm.js
@@ -278,6 +278,9 @@ const EditForm = ({ tenantId, data }) => {
     requestdata["user"]["name"] = input?.SelectEmployeeName?.employeeName;
     requestdata.user.correspondenceAddress = input?.SelectEmployeeCorrespondenceAddress?.correspondenceAddress;
     requestdata.user.roles = roles.filter((role) => role && role.name);
+    // egov-hrms/employees/_update NPEs on Employee.getReActivateEmployee().booleanValue()
+    // when this field is null — carry over the value the _search response gave us.
+    requestdata.reActivateEmployee = data?.reActivateEmployee ?? false;
     let Employees = [requestdata];
 
     /* use customiseUpdateFormData hook to make some chnages to the Employee object */


### PR DESCRIPTION
…Exception (#813)

egov-hrms/employees/_update NPEs on Employee.getReActivateEmployee() .booleanValue() whenever the field is null. The plain edit form never forwarded it and the deactivate/reactivate action never set it either, so every configurator edit failed once an employee lacked this field.

- EditForm: carry over the value from the _search response, falling back to false only when it's null.
- EmployeeAction: set it explicitly to match the action being performed (false on deactivate, true on reactivate), same as the adjacent isActive flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved employee activation and deactivation handling so the update flow now consistently carries a reactivation status.
  * Reduced null-related errors during employee updates by ensuring this status always has a valid value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->