### PR TITLE
fix(core): employee sidebar — visible search text + legacy action: icon resolution (CCSD-1947)

### DIFF
--- a/digit-ui-esbuild/packages/modules/core/src/components/TopBarSideBar/SideBar/EmployeeSideBar.js
+++ b/digit-ui-esbuild/packages/modules/core/src/components/TopBarSideBar/SideBar/EmployeeSideBar.js
@@ -4,10 +4,43 @@ import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 import MediaQuery from 'react-responsive';
 
+// CCSD-1947: the SideNav search input ships with NO styles — inside the dark
+// sidebar it inherits white text over the input's native white background, so
+// the placeholder and anything the user types are invisible. Scoped style
+// injection (same pattern as PGRDatePicker/PgrFileUpload).
+const SIDEBAR_STYLE_ID = "pgr-employee-sidebar-css";
+const SIDEBAR_CSS = `
+.digit-sidebar-search-container input,
+.digit-sidebar-search-container input[type="search"] {
+  color: #363636 !important;
+  background: #fff !important;
+  caret-color: #363636;
+}
+.digit-sidebar-search-container input::placeholder {
+  color: #787878 !important;
+  opacity: 1 !important;
+}
+`;
+const ensureSidebarStyles = () => {
+  if (typeof document === "undefined" || document.getElementById(SIDEBAR_STYLE_ID)) return;
+  const el = document.createElement("style");
+  el.id = SIDEBAR_STYLE_ID;
+  el.textContent = SIDEBAR_CSS;
+  document.head.appendChild(el);
+};
 
-
+// Sidebar actions seeded with the legacy "action:<name>" leftIcon format
+// (e.g. "action:home") don't resolve in the svg-components icon set (exports
+// are PascalCase: Home, HomeFilled, …) — iconRender warned "Icon not found"
+// and the row rendered iconless. Normalize the legacy form.
+const normalizeIcon = (icon) => {
+  if (typeof icon !== "string" || !icon.startsWith("action:")) return icon;
+  const name = icon.slice("action:".length);
+  return name ? name.charAt(0).toUpperCase() + name.slice(1) : icon;
+};
 
 const EmployeeSideBar = () => {
+  ensureSidebarStyles();
   const { isLoading, data } = Digit.Hooks.useAccessControl();
   const isMultiRootTenant = Digit.Utils.getMultiRootTenant();
   const { t } = useTranslation();
@@ -142,7 +175,7 @@ const EmployeeSideBar = () => {
       if (value.item) {
         return {
           label: t(value.item.displayName),
-          icon: { icon: value.item.leftIcon, width: "1.5rem", height: "1.5rem" },
+          icon: { icon: normalizeIcon(value.item.leftIcon), width: "1.5rem", height: "1.5rem" },
           navigationUrl: value.item.navigationURL,
           orderNumber:value.item.orderNumber,
         };
@@ -151,7 +184,7 @@ const EmployeeSideBar = () => {
       const iconKey = extractLeftIcon(value);
       return {
         label: t(key),
-        icon: { icon: iconKey, width: "1.5rem", height: "1.5rem" },
+        icon: { icon: normalizeIcon(iconKey), width: "1.5rem", height: "1.5rem" },
         children: children,
       };
     };


### PR DESCRIPTION
## Problem (JIRA CCSD-1947)

1. Typing in the employee sidebar's search box showed nothing — the `SideNav` search input has **no styles anywhere in the bundle**, so inside the dark sidebar it inherits **white text on the input's native white background**. Users typed invisible text and saw "No Results Found" with no visible cause.
2. "No option to navigate back to home" + the `Icon not found, action:home` console warning: sidebar rows are data-driven (ACCESSCONTROL role-actions). Rows seeded with the legacy `action:<name>` icon format don't resolve against the PascalCase svg-components exports, so the Home row (where seeded) rendered without its icon.

## Fix

- Scoped CSS injection (same pattern as PGRDatePicker/PgrFileUpload): the sidebar search input gets dark text, white background, caret color, and a visible grey placeholder.
- `normalizeIcon`: legacy `action:home` → `Home` before handing to `iconRender` — Home (and any other legacy-format row) gets its icon, warning gone.

## Data note (the other half of the ticket)

The **absence** of the Home item on `20.40.49.209` is seeding, not code: the Home action (`ACCESSCONTROL-ACTIONS-TEST` `actions-test`, path `Home`, `navigationURL /digit-ui/employee`, orderNumber 1) exists locally and on current envs but is missing there — it needs the action row (+ its role mapping) seeded.

## Testing (local, deployed)

- Sidebar expanded → search box shows grey "Search" placeholder; typed text is dark and visible; filtering works.
- Home row shows the house icon; `Icon not found, action:home` warning gone from the console.
- Menu items/navigation otherwise unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)