### PR TITLE
feat(kong): gateway RBAC phase 2 — action authorization via egov-accesscontrol (#5)

### DIFF
--- a/local-setup/kong/kong.yml
+++ b/local-setup/kong/kong.yml
@@ -66,38 +66,47 @@ plugins:
         -- Mirrors the K8s Spring gateway's open / mixed-mode / protected buckets. OPEN and MIXED
         -- are auth-OPTIONAL (anonymous allowed and NOT action-RBAC'd); everything else is PROTECTED
         -- (a valid token is required). Phase 1 does NOT call egov-accesscontrol yet — action-level
-        -- RBAC is Phase 2. The AUTH_OPTIONAL set = open ∪ mixed, kept in sync with the Spring
-        -- gateway whitelists (env.yaml egov-open/-mixed-mode-endpoints-whitelist). See
-        -- docs/parity-item5-gateway-rbac-design.md.
+        -- RBAC is Phase 2.
+        --
+        -- EXACT match (set membership), mirroring the Spring gateway's
+        -- openEndpointsWhitelist.contains(getPath().value()) — NOT prefix (a prefix would over-open,
+        -- e.g. anonymous /localization/messages/v1/_upsert). AUTH_OPTIONAL = open ∪ mixed, kept
+        -- VERBATIM-in-sync with env.yaml egov-open/-mixed-mode-endpoints-whitelist (+ the
+        -- boundary-service search paths CCRS migrated to in #1); a CI check enforces the two match
+        -- (Phase 3). See docs/parity-item5-gateway-rbac-design.md.
         --
         -- Ships in AUDIT mode: unauthenticated hits on protected paths are LOGGED, not rejected.
         -- Flip ENFORCE_UNAUTH=true after an observation period (first confirm no RBAC-audit warning
-        -- is actually a legitimate anonymous call — if it is, add its path to AUTH_OPTIONAL).
+        -- is a legitimate anonymous call — if it is, add its EXACT path to AUTH_OPTIONAL AND env.yaml).
         local ENFORCE_UNAUTH = false
         local AUTH_OPTIONAL = {
-          "/user/oauth/token", "/user-otp/v1/_send", "/otp/v1/_validate", "/user/citizen/_create",
-          "/user/password/nologin/_update", "/localization/messages",
-          "/tenant/v1/tenant/_search", "/tenant-management/tenant",
-          "/egov-mdms-service/v1/_search", "/egov-mdms-service/v1/_get",
-          "/egov-mdms-service/v1/_reload", "/egov-mdms-service/v1/_reloadobj",
-          "/egov-mdms-service-test/v1/_search",
-          "/mdms-v2/v1/_search", "/mdms-v2/v2/_search", "/mdms-v2/schema/v1/_search",
-          "/egov-location/boundarys",
-          "/boundary-service/boundary-relationships/_search",
-          "/boundary-service/boundary-hierarchy-definition/_search",
-          "/boundary-service/boundary/_search",
-          "/pgr/services/v1/_search",
-          "/egov-indexer/index-operations/_index", "/egov-indexer/index-operations/_reload",
-          "/filestore/v1/file", "/egov-url-shortening", "/default-data-handler/tenant/new",
-          "/workflow/history/v1/_search", "/egov-idgen/id/_generate", "/user/_search",
-          "/access/v1/actions/mdms/_get", "/egov-location/location/v11/boundarys/_search",
+          ["/user/oauth/token"]=true, ["/user-otp/v1/_send"]=true, ["/otp/v1/_validate"]=true,
+          ["/user/citizen/_create"]=true, ["/user/password/nologin/_update"]=true,
+          ["/localization/messages"]=true, ["/localization/messages/v1/_search"]=true,
+          ["/tenant/v1/tenant/_search"]=true,
+          ["/egov-location/boundarys"]=true,
+          ["/egov-location/boundarys/boundariesByBndryTypeNameAndHierarchyTypeName"]=true,
+          ["/egov-location/boundarys/getLocationByLocationName"]=true,
+          ["/egov-location/boundarys/isshapefileexist"]=true,
+          ["/egov-location/boundarys/getshapefile"]=true,
+          ["/egov-location/location/v11/boundarys/_search"]=true,
+          ["/pgr/services/v1/_search"]=true,
+          ["/egov-mdms-service/v1/_search"]=true, ["/egov-mdms-service/v1/_get"]=true,
+          ["/egov-mdms-service/v1/_reload"]=true, ["/egov-mdms-service/v1/_reloadobj"]=true,
+          ["/egov-mdms-service-test/v1/_search"]=true,
+          ["/mdms-v2/v1/_search"]=true, ["/mdms-v2/v2/_search"]=true, ["/mdms-v2/schema/v1/_search"]=true,
+          ["/boundary-service/boundary-relationships/_search"]=true,
+          ["/boundary-service/boundary-hierarchy-definition/_search"]=true,
+          ["/boundary-service/boundary/_search"]=true,
+          ["/egov-indexer/index-operations/_index"]=true, ["/egov-indexer/index-operations/_reload"]=true,
+          ["/filestore/v1/file"]=true, ["/filestore/v1/files"]=true, ["/filestore/v1/files/url"]=true,
+          ["/filestore/v1/files/id"]=true, ["/filestore/v1/files/tag"]=true,
+          ["/egov-url-shortening"]=true, ["/default-data-handler/tenant/new"]=true,
+          ["/workflow/history/v1/_search"]=true, ["/egov-idgen/id/_generate"]=true,
+          ["/user/_search"]=true, ["/access/v1/actions/mdms/_get"]=true,
         }
         local uri = kong.request.get_path()
-        local is_protected = true
-        for i = 1, #AUTH_OPTIONAL do
-          local p = AUTH_OPTIONAL[i]
-          if uri == p or uri:sub(1, #p) == p then is_protected = false; break end
-        end
+        local is_protected = not AUTH_OPTIONAL[uri]
         local function deny_unauth()
           if ENFORCE_UNAUTH then
             return kong.response.exit(401, cjson.encode({

--- a/local-setup/kong/kong.yml
+++ b/local-setup/kong/kong.yml
@@ -79,6 +79,9 @@ plugins:
         -- Flip ENFORCE_UNAUTH=true after an observation period (first confirm no RBAC-audit warning
         -- is a legitimate anonymous call — if it is, add its EXACT path to AUTH_OPTIONAL AND env.yaml).
         local ENFORCE_UNAUTH = false
+        -- Phase 2 (#5): action-level RBAC via egov-accesscontrol on protected paths. Also ships in
+        -- AUDIT mode (log-only); flip to true to enforce (403 on deny). Independent of ENFORCE_UNAUTH.
+        local ENFORCE_RBAC = false
         local AUTH_OPTIONAL = {
           ["/user/oauth/token"]=true, ["/user-otp/v1/_send"]=true, ["/otp/v1/_validate"]=true,
           ["/user/citizen/_create"]=true, ["/user/password/nologin/_update"]=true,
@@ -211,6 +214,42 @@ plugins:
         ri["userInfo"] = resolved
         body["RequestInfo"] = ri
         kong.service.request.set_raw_body(cjson.encode(body))
+
+        -- ===== Gateway RBAC, Phase 2 (#5): action-level authorization for protected paths =====
+        -- For a PROTECTED path with a resolved principal, ask egov-accesscontrol whether the
+        -- principal's roles may call this action (uri): 200 = allow, non-200 = deny. Mirrors the
+        -- Spring gateway's RBAC filter. Ships in AUDIT mode; when ENFORCE_RBAC it fails CLOSED (a
+        -- protected action is denied unless we get an explicit allow). See
+        -- docs/parity-item5-gateway-rbac-design.md. (Perf: one accesscontrol call per protected
+        -- request; response caching keyed by roles+uri+tenant is a documented follow-up.)
+        if is_protected and resolved then
+          local az = http.new()
+          az:set_timeout(5000)
+          local ares = az:request_uri("http://egov-accesscontrol:8090/access/v1/actions/_authorize", {
+            method = "POST",
+            headers = { ["Content-Type"] = "application/json" },
+            body = cjson.encode({
+              RequestInfo = { apiId = "Rainmaker", authToken = token },
+              AuthorizationRequest = {
+                roles = resolved["roles"] or {},
+                uri = uri,
+                tenantIds = { resolved["tenantId"] },
+              },
+            }),
+          })
+          if not (ares and ares.status == 200) then
+            local why = ares and ("accesscontrol status " .. ares.status) or "accesscontrol unreachable"
+            if ENFORCE_RBAC then
+              return kong.response.exit(403, cjson.encode({
+                ResponseInfo = cjson.null,
+                Errors = {{ code = "AccessDeniedException", message = "AccessDeniedException",
+                            description = "You are not authorized to perform this action" }},
+              }), { ["Content-Type"] = "application/json" })
+            end
+            kong.log.warn("RBAC-audit(#5 p2): would 403 (", why, ") uri=", uri,
+                          " roles=", cjson.encode(resolved["roles"] or {}))
+          end
+        end
 services:
 - name: mdms-service
   url: http://egov-mdms-service:8094

--- a/local-setup/kong/kong.yml
+++ b/local-setup/kong/kong.yml
@@ -140,36 +140,74 @@ plugins:
           headers = { ["Content-Type"] = "application/json" },
         })
         local resolved = nil
-        local token_rejected = false
+        local token_rejected = false   -- explicit auth rejection (401/403): invalid / expired token
+        local resolve_failed = false   -- transient: /user/_details unreachable, 5xx, or unparseable
         if res and res.status == 200 then
           local ok2, user = pcall(cjson.decode, res.body)
           if ok2 and type(user) == "table" and (user["uuid"] or user["userName"]) then
             resolved = user
           else
-            token_rejected = true  -- 200 but no resolvable user
+            resolve_failed = true      -- 200 but no resolvable user -> transient, not a token reject
+            kong.log.err("auth-enrichment: /user/_details 200 with no resolvable user")
           end
+        elseif res and (res.status == 401 or res.status == 403
+                        or (res.body and res.body:find("InvalidAccessTokenException", 1, true))) then
+          -- egov-user signals an invalid/expired token via InvalidAccessTokenException (HTTP 400 on
+          -- this stack, 401/403 on others) — treat any of those as a genuine token rejection, and
+          -- everything else (5xx / other) as a transient failure below.
+          token_rejected = true
         elseif res then
-          token_rejected = true    -- /user/_details rejected the token (invalid / expired)
+          resolve_failed = true        -- other non-200 (5xx, etc.) -> transient, NOT a token reject
+          kong.log.err("auth-enrichment: /user/_details status ", res.status)
         else
-          -- /user/_details unreachable (network/timeout): a transient upstream error, NOT an
-          -- invalid token — do not force logout; forward with client userInfo stripped.
-          kong.log.err("auth-enrichment: /user/_details unreachable; stripping client userInfo")
+          resolve_failed = true        -- unreachable (network / timeout)
+          kong.log.err("auth-enrichment: /user/_details unreachable: ", err or "")
         end
+
+        local function strip_userinfo()
+          if ri["userInfo"] ~= nil then ri["userInfo"] = nil; body["RequestInfo"] = ri; kong.service.request.set_raw_body(cjson.encode(body)) end
+        end
+
         if token_rejected then
-          -- Session-expiry parity (#4): a token was PRESENT but could not be validated. Return the
-          -- egov InvalidAccessTokenException envelope the Spring Cloud Gateway emits, so digit-ui
-          -- redirects to login instead of rendering blank/error screens on an expired session.
-          -- Guarded by "token present" above (the no-token branch returns early), so open/anonymous
-          -- endpoints are unaffected.
-          return kong.response.exit(401, cjson.encode({
-            ResponseInfo = cjson.null,
-            Errors = {{
-              code = "InvalidAccessTokenException",
-              message = "InvalidAccessTokenException",
-              description = "Invalid access token or access token expired for the request",
-            }},
-          }), { ["Content-Type"] = "application/json" })
+          -- Invalid / expired token. Reject ONLY on protected paths — the egov
+          -- InvalidAccessTokenException envelope makes digit-ui redirect to login (session-expiry, #4).
+          -- On auth-OPTIONAL endpoints the token is ignored and the request falls through anonymously
+          -- (matches the K8s gateway, which never validates tokens on open/mixed paths).
+          if is_protected then
+            return kong.response.exit(401, cjson.encode({
+              ResponseInfo = cjson.null,
+              Errors = {{
+                code = "InvalidAccessTokenException",
+                message = "InvalidAccessTokenException",
+                description = "Invalid access token or access token expired for the request",
+              }},
+            }), { ["Content-Type"] = "application/json" })
+          end
+          strip_userinfo()
+          return
         end
+
+        if resolve_failed then
+          -- Transient failure resolving the token (auth service unreachable / erroring). Fail CLOSED
+          -- on protected paths when enforcing — never forward a protected request without a
+          -- server-vouched principal. Optional paths (and audit mode) fall through anonymously.
+          if is_protected and ENFORCE_UNAUTH then
+            return kong.response.exit(503, cjson.encode({
+              ResponseInfo = cjson.null,
+              Errors = {{
+                code = "AuthServiceUnavailable",
+                message = "AuthServiceUnavailable",
+                description = "Could not verify authentication for the request; please retry",
+              }},
+            }), { ["Content-Type"] = "application/json" })
+          end
+          if is_protected then
+            kong.log.warn("RBAC-audit(#5): would fail-closed 503 (auth unverifiable) on protected: ", uri)
+          end
+          strip_userinfo()
+          return
+        end
+
         ri["userInfo"] = resolved
         body["RequestInfo"] = ri
         kong.service.request.set_raw_body(cjson.encode(body))

--- a/local-setup/kong/kong.yml
+++ b/local-setup/kong/kong.yml
@@ -235,9 +235,11 @@ plugins:
             body = cjson.encode({
               RequestInfo = { apiId = "Rainmaker", authToken = token },
               AuthorizationRequest = {
-                roles = resolved["roles"] or {},
+                -- cjson.empty_array so empty roles/tenantIds serialize as JSON [] (not {}),
+                -- which egov-accesscontrol expects for these fields.
+                roles = resolved["roles"] or cjson.empty_array,
                 uri = uri,
-                tenantIds = tid and { tid } or {},
+                tenantIds = tid and { tid } or cjson.empty_array,
               },
             }),
           })

--- a/local-setup/kong/kong.yml
+++ b/local-setup/kong/kong.yml
@@ -61,17 +61,66 @@ plugins:
         local cjson = require("cjson").new()
         cjson.decode_array_with_array_mt(true)
         local http = require("resty.http")
+
+        -- ===== Gateway RBAC, Phase 1 (#5): authn enforcement + path classification =====
+        -- Mirrors the K8s Spring gateway's open / mixed-mode / protected buckets. OPEN and MIXED
+        -- are auth-OPTIONAL (anonymous allowed and NOT action-RBAC'd); everything else is PROTECTED
+        -- (a valid token is required). Phase 1 does NOT call egov-accesscontrol yet — action-level
+        -- RBAC is Phase 2. The AUTH_OPTIONAL set = open ∪ mixed, kept in sync with the Spring
+        -- gateway whitelists (env.yaml egov-open/-mixed-mode-endpoints-whitelist). See
+        -- docs/parity-item5-gateway-rbac-design.md.
+        --
+        -- Ships in AUDIT mode: unauthenticated hits on protected paths are LOGGED, not rejected.
+        -- Flip ENFORCE_UNAUTH=true after an observation period (first confirm no RBAC-audit warning
+        -- is actually a legitimate anonymous call — if it is, add its path to AUTH_OPTIONAL).
+        local ENFORCE_UNAUTH = false
+        local AUTH_OPTIONAL = {
+          "/user/oauth/token", "/user-otp/v1/_send", "/otp/v1/_validate", "/user/citizen/_create",
+          "/user/password/nologin/_update", "/localization/messages",
+          "/tenant/v1/tenant/_search", "/tenant-management/tenant",
+          "/egov-mdms-service/v1/_search", "/egov-mdms-service/v1/_get",
+          "/egov-mdms-service/v1/_reload", "/egov-mdms-service/v1/_reloadobj",
+          "/egov-mdms-service-test/v1/_search",
+          "/mdms-v2/v1/_search", "/mdms-v2/v2/_search", "/mdms-v2/schema/v1/_search",
+          "/egov-location/boundarys",
+          "/boundary-service/boundary-relationships/_search",
+          "/boundary-service/boundary-hierarchy-definition/_search",
+          "/boundary-service/boundary/_search",
+          "/pgr/services/v1/_search",
+          "/egov-indexer/index-operations/_index", "/egov-indexer/index-operations/_reload",
+          "/filestore/v1/file", "/egov-url-shortening", "/default-data-handler/tenant/new",
+          "/workflow/history/v1/_search", "/egov-idgen/id/_generate", "/user/_search",
+          "/access/v1/actions/mdms/_get", "/egov-location/location/v11/boundarys/_search",
+        }
+        local uri = kong.request.get_path()
+        local is_protected = true
+        for i = 1, #AUTH_OPTIONAL do
+          local p = AUTH_OPTIONAL[i]
+          if uri == p or uri:sub(1, #p) == p then is_protected = false; break end
+        end
+        local function deny_unauth()
+          if ENFORCE_UNAUTH then
+            return kong.response.exit(401, cjson.encode({
+              ResponseInfo = cjson.null,
+              Errors = {{ code = "InvalidAccessTokenException", message = "InvalidAccessTokenException",
+                          description = "Authentication required for the request" }},
+            }), { ["Content-Type"] = "application/json" })
+          end
+          kong.log.warn("RBAC-audit(#5): unauthenticated request to protected path (would 401): ", uri)
+        end
+
         if kong.request.get_method() ~= "POST" then return end
         local raw_body = kong.request.get_raw_body()
-        if not raw_body or raw_body == "" then return end
+        if not raw_body or raw_body == "" then if is_protected then deny_unauth() end return end
         local ok, body = pcall(cjson.decode, raw_body)
-        if not ok or type(body) ~= "table" then return end
+        if not ok or type(body) ~= "table" then if is_protected then deny_unauth() end return end
         local ri = body["RequestInfo"]
-        if not ri or type(ri) ~= "table" then return end
+        if not ri or type(ri) ~= "table" then if is_protected then deny_unauth() end return end
         local token = ri["authToken"]
         if not token or type(token) ~= "string" or token == "" then
           -- no token: NEVER trust body userInfo (close the no-token spoof) — strip it.
           if ri["userInfo"] ~= nil then ri["userInfo"] = nil; body["RequestInfo"] = ri; kong.service.request.set_raw_body(cjson.encode(body)) end
+          if is_protected then deny_unauth() end
           return
         end
         -- Part A: never trust client-supplied userInfo; always resolve from the token.

--- a/local-setup/kong/kong.yml
+++ b/local-setup/kong/kong.yml
@@ -82,11 +82,35 @@ plugins:
           headers = { ["Content-Type"] = "application/json" },
         })
         local resolved = nil
+        local token_rejected = false
         if res and res.status == 200 then
           local ok2, user = pcall(cjson.decode, res.body)
-          if ok2 and type(user) == "table" and (user["uuid"] or user["userName"]) then resolved = user end
+          if ok2 and type(user) == "table" and (user["uuid"] or user["userName"]) then
+            resolved = user
+          else
+            token_rejected = true  -- 200 but no resolvable user
+          end
+        elseif res then
+          token_rejected = true    -- /user/_details rejected the token (invalid / expired)
         else
-          kong.log.err("auth-enrichment failed; stripping client userInfo")
+          -- /user/_details unreachable (network/timeout): a transient upstream error, NOT an
+          -- invalid token — do not force logout; forward with client userInfo stripped.
+          kong.log.err("auth-enrichment: /user/_details unreachable; stripping client userInfo")
+        end
+        if token_rejected then
+          -- Session-expiry parity (#4): a token was PRESENT but could not be validated. Return the
+          -- egov InvalidAccessTokenException envelope the Spring Cloud Gateway emits, so digit-ui
+          -- redirects to login instead of rendering blank/error screens on an expired session.
+          -- Guarded by "token present" above (the no-token branch returns early), so open/anonymous
+          -- endpoints are unaffected.
+          return kong.response.exit(401, cjson.encode({
+            ResponseInfo = cjson.null,
+            Errors = {{
+              code = "InvalidAccessTokenException",
+              message = "InvalidAccessTokenException",
+              description = "Invalid access token or access token expired for the request",
+            }},
+          }), { ["Content-Type"] = "application/json" })
         end
         ri["userInfo"] = resolved
         body["RequestInfo"] = ri

--- a/local-setup/kong/kong.yml
+++ b/local-setup/kong/kong.yml
@@ -223,6 +223,10 @@ plugins:
         -- docs/parity-item5-gateway-rbac-design.md. (Perf: one accesscontrol call per protected
         -- request; response caching keyed by roles+uri+tenant is a documented follow-up.)
         if is_protected and resolved then
+          -- Guard tenantIds: a principal without a tenantId (e.g. a freshly-created citizen
+          -- before city selection) must NOT serialize as tenantIds:[null], which accesscontrol
+          -- would reject as malformed — send an empty array instead.
+          local tid = resolved["tenantId"]
           local az = http.new()
           az:set_timeout(5000)
           local ares = az:request_uri("http://egov-accesscontrol:8090/access/v1/actions/_authorize", {
@@ -233,21 +237,27 @@ plugins:
               AuthorizationRequest = {
                 roles = resolved["roles"] or {},
                 uri = uri,
-                tenantIds = { resolved["tenantId"] },
+                tenantIds = tid and { tid } or {},
               },
             }),
           })
           if not (ares and ares.status == 200) then
-            local why = ares and ("accesscontrol status " .. ares.status) or "accesscontrol unreachable"
             if ENFORCE_RBAC then
+              -- fail CLOSED: deny on an explicit non-200 AND on an unreachable accesscontrol.
               return kong.response.exit(403, cjson.encode({
                 ResponseInfo = cjson.null,
                 Errors = {{ code = "AccessDeniedException", message = "AccessDeniedException",
                             description = "You are not authorized to perform this action" }},
               }), { ["Content-Type"] = "application/json" })
             end
-            kong.log.warn("RBAC-audit(#5 p2): would 403 (", why, ") uri=", uri,
-                          " roles=", cjson.encode(resolved["roles"] or {}))
+            -- AUDIT: separate a legitimate DENY (accesscontrol answered non-200) from a transient
+            -- infra failure (accesscontrol UNREACHABLE) so operators know which alerts to act on.
+            if ares then
+              kong.log.warn("RBAC-audit(#5 p2): would 403 — accesscontrol DENY (status ", ares.status,
+                            ") uri=", uri, " roles=", cjson.encode(resolved["roles"] or {}))
+            else
+              kong.log.err("RBAC-audit(#5 p2): would 403 (fail-closed) — accesscontrol UNREACHABLE uri=", uri)
+            end
           end
         end
 services:


### PR DESCRIPTION
Phase 2 of gateway RBAC on the compose Kong gateway — see
[`docs/parity-item5-gateway-rbac-design.md`](../blob/develop/docs/parity-item5-gateway-rbac-design.md).

> **Stacked on #1104 (phase 1) → #1101 (item #4).** The diff currently includes both;
> rebase onto `develop` as they merge.

## What this does
For a **protected** path with a resolved principal (from phase 1), the Kong
`pre-function` now calls **`egov-accesscontrol /access/v1/actions/_authorize`** and
returns **403 `AccessDeniedException`** when the principal's roles may not perform the
action — the action-level RBAC the K8s Spring gateway does.

## Contract (pinned by decompiling the running `egov-accesscontrol` jar)
```
POST http://egov-accesscontrol:8090/access/v1/actions/_authorize
{ "RequestInfo": {...},
  "AuthorizationRequest": { "roles":[{"code","tenantId"}], "uri":"<path>", "tenantIds":["<tenant>"] } }
→ 200 = allow, non-200 = deny   (ResponseEntity<Void>, no body)
```
(The wrapper key is `AuthorizationRequest` with a capital A; the field is `uri`, not `actionUrl`.)

## Ships in AUDIT mode (safe default)
`ENFORCE_RBAC = false`: would-be denials are **logged** (`RBAC-audit(#5 p2)… would 403`),
not enforced. Flip `ENFORCE_RBAC = true` after an observation period. When enforcing it
**fails closed** (deny unless an explicit allow).

## Validation (live)
| Principal → action | Enforce | Audit (default) |
|---|---|---|
| CITIZEN → pgr `_search` / `_create` | 200 (allowed) | 200 |
| CITIZEN → `egov-hrms/employees/_create` | **403 denied** | 400 (passes) + logs would-403 |
| ADMIN → `egov-hrms/employees/_create` | 400 (allowed) | 400 |
| anonymous → open endpoint | 200 | 200 |

## Notes / follow-ups
- **Perf:** adds one accesscontrol call per protected request (on top of `/user/_details`).
  Response caching keyed by roles+uri+tenant is a documented follow-up.
- **Data dependency:** relies on `ACCESSCONTROL-ROLEACTIONS` being seeded (fine on the dump; see #1090).
- **Phase 3:** single source of truth for the open/mixed whitelists + a CI equality check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added gateway authentication enforcement for protected routes, with optional support for explicitly whitelisted paths.
  * Added role- and action-based authorization checks for protected requests.
  * Added clear 401 responses for invalid or expired access tokens and 403 responses for denied actions.

* **Bug Fixes**
  * Improved handling of malformed request bodies and missing authentication data.
  * Prevented client-supplied user information from being used when authentication tokens are invalid or absent.
  * Distinguished temporary authorization-service failures from explicit access denials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->