### PR TITLE
fix(pgr): citizen hierarchy fetch — tenant must ride inside the mdmsv2 arg

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintDetails.js
@@ -256,7 +256,11 @@ const ComplaintDetailsPage = () => {
         return { defs, allRows };
       },
     },
-    { schemaCode: "PGR_COMPLAINT_HIERARCHY_DETAILS" }
+    // NOTE: this 5th arg switches useCustomMDMS into its v2 branch, which
+    // IGNORES the positional tenantId — the tenant must ride inside this
+    // object (mdmsv2.tenantId) or the fetch silently uses the logged-in
+    // tenant (the citizen's home/state root) no matter what we pass above.
+    { schemaCode: "PGR_COMPLAINT_HIERARCHY_DETAILS", tenantId: hierarchyTenant }
   );
 
   // Pick the hierarchy DEFINITION that owns this complaint's leaf node — a


### PR DESCRIPTION
## Why #1073 didn't take effect
`useCustomMDMS(tenantId, module, masters, config, mdmsv2)`: passing `{ schemaCode }` as the 5th arg flips the hook into its **v2 branch**, which **ignores the positional `tenantId`** and uses `mdmsv2.tenantId || getCurrentTenantId()`. So the citizen details hierarchy fetch silently stayed at the citizen's home tenant on every environment — the exact behavior #1073 meant to change. (Verified: same complaint renders per-level rows on the employee page, raw keys on the citizen page, on both local and digit.mctd.gov.mz with #1073 deployed.)

## Fix
Pass the complaint's tenant **inside** the `mdmsv2` object — the hook's documented opt-in (`mdmsv2.tenantId`) — which also tenant-scopes the react-query cache key.

One line + explanatory comment. With this, the #1073 pair (complaint-tenant read + leaf-owned definition) actually engages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)