### PR TITLE
feat(pgr): filter search/count by department in additionalDetails

### DIFF
--- a/backend/pgr-services/src/main/java/org/egov/pgr/repository/rowmapper/PGRQueryBuilder.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/repository/rowmapper/PGRQueryBuilder.java
@@ -107,6 +107,13 @@ public class PGRQueryBuilder {
             addToPreparedStatement(preparedStmtList, ids);
         }
 
+        //department is stored under ser.additionaldetails (JSON), not a column - see PGRService#getDepartmentFromMDMS.
+        if (StringUtils.hasText(criteria.getDepartment())) {
+            addClauseIfRequired(preparedStmtList, builder);
+            builder.append(" ser.additionaldetails->>'department' = ? ");
+            preparedStmtList.add(criteria.getDepartment());
+        }
+
         //When UI tries to fetch "escalated" complaints count.
         if(criteria.getSlaDeltaMaxLimit() != null && criteria.getSlaDeltaMinLimit() == null){
             addClauseIfRequired(preparedStmtList, builder);

--- a/backend/pgr-services/src/main/java/org/egov/pgr/web/models/RequestSearchCriteria.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/web/models/RequestSearchCriteria.java
@@ -96,13 +96,17 @@ public class RequestSearchCriteria {
     @JsonProperty("assignee")
     private String assignee;
 
+    @SafeHtml
+    @JsonProperty("department")
+    private String department;
+
     @JsonIgnore
     private Set<String> serviceRequestIds;
 
     public boolean isEmpty(){
         return (this.tenantId==null && this.serviceCode==null && this.mobileNumber==null && this.serviceRequestId==null
         && this.applicationStatus==null && this.ids==null && this.userIds==null && this.locality==null
-        && this.assignee==null);
+        && this.assignee==null && this.department==null);
     }
 
 }


### PR DESCRIPTION
## Summary
- Adds a `department` query param to the PGR `_search`/`_plainsearch`/`_count` APIs (`RequestSearchCriteria`), filtering on `ser.additionaldetails->>'department'` when non-empty.
- `department` is written into `additionalDetails.department` by `PGRService#getDepartmentFromMDMS` — this filter reads that same JSON key.
- `_count` reuses `_search`'s WHERE-clause builder (`PGRQueryBuilder#getPGRSearchQuery`), so one change covers both endpoints consistently.
- Updated `RequestSearchCriteria#isEmpty()` so a department-only search isn't short-circuited as an empty criteria.

## Test plan
- [x] `mvn -f backend/pgr-services/pom.xml compile` / `test` — pass
- [x] Hot-swapped the built jar into the running local-setup `digit-pgr-services-1` container and exercised `_count` against tenant `pg.citest` (3 total complaints: 2 tagged `DEPT_5`, 1 tagged `DEPT_3`):
  - no filter → 3
  - `department=DEPT_5` → 2
  - `department=DEPT_3` → 1
  - `department=NONEXISTENT` → 0
- [x] Verified `_search` with `department=DEPT_5` returns exactly the 2 matching records (cross-checked against Postgres directly)
- [ ] Reviewer sign-off

🤖 Generated with [Claude Code](https://claude.com/claude-code)