### PR TITLE
feat(kong): gateway RBAC phase 1 — path classification + authn enforcement (#5)

### DIFF
--- a/local-setup/kong/kong.yml
+++ b/local-setup/kong/kong.yml
@@ -66,38 +66,47 @@ plugins:
         -- Mirrors the K8s Spring gateway's open / mixed-mode / protected buckets. OPEN and MIXED
         -- are auth-OPTIONAL (anonymous allowed and NOT action-RBAC'd); everything else is PROTECTED
         -- (a valid token is required). Phase 1 does NOT call egov-accesscontrol yet — action-level
-        -- RBAC is Phase 2. The AUTH_OPTIONAL set = open ∪ mixed, kept in sync with the Spring
-        -- gateway whitelists (env.yaml egov-open/-mixed-mode-endpoints-whitelist). See
-        -- docs/parity-item5-gateway-rbac-design.md.
+        -- RBAC is Phase 2.
+        --
+        -- EXACT match (set membership), mirroring the Spring gateway's
+        -- openEndpointsWhitelist.contains(getPath().value()) — NOT prefix (a prefix would over-open,
+        -- e.g. anonymous /localization/messages/v1/_upsert). AUTH_OPTIONAL = open ∪ mixed, kept
+        -- VERBATIM-in-sync with env.yaml egov-open/-mixed-mode-endpoints-whitelist (+ the
+        -- boundary-service search paths CCRS migrated to in #1); a CI check enforces the two match
+        -- (Phase 3). See docs/parity-item5-gateway-rbac-design.md.
         --
         -- Ships in AUDIT mode: unauthenticated hits on protected paths are LOGGED, not rejected.
         -- Flip ENFORCE_UNAUTH=true after an observation period (first confirm no RBAC-audit warning
-        -- is actually a legitimate anonymous call — if it is, add its path to AUTH_OPTIONAL).
+        -- is a legitimate anonymous call — if it is, add its EXACT path to AUTH_OPTIONAL AND env.yaml).
         local ENFORCE_UNAUTH = false
         local AUTH_OPTIONAL = {
-          "/user/oauth/token", "/user-otp/v1/_send", "/otp/v1/_validate", "/user/citizen/_create",
-          "/user/password/nologin/_update", "/localization/messages",
-          "/tenant/v1/tenant/_search", "/tenant-management/tenant",
-          "/egov-mdms-service/v1/_search", "/egov-mdms-service/v1/_get",
-          "/egov-mdms-service/v1/_reload", "/egov-mdms-service/v1/_reloadobj",
-          "/egov-mdms-service-test/v1/_search",
-          "/mdms-v2/v1/_search", "/mdms-v2/v2/_search", "/mdms-v2/schema/v1/_search",
-          "/egov-location/boundarys",
-          "/boundary-service/boundary-relationships/_search",
-          "/boundary-service/boundary-hierarchy-definition/_search",
-          "/boundary-service/boundary/_search",
-          "/pgr/services/v1/_search",
-          "/egov-indexer/index-operations/_index", "/egov-indexer/index-operations/_reload",
-          "/filestore/v1/file", "/egov-url-shortening", "/default-data-handler/tenant/new",
-          "/workflow/history/v1/_search", "/egov-idgen/id/_generate", "/user/_search",
-          "/access/v1/actions/mdms/_get", "/egov-location/location/v11/boundarys/_search",
+          ["/user/oauth/token"]=true, ["/user-otp/v1/_send"]=true, ["/otp/v1/_validate"]=true,
+          ["/user/citizen/_create"]=true, ["/user/password/nologin/_update"]=true,
+          ["/localization/messages"]=true, ["/localization/messages/v1/_search"]=true,
+          ["/tenant/v1/tenant/_search"]=true,
+          ["/egov-location/boundarys"]=true,
+          ["/egov-location/boundarys/boundariesByBndryTypeNameAndHierarchyTypeName"]=true,
+          ["/egov-location/boundarys/getLocationByLocationName"]=true,
+          ["/egov-location/boundarys/isshapefileexist"]=true,
+          ["/egov-location/boundarys/getshapefile"]=true,
+          ["/egov-location/location/v11/boundarys/_search"]=true,
+          ["/pgr/services/v1/_search"]=true,
+          ["/egov-mdms-service/v1/_search"]=true, ["/egov-mdms-service/v1/_get"]=true,
+          ["/egov-mdms-service/v1/_reload"]=true, ["/egov-mdms-service/v1/_reloadobj"]=true,
+          ["/egov-mdms-service-test/v1/_search"]=true,
+          ["/mdms-v2/v1/_search"]=true, ["/mdms-v2/v2/_search"]=true, ["/mdms-v2/schema/v1/_search"]=true,
+          ["/boundary-service/boundary-relationships/_search"]=true,
+          ["/boundary-service/boundary-hierarchy-definition/_search"]=true,
+          ["/boundary-service/boundary/_search"]=true,
+          ["/egov-indexer/index-operations/_index"]=true, ["/egov-indexer/index-operations/_reload"]=true,
+          ["/filestore/v1/file"]=true, ["/filestore/v1/files"]=true, ["/filestore/v1/files/url"]=true,
+          ["/filestore/v1/files/id"]=true, ["/filestore/v1/files/tag"]=true,
+          ["/egov-url-shortening"]=true, ["/default-data-handler/tenant/new"]=true,
+          ["/workflow/history/v1/_search"]=true, ["/egov-idgen/id/_generate"]=true,
+          ["/user/_search"]=true, ["/access/v1/actions/mdms/_get"]=true,
         }
         local uri = kong.request.get_path()
-        local is_protected = true
-        for i = 1, #AUTH_OPTIONAL do
-          local p = AUTH_OPTIONAL[i]
-          if uri == p or uri:sub(1, #p) == p then is_protected = false; break end
-        end
+        local is_protected = not AUTH_OPTIONAL[uri]
         local function deny_unauth()
           if ENFORCE_UNAUTH then
             return kong.response.exit(401, cjson.encode({

--- a/local-setup/kong/kong.yml
+++ b/local-setup/kong/kong.yml
@@ -140,36 +140,74 @@ plugins:
           headers = { ["Content-Type"] = "application/json" },
         })
         local resolved = nil
-        local token_rejected = false
+        local token_rejected = false   -- explicit auth rejection (401/403): invalid / expired token
+        local resolve_failed = false   -- transient: /user/_details unreachable, 5xx, or unparseable
         if res and res.status == 200 then
           local ok2, user = pcall(cjson.decode, res.body)
           if ok2 and type(user) == "table" and (user["uuid"] or user["userName"]) then
             resolved = user
           else
-            token_rejected = true  -- 200 but no resolvable user
+            resolve_failed = true      -- 200 but no resolvable user -> transient, not a token reject
+            kong.log.err("auth-enrichment: /user/_details 200 with no resolvable user")
           end
+        elseif res and (res.status == 401 or res.status == 403
+                        or (res.body and res.body:find("InvalidAccessTokenException", 1, true))) then
+          -- egov-user signals an invalid/expired token via InvalidAccessTokenException (HTTP 400 on
+          -- this stack, 401/403 on others) — treat any of those as a genuine token rejection, and
+          -- everything else (5xx / other) as a transient failure below.
+          token_rejected = true
         elseif res then
-          token_rejected = true    -- /user/_details rejected the token (invalid / expired)
+          resolve_failed = true        -- other non-200 (5xx, etc.) -> transient, NOT a token reject
+          kong.log.err("auth-enrichment: /user/_details status ", res.status)
         else
-          -- /user/_details unreachable (network/timeout): a transient upstream error, NOT an
-          -- invalid token — do not force logout; forward with client userInfo stripped.
-          kong.log.err("auth-enrichment: /user/_details unreachable; stripping client userInfo")
+          resolve_failed = true        -- unreachable (network / timeout)
+          kong.log.err("auth-enrichment: /user/_details unreachable: ", err or "")
         end
+
+        local function strip_userinfo()
+          if ri["userInfo"] ~= nil then ri["userInfo"] = nil; body["RequestInfo"] = ri; kong.service.request.set_raw_body(cjson.encode(body)) end
+        end
+
         if token_rejected then
-          -- Session-expiry parity (#4): a token was PRESENT but could not be validated. Return the
-          -- egov InvalidAccessTokenException envelope the Spring Cloud Gateway emits, so digit-ui
-          -- redirects to login instead of rendering blank/error screens on an expired session.
-          -- Guarded by "token present" above (the no-token branch returns early), so open/anonymous
-          -- endpoints are unaffected.
-          return kong.response.exit(401, cjson.encode({
-            ResponseInfo = cjson.null,
-            Errors = {{
-              code = "InvalidAccessTokenException",
-              message = "InvalidAccessTokenException",
-              description = "Invalid access token or access token expired for the request",
-            }},
-          }), { ["Content-Type"] = "application/json" })
+          -- Invalid / expired token. Reject ONLY on protected paths — the egov
+          -- InvalidAccessTokenException envelope makes digit-ui redirect to login (session-expiry, #4).
+          -- On auth-OPTIONAL endpoints the token is ignored and the request falls through anonymously
+          -- (matches the K8s gateway, which never validates tokens on open/mixed paths).
+          if is_protected then
+            return kong.response.exit(401, cjson.encode({
+              ResponseInfo = cjson.null,
+              Errors = {{
+                code = "InvalidAccessTokenException",
+                message = "InvalidAccessTokenException",
+                description = "Invalid access token or access token expired for the request",
+              }},
+            }), { ["Content-Type"] = "application/json" })
+          end
+          strip_userinfo()
+          return
         end
+
+        if resolve_failed then
+          -- Transient failure resolving the token (auth service unreachable / erroring). Fail CLOSED
+          -- on protected paths when enforcing — never forward a protected request without a
+          -- server-vouched principal. Optional paths (and audit mode) fall through anonymously.
+          if is_protected and ENFORCE_UNAUTH then
+            return kong.response.exit(503, cjson.encode({
+              ResponseInfo = cjson.null,
+              Errors = {{
+                code = "AuthServiceUnavailable",
+                message = "AuthServiceUnavailable",
+                description = "Could not verify authentication for the request; please retry",
+              }},
+            }), { ["Content-Type"] = "application/json" })
+          end
+          if is_protected then
+            kong.log.warn("RBAC-audit(#5): would fail-closed 503 (auth unverifiable) on protected: ", uri)
+          end
+          strip_userinfo()
+          return
+        end
+
         ri["userInfo"] = resolved
         body["RequestInfo"] = ri
         kong.service.request.set_raw_body(cjson.encode(body))

--- a/local-setup/kong/kong.yml
+++ b/local-setup/kong/kong.yml
@@ -61,17 +61,66 @@ plugins:
         local cjson = require("cjson").new()
         cjson.decode_array_with_array_mt(true)
         local http = require("resty.http")
+
+        -- ===== Gateway RBAC, Phase 1 (#5): authn enforcement + path classification =====
+        -- Mirrors the K8s Spring gateway's open / mixed-mode / protected buckets. OPEN and MIXED
+        -- are auth-OPTIONAL (anonymous allowed and NOT action-RBAC'd); everything else is PROTECTED
+        -- (a valid token is required). Phase 1 does NOT call egov-accesscontrol yet — action-level
+        -- RBAC is Phase 2. The AUTH_OPTIONAL set = open ∪ mixed, kept in sync with the Spring
+        -- gateway whitelists (env.yaml egov-open/-mixed-mode-endpoints-whitelist). See
+        -- docs/parity-item5-gateway-rbac-design.md.
+        --
+        -- Ships in AUDIT mode: unauthenticated hits on protected paths are LOGGED, not rejected.
+        -- Flip ENFORCE_UNAUTH=true after an observation period (first confirm no RBAC-audit warning
+        -- is actually a legitimate anonymous call — if it is, add its path to AUTH_OPTIONAL).
+        local ENFORCE_UNAUTH = false
+        local AUTH_OPTIONAL = {
+          "/user/oauth/token", "/user-otp/v1/_send", "/otp/v1/_validate", "/user/citizen/_create",
+          "/user/password/nologin/_update", "/localization/messages",
+          "/tenant/v1/tenant/_search", "/tenant-management/tenant",
+          "/egov-mdms-service/v1/_search", "/egov-mdms-service/v1/_get",
+          "/egov-mdms-service/v1/_reload", "/egov-mdms-service/v1/_reloadobj",
+          "/egov-mdms-service-test/v1/_search",
+          "/mdms-v2/v1/_search", "/mdms-v2/v2/_search", "/mdms-v2/schema/v1/_search",
+          "/egov-location/boundarys",
+          "/boundary-service/boundary-relationships/_search",
+          "/boundary-service/boundary-hierarchy-definition/_search",
+          "/boundary-service/boundary/_search",
+          "/pgr/services/v1/_search",
+          "/egov-indexer/index-operations/_index", "/egov-indexer/index-operations/_reload",
+          "/filestore/v1/file", "/egov-url-shortening", "/default-data-handler/tenant/new",
+          "/workflow/history/v1/_search", "/egov-idgen/id/_generate", "/user/_search",
+          "/access/v1/actions/mdms/_get", "/egov-location/location/v11/boundarys/_search",
+        }
+        local uri = kong.request.get_path()
+        local is_protected = true
+        for i = 1, #AUTH_OPTIONAL do
+          local p = AUTH_OPTIONAL[i]
+          if uri == p or uri:sub(1, #p) == p then is_protected = false; break end
+        end
+        local function deny_unauth()
+          if ENFORCE_UNAUTH then
+            return kong.response.exit(401, cjson.encode({
+              ResponseInfo = cjson.null,
+              Errors = {{ code = "InvalidAccessTokenException", message = "InvalidAccessTokenException",
+                          description = "Authentication required for the request" }},
+            }), { ["Content-Type"] = "application/json" })
+          end
+          kong.log.warn("RBAC-audit(#5): unauthenticated request to protected path (would 401): ", uri)
+        end
+
         if kong.request.get_method() ~= "POST" then return end
         local raw_body = kong.request.get_raw_body()
-        if not raw_body or raw_body == "" then return end
+        if not raw_body or raw_body == "" then if is_protected then deny_unauth() end return end
         local ok, body = pcall(cjson.decode, raw_body)
-        if not ok or type(body) ~= "table" then return end
+        if not ok or type(body) ~= "table" then if is_protected then deny_unauth() end return end
         local ri = body["RequestInfo"]
-        if not ri or type(ri) ~= "table" then return end
+        if not ri or type(ri) ~= "table" then if is_protected then deny_unauth() end return end
         local token = ri["authToken"]
         if not token or type(token) ~= "string" or token == "" then
           -- no token: NEVER trust body userInfo (close the no-token spoof) — strip it.
           if ri["userInfo"] ~= nil then ri["userInfo"] = nil; body["RequestInfo"] = ri; kong.service.request.set_raw_body(cjson.encode(body)) end
+          if is_protected then deny_unauth() end
           return
         end
         -- Part A: never trust client-supplied userInfo; always resolve from the token.

--- a/local-setup/kong/kong.yml
+++ b/local-setup/kong/kong.yml
@@ -82,11 +82,35 @@ plugins:
           headers = { ["Content-Type"] = "application/json" },
         })
         local resolved = nil
+        local token_rejected = false
         if res and res.status == 200 then
           local ok2, user = pcall(cjson.decode, res.body)
-          if ok2 and type(user) == "table" and (user["uuid"] or user["userName"]) then resolved = user end
+          if ok2 and type(user) == "table" and (user["uuid"] or user["userName"]) then
+            resolved = user
+          else
+            token_rejected = true  -- 200 but no resolvable user
+          end
+        elseif res then
+          token_rejected = true    -- /user/_details rejected the token (invalid / expired)
         else
-          kong.log.err("auth-enrichment failed; stripping client userInfo")
+          -- /user/_details unreachable (network/timeout): a transient upstream error, NOT an
+          -- invalid token — do not force logout; forward with client userInfo stripped.
+          kong.log.err("auth-enrichment: /user/_details unreachable; stripping client userInfo")
+        end
+        if token_rejected then
+          -- Session-expiry parity (#4): a token was PRESENT but could not be validated. Return the
+          -- egov InvalidAccessTokenException envelope the Spring Cloud Gateway emits, so digit-ui
+          -- redirects to login instead of rendering blank/error screens on an expired session.
+          -- Guarded by "token present" above (the no-token branch returns early), so open/anonymous
+          -- endpoints are unaffected.
+          return kong.response.exit(401, cjson.encode({
+            ResponseInfo = cjson.null,
+            Errors = {{
+              code = "InvalidAccessTokenException",
+              message = "InvalidAccessTokenException",
+              description = "Invalid access token or access token expired for the request",
+            }},
+          }), { ["Content-Type"] = "application/json" })
         end
         ri["userInfo"] = resolved
         body["RequestInfo"] = ri


### PR DESCRIPTION
Phase 1 of gateway RBAC on the compose Kong gateway — see the design doc
[`docs/parity-item5-gateway-rbac-design.md`](../blob/develop/docs/parity-item5-gateway-rbac-design.md).

> **Stacked on #1101 (item #4).** This extends the same auth `pre-function`, so the
> diff currently includes #1101's commit. Rebase onto `develop` once #1101 merges.

## What this does
Adds the K8s Spring-gateway request model to the Kong auth `pre-function`:
1. **Classify** every request as **auth-optional** (open ∪ mixed) or **PROTECTED**.
2. On **protected** paths, **require a valid token** (unauthenticated → 401).

It does **not** call `egov-accesscontrol` yet — action-level RBAC is **Phase 2**.
(In Phase 1, open and mixed collapse into one "auth-optional / RBAC-exempt" set;
Phase 2 keeps them exempt while adding the `_authorize` call for protected paths.)

## Ships in AUDIT mode (safe by default)
`ENFORCE_UNAUTH = false`: unauthenticated hits on protected paths are **logged**
(`RBAC-audit(#5)… would 401`), **not rejected**. So merging is a **no-op** until an
operator flips `ENFORCE_UNAUTH = true` after an observation period — first confirming
no logged warning is actually a legitimate anonymous call (if it is, add its path to
`AUTH_OPTIONAL`). This is the audit-first rollout the design doc recommends.

## Whitelist
`AUTH_OPTIONAL` is synced from the Spring gateway whitelists (`env.yaml`
`egov-open-endpoints-whitelist` / `egov-mixed-mode-endpoints-whitelist`) plus the
`boundary-service` search paths CCRS migrated to in #1. Keeping the two in sync is a
known maintenance concern — Phase 3 formalizes a single source of truth.

## Validation (live)
| Case | Enforce mode | Audit mode (default) |
|---|---|---|
| login / mdms / localization / boundary / otp-send (anonymous) | 200 | 200 |
| pgr `_search` / `_create`, **no token** | **401** | passes to backend + logs would-401 |
| pgr `_search`, **valid token** | 200 | 200 |

## Scope / limitations
- POST-request scope (the token lives in the JSON body); GET passes through, matching
  the existing filter. A GET whitelist can follow.
- Depends on `ACCESSCONTROL-ROLEACTIONS` being seeded for Phase 2 (fine on the dump; see #1090).

## Follow-ups
- **Phase 2**: call `egov-accesscontrol /access/v1/actions/_authorize` for protected paths (pin the exact contract first).
- **Phase 3**: single source of truth for the whitelists + CI equality check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Requests are now classified into protected and optional paths, with stricter authentication requirements for protected endpoints.
  * Requests lacking valid authentication information now follow clearer unauthenticated behavior.
* **Bug Fixes**
  * Protected requests with missing/empty/malformed request data now fail more consistently instead of proceeding silently.
  * Token validation now distinguishes invalid-token scenarios from upstream reachability issues, returning a clearer 401 response when access tokens are invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->