### PR TITLE
fix(local-setup): default to OTP mock, document real-OTP production steps

### DIFF
--- a/local-setup/ansible/inventory/host_vars/_example.yml
+++ b/local-setup/ansible/inventory/host_vars/_example.yml
@@ -208,11 +208,14 @@ enable_integration_tests_runner: false
 
 # Start the real OTP stack: egov-otp (stores OTPs), user-otp (orchestrates
 # send/validate), egov-notification-sms (delivers via SMS gateway).
-# Default true — real OTP services run by default.
-# Set false before deploying if you want to skip the OTP stack (lean/offline
-# environments); egov-user's fixed OTP (CITIZEN_LOGIN_PASSWORD_OTP_FIXED_VALUE=123456)
-# still allows login, but /user-otp/* requests will fail without a mock in kong.yml.
-enable_otp_services: true
+# Default false — local-setup/kong/kong.yml mocks /user-otp/* with a canned
+# 200 response so login/register work via the fixed OTP (123456, see
+# CITIZEN_LOGIN_PASSWORD_OTP_FIXED_VALUE) without any SMS infra.
+# Set true for production, AND follow the "TO ENABLE REAL OTP FOR PRODUCTION"
+# steps in local-setup/kong/kong.yml (remove the mock plugin there, and wire
+# up a real SMS_PROVIDER_CLASS in docker-compose.egov-digit.yaml — it
+# defaults to Console, which only logs OTP SMS instead of sending it).
+enable_otp_services: false
 
 # Bring up Elasticsearch + egov-indexer + inbox-v2. Heavy (~3GB RAM
 # extra). Off by default; only enable if you actually use the inbox.

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -1356,6 +1356,11 @@ services:
       OTEL_METRICS_EXPORTER: none
       OTEL_LOGS_EXPORTER: none
       JAVA_TOOL_OPTIONS: -Xms64m -Xmx128m
+      # Console only logs the OTP SMS to this container's stdout — no SMS is
+      # actually sent. For production, set enable_otp_services: true in the
+      # tenant's Ansible host_vars AND replace this with a real provider
+      # class + credentials (e.g. an SMSCountry/Twilio/MSG91 provider class
+      # supported by this image) before relying on real OTP delivery.
       SMS_PROVIDER_CLASS: Console
     deploy:
       resources:

--- a/local-setup/kong/kong.yml
+++ b/local-setup/kong/kong.yml
@@ -138,6 +138,30 @@ services:
     paths:
     - /user-otp
     strip_path: false
+    # MOCK (default): request-termination short-circuits every /user-otp/*
+    # call with a canned success response, so login/register work using the
+    # fixed OTP (123456, see CITIZEN_LOGIN_PASSWORD_OTP_FIXED_VALUE in
+    # docker-compose.egov-digit.yaml) without the real egov-otp/user-otp/
+    # egov-notification-sms stack running or any SMS gateway integrated.
+    #
+    # TO ENABLE REAL OTP FOR PRODUCTION, before deploying:
+    #   1. Delete the `plugins:` block below (the request-termination mock).
+    #   2. Set enable_otp_services: true in the tenant's Ansible host_vars
+    #      (local-setup/ansible/inventory/host_vars/<tenant>.yml) so compose
+    #      starts the `otp` profile (egov-otp, user-otp, egov-notification-sms).
+    #   3. Configure a real SMS gateway: egov-notification-sms defaults to
+    #      SMS_PROVIDER_CLASS: Console (logs OTP SMS to container stdout only)
+    #      in docker-compose.egov-digit.yaml — point it at a real provider
+    #      class + credentials before relying on SMS delivery.
+    # Without all three, the first OTP request has nothing to answer it
+    # (real stack down or SMS not actually sent), and only the fixed
+    # 123456 fallback keeps working.
+    plugins:
+    - name: request-termination
+      config:
+        status_code: 200
+        content_type: application/json
+        body: '{"ResponseInfo":{"apiId":"Rainmaker","ver":null,"ts":null,"resMsgId":"uief87324","msgId":null,"status":"successful"},"otp":{"identity":"","tenantId":"","type":"","otp":"","expiryTime":0}}'
 - name: enc-service
   url: http://egov-enc-service:1234
   tags:


### PR DESCRIPTION
## Summary
- A prior commit flipped `enable_otp_services` to `true` by default and removed the Kong `request-termination` mock on `/user-otp/*`. Without the mock, and without the real `egov-otp`/`user-otp`/`egov-notification-sms` stack + a real SMS gateway wired up, first-time real OTP requests have nothing to answer them — only the hardcoded `123456` fallback kept working.
- Restores `enable_otp_services: false` (mock) as the default in `local-setup/ansible/inventory/host_vars/_example.yml`.
- Restores the `request-termination` mock plugin on `/user-otp` in `local-setup/kong/kong.yml`, with inline comments listing the exact steps to switch to real OTP for production (flip the flag, remove the mock plugin, configure a real `SMS_PROVIDER_CLASS`).
- Adds a production note next to `SMS_PROVIDER_CLASS: Console` in `local-setup/docker-compose.egov-digit.yaml` clarifying it only logs OTP SMS to stdout and doesn't actually send anything.

## Test plan
- [ ] `python3 -c "import yaml; yaml.safe_load(open('local-setup/kong/kong.yml'))"` — kong.yml still parses as valid YAML (done locally)
- [ ] Fresh `docker compose up -d` / ansible deploy with default host_vars: confirm citizen login/register works via the mocked `/user-otp/*` + fixed OTP `123456`
- [ ] Set `enable_otp_services: true` + follow the in-file production steps on a tenant with a real SMS gateway configured: confirm real OTP delivery works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local OTP flows now use a mocked default response, so sign-in testing works without connecting to a real SMS provider.

* **Documentation**
  * Updated setup guidance to explain how to switch from the mock OTP flow to real OTP delivery when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->