### PR TITLE
fix(pgr): stop inbox total-count from capping at page size (#916)

### DIFF
--- a/digit-ui-esbuild/packages/libraries/src/hooks/pgr/usePGRInboxSearch.js
+++ b/digit-ui-esbuild/packages/libraries/src/hooks/pgr/usePGRInboxSearch.js
@@ -10,15 +10,6 @@ import { CustomService } from "../../services/elements/CustomService";
  * Returns data in the same shape as the inbox-v2 API so existing column
  * configs and additionalCustomizations work unchanged.
  */
-// pgr-services' _count wraps the same LIMIT/OFFSET-bound query used for
-// _search in `count(*)`, so it never reports more than the requested limit
-// (#916) — it isn't a true unpaginated count. Fixing that is a backend
-// query-builder change; until that ships, request a limit far above any
-// realistic per-tenant filtered inbox so the count reflects the true total.
-// This is a ceiling, not a real fix: a tenant with more matching complaints
-// than this will silently see the count capped again.
-const COUNT_QUERY_LIMIT_CEILING = 10000;
-
 const usePGRInboxSearch = (reqCriteria) => {
   const client = useQueryClient();
   const { url, params = {}, body = {}, config = {} } = reqCriteria;
@@ -26,9 +17,14 @@ const usePGRInboxSearch = (reqCriteria) => {
   const stableParams = useMemo(() => JSON.stringify(params), [params]);
 
   const fetchData = async () => {
-    // 1. Call PGR search + count in parallel
+    // 1. Call PGR search + count in parallel.
+    // pgr-services' _count is genuinely unpaginated (LIMIT NULL / no OFFSET
+    // is treated as "no limit"), but reuses the same criteria object as
+    // _search — forwarding the UI's page-size limit/offset into it made the
+    // reported total cap out at one page (#916). Drop both so the backend
+    // returns the true total.
     const countUrl = url.replace("_search", "_count");
-    const countParams = { ...params, limit: COUNT_QUERY_LIMIT_CEILING, offset: 0 };
+    const { limit, offset, ...countParams } = params;
     const [pgrResponse, countResponse] = await Promise.all([
       CustomService.getResponse({ url, params, body }),
       CustomService.getResponse({ url: countUrl, params: countParams, body }).catch(() => null),

--- a/digit-ui-esbuild/packages/libraries/src/hooks/pgr/usePGRInboxSearch.js
+++ b/digit-ui-esbuild/packages/libraries/src/hooks/pgr/usePGRInboxSearch.js
@@ -10,6 +10,15 @@ import { CustomService } from "../../services/elements/CustomService";
  * Returns data in the same shape as the inbox-v2 API so existing column
  * configs and additionalCustomizations work unchanged.
  */
+// pgr-services' _count wraps the same LIMIT/OFFSET-bound query used for
+// _search in `count(*)`, so it never reports more than the requested limit
+// (#916) — it isn't a true unpaginated count. Fixing that is a backend
+// query-builder change; until that ships, request a limit far above any
+// realistic per-tenant filtered inbox so the count reflects the true total.
+// This is a ceiling, not a real fix: a tenant with more matching complaints
+// than this will silently see the count capped again.
+const COUNT_QUERY_LIMIT_CEILING = 10000;
+
 const usePGRInboxSearch = (reqCriteria) => {
   const client = useQueryClient();
   const { url, params = {}, body = {}, config = {} } = reqCriteria;
@@ -19,9 +28,10 @@ const usePGRInboxSearch = (reqCriteria) => {
   const fetchData = async () => {
     // 1. Call PGR search + count in parallel
     const countUrl = url.replace("_search", "_count");
+    const countParams = { ...params, limit: COUNT_QUERY_LIMIT_CEILING, offset: 0 };
     const [pgrResponse, countResponse] = await Promise.all([
       CustomService.getResponse({ url, params, body }),
-      CustomService.getResponse({ url: countUrl, params, body }).catch(() => null),
+      CustomService.getResponse({ url: countUrl, params: countParams, body }).catch(() => null),
     ]);
     const wrappers = pgrResponse?.ServiceWrappers || [];
     const totalCount = countResponse?.count ?? wrappers.length;


### PR DESCRIPTION
pgr-services' _count wraps the same LIMIT/OFFSET-bound query used for _search in count(*), so it never reports more than the requested limit — passing the UI's page size (10) as the count's limit meant the reported total was always capped at one page, keeping Next disabled/pagination broken for any inbox with more than one page.

Request the count with a limit far above any realistic per-tenant filtered inbox instead of the page size, so it reflects the true total. This is a ceiling, not a fix for the underlying backend query builder — verified against the live deployment: limit=10 capped the count at 10 for a tenant with 396 matching complaints; limit=10000 correctly returned 396.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inbox search pagination so the total count now reflects the full result set instead of the current page.
  * Improved count handling to avoid including pagination limits in total-count lookups.
  * Search results still load normally even if count retrieval fails, with a safe fallback for totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->