### PR TITLE
fix(pgr): 5 MB upload limit on the last remaining path — citizen reopen (CCSD-1971 A7)

### DIFF
--- a/digit-ui-esbuild/packages/react-components/src/atoms/ImageUploadHandler.js
+++ b/digit-ui-esbuild/packages/react-components/src/atoms/ImageUploadHandler.js
@@ -36,7 +36,9 @@ export const ImageUploadHandler = (props) => {
   }, [uploadedImagesIds]);
 
   useEffect(() => {
-    if (imageFile && imageFile.size > 2097152) {
+    // 5 MB per file (CCSD-1971 A7) — aligned with PgrFileUpload and the
+    // profile-picture drawer; CS_FILE_TOO_LARGE message text says 5 MB.
+    if (imageFile && imageFile.size > 5 * 1024 * 1024) {
       setError(t("CS_FILE_TOO_LARGE") || "File is too large");
     } else {
       setImage(imageFile);

--- a/digit-ui-esbuild/products/pgr/src/components/ActionUploadComponent.js
+++ b/digit-ui-esbuild/products/pgr/src/components/ActionUploadComponent.js
@@ -4,7 +4,7 @@ import PgrFileUpload from "./PgrFileUpload";
 
 // Workflow-action attachment field (CCSD-1965) — thin FormComposerV2 adapter
 // around the SAME enhanced uploader the citizen create wizard uses
-// (PgrFileUpload: drag-drop zone, preview cards, remove, 2MB/file).
+// (PgrFileUpload: drag-drop zone, preview cards, remove, 5MB/file).
 //
 // Contract: renders in the generic action modal for EVERY workflow action;
 // emits the ALREADY-SHAPED document array handleActionSubmit forwards as

--- a/digit-ui-esbuild/products/pgr/src/components/PgrFileUpload.js
+++ b/digit-ui-esbuild/products/pgr/src/components/PgrFileUpload.js
@@ -3,7 +3,7 @@ import React from "react";
 // Shared PGR file uploader — the SAME component/UX as the citizen create
 // wizard's Step-4 uploader (CreatePGRFlowV2 PgrFileUpload): dashed drop-zone
 // with cloud icon + "Choose files", preview-card grid (image thumb or doc
-// icon, check badge, ✕ remove, name + size), drag-and-drop, 2MB/file,
+// icon, check badge, ✕ remove, name + size), drag-and-drop, 5MB/file,
 // keyboard accessible. Extracted here so the employee workflow-action modal
 // (CCSD-1965) reuses it verbatim; the citizen wizard keeps its inline copy
 // with identical markup/classes (unifying that import is a follow-up).


### PR DESCRIPTION
## What (JIRA CCSD-1971, feedback item A7)

`ImageUploadHandler` — the uploader behind the **citizen reopen** photo flow — still enforced the legacy **2 MB** cap while every other path (create wizard, workflow-action modal, profile drawer) moved to 5 MB in #1121. Worse, its `CS_FILE_TOO_LARGE` message already reads "max 5 MB", so a 3 MB photo was rejected by a message claiming the limit is 5 MB. Raised to 5 MB; two stale "2MB/file" comments on the shared uploader fixed alongside.

Left untouched deliberately: `UploadPitPhoto` (2 MB, FSM module — not PGR scope) and the prop-driven `FileUpload` atom.

## Server-side verification (through the gateway, live stack)

- **4.9 MB PNG → HTTP 201**, fileStoreId returned ✅
- **6.35 MB → HTTP 400 `MaxUploadSizeExceededException`** — filestore's own cap already sits at ~5 MB, matching the client limit; **no backend size change needed** (allowed *formats* remain CCSD-1972).

🤖 Generated with [Claude Code](https://claude.com/claude-code)