### PR TITLE
chore(k8s): disable unused services (DSS/service-request/pdf) + prune their dead config

### DIFF
--- a/devops/deploy-as-code/charts/analytics/analytics-helmfile.yaml
+++ b/devops/deploy-as-code/charts/analytics/analytics-helmfile.yaml
@@ -17,12 +17,15 @@ templates:
       - {{ .Values | toYaml | nindent 8 }}
 
 releases:
+  # DSS (dashboard-analytics/ingest): not used by CCRS — the digit-ui app enables only
+  # ["Utilities","PGR"] (no DSS module), so nothing calls /dashboard-analytics/*. Disabled
+  # to cut footprint + attack surface. Re-enable if a DSS dashboard is ever surfaced.
   - name: dashboard-analytics
-    installed: true
+    installed: false
     <<: *default
 
   - name: dashboard-ingest
-    installed: true
+    installed: false
     <<: *default
 
   - name: inbox

--- a/devops/deploy-as-code/charts/core-services/coreservices-helmfile.yaml
+++ b/devops/deploy-as-code/charts/core-services/coreservices-helmfile.yaml
@@ -97,12 +97,15 @@ releases:
     installed: true
     <<: *default
 
+  # service-request / pdf-service: not used by CCRS — zero callers in pgr-services, the
+  # digit-ui app (Utilities/PGR modules), or configs. Disabled to cut footprint + attack
+  # surface. Re-enable if a future CCRS feature needs them.
   - name: service-request
-    installed: true
+    installed: false
     <<: *default
 
   - name: pdf-service
-    installed: true
+    installed: false
     <<: *default
   
   - name: gateway

--- a/devops/deploy-as-code/charts/environments/env.yaml
+++ b/devops/deploy-as-code/charts/environments/env.yaml
@@ -27,8 +27,6 @@ configmaps:
   egov-service-host:
       data:
         internal-gateway-scg: "http://internal-gateway-scg.egov:8080/"
-        dashboard-analytics: "http://dashboard-analytics.egov:8080/"
-        dashboard-ingest: "http://dashboard-ingest.egov:8080/"
         egov-enc-service: "http://egov-enc-service.egov:8080/"
         egov-accesscontrol: "http://egov-accesscontrol.egov:8080/"
         egov-user: "http://egov-user.egov:8080/"
@@ -44,7 +42,6 @@ configmaps:
         egov-hrms: "http://egov-hrms.egov:8080/"
         es-client: "http://elasticsearch-data-v1.es-cluster:9200"
         location: "http://location.egov:8080/"
-        pdf-service: "http://pdf-service.egov:8080/"
         user-otp: "http://user-otp.egov:8080/"
         minio-url: "http://minio-svc.backbone:9000/"
         egov-url-shortening: "http://egov-url-shortening.egov:8080/"
@@ -203,7 +200,7 @@ gateway:
   server-tomcat-max-threads: "350"
   server-tomcat-max-connections: "1500"
   #egov-statelevel-tenant-map: "{'kenya-demo.digit.org':'ke','unified-demo.digit.org':'pg','central-instance.digit.org':'in'}"
-  egov-open-endpoints-whitelist: "/user/oauth/token,/user-otp/v1/_send,/otp/v1/_validate,/user/citizen/_create,/localization/messages,/localization/messages/v1/_search,/user/password/nologin/_update,/tenant/v1/tenant/_search,/egov-location/boundarys,/egov-location/boundarys/boundariesByBndryTypeNameAndHierarchyTypeName,/egov-location/boundarys/getLocationByLocationName,/egov-location/boundarys/isshapefileexist,/pgr/services/v1/_search,/egov-mdms-service/v1/_search,/egov-mdms-service/v1/_get,/egov-mdms-service/v1/_reload,/egov-mdms-service/v1/_reloadobj,/egov-location/boundarys/getshapefile,/egov-indexer/index-operations/_index,/egov-indexer/index-operations/_reload,/egov-mdms-service-test/v1/_search,/filestore/v1/files/url,/egov-url-shortening,/mdms-v2/schema/v1/_search,/mdms-v2/v2/_search,/mdms-v2/v1/_search,/dashboard-analytics/dashboard/getChartV2,/dashboard-analytics/dashboard/getDashboardConfig/overview,/filestore/v1/file,/default-data-handler/tenant/new,/filestore/v1/files/id,/filestore/v1/files"
+  egov-open-endpoints-whitelist: "/user/oauth/token,/user-otp/v1/_send,/otp/v1/_validate,/user/citizen/_create,/localization/messages,/localization/messages/v1/_search,/user/password/nologin/_update,/tenant/v1/tenant/_search,/egov-location/boundarys,/egov-location/boundarys/boundariesByBndryTypeNameAndHierarchyTypeName,/egov-location/boundarys/getLocationByLocationName,/egov-location/boundarys/isshapefileexist,/pgr/services/v1/_search,/egov-mdms-service/v1/_search,/egov-mdms-service/v1/_get,/egov-mdms-service/v1/_reload,/egov-mdms-service/v1/_reloadobj,/egov-location/boundarys/getshapefile,/egov-indexer/index-operations/_index,/egov-indexer/index-operations/_reload,/egov-mdms-service-test/v1/_search,/filestore/v1/files/url,/egov-url-shortening,/mdms-v2/schema/v1/_search,/mdms-v2/v2/_search,/mdms-v2/v1/_search,/filestore/v1/file,/default-data-handler/tenant/new,/filestore/v1/files/id,/filestore/v1/files"
   egov-mixed-mode-endpoints-whitelist: "/workflow/history/v1/_search,/filestore/v1/files/tag,/egov-idgen/id/_generate,/user/_search,/access/v1/actions/mdms/_get,/egov-location/location/v11/boundarys/_search"
 # <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 


### PR DESCRIPTION
K8s deploy hygiene from the compose-vs-K8s parity review — items **#12** and **#14**.

## #12 — disable services CCRS doesn't use
Set `installed: false` for four services, each **verified unused** by inspecting the deployed digit-ui app and pgr-services:

| Service | Why it's unused |
|---|---|
| `dashboard-analytics` + `dashboard-ingest` (DSS) | The digit-ui app (`src/App.js`) enables only `["Utilities","PGR"]` — **no DSS module** — so `/dashboard-analytics/*` is never called. The `urls.js` DSS defs + whitelist entry are inherited library/config cruft. |
| `service-request` | Zero references anywhere (pgr-services, digit-ui bundle, configs, whitelist, hosts). |
| `pdf-service` | Zero real callers in the enabled modules — the only `.pdf` hits are a `DocViewer` file-extension check; the `pdf-service` URLs are library-level defs. |

Cuts cluster footprint + attack surface. Each has a re-enable comment.

## #14 — remove the now-dead config for those services
- **`service-host` map** (`env.yaml`): dropped `dashboard-analytics`, `dashboard-ingest`, `pdf-service`.
- **Gateway whitelist**: dropped `/dashboard-analytics/dashboard/getChartV2` and `/dashboard-analytics/dashboard/getDashboardConfig/overview`.

## Deliberately left for a separate follow-up (flagged, not touched)
- **`inbox` `service-map` / `bs-service-map`** (FSM/PT/TL/WS/SW/BPA/NOC/billing hosts) — these are consumed by the **deployed inbox service**, so emptying them warrants its own review + test (none reference PGR, so they're almost certainly dead for CCRS, but I didn't want to hand-edit a live service's config here).
- **`es-client`** — actually **used** by egov-indexer (→ ES); not cruft (the `.es-cluster` namespace question is a separate item).
- **`egov-location`** host + whitelist entries — coupled with the in-flight client migration in #1 (PR #1098); prune after that merges.

## Validation
`env.yaml` parses as YAML; helmfile edits are `true`→`false` + comments only (anchors `<<: *default` intact); confirmed the removed host/whitelist entries are gone and `es-client`/`service-map` are untouched. K8s-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)