### PR TITLE
fix(configurator): stop stale form data from nulling reActivateEmploy…

### DIFF
--- a/configurator/packages/data-provider/src/providers/dataProvider.test.ts
+++ b/configurator/packages/data-provider/src/providers/dataProvider.test.ts
@@ -133,4 +133,44 @@ describe('createDigitDataProvider', () => {
     assert.equal((captured as { name: string }).name, 'New Name');
     assert.equal((captured as { active: boolean }).active, false);
   });
+
+  it('does not let a stale reActivateEmployee in the form payload override the fresh fetch (closes #813)', async () => {
+    // EmployeeEdit.tsx has no input bound to reActivateEmployee, so any value
+    // present in the submitted form data is a stale leftover from whatever
+    // populated the form's initial defaultValues (e.g. a just-created
+    // employee's cached create-response, which never sets this field) —
+    // not an intentional edit. egov-hrms/employees/_update NPEs on
+    // Employee.getReActivateEmployee().booleanValue() when it's null, so this
+    // silently broke editing any newly created employee.
+    mock.method(client, 'employeeSearch', async () => [
+      {
+        id: 42,
+        uuid: 'emp-uuid-1',
+        code: 'LOKI3',
+        tenantId: 'ke',
+        reActivateEmployee: false, // fresh fetch: correct, non-null value
+      },
+    ]);
+    let captured: Record<string, unknown> | null = null;
+    mock.method(client, 'employeeUpdate', async (_t: string, employees: Record<string, unknown>[]) => {
+      captured = employees[0];
+      return employees;
+    });
+
+    const dp = createDigitDataProvider(client, 'ke');
+    await dp.update('employees', {
+      id: 'emp-uuid-1',
+      data: {
+        id: 'emp-uuid-1',
+        uuid: 'emp-uuid-1',
+        code: 'LOKI3',
+        tenantId: 'ke',
+        reActivateEmployee: null, // stale form payload — must not win
+      },
+      previousData: {} as never,
+    });
+
+    assert.ok(captured, 'employeeUpdate should have been called');
+    assert.equal((captured as { reActivateEmployee: unknown }).reActivateEmployee, false);
+  });
 });

--- a/configurator/packages/data-provider/src/providers/dataProvider.ts
+++ b/configurator/packages/data-provider/src/providers/dataProvider.ts
@@ -1064,6 +1064,15 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
         const { id: _stringId, ...rest } = data;
         void _stringId;
         const merged: Record<string, unknown> = { ...base, ...rest };
+        // No form input ever edits reActivateEmployee (EmployeeEdit.tsx has no
+        // field for it), so any value present in `rest` is a stale artifact of
+        // the form's initial defaultValues (e.g. a create-response cache that
+        // never set it) rather than an intentional edit. egov-hrms/employees/
+        // _update NPEs on Employee.getReActivateEmployee().booleanValue() when
+        // this is null, so `rest`'s value silently overriding the freshly
+        // re-fetched `base` — the same failure mode `id` is guarded against
+        // above — breaks editing (closes #813). Always trust the fresh fetch.
+        merged.reActivateEmployee = base.reActivateEmployee ?? false;
         const [employee] = await client.employeeUpdate(targetTenantId, [merged]);
         return { data: normalizeRecord(employee, config) };
       }


### PR DESCRIPTION
…ee (#813)

Issue #813 ("Configurator: Unable to edit employee from UI") was originally misdiagnosed against digit-ui-esbuild's HRMS module — the actual bug is in the separate "configurator" app
(bometfeedbackhub.digit.org/configurator), specifically its own local copy of the data-provider package at configurator/packages/data-provider (resolved via "file:packages/data-provider" in configurator/package.json, independent from the digit-mcp and digit-ui-v2 copies of the same file).

Editing an older employee worked (reActivateEmployee correctly sent as false), but editing a newly created employee sent it as null and hit egov-hrms's known NPE (Employee.getReActivateEmployee().booleanValue() on a null field). Root cause: dataProvider.ts's HRMS update path re-fetches the employee fresh (to get the authoritative numeric id, etc.) but then does `{ ...base, ...rest }`, letting the submitted form data's reActivateEmployee silently override the fresh, correct value from `base` — even though EmployeeEdit.tsx has no input bound to this field, so whatever's in the form is a stale artifact (e.g. a create-response cache that never set it), not an intentional edit. Confirmed live: employeeSearch for the affected employee returns reActivateEmployee: false, but the _update payload sent null.

Fixed the same way the adjacent `id` field is already handled (comment right above this code already explains why re-fetching fresh and not trusting the form matters for id) — always take reActivateEmployee from the fresh base fetch. Added a regression test verified to fail without the fix and pass with it.

digit-ui-v2/packages/data-provider has an identical, word-for-word copy of this same bug, but that app depends on an external sibling repo clone per its README and isn't the one currently deployed at bometfeedbackhub.digit.org/configurator — left unfixed here, flagging for whoever maintains that repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed employee updates so the latest reactivation status from the server is preserved.
  * Prevented outdated form values from unintentionally changing an employee’s reactivation setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->