### PR TITLE
fix(pgr): restore masked extended attributes on complaint update

### DIFF
--- a/backend/pgr-services/src/main/java/org/egov/pgr/service/EncryptionDecryptionService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/service/EncryptionDecryptionService.java
@@ -14,6 +14,8 @@ import org.springframework.web.client.RestTemplate;
 
 import java.util.*;
 
+import static org.egov.pgr.util.PGRConstants.MASK_SENTINEL;
+
 /**
  * Encrypt/decrypt/mask extendedAttributes fields via egov-enc-service.
  *
@@ -104,10 +106,10 @@ public class EncryptionDecryptionService {
         try {
             List<String> plains = callDecryptBatch(ciphers);
             for (int i = 0; i < keys.size(); i++)
-                ext.putField(keys.get(i), i < plains.size() ? plains.get(i) : "****");
+                ext.putField(keys.get(i), i < plains.size() ? plains.get(i) : MASK_SENTINEL);
         } catch (Exception e) {
             log.error("Batch decryption failed for fields {}; masking values", keys, e);
-            keys.forEach(k -> ext.putField(k, "****"));
+            keys.forEach(k -> ext.putField(k, MASK_SENTINEL));
         }
 
         return ext;
@@ -121,7 +123,7 @@ public class EncryptionDecryptionService {
         if (ext == null || ext.getDynamicFields() == null || ext.getDynamicFields().isEmpty())
             return ext;
         new ArrayList<>(ext.getDynamicFields().keySet())
-                .forEach(k -> ext.putField(k, "****"));
+                .forEach(k -> ext.putField(k, MASK_SENTINEL));
         return ext;
     }
 

--- a/backend/pgr-services/src/main/java/org/egov/pgr/service/PGRService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/service/PGRService.java
@@ -26,6 +26,7 @@ import static org.egov.pgr.util.PGRConstants.MDMS_DEPARTMENT_SEARCH;
 import static org.egov.pgr.util.PGRConstants.MDMS_DEPARTMENT_NAME_SEARCH;
 import static org.egov.pgr.util.PGRConstants.MDMS_SERVICENAME_SEARCH;
 import static org.egov.pgr.util.PGRConstants.ROLE_CONFIDENTIAL_VIEWER;
+import static org.egov.pgr.util.PGRConstants.MASK_SENTINEL;
 
 import java.util.stream.Collectors;
 
@@ -230,6 +231,7 @@ public class PGRService {
 			if (cfg == null)
 				throw new CustomException("INVALID_CASE_RELATED_TO",
 						"No MDMS config found for caseRelatedTo: " + updatedExt.getCaseRelatedTo());
+			restoreMaskedPlaceholders(updatedExt, updateService.getId(), tenantId);
 			extendedAttributesValidationService.validate(updatedExt, cfg, updateService);
 			plainExt = updatedExt.copy(); // snapshot before encrypt — avoids decrypt round-trip for response
 			updateService.setExtendedAttributes(
@@ -342,6 +344,35 @@ public class PGRService {
             if (cfg != null) cache.put(cat, cfg);
         }
         return cache;
+    }
+
+    /**
+     * Clients that fetched a complaint while it was masked (e.g. a transient MDMS lookup
+     * failure, or the citizen UI caching a stale view) may echo the "****" sentinel back
+     * on a later update — the citizen RATE flow resubmits the whole cached service object.
+     * Restore the currently-stored value for any field the client sends back as the
+     * sentinel, so a masked placeholder never permanently overwrites real data.
+     */
+    private void restoreMaskedPlaceholders(ExtendedAttributes updatedExt, String serviceId, String tenantId) {
+        boolean hasMasked = updatedExt.getDynamicFields().values().stream().anyMatch(MASK_SENTINEL::equals);
+        if (!hasMasked) return;
+
+        RequestSearchCriteria criteria = RequestSearchCriteria.builder()
+                .ids(Collections.singleton(serviceId)).tenantId(tenantId).build();
+        criteria.setIsPlainSearch(false);
+        List<ServiceWrapper> existing = repository.getServiceWrappers(criteria);
+        if (CollectionUtils.isEmpty(existing)) return;
+
+        ExtendedAttributes existingExt = existing.get(0).getService().getExtendedAttributes();
+        if (existingExt == null) return;
+
+        new ArrayList<>(updatedExt.getDynamicFields().keySet()).forEach(key -> {
+            if (MASK_SENTINEL.equals(updatedExt.getField(key))) {
+                Object existingValue = existingExt.getField(key);
+                if (existingValue != null) updatedExt.putField(key, existingValue);
+                else updatedExt.removeField(key);
+            }
+        });
     }
 
     /**

--- a/backend/pgr-services/src/main/java/org/egov/pgr/util/PGRConstants.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/util/PGRConstants.java
@@ -174,8 +174,11 @@ public class PGRConstants {
     // Extended attributes — complaint category config and field schemas
     public static final String MDMS_COMPLAINT_RELATED_TO_MAP = "ComplaintRelatedToMap";
     public static final String MDMS_COMPLAINT_TEMPLATE_TYPE  = "ComplaintTemplateType";
-    public static final String MDMS_COMPLAINT_SCHEMA         = "ComplaintSchema";
+    public static final String MDMS_COMPLAINT_SCHEMA         = "ComplaintExtendedAttributeSchema";
 
     public static final String ROLE_CONFIDENTIAL_VIEWER = "CONFIDENTIAL_COMPLAINT_VIEWER";
+
+    // Placeholder written over dynamic fields the caller isn't authorized to see in plaintext.
+    public static final String MASK_SENTINEL = "****";
 
 }


### PR DESCRIPTION
- Extract mask sentinel "****" to MDMS_COMPLAINT_SCHEMA constant for consistency
- Add restoreMaskedPlaceholders() method to prevent masked placeholders from overwriting real data when clients echo cached complaint objects
- Invoke restoreMaskedPlaceholders() before validation to restore current stored values for any fields sent back as sentinel
- Update EncryptionDecryptionService to use MASK_SENTINEL constant instead of hardcoded strings
- Correct MDMS constant name from ComplaintSchema to ComplaintExtendedAttributeSchema When a client caches and resubmits a masked complaint (e.g., during RATE flow), the masked placeholder should not permanently replace the actual stored value. This ensures data integrity when authorization changes or MDMS lookups recover from transient failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing complaint details when updating records with masked dynamic fields, preventing hidden placeholder values from overwriting real data.
  * Improved handling of masked fields during decryption so unavailable values are consistently shown as masked.

* **Chores**
  * Updated complaint metadata mapping to use the latest extended attribute schema.
  * Standardized the masking placeholder used across complaint-related flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->