### PR TITLE
fix(pgr): avoid overwriting client-provided department in service upd…

### DIFF
--- a/backend/pgr-services/src/main/java/org/egov/pgr/service/PGRService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/service/PGRService.java
@@ -211,7 +211,10 @@ public class PGRService {
         Service updateService = request.getService();
 		Map<String, Object> existing = pgrUtils.extractAdditionalDetails(updateService.getAdditionalDetail());
 		Map<String, Object> backend = new HashMap<>();
-		backend.put("department", getDepartmentFromMDMS(request, mdmsData));
+		Object clientDept = existing.get("department");
+        if (clientDept == null || (clientDept instanceof String s && (s.isBlank() || s.equalsIgnoreCase("NA")))) {
+            backend.put("department", getDepartmentFromMDMS(request, mdmsData));
+        }
 		backend.put("serviceName", getServiceNameFromMDMS(request, mdmsData));
 		Map<String, Object> merged = pgrUtils.deepMerge(existing, backend);
 		updateService.setAdditionalDetail(merged);


### PR DESCRIPTION
…ates

- Check if client provided a department value before fetching from MDMS
- Only populate department from MDMS if client value is null, blank, or "NA"
- Preserve client-provided department data instead of unconditionally overwriting
- Prevents loss of explicitly set department information during service updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved a customer-provided department value during service updates when it is already set, while still replacing missing, blank, or `NA` values with the correct department.
  * Continued to refresh the service name from the source data and keep the existing update flow unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->