### PR TITLE
fix(ansible): make on-host digit-ui build work on Ubuntu (Node 20 + npm)

### DIFF
--- a/local-setup/ansible/inventory/group_vars/digit.yml
+++ b/local-setup/ansible/inventory/group_vars/digit.yml
@@ -141,3 +141,15 @@ mcp_ref: main
 # at a fork.
 digit_ui_esbuild_repo: https://github.com/theflywheel/digit-ui-esbuild.git
 digit_ui_esbuild_branch: main
+
+# Prebuilt digit-ui bundle (static mode) — the ROBUST alternative to building
+# the SPA on-host. When set, the playbook pulls this image and extracts its
+# baked /var/web/digit-ui into build/, skipping the on-host node/npm/esbuild
+# build entirely (no Node-version / missing-npm fragility). The image below is
+# public and pulls off-VPC.
+#
+# Left commented so existing tenants keep their current on-host build. To make
+# the bundle the default for ALL tenants, uncomment this line; to opt in for a
+# single tenant, set digit_ui_bundle_image in that host_vars file (as pg.test
+# does). Set to "" in host_vars to force an on-host build even if this is on.
+# digit_ui_bundle_image: "ghcr.io/subhashini-egov/digit-ui-esbuild:nightly-develop"

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -883,34 +883,17 @@
         - digit_ui_mode == "static"
         - (digit_ui_bundle_image | default('')) | length > 0
 
-    # Ubuntu's `apt install nodejs` ships Node 18 AND NO npm (npm is a
-    # separate archive package). esbuild.build.js needs Node 20 + npm, so
-    # apt alone left node present but npm missing -> the npm-install task
-    # below silently no-op'd and the build failed with "Cannot find module
-    # 'esbuild'". Install from NodeSource (bundles a matching npm), gated on
-    # a version check so re-deploys are a no-op once Node >=20 is present.
+    # Node 20 + npm for the on-host esbuild build. esbuild.build.js needs
+    # Node 20 + npm; see tasks/ensure-node20.yml for why apt's nodejs isn't
+    # enough on Ubuntu (Node 18, no npm) and how the version gate works.
     - name: "digit-ui mode=static — ensure Node 20 + npm (NodeSource) for on-host build"
+      ansible.builtin.include_tasks: "{{ playbook_dir }}/tasks/ensure-node20.yml"
+      vars:
+        node_ensure_label: "digit-ui static"
       when:
         - digit_ui_mode == "static"
         - ansible_system != "Darwin"
         - (digit_ui_bundle_image | default('')) | length == 0
-      block:
-        - name: "digit-ui static — probe installed node version"
-          ansible.builtin.command: node --version
-          register: dui_node_ver
-          changed_when: false
-          failed_when: false
-
-        - name: "digit-ui static — install NodeSource Node 20 (node <20 or npm absent)"
-          ansible.builtin.shell: |
-            set -euo pipefail
-            curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
-            apt-get install -y nodejs
-          args:
-            executable: /bin/bash
-          when: >-
-            dui_node_ver.rc != 0
-            or (dui_node_ver.stdout | default('') is not match('^v(2[0-9]|[3-9][0-9])\.'))
 
     - name: "digit-ui mode=static — npm install if package.json is newer than node_modules"
       ansible.builtin.shell: |
@@ -1051,29 +1034,14 @@
         force: true
       when: enable_digit_ui_v2 | default(false)
 
-    # Ubuntu's apt nodejs is Node 18 + no npm; the Vite build needs Node 20
-    # + npm. Install from NodeSource (bundles npm), gated on a version check.
+    # Node 20 + npm for the Vite build (see tasks/ensure-node20.yml).
     - name: "digit-ui-v2 — ensure Node 20 + npm (NodeSource) for Vite build"
+      ansible.builtin.include_tasks: "{{ playbook_dir }}/tasks/ensure-node20.yml"
+      vars:
+        node_ensure_label: "digit-ui-v2"
       when:
         - enable_digit_ui_v2 | default(false)
         - ansible_system != "Darwin"
-      block:
-        - name: "digit-ui-v2 — probe installed node version"
-          ansible.builtin.command: node --version
-          register: dui2_node_ver
-          changed_when: false
-          failed_when: false
-
-        - name: "digit-ui-v2 — install NodeSource Node 20 (node <20 or npm absent)"
-          ansible.builtin.shell: |
-            set -euo pipefail
-            curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
-            apt-get install -y nodejs
-          args:
-            executable: /bin/bash
-          when: >-
-            dui2_node_ver.rc != 0
-            or (dui2_node_ver.stdout | default('') is not match('^v(2[0-9]|[3-9][0-9])\.'))
 
     - name: "digit-ui-v2 — npm install if package.json newer than node_modules"
       ansible.builtin.shell: |
@@ -1622,29 +1590,14 @@
     # nginx_preserve_vhost (e.g. Bomet) the template is NOT rendered, so wire
     # the blocks from tests/integration-tests/deploy/nginx-integration-tests.conf
     # by hand there.
-    # Ubuntu's apt nodejs is Node 18 + no npm; the Vite build needs Node 20
-    # + npm. Install from NodeSource (bundles npm), gated on a version check.
+    # Node 20 + npm for the Vite build (see tasks/ensure-node20.yml).
     - name: "integration-tests — ensure Node 20 + npm (NodeSource) for Vite build"
+      ansible.builtin.include_tasks: "{{ playbook_dir }}/tasks/ensure-node20.yml"
+      vars:
+        node_ensure_label: "integration-tests"
       when:
         - enable_integration_tests | default(false)
         - ansible_system != "Darwin"
-      block:
-        - name: "integration-tests — probe installed node version"
-          ansible.builtin.command: node --version
-          register: itest_node_ver
-          changed_when: false
-          failed_when: false
-
-        - name: "integration-tests — install NodeSource Node 20 (node <20 or npm absent)"
-          ansible.builtin.shell: |
-            set -euo pipefail
-            curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
-            apt-get install -y nodejs
-          args:
-            executable: /bin/bash
-          when: >-
-            itest_node_ver.rc != 0
-            or (itest_node_ver.stdout | default('') is not match('^v(2[0-9]|[3-9][0-9])\.'))
 
     - name: "integration-tests — build react-admin dashboard (vendored in-tree source)"
       ansible.builtin.command: >-
@@ -2891,14 +2844,13 @@
         msg: "Claude Code install disabled. Set install_claude_code: true in host_vars to enable."
       when: not (install_claude_code | default(false))
 
-    - name: Install Node.js 20 LTS (needed for CC and tests)
-      shell: |
-        if ! node --version 2>/dev/null | grep -qE "^v2[02]"; then
-          curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
-          apt-get install -y nodejs
-        fi
-      register: nodejs_install
-      changed_when: "'nodejs is already' not in nodejs_install.stdout"
+    # Node 20 + npm for Claude Code + tests (see tasks/ensure-node20.yml).
+    # (Was an inline `^v2[02]` check that would needlessly downgrade a
+    # Node 24 box; the shared gate accepts any Node >=20.)
+    - name: "Claude Code — ensure Node.js 20 LTS (needed for CC and tests)"
+      ansible.builtin.include_tasks: "{{ playbook_dir }}/tasks/ensure-node20.yml"
+      vars:
+        node_ensure_label: "Claude Code"
       when:
         - install_claude_code | default(false)
         - ansible_system != "Darwin"

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -926,7 +926,9 @@
         # still echoed "installed" and reported success — the real error
         # only surfaced one task later as a confusing "Cannot find module
         # esbuild". Detect a broken environment here, at the right task.
-        set -uo pipefail
+        # -e so a failed `cd` aborts instead of running the npm checks (and
+        # echoing a false "skipped"/"installed") in the wrong directory.
+        set -euo pipefail
         cd /opt/digit-ui-esbuild
         command -v npm >/dev/null || { echo "ERROR: npm not on PATH (apt nodejs ships no npm on Ubuntu; NodeSource task above should have fixed this)"; exit 1; }
         if [ ! -d node_modules ] \

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -883,14 +883,34 @@
         - digit_ui_mode == "static"
         - (digit_ui_bundle_image | default('')) | length > 0
 
-    - name: "digit-ui mode=static — install Node 20 if missing (esbuild.build.js needs it)"
-      ansible.builtin.apt:
-        name: nodejs
-        state: present
+    # Ubuntu's `apt install nodejs` ships Node 18 AND NO npm (npm is a
+    # separate archive package). esbuild.build.js needs Node 20 + npm, so
+    # apt alone left node present but npm missing -> the npm-install task
+    # below silently no-op'd and the build failed with "Cannot find module
+    # 'esbuild'". Install from NodeSource (bundles a matching npm), gated on
+    # a version check so re-deploys are a no-op once Node >=20 is present.
+    - name: "digit-ui mode=static — ensure Node 20 + npm (NodeSource) for on-host build"
       when:
         - digit_ui_mode == "static"
         - ansible_system != "Darwin"
         - (digit_ui_bundle_image | default('')) | length == 0
+      block:
+        - name: "digit-ui static — probe installed node version"
+          ansible.builtin.command: node --version
+          register: dui_node_ver
+          changed_when: false
+          failed_when: false
+
+        - name: "digit-ui static — install NodeSource Node 20 (node <20 or npm absent)"
+          ansible.builtin.shell: |
+            set -euo pipefail
+            curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+            apt-get install -y nodejs
+          args:
+            executable: /bin/bash
+          when: >-
+            dui_node_ver.rc != 0
+            or (dui_node_ver.stdout | default('') is not match('^v(2[0-9]|[3-9][0-9])\.'))
 
     - name: "digit-ui mode=static — npm install if package.json is newer than node_modules"
       ansible.builtin.shell: |
@@ -900,15 +920,25 @@
         # node_modules is stale and esbuild.build.js fails to resolve.
         # Re-run if package.json or package-lock.json is newer than the
         # node_modules root, or if node_modules doesn't exist at all.
+        #
+        # Fail LOUD: this block previously had no error handling, so a
+        # missing npm (Ubuntu apt nodejs ships no npm) or a failed install
+        # still echoed "installed" and reported success — the real error
+        # only surfaced one task later as a confusing "Cannot find module
+        # esbuild". Detect a broken environment here, at the right task.
+        set -uo pipefail
         cd /opt/digit-ui-esbuild
+        command -v npm >/dev/null || { echo "ERROR: npm not on PATH (apt nodejs ships no npm on Ubuntu; NodeSource task above should have fixed this)"; exit 1; }
         if [ ! -d node_modules ] \
            || [ package.json -nt node_modules ] \
            || [ package-lock.json -nt node_modules ]; then
-          npm install --legacy-peer-deps
+          npm install --legacy-peer-deps || { echo "ERROR: npm install failed"; exit 1; }
           echo installed
         else
           echo skipped
         fi
+      args:
+        executable: /bin/bash
       register: npm_install
       changed_when: npm_install.stdout == "installed"
       when:
@@ -1019,13 +1049,29 @@
         force: true
       when: enable_digit_ui_v2 | default(false)
 
-    - name: "digit-ui-v2 — install Node 20 if missing (Vite build needs it)"
-      ansible.builtin.apt:
-        name: nodejs
-        state: present
+    # Ubuntu's apt nodejs is Node 18 + no npm; the Vite build needs Node 20
+    # + npm. Install from NodeSource (bundles npm), gated on a version check.
+    - name: "digit-ui-v2 — ensure Node 20 + npm (NodeSource) for Vite build"
       when:
         - enable_digit_ui_v2 | default(false)
         - ansible_system != "Darwin"
+      block:
+        - name: "digit-ui-v2 — probe installed node version"
+          ansible.builtin.command: node --version
+          register: dui2_node_ver
+          changed_when: false
+          failed_when: false
+
+        - name: "digit-ui-v2 — install NodeSource Node 20 (node <20 or npm absent)"
+          ansible.builtin.shell: |
+            set -euo pipefail
+            curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+            apt-get install -y nodejs
+          args:
+            executable: /bin/bash
+          when: >-
+            dui2_node_ver.rc != 0
+            or (dui2_node_ver.stdout | default('') is not match('^v(2[0-9]|[3-9][0-9])\.'))
 
     - name: "digit-ui-v2 — npm install if package.json newer than node_modules"
       ansible.builtin.shell: |
@@ -1574,13 +1620,29 @@
     # nginx_preserve_vhost (e.g. Bomet) the template is NOT rendered, so wire
     # the blocks from tests/integration-tests/deploy/nginx-integration-tests.conf
     # by hand there.
-    - name: "integration-tests — install Node 20 if missing (Vite build needs it)"
-      ansible.builtin.apt:
-        name: nodejs
-        state: present
+    # Ubuntu's apt nodejs is Node 18 + no npm; the Vite build needs Node 20
+    # + npm. Install from NodeSource (bundles npm), gated on a version check.
+    - name: "integration-tests — ensure Node 20 + npm (NodeSource) for Vite build"
       when:
         - enable_integration_tests | default(false)
         - ansible_system != "Darwin"
+      block:
+        - name: "integration-tests — probe installed node version"
+          ansible.builtin.command: node --version
+          register: itest_node_ver
+          changed_when: false
+          failed_when: false
+
+        - name: "integration-tests — install NodeSource Node 20 (node <20 or npm absent)"
+          ansible.builtin.shell: |
+            set -euo pipefail
+            curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+            apt-get install -y nodejs
+          args:
+            executable: /bin/bash
+          when: >-
+            itest_node_ver.rc != 0
+            or (itest_node_ver.stdout | default('') is not match('^v(2[0-9]|[3-9][0-9])\.'))
 
     - name: "integration-tests — build react-admin dashboard (vendored in-tree source)"
       ansible.builtin.command: >-

--- a/local-setup/ansible/tasks/ensure-node20.yml
+++ b/local-setup/ansible/tasks/ensure-node20.yml
@@ -1,0 +1,30 @@
+# Ensure Node 20 + a matching npm from NodeSource.
+#
+# Why not just `apt install nodejs`? On Ubuntu that ships Node 18 AND NO npm
+# (npm is a separate archive package), so apt alone leaves node present but
+# npm missing — downstream `npm install` silently no-op'd and builds failed
+# later with a confusing "Cannot find module 'esbuild'". NodeSource bundles a
+# matching npm. The install is gated on a version probe so re-deploys are a
+# no-op once Node >=20 is already present.
+#
+# Contract for callers:
+#   - Set `node_ensure_label` (a string) for readable task names.
+#   - Apply the enabling `when:` (e.g. feature flags) on the `include_tasks`
+#     statement — it propagates to every task in this file. Always exclude
+#     Darwin at the call site (NodeSource + apt-get is Debian/Ubuntu only).
+- name: "{{ node_ensure_label }} — probe installed node version"
+  ansible.builtin.command: node --version
+  register: _ensure_node_ver
+  changed_when: false
+  failed_when: false
+
+- name: "{{ node_ensure_label }} — install NodeSource Node 20 (node <20 or npm absent)"
+  ansible.builtin.shell: |
+    set -euo pipefail
+    curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+    apt-get install -y nodejs
+  args:
+    executable: /bin/bash
+  when: >-
+    _ensure_node_ver.rc != 0
+    or (_ensure_node_ver.stdout | default('') is not match('^v(2[0-9]|[3-9][0-9])\.'))


### PR DESCRIPTION
## Problem

Fresh Ubuntu 24.04 Ansible deploys (`local-setup/ansible/deploy.sh`) failed at the **digit-ui static build** with `Cannot find module 'esbuild'`, even though the entire backend came up healthy. Two stacked bugs:

1. **`apt install nodejs` is wrong on Ubuntu.** Ubuntu's `nodejs` package is Node **18** and ships **no `npm`** (npm is a separate archive package). The task was named "install Node 20" but delivered neither Node 20 nor npm — so `node_modules` could never be populated.
2. **The npm step swallowed its own failure.** The `npm install` shell block had no error handling, so `npm: command not found` still echoed `installed` and reported success. The real failure only surfaced one task later as the confusing esbuild error.

Same latent `apt: name: nodejs` bug also sat in the `digit-ui-v2` and `integration-tests` tasks.

## Fix

- Replace the three `apt: name: nodejs` tasks (digit-ui static, digit-ui-v2, integration-tests) with a **NodeSource Node 20 install** (bundles a matching npm), gated on a `node --version` check so re-deploys are a no-op.
- Make the digit-ui npm step **fail loud**: assert `npm` is on PATH and that `npm install` succeeds, so a broken environment fails at the right task with an accurate message.
- Run the new shell blocks under **`/bin/bash`** — they use `set -o pipefail`, which the default `/bin/sh` (dash) rejects.
- Document a commented **`digit_ui_bundle_image`** default in `group_vars/digit.yml` — the robust prebuilt-bundle path that sidesteps on-host builds entirely. Left commented so existing tenants (bomet/nairobi) are unaffected; flip it on to make the bundle the global default.

## Verification

Verified end-to-end on a fresh Ubuntu 24.04 box:

- **On-host build path** (forced): node `18 → 20.20.2`, npm installed (`10.8.2`), `node_modules` populated (439 pkgs), real `esbuild.build.js` rebuild → `PLAY RECAP failed=0`, UI serving `200`.
- **Prebuilt-bundle path**: bundle extracted, on-host build tasks correctly skipped → `PLAY RECAP failed=0`, UI serving `200`, 0 unhealthy containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local build setup so Node.js and npm are installed more reliably during frontend build steps.
  * Added clearer checks to stop earlier when npm is unavailable, reducing failed builds later in the process.
  * Added an optional prebuilt UI bundle path for environments that want to use a packaged static build instead of building on the host.

* **Documentation**
  * Added guidance for the optional prebuilt UI bundle configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->