### PR TITLE
fix(pgr): employee create-complaint page crashes to error boundary (TDZ from #1093)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/employee/CreateComplaint/createComplaintForm.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/CreateComplaint/createComplaintForm.js
@@ -45,7 +45,10 @@ const CreateComplaintForm = ({
   // mismatch: after a ULB switch (ChangeCity) or a re-login, restoring the old
   // tenant's SelectComplaintType/SelectedBoundary would submit foreign codes
   // under the new tenant while the pickers render blank.
-  const draftUserUuid = user?.info?.uuid;
+  // NOTE: read the user directly — `const user` is declared further down and
+  // referencing it here is a temporal-dead-zone ReferenceError that crashed
+  // the whole page to the error boundary.
+  const draftUserUuid = Digit.UserService.getUser()?.info?.uuid;
   const initialDraftRef = useRef(null);
   if (initialDraftRef.current === null) {
     const { __draftMeta, ...draftValues } = sessionFormData || {};


### PR DESCRIPTION
## Problem

`/employee/pgr/create-complaint` crashed straight to `/employee/user/error` ("Something went wrong") for every employee.

## Cause

The tenant/user draft-validity stamp added in #1093 read `user?.info?.uuid` **above** the `const user = Digit.UserService.getUser()` declaration — a temporal-dead-zone `ReferenceError` thrown on every render of the form component, caught by the app error boundary.

Optional chaining doesn't save you from TDZ: `user?.` on a `const` declared later in the same scope throws before the chain is evaluated. esbuild can't catch this (runtime error), which is how it slipped through the build.

## Fix

Read the user directly at the stamp site (`Digit.UserService.getUser()?.info?.uuid`). One line + comment. Audited the rest of the file for other pre-declaration reads — none.

## Testing

Local: `/employee/pgr/create-complaint` renders again (Ige tenant); draft persistence + tenant/user stamp behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)