### PR TITLE
feat(pgr): complainant Address on the employee create-complaint form

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
+++ b/digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
@@ -61,6 +61,22 @@ export const CreateComplaintConfig = {
                 }
               },
             },
+            {
+              // Complainant address — citizen-flow parity ("Your details" card).
+              // Optional; travels as extendedAttributes.complainantAddress so it
+              // shows on the employee details page and never round-trips the
+              // user service.
+              inline: true,
+              label: "ES_CREATECOMPLAINT_ADDRESS",
+              isMandatory: false,
+              type: "text",
+              key: "ComplainantAddress",
+              disable: false,
+              populators: {
+                name: "ComplainantAddress",
+                validation: { maxLength: 300 },
+              },
+            },
 
           ],
         },

--- a/digit-ui-esbuild/products/pgr/src/utils/index.js
+++ b/digit-ui-esbuild/products/pgr/src/utils/index.js
@@ -239,6 +239,18 @@ export const formPayloadToCreateComplaint = (formData, tenantId, user, extOpts) 
     complaint.service.extendedAttributes = ext;
   }
 
+  // Complainant address (citizen-flow parity — same extendedAttributes key the
+  // citizen "Your details" card writes). Attached even when the tenant has no
+  // category mapping so the field never silently drops its value; deliberately
+  // NOT citizen.correspondenceAddress, which would round-trip the user service.
+  const complainantAddress = formData?.ComplainantAddress?.trim();
+  if (complainantAddress) {
+    complaint.service.extendedAttributes = {
+      ...(complaint.service.extendedAttributes || {}),
+      complainantAddress,
+    };
+  }
+
   return complaint;
 };
 


### PR DESCRIPTION
## Change
Citizen-flow parity: adds an **optional Address field below Complainant Name** on `/employee/pgr/create-complaint`.

- Label reuses the existing `ES_CREATECOMPLAINT_ADDRESS` localization key (already seeded = "Address")
- Value travels as **`extendedAttributes.complainantAddress`** — the same key the citizen "Your details" card writes, so the employee complaint-details page shows it in *Additional Details* automatically
- Deliberately **not** `citizen.correspondenceAddress` — no user-service round-trip (avoids the masked-update rejection)
- Attached even on tenants without a category mapping, so an entered value is never silently dropped
- Optional; empty ⇒ payload unchanged (fully backward compatible)

## Testing
- Local: field renders under Complainant Name; create with/without address succeeds; entered address appears on the employee details page's Additional Details card; empty address produces a byte-identical payload to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)