### PR TITLE
fix(kong): emit InvalidAccessTokenException on expired session so digit-ui re-logs in

### DIFF
--- a/local-setup/kong/kong.yml
+++ b/local-setup/kong/kong.yml
@@ -82,11 +82,35 @@ plugins:
           headers = { ["Content-Type"] = "application/json" },
         })
         local resolved = nil
+        local token_rejected = false
         if res and res.status == 200 then
           local ok2, user = pcall(cjson.decode, res.body)
-          if ok2 and type(user) == "table" and (user["uuid"] or user["userName"]) then resolved = user end
+          if ok2 and type(user) == "table" and (user["uuid"] or user["userName"]) then
+            resolved = user
+          else
+            token_rejected = true  -- 200 but no resolvable user
+          end
+        elseif res then
+          token_rejected = true    -- /user/_details rejected the token (invalid / expired)
         else
-          kong.log.err("auth-enrichment failed; stripping client userInfo")
+          -- /user/_details unreachable (network/timeout): a transient upstream error, NOT an
+          -- invalid token — do not force logout; forward with client userInfo stripped.
+          kong.log.err("auth-enrichment: /user/_details unreachable; stripping client userInfo")
+        end
+        if token_rejected then
+          -- Session-expiry parity (#4): a token was PRESENT but could not be validated. Return the
+          -- egov InvalidAccessTokenException envelope the Spring Cloud Gateway emits, so digit-ui
+          -- redirects to login instead of rendering blank/error screens on an expired session.
+          -- Guarded by "token present" above (the no-token branch returns early), so open/anonymous
+          -- endpoints are unaffected.
+          return kong.response.exit(401, cjson.encode({
+            ResponseInfo = cjson.null,
+            Errors = {{
+              code = "InvalidAccessTokenException",
+              message = "InvalidAccessTokenException",
+              description = "Invalid access token or access token expired for the request",
+            }},
+          }), { ["Content-Type"] = "application/json" })
         end
         ri["userInfo"] = resolved
         body["RequestInfo"] = ri


### PR DESCRIPTION
## Problem
digit-ui keys its "session expired → redirect to login" behaviour off receiving an **`InvalidAccessTokenException`** error envelope from the gateway (its axios interceptor checks `err.response.data.Errors[].message` for that string). The Spring Cloud Gateway (K8s) emits it, so re-login works there. The compose **Kong** auth pre-function did **not**: on an invalid/expired token it set `userInfo=nil` and **forwarded** the request, so the backend NPE'd (HTTP 400) and the UI rendered blank/error screens instead of redirecting to login.

Found during the compose-vs-K8s deployment-parity review (item #4). UX gap, not a security hole (the token is genuinely rejected either way).

## Fix
In the auth-enrichment `pre-function`, when a token is **present** but `/user/_details` rejects it (non-200), return the egov `InvalidAccessTokenException` **401** envelope. Two guards keep it safe:
- The **no-token** branch already returns early → open/anonymous endpoints are unaffected.
- A **transient `/user/_details` outage** (no HTTP response at all) does **not** force logout — only an actual token rejection does.

## Validation (live, on the running compose stack)
| Case | Before | After |
|---|---|---|
| Invalid / expired token | HTTP 400 `NullPointerException`, no signal | **HTTP 401** `InvalidAccessTokenException` ✅ |
| Valid token | 200 | **200** `successful` (unaffected) |
| No token, open endpoint (mdms) | 200 | **200** (no leak) |

The returned envelope: `{"ResponseInfo":null,"Errors":[{"code":"InvalidAccessTokenException","message":"InvalidAccessTokenException","description":"Invalid access token or access token expired for the request"}]}` — matches what the UI interceptor checks.

Compose-only change (K8s already behaves this way). A full gateway-side RBAC layer (parity #5) would also cover this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)