### PR TITLE
fix(bomet): add EscalationScheduler system-user UUID to pgr-services overlay

### DIFF
--- a/local-setup/docker-compose.bomet.yml
+++ b/local-setup/docker-compose.bomet.yml
@@ -31,4 +31,10 @@ services:
     environment:
       PGR_NOTIFICATION_CONFIG_DRIVEN: "true"
       KAFKA_TOPICS_COMPLAINTS_DOMAIN_EVENTS: complaints.domain.events
+      # System user the PGR EscalationScheduler runs as (not in the shared
+      # egov-digit base compose). Kept in this same pgr-services block so the
+      # bomet overlay is a single source of truth — previously injected by the
+      # on-box redeploy wrapper, which appended a *second* pgr-services key here
+      # and broke `docker compose config` once this block existed (see #1131).
+      EGOV_INTERNAL_MICROSERVICE_USER_UUID: a6966a30-947d-46d9-8226-7d94b67de581
 


### PR DESCRIPTION
Closes #1131.

## Problem
develop's `local-setup/docker-compose.bomet.yml` gained a `pgr-services` block in #1059 (config-driven notification cutover) but it omits `EGOV_INTERNAL_MICROSERVICE_USER_UUID` — the system user the PGR **EscalationScheduler** runs as. On bomet that env is injected by the nightly redeploy wrapper's `ensure_overlay_fixes`, not by the repo.

Because the wrapper appended its **own** `pgr-services:` block to add the UUID, after #1059 there were **two `pgr-services` mapping keys** →
```
yaml: mapping key "pgr-services" already defined
```
`docker compose config` failed and the wrapper aborted **before the converge** — this broke a real `deploy.sh bomet` off develop on 2026-07-09.

## Fix
Add `EGOV_INTERNAL_MICROSERVICE_USER_UUID` to the **existing** `pgr-services` block in `bomet.yml` (one line + comment). Single source of truth:
- The wrapper's guard (`grep -q EGOV_INTERNAL_MICROSERVICE_USER_UUID`) is now satisfied → it skips its append → no duplicate key.
- A fresh box deploying straight from develop gets a correct escalation system user (otherwise auto-escalation silently resolves the wrong/absent user).

## Verification
- `docker compose config` / `yaml.safe_load` on the merged `bomet.yml`: parses, exactly **one** `pgr-services` key.
- On bomet the escalation UUID is already present and `pgr system UUID present` passed in the redeploy smoke test.

## Notes
- `bomet.yml` is the committed bomet-specific overlay; the value is an internal-microservice user identifier (not a credential).
- Related: the wrapper was hot-patched to inject-not-append as a stopgap; this closes it durably.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the Bomet tenant setup with a fixed internal service user identifier.
  * Maintains configuration-driven notifications and complaint event routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->