### PR TITLE
feat(pgr): city-tenant localization overlay + complaint-type labels resolved at the complaint's tenant

### DIFF
--- a/digit-ui-esbuild/packages/libraries/src/services/elements/Localization/service.js
+++ b/digit-ui-esbuild/packages/libraries/src/services/elements/Localization/service.js
@@ -96,9 +96,31 @@ export const LocalizationService = {
     // never correct. Drop it.
     const [newModules, messages] = LocalizationStore.get(locale, modules);
     if (newModules.length > 0) {
-      const data = await Request({ url: Urls.localization, params: { module: newModules.join(","), locale, tenantId }, useCache: false });
-      messages.push(...data.messages);
-      setTimeout(() => LocalizationStore.store(locale, newModules, data.messages), 100);
+      // City overlay: modules are loaded at the STATE tenant, but data
+      // onboarding seeds label keys at the LOGGED-IN city tenant
+      // (COMPLAINT_HIERARCHY.*, COMMON_MASTERS_DEPARTMENT_*, boundary level
+      // headings, …) — those never loaded, so employee screens rendered raw
+      // codes. Fetch the same modules at the current tenant in parallel and
+      // let the city copy win per code (a city can override a state label,
+      // and the state set — often newer — fills everything the city copy
+      // lacks). Best-effort: a city fetch failure must never break the load.
+      const cityTenant = (() => {
+        try { return Digit.ULBService.getCurrentTenantId(); } catch (e) { return null; }
+      })();
+      const wantCityOverlay = !!cityTenant && cityTenant !== tenantId && String(cityTenant).includes(".");
+      const [data, cityData] = await Promise.all([
+        Request({ url: Urls.localization, params: { module: newModules.join(","), locale, tenantId }, useCache: false }),
+        wantCityOverlay
+          ? Request({ url: Urls.localization, params: { module: newModules.join(","), locale, tenantId: cityTenant }, useCache: false }).catch(() => null)
+          : Promise.resolve(null),
+      ]);
+      let merged = data.messages;
+      if (cityData?.messages?.length) {
+        const cityCodes = new Set(cityData.messages.map((m) => m.code));
+        merged = [...merged.filter((m) => !cityCodes.has(m.code)), ...cityData.messages];
+      }
+      messages.push(...merged);
+      setTimeout(() => LocalizationStore.store(locale, newModules, merged), 100);
     }
     LocalizationStore.updateResources(locale, messages);
     return messages;

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintsList.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintsList.js
@@ -84,9 +84,39 @@ function StatusPill({ status, t }) {
 
 function ComplaintRow({ data, onClick, t, typeCode, typeName }) {
   const { serviceRequestId, applicationStatus, auditDetails } = data;
+  // The list aggregates complaints across authority tenants (mz.ige/mz.igsae/…)
+  // while the list-level serviceDefs are fetched at the CITIZEN's tenant — so
+  // foreign complaints missed the map and rendered the raw serviceCode. Fetch
+  // the hierarchy at THIS complaint's tenant (same read-at-complaint-tenant fix
+  // as the details page; react-query dedupes rows of the same tenant into one
+  // request, cached indefinitely). NOTE the useCustomMDMS v2 quirk: the tenant
+  // must ride inside the 5th (mdmsv2) arg — the positional one is ignored.
+  const { data: ownRows } = Digit.Hooks.useCustomMDMS(
+    data.tenantId,
+    "RAINMAKER-PGR",
+    [{ name: "ComplaintHierarchy" }],
+    {
+      cacheTime: Infinity,
+      enabled: !!data.tenantId,
+      select: (raw) => raw?.["RAINMAKER-PGR"]?.ComplaintHierarchy || [],
+    },
+    { schemaCode: "PGR_COMPLAINT_HIERARCHY_DETAILS", tenantId: data.tenantId }
+  );
+  const own = React.useMemo(() => {
+    const rows = Array.isArray(ownRows) ? ownRows : [];
+    const self = rows.find((n) => n?.code === data.serviceCode);
+    if (!self) return null;
+    const parent = self.parentCode ? rows.find((n) => n?.code === self.parentCode) : null;
+    // Card shows the complaint TYPE (parent group); a root/parentless node is
+    // its own group.
+    return parent
+      ? { code: parent.code, name: parent.name }
+      : { code: self.code, name: self.name };
+  }, [ownRows, data.serviceCode]);
   // Complaint Type label = key-based (COMPLAINT_HIERARCHY.<code>) like every
   // other service, falling back to the node name; OTHERS for no resolvable group.
-  const title = complaintLabel(t, typeCode, typeName) || t("CS_COMPLAINT_TYPE_OTHERS");
+  const title =
+    complaintLabel(t, own?.code || typeCode, own?.name || typeName) || t("CS_COMPLAINT_TYPE_OTHERS");
   const dateStr = auditDetails?.createdTime
     ? Digit.DateUtils.ConvertTimestampToDate(auditDetails.createdTime)
     : "";


### PR DESCRIPTION
## Problem

Employee screens showed raw codes — complaint types in the inbox/details/assign modal, department names, boundary level headings — and the citizen "My Complaints" list showed raw `serviceCode`s (e.g. `CommerceUnfairPricing`, `TestUnmappedComplaint`).

Two causes:

1. **Localization loads only at the STATE tenant**, while data onboarding seeds label keys at the **logged-in city tenant**. Measured locally: `mz.ige` holds **79 city-only keys** (all the `COMPLAINT_HIERARCHY.*` complaint-type labels) while `mz` holds **162 state-only keys** the city copy lacks — so neither "state only" (current) nor "switch to logged-in tenant" works alone.
2. The citizen list resolved type labels from serviceDefs fetched at the **citizen's** tenant, so complaints filed at authority tenants missed the map entirely.

## Fix

- **`LocalizationService.getLocale` city overlay**: each newly-loaded module is fetched at both tenants in parallel (the city fetch only fires when the current tenant differs from the requested one and is a sub-tenant), merged per code with the **city copy winning** — a city can override a state label, and the state set fills everything else. A city fetch failure is swallowed (never breaks the load). Applies app-wide: bootstrap, per-module loads, and language switch.
- **Citizen list**: each card resolves its complaint-type label from the `ComplaintHierarchy` fetched at **that complaint's tenant** (the same read-at-complaint-tenant pattern as the details page — PRs #1073/#1078); react-query collapses rows of one tenant into a single cached request. List-level map kept as fallback.

## Data note (env seeding)

The inbox status-filter keys `CS_COMMON_PGR_STATE_{PENDINGATSUPERVISOR, RESOLVEDBYSUPERVISOR, CANCELLED}` were seeded in **no tenant** — seeded at `mz`/`en_IN` locally via the localization API. Other environments need the same three keys (+ `pt` values, still pending).

## Testing (local, fresh incognito — localization modules cache in localStorage)

- Employee inbox filters show readable state labels; complaint-type names render in inbox rows, details, and the assign modal.
- Citizen "My Complaints" shows localized type names for complaints across `mz.ige`/`mz.igsae`.
- Language switch re-applies the overlay; citizen flows at a state-level home tenant skip the extra fetch entirely.
- Crash reported during testing was unrelated to these files (TDZ in createComplaintForm — fixed in #1095) and is verified resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)