### PR TITLE
fix(core): language selector removed from the MAIN employee wrapper too (CCSD-1971 B1, orphaned commit)

### DIFF
--- a/digit-ui-esbuild/packages/modules/core/src/pages/employee/index.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/employee/index.js
@@ -144,6 +144,11 @@ const EmployeeApp = ({
               logoUrl={logoUrl}
               logoUrlWhite={logoUrlWhite}
               modules={modules}
+              // CCSD-1971 (B1): no language selector on the employee surface.
+              // This is the MAIN employee wrapper — the prop defaulted to true
+              // here, which kept the dropdown alive despite the other wrapper
+              // passing false.
+              showLanguageChange={false}
             />}
             <div className={!noTopBar ? `${(isSuperUserWithMultipleRootTenant) ? "" : "main"} ${DSO ? "m-auto" : ""} digit-home-main` : ""}>
 


### PR DESCRIPTION
Commit 4 of #1121 was pushed moments after the merge and got orphaned — re-raised here.

The employee surface renders `TopBarSideBar` from **two** sites in `pages/employee/index.js`; #1121's merge covered only the first. The **main app wrapper** (used by every logged-in employee page) passed nothing, and `showLanguageChange` defaults to `true` — so the language dropdown survived. Caught by the automated Playwright verification pass (which now passes 14/14 with this in).

JIRA: CCSD-1971 (feedback item B1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)