### PR TITLE
fix(k8s): correct egov-user-event service-host namespace (.staging → .egov)

### DIFF
--- a/devops/deploy-as-code/charts/environments/env.yaml
+++ b/devops/deploy-as-code/charts/environments/env.yaml
@@ -50,7 +50,7 @@ configmaps:
         egov-url-shortening: "http://egov-url-shortening.egov:8080/"
         inbox: "http://inbox.egov:8080/"
         mdms-service-v2: "http://mdms-v2.egov:8080/"
-        egov-user-event: "http://egov-user-event.staging:8080"
+        egov-user-event: "http://egov-user-event.egov:8080/"
         boundary-service: "http://boundary-service.egov:8080/"
         egov-user-egov: "http://egov-user.egov:8080/"
         digit-config-service: "http://digit-config-service.egov:8080/"


### PR DESCRIPTION
## Problem
In `charts/environments/env.yaml`, the `service-host` map points `egov-user-event` at the stale `.staging` namespace:
```
egov-user-event: "http://egov-user-event.staging:8080"
```
The service actually deploys in the **`egov`** namespace — like every sibling entry (`egov-hrms.egov`, `boundary-service.egov`, …). It's a leftover from a staging environment template.

## Impact
**None functionally** — confirmed dead config: no chart consumes this `service-host` key, and the K8s gateway routes to services via Kubernetes service discovery (resolving `egov-user-event.egov`), not this map. Fixing it purely removes a misleading/stale value.

## Fix
`.staging` → `.egov`, and normalized the trailing slash to match sibling entries.

Found during the compose-vs-K8s deployment-parity review (item #3). This is also a subset of the broader `service-host` cleanup tracked as item #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)