### PR TITLE
fix(analytics): SLA target from MDMS + registry-driven hierarchy grains

### DIFF
--- a/ansible/nairobi-mdms/mdms/dss/KpiDefinition.json
+++ b/ansible/nairobi-mdms/mdms/dss/KpiDefinition.json
@@ -1585,7 +1585,6 @@
       "params": [
         {
           "name": "window",
-          "default": "last_7d",
           "allowed": [
             "last_1d",
             "last_7d",

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsCatalog.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsCatalog.java
@@ -29,6 +29,7 @@ public class AnalyticsCatalog {
         public final Set<String> epochMsColumns;        // columns stored as epoch-ms (vs sql date)
         public final Set<String> groupable;
         public final Set<String> filterable;
+        public final Set<String> prefixFilterable;      // #1079: starts_with (path rollup/scope) allowlist — ONLY these
         public final Set<String> measurable;            // numeric -> sum/avg/min/max/percentile
         public final Set<String> distinctable;          // -> count_distinct
         public final String tenantColumn;
@@ -38,11 +39,13 @@ public class AnalyticsCatalog {
         public final String defaultTimeRole;
 
         Grain(String name, String table, Map<String,String> timeRoles, Set<String> epochMsColumns,
-              Set<String> groupable, Set<String> filterable, Set<String> measurable, Set<String> distinctable,
+              Set<String> groupable, Set<String> filterable, Set<String> prefixFilterable,
+              Set<String> measurable, Set<String> distinctable,
               String tenantColumn, String boundaryColumn, String citizenColumn, String departmentColumn,
               String defaultTimeRole) {
             this.name = name; this.table = table; this.timeRoles = timeRoles; this.epochMsColumns = epochMsColumns;
-            this.groupable = groupable; this.filterable = filterable; this.measurable = measurable;
+            this.groupable = groupable; this.filterable = filterable; this.prefixFilterable = prefixFilterable;
+            this.measurable = measurable;
             this.distinctable = distinctable; this.tenantColumn = tenantColumn; this.boundaryColumn = boundaryColumn;
             this.citizenColumn = citizenColumn; this.departmentColumn = departmentColumn; this.defaultTimeRole = defaultTimeRole;
         }
@@ -58,6 +61,8 @@ public class AnalyticsCatalog {
             setOf("created_at","resolved_at","last_transition_at","first_assigned_at","facts_built_at"),
             // groupable
             setOf("service_code","application_status","source","ward_code","zone_code","boundary_path",
+                  "boundary_leaf_code","boundary_leaf_type",   // #1079: depth-agnostic leaf node
+                  "complaint_depth","service_parent_code",     // #1079: complaint taxonomy axis
                   "service_request_id",   // D1b: natural row id for the at-risk table (already distinctable)
                   "service_group","department_code","aging_bucket","sla_status_bucket","current_assignee_uuid",
                   "is_open","is_resolved","is_reopened","was_rejected","sla_breached","current_state_sla_breached",
@@ -67,6 +72,8 @@ public class AnalyticsCatalog {
                   "created_date","created_dow","created_is_weekend","created_is_business_hr","tenant_id"),
             // filterable (NOTE: UUID columns intentionally absent)
             setOf("service_code","application_status","source","ward_code","zone_code","service_group",
+                  "boundary_leaf_code","boundary_leaf_type",                       // #1079
+                  "complaint_node_path","complaint_depth","service_parent_code",   // #1079
                   "department_code","aging_bucket","sla_status_bucket","is_open","is_resolved","is_reopened",
                   "was_rejected","sla_breached","current_state_sla_breached","has_rating","is_negative_rating",
                   "is_first_time_complainant","has_geo_pin","created_month","created_year","created_quarter",
@@ -77,6 +84,8 @@ public class AnalyticsCatalog {
                   // escalation_count filterable so the employee-performance escalation rate can be a
                   // count(escalation_count>=1)/count ratio (mirrors the reference escalation companion).
                   "escalation_count"),
+            // prefix-filterable (#1079: starts_with rollup/scope on materialized paths ONLY)
+            setOf("boundary_path","complaint_node_path"),
             // measurable (numeric)
             setOf("resolution_ms","time_to_assign_ms","open_age_ms","current_state_age_ms","first_escalation_ms",
                   "max_dwell_ms","assigned_dwell_ms","unassigned_dwell_ms","transition_count","assignment_count",
@@ -93,17 +102,22 @@ public class AnalyticsCatalog {
             setOf("entered_at","exited_at","complaint_created_at"),
             setOf("status","previous_status","action","escalation_source","ward_code","zone_code","service_code",
                   "department_code",   // S2: events now carries department_code (from MDMS ServiceDefs)
+                  "boundary_leaf_code","boundary_leaf_type","complaint_depth",   // #1079
                   "source","occurred_month","occurred_week_start","occurred_date","occurred_dow","occurred_hour",
                   "occurred_is_weekend","occurred_is_business_hr","is_assignment","is_escalation","is_reopen",
                   "is_backward_transition","status_is_terminal","status_is_open","has_comment","has_multiple_assignees",
                   "actor_is_system","is_current_state","assignee_uuid","actor_uuid","status_seq","tenant_id"),
             setOf("status","previous_status","action","escalation_source","ward_code","zone_code","service_code",
                   "department_code",   // S2
+                  "boundary_leaf_code","boundary_leaf_type",                      // #1079
+                  "complaint_node_path","complaint_depth",                        // #1079
                   "source","occurred_month","occurred_is_weekend","occurred_is_business_hr","is_assignment",
                   "is_escalation","is_reopen","is_backward_transition","status_is_terminal","status_is_open",
                   "has_comment","has_multiple_assignees","actor_is_system","is_current_state","entered_at",
                   "complaint_created_at",   // D2: real epoch-ms col on complaint_events; lets the global date range / compare:prior actually narrow events-grain tiles
                   "status_seq"),
+            // prefix-filterable (#1079)
+            setOf("boundary_path","complaint_node_path"),
             setOf("dwell_ms","state_sla_ms","business_sla_ms","comment_length","seq_delta","complaint_age_at_event_ms",
                   "event_rating","assignee_count"),
             setOf("service_request_id","assignee_uuid","actor_uuid","account_id"),
@@ -119,6 +133,8 @@ public class AnalyticsCatalog {
             setOf("snapshot_date","ward_code","zone_code","service_code","sla_status_bucket","aging_bucket",
                   "department_code",   // S2
                   "is_open","sla_breached"),
+            // prefix-filterable (#1079: daily carries boundary_path only)
+            setOf("boundary_path"),
             setOf(),
             setOf("service_request_id","current_assignee_uuid","ward_code","account_id"),
             "tenant_id","boundary_path","account_id","department_code","snapshot_date"));   // S2: department + citizen row-scope axes

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java
@@ -172,14 +172,32 @@ public class AnalyticsPlanner {
 
     // ---------- predicates (filterable whitelist + bound params) ----------
     private String predicate(Grain g, String colKey, JsonNode spec, List<Object> params){
-        if (!g.filterable.contains(colKey))
+        // #1079: a column may be plain-filterable, prefix-filterable (starts_with only), or both.
+        boolean plainFilterable  = g.filterable.contains(colKey);
+        boolean prefixFilterable = g.prefixFilterable.contains(colKey);
+        if (!plainFilterable && !prefixFilterable)
             throw new IllegalArgumentException("op_not_allowed: column '" + colKey + "' is not filterable on " + g.name);
-        if (!spec.isObject()) { params.add(value(spec)); return colKey + " = ?"; }      // shorthand: eq
+        if (!spec.isObject()) {
+            if (!plainFilterable) throw new IllegalArgumentException(
+                    "op_not_allowed: column '" + colKey + "' on " + g.name + " only supports the 'starts_with' filter op");
+            params.add(value(spec)); return colKey + " = ?";      // shorthand: eq
+        }
         List<String> parts = new ArrayList<>();
         Iterator<Map.Entry<String,JsonNode>> it = spec.fields();
         while (it.hasNext()) {
             Map.Entry<String,JsonNode> e = it.next();
             String op = e.getKey(); JsonNode v = e.getValue();
+            // #1079: starts_with is ONLY valid on the per-column prefix allowlist (materialized
+            // paths); every other op needs plain filterability. Both rejections are explicit.
+            if ("starts_with".equals(op)) {
+                if (!prefixFilterable) throw new IllegalArgumentException(
+                        "op_not_allowed: 'starts_with' is only permitted on prefix-filterable path columns, not '" + colKey + "' on " + g.name);
+                params.add(escapeLike(v.asText()));
+                parts.add(colKey + " LIKE ? || '%'");
+                continue;
+            }
+            if (!plainFilterable) throw new IllegalArgumentException(
+                    "op_not_allowed: column '" + colKey + "' on " + g.name + " only supports the 'starts_with' filter op");
             switch (op) {
                 case "eq":  params.add(value(v)); parts.add(colKey + " = ?"); break;
                 case "ne":  params.add(value(v)); parts.add(colKey + " <> ?"); break;
@@ -199,6 +217,11 @@ public class AnalyticsPlanner {
             }
         }
         return parts.size()==1 ? parts.get(0) : "(" + String.join(" AND ", parts) + ")";
+    }
+
+    /** Escape LIKE metacharacters (backslash default escape) so a starts_with value is a literal prefix. */
+    private String escapeLike(String s){
+        return s.replace("\\","\\\\").replace("%","\\%").replace("_","\\_");
     }
 
     private Object value(JsonNode v){

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
@@ -172,17 +172,49 @@ public class AnalyticsService {
             log.debug("kpiId '{}' not found or not authorized (roles={})", kpiId, callerRoles);
             return null;
         }
-        // C1: validate the request's window param against the def's params.allowed allow-list
+        // #1026: apply the def's declared params[].default for any param the caller omitted.
+        // Precedence: explicit caller param > declared default > the def's baked query.
+        JsonNode effectiveParams = withDeclaredDefaults(def.get(), queryNode.get("params"));
+
+        // C1: validate the EFFECTIVE window param against the def's params.allowed allow-list
         // (the def is in scope here). An out-of-list window must be a per-entry invalid_param,
         // not silently honoured by the composer/planner (which accept any well-formed window).
-        validateWindowParam(def.get(), queryNode.get("params"));
+        validateWindowParam(def.get(), effectiveParams);
 
         JsonNode storedQuery = def.get().getQuery();
         if (storedQuery == null || storedQuery.isNull())
             // D1a backend-composed defs are intercepted by maybeComposeResult before this point;
             // a query:null def WITHOUT a valid compose op is a genuine misconfiguration.
             throw new IllegalArgumentException("invalid_kpi: KPI '" + kpiId + "' has no query defined");
-        return queryComposer.mergeParams(storedQuery, queryNode.get("params"));
+        return queryComposer.mergeParams(storedQuery, effectiveParams);
+    }
+
+    /**
+     * #1026 — server-side application of the def's declared {@code params[].default}. Any declared
+     * param with a non-empty default that the caller did NOT supply is filled in, so a bare
+     * {@code {kpiId}} reference behaves like the dashboard's default global-filter state instead of
+     * silently ignoring the declared default. Precedence: explicit caller param > declared default
+     * > the def's baked query (a defaulted param flows through {@link KpiQueryComposer#mergeParams}
+     * exactly like a caller-sent one, and the C1 window allow-list check runs on the EFFECTIVE
+     * params). Returns {@code reqParams} untouched (possibly null) when no default applies.
+     */
+    private JsonNode withDeclaredDefaults(KpiDefinition def, JsonNode reqParams) {
+        List<KpiDefinition.KpiParam> declared = def.getParams();
+        if (declared == null || declared.isEmpty()) return reqParams;
+        com.fasterxml.jackson.databind.node.ObjectNode merged = null;
+        for (KpiDefinition.KpiParam p : declared) {
+            if (p == null || p.getName() == null) continue;
+            String dflt = p.getDefaultValue();
+            if (dflt == null || dflt.isEmpty()) continue;
+            if (reqParams != null && reqParams.hasNonNull(p.getName())) continue;   // explicit wins
+            if (merged == null) {
+                merged = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+                if (reqParams != null && reqParams.isObject())
+                    merged.setAll((com.fasterxml.jackson.databind.node.ObjectNode) reqParams);
+            }
+            merged.put(p.getName(), dflt);
+        }
+        return merged != null ? merged : reqParams;
     }
 
     /**
@@ -231,12 +263,15 @@ public class AnalyticsService {
         if (!def.isPublished() || !def.isVisibleTo(callerRoles))
             return Map.of("error", "kpi_forbidden", "message", "KPI not found or not authorized for role set");
 
-        // C1: the compose def's window allow-list still applies to the request params.
-        validateWindowParam(def, queryNode.get("params"));
+        // #1026: apply the compose def's declared params[].default before validation/propagation,
+        // so a bare {kpiId} compose ref honours its declared defaults too (explicit caller wins).
+        JsonNode params = withDeclaredDefaults(def, queryNode.get("params"));
+
+        // C1: the compose def's window allow-list still applies to the effective params.
+        validateWindowParam(def, params);
 
         JsonNode compose = def.getViz().getCompose();
         String type = compose.get("type").asText();
-        JsonNode params = queryNode.get("params");
 
         // Resolve + run each source kpiId with the same params, RBAC and row-scope.
         List<Map<String,Object>> sourceRows = new ArrayList<>();
@@ -394,7 +429,7 @@ public class AnalyticsService {
     public Map<String,Object> schema(){
         Map<String,Object> out = new LinkedHashMap<>();
         out.put("aggFns", AnalyticsCatalog.AGG_FNS);
-        out.put("filterOps", Arrays.asList("eq","ne","gt","gte","lt","lte","in","isnull"));
+        out.put("filterOps", Arrays.asList("eq","ne","gt","gte","lt","lte","in","isnull","starts_with"));
         out.put("windows", Arrays.asList("all","live","last_<N>d","wtd","mtd","qtd","ytd"));
         out.put("timeBuckets", Arrays.asList("day","week","month","quarter","year"));
         Map<String,Object> grains = new LinkedHashMap<>();
@@ -404,6 +439,7 @@ public class AnalyticsService {
             gi.put("defaultTimeRole", g.defaultTimeRole);
             gi.put("dimensions", g.groupable);
             gi.put("filterable", g.filterable);
+            gi.put("prefixFilterable", g.prefixFilterable);   // #1079: starts_with-eligible path columns
             gi.put("measurable", g.measurable);
             gi.put("distinctCountable", g.distinctable);
             gi.put("scopeColumns", scopeCols(g));

--- a/backend/pgr-services/src/main/resources/db/migration/main/V20260708000000__sla_and_hierarchy_grains.sql
+++ b/backend/pgr-services/src/main/resources/db/migration/main/V20260708000000__sla_and_hierarchy_grains.sql
@@ -1,0 +1,449 @@
+-- ============================================================================
+-- #1028 (SLA target sourcing) + #1079 (arbitrary-depth hierarchy grains).
+--
+-- ---- #1028: sla_target_ms ---------------------------------------------------
+-- sla_target_ms was sourced ONLY from workflow eg_wf_businessservice_v2 joined
+-- on the EXACT tenant. The PGR business service exists only at the state root
+-- (`ke`), so every city-tenant (`ke.*`) complaint got sla_target_ms = NULL:
+-- the dashboard SLA column rendered blank and sla_breached / sla_status_bucket /
+-- SLA-compliance KPIs undercounted (NULL target can never breach).
+--
+-- New sla_target_ms semantics (per-complaint COALESCE):
+--   1) MDMS ServiceDefs slaHours -> ms  (mdms_sla_hours * 3600000, per subtype);
+--   2) escalation-ladder total from MDMS RAINMAKER-PGR.EscalationConfig
+--      (SUM of overrides-><serviceCode> if present, else SUM of
+--      defaultSlaByLevel; values already in ms); config resolved from the
+--      complaint's exact tenant, else its state root (split_part(tenantid,'.',1));
+--   3) workflow businessservicesla, with the tenant join FIXED to fall back to
+--      the state root (exact tenant preferred via longest-match).
+-- sla_breached and sla_status_bucket now derive from the new sla_target_ms.
+-- sla_config_mismatch keeps its original semantics (MDMS slaHours vs the
+-- workflow value, where the workflow value exists) — only the workflow value's
+-- tenant fallback (fix 3) widens where it applies.
+--
+-- ---- #1079: registry-driven hierarchy axes ----------------------------------
+-- JURISDICTION: zone_code/ward_code were extracted by FIXED position
+-- (split_part(boundary_path,'|',2|3)), which mislabels any tenant whose tree
+-- is not exactly root>zone>ward. They are now resolved from the level registry:
+-- ward_code = the path segment whose boundarytype matches the tenant's 'Ward'
+-- level (case-insensitive, from boundary_hierarchy); zone_code = the segment
+-- at the level directly ABOVE ward (the ward level's parentBoundaryType).
+-- FALLBACK when the tenant's hierarchy has no Ward level: ward_code = leaf
+-- segment, zone_code = parent-of-leaf. New columns boundary_leaf_code /
+-- boundary_leaf_type carry the leaf node regardless of depth. boundary_path
+-- ('|'-delimited) and boundary_depth are unchanged.
+--
+-- COMPLAINT: the taxonomy now rides RAINMAKER-PGR.ComplaintHierarchy (node
+-- dedupe prefers records at levels flagged isLeafServiceCode in
+-- ComplaintHierarchyDefinition — registry leaf detection, not a
+-- department-IS-NOT-NULL heuristic). New complaint_node_path ('.'-delimited)
+-- comes from ComplaintHierarchy.path verbatim, with a recursive parentCode
+-- walk as fallback (COALESCE(path, recursive)); complaint_depth = segment
+-- count. service_group is now the ROOT category (first path segment, falling
+-- back to legacy ServiceDefs.menuPath where a code has no hierarchy node);
+-- NEW service_parent_code = the leaf's immediate parent (== service_group on
+-- 2-level tenants, so existing service_group consumers are unaffected there).
+-- ServiceDefs is still joined for mdms_sla_hours / service_order /
+-- department_code (no regression).
+--
+-- complaint_open_state_daily (a table) is NOT rewritten: historical snapshots
+-- keep the values as computed on their snapshot date; forward snapshots pick
+-- up the new definitions automatically (the scheduler copies its columns from
+-- complaint_facts). MVs are refreshed manually in ops, unchanged.
+--
+-- NOTE: this supersedes the events/facts definitions in V20260629000000 (which
+-- superseded V20260608000000). Edit ALL if the grain shape changes again
+-- (flyway migrations are append-only — the originals cannot be edited without
+-- breaking deployed checksums).
+-- ============================================================================
+
+-- ---- grain 1: complaint_events ----------------------------------------------
+DROP MATERIALIZED VIEW IF EXISTS complaint_events CASCADE;
+CREATE MATERIALIZED VIEW complaint_events AS
+WITH RECURSIVE svc AS (
+  SELECT s.servicerequestid, s.id AS pgr_id, s.tenantid, s.servicecode, s.accountid,
+         s.source, s.createdtime AS complaint_created_at, s.createdby AS filed_by_uuid,
+         a.locality AS locality_code, a.latitude, a.longitude,
+         (a.latitude IS NOT NULL AND a.longitude IS NOT NULL) AS has_geo_pin
+  FROM eg_pgr_service_v2 s
+  LEFT JOIN eg_pgr_address_v2 a ON a.parentid = s.id
+),
+bnd0 AS (   -- one row per boundary code: full root->leaf path + the node's own (leaf) type,
+            -- tenant and hierarchy; longest ancestral path wins (as before)
+  SELECT DISTINCT ON (code) code, tenantid, hierarchytype,
+         boundarytype AS leaf_type,
+         (ancestralmaterializedpath || '|' || code) AS boundary_path
+  FROM boundary_relationship
+  ORDER BY code, length(ancestralmaterializedpath) DESC
+),
+btype AS (  -- per-node level type (same dedupe rule), to type every path segment
+  SELECT DISTINCT ON (code) code, boundarytype
+  FROM boundary_relationship
+  ORDER BY code, length(ancestralmaterializedpath) DESC
+),
+wardlvl AS (   -- #1079: the tenant's 'Ward' level and the level directly above it,
+               -- from the boundary_hierarchy level registry
+  SELECT DISTINCT ON (h.tenantid, h.hierarchytype) h.tenantid, h.hierarchytype,
+         lvl->>'boundaryType'       AS ward_type,
+         lvl->>'parentBoundaryType' AS zone_type
+  FROM boundary_hierarchy h
+  CROSS JOIN LATERAL jsonb_array_elements(h.boundaryhierarchy) lvl
+  WHERE lower(lvl->>'boundaryType') = 'ward'
+),
+bnd AS (   -- #1079: registry-resolved named levels per boundary code.
+           -- FALLBACK (no Ward level in the tenant's hierarchy): leaf / parent-of-leaf.
+  SELECT b.code, b.boundary_path,
+         b.code      AS boundary_leaf_code,
+         b.leaf_type AS boundary_leaf_type,
+         CASE WHEN w.ward_type IS NOT NULL THEN seg.ward_seg
+              ELSE segs.arr[array_length(segs.arr,1)] END     AS ward_code,
+         CASE WHEN w.ward_type IS NOT NULL THEN seg.zone_seg
+              ELSE segs.arr[array_length(segs.arr,1)-1] END   AS zone_code
+  FROM bnd0 b
+  LEFT JOIN wardlvl w ON w.tenantid = b.tenantid AND w.hierarchytype = b.hierarchytype
+  CROSS JOIN LATERAL (SELECT string_to_array(b.boundary_path,'|') AS arr) segs
+  LEFT JOIN LATERAL (
+    SELECT max(s.seg) FILTER (WHERE lower(bt.boundarytype) = lower(w.ward_type)) AS ward_seg,
+           max(s.seg) FILTER (WHERE lower(bt.boundarytype) = lower(w.zone_type)) AS zone_seg
+    FROM unnest(segs.arr) s(seg)
+    LEFT JOIN btype bt ON bt.code = s.seg
+  ) seg ON true
+),
+bs AS (
+  SELECT DISTINCT ON (tenantid, businessservice) tenantid, businessservice, businessservicesla
+  FROM eg_wf_businessservice_v2
+),
+asg AS (
+  SELECT processinstanceid, count(*) AS assignee_count,
+         (array_agg(assignee ORDER BY assignee))[1] AS assignee_uuid
+  FROM eg_wf_assignee_v2 GROUP BY processinstanceid
+),
+mdms AS (   -- ServiceDefs; dedupe by serviceCode preferring the root (shortest) tenant
+  SELECT DISTINCT ON (data->>'serviceCode')
+         data->>'serviceCode' AS service_code,
+         data->>'department'  AS department_code
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.ServiceDefs' AND isactive
+  ORDER BY data->>'serviceCode', length(tenantid)
+),
+chlvl AS (   -- #1079: levelCodes flagged isLeafServiceCode in ComplaintHierarchyDefinition
+  SELECT DISTINCT lvl->>'levelCode' AS level_code
+  FROM eg_mdms_data d
+  CROSS JOIN LATERAL jsonb_array_elements(d.data->'levels') lvl
+  WHERE d.schemacode = 'RAINMAKER-PGR.ComplaintHierarchyDefinition' AND d.isactive
+    AND (lvl->>'isLeafServiceCode')::boolean
+),
+ch AS (   -- ComplaintHierarchy nodes; dedupe by code preferring leaf-level records
+          -- (registry leaf detection), then the root (shortest) tenant
+  SELECT DISTINCT ON (data->>'code')
+         data->>'code'                  AS code,
+         NULLIF(data->>'path','')       AS node_path,
+         NULLIF(data->>'parentCode','') AS parent_code
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.ComplaintHierarchy' AND isactive
+  ORDER BY data->>'code',
+           (data->>'levelCode' IN (SELECT level_code FROM chlvl)) DESC,
+           length(tenantid)
+),
+chwalk AS (   -- recursive parentCode walk (robust fallback when path is absent)
+  SELECT code AS leaf_code, code, parent_code, code::text AS built_path, 1 AS depth
+  FROM ch
+  UNION ALL
+  SELECT w.leaf_code, p.code, p.parent_code, (p.code || '.' || w.built_path), w.depth + 1
+  FROM chwalk w
+  JOIN ch p ON p.code = w.parent_code
+  WHERE w.depth < 12
+),
+cnp AS (   -- #1079: complaint_node_path per code = master path, else recursive build
+  SELECT ch.code,
+         coalesce(ch.node_path, walk.built_path) AS complaint_node_path
+  FROM ch
+  LEFT JOIN LATERAL (
+    SELECT w.built_path FROM chwalk w WHERE w.leaf_code = ch.code
+    ORDER BY w.depth DESC LIMIT 1
+  ) walk ON true
+),
+tx AS (
+  SELECT pi.id AS event_id, pi.businessid AS service_request_id, pi.tenantid,
+         pi.businessservice, pi.action, pi.assigner AS actor_uuid,
+         pi.escalated, pi.rating AS event_rating, pi.comment,
+         pi.createdtime AS entered_at,
+         st.state AS status, st.seq AS status_seq, st.sla AS state_sla_ms,
+         st.isterminatestate AS status_is_terminal,
+         lead(pi.createdtime) OVER w AS exited_at,
+         lag(st.state)        OVER w AS previous_status,
+         lag(st.seq)          OVER w AS previous_status_seq,
+         row_number()         OVER w AS seq_no,
+         (lead(pi.id) OVER w IS NULL) AS is_current_state
+  FROM eg_wf_processinstance_v2 pi
+  LEFT JOIN eg_wf_state_v2 st ON st.uuid = pi.status
+  WINDOW w AS (PARTITION BY pi.businessid ORDER BY pi.createdtime, pi.id)
+)
+SELECT
+  tx.event_id, tx.service_request_id, tx.tenantid AS tenant_id,
+  tx.businessservice AS business_service, tx.seq_no, tx.is_current_state,
+  tx.action, tx.status, tx.previous_status,
+  coalesce(tx.status_is_terminal,false)        AS status_is_terminal,
+  (NOT coalesce(tx.status_is_terminal,false))  AS status_is_open,
+  tx.actor_uuid, asg.assignee_uuid,
+  (ua.type = 'SYSTEM')                         AS actor_is_system,
+  tx.entered_at, tx.exited_at,
+  (tx.exited_at - tx.entered_at)               AS dwell_ms,
+  tx.status_seq, tx.previous_status_seq,
+  (tx.status_seq - tx.previous_status_seq)     AS seq_delta,
+  (tx.status_seq < tx.previous_status_seq)     AS is_backward_transition,
+  tx.state_sla_ms,
+  CASE WHEN tx.state_sla_ms IS NOT NULL AND tx.exited_at IS NOT NULL
+       THEN (tx.exited_at - tx.entered_at) > tx.state_sla_ms END AS state_sla_breached_on_exit,
+  bs.businessservicesla                        AS business_sla_ms,
+  (tx.action IN ('ASSIGN','REASSIGN'))         AS is_assignment,
+  (tx.action = 'REOPEN')                       AS is_reopen,
+  coalesce(tx.escalated,false)                 AS is_escalation,
+  CASE WHEN coalesce(tx.escalated,false)
+       THEN (CASE WHEN ua.type='SYSTEM' THEN 'auto' ELSE 'manual' END) END AS escalation_source,
+  (tx.comment IS NOT NULL AND tx.comment <> '') AS has_comment,
+  length(tx.comment)                           AS comment_length,
+  tx.event_rating,
+  coalesce(asg.assignee_count,0)               AS assignee_count,
+  (coalesce(asg.assignee_count,0) > 1)         AS has_multiple_assignees,
+  svc.accountid AS account_id, svc.source, svc.servicecode AS service_code,
+  m.department_code,                                                      -- S2: department row-scope axis
+  cnp.complaint_node_path,                                                -- #1079: complaint taxonomy axis
+  array_length(string_to_array(cnp.complaint_node_path,'.'),1)::smallint AS complaint_depth,
+  svc.locality_code, svc.has_geo_pin,
+  svc.complaint_created_at,
+  (tx.entered_at - svc.complaint_created_at)   AS complaint_age_at_event_ms,
+  bnd.boundary_path,
+  bnd.zone_code,                               -- #1079: registry-resolved (was split_part pos 2)
+  bnd.ward_code,                               -- #1079: registry-resolved (was split_part pos 3)
+  bnd.boundary_leaf_code,                      -- #1079: leaf node, depth-agnostic
+  bnd.boundary_leaf_type,
+  (to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3')::date AS occurred_date,
+  date_trunc('week',(to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3'))::date AS occurred_week_start,
+  to_char((to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3'),'YYYY-MM') AS occurred_month,
+  extract(hour   FROM (to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3'))::smallint AS occurred_hour,
+  extract(isodow FROM (to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3'))::smallint AS occurred_dow,
+  (extract(isodow FROM (to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3')) IN (6,7)) AS occurred_is_weekend,
+  (extract(hour  FROM (to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3')) BETWEEN 8 AND 17) AS occurred_is_business_hr
+FROM tx
+LEFT JOIN svc ON svc.servicerequestid = tx.service_request_id
+LEFT JOIN bnd ON bnd.code = svc.locality_code
+LEFT JOIN cnp ON cnp.code = svc.servicecode
+LEFT JOIN LATERAL (                          -- #1028 fix 3: exact tenant, else state root
+  SELECT b.businessservicesla
+  FROM bs b
+  WHERE b.businessservice = tx.businessservice
+    AND b.tenantid IN (tx.tenantid, split_part(tx.tenantid,'.',1))
+  ORDER BY length(b.tenantid) DESC
+  LIMIT 1
+) bs ON true
+LEFT JOIN asg ON asg.processinstanceid = tx.event_id
+LEFT JOIN mdms m ON m.service_code = svc.servicecode
+LEFT JOIN eg_user ua ON ua.uuid = tx.actor_uuid;
+
+CREATE UNIQUE INDEX ux_complaint_events ON complaint_events(event_id);
+CREATE INDEX ix_ce_timeline ON complaint_events(service_request_id, seq_no);
+CREATE INDEX ix_ce_status   ON complaint_events(status);
+CREATE INDEX ix_ce_assignee ON complaint_events(assignee_uuid);
+CREATE INDEX ix_ce_week     ON complaint_events(occurred_week_start);
+CREATE INDEX ix_ce_dept     ON complaint_events(department_code);
+
+-- ---- grain 2: complaint_facts (CASCADE dropped by the events recreate) ------
+DROP MATERIALIZED VIEW IF EXISTS complaint_facts CASCADE;
+CREATE MATERIALIZED VIEW complaint_facts AS
+WITH RECURSIVE clock AS (SELECT (extract(epoch FROM now())*1000)::bigint AS now_ms),
+roll AS (
+  SELECT service_request_id,
+         min(entered_at)                                            AS created_at,
+         max(entered_at)                                            AS last_transition_at,
+         count(*)                                                   AS transition_count,
+         count(*) FILTER (WHERE is_assignment)                      AS assignment_count,
+         count(*) FILTER (WHERE is_escalation)                      AS escalation_count,
+         count(*) FILTER (WHERE is_reopen)                          AS reopen_count,
+         count(DISTINCT assignee_uuid)                              AS distinct_assignee_count,
+         count(DISTINCT actor_uuid)                                 AS distinct_actor_count,
+         count(*) FILTER (WHERE actor_is_system)                    AS system_transition_count,
+         count(*) FILTER (WHERE NOT actor_is_system)                AS manual_transition_count,
+         bool_or(status IN ('REJECTED','CLOSEDAFTERREJECTION'))     AS was_rejected,
+         min(entered_at) FILTER (WHERE is_assignment)               AS first_assigned_at,
+         min(entered_at) FILTER (WHERE status IN ('RESOLVED','CLOSEDAFTERRESOLUTION')) AS resolved_at,
+         max(entered_at) FILTER (WHERE is_escalation)               AS last_escalated_at,
+         min(entered_at) FILTER (WHERE is_escalation)               AS first_escalated_at,
+         max(dwell_ms)                                              AS max_dwell_ms,
+         sum(dwell_ms) FILTER (WHERE assignee_uuid IS NOT NULL)     AS assigned_dwell_ms,
+         sum(dwell_ms) FILTER (WHERE assignee_uuid IS NULL)         AS unassigned_dwell_ms
+  FROM complaint_events GROUP BY service_request_id
+),
+cur AS (
+  SELECT service_request_id, status AS application_status, status_seq AS current_state_seq,
+         status_is_open AS is_open, assignee_uuid AS current_assignee_uuid,
+         state_sla_ms AS current_state_sla_ms, business_sla_ms,
+         boundary_path, ward_code, zone_code,
+         boundary_leaf_code, boundary_leaf_type                     -- #1079
+  FROM complaint_events WHERE is_current_state
+),
+mdms AS (
+  SELECT DISTINCT ON (data->>'serviceCode')
+         data->>'serviceCode'            AS service_code,
+         (data->>'slaHours')::int        AS mdms_sla_hours,
+         NULLIF(data->>'menuPath','')    AS legacy_service_group,   -- #1079: fallback only
+         (data->>'order')::smallint      AS service_order,
+         data->>'department'             AS department_code
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.ServiceDefs' AND isactive
+  ORDER BY data->>'serviceCode', length(tenantid)
+),
+chlvl AS (   -- #1079: levelCodes flagged isLeafServiceCode in ComplaintHierarchyDefinition
+  SELECT DISTINCT lvl->>'levelCode' AS level_code
+  FROM eg_mdms_data d
+  CROSS JOIN LATERAL jsonb_array_elements(d.data->'levels') lvl
+  WHERE d.schemacode = 'RAINMAKER-PGR.ComplaintHierarchyDefinition' AND d.isactive
+    AND (lvl->>'isLeafServiceCode')::boolean
+),
+ch AS (   -- ComplaintHierarchy nodes; dedupe by code preferring leaf-level records
+          -- (registry leaf detection), then the root (shortest) tenant
+  SELECT DISTINCT ON (data->>'code')
+         data->>'code'                  AS code,
+         NULLIF(data->>'path','')       AS node_path,
+         NULLIF(data->>'parentCode','') AS parent_code
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.ComplaintHierarchy' AND isactive
+  ORDER BY data->>'code',
+           (data->>'levelCode' IN (SELECT level_code FROM chlvl)) DESC,
+           length(tenantid)
+),
+chwalk AS (   -- recursive parentCode walk (robust fallback when path is absent)
+  SELECT code AS leaf_code, code, parent_code, code::text AS built_path, 1 AS depth
+  FROM ch
+  UNION ALL
+  SELECT w.leaf_code, p.code, p.parent_code, (p.code || '.' || w.built_path), w.depth + 1
+  FROM chwalk w
+  JOIN ch p ON p.code = w.parent_code
+  WHERE w.depth < 12
+),
+cnp AS (   -- #1079: complaint_node_path per code = master path, else recursive build
+  SELECT ch.code,
+         coalesce(ch.node_path, walk.built_path) AS complaint_node_path
+  FROM ch
+  LEFT JOIN LATERAL (
+    SELECT w.built_path FROM chwalk w WHERE w.leaf_code = ch.code
+    ORDER BY w.depth DESC LIMIT 1
+  ) walk ON true
+),
+esc AS (   -- #1028 fix 2: EscalationConfig ladder source (one record per tenant, at state root)
+  SELECT tenantid,
+         data->'overrides'         AS overrides,
+         data->'defaultSlaByLevel' AS default_levels
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.EscalationConfig' AND isactive
+),
+seq AS (
+  SELECT id, row_number() OVER (PARTITION BY accountid ORDER BY createdtime, id) AS complaint_seq_for_citizen
+  FROM eg_pgr_service_v2
+)
+SELECT
+  s.servicerequestid AS service_request_id, s.id AS pgr_id, s.tenantid AS tenant_id,
+  s.accountid AS account_id, 'PGR'::text AS business_service,
+  s.servicecode AS service_code, cur.application_status, s.source, s.rating AS rating_raw, s.active,
+  length(s.description) AS description_length,
+  (s.description IS NOT NULL AND s.description <> '') AS has_description,
+  s.createdby AS filed_by_uuid, (s.createdby <> s.accountid) AS filed_on_behalf,
+  a.locality AS locality_code, a.pincode, a.city, a.latitude, a.longitude,
+  (a.latitude IS NOT NULL AND a.longitude IS NOT NULL) AS has_geo_pin,
+  (a.parentid IS NOT NULL) AS has_address,
+  cur.boundary_path,
+  (length(coalesce(cur.boundary_path,'')) - length(replace(coalesce(cur.boundary_path,''),'|','')) + 1)::smallint AS boundary_depth,
+  cur.ward_code, cur.zone_code,
+  cur.boundary_leaf_code, cur.boundary_leaf_type,                          -- #1079
+  cnp.complaint_node_path,                                                 -- #1079
+  cx.complaint_depth,                                                      -- #1079
+  coalesce(cx.root_code, m.legacy_service_group) AS service_group,         -- #1079: ROOT category
+  cx.service_parent_code,                                                  -- #1079: immediate parent
+  m.service_order, m.mdms_sla_hours, m.department_code,
+  cur.current_state_seq, cur.current_state_sla_ms, tgt.sla_target_ms,      -- #1028: COALESCE'd target
+  (m.mdms_sla_hours IS NOT NULL AND cur.business_sla_ms IS NOT NULL
+    AND m.mdms_sla_hours::bigint*3600000 <> cur.business_sla_ms) AS sla_config_mismatch,
+  roll.created_at, roll.first_assigned_at, roll.first_assigned_at AS first_response_at,
+  roll.resolved_at, roll.last_transition_at, roll.first_escalated_at, roll.last_escalated_at,
+  roll.transition_count, roll.assignment_count, roll.escalation_count, roll.reopen_count,
+  roll.distinct_assignee_count, roll.distinct_actor_count,
+  roll.system_transition_count, roll.manual_transition_count,
+  roll.was_rejected, (roll.reopen_count > 0) AS is_reopened,
+  cur.is_open, (roll.resolved_at IS NOT NULL) AS is_resolved,
+  roll.max_dwell_ms, roll.assigned_dwell_ms, roll.unassigned_dwell_ms,
+  cur.current_assignee_uuid,
+  (roll.resolved_at - roll.created_at)                            AS resolution_ms,
+  (roll.first_assigned_at - roll.created_at)                      AS time_to_assign_ms,
+  CASE WHEN cur.is_open THEN clock.now_ms - roll.created_at END   AS open_age_ms,
+  CASE WHEN cur.is_open THEN clock.now_ms - roll.last_transition_at END AS current_state_age_ms,
+  (roll.first_escalated_at - roll.created_at)                     AS first_escalation_ms,
+  CASE WHEN cur.is_open  THEN (tgt.sla_target_ms IS NOT NULL AND (clock.now_ms - roll.created_at) > tgt.sla_target_ms)
+       WHEN roll.resolved_at IS NOT NULL THEN (tgt.sla_target_ms IS NOT NULL AND (roll.resolved_at - roll.created_at) > tgt.sla_target_ms)
+       ELSE false END                                            AS sla_breached,
+  (cur.is_open AND cur.current_state_sla_ms IS NOT NULL
+    AND (clock.now_ms - roll.last_transition_at) > cur.current_state_sla_ms) AS current_state_sla_breached,
+  CASE WHEN NOT cur.is_open THEN NULL
+       WHEN (clock.now_ms - roll.created_at) < 86400000  THEN '<1d'
+       WHEN (clock.now_ms - roll.created_at) < 259200000 THEN '1-3d'
+       WHEN (clock.now_ms - roll.created_at) < 604800000 THEN '3-7d'
+       ELSE '>7d' END                                            AS aging_bucket,
+  CASE WHEN NOT cur.is_open OR tgt.sla_target_ms IS NULL THEN NULL
+       WHEN (clock.now_ms - roll.created_at) > tgt.sla_target_ms       THEN 'breached'
+       WHEN (clock.now_ms - roll.created_at) > 0.8*tgt.sla_target_ms   THEN 'approaching'
+       ELSE 'within' END                                         AS sla_status_bucket,
+  (s.rating IS NOT NULL) AS has_rating, s.rating, (s.rating IS NOT NULL AND s.rating <= 2) AS is_negative_rating,
+  seq.complaint_seq_for_citizen, (seq.complaint_seq_for_citizen = 1) AS is_first_time_complainant,
+  (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3')::date AS created_date,
+  date_trunc('week',(to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'))::date AS created_week_start,
+  to_char((to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'),'YYYY-MM') AS created_month,
+  extract(year FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'))::smallint AS created_year,
+  to_char((to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'),'YYYY-"Q"Q') AS created_quarter,
+  extract(hour FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'))::smallint AS created_hour,
+  extract(isodow FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'))::smallint AS created_dow,
+  (extract(isodow FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3')) IN (6,7)) AS created_is_weekend,
+  (extract(hour FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3')) BETWEEN 8 AND 17) AS created_is_business_hr,
+  (to_timestamp(roll.resolved_at/1000) AT TIME ZONE 'Etc/GMT-3')::date AS resolved_date,
+  to_char((to_timestamp(roll.resolved_at/1000) AT TIME ZONE 'Etc/GMT-3'),'YYYY-MM') AS resolved_month,
+  clock.now_ms AS facts_built_at
+FROM eg_pgr_service_v2 s
+CROSS JOIN clock
+LEFT JOIN eg_pgr_address_v2 a ON a.parentid = s.id
+LEFT JOIN roll ON roll.service_request_id = s.servicerequestid
+LEFT JOIN cur  ON cur.service_request_id  = s.servicerequestid
+LEFT JOIN mdms m ON m.service_code = s.servicecode
+LEFT JOIN cnp ON cnp.code = s.servicecode
+CROSS JOIN LATERAL (                         -- #1079: path-derived complaint-axis fields
+  SELECT x.arr[1]                            AS root_code,
+         array_length(x.arr,1)::smallint     AS complaint_depth,
+         x.arr[array_length(x.arr,1)-1]      AS service_parent_code
+  FROM (SELECT string_to_array(cnp.complaint_node_path,'.') AS arr) x
+) cx
+LEFT JOIN LATERAL (                          -- #1028 fix 2: ladder total for this complaint's
+  SELECT CASE                                -- service code, from the nearest EscalationConfig
+           WHEN jsonb_typeof(e.overrides -> s.servicecode) = 'array'   -- (exact tenant, else state root)
+             THEN (SELECT sum(v.value::numeric)::bigint
+                   FROM jsonb_array_elements_text(e.overrides -> s.servicecode) v)
+           WHEN jsonb_typeof(e.default_levels) = 'array'
+             THEN (SELECT sum(v.value::numeric)::bigint
+                   FROM jsonb_array_elements_text(e.default_levels) v)
+         END AS ladder_sla_ms
+  FROM esc e
+  WHERE e.tenantid IN (s.tenantid, split_part(s.tenantid,'.',1))
+  ORDER BY length(e.tenantid) DESC
+  LIMIT 1
+) lad ON true
+CROSS JOIN LATERAL (                         -- #1028: the decided SLA-target precedence
+  SELECT coalesce(m.mdms_sla_hours::bigint * 3600000,   -- 1) ServiceDefs slaHours
+                  lad.ladder_sla_ms,                    -- 2) escalation-ladder total
+                  cur.business_sla_ms                   -- 3) workflow SLA (state-root fallback)
+         ) AS sla_target_ms
+) tgt
+LEFT JOIN seq ON seq.id = s.id
+WHERE s.active = true;
+
+CREATE UNIQUE INDEX ux_complaint_facts ON complaint_facts(service_request_id);
+CREATE INDEX ix_cf_service ON complaint_facts(service_code);
+CREATE INDEX ix_cf_status  ON complaint_facts(application_status);
+CREATE INDEX ix_cf_created ON complaint_facts(created_week_start);
+CREATE INDEX ix_cf_open    ON complaint_facts(is_open) WHERE is_open;
+CREATE INDEX ix_cf_ward    ON complaint_facts(ward_code);

--- a/docs/dashboard-configuration/10-kpi-catalog.md
+++ b/docs/dashboard-configuration/10-kpi-catalog.md
@@ -1,0 +1,245 @@
+# 10 — The KPI Catalog: `dss.KpiDefinition`
+
+Every tile on the supervisor dashboard is a **KpiDefinition** record in MDMS (module `dss`,
+master `KpiDefinition`). The backend loads them at the **state-root tenant** (a city tenantId is
+collapsed to its root before the MDMS lookup — `KpiCatalogService.getVisibleDefs` →
+`MultiStateInstanceUtil.getStateLevelTenant`), so definitions are authored once per state root
+(e.g. `ke`), never per city.
+
+- Live seed example: `ansible/nairobi-mdms/mdms/dss/KpiDefinition.json` (28 defs on `ke`)
+- Loader: `backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiCatalogService.java`
+- POJO / accepted fields: `backend/pgr-services/src/main/java/org/egov/pgr/analytics/model/KpiDefinition.java`
+- Query grammar reference (authoritative): `backend/pgr-services/ANALYTICS-QUERY-API.md`
+
+Adding, changing, or retiring a KPI is an **MDMS edit — no rebuild, no deploy**.
+
+## 1. Anatomy of a definition
+
+```jsonc
+{
+  "tenantId": "ke",                       // state root; MDMS record wrapper
+  "data": {
+    "id": "cl_resolution_rate_count",     // stable id — referenced by packs, layout, FE refs
+    "version": "1.0.0",                   // informational; passed through to the FE (see §6)
+    "status": "published",                // lifecycle gate (see §5)
+    "query": { ... },                     // the baked analytics query (see §2), or null for compose defs
+    "supportsSeries": true,               // FE hint: tile can be re-rendered as a daily series
+    "viz": { ... },                       // how the FE renders it (see §3)
+    "params": [ ... ],                    // caller-tunable knobs + allow-lists + defaults (see §4)
+    "rbac": { "visibleTo": ["PUBLIC"] }   // role ceiling — see 20-packs-and-rbac.md
+  }
+}
+```
+
+## 2. The `query` block — grammar essentials
+
+The full grammar lives in `backend/pgr-services/ANALYTICS-QUERY-API.md`; this is the operator's
+summary. A query targets **exactly one grain**:
+
+| grain | table/MV | one row is | typical measures |
+|---|---|---|---|
+| `facts` | `complaint_facts` | one complaint | counts, rates, `resolution_ms`, `sla_target_ms` |
+| `events` | `complaint_events` | one workflow transition | `dwell_ms`, bottlenecks, transition matrix |
+| `daily` | `complaint_open_state_daily` | one open complaint per day | backlog history, sparklines |
+
+If `grain` is omitted it is inferred from the measure columns (events-only columns like
+`dwell_ms` → `events`; otherwise `facts`) — set it explicitly in defs.
+
+**Measures** — each has a caller-chosen `name` (becomes the result column) and an `agg`:
+`count` (optional `filter`), `count_distinct` (needs `column`), `sum`/`avg`/`min`/`max`
+(numeric `column`, optional `filter`), `percentile` (`column` + `p` in (0,100) — prefer
+median/p90 over `avg` for durations), and `ratio`:
+
+```json
+{ "name": "pct", "agg": "ratio",
+  "numerator":   { "agg": "count", "filter": { "is_resolved": true } },
+  "denominator": { "agg": "count" } }
+```
+
+Ratio sides support `count`/`sum`, each with its own `filter`; the planner emits
+`round(num::numeric / NULLIF(den,0), 4)` — **ratios come back as a 0..1 fraction**, and the FE
+`percent*` formats expect that.
+
+**Filters** — `{ column: predicate }` where a predicate is a bare value (shorthand `eq`) or an
+operator object: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `isnull`. Every column must be in
+the grain's `filterable` whitelist (`AnalyticsCatalog.java`); UUID/PII-adjacent columns
+(`account_id`, `current_assignee_uuid`, …) are deliberately **not** filterable.
+
+**Window + timeRoles**:
+
+```json
+"window": { "name": "last_30d", "timeBucket": "month", "timeRole": "filed_at" }
+```
+
+- `name`: `all` | `live` | `last_<N>d` | `wtd` | `mtd` | `qtd` | `ytd` (computed in the dashboard
+  zone, Africa/Nairobi UTC+3 — `AnalyticsPlanner.EAT`).
+- `timeRole`: a *named* time axis per grain — facts: `filed_at` (→ `created_at`) and
+  `resolved_at`; events: `event_at` (→ `entered_at`); daily: `snapshot_date`. Free-form time
+  columns are rejected. The timeRole also steers which column a global date-range narrows
+  (`KpiQueryComposer.dateFilterColumn`): a facts def carrying `timeRole:"resolved_at"` gets its
+  date range applied to `resolved_at`.
+- `timeBucket`: `day|week|month|quarter|year` — adds a grouped `bucket` column.
+
+**Sort / limit** — `sort` entries must reference a selected dimension or measure name;
+`limit` is capped at 1000 (`AnalyticsPlanner.MAX_LIMIT`).
+
+**Live-open-snapshot semantics** (matters when authoring "open now" tiles): a query with
+`filters.is_open: true`, a non-daily grain and **no base window** is treated as a point-in-time
+snapshot — the server deliberately does *not* narrow it by the global window/date-range params
+(`KpiQueryComposer.isLiveOpenSnapshot`). Give an open-metric a window if you want it
+time-bounded.
+
+## 3. The `viz` block — rendering contract
+
+The FE render engine is `frontend/micro-ui/web/src/dashboard/components/KpiTile.jsx`
+(`renderByKind`). Every `viz.kind` it dispatches:
+
+| `viz.kind` (aliases) | renders as | key extra fields |
+|---|---|---|
+| `scalar`, `number-tile`, `number-tile-delta` | KPI number card with optional delta | `valueKey`, `format`, `priorKey`, `delta {mode, compare}`, `deltaLabel`, `threshold` |
+| `number-tile-sparkline`, `sparkline-card` | number card + mini trend | + `dateKey`, `sparklineMeasureKey`, `seriesColor` |
+| `bar`, `bar-chart` | vertical bar chart | `dimensionKey`, `measureKeys`, `colors`, `categoryOrder` |
+| `histogram` | vertical bars, insertion order kept | same as bar |
+| `horizontal-bar` | horizontal bars | same as bar |
+| `stacked-bar` | stacked bars | `stackSeries` / stack keys |
+| `pie`, `pie-chart` | pie/donut | `dimensionKey`, `measureKey` |
+| `line`, `line-chart` | time-series line | `dateKey`, `measureKeys` |
+| `sla-risk-table` | the complaints-at-risk table | `columns` |
+| `choropleth-map`, `map` | ward choropleth / pin map | see `GeographyChoroplethMap.jsx` |
+| `ranked-list`, `rankedList` | ranked list | — |
+| `dow`, `day-of-week` | day-of-week profile | — |
+| `table`, `data-table`, *anything else* | generic data table (the **default** fallback) | `columns` |
+
+First-class `viz` fields on the BE POJO: `kind`, `format`, `valueKey`, `accent`, `group`,
+`titleKey`, `dimensionKey`, `measureKeys`, `variants`, `compose`, `pii`. **Anything else is
+passed through verbatim** (`KpiDefinition.KpiViz.extra`, `@JsonAnySetter`) — `threshold`,
+`delta`, `dateKey`, `sparklineMeasureKey`, `seriesColor`, `contextLabel`, `deltaLabel`,
+`colors`, `stackSeries`, `columns`, `title`, … — so new FE viz options need **no backend
+schema change**, only a KpiTile capability.
+
+**Titles / localization**: the FE currently prefers the human `viz.title` string
+(`KpiTile.resolveTitle`); `viz.titleKey` (convention `RAINMAKER-PGR.DASHBOARD_KPI_<ID>`) is
+retained for a future i18n layer and is only ever *prettified* as a last-resort fallback, never
+rendered verbatim. Ship both: `title` for today, `titleKey` so the def is i18n-ready.
+
+**Thresholds** color the card by value: `viz.threshold = { kind: "percent"|..., higherIsBetter,
+onTrack, breaching }` — percent thresholds are in display units (e.g. `onTrack: 70`) while the
+ratio value is 0..1; KpiTile normalizes.
+
+**Backend-composed defs**: a def with `query: null` plus
+`viz.compose = { type, sourceKpiIds: [...], elapsedFromAsOf? }` is computed server-side from
+other KPIs' results (`AnalyticsService.maybeComposeResult`). Supported ops:
+`dailyAvgFromWeekly`, `hourlyAvgFromDaily`, `openRateComplement`, `netBacklogDaily`.
+Source KPIs are resolved with the caller's RBAC and the same params.
+
+## 4. `params` — the caller-tunable knobs
+
+```json
+"params": [
+  { "name": "window", "default": "last_7d",
+    "allowed": ["last_1d","last_7d","last_30d","wtd","mtd"] }
+]
+```
+
+The dashboard sends `{ kpiId, params }` and the server layers the params onto the baked query
+(`KpiQueryComposer.mergeParams`). Supported param names (fixed vocabulary — anything else is
+ignored):
+
+| param | effect |
+|---|---|
+| `window` | overrides `query.window.name`, preserving `timeRole`/`timeBucket` |
+| `dateFrom` + `dateTo` | inclusive ISO dates → half-open `gte`/`lt` range on the grain's time column; removes the base window. Unparseable values are a hard `invalid_param`, not a silent fallback |
+| `ward` | narrows `ward_code = ?` iff filterable on the grain |
+| `serviceCode` | narrows `service_code = ?` iff filterable |
+| `compare: "prior"` | immediately-preceding equal-duration range (prior calendar week when no range is set) — powers "vs prior period" deltas |
+| `series: "daily"` | scalar → daily time series (adds the grain's date dimension + asc sort, caps limit at min(366, days)) — powers sparklines |
+
+Rules enforced server-side:
+
+- **`allowed` list** (C1): a requested `window` outside the def's `allowed` list is rejected
+  with `invalid_param` — it is never silently honoured.
+- **`default`** is applied **server-side** for any declared param the caller omitted, with
+  precedence *explicit caller param > declared default > the def's baked query*
+  (`AnalyticsService.withDeclaredDefaults`). A bare `{ "kpiId": "..." }` reference therefore
+  behaves like the dashboard's default filter state. *(Changed in this PR — the #1026
+  params-default fix; previously a declared `default` was documentation-only.)*
+- Params can only **narrow**: the server-injected RBAC row-scope is layered on top by the
+  planner and is never widened by params.
+
+Design consequence: a KPI that should cover *all time* by default (e.g. the Complaint Type
+Details table) must **not** declare a `window` default — with the server-side default fix, a
+declared default now actually applies. *(Changed in this PR: `cl_table_complaint_type_details`
+dropped its `last_7d` default for exactly this reason — issue #1028 / PR #1074 context.)*
+
+## 5. Status lifecycle
+
+`status` is a free string; the server serves a def **only when `status == "published"`**
+(`KpiDefinition.isPublished`). Anything else (`draft`, `retired`, …) is invisible to `/packs`,
+`/catalog/_search` and unresolvable via `kpiId` (callers get `kpi_forbidden`). So:
+
+- **draft** → author with `status: "draft"`, flip to `published` when ready (MDMS `_update`).
+- **retire** → flip status away from `published` (mdms-v2 has no `_delete`; you can also set the
+  MDMS record `isActive: false`).
+
+## 6. Versioning
+
+`version` is a semver-style string carried on the def and echoed to the FE in `/packs` /
+`/catalog/_search` tile descriptors (`AnalyticsController.safeTile`). The server attaches **no
+semantics** to it today — no side-by-side versions, no negotiation. Treat it as a change marker:
+bump it whenever `query`/`viz` changes shape so FE caches and humans can tell defs apart.
+
+## 7. Cookbook — add a new KPI end-to-end
+
+Goal: a "Complaints via WhatsApp (last 30d)" number card for supervisors.
+
+1. **Author the def** (validate the query first by POSTing it inline to
+   `/pgr-services/v2/analytics/_query` as an admin):
+
+   ```json
+   {
+     "id": "cl_whatsapp_count",
+     "version": "1.0.0",
+     "status": "published",
+     "query": {
+       "grain": "facts",
+       "measures": [ { "name": "total", "agg": "count" } ],
+       "filters": { "source": "whatsapp" },
+       "window": { "name": "last_30d" }
+     },
+     "viz": {
+       "kind": "number-tile-delta",
+       "format": "number",
+       "valueKey": "total",
+       "accent": "blue",
+       "group": "complaint-landscape",
+       "title": "WhatsApp complaints",
+       "titleKey": "RAINMAKER-PGR.DASHBOARD_KPI_CL_WHATSAPP_COUNT",
+       "delta": { "compare": "prior" },
+       "deltaLabel": "vs prior period"
+     },
+     "params": [ { "name": "window", "default": "last_30d",
+                   "allowed": ["last_7d","last_30d","mtd"] } ],
+     "rbac": { "visibleTo": ["SUPERVISOR","PGR_SUPERVISOR","PGR_ADMIN"] }
+   }
+   ```
+
+2. **Set the role ceiling** — `rbac.visibleTo` (see `20-packs-and-rbac.md` §visibleTo for the
+   exact semantics of `[]` and `PUBLIC`).
+
+3. **Upsert to MDMS** at the state root (`dss` / `KpiDefinition`, tenant `ke`) via
+   mdms-v2 `_create`/`_update`. In git-driven deployments also add it to the seed file
+   (`ansible/nairobi-mdms/mdms/dss/KpiDefinition.json`) so a redeploy doesn't lose it.
+
+4. **Optionally add it to a pack** so it appears in the default layout: append the id to
+   `tiles` and a `{kpiId,x,y,w,h}` entry to `layout` in `dss.DashboardPack`
+   (see `20-packs-and-rbac.md`). Without a pack entry the KPI is still available in the
+   dashboard's Add-KPI picker (served by `/catalog/_search`) for any role that passes
+   `visibleTo`.
+
+5. **Title/localization** — `viz.title` renders today; if/when the i18n layer lands, add the
+   `titleKey` message to the localization store (module upsert + cache flush — see
+   `30-view-access.md` for the localization cache-bust procedure).
+
+6. **Verify**: `POST /v2/analytics/catalog/_search` as the target role should list the tile;
+   `POST /v2/analytics/_query` with `{"queries":{"t":{"kpiId":"cl_whatsapp_count"}}}` should
+   return rows. No service restart is involved anywhere in this flow.

--- a/docs/dashboard-configuration/20-packs-and-rbac.md
+++ b/docs/dashboard-configuration/20-packs-and-rbac.md
@@ -1,0 +1,143 @@
+# 20 — Dashboard Packs and the Four RBAC Layers
+
+## 1. `dss.DashboardPack` — who gets which default dashboard
+
+A **DashboardPack** picks the default tile set + grid layout per audience. Like KpiDefinition it
+lives in MDMS module `dss`, master `DashboardPack`, at the **state-root tenant**.
+
+- Live example: `ansible/nairobi-mdms/mdms/dss/DashboardPack.json` (`supervisor-default` on `ke`)
+- POJO: `backend/pgr-services/src/main/java/org/egov/pgr/analytics/model/DashboardPack.java`
+- Selection logic: `KpiCatalogService.getBestPack`
+
+```jsonc
+{
+  "tenantId": "ke",
+  "data": {
+    "id": "supervisor-default",
+    "description": "Default supervisor dashboard pack",
+    "roles": ["SUPERVISOR","PGR_SUPERVISOR","GRO","DGRO","PGR_LME","PGR_ADMIN","SUPERUSER"],
+    "tiles":  ["cl_resolution_rate_count", "rs_breach_total", ...],   // KpiDefinition ids
+    "layout": [ { "kpiId": "cl_resolution_rate_count", "x": 0, "y": 0, "w": 2, "h": 2 }, ... ]
+  }
+}
+```
+
+Semantics (`POST /pgr-services/v2/analytics/packs`):
+
+- **Role match**: the **first** pack (in MDMS record order) whose `roles` overlap the caller's
+  roles wins. There is no specificity scoring — order your packs most-specific-first.
+- **Ceiling filter**: pack `tiles`/`layout` are filtered down to the KPIs the caller can actually
+  see (`rbac.visibleTo` + `status:published`). A pack can never leak a tile past the catalog
+  ceiling.
+- **No matching pack**: the caller gets *all* visible defs as tiles with an empty
+  `defaultLayout` — functional but unlaid-out. Give every dashboard-holding role a pack.
+- **Layout grid**: `x/y/w/h` in react-grid-layout units on a **12-column** grid (see the live
+  layout: rows of five `w:2` cards, full-width `w:12` tables). Users can rearrange locally; the
+  FE persists per-browser layout to localStorage (`frontend/micro-ui/web/src/dashboard/hooks/useCatalogLayout.js`) —
+  the pack is only the *default*.
+- The response (`AnalyticsController.safeTile`) contains viz metadata only — **never** the
+  def's `query` or `rbac` blocks.
+
+Editing a pack (add/remove/rearrange default tiles for a role) is an MDMS `_update` — no deploy.
+
+## 2. The four RBAC layers
+
+Design series: `docs/dashboard-rbac-design/` (parts A–F + 70-view-management). What is actually
+enforced in `backend/pgr-services/src/main/java/org/egov/pgr/analytics/`:
+
+### Layer 1 — Row-scope ABAC (what rows a query may aggregate)
+
+Resolved once per request by `PrincipalScopeResolver.resolve` ("the seam") and injected by
+`AnalyticsPlanner.applyScope` as WHERE conjuncts. Never taken from the request body.
+
+| principal | injected scope |
+|---|---|
+| any caller | tenant scope, always: state-root tenant → `tenant_id LIKE 'ke%'`, city tenant → `tenant_id = ?` |
+| pure citizen | `account_id = <own uuid>` (self-scope) |
+| employee | `department_code IN (<active HRMS assignment departments>)` — resolved live via `POST /egov-hrms/employees/_search?codes=<userName>` |
+| employee with a `TENANT_WIDE_ROLES` role | unrestricted within tenant (`PGR_ADMIN`, `SUPERUSER`, `MDMS_ADMIN`, `HRMS_ADMIN`, `STADMIN`, `SUPERVISOR`, `PGR_SUPERVISOR`) |
+| employee whose department cannot be resolved (no HRMS record, no active assignment, HRMS error) | **fail-closed**: sentinel department `__scope_denied__` that matches no row — unless they hold a tenant-wide role |
+
+Boundary/jurisdiction scope (`boundary_path LIKE '<prefix>%'`) is wired end-to-end but
+deliberately disabled in the resolver today (`boundaryPrefix = null` with the enabling block
+commented out in `PrincipalScopeResolver.java` — see the inline rationale).
+
+Operator consequences:
+
+- A department-scoped supervisor's dashboard (all tiles, and the filter option lists) shows
+  **only their departments' complaints**. That is scoping, not "missing data".
+- An officer role that should see the dashboard **must have an active HRMS assignment with a
+  department**, or hold a tenant-wide role — otherwise every tile returns zero rows.
+- `department_code` on the grains comes from `RAINMAKER-PGR.ServiceDefs.department` per
+  serviceCode; complaints whose type has no department are excluded for department-scoped users
+  (NULL never matches an `IN` list).
+
+### Layer 2 — Catalog visibility (`rbac.visibleTo`)
+
+Per-KPI role ceiling, evaluated in `KpiDefinition.isVisibleTo`:
+
+- `visibleTo: []` (or absent) → visible to **every authenticated** role. Not to anonymous.
+- `visibleTo: ["ROLE_A","ROLE_B"]` → any listed role.
+- `"PUBLIC"` in the list is an **additive audience marker**, not a ceiling: it opts the tile into
+  anonymous access and is stripped before evaluating the authenticated ceiling (so tagging a tile
+  PUBLIC never narrows who can see it; `["PUBLIC"]` alone = everyone incl. anonymous).
+
+Applies uniformly to `/packs`, `/catalog/_search`, and `kpiId`-by-reference `/_query` calls.
+
+### Layer 3 — Inline PII gate
+
+The `kpiId` path is governed by layer 2, but `/_query` also accepts **inline** query bodies. An
+inline query that projects an officer/citizen-identity column as a raw *dimension*
+(`AnalyticsService.PII_DIMENSIONS`: `current_assignee_uuid`, `assignee_uuid`, `actor_uuid`,
+`account_id`) is rejected with `pii_forbidden` unless the caller holds one of
+`OFFICER_PII_ROLES` (`SUPERVISOR`, `PGR_SUPERVISOR`, `PGR_ADMIN`, `SUPERUSER`, `MDMS_ADMIN`,
+`HRMS_ADMIN`). Aggregate `count_distinct` over these columns is *not* gated (never exposes an
+individual UUID). Additionally, these columns are groupable/distinct-countable but **never
+filterable** (no UUID probing), and the API returns raw UUIDs only — name resolution happens at
+the edge with the caller's own credentials.
+
+### Layer 4 — Public floor
+
+An unauthenticated / role-less caller degrades to the synthetic `PUBLIC` role
+(`AnalyticsService.extractRoles`), which may:
+
+- see only tiles whose `visibleTo` explicitly contains `"PUBLIC"` (10 of the 28 live `ke` defs);
+- run **only** `kpiId`-by-reference queries — every inline body gets `kpi_forbidden`.
+
+This is a deliberate degrade-to-curated-aggregates, not a lock-out; it closed the old fail-open
+where anonymous callers could read every `visibleTo: []` tile.
+
+## 3. Error codes and what to do about them
+
+Per-entry in a batch (`results.<name>.error` + top-level `partial: true`) or a 400 body on a
+single query. Codes are the prefix before `:` in the message (`AnalyticsService.err`).
+
+| code | meaning | operator action |
+|---|---|---|
+| `scope_incomplete` | the caller's mandatory row-scope (citizen / department / boundary) cannot be **enforced on the target grain** — the grain lacks that scope column, so the server refuses rather than silently widening | Since `V20260629000000__grain_scope_columns.sql` all three grains carry department + citizen axes, so this signals a custom grain/def problem, not a user problem |
+| `kpi_forbidden` | kpiId not found, not `published`, or caller's roles fail `visibleTo`; also any inline/public-floor violation | Check def status + `visibleTo` vs the user's roles; FE renders "No access" |
+| `pii_forbidden` | inline query projected a PII dimension without an officer-PII role | Use a curated KPI def (layer 2) instead of inline, or grant the proper role; FE renders "Restricted" |
+| `invalid_param` | bad grammar value: unknown window, `window` outside the def's `allowed` list, unparseable `dateFrom/dateTo`, bad percentile/sort/limit | Fix the def or the caller's params |
+| `unknown_column` / `op_not_allowed` / `unknown_grain` / `unknown_agg` | identifier not in the `AnalyticsCatalog` whitelist for that operation | Register the column (developer change — see 50-sla-and-hierarchies.md §extending) |
+| `invalid_kpi` | def misconfiguration (e.g. `query: null` without a valid `viz.compose`) | Fix the def in MDMS |
+| `query_failed` | anything else (SQL/runtime) | Check pgr-services logs |
+
+Note for FE developers: `KpiTile.errorLabel` maps `pii_forbidden` → "Restricted",
+`kpi_forbidden` → "No access", and a `scope_forbidden` code → "Out of scope" — but the backend
+emits `scope_incomplete`, which currently falls through to the raw-code default label.
+(TODO-verify: align `errorLabel` with `scope_incomplete` or add the alias.)
+
+## 4. Granting access — which knob for which outcome
+
+| you want | change | where |
+|---|---|---|
+| role R sees KPI X (picker + by-reference query) | add R to X's `rbac.visibleTo` (or leave `[]` for all-authenticated) | `dss.KpiDefinition` (MDMS) |
+| role R gets a curated default dashboard | add R to a pack's `roles` (and X to its `tiles`/`layout`) | `dss.DashboardPack` (MDMS) |
+| role R sees only its own department's numbers | give the user an HRMS assignment with that department; keep R out of `TENANT_WIDE_ROLES` | HRMS + (code constant, deploy) |
+| role R sees the whole tenant | grant one of the `TENANT_WIDE_ROLES` (e.g. `PGR_SUPERVISOR`) | HRMS/user roles |
+| anonymous/public page shows KPI X | add `"PUBLIC"` to X's `visibleTo` | `dss.KpiDefinition` (MDMS) |
+| role R can *open the dashboard view at all* (home card, sidebar entry) | `tenant.citymodule` + ACCESSCONTROL actions/roleactions — **a different system entirely** | see `30-view-access.md` |
+
+The last row is the classic confusion: `visibleTo`/packs govern *what renders inside* the
+dashboard; whether the user can *navigate to* the dashboard is the digit-ui access-control
+surface documented in `30-view-access.md`.

--- a/docs/dashboard-configuration/30-view-access.md
+++ b/docs/dashboard-configuration/30-view-access.md
@@ -1,0 +1,146 @@
+# 30 — Making the Dashboard View Reachable in digit-ui
+
+`20-packs-and-rbac.md` governs what renders *inside* the dashboard. This doc covers the separate,
+older DIGIT access-control surface that decides whether a user can *get to* it at all: the home
+card, the module mount, and the sidebar entry. All of it is MDMS data — no rebuild — but it has
+sharp edges (§5) and a multi-layer cache (§4).
+
+## 1. `tenant.citymodule` — home card + module mount
+
+File (seed): `ansible/nairobi-mdms/mdms/tenant/citymodule.json`
+
+```jsonc
+{ "tenantId": "ke",                       // MDMS owning tenant (state root)
+  "data": {
+    "code": "PGR",                        // module code — must match the FE module registration
+    "module": "PGR",
+    "order": 2,                           // home-card sort order
+    "active": true,
+    "tenants": [ { "code": "ke" }, { "code": "ke.nairobi" } ]   // tenants the module is on for
+  } }
+```
+
+How digit-ui consumes it:
+
+- Fetched during app init (`digit-ui-esbuild/packages/libraries/src/services/elements/MDMS.js`,
+  master list includes `citymodule`).
+- Filtered into `initData.modules` by
+  `digit-ui-esbuild/packages/libraries/src/services/molecules/Store/service.js`:
+  `active === true` AND `code ∈ enabledModules` (the build's enabled-module list), sorted by
+  `order`.
+- The employee home (`digit-ui-esbuild/packages/modules/core/src/components/Home.js`) renders one
+  card per module by looking up the component registered as `` `${code}Card` `` in the component
+  registry; the module's routes mount under the same code.
+
+So: **no `citymodule` row (or `active:false`, or your tenant missing from `tenants[]`) = no home
+card and no mounted module**, regardless of roles.
+
+## 2. Actions + roleactions — the sidebar and role gating
+
+Two masters in module scope `ACCESSCONTROL-*`:
+
+**`ACCESSCONTROL-ACTIONS-TEST` / master `actions-test`** — the universe of navigable actions.
+Seed: `ansible/nairobi-mdms/mdms/ACCESSCONTROL-ACTIONS-TEST/actions-test.json`. Entry shape:
+
+```jsonc
+{ "tenantId": "ke",
+  "data": {
+    "id": 1958,                            // numeric id — the cross-reference key
+    "name": "rainmaker-common-dashboard",
+    "url": "url",                          // "url" = sidebar link; "card" = home card entry
+    "displayName": "Supervisor Dashboard",
+    "orderNumber": 2,
+    "enabled": true,
+    "path": "Dashboard.PGR",               // dot-path builds the sidebar tree
+    "navigationURL": "/dashboard",         // where clicking goes
+    "leftIcon": "action:dashboard", "rightIcon": "",
+    "serviceCode": "PGR", "parentModule": "", "queryParams": ""
+  } }
+```
+
+**`ACCESSCONTROL-ROLEACTIONS` / master `roleactions`** — role → action grants.
+Seed: `ansible/nairobi-mdms/mdms/ACCESSCONTROL-ROLEACTIONS/roleactions.json`. Entry shape:
+
+```jsonc
+{ "tenantId": "ke",                        // outer/MDMS record tenant
+  "data": { "id": 1083, "actionid": 1958, "rolecode": "PGR_SUPERVISOR",
+            "tenantId": "ke", "actioncode": "" } }   // INNER tenantId — see §5
+```
+
+**Server-side role intersection**: the FE never filters actions itself. On login it POSTs the
+user's role codes to `/access/v1/actions/mdms/_get` (egov-accesscontrol) — see
+`digit-ui-esbuild/packages/libraries/src/services/elements/Access.js`:
+`{ roleCodes, tenantId: <stateId>, actionMaster: "actions-test", enabled: true }` — and the
+service returns the intersected, enabled action list. The sidebar
+(`digit-ui-esbuild/packages/modules/core/src/components/TopBarSideBar/SideBar/SideBar.js`)
+builds its tree from each action's dot-`path` and labels every node with
+`t(getTransformedLocale("ACTION_TEST_" + <name segment>))`.
+
+**To give role R a "Dashboard" sidebar entry**: (1) ensure the action exists (or create one with
+a fresh id — §5), (2) `_create` a roleactions row `{rolecode: R, actionid: <that id>, tenantId:
+<state root>}`, (3) bust the caches (§4). No restart.
+
+## 3. Localization keys
+
+- **`ACTION_TEST_DASHBOARD`** — the sidebar/menu label for a node whose transformed path/name
+  segment is `DASHBOARD` (the `ACTION_TEST_<X>` pattern in §2; keys are generated at runtime,
+  UPPER_SNAKE). Module: **`rainmaker-common`**. Upsert it via
+  `/localization/messages/v1/_upsert` for every enabled locale (see
+  `common-masters.StateInfo.languages` — that list is the only source of enabled locales).
+- **`DASHBOARD_CARD_HEADER`** — home-card header key used by card components.
+  TODO-verify: this key appears in operational runbooks but is not present anywhere in this
+  checkout (FE source, ansible seeds, or `local-setup/db/full-dump.sql`); confirm the exact key
+  your card component requests (the citizen home derives `ACTION_TEST_<code>` instead —
+  `Home.js`).
+
+Missing keys render as the raw UPPER_SNAKE code in the UI — that is a localization gap, not a
+routing failure.
+
+## 4. The FULL cache-bust story
+
+Localization and init data are cached at **three** layers. After editing actions, roleactions,
+citymodule, or localization messages, work through all of them top-down:
+
+1. **Server — redis**: the localization service caches messages in the `digit-redis` hash
+   `messages`. Bust with: `redis-cli DEL messages` (inside the redis container). Until then,
+   `_search` keeps serving the old messages regardless of what's in Postgres.
+2. **Client — sessionStorage `Digit.initData`**: tenant/module/citymodule init payload is cached
+   per-tab (`Store/service.js` `Storage.set("initData", …)`; keys are prefixed `Digit.` by
+   `digit-ui-esbuild/packages/libraries/src/services/atoms/Utils/Storage.js`). A normal reload
+   reuses it; close the tab or clear sessionStorage (or log out/in) to refetch.
+3. **Client — localStorage `Digit.Locale.*`**: localization messages are cached **persistently**
+   with a TTL — keys `Digit.Locale.<locale>.<module>` and `Digit.Locale.<locale>.List`
+   (`digit-ui-esbuild/packages/libraries/src/services/elements/Localization/service.js`).
+   **These survive a hard refresh and even a browser restart.** For a deterministic result have
+   the user run `localStorage.clear()` (or clear site data) — switching languages back and forth
+   also repopulates.
+
+Symptom table: stale label after `_upsert` → redis (1); new sidebar entry missing but API shows
+it → initData (2); label fixed for new users but not existing ones → `Digit.Locale.*` (3).
+
+## 5. Operational gotchas (all learned the hard way)
+
+- **mdms-v2 has no `_delete`.** Retire records by `_update` with `isActive: false`. This applies
+  to actions, roleactions, citymodule, KpiDefinition — everything.
+- **Deactivate roleactions BEFORE their action.** `roleactions.actionid` cross-references the
+  action's `data.id` and mdms-v2 validates the reference; deactivating an action that live
+  roleactions still point at fails validation. Order: roleactions rows first, then the action.
+  (Reference: the ordering comments in `digit-mcp/src/tools/mdms-tenant.ts` — "actions-test must
+  land before roleactions (the latter x-refs action ids)".)
+- **Allocate new action ids from a live max-id scan.** Action `data.id` must be unique across
+  the master. The seed files carry thousands of ids from multiple sources; don't pick "a nice
+  round number" — query the live master for `max(id)` and go above it, or you will collide with
+  a bootstrapped record.
+- **Mirror the live inner-`tenantId` convention.** Roleaction records carry an *inner*
+  `data.tenantId` distinct from the MDMS record tenant. On MCP-bootstrapped tenants the copied
+  rows keep the inner tenantId of the *source* root (e.g. `pg`) — check what the live rows on
+  your instance use and match it exactly; a mismatched inner tenantId makes the grant silently
+  inapplicable.
+- **ACTIONS bridge for MCP-bootstrapped tenants.** egov-accesscontrol reads
+  `ACCESSCONTROL-ACTIONS.actions`, but the shipped seeds only define
+  `ACCESSCONTROL-ACTIONS-TEST.actions-test`. `tenant_bootstrap` (Step 3c in
+  `digit-mcp/src/tools/mdms-tenant.ts`) clones the schema + rows to the non-TEST code,
+  preserving `data.id` so roleaction cross-refs resolve. If you hand-add actions on such a
+  tenant, add them to **both** masters or the menu will not appear ("no actions → blank menu").
+- **`dss.*` is NOT copied by tenant_bootstrap** — a fresh tenant has actions but no
+  KpiDefinition/DashboardPack. See `60-operations.md` §tenant-bootstrap.

--- a/docs/dashboard-configuration/40-filters-and-options.md
+++ b/docs/dashboard-configuration/40-filters-and-options.md
@@ -1,0 +1,110 @@
+# 40 — The Global Filter Bar: Options, Persistence, "No Data"
+
+The bar at the top of the dashboard (date range, geography/ward, complaint type) feeds the
+`params` object sent with every `{kpiId, params}` tile query (see `10-kpi-catalog.md` §4 for how
+params merge server-side).
+
+FE anatomy:
+
+- `frontend/micro-ui/web/src/dashboard/components/DashboardFilters.jsx` — the bar
+- `frontend/micro-ui/web/src/dashboard/config/globalFilterGroups.js` — field definitions
+  (`GLOBAL_FILTER_FIELDS`: dateFrom/dateTo/geography/complaintType), placeholder option lists,
+  and the sanitizer
+- `frontend/micro-ui/web/src/dashboard/config/dashboardFilters.js` — load/persist/reconcile
+- `frontend/micro-ui/web/src/dashboard/hooks/useDashboardFilters.js` — the store
+- `frontend/micro-ui/web/src/dashboard/hooks/useFilterOptions.js` — server-scoped option fetch
+  *(changed in PR #1075 — new file; before it the bar showed only the static "All wards"/"All
+  types" placeholders and `applyFilterOptions` was never invoked)*
+
+## 1. Where the options come from — scoped distincts via `_query`
+
+The ward and complaint-type dropdowns are populated from the **analytics API itself**, not from a
+separate masters call. `useFilterOptions` runs one inline batch `POST /v2/analytics/_query`:
+
+```js
+complaintTypes: { grain: "facts", window: { name: "all" },
+                  dimensions: ["service_code"], measures: [{ name: "n", agg: "count" }], limit: 300 }
+wards:          { grain: "facts", window: { name: "all" },
+                  dimensions: ["ward_code"], ... }
+```
+
+Because these run through the normal planner, the server-injected **ABAC row-scope applies to the
+option lists too** (`20-packs-and-rbac.md` layer 1): a Water-department supervisor's complaint-type
+dropdown contains only water types; a citizen-scoped caller only their own history's values. This
+is intentional — the option list is itself scoped data. Blank-code rows are dropped, options are
+label-sorted, and each list is prepended with its "all" sentinel. On failure the selects keep
+their placeholder lists — the dashboard is never blocked on options. *(Changed in PR #1075.)*
+
+**Labels**: option labels are derived from the code via the shared humanizer
+(`frontend/micro-ui/web/src/dashboard/config/labelFormat.js` `formatDimensionLabel`), because
+`ward_name` is not a groupable facts column. Complaint-type **labels and grouping** for tenants
+running the N-level taxonomy come from `RAINMAKER-PGR.ComplaintHierarchy` (node `name`/`path`);
+the dashboard FE does not read that master directly today — the grains bake its grouping in as
+`service_group` / `complaint_node_path` (see `50-sla-and-hierarchies.md` §hierarchies), and the
+humanizer covers display. TODO-verify once the #1079 grain columns land whether the filter bar
+switches its type dropdown to hierarchy-grouped options (`ComplaintHierarchy` labels) or stays on
+humanized codes.
+
+## 2. How selections travel
+
+`DashboardFilters` writes into `useDashboardFilters`; `AdminDashboard.jsx` translates the state
+into per-tile params: `dateFrom`/`dateTo` (ISO dates), `ward` (geography id unless `all`),
+`serviceCode` (complaint type id unless `all`). Server-side these can only **narrow** — RBAC
+scope is layered on top by the planner. Two server behaviors worth knowing when a filter "does
+nothing":
+
+- A param is applied only if the grain can express it (`ward_code`/`service_code` filterable) —
+  otherwise it is *silently skipped* for that tile (`KpiQueryComposer.applyEqFilter`).
+- **Live open snapshots ignore the date range** by design (`is_open` + no base window = point-in-
+  time metric; `KpiQueryComposer.isLiveOpenSnapshot`). "Open complaints" not shrinking when you
+  narrow the dates is correct behavior.
+
+## 3. Persistence and reconciliation against live options
+
+Selections persist per-browser in localStorage (keys from
+`config/dashboardConfig.js` `getFiltersStorageKey()` / `getSubMetricStorageKey()`).
+
+On load, `loadDashboardFilters()` runs `sanitizeFilters(stored, dynamicOptions)`
+(`globalFilterGroups.js`): each select keeps its stored value **only if it exists in the current
+option list** (`fieldOptions.some(opt => opt.id === value)`), otherwise it resets to the field
+default; dates must pass an ISO-date check. When the server-scoped options arrive,
+`reconcileFiltersWithOptions(filters, filterOptions)` re-runs the sanitize and re-persists only
+if something changed (`useDashboardFilters.js`). A `null`/absent options object deliberately does
+**not** blank anything (guard in `sanitizeFilters`) — no options yet ≠ options are empty.
+
+Net effect: a persisted ward that no longer exists — or that the *current* (differently-scoped)
+user is not allowed to see — is silently reset to "All" instead of being sent as a dead param.
+*(Effective end-to-end with PR #1075; before it, reconciliation only ran against the static
+placeholder lists.)*
+
+## 4. When an option "shows no data" — checklist
+
+A user picks a ward/type and tiles go empty or show "No data" (`KpiTile` renders a
+`kpi-tile--empty` placeholder per tile; tables render their `emptyMessage`; there is no global
+banner — each widget degrades independently. The map now stays mounted and overlays its empty
+state instead of unmounting Leaflet — *changed in PR #1076*).
+
+Check in this order:
+
+1. **Is it genuinely empty?** Run the tile's KPI by hand as the same user:
+   `POST /v2/analytics/_query` with `{"queries":{"t":{"kpiId":"<id>","params":{"ward":"<code>"}}}}`.
+   `rowCount: 0` with no `error` = real empty set.
+2. **RBAC scope intersection.** The option list is scoped, but scope can still shrink between
+   sessions (HRMS assignment changed). Check the response's `scope` object (`departments`,
+   `restrictedTo`) — a department-scoped user filtering to a type outside their departments
+   yields a legitimate empty intersection.
+3. **Stale persisted filter.** If the selection isn't in the current dropdown at all, clear the
+   dashboard's localStorage filter key (or the reconcile pass will fix it on next options load).
+4. **Grain can't express the filter.** Tiles on grains where the column isn't filterable ignore
+   the param (§2) — mixed dashboards can show some tiles narrowing and others not. That's
+   per-design; check the def's grain.
+5. **Data drift between the option source and the tile's grain.** Options come from `facts`;
+   a `daily`-grain tile only has rows since the daily snapshots began accumulating. Early
+   deployments have facts history but a short daily history.
+6. **MV staleness.** Compare the response `asOf` with now — see `60-operations.md`. A complaint
+   filed a minute ago is not in the grains until the next refresh cycle.
+7. **The SLA column specifically**: blank SLA values on the Complaint Type Details table were
+   the #1028 bug (SLA target only resolved from workflow config at the exact tenant). Fixed by
+   the MDMS-first COALESCE in this PR — see `50-sla-and-hierarchies.md`. The table also covers
+   all complaints (not week-to-date) since *PR #1074* removed its baked `wtd` window and its
+   `window` param default.

--- a/docs/dashboard-configuration/50-sla-and-hierarchies.md
+++ b/docs/dashboard-configuration/50-sla-and-hierarchies.md
@@ -1,0 +1,152 @@
+# 50 — SLA Semantics and Hierarchy Configuration
+
+This doc describes the **post-#1028 / post-#1079 end-state shipped in this PR** — both land in
+one migration:
+`backend/pgr-services/src/main/resources/db/migration/main/V20260708000000__sla_and_hierarchy_grains.sql`
+(+ the matching `AnalyticsCatalog`/`AnalyticsPlanner` changes).
+
+## 1. SLA: the three sources and their precedence
+
+`sla_target_ms` on the `complaint_facts` grain is the complaint's **overall resolution SLA
+target**. Since the `V20260708…` migration *(this PR — fixes #1028)* it is a per-complaint
+COALESCE over three sources, best first:
+
+| # | source | meaning | resolution |
+|---|---|---|---|
+| 1 | **MDMS `RAINMAKER-PGR.ServiceDefs.slaHours`** | per-subtype resolution SLA, in hours (`slaHours × 3,600,000` → ms) | deduped by `serviceCode`, preferring the record at the shortest (root-most) tenant |
+| 2 | **MDMS `RAINMAKER-PGR.EscalationConfig`** — SUM of `overrides.<serviceCode>` if present, else SUM of `defaultSlaByLevel` | the escalation ladder's *total*: these arrays are **per-assignment-level escalation timers in ms** (level 1 → level N), owned by the auto-escalation engine; their sum is used **only as a fallback** overall target | config record at the complaint's exact tenant, else its state root (`split_part(tenantid,'.',1)`), longest match first |
+| 3 | **workflow `eg_wf_businessservice_v2.businessservicesla`** | the legacy single constant per business service — last resort | exact tenant preferred, **state-root fallback** (also fixed in this migration; previously an exact-tenant join, which is why every `ke.*` complaint had a NULL target: the PGR business service exists only at `ke`) |
+
+Live shapes:
+
+```jsonc
+// ansible/nairobi-mdms/mdms/RAINMAKER-PGR/ServiceDefs.json (per subtype)
+{ "serviceCode": "NoWaterSupply", "slaHours": 72, "department": "DEPT_01", ... }
+
+// ansible/nairobi-mdms/mdms/RAINMAKER-PGR/EscalationConfig.json (one per state root)
+{ "maxDepth": 3, "defaultSlaByLevel": [3600000, 14400000, 86400000], "overrides": {} }
+```
+
+**Operator rule of thumb**: give every ServiceDefs row a real `slaHours` — that is the intended,
+operator-owned source. The ladder sum and workflow constant exist so the dashboard degrades
+sanely instead of blanking, not as places to configure resolution SLAs.
+
+### What derives from `sla_target_ms`
+
+All in `complaint_facts` (same migration):
+
+- `sla_breached` — open: `now - created_at > target`; resolved: `resolution > target`; `false`
+  when no target could be resolved anywhere.
+- `sla_status_bucket` — open complaints only: `breached` / `approaching` (>80% of target) /
+  `within`; NULL when closed or no target.
+- `sla_target_ms` itself is a measurable column (avg/percentile/sum) — the Complaint Type
+  Details table's SLA column reads it (blank SLA cells were the visible symptom of #1028).
+- `mdms_sla_hours` — the raw source-1 value, also measurable.
+- `sla_config_mismatch` — flags subtypes where MDMS `slaHours` disagrees with the workflow
+  constant (config-hygiene signal, semantics unchanged by #1028).
+
+KPIs riding on these (live `ke` catalog, `ansible/nairobi-mdms/mdms/dss/KpiDefinition.json`):
+`rs_breach_total`, `cl_sla_compliance_rate_count`, `cl_sla_noncompliance_rate_count`,
+`cl_resolved_on_time_rate_count`, the open-by-SLA-stage charts (`sla_status_bucket` dimension),
+and `cl_table_complaints_at_risk` (approaching/breached rows).
+
+Distinct and *not* affected: `current_state_sla_breached` / `state_sla_ms` (per-workflow-state
+dwell SLA from `eg_wf_state_v2.sla`) and `business_sla_ms` on the events grain (which now also
+gets the state-root fallback, fix 3).
+
+### Migration mechanics you must know
+
+- Recreating `complaint_events` CASCADE-drops `complaint_facts`, so the migration reproduces
+  both MVs in full. Flyway migrations are **append-only**: the grain definition now lives in
+  `V20260708…` (superseding `V20260629…`, which superseded `V20260608…`). If you change the
+  grain shape again, write a *new* migration reproducing the whole MV.
+- `complaint_open_state_daily` is **not** rewritten: historical snapshots keep the
+  `sla_breached`/`sla_status_bucket` values computed on their snapshot date; forward snapshots
+  pick up the new definition automatically (the scheduler copies them from `complaint_facts`).
+  Expect a step-change in backlog-breach trend charts at the migration date.
+
+## 2. Hierarchies: one pattern, two axes
+
+Both the jurisdiction (boundary) axis and the complaint-type axis follow the same design
+(issue #1079; design notes: `docs/dashboard-rbac-design/80-multi-tier-complaint-types.md`):
+a **materialized path column** carried losslessly on every grain row, plus a **level registry**
+that names the depths — so nothing assumes a fixed tree depth.
+
+| | boundary axis | complaint axis |
+|---|---|---|
+| path column | `boundary_path` | `complaint_node_path` *(this PR)* |
+| path source | `boundary_relationship.ancestralmaterializedpath \|\| '\|' \|\| code` | `RAINMAKER-PGR.ComplaintHierarchy.path` verbatim (keyed by `code == serviceCode`), with a recursive `parentCode` walk as fallback |
+| **delimiter** | `\|` (pipe), root-first | `.` (dot), root-first |
+| depth column | `boundary_depth` | `complaint_depth` (segment count) *(this PR)* |
+| level registry | `boundary_hierarchy` (level chain via `parentBoundaryType`) + per-node `boundary_relationship.boundarytype` | `RAINMAKER-PGR.ComplaintHierarchyDefinition.levels[]` (`levelCode`, `order`, `parentLevel`, `isLeafServiceCode`) + per-node `ComplaintHierarchy.levelCode` |
+| named level columns | `ward_code`, `zone_code`, + new `boundary_leaf_code`/`boundary_leaf_type` | `service_group`, new `service_parent_code`; `service_code` is always the leaf |
+
+### Registry-resolved named levels *(changed in this PR — #1079)*
+
+Previously the named columns were extracted **by position** (`split_part(boundary_path,'|',2)`
+= zone, `…,'|',3)` = ward — see the flagged lines in `V20260608000000`/`V20260629000000`), which
+mislabels or NULLs on any tree that isn't exactly `root > zone > ward`; and the complaint axis
+captured only leaf + immediate parent (`ServiceDefs.menuPath`). Now (per the `V20260708…`
+migration):
+
+- **`ward_code`** = the path segment whose `boundarytype` matches the tenant's *Ward* level
+  (case-insensitive, from the `boundary_hierarchy` registry); **`zone_code`** = the segment at
+  the level directly **above** ward (the ward level's `parentBoundaryType`). **Fallback** when
+  the tenant's hierarchy defines no Ward level: `ward_code` = the leaf segment, `zone_code` =
+  the parent of the leaf. `boundary_leaf_code` / `boundary_leaf_type` always carry the leaf node
+  regardless of depth.
+- **`service_group`** = the **root** category (first `complaint_node_path` segment), falling
+  back to legacy `ServiceDefs.menuPath` where a code has no hierarchy node;
+  **`service_parent_code`** = the leaf's immediate parent (identical to `service_group` on
+  2-level taxonomies, so existing `service_group` consumers are unaffected there). Node dedupe
+  prefers records at levels flagged `isLeafServiceCode` in `ComplaintHierarchyDefinition` —
+  registry leaf detection, not the old department-IS-NOT-NULL heuristic. `ServiceDefs` is still
+  joined for `mdms_sla_hours` / `service_order` / `department_code`.
+
+KPI defs keep referencing `ward_code`/`service_group` unchanged; only their derivation became
+depth-agnostic.
+
+### Prefix scoping and rollup on path columns *(this PR)*
+
+Path columns support a new **`starts_with`** filter operator, giving arbitrary-depth subtree
+rollups on both axes — e.g. `{"boundary_path": {"starts_with": "BOMET|CENTRAL"}}` or
+`{"complaint_node_path": {"starts_with": "WaterAndSanitation"}}` — the same mechanism the RBAC
+boundary row-scope already uses internally (`boundary_path LIKE '<escaped prefix>%'`; LIKE
+metacharacters are escaped so the value is a literal prefix). It is deliberately narrow: valid
+**only** on the per-grain `prefixFilterable` allowlist in `AnalyticsCatalog` (facts/events:
+`boundary_path` + `complaint_node_path`; daily: `boundary_path` only), and those path columns
+accept **only** `starts_with` — any other operator on them, or `starts_with` on a normal column,
+is rejected with `op_not_allowed` (`AnalyticsPlanner.predicate`).
+
+### Configuring the hierarchies (operator view)
+
+- **Boundary tree**: loaded per tenant via boundary-service (`boundary_hierarchy` +
+  `boundary_relationship`); the dashboard consumes whatever depth exists. Complaints attach to a
+  boundary via the address `locality`; rows whose locality has no relationship row get a NULL
+  path (they show under no ward — check boundary seeding, see `40-filters-and-options.md` §4).
+- **Complaint taxonomy**: `RAINMAKER-PGR.ComplaintHierarchyDefinition` declares the levels;
+  `RAINMAKER-PGR.ComplaintHierarchy` holds the nodes with `code`, `parentCode`, `path`,
+  `levelCode`, `name`. The grain trusts `ComplaintHierarchy.path` — keep it consistent when
+  hand-editing nodes (the configurator maintains it; a broken `path` misfiles analytics for that
+  subtype until the next refresh after the fix). Leaf detection uses
+  `ComplaintHierarchyDefinition.isLeafServiceCode`, not the "has a department" heuristic
+  *(this PR)*.
+- 2-level tenants that still ship only `ServiceDefs` (`menuPath` as the single grouping) remain
+  supported via the fallback derivation.
+- After **any** MDMS hierarchy/SLA edit, the grains pick it up on the next MV refresh cycle
+  (≤5 min by default) — the MDMS values are baked into the MVs at refresh time, not read live.
+  See `60-operations.md`.
+
+## 3. Extending the analytics catalog (developer)
+
+To expose a new dimension/measure (full recipe: `backend/pgr-services/ANALYTICS-QUERY-API.md` §8):
+
+1. Add the column in a **new** migration that reproduces the grain MV(s) (append-only rule
+   above; remember the events→facts CASCADE).
+2. Register it in the corresponding sets in
+   `backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsCatalog.java`
+   (`groupable` / `filterable` / `measurable` / `distinctable`; PII-adjacent columns: groupable +
+   distinctable only, never filterable).
+3. It is immediately queryable and self-describes via `/_schema` — no grammar change. A new
+   *grain* is the same recipe plus a `grains.put(...)` entry (set its tenant/boundary/citizen/
+   department scope columns, or constrained principals will get `scope_incomplete` on it).

--- a/docs/dashboard-configuration/60-operations.md
+++ b/docs/dashboard-configuration/60-operations.md
@@ -1,0 +1,126 @@
+# 60 — Operations: Freshness, Bootstrap, Redeploys
+
+## 1. Materialized-view refresh — how the numbers get fresh
+
+The dashboard never reads live transactional tables; every KPI reads the grains
+(`complaint_facts`, `complaint_events` — materialized views — and the
+`complaint_open_state_daily` table).
+
+**One scheduler refreshes everything**:
+`backend/pgr-services/src/main/java/org/egov/pgr/service/DashboardRefreshScheduler.java`, every
+`pgr.dashboard.refresh.interval.ms` (default **300000 = 5 min**, gated by
+`pgr.dashboard.refresh.enabled=true` — both in `backend/pgr-services/src/main/resources/application.properties`).
+Per run, in order:
+
+1. **V2 grains, dependency order**: `complaint_events` then `complaint_facts` (facts is built
+   FROM events) — `REFRESH MATERIALIZED VIEW CONCURRENTLY`, each wrapped in its own try/catch so
+   one failure only logs a warning and the rest proceed.
+2. **Daily backlog capture**: idempotent upsert into `complaint_open_state_daily` (one row per
+   still-open complaint per day; `ON CONFLICT (snapshot_date, service_request_id) DO NOTHING` —
+   the day's backlog is fixed at its **first** capture that day).
+3. **Legacy MVs** (back-compat, superseded by the grains): `pgr_mv_kpi`, `pgr_mv_monthly`,
+   `pgr_mv_monthly_source`, `pgr_mv_dimension`
+   (from `V20260422000000__create_dashboard_mvs.sql`).
+
+> Historical note: `backend/pgr-services/ANALYTICS-QUERY-API.md` §9 still says the scheduler
+> "does not yet include" the V2 grains, and some migration headers say "MVs are refreshed
+> manually in ops" — both predate the scheduler covering the grains; the scheduler above is the
+> current source of truth. (TODO-verify: update those stale mentions; if a given deployment
+> runs with `pgr.dashboard.refresh.enabled=false`, the manual commands below ARE the refresh
+> story there.)
+
+**Manual refresh** — needed right after a data backfill, an MDMS SLA/hierarchy edit you want
+reflected *now*, or on an instance running with the scheduler disabled:
+
+```sql
+-- order matters; CONCURRENTLY works because every MV has the required unique index
+-- (ux_complaint_events, ux_complaint_facts, pgr_mv_*_idx)
+REFRESH MATERIALIZED VIEW CONCURRENTLY complaint_events;
+REFRESH MATERIALIZED VIEW CONCURRENTLY complaint_facts;
+REFRESH MATERIALIZED VIEW CONCURRENTLY pgr_mv_kpi;
+REFRESH MATERIALIZED VIEW CONCURRENTLY pgr_mv_monthly;
+REFRESH MATERIALIZED VIEW CONCURRENTLY pgr_mv_monthly_source;
+REFRESH MATERIALIZED VIEW CONCURRENTLY pgr_mv_dimension;
+```
+
+(`psql` into the pgr-services database; on compose deployments:
+`docker exec -it <postgres-container> psql -U <user> -d <db>`.) Do **not** hand-insert into
+`complaint_open_state_daily`; the scheduler's upsert owns it.
+
+Remember: MDMS masters (ServiceDefs SLA, EscalationConfig, ComplaintHierarchy, department
+mapping) are **baked into the grains at refresh time** — an MDMS edit is invisible to the
+dashboard until the next refresh cycle.
+
+## 2. `asOf` — the staleness signal
+
+Every `/v2/analytics/_query` response carries `asOf` = `SELECT max(facts_built_at) FROM
+complaint_facts` (`AnalyticsService.asOf()`), i.e. the epoch-ms wall-clock of the last successful
+facts build (each refresh stamps `facts_built_at = now()`). Consumers should treat it as "data
+current as of": with the default interval the dashboard lags reality by up to ~5 min. The FE
+shows it in the header/tile stamps (`frontend/micro-ui/web/src/dashboard/components/DashboardHeader.jsx`,
+`CardUpdatedStamp.jsx`), and the server itself uses `asOf` as the clock authority for
+elapsed-time compose math.
+
+**An old `asOf` is your primary "refresh is broken" alarm** — check pgr-services logs for
+`Failed to refresh <mv>` warnings (a failed refresh does not crash anything; it just goes stale).
+Caveat: `/packs` returns `asOf = System.currentTimeMillis()` (schema bootstrap, no data) — only
+`_query`'s `asOf` measures data freshness.
+
+## 3. Tenant bootstrap — what a new tenant does and doesn't get
+
+`tenant_bootstrap` (and `city_setup` / `city_setup_from_xlsx`) in
+`digit-mcp/src/tools/mdms-tenant.ts` copy MDMS masters from the source root to a new tenant via
+an explicit allowlist (`essentialSchemas`, ~line 1276). Relevant to the dashboard:
+
+**Copied**: `ACCESSCONTROL-ACTIONS-TEST.actions-test`, `ACCESSCONTROL-ROLES.roles`,
+`ACCESSCONTROL-ROLEACTIONS.roleactions` (+ the ACTIONS bridge, `30-view-access.md` §5),
+`tenant.citymodule`, `common-masters.StateInfo`/branding, `RAINMAKER-PGR.UIConstants`,
+`Workflow.*`, `INBOX.InboxQueryConfiguration` — i.e. the **view-access surface** arrives.
+
+**NOT copied — the `dss.*` allowlist gap**: no `dss.KpiDefinition`, no `dss.DashboardPack`
+(zero references to `dss` in `digit-mcp/src`). Also `RAINMAKER-PGR.ComplaintHierarchy` is
+*deliberately* excluded (operator-loaded in configurator Phase 3).
+
+Mitigations:
+
+- **New city under an existing state root** (`ke.newcity`): nothing to do — the KPI catalog is
+  read at the **state root** (`KpiCatalogService` collapses the tenant), so city tenants inherit
+  `ke`'s defs/packs automatically. This is why the gap rarely bites on Bomet/Nairobi-shaped
+  installs.
+- **New state root** (`mz`, `pg.x` as its own root): seed `dss.KpiDefinition` +
+  `dss.DashboardPack` yourself (copy `ansible/nairobi-mdms/mdms/dss/*.json`, rewrite `tenantId`,
+  mdms-v2 `_create`), or the dashboard renders empty (`/packs` returns no tiles; the service
+  logs "MDMS path not found for dss.KpiDefinition" and gracefully returns empty).
+
+## 4. What a redeploy wipes — never hand-patch bundles
+
+The canonical converge (`local-setup/ansible/deploy.sh <tenant>` →
+`local-setup/ansible/playbook-deploy.yml`) **overwrites the served frontend on every run**: the
+static-mode task pulls the `digit_ui_bundle_image`, `docker cp`s the bundle out, and
+`rsync -a --delete`s it into the nginx-served `/opt/digit-ui-esbuild/build/`. `--delete` means
+any file you hand-edited in the served bundle is gone; the repo checkout itself is force-cleaned
+to the target ref earlier in the play. On Bomet the nightly cron additionally resets `/opt/ccrs`
+to `origin/develop`, rebuilds `nightly-develop` images, and re-converges — **every** manual
+patch on the box (source or bundle) has a lifespan of one night.
+
+Therefore:
+
+- FE dashboard changes (KpiTile kinds, filter bar, hooks) go through
+  `frontend/micro-ui/web/src/dashboard/` → PR → image/bundle. Never patch `/opt/*/build/`.
+- Backend/grain changes go through `backend/pgr-services` source + a Flyway migration → rebuilt
+  image (never patch JARs in containers).
+- **MDMS-backed dashboard state survives redeploys** (it lives in the DB) — but keep the ansible
+  seed files (`ansible/nairobi-mdms/mdms/dss/*.json`, `tenant/citymodule.json`,
+  `ACCESSCONTROL-*/*.json`) in sync with what you upsert by hand, because fresh installs and
+  repro environments are seeded from those files, and drift between DB and seed is how "works on
+  bomet, empty on the repro box" happens.
+
+## 5. Quick health checklist
+
+1. `POST /v2/analytics/_query` (any KPI) → is `asOf` within ~2× the refresh interval?
+2. `pgr.dashboard.refresh.enabled=true` and no `Failed to refresh` warnings in pgr-services logs?
+3. `POST /v2/analytics/packs` as a supervisor → non-empty `tiles` + `defaultLayout`? (Empty ⇒
+   `dss.*` missing at the state root, §3, or role not in any pack, `20-packs-and-rbac.md`.)
+4. Dashboard reachable? (Home card / sidebar ⇒ `30-view-access.md`.)
+5. Tiles empty for one user only? ⇒ RBAC scope, `20-packs-and-rbac.md` layer 1 and
+   `40-filters-and-options.md` §4.

--- a/docs/dashboard-configuration/README.md
+++ b/docs/dashboard-configuration/README.md
@@ -1,0 +1,61 @@
+# Configuring the CCRS Supervisor Dashboard
+
+Operator/developer documentation for the catalog-driven supervisor dashboard: pgr-services'
+dynamic analytics API (`/v2/analytics/*`) + the MDMS `dss` catalog + the digit-ui dashboard
+frontend. Two audiences:
+
+- **Operators / implementers** — configure a deployment through MDMS. Almost everything a
+  deployment needs to change is data: **no rebuild, no deploy, no restart.**
+- **Developers** — extend the platform: new grain columns, planner/catalog changes, new FE viz
+  kinds.
+
+## The config surface at a glance
+
+| you want to change | mechanism | deploy needed? | doc |
+|---|---|---|---|
+| add / edit / retire a KPI tile (query, viz, thresholds, params) | MDMS `dss.KpiDefinition` (state root) | **No** | [10-kpi-catalog.md](10-kpi-catalog.md) |
+| which roles see which KPI | `rbac.visibleTo` on the def | **No** | [10](10-kpi-catalog.md) §7, [20](20-packs-and-rbac.md) |
+| default tile set + grid layout per role | MDMS `dss.DashboardPack` | **No** | [20-packs-and-rbac.md](20-packs-and-rbac.md) |
+| expose a KPI to anonymous/public | add `"PUBLIC"` to `visibleTo` | **No** | [20](20-packs-and-rbac.md) §2 |
+| which rows a user's tiles aggregate (department scoping) | HRMS assignments (+ role choice) | **No** | [20](20-packs-and-rbac.md) layer 1 |
+| home card / module mount for the dashboard | MDMS `tenant.citymodule` | **No** | [30-view-access.md](30-view-access.md) |
+| sidebar entry + role gating of the view | MDMS `ACCESSCONTROL-ACTIONS-TEST` + `ACCESSCONTROL-ROLEACTIONS` | **No** | [30-view-access.md](30-view-access.md) |
+| menu/card labels | localization `_upsert` + cache bust | **No** | [30](30-view-access.md) §3–4 |
+| per-subtype resolution SLA | MDMS `RAINMAKER-PGR.ServiceDefs.slaHours` | **No** (next MV refresh) | [50-sla-and-hierarchies.md](50-sla-and-hierarchies.md) |
+| escalation ladder timers | MDMS `RAINMAKER-PGR.EscalationConfig` | **No** (next MV refresh) | [50](50-sla-and-hierarchies.md) §1 |
+| complaint-type taxonomy (N-level) | MDMS `RAINMAKER-PGR.ComplaintHierarchy(+Definition)` | **No** (next MV refresh) | [50](50-sla-and-hierarchies.md) §2 |
+| filter-bar option lists | derived automatically (ABAC-scoped distincts) | **No** | [40-filters-and-options.md](40-filters-and-options.md) |
+| MV refresh cadence / freshness | `pgr.dashboard.refresh.*` properties | restart pgr-services | [60-operations.md](60-operations.md) |
+| new queryable column / grain | Flyway migration + `AnalyticsCatalog` registration | **Yes** (pgr-services image) | [50](50-sla-and-hierarchies.md) §3 |
+| SLA precedence / grain shape | Flyway migration (append-only; reproduce the MVs) | **Yes** | [50](50-sla-and-hierarchies.md) |
+| new `viz.kind` / render behavior | `KpiTile.jsx` + dashboard components | **Yes** (FE bundle) | [10](10-kpi-catalog.md) §3 |
+| scope-resolution policy (HRMS → policy engine) | `PrincipalScopeResolver` ("the seam") | **Yes** | [20](20-packs-and-rbac.md) layer 1 |
+
+Rule of thumb: **tenant-specific values live in MDMS, never in code.** If you find yourself
+wanting to hardcode a deployment's ward list, SLA, or role name in the FE or a service — stop
+and find the master.
+
+## The documents
+
+| doc | contents |
+|---|---|
+| [10-kpi-catalog.md](10-kpi-catalog.md) | `dss.KpiDefinition` anatomy: query grammar essentials, every `viz.kind`, params & server-side defaults, status lifecycle, versioning, and the add-a-KPI-end-to-end cookbook |
+| [20-packs-and-rbac.md](20-packs-and-rbac.md) | `dss.DashboardPack` (roles/tiles/12-col layout), the four RBAC layers (row-scope ABAC, `visibleTo`, inline PII gate, public floor), error-code table, which knob grants what |
+| [30-view-access.md](30-view-access.md) | Reaching the dashboard in digit-ui: citymodule, actions/roleactions + `/access/v1/actions/mdms/_get`, localization keys, the three-layer cache-bust story, and the mdms-v2 operational gotchas |
+| [40-filters-and-options.md](40-filters-and-options.md) | Where the global filter bar's options come from (scoped `_query` distincts), persistence/reconciliation, and the "option shows no data" checklist |
+| [50-sla-and-hierarchies.md](50-sla-and-hierarchies.md) | SLA target: the three sources and COALESCE order (post-#1028); boundary & complaint hierarchies as materialized path + level registry (post-#1079); extending the catalog |
+| [60-operations.md](60-operations.md) | MV refresh scheduler + manual REFRESH commands, the `asOf` staleness signal, tenant-bootstrap coverage (and the `dss.*` gap), what a redeploy wipes |
+
+## Primary sources (cross-linked throughout)
+
+- Query grammar reference: `backend/pgr-services/ANALYTICS-QUERY-API.md`
+- RBAC design series: `docs/dashboard-rbac-design/`
+- Live MDMS examples: `ansible/nairobi-mdms/mdms/dss/KpiDefinition.json`, `DashboardPack.json`
+- Backend: `backend/pgr-services/src/main/java/org/egov/pgr/analytics/`
+- Frontend: `frontend/micro-ui/web/src/dashboard/`
+- Grain migrations: `backend/pgr-services/src/main/resources/db/migration/main/V20260608*/V20260629*/V20260708*`
+
+In-flight changes referenced with "changed in PR #NNNN" notes: server-side params defaults +
+SLA-target COALESCE (**this PR**, #1028/#1026), Complaint Type Details all-time coverage
+(**#1074**), ABAC-scoped filter options (**#1075**), map mounted through empty results
+(**#1076**), registry-driven hierarchy levels (**#1079**, companion change on this branch).


### PR DESCRIPTION
## Summary
One grain rebuild, three coordinated changes (per maintainer decision), plus the dashboard-configuration docs.

Fixes #1028. Implements #1079.

### 1. SLA sourcing (#1028)
`sla_target_ms` was the workflow `businessservicesla` joined on **exact tenant** — NULL for every city-tenant complaint (blank SLA column in Complaint Type Details; `sla_breached`/compliance KPIs silently undercounting — 118 open complaints could never breach). New definition, per the decided semantics:
```
sla_target_ms = COALESCE(
  ServiceDefs.slaHours → ms,                     -- per-subtype resolution SLA (MDMS)
  EscalationConfig ladder total,                 -- per-type overrides, else summed defaultSlaByLevel
  workflow SLA (join falls back to state root))  -- legacy last resort
```
Escalation timers are per-assignment-level clocks, so only the **ladder sum** is used, and only as a fallback.

### 2. Registry-driven hierarchy grains (#1079)
- `ward_code`/`zone_code` resolved from `boundary_hierarchy` types instead of `split_part` positions (leaf/parent-of-leaf fallback for tenants without a Ward level); new `boundary_leaf_code`/`boundary_leaf_type`.
- Complaint axis: `complaint_node_path` (from `ComplaintHierarchy.path`, recursive `parentCode` fallback), `complaint_depth`, `service_parent_code`; `service_group` = **root category** (byte-compatible on 2-level taxonomies); leaf detection from `ComplaintHierarchyDefinition.isLeafServiceCode`.
- Planner: new `starts_with` prefix operator (parameterized, LIKE-metachar-escaped) allowed **only** on `boundary_path`/`complaint_node_path`; `_schema` exposes the new columns and operator.

### 3. `params[].default` applied server-side
Declared KPI param defaults were parsed but never applied (dead config). Precedence: explicit caller > declared default > baked query. The now-obsolete window default on `cl_table_complaint_type_details` is stripped in the same file so #1074's all-complaints intent survives (different hunks than #1074; trivial rebase for whichever lands second).

### Docs
`docs/dashboard-configuration/` — 7-part operator/developer guide: what lives in MDMS vs code, KPI catalog + query grammar cookbook, packs & the four RBAC layers, view access via ACS (with the mdms-v2 operational gotchas), filter options, SLA & hierarchy semantics (this PR's end-state), and operations (refresh scheduler, bootstrap coverage).

## Validation (read-only probes on the live bomet DB; both full MV bodies executed)
| Check | Result |
|---|---|
| `sla_target_ms` coverage | 299 → **436/436** (tiers: 406 ServiceDefs, 30 ladder, 0 workflow; all 137 city-tenant NULLs resolved) |
| `sla_breached` | 217 → **350** (undercount fixed); never-breach opens 118 → **0** |
| ward/zone registry vs positional | **436/436 identical** |
| `service_group` root==parent (2-level compat) | **403/403** |
| ComplaintHierarchy path vs recursive rebuild | **447/447** |
| `mvn compile` | clean |

Byte-diffs vs the old `service_group` exist only where bomet's master data is stale/polluted (e.g. 163 rows get the *correct* post-#917 `StaffMisconductGroup`); side-finding logged: 308/446 `ke` ComplaintHierarchy records carry junk `complaints.categories.*` paths — data cleanup, deliberately not coded around.

## Deploy notes
- New flyway migration `V20260708000000__sla_and_hierarchy_grains.sql` recreates both grain MVs; `DashboardRefreshScheduler` picks them up on its 5-minute cycle — no manual refresh step.
- Historical breach numbers move up (that's the fix); `complaint_open_state_daily` history is untouched.

Related: #1074 #1075 #1076 (same bug-family, separate one-concern PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)