### PR TITLE
fix(novu-bridge): don't persist a dispatch-log row on missing-subscriberId rejection

### DIFF
--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/service/DispatchPipelineService.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/service/DispatchPipelineService.java
@@ -66,11 +66,10 @@ public class DispatchPipelineService {
                 ? event.getSubscriberId()
                 : context.getSubscriberId();
         if (!StringUtils.hasText(subscriberId)) {
-            // Record the terminal status before throwing — every other branch in
-            // process() persists, and the class invariant is that every consumed
-            // event leaves an explicit status row in nb_dispatch_log.
-            persist(event, context, "FAILED", "NB_SUBSCRIBER_ID_MISSING",
-                    "subscriberId is required (PGR resolved it; null means a bad event)", null, 1);
+            // A blank subscriberId is a pre-delivery validation-family rejection: throw
+            // WITHOUT writing a dispatch-log row. This is the tested contract — see
+            // EnvelopePipelineNegativesTest.assertRejected (verify(dispatchLogRepository,
+            // never()).upsert(...)). Do NOT add a persist() here.
             throw new CustomException("NB_SUBSCRIBER_ID_MISSING",
                     "subscriberId is required (PGR resolved it; null means a bad event)");
         }


### PR DESCRIPTION
Closes #1136.

## Problem
novu-bridge fails to build from `develop` — `mvn package` fails on `EnvelopePipelineNegativesTest.legacyShape_withWorkflow_butNoRecipient_isSubscriberMissing` (`Tests run: 88, Failures: 1` → BUILD FAILURE). The nightly bomet redeploy therefore can't rebuild novu-bridge and silently falls back to the prior image.

## Cause
A CodeRabbit suggestion in #1059 ("missing-subscriberId path skips the dispatch log") added:
```java
persist(event, context, "FAILED", "NB_SUBSCRIBER_ID_MISSING", …);  // → dispatchLogRepository.upsert(...)
throw new CustomException("NB_SUBSCRIBER_ID_MISSING", …);
```
But a blank `subscriberId` is a **pre-delivery validation-family rejection**, and the codebase's tested contract is that such rejections write **no** dispatch-log row:
```java
// EnvelopePipelineNegativesTest.assertRejected
verify(dispatchLogRepository, never()).upsert(any());
```
So the added `persist` violated the contract → `NeverWantedButInvoked`. It merged because CCRS CI status checks are advisory, not merge-gating (see the ruleset).

## Fix
Revert just the `persist(...)` call on that branch (keep the `throw`; **keep** the unrelated PII-masking of `subscriberId`/`transactionId` added in the same #1059 commit). Add a comment citing the test so it isn't re-added.

## Verification
Rebuilt novu-bridge from this branch on the box (`docker build … build/maven/Dockerfile`): **`Tests run: 88, Failures: 0, Errors: 0` → BUILD SUCCESS.**

## Note
The two intents ("every terminal branch persists" vs "rejections don't persist") genuinely conflict. If we later decide a missing-subscriberId **should** be audited, that's a deliberate design change with a matching test update — not restored here.