### PR TITLE
fix(otp): repair the real-OTP enablement path on compose

### DIFF
--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -1290,7 +1290,9 @@ services:
     deploy:
       resources:
         limits:
-          memory: 256M
+          # 256M OOM-kills (Exited 137) this Spring Boot 3.2 / Java 17 service — heap
+          # (Xmx192m) + metaspace/threads/off-heap exceeds the container cap. 512M is headroom.
+          memory: 512M
           cpus: '0.2'
     networks:
       - egov-network
@@ -1332,7 +1334,8 @@ services:
     deploy:
       resources:
         limits:
-          memory: 256M
+          # 256M OOM-kills (Exited 137) this Spring Boot 3.2 / Java 17 service — see egov-otp above.
+          memory: 512M
           cpus: '0.2'
     networks:
       - egov-network
@@ -1366,7 +1369,8 @@ services:
     deploy:
       resources:
         limits:
-          memory: 256M
+          # Bumped 256M→512M with the other otp-profile services for headroom (Spring Boot 3.2 / Java 17).
+          memory: 512M
           cpus: '0.1'
     networks:
       - egov-network

--- a/local-setup/kong/kong.yml
+++ b/local-setup/kong/kong.yml
@@ -495,9 +495,20 @@ services:
     paths:
     - /kc
     strip_path: true
-# OTP validate mock — returns success for citizen OTP login flow
+# OTP validate — real upstream (egov-otp:8089) fronted by a default request-termination MOCK.
+# Mirrors /user-otp: the mock rubber-stamps every OTP validation as successful, so citizen
+# login works with the fixed OTP (123456) without the `otp` profile running.
+#
+# TO ENABLE REAL OTP VALIDATION FOR PRODUCTION, before deploying:
+#   1. Delete the `plugins:` block below (the request-termination mock).
+#   2. Set enable_otp_services: true in the tenant's Ansible host_vars so compose
+#      starts the `otp` profile (egov-otp, user-otp, egov-notification-sms).
+#   3. Configure a real SMS gateway (see egov-notification-sms SMS_PROVIDER_CLASS).
+# With the mock removed and the otp profile running, /otp reaches egov-otp for real
+# validation (an incorrect OTP is rejected instead of rubber-stamped). The upstream was
+# previously a dead localhost:9999, so de-mocking alone returned HTTP 502 — now fixed.
 - name: otp-validate-mock
-  url: http://localhost:9999
+  url: http://egov-otp:8089
   tags:
   - core
   - auth


### PR DESCRIPTION
## Problem
Compose mocks OTP by default (Kong request-termination + fixed OTP `123456`) so dev/test login works without an SMS stack. But **enabling real OTP** (the `otp` profile) was broken in three independent ways — found and validated live during the compose-vs-K8s deployment-parity review (item #7):

- **(a) OOM** — `egov-otp`, `user-otp`, `egov-notification-sms` cap at `memory: 256M`, but the Spring Boot 3.2 / Java 17 images need more (heap `Xmx192m` + metaspace/threads/off-heap exceeds the container cap) → the services `Exited 137`.
- **(b) Dead upstream** — the Kong `/otp` route pointed at `http://localhost:9999`, so removing the mock alone returned **HTTP 502**.
- **(c) Undocumented** — `/user-otp` carried a `TO ENABLE` comment; `/otp` did not.

## Fix
- **(a)** Bump the three `otp`-profile services to `memory: 512M` (proven healthy).
- **(b)** Repoint the Kong `/otp` route to the real `http://egov-otp:8089`.
- **(c)** Add the equivalent enable-steps comment on `/otp`.

**Default behaviour is unchanged** — the request-termination mock stays on, so fixed OTP `123456` keeps working for dev/test. This only makes the *real* path work when an operator removes the mock + enables the `otp` profile.

## Validation (done live during the review)
- Bump → 512M: services come up **healthy** (no more `Exited 137`).
- Repoint `/otp` → `egov-otp:8089`: **real validation** — an incorrect OTP is rejected, versus the mock rubber-stamping every attempt as `isValidationSuccessful:true`.

Config re-checked here: both YAMLs parse, `docker compose config` OK, exactly the three otp services bumped, `/otp` upstream now `egov-otp:8089`.

## Related
- Real OTP is the prerequisite for turning **off** the fixed-OTP `123456` default in production (parity #8) — do #7 first, then flip #8, else citizens can't log in.
- Compose-only; K8s runs the OTP services for real already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)