### PR TITLE
chore(pgr): surface PGR_ESCALATION_ENABLED in deploy env blocks

### DIFF
--- a/docker-compose.egov-digit.yaml
+++ b/docker-compose.egov-digit.yaml
@@ -1433,6 +1433,11 @@ services:
       NEW_COMPLAINT_ENABLED: 'true'
       REASSIGN_COMPLAINT_ENABLED: 'true'
       REOPEN_COMPLAINT_ENABLED: 'true'
+      # Master switch for pgr-services' EscalationScheduler (@Scheduled scan).
+      # Baked-in default is already 'true'; surfaced here so the auto-escalation
+      # engine is a visible, per-tenant-overridable knob. Set 'false' to disable
+      # the scan entirely (no workflow transitions / kafka events).
+      PGR_ESCALATION_ENABLED: 'true'
       COMMENT_BY_EMPLOYEE_NOTIF_ENABLED: 'false'
       NOTIFICATION_ALLOWED_ON_STATUS: 'open,assigned,rejected,resolved'
       EGOV_USR_EVENTS_NOTIFICATION_ENABLED: 'true'

--- a/local-setup/docker-compose.deploy.yaml
+++ b/local-setup/docker-compose.deploy.yaml
@@ -799,6 +799,11 @@ services:
       NEW_COMPLAINT_ENABLED: 'true'
       REASSIGN_COMPLAINT_ENABLED: 'true'
       REOPEN_COMPLAINT_ENABLED: 'true'
+      # Master switch for pgr-services' EscalationScheduler (@Scheduled scan).
+      # Baked-in default is already 'true'; surfaced here so the auto-escalation
+      # engine is a visible, per-tenant-overridable knob. Set 'false' to disable
+      # the scan entirely (no workflow transitions / kafka events).
+      PGR_ESCALATION_ENABLED: 'true'
       COMMENT_BY_EMPLOYEE_NOTIF_ENABLED: 'false'
       NOTIFICATION_ALLOWED_ON_STATUS: 'open,assigned,rejected,resolved'
       EGOV_USR_EVENTS_NOTIFICATION_ENABLED: 'true'

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -1440,6 +1440,13 @@ services:
       NEW_COMPLAINT_ENABLED: 'true'
       REASSIGN_COMPLAINT_ENABLED: 'true'
       REOPEN_COMPLAINT_ENABLED: 'true'
+      # Master switch for pgr-services' EscalationScheduler (@Scheduled scan).
+      # Baked-in default is already 'true'; surfaced here so the auto-escalation
+      # engine is a visible, per-tenant-overridable knob. Set 'false' to disable
+      # the scan entirely (no workflow transitions / kafka events). Note: with
+      # EGOV_UI_APP_HOST_MAP set above, this scan actively fires on the 5-day
+      # fallback SLA when MDMS EscalationConfig is unseeded.
+      PGR_ESCALATION_ENABLED: 'true'
       COMMENT_BY_EMPLOYEE_NOTIF_ENABLED: 'false'
       NOTIFICATION_ALLOWED_ON_STATUS: 'open,assigned,rejected,resolved'
       EGOV_USR_EVENTS_NOTIFICATION_ENABLED: 'true'

--- a/local-setup/k8s/app-services/pgr-services.yaml
+++ b/local-setup/k8s/app-services/pgr-services.yaml
@@ -60,6 +60,12 @@ spec:
               value: "true"
             - name: REOPEN_COMPLAINT_ENABLED
               value: "true"
+            # Master switch for pgr-services' EscalationScheduler (@Scheduled scan).
+            # Baked-in default is already "true"; surfaced here so the auto-escalation
+            # engine is a visible, per-tenant-overridable knob. Set "false" to disable
+            # the scan entirely (no workflow transitions / kafka events).
+            - name: PGR_ESCALATION_ENABLED
+              value: "true"
             - name: COMMENT_BY_EMPLOYEE_NOTIF_ENABLED
               value: "false"
             - name: NOTIFICATION_ALLOWED_ON_STATUS


### PR DESCRIPTION
## What

Adds `PGR_ESCALATION_ENABLED: 'true'` to all four pgr-services deploy env blocks:
- `docker-compose.egov-digit.yaml`
- `local-setup/docker-compose.egov-digit.yaml`
- `local-setup/docker-compose.deploy.yaml`
- `local-setup/k8s/app-services/pgr-services.yaml`

## Why

The `EscalationScheduler`'s master switch is a Spring `@Value("${pgr.escalation.enabled}")` that ships as a baked-in `true` in `application.properties`, but it was **absent from every deploy env block** — so the auto-escalation scan was an invisible always-on default that operators couldn't see or toggle without a rebuild.

A common assumption is that *not seeding the MDMS `EscalationConfig` master* keeps escalation off. It does **not**: `fetchEscalationConfig()` returning null just falls back to the property defaults (maxDepth=3, 5-day SLA), and the scan still fires real side effects — `ESCALATE` workflow transitions, supervisor reassignment, and `pgr-escalation-events` kafka. The only genuine off-switch is this property.

Surfacing it (value unchanged, `true`) makes it a visible, per-tenant-overridable knob: a tenant that doesn't want auto-escalation can set `PGR_ESCALATION_ENABLED=false` in its `host_vars` without touching code.

## Behavior change

None. Value matches the existing baked-in default, so live escalation (e.g. bomet) is unaffected. This is purely making an implicit flag explicit + documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configurable toggle for escalation processing, enabled by default in deployment setups.
  * Documented that this setting can be turned off to stop the scheduled escalation scan and related activity.

* **Documentation**
  * Clarified the meaning and impact of the new escalation toggle in environment configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->