### PR TITLE
feat(pgr): assignee dropdown scoped by the routed department (additionalDetail stamp)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
@@ -27,6 +27,17 @@ import { selectServiceDefsFromComplaintHierarchy } from "../../utils";
 //   • comments        — always
 // Per-action extras can later be driven by an MDMS master (RAINMAKER-PGR.WorkflowActionUiConfig)
 // without touching this code.
+// additionalDetail arrives as an OBJECT on some complaints and a JSON STRING on
+// others (citizen create sends "{}", employee create sends a stringified object).
+// Parse both shapes; anything unparseable is treated as empty.
+const parseAdditionalDetail = (ad) => {
+  if (ad && typeof ad === "object") return ad;
+  if (typeof ad === "string") {
+    try { const o = JSON.parse(ad); return o && typeof o === "object" ? o : {}; } catch (e) { return {}; }
+  }
+  return {};
+};
+
 const buildActionFormConfig = ({ action, assigneeRoles = [], isTerminal = false, docUploadRequired = false, assigneeMandatory }) => {
   const body = [];
   if (action === "REJECT") {
@@ -265,10 +276,9 @@ const PGRDetails = () => {
     // department is picked (REJECT/RESOLVE etc. leave additionalDetail untouched).
     const baseService = pgrData?.ServiceWrappers[0].service;
     const assigneeDept = _data?.SelectedAssignee?.department;
-    const baseAdditionalDetail =
-      baseService?.additionalDetail && typeof baseService.additionalDetail === "object"
-        ? baseService.additionalDetail
-        : {};
+    // Parse (object OR stringified) so stamping never discards existing keys
+    // like supervisorName / serviceName that older flows stored as a string.
+    const baseAdditionalDetail = parseAdditionalDetail(baseService?.additionalDetail);
     const updateRequest = {
       service: assigneeDept
         ? { ...baseService, additionalDetail: { ...baseAdditionalDetail, department: assigneeDept } }
@@ -315,7 +325,14 @@ const PGRDetails = () => {
   // Enhance config with roles and department dynamically
   const getUpdatedConfig = (selectedAction, workflowData, configs, serviceDefs, complaintData) => {
     const def = serviceDefs?.find((d) => d.serviceCode === complaintData?.ServiceWrappers[0]?.service?.serviceCode);
-    const department = def?.department;
+    // Assignee-scoping department, in precedence order:
+    //   1. the complaint TYPE's mapped department (MDMS — authoritative, backend enforces it)
+    //   2. the ROUTED department stamped on additionalDetail at the previous ASSIGN
+    //      (screening picked the department; every later stage stays inside it)
+    //   3. none -> the assignee list stays unscoped (all departments, grouped)
+    const typeDept = def?.department;
+    const routedDept = parseAdditionalDetail(complaintData?.ServiceWrappers?.[0]?.service?.additionalDetail)?.department;
+    const department = typeDept && typeDept !== "NA" ? typeDept : routedDept || typeDept;
     // Build the modal form generically from workflow metadata — no hardcoded per-action allowlist,
     // so ANY action defined on the BusinessService (standard PGR + the CMS workflow) renders a form.
     const actionConfig = { formConfig: buildActionFormConfig({ ...selectedAction, assigneeMandatory: isAssigneeMandatory(selectedAction) }) };


### PR DESCRIPTION
## Model
On deployments where complaint types are deliberately **not** mapped to departments, routing is human: central screening picks the department by assigning that department's supervisor. The assignee's department is already stamped onto `additionalDetail.department` at ASSIGN (and REJECT/RESOLVE deliberately never stamp).

## Gap fixed
Later stages ignored the stamp — a supervisor's assignee dropdown showed **every** department's case managers. Now the scoping department resolves in precedence order:
1. complaint **type's** mapped department (MDMS — authoritative, backend-enforced)
2. the **routed** department stamped at the previous ASSIGN ← the new part
3. none → unscoped (all departments, grouped)

Screening (`CMS_SCREENING_OFFICER`) keeps the all-departments view — routing is their job.

## Hardening included
`additionalDetail` arrives as an object on some complaints and a JSON **string** on others; both the read and the stamp-merge now parse either shape (previously stamping silently discarded string-stored keys like `supervisorName`).

## Behavior matrix
| Type dept | Stamp | Non-screening assignee list |
|---|---|---|
| mapped | — | that department (unchanged, backend enforces) |
| NA | present | **the routed department only** ← new |
| NA | absent (legacy/pre-routing) | all departments, grouped (unchanged) |

## Testing (local mz.igsae)
- Unmapped type routed by screening to a BUSINESS_OPS supervisor → supervisor's ASSIGN list shows **only BUSINESS_OPS** (the EDUCATION_OPS case manager no longer appears); REASSIGN → screening re-routes to a different department → stamp overwrites → next supervisor scoped to the new department.
- Mapped type unchanged; REJECT leaves additionalDetail untouched; complaints with string additionalDetail keep their existing keys after stamping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)