### PR TITLE
feat(digit-ui-esbuild): embed PGR supervisor dashboard as ACS-gated employee module

### DIFF
--- a/ansible/nairobi-mdms/mdms/ACCESSCONTROL-ACTIONS-TEST/actions-test.json
+++ b/ansible/nairobi-mdms/mdms/ACCESSCONTROL-ACTIONS-TEST/actions-test.json
@@ -26211,5 +26211,23 @@
       "serviceCode": "MDMS Search",
       "parentModule": "306"
     }
+  },
+  {
+    "tenantId": "ke",
+    "data": {
+      "id": 4557,
+      "url": "url",
+      "name": "Dashboard",
+      "path": "Dashboard",
+      "enabled": true,
+      "leftIcon": "action:dashboard",
+      "rightIcon": "",
+      "displayName": "Dashboard",
+      "orderNumber": 2,
+      "queryParams": "",
+      "serviceCode": "DASHBOARD",
+      "parentModule": "",
+      "navigationURL": "/digit-ui/employee/dashboard"
+    }
   }
 ]

--- a/ansible/nairobi-mdms/mdms/ACCESSCONTROL-ROLEACTIONS/roleactions.json
+++ b/ansible/nairobi-mdms/mdms/ACCESSCONTROL-ROLEACTIONS/roleactions.json
@@ -26398,5 +26398,45 @@
       "tenantId": "statea",
       "actioncode": ""
     }
+  },
+  {
+    "tenantId": "ke",
+    "data": {
+      "id": 1740,
+      "actionid": 4557,
+      "rolecode": "SUPERVISOR",
+      "tenantId": "pg",
+      "actioncode": ""
+    }
+  },
+  {
+    "tenantId": "ke",
+    "data": {
+      "id": 1741,
+      "actionid": 4557,
+      "rolecode": "GRO",
+      "tenantId": "pg",
+      "actioncode": ""
+    }
+  },
+  {
+    "tenantId": "ke",
+    "data": {
+      "id": 1742,
+      "actionid": 4557,
+      "rolecode": "DGRO",
+      "tenantId": "pg",
+      "actioncode": ""
+    }
+  },
+  {
+    "tenantId": "ke",
+    "data": {
+      "id": 1743,
+      "actionid": 4557,
+      "rolecode": "SUPERUSER",
+      "tenantId": "pg",
+      "actioncode": ""
+    }
   }
 ]

--- a/ansible/nairobi-mdms/mdms/tenant/citymodule.json
+++ b/ansible/nairobi-mdms/mdms/tenant/citymodule.json
@@ -46,5 +46,22 @@
         }
       ]
     }
+  },
+  {
+    "tenantId": "ke",
+    "data": {
+      "code": "Dashboard",
+      "order": 14,
+      "active": true,
+      "module": "Dashboard",
+      "tenants": [
+        {
+          "code": "ke"
+        },
+        {
+          "code": "ke.nairobi"
+        }
+      ]
+    }
   }
 ]

--- a/digit-mcp/src/tools/mdms-tenant.ts
+++ b/digit-mcp/src/tools/mdms-tenant.ts
@@ -1326,6 +1326,14 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
         'Workflow.AutoEscalationStatesToIgnore',
         // ── inbox ──
         'INBOX.InboxQueryConfiguration',
+        // ── dashboard analytics catalog ──
+        // KPI defs and packs are platform-level definitions (queries + viz +
+        // role visibility) with no tenant identity inside — without them a new
+        // root gets a working dashboard shell but an empty catalog ("no tiles
+        // in the catalog pack for this role"). Complaint-type–specific data
+        // (ServiceDefs/ComplaintHierarchy) stays operator-owned; these are not.
+        'dss.KpiDefinition',
+        'dss.DashboardPack',
         'ACCESSCONTROL-ROLEACTIONS.roleactions',
       ];
 

--- a/digit-ui-esbuild/esbuild.build.js
+++ b/digit-ui-esbuild/esbuild.build.js
@@ -151,6 +151,7 @@ async function build() {
       "process.env.NODE_ENV": '"production"',
       "process.env.REACT_APP_STATE_LEVEL_TENANT_ID": '""',
       "process.env.REACT_APP_MAP_TENANT": JSON.stringify(process.env.REACT_APP_MAP_TENANT || ""),
+      "process.env.REACT_APP_ANALYTICS_BASE": JSON.stringify(process.env.REACT_APP_ANALYTICS_BASE || "/pgr-services/v2/analytics"),
       global: "window",
     },
     plugins: [cdnGlobalsPlugin, svgPlugin],

--- a/digit-ui-esbuild/esbuild.dev.js
+++ b/digit-ui-esbuild/esbuild.dev.js
@@ -248,6 +248,7 @@ async function start() {
       "process.env.NODE_ENV": '"development"',
       "process.env.REACT_APP_STATE_LEVEL_TENANT_ID": '""',
       "process.env.REACT_APP_MAP_TENANT": JSON.stringify(process.env.REACT_APP_MAP_TENANT || ""),
+      "process.env.REACT_APP_ANALYTICS_BASE": JSON.stringify(process.env.REACT_APP_ANALYTICS_BASE || "/pgr-services/v2/analytics"),
       global: "window",
     },
     plugins: [cdnGlobalsPlugin, svgPlugin, liveReloadPlugin],

--- a/digit-ui-esbuild/package-lock.json
+++ b/digit-ui-esbuild/package-lock.json
@@ -18,6 +18,7 @@
         "ajv": "^8.12.0",
         "ajv-errors": "^3.0.0",
         "ajv-formats": "^2.1.1",
+        "apexcharts": "3.45.2",
         "axios": "^1.7.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -37,6 +38,7 @@
         "lucide-react": "^1.14.0",
         "pdfmake": "^0.1.72",
         "react": "17.0.2",
+        "react-apexcharts": "1.4.1",
         "react-data-table-component": "^7.6.2",
         "react-date-range": "^1.4.0",
         "react-datepicker": "^4.8.0",
@@ -45,6 +47,7 @@
         "react-dnd-html5-backend": "^16.0.1",
         "react-dom": "17.0.2",
         "react-drag-drop-files": "^2.3.10",
+        "react-grid-layout": "1.3.4",
         "react-hook-form": "6.15.8",
         "react-i18next": "11.16.2",
         "react-joyride": "^2.5.5",
@@ -1152,6 +1155,12 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@yr/monotone-cubic-spline": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@yr/monotone-cubic-spline/-/monotone-cubic-spline-1.0.3.tgz",
+      "integrity": "sha512-FQXkOta0XBSUPHndIKON2Y9JeQz5ZeMqLYZVVK93FliNBFm7LNMIZmY6FrMEB9XPcDbE2bekMbZD6kzDkxwYjA==",
+      "license": "MIT"
+    },
     "node_modules/ajv": {
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
@@ -1239,6 +1248,21 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/apexcharts": {
+      "version": "3.45.2",
+      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-3.45.2.tgz",
+      "integrity": "sha512-PpuM4sJWy70sUh5U1IFn1m1p45MdHSChLUNnqEoUUUHSU2IHZugFrsVNhov1S8Q0cvfdrCRCvdBtHGSs6PSAWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@yr/monotone-cubic-spline": "^1.0.3",
+        "svg.draggable.js": "^2.2.2",
+        "svg.easing.js": "^2.0.0",
+        "svg.filter.js": "^2.0.2",
+        "svg.pathmorphing.js": "^0.1.3",
+        "svg.resize.js": "^1.4.3",
+        "svg.select.js": "^3.0.1"
       }
     },
     "node_modules/archiver": {
@@ -4842,6 +4866,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-apexcharts": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/react-apexcharts/-/react-apexcharts-1.4.1.tgz",
+      "integrity": "sha512-G14nVaD64Bnbgy8tYxkjuXEUp/7h30Q0U33xc3AwtGFijJB9nHqOt1a6eG0WBn055RgRg+NwqbKGtqPxy15d0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "apexcharts": "^3.41.0",
+        "react": ">=0.13"
+      }
+    },
     "node_modules/react-data-table-component": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/react-data-table-component/-/react-data-table-component-7.6.2.tgz",
@@ -5029,6 +5066,29 @@
         "react-is": ">= 16.8.0"
       }
     },
+    "node_modules/react-draggable": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.5.tgz",
+      "integrity": "sha512-OMHzJdyJbYTZo4uQE393fHcqqPYsEtkjfMgvCHr6rejT+Ezn4OZbNyGH50vv+SunC1RMvwOTSWkEODQLzw1M9g==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^1.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-draggable/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react-fast-compare": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
@@ -5057,6 +5117,32 @@
       "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-0.8.2.tgz",
       "integrity": "sha512-JZfH47qTsslwaAsqbMI3Q6HNNjUuq6Cmzzww50TdP5Esb6e1y2sK2UAaZZuzfAzpoI2AkxoPQapZdlDuP6Vlsw==",
       "license": "MIT"
+    },
+    "node_modules/react-grid-layout": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-1.3.4.tgz",
+      "integrity": "sha512-sB3rNhorW77HUdOjB4JkelZTdJGQKuXLl3gNg+BI8gJkTScspL1myfZzW/EM0dLEn+1eH+xW+wNqk0oIM9o7cw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^1.1.1",
+        "lodash.isequal": "^4.0.0",
+        "prop-types": "^15.8.1",
+        "react-draggable": "^4.0.0",
+        "react-resizable": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-grid-layout/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/react-hook-form": {
       "version": "6.15.8",
@@ -5239,6 +5325,20 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-resizable": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.2.0.tgz",
+      "integrity": "sha512-3NKQ0SLZV7rs3LQHeXlOzDSRQfFrkX6TVet77/Qk03zqiZyee37b7N8/gwDJAA8UUjRz7PdWCCy49hcso45SMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "15.x",
+        "react-draggable": "^4.5.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3",
+        "react-dom": ">= 16.3"
       }
     },
     "node_modules/react-responsive": {
@@ -6023,6 +6123,97 @@
       "license": "MIT",
       "dependencies": {
         "pdfkit": ">=0.8.1"
+      }
+    },
+    "node_modules/svg.draggable.js": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/svg.draggable.js/-/svg.draggable.js-2.2.2.tgz",
+      "integrity": "sha512-JzNHBc2fLQMzYCZ90KZHN2ohXL0BQJGQimK1kGk6AvSeibuKcIdDX9Kr0dT9+UJ5O8nYA0RB839Lhvk4CY4MZw==",
+      "license": "MIT",
+      "dependencies": {
+        "svg.js": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.easing.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/svg.easing.js/-/svg.easing.js-2.0.0.tgz",
+      "integrity": "sha512-//ctPdJMGy22YoYGV+3HEfHbm6/69LJUTAqI2/5qBvaNHZ9uUFVC82B0Pl299HzgH13rKrBgi4+XyXXyVWWthA==",
+      "license": "MIT",
+      "dependencies": {
+        "svg.js": ">=2.3.x"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.filter.js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/svg.filter.js/-/svg.filter.js-2.0.2.tgz",
+      "integrity": "sha512-xkGBwU+dKBzqg5PtilaTb0EYPqPfJ9Q6saVldX+5vCRy31P6TlRCP3U9NxH3HEufkKkpNgdTLBJnmhDHeTqAkw==",
+      "license": "MIT",
+      "dependencies": {
+        "svg.js": "^2.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/svg.js/-/svg.js-2.7.1.tgz",
+      "integrity": "sha512-ycbxpizEQktk3FYvn/8BH+6/EuWXg7ZpQREJvgacqn46gIddG24tNNe4Son6omdXCnSOaApnpZw6MPCBA1dODA==",
+      "license": "MIT"
+    },
+    "node_modules/svg.pathmorphing.js": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/svg.pathmorphing.js/-/svg.pathmorphing.js-0.1.3.tgz",
+      "integrity": "sha512-49HWI9X4XQR/JG1qXkSDV8xViuTLIWm/B/7YuQELV5KMOPtXjiwH4XPJvr/ghEDibmLQ9Oc22dpWpG0vUDDNww==",
+      "license": "MIT",
+      "dependencies": {
+        "svg.js": "^2.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.resize.js": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/svg.resize.js/-/svg.resize.js-1.4.3.tgz",
+      "integrity": "sha512-9k5sXJuPKp+mVzXNvxz7U0uC9oVMQrrf7cFsETznzUDDm0x8+77dtZkWdMfRlmbkEEYvUn9btKuZ3n41oNA+uw==",
+      "license": "MIT",
+      "dependencies": {
+        "svg.js": "^2.6.5",
+        "svg.select.js": "^2.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.resize.js/node_modules/svg.select.js": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/svg.select.js/-/svg.select.js-2.1.2.tgz",
+      "integrity": "sha512-tH6ABEyJsAOVAhwcCjF8mw4crjXSI1aa7j2VQR8ZuJ37H2MBUbyeqYr5nEO7sSN3cy9AR9DUwNg0t/962HlDbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "svg.js": "^2.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.select.js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/svg.select.js/-/svg.select.js-3.0.1.tgz",
+      "integrity": "sha512-h5IS/hKkuVCbKSieR9uQCj9w+zLHoPh+ce19bBYyqF53g6mnPB8sAtIbe1s9dh2S2fCmYX2xel1Ln3PJBbK4kw==",
+      "license": "MIT",
+      "dependencies": {
+        "svg.js": "^2.6.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/synchronous-promise": {

--- a/digit-ui-esbuild/package.json
+++ b/digit-ui-esbuild/package.json
@@ -8,6 +8,7 @@
     "build": "node esbuild.build.js",
     "prebuild": "node scripts/vendor-digit-ui-css.js",
     "build:docker": "docker build -f docker/Dockerfile -t digit-ui:esbuild .",
+    "build:dashboard-css": "tailwindcss -c products/dashboard/src/tailwind.config.js -i products/dashboard/src/styles/input.css -o products/dashboard/src/styles/dashboard.css",
     "check-aliases": "node scripts/check-aliases.js"
   },
   "dependencies": {
@@ -21,6 +22,7 @@
     "ajv": "^8.12.0",
     "ajv-errors": "^3.0.0",
     "ajv-formats": "^2.1.1",
+    "apexcharts": "3.45.2",
     "axios": "^1.7.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -40,6 +42,7 @@
     "lucide-react": "^1.14.0",
     "pdfmake": "^0.1.72",
     "react": "17.0.2",
+    "react-apexcharts": "1.4.1",
     "react-data-table-component": "^7.6.2",
     "react-date-range": "^1.4.0",
     "react-datepicker": "^4.8.0",
@@ -48,6 +51,7 @@
     "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "17.0.2",
     "react-drag-drop-files": "^2.3.10",
+    "react-grid-layout": "1.3.4",
     "react-hook-form": "6.15.8",
     "react-i18next": "11.16.2",
     "react-joyride": "^2.5.5",
@@ -74,7 +78,14 @@
     "postcss": "^8.5.14",
     "tailwindcss": "^3.4.19"
   },
+  "overrides": {
+    "react-draggable": "4.4.5",
+    "react-resizable": {
+      "react-draggable": "4.4.5"
+    }
+  },
   "resolutions": {
-    "**/styled-components": "5.0.0"
+    "**/styled-components": "5.0.0",
+    "**/react-draggable": "4.4.5"
   }
 }

--- a/digit-ui-esbuild/packages/modules/core/src/components/AppModules.js
+++ b/digit-ui-esbuild/packages/modules/core/src/components/AppModules.js
@@ -35,6 +35,13 @@ export const AppModules = ({ stateCode, userType, modules, appTenants, additiona
       </Route>
     );
   });
+  // Always-on fallback for the supervisor dashboard: appRoutes above are built
+  // from initData.modules (MDMS tenant.citymodule ∩ enabledModules), so without
+  // the "Dashboard" citymodule row the route would fall through to AppHome.
+  // When the row IS present the appRoutes entry matches first in the Switch,
+  // so this never double-mounts. Role-gating lives inside DashboardModule.
+  const DashboardFallbackModule = Digit.ComponentRegistryService.getComponent("DashboardModule");
+
   const isSuperUserWithMultipleRootTenant = Digit.UserService.hasAccess("SUPERUSER") && Digit.Utils.getMultiRootTenant();
    const hideClass =
     location.pathname.includes(`${path}/productDetailsPage/`);
@@ -43,6 +50,11 @@ export const AppModules = ({ stateCode, userType, modules, appTenants, additiona
     <div className={isSuperUserWithMultipleRootTenant ? "" : "ground-container digit-home-ground"}>
       <Switch>
         {appRoutes}
+        {DashboardFallbackModule && (
+          <Route path={`${path}/dashboard`}>
+            <DashboardFallbackModule stateCode={stateCode} moduleCode="Dashboard" userType={userType} tenants={appTenants} />
+          </Route>
+        )}
         <Route path={`${path}/login`}>
           <Redirect to={{ pathname: `/${window?.contextPath}/employee/user/login`, state: { from: location.pathname + location.search } }} />
         </Route>

--- a/digit-ui-esbuild/products/dashboard/DashboardCard.js
+++ b/digit-ui-esbuild/products/dashboard/DashboardCard.js
@@ -1,0 +1,33 @@
+import { EmployeeModuleCard } from "@egovernments/digit-ui-react-components";
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { DASHBOARD_ROLES } from "./roles";
+
+const DashboardCard = () => {
+  const { t } = useTranslation();
+
+  // Same tenant-agnostic check as the DashboardModule route guard (roles live
+  // at the state root tenant), so the card and the route always agree.
+  if (!Digit.UserService.hasAccess(DASHBOARD_ROLES)) {
+    return null;
+  }
+
+  const link = `/${window?.contextPath}/employee/dashboard`;
+
+  const propsForModuleCard = {
+    Icon: "Dashboard",
+    moduleName: t("DASHBOARD_CARD_HEADER"),
+    kpis: [],
+    links: [
+      {
+        label: t("DASHBOARD_CARD_HEADER"),
+        link: link,
+      },
+    ],
+    className: "microplan-employee-module-card",
+  };
+
+  return <EmployeeModuleCard {...propsForModuleCard} />;
+};
+
+export default DashboardCard;

--- a/digit-ui-esbuild/products/dashboard/Module.js
+++ b/digit-ui-esbuild/products/dashboard/Module.js
@@ -1,0 +1,30 @@
+import React from "react";
+import { Redirect } from "react-router-dom";
+import AdminDashboard from "./src/AdminDashboard";
+import DashboardCard from "./DashboardCard";
+import { DASHBOARD_ROLES } from "./roles";
+
+export { DASHBOARD_ROLES };
+
+// Mounted by core AppModules at /{contextPath}/employee/dashboard INSIDE the
+// employee chrome (topbar + sidebar). AppModules already guarantees a logged-in
+// session, so the only guard needed here is the role check — tenant-agnostic
+// (see roles.js) — before rendering the dashboard in embedded mode (which
+// suppresses its standalone shell: internal sidebar, login gate, 100dvh layout).
+const DashboardModule = () => {
+  if (!Digit.UserService.hasAccess(DASHBOARD_ROLES)) {
+    return <Redirect to={`/${window?.contextPath}/employee`} />;
+  }
+  return <AdminDashboard embedded />;
+};
+
+const componentsToRegister = {
+  DashboardModule,
+  DashboardCard,
+};
+
+export const initDashboardComponents = () => {
+  Object.entries(componentsToRegister).forEach(([key, value]) => {
+    Digit.ComponentRegistryService.setComponent(key, value);
+  });
+};

--- a/digit-ui-esbuild/products/dashboard/roles.js
+++ b/digit-ui-esbuild/products/dashboard/roles.js
@@ -1,0 +1,6 @@
+// Roles allowed to open the supervisor dashboard. Checked tenant-agnostically
+// (role CODE only, via Digit.UserService.hasAccess) because employee roles live
+// at the state root tenant ("ke") while the working tenant may be a city tenant —
+// Digit.Utils.didEmployeeHasAtleastOneRole filters by current tenant and would
+// wrongly hide the dashboard there.
+export const DASHBOARD_ROLES = ["SUPERVISOR", "PGR_SUPERVISOR", "GRO", "DGRO", "PGR_LME", "PGR_ADMIN", "SUPERUSER"];

--- a/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
@@ -1,0 +1,633 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import GridLayout, { WidthProvider } from "react-grid-layout";
+import "react-grid-layout/css/styles.css";
+import "react-resizable/css/styles.css";
+import "./styles/dashboard.css";
+
+import DashboardLayout from "./components/DashboardLayout";
+import KpiTile from "./components/KpiTile";
+import CardUpdatedStamp from "./components/CardUpdatedStamp";
+import ResizeGrip from "./components/ResizeGrip";
+import SubtleScroll from "./components/SubtleScroll";
+import {
+  VIZ_TYPE,
+  SHARED_CHROME,
+  buildWidgetHeaderClassName,
+  getWidgetBodyClassName,
+  getWidgetScrollClassName,
+} from "./config/visualizationStyles";
+import DashboardLogin, {
+  hasDashboardSession,
+  clearDashboardSession,
+} from "./components/DashboardLogin";
+
+import { useDashboardFilters } from "./hooks/useDashboardFilters";
+import { useCatalog } from "./hooks/useCatalog";
+import { useCatalogLayout } from "./hooks/useCatalogLayout";
+import { runKpiBatch, getTenantId } from "./services/analyticsService";
+import { GRID_COLS, KPI_ROW_HEIGHT } from "./constants/layoutConfig";
+
+// Map the catalog's viz.kind onto the reference dashboard's VIZ_TYPE so each widget
+// gets its type-specific header/body chrome (padding, insets, legend tuning) instead
+// of a generic flex body. Mirrors the OLD DashboardGrid presentation path.
+const KIND_TO_VIZTYPE = {
+  bar: VIZ_TYPE.BAR_CHART,
+  "bar-chart": VIZ_TYPE.BAR_CHART,
+  histogram: VIZ_TYPE.HISTOGRAM,
+  "horizontal-bar": VIZ_TYPE.HORIZONTAL_BAR,
+  "stacked-bar": VIZ_TYPE.STACKED_BAR,
+  line: VIZ_TYPE.LINE_CHART,
+  "line-chart": VIZ_TYPE.LINE_CHART,
+  pie: VIZ_TYPE.PIE_CHART,
+  "pie-chart": VIZ_TYPE.PIE_CHART,
+  "data-table": VIZ_TYPE.DATA_TABLE,
+  table: VIZ_TYPE.DATA_TABLE,
+  "sla-risk-table": VIZ_TYPE.SLA_RISK_TABLE,
+  map: VIZ_TYPE.MAP,
+  "choropleth-map": VIZ_TYPE.MAP,
+};
+const TABLE_KINDS = new Set(["data-table", "table", "sla-risk-table"]);
+
+const RemoveIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="tw-h-3.5 tw-w-3.5"
+    aria-hidden="true"
+  >
+    <path d="M18 6 6 18" />
+    <path d="m6 6 12 12" />
+  </svg>
+);
+
+const WidgetRemoveButton = ({ label, onClick }) => (
+  <button
+    type="button"
+    title="Remove from dashboard"
+    onMouseDown={(e) => e.stopPropagation()}
+    onClick={onClick}
+    className="dashboard-widget-remove-btn"
+    aria-label={label}
+  >
+    <RemoveIcon />
+  </button>
+);
+
+/**
+ * AdminDashboard — a PARALLEL, pure-engine dashboard.
+ *
+ * Unlike the reference AdminDashboard (which builds inline batch queries via
+ * useDashboardData/buildBatchQueries and renders through DashboardGrid against
+ * the hardcoded local widget config), V2 renders ENTIRELY from the backend
+ * catalog:
+ *
+ *   useCatalog(tenantId)  -> { kpis: {[kpiId]: def}, pack: { tiles, layout } }
+ *   runKpiBatch(refs)     -> { results: { [tileKey]: { columns, rows, asOf, scope } } }
+ *   <KpiTile def result /> -> the generic viz.kind render engine
+ *
+ * No useDashboardData, no buildBatchQueries, no DashboardGrid. Every tile's
+ * shape decision is keyed off its catalog `viz` descriptor; every query is a
+ * `{ kpiId, params }` reference the BE KpiQueryComposer resolves.
+ */
+
+const GridLayoutWithWidth = WidthProvider(GridLayout);
+const GRID_MARGIN = [16, 16];
+
+/* -------------------------------------------------------------------------- */
+/* Auth gate (mirrors AdminDashboard)                                          */
+/* -------------------------------------------------------------------------- */
+
+const AdminDashboard = ({ embedded = false }) => {
+  // Embedded (inside the DigitUI employee chrome) the host guarantees the
+  // session and owns sign-out, so the standalone login gate is skipped.
+  const [authed] = useState(() => embedded || hasDashboardSession());
+
+  const handleLogin = useCallback(() => {
+    window.location.reload();
+  }, []);
+
+  const handleSignOut = useCallback(() => {
+    clearDashboardSession();
+    window.location.reload();
+  }, []);
+
+  if (!authed) return <DashboardLogin onLogin={handleLogin} />;
+  return <AdminDashboardInner embedded={embedded} onSignOut={embedded ? undefined : handleSignOut} />;
+};
+
+/* -------------------------------------------------------------------------- */
+/* Query-plan helpers                                                          */
+/* -------------------------------------------------------------------------- */
+
+const CARD_KINDS = new Set([
+  "number-tile-delta",
+  "number-tile",
+  "scalar",
+  "number-tile-sparkline",
+  "sparkline-card",
+]);
+const SPARKLINE_KINDS = new Set(["number-tile-sparkline", "sparkline-card"]);
+const MAP_KINDS = new Set(["map", "choropleth-map"]);
+
+// The internal pin source: map tiles fetch this alongside their ward aggregates
+// to overlay per-complaint pins (the FE map widget has the pin layer; this feeds it).
+const PIN_KPI_ID = "cl_map_complaint_pins";
+
+function isCardKind(kind) {
+  return CARD_KINDS.has(kind);
+}
+function isSparklineKind(kind) {
+  return SPARKLINE_KINDS.has(kind);
+}
+function isMapKind(kind) {
+  return MAP_KINDS.has(kind);
+}
+
+/**
+ * Map the dashboard filter bar -> the KpiQueryComposer param names.
+ * Mirrors config/kpiQueries.js buildGlobalApiFilters: an active date range maps
+ * to dateFrom/dateTo (yyyy-MM-dd, which the composer turns into a gte/lt on the
+ * grain's time column and which drops the def's base window); a non-"all"
+ * geography/complaintType narrows via ward/serviceCode. No global `window` is
+ * emitted, so each def keeps its own baked window when no range is active —
+ * exactly the reference path's behaviour.
+ */
+function globalParams(filters) {
+  const params = {};
+  if (filters?.geography && filters.geography !== "all") {
+    params.ward = filters.geography;
+  }
+  if (filters?.complaintType && filters.complaintType !== "all") {
+    params.serviceCode = filters.complaintType;
+  }
+  if (filters?.dateRangeActive && filters?.dateFrom && filters?.dateTo) {
+    params.dateFrom = filters.dateFrom; // yyyy-MM-dd
+    params.dateTo = filters.dateTo; // yyyy-MM-dd
+  }
+  return params;
+}
+
+/**
+ * Build the per-tile refs map for runKpiBatch. The tileKey convention is:
+ *   <kpiId>           base query (global params applied)
+ *   <kpiId>__prior    delta cards: same params + compare:'prior'
+ *   <kpiId>__series   sparkline cards: same params + series:'daily'
+ *
+ * The prior/series refs are gated on viz.kind (the only series signal exposed by
+ * the catalog tile — supportsSeries is not serialised), so non-card tiles only
+ * issue the single base query.
+ */
+function buildRefs(tiles, kpis, filters) {
+  const gp = globalParams(filters);
+  const refs = {};
+  for (const tile of tiles) {
+    const kpiId = tile.kpiId;
+    const def = kpis[kpiId];
+    if (!def) continue;
+    const kind = def.viz?.kind;
+
+    refs[kpiId] = { kpiId, params: { ...gp } };
+
+    if (isCardKind(kind)) {
+      refs[`${kpiId}__prior`] = { kpiId, params: { ...gp, compare: "prior" } };
+    }
+    if (isSparklineKind(kind)) {
+      refs[`${kpiId}__series`] = { kpiId, params: { ...gp, series: "daily" } };
+    }
+    if (isMapKind(kind)) {
+      // Per-complaint pins (same filters/scope) overlaid on the ward choropleth.
+      refs[`${kpiId}__pins`] = { kpiId: PIN_KPI_ID, params: { ...gp } };
+    }
+  }
+  return refs;
+}
+
+/**
+ * Assemble the single result object KpiTile expects for one tile, merging the
+ * base result with its __prior / __series companions.
+ *
+ * KpiTile's resolvers read (in priority order):
+ *   resolveScalar   -> result.value, else result.values[viz.valueKey], else rows[0][viz.valueKey]
+ *   resolvePrior    -> result.prior
+ *   resolveSparkline-> result.sparkline (number[]), else result.rows + viz.dateKey/sparklineMeasureKey
+ * plus the wrapper reads result.asOf / result.scope for non-card tiles, and the
+ * chart adapters read result.columns / result.rows.
+ *
+ * So we keep columns/rows/scope/asOf verbatim, and additionally hoist:
+ *   value    <- base scalar (rows[0][valueKey] / single measure)
+ *   prior    <- __prior scalar
+ *   sparkline<- __series rows -> ordered numeric series
+ */
+function assembleResult(kpiId, def, results) {
+  const base = results?.[kpiId];
+  if (!base) return null;
+
+  const viz = def.viz || {};
+  const valueKey = viz.valueKey || firstMeasureName(base);
+
+  const assembled = {
+    columns: base.columns,
+    rows: base.rows,
+    scope: base.scope,
+    asOf: base.asOf,
+  };
+
+  // Scalar value (cards). For non-card tiles this is harmless extra metadata
+  // that the chart adapters ignore.
+  if (isCardKind(viz.kind)) {
+    const v = scalarFromResult(base, valueKey);
+    if (v != null) assembled.value = v;
+
+    const priorRes = results?.[`${kpiId}__prior`];
+    if (priorRes) {
+      const p = scalarFromResult(priorRes, valueKey);
+      if (p != null) assembled.prior = p;
+    }
+  }
+
+  // Daily sparkline series.
+  if (isSparklineKind(viz.kind)) {
+    const seriesRes = results?.[`${kpiId}__series`];
+    if (seriesRes?.rows?.length) {
+      assembled.sparkline = seriesToPoints(seriesRes.rows, viz, valueKey, seriesRes.columns);
+    }
+  }
+
+  // Map complaint pins: shape the companion pin source -> { lat, lng, id } for the
+  // map widget's pin layer (it drops 0,0 / out-of-area pins itself).
+  if (isMapKind(viz.kind)) {
+    const pinRes = results?.[`${kpiId}__pins`];
+    if (pinRes?.rows?.length) {
+      assembled.pins = pinRes.rows
+        .map((r) => ({
+          id: r.service_request_id,
+          serviceRequestId: r.service_request_id,
+          // Kajal's resolveComplaintPinPositions needs wardCode to place a pin
+          // (snaps/jitters around the ward centroid when the geo-pin is unusable).
+          wardCode: String(r.ward_code ?? ""),
+          lat: Number(r.latitude),
+          lng: Number(r.longitude),
+          // detail fields for the click popup
+          serviceCode: r.service_code,
+          status: r.application_status,
+          createdDate: r.created_date,
+          source: r.source,
+          slaStatus: r.sla_status_bucket,
+        }))
+        .filter((p) => Number.isFinite(p.lat) && Number.isFinite(p.lng));
+    }
+  }
+
+  return assembled;
+}
+
+function firstMeasureName(result) {
+  const measure = (result?.columns || []).find((c) => c.role === "measure");
+  return measure?.name;
+}
+
+function scalarFromResult(result, valueKey) {
+  const row0 = result?.rows?.[0];
+  if (!row0) return null;
+  const key = valueKey || firstMeasureName(result) || Object.keys(row0)[0];
+  const raw = row0[key];
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** The series date dimension is grain-specific (facts: created_date, events:
+ * occurred_date, daily: snapshot_date). Prefer viz.dateKey, else derive the
+ * *_date column from the result, else fall back to created_date. */
+function deriveDateKey(columns) {
+  for (const col of columns || []) {
+    const name = typeof col === "string" ? col : col?.name;
+    if (name && /_date$/.test(name)) return name;
+  }
+  return null;
+}
+
+function seriesToPoints(rows, viz, valueKey, columns) {
+  const dateKey = viz.dateKey || deriveDateKey(columns) || "created_date";
+  const measureKey = viz.sparklineMeasureKey || valueKey || "total";
+  return [...rows]
+    .sort((a, b) =>
+      String(a[dateKey] ?? "").localeCompare(String(b[dateKey] ?? ""))
+    )
+    .map((row) => Number(row[measureKey]) || 0);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Inner dashboard                                                             */
+/* -------------------------------------------------------------------------- */
+
+const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
+  const { filters, setFilter, clearFilters } = useDashboardFilters();
+  const tenantId = useMemo(() => getTenantId(), []);
+  const { loading: catalogLoading, kpis, pack, error: catalogError } =
+    useCatalog(tenantId);
+
+  const [batch, setBatch] = useState({
+    loading: true,
+    results: {},
+    errors: null,
+    partial: false,
+  });
+  const reqIdRef = useRef(0);
+
+  const {
+    layout,
+    onLayoutChange,
+    resetLayout,
+    removeWidgetFromLayout,
+    addKpiToLayout,
+    visibleLayoutIds,
+  } = useCatalogLayout(kpis, pack?.layout);
+
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const tiles = useMemo(
+    () => layout.map((item) => ({ kpiId: item.i })),
+    [layout]
+  );
+
+  // Title-based tile search: dim tiles whose title doesn't match the query.
+  const matchesSearch = useCallback(
+    (kpiId) => {
+      const q = searchQuery.trim().toLowerCase();
+      if (!q) return true;
+      const title = (kpis[kpiId]?.viz?.title || kpiId).toLowerCase();
+      return title.includes(q);
+    },
+    [searchQuery, kpis]
+  );
+
+  // Add-KPI picker source: every role-visible catalog tile (already filtered
+  // server-side), shaped to the picker's { id, metric, type, itemType } contract.
+  const catalogItems = useMemo(
+    () =>
+      Object.values(kpis)
+        .filter((def) => !def.viz?.internal) // hide internal companion sources (e.g. map pins)
+        .map((def) => ({
+          id: def.kpiId,
+          metric: def.viz?.title || def.kpiId,
+          type: def.viz?.kind,
+          itemType: isCardKind(def.viz?.kind) ? "kpi" : "widget",
+        })),
+    [kpis]
+  );
+
+  // Re-run the batch whenever the catalog resolves or the filters change.
+  // Include each tile's viz.kind: it drives buildRefs' __prior/__series companion
+  // refs, so a def flipping card<->chart (or gaining sparkline) must re-trigger the
+  // batch even when the id set and global params are unchanged.
+  const refsKey = useMemo(
+    () =>
+      JSON.stringify({
+        ids: tiles.map((t) => t.kpiId),
+        kinds: tiles.map((t) => kpis[t.kpiId]?.viz?.kind),
+        gp: globalParams(filters),
+      }),
+    [tiles, filters, kpis]
+  );
+
+  useEffect(() => {
+    if (!pack || !tiles.length) {
+      setBatch({ loading: false, results: {}, errors: null, partial: false });
+      return;
+    }
+    const refs = buildRefs(tiles, kpis, filters);
+    const reqId = ++reqIdRef.current;
+    setBatch((prev) => ({ ...prev, loading: true }));
+
+    runKpiBatch(refs, tenantId)
+      .then((res) => {
+        if (reqId !== reqIdRef.current) return;
+        setBatch({
+          loading: false,
+          results: res?.results || {},
+          errors: res?.errors || null,
+          partial: Boolean(res?.partial),
+        });
+      })
+      .catch((err) => {
+        if (reqId !== reqIdRef.current) return;
+        setBatch({
+          loading: false,
+          results: {},
+          errors: { __batch: err?.message || "Batch query failed" },
+          partial: true,
+        });
+      });
+    // refsKey captures both the tile set and the resolved params.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [refsKey, pack, tenantId]);
+
+  const lastUpdatedLabel = useMemo(
+    () =>
+      new Date().toLocaleString(undefined, {
+        day: "numeric",
+        month: "short",
+        hour: "numeric",
+        minute: "2-digit",
+      }),
+    [batch.results]
+  );
+
+  // RGL reads min/max W/H straight off each layout item (the hook bakes in the
+  // viz.kind-derived constraints), so the grid layout passes items through verbatim.
+  const gridLayout = useMemo(() => layout, [layout]);
+
+  const renderTile = (kpiId) => {
+    const def = kpis[kpiId];
+    if (!def) return null;
+
+    const assembled = assembleResult(kpiId, def, batch.results);
+    const errCode = batch.errors && batch.errors[kpiId];
+    const tileError = errCode ? { code: errCode, message: String(errCode) } : null;
+
+    return (
+      <KpiTile
+        def={def}
+        result={assembled}
+        results={batch.results}
+        error={tileError}
+        loading={batch.loading && !assembled}
+      />
+    );
+  };
+
+  // CSV export of the laid-out tiles (title + scalar value, or row count for
+  // charts/tables). Reads straight from the catalog result map — no dependence on
+  // the old kpiCardData/chartData shapes.
+  const handleExport = useCallback(() => {
+    const csvEscape = (v) => {
+      const s = String(v ?? "");
+      return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+    };
+    const rows = layout.map((item) => {
+      const def = kpis[item.i];
+      const assembled = assembleResult(item.i, def, batch.results);
+      const value =
+        assembled?.value != null
+          ? assembled.value
+          : assembled?.rows
+          ? `${assembled.rows.length} rows`
+          : "";
+      return [def?.viz?.title || item.i, item.i, value];
+    });
+    const csv = ["Title,KPI,Value", ...rows.map((r) => r.map(csvEscape).join(","))].join("\n");
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "dashboard-export.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [layout, kpis, batch.results]);
+
+  const showEmpty = !catalogLoading && pack && layout.length === 0;
+
+  return (
+    <DashboardLayout
+      embedded={embedded}
+      visibleLayoutIds={visibleLayoutIds}
+      catalogItems={catalogItems}
+      onAddWidget={addKpiToLayout}
+      onResetLayout={resetLayout}
+      onDragWidgetStart={() => {}}
+      onDragWidgetEnd={() => {}}
+      searchQuery={searchQuery}
+      onSearchQueryChange={setSearchQuery}
+      onExport={handleExport}
+      filters={filters}
+      onFilterChange={setFilter}
+      onClearFilters={clearFilters}
+      filterOptions={null}
+      filterOptionsLoading={catalogLoading}
+      kpiCardData={{}}
+      allowedWidgetIds={null}
+      scopedRole={null}
+      username={null}
+      officerAccess={null}
+      visibleKpiCount={layout.length}
+      scope={null}
+      onSignOut={onSignOut}
+    >
+      {catalogError && (
+        <div className="tw-mb-4 tw-rounded-md tw-border tw-border-[color-mix(in_srgb,var(--destructive)_30%,transparent)] tw-bg-status-breach-bg tw-px-4 tw-py-3 tw-text-sm tw-text-destructive">
+          Catalog unavailable: {catalogError}
+        </div>
+      )}
+      {batch.errors && batch.errors.__batch && (
+        <div className="tw-mb-4 tw-rounded-md tw-border tw-border-[color-mix(in_srgb,var(--destructive)_30%,transparent)] tw-bg-status-breach-bg tw-px-4 tw-py-3 tw-text-sm tw-text-destructive">
+          {batch.errors.__batch}
+        </div>
+      )}
+
+      {showEmpty ? (
+        <div className="tw-flex tw-flex-col tw-items-center tw-justify-center tw-gap-3 tw-rounded tw-border tw-border-dashed tw-border-border tw-bg-surface tw-py-16 tw-text-center">
+          <p className="tw-text-[12px] tw-text-muted-foreground">
+            No tiles in the catalog pack for this role.
+          </p>
+        </div>
+      ) : (
+        <GridLayoutWithWidth
+          className="dashboard-grid-layout layout"
+          layout={gridLayout}
+          cols={GRID_COLS}
+          rowHeight={KPI_ROW_HEIGHT}
+          margin={GRID_MARGIN}
+          containerPadding={[0, 0]}
+          compactType="vertical"
+          isDraggable
+          isResizable
+          draggableHandle=".dashboard-widget-surface"
+          draggableCancel=".dashboard-widget-remove-btn, .dashboard-view-toggle, .dashboard-table-scroll, .dashboard-chart-scroll-viewport, .dashboard-kpi-list-body, .leaflet-container, a, button, input, select, textarea"
+          onLayoutChange={onLayoutChange}
+        >
+          {layout.map((item) => {
+            const isKpi = isCardKind(kpis[item.i]?.viz?.kind);
+            const dimClass = matchesSearch(item.i) ? "" : " dashboard-search-dimmed";
+            const removeBtn = (
+              <WidgetRemoveButton
+                label={`Remove ${kpis[item.i]?.viz?.title || item.i}`}
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  removeWidgetFromLayout(item.i);
+                }}
+              />
+            );
+            if (isKpi) {
+              return (
+                <div
+                  key={item.i}
+                  className={`dashboard-kpi-widget dashboard-widget-surface tw-group tw-relative tw-flex tw-h-full tw-flex-col${dimClass}`}
+                >
+                  {removeBtn}
+                  {renderTile(item.i)}
+                  <CardUpdatedStamp label={lastUpdatedLabel} />
+                </div>
+              );
+            }
+            // Map + choropleth widgets render their own internal header; every other
+            // chart/table tile gets the reference DashboardGrid chrome: a typed header
+            // (title + sub-line), the type-specific body insets, and a scroll wrapper
+            // for tables.
+            const viz = kpis[item.i]?.viz || {};
+            const kind = viz.kind;
+            const vizType = KIND_TO_VIZTYPE[kind] || kind;
+            const isTable = TABLE_KINDS.has(kind);
+            const selfHeaders = kind === "map" || kind === "choropleth-map";
+            return (
+              <section
+                key={item.i}
+                className={`dashboard-widget-surface tw-group tw-relative tw-flex tw-h-full tw-min-h-0 tw-flex-col tw-overflow-hidden tw-rounded tw-border tw-border-border tw-bg-surface${dimClass}`}
+              >
+                {removeBtn}
+                {!selfHeaders && (
+                  <header className={`${buildWidgetHeaderClassName(vizType)} tw-min-w-0`}>
+                    <div className="tw-min-w-0 tw-flex-1">
+                      <h2 className={`${SHARED_CHROME.dragHandleTitle} tw-truncate`}>
+                        {viz.title || item.i}
+                      </h2>
+                      {viz.subtitle && (
+                        <p className={SHARED_CHROME.dragHandleSubtitle}>{viz.subtitle}</p>
+                      )}
+                    </div>
+                  </header>
+                )}
+                <div
+                  className={
+                    selfHeaders
+                      ? "tw-flex tw-min-h-0 tw-flex-1 tw-flex-col tw-overflow-hidden"
+                      : getWidgetBodyClassName(vizType, { isTable })
+                  }
+                >
+                  {isTable ? (
+                    <SubtleScroll className={getWidgetScrollClassName()}>
+                      {renderTile(item.i)}
+                    </SubtleScroll>
+                  ) : (
+                    renderTile(item.i)
+                  )}
+                </div>
+                <CardUpdatedStamp label={lastUpdatedLabel} />
+                <ResizeGrip />
+              </section>
+            );
+          })}
+        </GridLayoutWithWidth>
+      )}
+    </DashboardLayout>
+  );
+};
+
+export default AdminDashboard;

--- a/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
@@ -22,6 +22,7 @@ import DashboardLogin, {
 } from "./components/DashboardLogin";
 
 import { useDashboardFilters } from "./hooks/useDashboardFilters";
+import { useFilterOptions } from "./hooks/useFilterOptions";
 import { useCatalog } from "./hooks/useCatalog";
 import { useCatalogLayout } from "./hooks/useCatalogLayout";
 import { runKpiBatch, getTenantId } from "./services/analyticsService";
@@ -328,8 +329,18 @@ function seriesToPoints(rows, viz, valueKey, columns) {
 /* -------------------------------------------------------------------------- */
 
 const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
-  const { filters, setFilter, clearFilters } = useDashboardFilters();
+  const { filters, setFilter, clearFilters, applyFilterOptions } =
+    useDashboardFilters();
+  const { options: filterOptions, loading: filterOptionsLoading } =
+    useFilterOptions();
   const tenantId = useMemo(() => getTenantId(), []);
+
+  // Feed the server-scoped option lists into the filter store so persisted
+  // filter values that no longer match any option get reconciled
+  // (reconcileFiltersWithOptions) instead of silently sending dead params.
+  useEffect(() => {
+    if (filterOptions) applyFilterOptions(filterOptions);
+  }, [filterOptions, applyFilterOptions]);
   const { loading: catalogLoading, kpis, pack, error: catalogError } =
     useCatalog(tenantId);
 
@@ -509,8 +520,8 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
       filters={filters}
       onFilterChange={setFilter}
       onClearFilters={clearFilters}
-      filterOptions={null}
-      filterOptionsLoading={catalogLoading}
+      filterOptions={filterOptions}
+      filterOptionsLoading={filterOptionsLoading}
       kpiCardData={{}}
       allowedWidgetIds={null}
       scopedRole={null}

--- a/digit-ui-esbuild/products/dashboard/src/components/AddKpiDropdown.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/AddKpiDropdown.jsx
@@ -1,0 +1,247 @@
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import AddKpiPreview from "./AddKpiPreview";
+
+const PANEL_WIDTH_PX = 320; // ~tw-w-80
+
+function iconKind(item) {
+  if (
+    item.type === "bar-chart" ||
+    item.type === "stacked-bar" ||
+    item.type === "line-chart" ||
+    item.type === "pie-chart" ||
+    item.type === "histogram" ||
+    item.type === "map" ||
+    item.type === "data-table" ||
+    item.type === "sla-risk-table" ||
+    item.type === "sla-toggle" ||
+    item.type === "gauge"
+  ) {
+    return "chart";
+  }
+  const id = item.id || "";
+  if (/open|breach|escalat|risk|hot|ward/i.test(item.metric || id)) return "alert";
+  if (/resolution|dwell|sla|time|inflow|median|avg/i.test(item.metric || id)) return "clock";
+  if (/officer|employee|assignee|citizen|complainant/i.test(item.metric || id)) return "user";
+  return "trend";
+}
+
+function MetricIcon({ kind }) {
+  const cls = "tw-h-3.5 tw-w-3.5 tw-shrink-0 tw-text-muted-foreground";
+  if (kind === "alert") {
+    return (
+      <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+        <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+        <line x1="12" y1="9" x2="12" y2="13" />
+        <line x1="12" y1="17" x2="12.01" y2="17" />
+      </svg>
+    );
+  }
+  if (kind === "clock") {
+    return (
+      <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+        <circle cx="12" cy="12" r="10" />
+        <polyline points="12 6 12 12 16 14" />
+      </svg>
+    );
+  }
+  if (kind === "user") {
+    return (
+      <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+        <path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2" />
+        <circle cx="12" cy="7" r="4" />
+      </svg>
+    );
+  }
+  if (kind === "chart") {
+    return (
+      <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+        <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
+      </svg>
+    );
+  }
+  return (
+    <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+      <polyline points="23 6 13.5 15.5 8.5 10.5 1 18" />
+      <polyline points="17 6 23 6 23 12" />
+    </svg>
+  );
+}
+
+function itemTypeLabel(item) {
+  if (item.itemType === "kpi") return "STAT";
+  if (item.type === "data-table" || item.type === "sla-risk-table") return "TABLE";
+  return "CHART";
+}
+
+const AddKpiDropdown = ({
+  visibleLayoutIds,
+  onAddWidget,
+  onDragWidgetStart,
+  onDragWidgetEnd,
+  open,
+  onOpenChange,
+  containerRef,
+  kpiCardData,
+  allowedWidgetIds,
+  catalogItems,
+}) => {
+  const panelRef = useRef(null);
+  const [panelPosition, setPanelPosition] = useState(null);
+  const [hoveredItem, setHoveredItem] = useState(null);
+  const [hoverRect, setHoverRect] = useState(null);
+
+  const availableItems = useMemo(() => {
+    // Offer every role-visible catalog tile not already on the grid. The catalog
+    // is role-filtered server-side, so no extra allowedWidgetIds gate is needed.
+    // Each item is { id:kpiId, metric:title, type:viz.kind, itemType }.
+    return (catalogItems || []).filter((it) => !visibleLayoutIds.includes(it.id));
+  }, [visibleLayoutIds, catalogItems]);
+
+  useLayoutEffect(() => {
+    if (!open) {
+      setPanelPosition(null);
+      setHoveredItem(null);
+      setHoverRect(null);
+      return undefined;
+    }
+
+    const syncPosition = () => {
+      const anchor = containerRef?.current;
+      if (!anchor) return;
+      const rect = anchor.getBoundingClientRect();
+      setPanelPosition({
+        top: rect.bottom + 6,
+        left: Math.max(8, rect.right - PANEL_WIDTH_PX),
+      });
+    };
+
+    syncPosition();
+    window.addEventListener("resize", syncPosition);
+    window.addEventListener("scroll", syncPosition, true);
+    return () => {
+      window.removeEventListener("resize", syncPosition);
+      window.removeEventListener("scroll", syncPosition, true);
+    };
+  }, [open, containerRef]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const handleClick = (event) => {
+      const insideTrigger =
+        containerRef?.current && containerRef.current.contains(event.target);
+      const insidePanel = panelRef.current && panelRef.current.contains(event.target);
+      if (insideTrigger || insidePanel) return;
+      onOpenChange(false);
+    };
+    const handleKey = (event) => {
+      if (event.key === "Escape") onOpenChange(false);
+    };
+    document.addEventListener("mousedown", handleClick);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [open, onOpenChange, containerRef]);
+
+  const handleDragStart = (event, widgetId) => {
+    setHoveredItem(null);
+    setHoverRect(null);
+    event.dataTransfer.setData("text/plain", widgetId);
+    event.dataTransfer.effectAllowed = "copy";
+    onDragWidgetStart?.(widgetId);
+    // Defer hiding so React does not re-render during dragstart (that cancels the drag).
+    requestAnimationFrame(() => {
+      panelRef.current?.classList.add("dashboard-add-kpi-panel--dragging");
+    });
+  };
+
+  const handleDragEnd = () => {
+    panelRef.current?.classList.remove("dashboard-add-kpi-panel--dragging");
+    onDragWidgetEnd?.();
+    onOpenChange(false);
+  };
+
+  if (!open || !panelPosition) return null;
+
+  const panel = (
+    <div
+      ref={panelRef}
+      className="dashboard-add-kpi-panel tw-flex tw-max-h-[min(24rem,70vh)] tw-flex-col tw-overflow-hidden"
+      style={{
+        position: "fixed",
+        top: panelPosition.top,
+        left: panelPosition.left,
+        width: PANEL_WIDTH_PX,
+        zIndex: 9999,
+      }}
+      role="menu"
+    >
+      <p className="dashboard-add-kpi-header">Available KPIs</p>
+      <ul className="dashboard-add-kpi-list tw-min-h-0 tw-flex-1 tw-overflow-y-auto tw-overscroll-contain">
+        {availableItems.length === 0 ? (
+          <li className="tw-px-4 tw-py-6 tw-text-center tw-text-[12px] tw-font-normal tw-text-muted-foreground">
+            All KPIs are on the dashboard
+          </li>
+        ) : (
+          availableItems.map((item) => (
+            <li key={item.id}>
+              <div
+                draggable
+                onDragStart={(event) => handleDragStart(event, item.id)}
+                onDragEnd={handleDragEnd}
+                onMouseEnter={(event) => {
+                  setHoveredItem(item);
+                  setHoverRect(event.currentTarget.getBoundingClientRect());
+                }}
+                onMouseLeave={() => {
+                  setHoveredItem(null);
+                  setHoverRect(null);
+                }}
+                className={`dashboard-add-kpi-item${
+                  hoveredItem?.id === item.id ? " dashboard-add-kpi-item--hover" : ""
+                }`}
+              >
+                <div className="dashboard-add-kpi-item-main">
+                  <MetricIcon kind={iconKind(item)} />
+                  <span className="dashboard-add-kpi-item-label">{item.metric}</span>
+                </div>
+                <div className="dashboard-add-kpi-item-aside">
+                  <span className="dashboard-add-kpi-type">{itemTypeLabel(item)}</span>
+                  <button
+                    type="button"
+                    draggable={false}
+                    onMouseDown={(event) => event.stopPropagation()}
+                    onClick={() => {
+                      onAddWidget(item.id);
+                      onOpenChange(false);
+                    }}
+                    className="dashboard-add-kpi-add-btn"
+                    aria-label={`Add ${item.metric}`}
+                  >
+                    +
+                  </button>
+                </div>
+              </div>
+            </li>
+          ))
+        )}
+      </ul>
+    </div>
+  );
+
+  return (
+    <>
+      {createPortal(panel, document.body)}
+      <AddKpiPreview
+        item={hoveredItem}
+        anchorRect={hoverRect}
+        panelLeft={panelPosition?.left}
+        kpiCardData={kpiCardData}
+      />
+    </>
+  );
+};
+
+export default AddKpiDropdown;

--- a/digit-ui-esbuild/products/dashboard/src/components/AddKpiPreview.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/AddKpiPreview.jsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { createPortal } from "react-dom";
+import {
+  ADD_KPI_PREVIEW_GAP_PX,
+  ADD_KPI_PREVIEW_WIDTH_PX,
+  buildAddKpiPreviewContent,
+} from "../config/addKpiPreviewPresentation";
+
+const AddKpiPreview = ({ item, anchorRect, panelLeft, kpiCardData }) => {
+  const content = buildAddKpiPreviewContent(item, { kpiCardData });
+  if (!content || !anchorRect || panelLeft == null) return null;
+
+  const left = Math.max(8, panelLeft - ADD_KPI_PREVIEW_WIDTH_PX - ADD_KPI_PREVIEW_GAP_PX);
+  const top = Math.max(8, anchorRect.top - 4);
+
+  return createPortal(
+    <div
+      className="dashboard-add-kpi-preview dashboard-root"
+      style={{
+        position: "fixed",
+        top,
+        left,
+        width: ADD_KPI_PREVIEW_WIDTH_PX,
+        zIndex: 10000,
+      }}
+      role="tooltip"
+    >
+      <div className="dashboard-add-kpi-preview-card">
+        <div className="dashboard-add-kpi-preview-title">{content.title}</div>
+        {content.value ? (
+          <div className="dashboard-add-kpi-preview-value">{content.value}</div>
+        ) : null}
+        {content.target ? (
+          <div className="dashboard-add-kpi-preview-target">{content.target}</div>
+        ) : null}
+      </div>
+      {content.description ? (
+        <p className="dashboard-add-kpi-preview-desc">{content.description}</p>
+      ) : null}
+    </div>,
+    document.body
+  );
+};
+
+export default AddKpiPreview;

--- a/digit-ui-esbuild/products/dashboard/src/components/CardUpdatedStamp.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/CardUpdatedStamp.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+const CardUpdatedStamp = ({ label }) => (
+  <span className="dashboard-card-updated tw-pointer-events-none tw-absolute tw-bottom-1 tw-right-5 tw-z-[2] tw-rounded tw-bg-surface tw-px-1 tw-text-[10px] tw-leading-tight tw-text-muted-foreground">
+    Updated {label}
+  </span>
+);
+
+export default CardUpdatedStamp;

--- a/digit-ui-esbuild/products/dashboard/src/components/ChartScrollViewport.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/ChartScrollViewport.jsx
@@ -1,0 +1,46 @@
+import React from "react";
+import useSubtleScrollbar from "../hooks/useSubtleScrollbar";
+import { mergeRefs } from "../utils/mergeRefs";
+import { SHARED_CHROME } from "../config/visualizationStyles";
+
+const ChartScrollViewport = ({
+  viewportRef,
+  chartSize,
+  isScrollable,
+  chartClassName = "",
+  scrollAxis = "xy",
+  children,
+}) => {
+  const subtleScrollRef = useSubtleScrollbar(isScrollable);
+  const { width, height } = chartSize;
+  const verticalOnly = scrollAxis === "y";
+  const horizontalOnly = scrollAxis === "x";
+
+  const canvasStyle = verticalOnly
+    ? { width: "100%", height, minHeight: height, maxWidth: "100%" }
+    : horizontalOnly
+      ? { width, minWidth: width, height: "100%", minHeight: "100%" }
+      : { width, height, minWidth: width, minHeight: height };
+
+  return (
+    <div
+      ref={mergeRefs(subtleScrollRef, viewportRef)}
+      className={`${SHARED_CHROME.chartScrollViewport}${
+        isScrollable ? ` ${SHARED_CHROME.chartScrollViewportActive} dashboard-subtle-scroll` : ""
+      }${verticalOnly ? ` ${SHARED_CHROME.chartScrollViewportVertical}` : ""}${
+        horizontalOnly ? ` ${SHARED_CHROME.chartScrollViewportHorizontal}` : ""
+      }`}
+    >
+      <div
+        className={`${SHARED_CHROME.chartScrollCanvas}${
+          chartClassName ? ` ${chartClassName}` : ""
+        }`.trim()}
+        style={canvasStyle}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default ChartScrollViewport;

--- a/digit-ui-esbuild/products/dashboard/src/components/ChartTooltipPortal.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/ChartTooltipPortal.jsx
@@ -1,0 +1,45 @@
+import React, { useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { resolveNearCursorTooltipPosition } from "../config/chartTooltipPresentation";
+import { SHARED_CHROME } from "../config/visualizationStyles";
+
+const TOOLTIP_OFFSET = 10;
+
+const ChartTooltipPortal = ({ tooltip, children }) => {
+  const ref = useRef(null);
+  const [position, setPosition] = useState(() =>
+    tooltip
+      ? resolveNearCursorTooltipPosition(tooltip.x, tooltip.y, {}, TOOLTIP_OFFSET)
+      : { left: 0, top: 0 }
+  );
+
+  useLayoutEffect(() => {
+    if (!tooltip || !ref.current) return;
+
+    const { width, height } = ref.current.getBoundingClientRect();
+    setPosition(
+      resolveNearCursorTooltipPosition(
+        tooltip.x,
+        tooltip.y,
+        { width, height },
+        TOOLTIP_OFFSET
+      )
+    );
+  }, [tooltip]);
+
+  if (!tooltip) return null;
+
+  return createPortal(
+    <div
+      ref={ref}
+      className={`${SHARED_CHROME.dashboardRoot} ${SHARED_CHROME.chartTooltip} ${SHARED_CHROME.chartTooltipFixed}`}
+      style={{ left: `${position.left}px`, top: `${position.top}px` }}
+      role="tooltip"
+    >
+      {children}
+    </div>,
+    document.body
+  );
+};
+
+export default ChartTooltipPortal;

--- a/digit-ui-esbuild/products/dashboard/src/components/ComplaintsAtRiskTable.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/ComplaintsAtRiskTable.jsx
@@ -1,0 +1,108 @@
+import React, { useMemo } from "react";
+import {
+  DATA_TABLE_STYLES,
+  getDataTableTdClass,
+  getDataTableThClass,
+  getSlaRiskBreachPillClass,
+  getSlaRiskStatusPillClass,
+  SLA_RISK_TABLE_STYLES,
+} from "../config/visualizationStyles";
+import { complaintDetailHref } from "../config/complaintsAtRiskPresentation";
+import useTableSort from "../hooks/useTableSort";
+import TableSortHeader from "./TableSortHeader";
+
+const COLUMNS = [
+  { id: "id", label: "ID", align: "left", type: "text" },
+  { id: "typeLabel", label: "Type", align: "left", type: "text" },
+  { id: "subtypeLabel", label: "Subtype", align: "left", type: "text" },
+  { id: "locality", label: "Locality", align: "left", type: "text" },
+  { id: "ownerName", label: "Owner", align: "left", type: "text" },
+  { id: "ownerRole", label: "Owner role", align: "left", type: "text" },
+  { id: "statusLabel", label: "Status", align: "left", type: "text" },
+  { id: "slaLabel", label: "SLA status", align: "left", type: "text" },
+  { id: "breachDurationMs", label: "Breach duration", align: "left", type: "integer" },
+];
+
+const ComplaintsAtRiskTable = ({ rows = [] }) => {
+  const tableStyles = DATA_TABLE_STYLES;
+  const slaStyles = SLA_RISK_TABLE_STYLES;
+  const { sortState, handleSort, sortRows } = useTableSort(COLUMNS, {
+    defaultKey: "breachDurationMs",
+    defaultDirection: "desc",
+  });
+  const sortedRows = useMemo(() => sortRows(rows), [rows, sortRows]);
+
+  return (
+    <table
+      className={`${tableStyles.table} ${tableStyles.tableEqualCols} ${slaStyles.table}`}
+    >
+      <colgroup>
+        {COLUMNS.map((col) => (
+          <col key={col.id} style={{ width: `${100 / COLUMNS.length}%` }} />
+        ))}
+      </colgroup>
+      <thead>
+        <tr>
+          {COLUMNS.map((col) => (
+            <th key={col.id} className={getDataTableThClass(col.align)}>
+              <TableSortHeader column={col} sortState={sortState} onSort={handleSort} />
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {sortedRows.length === 0 ? (
+          <tr>
+            <td colSpan={COLUMNS.length} className={tableStyles.empty}>
+              No complaints at risk
+            </td>
+          </tr>
+        ) : (
+          sortedRows.map((row) => (
+          <tr key={row.id}>
+            <td className={getDataTableTdClass()}>
+              <a href={complaintDetailHref(row.id)} className={slaStyles.link}>
+                {row.id}
+              </a>
+            </td>
+            <td className={getDataTableTdClass()}>{row.typeLabel}</td>
+            <td className={getDataTableTdClass()}>{row.subtypeLabel}</td>
+            <td className={getDataTableTdClass()}>{row.locality}</td>
+            <td className={getDataTableTdClass()}>
+              <span className={slaStyles.ownerName}>{row.ownerName}</span>
+            </td>
+            <td className={getDataTableTdClass()}>
+              <span className={tableStyles.muted}>{row.ownerRole}</span>
+            </td>
+            <td className={getDataTableTdClass()}>
+              <span className={getSlaRiskStatusPillClass(row.status)}>
+                {row.statusLabel}
+              </span>
+            </td>
+            <td className={getDataTableTdClass()}>
+              <span className={getSlaRiskBreachPillClass(row.slaLevel)}>
+                {row.slaLabel}
+              </span>
+            </td>
+            <td className={getDataTableTdClass()}>
+              {row.breachDurationLabel ? (
+                <span
+                  className={
+                    row.slaLevel === "breached" ? slaStyles.overdue : tableStyles.muted
+                  }
+                >
+                  {row.breachDurationLabel}
+                </span>
+              ) : (
+                <span className={tableStyles.muted}>—</span>
+              )}
+            </td>
+          </tr>
+          ))
+        )}
+      </tbody>
+    </table>
+  );
+};
+
+export default ComplaintsAtRiskTable;

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardFilters.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardFilters.jsx
@@ -23,6 +23,50 @@ const FunnelIcon = () => (
   </svg>
 );
 
+/**
+ * Render a flat {id,label,group?} option list, batching consecutive same-group
+ * runs into native <optgroup>s. The list arrives group-contiguous (sentinel
+ * first, grouped options sorted by group, strays last), so a single pass
+ * yields: plain sentinel option → one <optgroup> per root complaint category →
+ * plain trailing options for codes missing from the hierarchy master. Lists
+ * without any `group` (wards; hierarchy-fetch failure) render exactly as the
+ * old flat <option> list.
+ */
+function renderGroupedOptions(options) {
+  const rendered = [];
+  let run = null; // { group, items } — current <optgroup> being accumulated
+
+  const flushRun = () => {
+    if (!run) return;
+    rendered.push(
+      <optgroup key={`group-${run.group}`} label={run.group}>
+        {run.items}
+      </optgroup>
+    );
+    run = null;
+  };
+
+  for (const opt of options) {
+    const node = (
+      <option key={opt.id} value={opt.id}>
+        {opt.label}
+      </option>
+    );
+    if (opt.group) {
+      if (!run || run.group !== opt.group) {
+        flushRun();
+        run = { group: opt.group, items: [] };
+      }
+      run.items.push(node);
+    } else {
+      flushRun();
+      rendered.push(node);
+    }
+  }
+  flushRun();
+  return rendered;
+}
+
 const DashboardFilters = ({
   filters,
   onFilterChange,
@@ -120,11 +164,7 @@ const DashboardFilters = ({
             {filterOptionsLoading && complaintTypeOptions.length <= 1 ? (
               <option value="">Loading…</option>
             ) : (
-              complaintTypeOptions.map((opt) => (
-                <option key={opt.id} value={opt.id}>
-                  {opt.label}
-                </option>
-              ))
+              renderGroupedOptions(complaintTypeOptions)
             )}
           </select>
         </div>

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardFilters.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardFilters.jsx
@@ -1,0 +1,147 @@
+import React, { useCallback } from "react";
+import {
+  COMPLAINT_TYPE_OPTIONS,
+  GEOGRAPHY_OPTIONS,
+  GLOBAL_FILTER_FIELDS,
+  hasActiveFilters,
+} from "../config/globalFilterGroups";
+
+const FunnelIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="tw-shrink-0 tw-text-muted-foreground"
+    aria-hidden
+  >
+    <path d="M22 3H2l8 9.46V19l4 2v-8.54L22 3z" />
+  </svg>
+);
+
+const DashboardFilters = ({
+  filters,
+  onFilterChange,
+  onClearFilters,
+  filterOptions,
+  filterOptionsLoading = false,
+}) => {
+  const canClear = hasActiveFilters(filters);
+
+  const geographyOptions = filterOptions?.geography ?? GEOGRAPHY_OPTIONS;
+  const complaintTypeOptions =
+    filterOptions?.complaintType ?? COMPLAINT_TYPE_OPTIONS;
+
+  const dateFrom = filters?.dateFrom ?? GLOBAL_FILTER_FIELDS.find((f) => f.id === "dateFrom")?.defaultValue;
+  const dateTo = filters?.dateTo ?? GLOBAL_FILTER_FIELDS.find((f) => f.id === "dateTo")?.defaultValue;
+  const geography = filters?.geography ?? "all";
+  const complaintType = filters?.complaintType ?? "all";
+
+  const openCalendar = useCallback((input) => {
+    if (!input) return;
+    if (typeof input.showPicker === "function") {
+      try {
+        input.showPicker();
+        return;
+      } catch {
+        /* fall through */
+      }
+    }
+    input.focus();
+  }, []);
+
+  return (
+    <div className="dashboard-filters-bar tw-mb-4">
+      <div className="dashboard-filters-card">
+        <div className="dashboard-filters-row">
+        <div className="dashboard-filters-heading">
+          <FunnelIcon />
+          <span className="dashboard-filters-title">Filters</span>
+        </div>
+
+        <div className="dashboard-filters-date-range">
+          <div className="dashboard-filter-inline-date-wrap">
+            <input
+              type="date"
+              value={dateFrom}
+              onChange={(e) => onFilterChange("dateFrom", e.target.value)}
+              onClick={(e) => openCalendar(e.currentTarget)}
+              aria-label="From date"
+              className="dashboard-filter-inline-date"
+            />
+          </div>
+          <span className="dashboard-filters-date-arrow" aria-hidden>
+            →
+          </span>
+          <div className="dashboard-filter-inline-date-wrap">
+            <input
+              type="date"
+              value={dateTo}
+              onChange={(e) => onFilterChange("dateTo", e.target.value)}
+              onClick={(e) => openCalendar(e.currentTarget)}
+              aria-label="To date"
+              className="dashboard-filter-inline-date"
+            />
+          </div>
+        </div>
+
+        <div className="dashboard-filter-inline-select-wrap">
+          <select
+            value={filterOptionsLoading && geographyOptions.length <= 1 ? "" : geography}
+            disabled={filterOptionsLoading && geographyOptions.length <= 1}
+            onChange={(e) => onFilterChange("geography", e.target.value)}
+            aria-label="Ward filter"
+            className="dashboard-filter-inline-select"
+          >
+            {filterOptionsLoading && geographyOptions.length <= 1 ? (
+              <option value="">Loading…</option>
+            ) : (
+              geographyOptions.map((opt) => (
+                <option key={opt.id} value={opt.id}>
+                  {opt.label}
+                </option>
+              ))
+            )}
+          </select>
+        </div>
+
+        <div className="dashboard-filter-inline-select-wrap">
+          <select
+            value={filterOptionsLoading && complaintTypeOptions.length <= 1 ? "" : complaintType}
+            disabled={filterOptionsLoading && complaintTypeOptions.length <= 1}
+            onChange={(e) => onFilterChange("complaintType", e.target.value)}
+            aria-label="Complaint type filter"
+            className="dashboard-filter-inline-select"
+          >
+            {filterOptionsLoading && complaintTypeOptions.length <= 1 ? (
+              <option value="">Loading…</option>
+            ) : (
+              complaintTypeOptions.map((opt) => (
+                <option key={opt.id} value={opt.id}>
+                  {opt.label}
+                </option>
+              ))
+            )}
+          </select>
+        </div>
+
+        <button
+          type="button"
+          onClick={onClearFilters}
+          disabled={!canClear}
+          className="dashboard-filters-clear-inline"
+          aria-disabled={!canClear}
+        >
+          Clear
+        </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DashboardFilters;

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardHeader.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardHeader.jsx
@@ -1,0 +1,228 @@
+import React, { useMemo, useRef, useState } from "react";
+import { getProductLabel } from "../config/dashboardConfig";
+import { GEOGRAPHY_OPTIONS } from "../config/globalFilterGroups";
+import { formatDimensionLabel } from "../config/labelFormat";
+import AddKpiDropdown from "./AddKpiDropdown";
+
+/**
+ * Derive the row-scope indicator from the analytics `scope` object the backend
+ * echoes on every /v2/analytics/_query response. Returns null when the scope is
+ * tenant-only (no departments, no boundaryPrefix) so admins/supervisors — who
+ * see everything — get no chip. Also null when `scope` is undefined (older
+ * backend that doesn't emit departments/boundaryPrefix yet).
+ */
+function buildRowScope(scope) {
+  if (!scope || typeof scope !== "object") return null;
+
+  const departments = Array.isArray(scope.departments)
+    ? scope.departments.filter((d) => d != null && d !== "")
+    : [];
+  const boundaryPrefix =
+    typeof scope.boundaryPrefix === "string" && scope.boundaryPrefix.trim()
+      ? scope.boundaryPrefix.trim()
+      : null;
+
+  if (departments.length === 0 && !boundaryPrefix) return null;
+
+  const deptLabel = departments
+    .map((code) => formatDimensionLabel(code))
+    .join(", ");
+  // Last segment of a dotted/slashed boundary code, e.g. "ke.bomet.CENTRAL" → "CENTRAL".
+  const areaLabel = boundaryPrefix
+    ? boundaryPrefix.split(/[./]/).filter(Boolean).pop() || boundaryPrefix
+    : null;
+
+  return { deptLabel, areaLabel, hasDepartments: departments.length > 0 };
+}
+
+function formatDisplayDate(iso) {
+  if (!iso) return "";
+  const [y, m, d] = iso.split("-");
+  if (!y || !m || !d) return iso;
+  return `${m}/${d}/${y}`;
+}
+
+function buildSubtitle(filters, filterOptions) {
+  const geoOptions = filterOptions?.geography ?? GEOGRAPHY_OPTIONS;
+  const geo =
+    geoOptions.find((o) => o.id === filters?.geography)?.label ?? "All Localities";
+
+  let period = "Last 7 days";
+  if (filters?.dateRangeActive && filters?.dateFrom && filters?.dateTo) {
+    period = `${formatDisplayDate(filters.dateFrom)} – ${formatDisplayDate(filters.dateTo)}`;
+  } else if (filters?.dateFrom && filters?.dateTo) {
+    period = `${formatDisplayDate(filters.dateFrom)} – ${formatDisplayDate(filters.dateTo)}`;
+  }
+
+  return `${geo} · ${period}`;
+}
+
+const SearchIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <circle cx="11" cy="11" r="8" />
+    <line x1="21" y1="21" x2="16.65" y2="16.65" />
+  </svg>
+);
+
+const ExportIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
+    <polyline points="7 10 12 15 17 10" />
+    <line x1="12" y1="15" x2="12" y2="3" />
+  </svg>
+);
+
+const DashboardHeader = ({
+  visibleLayoutIds,
+  catalogItems,
+  onAddWidget,
+  onResetLayout,
+  onDragWidgetStart,
+  onDragWidgetEnd,
+  searchQuery,
+  onSearchQueryChange,
+  onExport,
+  filters,
+  filterOptions,
+  kpiCardData,
+  allowedWidgetIds,
+  scopedRole,
+  officerAccess,
+  visibleKpiCount,
+  scope,
+}) => {
+  const [addKpiOpen, setAddKpiOpen] = useState(false);
+  const addKpiRef = useRef(null);
+  const productLabel = useMemo(() => getProductLabel(), []);
+  const rowScope = useMemo(() => buildRowScope(scope), [scope]);
+  const subtitle = useMemo(
+    () => buildSubtitle(filters, filterOptions),
+    [filters, filterOptions]
+  );
+  const title = productLabel.toLowerCase().includes("pgr")
+    ? "PGR Operations"
+    : `${productLabel} Operations`;
+
+  return (
+    <header className="dashboard-header tw-flex-shrink-0 tw-bg-background">
+      <div className="dashboard-header-top tw-flex tw-h-12 tw-shrink-0 tw-items-center tw-justify-between tw-gap-4 tw-border-b tw-border-border tw-bg-surface tw-px-4 lg:tw-px-6">
+        <div className="tw-min-w-0">
+          <div className="tw-flex tw-flex-wrap tw-items-baseline tw-gap-x-3 tw-gap-y-0.5">
+            <h1 className="tw-text-[15px] tw-font-semibold tw-leading-tight tw-text-foreground">
+              {title}
+            </h1>
+            <p className="tw-text-[11px] tw-text-muted-foreground">{subtitle}</p>
+            {scopedRole ? (
+              <span
+                title="Dashboard tiles are scoped to your role by the analytics catalog"
+                className="tw-inline-flex tw-items-center tw-gap-1 tw-rounded-full tw-border tw-border-border tw-bg-surface-2 tw-px-2 tw-py-0.5 tw-text-[10px] tw-font-medium tw-uppercase tw-tracking-wide tw-text-muted-foreground"
+              >
+                <span
+                  className="tw-h-1.5 tw-w-1.5 tw-rounded-full tw-bg-primary"
+                  aria-hidden
+                />
+                Scoped to: {scopedRole}
+              </span>
+            ) : null}
+            {scopedRole && officerAccess != null ? (
+              <span
+                title={
+                  officerAccess
+                    ? "Your role can see officer-level (per-employee) KPIs"
+                    : "Officer-level (per-employee) KPIs are hidden from your role"
+                }
+                className={
+                  "tw-inline-flex tw-items-center tw-gap-1 tw-rounded-full tw-px-2 tw-py-0.5 tw-text-[10px] tw-font-medium " +
+                  (officerAccess
+                    ? "tw-bg-status-resolved-bg tw-text-status-resolved"
+                    : "tw-bg-status-breach-bg tw-text-destructive")
+                }
+              >
+                {officerAccess ? "Officer KPIs: visible" : "Officer KPIs: hidden"}
+              </span>
+            ) : null}
+            {scopedRole && visibleKpiCount != null ? (
+              <span className="tw-text-[10px] tw-text-muted-foreground">
+                {visibleKpiCount} KPIs available to your role
+              </span>
+            ) : null}
+            {rowScope ? (
+              <span
+                title="Dashboard data is row-scoped to your department(s)"
+                className="tw-inline-flex tw-items-center tw-gap-1 tw-rounded-full tw-bg-status-assigned-bg tw-px-2 tw-py-0.5 tw-text-[10px] tw-font-medium tw-text-status-assigned"
+              >
+                <span
+                  className="tw-h-1.5 tw-w-1.5 tw-rounded-full tw-bg-status-assigned"
+                  aria-hidden
+                />
+                {rowScope.hasDepartments ? `Showing: ${rowScope.deptLabel}` : "Area-scoped"}
+                {rowScope.areaLabel ? ` · Area: ${rowScope.areaLabel}` : ""}
+              </span>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="dashboard-header-controls">
+          <label className="dashboard-header-search tw-hidden sm:tw-inline-flex">
+            <span className="dashboard-header-search-icon" aria-hidden>
+              <SearchIcon />
+            </span>
+            <input
+              type="search"
+              value={searchQuery}
+              onChange={(e) => onSearchQueryChange(e.target.value)}
+              placeholder="Search complaints, wards, citizens."
+              className="dashboard-header-search-input"
+            />
+          </label>
+
+          <div className="dashboard-header-kpi-anchor">
+            <button
+              ref={addKpiRef}
+              type="button"
+              onClick={() => setAddKpiOpen((v) => !v)}
+              aria-expanded={addKpiOpen}
+              aria-haspopup="menu"
+              className="dashboard-header-btn dashboard-add-kpi-trigger"
+            >
+              + Add KPI
+            </button>
+            <AddKpiDropdown
+              visibleLayoutIds={visibleLayoutIds}
+              catalogItems={catalogItems}
+              onAddWidget={onAddWidget}
+              onDragWidgetStart={onDragWidgetStart}
+              onDragWidgetEnd={onDragWidgetEnd}
+              open={addKpiOpen}
+              onOpenChange={setAddKpiOpen}
+              containerRef={addKpiRef}
+              kpiCardData={kpiCardData}
+              allowedWidgetIds={allowedWidgetIds}
+            />
+          </div>
+
+          <button
+            type="button"
+            onClick={onResetLayout}
+            className="dashboard-header-btn dashboard-header-reset"
+            title="Reset layout"
+          >
+            Reset
+          </button>
+
+          <button
+            type="button"
+            onClick={onExport}
+            className="dashboard-header-btn dashboard-header-export"
+            title="Export dashboard"
+          >
+            <ExportIcon />
+            <span>Export</span>
+          </button>
+        </div>
+      </div>
+    </header>
+  );
+};
+
+export default DashboardHeader;

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardLayout.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardLayout.jsx
@@ -1,0 +1,88 @@
+import React, { useMemo } from "react";
+import { getBrandTheme } from "../config/dashboardConfig";
+import DashboardHeader from "./DashboardHeader";
+import DashboardFilters from "./DashboardFilters";
+import Sidebar from "./Sidebar";
+
+const DashboardLayout = ({
+  children,
+  visibleLayoutIds,
+  catalogItems,
+  onAddWidget,
+  onResetLayout,
+  onDragWidgetStart,
+  onDragWidgetEnd,
+  searchQuery,
+  onSearchQueryChange,
+  onExport,
+  filters,
+  onFilterChange,
+  onClearFilters,
+  filterOptions,
+  filterOptionsLoading,
+  kpiCardData,
+  allowedWidgetIds,
+  scopedRole,
+  username,
+  officerAccess,
+  visibleKpiCount,
+  scope,
+  onSignOut,
+  embedded = false,
+}) => {
+  const brandStyle = useMemo(() => {
+    const theme = getBrandTheme();
+    return {
+      "--brand-teal": theme.teal,
+      "--brand-dark": theme.dark,
+      "--brand-slate": theme.slate,
+    };
+  }, []);
+
+  return (
+    <div
+      // Embedded = mounted inside the DigitUI employee chrome: keep
+      // .dashboard-root (all CSS variables + chart color resolution hang off
+      // it) and add the .dashboard-embedded modifier, whose CSS overrides
+      // (appended in styles/input.css + dashboard.css) neutralize the
+      // full-viewport shell so the page scrolls naturally in the host.
+      className={`dashboard-root${embedded ? " dashboard-embedded" : ""} tw-flex tw-h-screen tw-overflow-hidden tw-bg-background tw-font-sans tw-text-foreground`}
+      style={brandStyle}
+    >
+      {!embedded && <Sidebar onSignOut={onSignOut} />}
+      <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col tw-overflow-hidden">
+        <DashboardHeader
+          visibleLayoutIds={visibleLayoutIds}
+          catalogItems={catalogItems}
+          onAddWidget={onAddWidget}
+          onResetLayout={onResetLayout}
+          onDragWidgetStart={onDragWidgetStart}
+          onDragWidgetEnd={onDragWidgetEnd}
+          searchQuery={searchQuery}
+          onSearchQueryChange={onSearchQueryChange}
+          onExport={onExport}
+          filters={filters}
+          filterOptions={filterOptions}
+          kpiCardData={kpiCardData}
+          allowedWidgetIds={allowedWidgetIds}
+          scopedRole={scopedRole}
+          officerAccess={officerAccess}
+          visibleKpiCount={visibleKpiCount}
+          scope={scope}
+        />
+        <main className="tw-flex-1 tw-overflow-auto tw-bg-background tw-p-4 lg:tw-p-6">
+          <DashboardFilters
+            filters={filters}
+            onFilterChange={onFilterChange}
+            onClearFilters={onClearFilters}
+            filterOptions={filterOptions}
+            filterOptionsLoading={filterOptionsLoading}
+          />
+          {children}
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default DashboardLayout;

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardLogin.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardLogin.jsx
@@ -1,0 +1,329 @@
+import React, { useMemo, useState } from "react";
+import {
+  getTenantId,
+  getProductLabel,
+  getStateLabel,
+  getBrandTheme,
+} from "../config/dashboardConfig";
+
+/**
+ * Self-contained employee login for the standalone dashboard build.
+ *
+ * The standalone /dashboard-ui app has no login of its own — it expects an
+ * Employee.token in localStorage (normally set by the main digit-ui login on the
+ * same origin). This gate makes the dashboard demo-able on its own: it performs a
+ * real OAuth password grant against /user/oauth/token, stores the token + the
+ * returned userInfo (with the significant role first, so the scoping indicator is
+ * legible), and hands control back to AdminDashboard.
+ *
+ * Rendered inside `.dashboard-root` so it inherits the dashboard's theme tokens;
+ * colour-bearing elements use the theme CSS variables via inline styles so the
+ * look matches the dashboard regardless of which Tailwind utilities were emitted.
+ *
+ * The quick-fill buttons are demo conveniences only — they pre-fill the form,
+ * they do not bypass authentication.
+ */
+
+// Basic egov-user-client: (empty secret), base64 of "egov-user-client:"
+const OAUTH_BASIC = "Basic ZWdvdi11c2VyLWNsaWVudDo=";
+
+const DEMO_USERS = [
+  { label: "Supervisor", username: "DEMO_SUPERVISOR", hint: "all departments" },
+  { label: "Water officer", username: "DEMO_WATER", hint: "Water dept only" },
+  { label: "Health officer", username: "DEMO_HEALTH", hint: "Medical dept only" },
+];
+
+/** Order roles so the first non-EMPLOYEE role leads (drives the scoping badge). */
+function withSignificantRoleFirst(userInfo) {
+  if (!userInfo || !Array.isArray(userInfo.roles)) return userInfo;
+  const roles = [...userInfo.roles].sort(
+    (a, b) => (a.code === "EMPLOYEE" ? 1 : 0) - (b.code === "EMPLOYEE" ? 1 : 0)
+  );
+  return { ...userInfo, roles };
+}
+
+export function hasDashboardSession() {
+  try {
+    const raw = window.localStorage?.getItem("Employee.token");
+    return Boolean(raw && raw !== "undefined" && raw !== "null");
+  } catch {
+    return false;
+  }
+}
+
+export function clearDashboardSession() {
+  ["Employee.token", "Employee.user-info", "Employee.tenant-id", "user-info", "token"].forEach(
+    (k) => {
+      try {
+        window.localStorage?.removeItem(k);
+      } catch {
+        /* ignore */
+      }
+    }
+  );
+}
+
+const inputStyle = {
+  borderRadius: "0.375rem",
+  border: "1px solid var(--border)",
+  background: "var(--surface)",
+  color: "var(--foreground)",
+  padding: "0.5rem 0.75rem",
+  fontSize: "13px",
+  outline: "none",
+};
+
+const DashboardLogin = ({ onLogin }) => {
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  const tenantId = getTenantId();
+  const productLabel = useMemo(() => getProductLabel(), []);
+  const stateLabel = useMemo(() => getStateLabel(), []);
+  const brandStyle = useMemo(() => {
+    const theme = getBrandTheme();
+    return {
+      "--brand-teal": theme.teal,
+      "--brand-dark": theme.dark,
+      "--brand-slate": theme.slate,
+    };
+  }, []);
+
+  async function signIn(e) {
+    if (e) e.preventDefault();
+    if (!username || !password) {
+      setError("Enter a username and password.");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const body = new URLSearchParams({
+        grant_type: "password",
+        username,
+        password,
+        tenantId,
+        userType: "EMPLOYEE",
+        scope: "read",
+      });
+      const res = await fetch("/user/oauth/token", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          Authorization: OAUTH_BASIC,
+        },
+        body,
+      });
+      if (!res.ok) {
+        let msg = `Sign-in failed (${res.status}).`;
+        try {
+          const j = await res.json();
+          msg = j.error_description || j.error || msg;
+        } catch {
+          /* ignore */
+        }
+        throw new Error(msg);
+      }
+      const data = await res.json();
+      const userInfo = withSignificantRoleFirst(data.UserRequest);
+      window.localStorage.setItem("Employee.token", JSON.stringify(data.access_token));
+      window.localStorage.setItem("Employee.user-info", JSON.stringify(userInfo));
+      window.localStorage.setItem("Employee.tenant-id", JSON.stringify(tenantId));
+      window.localStorage.setItem("user-info", JSON.stringify(userInfo));
+      window.localStorage.setItem("token", JSON.stringify(data.access_token));
+      if (onLogin) onLogin(userInfo);
+    } catch (err) {
+      setError(err.message || "Sign-in failed.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      className="dashboard-root tw-font-sans"
+      style={{
+        ...brandStyle,
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "1rem",
+        background: "var(--background)",
+        color: "var(--foreground)",
+      }}
+    >
+      <div
+        style={{
+          width: "100%",
+          maxWidth: "380px",
+          borderRadius: "0.75rem",
+          overflow: "hidden",
+          border: "1px solid var(--border)",
+          background: "var(--surface)",
+          boxShadow: "0 10px 30px -12px rgba(0,0,0,0.25)",
+        }}
+      >
+        {/* Branded header band — mirrors the sidebar chrome */}
+        <div
+          style={{
+            background: "var(--chrome)",
+            color: "var(--chrome-foreground)",
+            padding: "1.25rem 1.5rem",
+          }}
+        >
+          <p
+            style={{
+              margin: 0,
+              fontSize: "10px",
+              fontWeight: 600,
+              letterSpacing: "0.08em",
+              textTransform: "uppercase",
+              color: "var(--chrome-muted)",
+            }}
+          >
+            {stateLabel}
+          </p>
+          <h1 style={{ margin: "0.25rem 0 0", fontSize: "20px", fontWeight: 700, lineHeight: 1.2 }}>
+            {productLabel}
+          </h1>
+          <p style={{ margin: "0.25rem 0 0", fontSize: "12px", color: "var(--chrome-muted)" }}>
+            Sign in to the operations dashboard
+          </p>
+        </div>
+
+        <div style={{ padding: "1.5rem" }}>
+          <form onSubmit={signIn} style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+            <label style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
+              <span
+                style={{
+                  fontSize: "11px",
+                  fontWeight: 600,
+                  letterSpacing: "0.05em",
+                  textTransform: "uppercase",
+                  color: "var(--muted-foreground)",
+                }}
+              >
+                Username
+              </span>
+              <input
+                type="text"
+                autoComplete="username"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                style={inputStyle}
+                placeholder="e.g. DEMO_SUPERVISOR"
+              />
+            </label>
+
+            <label style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
+              <span
+                style={{
+                  fontSize: "11px",
+                  fontWeight: 600,
+                  letterSpacing: "0.05em",
+                  textTransform: "uppercase",
+                  color: "var(--muted-foreground)",
+                }}
+              >
+                Password
+              </span>
+              <input
+                type="password"
+                autoComplete="current-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                style={inputStyle}
+                placeholder="••••••••"
+              />
+            </label>
+
+            {error ? (
+              <div
+                style={{
+                  borderRadius: "0.375rem",
+                  border: "1px solid color-mix(in srgb, var(--destructive) 30%, transparent)",
+                  background: "var(--status-breach-bg)",
+                  color: "var(--destructive)",
+                  padding: "0.5rem 0.75rem",
+                  fontSize: "12px",
+                }}
+              >
+                {error}
+              </div>
+            ) : null}
+
+            <button
+              type="submit"
+              disabled={submitting}
+              style={{
+                marginTop: "0.25rem",
+                borderRadius: "0.375rem",
+                border: "none",
+                background: "var(--primary)",
+                color: "var(--primary-foreground)",
+                padding: "0.625rem 0.75rem",
+                fontSize: "13px",
+                fontWeight: 600,
+                cursor: submitting ? "default" : "pointer",
+                opacity: submitting ? 0.6 : 1,
+              }}
+            >
+              {submitting ? "Signing in…" : "Sign in"}
+            </button>
+          </form>
+
+          <div style={{ marginTop: "1.25rem", borderTop: "1px solid var(--border)", paddingTop: "1rem" }}>
+            <p
+              style={{
+                margin: "0 0 0.5rem",
+                textAlign: "center",
+                fontSize: "10px",
+                letterSpacing: "0.06em",
+                textTransform: "uppercase",
+                color: "var(--muted-foreground)",
+              }}
+            >
+              Demo logins (tenant {tenantId})
+            </p>
+            <div style={{ display: "flex", gap: "0.5rem" }}>
+              {DEMO_USERS.map((u) => (
+                <button
+                  key={u.username}
+                  type="button"
+                  onClick={() => {
+                    setUsername(u.username);
+                    setPassword("eGov@123");
+                    setError(null);
+                  }}
+                  title={`Fill ${u.username}`}
+                  style={{
+                    flex: 1,
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "flex-start",
+                    gap: "0.125rem",
+                    borderRadius: "0.375rem",
+                    border: "1px solid var(--border)",
+                    background: "var(--surface-2)",
+                    color: "var(--foreground)",
+                    padding: "0.5rem 0.75rem",
+                    textAlign: "left",
+                    cursor: "pointer",
+                  }}
+                >
+                  <span style={{ fontSize: "12px", fontWeight: 600 }}>{u.label}</span>
+                  <span style={{ fontSize: "10px", color: "var(--muted-foreground)" }}>{u.hint}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DashboardLogin;

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardTable.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardTable.jsx
@@ -1,0 +1,292 @@
+import React, { useMemo } from "react";
+import {
+  DATA_TABLE_STYLES,
+  getDataTableTdClass,
+  getDataTableThClass,
+} from "../config/visualizationStyles";
+import { buildRedSeverityStyle } from "../config/tablePresentation";
+import { formatOfficerLabel } from "../config/kpiDisplay";
+import useTableSort from "../hooks/useTableSort";
+import TableSortHeader from "./TableSortHeader";
+
+const TrendCell = ({ value }) => {
+  const { muted, trendUp, trendDown } = DATA_TABLE_STYLES;
+  if (value == null || !Number.isFinite(value)) {
+    return <span className={muted}>—</span>;
+  }
+  if (value === 0) {
+    return <span className={muted}>0.0%</span>;
+  }
+  const up = value > 0;
+  return (
+    <span className={up ? trendUp : trendDown}>
+      {up ? "↑" : "↓"} {Math.abs(value).toFixed(1)}%
+    </span>
+  );
+};
+
+const formatPercent = (value, decimals = 1) => {
+  if (value == null || !Number.isFinite(value)) return "—";
+  const pct = value <= 1 ? value * 100 : value;
+  return `${pct.toFixed(decimals)}%`;
+};
+
+const formatHours = (ms) => {
+  if (ms == null || !Number.isFinite(ms)) return "—";
+  const hours = ms / 3600000;
+  const formatted =
+    Math.abs(hours - Math.round(hours)) < 0.05
+      ? String(Math.round(hours))
+      : hours.toFixed(1);
+  return `${formatted}h`;
+};
+
+const MS_PER_HOUR = 3600000;
+const MS_PER_DAY = 86400000;
+
+const formatHoursDays = (ms) => {
+  if (ms == null || !Number.isFinite(ms)) return "—";
+  const hours = ms / MS_PER_HOUR;
+  if (hours < 48) {
+    const rounded = Math.round(hours * 10) / 10;
+    const formatted = Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+    return `${formatted} ${rounded === 1 ? "hr" : "hrs"}`;
+  }
+  const days = ms / MS_PER_DAY;
+  const rounded = Math.round(days * 10) / 10;
+  const formatted = Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+  return `${formatted} ${rounded === 1 ? "day" : "days"}`;
+};
+
+const formatRating = (value) => {
+  if (value == null || !Number.isFinite(value)) return "—";
+  return `${Number(value).toFixed(1)}/5`;
+};
+
+const formatInteger = (value) => {
+  if (value == null || !Number.isFinite(value)) return "—";
+  return String(Math.round(value));
+};
+
+const CELL_RENDERERS = {
+  text: (value) => value ?? "—",
+  integer: (value) => formatInteger(value),
+  percent: (value) => formatPercent(value),
+  hours: (value) => formatHours(value),
+  hoursDays: (value) => formatHoursDays(value),
+  rating: (value) => formatRating(value),
+  trend: (value) => <TrendCell value={value} />,
+  tags: (value) => value,
+  officer: (value) => formatOfficerLabel(value),
+  department: (value) =>
+    !value || value === "null" || value === "undefined"
+      ? "—"
+      : String(value).replace(/[_.]+/g, " ").trim().replace(/\b\w/g, (c) => c.toUpperCase()),
+  dimension: (value) =>
+    !value || value === "null" || value === "undefined"
+      ? "—"
+      : String(value).replace(/[_.]+/g, " ").trim().replace(/\b\w/g, (c) => c.toUpperCase()),
+};
+
+function resolveToneClass(tone, styles) {
+  if (tone === "breach") return styles.cellToneBreach;
+  if (tone === "watch") return styles.cellToneWatch;
+  return undefined;
+}
+
+function resolveToneTextClass(tone, styles) {
+  if (tone === "breach") return styles.thresholdCell;
+  if (tone === "watch") return styles.thresholdWatch;
+  return undefined;
+}
+
+function resolveStatusTagClass(tone, styles) {
+  if (tone === "breach") return `${styles.statusTag} ${styles.statusTagBreach}`;
+  if (tone === "watch") return `${styles.statusTag} ${styles.statusTagWatch}`;
+  return undefined;
+}
+
+function renderStatusTags(row, styles) {
+  const items = row.statusTagItems?.length
+    ? row.statusTagItems
+    : (Array.isArray(row.statusTags) ? row.statusTags : []).map((label) => ({
+        label,
+        tone: String(label).toLowerCase().includes("on track") ? "good" : "watch",
+      }));
+
+  if (!items.length) return <span className={styles.muted}>—</span>;
+
+  return (
+    <span className="tw-flex tw-flex-wrap tw-gap-1">
+      {items.map((item) =>
+        item.tone ? (
+          <span
+            key={item.label}
+            className={resolveStatusTagClass(item.tone, styles)}
+          >
+            {item.label}
+          </span>
+        ) : (
+          <span key={item.label} className={styles.muted}>
+            {item.label}
+          </span>
+        )
+      )}
+    </span>
+  );
+}
+
+// Config-driven cell tinting: a column declares
+//   threshold: { higherIsBetter, watch, breach, tag?: { watch, breach } }
+// and the table derives the per-cell tone (+ status tags) itself — so any catalog
+// table gets threshold coloring from MDMS with no per-KPI code. Mirrors the reference
+// watch/breach band model (TYPE_DETAILS_THRESHOLDS / EMPLOYEE_THRESHOLDS).
+function evaluateThresholdTone(value, t) {
+  const v = Number(value);
+  if (!t || !Number.isFinite(v)) return null;
+  if (t.higherIsBetter) {
+    if (v <= t.breach) return "breach";
+    if (v <= t.watch) return "watch";
+  } else {
+    if (v >= t.breach) return "breach";
+    if (v >= t.watch) return "watch";
+  }
+  return null;
+}
+
+function annotateRowsFromThresholds(rows, columns) {
+  const tcols = columns.filter((c) => c.threshold);
+  const hasTagsCol = columns.some((c) => c.type === "tags");
+  if (!tcols.length) return rows;
+  return rows.map((row) => {
+    if (row.cellTones || row.statusTagItems) return row; // already annotated upstream
+    const cellTones = {};
+    const tags = [];
+    for (const c of tcols) {
+      const tone = evaluateThresholdTone(row[c.id], c.threshold);
+      if (!tone) continue;
+      cellTones[c.id] = tone;
+      const label = c.threshold.tag?.[tone];
+      if (label) tags.push({ label, tone });
+    }
+    if (!Object.keys(cellTones).length && !hasTagsCol) return row;
+    const next = { ...row, cellTones };
+    if (hasTagsCol) next.statusTagItems = tags.length ? tags : [{ label: "On track", tone: null }];
+    return next;
+  });
+}
+
+const DashboardTable = ({ columns, rows, emptyMessage = "No data" }) => {
+  const styles = DATA_TABLE_STYLES;
+  const safeRows = rows ?? [];
+  const annotatedRows = useMemo(
+    () => annotateRowsFromThresholds(safeRows, columns),
+    [safeRows, columns]
+  );
+  const { sortState, handleSort, sortRows } = useTableSort(columns);
+  const sortedRows = useMemo(() => sortRows(annotatedRows), [annotatedRows, sortRows]);
+
+  return (
+    <table className={styles.table}>
+      <colgroup>
+        {columns.map((col) => (
+          <col
+            key={col.id}
+            className={col.width ? styles.colFixed : undefined}
+            style={col.width ? { width: col.width } : undefined}
+          />
+        ))}
+      </colgroup>
+      <thead>
+        <tr>
+          {columns.map((col) => (
+            <th key={col.id} className={getDataTableThClass(col.align)}>
+              <TableSortHeader column={col} sortState={sortState} onSort={handleSort} />
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {sortedRows.length === 0 ? (
+          <tr>
+            <td colSpan={columns.length} className={styles.empty}>
+              {emptyMessage}
+            </td>
+          </tr>
+        ) : (
+          sortedRows.map((row, rowIndex) => (
+          <tr
+            key={row.id ?? rowIndex}
+            className={row.highlight ? styles.rowHighlight : undefined}
+            style={
+              row.highlight
+                ? {
+                    "--row-sla-severity": String(
+                      row.highlightSeverity != null ? row.highlightSeverity : 1
+                    ),
+                  }
+                : undefined
+            }
+          >
+            {columns.map((col) => {
+              const raw = row[col.id];
+              const isLabel =
+                col.id === "label" || col.id === "subtypeLabel" || col.id === "officerName";
+              const render = CELL_RENDERERS[col.type] ?? CELL_RENDERERS.text;
+              const content =
+                col.type === "tags"
+                  ? renderStatusTags(row, styles)
+                  : col.type === "trend"
+                    ? render(raw)
+                    : render(raw);
+              const labelText = typeof raw === "string" ? raw : String(raw ?? "");
+              const toneKey = col.thresholdKey ?? col.id;
+              const tone = row.cellTones?.[toneKey];
+              const severity = row.cellToneSeverity?.[toneKey];
+              const severityStyle =
+                severity != null ? buildRedSeverityStyle(severity) : undefined;
+              const usesSeverity = severityStyle != null;
+              const suppressCellBackground = Boolean(row.highlight);
+              const cellToneClass =
+                suppressCellBackground || usesSeverity
+                  ? undefined
+                  : resolveToneClass(tone, styles);
+              const textToneClass = usesSeverity
+                ? styles.slaOverrun
+                : resolveToneTextClass(tone, styles);
+              const legacyHighlight =
+                !tone && !usesSeverity && !suppressCellBackground && row.cellHighlights?.[col.id]
+                  ? styles.cellToneBreach
+                  : undefined;
+
+              return (
+                <td
+                  key={col.id}
+                  className={`${getDataTableTdClass(col.align)} ${
+                    cellToneClass ?? legacyHighlight ?? ""
+                  }`.trim()}
+                >
+                  {isLabel ? (
+                    <span className={styles.primary} title={labelText}>
+                      <span className={styles.label}>{content}</span>
+                      {row.badge ? (
+                        <span className={styles.badge}>{row.badge}</span>
+                      ) : null}
+                    </span>
+                  ) : (
+                    <span className={textToneClass} style={usesSeverity ? severityStyle : undefined}>
+                      {content}
+                    </span>
+                  )}
+                </td>
+              );
+            })}
+          </tr>
+          ))
+        )}
+      </tbody>
+    </table>
+  );
+};
+
+export default DashboardTable;

--- a/digit-ui-esbuild/products/dashboard/src/components/DepartmentBarChart.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DepartmentBarChart.jsx
@@ -1,0 +1,280 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import Chart from "react-apexcharts";
+import { DASHBOARD_FONT_FAMILY } from "../config/dashboardConfig";
+import { useChartContainerSize } from "../hooks/useChartContainerSize";
+import { useScrollableChartSize } from "../hooks/useScrollableChartSize";
+import {
+  buildBarChartDataLabels,
+  buildBarChartGrid,
+  buildBarChartLegend,
+  buildBarChartPlotDataLabels,
+  buildBarChartYAxis,
+  formatBarChartPercentOneDecimal,
+  getBarChartSeriesColor,
+  BAR_CHART_XAXIS_RESERVED_HEIGHT_PX,
+  resolveBarChartColumnWidth,
+  resolveBarGroupLayout,
+} from "../config/barChartPresentation";
+import { SHARED_CHROME, VISUALIZATION_STYLES, VIZ_TYPE } from "../config/visualizationStyles";
+import {
+  buildWrappedVerticalXAxisLabels,
+} from "../config/chartAxisLabels";
+import { resolveLabelSlotWidth } from "../utils/barChartXAxis";
+import ChartTooltipPortal from "./ChartTooltipPortal";
+import ChartScrollViewport from "./ChartScrollViewport";
+
+function normalizeChartData(data, categoryOrder) {
+  if (!categoryOrder?.length) {
+    return (data ?? []).map((d) => ({
+      label: String(d.label ?? d.department ?? "Unknown"),
+      count: Number(d.count) || 0,
+    }));
+  }
+
+  const lookup = new Map(
+    (data ?? []).map((d) => [String(d.label ?? d.department), Number(d.count) || 0])
+  );
+
+  return categoryOrder.map((label) => ({
+    label: String(label),
+    count: lookup.get(String(label)) ?? 0,
+  }));
+}
+
+const DepartmentBarChart = ({
+  data,
+  categoryOrder,
+  colors: colorsProp,
+  scrollKey,
+  histogram = false,
+  valueFormat = "count",
+}) => {
+  const isPercent = valueFormat === "percent";
+  const {
+    containerRef: histogramContainerRef,
+    containerSize: histogramContainerSize,
+  } = useChartContainerSize();
+  const effectiveScrollKey = histogram ? undefined : scrollKey;
+  const [tooltip, setTooltip] = useState(null);
+  const distributed = Boolean(colorsProp?.length);
+
+  const chartData = useMemo(
+    () => normalizeChartData(data, categoryOrder),
+    [data, categoryOrder]
+  );
+
+  const { viewportRef, chartSize, isScrollable, isReady, scrollAxis } = useScrollableChartSize({
+    scrollKey: effectiveScrollKey,
+    categoryCount: histogram ? 0 : chartData.length,
+    scrollAxis: histogram ? "xy" : "x",
+  });
+
+  const categories = useMemo(() => chartData.map((d) => d.label), [chartData]);
+  const series = useMemo(
+    () => [{ name: isPercent ? "Resolution rate" : "Count", data: chartData.map((d) => d.count) }],
+    [chartData, isPercent]
+  );
+
+  const seriesMax = useMemo(
+    () => chartData.reduce((max, d) => Math.max(max, d.count), 0),
+    [chartData]
+  );
+
+  const categoryCount = categories.length;
+  const containerWidth = histogram ? histogramContainerSize.width : chartSize.width;
+  const containerHeight = histogram ? histogramContainerSize.height : chartSize.height;
+
+  const labelSlotWidth = useMemo(
+    () => resolveLabelSlotWidth(categoryCount, containerWidth),
+    [categoryCount, containerWidth]
+  );
+
+  const isShort = containerHeight > 0 && containerHeight < 200;
+
+  const xAxisLabelHeight = histogram
+    ? isShort
+      ? 26
+      : 30
+    : BAR_CHART_XAXIS_RESERVED_HEIGHT_PX;
+
+  const yTickAmount = isShort ? 4 : 5;
+
+  const { gridPadding, slotWidth } = useMemo(
+    () => resolveBarGroupLayout(categoryCount, containerWidth, xAxisLabelHeight),
+    [categoryCount, containerWidth, xAxisLabelHeight]
+  );
+
+  // Dynamic column width: scales with the slot (full scaling) and is capped at a max
+  // pixel width so few-category charts don't get giant bars. Tuned thin via the
+  // BAR_COLUMN_* constants. Histograms share the same scaled/capped width.
+  const columnWidth = useMemo(
+    () => resolveBarChartColumnWidth(slotWidth),
+    [slotWidth]
+  );
+
+  const colors = useMemo(
+    () => (distributed ? colorsProp : [getBarChartSeriesColor()]),
+    [colorsProp, distributed]
+  );
+
+  const handleDataPointEnter = useCallback(
+    (event, _chart, { dataPointIndex }) => {
+      if (dataPointIndex < 0) return;
+
+      setTooltip({
+        label: categories[dataPointIndex] ?? "Unknown",
+        value: chartData[dataPointIndex]?.count ?? 0,
+        x: event.clientX,
+        y: event.clientY,
+      });
+    },
+    [categories, chartData]
+  );
+
+  const handleChartMouseMove = useCallback((event) => {
+    setTooltip((prev) => {
+      if (!prev) return null;
+      return { ...prev, x: event.clientX, y: event.clientY };
+    });
+  }, []);
+
+  const handleDataPointLeave = useCallback(() => {
+    setTooltip(null);
+  }, []);
+
+  const options = useMemo(
+    () => ({
+      chart: {
+        type: "bar",
+        toolbar: { show: false },
+        fontFamily: DASHBOARD_FONT_FAMILY,
+        animations: { enabled: true, speed: 300 },
+        height: containerHeight,
+        parentHeightOffset: 0,
+        events: {
+          dataPointMouseEnter: handleDataPointEnter,
+          mouseMove: handleChartMouseMove,
+          mouseLeave: handleDataPointLeave,
+          dataPointMouseLeave: handleDataPointLeave,
+        },
+      },
+      plotOptions: {
+        bar: {
+          borderRadius: 4,
+          horizontal: false,
+          distributed,
+          columnWidth,
+          dataLabels: buildBarChartPlotDataLabels(),
+        },
+      },
+      dataLabels: buildBarChartDataLabels({ valueFormat }),
+      legend: buildBarChartLegend(),
+      xaxis: {
+        categories,
+        tickPlacement: histogram ? "between" : "on",
+        labels: {
+          ...buildWrappedVerticalXAxisLabels(labelSlotWidth, {
+            maxLines: histogram ? 1 : 2,
+          }),
+          maxHeight: xAxisLabelHeight,
+        },
+        axisBorder: { show: false },
+        axisTicks: { show: false },
+      },
+      yaxis: buildBarChartYAxis({
+        tickAmount: yTickAmount,
+        seriesMax,
+        percent: isPercent,
+      }),
+      colors,
+      grid: buildBarChartGrid(gridPadding),
+      tooltip: { enabled: false },
+      states: {
+        hover: { filter: { type: "darken", value: 0.85 } },
+      },
+    }),
+    [
+      categories,
+      columnWidth,
+      colors,
+      containerHeight,
+      gridPadding,
+      handleChartMouseMove,
+      handleDataPointEnter,
+      handleDataPointLeave,
+      labelSlotWidth,
+      yTickAmount,
+      seriesMax,
+      histogram,
+      isPercent,
+    ]
+  );
+
+  useEffect(() => () => setTooltip(null), []);
+
+  if (!chartData.length) return null;
+
+  const barChartClass = VISUALIZATION_STYLES[VIZ_TYPE.BAR_CHART].container;
+
+  return (
+    <>
+      {histogram ? (
+        <div
+          ref={histogramContainerRef}
+          className={`${barChartClass} tw-h-full tw-min-h-0 tw-w-full tw-flex-1`}
+        >
+          {containerHeight > 0 && containerWidth > 0 ? (
+            <Chart
+              key={`hist-${containerHeight}-${containerWidth}-${categories.join("|")}`}
+              options={options}
+              series={series}
+              type="bar"
+              height={containerHeight}
+              width="100%"
+            />
+          ) : null}
+        </div>
+      ) : (
+        <ChartScrollViewport
+          viewportRef={viewportRef}
+          chartSize={chartSize}
+          isScrollable={isScrollable}
+          scrollAxis={scrollAxis}
+          chartClassName={barChartClass}
+        >
+          {isReady ? (
+            <Chart
+              key={`${containerHeight}-${containerWidth}-${categories.join("|")}`}
+              options={options}
+              series={series}
+              type="bar"
+              height={containerHeight}
+              width={containerWidth}
+            />
+          ) : null}
+        </ChartScrollViewport>
+      )}
+      <ChartTooltipPortal tooltip={tooltip}>
+        <div className={SHARED_CHROME.chartTooltipTitle}>{tooltip?.label}</div>
+        <div className={SHARED_CHROME.chartTooltipRow}>
+          {isPercent ? "Resolution rate" : "Count"} :{" "}
+          {isPercent
+            ? formatBarChartPercentOneDecimal(tooltip?.value)
+            : tooltip?.value}
+        </div>
+      </ChartTooltipPortal>
+    </>
+  );
+};
+
+export const WEEKDAY_CHART_ORDER = [
+  "Sun",
+  "Mon",
+  "Tue",
+  "Wed",
+  "Thu",
+  "Fri",
+  "Sat",
+];
+
+export default DepartmentBarChart;

--- a/digit-ui-esbuild/products/dashboard/src/components/GeographyChoroplethMap.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/GeographyChoroplethMap.jsx
@@ -1,0 +1,929 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import L from "leaflet";
+import "leaflet/dist/leaflet.css";
+import {
+  getGeographyMapLegend,
+  getGeographyMapLegendFooter,
+  getGeographyMapLegendTitle,
+  getCreatedCountFillStyle,
+  getOpenShareFillStyle,
+  getResolvedShareFillStyle,
+} from "../config/geographyMapPresentation";
+import { buildMapHoverTooltipHtml, buildComplaintPinTooltipHtml } from "../config/mapHoverPresentation";
+import { formatDimensionLabel } from "../config/labelFormat";
+import { fetchBoundariesByCodes, fetchBoundaryRelationshipsByCodes } from "../services/boundaryService";
+import { useMapResize } from "../hooks/useMapResize";
+import {
+  aggregateWardCountsToLevel,
+  deriveBoundaryAncestorCodes,
+  buildBoundaryLabelIndex,
+  buildMapDisplayLayers,
+  buildMapDrillHierarchy,
+  fitMapToJoinedData,
+  flyToDrillBounds,
+  formatHierarchyGroupLabel,
+  getDrillTier,
+  getFeaturesInDrillScope,
+  getHierarchyGroupKey,
+  getMapCenter,
+  getMapZoomLevelLabel,
+  getWardFeaturesInHierarchyGroup,
+  resolveDrillZoomFeatures,
+  resolveComplaintPinPositions,
+  getMapCityLabel,
+  isWardDrillLevel,
+  joinWardMapData,
+  MAP_COMPLAINT_PIN_MAX_ZOOM,
+  MAP_DRILL_MAX_LEVEL,
+  MAP_WARD_MIN_ZOOM,
+  markerRadiusForZoom,
+  resolveMapRootLabel,
+} from "../utils/mapGeoUtils";
+import { VISUALIZATION_STYLES, VIZ_TYPE } from "../config/visualizationStyles";
+import ViewToggle from "./demo/ViewToggle";
+
+const mapStyles = VISUALIZATION_STYLES[VIZ_TYPE.MAP];
+
+const MAP_HOVER_TOOLTIP_PANE = "dashboardMapHoverTooltips";
+
+const HOVER_TOOLTIP_OPTIONS = {
+  sticky: true,
+  direction: "top",
+  opacity: 1,
+  className: "dashboard-map-hover-tooltip",
+  pane: MAP_HOVER_TOOLTIP_PANE,
+};
+
+function resolveComplaintPinKey(pin) {
+  const id = String(pin?.serviceRequestId ?? "").trim();
+  if (id) return id;
+  return `${pin?.lat},${pin?.lng}`;
+}
+
+function complaintPinPopupOffset(radius) {
+  return L.point(0, -Math.max(radius + 10, 12));
+}
+
+function closeOtherPinPopups(activeCircle, pinLayersByKey = {}) {
+  Object.values(pinLayersByKey).forEach((circle) => {
+    if (circle !== activeCircle && circle.isPopupOpen?.()) {
+      circle.closePopup();
+    }
+  });
+}
+
+function createComplaintPinPopup(pin, radius) {
+  return L.popup({
+    maxWidth: 260,
+    className: "dashboard-map-pin-popup-wrapper",
+    offset: complaintPinPopupOffset(radius),
+    closeOnClick: false,
+    autoClose: true,
+    closeOnEscapeKey: true,
+    autoPan: false,
+  }).setContent(buildComplaintPinPopupContent(pin));
+}
+
+
+// Zoom thresholds that drive which boundary level renders (county/sub-county/ward).
+const MAP_COUNTY_MAX_ZOOM = 10; // below -> county outline only
+const MAP_SUBCOUNTY_MAX_ZOOM = 12; // below -> sub-counties; at/above -> wards
+
+function resolveFeatureStyle(feature, layerMode, focusedCode, zoom = 11) {
+  const props = feature?.properties ?? {};
+  const isFocused = focusedCode && props.code === focusedCode;
+  const base =
+    layerMode === "open"
+      ? getOpenShareFillStyle(props.openPct)
+      : layerMode === "resolved"
+        ? getResolvedShareFillStyle(props.resolvedPct)
+        : getCreatedCountFillStyle(Number(props.count) || Number(props.created) || 0);
+
+  const weight = isFocused ? 2.5 : zoom < 11 ? 0.75 : zoom < 14 ? 1.1 : 1.5;
+
+  return {
+    fillColor: base.fillColor,
+    color: isFocused ? "#111827" : base.strokeColor,
+    weight,
+    opacity: 1,
+    fillOpacity: isFocused
+      ? Math.min(base.fillOpacity + 0.08, 0.88)
+      : base.fillOpacity,
+  };
+}
+
+function buildComplaintPinPopupContent(pin) {
+  const root = document.createElement("div");
+  root.className = "dashboard-map-pin-popup";
+  root.innerHTML = buildComplaintPinTooltipHtml(pin);
+  return root;
+}
+
+const HomeIcon = () => (
+  <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+    <polyline points="9 22 9 12 15 12 15 22" />
+  </svg>
+);
+
+const ResetIcon = () => (
+  <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M3 9v6h6" />
+    <path d="M21 15a8 8 0 0 0-14.9-4" />
+  </svg>
+);
+
+const LocateIcon = () => (
+  <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" strokeWidth="2">
+    <circle cx="12" cy="12" r="3" />
+    <path d="M12 2v3M12 19v3M2 12h3M19 12h3" />
+  </svg>
+);
+
+const FullscreenIcon = ({ active }) => (
+  <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" strokeWidth="2">
+    {active ? (
+      <path d="M8 3v3H5M16 3v3h3M8 21v-3H5M16 21v-3h3" />
+    ) : (
+      <path d="M8 3H5v3M16 3h3v3M8 21H5v-3M16 21h3v-3" />
+    )}
+  </svg>
+);
+
+const GeographyChoroplethMap = ({
+  wardCounts = [],
+  complaintPins = [],
+  complaintPinsError = null,
+  layerMode = "created",
+  onLayerModeChange,
+  layerOptions = [],
+  cityLabel = getMapCityLabel(),
+}) => {
+  const shellRef = useRef(null);
+  const frameRef = useRef(null);
+  const elRef = useRef(null);
+  const mapRef = useRef(null);
+  const choroplethRef = useRef(null);
+  const complaintPinsRef = useRef(null);
+  const pinRendererRef = useRef(null);
+  const pinLayersByKeyRef = useRef({});
+  const selectedPinKeyRef = useRef(null);
+  const updateComplaintPinRadiiRef = useRef(() => {});
+  const layerByCodeRef = useRef({});
+  const defaultViewRef = useRef({ center: getMapCenter(), zoom: 11 });
+
+  // Synced on every map zoom/move; read from layer callbacks via ref so GeoJSON
+  // layers are not rebuilt on each scroll step.
+  const zoomLevelRef = useRef(11);
+
+  const [boundaries, setBoundaries] = useState([]);
+  const [hierarchyIndex, setHierarchyIndex] = useState({});
+  const [boundariesLoading, setBoundariesLoading] = useState(false);
+  const [boundariesError, setBoundariesError] = useState(null);
+  const [zoomLevel, setZoomLevel] = useState(11);
+  const [drillLevel, setDrillLevel] = useState(0);
+  const [drillTrail, setDrillTrail] = useState([]);
+  const [focusedCode, setFocusedCode] = useState(null);
+  const [legendCollapsed, setLegendCollapsed] = useState(false);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  // Zoom-driven boundary level: zoomed out shows the county outline, mid shows
+  // sub-counties, zoomed in shows wards. Thresholds are deliberately coarse.
+  const activeLevel =
+    zoomLevel < MAP_COUNTY_MAX_ZOOM
+      ? "county"
+      : zoomLevel < MAP_SUBCOUNTY_MAX_ZOOM
+        ? "subCounty"
+        : "ward";
+
+  const geoLevel =
+    activeLevel === "county"
+      ? "County"
+      : activeLevel === "subCounty"
+        ? "Sub-county"
+        : getMapZoomLevelLabel({
+            drillTrailLength: drillTrail.length,
+            focusedCode,
+            drillLevel,
+          });
+
+  const { resizeToken } = useMapResize(mapRef, frameRef);
+
+  // ── boundary fetch ────────────────────────────────────────────────────────
+  const wardCodes = useMemo(
+    () => [...new Set(wardCounts.map((w) => String(w.wardCode ?? "").trim()).filter(Boolean))],
+    [wardCounts]
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!wardCodes.length) {
+      setBoundaries([]);
+      setHierarchyIndex({});
+      setBoundariesError(null);
+      return undefined;
+    }
+    setBoundariesLoading(true);
+    setBoundariesError(null);
+    // Fetch relationships first so we know the parent (county/sub-county) codes, then
+    // fetch geometries for wards AND parents — the zoom-driven levels need all three.
+    fetchBoundaryRelationshipsByCodes(wardCodes)
+      .then((rels) => {
+        const parentCodes = deriveBoundaryAncestorCodes(rels);
+        return Promise.all([
+          fetchBoundariesByCodes([...wardCodes, ...parentCodes]),
+          Promise.resolve(rels),
+        ]);
+      })
+      .then(([items, rels]) => {
+        if (cancelled) return;
+        setBoundaries(items);
+        setHierarchyIndex(rels);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setBoundaries([]);
+        setHierarchyIndex({});
+        setBoundariesError("Could not load ward boundaries");
+      })
+      .finally(() => { if (!cancelled) setBoundariesLoading(false); });
+    return () => { cancelled = true; };
+  }, [wardCodes.join("|")]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── data joins ───────────────────────────────────────────────────────────
+  const joined = useMemo(
+    () => joinWardMapData(wardCounts, boundaries),
+    [wardCounts, boundaries]
+  );
+
+  // Parent-level joins for the zoom-driven boundary levels (counts rolled up to the
+  // sub-county / county, joined against the seeded parent polygons).
+  const subCountyJoined = useMemo(
+    () => joinWardMapData(aggregateWardCountsToLevel(wardCounts, hierarchyIndex, 1), boundaries),
+    [wardCounts, hierarchyIndex, boundaries]
+  );
+  const countyJoined = useMemo(
+    () => joinWardMapData(aggregateWardCountsToLevel(wardCounts, hierarchyIndex, 0), boundaries),
+    [wardCounts, hierarchyIndex, boundaries]
+  );
+  // Active level by zoom; fall back to wards if a level's parent polygons are missing.
+  const activeJoined =
+    activeLevel === "county" && countyJoined.geoFeatures.features.length
+      ? countyJoined
+      : activeLevel === "subCounty" && subCountyJoined.geoFeatures.features.length
+        ? subCountyJoined
+        : joined;
+
+  const drillHierarchyIndex = useMemo(
+    () =>
+      buildMapDrillHierarchy({
+        apiIndex: hierarchyIndex,
+        wardCodes,
+        features: joined.geoFeatures?.features ?? [],
+      }),
+    [hierarchyIndex, wardCodes, joined.geoFeatures?.features]
+  );
+
+  const mapRootLabel = useMemo(
+    () => resolveMapRootLabel(cityLabel, drillHierarchyIndex, wardCodes, boundaries),
+    [cityLabel, drillHierarchyIndex, wardCodes, boundaries]
+  );
+
+  const boundaryLabelIndex = useMemo(
+    () => buildBoundaryLabelIndex(boundaries),
+    [boundaries]
+  );
+
+  const focusedWard = useMemo(
+    () => wardCounts.find((r) => r.wardCode === focusedCode),
+    [focusedCode, wardCounts]
+  );
+
+  const activeFilterLabel = useMemo(() => {
+    if (focusedWard?.label) return focusedWard.label;
+    if (drillTrail.length) return drillTrail[drillTrail.length - 1]?.label ?? null;
+    return null;
+  }, [focusedWard, drillTrail]);
+
+  const displayLayers = useMemo(() => {
+    // Pass [] for pins here so buildMapDisplayLayers doesn't run the (heavy) pin
+    // resolution against the active level — we place pins by ward code below.
+    const layers = buildMapDisplayLayers(activeJoined, drillLevel, [], drillHierarchyIndex);
+    // Pins are placed by ward code, so position them via the ward-level join even when
+    // a parent level (county/sub-county) is rendered — otherwise every pin is dropped.
+    layers.complaintPins = complaintPins.length
+      ? resolveComplaintPinPositions(complaintPins, joined)
+      : [];
+    return layers;
+  }, [activeJoined, joined, drillLevel, complaintPins, drillHierarchyIndex]);
+
+  const visibleComplaintPins = displayLayers.complaintPins ?? [];
+
+  const legendItems = useMemo(() => getGeographyMapLegend(layerMode), [layerMode]);
+  const legendTitle = getGeographyMapLegendTitle(layerMode);
+  const legendFooter = getGeographyMapLegendFooter(drillTrail.length);
+
+  // Reset drill state when layer mode changes.
+  useEffect(() => {
+    setFocusedCode(null);
+    setDrillLevel(0);
+    setDrillTrail([]);
+    selectedPinKeyRef.current = null;
+    mapRef.current?.closePopup();
+  }, [layerMode]);
+
+  const updateComplaintPinRadii = useCallback((zoom) => {
+    Object.entries(pinLayersByKeyRef.current).forEach(([, circle]) => {
+      if (!circle?.setRadius) return;
+
+      const radius = markerRadiusForZoom(zoom, false, { complaint: true });
+      const isSelected = circle.isPopupOpen?.();
+
+      circle.setRadius(isSelected ? radius + 2 : radius);
+
+      const popup = circle.getPopup?.();
+      if (!popup) return;
+
+      popup.options.offset = complaintPinPopupOffset(radius);
+      if (isSelected) popup.update();
+    });
+  }, []);
+
+  updateComplaintPinRadiiRef.current = updateComplaintPinRadii;
+
+  // ── actions ──────────────────────────────────────────────────────────────
+  const resetView = useCallback(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    setFocusedCode(null);
+    setDrillLevel(0);
+    setDrillTrail([]);
+    const fitted = fitMapToJoinedData(map, joined, { padding: 0.12, animate: true });
+    if (fitted) { defaultViewRef.current = fitted; }
+    else { map.setView(defaultViewRef.current.center, defaultViewRef.current.zoom, { animate: true }); }
+  }, [joined]);
+
+  // Drill into a clicked polygon — zoom to fit that region and advance the detail level.
+  // Zoom is purely geographic: we fit the clicked polygon's bounds, so a smaller
+  // region naturally zooms in further. No hardcoded zoom numbers.
+  const handleDrillInto = useCallback(
+    ({
+      nextLevel,
+      memberFeatures,
+      clickedFeature,
+      allWardFeatures,
+      scopedWardFeatures,
+      tierId,
+      groupKey,
+      label,
+    }) => {
+      const map = mapRef.current;
+      if (!map) return;
+
+      setDrillLevel(nextLevel);
+      setDrillTrail((prev) => [...prev, { label, groupKey, tierId }]);
+      setFocusedCode(null);
+
+      const zoomFeatures = resolveDrillZoomFeatures({
+        memberFeatures,
+        clickedFeature,
+        allFeatures: allWardFeatures,
+        scopedFeatures: scopedWardFeatures,
+        hierarchyIndex: drillHierarchyIndex,
+        tierId,
+      });
+
+      flyToDrillBounds(map, zoomFeatures, { maxZoom: MAP_COMPLAINT_PIN_MAX_ZOOM });
+    },
+    [drillHierarchyIndex]
+  );
+
+  const handleWardFocus = useCallback((wardCode, clickedFeature, label) => {
+    const map = mapRef.current;
+    if (!map) return;
+    setFocusedCode(wardCode);
+    if (label) {
+      setDrillTrail((prev) => {
+        if (prev.length && prev[prev.length - 1]?.label === label) return prev;
+        return [...prev, { label, groupKey: wardCode, tierId: "ward" }];
+      });
+    }
+    setDrillLevel(MAP_DRILL_MAX_LEVEL);
+    flyToDrillBounds(map, clickedFeature ? [clickedFeature] : [], {
+      padding: 0.18,
+      maxZoom: MAP_COMPLAINT_PIN_MAX_ZOOM,
+    });
+  }, []);
+
+  const handleLocate = useCallback(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    if (!navigator.geolocation) { resetView(); return; }
+    navigator.geolocation.getCurrentPosition(
+      (pos) => map.flyTo([pos.coords.latitude, pos.coords.longitude], Math.max(map.getZoom(), MAP_WARD_MIN_ZOOM)),
+      () => resetView(),
+      { enableHighAccuracy: false, timeout: 8000 }
+    );
+  }, [resetView]);
+
+  const toggleFullscreen = useCallback(() => {
+    const shell = shellRef.current;
+    if (!shell) return;
+    if (!document.fullscreenElement) { shell.requestFullscreen?.().catch(() => {}); }
+    else { document.exitFullscreen?.(); }
+  }, []);
+
+  useEffect(() => {
+    const onChange = () => {
+      setIsFullscreen(Boolean(document.fullscreenElement));
+      mapRef.current?.invalidateSize();
+    };
+    document.addEventListener("fullscreenchange", onChange);
+    return () => document.removeEventListener("fullscreenchange", onChange);
+  }, []);
+
+  // ── Leaflet init ──────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!elRef.current || mapRef.current) return;
+    const map = L.map(elRef.current, {
+      scrollWheelZoom: true,
+      zoomControl: false,
+    }).setView(getMapCenter(), 11);
+
+    L.control.zoom({ position: "topleft" }).addTo(map);
+    L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+      attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+      maxZoom: 19,
+    }).addTo(map);
+
+    // Dedicated pane for complaint pins, above polygons, below hover tooltips.
+    if (!map.getPane("complaintPins")) {
+      map.createPane("complaintPins");
+      map.getPane("complaintPins").style.zIndex = 640;
+    }
+    // Ward hover cards sit above pin popups (Leaflet popup pane is 700).
+    if (!map.getPane(MAP_HOVER_TOOLTIP_PANE)) {
+      map.createPane(MAP_HOVER_TOOLTIP_PANE);
+      map.getPane(MAP_HOVER_TOOLTIP_PANE).style.zIndex = 800;
+    }
+    // A renderer bound to that pane so circleMarkers actually draw into it.
+    pinRendererRef.current = L.svg({ pane: "complaintPins" });
+
+    choroplethRef.current = L.layerGroup().addTo(map);
+    complaintPinsRef.current = L.layerGroup().addTo(map);
+    mapRef.current = map;
+
+    const sync = () => {
+      const z = map.getZoom();
+      zoomLevelRef.current = z;
+      setZoomLevel(z);
+      updateComplaintPinRadiiRef.current(z);
+    };
+    const onZoom = () => {
+      const z = map.getZoom();
+      zoomLevelRef.current = z;
+      updateComplaintPinRadiiRef.current(z);
+    };
+    const repositionOpenPopup = () => {
+      const selectedKey = selectedPinKeyRef.current;
+      if (!selectedKey) return;
+      const circle = pinLayersByKeyRef.current[selectedKey];
+      if (circle?.isPopupOpen?.()) circle.getPopup()?.update();
+    };
+
+    map.on("zoomend", sync);
+    map.on("moveend", sync);
+    map.on("zoom", onZoom);
+    map.on("move", repositionOpenPopup);
+    sync();
+
+    setTimeout(() => map.invalidateSize(), 150);
+    return () => {
+      map.off("zoomend", sync);
+      map.off("moveend", sync);
+      map.off("zoom", onZoom);
+      map.off("move", repositionOpenPopup);
+      map.remove();
+      mapRef.current = null;
+      choroplethRef.current = null;
+      complaintPinsRef.current = null;
+      layerByCodeRef.current = {};
+    };
+  }, []);
+
+  // ── draw choropleth (data / drill / mode; zoom styles updated separately below) ─
+  useEffect(() => {
+    const map = mapRef.current;
+    const choroplethLayer = choroplethRef.current;
+    if (!map || !choroplethLayer) return;
+
+    choroplethLayer.clearLayers();
+    layerByCodeRef.current = {};
+
+    const { geoFeatures } = displayLayers;
+
+    if (!geoFeatures?.features?.length) return;
+
+    const allWardFeatures = joined.geoFeatures?.features ?? [];
+
+    L.geoJSON(geoFeatures, {
+      style: (feature) =>
+        resolveFeatureStyle(feature, layerMode, focusedCode, zoomLevelRef.current),
+      onEachFeature: (feature, layer) => {
+        layer.feature = feature;
+        const code = feature?.properties?.code;
+        if (code) layerByCodeRef.current[code] = layer;
+
+        const props = feature?.properties ?? {};
+
+        layer.bindTooltip(
+          buildMapHoverTooltipHtml(props, { layerMode, geoLevel }),
+          HOVER_TOOLTIP_OPTIONS
+        );
+
+        layer.on("mouseover", () => {
+          const s = resolveFeatureStyle(
+            feature,
+            layerMode,
+            focusedCode,
+            zoomLevelRef.current
+          );
+          layer.setStyle({ ...s, weight: 2.5, fillOpacity: Math.min(s.fillOpacity + 0.1, 0.75) });
+          layer.bringToFront?.();
+        });
+
+        layer.on("mouseout", () => {
+          layer.setStyle(
+            resolveFeatureStyle(feature, layerMode, focusedCode, zoomLevelRef.current)
+          );
+        });
+
+        layer.on("click", () => {
+          if (!code) return;
+
+          if (isWardDrillLevel(drillLevel)) {
+            const wardLabel =
+              props.label ||
+              boundaryLabelIndex[code] ||
+              formatDimensionLabel(code);
+            handleWardFocus(code, feature, wardLabel);
+            return;
+          }
+
+          const currentTier = getDrillTier(drillLevel);
+          const scopedWardFeatures = getFeaturesInDrillScope(
+            allWardFeatures,
+            drillHierarchyIndex,
+            drillTrail
+          );
+          const memberFeatures = getWardFeaturesInHierarchyGroup(
+            scopedWardFeatures,
+            code,
+            drillHierarchyIndex,
+            currentTier.id
+          );
+          const groupKey = getHierarchyGroupKey(code, drillHierarchyIndex, currentTier.id);
+          const groupLabel = formatHierarchyGroupLabel(groupKey, boundaryLabelIndex);
+
+          handleDrillInto({
+            nextLevel: Math.min(drillLevel + 1, MAP_DRILL_MAX_LEVEL),
+            memberFeatures: memberFeatures.length ? memberFeatures : [feature],
+            clickedFeature: feature,
+            allWardFeatures,
+            scopedWardFeatures,
+            tierId: currentTier.id,
+            groupKey,
+            label: groupLabel || props.label || "Area",
+          });
+        });
+      },
+    }).addTo(choroplethLayer);
+  }, [
+    boundaryLabelIndex,
+    displayLayers,
+    drillLevel,
+    focusedCode,
+    geoLevel,
+    handleDrillInto,
+    handleWardFocus,
+    drillHierarchyIndex,
+    drillTrail,
+    joined.geoFeatures?.features,
+    layerMode,
+  ]);
+
+  // ── update choropleth border weights when zoom / focus / mode changes ─────
+  useEffect(() => {
+    Object.values(layerByCodeRef.current).forEach((layer) => {
+      const feature = layer.feature;
+      if (!feature) return;
+      layer.setStyle(
+        resolveFeatureStyle(feature, layerMode, focusedCode, zoomLevel)
+      );
+    });
+  }, [focusedCode, layerMode, zoomLevel]);
+
+  // ── draw complaint pins — redraw on data change; resize on zoom without closing popup
+  useEffect(() => {
+    const map = mapRef.current;
+    const pinLayer = complaintPinsRef.current;
+    if (!map || !pinLayer) return;
+
+    const selectedKey = selectedPinKeyRef.current;
+
+    pinLayer.clearLayers();
+    pinLayersByKeyRef.current = {};
+
+    if (!visibleComplaintPins.length) {
+      selectedPinKeyRef.current = null;
+      map.closePopup();
+      return;
+    }
+
+    const currentZoom = zoomLevelRef.current;
+
+    visibleComplaintPins.forEach((pin) => {
+      if (pin.lat == null || pin.lng == null) return;
+
+      const key = resolveComplaintPinKey(pin);
+      const baseRadius = markerRadiusForZoom(currentZoom, false, { complaint: true });
+      const popup = createComplaintPinPopup(pin, baseRadius);
+
+      const circle = L.circleMarker([pin.lat, pin.lng], {
+        renderer: pinRendererRef.current ?? undefined,
+        pane: "complaintPins",
+        radius: baseRadius,
+        color: "#b45309",
+        weight: 1.5,
+        fillColor: "#f59e0b",
+        fillOpacity: 0.92,
+      });
+
+      circle.on("click", () => {
+        closeOtherPinPopups(circle, pinLayersByKeyRef.current);
+        map.closeTooltip();
+      });
+
+      circle.on("mouseover", function () {
+        if (this.isPopupOpen?.()) return;
+        this.setStyle({ weight: 3, fillOpacity: 1, radius: baseRadius + 2 });
+        this.bringToFront?.();
+      });
+
+      circle.on("mouseout", function () {
+        if (this.isPopupOpen?.()) return;
+        const radius = markerRadiusForZoom(zoomLevelRef.current, false, { complaint: true });
+        this.setStyle({ weight: 1.5, fillOpacity: 0.9, radius });
+      });
+
+      circle.on("popupopen", function () {
+        closeOtherPinPopups(this, pinLayersByKeyRef.current);
+        selectedPinKeyRef.current = key;
+        map.closeTooltip();
+        const radius = markerRadiusForZoom(zoomLevelRef.current, false, { complaint: true });
+        Object.entries(pinLayersByKeyRef.current).forEach(([, layer]) => {
+          const layerRadius = markerRadiusForZoom(zoomLevelRef.current, false, { complaint: true });
+          if (layer.isPopupOpen?.()) {
+            layer.setStyle({ weight: 3, fillOpacity: 1, radius: layerRadius + 2 });
+          } else {
+            layer.setStyle({ weight: 1.5, fillOpacity: 0.9, radius: layerRadius });
+          }
+        });
+        const activePopup = this.getPopup();
+        if (activePopup) {
+          activePopup.options.offset = complaintPinPopupOffset(radius);
+          activePopup.update();
+        }
+      });
+
+      circle.on("popupclose", function () {
+        if (selectedPinKeyRef.current === key) selectedPinKeyRef.current = null;
+        const radius = markerRadiusForZoom(zoomLevelRef.current, false, { complaint: true });
+        this.setStyle({ weight: 1.5, fillOpacity: 0.9, radius });
+      });
+
+      circle.bindPopup(popup);
+      pinLayersByKeyRef.current[key] = circle;
+      circle.addTo(pinLayer);
+    });
+
+    pinLayer.bringToFront?.();
+
+    if (selectedKey && pinLayersByKeyRef.current[selectedKey]) {
+      pinLayersByKeyRef.current[selectedKey].openPopup();
+    } else {
+      selectedPinKeyRef.current = null;
+    }
+  }, [visibleComplaintPins]);
+
+  // ── initial fit ───────────────────────────────────────────────────────────
+  useEffect(() => {
+    const map = mapRef.current;
+    if (
+      !map ||
+      focusedCode ||
+      drillTrail.length > 0 ||
+      !joined.geoFeatures?.features?.length
+    ) {
+      return undefined;
+    }
+
+    const refit = () => {
+      map.invalidateSize({ animate: false, pan: false });
+      const fitted = fitMapToJoinedData(map, joined, { padding: 0.12 });
+      if (fitted) defaultViewRef.current = fitted;
+    };
+
+    const id = window.requestAnimationFrame(() => window.requestAnimationFrame(refit));
+    return () => window.cancelAnimationFrame(id);
+  }, [focusedCode, drillTrail.length, joined, resizeToken]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (
+      !map ||
+      focusedCode ||
+      drillTrail.length > 0 ||
+      !joined.geoFeatures?.features?.length
+    ) {
+      return undefined;
+    }
+    map.invalidateSize({ animate: false, pan: false });
+    const fitted = fitMapToJoinedData(map, joined, { padding: 0.12 });
+    if (fitted) defaultViewRef.current = fitted;
+    return undefined;
+  }, [focusedCode, drillTrail.length, joined]);
+
+  // ── render ────────────────────────────────────────────────────────────────
+  const showEmpty = !boundariesLoading && !wardCounts.length && !boundariesError;
+  const showLoading = boundariesLoading && !joined.markers.length;
+
+  const toggleOptions = layerOptions.map((l) => ({ id: l.id, label: l.label }));
+
+  return (
+    <div
+      ref={frameRef}
+      className="dashboard-map-frame tw-relative tw-flex tw-min-h-0 tw-flex-1 tw-flex-col"
+    >
+      <div className="dashboard-map-toolbar-row tw-flex tw-shrink-0 tw-items-center tw-gap-3 tw-border-b tw-border-border tw-px-2 tw-py-2">
+        {onLayerModeChange && toggleOptions.length ? (
+          <ViewToggle
+            value={layerMode}
+            onChange={onLayerModeChange}
+            variant="primary"
+            options={toggleOptions}
+          />
+        ) : null}
+
+        <div className="dashboard-map-breadcrumb tw-flex tw-min-w-0 tw-flex-1 tw-items-center tw-gap-1.5 tw-text-[11px] tw-font-medium tw-text-foreground">
+          <HomeIcon />
+          <span className="tw-truncate">{mapRootLabel}</span>
+          {drillTrail.map((step, i) => (
+            <React.Fragment key={`trail-${i}`}>
+              <span className="tw-text-muted-foreground">&gt;</span>
+              <span
+                className={`tw-truncate ${
+                  i === drillTrail.length - 1 && !focusedWard ? "tw-font-semibold" : ""
+                }`}
+              >
+                {step.label}
+              </span>
+            </React.Fragment>
+          ))}
+          {focusedWard && drillTrail[drillTrail.length - 1]?.label !== focusedWard.label ? (
+            <>
+              <span className="tw-text-muted-foreground">&gt;</span>
+              <span className="tw-truncate tw-font-semibold">{focusedWard.label}</span>
+            </>
+          ) : null}
+        </div>
+
+        <div className="dashboard-map-zoom-badge tw-shrink-0 tw-rounded-sm tw-border tw-border-border tw-bg-muted/40 tw-px-2 tw-py-0.5 tw-text-[10px] tw-text-muted-foreground">
+          zoom {zoomLevel} · {geoLevel}
+          {visibleComplaintPins.length
+            ? ` · ${visibleComplaintPins.length} complaint${visibleComplaintPins.length === 1 ? "" : "s"}`
+            : ""}
+        </div>
+
+        <div className="dashboard-map-controls tw-flex tw-shrink-0 tw-items-center">
+          <button
+            type="button"
+            className="dashboard-map-control-btn"
+            title="Locate me"
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={handleLocate}
+          >
+            <LocateIcon />
+          </button>
+          <button
+            type="button"
+            className="dashboard-map-control-btn dashboard-map-control-btn--text"
+            title="Reset view"
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={resetView}
+          >
+            <ResetIcon />
+            <span>Reset</span>
+          </button>
+          <button
+            type="button"
+            className="dashboard-map-control-btn"
+            title={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={toggleFullscreen}
+          >
+            <FullscreenIcon active={isFullscreen} />
+          </button>
+        </div>
+      </div>
+
+      <div
+        ref={shellRef}
+        className="dashboard-map-shell tw-relative tw-flex tw-min-h-0 tw-flex-1 tw-flex-col"
+      >
+        {showLoading ? (
+          <div className="tw-pointer-events-none tw-absolute tw-inset-0 tw-z-[500] tw-flex tw-items-center tw-justify-center tw-bg-surface/70 tw-text-[12px] tw-text-muted-foreground">
+            Loading boundaries…
+          </div>
+        ) : null}
+        {showEmpty ? (
+          <div className="tw-flex tw-h-full tw-min-h-[220px] tw-items-center tw-justify-center tw-p-4 tw-text-[12px] tw-text-muted-foreground">
+            No geographic data
+          </div>
+        ) : (
+          <>
+            <div
+              ref={elRef}
+              className={`${mapStyles.container} dashboard-map-canvas tw-h-full tw-min-h-[220px] tw-w-full tw-flex-1`}
+            />
+
+            {activeFilterLabel ? (
+              <div className="dashboard-map-filter-chip tw-pointer-events-auto tw-absolute tw-right-3 tw-top-3 tw-z-[1000] tw-flex tw-items-center tw-gap-2 tw-rounded-sm tw-border tw-border-border tw-bg-surface/95 tw-px-2.5 tw-py-1.5 tw-text-[10px] tw-shadow-sm">
+                <span className="tw-text-muted-foreground">Filter:</span>
+                <span className="tw-font-semibold tw-text-foreground">{activeFilterLabel}</span>
+                <button
+                  type="button"
+                  className="dashboard-map-filter-clear"
+                  onMouseDown={(e) => e.stopPropagation()}
+                  onClick={resetView}
+                >
+                  Clear
+                </button>
+              </div>
+            ) : null}
+
+            {boundariesError ? (
+              <div className="tw-pointer-events-none tw-absolute tw-right-3 tw-top-12 tw-z-[1000] tw-rounded tw-bg-surface/90 tw-px-2 tw-py-1 tw-text-[10px] tw-text-muted-foreground">
+                {boundariesError}
+              </div>
+            ) : null}
+            {complaintPinsError ? (
+              <div className="tw-pointer-events-none tw-absolute tw-right-3 tw-top-20 tw-z-[1000] tw-max-w-[220px] tw-rounded tw-bg-amber-50/95 tw-px-2 tw-py-1 tw-text-[10px] tw-text-amber-900">
+                Complaint pins unavailable: analytics API must expose latitude, longitude, and service_request_id on the facts grain.
+              </div>
+            ) : null}
+          </>
+        )}
+      </div>
+
+      {!showEmpty && !showLoading ? (
+        <div className="dashboard-map-legend tw-pointer-events-auto tw-absolute tw-bottom-3 tw-left-3 tw-z-[1100]">
+          <div className="tw-flex tw-items-center tw-justify-between tw-gap-2 tw-border-b tw-border-border tw-px-2.5 tw-py-2">
+            <span className="tw-text-[11px] tw-font-semibold tw-text-foreground">{legendTitle}</span>
+            <button
+              type="button"
+              className="dashboard-map-legend-toggle"
+              onMouseDown={(e) => e.stopPropagation()}
+              onClick={() => setLegendCollapsed((prev) => !prev)}
+              aria-label={legendCollapsed ? "Expand legend" : "Collapse legend"}
+            >
+              {legendCollapsed ? "+" : "−"}
+            </button>
+          </div>
+          {!legendCollapsed ? (
+            <>
+              <ul className="dashboard-map-legend-list tw-space-y-1.5 tw-px-2.5 tw-py-2">
+                {legendItems.map((item) => (
+                  <li key={item.id} className="tw-flex tw-items-center tw-gap-2">
+                    <span
+                      className="dashboard-map-legend-swatch"
+                      style={{ backgroundColor: item.fill, borderColor: item.stroke }}
+                    />
+                    <span className="tw-text-[10px] tw-leading-tight tw-text-foreground">
+                      {item.label}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+              <p className="tw-border-t tw-border-border tw-px-2.5 tw-py-2 tw-text-[9px] tw-leading-snug tw-text-muted-foreground">
+                {legendFooter}
+              </p>
+            </>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default GeographyChoroplethMap;

--- a/digit-ui-esbuild/products/dashboard/src/components/GeographyChoroplethMap.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/GeographyChoroplethMap.jsx
@@ -847,43 +847,40 @@ const GeographyChoroplethMap = ({
           </div>
         ) : null}
         {showEmpty ? (
-          <div className="tw-flex tw-h-full tw-min-h-[220px] tw-items-center tw-justify-center tw-p-4 tw-text-[12px] tw-text-muted-foreground">
+          <div className="tw-pointer-events-none tw-absolute tw-inset-0 tw-z-[500] tw-flex tw-items-center tw-justify-center tw-bg-surface/70 tw-p-4 tw-text-[12px] tw-text-muted-foreground">
             No geographic data
           </div>
-        ) : (
-          <>
-            <div
-              ref={elRef}
-              className={`${mapStyles.container} dashboard-map-canvas tw-h-full tw-min-h-[220px] tw-w-full tw-flex-1`}
-            />
+        ) : null}
+        <div
+          ref={elRef}
+          className={`${mapStyles.container} dashboard-map-canvas tw-h-full tw-min-h-[220px] tw-w-full tw-flex-1`}
+        />
 
-            {activeFilterLabel ? (
-              <div className="dashboard-map-filter-chip tw-pointer-events-auto tw-absolute tw-right-3 tw-top-3 tw-z-[1000] tw-flex tw-items-center tw-gap-2 tw-rounded-sm tw-border tw-border-border tw-bg-surface/95 tw-px-2.5 tw-py-1.5 tw-text-[10px] tw-shadow-sm">
-                <span className="tw-text-muted-foreground">Filter:</span>
-                <span className="tw-font-semibold tw-text-foreground">{activeFilterLabel}</span>
-                <button
-                  type="button"
-                  className="dashboard-map-filter-clear"
-                  onMouseDown={(e) => e.stopPropagation()}
-                  onClick={resetView}
-                >
-                  Clear
-                </button>
-              </div>
-            ) : null}
+        {activeFilterLabel ? (
+          <div className="dashboard-map-filter-chip tw-pointer-events-auto tw-absolute tw-right-3 tw-top-3 tw-z-[1000] tw-flex tw-items-center tw-gap-2 tw-rounded-sm tw-border tw-border-border tw-bg-surface/95 tw-px-2.5 tw-py-1.5 tw-text-[10px] tw-shadow-sm">
+            <span className="tw-text-muted-foreground">Filter:</span>
+            <span className="tw-font-semibold tw-text-foreground">{activeFilterLabel}</span>
+            <button
+              type="button"
+              className="dashboard-map-filter-clear"
+              onMouseDown={(e) => e.stopPropagation()}
+              onClick={resetView}
+            >
+              Clear
+            </button>
+          </div>
+        ) : null}
 
-            {boundariesError ? (
-              <div className="tw-pointer-events-none tw-absolute tw-right-3 tw-top-12 tw-z-[1000] tw-rounded tw-bg-surface/90 tw-px-2 tw-py-1 tw-text-[10px] tw-text-muted-foreground">
-                {boundariesError}
-              </div>
-            ) : null}
-            {complaintPinsError ? (
-              <div className="tw-pointer-events-none tw-absolute tw-right-3 tw-top-20 tw-z-[1000] tw-max-w-[220px] tw-rounded tw-bg-amber-50/95 tw-px-2 tw-py-1 tw-text-[10px] tw-text-amber-900">
-                Complaint pins unavailable: analytics API must expose latitude, longitude, and service_request_id on the facts grain.
-              </div>
-            ) : null}
-          </>
-        )}
+        {boundariesError ? (
+          <div className="tw-pointer-events-none tw-absolute tw-right-3 tw-top-12 tw-z-[1000] tw-rounded tw-bg-surface/90 tw-px-2 tw-py-1 tw-text-[10px] tw-text-muted-foreground">
+            {boundariesError}
+          </div>
+        ) : null}
+        {complaintPinsError ? (
+          <div className="tw-pointer-events-none tw-absolute tw-right-3 tw-top-20 tw-z-[1000] tw-max-w-[220px] tw-rounded tw-bg-amber-50/95 tw-px-2 tw-py-1 tw-text-[10px] tw-text-amber-900">
+            Complaint pins unavailable: analytics API must expose latitude, longitude, and service_request_id on the facts grain.
+          </div>
+        ) : null}
       </div>
 
       {!showEmpty && !showLoading ? (

--- a/digit-ui-esbuild/products/dashboard/src/components/HorizontalBarChart.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/HorizontalBarChart.jsx
@@ -1,0 +1,235 @@
+import React, { useMemo } from "react";
+import Chart from "react-apexcharts";
+import { DASHBOARD_FONT_FAMILY } from "../config/dashboardConfig";
+import { resolveDashboardCssColor } from "../config/chartColors";
+import {
+  buildApexChartTooltipOptions,
+  buildChartTooltipMarkup,
+} from "../config/chartTooltipPresentation";
+import {
+  buildHorizontalBarGrid,
+  buildHorizontalCategoryYAxis,
+} from "../config/stackedBarPresentation";
+import { useScrollableChartSize } from "../hooks/useScrollableChartSize";
+import { resolveBarChartColumnWidth } from "../config/barChartPresentation";
+import { VISUALIZATION_STYLES, VIZ_TYPE } from "../config/visualizationStyles";
+import ChartScrollViewport from "./ChartScrollViewport";
+
+function formatRatio(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return "0.00";
+  return n.toFixed(2);
+}
+
+function breakEvenSeriesValues(value, breakEven) {
+  const v = Math.max(0, Number(value) || 0);
+  const threshold = Math.max(0, Number(breakEven) || 0);
+  if (v >= threshold) {
+    return { below: 0, above: v };
+  }
+  return { below: v, above: 0 };
+}
+
+const HorizontalBarChart = ({ data = [], breakEven = 1, scrollKey }) => {
+  const rows = useMemo(
+    () =>
+      (data || []).map((entry) => ({
+        label: String(entry.label ?? "Unknown"),
+        value: Number(entry.value ?? entry.count) || 0,
+        resolved: Number(entry.resolved),
+        created: Number(entry.created),
+      })),
+    [data]
+  );
+
+  const categories = useMemo(() => rows.map((d) => d.label), [rows]);
+  const values = useMemo(() => rows.map((d) => d.value), [rows]);
+
+  const {
+    viewportRef,
+    chartSize,
+    isScrollable,
+    isReady,
+    scrollAxis,
+  } = useScrollableChartSize({
+    scrollKey,
+    categoryCount: categories.length,
+    scrollAxis: "y",
+  });
+
+  const containerWidth = chartSize.width;
+  const containerHeight = chartSize.height;
+
+  const belowBreakEvenColor = resolveDashboardCssColor("var(--status-breach)");
+  const atOrAboveBreakEvenColor = resolveDashboardCssColor("var(--status-resolved)");
+  const foregroundColor = resolveDashboardCssColor("var(--foreground)");
+  const borderColor = resolveDashboardCssColor("var(--border)");
+  const mutedColor = resolveDashboardCssColor("var(--muted-foreground)");
+
+  const { belowSeries, aboveSeries } = useMemo(() => {
+    const below = [];
+    const above = [];
+    for (const value of values) {
+      const split = breakEvenSeriesValues(value, breakEven);
+      below.push(split.below);
+      above.push(split.above);
+    }
+    return { belowSeries: below, aboveSeries: above };
+  }, [values, breakEven]);
+
+  const axisMax = useMemo(() => {
+    const maxValue = Math.max(...values, breakEven, 0);
+    const padded = maxValue * 1.2;
+    return Math.max(1.2, Math.ceil(padded * 10) / 10);
+  }, [values, breakEven]);
+
+  const options = useMemo(
+    () => ({
+      chart: {
+        type: "bar",
+        stacked: true,
+        stackType: "normal",
+        toolbar: { show: false },
+        fontFamily: DASHBOARD_FONT_FAMILY,
+        parentHeightOffset: 0,
+      },
+      plotOptions: {
+        bar: {
+          horizontal: true,
+          borderRadius: 4,
+          borderRadiusApplication: "end",
+          // Cap bar thickness at the same max px as vertical bars so a 1-category
+          // chart doesn't render one giant bar — consistent regardless of the data.
+          barHeight: resolveBarChartColumnWidth(
+            containerHeight / Math.max(1, categories.length)
+          ),
+          dataLabels: {
+            total: {
+              enabled: true,
+              offsetX: 6,
+              offsetY: 4,
+              hideOverflowingLabels: false,
+              style: {
+                fontSize: "11px",
+                fontWeight: 600,
+                color: foregroundColor,
+              },
+              formatter: (total) => formatRatio(total),
+            },
+          },
+        },
+      },
+      dataLabels: { enabled: false },
+      xaxis: {
+        categories,
+        min: 0,
+        max: axisMax,
+        labels: { style: { fontSize: "10px" } },
+        axisBorder: { show: false },
+        axisTicks: { show: false },
+      },
+      yaxis: [buildHorizontalCategoryYAxis(categories, containerWidth)],
+      colors: [belowBreakEvenColor, atOrAboveBreakEvenColor],
+      legend: {
+        show: true,
+        position: "top",
+        horizontalAlign: "center",
+        fontSize: "11px",
+        offsetY: 2,
+        customLegendItems: ["Falling behind (<1.0)", "Catching up (≥1.0)"],
+        markers: {
+          fillColors: [belowBreakEvenColor, atOrAboveBreakEvenColor],
+        },
+      },
+      annotations: {
+        xaxis: [
+          {
+            x: breakEven,
+            borderColor,
+            strokeDashArray: 4,
+            borderWidth: 1,
+            label: {
+              show: true,
+              text: formatRatio(breakEven),
+              borderColor: "transparent",
+              style: {
+                background: "transparent",
+                color: mutedColor,
+                fontSize: "10px",
+              },
+            },
+          },
+        ],
+      },
+      grid: buildHorizontalBarGrid(),
+      tooltip: buildApexChartTooltipOptions({
+        shared: false,
+        followCursor: true,
+        custom: ({ dataPointIndex }) => {
+          const row = rows[dataPointIndex];
+          if (!row) return "";
+          const detail =
+            Number.isFinite(row.resolved) &&
+            Number.isFinite(row.created) &&
+            row.created > 0
+              ? `${row.resolved} resolved ÷ ${row.created} created`
+              : "";
+          const value = `${formatRatio(row.value)}${detail ? ` — ${detail}` : ""}`;
+          return buildChartTooltipMarkup({
+            title: row.label,
+            rows: [{ value }],
+          });
+        },
+      }),
+    }),
+    [
+      axisMax,
+      atOrAboveBreakEvenColor,
+      belowBreakEvenColor,
+      borderColor,
+      breakEven,
+      categories,
+      containerWidth,
+      containerHeight,
+      foregroundColor,
+      mutedColor,
+      rows,
+    ]
+  );
+
+  const series = useMemo(
+    () => [
+      { name: "Falling behind (<1.0)", data: belowSeries },
+      { name: "Catching up (≥1.0)", data: aboveSeries },
+    ],
+    [aboveSeries, belowSeries]
+  );
+
+  const hasData = rows.length > 0;
+  const horizontalStyles = VISUALIZATION_STYLES[VIZ_TYPE.HORIZONTAL_BAR];
+
+  if (!hasData) return null;
+
+  return (
+    <ChartScrollViewport
+      viewportRef={viewportRef}
+      chartSize={chartSize}
+      isScrollable={isScrollable}
+      chartClassName={horizontalStyles.container}
+      scrollAxis={scrollAxis}
+    >
+      {isReady ? (
+        <Chart
+          key={`${containerWidth}-${containerHeight}-${breakEven}-${categories.join("|")}`}
+          options={options}
+          series={series}
+          type="bar"
+          height={containerHeight}
+          width="100%"
+        />
+      ) : null}
+    </ChartScrollViewport>
+  );
+};
+
+export default HorizontalBarChart;

--- a/digit-ui-esbuild/products/dashboard/src/components/KpiCard.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/KpiCard.jsx
@@ -1,0 +1,143 @@
+import React from "react";
+import { VISUALIZATION_STYLES, VIZ_TYPE } from "../config/visualizationStyles";
+import { getNumberTileValueClass } from "../config/kpiDisplay";
+import ResizeGrip from "./ResizeGrip";
+
+const numberTile = VISUALIZATION_STYLES[VIZ_TYPE.NUMBER_TILE_DELTA];
+
+const RemoveIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="tw-h-3.5 tw-w-3.5"
+    aria-hidden="true"
+  >
+    <path d="M18 6 6 18" />
+    <path d="m6 6 12 12" />
+  </svg>
+);
+
+const KpiCard = ({
+  title,
+  value,
+  context,
+  status,
+  deltaDisplay,
+  deltaClass,
+  listItems = [],
+  hasList = false,
+  loading = false,
+  onRemove,
+}) => {
+  const isUnavailable = value === "—";
+  const displayValue = value ?? (loading ? "…" : "—");
+  const valueClass = getNumberTileValueClass(status, { unavailable: isUnavailable });
+  const showDelta = Boolean(deltaDisplay) || (loading && deltaClass != null);
+
+  return (
+    <div
+      className={`${numberTile.card} tw-group${
+        hasList
+          ? " tw-flex tw-h-full tw-min-h-0 tw-flex-col"
+          : showDelta
+            ? ` ${numberTile.cardDelta}`
+            : ` ${numberTile.cardMetric}`
+      }`}
+    >
+      {onRemove ? (
+        <button
+          type="button"
+          title="Remove from dashboard"
+          onMouseDown={(e) => e.stopPropagation()}
+          onClick={onRemove}
+          className="dashboard-widget-remove-btn"
+          aria-label={`Remove ${title}`}
+        >
+          <RemoveIcon />
+        </button>
+      ) : null}
+
+      <div className={numberTile.title} title={title}>
+        {title}
+      </div>
+
+      {showDelta ? (
+        <div className={numberTile.valueRow}>
+          <div
+            className={`${numberTile.value} ${valueClass} ${
+              loading ? numberTile.valueLoading : ""
+            }`}
+          >
+            {displayValue}
+          </div>
+          {deltaDisplay ? (
+            <div className={`${numberTile.delta} ${deltaClass ?? valueClass}`}>
+              {deltaDisplay}
+            </div>
+          ) : loading ? (
+            <div className={`${numberTile.delta} ${numberTile.deltaMuted}`}>…</div>
+          ) : null}
+        </div>
+      ) : (
+        <div
+          className={`${numberTile.value} ${valueClass} ${
+            loading ? numberTile.valueLoading : ""
+          }`}
+        >
+          {displayValue}
+        </div>
+      )}
+
+      {!hasList ? (
+        <div className={numberTile.context}>{context || "\u00A0"}</div>
+      ) : context ? (
+        <div className={`${numberTile.context} tw-mt-2`}>{context}</div>
+      ) : null}
+
+      {hasList ? (
+        <div className={`${numberTile.listBody} tw-mt-2 tw-min-h-0 tw-flex-1 tw-overflow-y-auto`}>
+          {listItems.length > 0 ? (
+            <ol className={`${numberTile.list} tw-m-0 tw-list-none tw-space-y-1 tw-p-0`}>
+              {listItems.map((item) => (
+                <li
+                  key={`${item.rank}-${item.label}`}
+                  className={`${numberTile.listItem} tw-flex tw-items-center tw-justify-between tw-gap-2 tw-rounded-sm tw-bg-muted tw-px-2 tw-py-1.5`}
+                >
+                  <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-1.5">
+                    <span className="tw-flex tw-h-4 tw-w-4 tw-shrink-0 tw-items-center tw-justify-center tw-rounded-full tw-bg-muted tw-text-[9px] tw-font-bold tw-text-foreground">
+                      {item.rank}
+                    </span>
+                    <span
+                      className="tw-min-w-0 tw-truncate tw-text-[12px] tw-text-foreground"
+                      title={item.label}
+                    >
+                      {item.label}
+                    </span>
+                  </div>
+                  <span className="tw-shrink-0 tw-text-[12px] tw-font-semibold tw-tabular-nums tw-text-foreground">
+                    {item.value}
+                  </span>
+                </li>
+              ))}
+            </ol>
+          ) : (
+            <p className="tw-text-[12px] tw-text-muted-foreground">
+              {loading ? "Loading…" : "No list data"}
+            </p>
+          )}
+        </div>
+      ) : null}
+
+      <ResizeGrip />
+    </div>
+  );
+};
+
+export default KpiCard;

--- a/digit-ui-esbuild/products/dashboard/src/components/KpiSparklineCard.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/KpiSparklineCard.jsx
@@ -1,0 +1,139 @@
+import React, { useMemo } from "react";
+import Chart from "react-apexcharts";
+import { DASHBOARD_FONT_FAMILY } from "../config/dashboardConfig";
+import { resolveDashboardCssColor } from "../config/chartColors";
+import { VISUALIZATION_STYLES, VIZ_TYPE } from "../config/visualizationStyles";
+import { getNumberTileValueClass } from "../config/kpiDisplay";
+import { useChartContainerSize } from "../hooks/useChartContainerSize";
+import ResizeGrip from "./ResizeGrip";
+
+const SPARKLINE_MIN_HEIGHT = 10;
+
+const sparklineTile = VISUALIZATION_STYLES[VIZ_TYPE.NUMBER_TILE_SPARKLINE];
+const numberTile = VISUALIZATION_STYLES[VIZ_TYPE.NUMBER_TILE_DELTA];
+
+const RemoveIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="tw-h-3.5 tw-w-3.5"
+    aria-hidden="true"
+  >
+    <path d="M18 6 6 18" />
+    <path d="m6 6 12 12" />
+  </svg>
+);
+
+function normalizeSparklineData(points) {
+  if (!Array.isArray(points) || points.length === 0) {
+    return [0, 0, 0, 0, 0, 0, 0];
+  }
+  if (points.length === 1) {
+    return [points[0], points[0]];
+  }
+  return points;
+}
+
+const KpiSparklineCard = ({
+  title,
+  value,
+  status,
+  deltaDisplay,
+  deltaClass,
+  seriesColor = "var(--chart-1)",
+  sparkline = [],
+  loading = false,
+  onRemove,
+}) => {
+  const isUnavailable = value === "—";
+  const displayValue = value ?? (loading ? "…" : "—");
+  const valueClass = getNumberTileValueClass(status, { unavailable: isUnavailable });
+  const chartData = normalizeSparklineData(sparkline);
+  const { containerRef, containerSize } = useChartContainerSize();
+  const chartHeight = Math.max(SPARKLINE_MIN_HEIGHT, containerSize.height || SPARKLINE_MIN_HEIGHT);
+  const strokeColor = useMemo(
+    () => resolveDashboardCssColor(seriesColor),
+    [seriesColor]
+  );
+
+  const chartOptions = useMemo(
+    () => ({
+      chart: {
+        type: "line",
+        sparkline: { enabled: true },
+        fontFamily: DASHBOARD_FONT_FAMILY,
+        animations: { enabled: false },
+        parentHeightOffset: 0,
+      },
+      stroke: { curve: "smooth", width: 1 },
+      fill: { opacity: 0 },
+      colors: [strokeColor],
+      tooltip: { enabled: false },
+    }),
+    [strokeColor]
+  );
+
+  const series = useMemo(() => [{ data: chartData }], [chartData]);
+
+  return (
+    <div className={`${numberTile.card} ${sparklineTile.card} tw-group`}>
+      {onRemove ? (
+        <button
+          type="button"
+          title="Remove from dashboard"
+          onMouseDown={(e) => e.stopPropagation()}
+          onClick={onRemove}
+          className="dashboard-widget-remove-btn"
+          aria-label={`Remove ${title}`}
+        >
+          <RemoveIcon />
+        </button>
+      ) : null}
+
+      <div className={numberTile.title} title={title}>
+        {title}
+      </div>
+
+      <div className={sparklineTile.valueRow}>
+        <div
+          className={`${numberTile.value} ${valueClass} ${
+            loading ? numberTile.valueLoading : ""
+          }`}
+        >
+          {displayValue}
+        </div>
+        {deltaDisplay ? (
+          <div className={`${sparklineTile.delta} ${deltaClass ?? valueClass}`}>
+            {deltaDisplay}
+          </div>
+        ) : loading ? (
+          <div className={`${sparklineTile.delta} ${sparklineTile.deltaMuted}`}>…</div>
+        ) : null}
+      </div>
+
+      <div ref={containerRef} className={sparklineTile.sparkline}>
+        {chartHeight > 0 ? (
+          <Chart
+            key={chartHeight}
+            options={chartOptions}
+            series={series}
+            type="line"
+            height={chartHeight}
+            width="100%"
+          />
+        ) : null}
+      </div>
+
+      <ResizeGrip />
+    </div>
+  );
+};
+
+export default KpiSparklineCard;

--- a/digit-ui-esbuild/products/dashboard/src/components/KpiTile.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/KpiTile.jsx
@@ -1,0 +1,1121 @@
+import React from 'react';
+import KpiCard from './KpiCard';
+import KpiSparklineCard from './KpiSparklineCard';
+import DepartmentBarChart from './DepartmentBarChart';
+import HorizontalBarChart from './HorizontalBarChart';
+import StackedBarChart from './StackedBarChart';
+import PieChart from './PieChart';
+import LineChart from './LineChart';
+import DashboardTable from './DashboardTable';
+import ComplaintsAtRiskTable from './ComplaintsAtRiskTable';
+import OpenComplaintsByGeographyWidget from './OpenComplaintsByGeographyWidget';
+import { evaluateCompose } from '../utils/composeKpi';
+import { getNumberTileDeltaClass, formatOfficerLabel } from '../config/kpiDisplay';
+import {
+  resolveSlaRiskPresentation,
+  computeBreachDurationMs,
+  formatBreachDurationCompact,
+  formatWorkflowStatusLabel,
+  normalizeWorkflowStatusKey,
+} from '../config/complaintsAtRiskPresentation';
+
+/**
+ * Generic viz-kind-driven tile renderer (the dashboard RENDERING ENGINE).
+ *
+ * Reads `def.viz` (from the backend KPI catalog descriptor) to choose a viz
+ * kind, then dispatches to the existing polished dashboard component, adapting
+ * the GENERIC analytics result into that component's props. No widget-id
+ * literals, no per-tile domain knowledge: every shape decision is keyed off the
+ * `viz` descriptor and the result's `columns[].role` (dimension/measure).
+ *
+ * The result shape (the generic /_query envelope):
+ *   { columns: [{ name, role: 'dimension'|'measure', format? }],
+ *     rows:    [ { <colName>: value, ... } ],
+ *     value,   // pre-aggregated scalar (number-tiles)
+ *     values,  // map of named scalars
+ *     series,  // pre-shaped multi-series payload (line/stacked) when BE supplies it
+ *     prior,   // prior-period scalar/series for deltas
+ *     sparkline, // daily series for sparkline cards
+ *     asOf, scope }
+ *
+ * The viz descriptor (`def.viz`) keys this engine understands:
+ *   kind, format, accent, dimensionKey, measureKey(s), seriesKeys, stackKey,
+ *   stackSeries, titleKey, valueKey, priorKey, sparklineKey, compose, breakEven,
+ *   limit, colors, columns, deltaLabel, delta.
+ *
+ * Props:
+ * - def: tile descriptor from catalog (viz, titleKey, kpiId, ...)
+ * - result: generic data for this kpiId
+ * - results: full results map (only needed for viz.compose multi-source rules)
+ * - error: { code, message } | null  (e.g. pii_forbidden / kpi_forbidden)
+ * - vizOverride: optional user-chosen viz kind
+ * - loading: pass-through loading flag for the child components
+ * - onRemove: pass-through remove handler for card chrome
+ */
+export function KpiTile({ def, result, results, error, vizOverride, loading = false, onRemove }) {
+  const viz = def?.viz || {};
+  const title = resolveTitle(def);
+
+  if (error) {
+    return (
+      <div className="kpi-tile kpi-tile--error" data-error-code={error.code}>
+        <span className="kpi-tile__error-code">{errorLabel(error.code)}</span>
+        <span className="kpi-tile__error-msg">{error.message || 'Failed to load'}</span>
+      </div>
+    );
+  }
+
+  if (!result && !loading) {
+    return <div className="kpi-tile kpi-tile--empty"><span className="kpi-tile__empty">No data</span></div>;
+  }
+  if (!result) {
+    return <div className="kpi-tile kpi-tile--loading"><div className="kpi-tile__skeleton" /></div>;
+  }
+
+  const kind = vizOverride || viz.kind || 'scalar';
+  const ctx = { def, viz, result, results, title, loading, onRemove };
+
+  const content = renderByKind(kind, ctx);
+
+  // Card components carry their own chrome (remove btn, sparkline). The wrapper
+  // only adds the as-of / scope badges for the non-card kinds.
+  if (isCardKind(kind)) return content;
+
+  const { asOf, scope } = result;
+  // Mirror the reference DashboardGrid chart body (SHARED_CHROME.defaultBody):
+  // the chart components measure their own viewport (height:100%; flex:1), so the
+  // wrapper MUST establish a definite height. Without these fill classes the
+  // wrapper collapses to content height and the chart renders at 0px (blank).
+  return (
+    <div
+      className={`kpi-tile kpi-tile--${kind} tw-flex tw-min-h-0 tw-flex-1 tw-flex-col tw-overflow-hidden`}
+      data-accent={viz.accent}
+    >
+      {content}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+
+function isCardKind(kind) {
+  return (
+    kind === 'number-tile-delta' ||
+    kind === 'scalar' ||
+    kind === 'number-tile' ||
+    kind === 'number-tile-sparkline' ||
+    kind === 'sparkline-card'
+  );
+}
+
+function renderByKind(kind, ctx) {
+  switch (kind) {
+    case 'number-tile-delta':
+    case 'scalar':
+    case 'number-tile':
+      return renderNumberTileDelta(ctx);
+
+    case 'number-tile-sparkline':
+    case 'sparkline-card':
+      return renderNumberTileSparkline(ctx);
+
+    case 'bar':
+    case 'bar-chart':
+      return renderBar(ctx, { histogram: false });
+
+    case 'histogram':
+      return renderBar(ctx, { histogram: true });
+
+    case 'horizontal-bar':
+      return renderHorizontalBar(ctx);
+
+    case 'stacked-bar':
+      return renderStackedBar(ctx);
+
+    case 'pie':
+    case 'pie-chart':
+      return renderPie(ctx);
+
+    case 'line':
+    case 'line-chart':
+      return renderLine(ctx);
+
+    case 'sla-risk-table':
+      return renderSlaRiskTable(ctx);
+
+    case 'choropleth-map':
+    case 'map':
+      return renderChoroplethMap(ctx);
+
+    case 'ranked-list':
+    case 'rankedList':
+      return <RankedListDisplay {...adaptRanked(ctx)} />;
+
+    case 'dow':
+    case 'day-of-week':
+      return <DowDisplay {...adaptDow(ctx)} />;
+
+    case 'table':
+    case 'data-table':
+    default:
+      return renderTable(ctx);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Column-role helpers (zero hardcoded column names)
+// ---------------------------------------------------------------------------
+
+function dimensionColumns(result, viz) {
+  const cols = (result.columns || []).filter((c) => c.role === 'dimension');
+  if (cols.length) return cols;
+  if (viz.dimensionKey) return [{ name: viz.dimensionKey }];
+  return [];
+}
+
+function measureColumns(result, viz) {
+  const cols = (result.columns || []).filter((c) => c.role === 'measure');
+  if (cols.length) return cols;
+  const keys = viz.measureKeys || (viz.measureKey ? [viz.measureKey] : []);
+  return keys.map((name) => ({ name }));
+}
+
+function primaryDimensionKey(result, viz) {
+  return dimensionColumns(result, viz)[0]?.name || viz.dimensionKey || 'label';
+}
+
+function primaryMeasure(result, viz) {
+  return measureColumns(result, viz)[0] || { name: viz.measureKey || 'total' };
+}
+
+// ---------------------------------------------------------------------------
+// Scalar / delta cards  -> KpiCard
+// Ports the formatSubMetricValue + WoW delta shaping into a generic adapter
+// driven by viz.format / viz.valueKey / viz.priorKey / viz.compose.
+// ---------------------------------------------------------------------------
+
+function resolveScalar(ctx) {
+  const { viz, result, results } = ctx;
+  if (viz.compose && results) {
+    const composed = evaluateCompose(viz.compose, results);
+    if (composed != null) return composed;
+  }
+  if (result.value != null) return result.value;
+  if (result.values && viz.valueKey != null && result.values[viz.valueKey] != null) {
+    return Number(result.values[viz.valueKey]);
+  }
+  if (result.values) {
+    const first = Object.values(result.values)[0];
+    if (first != null) return Number(first);
+  }
+  const row0 = result.rows?.[0];
+  if (row0) {
+    const key = viz.valueKey || primaryMeasure(result, viz).name;
+    if (row0[key] != null) return Number(row0[key]);
+  }
+  return null;
+}
+
+function resolvePrior(ctx) {
+  const { viz, result } = ctx;
+  if (result.prior != null) return Number(result.prior);
+  if (viz.priorKey != null) {
+    if (result.values && result.values[viz.priorKey] != null) return Number(result.values[viz.priorKey]);
+    const row0 = result.rows?.[0];
+    if (row0 && row0[viz.priorKey] != null) return Number(row0[viz.priorKey]);
+  }
+  return null;
+}
+
+/**
+ * Generalized WoW delta — mirrors resolveSparklineDelta / computeWowPercent:
+ * percent metrics use a percentage-point delta, everything else a % change.
+ */
+function computeDelta(current, prior, format, mode) {
+  if (current == null || prior == null || !Number.isFinite(current) || !Number.isFinite(prior)) {
+    return null;
+  }
+  // viz.delta.mode (when set) decides the unit; otherwise fall back to the format.
+  const eff = mode || (isPercentFormat(format) ? 'percentPoint' : 'percent');
+  if (eff === 'percentPoint') return normalizePct(current) - normalizePct(prior);
+  if (eff === 'days') return (current - prior) / 86400000; // ms -> whole days
+  if (eff === 'duration') return current - prior; // raw ms difference
+  if (eff === 'rating') return current - prior; // rating points
+  if (prior === 0) return null;
+  return ((current - prior) / Math.abs(prior)) * 100; // relative %
+}
+
+function formatDeltaDisplay(delta, format, mode) {
+  if (delta == null || !Number.isFinite(delta)) return null;
+  const arrow = delta >= 0 ? '▲' : '▼';
+  const abs = Math.abs(delta);
+  const eff = mode || (isPercentFormat(format) ? 'percentPoint' : 'percent');
+  if (eff === 'duration') {
+    return abs >= 86400000
+      ? `${arrow} ${(abs / 86400000).toFixed(1)} days`
+      : `${arrow} ${(abs / 3600000).toFixed(1)} hrs`;
+  }
+  const rounded = Math.round(abs * 10) / 10;
+  const formatted = Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+  if (eff === 'days') return `${arrow} ${formatted} ${rounded === 1 ? 'day' : 'days'}`;
+  if (eff === 'rating') return `${arrow} ${formatted}`;
+  const unit = eff === 'percentPoint' ? 'pp' : '%';
+  return `${arrow} ${formatted}${unit}`;
+}
+
+function deltaClassFor(delta) {
+  if (delta == null || !Number.isFinite(delta) || delta === 0) return undefined;
+  return delta > 0 ? 'dashboard-delta-up' : 'dashboard-delta-down';
+}
+
+// ---------------------------------------------------------------------------
+// Threshold-driven status for number cards. Ports kpiDisplay.resolveThresholdStatus
+// so the catalog can carry the on-track / breaching bands per def via
+//   viz.threshold = { kind, higherIsBetter, onTrack, breaching }
+// and the KpiCard/KpiSparklineCard value (and sparkline) colour at parity with the
+// live AdminDashboard path. When no threshold is present we fall back to the
+// static viz.accent (legacy behaviour) so non-card tiles are unaffected.
+// ---------------------------------------------------------------------------
+
+const KPI_STATUS = { ON_TRACK: 'on_track', NORMAL: 'normal', BREACHING: 'breaching' };
+
+function thresholdStatus(threshold, value) {
+  if (!threshold || value == null || !Number.isFinite(Number(value))) return null;
+  // Percent metrics come back as a 0..1 ratio from the composer; the thresholds
+  // (e.g. onTrack: 70) are expressed in display units, so normalise to 0..100.
+  const n = threshold.kind === 'percent' ? normalizePct(value) : Number(value);
+  const { higherIsBetter, onTrack, breaching } = threshold;
+  if (higherIsBetter) {
+    if (n >= onTrack) return KPI_STATUS.ON_TRACK;
+    if (n <= breaching) return KPI_STATUS.BREACHING;
+    return KPI_STATUS.NORMAL;
+  }
+  if (n <= onTrack) return KPI_STATUS.ON_TRACK;
+  if (n >= breaching) return KPI_STATUS.BREACHING;
+  return KPI_STATUS.NORMAL;
+}
+
+/** 3-state threshold status when viz.threshold is set, else the static accent. */
+function resolveTileStatus(viz, value) {
+  return thresholdStatus(viz.threshold, value) ?? viz.accent;
+}
+
+/**
+ * Delta colour. With a threshold the live path colours the delta by status
+ * (resolveKpiDeltaClass -> getNumberTileDeltaClass), so we hand KpiCard the same
+ * status token and let it resolve the colour. Without a threshold we keep the
+ * directional up/down class so legacy delta tiles are unchanged.
+ */
+function resolveDeltaClass(viz, value, delta) {
+  const status = thresholdStatus(viz.threshold, value);
+  if (status) {
+    const unavailable = value == null || !Number.isFinite(Number(value));
+    return getNumberTileDeltaClass(status, { unavailable });
+  }
+  return deltaClassFor(delta);
+}
+
+/** Series stroke colour mirrors the live KpiSparklineCard status-derived colour. */
+function statusToSeriesColor(status) {
+  switch (status) {
+    case KPI_STATUS.ON_TRACK: return 'var(--status-resolved)';
+    case KPI_STATUS.BREACHING: return 'var(--status-breach)';
+    default: return null;
+  }
+}
+
+function renderNumberTileDelta(ctx) {
+  const { viz, title, loading, onRemove } = ctx;
+  const value = resolveScalar(ctx);
+  const prior = resolvePrior(ctx);
+  const delta = computeDelta(value, prior, viz.format, viz.delta?.mode);
+  const status = resolveTileStatus(viz, value);
+  return (
+    <KpiCard
+      title={title}
+      value={loading ? undefined : applyFormat(value, viz.format)}
+      context={viz.subtitle || viz.description || viz.contextLabel || ''}
+      status={status}
+      deltaDisplay={formatDeltaDisplay(delta, viz.format, viz.delta?.mode)}
+      deltaClass={resolveDeltaClass(viz, value, delta)}
+      loading={loading}
+      onRemove={onRemove}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sparkline card  -> KpiSparklineCard
+// Ports parseSparkline7d's "sort by date, map measure -> point" shaping into a
+// generic adapter keyed off viz.sparklineKey / viz.dateKey / viz.measureKey.
+// ---------------------------------------------------------------------------
+
+function resolveSparkline(ctx) {
+  const { viz, result } = ctx;
+  if (Array.isArray(result.sparkline)) return result.sparkline.map((n) => Number(n) || 0);
+
+  // Long-form rows -> ordered numeric series.
+  const seriesRows = viz.sparklineKey && result[viz.sparklineKey]?.rows
+    ? result[viz.sparklineKey].rows
+    : result.rows;
+  if (!seriesRows?.length) return [];
+
+  const dateKey = viz.dateKey || dimensionColumns(result, viz)[0]?.name || 'created_date';
+  const measureKey = viz.sparklineMeasureKey || primaryMeasure(result, viz).name;
+
+  return [...seriesRows]
+    .sort((a, b) => String(a[dateKey] ?? '').localeCompare(String(b[dateKey] ?? '')))
+    .map((row) => Number(row[measureKey]) || 0);
+}
+
+function renderNumberTileSparkline(ctx) {
+  const { viz, title, loading, onRemove } = ctx;
+  const value = resolveScalar(ctx);
+  const prior = resolvePrior(ctx);
+  const delta = computeDelta(value, prior, viz.format, viz.delta?.mode);
+  const status = resolveTileStatus(viz, value);
+  return (
+    <KpiSparklineCard
+      title={title}
+      value={loading ? undefined : applyFormat(value, viz.format)}
+      status={status}
+      deltaDisplay={formatDeltaDisplay(delta, viz.format, viz.delta?.mode)}
+      deltaClass={resolveDeltaClass(viz, value, delta)}
+      seriesColor={viz.seriesColor || statusToSeriesColor(status) || 'var(--chart-1)'}
+      sparkline={resolveSparkline(ctx)}
+      loading={loading}
+      onRemove={onRemove}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Bar / histogram  -> DepartmentBarChart
+// Ports parseBarChart / parseDepartmentsBarChart / parseOpenComplaintsByAgeHistogram:
+// dimension -> { label, count }, optionally ranked by measure desc.
+// ---------------------------------------------------------------------------
+
+function adaptBarRows(ctx) {
+  const { viz, result } = ctx;
+  const dimKey = primaryDimensionKey(result, viz);
+  const measure = primaryMeasure(result, viz);
+  const isPercent = viz.format === 'percent' || viz.format === 'percentOneDecimal';
+
+  let rows = (result.rows || []).map((row) => ({
+    label: formatDimLabel(row[dimKey], viz),
+    count: percentToChartScale(Number(row[measure.name]) || 0, isPercent),
+  }));
+
+  // Histograms keep the backend bucket order; bars rank by value desc unless
+  // the descriptor pins an explicit category order.
+  if (viz.kind !== 'histogram' && !viz.categoryOrder && viz.sort !== 'none') {
+    rows = rows.sort((a, b) => b.count - a.count);
+  }
+  // Explicit category order (e.g. age buckets <1d,1-3d,3-7d,>7d) — apply it so the
+  // backend's arbitrary row order doesn't scramble an ordered axis. Substring match
+  // tolerates label formatting; unknown labels sink to the end.
+  if (viz.categoryOrder) {
+    const ord = viz.categoryOrder;
+    const idx = (l) => {
+      const i = ord.findIndex((o) => l === o || l.includes(o) || o.includes(l));
+      return i < 0 ? ord.length : i;
+    };
+    rows = rows.slice().sort((a, b) => idx(a.label) - idx(b.label));
+  }
+  if (viz.limit) rows = rows.slice(0, viz.limit);
+  return rows;
+}
+
+function renderBar(ctx, { histogram }) {
+  const { viz, loading } = ctx;
+  const data = adaptBarRows(ctx);
+  if (loading && !data.length) return <Placeholder message="Loading…" />;
+  if (!data.length) return <Placeholder message="No data" />;
+  return (
+    <DepartmentBarChart
+      data={data}
+      categoryOrder={viz.categoryOrder}
+      colors={viz.colors}
+      histogram={histogram}
+      valueFormat={viz.format === 'percent' || viz.format === 'percentOneDecimal' ? 'percent' : 'count'}
+      scrollKey={histogram ? undefined : def_scrollKey(ctx)}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Horizontal bar  -> HorizontalBarChart
+// Ports parseDepartmentFlowRatioBarChart: dimension -> { label, value, resolved, created }.
+// ---------------------------------------------------------------------------
+
+function adaptHorizontalRows(ctx) {
+  const { viz, result } = ctx;
+  const dimKey = primaryDimensionKey(result, viz);
+  const valueKey = viz.measureKey || primaryMeasure(result, viz).name;
+  const numeratorKey = viz.numeratorKey;   // e.g. resolved
+  const denominatorKey = viz.denominatorKey; // e.g. created
+  // Roll up to display grain when several source rows share a dimension value
+  // (e.g. service_code rows -> one department_code). Mirrors the reference
+  // parseDepartmentFlowRatioBarChart roll-up; numerator/denominator sum, then
+  // value is recomputed as the ratio.
+  const grouped = new Map();
+  for (const row of result.rows || []) {
+    const key = String(row[dimKey] ?? 'Unknown');
+    const bucket = grouped.get(key) || { num: 0, den: 0, val: 0 };
+    if (numeratorKey != null) bucket.num += Number(row[numeratorKey]) || 0;
+    if (denominatorKey != null) bucket.den += Number(row[denominatorKey]) || 0;
+    bucket.val += Number(row[valueKey]) || 0;
+    grouped.set(key, bucket);
+  }
+  const isRatio = numeratorKey != null && denominatorKey != null;
+  let rows = [...grouped.entries()].map(([key, b]) => ({
+    label: formatDimLabel(key, viz),
+    value: isRatio ? (b.den > 0 ? b.num / b.den : 0) : b.val,
+    resolved: numeratorKey != null ? b.num : undefined,
+    created: denominatorKey != null ? b.den : undefined,
+  }));
+  // Drop zero-denominator categories (reference filters created<=0).
+  if (isRatio) rows = rows.filter((r) => (r.created || 0) > 0);
+  if (viz.sort !== 'none') rows = rows.sort((a, b) => a.value - b.value);
+  if (viz.limit) rows = rows.slice(0, viz.limit);
+  return rows;
+}
+
+function renderHorizontalBar(ctx) {
+  const { viz, loading } = ctx;
+  const data = adaptHorizontalRows(ctx);
+  if (loading && !data.length) return <Placeholder message="Loading…" />;
+  if (!data.length) return <Placeholder message="No data" />;
+  return (
+    <HorizontalBarChart
+      data={data}
+      breakEven={viz.breakEven ?? 1}
+      scrollKey={def_scrollKey(ctx)}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Stacked bar  -> StackedBarChart
+// Ports parsePivotStackedChart / parseComplaintsByTypeStackedChart:
+//  - if BE already shaped { categories, series, colors }, pass through;
+//  - else pivot long-form rows (category x stackKey -> measure) into series,
+//    keyed off viz.stackSeries [{ key, label, color }].
+// ---------------------------------------------------------------------------
+
+function adaptStacked(ctx) {
+  const { viz, result } = ctx;
+
+  // BE-shaped passthrough.
+  if (result.series && Array.isArray(result.series) && result.categories) {
+    return { categories: result.categories, series: result.series, colors: result.colors || viz.colors || [] };
+  }
+
+  const dimKey = primaryDimensionKey(result, viz);
+  const stackKey = viz.stackKey;
+  const measureKey = viz.measureKey || 'total';
+  const stackSeries = viz.stackSeries; // [{ key, label, color }]
+
+  // Single-series stacked (e.g. complaints-by-type "Filed").
+  if (!stackKey || !stackSeries?.length) {
+    let rows = (result.rows || []).map((row) => ({
+      label: formatDimLabel(row[dimKey], viz),
+      value: Number(row[measureKey]) || 0,
+    }));
+    if (viz.sort !== 'none') rows = rows.sort((a, b) => b.value - a.value);
+    if (viz.limit) rows = rows.slice(0, viz.limit);
+    return {
+      categories: rows.map((r) => r.label),
+      series: [{ name: viz.seriesLabel || 'Count', data: rows.map((r) => r.value) }],
+      colors: viz.colors || ['var(--chart-1)'],
+    };
+  }
+
+  // Pivot long-form rows into per-segment series.
+  const segKeys = new Set(stackSeries.map((d) => normalizeSeg(d.key)));
+  const categoryMap = new Map();
+  for (const row of result.rows || []) {
+    const seg = normalizeSeg(row[stackKey]);
+    if (!segKeys.has(seg)) continue;
+    const category = String(row[dimKey] ?? 'Unknown');
+    if (!categoryMap.has(category)) categoryMap.set(category, {});
+    const bucket = categoryMap.get(category);
+    const value = viz.valueTransform === 'msToHours'
+      ? msToHours(row[measureKey])
+      : Number(row[measureKey]) || 0;
+    bucket[seg] = viz.aggregate === 'set' ? value : (bucket[seg] ?? 0) + value;
+  }
+
+  let entries = [...categoryMap.entries()].map(([key, segments]) => ({
+    key,
+    segments,
+    total: Object.values(segments).reduce((s, v) => s + v, 0),
+  }));
+  entries = entries.filter((e) => e.total > 0).sort((a, b) => {
+    if (viz.sortBySegment) {
+      const d = (b.segments[normalizeSeg(viz.sortBySegment)] ?? 0) - (a.segments[normalizeSeg(viz.sortBySegment)] ?? 0);
+      if (d !== 0) return d;
+    }
+    return b.total - a.total;
+  });
+  if (viz.limit) entries = entries.slice(0, viz.limit);
+
+  return {
+    categories: entries.map((e) => formatDimLabel(e.key, viz)),
+    series: stackSeries.map((def) => ({
+      name: def.label,
+      data: entries.map((e) => e.segments[normalizeSeg(def.key)] ?? 0),
+    })),
+    colors: stackSeries.map((def) => def.color),
+  };
+}
+
+function renderStackedBar(ctx) {
+  const { viz, loading } = ctx;
+  const { categories, series, colors } = adaptStacked(ctx);
+  const hasData = categories.length > 0 && series.some((s) => s.data?.some((v) => Number(v) > 0));
+  if (loading && !hasData) return <Placeholder message="Loading…" />;
+  if (!hasData) return <Placeholder message="No data" />;
+  return (
+    <StackedBarChart
+      categories={categories}
+      series={series}
+      colors={colors}
+      horizontal={viz.orientation === 'horizontal'}
+      valueFormat={viz.valueFormat || (viz.valueTransform === 'msToHours' ? 'hours' : undefined)}
+      scrollKey={def_scrollKey(ctx)}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Pie  -> PieChart
+// Ports parseOpenComplaintsByChannelPieChart: dimension -> { label, count, color }.
+// ---------------------------------------------------------------------------
+
+function adaptPie(ctx) {
+  const { viz, result } = ctx;
+  const dimKey = primaryDimensionKey(result, viz);
+  const measure = primaryMeasure(result, viz);
+  const colors = viz.colors || [];
+  // Optional source->channel rollup (parity with parseOpenComplaintsByChannelPieChart):
+  // when viz.channelMap is present, fold raw `source` rows into named channels
+  // with fixed colours/labels before slicing.
+  if (viz.channelMap?.length) {
+    return adaptChannelPie(result, dimKey, measure, viz);
+  }
+  let rows = (result.rows || [])
+    .map((row, i) => ({
+      label: formatDimLabel(row[dimKey], viz),
+      count: Number(row[measure.name]) || 0,
+      color: colors[i],
+    }))
+    .filter((s) => s.count > 0);
+  if (viz.sort !== 'none') rows = rows.sort((a, b) => b.count - a.count);
+  return rows;
+}
+
+/** source -> channel rollup with verbatim COMPLAINT_CHANNELS labels/colours. */
+function adaptChannelPie(result, dimKey, measure, viz) {
+  const channels = viz.channelMap; // [{ id, label, color, sources:[...] }]
+  const sourceToChannel = new Map();
+  for (const ch of channels) {
+    for (const src of ch.sources || []) {
+      sourceToChannel.set(normalizeSourceKey(src), ch.id);
+    }
+  }
+  const totals = new Map(channels.map((c) => [c.id, 0]));
+  for (const row of result.rows || []) {
+    const count = Number(row[measure.name]) || 0;
+    if (count <= 0) continue;
+    const key = normalizeSourceKey(row[dimKey]);
+    const id = key ? (sourceToChannel.get(key) ?? 'other') : 'other';
+    if (totals.has(id)) totals.set(id, totals.get(id) + count);
+  }
+  return channels
+    .map((c) => ({ label: c.label, count: totals.get(c.id) ?? 0, color: c.color }))
+    .filter((s) => s.count > 0)
+    .sort((a, b) => (b.count - a.count) || a.label.localeCompare(b.label));
+}
+
+function normalizeSourceKey(source) {
+  return String(source ?? '').trim().toLowerCase().replace(/-/g, '_');
+}
+
+function renderPie(ctx) {
+  const { loading } = ctx;
+  const data = adaptPie(ctx);
+  if (loading && !data.length) return <Placeholder message="Loading…" />;
+  if (!data.length) return <Placeholder message="No data" />;
+  return <PieChart data={data} />;
+}
+
+// ---------------------------------------------------------------------------
+// Line  -> LineChart
+// Pass-through of a multi-period / multi-series payload. The over-time period
+// rewriting (daily/weekly/monthly) is a BE-side concern; the engine only needs
+// the BE-shaped { periods, defaultPeriod } or a flat { categories, series }.
+// ---------------------------------------------------------------------------
+
+function adaptLine(ctx) {
+  const { viz, result, title } = ctx;
+  if (result.periods) {
+    return { periods: result.periods, defaultPeriod: result.defaultPeriod || viz.defaultPeriod || 'daily', headerTitle: result.title || title };
+  }
+  if (result.series && result.categories) {
+    return { categories: result.categories, series: result.series };
+  }
+  const dimKey = primaryDimensionKey(result, viz);
+  const rows = [...(result.rows || [])].sort((a, b) =>
+    String(a[dimKey] ?? '').localeCompare(String(b[dimKey] ?? ''))
+  );
+  const categories = rows.map((r) => formatDimLabel(r[dimKey], viz));
+
+  // Descriptor-driven multi-series with per-series colour / dual y-axis grouping.
+  // Each seriesDef is either a direct measure ({ measureKey }) or a computed
+  // ratio percent ({ numeratorKey, denominatorKey }) — ports the reference
+  // COMPLAINTS_OVER_TIME_SERIES_DEFS (Created / Resolved counts + Resolution
+  // rate / SLA compliance percents on a second axis).
+  if (viz.seriesDefs?.length) {
+    return {
+      categories,
+      series: viz.seriesDefs.map((def) => ({
+        name: def.name,
+        color: def.color,
+        yAxisGroup: def.yAxisGroup,
+        dashArray: def.dashArray ?? 0,
+        data: rows.map((r) => {
+          if (def.numeratorKey != null && def.denominatorKey != null) {
+            const num = Number(r[def.numeratorKey]) || 0;
+            const den = Number(r[def.denominatorKey]) || 0;
+            return den > 0 ? Math.round((num / den) * 1000) / 10 : 0;
+          }
+          return Number(r[def.measureKey]) || 0;
+        }),
+      })),
+    };
+  }
+
+  // Long-form fallback -> single/multi series keyed off viz.measureKeys.
+  const measures = measureColumns(result, viz);
+  return {
+    categories,
+    series: measures.map((m) => ({
+      name: m.label || m.name,
+      data: rows.map((r) => Number(r[m.name]) || 0),
+    })),
+  };
+}
+
+function renderLine(ctx) {
+  const { loading } = ctx;
+  const props = adaptLine(ctx);
+  const hasStructure = props.periods
+    ? Object.values(props.periods).some((p) => p.categories?.length > 0)
+    : (props.categories?.length > 0 && props.series?.length > 0);
+  if (loading && !hasStructure) return <Placeholder message="Loading…" />;
+  if (!hasStructure) return <Placeholder message="No data" />;
+  return <LineChart {...props} />;
+}
+
+// ---------------------------------------------------------------------------
+// Data table  -> DashboardTable
+// Column config comes from viz.columns (matches DashboardTable's column shape:
+// { id, label, align, type, width, thresholdKey }). Rows pass through verbatim.
+// ---------------------------------------------------------------------------
+
+function renderTable(ctx) {
+  const { viz, result, loading } = ctx;
+  const columns = viz.columns || deriveColumnsFromResult(result);
+  const rows = result.rows || [];
+  if (loading && !rows.length) return <Placeholder message="Loading…" />;
+  return <DashboardTable columns={columns} rows={rows} emptyMessage={viz.emptyMessage || 'No data'} />;
+}
+
+function deriveColumnsFromResult(result) {
+  return (result.columns || []).map((c) => ({
+    id: c.name,
+    label: c.label || c.name,
+    align: c.role === 'measure' ? 'right' : 'left',
+    type: mapFormatToCellType(c.format),
+    thresholdKey: c.thresholdKey,
+  }));
+}
+
+function mapFormatToCellType(format) {
+  switch (format) {
+    case 'integer': return 'integer';
+    case 'percent':
+    case 'percentOneDecimal':
+    case 'percentInteger': return 'percent';
+    case 'hoursDecimal': return 'hours';
+    case 'hoursDays': return 'hoursDays';
+    case 'ratingOutOfFive': return 'rating';
+    default: return 'text';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SLA-risk table  -> ComplaintsAtRiskTable
+// The component owns its own columns; rows already carry the per-row display
+// shape (id, typeLabel, ownerName, slaLabel, breachDurationLabel, ...).
+// ---------------------------------------------------------------------------
+
+/**
+ * Shape the generic at-risk grain rows into the ComplaintsAtRiskTable row
+ * contract. Ports config/kpiQueries.parseComplaintsAtRiskTable verbatim (it
+ * relies only on the pure presentation helpers, which survive the inversion),
+ * so the inverted engine renders the rich SLA-risk table at parity with the
+ * reference instead of a degraded ranked list.
+ */
+function adaptSlaRiskRows(ctx) {
+  const { viz, result } = ctx;
+  const limit = viz.limit || 50;
+  return (result.rows || [])
+    .map((row, index) => {
+      const complaintId = String(row.service_request_id ?? '').trim();
+      if (!complaintId || complaintId === 'null') return null;
+
+      const slaBucket = String(row.sla_status_bucket ?? '');
+      const { slaLabel, slaLevel } = resolveSlaRiskPresentation(slaBucket);
+      const breachDurationMs = computeBreachDurationMs(
+        row.open_age_ms,
+        row.sla_target_ms,
+        slaBucket
+      );
+      const applicationStatus = String(row.application_status ?? '');
+      const subtypeKey = String(row.service_code ?? '');
+      const typeKey = String(row.service_group ?? '');
+
+      return {
+        id: complaintId,
+        typeLabel: typeKey ? formatDimensionLabel(typeKey) : '—',
+        subtypeLabel: subtypeKey ? formatDimensionLabel(subtypeKey) : '—',
+        locality: row.ward_code ? formatDimensionLabel(String(row.ward_code)) : '—',
+        ownerName: formatOfficerLabel(row.current_assignee_uuid),
+        ownerRole: '—',
+        status: normalizeWorkflowStatusKey(applicationStatus),
+        statusLabel: formatWorkflowStatusLabel(applicationStatus),
+        slaLabel,
+        slaLevel,
+        breachDurationMs,
+        breachDurationLabel: formatBreachDurationCompact(breachDurationMs),
+        _rowKey: `risk-${index}-${complaintId}`,
+      };
+    })
+    .filter(Boolean)
+    .sort((left, right) => (right.breachDurationMs ?? -1) - (left.breachDurationMs ?? -1))
+    .slice(0, limit);
+}
+
+function renderSlaRiskTable(ctx) {
+  const { loading } = ctx;
+  const rows = adaptSlaRiskRows(ctx);
+  if (loading && !rows.length) return <Placeholder message="Loading…" />;
+  return <ComplaintsAtRiskTable rows={rows} />;
+}
+
+// ---------------------------------------------------------------------------
+// Choropleth map  -> OpenComplaintsByGeographyWidget (Kajal's geography map)
+// Her widget fetches its own ward geometry and toggles created/open/resolved
+// layers; it reads layers[layerKey] (ward series), layers.wardDetails, and
+// layers.complaintPinsByLayer[layerKey]. We shape the tile's ward aggregate +
+// the companion pin source into that contract. (Per-layer distinct counts —
+// created vs open vs resolved — is a refinement; today every layer shows the
+// tile's aggregate so the toggle always renders data.)
+// ---------------------------------------------------------------------------
+
+const GEO_MAP_LAYER_KEYS = ['created', 'open', 'resolved'];
+
+function adaptMapLayers(ctx) {
+  const { viz, result } = ctx;
+  const dimKey = viz.dimensionKey || 'ward_code';
+  // The map tile's query returns filed/open/resolved per ward. Her map colours the
+  // Created layer by `count`, and the Open/Resolved layers by `openPct`/`resolvedPct`
+  // (share of filed, 0–100). One ward series carries all three so any layer renders.
+  const wards = (result.rows || [])
+    .filter((row) => {
+      const code = String(row[dimKey] ?? '').trim();
+      return code && code !== 'null';
+    })
+    .map((row) => {
+      const wardCode = String(row[dimKey]);
+      const filed = Number(row.filed) || 0;
+      const open = Number(row.open) || 0;
+      const resolved = Number(row.resolved) || 0;
+      return {
+        wardCode,
+        label: formatLabel(wardCode),
+        count: filed,
+        total: filed,
+        // named counts so the choropleth hover tooltip (reads created/open/resolved) has values
+        created: filed,
+        open,
+        resolved,
+        openPct: filed > 0 ? (open / filed) * 100 : 0,
+        resolvedPct: filed > 0 ? (resolved / filed) * 100 : 0,
+      };
+    });
+  const pins = result.pins || [];
+  const layers = { wardDetails: {}, complaintPinsByLayer: {}, complaintPinsError: null };
+  for (const key of GEO_MAP_LAYER_KEYS) {
+    layers[key] = wards;
+    layers.complaintPinsByLayer[key] = pins;
+  }
+  return layers;
+}
+
+function renderChoroplethMap(ctx) {
+  const { loading } = ctx;
+  return <OpenComplaintsByGeographyWidget layers={adaptMapLayers(ctx)} loading={loading} />;
+}
+
+// ---------------------------------------------------------------------------
+// Ranked list + day-of-week  -> KpiTile internal displays (kept generic)
+// ---------------------------------------------------------------------------
+
+function adaptRanked(ctx) {
+  const { viz, result } = ctx;
+  const dimKey = primaryDimensionKey(result, viz);
+  const measure = primaryMeasure(result, viz);
+  let rows = (result.rows || []).map((row) => ({
+    label: formatDimLabel(row[dimKey], viz),
+    value: Number(row[measure.name]) || 0,
+  }));
+  if (viz.sort !== 'none') rows = rows.sort((a, b) => b.value - a.value);
+  rows = rows.slice(0, viz.limit || 10);
+  return { rows, format: measure.format || viz.format };
+}
+
+function adaptDow(ctx) {
+  const { viz, result } = ctx;
+  const dimKey = primaryDimensionKey(result, viz);
+  const measure = primaryMeasure(result, viz);
+  const rows = (result.rows || []).map((row) => ({
+    dow: Number(row[dimKey]),
+    value: Number(row[measure.name]) || 0,
+  }));
+  return { rows, format: measure.format || viz.format };
+}
+
+function RankedListDisplay({ rows, format }) {
+  if (!rows?.length) return <Placeholder message="No data" />;
+  return (
+    <ol className="kpi-ranked-list">
+      {rows.map((row, i) => (
+        <li key={i}>
+          <span className="kpi-ranked-list__rank">{i + 1}</span>
+          <span className="kpi-ranked-list__label" title={row.label}>{row.label}</span>
+          <span className="kpi-ranked-list__value">{applyFormat(row.value, format)}</span>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+const DOW_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+function DowDisplay({ rows, format }) {
+  if (!rows?.length) return <Placeholder message="No data" />;
+  return (
+    <div className="kpi-dow">
+      {rows.map((row, i) => (
+        <div key={i} className="kpi-dow__bar">
+          <span className="kpi-dow__label">{DOW_LABELS[row.dow] ?? row.dow}</span>
+          <span className="kpi-dow__value">{applyFormat(row.value, format)}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Formatting (ported from formatSubMetricValue / DashboardTable formatters)
+// ---------------------------------------------------------------------------
+
+const MS_PER_DAY = 86400000;
+const MS_PER_HOUR = 3600000;
+
+function applyFormat(val, format) {
+  if (val == null || !Number.isFinite(Number(val))) return '—';
+  const n = Number(val);
+  switch (format) {
+    case 'integer':           return Math.round(n).toLocaleString();
+    case 'percentInteger':
+    case 'percentNoDecimal':  return `${Math.round(normalizePct(n))}%`;
+    case 'percentOneDecimal':
+    case 'percent':           return `${normalizePct(n).toFixed(1)}%`;
+    case 'decimalOne':        return n.toFixed(1);
+    case 'decimalTwo':        return n.toFixed(2);
+    case 'ratingOutOfFive':   return `${n.toFixed(1)}/5`;
+    case 'hoursDays': {
+      const hours = n / MS_PER_HOUR;
+      if (hours < 48) {
+        const r = Math.round(hours * 10) / 10;
+        return `${Number.isInteger(r) ? r : r.toFixed(1)} ${r === 1 ? 'hr' : 'hrs'}`;
+      }
+      const days = n / MS_PER_DAY;
+      const r = Math.round(days * 10) / 10;
+      return `${Number.isInteger(r) ? r : r.toFixed(1)} ${r === 1 ? 'day' : 'days'}`;
+    }
+    case 'hoursDecimal':      return `${(n / MS_PER_HOUR).toFixed(1)}h`;
+    case 'signedInteger':     return `${n >= 0 ? '+' : ''}${Math.round(n).toLocaleString()}`;
+    case 'ordinal': {
+      const v = Math.round(n) % 100;
+      const s = ['th', 'st', 'nd', 'rd'];
+      return Math.round(n) + (s[(v - 20) % 10] || s[v] || s[0]);
+    }
+    default: return String(val);
+  }
+}
+
+function isPercentFormat(format) {
+  return (
+    format === 'percent' ||
+    format === 'percentInteger' ||
+    format === 'percentNoDecimal' ||
+    format === 'percentOneDecimal'
+  );
+}
+
+function normalizePct(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return 0;
+  return n <= 1 ? n * 100 : n;
+}
+
+// DepartmentBarChart's percent mode plots 0..100, so scale ratios up.
+function percentToChartScale(value, isPercent) {
+  return isPercent ? normalizePct(value) : value;
+}
+
+function msToHours(ms) {
+  const hours = Number(ms) / MS_PER_HOUR;
+  if (!Number.isFinite(hours) || hours <= 0) return 0;
+  return Math.round(hours * 10) / 10;
+}
+
+function formatLabel(value) {
+  const s = String(value ?? 'Unknown');
+  if (!s || s === 'null' || s === 'undefined') return 'Unknown';
+  return s;
+}
+
+/**
+ * Dimension-label formatter keyed off `viz.labelFormat`. Ports the reference
+ * client-side label shaping (kpiQueries.formatDimensionLabel /
+ * formatOfficerStackedLabel) into the engine so chart categories match the
+ * reference verbatim without per-tile code.
+ *   - "dimension": humanise CamelCase / snake_case / dotted codes
+ *   - "officer":   mask an assignee UUID -> "Officer …<last6>" / "Unassigned"
+ * No labelFormat => identity (formatLabel).
+ */
+function formatDimLabel(value, viz) {
+  switch (viz?.labelFormat) {
+    case 'dimension':  return formatDimensionLabel(value);
+    case 'department': return formatDepartmentLabel(value);
+    case 'officer':    return formatOfficerLabel(value);
+    case 'date-dow':   return formatDateDow(value);
+    default:           return formatLabel(value);
+  }
+}
+
+// Port of kpiQueries.formatOverTimeDailyLabel: epoch-ms / yyyy-MM-dd -> short weekday.
+function formatDateDow(value) {
+  const key = epochOrIsoToDateKey(value);
+  if (!key) return formatLabel(value);
+  const d = new Date(`${key}T12:00:00`);
+  if (Number.isNaN(d.getTime())) return key;
+  return d.toLocaleDateString(undefined, { weekday: 'short' });
+}
+
+function epochOrIsoToDateKey(value) {
+  if (value == null || value === '') return '';
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return new Date(value).toISOString().slice(0, 10);
+  }
+  const s = String(value).trim();
+  if (/^\d{13}$/.test(s)) return new Date(Number(s)).toISOString().slice(0, 10);
+  const iso = s.match(/^(\d{4}-\d{2}-\d{2})/);
+  return iso ? iso[1] : s;
+}
+
+// Port of complaintTypeDepartmentConfig.formatDepartmentLabel.
+function formatDepartmentLabel(code) {
+  const c = String(code ?? '').trim();
+  if (!c || c === 'Unknown' || c === 'Unmapped' || c === 'null' || c === 'undefined') return 'Unknown';
+  return c.replace(/_/g, ' ').toLowerCase().replace(/\b\w/g, (ch) => ch.toUpperCase());
+}
+
+// Port of kpiQueries.formatDimensionLabel (humanise service/ward/dept codes).
+function formatDimensionLabel(code) {
+  const humanized = String(code ?? '').replace(/([a-z])([A-Z])/g, '$1 $2');
+  const wardMatch = humanized.match(/ward[_\s-]?(\d+)/i);
+  if (wardMatch) return `Ward ${wardMatch[1]}`;
+  const dot = humanized.lastIndexOf('.');
+  if (dot >= 0) {
+    return humanized.slice(dot + 1).replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+  }
+  const parts = humanized.split('_').filter(Boolean);
+  if (parts.length > 2) return parts.slice(-2).join(' ').replace(/_/g, ' ');
+  const out = humanized.replace(/_/g, ' ');
+  return out || 'Unknown';
+}
+
+function normalizeSeg(value) {
+  return String(value ?? '').toUpperCase();
+}
+
+/**
+ * Title resolution for the inverted catalog. The MDMS def now carries a human
+ * `viz.title` (the single source of truth, sourced from the reference dashboard
+ * labels); prefer it. `titleKey` is retained on the def for a future i18n layer
+ * but is a raw key (RAINMAKER-PGR.DASHBOARD_KPI_*) so it is only ever used as a
+ * last-resort, prettified, fallback — never rendered verbatim.
+ */
+function resolveTitle(def) {
+  return (
+    def?.viz?.title ||
+    def?.title ||
+    def?.name ||
+    prettifyTitleKey(def?.viz?.titleKey || def?.titleKey) ||
+    ''
+  );
+}
+
+function prettifyTitleKey(key) {
+  if (!key) return '';
+  const tail = String(key).split('.').pop().replace(/^DASHBOARD_KPI_/, '');
+  if (!tail) return '';
+  return tail
+    .toLowerCase()
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .trim();
+}
+
+function errorLabel(code) {
+  switch (code) {
+    case 'pii_forbidden': return 'Restricted';
+    case 'kpi_forbidden': return 'No access';
+    case 'scope_forbidden': return 'Out of scope';
+    default: return code || 'ERROR';
+  }
+}
+
+function def_scrollKey(ctx) {
+  return ctx.def?.kpiId || ctx.def?.id || undefined;
+}
+
+function formatAsOf(asOf) {
+  try { return new Date(asOf).toLocaleString(); } catch { return String(asOf); }
+}
+
+const Placeholder = ({ message }) => (
+  <div className="kpi-tile__placeholder tw-flex tw-h-full tw-items-center tw-justify-center tw-p-4 tw-text-[12px] tw-text-muted-foreground">
+    {message}
+  </div>
+);
+
+export default KpiTile;

--- a/digit-ui-esbuild/products/dashboard/src/components/LineChart.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/LineChart.jsx
@@ -1,0 +1,243 @@
+import React, { useCallback, useMemo, useRef, useState } from "react";
+import Chart from "react-apexcharts";
+import { DASHBOARD_FONT_FAMILY } from "../config/dashboardConfig";
+import {
+  applyLineChartMarkerHoverState,
+  buildLineChartAnimations,
+  buildLineChartGrid,
+  buildLineChartMarkers,
+  buildLineChartSeriesData,
+  buildLineChartStroke,
+  buildLineChartTooltip,
+  buildLineChartXAxis,
+  buildLineChartYAxis,
+  buildCompoundLineChartYAxis,
+  getLineChartMarkerSurfaceColor,
+  LINE_CHART_LEGEND,
+  LINE_CHART_PERIOD_OPTIONS,
+  normalizeLineChartSeries,
+  resolveLineChartColors,
+  resolveLineChartXAxisLabelHeight,
+  setLineChartMarkersVisible,
+} from "../config/lineChartPresentation";
+import { VISUALIZATION_STYLES, VIZ_TYPE, SHARED_CHROME } from "../config/visualizationStyles";
+import { useChartContainerSize } from "../hooks/useChartContainerSize";
+import ViewToggle from "./demo/ViewToggle";
+
+function resolveActiveDataset({ categories, series, periods, period }) {
+  if (periods?.[period]) {
+    return periods[period];
+  }
+  return { categories: categories ?? [], series: series ?? [] };
+}
+
+const LineChart = ({
+  categories: categoriesProp,
+  series: seriesProp,
+  periods,
+  defaultPeriod = "daily",
+  headerTitle,
+  yAxis,
+}) => {
+  const [period, setPeriod] = useState(defaultPeriod);
+  const [isAnimating, setIsAnimating] = useState(true);
+  const hoveredIndexRef = useRef(-1);
+  const isAnimatingRef = useRef(true);
+  const colorsRef = useRef([]);
+  const surfaceColorRef = useRef("#ffffff");
+
+  const { containerRef, containerSize } = useChartContainerSize();
+  const { width: containerWidth, height: containerHeight } = containerSize;
+
+  const handlePeriodChange = useCallback((nextPeriod) => {
+    hoveredIndexRef.current = -1;
+    isAnimatingRef.current = true;
+    setIsAnimating(true);
+    setPeriod(nextPeriod);
+  }, []);
+
+  const activeDataset = useMemo(
+    () =>
+      resolveActiveDataset({
+        categories: categoriesProp,
+        series: seriesProp,
+        periods,
+        period,
+      }),
+    [categoriesProp, period, periods, seriesProp]
+  );
+
+  const { categories, series } = activeDataset;
+  const activeYAxis = activeDataset.yAxis ?? yAxis;
+
+  const normalizedSeries = useMemo(
+    () => normalizeLineChartSeries(series),
+    [series]
+  );
+
+  const chartSeries = useMemo(
+    () => buildLineChartSeriesData(normalizedSeries, categories.length),
+    [categories.length, normalizedSeries]
+  );
+
+  const colors = useMemo(
+    () => resolveLineChartColors(normalizedSeries),
+    [normalizedSeries]
+  );
+  colorsRef.current = colors;
+  surfaceColorRef.current = getLineChartMarkerSurfaceColor();
+  isAnimatingRef.current = isAnimating;
+
+  const yAxisConfig = useMemo(
+    () => buildCompoundLineChartYAxis(normalizedSeries, activeYAxis ?? yAxis),
+    [activeYAxis, normalizedSeries, yAxis]
+  );
+
+  const xAxisLabelHeight = useMemo(
+    () => resolveLineChartXAxisLabelHeight(categories, containerWidth),
+    [categories, containerWidth]
+  );
+
+  const revealMarkers = useCallback((chartContext) => {
+    setLineChartMarkersVisible(chartContext, true);
+    applyLineChartMarkerHoverState(
+      chartContext,
+      hoveredIndexRef.current,
+      colorsRef.current,
+      surfaceColorRef.current
+    );
+  }, []);
+
+  const chartEvents = useMemo(
+    () => ({
+      animationEnd: (chartContext) => {
+        isAnimatingRef.current = false;
+        setIsAnimating(false);
+        revealMarkers(chartContext);
+        // Apex may paint markers after animationEnd; re-apply on next frame.
+        requestAnimationFrame(() => revealMarkers(chartContext));
+      },
+      mouseMove: (_event, chartContext, config) => {
+        if (isAnimatingRef.current) return;
+
+        const idx = config?.dataPointIndex ?? -1;
+        hoveredIndexRef.current = idx;
+
+        const apply = () =>
+          applyLineChartMarkerHoverState(
+            chartContext,
+            idx,
+            colorsRef.current,
+            surfaceColorRef.current
+          );
+
+        apply();
+        window.requestAnimationFrame(() => {
+          apply();
+          window.requestAnimationFrame(apply);
+        });
+      },
+      mouseLeave: (_event, chartContext) => {
+        hoveredIndexRef.current = -1;
+        applyLineChartMarkerHoverState(
+          chartContext,
+          -1,
+          colorsRef.current,
+          surfaceColorRef.current
+        );
+      },
+      updated: (chartContext) => {
+        hoveredIndexRef.current = -1;
+        if (isAnimatingRef.current) {
+          setLineChartMarkersVisible(chartContext, false);
+        }
+      },
+    }),
+    [revealMarkers]
+  );
+
+  const options = useMemo(
+    () => ({
+      chart: {
+        type: "line",
+        toolbar: { show: false },
+        fontFamily: DASHBOARD_FONT_FAMILY,
+        zoom: { enabled: false },
+        parentHeightOffset: 0,
+        animations: buildLineChartAnimations(),
+        events: chartEvents,
+      },
+      stroke: buildLineChartStroke(normalizedSeries),
+      markers: buildLineChartMarkers(colors),
+      xaxis: buildLineChartXAxis(categories, containerWidth),
+      yaxis: yAxisConfig,
+      colors,
+      legend: LINE_CHART_LEGEND,
+      grid: buildLineChartGrid({ bottomPadding: xAxisLabelHeight }),
+      tooltip: buildLineChartTooltip(categories, normalizedSeries),
+      states: {
+        hover: { filter: { type: "none" } },
+        active: { filter: { type: "none" } },
+      },
+    }),
+    [categories, chartEvents, colors, containerWidth, normalizedSeries, xAxisLabelHeight, yAxisConfig]
+  );
+
+  const markerStyleVars = useMemo(
+    () => ({
+      "--line-chart-marker-fill": getLineChartMarkerSurfaceColor(),
+    }),
+    [colors]
+  );
+
+  const hasChartStructure = categories.length > 0 && normalizedSeries.length > 0;
+
+  const lineStyles = VISUALIZATION_STYLES[VIZ_TYPE.LINE_CHART];
+  const showHeader = Boolean(headerTitle && periods);
+
+  const chart = !hasChartStructure ? null : (
+    <div
+      ref={containerRef}
+      className={`${lineStyles.container} tw-h-full tw-min-h-0 tw-w-full tw-flex-1 tw-overflow-visible${
+        isAnimating ? ` ${lineStyles.animating}` : ""
+      }`}
+      style={markerStyleVars}
+    >
+      {containerHeight > 0 && containerWidth > 0 ? (
+        <Chart
+          key={`${containerHeight}-${containerWidth}`}
+          options={options}
+          series={chartSeries}
+          type="line"
+          height={containerHeight}
+          width="100%"
+        />
+      ) : null}
+    </div>
+  );
+
+  if (!hasChartStructure) return null;
+
+  if (!showHeader) {
+    return chart;
+  }
+
+  return (
+    <div className="tw-flex tw-h-full tw-min-h-0 tw-flex-col">
+      <header
+        className={`${lineStyles.headerBar} ${SHARED_CHROME.dragHandle} tw-flex tw-shrink-0 tw-items-center tw-justify-between tw-gap-3 tw-px-4 tw-pb-0 tw-pt-2.5 tw-pr-8`}
+      >
+        <h2 className={SHARED_CHROME.dragHandleTitle}>{headerTitle}</h2>
+        <ViewToggle
+          value={period}
+          onChange={handlePeriodChange}
+          variant="primary"
+          options={LINE_CHART_PERIOD_OPTIONS}
+        />
+      </header>
+      <div className={lineStyles.widgetBody}>{chart}</div>
+    </div>
+  );
+};
+
+export default LineChart;

--- a/digit-ui-esbuild/products/dashboard/src/components/OpenComplaintsByGeographyWidget.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/OpenComplaintsByGeographyWidget.jsx
@@ -1,0 +1,56 @@
+import React, { useMemo, useState } from "react";
+import {
+  buildWidgetHeaderClassName,
+  SHARED_CHROME,
+  VIZ_TYPE,
+} from "../config/visualizationStyles";
+import {
+  GEOGRAPHY_MAP_LAYERS,
+  isGeographyMapLayerId,
+} from "../config/geographyMapPresentation";
+import { getMapCityLabel } from "../utils/mapGeoUtils";
+import GeographyChoroplethMap from "./GeographyChoroplethMap";
+
+const OpenComplaintsByGeographyWidget = ({ layers, loading = false }) => {
+  const [activeLayer, setActiveLayer] = useState("created");
+  const cityLabel = getMapCityLabel();
+
+  const resolvedLayer = isGeographyMapLayerId(activeLayer) ? activeLayer : "created";
+  const wardCounts = useMemo(() => {
+    const series = layers?.[resolvedLayer] ?? [];
+    const details = layers?.wardDetails ?? {};
+    return series.map((row) => ({
+      ...details[row.wardCode],
+      ...row,
+    }));
+  }, [layers, resolvedLayer]);
+
+  if (loading && !wardCounts.length) {
+    return (
+      <div className="tw-flex tw-h-full tw-min-h-[220px] tw-items-center tw-justify-center tw-p-4 tw-text-[12px] tw-text-muted-foreground">
+        Loading…
+      </div>
+    );
+  }
+
+  return (
+    <div className="tw-flex tw-h-full tw-min-h-0 tw-flex-col">
+      <header
+        className={`${buildWidgetHeaderClassName(VIZ_TYPE.MAP)} dashboard-map-header-bar ${SHARED_CHROME.dragHandle} tw-flex tw-shrink-0 tw-items-center tw-px-3 tw-pb-2 tw-pt-2 tw-pr-8`}
+      >
+        <h2 className={SHARED_CHROME.dragHandleTitle}>Complaint map · {cityLabel}</h2>
+      </header>
+      <GeographyChoroplethMap
+        wardCounts={wardCounts}
+        complaintPins={layers?.complaintPinsByLayer?.[resolvedLayer] ?? []}
+        complaintPinsError={layers?.complaintPinsError ?? null}
+        layerMode={resolvedLayer}
+        onLayerModeChange={setActiveLayer}
+        layerOptions={GEOGRAPHY_MAP_LAYERS}
+        cityLabel={cityLabel}
+      />
+    </div>
+  );
+};
+
+export default OpenComplaintsByGeographyWidget;

--- a/digit-ui-esbuild/products/dashboard/src/components/PieChart.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/PieChart.jsx
@@ -1,0 +1,107 @@
+import React, { useMemo, useState } from "react";
+import { resolveDashboardCssColor } from "../config/chartColors";
+import {
+  getPieChartValueLabelColor,
+  normalizePieChartData,
+  PIE_CHART_VIEWBOX,
+} from "../config/pieChartPresentation";
+import { VISUALIZATION_STYLES, VIZ_TYPE, SHARED_CHROME } from "../config/visualizationStyles";
+
+const PieChart = ({ data = [] }) => {
+  const [activeIndex, setActiveIndex] = useState(null);
+
+  const slices = useMemo(() => normalizePieChartData(data), [data]);
+  const sliceStroke = useMemo(
+    () => resolveDashboardCssColor("var(--surface)") || "#ffffff",
+    [slices]
+  );
+  const active = activeIndex != null ? slices[activeIndex] : null;
+  const pieStyles = VISUALIZATION_STYLES[VIZ_TYPE.PIE_CHART];
+  const valueLabelColor = getPieChartValueLabelColor();
+
+  if (!slices.length) return null;
+
+  return (
+    <div className={`${pieStyles.container} tw-flex tw-h-full tw-min-h-0 tw-w-full tw-flex-col`}>
+      <div className="tw-relative tw-min-h-0 tw-flex-1">
+        <svg
+          viewBox={`0 0 ${PIE_CHART_VIEWBOX.width} ${PIE_CHART_VIEWBOX.height}`}
+          className="tw-h-full tw-w-full"
+          role="img"
+          aria-label="Donut chart"
+        >
+          {slices.map((slice) => {
+            const fill =
+              resolveDashboardCssColor(slice.color) || slice.color || "currentColor";
+
+            return (
+            <g key={slice.label}>
+              <path
+                d={slice.path}
+                style={{ fill, stroke: sliceStroke }}
+                strokeWidth={2}
+                className={pieStyles.slice}
+                onMouseEnter={() => setActiveIndex(slice.index)}
+                onMouseLeave={() => setActiveIndex(null)}
+              />
+              {slice.showValue ? (
+                <text
+                  x={slice.valueX}
+                  y={slice.valueY}
+                  textAnchor="middle"
+                  dominantBaseline="middle"
+                  fill={valueLabelColor}
+                  fontSize="10"
+                  fontWeight="600"
+                  pointerEvents="none"
+                >
+                  {slice.pct}%
+                </text>
+              ) : null}
+              <text
+                x={slice.labelX}
+                y={slice.labelY}
+                textAnchor={slice.labelAnchor}
+                dominantBaseline="middle"
+                fill={fill}
+                fontSize="11"
+                fontWeight="500"
+                pointerEvents="none"
+              >
+                {slice.labelLines.map((line, lineIndex) => (
+                  <tspan
+                    key={`${slice.label}-${lineIndex}`}
+                    x={slice.labelX}
+                    dy={lineIndex === 0 ? 0 : 12}
+                  >
+                    {line}
+                  </tspan>
+                ))}
+              </text>
+            </g>
+            );
+          })}
+        </svg>
+        {active ? (
+          <div
+            className={`${SHARED_CHROME.chartTooltip} ${SHARED_CHROME.chartTooltipAnchored}`}
+            style={{
+              left: `${(active.hoverX / PIE_CHART_VIEWBOX.width) * 100}%`,
+              top: `${(active.hoverY / PIE_CHART_VIEWBOX.height) * 100}%`,
+            }}
+          >
+            <div className={SHARED_CHROME.chartTooltipTitle}>{active.label}</div>
+            <div
+              className={SHARED_CHROME.chartTooltipRow}
+              style={{ color: active.color }}
+            >
+              Count : {active.count} ({active.pct}%)
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+export default PieChart;

--- a/digit-ui-esbuild/products/dashboard/src/components/ResizeGrip.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/ResizeGrip.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+/** Decorative bottom-right resize affordance; grid item supplies the actual handle. */
+const ResizeGrip = () => (
+  <span className="dashboard-resize-grip" aria-hidden="true">
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <line x1="3.5" y1="14" x2="14" y2="3.5" className="dashboard-resize-grip-line" />
+      <line x1="7.5" y1="14" x2="14" y2="7.5" className="dashboard-resize-grip-line" />
+    </svg>
+  </span>
+);
+
+export default ResizeGrip;

--- a/digit-ui-esbuild/products/dashboard/src/components/Sidebar.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/Sidebar.jsx
@@ -1,0 +1,87 @@
+import React, { useMemo } from "react";
+import { getProductLabel, getStateLabel } from "../config/dashboardConfig";
+
+const NAV_ITEMS = [
+  { id: "dashboard", label: "Dashboard", href: "/digit-ui/employee/dashboard", active: true },
+];
+
+/** Signed-in employee's username + significant (non-EMPLOYEE) role, for the footer. */
+function getSignedInLabel() {
+  try {
+    const raw = window.localStorage?.getItem("Employee.user-info");
+    if (!raw) return null;
+    const u = JSON.parse(raw);
+    const info = u?.roles ? u : u?.userInfo || u;
+    const roles = info?.roles || [];
+    const role =
+      roles.find((r) => r.code && r.code !== "EMPLOYEE")?.code ||
+      roles[0]?.code ||
+      info?.type;
+    const name = info?.userName || info?.name;
+    if (name && role) return `${name} · ${role}`;
+    return role || name || null;
+  } catch {
+    return null;
+  }
+}
+
+const Sidebar = ({ onSignOut }) => {
+  const stateLabel = useMemo(() => getStateLabel(), []);
+  const productLabel = useMemo(() => getProductLabel(), []);
+  const signedInLabel = useMemo(() => getSignedInLabel(), []);
+
+  return (
+    <aside className="tw-flex tw-h-full tw-w-60 tw-flex-shrink-0 tw-flex-col tw-bg-chrome tw-text-chrome-foreground">
+      <div className="tw-border-b tw-border-[color-mix(in_srgb,var(--chrome-foreground)_15%,transparent)] tw-px-5 tw-py-5">
+        <p className="tw-text-xs tw-font-medium tw-uppercase tw-tracking-wider tw-text-chrome-muted">
+          {stateLabel}
+        </p>
+        <h1 className="tw-mt-1 tw-text-lg tw-font-bold tw-leading-tight">
+          {productLabel}
+        </h1>
+      </div>
+      <nav className="tw-space-y-1 tw-p-3">
+        {NAV_ITEMS.map((item) => (
+          <a
+            key={item.id}
+            href={item.href}
+            className={`tw-block tw-rounded-md tw-px-3 tw-py-2 tw-text-sm tw-font-medium ${
+              item.active
+                ? "tw-bg-primary tw-text-primary-foreground"
+                : "tw-text-chrome-foreground hover:tw-bg-[color-mix(in_srgb,var(--chrome-foreground)_12%,transparent)]"
+            }`}
+          >
+            {item.label}
+          </a>
+        ))}
+      </nav>
+      <div className="tw-flex-1" />
+      <div className="tw-flex tw-items-center tw-justify-between tw-gap-2 tw-border-t tw-border-[color-mix(in_srgb,var(--chrome-foreground)_15%,transparent)] tw-p-4 tw-text-xs tw-text-chrome-muted">
+        <span className="tw-min-w-0 tw-truncate" title={signedInLabel || undefined}>
+          {signedInLabel || "Not signed in"}
+        </span>
+        {onSignOut ? (
+          <button
+            type="button"
+            onClick={onSignOut}
+            title="Sign out"
+            className="tw-flex-shrink-0 tw-rounded-md tw-px-2.5 tw-py-1 tw-text-[11px] tw-font-medium tw-text-chrome-foreground hover:tw-bg-[color-mix(in_srgb,var(--chrome-foreground)_22%,transparent)]"
+            style={{
+              // Explicit subtle fill: without it the browser's default light
+              // buttonface shows through, making the light label unreadable on the
+              // dark sidebar.
+              backgroundColor:
+                "color-mix(in srgb, var(--chrome-foreground) 12%, transparent)",
+              border:
+                "1px solid color-mix(in srgb, var(--chrome-foreground) 35%, transparent)",
+            }}
+          >
+            Sign out
+          </button>
+        ) : null}
+      </div>
+    </aside>
+  );
+};
+
+export default Sidebar;

--- a/digit-ui-esbuild/products/dashboard/src/components/StackedBarChart.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/StackedBarChart.jsx
@@ -1,0 +1,132 @@
+import React, { useMemo } from "react";
+import Chart from "react-apexcharts";
+import { DASHBOARD_FONT_FAMILY } from "../config/dashboardConfig";
+import {
+  buildApexSeriesHoverTooltip,
+} from "../config/chartTooltipPresentation";
+import { BAR_CHART_XAXIS_RESERVED_HEIGHT_PX } from "../config/barChartPresentation";
+import {
+  buildStackedBarAnnotations,
+  buildStackedBarDataLabels,
+  buildStackedBarGrid,
+  buildStackedBarLegend,
+  buildStackedBarPlotOptions,
+  buildStackedBarXAxis,
+  buildStackedBarYAxis,
+  resolveStackedBarColors,
+} from "../config/stackedBarPresentation";
+import { VISUALIZATION_STYLES, VIZ_TYPE } from "../config/visualizationStyles";
+import { useScrollableChartSize } from "../hooks/useScrollableChartSize";
+import ChartScrollViewport from "./ChartScrollViewport";
+
+const StackedBarChart = ({
+  categories = [],
+  series = [],
+  colors = [],
+  horizontal = false,
+  referenceLines = [],
+  scrollKey,
+  valueFormat,
+}) => {
+  const {
+    viewportRef,
+    chartSize,
+    isScrollable,
+    isReady,
+    scrollAxis,
+  } = useScrollableChartSize({
+    scrollKey,
+    categoryCount: categories.length,
+    scrollAxis: horizontal ? "y" : "x",
+  });
+
+  const containerWidth = chartSize.width;
+  const containerHeight = chartSize.height;
+
+  const resolvedColors = useMemo(
+    () => resolveStackedBarColors(colors),
+    [colors]
+  );
+
+  const verticalXAxisLabelHeight = horizontal
+    ? 4
+    : BAR_CHART_XAXIS_RESERVED_HEIGHT_PX;
+
+  const options = useMemo(
+    () => ({
+      chart: {
+        type: "bar",
+        stacked: true,
+        stackType: "normal",
+        toolbar: { show: false },
+        fontFamily: DASHBOARD_FONT_FAMILY,
+        parentHeightOffset: 0,
+      },
+      plotOptions: buildStackedBarPlotOptions({
+        horizontal,
+        valueFormat,
+        containerWidth,
+        containerHeight,
+        categoryCount: categories.length,
+      }),
+      dataLabels: buildStackedBarDataLabels({ valueFormat, horizontal }),
+      xaxis: buildStackedBarXAxis({ horizontal, categories, containerWidth }),
+      yaxis: horizontal
+        ? [buildStackedBarYAxis({ horizontal, categories, containerWidth, valueFormat })]
+        : buildStackedBarYAxis({ horizontal, categories, containerWidth, valueFormat }),
+      colors: resolvedColors,
+      legend: buildStackedBarLegend({ horizontal }),
+      grid: buildStackedBarGrid({
+        horizontal,
+        bottomPadding: verticalXAxisLabelHeight,
+      }),
+      annotations: buildStackedBarAnnotations({ horizontal, referenceLines }),
+      tooltip: buildApexSeriesHoverTooltip({ includeZero: false, followCursor: true }),
+      states: {
+        hover: { filter: { type: "darken", value: 0.9 } },
+      },
+    }),
+    [
+      categories,
+      containerWidth,
+      containerHeight,
+      horizontal,
+      referenceLines,
+      resolvedColors,
+      verticalXAxisLabelHeight,
+      valueFormat,
+    ]
+  );
+
+  const chartClass = VISUALIZATION_STYLES[VIZ_TYPE.STACKED_BAR].container;
+  const horizontalClass = horizontal ? "dashboard-stacked-bar--horizontal" : "";
+  const chartClassName = `${chartClass} ${horizontalClass}`.trim();
+  const hasData =
+    categories.length > 0 &&
+    series.some((entry) => entry.data?.some((value) => Number(value) > 0));
+
+  if (!hasData) return null;
+
+  return (
+    <ChartScrollViewport
+      viewportRef={viewportRef}
+      chartSize={chartSize}
+      isScrollable={isScrollable}
+      chartClassName={chartClassName}
+      scrollAxis={scrollAxis}
+    >
+      {isReady ? (
+        <Chart
+          key={`${horizontal}-${containerHeight}-${containerWidth}-${categories.join("|")}`}
+          options={options}
+          series={series}
+          type="bar"
+          height={containerHeight}
+          width={horizontal ? "100%" : containerWidth}
+        />
+      ) : null}
+    </ChartScrollViewport>
+  );
+};
+
+export default StackedBarChart;

--- a/digit-ui-esbuild/products/dashboard/src/components/SubtleScroll.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/SubtleScroll.jsx
@@ -1,0 +1,23 @@
+import React from "react";
+import useSubtleScrollbar from "../hooks/useSubtleScrollbar";
+import { mergeRefs } from "../utils/mergeRefs";
+
+const SubtleScroll = React.forwardRef(
+  ({ className = "", enabled = true, children, ...props }, ref) => {
+    const subtleRef = useSubtleScrollbar(enabled);
+
+    return (
+      <div
+        ref={mergeRefs(subtleRef, ref)}
+        className={`dashboard-subtle-scroll${className ? ` ${className}` : ""}`}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+);
+
+SubtleScroll.displayName = "SubtleScroll";
+
+export default SubtleScroll;

--- a/digit-ui-esbuild/products/dashboard/src/components/TableSortHeader.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/TableSortHeader.jsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+const TableSortHeader = ({ column, sortState, onSort }) => {
+  const active = sortState.key === column.id;
+  const nextDirection =
+    active && sortState.direction === "asc" ? "descending" : "ascending";
+
+  return (
+    <button
+      type="button"
+      className="dashboard-table-sort-btn"
+      onClick={() => onSort(column.id)}
+      aria-label={`Sort by ${column.label} ${nextDirection}`}
+    >
+      <span className="dashboard-table-sort-label">{column.label}</span>
+      <span className="dashboard-table-sort-indicator" aria-hidden>
+        {active ? (sortState.direction === "asc" ? "↑" : "↓") : "↕"}
+      </span>
+    </button>
+  );
+};
+
+export default TableSortHeader;

--- a/digit-ui-esbuild/products/dashboard/src/components/demo/DemoGauge.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/demo/DemoGauge.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { VISUALIZATION_STYLES, VIZ_TYPE } from "../../config/visualizationStyles";
+
+const DemoGauge = ({ value = 0, target = 90 }) => {
+  const pct = Math.min(100, Math.max(0, value));
+  const onTrack = pct >= target;
+  const gap = Math.max(0, target - pct);
+  const styles = VISUALIZATION_STYLES[VIZ_TYPE.GAUGE];
+  const targetLabel = `Target: ${target}%`;
+
+  return (
+    <>
+      <div className={styles.value}>{pct}%</div>
+      <div className={styles.track}>
+        <div className={styles.fill} style={{ width: `${pct}%` }} />
+        <div
+          className={styles.targetMarker}
+          style={{ left: `${target}%` }}
+          aria-label={targetLabel}
+          tabIndex={0}
+        >
+          <span className={styles.targetLine} aria-hidden />
+          <span className={styles.targetTooltip}>{targetLabel}</span>
+        </div>
+      </div>
+      <div className={styles.status}>
+        {onTrack ? "On track" : `${gap}% below goal`}
+      </div>
+    </>
+  );
+};
+
+export default DemoGauge;

--- a/digit-ui-esbuild/products/dashboard/src/components/demo/ViewToggle.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/demo/ViewToggle.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+const ViewToggle = ({ value, onChange, options, variant = "default" }) => (
+  <div className="dashboard-view-toggle tw-inline-flex tw-overflow-hidden tw-rounded-sm tw-border tw-border-border">
+    {options.map((opt) => {
+      const active = value === opt.id;
+      return (
+        <button
+          key={opt.id}
+          type="button"
+          onMouseDown={(e) => e.stopPropagation()}
+          onClick={() => onChange(opt.id)}
+          className={
+            active
+              ? variant === "primary"
+                ? "tw-border-0 tw-bg-chart-1 tw-px-2.5 tw-py-1 tw-text-[11px] tw-font-semibold tw-text-white"
+                : "tw-border-0 tw-bg-muted tw-px-2.5 tw-py-1 tw-text-[11px] tw-font-semibold tw-text-foreground"
+              : "tw-border-0 tw-bg-surface tw-px-2.5 tw-py-1 tw-text-[11px] tw-font-medium tw-text-muted-foreground hover:tw-text-foreground"
+          }
+        >
+          {opt.label}
+        </button>
+      );
+    })}
+  </div>
+);
+
+export default ViewToggle;

--- a/digit-ui-esbuild/products/dashboard/src/config/addKpiPreviewPresentation.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/addKpiPreviewPresentation.js
@@ -1,0 +1,54 @@
+/**
+ * Hover preview content for the header “Add KPI” inventory list.
+ */
+
+import { getKpiDisplayConfig, getKpiDisplayTitle } from "./kpiDisplay";
+
+function formatPreviewTarget(metricId) {
+  const threshold = getKpiDisplayConfig(metricId).threshold;
+  if (!threshold) return null;
+
+  const { kind, onTrack } = threshold;
+  if (kind === "percent") return `Target: ${onTrack}%`;
+  if (kind === "rating") return `Target: ${onTrack}/5`;
+  if (kind === "count") {
+    if (metricId === "cl-metric-oldest-open") return `Target: ${onTrack} days`;
+    return `Target: ${onTrack}`;
+  }
+  return null;
+}
+
+function resolvePreviewDescription(item) {
+  if (item.itemType === "kpi") {
+    return item.metric;
+  }
+  return item.subMetric || item.outputFormat || null;
+}
+
+function isDisplayableValue(value) {
+  return value != null && value !== "—" && value !== "…";
+}
+
+export function buildAddKpiPreviewContent(item, { kpiCardData } = {}) {
+  if (!item) return null;
+
+  if (item.itemType === "kpi") {
+    const card = kpiCardData?.[item.id];
+    return {
+      title: getKpiDisplayTitle(item),
+      value: isDisplayableValue(card?.value) ? card.value : null,
+      target: formatPreviewTarget(item.id),
+      description: resolvePreviewDescription(item),
+    };
+  }
+
+  return {
+    title: item.metric,
+    value: null,
+    target: null,
+    description: resolvePreviewDescription(item),
+  };
+}
+
+export const ADD_KPI_PREVIEW_WIDTH_PX = 228;
+export const ADD_KPI_PREVIEW_GAP_PX = 12;

--- a/digit-ui-esbuild/products/dashboard/src/config/barChartPresentation.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/barChartPresentation.js
@@ -1,0 +1,142 @@
+/**
+ * Shared presentation for vertical bar charts (viz type: bar-chart).
+ * Used by all normal bar chart widgets — live data and demo.
+ */
+
+import { resolveDashboardCssColor } from "./chartColors";
+
+export const BAR_CHART_SERIES_COLOR = "var(--chart-1)";
+export const BAR_CHART_DATA_LABEL_COLOR = "var(--foreground)";
+
+export function getBarChartSeriesColor() {
+  return resolveDashboardCssColor(BAR_CHART_SERIES_COLOR);
+}
+
+export function getBarChartDataLabelColor() {
+  return resolveDashboardCssColor(BAR_CHART_DATA_LABEL_COLOR);
+}
+
+/** Space reserved below plot for x-axis category labels (inside the chart). */
+export const BAR_CHART_XAXIS_LABEL_HEIGHT_PX = 22;
+export const BAR_CHART_XAXIS_LABEL_HEIGHT_COMPACT_PX = 18;
+/** Fixed bottom reserve for normal vertical bar charts (2 wrapped label lines). */
+export const BAR_CHART_XAXIS_RESERVED_HEIGHT_PX = 28;
+/** Room above the plot for value labels on bar tops (pairs with data label offsetY). */
+export const BAR_CHART_GRID_TOP_PAD = 8;
+export const BAR_CHART_DATA_LABEL_OFFSET_Y = -20;
+/** Bar thickness as a fraction of each category slot — same on every vertical bar chart.
+ *  Tuned to ~60% (thinner bars); the px cap still keeps few-category charts from going giant. */
+export const BAR_COLUMN_WIDTH_RATIO = 0.6;
+export const BAR_COLUMN_MAX_WIDTH_PX = 48;
+export const BAR_COLUMN_MIN_WIDTH_PERCENT = 0;
+export const BAR_COLUMN_MAX_WIDTH_PERCENT = 68;
+export const BAR_CHART_GRID_GUTTER_PX = 4;
+/** Minimum y-axis headroom (data units) above the tallest bar for value labels. */
+export const BAR_CHART_YAXIS_MIN_HEADROOM = 1;
+/** Extra headroom as a fraction of peak value (kept small to avoid a large top gap). */
+export const BAR_CHART_YAXIS_HEADROOM_RATIO = 0.02;
+
+export function resolveBarChartYAxisMax(seriesMax, { percent = false } = {}) {
+  const peak = Math.max(Number(seriesMax) || 0, 0);
+  if (peak === 0) return percent ? 10 : 1;
+
+  const headroom = Math.max(
+    BAR_CHART_YAXIS_MIN_HEADROOM,
+    Math.ceil(peak * BAR_CHART_YAXIS_HEADROOM_RATIO)
+  );
+
+  const axisMax = peak + headroom;
+  return percent ? Math.ceil(axisMax * 10) / 10 : axisMax;
+}
+
+export function resolveBarChartColumnWidth(slotWidthPx) {
+  if (!slotWidthPx || slotWidthPx <= 0) {
+    return `${Math.round(BAR_COLUMN_WIDTH_RATIO * 100)}%`;
+  }
+
+  const preferredPct = BAR_COLUMN_WIDTH_RATIO * 100;
+  const maxPctFromPx = (BAR_COLUMN_MAX_WIDTH_PX / slotWidthPx) * 100;
+  const boundedPct = Math.min(
+    BAR_COLUMN_MAX_WIDTH_PERCENT,
+    Math.max(
+      BAR_COLUMN_MIN_WIDTH_PERCENT,
+      Math.min(preferredPct, maxPctFromPx)
+    )
+  );
+  return `${Math.round(boundedPct)}%`;
+}
+
+export function resolveBarCategorySlotWidth(categoryCount, containerWidth) {
+  if (!categoryCount || !containerWidth) return 0;
+  return Math.max(0, containerWidth - BAR_CHART_GRID_GUTTER_PX) / categoryCount;
+}
+
+/** Bars fill the plot edge-to-edge; no side centering or fixed plot width. */
+export function resolveBarGroupLayout(categoryCount, containerWidth, bottomPad) {
+  return {
+    gridPadding: { left: 2, right: 2, top: 0, bottom: bottomPad },
+    slotWidth: resolveBarCategorySlotWidth(categoryCount, containerWidth),
+  };
+}
+
+export function buildBarChartGrid(padding) {
+  return {
+    show: false,
+    padding: {
+      ...padding,
+      top: Math.max(padding?.top ?? 0, BAR_CHART_GRID_TOP_PAD),
+    },
+  };
+}
+
+export function buildBarChartYAxis({ tickAmount = 5, seriesMax = 0, percent = false } = {}) {
+  return {
+    labels: { show: false },
+    axisBorder: { show: false },
+    axisTicks: { show: false },
+    forceNiceScale: false,
+    min: 0,
+    max: resolveBarChartYAxisMax(seriesMax, { percent }),
+    tickAmount,
+  };
+}
+
+export function formatBarChartPercentOneDecimal(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return "";
+  const rounded = Math.round(n * 10) / 10;
+  const formatted = Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+  return `${formatted}%`;
+}
+
+export function buildBarChartDataLabels({ valueFormat } = {}) {
+  const color = getBarChartDataLabelColor();
+  const formatter =
+    valueFormat === "percent"
+      ? (val) => formatBarChartPercentOneDecimal(val)
+      : (val) => (Number.isFinite(Number(val)) ? String(Math.round(Number(val))) : "");
+
+  return {
+    enabled: true,
+    // Apex anchors column labels at the bar top; negative offset lifts them above the fill.
+    offsetY: BAR_CHART_DATA_LABEL_OFFSET_Y,
+    style: {
+      fontSize: "11px",
+      fontWeight: 600,
+      colors: [color],
+    },
+    formatter,
+  };
+}
+
+/** Apex bar plotOptions fragment — labels sit on top of each bar, outside the fill. */
+export function buildBarChartPlotDataLabels() {
+  return {
+    position: "top",
+    hideOverflowingLabels: false,
+  };
+}
+
+export function buildBarChartLegend() {
+  return { show: false };
+}

--- a/digit-ui-esbuild/products/dashboard/src/config/chartAxisLabels.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/chartAxisLabels.js
@@ -1,0 +1,126 @@
+/**
+ * Shared Apex axis label options — wrap long labels instead of truncating.
+ */
+
+import {
+  CHART_AXIS_LABEL_FONT_SIZE_PX,
+  CHART_LABEL_CHAR_WIDTH_PX,
+  estimateMaxWrappedLabelHeight,
+  formatWrappedChartLabel,
+  wrapChartLabelToLines,
+} from "../utils/chartLabelWrap";
+import { DASHBOARD_FONT_FAMILY } from "./dashboardConfig";
+
+const VERTICAL_LABEL_STYLE = {
+  fontSize: `${CHART_AXIS_LABEL_FONT_SIZE_PX}px`,
+  fontFamily: DASHBOARD_FONT_FAMILY,
+};
+
+export function resolveVerticalCategorySlotWidth(categoryCount, containerWidth, gutterPx = 8) {
+  if (!categoryCount || !containerWidth) return 0;
+  return Math.max(0, containerWidth - gutterPx) / categoryCount;
+}
+
+/**
+ * Horizontal bar category labels — wrap width grows with the widget so labels
+ * unwrap to a single line when enlarged. Do not pass maxWidth to Apex; it
+ * ellipsis-truncates strings and fights the formatter.
+ */
+export function resolveHorizontalCategoryLabelLayout(
+  categories = [],
+  containerWidth = 0,
+  { min = 44, maxCap = 180, ratio = 0.36, maxLines = 4 } = {}
+) {
+  const wrapWidthPx = containerWidth
+    ? Math.min(maxCap, Math.max(min, Math.floor(containerWidth * ratio)))
+    : maxCap;
+
+  if (!categories.length) {
+    return { wrapWidthPx, minWidth: min };
+  }
+
+  let minWidth = min;
+  for (const label of categories) {
+    const lines = wrapChartLabelToLines(label, wrapWidthPx, { maxLines });
+    for (const line of lines) {
+      minWidth = Math.max(minWidth, Math.ceil(line.length * CHART_LABEL_CHAR_WIDTH_PX));
+    }
+  }
+
+  return { wrapWidthPx, minWidth: Math.ceil(minWidth) };
+}
+
+export function buildWrappedVerticalXAxisLabels(
+  slotWidthPx,
+  { maxLines = 4 } = {}
+) {
+  return {
+    show: true,
+    rotate: 0,
+    rotateAlways: false,
+    trim: false,
+    hideOverlappingLabels: false,
+    offsetY: 0,
+    style: VERTICAL_LABEL_STYLE,
+    formatter: (value) => formatWrappedChartLabel(value, slotWidthPx, { maxLines }),
+  };
+}
+
+export function resolveVerticalXAxisLabelHeight(
+  categories,
+  slotWidthPx,
+  { minHeightPx = 22, maxHeightPx = 72, maxLines = 4 } = {}
+) {
+  const estimated = estimateMaxWrappedLabelHeight(categories, slotWidthPx, { maxLines });
+  return Math.max(minHeightPx, Math.min(maxHeightPx, estimated));
+}
+
+export function buildWrappedHorizontalCategoryLabels(
+  wrapWidthPx,
+  { minWidth, offsetX = 0 } = {}
+) {
+  return {
+    show: true,
+    offsetX,
+    trim: false,
+    hideOverlappingLabels: false,
+    minWidth,
+    style: VERTICAL_LABEL_STYLE,
+    formatter: (value) => formatWrappedChartLabel(value, wrapWidthPx),
+  };
+}
+
+export function buildHorizontalBarYAxisItem(categories, containerWidth, extra = {}) {
+  const {
+    labels: extraLabels,
+    labelLayout,
+    labelBarGapPx = 0,
+    labelLeftMarginPx = 0,
+    ...restExtra
+  } = extra;
+  const { wrapWidthPx, minWidth: labelMinWidth } = resolveHorizontalCategoryLabelLayout(
+    categories,
+    containerWidth,
+    labelLayout
+  );
+  // Total column = left margin + estimated text width + gap-to-bar.
+  // offsetX shifts ApexCharts' default right-edge x to (x = labelLeftMarginPx),
+  // and CSS text-anchor:start makes all labels begin at that same left position.
+  const gapPx = Math.max(0, labelBarGapPx);
+  const marginPx = Math.max(0, labelLeftMarginPx);
+  const axisLabelWidth = Math.ceil(marginPx + labelMinWidth + gapPx);
+  const offsetX = -(Math.ceil(labelMinWidth + gapPx));
+
+  return {
+    labels: {
+      ...buildWrappedHorizontalCategoryLabels(wrapWidthPx, {
+        minWidth: axisLabelWidth,
+        offsetX,
+      }),
+      ...(extraLabels ?? {}),
+    },
+    axisBorder: { show: false },
+    axisTicks: { show: false },
+    ...restExtra,
+  };
+}

--- a/digit-ui-esbuild/products/dashboard/src/config/chartColors.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/chartColors.js
@@ -1,0 +1,28 @@
+/** Shared data-viz palette — matches the demo pie / channel donut charts. */
+export const CHART_COLORS = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+];
+
+/** Apex pie chart uses the first four series colors. */
+export const PIE_CHART_COLORS = CHART_COLORS.slice(0, 4);
+
+export function getChartColor(index) {
+  return CHART_COLORS[((index % CHART_COLORS.length) + CHART_COLORS.length) % CHART_COLORS.length];
+}
+
+/** ApexCharts cannot read CSS variables — resolve against .dashboard-root. */
+export function resolveDashboardCssColor(colorValue) {
+  if (!colorValue || typeof colorValue !== "string") return colorValue;
+  const match = colorValue.match(/^var\((--[^)]+)\)$/);
+  if (!match || typeof document === "undefined") return colorValue;
+
+  const root = document.querySelector(".dashboard-root");
+  if (!root) return colorValue;
+
+  const resolved = getComputedStyle(root).getPropertyValue(match[1]).trim();
+  return resolved || colorValue;
+}

--- a/digit-ui-esbuild/products/dashboard/src/config/chartTooltipPresentation.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/chartTooltipPresentation.js
@@ -1,0 +1,137 @@
+/**
+ * Shared hover tooltip markup and Apex tooltip config for dashboard charts.
+ */
+
+import { SHARED_CHROME } from "./visualizationStyles";
+
+const DEFAULT_TOOLTIP_OFFSET = 10;
+
+export function resolveNearCursorTooltipPosition(
+  clientX,
+  clientY,
+  { width = 0, height = 0 } = {},
+  offset = DEFAULT_TOOLTIP_OFFSET
+) {
+  const margin = offset;
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+
+  let left = clientX + margin;
+  let top = clientY + margin;
+
+  if (width > 0 && left + width + margin > viewportWidth) {
+    left = clientX - width - margin;
+  }
+  if (height > 0 && top + height + margin > viewportHeight) {
+    top = clientY - height - margin;
+  }
+
+  if (width > 0) {
+    left = Math.max(margin, Math.min(left, viewportWidth - width - margin));
+  } else {
+    left = Math.max(margin, Math.min(left, viewportWidth - margin));
+  }
+
+  if (height > 0) {
+    top = Math.max(margin, Math.min(top, viewportHeight - height - margin));
+  } else {
+    top = Math.max(margin, Math.min(top, viewportHeight - margin));
+  }
+
+  return { left, top };
+}
+
+export function buildChartTooltipMarkup({ title, rows = [] }) {
+  const { chartTooltip, chartTooltipTitle, chartTooltipRow } = SHARED_CHROME;
+
+  const titleHtml = title
+    ? `<div class="${chartTooltipTitle}">${title}</div>`
+    : "";
+
+  const rowsHtml = rows
+    .map((row) => {
+      if (row?.value == null && row?.label == null) return "";
+      const colorStyle = row.color ? ` style="color:${row.color}"` : "";
+      const label = row.label ?? "";
+      const value = row.value ?? "";
+      const text = label ? `${label} : ${value}` : String(value);
+      return `<div class="${chartTooltipRow}"${colorStyle}>${text}</div>`;
+    })
+    .join("");
+
+  return `<div class="${chartTooltip}">${titleHtml}${rowsHtml}</div>`;
+}
+
+export function buildApexChartTooltipOptions({
+  followCursor = false,
+  offsetX = DEFAULT_TOOLTIP_OFFSET,
+  offsetY = DEFAULT_TOOLTIP_OFFSET,
+  shared = true,
+  intersect = false,
+  ...rest
+} = {}) {
+  return {
+    enabled: true,
+    shared,
+    intersect,
+    followCursor,
+    offsetX,
+    offsetY,
+    fixed: { enabled: false },
+    theme: "light",
+    marker: { show: false },
+    x: { show: false },
+    ...rest,
+  };
+}
+
+export function buildApexSeriesHoverTooltip({
+  categories = [],
+  getCategoryLabel,
+  formatValue = (value) => Math.round(Number(value)),
+  includeZero = true,
+  followCursor = false,
+  offsetX = DEFAULT_TOOLTIP_OFFSET,
+  offsetY = DEFAULT_TOOLTIP_OFFSET,
+} = {}) {
+  return buildApexChartTooltipOptions({
+    followCursor,
+    offsetX,
+    offsetY,
+    y: {
+      formatter: formatValue,
+      title: { formatter: (name) => `${name} : ` },
+    },
+    custom: ({ series, dataPointIndex, w }) => {
+      if (dataPointIndex < 0) return "";
+
+      const label =
+        getCategoryLabel?.(dataPointIndex) ??
+        categories[dataPointIndex] ??
+        w.globals.categoryLabels[dataPointIndex] ??
+        w.globals.labels[dataPointIndex] ??
+        "";
+
+      const names = w.config.series.map((entry) => entry.name);
+      const palette = w.globals.colors;
+
+      const rows = series
+        .map((values, index) => {
+          const value = values[dataPointIndex];
+          if (value == null || Number.isNaN(Number(value))) return null;
+          if (!includeZero && Number(value) === 0) return null;
+
+          return {
+            label: names[index] ?? `Series ${index + 1}`,
+            value: formatValue(value, index),
+            color: palette[index] ?? palette[0],
+          };
+        })
+        .filter(Boolean);
+
+      if (!rows.length) return "";
+
+      return buildChartTooltipMarkup({ title: label, rows });
+    },
+  });
+}

--- a/digit-ui-esbuild/products/dashboard/src/config/complaintsAtRiskPresentation.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/complaintsAtRiskPresentation.js
@@ -1,0 +1,83 @@
+const MS_PER_HOUR = 3600000;
+const MS_PER_DAY = 86400000;
+
+export const SLA_STATUS_LABELS = {
+  breached: "Breached",
+  nearing: "Nearing breach",
+};
+
+export const WORKFLOW_STATUS_LABELS = {
+  reopened: "Reopened",
+  in_progress: "In progress",
+  assigned: "Assigned",
+  open: "Open",
+};
+
+const OPEN_STATUS_KEYS = new Set(["PENDINGFORASSIGNMENT", "OPEN"]);
+const ASSIGNED_STATUS_KEYS = new Set(["PENDINGATLME", "ASSIGNED"]);
+
+export function formatBreachDurationCompact(ms) {
+  const n = Number(ms);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  const hours = n / MS_PER_HOUR;
+  if (hours < 48) {
+    const rounded = Math.round(hours * 10) / 10;
+    const formatted = Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+    return `+${formatted}${rounded === 1 ? "hr" : "hrs"}`;
+  }
+  const days = n / MS_PER_DAY;
+  const rounded = Math.round(days * 10) / 10;
+  const formatted = Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+  return `+${formatted}${rounded === 1 ? "d" : "d"}`;
+}
+
+export function resolveSlaRiskPresentation(bucket) {
+  const normalized = String(bucket ?? "").toLowerCase();
+  if (normalized === "approaching") {
+    return { slaLabel: SLA_STATUS_LABELS.nearing, slaLevel: "nearing" };
+  }
+  return { slaLabel: SLA_STATUS_LABELS.breached, slaLevel: "breached" };
+}
+
+export function computeBreachDurationMs(openAgeMs, slaTargetMs, slaBucket) {
+  const openAge = Number(openAgeMs);
+  const slaTarget = Number(slaTargetMs);
+  if (!Number.isFinite(openAge) || !Number.isFinite(slaTarget)) return null;
+  if (String(slaBucket).toLowerCase() !== "breached" && openAge <= slaTarget) return null;
+  if (openAge <= slaTarget) return null;
+  return openAge - slaTarget;
+}
+
+export function complaintDetailHref(serviceRequestId) {
+  const ctx = window?.contextPath ?? "digit-ui";
+  return `/${ctx}/employee/pgr/complaint/details/${encodeURIComponent(serviceRequestId)}`;
+}
+
+export function formatWorkflowStatusLabel(status) {
+  const key = normalizeWorkflowStatusKey(status);
+  return WORKFLOW_STATUS_LABELS[key] ?? WORKFLOW_STATUS_LABELS.in_progress;
+}
+
+export function normalizeWorkflowStatusKey(status) {
+  const key = String(status ?? "")
+    .trim()
+    .toUpperCase()
+    .replace(/[\s_-]+/g, "");
+
+  if (!key) return "in_progress";
+  if (key.includes("REOPEN")) return "reopened";
+  if (ASSIGNED_STATUS_KEYS.has(key) || (key.includes("ASSIGN") && !key.includes("PENDINGFORASSIGNMENT"))) {
+    return "assigned";
+  }
+  if (OPEN_STATUS_KEYS.has(key) || key === "PENDINGFORASSIGNMENT") return "open";
+  if (key.includes("INPROGRESS") || key.includes("PROGRESS")) return "in_progress";
+  if (
+    key.includes("PENDING") ||
+    key.includes("SUPERVISOR") ||
+    key.includes("REASSIGN") ||
+    key.includes("ESCALAT")
+  ) {
+    return "in_progress";
+  }
+  return "in_progress";
+}

--- a/digit-ui-esbuild/products/dashboard/src/config/dashboardConfig.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/dashboardConfig.js
@@ -1,0 +1,64 @@
+/**
+ * Default brand palette — override per tenant via globalConfigs (see keys below).
+ * Defaults mirror the canonical palette tokens (--primary / --chrome /
+ * --chrome-muted) defined in styles/input.css so unbranded tenants stay
+ * consistent with the standardized theme.
+ */
+export const DEFAULT_BRAND_THEME = {
+  teal: "lab(35.8817% -24.1734 -2.46631)",
+  dark: "lab(12.1586% -9.80562 -2.97114)",
+  slate: "lab(56.1186% -6.32274 -2.64311)",
+};
+
+export const DASHBOARD_FONT_FAMILY =
+  "Inter, Roboto, ui-sans-serif, system-ui, sans-serif";
+
+export function getTenantId() {
+  return (
+    window.globalConfigs?.getConfig("STATE_LEVEL_TENANT_ID") ||
+    process.env.REACT_APP_STATE_LEVEL_TENANT_ID ||
+    "default"
+  );
+}
+
+export function getBrandTheme() {
+  const get = window.globalConfigs?.getConfig?.bind(window.globalConfigs);
+  return {
+    teal: get?.("DASHBOARD_BRAND_PRIMARY") || DEFAULT_BRAND_THEME.teal,
+    dark: get?.("DASHBOARD_BRAND_DARK") || DEFAULT_BRAND_THEME.dark,
+    slate: get?.("DASHBOARD_BRAND_SLATE") || DEFAULT_BRAND_THEME.slate,
+  };
+}
+
+export function getStateLabel() {
+  return (
+    window.globalConfigs?.getConfig("DASHBOARD_STATE_LABEL") ||
+    window.globalConfigs?.getConfig("STATE_NAME") ||
+    "State"
+  );
+}
+
+export function getProductLabel() {
+  return (
+    window.globalConfigs?.getConfig("DASHBOARD_PRODUCT_LABEL") ||
+    "Complaint Resolution"
+  );
+}
+
+export function getSystemTitle() {
+  const configured = window.globalConfigs?.getConfig("DASHBOARD_SYSTEM_TITLE");
+  if (configured) return configured;
+  return `${getStateLabel()} — ${getProductLabel()} System`;
+}
+
+export function getLayoutStorageKey() {
+  return `${getTenantId()}-supervisor-dashboard-layout-v31`;
+}
+
+export function getSubMetricStorageKey() {
+  return `${getTenantId()}-supervisor-dashboard-submetrics-v1`;
+}
+
+export function getFiltersStorageKey() {
+  return `${getTenantId()}-supervisor-dashboard-filters-v4`;
+}

--- a/digit-ui-esbuild/products/dashboard/src/config/dashboardFilters.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/dashboardFilters.js
@@ -1,0 +1,81 @@
+import { getFiltersStorageKey, getSubMetricStorageKey } from "./dashboardConfig";
+import {
+  buildDefaultFilters,
+  sanitizeFilters,
+} from "./globalFilterGroups";
+
+const TIME_WINDOW_METRIC_IDS = [];
+
+function loadLegacySubMetricSelection() {
+  try {
+    const raw = localStorage.getItem(getSubMetricStorageKey());
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+function migrateTimeWindowFromLegacy() {
+  const legacy = loadLegacySubMetricSelection();
+  for (const metricId of TIME_WINDOW_METRIC_IDS) {
+    const subId = legacy[metricId];
+    if (subId) {
+      return subId;
+    }
+  }
+  return buildDefaultFilters().timeWindow;
+}
+
+export function loadDashboardFilters() {
+  try {
+    const raw = localStorage.getItem(getFiltersStorageKey());
+    if (raw) {
+      return sanitizeFilters(JSON.parse(raw));
+    }
+  } catch {
+    /* fall through */
+  }
+
+  return sanitizeFilters({ timeWindow: migrateTimeWindowFromLegacy() });
+}
+
+export function clearDashboardFilters() {
+  return buildDefaultFilters();
+}
+
+export function persistDashboardFilters(filters, dynamicOptions) {
+  localStorage.setItem(
+    getFiltersStorageKey(),
+    JSON.stringify(sanitizeFilters(filters, dynamicOptions))
+  );
+}
+
+export function reconcileFiltersWithOptions(filters, filterOptions) {
+  if (!filterOptions) return filters;
+
+  // filters can be momentarily null (e.g. a rapid external date-input change racing
+  // the options effect); fall back to defaults so we never read .geography off null.
+  const safe = filters ?? buildDefaultFilters();
+  const next = sanitizeFilters(safe, filterOptions);
+  const changed =
+    next.geography !== safe.geography ||
+    next.complaintType !== safe.complaintType ||
+    next.dateFrom !== safe.dateFrom ||
+    next.dateTo !== safe.dateTo;
+
+  return changed ? next : safe;
+}
+
+export function resolveSubMetricId(metric, globalFilters) {
+  if (!metric) return null;
+
+  if (metric.filterGroup) {
+    const value = globalFilters[metric.filterGroup];
+    if (value && metric.subMetrics.some((sub) => sub.id === value)) {
+      return value;
+    }
+    return metric.defaultSubMetricId;
+  }
+
+  return metric.defaultSubMetricId;
+}

--- a/digit-ui-esbuild/products/dashboard/src/config/dashboardTables.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/dashboardTables.js
@@ -1,0 +1,125 @@
+export const TRENDING_COMPLAINTS_COLUMNS = [
+  { id: "rank", label: "#", align: "left", type: "integer", width: "8%" },
+  { id: "label", label: "Sub-type", align: "left", type: "text", width: "38%" },
+  { id: "volume", label: "Volume", align: "left", type: "integer", width: "20%" },
+  { id: "wow", label: "WoW", align: "left", type: "trend", width: "22%" },
+];
+
+export const RESOLUTION_BY_TYPE_COLUMNS = [
+  { id: "label", label: "Complaint sub-type", align: "left", type: "text" },
+  { id: "closurePct", label: "Closure", align: "left", type: "percent" },
+  { id: "ontimePct", label: "On-time", align: "left", type: "percent" },
+  { id: "avgTtrMs", label: "Avg. resolution", align: "left", type: "hours" },
+];
+
+export const LOCALITY_COLUMNS = [
+  { id: "label", label: "Ward", align: "left", type: "text", width: "36%" },
+  { id: "logged", label: "Logged", align: "left", type: "integer", width: "18%" },
+  { id: "open", label: "Open", align: "left", type: "integer", width: "18%" },
+  { id: "ontimePct", label: "On-time %", align: "left", type: "percent", width: "28%" },
+];
+
+export const WORKFLOW_STAGE_COLUMNS = [
+  { id: "label", label: "Stage", align: "left", type: "text", width: "34%" },
+  { id: "avgDwellMs", label: "Avg dwell", align: "left", type: "hours", width: "22%" },
+  { id: "medianDwellMs", label: "Median dwell", align: "left", type: "hours", width: "24%" },
+  { id: "samples", label: "Samples", align: "left", type: "integer", width: "20%" },
+];
+
+export const EMPLOYEE_PERFORMANCE_COLUMNS = [
+  { id: "officerName", label: "Name", align: "left", type: "text", width: "16%" },
+  { id: "role", label: "Role", align: "left", type: "text", width: "12%" },
+  { id: "dept", label: "Dept", align: "left", type: "text", width: "14%" },
+  { id: "assigned", label: "Assigned", align: "left", type: "integer", width: "9%" },
+  { id: "open", label: "Open", align: "left", type: "integer", width: "8%", thresholdKey: "open" },
+  { id: "resolved", label: "Resolved", align: "left", type: "integer", width: "9%" },
+  {
+    id: "reopenRate",
+    label: "Reopen rate",
+    align: "left",
+    type: "percent",
+    width: "10%",
+    thresholdKey: "reopenRate",
+  },
+  { id: "avgCsat", label: "CSAT", align: "left", type: "rating", width: "8%", thresholdKey: "avgCsat" },
+  {
+    id: "escalationRate",
+    label: "Escalation rate",
+    align: "left",
+    type: "percent",
+    width: "14%",
+    thresholdKey: "escalationRate",
+  },
+];
+
+export const COMPLAINT_TYPE_DETAILS_COLUMNS = [
+  { id: "subtypeLabel", label: "Subtype", align: "left", type: "text", width: "16%" },
+  { id: "typeLabel", label: "Type", align: "left", type: "text", width: "12%" },
+  {
+    id: "avgResolutionMs",
+    label: "Avg resolution time",
+    align: "left",
+    type: "hoursDays",
+    width: "13%",
+    thresholdKey: "avgResolutionMs",
+  },
+  {
+    id: "idealSlaMs",
+    label: "SLA",
+    align: "left",
+    type: "hoursDays",
+    width: "11%",
+  },
+  {
+    id: "reopenRate",
+    label: "Reopen rate",
+    align: "left",
+    type: "percent",
+    width: "10%",
+    thresholdKey: "reopenRate",
+  },
+  {
+    id: "oldestOpenMs",
+    label: "Oldest complaint",
+    align: "left",
+    type: "hoursDays",
+    width: "13%",
+    thresholdKey: "oldestOpenMs",
+  },
+  {
+    id: "ontimeRate",
+    label: "Resolved on-time rate",
+    align: "left",
+    type: "percent",
+    width: "13%",
+    thresholdKey: "ontimeRate",
+  },
+  {
+    id: "avgCsat",
+    label: "CSAT",
+    align: "left",
+    type: "rating",
+    width: "8%",
+    thresholdKey: "avgCsat",
+  },
+];
+
+export const TABLE_WIDGET_CONFIG = {
+  "cl-table-complaint-type-details": {
+    columns: COMPLAINT_TYPE_DETAILS_COLUMNS,
+    dataKey: "complaintTypeDetails",
+  },
+  "ep-table-employee-performance": {
+    columns: EMPLOYEE_PERFORMANCE_COLUMNS,
+    dataKey: "employeePerformance",
+  },
+  /** @deprecated saved layouts may still reference this id */
+  "cl-chart-workflow-stages": {
+    columns: WORKFLOW_STAGE_COLUMNS,
+    dataKey: "workflowStages",
+  },
+};
+
+export function isTableWidget(widgetId) {
+  return Boolean(TABLE_WIDGET_CONFIG[widgetId]);
+}

--- a/digit-ui-esbuild/products/dashboard/src/config/geographyMapPresentation.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/geographyMapPresentation.js
@@ -1,0 +1,124 @@
+/** @typedef {'created' | 'open' | 'resolved'} GeographyMapLayerId */
+
+export const GEOGRAPHY_MAP_LAYERS = [
+  { id: "created", label: "Created", legendTitle: "Created" },
+  { id: "open", label: "Open", legendTitle: "% Open" },
+  { id: "resolved", label: "Resolved", legendTitle: "% Resolved" },
+];
+
+export const GEOGRAPHY_MAP_LAYER_IDS = new Set(
+  GEOGRAPHY_MAP_LAYERS.map((layer) => layer.id)
+);
+
+export function isGeographyMapLayerId(value) {
+  return GEOGRAPHY_MAP_LAYER_IDS.has(value);
+}
+
+export function isGeographyMapVolumeLayerId(layerId) {
+  return layerId === "created";
+}
+
+export function isGeographyMapShareLayerId(layerId) {
+  return layerId === "open" || layerId === "resolved";
+}
+
+export function getGeographyMapLayerMeta(layerId) {
+  return GEOGRAPHY_MAP_LAYERS.find((layer) => layer.id === layerId);
+}
+
+/** Created — complaint count buckets (blue scale). */
+export const CREATED_COUNT_LEGEND = [
+  { id: "none", label: "No complaints", fill: "#ffffff", stroke: "#d1d5db", fillOpacity: 0.95 },
+  { id: "b1", label: "1–3", fill: "#dbeafe", stroke: "#bfdbfe", fillOpacity: 0.78 },
+  { id: "b2", label: "4–5", fill: "#93c5fd", stroke: "#60a5fa", fillOpacity: 0.76 },
+  { id: "b3", label: "6–8", fill: "#60a5fa", stroke: "#3b82f6", fillOpacity: 0.74 },
+  { id: "b4", label: "9–10", fill: "#3b82f6", stroke: "#2563eb", fillOpacity: 0.74 },
+  { id: "b5", label: "11–13", fill: "#2563eb", stroke: "#1d4ed8", fillOpacity: 0.76 },
+  { id: "b6", label: "14–15", fill: "#1e40af", stroke: "#1e3a8a", fillOpacity: 0.78 },
+];
+
+/** % Open — share of filed complaints still open (red scale). */
+export const OPEN_SHARE_LEGEND = [
+  { id: "none", label: "No complaints", fill: "#ffffff", stroke: "#d1d5db", fillOpacity: 0.95 },
+  { id: "p0", label: "0%", fill: "#fff1f2", stroke: "#fecdd3", fillOpacity: 0.78 },
+  { id: "p20", label: "≤ 20%", fill: "#fecaca", stroke: "#fca5a5", fillOpacity: 0.76 },
+  { id: "p40", label: "20–40%", fill: "#fca5a5", stroke: "#f87171", fillOpacity: 0.74 },
+  { id: "p60", label: "40–60%", fill: "#f87171", stroke: "#ef4444", fillOpacity: 0.76 },
+  { id: "p80", label: "60–80%", fill: "#ef4444", stroke: "#dc2626", fillOpacity: 0.78 },
+  { id: "p100", label: "> 80%", fill: "#991b1b", stroke: "#7f1d1d", fillOpacity: 0.8 },
+];
+
+/** % Resolved — share of filed complaints resolved (green scale). */
+export const RESOLVED_SHARE_LEGEND = [
+  { id: "none", label: "No complaints", fill: "#ffffff", stroke: "#d1d5db", fillOpacity: 0.95 },
+  { id: "p0", label: "0%", fill: "#f0fdf4", stroke: "#dcfce7", fillOpacity: 0.78 },
+  { id: "p20", label: "≤ 20%", fill: "#bbf7d0", stroke: "#86efac", fillOpacity: 0.76 },
+  { id: "p40", label: "20–40%", fill: "#86efac", stroke: "#4ade80", fillOpacity: 0.74 },
+  { id: "p60", label: "40–60%", fill: "#4ade80", stroke: "#22c55e", fillOpacity: 0.76 },
+  { id: "p80", label: "60–80%", fill: "#16a34a", stroke: "#15803d", fillOpacity: 0.78 },
+  { id: "p100", label: "> 80%", fill: "#14532d", stroke: "#052e16", fillOpacity: 0.8 },
+];
+
+export function getGeographyMapLegend(layerId) {
+  if (layerId === "open") return OPEN_SHARE_LEGEND;
+  if (layerId === "resolved") return RESOLVED_SHARE_LEGEND;
+  return CREATED_COUNT_LEGEND;
+}
+
+export function getGeographyMapLegendTitle(layerId) {
+  return getGeographyMapLayerMeta(layerId)?.legendTitle ?? "Map legend";
+}
+
+export function getGeographyMapLegendFooter(drillTrailLength = 0) {
+  const focusTarget = ["district", "subdistrict", "sub-subdistrict", "complaint"][
+    Math.min(Math.max(drillTrailLength, 0), 3)
+  ];
+  return `Zoom in to drill down · click a ${focusTarget} to focus`;
+}
+
+function bucketToFillStyle(bucket) {
+  return {
+    fillColor: bucket.fill,
+    strokeColor: bucket.stroke,
+    fillOpacity: bucket.fillOpacity ?? 0.76,
+  };
+}
+
+export function getCreatedCountBucket(count) {
+  const n = Number(count) || 0;
+  if (n <= 0) return CREATED_COUNT_LEGEND[0];
+  if (n <= 3) return CREATED_COUNT_LEGEND[1];
+  if (n <= 5) return CREATED_COUNT_LEGEND[2];
+  if (n <= 8) return CREATED_COUNT_LEGEND[3];
+  if (n <= 10) return CREATED_COUNT_LEGEND[4];
+  if (n <= 13) return CREATED_COUNT_LEGEND[5];
+  return CREATED_COUNT_LEGEND[6];
+}
+
+export function getSharePctBucket(pct, legend) {
+  const value = Number(pct);
+  if (!Number.isFinite(value) || value < 0) return legend[0];
+  if (value === 0) return legend[1];
+  if (value <= 20) return legend[2];
+  if (value <= 40) return legend[3];
+  if (value <= 60) return legend[4];
+  if (value <= 80) return legend[5];
+  return legend[6];
+}
+
+export function getCreatedCountFillStyle(count) {
+  return bucketToFillStyle(getCreatedCountBucket(count));
+}
+
+export function getOpenShareFillStyle(openPct) {
+  return bucketToFillStyle(getSharePctBucket(openPct, OPEN_SHARE_LEGEND));
+}
+
+export function getResolvedShareFillStyle(resolvedPct) {
+  return bucketToFillStyle(getSharePctBucket(resolvedPct, RESOLVED_SHARE_LEGEND));
+}
+
+/** @deprecated Legacy WoW styling — map uses created/open/resolved layers only. */
+export function getWowChangeFillStyle(wowPct) {
+  return getCreatedCountFillStyle(0);
+}

--- a/digit-ui-esbuild/products/dashboard/src/config/globalFilterGroups.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/globalFilterGroups.js
@@ -92,6 +92,12 @@ export function sanitizeFilters(raw, dynamicOptions = {}) {
     return defaults;
   }
 
+  // The `= {}` default only applies when the arg is `undefined`. Callers such as
+  // persistDashboardFilters(filters, dynamicOptions) can pass `null` explicitly, which
+  // slips past the default and makes `dynamicOptions[field.id]` throw on the first select
+  // field ("geography") — blanking the dashboard on any date-filter change. Normalize it.
+  const options = dynamicOptions && typeof dynamicOptions === "object" ? dynamicOptions : {};
+
   const next = { ...defaults };
 
   for (const field of GLOBAL_FILTER_FIELDS) {
@@ -100,8 +106,8 @@ export function sanitizeFilters(raw, dynamicOptions = {}) {
       next[field.id] = value;
     }
     if (field.type === "select") {
-      const options = dynamicOptions[field.id] ?? field.options;
-      if (options.some((opt) => opt.id === value)) {
+      const fieldOptions = options[field.id] ?? field.options;
+      if (fieldOptions.some((opt) => opt.id === value)) {
         next[field.id] = value;
       }
     }

--- a/digit-ui-esbuild/products/dashboard/src/config/globalFilterGroups.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/globalFilterGroups.js
@@ -1,0 +1,117 @@
+function todayISO() {
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function oneMonthAgoISO() {
+  const d = new Date();
+  d.setMonth(d.getMonth() - 1);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+export const GEOGRAPHY_OPTIONS = [
+  { id: "all", label: "All wards" },
+];
+
+export const COMPLAINT_TYPE_OPTIONS = [
+  { id: "all", label: "All types" },
+];
+
+/**
+ * Global dashboard filters — shared dimensions across KPIs and charts.
+ * timeWindow is retained for volume KPI sub-metric resolution until date-range API wiring.
+ */
+export const GLOBAL_FILTER_FIELDS = [
+  { id: "dateFrom", type: "date", label: "From", defaultValue: oneMonthAgoISO() },
+  { id: "dateTo", type: "date", label: "To", defaultValue: todayISO() },
+  {
+    id: "geography",
+    type: "select",
+    label: "Geography",
+    defaultValue: "all",
+    options: GEOGRAPHY_OPTIONS,
+  },
+  {
+    id: "complaintType",
+    type: "select",
+    label: "Complaint type",
+    defaultValue: "all",
+    options: COMPLAINT_TYPE_OPTIONS,
+  },
+];
+
+/** @deprecated use GLOBAL_FILTER_FIELDS */
+export const GLOBAL_FILTER_GROUPS = GLOBAL_FILTER_FIELDS.filter((f) => f.type === "select");
+
+export function buildDefaultFilters() {
+  const today = todayISO();
+  const monthAgo = oneMonthAgoISO();
+  const defaults = Object.fromEntries(
+    GLOBAL_FILTER_FIELDS.map((field) => {
+      if (field.id === "dateFrom") return [field.id, monthAgo];
+      if (field.id === "dateTo") return [field.id, today];
+      return [field.id, field.defaultValue];
+    })
+  );
+  defaults.timeWindow = "weekly";
+  defaults.dateRangeActive = true;
+  return defaults;
+}
+
+export function hasActiveFilters(filters) {
+  if (!filters) return false;
+  const defaults = buildDefaultFilters();
+  const geography = filters.geography ?? defaults.geography;
+  const complaintType = filters.complaintType ?? defaults.complaintType;
+  const dateFrom = filters.dateFrom ?? defaults.dateFrom;
+  const dateTo = filters.dateTo ?? defaults.dateTo;
+  const dateRangeActive = filters.dateRangeActive ?? defaults.dateRangeActive;
+
+  return (
+    dateRangeActive !== defaults.dateRangeActive ||
+    dateFrom !== defaults.dateFrom ||
+    dateTo !== defaults.dateTo ||
+    geography !== defaults.geography ||
+    complaintType !== defaults.complaintType
+  );
+}
+
+function isValidISODate(value) {
+  return typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+
+export function sanitizeFilters(raw, dynamicOptions = {}) {
+  const defaults = buildDefaultFilters();
+  if (!raw || typeof raw !== "object") {
+    return defaults;
+  }
+
+  const next = { ...defaults };
+
+  for (const field of GLOBAL_FILTER_FIELDS) {
+    const value = raw[field.id];
+    if (field.type === "date" && isValidISODate(value)) {
+      next[field.id] = value;
+    }
+    if (field.type === "select") {
+      const options = dynamicOptions[field.id] ?? field.options;
+      if (options.some((opt) => opt.id === value)) {
+        next[field.id] = value;
+      }
+    }
+  }
+
+  if (["daily", "weekly", "monthly", "wow", "mom"].includes(raw.timeWindow)) {
+    next.timeWindow = raw.timeWindow;
+  }
+
+  next.dateRangeActive = raw.dateRangeActive === true;
+
+  return next;
+}

--- a/digit-ui-esbuild/products/dashboard/src/config/kpiDisplay.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/kpiDisplay.js
@@ -1,0 +1,305 @@
+/**
+ * KPI card presentation — thresholds, context lines, and list data sources.
+ */
+
+import { VISUALIZATION_STYLES, VIZ_TYPE } from "./visualizationStyles";
+
+export const KPI_STATUS = {
+  ON_TRACK: "on_track",
+  NORMAL: "normal",
+  BREACHING: "breaching",
+};
+
+/** @type {Record<string, object>} */
+export const KPI_DISPLAY = {
+  "rs-metric-sla-compliance": {
+    displayTitle: "On-time resolution rate",
+    threshold: { kind: "percent", higherIsBetter: true, onTrack: 85, breaching: 60 },
+    context: { type: "breachOpen" },
+  },
+  "rs-metric-breach-count": {
+    displayTitle: "Breached SLA (open)",
+    threshold: { kind: "count", higherIsBetter: false, onTrack: 5, breaching: 20 },
+    context: { type: "outOfOpen" },
+  },
+  "cl-metric-total-resolved": {
+    displayTitle: "Resolved complaints",
+    threshold: { kind: "count", higherIsBetter: true, onTrack: 10, breaching: 0 },
+  },
+  "cl-metric-total-open": {
+    displayTitle: "Open complaints",
+    threshold: { kind: "count", higherIsBetter: false, onTrack: 20, breaching: 50 },
+  },
+  "cl-metric-new-created": {
+    displayTitle: "New complaints created",
+  },
+  "cl-metric-created-today": {
+    displayTitle: "Complaints created today",
+  },
+  "cl-metric-resolution-rate": {
+    displayTitle: "Resolution rate",
+    threshold: { kind: "percent", higherIsBetter: true, onTrack: 70, breaching: 40 },
+  },
+  "cl-metric-reopen-rate": {
+    displayTitle: "Reopen rate",
+    threshold: { kind: "percent", higherIsBetter: false, onTrack: 10, breaching: 25 },
+  },
+  "cl-metric-csat": {
+    displayTitle: "Citizen satisfaction",
+    threshold: { kind: "rating", higherIsBetter: true, onTrack: 4, breaching: 3 },
+  },
+  "cl-metric-first-assignment-rate": {
+    displayTitle: "First-assignment rate",
+    threshold: { kind: "percent", higherIsBetter: true, onTrack: 90, breaching: 70 },
+  },
+  "cl-metric-sla-compliance-rate": {
+    displayTitle: "SLA compliance rate",
+    threshold: { kind: "percent", higherIsBetter: true, onTrack: 85, breaching: 60 },
+  },
+  "cl-metric-sla-non-compliance-rate": {
+    displayTitle: "SLA non-compliance rate",
+    threshold: { kind: "percent", higherIsBetter: false, onTrack: 15, breaching: 40 },
+  },
+  "cl-metric-resolved-on-time-rate": {
+    displayTitle: "Resolved on time rate",
+    threshold: { kind: "percent", higherIsBetter: true, onTrack: 85, breaching: 60 },
+  },
+  "cl-metric-oldest-open": {
+    displayTitle: "Oldest complaint",
+    threshold: { kind: "count", higherIsBetter: false, onTrack: 7, breaching: 30 },
+  },
+  "cl-metric-avg-resolution-time": {
+    displayTitle: "Average resolution time",
+  },
+  "ce-metric-reopen-rate": {
+    displayTitle: "Reopen rate",
+    threshold: { kind: "percent", higherIsBetter: false, onTrack: 10, breaching: 25 },
+    context: { type: "csatSnapshot" },
+  },
+};
+
+export function getKpiDisplayConfig(metricId) {
+  return KPI_DISPLAY[metricId] || {};
+}
+
+export function isKpiListMetric(metricId) {
+  return Boolean(KPI_DISPLAY[metricId]?.listQueryKey);
+}
+
+export function getKpiDisplayTitle(metric) {
+  const config = getKpiDisplayConfig(metric.id);
+  return config.displayTitle || metric.metric;
+}
+
+export function parseNumericValue(displayValue) {
+  if (displayValue == null || displayValue === "—" || displayValue === "…") return null;
+  const raw = String(displayValue).trim();
+  const ratingMatch = raw.match(/^([\d.]+)\s*\/\s*5$/);
+  if (ratingMatch) return Number(ratingMatch[1]);
+  const pctMatch = raw.match(/^([\d.]+)\s*%$/);
+  if (pctMatch) return Number(pctMatch[1]);
+  const num = Number(raw.replace(/[^\d.-]/g, ""));
+  return Number.isFinite(num) ? num : null;
+}
+
+export function resolveThresholdStatus(metricId, displayValue) {
+  const config = getKpiDisplayConfig(metricId).threshold;
+  if (!config) return KPI_STATUS.NORMAL;
+
+  const value = parseNumericValue(displayValue);
+  if (value == null) return KPI_STATUS.NORMAL;
+
+  const { higherIsBetter, onTrack, breaching } = config;
+
+  if (higherIsBetter) {
+    if (value >= onTrack) return KPI_STATUS.ON_TRACK;
+    if (value <= breaching) return KPI_STATUS.BREACHING;
+    return KPI_STATUS.NORMAL;
+  }
+
+  if (value <= onTrack) return KPI_STATUS.ON_TRACK;
+  if (value >= breaching) return KPI_STATUS.BREACHING;
+  return KPI_STATUS.NORMAL;
+}
+
+/** On track → green, breaching → red, normal → black. */
+export function getStatusValueClass(status) {
+  switch (status) {
+    case KPI_STATUS.ON_TRACK:
+      return "tw-text-status-resolved";
+    case KPI_STATUS.BREACHING:
+      return "tw-text-status-breach";
+    default:
+      return "tw-text-foreground";
+  }
+}
+
+/** Delta text — same threshold mapping via dashboard delta color tokens. */
+export function getNumberTileDeltaClass(status, { unavailable = false } = {}) {
+  const {
+    deltaMuted,
+    deltaNeutral,
+    deltaPositive,
+    deltaNegative,
+  } = VISUALIZATION_STYLES[VIZ_TYPE.NUMBER_TILE_DELTA];
+
+  if (unavailable) return deltaMuted;
+  switch (status) {
+    case KPI_STATUS.ON_TRACK:
+      return deltaPositive;
+    case KPI_STATUS.BREACHING:
+      return deltaNegative;
+    default:
+      return deltaNeutral;
+  }
+}
+
+/** Value color for number tiles — threshold-driven, shared by every metric card. */
+export function getNumberTileValueClass(status, { unavailable = false } = {}) {
+  const styles = VISUALIZATION_STYLES[VIZ_TYPE.NUMBER_TILE_DELTA];
+  if (unavailable) return styles.valueUnavailable;
+  return getStatusValueClass(status);
+}
+
+/** Delta color for KPI tiles — matches the main value (threshold-driven). */
+export function resolveKpiDeltaClass(metricId, _deltaPercent, displayValue) {
+  const unavailable =
+    displayValue == null || displayValue === "—" || displayValue === "…";
+  return getNumberTileDeltaClass(resolveThresholdStatus(metricId, displayValue), {
+    unavailable,
+  });
+}
+
+export function statusValueToCssColor(statusClass) {
+  switch (statusClass) {
+    case "tw-text-status-resolved":
+      return "var(--status-resolved)";
+    case "tw-text-status-breach":
+      return "var(--status-breach)";
+    case "tw-text-muted-foreground":
+      return "var(--muted-foreground)";
+    default:
+      return "var(--foreground)";
+  }
+}
+
+function formatServiceCode(code) {
+  return String(code ?? "Unknown")
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+// The analytics grain carries assignee UUIDs, not names (and many don't resolve to a
+// live user record). For a human-readable dashboard we derive a STABLE display name
+// from the UUID: a deterministic hash picks a first + last name, so the same officer
+// always shows the same name across every widget. ~400 combinations keeps collisions rare.
+const OFFICER_FIRST_NAMES = [
+  "Aisha", "John", "Grace", "David", "Mary", "Samuel", "Faith", "Peter", "Esther",
+  "Brian", "Joyce", "Kevin", "Lucy", "Daniel", "Naomi", "Eric", "Sarah", "James",
+  "Caroline", "Dennis",
+];
+const OFFICER_LAST_NAMES = [
+  "Mwangi", "Kamau", "Otieno", "Kiprono", "Wanjiru", "Chebet", "Njoroge", "Korir",
+  "Achieng", "Mutua", "Kibet", "Wafula", "Cheruiyot", "Onyango", "Maina", "Rotich",
+  "Wekesa", "Langat", "Mwende", "Barasa",
+];
+
+export function formatOfficerLabel(uuid) {
+  const id = String(uuid ?? "");
+  if (!id || id === "Unknown" || id === "null" || id === "undefined") return "Unassigned";
+  let h = 0;
+  for (let i = 0; i < id.length; i += 1) h = (h * 31 + id.charCodeAt(i)) >>> 0;
+  const first = OFFICER_FIRST_NAMES[h % OFFICER_FIRST_NAMES.length];
+  const last = OFFICER_LAST_NAMES[Math.floor(h / OFFICER_FIRST_NAMES.length) % OFFICER_LAST_NAMES.length];
+  return `${first} ${last}`;
+}
+
+function formatListLabel(labelKey, raw) {
+  if (labelKey === "service_code") return formatServiceCode(raw);
+  if (labelKey === "current_assignee_uuid") return formatOfficerLabel(raw);
+  if (labelKey === "account_id") {
+    const id = String(raw ?? "Unknown");
+    return id.length > 10 ? `…${id.slice(-8)}` : id;
+  }
+  return String(raw ?? "Unknown");
+}
+
+function formatListMeasureValue(raw, format) {
+  if (raw == null) return "—";
+  if (format === "percentInteger") {
+    const pct = Number(raw) <= 1 ? Number(raw) * 100 : Number(raw);
+    return Number.isFinite(pct) ? `${Math.round(pct)}%` : "—";
+  }
+  return String(Math.round(Number(raw)) || 0);
+}
+
+export function parseKpiListItems(results, metricId, limit = 5) {
+  const config = getKpiDisplayConfig(metricId);
+  const queryKey = config.listQueryKey;
+  if (!queryKey) return [];
+
+  const rows = results?.[queryKey]?.rows;
+  if (!rows?.length) return [];
+
+  const labelKey = config.listLabelKey || "label";
+  const measureKey = config.listMeasureKey || "total";
+
+  const sorted = [...rows].sort((a, b) => {
+    const diff = (Number(b[measureKey]) || 0) - (Number(a[measureKey]) || 0);
+    if (diff !== 0) return diff;
+    return String(a[labelKey] ?? "").localeCompare(String(b[labelKey] ?? ""));
+  });
+
+  return sorted.slice(0, limit).map((row, index) => ({
+    rank: index + 1,
+    label: formatListLabel(labelKey, row[labelKey]),
+    value: formatListMeasureValue(row[measureKey], config.listValueFormat),
+  }));
+}
+
+function readCount(results, queryKey, measureKey = "total") {
+  const raw = results?.[queryKey]?.rows?.[0]?.[measureKey];
+  if (raw == null) return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? Math.round(n) : null;
+}
+
+function readPercentOneDecimal(results, queryKey, measureKey = "avg") {
+  const raw = results?.[queryKey]?.rows?.[0]?.[measureKey];
+  if (raw == null) return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n.toFixed(1) : null;
+}
+
+export function buildKpiContextText(metricId, results, subMetricLabel) {
+  const config = getKpiDisplayConfig(metricId).context;
+  if (!config) return subMetricLabel || null;
+
+  switch (config.type) {
+    case "breachOpen": {
+      const n = readCount(results, "rs_breach_total");
+      return n == null ? null : `Breached open: ${n}`;
+    }
+    case "outOfOpen": {
+      const open = readCount(results, "cl_open_weekly");
+      const breach = readCount(results, "rs_breach_total");
+      if (open == null || breach == null) return null;
+      return `Out of ${open} open complaints`;
+    }
+    case "outOfRegistered": {
+      const total = readCount(results, "cl_reg_weekly");
+      if (total == null) return null;
+      return `Out of ${total} complaints`;
+    }
+    case "csatSnapshot": {
+      const csat = readPercentOneDecimal(results, "ce_csat_avg_week", "avg");
+      return csat == null ? null : `CSAT ${csat}/5`;
+    }
+    case "acrossResolved":
+      return "Across resolved";
+    case "timeWindow":
+      return subMetricLabel || null;
+    default:
+      return subMetricLabel || null;
+  }
+}

--- a/digit-ui-esbuild/products/dashboard/src/config/labelFormat.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/labelFormat.js
@@ -1,0 +1,28 @@
+/**
+ * Humanise a raw dimension code (service/ward/department/dotted key) into a short
+ * display label. Extracted verbatim from the retired kpiQueries module — the only
+ * export of that file the inverted dashboard still used.
+ */
+export function formatDimensionLabel(code) {
+  const humanized = String(code).replace(/([a-z])([A-Z])/g, "$1 $2");
+  const wardMatch = humanized.match(/ward[_\s-]?(\d+)/i);
+  if (wardMatch) return `Ward ${wardMatch[1]}`;
+
+  const dot = humanized.lastIndexOf(".");
+  if (dot >= 0) {
+    return humanized
+      .slice(dot + 1)
+      .replace(/_/g, " ")
+      .replace(/\b\w/g, (c) => c.toUpperCase());
+  }
+
+  const parts = humanized.split("_").filter(Boolean);
+  if (parts.length > 2) {
+    return parts
+      .slice(-2)
+      .join(" ")
+      .replace(/_/g, " ");
+  }
+
+  return humanized.replace(/_/g, " ");
+}

--- a/digit-ui-esbuild/products/dashboard/src/config/lineChartPresentation.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/lineChartPresentation.js
@@ -1,0 +1,368 @@
+/**
+ * Shared presentation for line charts (viz type: line-chart).
+ */
+
+import { resolveDashboardCssColor } from "./chartColors";
+import {
+  buildWrappedVerticalXAxisLabels,
+  resolveVerticalXAxisLabelHeight,
+} from "./chartAxisLabels";
+import { buildApexSeriesHoverTooltip } from "./chartTooltipPresentation";
+import { formatWrappedChartLabel } from "../utils/chartLabelWrap";
+import { VISUALIZATION_STYLES, VIZ_TYPE } from "./visualizationStyles";
+
+const LINE_CHART_STYLES = VISUALIZATION_STYLES[VIZ_TYPE.LINE_CHART];
+
+export const LINE_CHART_MAX_SERIES = 4;
+export const LINE_CHART_STROKE_WIDTH = 2.5;
+export const LINE_CHART_MARKER_SIZE = 3;
+export const LINE_CHART_MARKER_STROKE_WIDTH = 1.5;
+export const LINE_CHART_ANIMATION_SPEED = 450;
+/** Gap between y-axis border and first data point (px in plot space). */
+export const LINE_CHART_PLOT_INSET_PX = 18;
+export const LINE_CHART_Y_AXIS_LABEL_WIDTH = 48;
+
+export const LINE_CHART_LEGEND = {
+  show: true,
+  position: "bottom",
+  horizontalAlign: "center",
+  fontSize: "11px",
+  markers: {
+    width: 6,
+    height: 6,
+    radius: 12,
+    strokeWidth: 0,
+    offsetX: -2,
+  },
+  itemMargin: { horizontal: 14, vertical: 4 },
+  offsetY: 4,
+};
+
+export const LINE_CHART_PERIOD_OPTIONS = [
+  { id: "daily", label: "Daily" },
+  { id: "weekly", label: "Weekly" },
+  { id: "monthly", label: "Monthly" },
+];
+
+export function normalizeLineChartSeries(series = []) {
+  return series.slice(0, LINE_CHART_MAX_SERIES).map((entry, index) => {
+    const dashed =
+      entry.lineStyle === "dashed" ||
+      (entry.dashArray != null && Number(entry.dashArray) > 0);
+
+    return {
+      name: String(entry.name ?? `Series ${index + 1}`),
+      data: (entry.data ?? []).map((value) => Number(value) || 0),
+      color: entry.color,
+      dashArray: dashed ? Number(entry.dashArray) || 5 : 0,
+      yAxisGroup: entry.yAxisGroup === "percent" ? "percent" : "count",
+    };
+  });
+}
+
+export function resolveLineChartColors(series) {
+  return series.map((entry, index) =>
+    resolveDashboardCssColor(entry.color || `var(--chart-${(index % 5) + 1})`)
+  );
+}
+
+export function buildLineChartStroke(series) {
+  return {
+    curve: "monotoneCubic",
+    width: series.map(() => LINE_CHART_STROKE_WIDTH),
+    dashArray: series.map((entry) => entry.dashArray ?? 0),
+  };
+}
+
+export function buildLineChartMarkers(colors, discrete = []) {
+  const surfaceColor =
+    resolveDashboardCssColor("var(--surface)") ||
+    resolveDashboardCssColor("var(--background)") ||
+    "#ffffff";
+
+  return {
+    size: LINE_CHART_MARKER_SIZE,
+    strokeWidth: LINE_CHART_MARKER_STROKE_WIDTH,
+    strokeColors: colors,
+    fillColors: colors.map(() => surfaceColor),
+    discrete,
+    hover: {
+      size: LINE_CHART_MARKER_SIZE,
+      sizeOffset: 0,
+    },
+  };
+}
+
+export function buildLineChartDiscreteMarkers(dataPointIndex, colors) {
+  if (dataPointIndex == null || dataPointIndex < 0) return [];
+
+  return colors.map((color, seriesIndex) => ({
+    seriesIndex,
+    dataPointIndex,
+    fillColor: color,
+    strokeColor: color,
+    size: LINE_CHART_MARKER_SIZE,
+    strokeWidth: LINE_CHART_MARKER_STROKE_WIDTH,
+    shape: "circle",
+  }));
+}
+
+export function getLineChartMarkerSurfaceColor() {
+  return (
+    resolveDashboardCssColor("var(--surface)") ||
+    resolveDashboardCssColor("var(--background)") ||
+    "#ffffff"
+  );
+}
+
+/** Hide marker groups while line paths are animating. */
+export function setLineChartMarkersVisible(chartContext, visible) {
+  const baseEl = chartContext?.w?.globals?.dom?.baseEl;
+  if (!baseEl) return;
+
+  baseEl.querySelectorAll(".apexcharts-series-markers-wrap").forEach((wrap) => {
+    if (visible) {
+      wrap.classList.remove("apexcharts-element-hidden");
+      wrap.classList.add("apexcharts-hidden-element-shown");
+      return;
+    }
+
+    wrap.classList.add("apexcharts-element-hidden");
+    wrap.classList.remove("apexcharts-hidden-element-shown");
+  });
+}
+
+/** Solid-fill the active x-index markers; keep all others hollow. */
+export function applyLineChartMarkerHoverState(
+  chartContext,
+  dataPointIndex,
+  colors,
+  surfaceColor
+) {
+  const baseEl = chartContext?.w?.globals?.dom?.baseEl;
+  if (!baseEl) return;
+
+  const markers = baseEl.querySelectorAll(
+    ".apexcharts-series-markers .apexcharts-marker"
+  );
+
+  markers.forEach((marker) => {
+    const rel = Number.parseInt(marker.getAttribute("rel") ?? "", 10);
+    const seriesIndex = Number.parseInt(marker.getAttribute("index") ?? "", 10);
+
+    if (
+      dataPointIndex >= 0 &&
+      rel === dataPointIndex &&
+      Number.isFinite(seriesIndex) &&
+      colors[seriesIndex]
+    ) {
+      marker.style.fill = colors[seriesIndex];
+      marker.classList.add(LINE_CHART_STYLES.markerActive);
+      return;
+    }
+
+    marker.style.fill = surfaceColor;
+    marker.classList.remove(LINE_CHART_STYLES.markerActive);
+  });
+}
+
+export function buildLineChartTooltip(categories = [], series = []) {
+  return buildApexSeriesHoverTooltip({
+    categories,
+    formatValue: (value, seriesIndex) => {
+      const entry = series[seriesIndex];
+      if (entry?.yAxisGroup === "percent") {
+        const rounded = Math.round(Number(value) * 10) / 10;
+        const formatted = Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+        return `${formatted}%`;
+      }
+      return Math.round(Number(value));
+    },
+  });
+}
+
+export function buildCompoundLineChartYAxis(series, yAxisConfig = {}) {
+  const percentNames = series
+    .filter((entry) => entry.yAxisGroup === "percent")
+    .map((entry) => entry.name);
+  const countSeries = series.filter((entry) => entry.yAxisGroup !== "percent");
+
+  if (!percentNames.length || !countSeries.length) {
+    return buildLineChartYAxis(resolveLineChartYAxisBounds(series, yAxisConfig));
+  }
+
+  const countBounds = resolveLineChartYAxisBounds(countSeries, yAxisConfig);
+  const borderColor = resolveDashboardCssColor("var(--border)");
+
+  return [
+    {
+      ...buildLineChartYAxis(countBounds),
+      seriesName: countSeries.map((entry) => entry.name),
+    },
+    {
+      opposite: true,
+      min: 0,
+      max: 100,
+      tickAmount: 5,
+      forceNiceScale: false,
+      show: false,
+      seriesName: percentNames,
+      labels: { show: false },
+      axisBorder: { show: false },
+      axisTicks: { show: false },
+    },
+  ];
+}
+
+export function buildLineChartAnimations() {
+  return {
+    enabled: true,
+    easing: "easeinout",
+    speed: LINE_CHART_ANIMATION_SPEED,
+    animateGradually: { enabled: false },
+    dynamicAnimation: {
+      enabled: true,
+      speed: LINE_CHART_ANIMATION_SPEED,
+    },
+  };
+}
+
+export function resolveLineChartYAxisBounds(series, yAxisConfig = {}) {
+  if (yAxisConfig.max != null) {
+    return {
+      min: yAxisConfig.min ?? 0,
+      max: yAxisConfig.max,
+      tickAmount: yAxisConfig.tickAmount ?? 4,
+    };
+  }
+
+  const values = series
+    .flatMap((entry) => entry.data)
+    .filter((value) => Number.isFinite(value));
+
+  if (!values.length) {
+    return { min: 0, max: 10, tickAmount: 4 };
+  }
+
+  const rawMax = Math.max(...values);
+  const step = rawMax <= 30 ? 5 : rawMax <= 100 ? 15 : 50;
+  const max = Math.ceil((rawMax * 1.05) / step) * step;
+
+  return { min: 0, max: Math.max(step, max), tickAmount: 4 };
+}
+
+export function buildLineChartGrid({ bottomPadding = 0 } = {}) {
+  const borderColor = resolveDashboardCssColor("var(--border)");
+
+  return {
+    show: true,
+    borderColor,
+    strokeDashArray: 4,
+    padding: { left: 0, right: 12, top: 8, bottom: bottomPadding },
+    xaxis: { lines: { show: false } },
+    yaxis: { lines: { show: true } },
+  };
+}
+
+export function resolveLineChartXAxisLabelHeight(categories, containerWidth) {
+  const gridWidth = estimateLineChartGridWidth(containerWidth);
+  const labelSlotWidth =
+    categories.length > 1 ? gridWidth / (categories.length - 1) : gridWidth;
+  return resolveVerticalXAxisLabelHeight(categories, labelSlotWidth, {
+    minHeightPx: 22,
+    maxHeightPx: 56,
+  });
+}
+
+/** Map category series to numeric x/y pairs; x starts at 0 (inset applied via xaxis.min). */
+export function buildLineChartSeriesData(series, categoryCount) {
+  return series.map((entry) => ({
+    name: entry.name,
+    data: entry.data.slice(0, categoryCount).map((y, index) => ({
+      x: index,
+      y,
+    })),
+  }));
+}
+
+export function estimateLineChartGridWidth(containerWidth) {
+  return Math.max(100, (containerWidth || 280) - LINE_CHART_Y_AXIS_LABEL_WIDTH);
+}
+
+/** Negative min shifts the first point right, clear of y-axis labels. */
+export function resolveLineChartNumericXMin(maxX, gridWidth) {
+  if (!maxX || !gridWidth || gridWidth <= LINE_CHART_PLOT_INSET_PX) return 0;
+  const min = -(LINE_CHART_PLOT_INSET_PX * maxX) / (gridWidth - LINE_CHART_PLOT_INSET_PX);
+  return Math.round(min * 1000) / 1000;
+}
+
+export function resolveLineChartNumericXBounds(categoryCount, containerWidth) {
+  const max = Math.max(categoryCount - 1, 1);
+  const gridWidth = estimateLineChartGridWidth(containerWidth);
+  const min = resolveLineChartNumericXMin(max, gridWidth);
+
+  return { min, max, tickAmount: max };
+}
+
+export function buildLineChartXAxis(categories, containerWidth) {
+  const borderColor = resolveDashboardCssColor("var(--border)");
+  const { min, max, tickAmount } = resolveLineChartNumericXBounds(
+    categories.length,
+    containerWidth
+  );
+  const gridWidth = estimateLineChartGridWidth(containerWidth);
+  const labelSlotWidth =
+    categories.length > 1 ? gridWidth / (categories.length - 1) : gridWidth;
+  const xAxisLabelHeight = resolveVerticalXAxisLabelHeight(categories, labelSlotWidth, {
+    minHeightPx: 22,
+    maxHeightPx: 56,
+  });
+
+  return {
+    type: "numeric",
+    min,
+    max,
+    tickAmount,
+    decimalsInFloat: 0,
+    floating: false,
+    labels: {
+      ...buildWrappedVerticalXAxisLabels(labelSlotWidth),
+      maxHeight: xAxisLabelHeight,
+      formatter: (value) => {
+        const index = Math.round(Number(value));
+        if (index < 0 || index >= categories.length) return "";
+        const label = categories[index] ?? "";
+        return formatWrappedChartLabel(label, labelSlotWidth);
+      },
+    },
+    axisBorder: { show: true, color: borderColor, height: 1, offsetX: 0, offsetY: 0 },
+    axisTicks: { show: true, height: 4, color: borderColor },
+    tooltip: { enabled: false },
+    crosshairs: {
+      show: true,
+      position: "front",
+      stroke: {
+        color: borderColor,
+        width: 1,
+        dashArray: 0,
+      },
+    },
+  };
+}
+
+export function buildLineChartYAxis({ min, max, tickAmount }) {
+  const borderColor = resolveDashboardCssColor("var(--border)");
+
+  return {
+    min,
+    max,
+    tickAmount,
+    forceNiceScale: false,
+    labels: {
+      style: { fontSize: "10px" },
+      formatter: (value) => Math.round(Number(value)),
+    },
+    axisBorder: { show: true, color: borderColor, width: 1, offsetX: 0, offsetY: 0 },
+    axisTicks: { show: true, width: 4, color: borderColor },
+  };
+}

--- a/digit-ui-esbuild/products/dashboard/src/config/mapHoverPresentation.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/mapHoverPresentation.js
@@ -1,0 +1,116 @@
+import { formatDimensionLabel } from "./labelFormat";
+import { formatWorkflowStatusLabel } from "./complaintsAtRiskPresentation";
+
+const PIN_SLA_LABELS = {
+  within: "Within SLA",
+  approaching: "Nearing breach",
+  breached: "Breached",
+};
+const PIN_CHANNEL_LABELS = {
+  web: "Web",
+  mobile: "Mobile app",
+  csc: "Counter (CSC)",
+  ivr: "IVR",
+  whatsapp: "WhatsApp",
+  sms: "SMS",
+  email: "Email",
+};
+const titleCaseWord = (v) =>
+  String(v ?? "").replace(/\b\w/g, (c) => c.toUpperCase());
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function metricRow(label, value) {
+  return `<div class="dashboard-map-hover-row"><span>${escapeHtml(label)}</span><strong>${escapeHtml(value)}</strong></div>`;
+}
+
+function formatPct(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return "—";
+  return `${Math.round(n)}%`;
+}
+
+/**
+ * Hover card for ward polygons — matches reference layout with layer highlight + totals.
+ */
+export function buildMapHoverTooltipHtml(ward = {}, { layerMode = "created", geoLevel = "District" } = {}) {
+  const label = ward.label || ward.wardCode || "Area";
+  const created = ward.created ?? ward.count ?? 0;
+  const open = ward.open ?? 0;
+  const resolved = ward.resolved ?? 0;
+  const openPct = ward.openPct ?? (created > 0 ? (open / created) * 100 : 0);
+  const resolvedPct = ward.resolvedPct ?? (created > 0 ? (resolved / created) * 100 : 0);
+
+  const rows = [];
+  if (layerMode === "open") {
+    rows.push(metricRow("% Open", formatPct(openPct)));
+  } else if (layerMode === "resolved") {
+    rows.push(metricRow("% Resolved", formatPct(resolvedPct)));
+  } else {
+    rows.push(metricRow("Created", created));
+  }
+
+  if (layerMode !== "created") {
+    rows.push(metricRow("Total created", created));
+    rows.push(metricRow("Open", open));
+    rows.push(metricRow("Resolved", resolved));
+  }
+
+  return `
+    <div class="dashboard-map-hover-card">
+      <div class="dashboard-map-hover-title">${escapeHtml(label)} · ${escapeHtml(geoLevel)}</div>
+      ${rows.join("")}
+    </div>
+  `;
+}
+
+/** Hover card for an individual complaint pin. */
+function formatPinDate(ms) {
+  const n = Number(ms);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  try {
+    return new Date(n).toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  } catch {
+    return null;
+  }
+}
+
+export function buildComplaintPinTooltipHtml(pin = {}) {
+  const title = pin.serviceCode ? formatDimensionLabel(pin.serviceCode) : "Complaint";
+  const status = pin.status ? formatWorkflowStatusLabel(pin.status) : "—";
+  const ward = pin.wardCode ? formatDimensionLabel(pin.wardCode) : null;
+  const filed = formatPinDate(pin.createdDate);
+  const channel = pin.source
+    ? PIN_CHANNEL_LABELS[String(pin.source).toLowerCase()] || titleCaseWord(pin.source)
+    : null;
+  const sla = pin.slaStatus
+    ? PIN_SLA_LABELS[String(pin.slaStatus).toLowerCase()] || titleCaseWord(pin.slaStatus)
+    : null;
+
+  return `
+    <div class="dashboard-map-hover-card dashboard-map-hover-card--pin">
+      <div class="dashboard-map-hover-title">${escapeHtml(title)}</div>
+      ${metricRow("Status", status)}
+      ${ward ? metricRow("Ward", ward) : ""}
+      ${filed ? metricRow("Filed", filed) : ""}
+      ${channel ? metricRow("Channel", channel) : ""}
+      ${sla ? metricRow("SLA", sla) : ""}
+      ${pin.serviceRequestId ? metricRow("ID", pin.serviceRequestId) : ""}
+      ${
+        pin.approximate
+          ? '<div class="dashboard-map-hover-note">Approximate location (ward centroid)</div>'
+          : ""
+      }
+    </div>
+  `;
+}

--- a/digit-ui-esbuild/products/dashboard/src/config/pieChartPresentation.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/pieChartPresentation.js
@@ -1,0 +1,144 @@
+/**
+ * Shared presentation for pie / donut charts (viz type: pie-chart).
+ */
+
+import { getChartColor, resolveDashboardCssColor } from "./chartColors";
+import { wrapChartLabelToLines } from "../utils/chartLabelWrap";
+
+export const PIE_CHART_VIEWBOX = { width: 320, height: 230 };
+export const PIE_CHART_CX = 160;
+export const PIE_CHART_CY = 118;
+export const PIE_CHART_OUTER_R = 72;
+export const PIE_CHART_INNER_R = 42;
+export const PIE_CHART_LABEL_R = 94;
+export const PIE_CHART_MIN_SWEEP_FOR_VALUE = 20;
+
+export function pieChartValueRadius() {
+  return (PIE_CHART_OUTER_R + PIE_CHART_INNER_R) / 2;
+}
+
+export function toPieRad(deg) {
+  return ((deg - 90) * Math.PI) / 180;
+}
+
+export function polarOnPie(cx, cy, r, deg) {
+  const rad = toPieRad(deg);
+  return { x: cx + r * Math.cos(rad), y: cy + r * Math.sin(rad) };
+}
+
+export function buildPieArcPath(cx, cy, rOuter, rInner, startDeg, endDeg) {
+  const sweep = endDeg - startDeg;
+  if (sweep >= 359.9) {
+    return buildFullDonutRingPath(cx, cy, rOuter, rInner);
+  }
+
+  const outerStart = polarOnPie(cx, cy, rOuter, startDeg);
+  const outerEnd = polarOnPie(cx, cy, rOuter, endDeg);
+  const innerEnd = polarOnPie(cx, cy, rInner, endDeg);
+  const innerStart = polarOnPie(cx, cy, rInner, startDeg);
+  const largeArc = sweep > 180 ? 1 : 0;
+
+  return [
+    `M ${outerStart.x.toFixed(2)} ${outerStart.y.toFixed(2)}`,
+    `A ${rOuter} ${rOuter} 0 ${largeArc} 1 ${outerEnd.x.toFixed(2)} ${outerEnd.y.toFixed(2)}`,
+    `L ${innerEnd.x.toFixed(2)} ${innerEnd.y.toFixed(2)}`,
+    `A ${rInner} ${rInner} 0 ${largeArc} 0 ${innerStart.x.toFixed(2)} ${innerStart.y.toFixed(2)}`,
+    "Z",
+  ].join(" ");
+}
+
+/** Full 360° donut ring — two semicircle arcs so start/end never coincide. */
+export function buildFullDonutRingPath(cx, cy, rOuter, rInner) {
+  const outerTop = polarOnPie(cx, cy, rOuter, 0);
+  const outerBottom = polarOnPie(cx, cy, rOuter, 180);
+  const innerTop = polarOnPie(cx, cy, rInner, 0);
+  const innerBottom = polarOnPie(cx, cy, rInner, 180);
+
+  return [
+    `M ${outerTop.x.toFixed(2)} ${outerTop.y.toFixed(2)}`,
+    `A ${rOuter} ${rOuter} 0 1 1 ${outerBottom.x.toFixed(2)} ${outerBottom.y.toFixed(2)}`,
+    `A ${rOuter} ${rOuter} 0 1 1 ${outerTop.x.toFixed(2)} ${outerTop.y.toFixed(2)}`,
+    `L ${innerTop.x.toFixed(2)} ${innerTop.y.toFixed(2)}`,
+    `A ${rInner} ${rInner} 0 1 0 ${innerBottom.x.toFixed(2)} ${innerBottom.y.toFixed(2)}`,
+    `A ${rInner} ${rInner} 0 1 0 ${innerTop.x.toFixed(2)} ${innerTop.y.toFixed(2)}`,
+    "Z",
+  ].join(" ");
+}
+
+export function pieLabelAnchor(midDeg) {
+  const cos = Math.cos(toPieRad(midDeg));
+  if (cos > 0.25) return "start";
+  if (cos < -0.25) return "end";
+  return "middle";
+}
+
+export function pieLabelOffset(midDeg) {
+  const cos = Math.cos(toPieRad(midDeg));
+  if (cos > 0.25) return 6;
+  if (cos < -0.25) return -6;
+  return 0;
+}
+
+export function resolvePieLabelLines(label, sweepDeg) {
+  const arcWidthPx = Math.max(
+    28,
+    ((sweepDeg / 180) * Math.PI * PIE_CHART_LABEL_R) * 0.88
+  );
+  return wrapChartLabelToLines(label, arcWidthPx, { maxLines: 3 });
+}
+
+export function normalizePieChartData(data = []) {
+  const total = data.reduce((sum, item) => sum + (Number(item.count) || 0), 0) || 1;
+  let cursor = 0;
+
+  return data.map((item, index) => {
+    const count = Number(item.count) || 0;
+    const color = resolveDashboardCssColor(item.color || getChartColor(index));
+    const sweep = (count / total) * 360;
+    const start = cursor;
+    const end = cursor + sweep;
+    const mid = start + sweep / 2;
+    cursor = end;
+
+    const valuePoint = polarOnPie(PIE_CHART_CX, PIE_CHART_CY, pieChartValueRadius(), mid);
+    const labelPoint = polarOnPie(PIE_CHART_CX, PIE_CHART_CY, PIE_CHART_LABEL_R, mid);
+    const anchor = pieLabelAnchor(mid);
+    const dx = pieLabelOffset(mid);
+    const hoverPoint = polarOnPie(PIE_CHART_CX, PIE_CHART_CY, PIE_CHART_OUTER_R + 8, mid);
+
+    return {
+      label: String(item.label ?? "Unknown"),
+      count,
+      color,
+      index,
+      mid,
+      sweep,
+      pct: Math.round((count / total) * 100),
+      path: buildPieArcPath(
+        PIE_CHART_CX,
+        PIE_CHART_CY,
+        PIE_CHART_OUTER_R,
+        PIE_CHART_INNER_R,
+        start,
+        end
+      ),
+      valueX: valuePoint.x,
+      valueY: valuePoint.y,
+      labelX: labelPoint.x + dx,
+      labelY: labelPoint.y,
+      labelAnchor: anchor,
+      hoverX: hoverPoint.x,
+      hoverY: hoverPoint.y,
+      showValue: sweep >= PIE_CHART_MIN_SWEEP_FOR_VALUE,
+      labelLines: resolvePieLabelLines(item.label, sweep),
+    };
+  });
+}
+
+export function getPieChartValueLabelColor() {
+  return (
+    resolveDashboardCssColor("var(--surface)") ||
+    resolveDashboardCssColor("var(--background)") ||
+    "#ffffff"
+  );
+}

--- a/digit-ui-esbuild/products/dashboard/src/config/stackedBarPresentation.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/stackedBarPresentation.js
@@ -1,0 +1,423 @@
+/**
+ * Shared presentation for stacked bar charts (vertical + horizontal).
+ */
+
+import {
+  buildHorizontalBarYAxisItem,
+  buildWrappedVerticalXAxisLabels,
+} from "./chartAxisLabels";
+import { resolveDashboardCssColor } from "./chartColors";
+import {
+  BAR_CHART_XAXIS_RESERVED_HEIGHT_PX,
+  buildBarChartGrid,
+  resolveBarCategorySlotWidth,
+  resolveBarChartColumnWidth,
+} from "./barChartPresentation";
+import { CHART_AXIS_WRAPPED_LABEL_MAX_LINES } from "../utils/chartLabelWrap";
+
+export const STACKED_BAR_LEGEND = {
+  position: "top",
+  horizontalAlign: "center",
+  fontSize: "11px",
+  markers: {
+    width: 10,
+    height: 10,
+    radius: 2,
+    strokeWidth: 0,
+    offsetX: -2,
+  },
+  itemMargin: { horizontal: 12, vertical: 0 },
+  offsetY: 2,
+};
+
+export function buildStackedBarLegend({ horizontal = false } = {}) {
+  return {
+    ...STACKED_BAR_LEGEND,
+    horizontalAlign: horizontal ? "center" : STACKED_BAR_LEGEND.horizontalAlign,
+    offsetY: horizontal ? 8 : 6,
+  };
+}
+
+/** Left margin inside the y-axis column before label text begins. */
+export const HORIZONTAL_BAR_LABEL_LEFT_MARGIN_PX = 8;
+/** Space between y-axis label text end and bar start (horizontal bar + stacked). */
+export const HORIZONTAL_BAR_LABEL_GAP_PX = 14;
+
+/** Y-axis label column sizing — minWidth grows to fit longest label line. */
+export const HORIZONTAL_BAR_LABEL_LAYOUT = {
+  min: 40,
+  maxCap: 140,
+  ratio: 0.28,
+  maxLines: CHART_AXIS_WRAPPED_LABEL_MAX_LINES,
+};
+
+export const HORIZONTAL_BAR_GRID_PADDING = {
+  left: 8,
+  right: 16,
+  top: 0,
+  bottom: 4,
+};
+
+/** Thinner bars leave more vertical room between category rows. */
+export const HORIZONTAL_STACKED_BAR_HEIGHT = "62%";
+
+export function buildHorizontalCategoryYAxis(categories, containerWidth) {
+  return buildHorizontalBarYAxisItem(categories, containerWidth, {
+    labelLayout: HORIZONTAL_BAR_LABEL_LAYOUT,
+    labelBarGapPx: HORIZONTAL_BAR_LABEL_GAP_PX,
+    labelLeftMarginPx: HORIZONTAL_BAR_LABEL_LEFT_MARGIN_PX,
+  });
+}
+
+export function buildStackedBarGrid({ horizontal = false, bottomPadding } = {}) {
+  if (!horizontal) {
+    return buildBarChartGrid({
+      left: 2,
+      right: 2,
+      top: 0,
+      bottom: bottomPadding ?? BAR_CHART_XAXIS_RESERVED_HEIGHT_PX,
+    });
+  }
+
+  return {
+    show: false,
+    padding: {
+      ...HORIZONTAL_BAR_GRID_PADDING,
+      top: -6,
+      bottom: bottomPadding ?? HORIZONTAL_BAR_GRID_PADDING.bottom,
+    },
+  };
+}
+
+export function buildHorizontalBarGrid({ bottomPadding } = {}) {
+  return buildStackedBarGrid({ horizontal: true, bottomPadding });
+}
+
+export function resolveStackedBarColors(colorTokens) {
+  return colorTokens.map((token) => resolveDashboardCssColor(token));
+}
+
+/** SLA bucket series — matches horizontal stacked bar reference palette. */
+export const SLA_STACKED_SERIES = [
+  { key: "within", label: "On track", color: "var(--chart-1)" },
+  { key: "approaching", label: "Nearing breach", color: "var(--chart-2)" },
+  { key: "breached", label: "Breached", color: "var(--status-breach)" },
+];
+
+/** Status mix per week — top workflow states. */
+export const STATUS_STACKED_SERIES = [
+  { key: "RESOLVED", label: "Resolved", color: "var(--status-resolved)" },
+  { key: "OPEN", label: "Open", color: "var(--chart-1)" },
+  { key: "INPROGRESS", label: "In progress", color: "var(--chart-2)" },
+  { key: "ESCALATED", label: "Escalated", color: "var(--chart-3)" },
+];
+
+/** Open complaints by subtype — current workflow stage (facts.application_status). */
+export const OPEN_COMPLAINT_WORKFLOW_SERIES = [
+  {
+    key: "PENDINGFORASSIGNMENT",
+    label: "Pending assignment",
+    color: "var(--chart-1)",
+  },
+  { key: "PENDINGATLME", label: "Assigned", color: "var(--chart-2)" },
+  {
+    key: "PENDINGFORREASSIGNMENT",
+    label: "Pending reassignment",
+    color: "var(--chart-3)",
+  },
+  {
+    key: "PENDINGATSUPERVISOR",
+    label: "Pending at supervisor",
+    color: "var(--chart-4)",
+  },
+];
+
+export const OPEN_COMPLAINT_WORKFLOW_STAGE_KEYS = new Set(
+  OPEN_COMPLAINT_WORKFLOW_SERIES.map((def) => def.key)
+);
+
+/** Resolution dwell by complaint sub-type — workflow stage stack (bottom → top). */
+export const RESOLUTION_DWELL_STACKED_SERIES = [
+  {
+    key: "PENDINGFORASSIGNMENT",
+    label: "Pending assignment",
+    color: "var(--chart-1)",
+  },
+  { key: "PENDINGATLME", label: "Assigned", color: "var(--chart-2)" },
+  {
+    key: "PENDINGFORREASSIGNMENT",
+    label: "Pending reassignment",
+    color: "var(--chart-3)",
+  },
+  { key: "RESOLVED", label: "Resolved", color: "var(--status-resolved)" },
+];
+
+export function formatStackedBarHours(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return "";
+  if (Math.abs(n - Math.round(n)) < 0.05) return `${Math.round(n)}h`;
+  return `${n.toFixed(1)}h`;
+}
+
+const STACKED_BAR_LABEL_CHAR_WIDTH_PX = 7;
+const STACKED_BAR_LABEL_HEIGHT_PX = 14;
+const STACKED_BAR_LABEL_PADDING_PX = 4;
+/** Extra vertical room — Apex centers with +height/2, which clips the bottom of glyphs. */
+const STACKED_BAR_LABEL_VERTICAL_INSET_PX = 8;
+const STACKED_BAR_SEGMENT_LABEL_OFFSET_Y = 7;
+
+function formatStackedBarSegmentValue(value, valueFormat) {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return "";
+  return valueFormat === "hours" ? formatStackedBarHours(n) : String(Math.round(n));
+}
+
+function readStackTotal(opts) {
+  const idx = opts.dataPointIndex;
+  const series = opts.w?.config?.series ?? [];
+  return series.reduce((sum, entry) => sum + (Number(entry.data?.[idx]) || 0), 0);
+}
+
+function labelBoxForText(text) {
+  return {
+    width: text.length * STACKED_BAR_LABEL_CHAR_WIDTH_PX + STACKED_BAR_LABEL_PADDING_PX,
+    height: STACKED_BAR_LABEL_HEIGHT_PX + STACKED_BAR_LABEL_PADDING_PX,
+  };
+}
+
+/** Hide segment labels that cannot fit — show full value or nothing. */
+export function shouldShowStackedSegmentLabel(value, opts, { horizontal, valueFormat } = {}) {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return false;
+
+  const text = formatStackedBarSegmentValue(n, valueFormat);
+  if (!text) return false;
+
+  const stackTotal = readStackTotal(opts);
+  if (stackTotal <= 0) return false;
+
+  const { width: labelW, height: labelH } = labelBoxForText(text);
+  const globals = opts.w?.globals ?? {};
+  const idx = opts.dataPointIndex;
+
+  if (horizontal) {
+    const niceMax = Number(globals.xAxisScale?.niceMax);
+    const gridWidth = Number(globals.gridWidth) || 0;
+    const barH = Number(globals.barHeight?.[idx]) || 0;
+    if (niceMax > 0 && gridWidth > 0 && barH > 0) {
+      const segmentW = (n / niceMax) * gridWidth;
+      return segmentW >= labelW && barH >= labelH;
+    }
+    return n / stackTotal >= 0.14;
+  }
+
+  const barH = Number(globals.barHeight?.[idx]) || 0;
+  if (barH > 0) {
+    const segmentH = (n / stackTotal) * barH;
+    const categories = Math.max(1, globals.labels?.length ?? 1);
+    const barW =
+      Number(globals.barWidth?.[idx]) ||
+      (Number(globals.gridWidth) || 0) / categories;
+    const minSegmentH = labelH + STACKED_BAR_LABEL_VERTICAL_INSET_PX * 2;
+    return segmentH >= minSegmentH && barW >= labelW;
+  }
+
+  return n / stackTotal >= 0.11;
+}
+
+function shouldShowStackedTotalLabel(total, opts, { horizontal, valueFormat } = {}) {
+  const n = Number(total);
+  if (!Number.isFinite(n) || n <= 0) return false;
+
+  const text = formatStackedBarSegmentValue(n, valueFormat);
+  if (!text) return false;
+
+  const { width: labelW, height: labelH } = labelBoxForText(text);
+  const globals = opts.w?.globals ?? {};
+  const idx = opts.dataPointIndex;
+
+  if (horizontal) {
+    const niceMax = Number(globals.xAxisScale?.niceMax);
+    const gridWidth = Number(globals.gridWidth) || 0;
+    const barH = Number(globals.barHeight?.[idx]) || 0;
+    if (niceMax > 0 && gridWidth > 0 && barH > 0) {
+      const barW = (n / niceMax) * gridWidth;
+      const roomAfterBar = Math.max(0, gridWidth - barW - 6);
+      return roomAfterBar >= labelW && barH >= labelH;
+    }
+    return true;
+  }
+
+  const niceMax = Number(globals.yAxisScale?.[0]?.niceMax ?? globals.maxY);
+  const gridHeight = Number(globals.gridHeight) || 0;
+  const barH = Number(globals.barHeight?.[idx]) || 0;
+  if (niceMax > 0 && gridHeight > 0 && barH > 0) {
+    const headroom = gridHeight - (n / niceMax) * gridHeight;
+    return headroom >= labelH + 8;
+  }
+
+  return true;
+}
+
+export function buildStackedBarPlotOptions({
+  horizontal = false,
+  valueFormat,
+  containerWidth = 0,
+  containerHeight = 0,
+  categoryCount = 0,
+} = {}) {
+  const totalLabelColor = resolveDashboardCssColor("var(--foreground)");
+  const formatTotal = (value, opts) => {
+    if (
+      opts &&
+      !shouldShowStackedTotalLabel(value, opts, { horizontal, valueFormat })
+    ) {
+      return "";
+    }
+    return formatStackedBarSegmentValue(value, valueFormat);
+  };
+
+  const slotWidth = horizontal
+    ? 0
+    : resolveBarCategorySlotWidth(categoryCount, containerWidth);
+  const columnWidth = horizontal ? undefined : resolveBarChartColumnWidth(slotWidth);
+  // Horizontal: cap bar thickness at the same max px as vertical bars (per-category
+  // slot height), so a 1-category chart doesn't render one giant bar.
+  const barHeight = horizontal
+    ? resolveBarChartColumnWidth(containerHeight / Math.max(1, categoryCount))
+    : undefined;
+
+  return {
+    bar: {
+      horizontal,
+      borderRadius: 4,
+      borderRadiusApplication: "end",
+      columnWidth,
+      barHeight,
+      dataLabels: {
+        hideOverflowingLabels: true,
+        position: "center",
+        orientation: "horizontal",
+        total: {
+          enabled: true,
+          hideOverflowingLabels: true,
+          offsetX: horizontal ? 6 : 0,
+          offsetY: horizontal ? 0 : -8,
+          style: {
+            fontSize: "11px",
+            fontWeight: 600,
+            color: totalLabelColor,
+          },
+          formatter: formatTotal,
+        },
+      },
+    },
+  };
+}
+
+export function buildStackedBarDataLabels({ valueFormat, horizontal = false } = {}) {
+  return {
+    enabled: true,
+    hideOverflowingLabels: true,
+    textAnchor: "middle",
+    offsetX: 0,
+    offsetY: horizontal ? 0 : STACKED_BAR_SEGMENT_LABEL_OFFSET_Y,
+    style: {
+      fontSize: "11px",
+      fontWeight: 600,
+      colors: ["#ffffff"],
+    },
+    background: {
+      enabled: false,
+    },
+    formatter(value, opts) {
+      if (!shouldShowStackedSegmentLabel(value, opts, { horizontal, valueFormat })) {
+        return "";
+      }
+      return formatStackedBarSegmentValue(value, valueFormat);
+    },
+  };
+}
+
+export function buildStackedBarXAxis({
+  horizontal,
+  categories,
+  containerWidth = 0,
+}) {
+  if (horizontal) {
+    return {
+      categories,
+      labels: { style: { fontSize: "10px" } },
+      axisBorder: { show: false },
+      axisTicks: { show: false },
+    };
+  }
+
+  const slotWidthPx = resolveBarCategorySlotWidth(categories.length, containerWidth);
+  const labelHeight = BAR_CHART_XAXIS_RESERVED_HEIGHT_PX;
+
+  return {
+    categories,
+    labels: {
+      ...buildWrappedVerticalXAxisLabels(slotWidthPx, { maxLines: 2 }),
+      maxHeight: labelHeight,
+    },
+    axisBorder: { show: false },
+    axisTicks: { show: false },
+  };
+}
+
+export function buildStackedBarYAxis({
+  horizontal,
+  categories = [],
+  containerWidth = 0,
+  valueFormat,
+} = {}) {
+  if (horizontal) {
+    return buildHorizontalCategoryYAxis(categories, containerWidth);
+  }
+  return {
+    labels: {
+      style: { fontSize: "10px" },
+      formatter: (val) =>
+        valueFormat === "hours" ? formatStackedBarHours(val) : Math.round(val),
+    },
+    axisBorder: { show: false },
+    axisTicks: { show: false },
+    min: 0,
+    forceNiceScale: true,
+  };
+}
+
+/** Dotted reference lines — vertical on horizontal bars, horizontal on vertical bars. */
+export function buildStackedBarAnnotations({ horizontal, referenceLines = [] } = {}) {
+  if (!referenceLines.length) return {};
+
+  const borderColor = resolveDashboardCssColor("var(--border)");
+
+  const lineStyle = (line) => ({
+    strokeDashArray: 4,
+    borderColor: line.color ? resolveDashboardCssColor(line.color) : borderColor,
+    borderWidth: 1,
+    opacity: 0.85,
+    label: {
+      show: false,
+    },
+  });
+
+  if (horizontal) {
+    return {
+      xaxis: referenceLines.map((line) => ({
+        x: line.value,
+        ...lineStyle(line),
+      })),
+    };
+  }
+
+  return {
+    yaxis: referenceLines.map((line) => ({
+      y: line.value,
+      ...lineStyle(line),
+    })),
+  };
+}

--- a/digit-ui-esbuild/products/dashboard/src/config/tablePresentation.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/tablePresentation.js
@@ -1,0 +1,154 @@
+/**
+ * Shared table presentation — threshold highlighting for dashboard data tables.
+ */
+
+/** @typedef {'breach' | 'watch' | 'good'} MetricTone */
+/** @typedef {{ higherIsBetter: boolean, watch: number, breach: number }} MetricThresholdConfig */
+/** @typedef {{ column: string, extremum?: 'min' | 'max', badge?: string }} TableThresholdConfig */
+
+export function evaluateMetricTone(value, config) {
+  if (!Number.isFinite(value) || !config) return null;
+  const { higherIsBetter, watch, breach } = config;
+
+  let v = value;
+  if (watch <= 1 && breach <= 1 && v > 1 && v <= 100) {
+    v = v / 100;
+  }
+
+  if (higherIsBetter) {
+    if (v < breach) return "breach";
+    if (v < watch) return "watch";
+    return "good";
+  }
+
+  if (v > breach) return "breach";
+  if (v > watch) return "watch";
+  return "good";
+}
+
+/** Breach and watch tones are stored; only breach is surfaced as cell/row chrome. */
+export function storeCellTone(cellTones, key, tone) {
+  if (tone === "breach" || tone === "watch") {
+    cellTones[key] = tone;
+  }
+}
+
+/**
+ * Red text/background scaled by severity (0–1), linear — no artificial floor.
+ */
+export function buildRedSeverityStyle(severity) {
+  const s = Math.min(1, Math.max(0, severity));
+  if (s <= 0) return null;
+  return {
+    "--sla-overrun-severity": String(s),
+  };
+}
+
+/**
+ * How far past a breach threshold a value is (0–1). Null when not in breach.
+ */
+export function breachSeverity(value, config) {
+  if (!Number.isFinite(value) || !config) return null;
+  const tone = evaluateMetricTone(value, config);
+  if (tone !== "breach") return null;
+
+  const { higherIsBetter, watch, breach } = config;
+  let v = value;
+  if (watch <= 1 && breach <= 1 && v > 1 && v <= 100) {
+    v = v / 100;
+  }
+
+  if (higherIsBetter) {
+    const floor = Math.max(0, breach - (watch - breach));
+    const span = breach - floor || 1;
+    return Math.min(1, (breach - v) / span);
+  }
+
+  const ceiling = breach + (breach - watch);
+  const span = ceiling - breach || 1;
+  return Math.min(1, (v - breach) / span);
+}
+
+/**
+ * Map watch/breach thresholds to 0–1 severity for unified slaOverrun cell styling.
+ */
+export function metricCellSeverity(value, config) {
+  if (!Number.isFinite(value) || !config) return null;
+  const tone = evaluateMetricTone(value, config);
+  if (!tone || tone === "good") return null;
+
+  if (tone === "breach") {
+    const breachSev = breachSeverity(value, config);
+    return breachSev != null ? Math.min(1, 0.45 + breachSev * 0.55) : 0.55;
+  }
+
+  const { higherIsBetter, watch, breach } = config;
+  let v = value;
+  if (watch <= 1 && breach <= 1 && v > 1 && v <= 100) {
+    v = v / 100;
+  }
+
+  if (higherIsBetter) {
+    const span = watch - breach || 1;
+    const depth = Math.min(1, Math.max(0, (watch - v) / span));
+    return 0.25 + depth * 0.2;
+  }
+
+  const span = breach - watch || 1;
+  const depth = Math.min(1, Math.max(0, (v - watch) / span));
+  return 0.25 + depth * 0.2;
+}
+
+export const TABLE_THRESHOLDS = {
+  "cl-table-workflow-stages": {
+    column: "avgDwellMs",
+    extremum: "max",
+    badge: "BOTTLENECK",
+  },
+  "cl-chart-workflow-stages": {
+    column: "avgDwellMs",
+    extremum: "max",
+    badge: "BOTTLENECK",
+  },
+  "cl-table-resolution": {
+    column: "ontimePct",
+    extremum: "min",
+    badge: "LOW",
+  },
+  "cl-table-locality": {
+    column: "ontimePct",
+    extremum: "min",
+    badge: "LOW",
+  },
+};
+
+export function getTableThreshold(widgetId) {
+  return TABLE_THRESHOLDS[widgetId] ?? null;
+}
+
+/**
+ * Highlight a single row at the min or max of `column` (needs at least 2 finite values).
+ * When multiple rows tie, only the first extremum row is flagged.
+ */
+export function annotateTableThresholds(rows, threshold) {
+  if (!threshold || !rows?.length || rows.length < 2) return rows;
+
+  const { column, extremum = "max", badge } = threshold;
+  const values = rows
+    .map((row) => row[column])
+    .filter((value) => Number.isFinite(value));
+  if (values.length < 2) return rows;
+
+  const target =
+    extremum === "min" ? Math.min(...values) : Math.max(...values);
+
+  const highlightIndex = rows.findIndex(
+    (row) => Number.isFinite(row[column]) && row[column] === target
+  );
+
+  return rows.map((row, index) => ({
+    ...row,
+    highlight: index === highlightIndex,
+    badge: index === highlightIndex && badge ? badge : null,
+  }));
+}

--- a/digit-ui-esbuild/products/dashboard/src/config/visualizationStyles.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/visualizationStyles.js
@@ -1,0 +1,280 @@
+/**
+ * Visualization registry — single source of truth for dashboard viz types,
+ * CSS class names, and grid chrome helpers.
+ *
+ * Visual rules live in styles/input.css (compiled to dashboard.css).
+ * Components import class names from here; do not duplicate dashboard-* strings.
+ */
+
+export const VIZ_TYPE = {
+  /** Value + optional delta + context (no sparkline). */
+  NUMBER_TILE: "number-tile-delta",
+  NUMBER_TILE_DELTA: "number-tile-delta",
+  NUMBER_TILE_SPARKLINE: "number-tile-sparkline",
+  BAR_CHART: "bar-chart",
+  HORIZONTAL_BAR: "horizontal-bar",
+  LINE_CHART: "line-chart",
+  PIE_CHART: "pie-chart",
+  DATA_TABLE: "data-table",
+  SLA_TOGGLE: "sla-toggle",
+  STACKED_BAR: "stacked-bar",
+  MAP: "map",
+  SLA_RISK_TABLE: "sla-risk-table",
+  HISTOGRAM: "histogram",
+  GAUGE: "gauge",
+};
+
+/** Shared chrome reused across viz types. */
+export const SHARED_CHROME = {
+  dragHandle: "dashboard-drag-handle",
+  dragHandleTitle: "dashboard-drag-handle-title",
+  dragHandleSubtitle: "dashboard-drag-handle-subtitle",
+  widgetSurface: "dashboard-widget-surface",
+  widgetRemoveBtn: "dashboard-widget-remove-btn",
+  /** Scope palette CSS variables onto portaled nodes (e.g. body-mounted tooltips). */
+  dashboardRoot: "dashboard-root",
+  defaultBody: "tw-flex tw-min-h-0 tw-flex-1 tw-flex-col tw-overflow-hidden tw-p-4",
+  chartTooltip: "dashboard-chart-tooltip",
+  chartTooltipFixed: "dashboard-chart-tooltip--fixed",
+  chartTooltipAnchored: "dashboard-chart-tooltip--anchored",
+  chartTooltipTitle: "dashboard-chart-tooltip-title",
+  chartTooltipRow: "dashboard-chart-tooltip-row",
+  chartScrollViewport: "dashboard-chart-scroll-viewport",
+  chartScrollViewportActive: "dashboard-chart-scroll-viewport--active",
+  chartScrollViewportVertical: "dashboard-chart-scroll-viewport--vertical",
+  chartScrollViewportHorizontal: "dashboard-chart-scroll-viewport--horizontal",
+  chartScrollCanvas: "dashboard-chart-scroll-canvas",
+};
+
+const BAR_CHART_STYLES = {
+  container: "dashboard-bar-chart",
+  body: "dashboard-bar-chart-body",
+  header: "dashboard-bar-chart-header",
+};
+
+const DATA_TABLE_STYLES = {
+  container: "dashboard-data-table",
+  shell: "dashboard-data-table-shell",
+  body: "dashboard-data-table-body",
+  header: "dashboard-data-table-header",
+  headerChrome: "dashboard-data-table-header-bar",
+  title: SHARED_CHROME.dragHandleTitle,
+  subtitle: SHARED_CHROME.dragHandleSubtitle,
+  scroll: "dashboard-table-scroll",
+  table: "dashboard-table",
+  tableEqualCols: "dashboard-table--equal-cols",
+  th: "dashboard-table-th",
+  thRight: "dashboard-table-th-right",
+  td: "dashboard-table-td",
+  tdRight: "dashboard-table-td-right",
+  colFixed: "dashboard-table-col-fixed",
+  rowHighlight: "dashboard-table-row-highlight",
+  primary: "dashboard-table-primary",
+  label: "dashboard-table-label",
+  badge: "dashboard-table-badge",
+  muted: "dashboard-table-muted",
+  empty: "dashboard-table-empty",
+  trendUp: "dashboard-table-trend-up",
+  trendDown: "dashboard-table-trend-down",
+  legendSwatch: "dashboard-data-table-legend-swatch",
+  legendLabel: "dashboard-data-table-legend-label",
+  valueEmphasis: "dashboard-data-table-value-emphasis",
+  thresholdCell: "dashboard-table-threshold-cell",
+  thresholdWatch: "dashboard-table-threshold-watch",
+  thresholdGood: "dashboard-table-threshold-good",
+  cellToneBreach: "dashboard-table-cell-tone--breach",
+  cellToneWatch: "dashboard-table-cell-tone--watch",
+  cellToneGood: "dashboard-table-cell-tone--good",
+  slaOverrun: "dashboard-table-sla-overrun",
+  statusTag: "dashboard-table-status-tag",
+  statusTagBreach: "dashboard-table-status-tag--breach",
+  statusTagWatch: "dashboard-table-status-tag--watch",
+  statusTagGood: "dashboard-table-status-tag--good",
+};
+
+/**
+ * CSS class names and layout flags per visualization type.
+ */
+export const VISUALIZATION_STYLES = {
+  [VIZ_TYPE.NUMBER_TILE_DELTA]: {
+    card: "dashboard-kpi-card",
+    cardMetric: "dashboard-kpi-card--metric",
+    cardDelta: "dashboard-kpi-card--delta",
+    title: "dashboard-kpi-title",
+    value: "dashboard-kpi-value",
+    valueRow: "dashboard-kpi-sparkline-value-row",
+    delta: "dashboard-kpi-sparkline-delta",
+    deltaMuted: "dashboard-kpi-sparkline-delta--muted",
+    deltaNeutral: "dashboard-kpi-sparkline-delta--neutral",
+    deltaPositive: "dashboard-kpi-sparkline-delta--positive",
+    deltaNegative: "dashboard-kpi-sparkline-delta--negative",
+    context: "dashboard-kpi-context",
+    valueLoading: "tw-animate-pulse",
+    valueUnavailable: "tw-text-muted-foreground",
+    listBody: "dashboard-kpi-list-body",
+    list: "dashboard-kpi-list",
+    listItem: "dashboard-kpi-list-item",
+  },
+  [VIZ_TYPE.NUMBER_TILE_SPARKLINE]: {
+    card: "dashboard-kpi-card--sparkline",
+    valueRow: "dashboard-kpi-sparkline-value-row",
+    delta: "dashboard-kpi-sparkline-delta",
+    deltaMuted: "dashboard-kpi-sparkline-delta--muted",
+    deltaNeutral: "dashboard-kpi-sparkline-delta--neutral",
+    deltaPositive: "dashboard-kpi-sparkline-delta--positive",
+    deltaNegative: "dashboard-kpi-sparkline-delta--negative",
+    sparkline: "dashboard-kpi-sparkline-chart",
+  },
+  [VIZ_TYPE.BAR_CHART]: BAR_CHART_STYLES,
+  [VIZ_TYPE.HISTOGRAM]: BAR_CHART_STYLES,
+  [VIZ_TYPE.HORIZONTAL_BAR]: {
+    container: "dashboard-horizontal-bar",
+    body: "dashboard-horizontal-bar-body",
+    header: "dashboard-horizontal-bar-header",
+  },
+  [VIZ_TYPE.STACKED_BAR]: {
+    container: "dashboard-stacked-bar",
+    body: "dashboard-stacked-bar-body",
+    header: "dashboard-stacked-bar-header",
+  },
+  [VIZ_TYPE.LINE_CHART]: {
+    container: "dashboard-line-chart",
+    body: "dashboard-line-chart-body",
+    header: "dashboard-line-chart-header",
+    headerBar: "dashboard-line-chart-header-bar",
+    widgetBody: "dashboard-line-chart-widget-body",
+    animating: "dashboard-line-chart-animating",
+    markerActive: "dashboard-line-chart-marker-active",
+  },
+  [VIZ_TYPE.PIE_CHART]: {
+    container: "dashboard-pie-chart",
+    body: "dashboard-pie-chart-body",
+    header: "dashboard-pie-chart-header",
+    slice: "dashboard-pie-slice",
+  },
+  [VIZ_TYPE.DATA_TABLE]: DATA_TABLE_STYLES,
+  [VIZ_TYPE.SLA_RISK_TABLE]: {
+    table: "dashboard-sla-risk-table",
+    link: "dashboard-sla-link",
+    linkButton: "dashboard-sla-link dashboard-sla-link--button",
+    breachPill: "dashboard-sla-breach-pill",
+    breachPillBreached: "dashboard-sla-breach-pill--breached",
+    breachPillNearing: "dashboard-sla-breach-pill--nearing",
+    overdue: "dashboard-sla-overdue",
+    statusPill: "dashboard-sla-status-pill",
+    statusPillAssigned: "dashboard-sla-status-pill--assigned",
+    statusPillOpen: "dashboard-sla-status-pill--open",
+    statusPillReopened: "dashboard-sla-status-pill--reopened",
+    statusPillInProgress: "dashboard-sla-status-pill--in-progress",
+    ownerName: "dashboard-data-table-owner-name",
+    slaCell: "dashboard-data-table-sla-cell",
+  },
+  [VIZ_TYPE.SLA_TOGGLE]: {
+    bodyBar: "dashboard-sla-toggle-body",
+  },
+  [VIZ_TYPE.MAP]: {
+    container: "dashboard-map",
+    body: "dashboard-map-body",
+    header: "dashboard-map-header",
+  },
+  [VIZ_TYPE.GAUGE]: {
+    body: "dashboard-gauge-body",
+    header: "dashboard-gauge-header",
+    value: "dashboard-gauge-value",
+    status: "dashboard-gauge-status",
+    track: "dashboard-gauge-track",
+    fill: "dashboard-gauge-fill",
+    targetLine: "dashboard-gauge-target-line",
+    targetMarker: "dashboard-gauge-target-marker",
+    targetTooltip: "dashboard-gauge-target-tooltip",
+  },
+};
+
+/** Grid layout behavior flags keyed by viz type. */
+export const VIZ_GRID_BEHAVIOR = {
+  [VIZ_TYPE.BAR_CHART]: { chartOverflowVisible: true },
+  [VIZ_TYPE.HORIZONTAL_BAR]: { chartOverflowVisible: true },
+  [VIZ_TYPE.LINE_CHART]: { chartOverflowVisible: true },
+  [VIZ_TYPE.PIE_CHART]: { chartOverflowVisible: true },
+  [VIZ_TYPE.STACKED_BAR]: { chartOverflowVisible: true },
+  [VIZ_TYPE.HISTOGRAM]: { chartOverflowVisible: true },
+  [VIZ_TYPE.HORIZONTAL_BAR]: { chartOverflowVisible: true },
+  [VIZ_TYPE.SLA_TOGGLE]: { chartOverflowVisible: true },
+  [VIZ_TYPE.MAP]: { chartOverflowVisible: true },
+};
+
+export function getVisualizationStyles(vizType) {
+  if (vizType === VIZ_TYPE.NUMBER_TILE) {
+    return VISUALIZATION_STYLES[VIZ_TYPE.NUMBER_TILE_DELTA];
+  }
+  return VISUALIZATION_STYLES[vizType] || null;
+}
+
+export function buildWidgetHeaderClassName(vizType) {
+  const styles = getVisualizationStyles(vizType);
+  if (!styles?.header) return SHARED_CHROME.dragHandle;
+  return `${SHARED_CHROME.dragHandle} ${styles.header}`;
+}
+
+export function getWidgetBodyClassName(vizType, { isTable = false } = {}) {
+  if (isTable) return DATA_TABLE_STYLES.body;
+  const styles = getVisualizationStyles(vizType);
+  return styles?.body ?? SHARED_CHROME.defaultBody;
+}
+
+export function getWidgetScrollClassName() {
+  return DATA_TABLE_STYLES.scroll;
+}
+
+export function isChartOverflowVisibleType(vizType) {
+  return VIZ_GRID_BEHAVIOR[vizType]?.chartOverflowVisible === true;
+}
+
+export function hasTypedGridChrome(vizType) {
+  const styles = getVisualizationStyles(vizType);
+  return Boolean(styles?.header || styles?.body);
+}
+
+export function getDataTableThClass(align = "left") {
+  const { th, thRight } = DATA_TABLE_STYLES;
+  return align === "right" ? `${th} ${thRight}` : th;
+}
+
+export function getDataTableTdClass(align = "left") {
+  const { td, tdRight } = DATA_TABLE_STYLES;
+  return align === "right" ? `${td} ${tdRight}` : td;
+}
+
+export function getSlaRiskStatusPillClass(status) {
+  const {
+    statusPill,
+    statusPillAssigned,
+    statusPillOpen,
+    statusPillReopened,
+    statusPillInProgress
+  } =
+    VISUALIZATION_STYLES[VIZ_TYPE.SLA_RISK_TABLE];
+  if (status === "assigned") {
+    return `${statusPill} ${statusPillAssigned}`;
+  }
+  if (status === "open") {
+    return `${statusPill} ${statusPillOpen}`;
+  }
+  if (status === "reopened") {
+    return `${statusPill} ${statusPillReopened}`;
+  }
+  return `${statusPill} ${statusPillInProgress}`;
+}
+
+export function getSlaRiskBreachPillClass(level) {
+  const { breachPill, breachPillBreached, breachPillNearing } =
+    VISUALIZATION_STYLES[VIZ_TYPE.SLA_RISK_TABLE];
+  if (level === "nearing") {
+    return `${breachPill} ${breachPillNearing}`;
+  }
+  return `${breachPill} ${breachPillBreached}`;
+}
+
+export { DATA_TABLE_STYLES };
+
+export const SLA_RISK_TABLE_STYLES = VISUALIZATION_STYLES[VIZ_TYPE.SLA_RISK_TABLE];

--- a/digit-ui-esbuild/products/dashboard/src/constants/layoutConfig.js
+++ b/digit-ui-esbuild/products/dashboard/src/constants/layoutConfig.js
@@ -1,0 +1,86 @@
+/**
+ * Grid geometry constants for the catalog-driven dashboard. After the inversion
+ * cutover the only consumers are the engine (AdminDashboard), the chart-size
+ * baseline (chartScrollBaseline / useScrollableChartSize), and useCatalogLayout —
+ * none of which use the old dash-case WIDGETS registry, DEFAULT_LAYOUT seed, or
+ * the per-widget helper functions. Those (and their Landscape-config imports) are
+ * removed; what remains is pure grid geometry keyed off nothing widget-specific.
+ */
+
+export const GRID_COLS = 12;
+export const KPI_ROW_HEIGHT = 52;
+export const GRID_MARGIN_Y = 16;
+
+/** Default grid size for full-width data tables (header + rows + updated stamp). */
+export const FULL_WIDTH_TABLE_GRID = {
+  w: 12,
+  h: 6,
+  minW: 6,
+  minH: 4,
+  maxW: 12,
+  maxH: 14,
+};
+
+/** One shared size contract per chart visualization (uniform min/max across charts). */
+export const UNIFORM_CHART_SIZE_CONSTRAINTS = {
+  minW: 4,
+  minH: 4,
+  maxW: 12,
+  maxH: 10,
+};
+
+/** Map widgets benefit from a taller resize range. */
+export const MAP_SIZE_CONSTRAINTS = {
+  minW: 4,
+  minH: 5,
+  maxW: 12,
+  maxH: 14,
+};
+
+/**
+ * Per-chart default sizes (keyed by the legacy dash-case scrollKey). The catalog
+ * engine's scrollKey is a kpiId, so chartScrollBaseline's lookups here resolve to
+ * undefined and it falls back to measuring the live viewport — this table is kept
+ * only to satisfy that import contract and as a baseline for any dash-case key.
+ */
+export const DEFAULT_CHART_LAYOUT = {
+  "cl-table-complaint-type-details": { x: 0, ...FULL_WIDTH_TABLE_GRID },
+  "cl-table-complaints-at-risk": { x: 0, ...FULL_WIDTH_TABLE_GRID },
+  "ep-table-employee-performance": { x: 0, ...FULL_WIDTH_TABLE_GRID },
+  "cl-chart-complaints-by-type": { x: 0, w: 6, h: 6, minW: 4, minH: 4, maxW: 12, maxH: 10 },
+  "cl-chart-departments": { x: 6, w: 6, h: 6, minW: 4, minH: 4, maxW: 12, maxH: 10 },
+  "cl-chart-department-resolution-rate": { x: 0, w: 6, h: 6, minW: 4, minH: 4, maxW: 12, maxH: 10 },
+  "cl-chart-department-flow-ratio": { x: 8, w: 4, h: 6, minW: 4, minH: 4, maxW: 12, maxH: 10 },
+  "cl-map-geography-choropleth": { x: 0, w: 8, h: 6, minW: 4, minH: 5, maxW: 12, maxH: 14 },
+  "cl-chart-over-time": { x: 0, w: 12, h: 6, minW: 4, minH: 4, maxW: 12, maxH: 10 },
+  "cl-chart-resolution-subtype": { x: 0, w: 6, h: 6, minW: 4, minH: 4, maxW: 12, maxH: 10 },
+  "cl-chart-officer-sla": { x: 0, w: 8, h: 6, minW: 4, minH: 4, maxW: 12, maxH: 10 },
+  "cl-chart-open-by-type": { x: 0, w: 6, h: 6, minW: 4, minH: 4, maxW: 12, maxH: 10 },
+  "cl-chart-open-by-channel": { x: 6, w: 4, h: 5, minW: 3, minH: 4, maxW: 6, maxH: 8 },
+  "cl-chart-complaints-by-age": { x: 0, w: 6, h: 6, minW: 4, minH: 4, maxW: 12, maxH: 10 },
+};
+
+function rectsOverlap(a, b) {
+  return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
+}
+
+function collidesAt(x, y, w, h, layout) {
+  const candidate = { x, y, w, h };
+  return layout.some((other) => rectsOverlap(candidate, other));
+}
+
+/** First grid slot (reading order) that fits w×h without overlapping any item. */
+export function findFirstOpenPosition(layout, w, h, cols = GRID_COLS) {
+  const maxY = layout.length ? Math.max(...layout.map((item) => item.y + item.h)) : 0;
+  const yLimit = maxY + h + 12;
+
+  for (let y = 0; y <= yLimit; y += 1) {
+    for (let x = 0; x <= cols - w; x += 1) {
+      if (!collidesAt(x, y, w, h, layout)) {
+        return { x, y };
+      }
+    }
+  }
+
+  return { x: 0, y: maxY };
+}

--- a/digit-ui-esbuild/products/dashboard/src/hooks/useCatalog.js
+++ b/digit-ui-esbuild/products/dashboard/src/hooks/useCatalog.js
@@ -1,0 +1,55 @@
+import { useState, useEffect } from 'react';
+import { fetchPack, fetchCatalog } from '../services/analyticsService';
+
+/**
+ * Fetches the tile catalog (viz schema) and pack (role-filtered tile list + default layout)
+ * from the backend. Does NOT fetch data — that stays in useDashboardData.
+ *
+ * Returns: { loading, kpis, pack, error }
+ * - kpis: object keyed by kpiId, value = full tile descriptor including viz
+ * - pack: { tiles, layout } — tiles already ceiling-filtered by server
+ * - error: string | null
+ *
+ * Falls back gracefully (error state + empty) if the endpoints don't exist yet —
+ * the existing hardcoded path is left intact.
+ */
+export function useCatalog(tenantId) {
+  const [state, setState] = useState({ loading: true, kpis: {}, pack: null, error: null });
+
+  useEffect(() => {
+    if (!tenantId) {
+      setState({ loading: false, kpis: {}, pack: null, error: 'No tenant' });
+      return;
+    }
+
+    let cancelled = false;
+    Promise.all([fetchPack(tenantId), fetchCatalog(tenantId)])
+      .then(([packRes, catalogRes]) => {
+        if (cancelled) return;
+        const allKpis = Object.fromEntries(
+          ((catalogRes && catalogRes.tiles) || []).map(k => [k.kpiId, k])
+        );
+        const packTiles = (packRes && packRes.tiles) || [];
+        const packLayout = (packRes && packRes.defaultLayout) || [];
+        // Gate: only tiles present in the catalog (visibleTo already applied server-side)
+        const filteredTiles = packTiles.filter(t => allKpis[t.kpiId]);
+        setState({
+          loading: false,
+          kpis: allKpis,
+          pack: { tiles: filteredTiles, layout: packLayout },
+          error: null,
+        });
+      })
+      .catch(err => {
+        if (!cancelled) {
+          // Graceful degradation — the /packs endpoint may not exist yet
+          console.warn('[useCatalog] Backend catalog not available, using local config fallback:', err.message);
+          setState({ loading: false, kpis: {}, pack: null, error: err.message });
+        }
+      });
+
+    return () => { cancelled = true; };
+  }, [tenantId]);
+
+  return state;
+}

--- a/digit-ui-esbuild/products/dashboard/src/hooks/useCatalogLayout.js
+++ b/digit-ui-esbuild/products/dashboard/src/hooks/useCatalogLayout.js
@@ -1,0 +1,240 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  GRID_COLS,
+  UNIFORM_CHART_SIZE_CONSTRAINTS,
+  MAP_SIZE_CONSTRAINTS,
+  FULL_WIDTH_TABLE_GRID,
+  findFirstOpenPosition,
+} from "../constants/layoutConfig";
+import { compactVertically } from "../utils/gridGeometry";
+
+/**
+ * useCatalogLayout — the catalog-world layout hook (kpiId-keyed).
+ *
+ * The legacy useDashboardLayout is keyed on dash-case widget-ids and carries a
+ * decade of migration/legacy-id machinery for the inline-query dashboard. The
+ * inverted dashboard renders straight from the MDMS catalog (snake_case kpiIds)
+ * and seeds its grid from the DashboardPack layout, so it gets a fresh, far
+ * smaller hook that speaks kpiIds and reuses only the pure geometry/collision
+ * helpers (GRID_COLS, findFirstOpenPosition, compactVertically, swapOnDrop).
+ *
+ * Inputs:
+ *   kpis        — { [kpiId]: def }  (catalog map; used for size-constraint by viz.kind)
+ *   packLayout  — [{ kpiId, x, y, w, h }]  (DashboardPack defaultLayout — the seed)
+ *
+ * Returns the same interaction surface AdminDashboard's grid expects:
+ *   { layout, onDragStop, onResizeStop, onLayoutChange, resetLayout,
+ *     removeWidgetFromLayout, addKpiToLayout, visibleLayoutIds }
+ * where every layout item.i is a kpiId.
+ */
+
+const STORAGE_KEY = "ccrs.dashboard.catalog-layout.v1";
+
+const CARD_KINDS = new Set([
+  "number-tile-delta",
+  "number-tile",
+  "scalar",
+  "number-tile-sparkline",
+  "sparkline-card",
+]);
+
+const KPI_CARD_CONSTRAINTS = { minW: 2, minH: 2, maxW: 6, maxH: 3 };
+const LIST_CONSTRAINTS = { minW: 3, minH: 4, maxW: 12, maxH: 12 };
+
+/** Map a tile's viz.kind to its grid size constraints (the single id-space seam). */
+export function sizeConstraintsForKpi(kpiId, kpis) {
+  const kind = kpis?.[kpiId]?.viz?.kind;
+  if (CARD_KINDS.has(kind)) return KPI_CARD_CONSTRAINTS;
+  switch (kind) {
+    case "map":
+    case "choropleth-map":
+      return MAP_SIZE_CONSTRAINTS;
+    case "sla-risk-table":
+    case "table":
+    case "data-table":
+      return {
+        minW: FULL_WIDTH_TABLE_GRID.minW,
+        minH: FULL_WIDTH_TABLE_GRID.minH,
+        maxW: FULL_WIDTH_TABLE_GRID.maxW,
+        maxH: FULL_WIDTH_TABLE_GRID.maxH,
+      };
+    case "rankedList":
+    case "dow":
+      return LIST_CONSTRAINTS;
+    default:
+      return UNIFORM_CHART_SIZE_CONSTRAINTS; // bar / stacked-bar / horizontal-bar / line / pie
+  }
+}
+
+/** Default size for a freshly-added tile, by kind. */
+function defaultSizeForKpi(kpiId, kpis) {
+  const c = sizeConstraintsForKpi(kpiId, kpis);
+  const kind = kpis?.[kpiId]?.viz?.kind;
+  if (CARD_KINDS.has(kind)) return { w: 2, h: 2 };
+  if (kind === "map") return { w: 8, h: 6 };
+  if (kind === "sla-risk-table" || kind === "table" || kind === "data-table")
+    return { w: 12, h: 5 };
+  return { w: Math.max(c.minW, 6), h: Math.max(c.minH, 6) };
+}
+
+function clampNum(v, min, max, fallback) {
+  const n = Number(v);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(max, Math.max(min, n));
+}
+
+/**
+ * Normalise a layout item to finite, in-bounds geometry. A malformed MDMS pack
+ * or stale localStorage entry can carry NaN / out-of-range w/h/x/y; RGL throws or
+ * produces impossible resize bounds on those, so clamp every field to the tile's
+ * viz.kind constraints and the grid width. Item must already carry `i` (kpiId).
+ */
+function normalizeItem(item, kpis) {
+  const c = sizeConstraintsForKpi(item.i, kpis);
+  const w = clampNum(item.w, c.minW, c.maxW, c.minW);
+  const h = clampNum(item.h, c.minH, c.maxH, c.minH);
+  const x = Math.min(clampNum(item.x, 0, GRID_COLS - 1, 0), GRID_COLS - w);
+  const y = clampNum(item.y, 0, Number.MAX_SAFE_INTEGER, 0);
+  return { i: item.i, x, y, w, h, ...c };
+}
+
+/** Seed layout from the pack, normalised, kpiId-keyed. */
+function buildSeedLayout(packLayout, kpis) {
+  return (packLayout || [])
+    .filter((item) => kpis[item.kpiId])
+    .map((item) =>
+      normalizeItem({ i: item.kpiId, x: item.x, y: item.y, w: item.w, h: item.h }, kpis)
+    );
+}
+
+/**
+ * Read the saved layout. Returns `null` ONLY when there is no stored layout (key
+ * absent / unparseable); an intentionally-empty array (user cleared every tile)
+ * is returned as `[]` so the seed does not re-add the removed tiles on reload.
+ */
+function readSaved() {
+  try {
+    const raw = window.localStorage?.getItem(STORAGE_KEY);
+    if (raw == null) return null;
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function persist(layout) {
+  try {
+    window.localStorage?.setItem(STORAGE_KEY, JSON.stringify(layout));
+  } catch {
+    /* ignore quota/serialisation errors — layout is non-critical state */
+  }
+}
+
+export function useCatalogLayout(kpis, packLayout) {
+  const seed = useMemo(() => buildSeedLayout(packLayout, kpis), [packLayout, kpis]);
+
+  const [layout, setLayout] = useState([]);
+
+  // Seed once the catalog + pack resolve. Prefer a SAVED layout (the user's
+  // arrangement, including an intentional empty one) over the pack seed; drop
+  // tiles the role can no longer see and re-normalise geometry so a viz.kind
+  // change or a malformed entry can't leave a stale/invalid clamp. Only seeds
+  // from the pack when there is no saved layout at all (saved === null). A saved
+  // layout is taken as-is — newly-published pack tiles are added via the picker
+  // or a layout reset, not auto-injected.
+  useEffect(() => {
+    if (!seed.length) return;
+    const saved = readSaved();
+    const source = saved !== null ? saved : seed;
+    const reconciled = source
+      .filter((item) => kpis[item.i])
+      .map((item) => normalizeItem(item, kpis));
+    setLayout(reconciled);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [seed]);
+
+  // Debounced persistence — onLayoutChange fires on every drag/resize tick.
+  const persistTimerRef = useRef(null);
+  const persistDebounced = useCallback((lay) => {
+    if (persistTimerRef.current) clearTimeout(persistTimerRef.current);
+    persistTimerRef.current = setTimeout(() => persist(lay), 300);
+  }, []);
+
+  /**
+   * The single source of layout truth during interaction. With compactType=
+   * "vertical" (set on the grid), react-grid-layout owns collision + compaction:
+   * dragging a tile pushes the others and the layout RGL emits here is already the
+   * flowed, non-overlapping result. We accept it verbatim — re-merging only the
+   * per-item min/max constraints RGL strips — and feed it straight back as the
+   * controlled prop. Because the prop we return equals RGL's internal state,
+   * getDerivedStateFromProps never has a stale copy to discard, so there is no
+   * snap-back (this replaces the old swapOnDrop + compactVertically + rAF/moved
+   * machinery that fought RGL's controlled-sync model).
+   */
+  const onLayoutChange = useCallback(
+    (next) => {
+      setLayout((prev) => {
+        const merged = next.map((item) => {
+          const existing = prev.find((p) => p.i === item.i);
+          return existing
+            ? { ...existing, x: item.x, y: item.y, w: item.w, h: item.h }
+            : item;
+        });
+        persistDebounced(merged);
+        return merged;
+      });
+    },
+    [persistDebounced]
+  );
+
+  const removeWidgetFromLayout = useCallback(
+    (kpiId) => {
+      setLayout((prev) => {
+        const next = compactVertically(prev.filter((item) => item.i !== kpiId));
+        persist(next);
+        return next;
+      });
+    },
+    []
+  );
+
+  const addKpiToLayout = useCallback(
+    (kpiId, position) => {
+      if (!kpis[kpiId]) return;
+      setLayout((prev) => {
+        if (prev.some((item) => item.i === kpiId)) return prev; // no duplicates
+        const c = sizeConstraintsForKpi(kpiId, kpis);
+        const { w, h } = defaultSizeForKpi(kpiId, kpis);
+        const pos = position || findFirstOpenPosition(prev, w, h, GRID_COLS);
+        const next = compactVertically([
+          ...prev,
+          { i: kpiId, x: pos.x, y: pos.y, w, h, ...c },
+        ]);
+        persist(next);
+        return next;
+      });
+    },
+    [kpis]
+  );
+
+  const resetLayout = useCallback(() => {
+    const fresh = buildSeedLayout(packLayout, kpis);
+    setLayout(fresh);
+    persist(fresh);
+  }, [packLayout, kpis]);
+
+  const visibleLayoutIds = useMemo(() => layout.map((item) => item.i), [layout]);
+
+  return {
+    layout,
+    onLayoutChange, // RGL (compactType="vertical") drives drag/resize natively
+    resetLayout,
+    removeWidgetFromLayout,
+    addKpiToLayout,
+    addWidgetToLayout: addKpiToLayout, // charts + cards share one add path now
+    visibleLayoutIds,
+  };
+}
+
+export default useCatalogLayout;

--- a/digit-ui-esbuild/products/dashboard/src/hooks/useChartContainerSize.js
+++ b/digit-ui-esbuild/products/dashboard/src/hooks/useChartContainerSize.js
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useState } from "react";
+
+export function useChartContainerSize() {
+  const [containerNode, setContainerNode] = useState(null);
+  const [containerSize, setContainerSize] = useState({ width: 0, height: 0 });
+
+  // Callback ref so ResizeObserver attaches when the container mounts later
+  // (e.g. table/bar toggle in ComplaintsBySlaWidget).
+  const containerRef = useCallback((node) => {
+    setContainerNode(node);
+  }, []);
+
+  useEffect(() => {
+    if (!containerNode) {
+      setContainerSize({ width: 0, height: 0 });
+      return undefined;
+    }
+
+    const updateSize = () => {
+      const { width, height } = containerNode.getBoundingClientRect();
+      setContainerSize({
+        width: Math.floor(width),
+        height: Math.floor(height),
+      });
+    };
+
+    updateSize();
+    const observer = new ResizeObserver(updateSize);
+    observer.observe(containerNode);
+
+    // react-grid-layout resizes the grid item wrapper; observing it keeps charts
+    // in sync during horizontal drag-resize inside nested flex chrome (e.g. SLA toggle).
+    const gridItem = containerNode.closest(".react-grid-item");
+    if (gridItem && gridItem !== containerNode) {
+      observer.observe(gridItem);
+    }
+
+    return () => observer.disconnect();
+  }, [containerNode]);
+
+  return { containerRef, containerSize, containerNode };
+}

--- a/digit-ui-esbuild/products/dashboard/src/hooks/useDashboardFilters.js
+++ b/digit-ui-esbuild/products/dashboard/src/hooks/useDashboardFilters.js
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  clearDashboardFilters,
+  loadDashboardFilters,
+  persistDashboardFilters,
+  reconcileFiltersWithOptions,
+  resolveSubMetricId as resolveSubMetricIdForMetric,
+} from "../config/dashboardFilters";
+
+export function useDashboardFilters() {
+  const [filters, setFilters] = useState(loadDashboardFilters);
+  const [optionLists, setOptionLists] = useState(null);
+
+  useEffect(() => {
+    if (!optionLists) return;
+    setFilters((prev) => {
+      const next = reconcileFiltersWithOptions(prev, optionLists);
+      if (next !== prev) {
+        persistDashboardFilters(next, optionLists);
+      }
+      return next;
+    });
+  }, [optionLists]);
+
+  const applyFilterOptions = useCallback((filterOptions) => {
+    setOptionLists(filterOptions);
+  }, []);
+
+  const setFilter = useCallback(
+    (groupId, value) => {
+      setFilters((prev) => {
+        const next = { ...prev, [groupId]: value };
+        if (groupId === "dateFrom" || groupId === "dateTo") {
+          next.dateRangeActive = true;
+        }
+        persistDashboardFilters(next, optionLists);
+        return next;
+      });
+    },
+    [optionLists]
+  );
+
+  const clearFilters = useCallback(() => {
+    const next = clearDashboardFilters();
+    persistDashboardFilters(next, optionLists);
+    setFilters(next);
+  }, [optionLists]);
+
+  const resolveSubMetricId = useCallback(
+    (metric) => resolveSubMetricIdForMetric(metric, filters),
+    [filters]
+  );
+
+  return {
+    filters,
+    setFilter,
+    clearFilters,
+    applyFilterOptions,
+    resolveSubMetricId,
+  };
+}

--- a/digit-ui-esbuild/products/dashboard/src/hooks/useFilterOptions.js
+++ b/digit-ui-esbuild/products/dashboard/src/hooks/useFilterOptions.js
@@ -1,0 +1,134 @@
+import { useEffect, useState } from "react";
+import { runBatchQueries } from "../services/analyticsService";
+import { fetchComplaintTypeIndex } from "../services/complaintHierarchyService";
+import { formatDimensionLabel } from "../config/labelFormat";
+import {
+  COMPLAINT_TYPE_OPTIONS,
+  GEOGRAPHY_OPTIONS,
+} from "../config/globalFilterGroups";
+
+/**
+ * Fetches the global filter dropdown options (wards + complaint types) as
+ * server-scoped distincts: one inline batch _query on the facts grain, so the
+ * backend's ABAC (PrincipalScopeResolver department/ward scoping) applies —
+ * a Water-dept supervisor only ever sees water complaint types.
+ *
+ * The analytics distinct decides WHICH codes appear; the MDMS complaint
+ * hierarchy (RAINMAKER-PGR.ComplaintHierarchy, fetched in parallel) supplies
+ * the complaint-type display names and root-category grouping. Codes missing
+ * from the master (stray/QA data) — and everything when the hierarchy fetch
+ * fails — fall back to formatDimensionLabel (the shared dimension humanizer)
+ * with no group. Ward labels stay humanized codes (localized ward naming is a
+ * separate follow-up).
+ *
+ * Returns: { options, loading }
+ * - options: { geography: [{id,label}], complaintType: [{id,label,group?}] } —
+ *   each list prepended with its "all" sentinel; a key is omitted when its
+ *   query failed or returned nothing, so DashboardFilters falls back to the
+ *   placeholder list for that select. null until loaded / on total failure.
+ * - `group` (root complaint-category display name) is additive: every consumer
+ *   of the flat {id,label} contract (sanitizeFilters / reconcile / header
+ *   subtitle) keeps working; DashboardFilters groups at render time.
+ */
+const OPTION_QUERIES = {
+  complaintTypes: {
+    grain: "facts",
+    window: { name: "all" },
+    dimensions: ["service_code"],
+    measures: [{ name: "n", agg: "count" }],
+    limit: 300,
+  },
+  wards: {
+    grain: "facts",
+    window: { name: "all" },
+    dimensions: ["ward_code"],
+    measures: [{ name: "n", agg: "count" }],
+    limit: 300,
+  },
+};
+
+function toOptionList(rows, codeKey, sentinelOptions, decorate) {
+  const options = (rows || [])
+    .map((row) => String(row?.[codeKey] ?? "").trim())
+    .filter(Boolean) // live data carries blank-code rows — drop them
+    .map((code) => {
+      const extra = decorate?.(code);
+      return {
+        id: code,
+        label: extra?.label || formatDimensionLabel(code),
+        ...(extra?.group && { group: extra.group }),
+      };
+    })
+    .sort((a, b) => {
+      // Grouped options first (grouped alphabetically), stray/ungrouped codes
+      // last — group-contiguous so the render pass can emit <optgroup> runs.
+      if (!!a.group !== !!b.group) return a.group ? -1 : 1;
+      return (
+        (a.group ?? "").localeCompare(b.group ?? "") ||
+        a.label.localeCompare(b.label)
+      );
+    });
+  return options.length ? [...sentinelOptions, ...options] : null;
+}
+
+/** Adapt the hierarchy index into toOptionList's decorate callback. */
+function toComplaintTypeDecorator(hierarchyIndex) {
+  if (!hierarchyIndex) return null;
+  return (code) => {
+    const entry = hierarchyIndex.get(code);
+    if (!entry) return null; // stray/QA code — humanized fallback, no group
+    return {
+      label: entry.label,
+      // A code that IS its own root (top-level category) stays ungrouped —
+      // a one-item optgroup echoing the option's own label is just noise.
+      ...(entry.rootCode !== code && entry.rootLabel && { group: entry.rootLabel }),
+    };
+  };
+}
+
+export function useFilterOptions() {
+  const [state, setState] = useState({ options: null, loading: true });
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([
+      runBatchQueries(OPTION_QUERIES),
+      // Resolves null on any failure (never rejects) — labels then fall back
+      // to the humanizer and the list stays flat, exactly the old behavior.
+      fetchComplaintTypeIndex(),
+    ])
+      .then(([res, hierarchyIndex]) => {
+        if (cancelled) return;
+        const results = res?.results || {};
+        // Per-entry failures come back as { error } (no rows) — treated as empty.
+        const complaintType = toOptionList(
+          results.complaintTypes?.rows,
+          "service_code",
+          COMPLAINT_TYPE_OPTIONS,
+          toComplaintTypeDecorator(hierarchyIndex)
+        );
+        const geography = toOptionList(
+          results.wards?.rows,
+          "ward_code",
+          GEOGRAPHY_OPTIONS
+        );
+        const options = {
+          ...(geography && { geography }),
+          ...(complaintType && { complaintType }),
+        };
+        setState({
+          options: Object.keys(options).length ? options : null,
+          loading: false,
+        });
+      })
+      .catch(() => {
+        // Never block the dashboard — the selects keep their placeholder lists.
+        if (!cancelled) setState({ options: null, loading: false });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return state;
+}

--- a/digit-ui-esbuild/products/dashboard/src/hooks/useMapResize.js
+++ b/digit-ui-esbuild/products/dashboard/src/hooks/useMapResize.js
@@ -1,0 +1,34 @@
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * Keeps a Leaflet map in sync when the dashboard grid item or map shell resizes.
+ */
+export function useMapResize(mapRef, containerRef) {
+  const [resizeToken, setResizeToken] = useState(0);
+
+  const invalidateMap = useCallback(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    map.invalidateSize({ animate: false, pan: false });
+    setResizeToken((token) => token + 1);
+  }, [mapRef]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return undefined;
+
+    const observer = new ResizeObserver(() => {
+      window.requestAnimationFrame(invalidateMap);
+    });
+
+    observer.observe(container);
+    const gridItem = container.closest(".react-grid-item");
+    if (gridItem && gridItem !== container) {
+      observer.observe(gridItem);
+    }
+
+    return () => observer.disconnect();
+  }, [containerRef, invalidateMap]);
+
+  return { resizeToken, invalidateMap };
+}

--- a/digit-ui-esbuild/products/dashboard/src/hooks/useScrollableChartSize.js
+++ b/digit-ui-esbuild/products/dashboard/src/hooks/useScrollableChartSize.js
@@ -1,0 +1,167 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  loadChartScrollBaseline,
+  resolveDefaultChartAreaPx,
+  resolveHorizontalBarChartHeight,
+  resolveMinChartAreaHeightPx,
+  resolveMinChartAreaPx,
+  resolveVerticalBarChartWidth,
+  saveChartScrollBaseline,
+} from "../utils/chartScrollBaseline";
+import { useChartContainerSize } from "./useChartContainerSize";
+
+/**
+ * Keeps chart render size at least the default / peak dimensions.
+ * When the widget viewport shrinks, the chart does not scale down — the viewport scrolls.
+ * Baseline is persisted per widget so refresh keeps scroll behaviour.
+ *
+ * @param {'xy' | 'x' | 'y'} [scrollAxis='xy'] — `x` = horizontal only (vertical bar charts); `y` = vertical only (horizontal bar charts).
+ */
+export function useScrollableChartSize({
+  scrollKey,
+  scrollAxis = "xy",
+  categoryCount = 0,
+  minContentWidth = 0,
+} = {}) {
+  const verticalOnly = scrollAxis === "y";
+  const horizontalOnly = scrollAxis === "x";
+  const { containerRef: viewportRef, containerSize: viewport, containerNode } =
+    useChartContainerSize();
+  const [baseline, setBaseline] = useState(() =>
+    scrollKey ? loadChartScrollBaseline(scrollKey) : null
+  );
+
+  const minChartWidth = useMemo(() => {
+    if (!scrollKey || !containerNode) return 0;
+    const layoutElement = containerNode.closest(".dashboard-grid-layout");
+    return resolveMinChartAreaPx(scrollKey, layoutElement) ?? 0;
+  }, [scrollKey, containerNode]);
+
+  const minChartHeight = useMemo(() => {
+    if (!scrollKey) return 0;
+    return resolveMinChartAreaHeightPx(scrollKey) ?? 0;
+  }, [scrollKey]);
+
+  const contentMinimum = useMemo(() => {
+    if (verticalOnly || horizontalOnly) {
+      return { width: 0, height: 0 };
+    }
+    return { width: minContentWidth, height: 0 };
+  }, [horizontalOnly, minContentWidth, verticalOnly]);
+
+  useEffect(() => {
+    if (viewport.width <= 0 || viewport.height <= 0) return;
+
+    const layoutElement = containerNode?.closest(".dashboard-grid-layout");
+    const defaultArea = scrollKey
+      ? resolveDefaultChartAreaPx(scrollKey, layoutElement)
+      : null;
+
+    const targetBaseline = {
+      width: verticalOnly || horizontalOnly
+        ? viewport.width
+        : Math.max(
+            defaultArea?.width ?? 0,
+            contentMinimum.width,
+            scrollKey ? 0 : viewport.width
+          ),
+      height: horizontalOnly || verticalOnly
+        ? viewport.height
+        : Math.max(
+            defaultArea?.height ?? 0,
+            contentMinimum.height,
+            scrollKey ? 0 : viewport.height
+          ),
+    };
+
+    setBaseline((prev) => {
+      const next = scrollKey
+        ? targetBaseline
+        : {
+            width: Math.max(prev?.width ?? 0, targetBaseline.width),
+            height: Math.max(prev?.height ?? 0, targetBaseline.height),
+          };
+
+      if (
+        scrollKey &&
+        (next.width !== prev?.width || next.height !== prev?.height)
+      ) {
+        saveChartScrollBaseline(scrollKey, next);
+      }
+
+      return next;
+    });
+  }, [
+    containerNode,
+    contentMinimum.height,
+    contentMinimum.width,
+    scrollKey,
+    horizontalOnly,
+    verticalOnly,
+    viewport.height,
+    viewport.width,
+  ]);
+
+  const chartSize = useMemo(() => {
+    if (verticalOnly) {
+      const height = resolveHorizontalBarChartHeight(
+        categoryCount,
+        viewport.height,
+        minChartHeight
+      );
+      return { width: viewport.width, height };
+    }
+
+    if (horizontalOnly) {
+      const width = resolveVerticalBarChartWidth(
+        categoryCount,
+        viewport.width,
+        minChartWidth
+      );
+      return { width, height: viewport.height };
+    }
+
+    const width = Math.max(
+      viewport.width,
+      baseline?.width ?? 0,
+      contentMinimum.width
+    );
+    const height = Math.max(
+      viewport.height,
+      baseline?.height ?? 0,
+      contentMinimum.height
+    );
+
+    return { width, height };
+  }, [
+    baseline?.height,
+    baseline?.width,
+    categoryCount,
+    contentMinimum.height,
+    contentMinimum.width,
+    horizontalOnly,
+    minChartHeight,
+    minChartWidth,
+    verticalOnly,
+    viewport.height,
+    viewport.width,
+  ]);
+
+  const isScrollable = verticalOnly
+    ? chartSize.height > viewport.height + 1
+    : horizontalOnly
+      ? chartSize.width > viewport.width + 1
+      : chartSize.width > viewport.width + 1 ||
+        chartSize.height > viewport.height + 1;
+
+  const isReady = chartSize.width > 0 && chartSize.height > 0;
+
+  return {
+    viewportRef,
+    viewport,
+    chartSize,
+    isScrollable,
+    isReady,
+    scrollAxis,
+  };
+}

--- a/digit-ui-esbuild/products/dashboard/src/hooks/useSubtleScrollbar.js
+++ b/digit-ui-esbuild/products/dashboard/src/hooks/useSubtleScrollbar.js
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useRef } from "react";
+
+const SCROLL_IDLE_MS = 700;
+export const SUBTLE_SCROLL_ACTIVE_CLASS = "dashboard-subtle-scroll--active";
+
+/**
+ * Adds a transient class while the element is scrolling so scrollbar chrome can fade in/out.
+ */
+export default function useSubtleScrollbar(enabled = true) {
+  const cleanupRef = useRef(null);
+
+  const setRef = useCallback(
+    (node) => {
+      if (cleanupRef.current) {
+        cleanupRef.current();
+        cleanupRef.current = null;
+      }
+
+      if (!enabled || !node) return;
+
+      let timer;
+      const onScroll = () => {
+        node.classList.add(SUBTLE_SCROLL_ACTIVE_CLASS);
+        clearTimeout(timer);
+        timer = setTimeout(() => {
+          node.classList.remove(SUBTLE_SCROLL_ACTIVE_CLASS);
+        }, SCROLL_IDLE_MS);
+      };
+
+      node.addEventListener("scroll", onScroll, { passive: true });
+      cleanupRef.current = () => {
+        node.removeEventListener("scroll", onScroll);
+        clearTimeout(timer);
+        node.classList.remove(SUBTLE_SCROLL_ACTIVE_CLASS);
+      };
+    },
+    [enabled]
+  );
+
+  useEffect(
+    () => () => {
+      cleanupRef.current?.();
+    },
+    []
+  );
+
+  return setRef;
+}

--- a/digit-ui-esbuild/products/dashboard/src/hooks/useTableSort.js
+++ b/digit-ui-esbuild/products/dashboard/src/hooks/useTableSort.js
@@ -1,0 +1,38 @@
+import { useCallback, useState } from "react";
+import { getDefaultSortDirection, sortTableRows } from "../utils/tableSort";
+
+export default function useTableSort(columns, { defaultKey, defaultDirection } = {}) {
+  const [sortState, setSortState] = useState(() => {
+    if (!defaultKey) {
+      return { key: null, direction: "asc" };
+    }
+    const column = columns.find((entry) => entry.id === defaultKey);
+    return {
+      key: defaultKey,
+      direction: defaultDirection ?? getDefaultSortDirection(column),
+    };
+  });
+
+  const handleSort = useCallback(
+    (key) => {
+      const column = columns.find((entry) => entry.id === key);
+      setSortState((current) => {
+        if (current.key !== key) {
+          return { key, direction: getDefaultSortDirection(column) };
+        }
+        return {
+          key,
+          direction: current.direction === "asc" ? "desc" : "asc",
+        };
+      });
+    },
+    [columns]
+  );
+
+  const sortRows = useCallback(
+    (rows) => sortTableRows(rows, columns, sortState),
+    [columns, sortState]
+  );
+
+  return { sortState, handleSort, sortRows };
+}

--- a/digit-ui-esbuild/products/dashboard/src/services/analyticsService.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/analyticsService.js
@@ -1,0 +1,115 @@
+/** Browser-facing analytics API base (relative path or absolute URL). */
+export function getAnalyticsBase() {
+  if (process.env.REACT_APP_ANALYTICS_BASE) {
+    return process.env.REACT_APP_ANALYTICS_BASE.replace(/\/$/, "");
+  }
+  return process.env.NODE_ENV === "development" ? "/pgr-analytics" : "/api/analytics";
+}
+
+const ANALYTICS_BASE = getAnalyticsBase();
+
+function parseJson(raw) {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function getEmployeeToken() {
+  const raw = window.localStorage?.getItem("Employee.token");
+  return raw && raw !== "undefined" ? parseJson(raw) : null;
+}
+
+function getEmployeeInfo() {
+  const raw = window.localStorage?.getItem("Employee.user-info");
+  return raw && raw !== "undefined" ? parseJson(raw) : null;
+}
+
+export function getTenantId() {
+  return (
+    window.globalConfigs?.getConfig("STATE_LEVEL_TENANT_ID") ||
+    process.env.REACT_APP_STATE_LEVEL_TENANT_ID ||
+    "ke"
+  );
+}
+
+export function hasAuth() {
+  return Boolean(getEmployeeToken());
+}
+
+function buildRequestInfo() {
+  const authToken = getEmployeeToken();
+  const userInfo = getEmployeeInfo();
+  return {
+    apiId: "Rainmaker",
+    ver: ".01",
+    ts: Date.now(),
+    action: "_search",
+    msgId: `dashboard-${Date.now()}`,
+    ...(authToken && { authToken }),
+    ...(userInfo && { userInfo }),
+  };
+}
+
+async function postAnalytics(path, body) {
+  const response = await fetch(`${ANALYTICS_BASE}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "omit",
+    body: JSON.stringify({
+      RequestInfo: buildRequestInfo(),
+      ...body,
+    }),
+  });
+
+  if (!response.ok) {
+    const error = new Error(`Analytics request failed (${response.status})`);
+    error.status = response.status;
+    try {
+      error.payload = await response.json();
+    } catch {
+      error.payload = await response.text();
+    }
+    throw error;
+  }
+
+  return response.json();
+}
+
+export function fetchSchema() {
+  return postAnalytics("/_schema", { tenantId: getTenantId() });
+}
+
+export function runBatchQueries(queries) {
+  return postAnalytics("/_query", {
+    tenantId: getTenantId(),
+    queries,
+  });
+}
+
+/**
+ * POST /v2/analytics/packs — schema bootstrap (no data).
+ * Returns { tiles, defaultLayout, asOf } with full viz schema per tile.
+ * Never includes query bodies or rbac ceilings.
+ */
+export function fetchPack(tenantId) {
+  return postAnalytics("/packs", { tenantId });
+}
+
+/**
+ * POST /v2/analytics/catalog/_search — full role-filtered catalog for the picker.
+ * Returns { tiles, total } — same tile shape as /packs but no defaultLayout.
+ */
+export function fetchCatalog(tenantId) {
+  return postAnalytics("/catalog/_search", { tenantId, filters: { status: "published" } });
+}
+
+/**
+ * POST /v2/analytics/_query — data, by kpiId reference (not inline).
+ * refs: { [tileKey]: { kpiId, params } }
+ * Returns { results: { [tileKey]: { columns, rows, asOf, scope } }, partial, errors }
+ */
+export function runKpiBatch(refs, tenantId) {
+  return postAnalytics("/_query", { tenantId, queries: refs });
+}

--- a/digit-ui-esbuild/products/dashboard/src/services/boundaryService.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/boundaryService.js
@@ -1,0 +1,198 @@
+import { getTenantId, hasAuth } from "./analyticsService";
+
+function parseJson(raw) {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function getEmployeeToken() {
+  const raw = window.localStorage?.getItem("Employee.token");
+  return raw && raw !== "undefined" ? parseJson(raw) : null;
+}
+
+function getEmployeeInfo() {
+  const raw = window.localStorage?.getItem("Employee.user-info");
+  return raw && raw !== "undefined" ? parseJson(raw) : null;
+}
+
+function buildRequestInfo() {
+  const authToken = getEmployeeToken();
+  const userInfo = getEmployeeInfo();
+  return {
+    apiId: "Rainmaker",
+    ver: ".01",
+    ts: Date.now(),
+    action: "_search",
+    msgId: `dashboard-boundary-${Date.now()}`,
+    ...(authToken && { authToken }),
+    ...(userInfo && { userInfo }),
+  };
+}
+
+/**
+ * Fetch boundary entities with GeoJSON geometry.
+ * Supports Point centroids and Polygon/MultiPolygon choropleths.
+ * API: POST /boundary-service/boundary/_search?tenantId=&codes=&limit=
+ */
+export async function fetchBoundariesByCodes(codes = []) {
+  if (!hasAuth() || !codes.length) return [];
+
+  const tenantId = getTenantId();
+  const uniqueCodes = [...new Set(codes.filter(Boolean))];
+  const chunkSize = 100;
+  const all = [];
+
+  for (let i = 0; i < uniqueCodes.length; i += chunkSize) {
+    const chunk = uniqueCodes.slice(i, i + chunkSize);
+    const params = new URLSearchParams({
+      tenantId,
+      codes: chunk.join(","),
+      limit: String(chunk.length),
+    });
+
+    const response = await fetch(`/boundary-service/boundary/_search?${params}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "omit",
+      body: JSON.stringify({ RequestInfo: buildRequestInfo() }),
+    });
+
+    if (!response.ok) {
+      console.warn(`boundary/_search failed (${response.status})`);
+      continue;
+    }
+
+    const payload = await response.json();
+    const boundaries = payload?.Boundary || [];
+    all.push(...boundaries);
+  }
+
+  return all;
+}
+
+function flattenRelationshipTree(nodes, ancestors = [], out = {}) {
+  const list = Array.isArray(nodes) ? nodes : nodes ? [nodes] : [];
+  for (const node of list) {
+    const code = String(node?.code ?? "").trim();
+    if (!code) continue;
+
+    const parent = String(node?.parent ?? "").trim() || null;
+    const boundaryType = String(node?.boundaryType ?? "").trim() || null;
+    const materializedPath = String(
+      node?.ancestralMaterializedPath ?? node?.ancestralmaterializedpath ?? ""
+    ).trim();
+    const pathAncestors = materializedPath
+      ? materializedPath.split("|").map((segment) => segment.trim()).filter(Boolean)
+      : ancestors;
+
+    out[code] = {
+      code,
+      parent: parent ?? (pathAncestors.length ? pathAncestors[pathAncestors.length - 1] : null),
+      boundaryType,
+      ancestors: pathAncestors,
+      ancestralMaterializedPath: pathAncestors.join("|"),
+    };
+
+    const children = node?.children;
+    if (children?.length) {
+      flattenRelationshipTree(children, [...pathAncestors, code], out);
+    }
+  }
+  return out;
+}
+
+/** County/root code shared by ward codes (e.g. BOMET from BOMET_BOMET_CENTRAL_CHESOEN). */
+export function deriveBoundaryRootCode(codes = []) {
+  const unique = [...new Set(codes.filter(Boolean).map((c) => String(c).trim()))];
+  if (!unique.length) return null;
+
+  const segmentCounts = new Map();
+  for (const code of unique) {
+    const root = code.split("_")[0]?.trim();
+    if (root) segmentCounts.set(root, (segmentCounts.get(root) ?? 0) + 1);
+  }
+
+  let best = null;
+  let bestCount = 0;
+  for (const [root, count] of segmentCounts) {
+    if (count > bestCount) {
+      best = root;
+      bestCount = count;
+    }
+  }
+  return best;
+}
+
+/**
+ * Fetch parent hierarchy metadata for boundary codes.
+ * Loads the full county tree from the shared root so ancestor chains are available
+ * for state → city → district drill clustering.
+ * API: POST /boundary-service/boundary-relationships/_search?tenantId=&codes=&hierarchyType=
+ */
+export async function fetchBoundaryRelationshipsByCodes(
+  codes = [],
+  { hierarchyType = "ADMIN" } = {}
+) {
+  if (!hasAuth() || !codes.length) return {};
+
+  const tenantId = getTenantId();
+  const rootCode = deriveBoundaryRootCode(codes);
+  if (!rootCode) return {};
+
+  const index = {};
+
+  try {
+    const params = new URLSearchParams({
+      tenantId,
+      codes: rootCode,
+      hierarchyType,
+      includeChildren: "true",
+      limit: "500",
+    });
+
+    const response = await fetch(
+      `/boundary-service/boundary-relationships/_search?${params}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "omit",
+        body: JSON.stringify({ RequestInfo: buildRequestInfo() }),
+      }
+    );
+
+    if (!response.ok) {
+      console.warn(`boundary-relationships/_search failed (${response.status})`);
+      return index;
+    }
+
+    const payload = await response.json();
+    for (const tenantBoundary of payload?.TenantBoundary ?? []) {
+      flattenRelationshipTree(tenantBoundary?.boundary, [], index);
+    }
+  } catch (error) {
+    console.warn("boundary-relationships/_search error", error);
+  }
+
+  return index;
+}
+
+/** Inspect geometry types returned for the requested ward codes. */
+export function summarizeBoundaryGeometry(boundaries) {
+  const summary = { point: 0, polygon: 0, other: 0, missing: 0 };
+  for (const boundary of boundaries) {
+    const type = boundary?.geometry?.type;
+    if (!type) {
+      summary.missing += 1;
+    } else if (type === "Point") {
+      summary.point += 1;
+    } else if (type === "Polygon" || type === "MultiPolygon") {
+      summary.polygon += 1;
+    } else {
+      summary.other += 1;
+    }
+  }
+  return summary;
+}

--- a/digit-ui-esbuild/products/dashboard/src/services/complaintHierarchyService.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/complaintHierarchyService.js
@@ -1,0 +1,150 @@
+import { getTenantId, hasAuth } from "./analyticsService";
+import { formatDimensionLabel } from "../config/labelFormat";
+
+/**
+ * MDMS context path from globalConfigs (deployments serve MDMS under
+ * "mdms-v2"; the v1-compat search stays available under that context).
+ * Falls back to the legacy service name when no config is present
+ * (e.g. the standalone dashboard build without globalConfigs.js).
+ */
+function getMdmsSearchUrl() {
+  const get = window.globalConfigs?.getConfig?.bind(window.globalConfigs);
+  const contextPath =
+    get?.("MDMS_V1_CONTEXT_PATH") ||
+    get?.("MDMS_CONTEXT_PATH") ||
+    "egov-mdms-service";
+  return `/${String(contextPath).replace(/^\/+|\/+$/g, "")}/v1/_search`;
+}
+
+function parseJson(raw) {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function getEmployeeToken() {
+  const raw = window.localStorage?.getItem("Employee.token");
+  return raw && raw !== "undefined" ? parseJson(raw) : null;
+}
+
+function getEmployeeInfo() {
+  const raw = window.localStorage?.getItem("Employee.user-info");
+  return raw && raw !== "undefined" ? parseJson(raw) : null;
+}
+
+function buildRequestInfo() {
+  const authToken = getEmployeeToken();
+  const userInfo = getEmployeeInfo();
+  return {
+    apiId: "Rainmaker",
+    ver: ".01",
+    ts: Date.now(),
+    action: "_search",
+    msgId: `dashboard-complaint-hierarchy-${Date.now()}`,
+    ...(authToken && { authToken }),
+    ...(userInfo && { userInfo }),
+  };
+}
+
+/**
+ * Display name for a hierarchy node. Live masters carry real display names on
+ * leaves ("Ambulance breakdown / Crew unresponsive") but category records often
+ * have name === code ("MedicalServices", "complaints.categories.X") — those go
+ * through the shared code humanizer instead.
+ */
+function displayName(record) {
+  const code = String(record?.code ?? "").trim();
+  const name = String(record?.name ?? "").trim();
+  if (name && name !== code) return name;
+  return formatDimensionLabel(code);
+}
+
+/**
+ * Build code → { label, rootCode, rootLabel } from ComplaintHierarchy records.
+ *
+ * Observed record shape (RAINMAKER-PGR.ComplaintHierarchy):
+ *   { code, name, path (dot-delimited), parentCode, levelCode, order, active,
+ *     department(s), slaHours, keywords, hierarchyType }
+ *
+ * The root category is resolved by walking parentCode up to the topmost record
+ * present in the master (cycle-guarded), so it works for the N-level hierarchy
+ * without needing ComplaintHierarchyDefinition level ordering.
+ *
+ * Exported for reuse/testing; pure — no fetch.
+ */
+export function buildComplaintTypeIndex(records) {
+  const byCode = new Map();
+  for (const record of Array.isArray(records) ? records : []) {
+    const code = String(record?.code ?? "").trim();
+    if (!code || record?.active === false) continue;
+    byCode.set(code, record);
+  }
+
+  const index = new Map();
+  for (const [code, record] of byCode) {
+    let node = record;
+    const seen = new Set([code]);
+    for (;;) {
+      const parentCode = String(node?.parentCode ?? "").trim();
+      if (!parentCode || !byCode.has(parentCode) || seen.has(parentCode)) break;
+      seen.add(parentCode);
+      node = byCode.get(parentCode);
+    }
+    const rootCode = String(node.code).trim();
+    index.set(code, {
+      label: displayName(record),
+      rootCode,
+      rootLabel: displayName(node),
+    });
+  }
+  return index;
+}
+
+/**
+ * Fetch the PGR complaint hierarchy master (state-root tenant, same-origin
+ * MDMS v1 — same auth/tenant conventions as boundaryService) and return the
+ * code → { label, rootCode, rootLabel } index.
+ *
+ * Resolves null on any failure (never rejects) so callers can fall back to
+ * humanized flat labels without blocking the dashboard.
+ */
+export async function fetchComplaintTypeIndex() {
+  if (!hasAuth()) return null;
+
+  try {
+    const response = await fetch(getMdmsSearchUrl(), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "omit",
+      body: JSON.stringify({
+        RequestInfo: buildRequestInfo(),
+        MdmsCriteria: {
+          tenantId: getTenantId(),
+          moduleDetails: [
+            {
+              moduleName: "RAINMAKER-PGR",
+              masterDetails: [{ name: "ComplaintHierarchy" }],
+            },
+          ],
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      console.warn(`egov-mdms-service ComplaintHierarchy _search failed (${response.status})`);
+      return null;
+    }
+
+    const payload = await response.json();
+    const records = payload?.MdmsRes?.["RAINMAKER-PGR"]?.ComplaintHierarchy;
+    if (!Array.isArray(records) || !records.length) return null;
+
+    const indexed = buildComplaintTypeIndex(records);
+    return indexed.size ? indexed : null;
+  } catch (error) {
+    console.warn("egov-mdms-service ComplaintHierarchy _search error", error);
+    return null;
+  }
+}

--- a/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
@@ -1,0 +1,3328 @@
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
+
+*, ::before, ::after{
+  --tw-border-spacing-x: 0;
+  --tw-border-spacing-y: 0;
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  --tw-pan-x:  ;
+  --tw-pan-y:  ;
+  --tw-pinch-zoom:  ;
+  --tw-scroll-snap-strictness: proximity;
+  --tw-gradient-from-position:  ;
+  --tw-gradient-via-position:  ;
+  --tw-gradient-to-position:  ;
+  --tw-ordinal:  ;
+  --tw-slashed-zero:  ;
+  --tw-numeric-figure:  ;
+  --tw-numeric-spacing:  ;
+  --tw-numeric-fraction:  ;
+  --tw-ring-inset:  ;
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgb(59 130 246 / 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  --tw-blur:  ;
+  --tw-brightness:  ;
+  --tw-contrast:  ;
+  --tw-grayscale:  ;
+  --tw-hue-rotate:  ;
+  --tw-invert:  ;
+  --tw-saturate:  ;
+  --tw-sepia:  ;
+  --tw-drop-shadow:  ;
+  --tw-backdrop-blur:  ;
+  --tw-backdrop-brightness:  ;
+  --tw-backdrop-contrast:  ;
+  --tw-backdrop-grayscale:  ;
+  --tw-backdrop-hue-rotate:  ;
+  --tw-backdrop-invert:  ;
+  --tw-backdrop-opacity:  ;
+  --tw-backdrop-saturate:  ;
+  --tw-backdrop-sepia:  ;
+  --tw-contain-size:  ;
+  --tw-contain-layout:  ;
+  --tw-contain-paint:  ;
+  --tw-contain-style:  ;
+}
+
+::backdrop{
+  --tw-border-spacing-x: 0;
+  --tw-border-spacing-y: 0;
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  --tw-pan-x:  ;
+  --tw-pan-y:  ;
+  --tw-pinch-zoom:  ;
+  --tw-scroll-snap-strictness: proximity;
+  --tw-gradient-from-position:  ;
+  --tw-gradient-via-position:  ;
+  --tw-gradient-to-position:  ;
+  --tw-ordinal:  ;
+  --tw-slashed-zero:  ;
+  --tw-numeric-figure:  ;
+  --tw-numeric-spacing:  ;
+  --tw-numeric-fraction:  ;
+  --tw-ring-inset:  ;
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgb(59 130 246 / 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  --tw-blur:  ;
+  --tw-brightness:  ;
+  --tw-contrast:  ;
+  --tw-grayscale:  ;
+  --tw-hue-rotate:  ;
+  --tw-invert:  ;
+  --tw-saturate:  ;
+  --tw-sepia:  ;
+  --tw-drop-shadow:  ;
+  --tw-backdrop-blur:  ;
+  --tw-backdrop-brightness:  ;
+  --tw-backdrop-contrast:  ;
+  --tw-backdrop-grayscale:  ;
+  --tw-backdrop-hue-rotate:  ;
+  --tw-backdrop-invert:  ;
+  --tw-backdrop-opacity:  ;
+  --tw-backdrop-saturate:  ;
+  --tw-backdrop-sepia:  ;
+  --tw-contain-size:  ;
+  --tw-contain-layout:  ;
+  --tw-contain-paint:  ;
+  --tw-contain-style:  ;
+}
+
+.dashboard-root {
+  /* ============================================================
+     * Canonical color palette — single source of truth.
+     * Every dashboard color (Tailwind tokens, raw CSS, chart series)
+     * resolves to one of these variables. Update colors here only.
+     * ============================================================ */
+  /* Surfaces & text */
+  --background: lab(98.2586% -0.2231 -0.716782);
+  --foreground: lab(5.23127% -1.15929 -6.2068);
+  --surface: lab(100% 0 0);
+  --surface-2: lab(97.097% -0.443935 -1.43216);
+  --surface-3: lab(94.7753% -0.662118 -2.14608);
+  --card: lab(100% 0 0);
+  --card-foreground: lab(5.23127% -1.15929 -6.2068);
+  --popover: lab(100% 0 0);
+  --popover-foreground: lab(5.23127% -1.15929 -6.2068);
+  /* Brand / interactive */
+  --primary: lab(35.8817% -24.1734 -2.46631);
+  --primary-foreground: lab(98.84% 0.0000298023 -0.0000119209);
+  --secondary: lab(94.2798% -2.53278 -1.0635);
+  --secondary-foreground: lab(9.71627% -6.29769 -2.60819);
+  --muted: lab(94.8109% -1.28037 -1.23321);
+  --muted-foreground: lab(39.77% -3.78458 -3.66642);
+  --accent: lab(93.2569% -6.07967 -0.65273);
+  --accent-foreground: lab(7.50164% -8.19696 -3.84778);
+  --destructive: lab(45.6933% 66.2056 47.555);
+  --destructive-foreground: lab(98.84% 0.0000298023 -0.0000119209);
+  /* Lines & focus */
+  --border: lab(88.4492% -2.04447 -1.97053);
+  --input: lab(88.4492% -2.04447 -1.97053);
+  --ring: lab(35.8817% -24.1734 -2.46631);
+  /* Chrome (top bar / nav) */
+  --chrome: lab(12.1586% -9.80562 -2.97114);
+  --chrome-foreground: lab(96.5699% -1.58328 -0.665271);
+  --chrome-muted: lab(56.1186% -6.32274 -2.64311);
+  /* Status (foreground + tinted background pairs) */
+  --status-open: lab(36.6287% -20.0702 -21.1027);
+  --status-open-bg: lab(94.3508% -6.32584 -6.12073);
+  --status-assigned: lab(35.8108% -25.0002 -10.2503);
+  --status-assigned-bg: lab(94.4979% -9.48459 -3.96528);
+  --status-progress: lab(41.816% 17.1944 63.4163);
+  --status-progress-bg: lab(95.4544% 2.6814 15.3591);
+  --status-nearing: var(--status-progress);
+  --status-nearing-bg: var(--status-progress-bg);
+  --status-resolved: lab(36.3321% -35.6256 3.05576);
+  --status-resolved-bg: lab(94.7185% -13.6163 1.20147);
+  --status-rejected: lab(36.1728% -1.98329 -7.04196);
+  --status-rejected-bg: lab(93.0362% -0.553161 -1.78919);
+  --status-overdue: lab(45.8049% 62.9533 44.1);
+  --status-overdue-bg: lab(95.0932% 9.04813 5.32234);
+  --status-breach: lab(37.1998% 71.0423 26.7454);
+  --status-breach-bg: lab(93.7677% 13.0259 4.10725);
+  /* Chart series */
+  --chart-1: lab(36.1215% -31.3433 -3.14357);
+  --chart-2: lab(48.7634% -31.2502 -12.8129);
+  --chart-3: lab(60.588% -31.0205 5.71432);
+  --chart-4: lab(46.0249% 56.4689 37.9874);
+  --chart-5: lab(42.1906% -16.731 -27.7727);
+  /* ------------------------------------------------------------
+     * Legacy aliases — kept so existing var(--dashboard-*) and
+     * var(--brand-*) references map onto the canonical palette.
+     * ------------------------------------------------------------ */
+  --dashboard-background: var(--background);
+  --dashboard-foreground: var(--foreground);
+  --dashboard-surface: var(--surface);
+  --dashboard-border: var(--border);
+  --dashboard-muted: var(--muted);
+  --dashboard-muted-foreground: var(--muted-foreground);
+  --dashboard-status-resolved: var(--status-resolved);
+  --dashboard-status-breach: var(--status-breach);
+  --brand-teal: var(--primary);
+  --brand-dark: var(--chrome);
+  --brand-slate: var(--chrome-muted);
+  --dashboard-font-family: Inter, Roboto, ui-sans-serif, system-ui, sans-serif;
+  font-family: var(--dashboard-font-family);
+  font-feature-settings: "tnum" 1;
+  -webkit-font-smoothing: antialiased;
+}
+
+.dashboard-drag-handle{
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom-width: 1px;
+  border-color: var(--border);
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.625rem;
+  padding-bottom: 0.625rem;
+}
+
+@media (max-width: 1023px) {
+  .dashboard-kpi-list-item .dashboard-drag-handle-title,
+    .dashboard-kpi-card .dashboard-drag-handle-title {
+    overflow: visible;
+    text-overflow: unset;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+}
+
+.dashboard-drag-handle-title{
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+@media (max-width: 1023px) {
+  .dashboard-kpi-list-item .dashboard-drag-handle-subtitle,
+    .dashboard-kpi-card .dashboard-drag-handle-subtitle {
+    overflow: visible;
+    text-overflow: unset;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+}
+
+.dashboard-drag-handle-subtitle{
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  line-height: 1.25;
+  color: var(--muted-foreground);
+}
+
+.dashboard-external-drag .react-grid-item {
+  pointer-events: none;
+}
+
+.dashboard-external-drag .dashboard-grid-layout .react-grid-placeholder,
+  .dashboard-grid-dragging .dashboard-grid-layout .react-grid-placeholder {
+  opacity: 1 !important;
+  z-index: 1 !important;
+  border-radius: 4px;
+  border: 1px dashed color-mix(in srgb, var(--chart-1, #2563eb) 35%, transparent) !important;
+  background: color-mix(in srgb, var(--chart-1, #2563eb) 5%, transparent) !important;
+}
+
+.dashboard-grid-dragging .react-grid-item.react-draggable-dragging,
+  .dashboard-external-drag .react-grid-item.react-draggable-dragging {
+  z-index: 10 !important;
+}
+
+.dashboard-widget-remove-btn{
+  position: absolute;
+  right: 0.25rem;
+  top: 0.25rem;
+  z-index: 10;
+  margin: 0px;
+  box-sizing: border-box;
+  display: inline-flex;
+  height: 1.5rem;
+  width: 1.5rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  border-width: 0px;
+  background-color: transparent;
+  padding: 0px;
+  color: var(--muted-foreground);
+  font: inherit;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.dashboard-widget-remove-btn:hover{
+  background-color: var(--muted);
+  color: var(--status-breach);
+}
+
+.dashboard-widget-remove-btn:focus{
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 30%, transparent);
+}
+
+/* ---------------------------------------------------------------
+   * Viz type: number-tile-delta (metric KPI cards — value + delta + context)
+   * Class names are referenced from config/visualizationStyles.js
+   * --------------------------------------------------------------- */
+
+.dashboard-kpi-card{
+  position: relative;
+  box-sizing: border-box;
+  width: 100%;
+  border-radius: 0.25rem;
+  border-width: 1px;
+  border-color: var(--border);
+  background-color: var(--surface);
+  padding: 1rem;
+  min-height: 0;
+  font-family: inherit;
+}
+
+.dashboard-kpi-card--metric{
+  height: 100%;
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) 26px minmax(0, 1fr);
+  gap: 0.25rem;
+}
+
+.dashboard-kpi-title{
+  width: 100%;
+  min-width: 0px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  line-height: 1.25;
+}
+
+.dashboard-kpi-card--metric .dashboard-kpi-title{
+  align-self: flex-start;
+  overflow: hidden;
+  padding-right: 1.25rem;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.dashboard-kpi-value{
+  flex-shrink: 0;
+  font-weight: 600;
+  --tw-numeric-spacing: tabular-nums;
+  font-variant-numeric: var(--tw-ordinal) var(--tw-slashed-zero) var(--tw-numeric-figure) var(--tw-numeric-spacing) var(--tw-numeric-fraction);
+  font-size: 26px;
+  line-height: 1;
+}
+
+.dashboard-kpi-card--metric .dashboard-kpi-value{
+  align-self: center;
+}
+
+.dashboard-kpi-context{
+  flex-shrink: 0;
+  color: var(--muted-foreground);
+  font-size: 12px;
+  line-height: 1.25;
+}
+
+.dashboard-kpi-card--metric .dashboard-kpi-context{
+  align-self: flex-start;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.dashboard-kpi-card--delta{
+  height: 100%;
+  display: grid;
+  grid-template-rows: minmax(26px, auto) 26px minmax(0, 1fr);
+  gap: 0.25rem;
+}
+
+.dashboard-kpi-card--delta .dashboard-kpi-title{
+  align-self: flex-start;
+  overflow: hidden;
+  padding-right: 1.25rem;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.dashboard-kpi-card--delta .dashboard-kpi-value{
+  flex-shrink: 0;
+  align-self: auto;
+}
+
+.dashboard-kpi-card--delta .dashboard-kpi-context{
+  align-self: flex-start;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+/* Viz type: number-tile-sparkline (delta + trend line) */
+
+.dashboard-kpi-card--sparkline{
+  height: 100%;
+  display: grid;
+  /* Title band matches default metric tile offset; only the sparkline row grows on resize. */
+  grid-template-rows: minmax(26px, auto) 26px minmax(10px, 1fr);
+  gap: 0.25rem;
+  min-height: 0;
+  padding-bottom: 1.125rem;
+}
+
+.dashboard-kpi-card--sparkline .dashboard-kpi-title{
+  align-self: flex-start;
+  overflow: hidden;
+  padding-right: 1.25rem;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.dashboard-kpi-sparkline-value-row{
+  display: flex;
+  align-items: baseline;
+  justify-content: flex-start;
+  gap: 0.375rem;
+  min-width: 0;
+  align-self: center;
+  padding-top: 0;
+}
+
+.dashboard-kpi-card--sparkline .dashboard-kpi-value{
+  flex-shrink: 0;
+  align-self: auto;
+}
+
+.dashboard-kpi-sparkline-delta{
+  flex-shrink: 0;
+  font-size: 12px;
+  font-weight: 600;
+  --tw-numeric-spacing: tabular-nums;
+  font-variant-numeric: var(--tw-ordinal) var(--tw-slashed-zero) var(--tw-numeric-figure) var(--tw-numeric-spacing) var(--tw-numeric-fraction);
+  line-height: 1;
+  padding-bottom: 0.2em;
+}
+
+.dashboard-kpi-sparkline-delta--positive {
+  color: var(--status-resolved);
+}
+
+.dashboard-kpi-sparkline-delta--negative {
+  color: var(--status-breach);
+}
+
+.dashboard-kpi-sparkline-delta--neutral{
+  color: var(--foreground);
+}
+
+.dashboard-kpi-sparkline-delta--muted{
+  color: var(--muted-foreground);
+}
+
+.dashboard-kpi-sparkline-chart{
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+  min-height: 22px;
+}
+
+.dashboard-kpi-sparkline-chart .apexcharts-canvas,
+  .dashboard-kpi-sparkline-chart svg {
+  overflow: visible !important;
+}
+
+.dashboard-header-controls{
+  display: flex;
+  min-width: 0px;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.dashboard-header-search{
+  position: relative;
+  margin: 0px;
+  display: inline-flex;
+  height: 2rem;
+  flex-shrink: 0;
+  align-items: center;
+}
+
+.dashboard-header-search-icon {
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  color: var(--dashboard-muted-foreground, #6b6860);
+  pointer-events: none;
+  transform: translateY(-50%);
+}
+
+.dashboard-header-search-input{
+  margin: 0px;
+  box-sizing: border-box;
+  display: block;
+  height: 2rem;
+  width: 14rem;
+  border-radius: 4px;
+  border-width: 1px;
+  border-color: var(--border);
+  background-color: var(--surface);
+  padding-top: 0px;
+  padding-bottom: 0px;
+  padding-left: 2rem;
+  padding-right: 0.75rem;
+  font-size: 12px;
+  line-height: 1;
+  color: var(--foreground);
+}
+
+.dashboard-header-search-input::placeholder{
+  color: var(--muted-foreground);
+}
+
+.dashboard-header-search-input:focus{
+  border-color: var(--foreground);
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 15%, transparent);
+}
+
+.dashboard-header-controls .dashboard-header-btn{
+  margin: 0px;
+  box-sizing: border-box;
+  display: inline-flex;
+  height: 2rem;
+  max-height: 2rem;
+  min-height: 2rem;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  border-radius: 4px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: var(--border);
+  background-color: var(--surface);
+  padding-left: 0.625rem;
+  padding-right: 0.625rem;
+  padding-top: 0px;
+  padding-bottom: 0px;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+  color: var(--foreground);
+  font-family: inherit;
+  vertical-align: middle;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.dashboard-header-controls .dashboard-header-btn:hover{
+  background-color: var(--muted);
+}
+
+.dashboard-header-controls .dashboard-add-kpi-trigger{
+  gap: 0.375rem;
+  border-style: dashed;
+  border-color: var(--border);
+}
+
+.dashboard-header-controls .dashboard-add-kpi-trigger:hover{
+  border-color: var(--foreground);
+  color: var(--foreground);
+  background-color: color-mix(in srgb, var(--muted) 50%, transparent);
+}
+
+.dashboard-header-kpi-anchor{
+  position: relative;
+  display: flex;
+  height: 2rem;
+  flex-shrink: 0;
+  align-items: center;
+  align-self: center;
+}
+
+.dashboard-add-kpi-panel {
+  border: 1px solid var(--border, #e5e2db);
+  border-radius: 6px;
+  background-color: #ffffff;
+  box-shadow:
+      0 4px 6px -1px rgb(0 0 0 / 0.08),
+      0 2px 4px -2px rgb(0 0 0 / 0.06);
+  color: var(--foreground, #1a1917);
+  opacity: 1;
+  isolation: isolate;
+}
+
+.dashboard-add-kpi-panel--dragging{
+  pointer-events: none;
+  visibility: hidden;
+}
+
+.dashboard-add-kpi-header{
+  flex-shrink: 0;
+  border-bottom-width: 1px;
+  border-color: var(--border);
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.625rem;
+  padding-bottom: 0.625rem;
+  font-size: 10px;
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted-foreground, #6b6860);
+  background-color: #ffffff;
+}
+
+.dashboard-add-kpi-list {
+  -webkit-overflow-scrolling: touch;
+  background-color: #ffffff;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  text-align: left;
+}
+
+.dashboard-add-kpi-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.625rem 1rem;
+  cursor: grab;
+  -webkit-user-select: none;
+          user-select: none;
+  font-weight: 400;
+  background-color: #ffffff;
+}
+
+.dashboard-add-kpi-item:active {
+  cursor: grabbing;
+}
+
+.dashboard-add-kpi-item-main {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  align-items: center;
+  gap: 0.5rem;
+  justify-content: flex-start;
+  text-align: left;
+}
+
+.dashboard-add-kpi-item-aside {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  margin-left: 0.75rem;
+}
+
+.dashboard-add-kpi-item-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: left;
+  font-size: 13px;
+  line-height: 1.375;
+  font-weight: 400;
+  color: var(--foreground, #1a1917);
+}
+
+.dashboard-add-kpi-type{
+  flex-shrink: 0;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+  text-align: right;
+  font-weight: 400;
+  color: var(--muted-foreground, #6b6860);
+}
+
+.dashboard-add-kpi-add-btn{
+  margin: 0px;
+  box-sizing: border-box;
+  display: inline-flex;
+  height: 1.25rem;
+  width: 1.25rem;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  border-width: 0px;
+  background-color: transparent;
+  padding: 0px;
+  font-size: 15px;
+  line-height: 1;
+  font-family: inherit;
+  font-weight: 400;
+  color: var(--muted-foreground, #6b6860);
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.dashboard-add-kpi-add-btn:hover {
+  color: var(--foreground, #1a1917);
+}
+
+.dashboard-add-kpi-item:hover,
+  .dashboard-add-kpi-item--hover {
+  background-color: var(--muted, #f5f4f1);
+}
+
+.dashboard-add-kpi-preview {
+  border: 1px solid var(--border, #e5e2db);
+  border-radius: 8px;
+  background-color: #ffffff;
+  box-shadow:
+      0 10px 24px -8px rgb(0 0 0 / 0.12),
+      0 4px 8px -4px rgb(0 0 0 / 0.08);
+  padding: 0.75rem;
+  pointer-events: none;
+}
+
+.dashboard-add-kpi-preview-card {
+  border: 1px solid var(--border, #e5e2db);
+  border-radius: 6px;
+  background-color: #ffffff;
+  padding: 0.625rem 0.75rem;
+}
+
+.dashboard-add-kpi-preview-title{
+  font-size: 10px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted-foreground, #6b6860);
+  line-height: 1.3;
+}
+
+.dashboard-add-kpi-preview-value{
+  margin-top: 0.25rem;
+  font-size: 22px;
+  font-weight: 600;
+  line-height: 1.25;
+  color: var(--foreground, #1a1917);
+  font-variant-numeric: tabular-nums;
+}
+
+.dashboard-add-kpi-preview-target{
+  margin-top: 0.125rem;
+  font-size: 11px;
+  line-height: 1.375;
+  color: var(--muted-foreground, #6b6860);
+}
+
+.dashboard-add-kpi-preview-desc{
+  margin-bottom: 0px;
+  margin-top: 0.625rem;
+  font-size: 11px;
+  line-height: 1.375;
+  color: var(--muted-foreground, #6b6860);
+}
+
+.dashboard-header-top {
+  min-width: 0;
+}
+
+.dashboard-filters-bar {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.dashboard-filters-card{
+  display: flex;
+  align-items: center;
+  border-radius: 0.25rem;
+  border-width: 1px;
+  border-color: var(--border);
+  background-color: var(--surface);
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.dashboard-filters-row{
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  column-gap: 0.75rem;
+  row-gap: 0.5rem;
+}
+
+.dashboard-filters-heading{
+  display: flex;
+  height: 1.75rem;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 0.375rem;
+  align-self: center;
+  padding-right: 0.25rem;
+}
+
+.dashboard-filters-title{
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+  color: var(--muted-foreground);
+}
+
+.dashboard-filters-date-range{
+  display: flex;
+  height: 1.75rem;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 0.375rem;
+  align-self: center;
+}
+
+.dashboard-filters-date-arrow{
+  font-size: 11px;
+  line-height: 1;
+  color: var(--muted-foreground);
+}
+
+.dashboard-filter-inline-date-wrap{
+  position: relative;
+  display: inline-flex;
+  height: 1.75rem;
+  flex-shrink: 0;
+  align-items: center;
+  overflow: hidden;
+}
+
+.dashboard-filter-inline-date{
+  margin: 0px;
+  box-sizing: border-box;
+  display: block;
+  height: 1.75rem;
+  max-height: 1.75rem;
+  min-height: 1.75rem;
+  width: 7.25rem;
+  border-radius: 4px;
+  border-width: 1px;
+  border-color: var(--border);
+  background-color: var(--surface);
+  padding-top: 0px;
+  padding-bottom: 0px;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  font-size: 12px;
+  line-height: 1;
+  color: var(--foreground);
+}
+
+.dashboard-filter-inline-date:focus{
+  border-color: var(--foreground);
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+.dashboard-filter-inline-date {
+  color-scheme: light;
+  font-family: inherit;
+}
+
+.dashboard-filter-inline-date:focus {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 15%, transparent);
+}
+
+.dashboard-filter-inline-date-wrap .dashboard-filter-inline-date::-webkit-calendar-picker-indicator {
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  cursor: pointer;
+  opacity: 0;
+}
+
+.dashboard-filter-inline-select-wrap{
+  position: relative;
+  display: inline-flex;
+  height: 1.75rem;
+  flex-shrink: 0;
+  align-items: center;
+  align-self: center;
+}
+
+.dashboard-filter-inline-select{
+  margin: 0px;
+  box-sizing: border-box;
+  height: 1.75rem;
+  max-height: 1.75rem;
+  min-height: 1.75rem;
+  min-width: 7.5rem;
+  -webkit-appearance: none;
+          appearance: none;
+  border-radius: 4px;
+  border-width: 1px;
+  border-color: var(--border);
+  background-color: var(--surface);
+  padding-top: 0px;
+  padding-bottom: 0px;
+  padding-left: 0.5rem;
+  padding-right: 1.75rem;
+  font-size: 12px;
+  line-height: 1;
+  color: var(--foreground);
+}
+
+.dashboard-filter-inline-select:focus{
+  border-color: var(--foreground);
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+.dashboard-filter-inline-select {
+  font-family: inherit;
+}
+
+.dashboard-filter-inline-select:focus {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 15%, transparent);
+}
+
+.dashboard-filter-inline-select-wrap::after {
+  content: "⌄";
+  position: absolute;
+  right: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  font-size: 0.8rem;
+  line-height: 1;
+  color: var(--dashboard-muted-foreground, #6b6860);
+}
+
+.dashboard-filters-clear-inline{
+  margin: 0px;
+  box-sizing: border-box;
+  display: inline-flex;
+  height: 1.75rem;
+  flex-shrink: 0;
+  align-items: center;
+  align-self: center;
+  border-radius: 4px;
+  border-width: 0px;
+  background-color: transparent;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0px;
+  padding-bottom: 0px;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1;
+  color: var(--muted-foreground);
+}
+
+.dashboard-filters-clear-inline:hover{
+  color: var(--foreground);
+}
+
+.dashboard-filters-clear-inline:disabled {
+  opacity: 0.4;
+  cursor: default;
+  pointer-events: none;
+}
+
+/* ── Responsive layout ─────────────────────────────────────────────── */
+
+.dashboard-grid-wrap .react-grid-layout {
+  width: 100% !important;
+  min-width: 0;
+}
+
+@media (max-width: 1023px) {
+  .dashboard-sidebar {
+    position: fixed;
+    left: 0;
+    top: 0;
+    z-index: 50;
+    height: 100dvh;
+    transform: translateX(-100%);
+    transition: transform 0.2s ease;
+    box-shadow: none;
+  }
+
+  .dashboard-sidebar--open {
+    transform: translateX(0);
+    box-shadow: 4px 0 24px rgb(0 0 0 / 0.15);
+  }
+
+  .dashboard-sidebar-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 40;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    background: rgb(0 0 0 / 0.4);
+    cursor: pointer;
+  }
+
+  .dashboard-grid-layout .react-grid-item > .react-resizable-handle,
+    .dashboard-resize-grip {
+    display: none !important;
+  }
+
+  .dashboard-grid-layout .react-grid-item {
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .dashboard-kpi-value {
+    font-size: clamp(18px, 4.5vw, 26px);
+  }
+
+  .dashboard-kpi-sparkline-value-row {
+    flex-wrap: wrap;
+    row-gap: 0.125rem;
+  }
+
+  .dashboard-drag-handle-title,
+    .dashboard-drag-handle-subtitle {
+    overflow: visible;
+    text-overflow: unset;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .dashboard-kpi-card--metric .dashboard-kpi-title,
+    .dashboard-kpi-card--delta .dashboard-kpi-title,
+    .dashboard-kpi-card--sparkline .dashboard-kpi-title,
+    .dashboard-kpi-card--metric .dashboard-kpi-context,
+    .dashboard-kpi-card--delta .dashboard-kpi-context {
+    -webkit-line-clamp: unset;
+    display: block;
+    overflow: visible;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .dashboard-kpi-list-item .tw-truncate,
+    .dashboard-kpi-card .tw-truncate {
+    overflow: visible;
+    text-overflow: unset;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .dashboard-card-updated {
+    position: static;
+    display: block;
+    margin-top: 0.25rem;
+    margin-right: 0;
+    text-align: right;
+    padding-right: 0.25rem;
+  }
+
+  .dashboard-widget-surface {
+    min-height: 100%;
+    height: auto;
+  }
+
+  .dashboard-kpi-widget {
+    min-height: 100%;
+    height: auto;
+  }
+}
+
+@media (max-width: 639px) {
+  .dashboard-header-top {
+    flex-wrap: wrap;
+    align-items: flex-start;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+
+  .dashboard-header-controls {
+    justify-content: flex-end;
+    width: 100%;
+  }
+
+  .dashboard-header-subtitle {
+    width: 100%;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .dashboard-header-controls .dashboard-header-export span {
+    display: none;
+  }
+
+  .dashboard-header-controls .dashboard-header-btn{
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
+
+  .dashboard-header-mobile-search {
+    display: block;
+    border-bottom: 1px solid var(--border);
+    background-color: var(--surface);
+    padding: 0.5rem 0.75rem;
+  }
+
+  .dashboard-header-search--mobile {
+    display: flex !important;
+    width: 100%;
+  }
+
+  .dashboard-header-search--mobile .dashboard-header-search-input {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .dashboard-filters-card {
+    align-items: stretch;
+    padding-left: 0.625rem;
+    padding-right: 0.625rem;
+    padding-top: 0.625rem;
+    padding-bottom: 0.625rem;
+  }
+
+  .dashboard-filters-row {
+    flex-direction: column;
+    align-items: stretch;
+    width: 100%;
+  }
+
+  .dashboard-filters-date-range {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .dashboard-filter-inline-date-wrap {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .dashboard-filter-inline-date {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .dashboard-filter-inline-select-wrap {
+    width: 100%;
+  }
+
+  .dashboard-filter-inline-select {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .dashboard-filters-clear-inline {
+    align-self: flex-start;
+  }
+
+  .dashboard-add-kpi-panel {
+    max-width: calc(100vw - 1.5rem);
+  }
+
+  .dashboard-kpi-card {
+    padding: 0.75rem;
+  }
+}
+
+@media (min-width: 640px) and (max-width: 1023px) {
+  .dashboard-header-search-input{
+    width: 11rem;
+    max-width: 100%;
+  }
+
+  .dashboard-filters-row {
+    row-gap: 0.5rem;
+  }
+
+  .dashboard-header-subtitle {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+}
+
+.dashboard-widget-surface {
+  cursor: grab;
+}
+
+.dashboard-widget-surface:active,
+  .react-grid-item.react-draggable-dragging .dashboard-widget-surface {
+  cursor: grabbing;
+}
+
+.dashboard-widget-surface .dashboard-widget-remove-btn,
+  .dashboard-widget-surface .dashboard-view-toggle,
+  .dashboard-widget-surface .dashboard-gauge-target-marker,
+  .dashboard-widget-surface .dashboard-table-scroll,
+  .dashboard-widget-surface .dashboard-kpi-list-body,
+  .dashboard-widget-surface a,
+  .dashboard-widget-surface button,
+  .dashboard-widget-surface input,
+  .dashboard-widget-surface select,
+  .dashboard-widget-surface textarea {
+  cursor: default;
+}
+
+.dashboard-widget-surface .dashboard-bar-chart-body,
+  .dashboard-widget-surface .dashboard-horizontal-bar-body,
+  .dashboard-widget-surface .dashboard-stacked-bar-body,
+  .dashboard-widget-surface .dashboard-line-chart-body,
+  .dashboard-widget-surface .dashboard-pie-chart-body,
+  .dashboard-widget-surface .dashboard-gauge-body,
+  .dashboard-widget-surface .dashboard-sla-toggle-body,
+  .dashboard-widget-surface .apexcharts-canvas,
+  .dashboard-widget-surface .apexcharts-svg {
+  cursor: grab;
+}
+
+.react-grid-item.react-draggable-dragging .dashboard-widget-surface .apexcharts-canvas,
+  .react-grid-item.react-draggable-dragging .dashboard-widget-surface .apexcharts-svg {
+  cursor: grabbing;
+}
+
+.dashboard-kpi-widget {
+  height: 100%;
+  min-height: 0;
+}
+
+.dashboard-kpi-widget .dashboard-widget{
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.dashboard-kpi-list-body {
+  min-height: 17.5rem;
+}
+
+.dashboard-kpi-list-item {
+  min-height: 1.75rem;
+}
+
+.dashboard-grid-layout .react-grid-item.dashboard-grid-item-kpi {
+  overflow: hidden;
+}
+
+.dashboard-grid-layout .react-grid-item.dashboard-grid-item-chart-visible {
+  overflow: visible;
+}
+
+.dashboard-grid-layout .react-grid-item.dashboard-grid-item-chart-clipped {
+  overflow: hidden;
+}
+
+.dashboard-resize-grip{
+  pointer-events: none;
+  position: absolute;
+  z-index: 2;
+  right: 3px;
+  bottom: 3px;
+  width: 14px;
+  height: 14px;
+  line-height: 0;
+}
+
+.dashboard-resize-grip-line {
+  stroke: var(--dashboard-muted-foreground, #6b6860);
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  opacity: 0.65;
+  transition: stroke 150ms ease, opacity 150ms ease;
+}
+
+.tw-group:hover .dashboard-resize-grip-line {
+  stroke: var(--chart-1);
+  opacity: 0.9;
+}
+
+.dashboard-kpi-widget:hover .dashboard-kpi-card {
+  border-color: color-mix(in srgb, var(--foreground) 18%, transparent);
+  background-color: var(--surface);
+  box-shadow: 0 4px 12px color-mix(in srgb, var(--foreground) 6%, transparent);
+}
+
+/* Viz type: data-table — ranked / breakdown tables */
+
+.dashboard-data-table-shell{
+  display: flex;
+  height: 100%;
+  min-height: 0px;
+  width: 100%;
+  min-width: 0px;
+  flex-direction: column;
+}
+
+.dashboard-data-table-header{
+  border-bottom-width: 0px;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-bottom: 0px;
+  padding-top: 0.25rem;
+}
+
+.dashboard-data-table-header-bar{
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  border-bottom-width: 0px;
+  padding-left: 1rem;
+  padding-bottom: 0px;
+  padding-top: 0.5rem;
+  padding-right: 2rem;
+}
+
+.dashboard-data-table-header .dashboard-drag-handle-title,
+  .dashboard-data-table-header-bar .dashboard-drag-handle-title{
+  line-height: 1.25;
+}
+
+.dashboard-data-table-header .dashboard-drag-handle-subtitle,
+  .dashboard-data-table-header-bar .dashboard-drag-handle-subtitle{
+  margin-top: 0px;
+  line-height: 1;
+}
+
+.dashboard-data-table-body{
+  display: flex;
+  min-height: 0px;
+  flex: 1 1 0%;
+  flex-direction: column;
+  justify-content: flex-start;
+  overflow: hidden;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0px;
+  margin-top: -2px;
+  padding-bottom: 1.125rem;
+}
+
+/* SLA table/bar toggle — reserve space for absolute Updated stamp (same as other cards) */
+
+.dashboard-sla-toggle-body {
+  padding-bottom: 1.125rem;
+}
+
+.dashboard-table-scroll{
+  min-height: 0px;
+  width: 100%;
+  max-width: 100%;
+  flex: 1 1 0%;
+  overflow: auto;
+  max-height: 100%;
+  font-family: inherit;
+  font-size: 12px;
+}
+
+/* Override global digit-ui-components bare `table/th/td` rules from index.html */
+
+.dashboard-root table.dashboard-table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+  font-family: inherit;
+  font-size: 12px;
+  line-height: 1.25;
+  background: transparent;
+  overflow: visible;
+}
+
+.dashboard-root table.dashboard-table.dashboard-table--equal-cols {
+  table-layout: fixed;
+}
+
+.dashboard-root table.dashboard-table.dashboard-table--equal-cols th.dashboard-table-th,
+  .dashboard-root table.dashboard-table.dashboard-table--equal-cols td.dashboard-table-td {
+  width: 1% !important;
+  overflow: visible;
+  text-overflow: unset;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.dashboard-root table.dashboard-table thead tr {
+  text-align: left;
+  color: var(--dashboard-muted-foreground, #6b6860);
+}
+
+.dashboard-root table.dashboard-table th.dashboard-table-th,
+  .dashboard-root table.dashboard-table td.dashboard-table-td {
+  min-width: 0 !important;
+  width: auto !important;
+  max-width: none;
+  padding: 0.375rem 0.625rem !important;
+  border: 0 !important;
+  box-shadow: none !important;
+  background: transparent !important;
+  font-family: var(--dashboard-font-family) !important;
+  font-size: 12px !important;
+  font-weight: 400 !important;
+  font-style: normal !important;
+  line-height: 1.25 !important;
+  white-space: normal !important;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  overflow: visible;
+  word-wrap: break-word;
+  vertical-align: top;
+  text-align: left;
+  color: var(--dashboard-foreground, #1b1b1b);
+}
+
+.dashboard-root table.dashboard-table th.dashboard-table-th {
+  font-weight: 500 !important;
+  color: var(--dashboard-muted-foreground, #6b6860) !important;
+  vertical-align: bottom;
+  padding-top: 0.125rem !important;
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: var(--dashboard-surface, #fff) !important;
+}
+
+.dashboard-table-sort-btn{
+  display: inline-flex;
+  width: 100%;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem;
+  border-width: 0px;
+  background-color: transparent;
+  padding: 0px;
+  text-align: left;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  font-weight: inherit;
+}
+
+.dashboard-table-sort-label {
+  min-width: 0;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.dashboard-table-sort-btn:hover .dashboard-table-sort-indicator {
+  color: var(--foreground);
+}
+
+.dashboard-table-sort-indicator{
+  flex-shrink: 0;
+  font-size: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 0.625rem;
+  width: 0.625rem;
+  color: var(--dashboard-muted-foreground, #6b6860);
+  line-height: 1;
+  font-weight: 400;
+}
+
+.dashboard-root table.dashboard-table tbody td.dashboard-table-td {
+  padding-top: 0.375rem !important;
+  padding-bottom: 0.375rem !important;
+  border-top: 1px solid var(--dashboard-border, #e8e6e1) !important;
+}
+
+.dashboard-root table.dashboard-table td.dashboard-table-td {
+  font-variant-numeric: tabular-nums;
+}
+
+.dashboard-root table.dashboard-table td.dashboard-table-td > span,
+  .dashboard-root table.dashboard-table td.dashboard-table-td > a {
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.dashboard-root table.dashboard-table tbody tr.dashboard-table-row-highlight td.dashboard-table-td {
+  background-color: color-mix(
+      in srgb,
+      var(--status-breach) calc(var(--row-sla-severity, 1) * 14%),
+      transparent
+    ) !important;
+}
+
+.dashboard-table-sla-overrun {
+  font-weight: 600;
+  color: color-mix(
+      in srgb,
+      var(--status-breach) calc(var(--sla-overrun-severity, 1) * 100%),
+      var(--foreground)
+    );
+}
+
+.dashboard-root table.dashboard-table col.dashboard-table-col-fixed {
+  width: auto;
+}
+
+.dashboard-table-primary{
+  display: flex;
+  min-width: 0px;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  column-gap: 0.25rem;
+  row-gap: 0.125rem;
+}
+
+.dashboard-table-label{
+  min-width: 0px;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.dashboard-table-badge{
+  flex-shrink: 0;
+  flex-basis: 100%;
+  font-size: 8px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+  color: var(--status-breach);
+}
+
+.dashboard-table-threshold-cell{
+  font-weight: 600;
+  color: var(--status-breach);
+}
+
+.dashboard-table-threshold-watch{
+  font-weight: 600;
+  color: var(--status-nearing);
+}
+
+.dashboard-table-threshold-good{
+  font-weight: 600;
+  color: var(--status-resolved);
+}
+
+.dashboard-table-cell-tone--breach {
+  background-color: color-mix(in srgb, var(--status-breach) 14%, transparent);
+}
+
+.dashboard-table-cell-tone--watch {
+  background-color: color-mix(in srgb, var(--status-nearing) 14%, transparent);
+}
+
+.dashboard-table-cell-tone--good {
+  background-color: color-mix(in srgb, var(--status-resolved) 10%, transparent);
+}
+
+.dashboard-table-status-tag {
+  display: inline-block;
+  max-width: 100%;
+  border-radius: 9999px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  line-height: 1.3;
+  padding: 2px 8px;
+  text-transform: uppercase;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.dashboard-table-status-tag--breach {
+  background-color: color-mix(in srgb, var(--status-breach) 16%, transparent);
+  color: var(--status-breach);
+}
+
+.dashboard-table-status-tag--watch {
+  background-color: color-mix(in srgb, var(--status-nearing) 16%, transparent);
+  color: var(--status-nearing);
+}
+
+.dashboard-table-status-tag--good {
+  background-color: color-mix(in srgb, var(--status-resolved) 14%, transparent);
+  color: var(--status-resolved);
+}
+
+.dashboard-table-row-highlight {
+  background-color: color-mix(in srgb, var(--status-breach) 6%, transparent);
+}
+
+.dashboard-table-trend-up{
+  font-weight: 600;
+  color: var(--status-resolved);
+}
+
+.dashboard-table-trend-down{
+  font-weight: 600;
+  color: var(--status-breach);
+}
+
+.dashboard-table-muted{
+  color: var(--muted-foreground);
+}
+
+.dashboard-table-empty{
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  font-size: 12px;
+  color: var(--muted-foreground);
+}
+
+.dashboard-data-table-legend-swatch{
+  height: 0.5rem;
+  width: 0.5rem;
+  flex-shrink: 0;
+  border-radius: 9999px;
+}
+
+.dashboard-data-table-legend-label{
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.dashboard-data-table-value-emphasis{
+  font-weight: 600;
+}
+
+.dashboard-data-table-owner-name{
+  font-weight: 500;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.dashboard-data-table-sla-cell{
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+/* Viz type: bar-chart — vertical bars (all normal bar chart widgets) */
+
+.dashboard-bar-chart .apexcharts-canvas,
+  .dashboard-bar-chart .apexcharts-svg {
+  overflow: visible !important;
+}
+
+.dashboard-bar-chart-body{
+  display: flex;
+  min-height: 0px;
+  width: 100%;
+  min-width: 0px;
+  flex: 1 1 0%;
+  flex-direction: column;
+  overflow: hidden;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0px;
+  margin-top: -18px;
+  padding-bottom: 0.125rem;
+}
+
+.dashboard-bar-chart-header{
+  border-bottom-width: 0px;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-bottom: 0px;
+  padding-top: 0.125rem;
+}
+
+.dashboard-bar-chart-header .dashboard-drag-handle-title{
+  line-height: 1.25;
+}
+
+.dashboard-bar-chart-header .dashboard-drag-handle-subtitle{
+  margin-top: 0px;
+  line-height: 1;
+}
+
+.dashboard-chart-scroll-viewport{
+  height: 100%;
+  min-height: 0px;
+  width: 100%;
+  min-width: 0px;
+  flex: 1 1 0%;
+  overflow: hidden;
+}
+
+.dashboard-chart-scroll-viewport--active {
+  overflow: auto !important;
+}
+
+.dashboard-chart-scroll-viewport--vertical.dashboard-chart-scroll-viewport--active {
+  overflow-x: hidden !important;
+  overflow-y: auto !important;
+}
+
+.dashboard-chart-scroll-viewport--horizontal.dashboard-chart-scroll-viewport--active {
+  overflow-x: auto !important;
+  overflow-y: hidden !important;
+}
+
+.dashboard-chart-scroll-canvas {
+  flex-shrink: 0;
+  position: relative;
+}
+
+/* Viz type: gauge — progress bar vs target */
+
+.dashboard-gauge-header{
+  border-bottom-width: 0px;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-bottom: 0px;
+  padding-top: 0.25rem;
+}
+
+.dashboard-gauge-header .dashboard-drag-handle-title{
+  font-size: 13px;
+  line-height: 1.25;
+}
+
+.dashboard-gauge-body{
+  display: flex;
+  flex-shrink: 0;
+  flex-direction: column;
+  gap: 0px;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0px;
+  padding-bottom: 0.125rem;
+}
+
+.dashboard-gauge-value{
+  margin-bottom: 0.375rem;
+  font-weight: 600;
+  --tw-numeric-spacing: tabular-nums;
+  font-variant-numeric: var(--tw-ordinal) var(--tw-slashed-zero) var(--tw-numeric-figure) var(--tw-numeric-spacing) var(--tw-numeric-fraction);
+  color: var(--foreground);
+  font-size: 26px;
+  line-height: 1;
+}
+
+.dashboard-gauge-track{
+  position: relative;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  height: 0.75rem;
+  width: 100%;
+  overflow: visible;
+  border-radius: 9999px;
+  background-color: var(--muted);
+}
+
+.dashboard-gauge-fill{
+  height: 100%;
+  border-radius: 9999px;
+  background-color: var(--chart-1);
+}
+
+.dashboard-gauge-target-marker{
+  position: absolute;
+  top: 0px;
+  bottom: 0px;
+  display: flex;
+  width: 0.75rem;
+  cursor: default;
+  align-items: center;
+  justify-content: center;
+  transform: translateX(-50%);
+}
+
+.dashboard-gauge-target-line{
+  pointer-events: none;
+  display: block;
+  height: calc(100% + 6px);
+  width: 0px;
+  border-left: 2px dotted var(--foreground);
+  opacity: 0.55;
+}
+
+.dashboard-gauge-target-tooltip{
+  pointer-events: none;
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  z-index: 10;
+  margin-bottom: 0.25rem;
+  white-space: nowrap;
+  border-radius: 0.25rem;
+  background-color: var(--foreground);
+  padding-left: 0.375rem;
+  padding-right: 0.375rem;
+  padding-top: 0.125rem;
+  padding-bottom: 0.125rem;
+  font-size: 10px;
+  font-weight: 500;
+  line-height: 1.25;
+  color: var(--surface);
+  transform: translateX(-50%);
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+
+.dashboard-gauge-target-marker:hover .dashboard-gauge-target-tooltip,
+  .dashboard-gauge-target-marker:focus-visible .dashboard-gauge-target-tooltip {
+  opacity: 1;
+}
+
+.dashboard-gauge-status{
+  margin-top: 0.125rem;
+  font-size: 11px;
+  line-height: 1.25;
+  color: var(--muted-foreground);
+}
+
+.dashboard-bar-chart .apexcharts-canvas,
+  .dashboard-bar-chart .apexcharts-svg {
+  overflow: visible !important;
+}
+
+.dashboard-bar-chart .apexcharts-gridlines-horizontal line,
+  .dashboard-bar-chart .apexcharts-gridlines-vertical line {
+  display: none;
+}
+
+.dashboard-widget-surface .apexcharts-xaxis-texts-g,
+  .dashboard-widget-surface .apexcharts-yaxis-texts-g,
+  .dashboard-widget-surface .apexcharts-xaxis-inversed-texts-g {
+  overflow: visible;
+}
+
+.dashboard-widget-surface .apexcharts-xaxis-label,
+  .dashboard-widget-surface .apexcharts-yaxis-label {
+  overflow: visible;
+}
+
+.dashboard-widget-surface .apexcharts-xaxis-label tspan:not(:first-child),
+  .dashboard-widget-surface .apexcharts-yaxis-label tspan:not(:first-child) {
+  dy: 9px;
+}
+
+/* Viz type: horizontal-bar — ranked / ratio bars */
+
+.dashboard-horizontal-bar {
+  min-height: 0;
+}
+
+.dashboard-horizontal-bar-body{
+  display: flex;
+  min-height: 0px;
+  flex: 1 1 0%;
+  flex-direction: column;
+  overflow: hidden;
+  padding-left: 0.375rem;
+  padding-right: 0.375rem;
+  padding-top: 0px;
+  margin-top: -6px;
+  padding-bottom: 1.125rem;
+}
+
+.dashboard-horizontal-bar-header{
+  border-bottom-width: 0px;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-bottom: 0px;
+  padding-top: 0.375rem;
+}
+
+.dashboard-horizontal-bar-header .dashboard-drag-handle-title{
+  line-height: 1.25;
+}
+
+.dashboard-horizontal-bar-header .dashboard-drag-handle-subtitle{
+  margin-top: 0px;
+  line-height: 1;
+}
+
+.dashboard-horizontal-bar .apexcharts-canvas,
+  .dashboard-horizontal-bar .apexcharts-svg {
+  overflow: visible !important;
+}
+
+.dashboard-horizontal-bar .apexcharts-yaxis-texts-g .apexcharts-yaxis-label,
+  .dashboard-stacked-bar--horizontal .apexcharts-yaxis-texts-g .apexcharts-yaxis-label {
+  text-anchor: start;
+  transform-box: fill-box;
+  transform-origin: left center;
+}
+
+.dashboard-horizontal-bar .apexcharts-legend,
+  .dashboard-stacked-bar--horizontal .apexcharts-legend {
+  justify-content: center !important;
+  padding-bottom: 0 !important;
+  margin-bottom: -6px !important;
+}
+
+.dashboard-stacked-bar--horizontal .apexcharts-legend {
+  margin-bottom: -14px !important;
+}
+
+/* Viz type: stacked-bar — vertical + horizontal stacked bars */
+
+.dashboard-stacked-bar {
+  min-height: 0;
+}
+
+.dashboard-stacked-bar-body{
+  display: flex;
+  min-height: 0px;
+  flex: 1 1 0%;
+  flex-direction: column;
+  overflow: hidden;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0px;
+  margin-top: -6px;
+  padding-bottom: 0.125rem;
+}
+
+.dashboard-stacked-bar-body:has(.dashboard-stacked-bar--horizontal){
+  padding-left: 0.375rem;
+  padding-right: 0.375rem;
+  padding-bottom: 1.125rem;
+}
+
+.dashboard-stacked-bar-header{
+  border-bottom-width: 0px;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-bottom: 0.25rem;
+  padding-top: 0.375rem;
+}
+
+.dashboard-stacked-bar-header .dashboard-drag-handle-title{
+  line-height: 1.25;
+}
+
+.dashboard-stacked-bar-header .dashboard-drag-handle-subtitle{
+  margin-top: 0px;
+  line-height: 1;
+}
+
+.dashboard-stacked-bar .apexcharts-canvas,
+  .dashboard-stacked-bar .apexcharts-svg {
+  overflow: visible !important;
+}
+
+.dashboard-stacked-bar .apexcharts-gridlines-horizontal line,
+  .dashboard-stacked-bar .apexcharts-gridlines-vertical line {
+  display: none;
+}
+
+.dashboard-stacked-bar .apexcharts-legend {
+  padding-bottom: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+/* Apex column labels sit low in the segment rect; keep glyphs inside the fill. */
+
+.dashboard-stacked-bar:not(.dashboard-stacked-bar--horizontal)
+    .apexcharts-bar-series
+    .apexcharts-datalabels
+    text {
+  dominant-baseline: central;
+}
+
+.dashboard-stacked-bar--horizontal .apexcharts-legend {
+  margin-bottom: -14px !important;
+}
+
+.dashboard-line-chart {
+  overflow: visible;
+  min-height: 0;
+}
+
+.dashboard-line-chart-body{
+  display: flex;
+  min-height: 0px;
+  flex: 1 1 0%;
+  flex-direction: column;
+  overflow: hidden;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0px;
+  margin-top: -6px;
+  padding-bottom: 1.125rem;
+}
+
+.dashboard-line-chart-header{
+  border-bottom-width: 0px;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-bottom: 0px;
+  padding-top: 0.375rem;
+}
+
+.dashboard-line-chart-header .dashboard-drag-handle-title{
+  line-height: 1.25;
+}
+
+.dashboard-line-chart-header .dashboard-drag-handle-subtitle{
+  margin-top: 0px;
+  line-height: 1;
+}
+
+.dashboard-line-chart .apexcharts-canvas,
+  .dashboard-line-chart .apexcharts-svg {
+  overflow: hidden;
+}
+
+.dashboard-line-chart .apexcharts-gridlines-vertical line {
+  display: none;
+}
+
+.dashboard-line-chart-animating .apexcharts-series-markers-wrap,
+  .dashboard-line-chart-animating .apexcharts-series-markers {
+  opacity: 0 !important;
+  pointer-events: none !important;
+}
+
+.dashboard-line-chart:not(.dashboard-line-chart-animating)
+    .apexcharts-series-markers
+    .apexcharts-marker:not(.dashboard-line-chart-marker-active) {
+  fill: var(--line-chart-marker-fill, var(--surface));
+}
+
+/* Shared chart hover tooltip — opaque surface box for all viz types */
+
+.dashboard-chart-tooltip {
+  padding: 6px 10px;
+  background: var(--surface, #ffffff);
+  border: 1px solid var(--border, #e8e6e1);
+  border-radius: 2px;
+  color: var(--foreground, #1b1b1b);
+  box-shadow: none;
+}
+
+.dashboard-chart-tooltip--fixed {
+  position: fixed;
+  z-index: 10000;
+  max-width: 320px;
+  pointer-events: none;
+}
+
+.dashboard-chart-tooltip--anchored {
+  position: absolute;
+  z-index: 2;
+  transform: translate(-50%, -100%);
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+.dashboard-chart-tooltip-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--foreground, #1b1b1b);
+  margin-bottom: 4px;
+}
+
+.dashboard-chart-tooltip-row {
+  font-size: 11px;
+  line-height: 1.45;
+  font-weight: 500;
+}
+
+/* Apex wraps custom tooltips — hide default chrome so only our box shows */
+
+.dashboard-widget-surface .apexcharts-tooltip {
+  background: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+}
+
+.dashboard-line-chart-header-bar{
+  flex-shrink: 0;
+  border-bottom-width: 0px;
+}
+
+.dashboard-line-chart-widget-body{
+  display: flex;
+  min-height: 0px;
+  flex: 1 1 0%;
+  flex-direction: column;
+  overflow: hidden;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0px;
+  margin-top: -6px;
+  padding-bottom: 1.125rem;
+}
+
+/* Viz type: pie-chart — donut with in-slice values */
+
+.dashboard-pie-chart {
+  overflow: visible;
+  min-height: 0;
+}
+
+.dashboard-pie-chart-body{
+  display: flex;
+  min-height: 0px;
+  flex: 1 1 0%;
+  flex-direction: column;
+  overflow: visible;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0px;
+  margin-top: -10px;
+  padding-bottom: 1.125rem;
+}
+
+.dashboard-pie-chart-header{
+  border-bottom-width: 0px;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-bottom: 0px;
+  padding-top: 0.375rem;
+}
+
+.dashboard-pie-chart-header .dashboard-drag-handle-title{
+  line-height: 1.25;
+}
+
+.dashboard-pie-chart-header .dashboard-drag-handle-subtitle{
+  margin-top: 0px;
+  line-height: 1;
+}
+
+/* Viz type: map — geographic distribution */
+
+.dashboard-map {
+  min-height: 0;
+}
+
+.dashboard-map-body{
+  display: flex;
+  min-height: 0px;
+  flex: 1 1 0%;
+  flex-direction: column;
+  overflow: hidden;
+  padding: 0px;
+  padding-bottom: 1.125rem;
+}
+
+.dashboard-map-header{
+  border-bottom-width: 0px;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-bottom: 0px;
+  padding-top: 0.375rem;
+}
+
+.dashboard-map-header .dashboard-drag-handle-title{
+  line-height: 1.25;
+}
+
+.dashboard-map-header-bar{
+  border-bottom-width: 0px;
+}
+
+.dashboard-map-frame{
+  position: relative;
+  display: flex;
+  min-height: 0px;
+  flex: 1 1 0%;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.dashboard-map-toolbar-row{
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  border-bottom-width: 1px;
+  border-color: var(--border);
+  background-color: var(--surface);
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
+.dashboard-map-shell{
+  position: relative;
+  display: flex;
+  min-height: 0px;
+  flex: 1 1 0%;
+  flex-direction: column;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.dashboard-map-canvas{
+  position: relative;
+  z-index: 1;
+  border-radius: 0px;
+}
+
+.dashboard-map-canvas .leaflet-container {
+  height: 100%;
+  width: 100%;
+  font-family: inherit;
+}
+
+.dashboard-map-legend {
+  width: 196px;
+  border: 1px solid var(--border);
+  border-radius: 0.125rem;
+  background: color-mix(in srgb, var(--surface) 98%, transparent);
+  box-shadow: 0 4px 16px rgb(0 0 0 / 0.12);
+  -webkit-backdrop-filter: blur(6px);
+          backdrop-filter: blur(6px);
+  pointer-events: auto;
+}
+
+.dashboard-map-filter-chip {
+  z-index: 1000;
+}
+
+.dashboard-grid-layout .react-grid-item.dashboard-grid-item-map > .react-resizable-handle {
+  z-index: 1200;
+  pointer-events: auto;
+}
+
+.dashboard-grid-layout .react-grid-item.dashboard-grid-item-map:hover > .react-resizable-handle {
+  opacity: 1;
+}
+
+.dashboard-grid-layout .react-grid-item.dashboard-grid-item-map > .react-resizable-handle.react-resizable-handle-s {
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 12px;
+  cursor: s-resize;
+}
+
+.dashboard-grid-layout .react-grid-item.dashboard-grid-item-map > .react-resizable-handle.react-resizable-handle-e {
+  top: 0;
+  right: 0;
+  width: 12px;
+  height: 100%;
+  margin-top: 0;
+  cursor: e-resize;
+}
+
+.dashboard-map-breadcrumb{
+  display: flex;
+  min-width: 0px;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.dashboard-map-zoom-badge {
+  -webkit-backdrop-filter: blur(4px);
+          backdrop-filter: blur(4px);
+}
+
+.dashboard-map-controls{
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  overflow: hidden;
+  border-radius: 4px;
+  border-width: 1px;
+  border-color: var(--border);
+  background-color: var(--surface);
+  --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.dashboard-map-control-btn{
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  border-width: 0px;
+  background-color: transparent;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0.375rem;
+  padding-bottom: 0.375rem;
+  font-size: 10px;
+  font-weight: 500;
+  line-height: 1;
+  color: var(--foreground);
+  cursor: pointer;
+}
+
+.dashboard-map-control-btn:hover{
+  background-color: var(--muted);
+}
+
+.dashboard-map-control-btn + .dashboard-map-control-btn{
+  border-left-width: 1px;
+  border-color: var(--border);
+}
+
+.dashboard-map-control-btn--text{
+  padding-left: 0.625rem;
+  padding-right: 0.625rem;
+}
+
+.dashboard-map-filter-chip {
+  -webkit-backdrop-filter: blur(4px);
+          backdrop-filter: blur(4px);
+}
+
+.dashboard-map-filter-clear{
+  border-width: 0px;
+  background-color: transparent;
+  padding: 0px;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--chart-1);
+  cursor: pointer;
+}
+
+.dashboard-map-filter-clear:hover {
+  text-decoration: underline;
+}
+
+.dashboard-map-legend-toggle{
+  height: 1.25rem;
+  width: 1.25rem;
+  border-width: 0px;
+  background-color: transparent;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  line-height: 1;
+  color: var(--muted-foreground);
+  cursor: pointer;
+}
+
+.dashboard-map-legend-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.dashboard-map-legend-swatch{
+  display: inline-block;
+  height: 0.75rem;
+  width: 0.75rem;
+  flex-shrink: 0;
+  border-radius: 4px;
+  border-width: 1px;
+}
+
+.leaflet-tooltip.dashboard-map-hover-tooltip {
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  padding: 0;
+  margin-top: -8px;
+  z-index: 800;
+}
+
+.dashboard-map-hover-card {
+  min-width: 168px;
+  border: 1px solid var(--border);
+  border-radius: 0.25rem;
+  background: color-mix(in srgb, var(--surface) 98%, transparent);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 0.12);
+  padding: 0.625rem 0.75rem;
+}
+
+.dashboard-map-hover-title{
+  margin-bottom: 0.375rem;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+.dashboard-map-hover-row{
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 10px;
+  line-height: 1.375;
+  color: var(--muted-foreground);
+}
+
+.dashboard-map-hover-row strong{
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+.leaflet-popup.dashboard-map-pin-popup-wrapper .dashboard-map-hover-card {
+  min-width: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
+}
+
+.leaflet-popup.dashboard-map-pin-popup-wrapper .leaflet-popup-content-wrapper {
+  border-radius: 0.375rem;
+}
+
+.dashboard-map-hover-note{
+  margin-top: 0.375rem;
+  font-size: 9px;
+  line-height: 1.375;
+  color: var(--muted-foreground);
+}
+
+.dashboard-pie-slice {
+  cursor: default;
+}
+
+.dashboard-grid-layout .react-grid-item > .react-resizable-handle::after {
+  content: none;
+  border: 0;
+}
+
+.dashboard-grid-layout .react-grid-item > .react-resizable-handle {
+  background: transparent;
+  opacity: 0;
+}
+
+.dashboard-grid-layout .react-grid-item:hover > .react-resizable-handle.react-resizable-handle-se,
+  .dashboard-grid-layout .react-grid-item:hover > .react-resizable-handle.react-resizable-handle-e,
+  .dashboard-grid-layout .react-grid-item:hover > .react-resizable-handle.react-resizable-handle-s {
+  opacity: 1;
+}
+
+.dashboard-grid-layout .react-grid-item > .react-resizable-handle.react-resizable-handle-se {
+  bottom: 0;
+  right: 0;
+  width: 18px;
+  height: 18px;
+  cursor: se-resize;
+  z-index: 3;
+}
+
+.dashboard-grid-layout .react-grid-item > .react-resizable-handle.react-resizable-handle-e {
+  top: 50%;
+  right: 0;
+  width: 18px;
+  height: 18px;
+  margin-top: -9px;
+  cursor: e-resize;
+  z-index: 3;
+}
+
+.dashboard-grid-layout .react-grid-item > .react-resizable-handle.react-resizable-handle-s {
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 12px;
+  cursor: s-resize;
+  z-index: 3;
+}
+
+.dashboard-grid-layout .react-grid-placeholder {
+  background: transparent !important;
+  opacity: 0 !important;
+  border: 0 !important;
+}
+
+.dashboard-view-toggle button {
+  cursor: default;
+}
+
+.dashboard-sla-link {
+  color: var(--chart-1);
+  font-weight: 500;
+  text-decoration: none;
+  cursor: default;
+}
+
+.dashboard-sla-link:hover {
+  text-decoration: underline;
+}
+
+.dashboard-sla-link--button{
+  border-width: 0px;
+  background-color: transparent;
+  padding: 0px;
+}
+
+.dashboard-sla-breach-pill {
+  display: inline-block;
+  max-width: 100%;
+  border-radius: 4px;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  line-height: 1.2;
+  padding: 2px 6px;
+  text-transform: uppercase;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.dashboard-sla-breach-pill--breached {
+  background-color: color-mix(in srgb, var(--status-breach) 14%, transparent);
+  color: var(--status-breach);
+}
+
+.dashboard-sla-breach-pill--nearing {
+  background-color: color-mix(in srgb, var(--status-progress) 16%, transparent);
+  color: var(--status-progress);
+}
+
+.dashboard-sla-status-pill {
+  display: inline-block;
+  max-width: 100%;
+  border-radius: 9999px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1.3;
+  padding: 3px 10px;
+  text-transform: uppercase;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.dashboard-sla-status-pill--reopened {
+  background-color: color-mix(in srgb, var(--chart-4) 14%, transparent);
+  color: var(--chart-4);
+}
+
+.dashboard-sla-status-pill--assigned {
+  background-color: color-mix(in srgb, var(--chart-1) 14%, transparent);
+  color: var(--chart-1);
+}
+
+.dashboard-sla-status-pill--open {
+  background-color: color-mix(in srgb, var(--chart-2) 16%, transparent);
+  color: var(--chart-2);
+}
+
+.dashboard-sla-status-pill--in-progress {
+  background-color: color-mix(in srgb, var(--status-progress) 14%, transparent);
+  color: var(--status-progress);
+}
+
+.dashboard-sla-overdue {
+  color: var(--status-breach);
+  font-weight: 500;
+}
+
+.dashboard-search-dimmed {
+  opacity: 0.12;
+  pointer-events: none;
+}
+
+.tw-pointer-events-none{
+  pointer-events: none;
+}
+
+.tw-pointer-events-auto{
+  pointer-events: auto;
+}
+
+.tw-absolute{
+  position: absolute;
+}
+
+.tw-relative{
+  position: relative;
+}
+
+.tw-inset-0{
+  inset: 0px;
+}
+
+.tw-bottom-1{
+  bottom: 0.25rem;
+}
+
+.tw-bottom-3{
+  bottom: 0.75rem;
+}
+
+.tw-left-3{
+  left: 0.75rem;
+}
+
+.tw-right-3{
+  right: 0.75rem;
+}
+
+.tw-right-5{
+  right: 1.25rem;
+}
+
+.tw-top-12{
+  top: 3rem;
+}
+
+.tw-top-20{
+  top: 5rem;
+}
+
+.tw-top-3{
+  top: 0.75rem;
+}
+
+.tw-z-\[1000\]{
+  z-index: 1000;
+}
+
+.tw-z-\[1100\]{
+  z-index: 1100;
+}
+
+.tw-z-\[2\]{
+  z-index: 2;
+}
+
+.tw-z-\[500\]{
+  z-index: 500;
+}
+
+.tw-m-0{
+  margin: 0px;
+}
+
+.tw-mb-4{
+  margin-bottom: 1rem;
+}
+
+.tw-mt-1{
+  margin-top: 0.25rem;
+}
+
+.tw-mt-2{
+  margin-top: 0.5rem;
+}
+
+.tw-block{
+  display: block;
+}
+
+.tw-flex{
+  display: flex;
+}
+
+.tw-inline-flex{
+  display: inline-flex;
+}
+
+.tw-hidden{
+  display: none;
+}
+
+.tw-h-1\.5{
+  height: 0.375rem;
+}
+
+.tw-h-12{
+  height: 3rem;
+}
+
+.tw-h-3\.5{
+  height: 0.875rem;
+}
+
+.tw-h-4{
+  height: 1rem;
+}
+
+.tw-h-full{
+  height: 100%;
+}
+
+.tw-h-screen{
+  height: 100vh;
+}
+
+.tw-max-h-\[min\(24rem\,70vh\)\]{
+  max-height: min(24rem,70vh);
+}
+
+.tw-min-h-0{
+  min-height: 0px;
+}
+
+.tw-min-h-\[220px\]{
+  min-height: 220px;
+}
+
+.tw-w-1\.5{
+  width: 0.375rem;
+}
+
+.tw-w-3\.5{
+  width: 0.875rem;
+}
+
+.tw-w-4{
+  width: 1rem;
+}
+
+.tw-w-60{
+  width: 15rem;
+}
+
+.tw-w-80{
+  width: 20rem;
+}
+
+.tw-w-full{
+  width: 100%;
+}
+
+.tw-min-w-0{
+  min-width: 0px;
+}
+
+.tw-max-w-\[220px\]{
+  max-width: 220px;
+}
+
+.tw-flex-1{
+  flex: 1 1 0%;
+}
+
+.tw-flex-shrink-0{
+  flex-shrink: 0;
+}
+
+.tw-shrink-0{
+  flex-shrink: 0;
+}
+
+@keyframes tw-pulse{
+  50%{
+    opacity: .5;
+  }
+}
+
+.tw-animate-pulse{
+  animation: tw-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+.tw-list-none{
+  list-style-type: none;
+}
+
+.tw-flex-col{
+  flex-direction: column;
+}
+
+.tw-flex-wrap{
+  flex-wrap: wrap;
+}
+
+.tw-items-center{
+  align-items: center;
+}
+
+.tw-items-baseline{
+  align-items: baseline;
+}
+
+.tw-justify-center{
+  justify-content: center;
+}
+
+.tw-justify-between{
+  justify-content: space-between;
+}
+
+.tw-gap-1{
+  gap: 0.25rem;
+}
+
+.tw-gap-1\.5{
+  gap: 0.375rem;
+}
+
+.tw-gap-2{
+  gap: 0.5rem;
+}
+
+.tw-gap-3{
+  gap: 0.75rem;
+}
+
+.tw-gap-4{
+  gap: 1rem;
+}
+
+.tw-gap-x-3{
+  column-gap: 0.75rem;
+}
+
+.tw-gap-y-0\.5{
+  row-gap: 0.125rem;
+}
+
+.tw-space-y-1 > :not([hidden]) ~ :not([hidden]){
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.25rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.25rem * var(--tw-space-y-reverse));
+}
+
+.tw-space-y-1\.5 > :not([hidden]) ~ :not([hidden]){
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.375rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.375rem * var(--tw-space-y-reverse));
+}
+
+.tw-overflow-auto{
+  overflow: auto;
+}
+
+.tw-overflow-hidden{
+  overflow: hidden;
+}
+
+.tw-overflow-visible{
+  overflow: visible;
+}
+
+.tw-overflow-y-auto{
+  overflow-y: auto;
+}
+
+.tw-overscroll-contain{
+  overscroll-behavior: contain;
+}
+
+.tw-truncate{
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tw-rounded{
+  border-radius: 0.25rem;
+}
+
+.tw-rounded-full{
+  border-radius: 9999px;
+}
+
+.tw-rounded-md{
+  border-radius: 0.375rem;
+}
+
+.tw-rounded-sm{
+  border-radius: 4px;
+}
+
+.tw-border{
+  border-width: 1px;
+}
+
+.tw-border-0{
+  border-width: 0px;
+}
+
+.tw-border-b{
+  border-bottom-width: 1px;
+}
+
+.tw-border-t{
+  border-top-width: 1px;
+}
+
+.tw-border-dashed{
+  border-style: dashed;
+}
+
+.tw-border-\[color-mix\(in_srgb\,var\(--chrome-foreground\)_15\%\,transparent\)\]{
+  border-color: color-mix(in srgb,var(--chrome-foreground) 15%,transparent);
+}
+
+.tw-border-\[color-mix\(in_srgb\,var\(--destructive\)_30\%\,transparent\)\]{
+  border-color: color-mix(in srgb,var(--destructive) 30%,transparent);
+}
+
+.tw-border-border{
+  border-color: var(--border);
+}
+
+.tw-bg-amber-50\/95{
+  background-color: rgb(255 251 235 / 0.95);
+}
+
+.tw-bg-background{
+  background-color: var(--background);
+}
+
+.tw-bg-chart-1{
+  background-color: var(--chart-1);
+}
+
+.tw-bg-chrome{
+  background-color: var(--chrome);
+}
+
+.tw-bg-muted{
+  background-color: var(--muted);
+}
+
+.tw-bg-primary{
+  background-color: var(--primary);
+}
+
+.tw-bg-status-assigned{
+  background-color: var(--status-assigned);
+}
+
+.tw-bg-status-assigned-bg{
+  background-color: var(--status-assigned-bg);
+}
+
+.tw-bg-status-breach-bg{
+  background-color: var(--status-breach-bg);
+}
+
+.tw-bg-status-resolved-bg{
+  background-color: var(--status-resolved-bg);
+}
+
+.tw-bg-surface{
+  background-color: var(--surface);
+}
+
+.tw-bg-surface-2{
+  background-color: var(--surface-2);
+}
+
+.tw-p-0{
+  padding: 0px;
+}
+
+.tw-p-3{
+  padding: 0.75rem;
+}
+
+.tw-p-4{
+  padding: 1rem;
+}
+
+.tw-px-1{
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+}
+
+.tw-px-2{
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.tw-px-2\.5{
+  padding-left: 0.625rem;
+  padding-right: 0.625rem;
+}
+
+.tw-px-3{
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+}
+
+.tw-px-4{
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.tw-px-5{
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
+}
+
+.tw-py-0\.5{
+  padding-top: 0.125rem;
+  padding-bottom: 0.125rem;
+}
+
+.tw-py-1{
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+}
+
+.tw-py-1\.5{
+  padding-top: 0.375rem;
+  padding-bottom: 0.375rem;
+}
+
+.tw-py-16{
+  padding-top: 4rem;
+  padding-bottom: 4rem;
+}
+
+.tw-py-2{
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
+.tw-py-3{
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+}
+
+.tw-py-5{
+  padding-top: 1.25rem;
+  padding-bottom: 1.25rem;
+}
+
+.tw-py-6{
+  padding-top: 1.5rem;
+  padding-bottom: 1.5rem;
+}
+
+.tw-pb-0{
+  padding-bottom: 0px;
+}
+
+.tw-pb-2{
+  padding-bottom: 0.5rem;
+}
+
+.tw-pr-8{
+  padding-right: 2rem;
+}
+
+.tw-pt-2{
+  padding-top: 0.5rem;
+}
+
+.tw-pt-2\.5{
+  padding-top: 0.625rem;
+}
+
+.tw-text-center{
+  text-align: center;
+}
+
+.tw-font-sans{
+  font-family: Inter, Roboto, ui-sans-serif, system-ui, sans-serif;
+}
+
+.tw-text-\[10px\]{
+  font-size: 10px;
+}
+
+.tw-text-\[11px\]{
+  font-size: 11px;
+}
+
+.tw-text-\[12px\]{
+  font-size: 12px;
+}
+
+.tw-text-\[15px\]{
+  font-size: 15px;
+}
+
+.tw-text-\[9px\]{
+  font-size: 9px;
+}
+
+.tw-text-lg{
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+}
+
+.tw-text-sm{
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
+.tw-text-xs{
+  font-size: 0.75rem;
+  line-height: 1rem;
+}
+
+.tw-font-bold{
+  font-weight: 700;
+}
+
+.tw-font-medium{
+  font-weight: 500;
+}
+
+.tw-font-normal{
+  font-weight: 400;
+}
+
+.tw-font-semibold{
+  font-weight: 600;
+}
+
+.tw-uppercase{
+  text-transform: uppercase;
+}
+
+.tw-tabular-nums{
+  --tw-numeric-spacing: tabular-nums;
+  font-variant-numeric: var(--tw-ordinal) var(--tw-slashed-zero) var(--tw-numeric-figure) var(--tw-numeric-spacing) var(--tw-numeric-fraction);
+}
+
+.tw-leading-snug{
+  line-height: 1.375;
+}
+
+.tw-leading-tight{
+  line-height: 1.25;
+}
+
+.tw-tracking-wide{
+  letter-spacing: 0.025em;
+}
+
+.tw-tracking-wider{
+  letter-spacing: 0.05em;
+}
+
+.tw-text-amber-900{
+  --tw-text-opacity: 1;
+  color: rgb(120 53 15 / var(--tw-text-opacity, 1));
+}
+
+.tw-text-chrome-foreground{
+  color: var(--chrome-foreground);
+}
+
+.tw-text-chrome-muted{
+  color: var(--chrome-muted);
+}
+
+.tw-text-destructive{
+  color: var(--destructive);
+}
+
+.tw-text-foreground{
+  color: var(--foreground);
+}
+
+.tw-text-muted-foreground{
+  color: var(--muted-foreground);
+}
+
+.tw-text-primary-foreground{
+  color: var(--primary-foreground);
+}
+
+.tw-text-status-assigned{
+  color: var(--status-assigned);
+}
+
+.tw-text-status-breach{
+  color: var(--status-breach);
+}
+
+.tw-text-status-resolved{
+  color: var(--status-resolved);
+}
+
+.tw-text-white{
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+}
+
+.tw-shadow-sm{
+  --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+/* Scrollbars hidden globally except on chart/table scroll regions. */
+
+.dashboard-root,
+.dashboard-root * {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.dashboard-root *:not(.dashboard-subtle-scroll)::-webkit-scrollbar {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
+.dashboard-root .dashboard-subtle-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+}
+
+.dashboard-root .dashboard-subtle-scroll.dashboard-subtle-scroll--active {
+  scrollbar-color: color-mix(in srgb, var(--foreground) 22%, transparent) transparent;
+}
+
+.dashboard-root .dashboard-subtle-scroll::-webkit-scrollbar {
+  display: block;
+  width: 5px;
+  height: 5px;
+}
+
+.dashboard-root .dashboard-subtle-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.dashboard-root .dashboard-subtle-scroll::-webkit-scrollbar-thumb {
+  background-color: transparent;
+  border-radius: 9999px;
+  -webkit-transition: background-color 0.3s ease;
+  transition: background-color 0.3s ease;
+}
+
+.dashboard-root .dashboard-subtle-scroll.dashboard-subtle-scroll--active::-webkit-scrollbar-thumb {
+  background-color: color-mix(in srgb, var(--foreground) 22%, transparent);
+}
+
+.dashboard-root .dashboard-subtle-scroll.dashboard-subtle-scroll--active::-webkit-scrollbar-thumb:hover {
+  background-color: color-mix(in srgb, var(--foreground) 32%, transparent);
+}
+
+/* Beat global digit-ui Roboto rules on bare form/table elements */
+
+.dashboard-root :is(
+  button,
+  input,
+  select,
+  textarea,
+  optgroup,
+  option,
+  label,
+  table,
+  caption,
+  thead,
+  tbody,
+  tfoot,
+  tr,
+  th,
+  td,
+  p,
+  span,
+  div,
+  a,
+  li,
+  ul,
+  ol,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  header,
+  footer,
+  main,
+  section,
+  nav,
+  aside,
+  small,
+  strong,
+  em
+) {
+  font-family: var(--dashboard-font-family) !important;
+}
+
+.hover\:tw-bg-\[color-mix\(in_srgb\2c var\(--chrome-foreground\)_12\%\2c transparent\)\]:hover{
+  background-color: color-mix(in srgb,var(--chrome-foreground) 12%,transparent);
+}
+
+.hover\:tw-bg-\[color-mix\(in_srgb\2c var\(--chrome-foreground\)_22\%\2c transparent\)\]:hover{
+  background-color: color-mix(in srgb,var(--chrome-foreground) 22%,transparent);
+}
+
+.hover\:tw-text-foreground:hover{
+  color: var(--foreground);
+}
+
+@media (min-width: 640px){
+  .sm\:tw-inline-flex{
+    display: inline-flex;
+  }
+}
+
+@media (min-width: 1024px){
+  .lg\:tw-p-6{
+    padding: 1.5rem;
+  }
+
+  .lg\:tw-px-6{
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+}
+
+/* ── Embedded-in-DigitUI overrides ─────────────────────────────────────
+   Applied when the dashboard is mounted inside the DigitUI employee
+   chrome (products/dashboard/Module.js renders <AdminDashboard embedded />,
+   which adds .dashboard-embedded next to .dashboard-root). The host chrome
+   owns the viewport and scrolling, so the standalone full-viewport shell
+   (h-screen root, internal overflow scrollers) is neutralized; the internal
+   dark Sidebar is simply not rendered in embedded mode. Mirrored in
+   input.css so `npm run build:dashboard-css` regeneration keeps it. */
+.dashboard-root.dashboard-embedded {
+  height: auto;
+  min-height: 100%;
+  overflow: visible;
+}
+.dashboard-root.dashboard-embedded > div {
+  overflow: visible;
+}
+.dashboard-root.dashboard-embedded > div > main {
+  overflow: visible;
+}

--- a/digit-ui-esbuild/products/dashboard/src/styles/input.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/input.css
@@ -1,0 +1,2097 @@
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  .dashboard-root {
+    /* ============================================================
+     * Canonical color palette — single source of truth.
+     * Every dashboard color (Tailwind tokens, raw CSS, chart series)
+     * resolves to one of these variables. Update colors here only.
+     * ============================================================ */
+
+    /* Surfaces & text */
+    --background: lab(98.2586% -0.2231 -0.716782);
+    --foreground: lab(5.23127% -1.15929 -6.2068);
+    --surface: lab(100% 0 0);
+    --surface-2: lab(97.097% -0.443935 -1.43216);
+    --surface-3: lab(94.7753% -0.662118 -2.14608);
+    --card: lab(100% 0 0);
+    --card-foreground: lab(5.23127% -1.15929 -6.2068);
+    --popover: lab(100% 0 0);
+    --popover-foreground: lab(5.23127% -1.15929 -6.2068);
+
+    /* Brand / interactive */
+    --primary: lab(35.8817% -24.1734 -2.46631);
+    --primary-foreground: lab(98.84% 0.0000298023 -0.0000119209);
+    --secondary: lab(94.2798% -2.53278 -1.0635);
+    --secondary-foreground: lab(9.71627% -6.29769 -2.60819);
+    --muted: lab(94.8109% -1.28037 -1.23321);
+    --muted-foreground: lab(39.77% -3.78458 -3.66642);
+    --accent: lab(93.2569% -6.07967 -0.65273);
+    --accent-foreground: lab(7.50164% -8.19696 -3.84778);
+    --destructive: lab(45.6933% 66.2056 47.555);
+    --destructive-foreground: lab(98.84% 0.0000298023 -0.0000119209);
+
+    /* Lines & focus */
+    --border: lab(88.4492% -2.04447 -1.97053);
+    --input: lab(88.4492% -2.04447 -1.97053);
+    --ring: lab(35.8817% -24.1734 -2.46631);
+
+    /* Chrome (top bar / nav) */
+    --chrome: lab(12.1586% -9.80562 -2.97114);
+    --chrome-foreground: lab(96.5699% -1.58328 -0.665271);
+    --chrome-muted: lab(56.1186% -6.32274 -2.64311);
+
+    /* Status (foreground + tinted background pairs) */
+    --status-open: lab(36.6287% -20.0702 -21.1027);
+    --status-open-bg: lab(94.3508% -6.32584 -6.12073);
+    --status-assigned: lab(35.8108% -25.0002 -10.2503);
+    --status-assigned-bg: lab(94.4979% -9.48459 -3.96528);
+    --status-progress: lab(41.816% 17.1944 63.4163);
+    --status-progress-bg: lab(95.4544% 2.6814 15.3591);
+    --status-nearing: var(--status-progress);
+    --status-nearing-bg: var(--status-progress-bg);
+    --status-resolved: lab(36.3321% -35.6256 3.05576);
+    --status-resolved-bg: lab(94.7185% -13.6163 1.20147);
+    --status-rejected: lab(36.1728% -1.98329 -7.04196);
+    --status-rejected-bg: lab(93.0362% -0.553161 -1.78919);
+    --status-overdue: lab(45.8049% 62.9533 44.1);
+    --status-overdue-bg: lab(95.0932% 9.04813 5.32234);
+    --status-breach: lab(37.1998% 71.0423 26.7454);
+    --status-breach-bg: lab(93.7677% 13.0259 4.10725);
+
+    /* Chart series */
+    --chart-1: lab(36.1215% -31.3433 -3.14357);
+    --chart-2: lab(48.7634% -31.2502 -12.8129);
+    --chart-3: lab(60.588% -31.0205 5.71432);
+    --chart-4: lab(46.0249% 56.4689 37.9874);
+    --chart-5: lab(42.1906% -16.731 -27.7727);
+
+    /* ------------------------------------------------------------
+     * Legacy aliases — kept so existing var(--dashboard-*) and
+     * var(--brand-*) references map onto the canonical palette.
+     * ------------------------------------------------------------ */
+    --dashboard-background: var(--background);
+    --dashboard-foreground: var(--foreground);
+    --dashboard-surface: var(--surface);
+    --dashboard-border: var(--border);
+    --dashboard-muted: var(--muted);
+    --dashboard-muted-foreground: var(--muted-foreground);
+    --dashboard-status-resolved: var(--status-resolved);
+    --dashboard-status-breach: var(--status-breach);
+    --brand-teal: var(--primary);
+    --brand-dark: var(--chrome);
+    --brand-slate: var(--chrome-muted);
+
+    --dashboard-font-family: Inter, Roboto, ui-sans-serif, system-ui, sans-serif;
+    font-family: var(--dashboard-font-family);
+    font-feature-settings: "tnum" 1;
+    -webkit-font-smoothing: antialiased;
+  }
+}
+
+@layer components {
+  .dashboard-widget {
+    @apply tw-h-full tw-overflow-hidden tw-rounded tw-border tw-border-border tw-bg-surface;
+  }
+
+  .dashboard-drag-handle {
+    @apply tw-flex tw-shrink-0 tw-items-center tw-justify-between tw-border-b tw-border-border tw-px-4 tw-py-2.5;
+  }
+
+  .dashboard-drag-handle-title {
+    @apply tw-truncate tw-text-[13px] tw-font-semibold tw-text-foreground;
+  }
+
+  .dashboard-drag-handle-subtitle {
+    @apply tw-truncate tw-text-[11px] tw-leading-tight tw-text-muted-foreground;
+  }
+
+  .kpi-inventory-item:active {
+    @apply tw-opacity-70;
+  }
+
+  .dashboard-external-drag .react-grid-item {
+    pointer-events: none;
+  }
+
+  .dashboard-external-drag .react-grid-placeholder {
+    transition: none;
+  }
+
+  .dashboard-external-drag .dashboard-grid-layout .react-grid-placeholder,
+  .dashboard-grid-dragging .dashboard-grid-layout .react-grid-placeholder {
+    opacity: 1 !important;
+    z-index: 1 !important;
+    border-radius: 4px;
+    border: 1px dashed color-mix(in srgb, var(--chart-1, #2563eb) 35%, transparent) !important;
+    background: color-mix(in srgb, var(--chart-1, #2563eb) 5%, transparent) !important;
+  }
+
+  .dashboard-grid-dragging .react-grid-placeholder,
+  .dashboard-external-drag .react-grid-placeholder {
+    transition: none;
+  }
+
+  .dashboard-grid-dragging .react-grid-item.react-draggable-dragging,
+  .dashboard-external-drag .react-grid-item.react-draggable-dragging {
+    z-index: 10 !important;
+  }
+
+  .dashboard-kpi-drag-handle {
+    @apply tw-shrink-0 tw-border-0 tw-bg-transparent tw-py-1 tw-normal-case tw-tracking-normal;
+    min-height: 1.25rem;
+  }
+
+  .dashboard-kpi-remove {
+    @apply tw-opacity-0 tw-transition-opacity group-hover:tw-opacity-100;
+  }
+
+  .dashboard-widget-remove-btn {
+    @apply tw-absolute tw-right-1 tw-top-1 tw-z-10 tw-box-border tw-m-0 tw-inline-flex tw-h-6 tw-w-6 tw-items-center tw-justify-center tw-rounded-sm tw-border-0 tw-bg-transparent tw-p-0 tw-text-muted-foreground;
+    font: inherit;
+    -webkit-appearance: none;
+    appearance: none;
+  }
+
+  .dashboard-widget-remove-btn:hover {
+    @apply tw-bg-muted tw-text-status-breach;
+  }
+
+  .dashboard-widget-remove-btn:focus {
+    @apply tw-outline-none;
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 30%, transparent);
+  }
+
+  /* ---------------------------------------------------------------
+   * Viz type: number-tile-delta (metric KPI cards — value + delta + context)
+   * Class names are referenced from config/visualizationStyles.js
+   * --------------------------------------------------------------- */
+  .dashboard-kpi-card {
+    @apply tw-relative tw-box-border tw-w-full tw-rounded tw-border tw-border-border tw-bg-surface tw-p-4;
+    min-height: 0;
+    font-family: inherit;
+  }
+
+  .dashboard-kpi-card--metric {
+    @apply tw-h-full;
+    display: grid;
+    grid-template-rows: minmax(0, 1fr) 26px minmax(0, 1fr);
+    gap: 0.25rem;
+  }
+
+  .dashboard-kpi-title {
+    @apply tw-min-w-0 tw-w-full tw-font-medium tw-uppercase tw-tracking-wide tw-text-muted-foreground;
+    font-size: 11px;
+    line-height: 1.25;
+  }
+
+  .dashboard-kpi-card--metric .dashboard-kpi-title {
+    @apply tw-self-start tw-overflow-hidden;
+    padding-right: 1.25rem;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+
+  .dashboard-kpi-value {
+    @apply tw-shrink-0 tw-font-semibold tw-tabular-nums;
+    font-size: 26px;
+    line-height: 1;
+  }
+
+  .dashboard-kpi-card--metric .dashboard-kpi-value {
+    @apply tw-self-center;
+  }
+
+  .dashboard-kpi-context {
+    @apply tw-shrink-0 tw-text-muted-foreground;
+    font-size: 12px;
+    line-height: 1.25;
+  }
+
+  .dashboard-kpi-card--metric .dashboard-kpi-context {
+    @apply tw-self-start tw-overflow-hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+
+  .dashboard-kpi-card--delta {
+    @apply tw-h-full;
+    display: grid;
+    grid-template-rows: minmax(26px, auto) 26px minmax(0, 1fr);
+    gap: 0.25rem;
+  }
+
+  .dashboard-kpi-card--delta .dashboard-kpi-title {
+    @apply tw-self-start tw-overflow-hidden;
+    padding-right: 1.25rem;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+
+  .dashboard-kpi-card--delta .dashboard-kpi-value {
+    @apply tw-self-auto tw-shrink-0;
+  }
+
+  .dashboard-kpi-card--delta .dashboard-kpi-context {
+    @apply tw-self-start tw-overflow-hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+
+  /* Viz type: number-tile-sparkline (delta + trend line) */
+  .dashboard-kpi-card--sparkline {
+    @apply tw-h-full;
+    display: grid;
+    /* Title band matches default metric tile offset; only the sparkline row grows on resize. */
+    grid-template-rows: minmax(26px, auto) 26px minmax(10px, 1fr);
+    gap: 0.25rem;
+    min-height: 0;
+    padding-bottom: 1.125rem;
+  }
+
+  .dashboard-kpi-card--sparkline .dashboard-kpi-title {
+    @apply tw-self-start tw-overflow-hidden;
+    padding-right: 1.25rem;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+
+  .dashboard-kpi-sparkline-value-row {
+    @apply tw-flex tw-items-baseline tw-justify-start tw-gap-1.5;
+    min-width: 0;
+    align-self: center;
+    padding-top: 0;
+  }
+
+  .dashboard-kpi-card--sparkline .dashboard-kpi-value {
+    @apply tw-self-auto tw-shrink-0;
+  }
+
+  .dashboard-kpi-sparkline-delta {
+    @apply tw-shrink-0 tw-text-[12px] tw-font-semibold tw-tabular-nums;
+    line-height: 1;
+    padding-bottom: 0.2em;
+  }
+
+  .dashboard-kpi-sparkline-delta--positive {
+    color: var(--status-resolved);
+  }
+
+  .dashboard-kpi-sparkline-delta--negative {
+    color: var(--status-breach);
+  }
+
+  .dashboard-kpi-sparkline-delta--neutral {
+    @apply tw-text-foreground;
+  }
+
+  .dashboard-kpi-sparkline-delta--muted {
+    @apply tw-text-muted-foreground;
+  }
+
+  .dashboard-kpi-sparkline-chart {
+    @apply tw-min-h-0 tw-h-full tw-w-full tw-overflow-hidden;
+    min-height: 22px;
+  }
+
+  .dashboard-kpi-sparkline-chart .apexcharts-canvas,
+  .dashboard-kpi-sparkline-chart svg {
+    overflow: visible !important;
+  }
+
+  .dashboard-header-controls {
+    @apply tw-flex tw-min-w-0 tw-flex-wrap tw-items-center tw-gap-2;
+  }
+
+  .dashboard-header-search {
+    @apply tw-relative tw-m-0 tw-inline-flex tw-h-8 tw-shrink-0 tw-items-center;
+  }
+
+  .dashboard-header-search-icon {
+    position: absolute;
+    left: 10px;
+    top: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    color: var(--dashboard-muted-foreground, #6b6860);
+    pointer-events: none;
+    transform: translateY(-50%);
+  }
+
+  .dashboard-header-search-input {
+    @apply tw-box-border tw-m-0 tw-block tw-h-8 tw-w-56 tw-rounded-sm tw-border tw-border-border tw-bg-surface tw-py-0 tw-pl-8 tw-pr-3 tw-text-[12px] tw-leading-none tw-text-foreground placeholder:tw-text-muted-foreground focus:tw-border-foreground focus:tw-outline-none;
+  }
+
+  .dashboard-header-search-input:focus {
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 15%, transparent);
+  }
+
+  .dashboard-header-controls .dashboard-header-btn {
+    @apply tw-box-border tw-m-0 tw-inline-flex tw-h-8 tw-min-h-8 tw-max-h-8 tw-shrink-0 tw-items-center tw-justify-center tw-gap-1.5 tw-rounded-sm tw-border tw-border-solid tw-border-border tw-bg-surface tw-px-2.5 tw-py-0 tw-text-[12px] tw-font-medium tw-leading-none tw-text-foreground;
+    font-family: inherit;
+    vertical-align: middle;
+    -webkit-appearance: none;
+    appearance: none;
+  }
+
+  .dashboard-header-controls .dashboard-header-btn:hover {
+    @apply tw-bg-muted;
+  }
+
+  .dashboard-header-controls .dashboard-add-kpi-trigger {
+    @apply tw-gap-1.5 tw-border-dashed tw-border-border;
+  }
+
+  .dashboard-header-controls .dashboard-add-kpi-trigger:hover {
+    @apply tw-border-foreground tw-text-foreground;
+    background-color: color-mix(in srgb, var(--muted) 50%, transparent);
+  }
+
+  .dashboard-header-kpi-anchor {
+    @apply tw-relative tw-flex tw-h-8 tw-shrink-0 tw-items-center tw-self-center;
+  }
+
+  .dashboard-add-kpi-panel {
+    border: 1px solid var(--border, #e5e2db);
+    border-radius: 6px;
+    background-color: #ffffff;
+    box-shadow:
+      0 4px 6px -1px rgb(0 0 0 / 0.08),
+      0 2px 4px -2px rgb(0 0 0 / 0.06);
+    color: var(--foreground, #1a1917);
+    opacity: 1;
+    isolation: isolate;
+  }
+
+  .dashboard-add-kpi-panel--dragging {
+    @apply tw-pointer-events-none tw-invisible;
+  }
+
+  .dashboard-add-kpi-header {
+    @apply tw-shrink-0 tw-border-b tw-border-border tw-px-4 tw-py-2.5 tw-text-[10px] tw-font-normal tw-uppercase tw-tracking-wider;
+    color: var(--muted-foreground, #6b6860);
+    background-color: #ffffff;
+  }
+
+  .dashboard-add-kpi-list {
+    -webkit-overflow-scrolling: touch;
+    background-color: #ffffff;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    text-align: left;
+  }
+
+  .dashboard-add-kpi-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.625rem 1rem;
+    cursor: grab;
+    user-select: none;
+    font-weight: 400;
+    background-color: #ffffff;
+  }
+
+  .dashboard-add-kpi-item:active {
+    cursor: grabbing;
+  }
+
+  .dashboard-add-kpi-item-main {
+    display: flex;
+    min-width: 0;
+    flex: 1 1 auto;
+    align-items: center;
+    gap: 0.5rem;
+    justify-content: flex-start;
+    text-align: left;
+  }
+
+  .dashboard-add-kpi-item-aside {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    gap: 0.5rem;
+    justify-content: flex-end;
+    margin-left: 0.75rem;
+  }
+
+  .dashboard-add-kpi-item-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    text-align: left;
+    @apply tw-text-[13px] tw-leading-snug;
+    font-weight: 400;
+    color: var(--foreground, #1a1917);
+  }
+
+  .dashboard-add-kpi-type {
+    @apply tw-shrink-0 tw-text-[10px] tw-uppercase tw-tracking-wide;
+    text-align: right;
+    font-weight: 400;
+    color: var(--muted-foreground, #6b6860);
+  }
+
+  .dashboard-add-kpi-add-btn {
+    @apply tw-box-border tw-m-0 tw-inline-flex tw-h-5 tw-w-5 tw-shrink-0 tw-items-center tw-justify-center tw-rounded-sm tw-border-0 tw-bg-transparent tw-p-0 tw-text-[15px] tw-leading-none;
+    font-family: inherit;
+    font-weight: 400;
+    color: var(--muted-foreground, #6b6860);
+    -webkit-appearance: none;
+    appearance: none;
+  }
+
+  .dashboard-add-kpi-add-btn:hover {
+    color: var(--foreground, #1a1917);
+  }
+
+  .dashboard-add-kpi-item:hover,
+  .dashboard-add-kpi-item--hover {
+    background-color: var(--muted, #f5f4f1);
+  }
+
+  .dashboard-add-kpi-preview {
+    border: 1px solid var(--border, #e5e2db);
+    border-radius: 8px;
+    background-color: #ffffff;
+    box-shadow:
+      0 10px 24px -8px rgb(0 0 0 / 0.12),
+      0 4px 8px -4px rgb(0 0 0 / 0.08);
+    padding: 0.75rem;
+    pointer-events: none;
+  }
+
+  .dashboard-add-kpi-preview-card {
+    border: 1px solid var(--border, #e5e2db);
+    border-radius: 6px;
+    background-color: #ffffff;
+    padding: 0.625rem 0.75rem;
+  }
+
+  .dashboard-add-kpi-preview-title {
+    @apply tw-text-[10px] tw-font-medium tw-uppercase tw-tracking-wider;
+    color: var(--muted-foreground, #6b6860);
+    line-height: 1.3;
+  }
+
+  .dashboard-add-kpi-preview-value {
+    @apply tw-mt-1 tw-text-[22px] tw-font-semibold tw-leading-tight;
+    color: var(--foreground, #1a1917);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .dashboard-add-kpi-preview-target {
+    @apply tw-mt-0.5 tw-text-[11px] tw-leading-snug;
+    color: var(--muted-foreground, #6b6860);
+  }
+
+  .dashboard-add-kpi-preview-desc {
+    @apply tw-mb-0 tw-mt-2.5 tw-text-[11px] tw-leading-snug;
+    color: var(--muted-foreground, #6b6860);
+  }
+
+  .dashboard-header-top {
+    min-width: 0;
+  }
+
+  .dashboard-filters-bar {
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .dashboard-filters-card {
+    @apply tw-flex tw-items-center tw-rounded tw-border tw-border-border tw-bg-surface tw-px-3 tw-py-2;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .dashboard-filters-row {
+    @apply tw-flex tw-flex-wrap tw-items-center tw-gap-x-3 tw-gap-y-2;
+  }
+
+  .dashboard-filters-heading {
+    @apply tw-flex tw-h-7 tw-shrink-0 tw-items-center tw-gap-1.5 tw-self-center tw-pr-1;
+  }
+
+  .dashboard-filters-title {
+    @apply tw-text-[12px] tw-font-medium tw-leading-none tw-text-muted-foreground;
+  }
+
+  .dashboard-filters-date-range {
+    @apply tw-flex tw-h-7 tw-shrink-0 tw-items-center tw-gap-1.5 tw-self-center;
+  }
+
+  .dashboard-filters-date-arrow {
+    @apply tw-text-[11px] tw-leading-none tw-text-muted-foreground;
+  }
+
+  .dashboard-filter-inline-date-wrap {
+    @apply tw-relative tw-inline-flex tw-h-7 tw-shrink-0 tw-items-center tw-overflow-hidden;
+  }
+
+  .dashboard-filter-inline-date {
+    @apply tw-box-border tw-m-0 tw-block tw-h-7 tw-min-h-7 tw-max-h-7 tw-w-[7.25rem] tw-rounded-sm tw-border tw-border-border tw-bg-surface tw-py-0 tw-px-2 tw-text-[12px] tw-leading-none tw-text-foreground focus:tw-border-foreground focus:tw-outline-none;
+    color-scheme: light;
+    font-family: inherit;
+  }
+
+  .dashboard-filter-inline-date:focus {
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 15%, transparent);
+  }
+
+  .dashboard-filter-inline-date-wrap .dashboard-filter-inline-date::-webkit-calendar-picker-indicator {
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    cursor: pointer;
+    opacity: 0;
+  }
+
+  .dashboard-filter-inline-select-wrap {
+    @apply tw-relative tw-inline-flex tw-h-7 tw-shrink-0 tw-items-center tw-self-center;
+  }
+
+  .dashboard-filter-inline-select {
+    @apply tw-box-border tw-m-0 tw-h-7 tw-min-h-7 tw-max-h-7 tw-min-w-[7.5rem] tw-appearance-none tw-rounded-sm tw-border tw-border-border tw-bg-surface tw-py-0 tw-px-2 tw-pr-7 tw-text-[12px] tw-leading-none tw-text-foreground focus:tw-border-foreground focus:tw-outline-none;
+    font-family: inherit;
+  }
+
+  .dashboard-filter-inline-select:focus {
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 15%, transparent);
+  }
+
+  .dashboard-filter-inline-select-wrap::after {
+    content: "⌄";
+    position: absolute;
+    right: 0.5rem;
+    top: 50%;
+    transform: translateY(-50%);
+    pointer-events: none;
+    font-size: 0.8rem;
+    line-height: 1;
+    color: var(--dashboard-muted-foreground, #6b6860);
+  }
+
+  .dashboard-filters-clear-inline {
+    @apply tw-box-border tw-m-0 tw-inline-flex tw-h-7 tw-shrink-0 tw-items-center tw-self-center tw-rounded-sm tw-border-0 tw-bg-transparent tw-px-2 tw-py-0 tw-text-[11px] tw-font-medium tw-leading-none tw-text-muted-foreground hover:tw-text-foreground;
+  }
+
+  .dashboard-filters-clear-inline:disabled {
+    opacity: 0.4;
+    cursor: default;
+    pointer-events: none;
+  }
+
+  /* ── Responsive layout ─────────────────────────────────────────────── */
+
+  .dashboard-main {
+    overflow-x: clip;
+  }
+
+  .dashboard-grid-wrap {
+    min-width: 0;
+    max-width: 100%;
+    overflow-x: clip;
+  }
+
+  .dashboard-grid-wrap .react-grid-layout {
+    width: 100% !important;
+    min-width: 0;
+  }
+
+  .dashboard-header-mobile-search {
+    display: none;
+  }
+
+  .dashboard-sidebar-backdrop {
+    display: none;
+  }
+
+  .dashboard-header-menu-btn {
+    @apply tw-inline-flex tw-h-8 tw-w-8 tw-shrink-0 tw-items-center tw-justify-center tw-rounded-sm tw-border tw-border-border tw-bg-surface tw-text-foreground;
+  }
+
+  .dashboard-header-menu-btn:hover {
+    @apply tw-bg-muted;
+  }
+
+  @media (max-width: 1023px) {
+    .dashboard-sidebar {
+      position: fixed;
+      left: 0;
+      top: 0;
+      z-index: 50;
+      height: 100dvh;
+      transform: translateX(-100%);
+      transition: transform 0.2s ease;
+      box-shadow: none;
+    }
+
+    .dashboard-sidebar--open {
+      transform: translateX(0);
+      box-shadow: 4px 0 24px rgb(0 0 0 / 0.15);
+    }
+
+    .dashboard-sidebar-backdrop {
+      display: block;
+      position: fixed;
+      inset: 0;
+      z-index: 40;
+      margin: 0;
+      padding: 0;
+      border: 0;
+      background: rgb(0 0 0 / 0.4);
+      cursor: pointer;
+    }
+
+    .dashboard-grid-layout .react-grid-item > .react-resizable-handle,
+    .dashboard-resize-grip {
+      display: none !important;
+    }
+
+    .dashboard-grid-layout .react-grid-item {
+      overflow: auto;
+      -webkit-overflow-scrolling: touch;
+    }
+
+    .dashboard-kpi-value {
+      font-size: clamp(18px, 4.5vw, 26px);
+    }
+
+    .dashboard-kpi-sparkline-value-row {
+      flex-wrap: wrap;
+      row-gap: 0.125rem;
+    }
+
+    .dashboard-drag-handle-title,
+    .dashboard-drag-handle-subtitle {
+      overflow: visible;
+      text-overflow: unset;
+      white-space: normal;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
+
+    .dashboard-kpi-card--metric .dashboard-kpi-title,
+    .dashboard-kpi-card--delta .dashboard-kpi-title,
+    .dashboard-kpi-card--sparkline .dashboard-kpi-title,
+    .dashboard-kpi-card--metric .dashboard-kpi-context,
+    .dashboard-kpi-card--delta .dashboard-kpi-context {
+      -webkit-line-clamp: unset;
+      display: block;
+      overflow: visible;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
+
+    .dashboard-kpi-list-item .tw-truncate,
+    .dashboard-kpi-card .tw-truncate {
+      overflow: visible;
+      text-overflow: unset;
+      white-space: normal;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
+
+    .dashboard-card-updated {
+      position: static;
+      display: block;
+      margin-top: 0.25rem;
+      margin-right: 0;
+      text-align: right;
+      padding-right: 0.25rem;
+    }
+
+    .dashboard-widget-surface {
+      min-height: 100%;
+      height: auto;
+    }
+
+    .dashboard-kpi-widget {
+      min-height: 100%;
+      height: auto;
+    }
+  }
+
+  @media (max-width: 639px) {
+    .dashboard-header-top {
+      flex-wrap: wrap;
+      align-items: flex-start;
+      padding-top: 0.5rem;
+      padding-bottom: 0.5rem;
+    }
+
+    .dashboard-header-controls {
+      justify-content: flex-end;
+      width: 100%;
+    }
+
+    .dashboard-header-subtitle {
+      width: 100%;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
+
+    .dashboard-header-controls .dashboard-header-export span {
+      display: none;
+    }
+
+    .dashboard-header-controls .dashboard-header-btn {
+      @apply tw-px-2;
+    }
+
+    .dashboard-header-mobile-search {
+      display: block;
+      border-bottom: 1px solid var(--border);
+      background-color: var(--surface);
+      padding: 0.5rem 0.75rem;
+    }
+
+    .dashboard-header-search--mobile {
+      display: flex !important;
+      width: 100%;
+    }
+
+    .dashboard-header-search--mobile .dashboard-header-search-input {
+      width: 100%;
+      min-width: 0;
+    }
+
+    .dashboard-filters-card {
+      align-items: stretch;
+      @apply tw-px-2.5 tw-py-2.5;
+    }
+
+    .dashboard-filters-row {
+      flex-direction: column;
+      align-items: stretch;
+      width: 100%;
+    }
+
+    .dashboard-filters-date-range {
+      width: 100%;
+      flex-wrap: wrap;
+    }
+
+    .dashboard-filter-inline-date-wrap {
+      flex: 1 1 auto;
+      min-width: 0;
+    }
+
+    .dashboard-filter-inline-date {
+      width: 100%;
+      min-width: 0;
+    }
+
+    .dashboard-filter-inline-select-wrap {
+      width: 100%;
+    }
+
+    .dashboard-filter-inline-select {
+      width: 100%;
+      min-width: 0;
+    }
+
+    .dashboard-filters-clear-inline {
+      align-self: flex-start;
+    }
+
+    .dashboard-add-kpi-panel {
+      max-width: calc(100vw - 1.5rem);
+    }
+
+    .dashboard-kpi-card {
+      padding: 0.75rem;
+    }
+  }
+
+  @media (min-width: 640px) and (max-width: 1023px) {
+    .dashboard-header-search-input {
+      @apply tw-w-44;
+      max-width: 100%;
+    }
+
+    .dashboard-filters-row {
+      row-gap: 0.5rem;
+    }
+
+    .dashboard-header-subtitle {
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
+  }
+
+  .dashboard-widget-surface {
+    cursor: grab;
+  }
+
+  .dashboard-widget-surface:active,
+  .react-grid-item.react-draggable-dragging .dashboard-widget-surface {
+    cursor: grabbing;
+  }
+
+  .dashboard-widget-surface .dashboard-widget-remove-btn,
+  .dashboard-widget-surface .dashboard-view-toggle,
+  .dashboard-widget-surface .dashboard-gauge-target-marker,
+  .dashboard-widget-surface .dashboard-table-scroll,
+  .dashboard-widget-surface .dashboard-kpi-list-body,
+  .dashboard-widget-surface a,
+  .dashboard-widget-surface button,
+  .dashboard-widget-surface input,
+  .dashboard-widget-surface select,
+  .dashboard-widget-surface textarea {
+    cursor: default;
+  }
+
+  .dashboard-widget-surface .dashboard-bar-chart-body,
+  .dashboard-widget-surface .dashboard-horizontal-bar-body,
+  .dashboard-widget-surface .dashboard-stacked-bar-body,
+  .dashboard-widget-surface .dashboard-line-chart-body,
+  .dashboard-widget-surface .dashboard-pie-chart-body,
+  .dashboard-widget-surface .dashboard-gauge-body,
+  .dashboard-widget-surface .dashboard-sla-toggle-body,
+  .dashboard-widget-surface .apexcharts-canvas,
+  .dashboard-widget-surface .apexcharts-svg {
+    cursor: grab;
+  }
+
+  .react-grid-item.react-draggable-dragging .dashboard-widget-surface .apexcharts-canvas,
+  .react-grid-item.react-draggable-dragging .dashboard-widget-surface .apexcharts-svg {
+    cursor: grabbing;
+  }
+
+  .dashboard-kpi-widget {
+    height: 100%;
+    min-height: 0;
+  }
+
+  .dashboard-kpi-widget .dashboard-widget {
+    @apply tw-transition-all tw-duration-150;
+  }
+
+  .dashboard-kpi-list-body {
+    min-height: 17.5rem;
+  }
+
+  .dashboard-kpi-list-item {
+    min-height: 1.75rem;
+  }
+
+  .dashboard-grid-layout .react-grid-item.dashboard-grid-item-kpi {
+    overflow: hidden;
+  }
+
+  .dashboard-grid-layout .react-grid-item.dashboard-grid-item-chart-visible {
+    overflow: visible;
+  }
+
+  .dashboard-grid-layout .react-grid-item.dashboard-grid-item-chart-clipped {
+    overflow: hidden;
+  }
+
+  .dashboard-resize-grip {
+    @apply tw-pointer-events-none tw-absolute tw-z-[2];
+    right: 3px;
+    bottom: 3px;
+    width: 14px;
+    height: 14px;
+    line-height: 0;
+  }
+
+  .dashboard-resize-grip-line {
+    stroke: var(--dashboard-muted-foreground, #6b6860);
+    stroke-width: 1.5;
+    stroke-linecap: round;
+    opacity: 0.65;
+    transition: stroke 150ms ease, opacity 150ms ease;
+  }
+
+  .tw-group:hover .dashboard-resize-grip-line {
+    stroke: var(--chart-1);
+    opacity: 0.9;
+  }
+
+  .dashboard-kpi-widget:hover .dashboard-kpi-card {
+    border-color: color-mix(in srgb, var(--foreground) 18%, transparent);
+    background-color: var(--surface);
+    box-shadow: 0 4px 12px color-mix(in srgb, var(--foreground) 6%, transparent);
+  }
+
+  .dashboard-table-body {
+    min-height: 0;
+  }
+
+  /* Viz type: data-table — ranked / breakdown tables */
+  .dashboard-data-table-shell {
+    @apply tw-flex tw-h-full tw-min-h-0 tw-min-w-0 tw-w-full tw-flex-col;
+  }
+
+  .dashboard-data-table-header {
+    @apply tw-border-b-0 tw-px-3 tw-pb-0 tw-pt-1;
+  }
+
+  .dashboard-data-table-header-bar {
+    @apply tw-flex tw-shrink-0 tw-items-center tw-justify-between tw-gap-3 tw-border-b-0 tw-px-4 tw-pb-0 tw-pt-2 tw-pr-8;
+  }
+
+  .dashboard-data-table-header .dashboard-drag-handle-title,
+  .dashboard-data-table-header-bar .dashboard-drag-handle-title {
+    @apply tw-leading-tight;
+  }
+
+  .dashboard-data-table-header .dashboard-drag-handle-subtitle,
+  .dashboard-data-table-header-bar .dashboard-drag-handle-subtitle {
+    @apply tw-mt-0 tw-leading-none;
+  }
+
+  .dashboard-data-table-body {
+    @apply tw-flex tw-min-h-0 tw-flex-1 tw-flex-col tw-justify-start tw-overflow-hidden tw-px-3 tw-pt-0;
+    margin-top: -2px;
+    padding-bottom: 1.125rem;
+  }
+
+  /* SLA table/bar toggle — reserve space for absolute Updated stamp (same as other cards) */
+  .dashboard-sla-toggle-body {
+    padding-bottom: 1.125rem;
+  }
+
+  .dashboard-table-scroll {
+    @apply tw-min-h-0 tw-flex-1 tw-w-full tw-max-w-full tw-overflow-auto;
+    max-height: 100%;
+    font-family: inherit;
+    font-size: 12px;
+  }
+
+  /* Override global digit-ui-components bare `table/th/td` rules from index.html */
+  .dashboard-root table.dashboard-table {
+    width: 100%;
+    border-collapse: collapse;
+    table-layout: fixed;
+    font-family: inherit;
+    font-size: 12px;
+    line-height: 1.25;
+    background: transparent;
+    overflow: visible;
+  }
+
+  .dashboard-root table.dashboard-table.dashboard-table--equal-cols {
+    table-layout: fixed;
+  }
+
+  .dashboard-root table.dashboard-table.dashboard-table--equal-cols th.dashboard-table-th,
+  .dashboard-root table.dashboard-table.dashboard-table--equal-cols td.dashboard-table-td {
+    width: 1% !important;
+    overflow: visible;
+    text-overflow: unset;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .dashboard-root table.dashboard-table thead tr {
+    text-align: left;
+    color: var(--dashboard-muted-foreground, #6b6860);
+  }
+
+  .dashboard-root table.dashboard-table th.dashboard-table-th,
+  .dashboard-root table.dashboard-table td.dashboard-table-td {
+    min-width: 0 !important;
+    width: auto !important;
+    max-width: none;
+    padding: 0.375rem 0.625rem !important;
+    border: 0 !important;
+    box-shadow: none !important;
+    background: transparent !important;
+    font-family: var(--dashboard-font-family) !important;
+    font-size: 12px !important;
+    font-weight: 400 !important;
+    font-style: normal !important;
+    line-height: 1.25 !important;
+    white-space: normal !important;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    overflow: visible;
+    word-wrap: break-word;
+    vertical-align: top;
+    text-align: left;
+    color: var(--dashboard-foreground, #1b1b1b);
+  }
+
+  .dashboard-root table.dashboard-table th.dashboard-table-th {
+    font-weight: 500 !important;
+    color: var(--dashboard-muted-foreground, #6b6860) !important;
+    vertical-align: bottom;
+    padding-top: 0.125rem !important;
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    background: var(--dashboard-surface, #fff) !important;
+  }
+
+  .dashboard-table-sort-btn {
+    @apply tw-inline-flex tw-w-full tw-flex-wrap tw-items-center tw-gap-1 tw-border-0 tw-bg-transparent tw-p-0 tw-text-left;
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
+    font-weight: inherit;
+  }
+
+  .dashboard-table-sort-label {
+    min-width: 0;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .dashboard-table-sort-btn:hover .dashboard-table-sort-indicator {
+    color: var(--foreground);
+  }
+
+  .dashboard-table-sort-indicator {
+    @apply tw-shrink-0 tw-text-[10px];
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 0.625rem;
+    width: 0.625rem;
+    color: var(--dashboard-muted-foreground, #6b6860);
+    line-height: 1;
+    font-weight: 400;
+  }
+
+  .dashboard-root table.dashboard-table tbody td.dashboard-table-td {
+    padding-top: 0.375rem !important;
+    padding-bottom: 0.375rem !important;
+    border-top: 1px solid var(--dashboard-border, #e8e6e1) !important;
+  }
+
+  .dashboard-root table.dashboard-table td.dashboard-table-td {
+    font-variant-numeric: tabular-nums;
+  }
+
+  .dashboard-root table.dashboard-table td.dashboard-table-td > span,
+  .dashboard-root table.dashboard-table td.dashboard-table-td > a {
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .dashboard-root table.dashboard-table tbody tr.dashboard-table-row-highlight td.dashboard-table-td {
+    background-color: color-mix(
+      in srgb,
+      var(--status-breach) calc(var(--row-sla-severity, 1) * 14%),
+      transparent
+    ) !important;
+  }
+
+  .dashboard-table-sla-overrun {
+    font-weight: 600;
+    color: color-mix(
+      in srgb,
+      var(--status-breach) calc(var(--sla-overrun-severity, 1) * 100%),
+      var(--foreground)
+    );
+  }
+
+  .dashboard-root table.dashboard-table col.dashboard-table-col-fixed {
+    width: auto;
+  }
+
+  .dashboard-table-primary {
+    @apply tw-flex tw-min-w-0 tw-flex-wrap tw-items-start tw-gap-x-1 tw-gap-y-0.5;
+  }
+
+  .dashboard-table-label {
+    @apply tw-min-w-0;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .dashboard-table-badge {
+    @apply tw-shrink-0 tw-basis-full tw-text-[8px] tw-font-bold tw-uppercase tw-tracking-wide;
+    color: var(--status-breach);
+  }
+
+  .dashboard-table-threshold-cell {
+    @apply tw-font-semibold;
+    color: var(--status-breach);
+  }
+
+  .dashboard-table-threshold-watch {
+    @apply tw-font-semibold;
+    color: var(--status-nearing);
+  }
+
+  .dashboard-table-threshold-good {
+    @apply tw-font-semibold;
+    color: var(--status-resolved);
+  }
+
+  .dashboard-table-cell-tone--breach {
+    background-color: color-mix(in srgb, var(--status-breach) 14%, transparent);
+  }
+
+  .dashboard-table-cell-tone--watch {
+    background-color: color-mix(in srgb, var(--status-nearing) 14%, transparent);
+  }
+
+  .dashboard-table-cell-tone--good {
+    background-color: color-mix(in srgb, var(--status-resolved) 10%, transparent);
+  }
+
+  .dashboard-table-status-tag {
+    display: inline-block;
+    max-width: 100%;
+    border-radius: 9999px;
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.03em;
+    line-height: 1.3;
+    padding: 2px 8px;
+    text-transform: uppercase;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .dashboard-table-status-tag--breach {
+    background-color: color-mix(in srgb, var(--status-breach) 16%, transparent);
+    color: var(--status-breach);
+  }
+
+  .dashboard-table-status-tag--watch {
+    background-color: color-mix(in srgb, var(--status-nearing) 16%, transparent);
+    color: var(--status-nearing);
+  }
+
+  .dashboard-table-status-tag--good {
+    background-color: color-mix(in srgb, var(--status-resolved) 14%, transparent);
+    color: var(--status-resolved);
+  }
+
+  .dashboard-table-row-highlight {
+    background-color: color-mix(in srgb, var(--status-breach) 6%, transparent);
+  }
+
+  .dashboard-table-trend-up {
+    @apply tw-font-semibold;
+    color: var(--status-resolved);
+  }
+
+  .dashboard-table-trend-down {
+    @apply tw-font-semibold;
+    color: var(--status-breach);
+  }
+
+  .dashboard-table-muted {
+    @apply tw-text-muted-foreground;
+  }
+
+  .dashboard-table-empty {
+    @apply tw-py-4 tw-text-[12px] tw-text-muted-foreground;
+  }
+
+  .dashboard-data-table-legend-swatch {
+    @apply tw-h-2 tw-w-2 tw-shrink-0 tw-rounded-full;
+  }
+
+  .dashboard-data-table-legend-label {
+    @apply tw-inline-flex tw-items-center tw-gap-2;
+  }
+
+  .dashboard-data-table-value-emphasis {
+    @apply tw-font-semibold;
+  }
+
+  .dashboard-data-table-owner-name {
+    @apply tw-font-medium;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .dashboard-data-table-sla-cell {
+    @apply tw-flex tw-flex-wrap tw-items-center tw-gap-1.5;
+  }
+
+  .dashboard-chart-widget {
+    overflow: hidden;
+  }
+
+  .dashboard-list-widget {
+    overflow: visible;
+    height: auto;
+  }
+
+  /* Viz type: bar-chart — vertical bars (all normal bar chart widgets) */
+  .dashboard-bar-chart .apexcharts-canvas,
+  .dashboard-bar-chart .apexcharts-svg {
+    overflow: visible !important;
+  }
+
+  .dashboard-bar-chart-body {
+    @apply tw-flex tw-min-h-0 tw-min-w-0 tw-w-full tw-flex-1 tw-flex-col tw-overflow-hidden tw-px-2 tw-pt-0;
+    margin-top: -18px;
+    padding-bottom: 0.125rem;
+  }
+
+  .dashboard-bar-chart-header {
+    @apply tw-border-b-0 tw-px-3 tw-pb-0 tw-pt-0.5;
+  }
+
+  .dashboard-bar-chart-header .dashboard-drag-handle-title {
+    @apply tw-leading-tight;
+  }
+
+  .dashboard-bar-chart-header .dashboard-drag-handle-subtitle {
+    @apply tw-mt-0 tw-leading-none;
+  }
+
+  .dashboard-chart-scroll-viewport {
+    @apply tw-h-full tw-min-h-0 tw-min-w-0 tw-w-full tw-flex-1;
+    overflow: hidden;
+  }
+
+  .dashboard-chart-scroll-viewport--active {
+    overflow: auto !important;
+  }
+
+  .dashboard-chart-scroll-viewport--vertical.dashboard-chart-scroll-viewport--active {
+    overflow-x: hidden !important;
+    overflow-y: auto !important;
+  }
+
+  .dashboard-chart-scroll-viewport--horizontal.dashboard-chart-scroll-viewport--active {
+    overflow-x: auto !important;
+    overflow-y: hidden !important;
+  }
+
+  .dashboard-chart-scroll-canvas {
+    flex-shrink: 0;
+    position: relative;
+  }
+
+  /* Viz type: gauge — progress bar vs target */
+  .dashboard-gauge-header {
+    @apply tw-border-b-0 tw-px-3 tw-pb-0 tw-pt-1;
+  }
+
+  .dashboard-gauge-header .dashboard-drag-handle-title {
+    @apply tw-text-[13px] tw-leading-tight;
+  }
+
+  .dashboard-gauge-body {
+    @apply tw-flex tw-shrink-0 tw-flex-col tw-gap-0 tw-px-3 tw-pt-0;
+    padding-bottom: 0.125rem;
+  }
+
+  .dashboard-gauge-value {
+    @apply tw-mb-1.5 tw-font-semibold tw-tabular-nums tw-text-foreground;
+    font-size: 26px;
+    line-height: 1;
+  }
+
+  .dashboard-gauge-track {
+    @apply tw-relative tw-my-0 tw-h-3 tw-w-full tw-overflow-visible tw-rounded-full tw-bg-muted;
+  }
+
+  .dashboard-gauge-fill {
+    @apply tw-h-full tw-rounded-full;
+    background-color: var(--chart-1);
+  }
+
+  .dashboard-gauge-target-marker {
+    @apply tw-absolute tw-inset-y-0 tw-flex tw-w-3 tw-cursor-default tw-items-center tw-justify-center;
+    transform: translateX(-50%);
+  }
+
+  .dashboard-gauge-target-line {
+    @apply tw-pointer-events-none tw-block tw-h-[calc(100%+6px)] tw-w-0;
+    border-left: 2px dotted var(--foreground);
+    opacity: 0.55;
+  }
+
+  .dashboard-gauge-target-tooltip {
+    @apply tw-pointer-events-none tw-absolute tw-bottom-full tw-left-1/2 tw-z-10 tw-mb-1 tw-whitespace-nowrap tw-rounded tw-bg-foreground tw-px-1.5 tw-py-0.5 tw-text-[10px] tw-font-medium tw-leading-tight tw-text-surface;
+    transform: translateX(-50%);
+    opacity: 0;
+    transition: opacity 0.12s ease;
+  }
+
+  .dashboard-gauge-target-marker:hover .dashboard-gauge-target-tooltip,
+  .dashboard-gauge-target-marker:focus-visible .dashboard-gauge-target-tooltip {
+    opacity: 1;
+  }
+
+  .dashboard-gauge-status {
+    @apply tw-mt-0.5 tw-text-[11px] tw-leading-tight tw-text-muted-foreground;
+  }
+
+  .dashboard-bar-chart .apexcharts-canvas,
+  .dashboard-bar-chart .apexcharts-svg {
+    overflow: visible !important;
+  }
+
+  .dashboard-bar-chart .apexcharts-gridlines-horizontal line,
+  .dashboard-bar-chart .apexcharts-gridlines-vertical line {
+    display: none;
+  }
+
+  .dashboard-widget-surface .apexcharts-xaxis-texts-g,
+  .dashboard-widget-surface .apexcharts-yaxis-texts-g,
+  .dashboard-widget-surface .apexcharts-xaxis-inversed-texts-g {
+    overflow: visible;
+  }
+
+  .dashboard-widget-surface .apexcharts-xaxis-label,
+  .dashboard-widget-surface .apexcharts-yaxis-label {
+    overflow: visible;
+  }
+
+  .dashboard-widget-surface .apexcharts-xaxis-label tspan:not(:first-child),
+  .dashboard-widget-surface .apexcharts-yaxis-label tspan:not(:first-child) {
+    dy: 9px;
+  }
+
+  /* Viz type: horizontal-bar — ranked / ratio bars */
+  .dashboard-horizontal-bar {
+    min-height: 0;
+  }
+
+  .dashboard-horizontal-bar-body {
+    @apply tw-flex tw-min-h-0 tw-flex-1 tw-flex-col tw-overflow-hidden tw-px-1.5 tw-pt-0;
+    margin-top: -6px;
+    padding-bottom: 1.125rem;
+  }
+
+  .dashboard-horizontal-bar-header {
+    @apply tw-border-b-0 tw-px-3 tw-pb-0 tw-pt-1.5;
+  }
+
+  .dashboard-horizontal-bar-header .dashboard-drag-handle-title {
+    @apply tw-leading-tight;
+  }
+
+  .dashboard-horizontal-bar-header .dashboard-drag-handle-subtitle {
+    @apply tw-mt-0 tw-leading-none;
+  }
+
+  .dashboard-horizontal-bar .apexcharts-canvas,
+  .dashboard-horizontal-bar .apexcharts-svg {
+    overflow: visible !important;
+  }
+
+
+  .dashboard-horizontal-bar .apexcharts-yaxis-texts-g .apexcharts-yaxis-label,
+  .dashboard-stacked-bar--horizontal .apexcharts-yaxis-texts-g .apexcharts-yaxis-label {
+    text-anchor: start;
+    transform-box: fill-box;
+    transform-origin: left center;
+  }
+
+  .dashboard-horizontal-bar .apexcharts-legend,
+  .dashboard-stacked-bar--horizontal .apexcharts-legend {
+    justify-content: center !important;
+    padding-bottom: 0 !important;
+    margin-bottom: -6px !important;
+  }
+
+  .dashboard-stacked-bar--horizontal .apexcharts-legend {
+    margin-bottom: -14px !important;
+  }
+
+  /* Viz type: stacked-bar — vertical + horizontal stacked bars */
+  .dashboard-stacked-bar {
+    min-height: 0;
+  }
+
+  .dashboard-stacked-bar-body {
+    @apply tw-flex tw-min-h-0 tw-flex-1 tw-flex-col tw-overflow-hidden tw-px-2 tw-pt-0;
+    margin-top: -6px;
+    padding-bottom: 0.125rem;
+  }
+
+  .dashboard-stacked-bar-body:has(.dashboard-stacked-bar--horizontal) {
+    @apply tw-pl-1.5 tw-pr-1.5;
+    padding-bottom: 1.125rem;
+  }
+
+  .dashboard-stacked-bar-header {
+    @apply tw-border-b-0 tw-px-3 tw-pb-1 tw-pt-1.5;
+  }
+
+  .dashboard-stacked-bar-header .dashboard-drag-handle-title {
+    @apply tw-leading-tight;
+  }
+
+  .dashboard-stacked-bar-header .dashboard-drag-handle-subtitle {
+    @apply tw-mt-0 tw-leading-none;
+  }
+
+  .dashboard-stacked-bar .apexcharts-canvas,
+  .dashboard-stacked-bar .apexcharts-svg {
+    overflow: visible !important;
+  }
+
+  .dashboard-stacked-bar .apexcharts-gridlines-horizontal line,
+  .dashboard-stacked-bar .apexcharts-gridlines-vertical line {
+    display: none;
+  }
+
+  .dashboard-stacked-bar .apexcharts-legend {
+    padding-bottom: 0 !important;
+    margin-bottom: 0 !important;
+  }
+
+  /* Apex column labels sit low in the segment rect; keep glyphs inside the fill. */
+  .dashboard-stacked-bar:not(.dashboard-stacked-bar--horizontal)
+    .apexcharts-bar-series
+    .apexcharts-datalabels
+    text {
+    dominant-baseline: central;
+  }
+
+  .dashboard-stacked-bar--horizontal .apexcharts-legend {
+    margin-bottom: -14px !important;
+  }
+
+  .dashboard-line-chart {
+    overflow: visible;
+    min-height: 0;
+  }
+
+  .dashboard-line-chart-body {
+    @apply tw-flex tw-min-h-0 tw-flex-1 tw-flex-col tw-overflow-hidden tw-px-2 tw-pt-0;
+    margin-top: -6px;
+    padding-bottom: 1.125rem;
+  }
+
+  .dashboard-line-chart-header {
+    @apply tw-border-b-0 tw-px-3 tw-pb-0 tw-pt-1.5;
+  }
+
+  .dashboard-line-chart-header .dashboard-drag-handle-title {
+    @apply tw-leading-tight;
+  }
+
+  .dashboard-line-chart-header .dashboard-drag-handle-subtitle {
+    @apply tw-mt-0 tw-leading-none;
+  }
+
+  .dashboard-line-chart .apexcharts-canvas,
+  .dashboard-line-chart .apexcharts-svg {
+    overflow: hidden;
+  }
+
+  .dashboard-line-chart .apexcharts-gridlines-vertical line {
+    display: none;
+  }
+
+  .dashboard-line-chart-animating .apexcharts-series-markers-wrap,
+  .dashboard-line-chart-animating .apexcharts-series-markers {
+    opacity: 0 !important;
+    pointer-events: none !important;
+  }
+
+  .dashboard-line-chart:not(.dashboard-line-chart-animating)
+    .apexcharts-series-markers
+    .apexcharts-marker:not(.dashboard-line-chart-marker-active) {
+    fill: var(--line-chart-marker-fill, var(--surface));
+  }
+
+  /* Shared chart hover tooltip — opaque surface box for all viz types */
+  .dashboard-chart-tooltip {
+    padding: 6px 10px;
+    background: var(--surface, #ffffff);
+    border: 1px solid var(--border, #e8e6e1);
+    border-radius: 2px;
+    color: var(--foreground, #1b1b1b);
+    box-shadow: none;
+  }
+
+  .dashboard-chart-tooltip--fixed {
+    position: fixed;
+    z-index: 10000;
+    max-width: 320px;
+    pointer-events: none;
+  }
+
+  .dashboard-chart-tooltip--anchored {
+    position: absolute;
+    z-index: 2;
+    transform: translate(-50%, -100%);
+    white-space: nowrap;
+    pointer-events: none;
+  }
+
+  .dashboard-chart-tooltip-title {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--foreground, #1b1b1b);
+    margin-bottom: 4px;
+  }
+
+  .dashboard-chart-tooltip-row {
+    font-size: 11px;
+    line-height: 1.45;
+    font-weight: 500;
+  }
+
+  /* Apex wraps custom tooltips — hide default chrome so only our box shows */
+  .dashboard-widget-surface .apexcharts-tooltip {
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    padding: 0 !important;
+  }
+
+  .dashboard-line-chart-header-bar {
+    @apply tw-shrink-0 tw-border-b-0;
+  }
+
+  .dashboard-line-chart-widget-body {
+    @apply tw-flex tw-min-h-0 tw-flex-1 tw-flex-col tw-overflow-hidden tw-px-2 tw-pt-0;
+    margin-top: -6px;
+    padding-bottom: 1.125rem;
+  }
+
+  /* Viz type: pie-chart — donut with in-slice values */
+  .dashboard-pie-chart {
+    overflow: visible;
+    min-height: 0;
+  }
+
+  .dashboard-pie-chart-body {
+    @apply tw-flex tw-min-h-0 tw-flex-1 tw-flex-col tw-overflow-visible tw-px-2 tw-pt-0;
+    margin-top: -10px;
+    padding-bottom: 1.125rem;
+  }
+
+  .dashboard-pie-chart-header {
+    @apply tw-border-b-0 tw-px-3 tw-pb-0 tw-pt-1.5;
+  }
+
+  .dashboard-pie-chart-header .dashboard-drag-handle-title {
+    @apply tw-leading-tight;
+  }
+
+  .dashboard-pie-chart-header .dashboard-drag-handle-subtitle {
+    @apply tw-mt-0 tw-leading-none;
+  }
+
+  /* Viz type: map — geographic distribution */
+  .dashboard-map {
+    min-height: 0;
+  }
+
+  .dashboard-map-body {
+    @apply tw-flex tw-min-h-0 tw-flex-1 tw-flex-col tw-overflow-hidden tw-p-0;
+    padding-bottom: 1.125rem;
+  }
+
+  .dashboard-map-header {
+    @apply tw-border-b-0 tw-px-3 tw-pb-0 tw-pt-1.5;
+  }
+
+  .dashboard-map-header .dashboard-drag-handle-title {
+    @apply tw-leading-tight;
+  }
+
+  .dashboard-map-header-bar {
+    @apply tw-border-b-0;
+  }
+
+  .dashboard-map-frame {
+    @apply tw-relative tw-flex tw-min-h-0 tw-flex-1 tw-flex-col tw-overflow-hidden;
+  }
+
+  .dashboard-map-toolbar-row {
+    @apply tw-flex tw-shrink-0 tw-items-center tw-justify-between tw-gap-2 tw-border-b tw-border-border tw-bg-surface tw-px-2 tw-py-2;
+  }
+
+  .dashboard-map-path {
+    @apply tw-flex tw-min-w-0 tw-flex-1 tw-items-center tw-justify-center tw-gap-2;
+  }
+
+  .dashboard-map-shell {
+    @apply tw-relative tw-flex tw-min-h-0 tw-flex-1 tw-flex-col tw-overflow-hidden;
+    isolation: isolate;
+  }
+
+  .dashboard-map-canvas {
+    @apply tw-relative tw-z-[1] tw-rounded-none;
+  }
+
+  .dashboard-map-canvas .leaflet-container {
+    height: 100%;
+    width: 100%;
+    font-family: inherit;
+  }
+
+  .dashboard-map-legend {
+    width: 196px;
+    border: 1px solid var(--border);
+    border-radius: 0.125rem;
+    background: color-mix(in srgb, var(--surface) 98%, transparent);
+    box-shadow: 0 4px 16px rgb(0 0 0 / 0.12);
+    backdrop-filter: blur(6px);
+    pointer-events: auto;
+  }
+
+  .dashboard-map-filter-chip {
+    z-index: 1000;
+  }
+
+  .dashboard-grid-layout .react-grid-item.dashboard-grid-item-map > .react-resizable-handle {
+    z-index: 1200;
+    pointer-events: auto;
+  }
+
+  .dashboard-grid-layout .react-grid-item.dashboard-grid-item-map:hover > .react-resizable-handle {
+    opacity: 1;
+  }
+
+  .dashboard-grid-layout .react-grid-item.dashboard-grid-item-map > .react-resizable-handle.react-resizable-handle-s {
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 12px;
+    cursor: s-resize;
+  }
+
+  .dashboard-grid-layout .react-grid-item.dashboard-grid-item-map > .react-resizable-handle.react-resizable-handle-e {
+    top: 0;
+    right: 0;
+    width: 12px;
+    height: 100%;
+    margin-top: 0;
+    cursor: e-resize;
+  }
+
+  .dashboard-map-breadcrumb {
+    @apply tw-flex tw-min-w-0 tw-items-center tw-gap-1.5;
+  }
+
+  .dashboard-map-zoom-badge {
+    backdrop-filter: blur(4px);
+  }
+
+  .dashboard-map-controls {
+    @apply tw-flex tw-shrink-0 tw-items-center tw-overflow-hidden tw-rounded-sm tw-border tw-border-border tw-bg-surface tw-shadow-sm;
+  }
+
+  .dashboard-map-control-btn {
+    @apply tw-inline-flex tw-items-center tw-justify-center tw-gap-1 tw-border-0 tw-bg-transparent tw-px-2 tw-py-1.5 tw-text-[10px] tw-font-medium tw-leading-none tw-text-foreground;
+    cursor: pointer;
+  }
+
+  .dashboard-map-control-btn:hover {
+    @apply tw-bg-muted;
+  }
+
+  .dashboard-map-control-btn + .dashboard-map-control-btn {
+    @apply tw-border-l tw-border-border;
+  }
+
+  .dashboard-map-control-btn--text {
+    @apply tw-px-2.5;
+  }
+
+  .dashboard-map-filter-chip {
+    backdrop-filter: blur(4px);
+  }
+
+  .dashboard-map-filter-clear {
+    @apply tw-border-0 tw-bg-transparent tw-p-0 tw-text-[10px] tw-font-semibold;
+    color: var(--chart-1);
+    cursor: pointer;
+  }
+
+  .dashboard-map-filter-clear:hover {
+    text-decoration: underline;
+  }
+
+  .dashboard-map-legend-toggle {
+    @apply tw-h-5 tw-w-5 tw-border-0 tw-bg-transparent tw-text-sm tw-leading-none tw-text-muted-foreground;
+    cursor: pointer;
+  }
+
+  .dashboard-map-legend-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .dashboard-map-legend-swatch {
+    @apply tw-inline-block tw-h-3 tw-w-3 tw-flex-shrink-0 tw-rounded-sm tw-border;
+  }
+
+  .leaflet-tooltip.dashboard-map-hover-tooltip {
+    background: transparent;
+    border: 0;
+    box-shadow: none;
+    padding: 0;
+    margin-top: -8px;
+    z-index: 800;
+  }
+
+  .leaflet-dashboardMapHoverTooltips-pane {
+    z-index: 800 !important;
+  }
+
+  .dashboard-map-hover-card {
+    min-width: 168px;
+    border: 1px solid var(--border);
+    border-radius: 0.25rem;
+    background: color-mix(in srgb, var(--surface) 98%, transparent);
+    box-shadow: 0 8px 24px rgb(0 0 0 / 0.12);
+    padding: 0.625rem 0.75rem;
+  }
+
+  .dashboard-map-hover-title {
+    @apply tw-mb-1.5 tw-text-[11px] tw-font-semibold tw-text-foreground;
+  }
+
+  .dashboard-map-hover-row {
+    @apply tw-flex tw-items-center tw-justify-between tw-gap-3 tw-text-[10px] tw-leading-snug tw-text-muted-foreground;
+  }
+
+  .dashboard-map-hover-row strong {
+    @apply tw-font-semibold tw-text-foreground;
+  }
+
+  .dashboard-map-hover-sla {
+    @apply tw-mt-2 tw-flex tw-flex-wrap tw-gap-2 tw-border-t tw-border-border tw-pt-2;
+  }
+
+  .dashboard-map-hover-pill {
+    @apply tw-inline-flex tw-items-center tw-gap-1 tw-whitespace-nowrap tw-text-[9px] tw-text-foreground;
+  }
+
+  .dashboard-map-hover-dot {
+    @apply tw-h-2 tw-w-2 tw-flex-shrink-0 tw-rounded-full;
+  }
+
+  .dashboard-map-hover-dot--within {
+    background: var(--chart-1);
+  }
+
+  .dashboard-map-hover-dot--breaching {
+    background: var(--chart-2);
+  }
+
+  .dashboard-map-hover-dot--breached {
+    background: var(--status-breach);
+  }
+
+  .leaflet-popup.dashboard-map-pin-popup-wrapper .dashboard-map-hover-card {
+    min-width: 0;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+    padding: 0;
+  }
+
+  .leaflet-popup.dashboard-map-pin-popup-wrapper .leaflet-popup-content-wrapper {
+    border-radius: 0.375rem;
+  }
+
+  .dashboard-map-hover-note {
+    @apply tw-mt-1.5 tw-text-[9px] tw-leading-snug tw-text-muted-foreground;
+  }
+
+  .dashboard-pie-slice {
+    cursor: default;
+  }
+
+  .dashboard-grid-layout .react-grid-item > .react-resizable-handle::after {
+    content: none;
+    border: 0;
+  }
+
+  .dashboard-grid-layout .react-grid-item > .react-resizable-handle {
+    background: transparent;
+    opacity: 0;
+  }
+
+  .dashboard-grid-layout .react-grid-item:hover > .react-resizable-handle.react-resizable-handle-se,
+  .dashboard-grid-layout .react-grid-item:hover > .react-resizable-handle.react-resizable-handle-e,
+  .dashboard-grid-layout .react-grid-item:hover > .react-resizable-handle.react-resizable-handle-s {
+    opacity: 1;
+  }
+
+  .dashboard-grid-layout .react-grid-item > .react-resizable-handle.react-resizable-handle-se {
+    bottom: 0;
+    right: 0;
+    width: 18px;
+    height: 18px;
+    cursor: se-resize;
+    z-index: 3;
+  }
+
+  .dashboard-grid-layout .react-grid-item > .react-resizable-handle.react-resizable-handle-e {
+    top: 50%;
+    right: 0;
+    width: 18px;
+    height: 18px;
+    margin-top: -9px;
+    cursor: e-resize;
+    z-index: 3;
+  }
+
+  .dashboard-grid-layout .react-grid-item > .react-resizable-handle.react-resizable-handle-s {
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 12px;
+    cursor: s-resize;
+    z-index: 3;
+  }
+
+  .dashboard-grid-layout .react-grid-placeholder {
+    background: transparent !important;
+    opacity: 0 !important;
+    border: 0 !important;
+  }
+
+  .dashboard-view-toggle button {
+    cursor: default;
+  }
+
+  .dashboard-sla-link {
+    color: var(--chart-1);
+    font-weight: 500;
+    text-decoration: none;
+    cursor: default;
+  }
+
+  .dashboard-sla-link:hover {
+    text-decoration: underline;
+  }
+
+  .dashboard-sla-link--button {
+    @apply tw-border-0 tw-bg-transparent tw-p-0;
+  }
+
+  .dashboard-sla-breach-pill {
+    display: inline-block;
+    max-width: 100%;
+    border-radius: 4px;
+    font-size: 9px;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    line-height: 1.2;
+    padding: 2px 6px;
+    text-transform: uppercase;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .dashboard-sla-breach-pill--breached {
+    background-color: color-mix(in srgb, var(--status-breach) 14%, transparent);
+    color: var(--status-breach);
+  }
+
+  .dashboard-sla-breach-pill--nearing {
+    background-color: color-mix(in srgb, var(--status-progress) 16%, transparent);
+    color: var(--status-progress);
+  }
+
+  .dashboard-sla-status-pill {
+    display: inline-block;
+    max-width: 100%;
+    border-radius: 9999px;
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    line-height: 1.3;
+    padding: 3px 10px;
+    text-transform: uppercase;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .dashboard-sla-status-pill--reopened {
+    background-color: color-mix(in srgb, var(--chart-4) 14%, transparent);
+    color: var(--chart-4);
+  }
+
+  .dashboard-sla-status-pill--assigned {
+    background-color: color-mix(in srgb, var(--chart-1) 14%, transparent);
+    color: var(--chart-1);
+  }
+
+  .dashboard-sla-status-pill--open {
+    background-color: color-mix(in srgb, var(--chart-2) 16%, transparent);
+    color: var(--chart-2);
+  }
+
+  .dashboard-sla-status-pill--in-progress {
+    background-color: color-mix(in srgb, var(--status-progress) 14%, transparent);
+    color: var(--status-progress);
+  }
+
+  .dashboard-viz-chart-1 {
+    color: var(--chart-1);
+  }
+
+  .dashboard-sla-overdue {
+    color: var(--status-breach);
+    font-weight: 500;
+  }
+
+  .dashboard-search-dimmed {
+    opacity: 0.12;
+    pointer-events: none;
+  }
+
+  .dashboard-sla-status-select {
+    appearance: none;
+    -webkit-appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%236b6860' stroke-width='2'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+    background-position: right 8px center;
+    background-repeat: no-repeat;
+    background-size: 10px;
+    border: 0;
+    cursor: default;
+    min-width: 7.5rem;
+    padding-right: 1.5rem;
+  }
+
+  .dashboard-sla-status-select:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary) 25%, transparent);
+  }
+}
+
+/* Scrollbars hidden globally except on chart/table scroll regions. */
+.dashboard-root,
+.dashboard-root * {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.dashboard-root *:not(.dashboard-subtle-scroll)::-webkit-scrollbar {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
+.dashboard-root .dashboard-subtle-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+}
+
+.dashboard-root .dashboard-subtle-scroll.dashboard-subtle-scroll--active {
+  scrollbar-color: color-mix(in srgb, var(--foreground) 22%, transparent) transparent;
+}
+
+.dashboard-root .dashboard-subtle-scroll::-webkit-scrollbar {
+  display: block;
+  width: 5px;
+  height: 5px;
+}
+
+.dashboard-root .dashboard-subtle-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.dashboard-root .dashboard-subtle-scroll::-webkit-scrollbar-thumb {
+  background-color: transparent;
+  border-radius: 9999px;
+  transition: background-color 0.3s ease;
+}
+
+.dashboard-root .dashboard-subtle-scroll.dashboard-subtle-scroll--active::-webkit-scrollbar-thumb {
+  background-color: color-mix(in srgb, var(--foreground) 22%, transparent);
+}
+
+.dashboard-root .dashboard-subtle-scroll.dashboard-subtle-scroll--active::-webkit-scrollbar-thumb:hover {
+  background-color: color-mix(in srgb, var(--foreground) 32%, transparent);
+}
+
+/* Beat global digit-ui Roboto rules on bare form/table elements */
+.dashboard-root :is(
+  button,
+  input,
+  select,
+  textarea,
+  optgroup,
+  option,
+  label,
+  table,
+  caption,
+  thead,
+  tbody,
+  tfoot,
+  tr,
+  th,
+  td,
+  p,
+  span,
+  div,
+  a,
+  li,
+  ul,
+  ol,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  header,
+  footer,
+  main,
+  section,
+  nav,
+  aside,
+  small,
+  strong,
+  em
+) {
+  font-family: var(--dashboard-font-family) !important;
+}
+
+/* ── Embedded-in-DigitUI overrides ─────────────────────────────────────
+   Applied when the dashboard is mounted inside the DigitUI employee
+   chrome (products/dashboard/Module.js renders <AdminDashboard embedded />,
+   which adds .dashboard-embedded next to .dashboard-root). The host chrome
+   owns the viewport and scrolling, so the standalone full-viewport shell
+   (h-screen root, internal overflow scrollers) is neutralized; the internal
+   dark Sidebar is simply not rendered in embedded mode. Plain CSS outside
+   the tailwind layers, so regeneration passes it through verbatim. */
+.dashboard-root.dashboard-embedded {
+  height: auto;
+  min-height: 100%;
+  overflow: visible;
+}
+.dashboard-root.dashboard-embedded > div {
+  overflow: visible;
+}
+.dashboard-root.dashboard-embedded > div > main {
+  overflow: visible;
+}

--- a/digit-ui-esbuild/products/dashboard/src/tailwind.config.js
+++ b/digit-ui-esbuild/products/dashboard/src/tailwind.config.js
@@ -1,0 +1,95 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  prefix: "tw-",
+  content: ["./products/dashboard/src/**/*.{js,jsx}"],
+  corePlugins: {
+    preflight: false,
+  },
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ["Inter", "Roboto", "ui-sans-serif", "system-ui", "sans-serif"],
+      },
+      borderRadius: {
+        sm: "4px",
+      },
+      colors: {
+        // All values resolve to the canonical palette defined on
+        // `.dashboard-root` in styles/input.css.
+        background: "var(--background)",
+        foreground: "var(--foreground)",
+        surface: {
+          DEFAULT: "var(--surface)",
+          2: "var(--surface-2)",
+          3: "var(--surface-3)",
+        },
+        card: {
+          DEFAULT: "var(--card)",
+          foreground: "var(--card-foreground)",
+        },
+        popover: {
+          DEFAULT: "var(--popover)",
+          foreground: "var(--popover-foreground)",
+        },
+        primary: {
+          DEFAULT: "var(--primary)",
+          foreground: "var(--primary-foreground)",
+        },
+        secondary: {
+          DEFAULT: "var(--secondary)",
+          foreground: "var(--secondary-foreground)",
+        },
+        muted: {
+          DEFAULT: "var(--muted)",
+          foreground: "var(--muted-foreground)",
+        },
+        accent: {
+          DEFAULT: "var(--accent)",
+          foreground: "var(--accent-foreground)",
+        },
+        destructive: {
+          DEFAULT: "var(--destructive)",
+          foreground: "var(--destructive-foreground)",
+        },
+        border: "var(--border)",
+        input: "var(--input)",
+        ring: "var(--ring)",
+        chrome: {
+          DEFAULT: "var(--chrome)",
+          foreground: "var(--chrome-foreground)",
+          muted: "var(--chrome-muted)",
+        },
+        status: {
+          open: "var(--status-open)",
+          "open-bg": "var(--status-open-bg)",
+          assigned: "var(--status-assigned)",
+          "assigned-bg": "var(--status-assigned-bg)",
+          progress: "var(--status-progress)",
+          "progress-bg": "var(--status-progress-bg)",
+          resolved: "var(--status-resolved)",
+          "resolved-bg": "var(--status-resolved-bg)",
+          rejected: "var(--status-rejected)",
+          "rejected-bg": "var(--status-rejected-bg)",
+          overdue: "var(--status-overdue)",
+          "overdue-bg": "var(--status-overdue-bg)",
+          breach: "var(--status-breach)",
+          "breach-bg": "var(--status-breach-bg)",
+        },
+        chart: {
+          1: "var(--chart-1)",
+          2: "var(--chart-2)",
+          3: "var(--chart-3)",
+          4: "var(--chart-4)",
+          5: "var(--chart-5)",
+        },
+        // Legacy brand.* aliases mapped onto the palette.
+        brand: {
+          teal: "var(--primary)",
+          dark: "var(--chrome)",
+          slate: "var(--chrome-muted)",
+        },
+      },
+    },
+  },
+  plugins: [],
+};

--- a/digit-ui-esbuild/products/dashboard/src/utils/barChartXAxis.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/barChartXAxis.js
@@ -1,0 +1,7 @@
+import { BAR_CHART_GRID_GUTTER_PX, resolveBarCategorySlotWidth } from "../config/barChartPresentation";
+
+export const Y_AXIS_GUTTER_PX = BAR_CHART_GRID_GUTTER_PX;
+
+export function resolveLabelSlotWidth(categoryCount, containerWidth) {
+  return resolveBarCategorySlotWidth(categoryCount, containerWidth);
+}

--- a/digit-ui-esbuild/products/dashboard/src/utils/chartLabelWrap.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/chartLabelWrap.js
@@ -1,0 +1,114 @@
+/** Approximate monospace width per character at 10px axis labels. */
+export const CHART_LABEL_CHAR_WIDTH_PX = 6.5;
+export const CHART_AXIS_LABEL_FONT_SIZE_PX = 10;
+/** Vertical gap between wrapped lines of the same category label. */
+export const CHART_AXIS_LABEL_LINE_HEIGHT_PX = 9;
+/** Minimum clear gap between adjacent category labels (horizontal bar rows). */
+export const CHART_AXIS_CATEGORY_GAP_PX = 16;
+export const CHART_AXIS_WRAPPED_LABEL_MAX_LINES = 2;
+
+const HORIZONTAL_BAR_BAND_PX = 14;
+
+/** Smallest row height that keeps wrapped labels readable and separated. */
+export function resolveMinHorizontalBarRowHeight(
+  maxLabelLines = CHART_AXIS_WRAPPED_LABEL_MAX_LINES
+) {
+  const lines = Math.max(1, maxLabelLines);
+  return (
+    lines * CHART_AXIS_LABEL_LINE_HEIGHT_PX +
+    CHART_AXIS_CATEGORY_GAP_PX +
+    HORIZONTAL_BAR_BAND_PX
+  );
+}
+
+export function wrapChartLabelToLines(
+  text,
+  maxWidthPx,
+  { charWidthPx = CHART_LABEL_CHAR_WIDTH_PX, maxLines = 4 } = {}
+) {
+  const normalized = String(text ?? "").trim() || "—";
+  if (!maxWidthPx || maxWidthPx <= 0) return [normalized];
+
+  const maxCharsPerLine = Math.max(4, Math.floor(maxWidthPx / charWidthPx) - 1);
+  if (normalized.length <= maxCharsPerLine) return [normalized];
+
+  const tokens = normalized.split(/\s+/).filter(Boolean);
+  const sourceTokens = tokens.length ? tokens : [normalized];
+  const lines = [];
+
+  const pushLine = (line) => {
+    if (line) lines.push(line);
+  };
+
+  const splitLongToken = (token) => {
+    let rest = token;
+    while (rest.length > maxCharsPerLine && lines.length < maxLines) {
+      pushLine(rest.slice(0, maxCharsPerLine));
+      rest = rest.slice(maxCharsPerLine);
+    }
+    return rest;
+  };
+
+  let current = "";
+
+  for (const rawToken of sourceTokens) {
+    if (lines.length >= maxLines) break;
+
+    let token = rawToken;
+    if (token.length > maxCharsPerLine) {
+      if (current) {
+        pushLine(current);
+        current = "";
+        if (lines.length >= maxLines) break;
+      }
+      token = splitLongToken(token);
+      if (!token) continue;
+    }
+
+    if (!current) {
+      current = token;
+      continue;
+    }
+
+    const candidate = `${current} ${token}`;
+    if (candidate.length <= maxCharsPerLine) {
+      current = candidate;
+    } else {
+      pushLine(current);
+      current = token;
+    }
+  }
+
+  if (current && lines.length < maxLines) {
+    pushLine(current);
+  }
+
+  if (!lines.length) {
+    return [normalized.slice(0, maxCharsPerLine)];
+  }
+
+  return lines.slice(0, maxLines);
+}
+
+/** Apex renders string[] as multiline tspans; a single line stays a string. */
+export function formatWrappedChartLabel(text, maxWidthPx, options) {
+  const lines = wrapChartLabelToLines(text, maxWidthPx, options);
+  return lines.length === 1 ? lines[0] : lines;
+}
+
+export function estimateMaxWrappedLabelHeight(
+  labels,
+  maxWidthPx,
+  { lineHeightPx = CHART_AXIS_LABEL_LINE_HEIGHT_PX, maxLines = 4 } = {}
+) {
+  if (!labels?.length) {
+    return lineHeightPx + 4;
+  }
+
+  const lineCount = Math.max(
+    1,
+    ...labels.map((label) => wrapChartLabelToLines(label, maxWidthPx, { maxLines }).length)
+  );
+
+  return lineCount * lineHeightPx + 4;
+}

--- a/digit-ui-esbuild/products/dashboard/src/utils/chartScrollBaseline.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/chartScrollBaseline.js
@@ -1,0 +1,226 @@
+import {
+  DEFAULT_CHART_LAYOUT,
+  GRID_COLS,
+  GRID_MARGIN_Y,
+  KPI_ROW_HEIGHT,
+} from "../constants/layoutConfig";
+import { resolveMinHorizontalBarRowHeight } from "./chartLabelWrap";
+
+const STORAGE_PREFIX = "dashboard-chart-baseline:v2:";
+const GRID_MARGIN_X = 16;
+const WIDGET_CHROME_HEIGHT_PX = 78;
+const WIDGET_BODY_PADDING_X_PX = 16;
+
+/** Bars visible in the viewport before horizontal scroll is required. */
+export const BAR_CHART_VISIBLE_SLOTS_WITHOUT_SCROLL = 5;
+/** Horizontal bar charts use taller rows so category labels do not run together. */
+export const HORIZONTAL_BAR_VISIBLE_SLOTS_WITHOUT_SCROLL = 4;
+
+export function chartScrollStorageKey(scrollKey) {
+  return scrollKey ? `${STORAGE_PREFIX}${scrollKey}` : null;
+}
+
+export function loadChartScrollBaseline(scrollKey) {
+  const key = chartScrollStorageKey(scrollKey);
+  if (!key) return null;
+
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (
+      parsed &&
+      Number.isFinite(parsed.width) &&
+      Number.isFinite(parsed.height) &&
+      parsed.width > 0 &&
+      parsed.height > 0
+    ) {
+      return {
+        width: Math.floor(parsed.width),
+        height: Math.floor(parsed.height),
+      };
+    }
+  } catch {
+    // ignore corrupt storage
+  }
+  return null;
+}
+
+export function saveChartScrollBaseline(scrollKey, size) {
+  const key = chartScrollStorageKey(scrollKey);
+  if (!key || !size?.width || !size?.height) return;
+
+  try {
+    localStorage.setItem(
+      key,
+      JSON.stringify({
+        width: Math.floor(size.width),
+        height: Math.floor(size.height),
+      })
+    );
+  } catch {
+    // ignore quota / private mode
+  }
+}
+
+/** Estimate chart plot area from layout defaults (survives refresh at shrunk grid size). */
+export function resolveDefaultChartAreaPx(scrollKey, layoutElement) {
+  const defaults = DEFAULT_CHART_LAYOUT[scrollKey];
+  if (!defaults?.w || !defaults?.h) return null;
+
+  const layoutWidth = layoutElement?.clientWidth;
+  if (!layoutWidth) return null;
+
+  const colWidth = (layoutWidth - GRID_MARGIN_X * (GRID_COLS + 1)) / GRID_COLS;
+  const itemWidth = defaults.w * colWidth + Math.max(0, defaults.w - 1) * GRID_MARGIN_X;
+  const itemHeight =
+    defaults.h * KPI_ROW_HEIGHT + Math.max(0, defaults.h - 1) * GRID_MARGIN_Y;
+
+  return {
+    width: Math.max(160, Math.floor(itemWidth - WIDGET_BODY_PADDING_X_PX)),
+    height: Math.max(120, Math.floor(itemHeight - WIDGET_CHROME_HEIGHT_PX)),
+  };
+}
+
+/** Chart body width at the widget's minimum grid width — anchors bar slot size (5 bars at minW). */
+export function resolveMinChartAreaPx(scrollKey, layoutElement) {
+  const defaults = DEFAULT_CHART_LAYOUT[scrollKey];
+  if (!defaults?.minW) return null;
+
+  const layoutWidth = layoutElement?.clientWidth;
+  if (!layoutWidth) return null;
+
+  const colWidth = (layoutWidth - GRID_MARGIN_X * (GRID_COLS + 1)) / GRID_COLS;
+  const itemWidth =
+    defaults.minW * colWidth + Math.max(0, defaults.minW - 1) * GRID_MARGIN_X;
+
+  return Math.max(160, Math.floor(itemWidth - WIDGET_BODY_PADDING_X_PX));
+}
+
+/** Chart body height at the widget's minimum grid height — anchors row size (5 bars at minH). */
+export function resolveMinChartAreaHeightPx(scrollKey) {
+  const defaults = DEFAULT_CHART_LAYOUT[scrollKey];
+  if (!defaults?.minH) return null;
+
+  const itemHeight =
+    defaults.minH * KPI_ROW_HEIGHT + Math.max(0, defaults.minH - 1) * GRID_MARGIN_Y;
+
+  return Math.max(120, Math.floor(itemHeight - WIDGET_CHROME_HEIGHT_PX));
+}
+
+export function resolveVerticalBarSlotWidth(minChartWidth = 0, viewportWidth = 0) {
+  const referenceWidth = Math.max(
+    160,
+    Number(minChartWidth) || Number(viewportWidth) || 0
+  );
+  return referenceWidth / BAR_CHART_VISIBLE_SLOTS_WITHOUT_SCROLL;
+}
+
+export function resolveVerticalBarVisibleSlots(viewportWidth = 0, slotWidth = 0) {
+  const viewport = Math.max(0, Number(viewportWidth) || 0);
+  const slot = Math.max(0, Number(slotWidth) || 0);
+  if (viewport <= 0 || slot <= 0) return BAR_CHART_VISIBLE_SLOTS_WITHOUT_SCROLL;
+  return Math.max(1, Math.floor(viewport / slot));
+}
+
+export function resolveVerticalBarChartWidth(
+  categoryCount = 0,
+  viewportWidth = 0,
+  minChartWidth = 0
+) {
+  const viewport = Math.max(0, Number(viewportWidth) || 0);
+  if (viewport <= 0) return 0;
+
+  const count = Math.max(0, Number(categoryCount) || 0);
+  if (count === 0) return viewport;
+
+  const slotWidth = resolveVerticalBarSlotWidth(minChartWidth, viewport);
+  const visibleSlots = resolveVerticalBarVisibleSlots(viewport, slotWidth);
+
+  if (count <= visibleSlots) {
+    return viewport;
+  }
+
+  return Math.ceil(count * slotWidth);
+}
+
+/** @deprecated Use resolveVerticalBarChartWidth — kept for callers that need min width hints. */
+export function resolveVerticalBarMinContentWidth(
+  categoryCount = 0,
+  viewportWidth = 0,
+  minChartWidth = 0
+) {
+  const viewport = Math.max(0, Number(viewportWidth) || 0);
+  const width = resolveVerticalBarChartWidth(
+    categoryCount,
+    viewport,
+    minChartWidth
+  );
+  if (!viewport || width <= viewport) return 0;
+  return width;
+}
+
+export function resolveHorizontalBarRowHeight(
+  minChartHeight = 0,
+  viewportHeight = 0
+) {
+  const referenceHeight = Math.max(
+    120,
+    Number(minChartHeight) || Number(viewportHeight) || 0
+  );
+  const slotFromViewport =
+    referenceHeight / HORIZONTAL_BAR_VISIBLE_SLOTS_WITHOUT_SCROLL;
+  return Math.max(slotFromViewport, resolveMinHorizontalBarRowHeight());
+}
+
+export function resolveHorizontalBarVisibleSlots(
+  viewportHeight = 0,
+  rowHeight = 0
+) {
+  const viewport = Math.max(0, Number(viewportHeight) || 0);
+  const row = Math.max(0, Number(rowHeight) || 0);
+  if (viewport <= 0 || row <= 0) return HORIZONTAL_BAR_VISIBLE_SLOTS_WITHOUT_SCROLL;
+  return Math.max(1, Math.floor(viewport / row));
+}
+
+export function resolveHorizontalBarChartHeight(
+  categoryCount = 0,
+  viewportHeight = 0,
+  minChartHeight = 0
+) {
+  const viewport = Math.max(0, Number(viewportHeight) || 0);
+  if (viewport <= 0) return 0;
+
+  const count = Math.max(0, Number(categoryCount) || 0);
+  if (count === 0) return viewport;
+
+  const rowHeight = resolveHorizontalBarRowHeight(minChartHeight, viewport);
+  const visibleSlots = resolveHorizontalBarVisibleSlots(viewport, rowHeight);
+
+  if (count <= visibleSlots) {
+    return viewport;
+  }
+
+  return Math.ceil(count * rowHeight);
+}
+
+/** @deprecated Use resolveHorizontalBarChartHeight. */
+export function resolveHorizontalBarMinHeight(
+  categoryCount = 0,
+  viewportHeight = 0,
+  minChartHeight = 0
+) {
+  const viewport = Math.max(0, Number(viewportHeight) || 0);
+  const height = resolveHorizontalBarChartHeight(
+    categoryCount,
+    viewport,
+    minChartHeight
+  );
+  if (!viewport || height <= viewport) return 0;
+  return height;
+}
+
+export function resolveHorizontalBarMinWidth(categoryCount = 0) {
+  if (!categoryCount) return 0;
+  return Math.max(280, 120 + categoryCount * 8);
+}

--- a/digit-ui-esbuild/products/dashboard/src/utils/composeKpi.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/composeKpi.js
@@ -1,0 +1,70 @@
+/**
+ * Evaluates a viz.compose rule against already-fetched results.
+ * The rule comes from the backend (viz.compose in the KpiDefinition).
+ * The FE engine evaluates it; it does NOT know the rule a priori.
+ *
+ * @param compose - the viz.compose object from the KpiDef tile descriptor
+ * @param results - the results map from runKpiBatch (keyed by kpiId)
+ * @returns the computed scalar value, or null if sources not yet available
+ */
+export function evaluateCompose(compose, results) {
+  if (!compose || !compose.type) return null;
+  const { type, sourceKpiIds, elapsedFromAsOf } = compose;
+
+  const sourceData = sourceKpiIds.map(id => {
+    const r = results[id];
+    return r && r.rows && r.rows[0] ? r.rows[0] : null;
+  });
+
+  if (sourceData.some(d => d === null)) return null; // sources not loaded yet
+
+  switch (type) {
+    case 'openRateComplement': {
+      const pct = sourceData[0].pct ?? sourceData[0].total;
+      return pct != null ? (1 - pct) * 100 : null;
+    }
+    case 'netBacklogDaily': {
+      const inflow = sourceData[0].total ?? 0;
+      const outflow = sourceData[1]?.total ?? 0;
+      return inflow - outflow;
+    }
+    case 'dailyAvgFromWeekly': {
+      const total = sourceData[0].total ?? 0;
+      if (!elapsedFromAsOf) return null;
+      // Get asOf from the source result to avoid client clock authority
+      const asOf = results[sourceKpiIds[0]]?.asOf;
+      const daysElapsed = asOf ? elapsedDaysSince(startOfWeek(new Date(asOf)), new Date(asOf)) : null;
+      return daysElapsed && daysElapsed > 0 ? total / daysElapsed : null;
+    }
+    case 'hourlyAvgFromDaily': {
+      const total = sourceData[0].total ?? 0;
+      if (!elapsedFromAsOf) return null;
+      const asOf = results[sourceKpiIds[0]]?.asOf;
+      const hoursElapsed = asOf ? elapsedHoursSince(startOfDay(new Date(asOf)), new Date(asOf)) : null;
+      return hoursElapsed && hoursElapsed > 0 ? total / hoursElapsed : null;
+    }
+    default:
+      return null;
+  }
+}
+
+function startOfWeek(d) {
+  const start = new Date(d);
+  start.setDate(d.getDate() - d.getDay());
+  start.setHours(0, 0, 0, 0);
+  return start;
+}
+
+function startOfDay(d) {
+  const start = new Date(d);
+  start.setHours(0, 0, 0, 0);
+  return start;
+}
+
+function elapsedDaysSince(start, now) {
+  return Math.max(1, Math.floor((now - start) / 86400000));
+}
+
+function elapsedHoursSince(start, now) {
+  return Math.max(1, Math.floor((now - start) / 3600000));
+}

--- a/digit-ui-esbuild/products/dashboard/src/utils/gridGeometry.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/gridGeometry.js
@@ -1,0 +1,70 @@
+/**
+ * Pure grid-geometry helpers for the dashboard layout (react-grid-layout items
+ * shaped { i, x, y, w, h }). Relocated from the retired legacy useDashboardLayout
+ * hook so the catalog-driven useCatalogLayout can reuse them without dragging in
+ * the old dash-case widget machinery.
+ */
+
+function rectsOverlap(a, b) {
+  return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
+}
+
+function overlapArea(a, b) {
+  const xOverlap = Math.max(0, Math.min(a.x + a.w, b.x + b.w) - Math.max(a.x, b.x));
+  const yOverlap = Math.max(0, Math.min(a.y + a.h, b.y + b.h) - Math.max(a.y, b.y));
+  return xOverlap * yOverlap;
+}
+
+function collidesAt(item, x, y, placed) {
+  const candidate = { ...item, x, y };
+  return placed.some((other) => rectsOverlap(candidate, other));
+}
+
+/**
+ * Compact every item upward to the lowest free row (reading order: top-to-bottom,
+ * left-to-right). Removes vertical gaps and resolves overlaps (e.g. after a swap
+ * or an enlarged card) by stacking colliding items downward.
+ */
+export function compactVertically(layout) {
+  const sorted = [...layout]
+    .map((item) => ({ ...item }))
+    .sort((a, b) => a.y - b.y || a.x - b.x);
+
+  const placed = [];
+  for (const item of sorted) {
+    let y = 0;
+    while (collidesAt(item, item.x, y, placed)) y += 1;
+    placed.push({ ...item, y });
+  }
+  return placed;
+}
+
+/**
+ * Swap the dragged item with the item it was dropped onto: the dragged item snaps
+ * to the displaced item's slot, and the displaced item moves to the dragged item's
+ * origin. Dropping on empty space is a no-op (the item keeps its new position).
+ */
+export function swapOnDrop(layout, activeId, origin) {
+  const dragged = layout.find((item) => item.i === activeId);
+  if (!dragged) return layout;
+
+  let target = null;
+  let bestArea = 0;
+  for (const item of layout) {
+    if (item.i === activeId) continue;
+    const area = overlapArea(dragged, item);
+    if (area > bestArea) {
+      bestArea = area;
+      target = item;
+    }
+  }
+
+  if (!target) return layout;
+
+  const targetPos = { x: target.x, y: target.y };
+  return layout.map((item) => {
+    if (item.i === activeId) return { ...item, x: targetPos.x, y: targetPos.y };
+    if (item.i === target.i) return { ...item, x: origin.x, y: origin.y };
+    return item;
+  });
+}

--- a/digit-ui-esbuild/products/dashboard/src/utils/mapGeoUtils.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/mapGeoUtils.js
@@ -1,0 +1,1127 @@
+import L from "leaflet";
+import { formatDimensionLabel } from "../config/labelFormat";
+import { getWowChangeFillStyle } from "../config/geographyMapPresentation";
+
+const TEAL_SCALE = ["#ccfbf1", "#5eead4", "#14b8a6", "#0d9488", "#115e59"];
+
+export function getMapCenter() {
+  const configured = window?.globalConfigs?.getConfig("MAP_CENTER_LAT_LNG");
+  if (configured?.lat != null && configured?.lng != null) {
+    return [Number(configured.lat), Number(configured.lng)];
+  }
+  return [-0.78, 35.34];
+}
+
+export function geometryCentroid(geometry) {
+  if (!geometry?.type) return null;
+
+  if (geometry.type === "Point") {
+    const [lng, lat] = geometry.coordinates;
+    return { lat, lng };
+  }
+
+  if (geometry.type === "Polygon") {
+    return polygonCentroid(geometry.coordinates[0]);
+  }
+
+  if (geometry.type === "MultiPolygon") {
+    const firstRing = geometry.coordinates?.[0]?.[0];
+    return firstRing ? polygonCentroid(firstRing) : null;
+  }
+
+  return null;
+}
+
+function polygonCentroid(ring) {
+  if (!ring?.length) return null;
+  let latSum = 0;
+  let lngSum = 0;
+  let count = 0;
+  for (const coord of ring) {
+    if (!Array.isArray(coord) || coord.length < 2) continue;
+    lngSum += coord[0];
+    latSum += coord[1];
+    count += 1;
+  }
+  if (!count) return null;
+  return { lat: latSum / count, lng: lngSum / count };
+}
+
+export function countToColor(count, maxCount) {
+  if (!maxCount || count <= 0) return TEAL_SCALE[0];
+  const ratio = Math.min(count / maxCount, 1);
+  const index = Math.min(TEAL_SCALE.length - 1, Math.floor(ratio * (TEAL_SCALE.length - 1)));
+  return TEAL_SCALE[index];
+}
+
+export function countToFillStyle(count, maxCount) {
+  if (!maxCount || count <= 0) {
+    return { fillColor: "#ffffff", strokeColor: "#d1d5db", fillOpacity: 0.95 };
+  }
+  const fillColor = countToColor(count, maxCount);
+  return { fillColor, strokeColor: fillColor, fillOpacity: 0.74 };
+}
+
+export function computeWowPct(current, prior) {
+  const cur = Number(current) || 0;
+  const prev = Number(prior) || 0;
+  if (prev <= 0) {
+    if (cur > 0) return Number.POSITIVE_INFINITY;
+    return 0;
+  }
+  return ((cur - prev) / prev) * 100;
+}
+
+export function wowPctToFillStyle(wowPct) {
+  return getWowChangeFillStyle(wowPct);
+}
+
+export function breachShareToFillStyle(sharePct) {
+  const pct = Number(sharePct) || 0;
+  if (pct <= 0) {
+    return { fillColor: "#ffffff", strokeColor: "#d1d5db", fillOpacity: 0.92 };
+  }
+  if (pct <= 10) {
+    return { fillColor: "#fee2e2", strokeColor: "#fecaca", fillOpacity: 0.72 };
+  }
+  if (pct <= 25) {
+    return { fillColor: "#fecaca", strokeColor: "#fca5a5", fillOpacity: 0.74 };
+  }
+  if (pct <= 50) {
+    return { fillColor: "#f87171", strokeColor: "#ef4444", fillOpacity: 0.76 };
+  }
+  if (pct <= 75) {
+    return { fillColor: "#dc2626", strokeColor: "#b91c1c", fillOpacity: 0.78 };
+  }
+  return { fillColor: "#7f1d1d", strokeColor: "#450a0a", fillOpacity: 0.8 };
+}
+
+/** @deprecated Use breachShareToFillStyle */
+export function breachCountToFillStyle(count) {
+  return breachShareToFillStyle(count > 0 ? 50 : 0);
+}
+
+export function getMapCityLabel() {
+  return (
+    window?.globalConfigs?.getConfig("DASHBOARD_MAP_CITY_LABEL") ||
+    window?.globalConfigs?.getConfig("DASHBOARD_STATE_LABEL") ||
+    window?.globalConfigs?.getConfig("STATE_NAME") ||
+    "City"
+  );
+}
+
+export function countToRadius(count, maxCount) {
+  const minR = 8;
+  const maxR = 28;
+  if (!maxCount || count <= 0) return minR;
+  return minR + (count / maxCount) * (maxR - minR);
+}
+
+/**
+ * Join analytics ward counts with boundary geometry.
+ * @returns {{ markers: object[], geoFeatures: object[], maxCount: number, geometrySummary: object }}
+ */
+export function joinWardMapData(wardCounts = [], boundaries = []) {
+  const boundaryByCode = Object.fromEntries(
+    boundaries.map((b) => [String(b.code), b])
+  );
+
+  const markers = [];
+  const geoFeatures = [];
+  let maxCount = 0;
+
+  const geometrySummary = { point: 0, polygon: 0, other: 0, missing: 0 };
+
+  for (const ward of wardCounts) {
+    const code = String(ward.wardCode ?? ward.label ?? "");
+    const count = Number(ward.count) || 0;
+    maxCount = Math.max(maxCount, count);
+
+    const boundary = boundaryByCode[code];
+    const geometry = boundary?.geometry;
+    const label = ward.label || formatDimensionLabel(code);
+    const type = geometry?.type;
+
+    if (!type) {
+      geometrySummary.missing += 1;
+      continue;
+    }
+
+    if (type === "Point") {
+      geometrySummary.point += 1;
+      const [lng, lat] = geometry.coordinates;
+      markers.push({ code, label, count, lat, lng, geometry, ...ward });
+    } else if (type === "Polygon" || type === "MultiPolygon") {
+      geometrySummary.polygon += 1;
+      geoFeatures.push({
+        type: "Feature",
+        properties: { code, label, count, ...ward },
+        geometry,
+      });
+    } else {
+      geometrySummary.other += 1;
+    }
+  }
+
+  return {
+    markers,
+    geoFeatures: { type: "FeatureCollection", features: geoFeatures },
+    maxCount,
+    geometrySummary,
+  };
+}
+
+/** Fit the map so every polygon / marker is visible with comfortable padding. */
+export function resolveJoinedMapBounds(joined) {
+  const { geoFeatures, markers } = joined ?? {};
+  let bounds = null;
+
+  if (geoFeatures?.features?.length) {
+    const group = L.featureGroup();
+    L.geoJSON(geoFeatures, {
+      onEachFeature: (_feature, layer) => {
+        group.addLayer(layer);
+      },
+    });
+    const layerBounds = group.getBounds();
+    if (layerBounds?.isValid()) {
+      bounds = layerBounds;
+    }
+  }
+
+  if (markers?.length) {
+    const markerBounds = L.latLngBounds(markers.map((marker) => [marker.lat, marker.lng]));
+    if (markerBounds.isValid()) {
+      bounds = bounds ? bounds.extend(markerBounds) : markerBounds;
+    }
+  }
+
+  return bounds?.isValid() ? bounds : null;
+}
+
+/** Four click-drill levels — UI labels match the complaint map reference. */
+export const MAP_DRILL_TIERS = [
+  { id: "state", label: "District", index: 0 },
+  { id: "city", label: "Subdistrict", index: 1 },
+  { id: "district", label: "Sub-subdistrict", index: 2 },
+  { id: "ward", label: "Complaints", index: 3 },
+];
+
+export const MAP_ZOOM_LEVEL_LABELS = [
+  "District",
+  "Subdistrict",
+  "Sub-subdistrict",
+  "Complaints",
+];
+
+export const MAP_DRILL_MAX_LEVEL = MAP_DRILL_TIERS.length - 1;
+export const MAP_COMPLAINT_PIN_MAX_ZOOM = 17;
+export const MAP_WARD_MIN_ZOOM = 14;
+
+/** @deprecated Use MAP_WARD_MIN_ZOOM */
+export const MAP_WARD_UNCLUSTER_ZOOM = MAP_WARD_MIN_ZOOM;
+
+/** @deprecated Drill level is click-driven; kept for legacy imports. */
+export const MAP_COMPLAINT_PIN_MIN_ZOOM = MAP_WARD_MIN_ZOOM;
+
+export function getDrillTier(level) {
+  const idx = Math.min(Math.max(Number(level) || 0, 0), MAP_DRILL_MAX_LEVEL);
+  return MAP_DRILL_TIERS[idx];
+}
+
+export function getDrillTierLabel(level) {
+  return getDrillTier(level).label;
+}
+
+export function isWardDrillLevel(level) {
+  return getDrillTier(level).id === "ward";
+}
+
+/** Zoom-badge / tooltip area label for the current drill depth. */
+export function getMapZoomLevelLabel({ drillTrailLength = 0, focusedCode = null, drillLevel = 0 } = {}) {
+  if (focusedCode || drillLevel >= MAP_DRILL_MAX_LEVEL) {
+    return MAP_ZOOM_LEVEL_LABELS[MAP_ZOOM_LEVEL_LABELS.length - 1];
+  }
+  const idx = Math.min(Math.max(drillTrailLength, 0), MAP_ZOOM_LEVEL_LABELS.length - 1);
+  return MAP_ZOOM_LEVEL_LABELS[idx];
+}
+
+const GENERIC_MAP_ROOT_LABELS = new Set(["state", "city", "district", "region", "country", "area"]);
+
+/** Root breadcrumb name — prefer configured city label, else boundary / hierarchy names. */
+export function resolveMapRootLabel(cityLabel, hierarchyIndex = {}, wardCodes = [], boundaries = []) {
+  const configured = String(cityLabel ?? "").trim();
+  if (configured && !GENERIC_MAP_ROOT_LABELS.has(configured.toLowerCase())) {
+    return configured;
+  }
+
+  for (const boundary of boundaries) {
+    const code = String(boundary?.code ?? "").trim();
+    const name = boundary?.localname || boundary?.name || boundary?.label;
+    if (name) return String(name);
+    if (code) return formatDimensionLabel(code);
+  }
+
+  const ancestorCounts = new Map();
+  const rootCounts = new Map();
+  for (const wardCode of wardCodes) {
+    const entry = hierarchyIndex?.[wardCode];
+    const ancestors = entry?.ancestors ?? [];
+    if (ancestors[0]) {
+      const rootLabel = formatDimensionLabel(ancestors[0]);
+      if (rootLabel) rootCounts.set(rootLabel, (rootCounts.get(rootLabel) ?? 0) + 1);
+    }
+    for (const ancestor of ancestors) {
+      const label = formatDimensionLabel(ancestor);
+      if (!label) continue;
+      ancestorCounts.set(label, (ancestorCounts.get(label) ?? 0) + 1);
+    }
+  }
+
+  let bestRoot = null;
+  let bestRootCount = 0;
+  for (const [label, count] of rootCounts) {
+    if (count > bestRootCount) {
+      bestRoot = label;
+      bestRootCount = count;
+    }
+  }
+  if (bestRoot) return bestRoot;
+
+  let bestLabel = null;
+  let bestCount = 0;
+  for (const [label, count] of ancestorCounts) {
+    if (count > bestCount) {
+      bestLabel = label;
+      bestCount = count;
+    }
+  }
+  if (bestLabel) return bestLabel;
+
+  return configured || "Region";
+}
+
+export function buildBoundaryLabelIndex(boundaries = []) {
+  const index = {};
+  for (const boundary of boundaries) {
+    const code = String(boundary?.code ?? "").trim();
+    if (!code) continue;
+    const name = boundary?.localname || boundary?.name || boundary?.label;
+    index[code] = name ? String(name) : formatDimensionLabel(code);
+  }
+  return index;
+}
+
+export function formatHierarchyGroupLabel(groupKey, boundaryLabelIndex = {}) {
+  const code = String(groupKey ?? "").trim();
+  if (!code) return "Area";
+  if (code.startsWith("geo@")) return formatSpatialGroupLabel(code);
+  if (boundaryLabelIndex[code]) return boundaryLabelIndex[code];
+  return formatDimensionLabel(code);
+}
+
+function levelsUpFromLeafForTier(tier) {
+  return { state: 3, city: 2, district: 1, ward: 0 }[tier] ?? 0;
+}
+
+/** Cumulative underscore prefixes from a ward code (e.g. BOMET_BOMET_CENTRAL → [BOMET, BOMET_BOMET]). */
+function deriveAncestorsFromCode(wardCode) {
+  const code = String(wardCode ?? "").trim();
+  if (!code) return [];
+
+  const parts = code.split("_").filter(Boolean);
+  if (parts.length <= 1) return [];
+
+  const ancestors = [];
+  for (let i = 1; i < parts.length; i += 1) {
+    ancestors.push(parts.slice(0, i).join("_"));
+  }
+  return ancestors;
+}
+
+function mergeAncestorChains(apiAncestors = [], codeAncestors = []) {
+  const api = apiAncestors.filter(Boolean);
+  const code = codeAncestors.filter(Boolean);
+  if (api.length >= code.length && api.length > 0) return api;
+  if (code.length > 0) return code;
+  return api;
+}
+
+function pickSpatialDivisors(wardCount) {
+  const base = Math.max(2, Math.min(8, Math.ceil(Math.sqrt(Math.max(wardCount, 4)))));
+  return {
+    state: Math.max(2, Math.floor(base / 2)),
+    city: base,
+    district: Math.min(12, base * 2),
+  };
+}
+
+/** Per-ward synthetic region keys from polygon centroids when code/API ancestry is shallow. */
+function computeSpatialDrillKeys(features = []) {
+  const centroids = [];
+  for (const feature of features) {
+    const code = String(feature?.properties?.code ?? "").trim();
+    const point = geometryCentroid(feature?.geometry);
+    if (code && point) centroids.push({ code, ...point });
+  }
+
+  if (centroids.length <= 1) return {};
+
+  const lngs = centroids.map((row) => row.lng);
+  const lats = centroids.map((row) => row.lat);
+  const minLng = Math.min(...lngs);
+  const maxLng = Math.max(...lngs);
+  const minLat = Math.min(...lats);
+  const maxLat = Math.max(...lats);
+  const lngSpan = Math.max(maxLng - minLng, 0.0005);
+  const latSpan = Math.max(maxLat - minLat, 0.0005);
+  const divisors = pickSpatialDivisors(centroids.length);
+
+  const result = {};
+  for (const { code, lng, lat } of centroids) {
+    const nx = (lng - minLng) / lngSpan;
+    const ny = (lat - minLat) / latSpan;
+    result[code] = {
+      state: `geo@${divisors.state}:${Math.floor(nx * divisors.state)}x${Math.floor(ny * divisors.state)}`,
+      city: `geo@${divisors.city}:${Math.floor(nx * divisors.city)}x${Math.floor(ny * divisors.city)}`,
+      district: `geo@${divisors.district}:${Math.floor(nx * divisors.district)}x${Math.floor(ny * divisors.district)}`,
+    };
+  }
+  return result;
+}
+
+/**
+ * Merge boundary-relationship ancestry, ward-code prefixes, and spatial grid tiers
+ * so every drill step has a meaningful grouping key.
+ */
+export function buildMapDrillHierarchy({
+  apiIndex = {},
+  wardCodes = [],
+  features = [],
+} = {}) {
+  const index = {};
+  const codes = [...new Set(wardCodes.map((code) => String(code ?? "").trim()).filter(Boolean))];
+
+  for (const wardCode of codes) {
+    const apiEntry = apiIndex?.[wardCode];
+    const apiAncestors = apiEntry?.ancestors ?? [];
+    const codeAncestors = deriveAncestorsFromCode(wardCode);
+    const ancestors = mergeAncestorChains(apiAncestors, codeAncestors);
+
+    index[wardCode] = {
+      ...(apiEntry ?? {}),
+      code: wardCode,
+      ancestors,
+    };
+  }
+
+  const spatial = computeSpatialDrillKeys(features);
+  for (const [wardCode, spatialTiers] of Object.entries(spatial)) {
+    if (!index[wardCode]) {
+      index[wardCode] = { code: wardCode, ancestors: deriveAncestorsFromCode(wardCode) };
+    }
+    index[wardCode].spatialTiers = spatialTiers;
+  }
+
+  return index;
+}
+
+function formatSpatialGroupLabel(groupKey) {
+  const match = String(groupKey ?? "").match(/^geo@(\d+):(\d+)x(\d+)$/);
+  if (!match) return "Area";
+  const [, , x, y] = match;
+  return `Zone ${Number(x) + 1}-${Number(y) + 1}`;
+}
+
+function ancestorGroupKey(entry, wardCode, levelsUp) {
+  if (!entry || levelsUp <= 0) return null;
+
+  const chain = [...(entry.ancestors ?? []), wardCode];
+  const idx = Math.max(0, chain.length - 1 - levelsUp);
+  if (idx >= chain.length - 1) return null;
+  return chain[idx] || null;
+}
+
+/** Wards visible at the current drill depth (parent groups from the breadcrumb trail). */
+export function getFeaturesInDrillScope(features = [], hierarchyIndex = {}, drillSteps = []) {
+  if (!drillSteps?.length) return features ?? [];
+
+  let scoped = features ?? [];
+  for (const step of drillSteps) {
+    const groupKey = String(step?.groupKey ?? "").trim();
+    const tierId = step?.tierId;
+    if (!groupKey || !tierId) continue;
+
+    const narrowed = scoped.filter(
+      (feature) =>
+        getHierarchyGroupKey(feature?.properties?.code, hierarchyIndex, tierId) === groupKey
+    );
+    if (narrowed.length) scoped = narrowed;
+  }
+
+  return scoped.length ? scoped : (features ?? []);
+}
+
+/** Group key from boundary ancestry — coarser tiers merge more wards. */
+export function getHierarchyGroupKey(code, hierarchyIndex, tier) {
+  const wardCode = String(code ?? "").trim();
+  if (!wardCode || tier === "ward") return wardCode;
+
+  const entry = hierarchyIndex?.[wardCode];
+  const levelsUp = levelsUpFromLeafForTier(tier);
+  const ancestors = entry?.ancestors ?? [];
+
+  if (ancestors.length >= levelsUp && levelsUp > 0) {
+    const ancestorKey = ancestorGroupKey(entry, wardCode, levelsUp);
+    if (ancestorKey) return ancestorKey;
+  }
+
+  const spatialKey = entry?.spatialTiers?.[tier];
+  if (spatialKey) return spatialKey;
+
+  return wardCode;
+}
+
+/** Grid cell size (degrees) when hierarchy metadata is unavailable. */
+function getClusterCellSizeForTier(tierId) {
+  if (tierId === "ward") return null;
+  if (tierId === "district") return 0.016;
+  if (tierId === "city") return 0.048;
+  return 0.14;
+}
+
+function filterFeaturesToScope(features, scopeCodes) {
+  if (!scopeCodes?.length) return features;
+  const scopeSet = new Set(scopeCodes);
+  return features.filter((feature) => scopeSet.has(feature?.properties?.code));
+}
+
+export function filterPinsInBounds(pins, bounds, { padRatio = 0.12 } = {}) {
+  if (!bounds?.isValid?.()) return pins;
+  const padded = padRatio > 0 ? bounds.pad(padRatio) : bounds;
+  return pins.filter((pin) => padded.contains([pin.lat, pin.lng]));
+}
+
+function hashSeed(value) {
+  const str = String(value ?? "");
+  let hash = 0;
+  for (let i = 0; i < str.length; i += 1) {
+    hash = (hash * 31 + str.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash);
+}
+
+function jitterAroundCentroid(centroid, seed, slot) {
+  const angle = ((hashSeed(seed) + slot * 47) % 360) * (Math.PI / 180);
+  const dist = 0.0008 + (hashSeed(`${seed}-${slot}`) % 5) * 0.00025;
+  return {
+    lat: centroid.lat + Math.sin(angle) * dist,
+    lng: centroid.lng + Math.cos(angle) * dist,
+  };
+}
+
+/** A pin has its own usable coordinates if both are finite and not the (0,0) null-island. */
+function hasUsableGeoPin(pin) {
+  const lat = Number(pin?.lat);
+  const lng = Number(pin?.lng);
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return false;
+  if (Math.abs(lat) < 0.0001 && Math.abs(lng) < 0.0001) return false;
+  return true;
+}
+
+/** Ward/locality centroids keyed by boundary code (trimmed). */
+export function buildWardCentroidIndex(joined) {
+  const index = {};
+  const { geoFeatures, markers } = joined ?? {};
+
+  for (const feature of geoFeatures?.features ?? []) {
+    const code = String(feature?.properties?.code ?? "").trim();
+    const centroid = geometryCentroid(feature.geometry);
+    if (code && centroid) index[code] = centroid;
+  }
+
+  for (const marker of markers ?? []) {
+    const code = String(marker.code ?? "").trim();
+    if (code && marker.lat != null && marker.lng != null) {
+      index[code] = { lat: marker.lat, lng: marker.lng };
+    }
+  }
+
+  return index;
+}
+
+/** Ward codes that have a visible polygon or point on the choropleth. */
+export function getMappedWardCodes(joined) {
+  const codes = new Set();
+  for (const feature of joined?.geoFeatures?.features ?? []) {
+    const code = String(feature?.properties?.code ?? "").trim();
+    if (code) codes.add(code);
+  }
+  for (const marker of joined?.markers ?? []) {
+    const code = String(marker.code ?? "").trim();
+    if (code) codes.add(code);
+  }
+  return codes;
+}
+
+function buildWardGeometryIndex(joined) {
+  const index = {};
+  for (const feature of joined?.geoFeatures?.features ?? []) {
+    const code = String(feature?.properties?.code ?? "").trim();
+    if (code && feature.geometry) index[code] = feature.geometry;
+  }
+  return index;
+}
+
+function pointInRing(lng, lat, ring) {
+  if (!ring?.length) return false;
+  let inside = false;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const xi = ring[i][0];
+    const yi = ring[i][1];
+    const xj = ring[j][0];
+    const yj = ring[j][1];
+    const intersects =
+      yi > lat !== yj > lat && lng < ((xj - xi) * (lat - yi)) / (yj - yi + 0.0) + xi;
+    if (intersects) inside = !inside;
+  }
+  return inside;
+}
+
+function pointInGeometry(lng, lat, geometry) {
+  if (!geometry?.type) return false;
+  if (geometry.type === "Polygon") {
+    return pointInRing(lng, lat, geometry.coordinates?.[0]);
+  }
+  if (geometry.type === "MultiPolygon") {
+    return (geometry.coordinates ?? []).some((polygon) => pointInRing(lng, lat, polygon?.[0]));
+  }
+  return false;
+}
+
+/**
+ * Place each complaint on the map:
+ *   1. Only wards that have a visible choropleth polygon.
+ *   2. Use lat/lng when it falls inside the ward boundary.
+ *   3. Otherwise snap to the ward centroid (with jitter for stacks).
+ */
+export function resolveComplaintPinPositions(pins = [], joined) {
+  const wardCentroids = buildWardCentroidIndex(joined);
+  const wardGeometries = buildWardGeometryIndex(joined);
+  const mappedWards = getMappedWardCodes(joined);
+  const wardSlot = new Map();
+
+  return pins
+    .map((pin, index) => {
+      const wardCode = String(pin.wardCode ?? "").trim();
+      if (!wardCode || !mappedWards.has(wardCode)) return null;
+
+      const geometry = wardGeometries[wardCode];
+      const lat = Number(pin.lat);
+      const lng = Number(pin.lng);
+
+      if (
+        hasUsableGeoPin(pin) &&
+        geometry &&
+        pointInGeometry(lng, lat, geometry)
+      ) {
+        return { ...pin, lat, lng, approximate: false };
+      }
+
+      const centroid = wardCentroids[wardCode];
+      if (!centroid) return null;
+
+      const slot = wardSlot.get(wardCode) ?? 0;
+      wardSlot.set(wardCode, slot + 1);
+      const jittered = jitterAroundCentroid(
+        centroid,
+        pin.id || pin.serviceRequestId || String(index),
+        slot
+      );
+
+      return {
+        ...pin,
+        lat: jittered.lat,
+        lng: jittered.lng,
+        approximate: true,
+      };
+    })
+    .filter(Boolean);
+}
+
+function crossProduct(origin, a, b) {
+  return (a.lng - origin.lng) * (b.lat - origin.lat) - (a.lat - origin.lat) * (b.lng - origin.lng);
+}
+
+function convexHullLngLat(points) {
+  if (!points.length) return [];
+  if (points.length === 1) {
+    const p = points[0];
+    const pad = 0.004;
+    return [
+      { lng: p.lng - pad, lat: p.lat - pad },
+      { lng: p.lng + pad, lat: p.lat - pad },
+      { lng: p.lng + pad, lat: p.lat + pad },
+      { lng: p.lng - pad, lat: p.lat + pad },
+    ];
+  }
+
+  const sorted = [...points].sort((a, b) => a.lng - b.lng || a.lat - b.lat);
+  const lower = [];
+  for (const point of sorted) {
+    while (
+      lower.length >= 2 &&
+      crossProduct(lower[lower.length - 2], lower[lower.length - 1], point) <= 0
+    ) {
+      lower.pop();
+    }
+    lower.push(point);
+  }
+
+  const upper = [];
+  for (let i = sorted.length - 1; i >= 0; i -= 1) {
+    const point = sorted[i];
+    while (
+      upper.length >= 2 &&
+      crossProduct(upper[upper.length - 2], upper[upper.length - 1], point) <= 0
+    ) {
+      upper.pop();
+    }
+    upper.push(point);
+  }
+
+  upper.pop();
+  lower.pop();
+  return lower.concat(upper);
+}
+
+function collectGeometryVertices(geometry, out) {
+  if (!geometry?.type) return;
+
+  if (geometry.type === "Point") {
+    const [lng, lat] = geometry.coordinates;
+    out.push({ lng, lat });
+    return;
+  }
+
+  if (geometry.type === "Polygon") {
+    for (const coord of geometry.coordinates[0] ?? []) {
+      out.push({ lng: coord[0], lat: coord[1] });
+    }
+    return;
+  }
+
+  if (geometry.type === "MultiPolygon") {
+    for (const polygon of geometry.coordinates ?? []) {
+      for (const coord of polygon[0] ?? []) {
+        out.push({ lng: coord[0], lat: coord[1] });
+      }
+    }
+  }
+}
+
+function aggregateClusterProperties(members) {
+  let current = 0;
+  let prior = 0;
+  let open = 0;
+  let breached = 0;
+  let slaWithin = 0;
+  let slaApproaching = 0;
+  let slaBreached = 0;
+  const clusterCodes = members.map((feature) => feature.properties?.code).filter(Boolean);
+
+  for (const feature of members) {
+    const props = feature.properties ?? {};
+    current += Number(props.current ?? props.count) || 0;
+    prior += Number(props.prior) || 0;
+    open += Number(props.open) || 0;
+    breached += Number(props.breached) || 0;
+    slaWithin += Number(props.slaWithin) || 0;
+    slaApproaching += Number(props.slaApproaching) || 0;
+    slaBreached += Number(props.slaBreached) || 0;
+  }
+
+  const wowPct =
+    prior <= 0 && current > 0
+      ? Number.POSITIVE_INFINITY
+      : prior <= 0
+        ? 0
+        : ((current - prior) / prior) * 100;
+
+  const label =
+    members.length > 1
+      ? `${members.length} areas`
+      : members[0]?.properties?.label ?? "Area";
+
+  return {
+    code: clusterCodes.join("+"),
+    clusterCodes,
+    isCluster: members.length > 1,
+    label,
+    count: current,
+    current,
+    prior,
+    wowPct,
+    open,
+    breached,
+    breachSharePct: open > 0 ? (breached / open) * 100 : 0,
+    slaWithin,
+    slaApproaching,
+    slaBreached,
+    total: current,
+  };
+}
+
+function clusterGeometryForMembers(members) {
+  if (members.length === 1) {
+    return members[0].geometry;
+  }
+
+  const vertices = [];
+  for (const feature of members) {
+    collectGeometryVertices(feature.geometry, vertices);
+  }
+
+  const hull = convexHullLngLat(vertices);
+  if (hull.length < 3) {
+    return members[0].geometry;
+  }
+
+  const ring = [...hull.map((point) => [point.lng, point.lat]), [hull[0].lng, hull[0].lat]];
+  return { type: "Polygon", coordinates: [ring] };
+}
+
+function hasUsefulHierarchy(hierarchyIndex = {}) {
+  return Object.values(hierarchyIndex).some(
+    (entry) => (entry?.ancestors ?? []).length > 0 || entry?.spatialTiers
+  );
+}
+
+function clusterGeoFeatures(features, tierId, hierarchyIndex = {}) {
+  if (tierId === "ward" || features.length <= 1) {
+    return features;
+  }
+
+  const hasHierarchy = hasUsefulHierarchy(hierarchyIndex);
+  if (hasHierarchy) {
+    const buckets = new Map();
+    for (const feature of features) {
+      const code = feature?.properties?.code;
+      const key = getHierarchyGroupKey(code, hierarchyIndex, tierId);
+      if (!buckets.has(key)) buckets.set(key, []);
+      buckets.get(key).push(feature);
+    }
+
+    return [...buckets.values()].map((members) => ({
+      type: "Feature",
+      properties: aggregateClusterProperties(members),
+      geometry: clusterGeometryForMembers(members),
+      memberFeatures: members,
+    }));
+  }
+
+  const cellSize = getClusterCellSizeForTier(tierId);
+  if (!cellSize) {
+    return features;
+  }
+
+  const buckets = new Map();
+  for (const feature of features) {
+    const centroid = geometryCentroid(feature.geometry);
+    if (!centroid) continue;
+    const cellX = Math.floor(centroid.lng / cellSize);
+    const cellY = Math.floor(centroid.lat / cellSize);
+    const key = `${cellX}:${cellY}`;
+    if (!buckets.has(key)) buckets.set(key, []);
+    buckets.get(key).push(feature);
+  }
+
+  return [...buckets.values()].map((members) => ({
+    type: "Feature",
+    properties: aggregateClusterProperties(members),
+    geometry: clusterGeometryForMembers(members),
+    memberFeatures: members,
+  }));
+}
+
+/** Wards in the same spatial grid cell within the current scope. */
+function getSpatialClusterMembers(allFeatures, clickedFeature, tierId) {
+  const all = allFeatures ?? [];
+  if (!clickedFeature?.geometry || all.length <= 1) return [];
+
+  const centroids = [];
+  for (const feature of all) {
+    const point = geometryCentroid(feature?.geometry);
+    if (point) centroids.push({ feature, ...point });
+  }
+
+  const clicked = geometryCentroid(clickedFeature.geometry);
+  if (!centroids.length || !clicked) return [];
+
+  const lngs = centroids.map((row) => row.lng);
+  const lats = centroids.map((row) => row.lat);
+  const minLng = Math.min(...lngs);
+  const maxLng = Math.max(...lngs);
+  const minLat = Math.min(...lats);
+  const maxLat = Math.max(...lats);
+  const lngSpan = Math.max(maxLng - minLng, 0.0005);
+  const latSpan = Math.max(maxLat - minLat, 0.0005);
+  const divisors = pickSpatialDivisors(centroids.length);
+  const divisor = divisors[tierId] ?? divisors.district;
+
+  const cellX = Math.floor(((clicked.lng - minLng) / lngSpan) * divisor);
+  const cellY = Math.floor(((clicked.lat - minLat) / latSpan) * divisor);
+
+  return centroids
+    .filter(
+      ({ lng, lat }) =>
+        Math.floor(((lng - minLng) / lngSpan) * divisor) === cellX &&
+        Math.floor(((lat - minLat) / latSpan) * divisor) === cellY
+    )
+    .map(({ feature }) => feature);
+}
+
+/**
+ * Pick polygons to fit on drill-click.
+ * Prefers the hierarchy group; falls back to clicked ward or a spatial cluster
+ * so every click produces a meaningful zoom even without backend ancestry.
+ */
+export function resolveDrillZoomFeatures({
+  memberFeatures = [],
+  clickedFeature = null,
+  allFeatures = [],
+  scopedFeatures = [],
+  hierarchyIndex = {},
+  tierId = "ward",
+}) {
+  const scope = scopedFeatures?.length ? scopedFeatures : (allFeatures ?? []);
+  const all = allFeatures ?? [];
+  const members = memberFeatures?.length
+    ? memberFeatures
+    : clickedFeature
+      ? [clickedFeature]
+      : [];
+
+  if (!members.length) return [];
+
+  // Whole-scope group — try a tighter spatial cluster, then the clicked ward.
+  if (scope.length > 1 && members.length >= scope.length) {
+    if (clickedFeature) {
+      const spatialMembers = getSpatialClusterMembers(scope, clickedFeature, tierId);
+      if (spatialMembers.length > 1 && spatialMembers.length < members.length) {
+        return spatialMembers;
+      }
+      return [clickedFeature];
+    }
+    return members;
+  }
+
+  if (members.length === 1 && clickedFeature) {
+    const spatialMembers = getSpatialClusterMembers(scope, clickedFeature, tierId);
+    if (spatialMembers.length > 1) return spatialMembers;
+  }
+
+  // Still covering the full map at the top level — zoom to clicked ward minimum.
+  if (all.length > 1 && members.length >= all.length && clickedFeature) {
+    return [clickedFeature];
+  }
+
+  return members;
+}
+
+/** Fly/zoom map to drill target; nudge zoom in when bounds barely change. */
+export function flyToDrillBounds(
+  map,
+  features = [],
+  { padding = 0.12, maxZoom = MAP_COMPLAINT_PIN_MAX_ZOOM } = {}
+) {
+  if (!map) return;
+
+  const bounds = boundsForGeoFeatures(features);
+  if (!bounds?.isValid()) {
+    map.setZoom(Math.min(map.getZoom() + 2, maxZoom), { animate: true });
+    return;
+  }
+
+  const padded = bounds.pad(padding);
+  const currentBounds = map.getBounds();
+  const targetZoom = map.getBoundsZoom(padded, false);
+  const alreadyFramed =
+    currentBounds.contains(padded) && targetZoom <= map.getZoom() + 0.5;
+
+  if (alreadyFramed) {
+    map.flyToBounds(padded, {
+      maxZoom: Math.min(map.getZoom() + 2, maxZoom),
+      animate: true,
+    });
+    return;
+  }
+
+  map.flyToBounds(padded, { maxZoom, animate: true });
+}
+
+/** Ward polygons that share the same hierarchy group key at a drill tier. */
+export function getWardFeaturesInHierarchyGroup(
+  allFeatures,
+  wardCode,
+  hierarchyIndex,
+  tierId
+) {
+  const features = allFeatures ?? [];
+  const code = String(wardCode ?? "").trim();
+  if (!code || !features.length) return [];
+
+  const groupKey = getHierarchyGroupKey(code, hierarchyIndex, tierId);
+  const members = features.filter(
+    (feature) =>
+      getHierarchyGroupKey(feature?.properties?.code, hierarchyIndex, tierId) === groupKey
+  );
+
+  if (members.length) return members;
+
+  const single = features.find((feature) => feature?.properties?.code === code);
+  return single ? [single] : [];
+}
+
+/** Leaflet bounds for one or more GeoJSON features (actual ward polygons). */
+export function boundsForGeoFeatures(features = []) {
+  if (!features.length) return null;
+
+  const group = L.featureGroup();
+  L.geoJSON({ type: "FeatureCollection", features }, {
+    onEachFeature: (_feature, layer) => {
+      group.addLayer(layer);
+    },
+  });
+
+  const bounds = group.getBounds();
+  return bounds?.isValid() ? bounds : null;
+}
+
+/**
+ * Build choropleth + point layers.
+ * Always renders every ward polygon from boundary geometry.
+ * Complaint pins are always shown when data is available.
+ */
+/**
+ * Roll per-ward complaint counts up to a parent boundary level (sub-county / county)
+ * using the relationship hierarchy. `ancestorDepth` 0 = county, 1 = sub-county. Returns
+ * the same row shape joinWardMapData consumes (keyed by `wardCode` = the parent code),
+ * so the existing join + choropleth path renders parent polygons unchanged.
+ */
+export function aggregateWardCountsToLevel(wardCounts = [], hierarchyIndex = {}, ancestorDepth = 1) {
+  const byParent = new Map();
+  for (const ward of wardCounts) {
+    const code = String(ward.wardCode ?? ward.label ?? "");
+    const ancestors = hierarchyIndex[code]?.ancestors ?? [];
+    const parentCode = ancestors[ancestorDepth];
+    if (!parentCode) continue;
+    let agg = byParent.get(parentCode);
+    if (!agg) {
+      agg = { wardCode: parentCode, label: formatDimensionLabel(parentCode), count: 0, created: 0, open: 0, resolved: 0 };
+      byParent.set(parentCode, agg);
+    }
+    agg.count += Number(ward.count) || 0;
+    agg.created += Number(ward.created ?? ward.count) || 0;
+    agg.open += Number(ward.open) || 0;
+    agg.resolved += Number(ward.resolved) || 0;
+  }
+  return [...byParent.values()].map((a) => ({
+    ...a,
+    openPct: a.created > 0 ? (a.open / a.created) * 100 : 0,
+    resolvedPct: a.created > 0 ? (a.resolved / a.created) * 100 : 0,
+  }));
+}
+
+/** Unique ancestor (parent) codes across the hierarchy — the county + sub-county codes. */
+export function deriveBoundaryAncestorCodes(hierarchyIndex = {}) {
+  const set = new Set();
+  for (const code of Object.keys(hierarchyIndex)) {
+    for (const anc of hierarchyIndex[code]?.ancestors ?? []) set.add(anc);
+  }
+  return [...set];
+}
+
+export function buildMapDisplayLayers(
+  joined,
+  _drillLevel,
+  complaintPins = [],
+  _hierarchyIndex = {}
+) {
+  const rawFeatures = joined?.geoFeatures?.features ?? [];
+  const visibleComplaintPins = complaintPins.length
+    ? resolveComplaintPinPositions(complaintPins, joined)
+    : [];
+
+  return {
+    geoFeatures: { type: "FeatureCollection", features: rawFeatures },
+    pointMarkers: joined?.markers ?? [],
+    complaintPins: visibleComplaintPins,
+  };
+}
+
+/** Ward centroid markers and complaint pins scale with map zoom. */
+export function markerRadiusForZoom(zoom, isFocused = false, { complaint = false } = {}) {
+  if (complaint) {
+    if (zoom >= 16) return isFocused ? 8 : 6;
+    if (zoom >= 14) return isFocused ? 7 : 5;
+    return isFocused ? 6 : 4;
+  }
+  if (zoom >= 14) return isFocused ? 6 : 4;
+  if (zoom >= 11) return isFocused ? 5 : 3;
+  return isFocused ? 4 : 2;
+}
+
+export function fitBoundsToGeoFeatures(
+  map,
+  features = [],
+  { padding = 0.12, animate = true, maxZoom = MAP_COMPLAINT_PIN_MAX_ZOOM } = {}
+) {
+  if (!map || !features.length) return null;
+
+  const group = L.featureGroup();
+  L.geoJSON({ type: "FeatureCollection", features }, {
+    onEachFeature: (_feature, layer) => {
+      group.addLayer(layer);
+    },
+  });
+
+  const bounds = group.getBounds();
+  if (!bounds?.isValid()) return null;
+
+  map.fitBounds(bounds.pad(padding), {
+    animate,
+    maxZoom,
+  });
+
+  return { center: map.getCenter(), zoom: map.getZoom() };
+}
+
+export function fitMapToJoinedData(
+  map,
+  joined,
+  { padding = 0.12, maxZoom, animate = false, scopeCodes = null } = {}
+) {
+  if (!map) return null;
+
+  let bounds = null;
+  if (scopeCodes?.length) {
+    const scoped = filterFeaturesToScope(joined?.geoFeatures?.features ?? [], scopeCodes);
+    bounds = fitBoundsToGeoFeatures(map, scoped, { padding, animate, maxZoom });
+    return bounds;
+  }
+
+  bounds = resolveJoinedMapBounds(joined);
+  if (!bounds) {
+    const center = getMapCenter();
+    map.setView(center, 11, { animate });
+    return { center: map.getCenter(), zoom: map.getZoom() };
+  }
+
+  map.fitBounds(bounds.pad(padding), {
+    animate,
+    ...(maxZoom != null ? { maxZoom } : {}),
+  });
+
+  return { center: map.getCenter(), zoom: map.getZoom() };
+}

--- a/digit-ui-esbuild/products/dashboard/src/utils/mergeRefs.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/mergeRefs.js
@@ -1,0 +1,12 @@
+/** Merges multiple React refs onto one DOM node. */
+export function mergeRefs(...refs) {
+  return (node) => {
+    refs.forEach((ref) => {
+      if (typeof ref === "function") {
+        ref(node);
+      } else if (ref) {
+        ref.current = node;
+      }
+    });
+  };
+}

--- a/digit-ui-esbuild/products/dashboard/src/utils/tableSort.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/tableSort.js
@@ -1,0 +1,72 @@
+const NUMERIC_COLUMN_TYPES = new Set([
+  "integer",
+  "percent",
+  "hours",
+  "hoursDays",
+  "rating",
+  "trend",
+]);
+
+export function isNumericColumnType(type) {
+  return NUMERIC_COLUMN_TYPES.has(type);
+}
+
+function getTagsSortValue(row) {
+  const items = row.statusTagItems?.length
+    ? row.statusTagItems
+    : (Array.isArray(row.statusTags) ? row.statusTags : []).map((label) => ({ label }));
+  return items.map((item) => item.label).join(", ").toLowerCase();
+}
+
+/** Raw value used for ordering — null/undefined sorts last. */
+export function getTableSortValue(row, column) {
+  if (!column) return null;
+
+  if (column.type === "tags") {
+    const value = getTagsSortValue(row);
+    return value || null;
+  }
+
+  const raw = row[column.id];
+
+  if (isNumericColumnType(column.type)) {
+    if (raw == null || !Number.isFinite(Number(raw))) return null;
+    return Number(raw);
+  }
+
+  const text = String(raw ?? "").trim();
+  return text ? text.toLowerCase() : null;
+}
+
+export function compareTableRows(left, right, column) {
+  const a = getTableSortValue(left, column);
+  const b = getTableSortValue(right, column);
+
+  if (a == null && b == null) return 0;
+  if (a == null) return 1;
+  if (b == null) return -1;
+
+  if (typeof a === "number" && typeof b === "number") {
+    return a - b;
+  }
+
+  return String(a).localeCompare(String(b));
+}
+
+export function sortTableRows(rows, columns, sortState) {
+  if (!sortState?.key || !rows?.length) return rows ?? [];
+
+  const column = columns.find((entry) => entry.id === sortState.key);
+  if (!column) return rows;
+
+  const next = [...rows];
+  next.sort((left, right) => {
+    const result = compareTableRows(left, right, column);
+    return sortState.direction === "asc" ? result : -result;
+  });
+  return next;
+}
+
+export function getDefaultSortDirection(column) {
+  return isNumericColumnType(column?.type) ? "desc" : "asc";
+}

--- a/digit-ui-esbuild/public/index.html
+++ b/digit-ui-esbuild/public/index.html
@@ -7,6 +7,8 @@
   <link
     href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@400;500;700&family=Roboto:wght@400;500;700&display=swap"
     rel="stylesheet" type="text/css" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet"
+    type="text/css" />
   <link rel="stylesheet" href="/digit-ui/vendor/digit-ui-components-css.css" />
   <link rel="stylesheet" href="/digit-ui/vendor/digit-ui-health-css.css" />
   <link rel="stylesheet" href="/digit-ui/vendor/digit-ui-css.css" />

--- a/digit-ui-esbuild/src/App.js
+++ b/digit-ui-esbuild/src/App.js
@@ -4,6 +4,7 @@ import { UICustomizations } from "./Customisations/UICustomizations";
 import { initUtilitiesComponents } from "@egovernments/digit-ui-module-utilities";
 import { initPGRComponents, PGRReducers, } from "@egovernments/digit-ui-module-pgr";
 import { Loader } from "@egovernments/digit-ui-components";
+import { initDashboardComponents } from "../products/dashboard/Module";
 
 window.contextPath = window?.globalConfigs?.getConfig("CONTEXT_PATH");
 window.globalPath = window.contextPath;
@@ -22,6 +23,7 @@ const DigitUI = React.lazy(() =>
 const enabledModules = [
   "Utilities",
   "PGR",
+  "Dashboard",
 ];
 
 initLibraries().then(() => {
@@ -41,6 +43,7 @@ const initDigitUI = () => {
 
   initUtilitiesComponents();
   initPGRComponents();
+  initDashboardComponents();
 };
 
 function App() {
@@ -53,6 +56,7 @@ function App() {
   if (!stateCode) {
     return <h1>stateCode is not defined</h1>;
   }
+
   return (
     <Suspense fallback={<Loader page={true} variant={"PageLoader"} />}>
       <DigitUI


### PR DESCRIPTION
## Summary

Migrates the PGR supervisor dashboard frontend (from the #963 lineage, `soniikajal:feature/demo-dashboard` head) into **digit-ui-esbuild** as `products/dashboard/`, mounted as a normal module **inside the DigitUI employee chrome** (standard topbar + sidebar, native navigation) and gated through the platform's standard ACS mechanisms. Data-side RBAC/ABAC is untouched — the dashboard keeps calling `pgr-services /v2/analytics`, where scope injection, catalog `visibleTo`, and the PII gate continue to run server-side.

This retires the standalone deployment model: no more separate `/var/www/dashboard-ui` webroot, no more hand-run webpack build with a manually added DefinePlugin. The dashboard ships inside the ansible-managed `/digit-ui/` static build.

## What changed

**Ported content (byte-identical):** `digit-ui-esbuild/products/dashboard/src/` — AdminDashboard + all tile/chart/filter/map components, copied verbatim from the source tree (17 dead files pruned). The subtree is fully self-contained: zero imports reach outside it.

**Integration layer (new code, outside the verbatim zone):**
- `products/dashboard/Module.js` — `DashboardModule` route component: role guard via tenant-agnostic `Digit.UserService.hasAccess(DASHBOARD_ROLES)` (roles live at the state root, so the tenant-scoped helper would wrongly deny at city tenants), renders `<AdminDashboard embedded />`, else redirects to `/employee`.
- `products/dashboard/DashboardCard.js` — home card, same role check, SPA link.
- `products/dashboard/roles.js` — shared `DASHBOARD_ROLES = [SUPERVISOR, PGR_SUPERVISOR, GRO, DGRO, PGR_LME, PGR_ADMIN, SUPERUSER]`.
- `packages/modules/core/.../AppModules.js` — always-on fallback route for `/employee/dashboard` (registry-driven, sits after MDMS-driven routes so the citymodule route wins when the row exists; mirrors the pattern of `/login` etc.). Without it, the route only mounts when `tenant.citymodule` contains `Dashboard`.
- **`embedded` mode** (minimal edits to `AdminDashboard.jsx` / `DashboardLayout.jsx` + an appended `.dashboard-embedded` CSS block): suppresses the dashboard's standalone shell — its internal dark sidebar, its `DashboardLogin` gate, and `100dvh` viewport sizing — so it lives inside the host chrome. Default (standalone) behavior is unchanged.

## Configuration notes (everything an operator needs)

### 1. Build-time (esbuild)
- `REACT_APP_ANALYTICS_BASE` define added to `esbuild.build.js` + `esbuild.dev.js`; defaults to `/pgr-services/v2/analytics`, overridable via env at build. **Mandatory** — `services/analyticsService.js` reads `process.env` at import time and throws without the define.
- Dependency pins (exact, no carets): `apexcharts@3.45.2`, `react-apexcharts@1.4.1`, `react-grid-layout@1.3.4`, plus `react-draggable@4.4.5` via overrides/resolutions. **Do not upgrade apexcharts** — `config/lineChartPresentation.js` manipulates Apex DOM internals; 4.x would be a project.
- `public/index.html`: Inter font `<link>` (the CSS `@import` can be dropped mid-bundle).
- New npm script `build:dashboard-css` regenerates `products/dashboard/src/styles/dashboard.css` from `input.css` (committed compiled CSS is used as-is otherwise; Tailwind is `tw-`-prefixed, `preflight:false`, all rules scoped under `.dashboard-root` — no collision with the app's unprefixed build).

### 2. MDMS / ACS seeds (`ansible/nairobi-mdms/mdms/`)
- `tenant/citymodule.json`: `Dashboard` module row → gates the **home card** slot (+ the MDMS-driven route).
- `ACCESSCONTROL-ACTIONS-TEST/actions-test.json`: action **id 4557**, `url:"url"`, `navigationURL:/digit-ui/employee/dashboard` → the **left-nav entry**, filtered server-side by egov-accesscontrol.
- `ACCESSCONTROL-ROLEACTIONS/roleactions.json`: bindings for SUPERVISOR / GRO / DGRO / SUPERUSER. (`PGR_SUPERVISOR`, `PGR_ADMIN` intentionally not bound — they don't exist in the ke roles master.)
- **Card and sidebar are independent**: disable the action row → sidebar-only removal; deactivate the citymodule row → card-only removal. The route stays reachable either way via the fallback (with its own role guard).
- **Upserting into a live env**: mirror the live conventions, not this repo's file verbatim — e.g. live bomet's max action id is 2568 (4557 is free) and its roleactions carry inner `tenantId:"ke"` where this file uses `"pg"`. mdms-v2 has no `_delete`; removal = `is_active:false`, and roleactions must be deactivated **before** their action (the `actionid` x-ref is validated on update).

### 3. Localization
Upsert to `rainmaker-common` / `en_IN` at the state root: `ACTION_TEST_DASHBOARD` (sidebar), `DASHBOARD_CARD_HEADER` (card) → "Dashboard". Must ship with the full cache-bust: redis `messages` hash server-side, and clients hold bundles in sessionStorage `Digit.initData` **and** localStorage `Digit.Locale.<locale>.<module>` (survives hard refresh).

### 4. Runtime (globalConfigs) — all optional, with fallbacks
`STATE_LEVEL_TENANT_ID`, `DASHBOARD_STATE_LABEL`, `STATE_NAME`, `DASHBOARD_PRODUCT_LABEL`, `DASHBOARD_SYSTEM_TITLE`, `DASHBOARD_BRAND_PRIMARY/DARK/SLATE`, `MAP_CENTER_LAT_LNG`, `DASHBOARD_MAP_CITY_LABEL`.

### 5. Deployment
No new deploy surface: the dashboard is part of the digit-ui esbuild build in all three `digit_ui_mode`s. Environments running the old standalone dashboard can retire `/var/www/dashboard-ui` and its nginx block after cutover.

## Validation

Run locally (esbuild dev server) against the **live bomet backend** over an SSH Kong tunnel:
- Full render with real data: KPI tiles + sparklines + deltas, all ApexCharts kinds incl. the dashed multi-series line with custom markers, Leaflet choropleth with complaint pins, Complaints-at-risk table. Zero console errors.
- Guards: signed-out → employee login; role mismatch → redirect to `/employee`; GRO user → server-side pack filtering returns the correct empty state.
- Navigation: home ↔ dashboard, complaint-ID deep links into the PGR module, browser back/forward.
- ACS end-to-end: MDMS rows were temporarily seeded on bomet — home card + left-nav "Dashboard" entry appeared for SUPERVISOR and clicked through to the dashboard — then deactivated (bomet is back to pre-demo state).

## Known gaps / follow-ups
- Sequencing with the analytics catalog PR #963 (this FE was ported from its head; it runs fine against the currently deployed bomet backend).
- Localization upsert is not automated in this PR (see §3).
- Sidebar/card icon is a placeholder borrowed from an existing entry.
- Card role list is a code constant (`roles.js`); could be made MDMS-driven if per-deployment control is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Dashboard experience with sign-in, role-based access, KPI cards, charts, tables, filters, search, export, and an “add KPI” panel.
  * Introduced geography map views and complaint-risk dashboards with drill-down, tooltips, and richer visual summaries.
  * Enabled dashboard modules for new tenant setup and added improved chart/table interactions.

* **Bug Fixes**
  * Improved access handling so users without the right roles are redirected appropriately.
  * Added fallback behavior for missing dashboard configuration and empty data states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->