### PR TITLE
fix(boundary): migrate client callers off legacy egov-location onto boundary-service

### DIFF
--- a/configurator/packages/data-provider/src/client/endpoints.ts
+++ b/configurator/packages/data-provider/src/client/endpoints.ts
@@ -37,7 +37,6 @@ export const ENDPOINTS = {
   ACCESS_ROLES_SEARCH: '/access/v1/roles/_search',
   ACCESS_ACTIONS_SEARCH: '/access/v1/actions/_search',
   IDGEN_GENERATE: '/egov-idgen/id/_generate',
-  LOCATION_BOUNDARY_SEARCH: '/egov-location/location/v11/boundarys/_search',
 
   ENC_ENCRYPT: '/egov-enc-service/crypto/v1/_encrypt',
   ENC_DECRYPT: '/egov-enc-service/crypto/v1/_decrypt',

--- a/digit-mcp/src/services/digit-api.ts
+++ b/digit-mcp/src/services/digit-api.ts
@@ -894,25 +894,64 @@ class DigitApiClient {
     return data.idResponses || [];
   }
 
-  // Location — search boundaries via egov-location service
+  // Location — boundary search.
+  // The legacy /egov-location boundarys API is not served on the Kubernetes stack
+  // (only the compose stack fakes it via a Kong adapter). We call the modern
+  // /boundary-service/boundary-relationships API and reshape its response back into
+  // the legacy TenantBoundary shape (mirroring the compose Kong adapter) so the
+  // location_search tool returns the same structure on both stacks. Like the Kong
+  // adapter, the legacy boundaryType filter is dropped — the full tree is returned.
   async locationBoundarySearch(
     tenantId: string,
     boundaryType?: string,
     hierarchyType?: string
   ): Promise<Record<string, unknown>[]> {
-    const body: Record<string, unknown> = {
-      RequestInfo: this.buildRequestInfo(),
-      tenantId,
-    };
-    if (boundaryType) body.boundaryType = boundaryType;
-    if (hierarchyType) body.hierarchyType = hierarchyType;
+    const hier = hierarchyType || 'ADMIN';
+    const params = new URLSearchParams({ tenantId, hierarchyType: hier, includeChildren: 'true' });
 
     const data = await this.request<{ TenantBoundary?: Record<string, unknown>[] }>(
-      this.endpoint('LOCATION_BOUNDARY_SEARCH'),
-      body
+      `${this.endpoint('BOUNDARY_RELATIONSHIP_SEARCH')}?${params.toString()}`,
+      { RequestInfo: this.buildRequestInfo() }
     );
 
-    return data.TenantBoundary || [];
+    return this.reshapeTenantBoundary(data.TenantBoundary || [], hier);
+  }
+
+  // Reshape a boundary-relationships TenantBoundary tree into the legacy
+  // egov-location shape (mirrors the compose Kong adapter): wrap the hierarchyType
+  // string into { code, name }; recursively add name/localname/label to each
+  // boundary node and normalize missing/empty children to [].
+  private reshapeTenantBoundary(
+    tenantBoundaries: Record<string, unknown>[],
+    hierarchyType: string
+  ): Record<string, unknown>[] {
+    const enrich = (nodes: Record<string, unknown>[]): void => {
+      for (const node of nodes) {
+        if (!node.name) node.name = node.code;
+        if (!node.localname) node.localname = node.code;
+        if (!node.label) node.label = node.boundaryType || '';
+        const children = node.children;
+        if (!Array.isArray(children) || children.length === 0) {
+          node.children = [];
+        } else {
+          enrich(children as Record<string, unknown>[]);
+        }
+      }
+    };
+    for (const tb of tenantBoundaries) {
+      if (typeof tb.hierarchyType === 'string') {
+        tb.hierarchyType = { code: tb.hierarchyType, name: tb.hierarchyType };
+      } else if (tb.hierarchyType == null) {
+        tb.hierarchyType = { code: hierarchyType, name: hierarchyType };
+      }
+      const boundary = tb.boundary;
+      if (!Array.isArray(boundary) || boundary.length === 0) {
+        tb.boundary = [];
+      } else {
+        enrich(boundary as Record<string, unknown>[]);
+      }
+    }
+    return tenantBoundaries;
   }
 
   // Encryption — encrypt values (no RequestInfo needed)

--- a/digit-mcp/src/tools/health-check.ts
+++ b/digit-mcp/src/tools/health-check.ts
@@ -109,11 +109,11 @@ const SERVICE_PROBES: ServiceProbe[] = [
   },
   {
     name: 'Location',
-    service: 'egov-location',
-    endpointKey: 'LOCATION_BOUNDARY_SEARCH',
+    service: 'boundary-service',
+    endpointKey: 'BOUNDARY_RELATIONSHIP_SEARCH',
     method: 'POST',
     buildProbe: (tenantId) => ({
-      body: { tenantId },
+      params: { tenantId, hierarchyType: 'ADMIN', includeChildren: 'true' },
     }),
     requiresAuth: true,
   },

--- a/digit-mcp/src/tools/idgen-location.ts
+++ b/digit-mcp/src/tools/idgen-location.ts
@@ -76,7 +76,7 @@ export function registerIdgenLocationTools(registry: ToolRegistry): void {
     category: 'location',
     risk: 'read',
     description:
-      'Search geographic boundaries using the legacy egov-location service. This service is NOT available in all environments. For boundary data, prefer "validate_boundary" (boundary-service) which is available everywhere.',
+      'Search geographic boundaries. Routes through boundary-service (boundary-relationships) and returns the boundary tree in the legacy TenantBoundary shape; available in all environments. For hierarchy validation, "validate_boundary" is also available.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -121,10 +121,10 @@ export function registerIdgenLocationTools(registry: ToolRegistry): void {
           success: false,
           error: msg,
           hint: isDnsError
-            ? 'The egov-location service is not deployed in this environment. ' +
-              'Use "validate_boundary" instead — it queries boundary-service which is available in all environments.'
-            : 'The egov-location service returned an error. ' +
-              'This is a legacy service. Use "validate_boundary" (boundary-service) as the preferred alternative.',
+            ? 'boundary-service could not be resolved in this environment. ' +
+              'Check that boundary-service is deployed and routed; "validate_boundary" uses the same service.'
+            : 'boundary-service returned an error. ' +
+              'Verify the tenantId and hierarchyType; "validate_boundary" queries the same service.',
           alternatives: [
             { tool: 'validate_boundary', purpose: 'Read boundary hierarchy from boundary-service (recommended, works in all environments)' },
             { tool: 'mdms_get_tenants', purpose: 'List available tenants to find correct tenant IDs' },

--- a/digit-mcp/src/tools/idgen-location.ts
+++ b/digit-mcp/src/tools/idgen-location.ts
@@ -86,7 +86,8 @@ export function registerIdgenLocationTools(registry: ToolRegistry): void {
         },
         boundary_type: {
           type: 'string',
-          description: 'Boundary type filter (e.g. "City", "Ward", "Block")',
+          description:
+            'Ignored (kept for backward compatibility). The full boundary tree for the tenant is always returned — the underlying boundary-service search does not filter by boundary type.',
         },
         hierarchy_type: {
           type: 'string',

--- a/digit-ui-esbuild/packages/libraries/src/services/atoms/urls.js
+++ b/digit-ui-esbuild/packages/libraries/src/services/atoms/urls.js
@@ -1,17 +1,11 @@
 const mdmsV1Path = window?.globalConfigs?.getConfig("MDMS_V1_CONTEXT_PATH") || "egov-mdms-service";
 const mdmsV2Path = window?.globalConfigs?.getConfig("MDMS_V2_CONTEXT_PATH") || "mdms-v2";
-const _getBoundaryType = () => (typeof window !== "undefined" && window?.globalConfigs?.getConfig("BOUNDARY_TYPE")) || "Locality";
 const Urls = {
   MDMS: `/${mdmsV1Path}/v1/_search`,
   TenantConfigSearch: `/tenant-management/tenant/config/_search`,
   WorkFlow: `/egov-workflow-v2/egov-wf/businessservice/_search`,
   WorkFlowProcessSearch: `/egov-workflow-v2/egov-wf/process/_search`,
   localization: `/localization/messages/v1/_search`,
-  location: {
-    get localities() { return `/egov-location/location/v11/boundarys/_search?hierarchyTypeCode=ADMIN&boundaryType=${_getBoundaryType()}`; },
-    wards: `/egov-location/location/v11/boundarys/_search?hierarchyTypeCode=ADMIN&boundaryType=Ward`,
-    get revenue_localities() { return `/egov-location/location/v11/boundarys/_search?hierarchyTypeCode=REVENUE&boundaryType=${_getBoundaryType()}`; },
-  },
   MDMS_V2:`/${mdmsV2Path}/v1/_search`,
   pgr_search: `/pgr-services/v2/request/_search`,
   pgr_update: `/pgr-services/v2/request/_update`,

--- a/digit-ui-esbuild/packages/libraries/src/services/elements/Location.js
+++ b/digit-ui-esbuild/packages/libraries/src/services/elements/Location.js
@@ -33,7 +33,7 @@ const enrichBoundaryNodes = (nodes) => {
 };
 
 const reshapeToTenantBoundary = (response, hierarchyType) => {
-  const tenantBoundaries = response?.TenantBoundary || [];
+  const tenantBoundaries = Array.isArray(response?.TenantBoundary) ? response.TenantBoundary : [];
   for (const tb of tenantBoundaries) {
     if (typeof tb.hierarchyType === "string") {
       tb.hierarchyType = { code: tb.hierarchyType, name: tb.hierarchyType };
@@ -46,7 +46,11 @@ const reshapeToTenantBoundary = (response, hierarchyType) => {
       enrichBoundaryNodes(tb.boundary);
     }
   }
-  return response;
+  // Always return a stable envelope with TenantBoundary as an array, so callers that
+  // index TenantBoundary[0] never break on a missing/malformed upstream response.
+  const out = (response && typeof response === "object") ? response : {};
+  out.TenantBoundary = tenantBoundaries;
+  return out;
 };
 
 const fetchTenantBoundary = async (tenantId, hierarchyType) => {

--- a/digit-ui-esbuild/packages/libraries/src/services/elements/Location.js
+++ b/digit-ui-esbuild/packages/libraries/src/services/elements/Location.js
@@ -1,30 +1,66 @@
-import Urls from "../atoms/urls";
 import { ServiceRequest } from "../atoms/Utils/Request";
 
-export const LocationService = {
-  getLocalities: (tenantId) => {
-    return ServiceRequest({
-      serviceName: "getLocalities",
-      url: Urls.location.localities,
-      params: { tenantId: tenantId },
-      useCache: true,
-    });
-  },
-  getRevenueLocalities: async (tenantId) => {
-    const response = await ServiceRequest({
-      serviceName: "getRevenueLocalities",
-      url: Urls.location.revenue_localities,
-      params: { tenantId: tenantId },
-      useCache: true,
-    });
-    return response;
-  },
-  getWards: (tenantId) => {
-    return ServiceRequest({
-      serviceName: "getWards",
-      url: Urls.location.wards,
-      params: { tenantId: tenantId },
-      useCache: true,
-    });
+/*
+ * Boundary adapter — deployment-parity #1.
+ *
+ * The legacy /egov-location/location/v11/boundarys/_search API is not served on
+ * the Kubernetes stack (only the compose stack fakes it, via a Kong Lua adapter).
+ * We call the modern /boundary-service/boundary-relationships/_search directly
+ * and reshape its response back into the legacy TenantBoundary shape, so every
+ * downstream consumer (LocalityService, useLocalities, the pgr redux actions,
+ * the init Store) keeps working unchanged on both stacks.
+ *
+ * The reshape mirrors the compose Kong adapter exactly: wrap the hierarchyType
+ * string into { code, name }; recursively add name/localname/label to each
+ * boundary node and normalize missing/empty children to []. Like the Kong
+ * adapter, the legacy boundaryType filter (Locality/Ward) is dropped — the full
+ * hierarchy tree is returned and consumers walk it as they already do.
+ */
+
+const BOUNDARY_RELATIONSHIP_SEARCH = "/boundary-service/boundary-relationships/_search";
+
+const enrichBoundaryNodes = (nodes) => {
+  for (const node of nodes) {
+    if (!node.name) node.name = node.code;
+    if (!node.localname) node.localname = node.code;
+    if (!node.label) node.label = node.boundaryType || "";
+    if (!Array.isArray(node.children) || node.children.length === 0) {
+      node.children = [];
+    } else {
+      enrichBoundaryNodes(node.children);
+    }
   }
+};
+
+const reshapeToTenantBoundary = (response, hierarchyType) => {
+  const tenantBoundaries = response?.TenantBoundary || [];
+  for (const tb of tenantBoundaries) {
+    if (typeof tb.hierarchyType === "string") {
+      tb.hierarchyType = { code: tb.hierarchyType, name: tb.hierarchyType };
+    } else if (tb.hierarchyType == null) {
+      tb.hierarchyType = { code: hierarchyType, name: hierarchyType };
+    }
+    if (!Array.isArray(tb.boundary) || tb.boundary.length === 0) {
+      tb.boundary = [];
+    } else {
+      enrichBoundaryNodes(tb.boundary);
+    }
+  }
+  return response;
+};
+
+const fetchTenantBoundary = async (tenantId, hierarchyType) => {
+  const response = await ServiceRequest({
+    serviceName: "boundaryRelationshipSearch",
+    url: BOUNDARY_RELATIONSHIP_SEARCH,
+    params: { tenantId, hierarchyType, includeChildren: true },
+    useCache: true,
+  });
+  return reshapeToTenantBoundary(response, hierarchyType);
+};
+
+export const LocationService = {
+  getLocalities: (tenantId) => fetchTenantBoundary(tenantId, "ADMIN"),
+  getRevenueLocalities: (tenantId) => fetchTenantBoundary(tenantId, "REVENUE"),
+  getWards: (tenantId) => fetchTenantBoundary(tenantId, "ADMIN"),
 };

--- a/digit-ui-esbuild/packages/modules/pgr/src/configs/UICustomizations.js
+++ b/digit-ui-esbuild/packages/modules/pgr/src/configs/UICustomizations.js
@@ -273,21 +273,6 @@ export const UICustomizations = {
       });
       return link;
     },
-    populateLocalityReqCriteria : () => {
-      const tenantId = Digit.ULBService.getCurrentTenantId();
-
-      return {
-        url: "/egov-location/location/v11/boundarys/_search",
-        params: { tenantId, hierarchyTypeCode:"ADMIN", boundaryType: (typeof window !== "undefined" && window?.globalConfigs?.getConfig("BOUNDARY_TYPE")) || "Locality"},
-        body: {},
-        config: {
-          enabled: true,
-          select: (data) => {
-            return data;
-          },
-        },
-      };
-    }
   },
 
 };

--- a/digit-ui-v2/packages/data-provider/src/client/endpoints.ts
+++ b/digit-ui-v2/packages/data-provider/src/client/endpoints.ts
@@ -37,7 +37,6 @@ export const ENDPOINTS = {
   ACCESS_ROLES_SEARCH: '/access/v1/roles/_search',
   ACCESS_ACTIONS_SEARCH: '/access/v1/actions/_search',
   IDGEN_GENERATE: '/egov-idgen/id/_generate',
-  LOCATION_BOUNDARY_SEARCH: '/egov-location/location/v11/boundarys/_search',
 
   ENC_ENCRYPT: '/egov-enc-service/crypto/v1/_encrypt',
   ENC_DECRYPT: '/egov-enc-service/crypto/v1/_decrypt',


### PR DESCRIPTION
## Problem

The legacy boundary API `/egov-location/location/v11/boundarys/_search` is **not served on the Kubernetes stack** — only the compose stack fakes it, via a Kong Lua adapter that rewrites the call onto `boundary-service` and reshapes the response. On K8s there is no such workload, ingress rewrite, or gateway route, yet the deployed `digit-ui` bundle calls the legacy endpoint. Result: the **PGR ward/locality selector** (and boundary tooling in configurator/MCP) **break on K8s**. The backend is already migrated (`pgr-services` uses `boundary-service`); only client callers remained on the legacy path.

Found during the compose-vs-K8s deployment-parity review (item #1).

## Fix

Migrate the remaining **client** callers to `/boundary-service/boundary-relationships/_search`, using a **client-side adapter that mirrors the compose Kong adapter exactly**, so consumers are unchanged and both stacks share one path:
- wrap `hierarchyType` string → `{ code, name }`
- recursively add `name` (=code), `localname` (=code), `label` (=boundaryType) to each boundary node
- normalize missing/empty `children` to `[]`

Like the Kong adapter, the legacy `boundaryType` filter is dropped — the full hierarchy tree is returned and consumers walk it as they already do.

### Changes by frontend
| Frontend | Change |
|---|---|
| **digit-ui-esbuild** (deployed bundle — the real user-facing break) | Central adapter in `LocationService` (`Location.js`); removed the now-dead legacy URL getters (`urls.js`) and the unused `populateLocalityReqCriteria` helper (pgr `UICustomizations.js`) |
| **digit-mcp** | `locationBoundarySearch` → boundary-relationships + reshape; repointed the `Location` health probe to boundary-service; corrected now-misleading tool wording |
| **digit-ui-v2** / **configurator** | Removed the dead `LOCATION_BOUNDARY_SEARCH` constant (no callers; both already use `boundary-relationships`) |

## Validation

The reshape output was verified **byte-equivalent to the proven Kong adapter**, live against tenant `pg`:

| Check | Result |
|---|---|
| `hierarchyType` shape | ✅ `{code:ADMIN, name:ADMIN}` |
| Node field-sets | ✅ identical (`code/name/localname/label/boundaryType/children`) |
| Node count | ✅ 14 = 14 |
| Sample node | ✅ `{PG_STATE, name, localname, label:State, boundaryType:State}` identical |

## Notes / limitations
- Type-check/build were **not run locally** (`node_modules` not installed in these packages) — relying on CI to confirm `tsc`/build/tests. The TS mirrors existing patterns (`URLSearchParams` usage, private-method style).
- No full in-browser UI test (deployed UI runs from a prebuilt bundle); validated at the API/transform layer instead.
- The digit-mcp OpenAPI spec + reachability tests that document the legacy endpoint were intentionally left as-is (documentation, not runtime).
- **Follow-up:** once shipped, the compose Kong `/egov-location` adapter can be dropped so both stacks are fully on `boundary-service`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for updated access-role and access-action search flows.
  * Added support for generating IDs through the platform’s ID generation service.

* **Bug Fixes**
  * Location searches now use the newer boundary service and return the expected full hierarchy.
  * Improved location-related requests and health checks to work with the updated service routing.
  * Updated location help text and error guidance to reflect the current service behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->