### PR TITLE
feat(pgr): attachments on every workflow action — citizen-style uploader in the action modal (CCSD-1965)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/Module.js
+++ b/digit-ui-esbuild/products/pgr/src/Module.js
@@ -12,6 +12,7 @@ import PGRDetails from "./pages/employee/PGRDetails";
 import TimelineWrapper from "./components/TimeLineWrapper";
 import AssigneeComponent from "./components/AssigneeComponent";
 import VerificationDocsComponent from "./components/VerificationDocsComponent";
+import ActionUploadComponent from "./components/ActionUploadComponent";
 import PGRSearchInbox from "./pages/employee/PGRInbox";
 import CreateComplaint from "./pages/employee/CreateComplaint";
 import Response from "./components/Response";
@@ -107,6 +108,7 @@ const componentsToRegister = {
   PGRTimeLineWrapper: TimelineWrapper,
   PGRAssigneeComponent: AssigneeComponent,
   PGRVerificationDocsComponent: VerificationDocsComponent,
+  PGRActionUploadComponent: ActionUploadComponent,
   PGRSearchInbox,
   PGRCreateComplaint: CreateComplaint,
   PGRResponse: Response,

--- a/digit-ui-esbuild/products/pgr/src/components/ActionUploadComponent.js
+++ b/digit-ui-esbuild/products/pgr/src/components/ActionUploadComponent.js
@@ -1,0 +1,48 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import PgrFileUpload from "./PgrFileUpload";
+
+// Workflow-action attachment field (CCSD-1965) — thin FormComposerV2 adapter
+// around the SAME enhanced uploader the citizen create wizard uses
+// (PgrFileUpload: drag-drop zone, preview cards, remove, 2MB/file).
+//
+// Contract: renders in the generic action modal for EVERY workflow action;
+// emits the ALREADY-SHAPED document array handleActionSubmit forwards as
+// workflow.verificationDocuments.
+const toDocument = (id) => ({
+  documentType: "PHOTO",
+  fileStoreId: id,
+  documentUid: id,
+  additionalDetails: {},
+});
+
+const ActionUploadComponent = ({ config, onSelect, formData }) => {
+  const { t } = useTranslation();
+  // Filestore is tenant-scoped: upload to the COMPLAINT's tenant (injected by
+  // getUpdatedConfig as populators.tenantId) so a root-tenant admin acting on
+  // a city complaint doesn't strand files where the display side (which reads
+  // at service.tenantId) can't fetch them.
+  const tenantId = config?.populators?.tenantId || Digit.ULBService.getCurrentTenantId();
+
+  // Live form value (session-restored on modal reopen) → fileStoreIds; the
+  // uploader rebuilds its preview cards from these via Filefetch.
+  const existing = formData?.[config?.key];
+  const value = Array.isArray(existing) ? existing.map((d) => d?.fileStoreId).filter(Boolean) : [];
+
+  return (
+    <PgrFileUpload
+      t={t}
+      tenantId={tenantId}
+      fieldKey={config?.key || "SelectedDocuments"}
+      value={value}
+      accept="image/*,.pdf"
+      compact
+      hint={t("CS_UPLOAD_HINT_DOCS") === "CS_UPLOAD_HINT_DOCS"
+        ? "JPG, PNG or PDF up to 2 MB each. You can upload up to 5 files."
+        : t("CS_UPLOAD_HINT_DOCS")}
+      onSelect={(key, ids) => onSelect(key, ids.map(toDocument))}
+    />
+  );
+};
+
+export default ActionUploadComponent;

--- a/digit-ui-esbuild/products/pgr/src/components/PgrFileUpload.js
+++ b/digit-ui-esbuild/products/pgr/src/components/PgrFileUpload.js
@@ -1,0 +1,355 @@
+import React from "react";
+
+// Shared PGR file uploader — the SAME component/UX as the citizen create
+// wizard's Step-4 uploader (CreatePGRFlowV2 PgrFileUpload): dashed drop-zone
+// with cloud icon + "Choose files", preview-card grid (image thumb or doc
+// icon, check badge, ✕ remove, name + size), drag-and-drop, 2MB/file,
+// keyboard accessible. Extracted here so the employee workflow-action modal
+// (CCSD-1965) reuses it verbatim; the citizen wizard keeps its inline copy
+// with identical markup/classes (unifying that import is a follow-up).
+//
+// Self-contained: injects its own scoped CSS once (.pgr-upload* — the same
+// class names/rules as the wizard's WIZARD_CSS block, so double-injection on
+// the citizen page is harmless).
+
+const MAX_BYTES = 2 * 1024 * 1024; // 2 MB per file
+
+function tr(t, key, fallback) {
+  const v = typeof t === "function" ? t(key) : key;
+  return v === key ? fallback : v;
+}
+
+function fmtSize(bytes) {
+  if (!bytes || bytes <= 0) return "";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+const CheckIcon = (
+  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+);
+const CloudIcon = (
+  <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d="M16 16l-4-4-4 4" />
+    <path d="M12 12v9" />
+    <path d="M20.39 18.39A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.3" />
+  </svg>
+);
+const XIcon = (
+  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <line x1="18" y1="6" x2="6" y2="18" />
+    <line x1="6" y1="6" x2="18" y2="18" />
+  </svg>
+);
+const DocIcon = (
+  <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+    <path d="M14 2v6h6" />
+  </svg>
+);
+
+const STYLE_ID = "pgr-file-upload-css";
+const UPLOAD_CSS = `
+.pgr-upload { width: 100%; }
+.pgr-upload-error {
+  margin-bottom: 0.75rem; padding: 0.5rem 0.75rem; border-radius: 0.5rem;
+  background: #fdecea; border: 1px solid #f5c2bc; color: #b3261e;
+  font-size: 0.8rem; text-align: center;
+}
+.pgr-upload-zone {
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  gap: 0.4rem; padding: 1.5rem 1rem; text-align: center; cursor: pointer;
+  border: 1px dashed var(--color-border, #cbd5e1); border-radius: 0.75rem;
+  background: var(--color-surface-secondary, #f8fafc);
+  transition: border-color .15s ease, background .15s ease;
+}
+.pgr-upload-zone--empty { padding: 2rem 1rem; }
+.pgr-upload-zone--cell { border-radius: 0.5rem; padding: 1rem; }
+.pgr-upload-zone:hover, .pgr-upload-zone:focus-visible, .pgr-upload-zone.is-dragover {
+  outline: none;
+  border-color: var(--color-primary-1, var(--color-primary-main, #c84c0e));
+  background: var(--color-primary-1-bg, #eef6ef);
+}
+.pgr-upload-cloud { color: var(--color-text-secondary, #94a3b8); display: inline-flex; }
+.pgr-upload-dnd { font-size: 0.85rem; color: var(--color-text-secondary, #64748b); }
+.pgr-upload-choose {
+  display: inline-block; border: 1px solid var(--color-border, #cbd5e1); border-radius: 0.375rem;
+  padding: 0.4rem 0.9rem; background: #fff; font-weight: 600; font-size: 0.85rem;
+  color: var(--color-primary-1, var(--color-primary-main, #c84c0e));
+}
+.pgr-upload-hint { margin: 0.25rem 0 0; font-size: 0.72rem; color: var(--color-text-secondary, #94a3b8); }
+.pgr-upload-row { display: grid; grid-template-columns: repeat(auto-fill, minmax(12rem, 1fr)); gap: 0.75rem; align-items: stretch; }
+.pgr-card {
+  display: flex; flex-direction: column;
+  border: 1px solid var(--color-border, #e2e8f0); border-radius: 0.5rem;
+  padding: 0.5rem; background: #fff;
+}
+.pgr-card-img {
+  position: relative; flex: 1 1 auto; min-height: 4.5rem; border-radius: 0.375rem; overflow: hidden;
+  background: var(--color-surface-secondary, #f1f5f9);
+}
+.pgr-card-img img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.pgr-card-doc { width: 100%; height: 100%; display: flex; align-items: center; justify-content: center; color: var(--color-text-secondary, #64748b); }
+.pgr-badge {
+  position: absolute; top: 6px; left: 6px; width: 20px; height: 20px; border-radius: 9999px;
+  background: var(--color-primary-1, var(--color-primary-main, #c84c0e)); color: #fff;
+  display: flex; align-items: center; justify-content: center;
+}
+.pgr-del {
+  position: absolute; top: 6px; right: 6px; width: 20px; height: 20px; border: none; border-radius: 9999px;
+  background: #fff; color: #475569; font-size: 15px; line-height: 1; cursor: pointer;
+  display: flex; align-items: center; justify-content: center; box-shadow: 0 1px 3px rgba(0,0,0,0.25);
+}
+.pgr-del:hover { background: #b3261e; color: #fff; }
+.pgr-card-name {
+  font-size: 0.78rem; font-weight: 600; margin-top: 0.35rem; color: var(--color-text, #1f2937);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.pgr-card-meta { display: flex; align-items: center; gap: 0.25rem; font-size: 0.72rem; color: var(--color-text-secondary, #64748b); }
+.pgr-card-ok { color: var(--color-primary-1, var(--color-primary-main, #c84c0e)); display: inline-flex; }
+@media (max-width: 480px) {
+  .pgr-upload-row { grid-template-columns: repeat(2, 1fr); }
+}
+/* Compact variant — for constrained containers (the workflow-action modal):
+   smaller drop-zone and small preview tiles so the section never balloons
+   the popup. */
+.pgr-upload--compact .pgr-upload-zone--empty { padding: 0.9rem 0.75rem; gap: 0.25rem; }
+.pgr-upload--compact .pgr-upload-zone--cell { padding: 0.5rem; border-radius: 0.375rem; }
+.pgr-upload--compact .pgr-upload-cloud svg { width: 22px; height: 22px; }
+.pgr-upload--compact .pgr-upload-dnd { font-size: 0.78rem; }
+.pgr-upload--compact .pgr-upload-choose { padding: 0.25rem 0.7rem; font-size: 0.78rem; }
+.pgr-upload--compact .pgr-upload-hint { font-size: 0.68rem; margin-top: 0.1rem; }
+.pgr-upload--compact .pgr-upload-row { grid-template-columns: repeat(auto-fill, minmax(6.5rem, 1fr)); gap: 0.5rem; }
+.pgr-upload--compact .pgr-card { padding: 0.35rem; }
+.pgr-upload--compact .pgr-card-img { min-height: 3rem; max-height: 4rem; }
+.pgr-upload--compact .pgr-card-name { font-size: 0.68rem; margin-top: 0.25rem; }
+.pgr-upload--compact .pgr-card-meta { font-size: 0.62rem; }
+.pgr-upload--compact .pgr-badge, .pgr-upload--compact .pgr-del { width: 16px; height: 16px; }
+/* In the compact filled state the inline "add more" cell keeps only the icon
+   + button — repeating the drag hint + format text made the cell taller than
+   the preview tiles and cramped the popup. */
+.pgr-upload--compact .pgr-upload-zone--cell .pgr-upload-dnd,
+.pgr-upload--compact .pgr-upload-zone--cell .pgr-upload-hint { display: none; }
+`;
+
+function ensureStyles() {
+  if (typeof document === "undefined" || document.getElementById(STYLE_ID)) return;
+  const el = document.createElement("style");
+  el.id = STYLE_ID;
+  el.textContent = UPLOAD_CSS;
+  document.head.appendChild(el);
+}
+
+const PgrFileUpload = ({ t, tenantId, value, onSelect, fieldKey, accept = "image/*", maxFiles = 5, hint, compact = false }) => {
+  ensureStyles();
+  const [items, setItems] = React.useState([]);
+  const [busy, setBusy] = React.useState(false);
+  const [dragOver, setDragOver] = React.useState(false);
+  const [error, setError] = React.useState("");
+  const inputRef = React.useRef(null);
+
+  // Rebuild previews for ids that arrive from outside (session-restored form
+  // values). Best-effort — the ids are valid for submit regardless.
+  React.useEffect(() => {
+    const have = new Set(items.map((i) => i.id));
+    const missing = (value || []).filter((id) => !have.has(id));
+    if (missing.length === 0) {
+      if (items.some((i) => !(value || []).includes(i.id))) {
+        setItems((prev) => prev.filter((i) => (value || []).includes(i.id)));
+      }
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await Digit.UploadServices.Filefetch(missing, tenantId);
+        if (cancelled) return;
+        const d = res?.data || {};
+        const byId = {};
+        (Array.isArray(d.fileStoreIds) ? d.fileStoreIds : []).forEach((o) => {
+          if (o && o.id) byId[o.id] = o.url;
+        });
+        const rebuilt = missing.map((id) => {
+          const raw = byId[id] != null ? byId[id] : (typeof d[id] === "string" ? d[id] : "");
+          const url = typeof raw === "string" ? raw.split(",").pop() || "" : "";
+          return { id, url, name: tr(t, "CS_UPLOADED_FILE", "Attachment"), size: 0 };
+        });
+        setItems((prev) => [...prev, ...rebuilt]);
+      } catch (e) {
+        /* preview rebuild is best-effort; ids still submit */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(value || []), tenantId]);
+
+  const emit = (next) => {
+    setItems(next);
+    onSelect(fieldKey, next.map((i) => i.id));
+  };
+
+  const uploadFiles = async (files) => {
+    setError("");
+    const room = maxFiles - items.length;
+    if (room <= 0) {
+      setError(tr(t, "CS_UPLOAD_MAX_FILES", `You can upload up to ${maxFiles} files.`));
+      return;
+    }
+    const accepted = [];
+    for (const f of files.slice(0, room)) {
+      if (f.size > MAX_BYTES) {
+        setError(tr(t, "CS_FILE_TOO_LARGE", "File is too large (max 2 MB)."));
+        continue;
+      }
+      accepted.push(f);
+    }
+    if (accepted.length === 0) return;
+    setBusy(true);
+    const uploaded = [];
+    for (const file of accepted) {
+      try {
+        const response = await Digit.UploadServices.Filestorage("property-upload", file, tenantId);
+        const id = response?.data?.files?.[0]?.fileStoreId;
+        if (id) {
+          uploaded.push({
+            id,
+            url: file.type && file.type.startsWith("image/") ? URL.createObjectURL(file) : "",
+            name: file.name,
+            size: file.size,
+          });
+        }
+      } catch (err) {
+        const apiMessage =
+          err?.response?.data?.Errors?.[0]?.message ||
+          err?.response?.data?.message ||
+          err?.message;
+        setError(apiMessage || tr(t, "CS_FILE_UPLOAD_FAILED", "File upload failed."));
+      }
+    }
+    setBusy(false);
+    if (uploaded.length) emit([...items, ...uploaded]);
+  };
+
+  const onInputChange = (e) => {
+    const files = Array.from(e.target.files || []);
+    if (files.length) uploadFiles(files);
+    if (inputRef.current) inputRef.current.value = ""; // allow re-picking same file
+  };
+  const onDrop = (e) => {
+    e.preventDefault();
+    setDragOver(false);
+    const files = Array.from(e.dataTransfer?.files || []);
+    if (files.length) uploadFiles(files);
+  };
+  const removeAt = (id) => {
+    const gone = items.find((i) => i.id === id);
+    if (gone?.url?.startsWith("blob:")) URL.revokeObjectURL(gone.url);
+    emit(items.filter((i) => i.id !== id));
+  };
+  const openPicker = () => inputRef.current && inputRef.current.click();
+  const atMax = items.length >= maxFiles;
+
+  const renderCue = (variant) => (
+    <div
+      className={"pgr-upload-zone " + variant + (dragOver ? " is-dragover" : "")}
+      role="button"
+      tabIndex={0}
+      onClick={openPicker}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          openPicker();
+        }
+      }}
+      onDragOver={(e) => {
+        e.preventDefault();
+        setDragOver(true);
+      }}
+      onDragLeave={() => setDragOver(false)}
+      onDrop={onDrop}
+    >
+      <span className="pgr-upload-cloud">{CloudIcon}</span>
+      <div className="pgr-upload-dnd">{tr(t, "CS_UPLOAD_DND", "Drag and drop files here or")}</div>
+      <span className="pgr-upload-choose">
+        {busy ? tr(t, "CS_UPLOADING", "Uploading…") : tr(t, "CS_UPLOAD_CHOOSE", "Choose files")}
+      </span>
+      <p className="pgr-upload-hint">
+        {hint || tr(t, "CS_UPLOAD_HINT", `JPG, PNG up to 2 MB each. You can upload up to ${maxFiles} files.`)}
+      </p>
+    </div>
+  );
+
+  return (
+    <div className={"pgr-upload" + (compact ? " pgr-upload--compact" : "")}>
+      {error ? (
+        <div className="pgr-upload-error" role="alert">
+          {error}
+        </div>
+      ) : null}
+      <input
+        ref={inputRef}
+        type="file"
+        accept={accept}
+        multiple
+        onChange={onInputChange}
+        // NOT display:none — some Android WebViews refuse to open the file
+        // chooser for programmatic clicks on display:none inputs.
+        style={{
+          position: "absolute",
+          width: 1,
+          height: 1,
+          opacity: 0,
+          overflow: "hidden",
+          border: 0,
+          padding: 0,
+          margin: -1,
+          clip: "rect(0 0 0 0)",
+          pointerEvents: "none",
+        }}
+        aria-hidden="true"
+        tabIndex={-1}
+      />
+      {items.length === 0 ? (
+        renderCue("pgr-upload-zone--empty")
+      ) : (
+        <div className="pgr-upload-row">
+          {items.map((it) => (
+            <div className="pgr-card" key={it.id}>
+              <div className="pgr-card-img">
+                <span className="pgr-badge">{CheckIcon}</span>
+                <button
+                  type="button"
+                  className="pgr-del"
+                  aria-label={tr(t, "CS_REMOVE", "Remove")}
+                  onClick={() => removeAt(it.id)}
+                >
+                  {XIcon}
+                </button>
+                {it.url ? (
+                  <img src={it.url} alt={it.name} />
+                ) : (
+                  <div className="pgr-card-doc">{DocIcon}</div>
+                )}
+              </div>
+              <div className="pgr-card-name" title={it.name}>
+                {it.name}
+              </div>
+              <div className="pgr-card-meta">
+                {it.size ? <span>{fmtSize(it.size)}</span> : null}
+                <span className="pgr-card-ok">{CheckIcon}</span>
+              </div>
+            </div>
+          ))}
+          {!atMax ? renderCue("pgr-upload-zone--cell") : null}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PgrFileUpload;

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
@@ -67,16 +67,19 @@ const buildActionFormConfig = ({ action, assigneeRoles = [], isTerminal = false,
       populators: { name: "SelectedAssignee" },
     });
   }
-  if (docUploadRequired) {
-    body.push({
-      type: "component",
-      isMandatory: true,
-      component: "PGRVerificationDocsComponent",
-      key: "SelectedDocuments",
-      label: "CS_UPLOAD_DOCUMENTS",
-      populators: { name: "SelectedDocuments" },
-    });
-  }
+  // Attachments on EVERY workflow action (CCSD-1965): the uploader always
+  // renders; it is MANDATORY only when the action's target state is flagged
+  // docUploadRequired on the BusinessService (previously that flag also gated
+  // visibility, so most actions had no way to attach evidence). The backend
+  // persists workflow.verificationDocuments per transition unconditionally.
+  body.push({
+    type: "component",
+    isMandatory: !!docUploadRequired,
+    component: "PGRActionUploadComponent",
+    key: "SelectedDocuments",
+    label: "CS_COMMON_ATTACHMENTS",
+    populators: { name: "SelectedDocuments" },
+  });
   body.push({
     type: "textarea",
     isMandatory: true,
@@ -363,6 +366,10 @@ const PGRDetails = () => {
             roles,
             department,
             allDepartments,
+            // Filestore is tenant-scoped — the uploader must write to the
+            // COMPLAINT's tenant so the attachment renders later (the display
+            // side fetches at service.tenantId).
+            tenantId: complaintTenantId,
             props: { ...bodyItem.populators.props, department, allDepartments },
           },
         })),
@@ -595,7 +602,7 @@ const PGRDetails = () => {
                     inline: false,
                     type: "custom",
                     renderCustomContent: () => (
-                      <TimelineWrapper isWorkFlowLoading={isWorkflowLoading} workflowData={workflowData} businessId={id} labelPrefix="WF_PGR_" />
+                      <TimelineWrapper isWorkFlowLoading={isWorkflowLoading} workflowData={workflowData} businessId={id} labelPrefix="WF_PGR_" tenantId={complaintTenantId} />
                     ),
                   },
                 ],
@@ -624,6 +631,19 @@ const PGRDetails = () => {
               key="action-button"
               label={t("ES_COMMON_TAKE_ACTION")}
               onOptionSelect={(selected) => {
+                // The modal's form values persist in the GLOBAL "COMPLAINT_UPDATE"
+                // session key — without scoping, values from a previous modal
+                // (a canceled attempt, a DIFFERENT action, or even a different
+                // complaint) silently restore into this one: stale attachments/
+                // comments would submit with the new action. Stamp the session
+                // with complaint+action and start clean on any mismatch; the
+                // restore convenience is kept for reopening the SAME action on
+                // the SAME complaint.
+                const sessionFor = `${id}:${selected?.action}`;
+                if (sessionFormData?.__for !== sessionFor) {
+                  clearSessionFormData();
+                  setSessionFormData({ __for: sessionFor });
+                }
                 setSelectedAction(selected);
                 setOpenModal(true);
               }}


### PR DESCRIPTION
## What (JIRA CCSD-1965)

> Moz: Employee user shall be able to add attachment at every step of the workflow

The generic workflow-action modal now renders an **Attachments** field for **every** action (ASSIGN / REJECT / RESOLVE / COMMENT / … — standard PGR and CMS workflows alike). Previously the uploader appeared only when the action's target state was `docUploadRequired` (only CMS `INFOFROMCITIZEN` is seeded), so most steps had no way to attach evidence. It stays **mandatory** where that flag demands docs, optional everywhere else.

**No backend change needed** — verified pgr-services copies `workflow.verificationDocuments` into the ProcessInstance unconditionally on every `_update` (`WorkflowService.java:188`); `docUploadRequired` is UI metadata only.

## UI

Reuses the **same enhanced uploader as the citizen create wizard** (per review feedback): drag-and-drop zone, preview-card grid with image thumbnails / doc icon, check badge, ✕ remove, file name + size, 2 MB/file, up to 5 files, `image/* + .pdf`. Extracted into a shared `PgrFileUpload` component with a **`compact` variant** for the popup — small tiles, slim drop-zone, and an icon+button-only "add more" cell so the section never balloons the modal. (The citizen wizard keeps its identical inline copy; unifying that import is a deliberate follow-up.)

## Correctness fixes included

- **Tenant-scoped uploads**: files now upload to the *complaint's* tenant (injected via populators) instead of the logged-in tenant — a root-tenant admin acting on a city complaint previously stranded files where the display side (`service.tenantId`) can't fetch them.
- **Session-leak fix**: the modal's form persistence used one global `COMPLAINT_UPDATE` key, so values from a canceled modal, a **different action**, or a **different complaint** silently restored into a fresh modal (stale attachments would submit with the new action — caught during testing when ghost "Attachment" tiles appeared). The session is now stamped `complaintId:action` and starts clean on mismatch; reopening the *same* action on the *same* complaint still restores, with previews rebuilt via Filefetch.

## Testing (local, deployed)

- Every action's modal shows the uploader; docs submit as `workflow.verificationDocuments` and appear in the complaint's Attachments card.
- CMS `AWAITINGINFORMATION` action still blocks submit without a file (mandatory path unchanged).
- Cancel + reopen same action → files restored as tiles; switch action/complaint → clean uploader (no ghost tiles).
- 2 MB rejection, PDF tile (doc icon), 5-file cap, drag-drop, keyboard access all exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)