### PR TITLE
fix(dashboard): Complaint Type Details covers all complaints, not week-to-date

### DIFF
--- a/ansible/nairobi-mdms/mdms/dss/KpiDefinition.json
+++ b/ansible/nairobi-mdms/mdms/dss/KpiDefinition.json
@@ -1409,10 +1409,6 @@
       "status": "published",
       "query": {
         "grain": "facts",
-        "window": {
-          "name": "wtd",
-          "timeRole": "filed_at"
-        },
         "dimensions": [
           "service_code",
           "service_group"
@@ -1488,7 +1484,7 @@
             "dir": "desc"
           }
         ],
-        "limit": 30
+        "limit": 100
       },
       "supportsSeries": false,
       "viz": {
@@ -1580,7 +1576,7 @@
             }
           }
         ],
-        "subtitle": "Resolution, SLA and reopen metrics per complaint type"
+        "subtitle": "Resolution, SLA and reopen metrics per complaint type - all complaints, narrowed by the date filter"
       },
       "params": [
         {


### PR DESCRIPTION
## Summary
Fixes #1026. The details table had a baked `window: {wtd, filed_at}` while "Open Complaints by Workflow Stage" is a windowless open-snapshot — the two tiles covered different complaint sets, so their subtype lists diverged (worst on Mondays: 1 vs 12 subtypes for a dept supervisor; Arushi saw 3-vs-8 and 0-vs-8 mid-week). Department ABAC was verified NOT to be the cause — both queries scope identically.

MDMS-only change to `dss.KpiDefinition` (`cl_table_complaint_type_details`): drop the baked window (table becomes an all-time per-subtype reference that still narrows when a global date range is set), raise `limit` 30→100 (supervisors sat exactly at the cap), state the scope in the subtitle. No deploy needed — MDMS upsert only.

Verified via live `_query` probes on bomet: without the window the table returns the same subtype set as the stage chart for DEMO_HEALTH / DEMO_WATER / DEMO_SUPERVISOR.

Follow-up (separate concern, not in this PR): the backend never applies `params[].default` for KPI-by-reference calls, so declared defaults are dead config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)