### PR TITLE
fix(pgr): citizen location step NEXT dead-locked after clearing the pin; boundary leaf check + locality precedence

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
@@ -391,9 +391,14 @@ function mapFormDataToRequest(formData: FormData, tenantId: string, user: any, d
         street: "",
         pincode: validateString(formData?.postalCode),
         locality: {
+          // SelectedBoundary FIRST: it is the confirmed cascade value (a real
+          // boundary-tree code, and the user's manual correction when they
+          // overrode the pin's auto-fill). The raw ward hint is only a
+          // fallback — it comes from the GeoJSON resolver and may not even be
+          // a valid tree code (e.g. KILIMANI vs NAIROBI_CITY_KILIMANI).
           code:
-            formData?.GeoLocationsPoint?.ward?.code ||
             formData?.SelectedBoundary?.code ||
+            formData?.GeoLocationsPoint?.ward?.code ||
             "",
         },
         geoLocation: validateGeoLocation({
@@ -433,8 +438,13 @@ function isFieldValid(data: FormData, fieldKey: keyof FormData | string): boolea
     case "SelectedBoundary": {
       const sb = data.SelectedBoundary;
       if (sb?.code) {
-        // Must be a leaf (no children) — mirrors the citizen-side fix in
-        // FormExplorer (egovernments/CCRS#478).
+        // Trust the emitter's isLeaf tag first (BoundaryComponent computes it
+        // from hierarchy depth precisely because `.children` isn't reliable —
+        // a tree deeper than the rendered levels leaves children on the
+        // deepest PICKABLE node, which dead-locked NEXT with every dropdown
+        // filled). The children check stays as fallback for untagged values
+        // (mirrors the FormExplorer fix, egovernments/CCRS#478).
+        if (typeof sb.isLeaf === "boolean") return sb.isLeaf;
         return !Array.isArray(sb.children) || sb.children.length === 0;
       }
       return false;
@@ -2011,11 +2021,12 @@ const CreatePGRFlowV2: React.FC = () => {
         return true;
       }
       case "where":
-        // Map pin + a leaf ward (auto-cascaded from the pin; manual fallback).
-        return (
-          isFieldValid(formData, "GeoLocationsPoint") &&
-          isFieldValid(formData, "SelectedBoundary")
-        );
+        // A leaf ward is what routing needs; the map pin is the fast path to
+        // it (auto-cascade) but NOT mandatory — clearing the pin (the map's ✕)
+        // and picking the cascade manually is a supported flow, and requiring
+        // the pin left NEXT disabled with every dropdown filled. Payload-safe:
+        // validateGeoLocation falls back to {} exactly like the employee flow.
+        return isFieldValid(formData, "SelectedBoundary");
       case "details": {
         if (!isFieldValid(formData, "description")) return false;
         // Mandatory dynamic fields (dispatcher flow).


### PR DESCRIPTION
## Problem (reported while testing #1093)

On the citizen "where" step, the map pin auto-fills the boundary cascade correctly — but **NEXT sometimes stays disabled even with every boundary dropdown filled**:

1. Clearing the pin (the map's ✕) and picking the cascade manually could never proceed — the step gate required `GeoLocationsPoint` **and** `SelectedBoundary`, so the manual path was dead with no feedback.
2. On boundary trees deeper than the rendered hierarchy levels, the deepest *pickable* node still carries `children` in the tree — and validity was judged by `children` emptiness, dead-locking NEXT with everything filled. The emitters tag `isLeaf` precisely because `children` can't be trusted; the validator never used it.

## Fix

- The "where" step now gates on the **leaf boundary alone**; the pin remains the fast path (auto-cascade) but is no longer mandatory. Payload-safe: without a pin, `validateGeoLocation` falls back to `{}` — exactly what the employee flow always sends (the persister's leaf-to-null handles missing lat/lng keys; only a missing `geoLocation` object crashes the address insert).
- `isFieldValid(SelectedBoundary)` trusts the emitter's `isLeaf` tag when present, with the `children` check kept as fallback for untagged values (CCRS#478 lineage).
- Submit payload's `locality.code` now prefers **`SelectedBoundary.code`** (the confirmed cascade value / the user's manual correction) over the raw GeoJSON ward hint — the hint may not even be a valid boundary-tree code (`KILIMANI` vs `NAIROBI_CITY_KILIMANI`) and silently overrode manual corrections at submit.

## Testing (local, deployed)

- Pin → auto-fill → ✕ the pin → pick Província/Distrito/Município manually → NEXT enables; create succeeds and the complaint is searchable (address row persists with `geoLocation: {}`).
- Pin → manually correct the Município → submitted complaint carries the corrected code.
- Pin + auto-fill untouched → unchanged behavior.

Follow-up to #1093 (this commit was pushed to that branch moments after it merged, so it's re-raised here on a clean branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)