### PR TITLE
fix(pgr): citizen wizard re-entry starts at step 1 — F5 still resumes the exact step

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
@@ -305,6 +305,21 @@ const STEPS = [
 // key, which Module.js clears on every citizen-home mount.
 const CREATE_DRAFT_KEY = "PGR_CREATE_CITIZEN_DRAFT";
 
+// The saved step POSITION may only be restored when the document itself was
+// RELOADED (mid-flow F5) — and only by the first wizard mount after it. Any
+// other entry (SPA links, and sidebar items that hard-navigate like "Citizen
+// Complaint Resolution System") starts at step 1 with the answers kept. The
+// flag is consumed on first use so later SPA re-entries within the same
+// document also start at step 1.
+let RESTORE_STEP_ARMED = (() => {
+  try {
+    const nav = performance.getEntriesByType("navigation")[0] as PerformanceNavigationTiming | undefined;
+    return nav?.type === "reload";
+  } catch (e) {
+    return false;
+  }
+})();
+
 // ---------------------------------------------------------------------------
 // Helpers (kept identical to the legacy FormExplorer so the API payload
 // shape is preserved byte-for-byte)
@@ -1871,6 +1886,10 @@ const CreatePGRFlowV2: React.FC = () => {
         : {};
   }
   const [stepIndex, setStepIndex] = React.useState(() => {
+    // Position restores ONLY right after a document reload (see
+    // RESTORE_STEP_ARMED); every other entry starts on step 1.
+    if (!RESTORE_STEP_ARMED) return 0;
+    RESTORE_STEP_ARMED = false;
     const saved = Number(savedDraftRef.current.stepIndex);
     return Number.isInteger(saved) ? Math.min(Math.max(saved, 0), STEPS.length - 1) : 0;
   });

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
@@ -1884,6 +1884,21 @@ const CreatePGRFlowV2: React.FC = () => {
     Digit.SessionStorage.set(CREATE_DRAFT_KEY, { formData, stepIndex, tenant: baseTenant, user: draftUserUuid });
   }, [formData, stepIndex, baseTenant, draftUserUuid]);
 
+  // Leaving the wizard via IN-APP navigation (sidebar Home, back, links) resets
+  // the saved POSITION to step 1 while keeping the answers — re-entering from
+  // "File a Complaint" should read as a fresh start, not resume on page 3
+  // (user feedback on the draft-persistence feature). A hard refresh tears the
+  // page down without running this cleanup, so mid-flow F5 still restores the
+  // exact step. Successful create deletes the key before navigating, and the
+  // formData guard keeps this cleanup from resurrecting it.
+  React.useEffect(
+    () => () => {
+      const d = Digit.SessionStorage.get(CREATE_DRAFT_KEY);
+      if (d && d.formData) Digit.SessionStorage.set(CREATE_DRAFT_KEY, { ...d, stepIndex: 0 });
+    },
+    []
+  );
+
   // Authority dispatcher (RAINMAKER-PGR.ComplaintRelatedToMap @ state tenant).
   // Empty (the default for any tenant that hasn't seeded it) => the legacy flow:
   // no authority step, catalogue fetched at the base tenant, no extendedAttributes.


### PR DESCRIPTION
## Problem (user feedback on #1093 draft persistence)

Fill the wizard partway → sidebar **Home** → **File a Complaint**: the citizen landed on **page 3** (the persisted step position), which reads as broken navigation. Fresh entry should start at page 1.

## Fix

Unmount cleanup rewrites the saved draft's `stepIndex` to `0` — so any **in-app navigation away** (Home, back, links) makes the next entry start at step 1 **with the answers still prefilled**. A **hard refresh** doesn't run React cleanup, so mid-flow F5 still restores the exact step — the original purpose of persisting the position. Successful create still deletes the draft outright (a guard stops the cleanup from resurrecting it), and the failure path ("Try Again") now also re-enters at step 1 with answers intact.

## Testing (local, deployed)

- Fill steps 1–2 → Home → File a Complaint → **step 1**, previously entered values present when stepping forward.
- Fill steps 1–2 → **F5** → resumes on the same step with values.
- Submit success → next visit is a clean, empty wizard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)