### PR TITLE
fix(pgr): citizen RATE/REOPEN inside the timeline row + rating stars display

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/TimeLineWrapper.js
+++ b/digit-ui-esbuild/products/pgr/src/components/TimeLineWrapper.js
@@ -5,7 +5,7 @@ import { convertEpochFormateToDate } from '../utils';
 
 // NOTE: no useMyContext() here — the citizen route tree has no MyContext
 // provider, and this wrapper renders on BOTH citizen and employee details.
-const TimelineWrapper = ({ businessId, isWorkFlowLoading, workflowData, labelPrefix = "" }) => {
+const TimelineWrapper = ({ businessId, isWorkFlowLoading, workflowData, labelPrefix = "", currentStateChildren = null }) => {
     const { t } = useTranslation();
 
     const tenantId = Digit.ULBService.getCurrentTenantId();
@@ -97,7 +97,10 @@ const TimelineWrapper = ({ businessId, isWorkFlowLoading, workflowData, labelPre
                     <Timeline
                         key={index}
                         label={step.label}
-                        subElements={step.subElements}
+                        // currentStateChildren renders inside the FIRST (current-state) row —
+                        // the citizen action links/rating live in the timeline, like the
+                        // legacy checkpoints did.
+                        subElements={index === 0 && currentStateChildren ? [...step.subElements, currentStateChildren] : step.subElements}
                         variant={step.variant}
                         showConnector={step.showConnector}
                     />

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintDetails.js
@@ -23,6 +23,7 @@ import TimelineWrapper from "../../components/TimeLineWrapper";
 import ComplaintPhotos from "../../components/ComplaintPhotos";
 import ComplaintLocationMap from "../../components/ComplaintLocationMap";
 import { buildExtendedAttributeRows } from "../../components/PgrExtendedAttributesView";
+import StarRated from "../../components/timelineInstances/StarRated";
 
 // Terminal (non-active) states across standard PGR *and* the mz.igsae CMS workflow.
 // CANCELLED / CLOSEDAFTER* are CMS terminals; without them CANCELLED wrongly showed
@@ -175,17 +176,16 @@ function WorkflowComponent({ complaintDetails, id }) {
     .filter((a) => a && a !== "COMMENT")
     .filter((a) => a !== "REOPEN" || reopenWindowOpen);
 
-  return (
-    <div>
-      <TimelineWrapper
-        businessId={id}
-        isWorkFlowLoading={isWorkFlowLoading}
-        workflowData={workflowData}
-        labelPrefix="WF_PGR_"
-      />
-      {citizenActions.length > 0 ? (
-        <div style={{ display: "flex", flexWrap: "wrap", gap: "0.75rem", marginTop: "1rem" }}>
-          {citizenActions.map((action) => {
+  // Rendered INSIDE the current-state timeline row (legacy-checkpoint parity):
+  // action buttons while actions are open; the given star rating once rated.
+  const rating = complaintDetails?.service?.rating;
+  const currentStateChildren =
+    rating || citizenActions.length > 0 ? (
+      <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: "0.75rem", marginTop: "0.5rem" }}>
+        {rating ? <StarRated text={t("CS_ADDCOMPLAINT_YOU_RATED")} rating={rating} /> : null}
+        {citizenActions
+          .filter((action) => !(rating && action === "RATE"))
+          .map((action) => {
             const key = `CS_COMMON_${action}`;
             const label = t(key) === key ? action : t(key);
             return (
@@ -193,7 +193,7 @@ function WorkflowComponent({ complaintDetails, id }) {
                 <button
                   type="button"
                   style={{
-                    padding: "0.5rem 1.25rem",
+                    padding: "0.4rem 1.1rem",
                     fontWeight: 600,
                     color: "#fff",
                     background: "var(--color-primary-1, var(--color-primary-main, #c84c0e))",
@@ -207,9 +207,17 @@ function WorkflowComponent({ complaintDetails, id }) {
               </Link>
             );
           })}
-        </div>
-      ) : null}
-    </div>
+      </div>
+    ) : null;
+
+  return (
+    <TimelineWrapper
+      businessId={id}
+      isWorkFlowLoading={isWorkFlowLoading}
+      workflowData={workflowData}
+      labelPrefix="WF_PGR_"
+      currentStateChildren={currentStateChildren}
+    />
   );
 }
 


### PR DESCRIPTION
Follow-up to #1064 — its second commit was pushed moments after the merge, so this lands separately.

## Changes
- **Placement:** the citizen RATE/REOPEN buttons render **inside the first (current-state) timeline row** — same spot the legacy Resolved/Rejected checkpoints used — instead of a separate block under the card.
- **Rating display restored:** once `service.rating` exists, the row shows **"You rated" + stars** (`StarRated`) and the RATE button is suppressed — this piece of the legacy UX was fully missing.
- `TimelineWrapper` gains an optional `currentStateChildren` node; employee usage passes nothing and is byte-identical in behavior.

## Testing
- Local: resolved complaint → Rate/Reopen buttons inline in the "Resolved" row; after rating → star display replaces the button; employee timeline unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)