### PR TITLE
fix(nginx): route Novu dashboard /env/ deep links to the dashboard SPA

### DIFF
--- a/local-setup/ansible/templates/nginx-site.conf.j2
+++ b/local-setup/ansible/templates/nginx-site.conf.j2
@@ -291,6 +291,19 @@ server {
     proxy_set_header Host $host;
     proxy_http_version 1.1;
   }
+
+  # React Router deep links — /env/<envId>/activity-feed, /env/<envId>/workflows,
+  # etc. Same class as /auth/ above: the dashboard is Vite base=/, so these are
+  # root-absolute. A direct load / hard-refresh must serve the container's
+  # index.html (the dashboard's http-server does SPA fallback) — otherwise it
+  # falls through `location /` to Kong and 404s ("no Route matched with those
+  # values"). Client-side nav from the dashboard home works either way; this is
+  # only needed for deep-link / refresh.
+  location /env/ {
+    proxy_pass http://127.0.0.1:14000;
+    proxy_set_header Host $host;
+    proxy_http_version 1.1;
+  }
   # Manifest + favicons (referenced unprefixed by the dashboard HTML).
   location = /manifest.json {
     proxy_pass http://127.0.0.1:14000/manifest.json;


### PR DESCRIPTION
Closes #1119.

## Problem
Opening/refreshing a Novu dashboard deep link (`/env/<envId>/activity-feed?…`) returns a **Kong 404** (`no Route matched with those values`) instead of the dashboard.

## Cause
The Novu dashboard image is built Vite `base=/`, so its routes are root-absolute (`/env/…`, `/auth/…`). `nginx-site.conf.j2` proxies `/novu/`, `/auth/`, `/assets/`, favicons — but **not `/env/`** — so `/env/…` falls through `location /` → Kong → 404. (Client-side nav works; only deep-link/refresh breaks.)

## Fix
Add an `/env/` location mirroring the existing `/auth/` block — proxy to the dashboard container (`127.0.0.1:14000`) so it serves `index.html` (SPA fallback) and the client router takes over. One block, inside the existing `{% if enable_novu %}` section.

## Verification
Applied the same block to bomet's active nginx: the deep link now loads the Novu dashboard (then client-routes to the activity feed / sign-in) instead of the Kong error page. `nginx -t` passes.

## Related issues / context
- **#1119** — the issue this fixes (Novu dashboard `/env/…` deep-links 404 through Kong). *Note: base is `develop`, not the default branch, so GitHub won't auto-close it on merge — close #1119 manually when this lands.*
- **#926** (`fix/novu-dashboard-subpath-image`) — the **proper** upstream fix: rebuild the dashboard image with `VITE_BASE_PATH=/novu` so ALL routes become `/novu`-prefixed and root-absolute `/env/`, `/auth/` disappear. **Once #926 is live (with `build_novu_dashboard: true`), this `/env/` passthrough becomes unnecessary** — #1120 is the stopgap for the stock `base=/` image.
- Same class of workaround as the existing `/auth/sign-in|sign-up|organization-list` and `/assets`, `/manifest.json`, favicon passthroughs in the template's `enable_novu` block (all consequences of the stock image's `base=/`). See the `⚠ WORKAROUND` comment there.
- Ops context: bomet's nightly redeploy re-renders nginx from this template, so the fix must live in the template (not an on-box patch) to survive.