### PR TITLE
local-setup: add hot-deploy.sh script + guide for pgr-services/digit-ui-esbuild/configurator

### DIFF
--- a/local-setup/docs/HOT-DEPLOY-GUIDE.md
+++ b/local-setup/docs/HOT-DEPLOY-GUIDE.md
@@ -72,7 +72,7 @@ there's no live class reload.
 ### `frontend` — digit-ui-esbuild
 
 ```bash
-cd digit-ui-esbuild && node esbuild.build.js
+(cd digit-ui-esbuild && node esbuild.build.js)
 tar -czf - -C digit-ui-esbuild/build . | docker exec -i digit-ui tar -xzf - -C /usr/share/nginx/html
 ```
 
@@ -87,8 +87,8 @@ restart is needed.
 ### `configurator` — DIGIT Studio
 
 ```bash
-cd configurator/packages/data-provider && npm run build   # + digit-datagrid
-cd configurator && npx vite build --base=/configurator/
+(cd configurator/packages/data-provider && npm run build)   # + digit-datagrid
+(cd configurator && npx vite build --base=/configurator/)
 sudo cp -r configurator/dist/. /var/www/configurator/ && sudo nginx -s reload
 ```
 

--- a/local-setup/docs/HOT-DEPLOY-GUIDE.md
+++ b/local-setup/docs/HOT-DEPLOY-GUIDE.md
@@ -27,6 +27,7 @@ cd local-setup
 ./scripts/hot-deploy.sh configurator    # after editing configurator/**
 ./scripts/hot-deploy.sh all             # all three, in sequence
 ```
+**If you encounter any permission issues while running the above commands, execute them with sudo.**
 
 Each target does exactly the same steps a developer would otherwise do by
 hand (see below), plus a health check at the end so you know whether the

--- a/local-setup/docs/HOT-DEPLOY-GUIDE.md
+++ b/local-setup/docs/HOT-DEPLOY-GUIDE.md
@@ -1,0 +1,154 @@
+# Hot deployment guide
+
+Once `ansible/deploy.sh <tenant>` (or `docker compose up -d`) has stood up the
+local-setup stack, you don't need to re-run the playbook or `docker compose
+build` every time you tweak a line of code. The three app-layer pieces of
+this repo can each be rebuilt and pushed into the *already-running*
+containers directly:
+
+| Service | Runs as | Hot-swap mechanism |
+|---|---|---|
+| `backend/pgr-services` | container `digit-pgr-services-1` | rebuild jar → `docker cp` into container → `docker restart` |
+| `digit-ui-esbuild` | container `digit-ui` (nginx) | rebuild bundle → `tar` pipe into container's docroot (no restart) |
+| `configurator` | host nginx (or bind-mounted container on macOS) | rebuild SPA → sync `dist/` to the nginx docroot → `nginx -s reload` |
+
+None of these touch the image registry or the compose/playbook definitions —
+they only replace files inside the container/docroot that's already up. A
+full `docker compose up -d --build` or ansible re-run is still the right tool
+when you change a Dockerfile, add a new service, or need a clean-slate
+rebuild.
+
+## The one-liner: `hot-deploy.sh`
+
+```bash
+cd local-setup
+./scripts/hot-deploy.sh backend         # after editing backend/pgr-services/**
+./scripts/hot-deploy.sh frontend        # after editing digit-ui-esbuild/** (e.g. products/pgr/**)
+./scripts/hot-deploy.sh configurator    # after editing configurator/**
+./scripts/hot-deploy.sh all             # all three, in sequence
+```
+
+Each target does exactly the same steps a developer would otherwise do by
+hand (see below), plus a health check at the end so you know whether the
+change actually landed. Run it from anywhere — it resolves paths relative to
+the repo root, not your cwd.
+
+If the target container isn't running, the script fails fast with a message
+telling you to bring the stack up first — hot-swap only makes sense against
+an already-deployed environment.
+
+### Config knobs
+
+- `CONFIGURATOR_WWW_DIR` — override the nginx docroot for `configurator`.
+  Defaults to `/var/www/configurator` (Linux host nginx). On macOS/OrbStack
+  deploys the playbook bind-mounts a different path per
+  `local-setup/ansible/inventory/group_vars/all.yml` (`configurator_www_dir`)
+  — check that file's value for your tenant and export it before running the
+  script, e.g. `CONFIGURATOR_WWW_DIR=/path/from/host_vars ./scripts/hot-deploy.sh configurator`.
+- `SKIP_SUBPKGS=1` — skip rebuilding `configurator/packages/{data-provider,digit-datagrid}`
+  before the SPA build. The script rebuilds them by default because they're
+  consumed via `file:` deps and a stale `dist/` there silently bundles old code.
+
+## What each target does under the hood
+
+### `backend` — pgr-services
+
+```bash
+mvn -f backend/pgr-services/pom.xml clean package -DskipTests
+docker cp backend/pgr-services/target/pgr-services-*.jar digit-pgr-services-1:/app/app.jar
+docker restart digit-pgr-services-1
+```
+
+`digit-pgr-services-1` runs a prebuilt registry image, not a repo Dockerfile
+build — the container itself never changes, only the jar inside `/app`.
+`clean package` (not just `package`) avoids leaving two jars in `target/`,
+which would make `docker cp`'s glob ambiguous. Tests are skipped for
+dev-loop speed; run `mvn test` separately before you consider the change done.
+
+Restart is required here because the JVM has the old jar's bytecode loaded —
+there's no live class reload.
+
+### `frontend` — digit-ui-esbuild
+
+```bash
+cd digit-ui-esbuild && node esbuild.build.js
+tar -czf - -C digit-ui-esbuild/build . | docker exec -i digit-ui tar -xzf - -C /usr/share/nginx/html
+```
+
+`digit-ui` serves a **flat** static layout (`index.html`, `index.js`,
+`vendor/`, `globalConfigs.js` directly under `/usr/share/nginx/html`, no
+`digit-ui/` subfolder). The esbuild script always builds every module —
+there's no per-app flag — so this rebuilds everything under
+`digit-ui-esbuild/products/*` in one pass. The tar pipe replaces the whole
+docroot atomically-ish in one shot; nginx serves static files directly, so no
+restart is needed.
+
+### `configurator` — DIGIT Studio
+
+```bash
+cd configurator/packages/data-provider && npm run build   # + digit-datagrid
+cd configurator && npx vite build --base=/configurator/
+sudo cp -r configurator/dist/. /var/www/configurator/ && sudo nginx -s reload
+```
+
+Two gotchas the script exists specifically to avoid:
+
+1. **Don't run the root `npm run build`.** That script is `tsc -b && vite
+   build`, and the project-wide typecheck has pre-existing errors unrelated
+   to most changes — it'll block a build that would otherwise work. The
+   script calls `vite build` directly, same as the ansible build path
+   (`local-setup/ansible/files/configurator-build.sh`).
+2. **Sync the whole `dist/` directory, never individual files.** Vite
+   content-hashes filenames on every build, so `index.html` from one build
+   paired with assets from a previous copy will 404.
+
+If the docroot isn't writable and there's no `sudo` (e.g. inside a sandboxed
+agent), the script falls back to a throwaway `alpine` container mounting the
+docroot to do the copy as root.
+
+**Root-owned leftovers.** The initial ansible deploy runs the configurator
+build as root, so `configurator/node_modules/.vite-temp/` and files under
+`$CONFIGURATOR_WWW_DIR/assets/` can end up root-owned even though the
+top-level directories are user-writable. The script detects this by trying a
+plain `rm`+`cp` first and falling back to `sudo` (then to the container
+fallback) on failure.
+
+That auto-fallback only works with **passwordless** sudo (`sudo -n`). If your
+account needs a password for sudo, the non-interactive `sudo -n true` check
+inside the script fails silently and it drops straight to the Docker
+container fallback — which itself can fail if Docker isn't set up to run
+without sudo on your box. In that case you'll see raw `EACCES`/`Permission
+denied` errors instead of a clean fallback message. The fix is simply to
+re-run the configurator step with sudo yourself, preserving your PATH so it
+still finds your Node/npm (important if Node is managed by nvm under your
+home directory, since sudo normally resets PATH to a root-only one):
+
+```bash
+sudo -E env "PATH=$PATH" ./scripts/hot-deploy.sh configurator
+```
+
+This will prompt for your password once, then run the whole build-and-sync
+as root, which has permission to touch the pre-existing root-owned files.
+It's safe to do every time if you'd rather not depend on passwordless sudo —
+the script's own `rm`+`cp` attempt is just a fast path.
+
+## When hot-deploy isn't enough
+
+Fall back to the full path if:
+- The container itself isn't running (`docker compose up -d <service>` first).
+- You changed a Dockerfile, `docker-compose*.yml`, or added a new service —
+  hot-deploy only replaces app code inside an existing container.
+- You changed Kong routes, MDMS seed data, or anything ansible provisions
+  once at deploy time (roles, `host_vars`) — re-run `ansible/deploy.sh <tenant>`.
+- You need to verify CI-equivalent behavior — hot-deploy is a dev-loop
+  shortcut, not a substitute for `local-setup/scripts/smoke-test.sh` /
+  `health-check.sh` before merging.
+
+## Equivalent Claude Code skills
+
+If you're driving changes through Claude Code rather than the terminal, the
+same three procedures are available as skills and are picked automatically
+after you edit the relevant code and ask to see it live:
+`redeploy-pgr-backend`, `redeploy-pgr-frontend`, `redeploy-configurator`
+(`.claude/skills/`). `hot-deploy.sh` is the terminal-native version of the
+same steps, for when you're iterating by hand.

--- a/local-setup/scripts/hot-deploy.sh
+++ b/local-setup/scripts/hot-deploy.sh
@@ -20,6 +20,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 CONFIGURATOR_WWW_DIR="${CONFIGURATOR_WWW_DIR:-/var/www/configurator}"
 SKIP_SUBPKGS="${SKIP_SUBPKGS:-0}"
+SKIP_TESTS="${SKIP_TESTS:-1}"
 
 usage() {
     cat <<EOF
@@ -51,13 +52,17 @@ require_container() {
 }
 
 cmd_backend() {
-    log "building backend/pgr-services jar..."
-    mvn -f "$REPO_ROOT/backend/pgr-services/pom.xml" clean package -DskipTests
-
     require_container digit-pgr-services-1
 
+    log "building backend/pgr-services jar..."
+    local mvn_args=(clean package)
+    if [ "$SKIP_TESTS" = "1" ]; then
+        mvn_args+=(-DskipTests)
+    fi
+    mvn -f "$REPO_ROOT/backend/pgr-services/pom.xml" "${mvn_args[@]}"
+
     local jar
-    jar="$(ls "$REPO_ROOT"/backend/pgr-services/target/pgr-services-*.jar 2>/dev/null | head -1)"
+    jar="$(find "$REPO_ROOT/backend/pgr-services/target" -maxdepth 1 -name 'pgr-services-*.jar' 2>/dev/null | head -1)"
     [ -n "$jar" ] || { echo "[hot-deploy] ERROR: no jar found under backend/pgr-services/target/" >&2; exit 1; }
 
     log "hot-swapping $(basename "$jar") into digit-pgr-services-1..."
@@ -69,8 +74,8 @@ cmd_backend() {
     until docker exec digit-pgr-services-1 wget -qO- http://localhost:8080/pgr-services/health >/dev/null 2>&1; do
         i=$((i + 1))
         if [ "$i" -ge 30 ]; then
-            echo "[hot-deploy] WARNING: health check still not responding after 60s — check 'docker logs digit-pgr-services-1'" >&2
-            return 0
+            echo "[hot-deploy] ERROR: health check still not responding after 60s — check 'docker logs digit-pgr-services-1'" >&2
+            return 1
         fi
         sleep 2
     done
@@ -78,17 +83,18 @@ cmd_backend() {
 }
 
 cmd_frontend() {
+    require_container digit-ui
+
     log "building digit-ui-esbuild bundle..."
     (cd "$REPO_ROOT/digit-ui-esbuild" && node esbuild.build.js)
-
-    require_container digit-ui
 
     log "pushing build/ into digit-ui container..."
     tar -czf - -C "$REPO_ROOT/digit-ui-esbuild/build" . | docker exec -i digit-ui tar -xzf - -C /usr/share/nginx/html
 
     local code
-    code="$(curl -sS -o /dev/null -w '%{http_code}' http://localhost:18080/digit-ui/ || true)"
+    code="$(curl -sS -o /dev/null -w '%{http_code}' http://localhost:18080/digit-ui/)" || { echo "[hot-deploy] ERROR: digit-ui did not respond" >&2; return 1; }
     log "digit-ui responded with HTTP $code"
+    [[ "$code" =~ ^[23] ]] || { echo "[hot-deploy] ERROR: digit-ui returned HTTP $code" >&2; return 1; }
 }
 
 cmd_configurator() {
@@ -105,31 +111,42 @@ cmd_configurator() {
     log "building configurator SPA (vite build, no root typecheck)..."
     (cd "$REPO_ROOT/configurator" && npx vite build --base=/configurator/)
 
-    log "syncing dist/ to $CONFIGURATOR_WWW_DIR..."
+    [ -d "$CONFIGURATOR_WWW_DIR" ] || { echo "[hot-deploy] ERROR: CONFIGURATOR_WWW_DIR must be an existing directory: $CONFIGURATOR_WWW_DIR" >&2; exit 1; }
+    local www_dir_real
+    www_dir_real="$(cd "$CONFIGURATOR_WWW_DIR" && pwd -P)"
+    [ "$www_dir_real" != "/" ] || { echo "[hot-deploy] ERROR: refusing to sync configurator into /" >&2; exit 1; }
+
+    log "syncing dist/ to $www_dir_real..."
     # Try a plain copy first (works when the docroot and everything in it is
     # user-owned); some files in there may be root-owned leftovers from an
     # ansible/root-run build, in which case rm/cp fails partway through even
     # though the top-level directory itself is writable — fall back to sudo,
     # then to a throwaway root container, on failure rather than pre-checking
     # only the top-level directory's permissions.
-    if rm -rf "${CONFIGURATOR_WWW_DIR:?}"/* 2>/dev/null && cp -r "$REPO_ROOT/configurator/dist/." "$CONFIGURATOR_WWW_DIR/" 2>/dev/null; then
+    if rm -rf "${www_dir_real:?}"/* 2>/dev/null && cp -r "$REPO_ROOT/configurator/dist/." "$www_dir_real/" 2>/dev/null; then
         :
     elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
         log "plain copy failed (likely root-owned leftovers) — retrying with sudo"
-        sudo rm -rf "${CONFIGURATOR_WWW_DIR:?}"/*
-        sudo cp -r "$REPO_ROOT/configurator/dist/." "$CONFIGURATOR_WWW_DIR/"
-        sudo nginx -s reload 2>/dev/null || true
+        sudo rm -rf "${www_dir_real:?}"/*
+        sudo cp -r "$REPO_ROOT/configurator/dist/." "$www_dir_real/"
     else
         log "plain copy failed and no passwordless sudo — falling back to a throwaway container to copy as root"
         docker run --rm \
             -v "$REPO_ROOT/configurator/dist:/src:ro" \
-            -v "$CONFIGURATOR_WWW_DIR:/dst" \
+            -v "$www_dir_real:/dst" \
             alpine sh -c "rm -rf /dst/* && cp -r /src/. /dst/"
     fi
 
+    if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+        sudo nginx -s reload 2>/dev/null || true
+    else
+        nginx -s reload 2>/dev/null || true
+    fi
+
     local code
-    code="$(curl -sS -o /dev/null -w '%{http_code}' http://localhost/configurator/ || true)"
+    code="$(curl -sS -o /dev/null -w '%{http_code}' http://localhost/configurator/)" || { echo "[hot-deploy] ERROR: configurator did not respond" >&2; return 1; }
     log "configurator responded with HTTP $code"
+    [[ "$code" =~ ^[23] ]] || { echo "[hot-deploy] ERROR: configurator returned HTTP $code" >&2; return 1; }
 }
 
 cmd_all() {

--- a/local-setup/scripts/hot-deploy.sh
+++ b/local-setup/scripts/hot-deploy.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# hot-deploy.sh — push a local code change into the already-running
+# (ansible-deployed) local-setup stack without a full docker compose /
+# playbook re-run.
+#
+# Usage:
+#   ./scripts/hot-deploy.sh backend        Rebuild + hot-swap pgr-services jar
+#   ./scripts/hot-deploy.sh frontend       Rebuild + push digit-ui-esbuild bundle
+#   ./scripts/hot-deploy.sh configurator   Rebuild + sync configurator SPA
+#   ./scripts/hot-deploy.sh all            Run all three, in that order
+#
+# Env overrides:
+#   CONFIGURATOR_WWW_DIR   nginx docroot for configurator (default: /var/www/configurator;
+#                           set this to the bind-mounted dir on macOS/OrbStack setups)
+#   SKIP_TESTS=1            (default) skip `mvn test` on backend rebuild
+#   SKIP_SUBPKGS=1          skip rebuilding configurator/packages/* before `vite build`
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CONFIGURATOR_WWW_DIR="${CONFIGURATOR_WWW_DIR:-/var/www/configurator}"
+SKIP_SUBPKGS="${SKIP_SUBPKGS:-0}"
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") <target>
+
+Targets:
+  backend         Rebuild backend/pgr-services and hot-swap the jar into digit-pgr-services-1
+  frontend        Rebuild digit-ui-esbuild and push the bundle into the digit-ui container
+  configurator    Rebuild configurator/ and sync dist/ to $CONFIGURATOR_WWW_DIR
+  all             Run backend, frontend, configurator in that order
+
+Examples:
+  ./scripts/hot-deploy.sh backend
+  ./scripts/hot-deploy.sh all
+EOF
+    exit 1
+}
+
+log() { echo "[hot-deploy] $*"; }
+
+require_container() {
+    local name="$1"
+    if ! docker ps --filter "name=^${name}\$" --format '{{.Names}}' | grep -q "^${name}\$"; then
+        echo "[hot-deploy] ERROR: container '$name' is not running." >&2
+        echo "[hot-deploy] Hot-swap only works against an already-deployed stack." >&2
+        echo "[hot-deploy] Bring it up first (e.g. 'docker compose up -d' in local-setup/) and retry." >&2
+        exit 1
+    fi
+}
+
+cmd_backend() {
+    log "building backend/pgr-services jar..."
+    mvn -f "$REPO_ROOT/backend/pgr-services/pom.xml" clean package -DskipTests
+
+    require_container digit-pgr-services-1
+
+    local jar
+    jar="$(ls "$REPO_ROOT"/backend/pgr-services/target/pgr-services-*.jar 2>/dev/null | head -1)"
+    [ -n "$jar" ] || { echo "[hot-deploy] ERROR: no jar found under backend/pgr-services/target/" >&2; exit 1; }
+
+    log "hot-swapping $(basename "$jar") into digit-pgr-services-1..."
+    docker cp "$jar" digit-pgr-services-1:/app/app.jar
+    docker restart digit-pgr-services-1 >/dev/null
+
+    log "waiting for health check (Spring Boot restart, up to 60s)..."
+    local i=0
+    until docker exec digit-pgr-services-1 wget -qO- http://localhost:8080/pgr-services/health >/dev/null 2>&1; do
+        i=$((i + 1))
+        if [ "$i" -ge 30 ]; then
+            echo "[hot-deploy] WARNING: health check still not responding after 60s — check 'docker logs digit-pgr-services-1'" >&2
+            return 0
+        fi
+        sleep 2
+    done
+    log "backend OK"
+}
+
+cmd_frontend() {
+    log "building digit-ui-esbuild bundle..."
+    (cd "$REPO_ROOT/digit-ui-esbuild" && node esbuild.build.js)
+
+    require_container digit-ui
+
+    log "pushing build/ into digit-ui container..."
+    tar -czf - -C "$REPO_ROOT/digit-ui-esbuild/build" . | docker exec -i digit-ui tar -xzf - -C /usr/share/nginx/html
+
+    local code
+    code="$(curl -sS -o /dev/null -w '%{http_code}' http://localhost:18080/digit-ui/ || true)"
+    log "digit-ui responded with HTTP $code"
+}
+
+cmd_configurator() {
+    if [ "$SKIP_SUBPKGS" != "1" ]; then
+        for pkg in data-provider digit-datagrid; do
+            local pkg_dir="$REPO_ROOT/configurator/packages/$pkg"
+            if [ -d "$pkg_dir" ]; then
+                log "building sub-package $pkg (if it has a build script)..."
+                (cd "$pkg_dir" && npm run build --if-present)
+            fi
+        done
+    fi
+
+    log "building configurator SPA (vite build, no root typecheck)..."
+    (cd "$REPO_ROOT/configurator" && npx vite build --base=/configurator/)
+
+    log "syncing dist/ to $CONFIGURATOR_WWW_DIR..."
+    # Try a plain copy first (works when the docroot and everything in it is
+    # user-owned); some files in there may be root-owned leftovers from an
+    # ansible/root-run build, in which case rm/cp fails partway through even
+    # though the top-level directory itself is writable — fall back to sudo,
+    # then to a throwaway root container, on failure rather than pre-checking
+    # only the top-level directory's permissions.
+    if rm -rf "${CONFIGURATOR_WWW_DIR:?}"/* 2>/dev/null && cp -r "$REPO_ROOT/configurator/dist/." "$CONFIGURATOR_WWW_DIR/" 2>/dev/null; then
+        :
+    elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+        log "plain copy failed (likely root-owned leftovers) — retrying with sudo"
+        sudo rm -rf "${CONFIGURATOR_WWW_DIR:?}"/*
+        sudo cp -r "$REPO_ROOT/configurator/dist/." "$CONFIGURATOR_WWW_DIR/"
+        sudo nginx -s reload 2>/dev/null || true
+    else
+        log "plain copy failed and no passwordless sudo — falling back to a throwaway container to copy as root"
+        docker run --rm \
+            -v "$REPO_ROOT/configurator/dist:/src:ro" \
+            -v "$CONFIGURATOR_WWW_DIR:/dst" \
+            alpine sh -c "rm -rf /dst/* && cp -r /src/. /dst/"
+    fi
+
+    local code
+    code="$(curl -sS -o /dev/null -w '%{http_code}' http://localhost/configurator/ || true)"
+    log "configurator responded with HTTP $code"
+}
+
+cmd_all() {
+    cmd_backend
+    cmd_frontend
+    cmd_configurator
+}
+
+case "${1:-}" in
+    backend)      cmd_backend ;;
+    frontend)     cmd_frontend ;;
+    configurator) cmd_configurator ;;
+    all)          cmd_all ;;
+    *)            usage ;;
+esac


### PR DESCRIPTION
## Summary
- Adds `local-setup/scripts/hot-deploy.sh` with `backend` / `frontend` / `configurator` / `all` targets to push local code changes into an already ansible-deployed stack (jar hot-swap, bundle push, SPA sync) without a full playbook/compose rebuild.
- Adds `local-setup/docs/HOT-DEPLOY-GUIDE.md` documenting the workflow, config knobs (`CONFIGURATOR_WWW_DIR`, `SKIP_SUBPKGS`), what each target does under the hood and why, known permission gotchas (root-owned leftovers from the initial root-run ansible build, and the sudo/PATH fallback for accounts without passwordless sudo), and when hot-deploy isn't enough.


## Test plan
- [x] `./scripts/hot-deploy.sh backend` — verified via a temporary log marker in `PGRApp.java`, confirmed in `docker logs digit-pgr-services-1` and health check passing; reverted cleanly.
- [x] `./scripts/hot-deploy.sh frontend` — verified via a temporary marker in `products/pgr/src/pages/citizen/ComplaintsList.js`, confirmed present in the file served from inside the `digit-ui` container; reverted cleanly.
- [x] `./scripts/hot-deploy.sh configurator` — verified via a temporary `<title>` marker in `index.html`, confirmed served by nginx at `/configurator/`; reverted cleanly. Along the way, fixed: `digit-datagrid` has no `build` script (switched to `npm run build --if-present`), and the docroot writability pre-check missed root-owned leftover files inside `assets/` (switched to try-then-fallback-to-sudo).
- [x] Confirmed no diffs left behind in any source file after testing (`git status` clean aside from the new script/doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a hot-deploy guide for updating local services without running the full deployment flow.
  * Introduced a command-line hot-deploy workflow for backend, frontend, configurator, or all services.

* **Bug Fixes**
  * Improved handling of local updates with health checks, endpoint verification, and safer fallback copy methods.
  * Added guidance for when hot-deploy is not enough and a full redeploy is still required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->