### PR TITLE
fix(pgr): lazy boundary loading — no pre-selection calls, level order from the cascade's own fetch

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/Module.js
+++ b/digit-ui-esbuild/products/pgr/src/Module.js
@@ -50,20 +50,16 @@ export const PGRModule = ({ stateCode, userType, tenants }) => {
   });
   let user = Digit?.SessionStorage.get("User");
 
-  // Initialize boundary hierarchy for both employee AND citizen users.
-  // Citizens reach the create-complaint flow on naipepea, where the
-  // location step is now driven by `<PGRBoundaryComponent>` (closes
-  // egovernments/CCRS#428 + #433). The component reads
-  // `boundaryHierarchyOrder` from SessionStorage, which this hook
-  // populates on module mount. Without it, the citizen location step
-  // would render nothing.
-  const { isLoading: isPGRInitializing } = Digit.Hooks.pgr.usePGRInitialization({
-    tenantId: tenantId,
-  });
+  // NOTE: the former usePGRInitialization mount-time boundary prefetch is gone.
+  // It fired before the citizen picked an authority (wrong tenant on
+  // multi-authority envs → 400 → react-query retry spam) and its failure left
+  // boundaryHierarchyOrder unset, blanking the cascade. fetchBoundaries now
+  // derives and stores boundaryHierarchyOrder from the SAME response the
+  // cascade renders — one call, right tenant, fired only when needed.
 
   Digit.SessionStorage.set("PGR_TENANTS", tenants);
 
-  if (isLoading || isPGRInitializing) {
+  if (isLoading) {
     return <Loader />;
   }
 

--- a/digit-ui-esbuild/products/pgr/src/components/BoundaryComponent.js
+++ b/digit-ui-esbuild/products/pgr/src/components/BoundaryComponent.js
@@ -83,16 +83,18 @@ const BoundaryComponent = ({ t, config, onSelect, userType, formData, readOnly }
     return hasAny ? filtered : rawChildrenData;
   }, [rawChildrenData, allowedRoots]);
 
-  // boundaryHierarchyOrder is populated by usePGRInitialization at
-  // module mount and changes when the operator switches city. Reading
-  // it once at render meant a city switch left the cascade pointing at
-  // the previous tenant's hierarchy — a 2-level tenant after coming
-  // from a 3-level tenant would still try to render a Sub-County
-  // dropdown that the new tenant doesn't have.
+  // boundaryHierarchyOrder is written by fetchBoundaries just before its data
+  // resolves (lazy loading — no more module-mount prefetch). The memo must be
+  // keyed on the fetched DATA, not just tenantId: on first visit the order
+  // lands AFTER mount, and a tenantId-only memo cached [] for the tenant's
+  // lifetime — blank cascade until a full page refresh remounted with the
+  // storage already seeded. Re-keying on rawChildrenData recomputes exactly
+  // when the tree (and therefore the freshly written order) arrives; the
+  // tenantId key still handles operator city switches.
   const boundaryHierarchy = useMemo(() => {
     const order = Digit.SessionStorage.get("boundaryHierarchyOrder");
     return Array.isArray(order) ? order.map((item) => item.code) : [];
-  }, [tenantId]);
+  }, [tenantId, rawChildrenData]);
   const hierarchyType = window?.globalConfigs?.getConfig("HIERARCHY_TYPE") || "ADMIN";
 
   // State to manage selected values and dropdown options

--- a/digit-ui-esbuild/products/pgr/src/services/boundary/BoundaryService.js
+++ b/digit-ui-esbuild/products/pgr/src/services/boundary/BoundaryService.js
@@ -97,6 +97,18 @@ const fetchBoundaries = async ({ tenantId }) => {
       throw new Error("Couldn't fetch boundary data");
     }
 
+    // Derive the cascade's level order from THIS response and store it under the
+    // key BoundaryComponent reads. This used to be done by a separate
+    // usePGRInitialization prefetch at module mount — which fired before the
+    // citizen picked an authority (wrong tenant → 400 → react-query retry spam)
+    // and on failure left the order unset, blanking the cascade. Computing it
+    // here means: no boundary call until the cascade loads, one call, right
+    // tenant, order always consistent with the tree being rendered.
+    const rootBoundary = fetchBoundaryData?.TenantBoundary?.[0]?.boundary;
+    if (Array.isArray(rootBoundary) && rootBoundary.length > 0) {
+      Digit.SessionStorage.set("boundaryHierarchyOrder", getBoundaryTypeOrder(rootBoundary));
+    }
+
     // Level-heading labels (e.g. DIVISAO_ADMINISTRATIVA_PROVINCIA) are also
     // seeded at the tree's tenant — fetch exactly those codes (derived from the
     // boundaryTypes present in the tree) and feed i18next. Best-effort.


### PR DESCRIPTION
## Problem (digit.mctd.gov.mz, citizen create)
Opening ANY PGR page fires `boundary-relationships/_search?tenantId=mz` repeatedly (400 × react-query retries) **before the citizen has selected anything** — and the location cascade can render blank even though the correct city-tenant fetch succeeds.

## Root cause
`usePGRInitialization` prefetched the boundary tree at **module mount** to compute `boundaryHierarchyOrder`:
- runs before the authority selection exists → citizen home tenant (state root) → 400
- throws → react-query default retries → the repeated calls in the network tab
- sole writer of `boundaryHierarchyOrder` → on failure the cascade renders nothing

## Fix
- `fetchBoundaries` (the cascade's own data call — already tenant-correct after #1067) now derives `boundaryHierarchyOrder` from the same response and stores it under the key `BoundaryComponent` reads.
- The module-mount prefetch is removed entirely.

**Result:** zero boundary calls until the cascade actually loads; exactly one call, at the resolved tenant; order always consistent with the rendered tree. Employee flow identical (fetch fires with the logged-in tenant when the form renders).

## Testing
- Local citizen flow: no boundary requests on step 1; single `mz.ige`/`mz.igsae` request on the location step; cascade + labels render; employee create unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)