### PR TITLE
feat(compose): per-service Flyway init containers — DB-migration parity with K8s (item #10)

### DIFF
--- a/.github/scripts/check-flyway-dump-alignment.py
+++ b/.github/scripts/check-flyway-dump-alignment.py
@@ -44,6 +44,7 @@ ROOT = pathlib.Path(__file__).resolve().parents[2]
 DUMP = ROOT / "local-setup/db/full-dump.sql"
 COMPOSE = ROOT / "local-setup/docker-compose.egov-digit.yaml"
 FAST_PATH = ROOT / "local-setup/docker-compose.fast-path.yml"
+MIGRATIONS = ROOT / "local-setup/docker-compose.migrations.yml"
 
 # ── Transitional allowlists (drive these to empty as item #10 lands) ──────────
 # Enabled services that legitimately create their history fresh: they claim a
@@ -107,24 +108,31 @@ def _env(spec) -> dict:
     return {}
 
 
-def merged_services(compose_text: str, fast_path_text: str) -> dict:
-    """Per-service env from the base compose with the fast-path env overlaid."""
-    base = yaml.safe_load(compose_text) or {}
-    over = yaml.safe_load(fast_path_text) or {}
-    services = {n: _env(s) for n, s in (base.get("services") or {}).items()}
-    for name, spec in (over.get("services") or {}).items():
-        services.setdefault(name, {}).update(_env(spec))
+def merged_services(*compose_texts: str) -> dict:
+    """Per-service env from the base compose with each overlay merged in order."""
+    services = {}
+    for text in compose_texts:
+        data = yaml.safe_load(text) or {}
+        for name, spec in (data.get("services") or {}).items():
+            services.setdefault(name, {}).update(_env(spec))
     return services
 
 
 def claimed_tables(services: dict) -> set:
-    """SPRING_FLYWAY_TABLE of every Flyway-enabled service that pins one.
+    """Tables claimed by (a) a per-service migration init container via SCHEMA_TABLE,
+    or (b) a Flyway-enabled app via SPRING_FLYWAY_TABLE.
 
     A service is Flyway-relevant if it carries any SPRING_FLYWAY_* / FLYWAY_ENABLED
     key; enabled unless that flag is explicitly false (the image default is on).
     """
     claimed = set()
     for env in services.values():
+        # (a) init-container migrator: SCHEMA_TABLE is the authoritative name.
+        schema_table = env.get("SCHEMA_TABLE")
+        if schema_table:
+            claimed.add(schema_table.strip())
+            continue
+        # (b) app with embedded Flyway still enabled.
         relevant = any(k.startswith("SPRING_FLYWAY") for k in env) or "FLYWAY_ENABLED" in env
         if not relevant:
             continue
@@ -221,8 +229,17 @@ def self_test() -> int:
     stale2 = analyze(dump, {"pgr_services_schema", "hrms_schema_version"})
     assert "hrms_schema_version" in stale2["stale_baseline_fresh"], stale2
 
+    # A service migrated to an init container claims its table via SCHEMA_TABLE,
+    # not SPRING_FLYWAY_TABLE. That must still count as claimed.
+    PENDING_ENABLE, BASELINE_FRESH = set(), set()
+    migrated = claimed_tables({
+        "pgr-services": {"SPRING_FLYWAY_ENABLED": "false"},
+        "pgr-services-migration": {"SCHEMA_TABLE": "pgr_services_schema"},
+    })
+    assert migrated == {"pgr_services_schema"}, f"migrator SCHEMA_TABLE not claimed: {migrated}"
+
     PENDING_ENABLE, BASELINE_FRESH = saved_p, saved_b
-    print("self-test OK: alignment, mismatch, orphan, and stale-allowlist all detected.")
+    print("self-test OK: alignment, mismatch, orphan, migrator-claim, and stale-allowlist all detected.")
     return 0
 
 
@@ -230,7 +247,8 @@ def main() -> int:
     if "--self-test" in sys.argv:
         return self_test()
     dump = dump_history_tables(DUMP.read_text())
-    claimed = claimed_tables(merged_services(COMPOSE.read_text(), FAST_PATH.read_text()))
+    claimed = claimed_tables(merged_services(
+        COMPOSE.read_text(), FAST_PATH.read_text(), MIGRATIONS.read_text()))
     return report(dump, claimed)
 
 

--- a/.github/scripts/check-flyway-dump-alignment.py
+++ b/.github/scripts/check-flyway-dump-alignment.py
@@ -60,17 +60,18 @@ BASELINE_FRESH = {
 # History tables the dump ships whose owning service currently has Flyway OFF
 # (item #10 decision #2 backlog). When you enable one, set its SPRING_FLYWAY_TABLE
 # to exactly this name and delete the entry here — the check then enforces it.
-PENDING_ENABLE = {
-    "egov_idgen_schema_version",        # egov-idgen        — SPRING_FLYWAY_ENABLED:false
-    "egov_localization_schema_version", # egov-localization — SPRING_FLYWAY_ENABLED:false
-    "egov_user_schema_version",         # egov-user         — FLYWAY_ENABLED:false
-}
+# Emptied in Phase 3: the dump was re-baked to the K8s <service>_schema names and
+# every core service (incl. idgen/localization/user/otp) now has a per-service
+# migration init container claiming its table, so nothing is pending-enable.
+PENDING_ENABLE = set()
 
 _FALSE = {"false", "0", "no", "off"}
 
 # CREATE TABLE public.<name> ( ... \n);  — non-greedy body up to the closing line.
+# The name may be double-quoted and contain hyphens (e.g. K8s's
+# "egov-url-shortening_schema"), so allow '-' inside the identifier.
 _CREATE = re.compile(
-    r'CREATE TABLE\s+(?:public\.)?"?([A-Za-z0-9_]+)"?\s*\((.*?)\n\);',
+    r'CREATE TABLE\s+(?:public\.)?"?([A-Za-z0-9_-]+)"?\s*\((.*?)\n\);',
     re.DOTALL,
 )
 

--- a/.github/scripts/check-flyway-dump-alignment.py
+++ b/.github/scripts/check-flyway-dump-alignment.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""CI guard: every Flyway history table baked into the compose dump must line up
+with the Flyway-enabled service that owns it (deployment-parity item #10).
+
+The compose stack boots from a prebuilt dump (local-setup/db/full-dump.sql) and
+then lets each service's Flyway apply anything newer on top. Flyway decides "what
+have I already applied?" by reading a per-service history table named by
+SPRING_FLYWAY_TABLE. If the name a service looks for does NOT match the history
+table the dump actually shipped, Flyway sees an empty history, re-runs its
+migrations from scratch, and hits `relation already exists` (42P07) on the first
+CREATE — the service crashes on boot. (This bit egov-url-shortening; the fix was a
+one-line SPRING_FLYWAY_TABLE override.)
+
+This asserts the two sides stay aligned so the mismatch is caught in a PR instead
+of at boot:
+
+  A. Every ENABLED service's SPRING_FLYWAY_TABLE is either present in the dump
+     (aligned) or an acknowledged baseline-fresh service (BASELINE_FRESH) whose
+     data tables are NOT in the dump, so it migrates from empty.
+
+  B. Every Flyway history table IN the dump is claimed by an ENABLED service
+     (via SPRING_FLYWAY_TABLE) or an acknowledged not-yet-enabled service
+     (PENDING_ENABLE) — the item #10 backlog of services whose Flyway is still
+     off. Enabling one MUST set its SPRING_FLYWAY_TABLE to the dump's name; drop
+     it from PENDING_ENABLE at the same time and this check starts enforcing it.
+
+The two allowlists are transitional and self-policed: a stale entry (one that no
+longer describes reality) is itself an error, so they can't rot.
+
+Sources of truth:
+  - Dump:    local-setup/db/full-dump.sql              -> Flyway history tables
+  - Compose: local-setup/docker-compose.egov-digit.yaml (+ fast-path.yml overlay)
+                                                        -> per-service Flyway env
+
+Run with --self-test to verify the comparison logic itself.
+"""
+import re
+import sys
+import pathlib
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+DUMP = ROOT / "local-setup/db/full-dump.sql"
+COMPOSE = ROOT / "local-setup/docker-compose.egov-digit.yaml"
+FAST_PATH = ROOT / "local-setup/docker-compose.fast-path.yml"
+
+# ── Transitional allowlists (drive these to empty as item #10 lands) ──────────
+# Enabled services that legitimately create their history fresh: they claim a
+# table absent from the dump AND their data tables are not in the dump, so Flyway
+# baselines from empty with no 42P07 risk. Remove an entry only if that service's
+# schema gets baked into the dump (then it must align instead).
+BASELINE_FRESH = {
+    "egov_indexer_schema",         # egov-indexer      — no eg_indexer* in dump
+    "digit_config_service_schema", # digit-config-svc  — no config tables in dump
+    "novu_bridge_schema",          # novu-bridge       — no novu tables in dump
+}
+
+# History tables the dump ships whose owning service currently has Flyway OFF
+# (item #10 decision #2 backlog). When you enable one, set its SPRING_FLYWAY_TABLE
+# to exactly this name and delete the entry here — the check then enforces it.
+PENDING_ENABLE = {
+    "egov_idgen_schema_version",        # egov-idgen        — SPRING_FLYWAY_ENABLED:false
+    "egov_localization_schema_version", # egov-localization — SPRING_FLYWAY_ENABLED:false
+    "egov_user_schema_version",         # egov-user         — FLYWAY_ENABLED:false
+}
+
+_FALSE = {"false", "0", "no", "off"}
+
+# CREATE TABLE public.<name> ( ... \n);  — non-greedy body up to the closing line.
+_CREATE = re.compile(
+    r'CREATE TABLE\s+(?:public\.)?"?([A-Za-z0-9_]+)"?\s*\((.*?)\n\);',
+    re.DOTALL,
+)
+
+
+def dump_history_tables(sql: str) -> set:
+    """Flyway history tables, identified by column signature (name-independent)."""
+    tables = set()
+    for name, body in _CREATE.findall(sql):
+        if "installed_rank" in body and "checksum" in body and "installed_on" in body:
+            tables.add(name)
+    if not tables:
+        sys.exit(f"ERROR: no Flyway history tables found in {DUMP} — parser broken?")
+    return tables
+
+
+def _env(spec) -> dict:
+    """A service's environment as a str->str dict (handles dict or list form)."""
+    if not isinstance(spec, dict):
+        return {}
+    env = spec.get("environment")
+    if isinstance(env, dict):
+        return {str(k): ("" if v is None else str(v)) for k, v in env.items()}
+    if isinstance(env, list):
+        out = {}
+        for item in env:
+            s = str(item)
+            if "=" in s:
+                k, v = s.split("=", 1)
+            elif ":" in s:
+                k, v = s.split(":", 1)
+            else:
+                continue
+            out[k.strip()] = v.strip()
+        return out
+    return {}
+
+
+def merged_services(compose_text: str, fast_path_text: str) -> dict:
+    """Per-service env from the base compose with the fast-path env overlaid."""
+    base = yaml.safe_load(compose_text) or {}
+    over = yaml.safe_load(fast_path_text) or {}
+    services = {n: _env(s) for n, s in (base.get("services") or {}).items()}
+    for name, spec in (over.get("services") or {}).items():
+        services.setdefault(name, {}).update(_env(spec))
+    return services
+
+
+def claimed_tables(services: dict) -> set:
+    """SPRING_FLYWAY_TABLE of every Flyway-enabled service that pins one.
+
+    A service is Flyway-relevant if it carries any SPRING_FLYWAY_* / FLYWAY_ENABLED
+    key; enabled unless that flag is explicitly false (the image default is on).
+    """
+    claimed = set()
+    for env in services.values():
+        relevant = any(k.startswith("SPRING_FLYWAY") for k in env) or "FLYWAY_ENABLED" in env
+        if not relevant:
+            continue
+        flag = env.get("SPRING_FLYWAY_ENABLED", env.get("FLYWAY_ENABLED", "")).strip().strip("'\"").lower()
+        if flag in _FALSE:
+            continue
+        table = env.get("SPRING_FLYWAY_TABLE")
+        if table:
+            claimed.add(table.strip())
+    return claimed
+
+
+def analyze(dump: set, claimed: set):
+    """Return the four error buckets (empty == aligned)."""
+    return {
+        # Enabled service points at a table absent from the dump and not a known
+        # baseline-fresh service -> 42P07 risk if its data is in the dump.
+        "claimed_not_in_dump": sorted(claimed - dump - BASELINE_FRESH),
+        # Dump ships a history table no enabled service reconciles and it isn't a
+        # known pending-enable -> orphaned history / latent 42P07 when enabled.
+        "dump_not_claimed": sorted(dump - claimed - PENDING_ENABLE),
+        # Allowlist hygiene: entries that no longer describe reality.
+        "stale_baseline_fresh": sorted((BASELINE_FRESH & dump) | (BASELINE_FRESH - claimed)),
+        "stale_pending_enable": sorted((PENDING_ENABLE & claimed) | (PENDING_ENABLE - dump)),
+    }
+
+
+_MESSAGES = {
+    "claimed_not_in_dump": (
+        "Enabled service(s) set SPRING_FLYWAY_TABLE to a name NOT in the dump. If that "
+        "service's data tables ARE in the dump this 42P07s on boot. Align the name to the "
+        "dump, or add it to BASELINE_FRESH if it truly migrates from empty:"
+    ),
+    "dump_not_claimed": (
+        "The dump ships Flyway history table(s) that no enabled service reconciles. Enable "
+        "the owning service and set its SPRING_FLYWAY_TABLE to this exact name, or add it to "
+        "PENDING_ENABLE if it is intentionally still disabled:"
+    ),
+    "stale_baseline_fresh": (
+        "BASELINE_FRESH is stale — these entries are now in the dump and/or not claimed by "
+        "any enabled service. Remove them and align the service to the dump instead:"
+    ),
+    "stale_pending_enable": (
+        "PENDING_ENABLE is stale — these entries are now claimed by an enabled service and/or "
+        "absent from the dump. Remove them so the check enforces alignment:"
+    ),
+}
+
+
+def report(dump: set, claimed: set) -> int:
+    buckets = analyze(dump, claimed)
+    if any(buckets.values()):
+        print("Flyway ↔ dump history-table MISALIGNMENT:\n")
+        for key, items in buckets.items():
+            if items:
+                print(_MESSAGES[key])
+                for t in items:
+                    print(f"    {t}")
+                print()
+        return 1
+    aligned = sorted(dump & claimed)
+    print(
+        f"OK: Flyway history tables aligned with the dump "
+        f"({len(aligned)} aligned, {len(BASELINE_FRESH)} baseline-fresh, "
+        f"{len(PENDING_ENABLE)} pending-enable)."
+    )
+    return 0
+
+
+def self_test() -> int:
+    dump = {"pgr_services_schema", "hrms_schema_version", "egov_idgen_schema_version"}
+
+    # Aligned: enabled claims match the dump; the disabled one is acknowledged.
+    global PENDING_ENABLE, BASELINE_FRESH
+    saved_p, saved_b = PENDING_ENABLE, BASELINE_FRESH
+    PENDING_ENABLE, BASELINE_FRESH = {"egov_idgen_schema_version"}, set()
+    ok = analyze(dump, {"pgr_services_schema", "hrms_schema_version"})
+    assert not any(ok.values()), f"clean case should pass: {ok}"
+
+    # Mismatch: enabled claims a table the dump lacks (the url-shortening bug shape).
+    bad = analyze(dump, {"pgr_services_schema", "hrms_schema_version", "typo_schema"})
+    assert bad["claimed_not_in_dump"] == ["typo_schema"], bad
+
+    # Orphan: dump ships a history table nobody enabled claims and it's not pending.
+    PENDING_ENABLE = set()
+    orphan = analyze(dump, {"pgr_services_schema", "hrms_schema_version"})
+    assert orphan["dump_not_claimed"] == ["egov_idgen_schema_version"], orphan
+
+    # Stale allowlists self-report.
+    PENDING_ENABLE = {"pgr_services_schema"}  # in dump AND claimed -> stale
+    stale = analyze(dump, {"pgr_services_schema", "hrms_schema_version"})
+    assert "pgr_services_schema" in stale["stale_pending_enable"], stale
+    PENDING_ENABLE, BASELINE_FRESH = {"egov_idgen_schema_version"}, {"hrms_schema_version"}
+    stale2 = analyze(dump, {"pgr_services_schema", "hrms_schema_version"})
+    assert "hrms_schema_version" in stale2["stale_baseline_fresh"], stale2
+
+    PENDING_ENABLE, BASELINE_FRESH = saved_p, saved_b
+    print("self-test OK: alignment, mismatch, orphan, and stale-allowlist all detected.")
+    return 0
+
+
+def main() -> int:
+    if "--self-test" in sys.argv:
+        return self_test()
+    dump = dump_history_tables(DUMP.read_text())
+    claimed = claimed_tables(merged_services(COMPOSE.read_text(), FAST_PATH.read_text()))
+    return report(dump, claimed)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check-flyway-dump-alignment.py
+++ b/.github/scripts/check-flyway-dump-alignment.py
@@ -45,25 +45,36 @@ DUMP = ROOT / "local-setup/db/full-dump.sql"
 COMPOSE = ROOT / "local-setup/docker-compose.egov-digit.yaml"
 FAST_PATH = ROOT / "local-setup/docker-compose.fast-path.yml"
 MIGRATIONS = ROOT / "local-setup/docker-compose.migrations.yml"
+MAP = ROOT / "local-setup/db/flyway-history-map.yml"
 
-# ── Transitional allowlists (drive these to empty as item #10 lands) ──────────
-# Enabled services that legitimately create their history fresh: they claim a
-# table absent from the dump AND their data tables are not in the dump, so Flyway
-# baselines from empty with no 42P07 risk. Remove an entry only if that service's
-# schema gets baked into the dump (then it must align instead).
+
+def _load_history_map() -> dict:
+    with open(MAP) as fh:
+        return yaml.safe_load(fh) or {}
+
+
+_HISTORY_MAP = _load_history_map()
+
+# Services that legitimately create their history fresh: their data tables are not
+# in the dump, so Flyway baselines from empty with no 42P07 risk. Declared in the
+# map (`baseline_fresh: true`) so the map and this check cannot drift apart.
 BASELINE_FRESH = {
-    "egov_indexer_schema",         # egov-indexer      — no eg_indexer* in dump
-    "digit_config_service_schema", # digit-config-svc  — no config tables in dump
-    "novu_bridge_schema",          # novu-bridge       — no novu tables in dump
+    spec["canonical"] for spec in _HISTORY_MAP.values() if spec.get("baseline_fresh")
 }
 
-# History tables the dump ships whose owning service currently has Flyway OFF
-# (item #10 decision #2 backlog). When you enable one, set its SPRING_FLYWAY_TABLE
-# to exactly this name and delete the entry here — the check then enforces it.
-# Emptied in Phase 3: the dump was re-baked to the K8s <service>_schema names and
-# every core service (incl. idgen/localization/user/otp) now has a per-service
-# migration init container claiming its table, so nothing is pending-enable.
+# Emptied in Phase 3: every core service now has a migration init container
+# claiming its table, so nothing is pending-enable. db-history-normalize renames
+# any legacy names in the dump before the migrators run, so a legacy alias in a
+# dump is no longer a misalignment — it is expected and handled.
 PENDING_ENABLE = set()
+
+# Legacy names the normalizer will rename into canonical form at deploy time.
+# A dump carrying these is fine, so they must not be reported as orphans.
+NORMALIZED_ALIASES = {
+    alias
+    for spec in _HISTORY_MAP.values()
+    for alias in (spec.get("aliases") or [])
+}
 
 _FALSE = {"false", "0", "no", "off"}
 
@@ -154,7 +165,7 @@ def analyze(dump: set, claimed: set):
         "claimed_not_in_dump": sorted(claimed - dump - BASELINE_FRESH),
         # Dump ships a history table no enabled service reconciles and it isn't a
         # known pending-enable -> orphaned history / latent 42P07 when enabled.
-        "dump_not_claimed": sorted(dump - claimed - PENDING_ENABLE),
+        "dump_not_claimed": sorted(dump - claimed - PENDING_ENABLE - NORMALIZED_ALIASES),
         # Allowlist hygiene: entries that no longer describe reality.
         "stale_baseline_fresh": sorted((BASELINE_FRESH & dump) | (BASELINE_FRESH - claimed)),
         "stale_pending_enable": sorted((PENDING_ENABLE & claimed) | (PENDING_ENABLE - dump)),
@@ -204,31 +215,45 @@ def report(dump: set, claimed: set) -> int:
 
 
 def self_test() -> int:
-    dump = {"pgr_services_schema", "hrms_schema_version", "egov_idgen_schema_version"}
+    # Synthetic names throughout: a real table name here would collide with the
+    # shipped map's aliases and make these cases depend on the map's contents.
+    dump = {"alpha_schema", "beta_schema", "gamma_schema_version"}
+
+    global PENDING_ENABLE, BASELINE_FRESH, NORMALIZED_ALIASES
+    saved_p, saved_b, saved_n = PENDING_ENABLE, BASELINE_FRESH, NORMALIZED_ALIASES
+    NORMALIZED_ALIASES = set()
 
     # Aligned: enabled claims match the dump; the disabled one is acknowledged.
-    global PENDING_ENABLE, BASELINE_FRESH
-    saved_p, saved_b = PENDING_ENABLE, BASELINE_FRESH
-    PENDING_ENABLE, BASELINE_FRESH = {"egov_idgen_schema_version"}, set()
-    ok = analyze(dump, {"pgr_services_schema", "hrms_schema_version"})
+    PENDING_ENABLE, BASELINE_FRESH = {"gamma_schema_version"}, set()
+    ok = analyze(dump, {"alpha_schema", "beta_schema"})
     assert not any(ok.values()), f"clean case should pass: {ok}"
 
     # Mismatch: enabled claims a table the dump lacks (the url-shortening bug shape).
-    bad = analyze(dump, {"pgr_services_schema", "hrms_schema_version", "typo_schema"})
+    bad = analyze(dump, {"alpha_schema", "beta_schema", "typo_schema"})
     assert bad["claimed_not_in_dump"] == ["typo_schema"], bad
 
     # Orphan: dump ships a history table nobody enabled claims and it's not pending.
     PENDING_ENABLE = set()
-    orphan = analyze(dump, {"pgr_services_schema", "hrms_schema_version"})
-    assert orphan["dump_not_claimed"] == ["egov_idgen_schema_version"], orphan
+    orphan = analyze(dump, {"alpha_schema", "beta_schema"})
+    assert orphan["dump_not_claimed"] == ["gamma_schema_version"], orphan
+
+    # ...but a LEGACY ALIAS the normalizer renames at deploy time is NOT an orphan.
+    # db-history-normalize turns gamma_schema_version into gamma_schema before any
+    # migrator runs, so a dump carrying the legacy name is handled, not misaligned.
+    NORMALIZED_ALIASES = {"gamma_schema_version"}
+    handled = analyze(dump, {"alpha_schema", "beta_schema"})
+    assert handled["dump_not_claimed"] == [], handled
+    NORMALIZED_ALIASES = set()
 
     # Stale allowlists self-report.
-    PENDING_ENABLE = {"pgr_services_schema"}  # in dump AND claimed -> stale
-    stale = analyze(dump, {"pgr_services_schema", "hrms_schema_version"})
-    assert "pgr_services_schema" in stale["stale_pending_enable"], stale
-    PENDING_ENABLE, BASELINE_FRESH = {"egov_idgen_schema_version"}, {"hrms_schema_version"}
-    stale2 = analyze(dump, {"pgr_services_schema", "hrms_schema_version"})
-    assert "hrms_schema_version" in stale2["stale_baseline_fresh"], stale2
+    PENDING_ENABLE = {"alpha_schema"}  # in dump AND claimed -> stale
+    stale = analyze(dump, {"alpha_schema", "beta_schema"})
+    assert "alpha_schema" in stale["stale_pending_enable"], stale
+    PENDING_ENABLE, BASELINE_FRESH = {"gamma_schema_version"}, {"beta_schema"}
+    stale2 = analyze(dump, {"alpha_schema", "beta_schema"})
+    assert "beta_schema" in stale2["stale_baseline_fresh"], stale2
+
+    NORMALIZED_ALIASES = saved_n
 
     # A service migrated to an init container claims its table via SCHEMA_TABLE,
     # not SPRING_FLYWAY_TABLE. That must still count as claimed.
@@ -240,7 +265,21 @@ def self_test() -> int:
     assert migrated == {"pgr_services_schema"}, f"migrator SCHEMA_TABLE not claimed: {migrated}"
 
     PENDING_ENABLE, BASELINE_FRESH = saved_p, saved_b
-    print("self-test OK: alignment, mismatch, orphan, migrator-claim, and stale-allowlist all detected.")
+
+    # The map must claim every canonical name the compose overlay declares, or the
+    # normalizer would not know about a service the migrators do run.
+    claimed_by_compose = claimed_tables(merged_services(
+        COMPOSE.read_text(), FAST_PATH.read_text(), MIGRATIONS.read_text()))
+    canonical_in_map = {spec["canonical"] for spec in _HISTORY_MAP.values()}
+    unmapped = claimed_by_compose - canonical_in_map
+    assert not unmapped, (
+        f"compose declares SCHEMA_TABLE(s) absent from flyway-history-map.yml: "
+        f"{sorted(unmapped)} — add them to the map or db-history-normalize will "
+        f"not protect them"
+    )
+
+    print("self-test OK: alignment, mismatch, orphan, migrator-claim, stale-allowlist, "
+          "and map-covers-compose all detected.")
     return 0
 
 

--- a/.github/workflows/flyway-dump-alignment.yml
+++ b/.github/workflows/flyway-dump-alignment.yml
@@ -1,0 +1,40 @@
+name: Flyway dump alignment
+
+# Deployment-parity item #10: the compose stack boots from a prebuilt dump and
+# then runs Flyway incrementally on top. Each Flyway-enabled service must point
+# SPRING_FLYWAY_TABLE at the history table the dump actually shipped — otherwise
+# Flyway re-runs its migrations and crashes on `relation already exists` (42P07).
+# This guards that alignment on every PR that touches the dump or Flyway config.
+
+on:
+  pull_request:
+    paths:
+      - 'local-setup/db/full-dump.sql'
+      - 'local-setup/docker-compose.egov-digit.yaml'
+      - 'local-setup/docker-compose.fast-path.yml'
+      - '.github/scripts/check-flyway-dump-alignment.py'
+      - '.github/workflows/flyway-dump-alignment.yml'
+  push:
+    branches: [develop]
+    paths:
+      - 'local-setup/db/full-dump.sql'
+      - 'local-setup/docker-compose.egov-digit.yaml'
+      - 'local-setup/docker-compose.fast-path.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  flyway-dump-alignment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install deps
+        run: pip install pyyaml
+      - name: Self-test the alignment check
+        run: python3 .github/scripts/check-flyway-dump-alignment.py --self-test
+      - name: Check Flyway ↔ dump history-table alignment
+        run: python3 .github/scripts/check-flyway-dump-alignment.py

--- a/.github/workflows/flyway-dump-alignment.yml
+++ b/.github/workflows/flyway-dump-alignment.yml
@@ -13,6 +13,9 @@ on:
       - 'local-setup/docker-compose.egov-digit.yaml'
       - 'local-setup/docker-compose.fast-path.yml'
       - 'local-setup/docker-compose.migrations.yml'
+      - 'local-setup/db/flyway-history-map.yml'
+      - 'local-setup/db/normalize/normalize.py'
+      - 'local-setup/tests/test_flyway_history_normalize.py'
       - '.github/scripts/check-flyway-dump-alignment.py'
       - '.github/workflows/flyway-dump-alignment.yml'
   push:
@@ -22,6 +25,9 @@ on:
       - 'local-setup/docker-compose.egov-digit.yaml'
       - 'local-setup/docker-compose.fast-path.yml'
       - 'local-setup/docker-compose.migrations.yml'
+      - 'local-setup/db/flyway-history-map.yml'
+      - 'local-setup/db/normalize/normalize.py'
+      - 'local-setup/tests/test_flyway_history_normalize.py'
 
 permissions:
   contents: read
@@ -35,8 +41,12 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install deps
-        run: pip install pyyaml
+        run: pip install pyyaml pytest
       - name: Self-test the alignment check
         run: python3 .github/scripts/check-flyway-dump-alignment.py --self-test
       - name: Check Flyway ↔ dump history-table alignment
         run: python3 .github/scripts/check-flyway-dump-alignment.py
+      # The decision table is where every safety property of db-history-normalize
+      # lives — including "never drop a populated table". Pin it on every PR.
+      - name: Normalizer decision-table unit tests
+        run: python3 -m pytest local-setup/tests/test_flyway_history_normalize.py -v

--- a/.github/workflows/flyway-dump-alignment.yml
+++ b/.github/workflows/flyway-dump-alignment.yml
@@ -12,6 +12,7 @@ on:
       - 'local-setup/db/full-dump.sql'
       - 'local-setup/docker-compose.egov-digit.yaml'
       - 'local-setup/docker-compose.fast-path.yml'
+      - 'local-setup/docker-compose.migrations.yml'
       - '.github/scripts/check-flyway-dump-alignment.py'
       - '.github/workflows/flyway-dump-alignment.yml'
   push:
@@ -20,6 +21,7 @@ on:
       - 'local-setup/db/full-dump.sql'
       - 'local-setup/docker-compose.egov-digit.yaml'
       - 'local-setup/docker-compose.fast-path.yml'
+      - 'local-setup/docker-compose.migrations.yml'
 
 permissions:
   contents: read

--- a/docs/db-migration-flow.md
+++ b/docs/db-migration-flow.md
@@ -20,9 +20,19 @@ it; the flow is:
 1. **Authoring (upstream, once).** A developer adds `V…__*.sql` to the service's
    repo (`.../db/migration/main/`). This is the only manual step, and it happens in
    the product repo — *not* per environment.
-2. **Packaging.** CI rebuilds that service's **`<service>-db` image** (`FROM
-   flyway/flyway` + `COPY migration/main /flyway/sql`) and publishes a **new image
-   tag** to `egovio` on Docker Hub.
+2. **Packaging (automatic).** The `-db` image is a **separate image from the app
+   image**, but nobody builds it by hand. Each service's CI builds **both** — the
+   service image *and* its `<service>-db` Flyway image (`FROM flyway/flyway` + `COPY
+   migration/main /flyway/sql`) — and publishes a **new tag** to `egovio` on Docker
+   Hub. This split is declared in **`build/build-config.yml`** (entries whose
+   `image-name` ends in `-db`) and driven by `.github/workflows/build.yml`, which
+   detects a service's `db/` folder and builds the `-db` target alongside the app.
+
+   > **New service?** Whoever adds it must add its **`<service>-db` entry to
+   > `build/build-config.yml`** (next to the app-image entry), the same way K8s
+   > needs a `-db` image. Without it, the service's migrations have no image to
+   > propagate through — CI won't build one, and there's nothing for the migrator
+   > to pull.
 3. **Propagation (the compose step).** Bump the service's image tag in
    `local-setup/docker-compose.migrations.yml`:
    ```yaml

--- a/docs/db-migration-flow.md
+++ b/docs/db-migration-flow.md
@@ -166,3 +166,55 @@ dump from the `-db` images** so its history matches them:
 
 The **CI alignment check** guards naming drift on every PR; the **smoke test** above
 guards the apply path. Regenerating the dump on a cadence guards content drift.
+
+## Deploying over a dump you did not build
+
+The stack boots from whatever dump sits at `local-setup/db/full-dump.sql`. A dump
+handed over by a service team, or lifted from a running environment, carries the
+**legacy compose** Flyway history-table names (`*_schema_version`) — but the `-db`
+migrator images look for the **K8s** names (`<service>_schema`).
+
+On a mismatch Flyway sees an empty history and replays every migration from V1
+against a populated database. Nine migrators crash with 42P07. Two do not:
+`egov-localization` and `egov-enc-service` open their V1 with `DROP TABLE IF EXISTS`,
+so they drop, recreate empty, and **exit 0**. Measured on a real team dump: 97,250
+rows → 26,377, including the encryption keys that decrypt all user PII. That loss is
+unrecoverable — `eg_user.name` and `mobilenumber` are ciphertext, and those keys were
+the only thing that could decrypt them.
+
+`db-history-normalize` runs before every migrator and prevents this. It reads
+`local-setup/db/flyway-history-map.yml`, renames legacy history tables to their
+canonical names, rebuilds empty orphan tables, and **aborts the deploy** on anything
+it cannot prove safe. It is idempotent, and it is gated in compose — so Ansible and a
+bare `docker compose up` are both covered, with no playbook change.
+
+What it does, per service:
+
+| Canonical | Legacy alias | Data tables | Action |
+|---|---|---|---|
+| present | — | — | no-op |
+| — | present | — | **rename** alias → canonical |
+| present | present | — | **abort** — ambiguous |
+| — | — | absent | no-op — fresh install |
+| — | — | present, **0 rows** | **drop**; the migrator rebuilds them |
+| — | — | present, **has rows** | **abort** — cannot prove which migrations are applied |
+
+A service whose empty tables were dropped (today: `egov-otp`/`eg_token`) will have its
+migrator **apply** its migrations rather than no-op. That is correct — the tables are
+gone and it must rebuild them.
+
+**Adding a service:** add it to `flyway-history-map.yml` — canonical name matching its
+`SCHEMA_TABLE`, any legacy aliases, and the tables its migrations create (derive these
+from its own `CREATE TABLE` statements; exclude materialized views). CI fails if a
+migrator's `SCHEMA_TABLE` has no map entry.
+
+**Testing a dump before you trust it:**
+
+```bash
+./local-setup/db/normalize/test-integration.sh /path/to/dump.sql
+```
+
+It loads the dump into a throwaway database, normalizes, runs all eleven pinned `-db`
+migrators, and asserts every pre-existing table is byte-identical afterwards. It also
+runs the same dump *without* the normalizer and asserts the data IS destroyed — if
+that half ever stops failing, the guard has been silently disabled.

--- a/docs/db-migration-flow.md
+++ b/docs/db-migration-flow.md
@@ -1,0 +1,158 @@
+# DB migrations on Docker Compose — how future migrations flow
+
+**Scope:** the Docker Compose stack (`local-setup/`). Explains how a new database
+migration reaches a running compose environment, the conditions that must hold for
+it to work, and how to add / test / troubleshoot one.
+
+**Model:** compose mirrors Kubernetes — **one Flyway "migration" init container per
+service** (`<service>-migration` in `local-setup/docker-compose.migrations.yml`),
+run *before* the app, using the **same `egovio/<service>-db:<tag>` image K8s pins**,
+writing to the same `<service>_schema` history table. The app's own (embedded)
+Flyway is off. Design detail: `docs/superpowers/specs/2026-07-10-compose-k8s-migration-parity-design.md`.
+
+---
+
+## How a future migration flows
+
+A migration is a versioned SQL file (`V<timestamp>__<desc>.sql`). Nobody hand-runs
+it; the flow is:
+
+1. **Authoring (upstream, once).** A developer adds `V…__*.sql` to the service's
+   repo (`.../db/migration/main/`). This is the only manual step, and it happens in
+   the product repo — *not* per environment.
+2. **Packaging.** CI rebuilds that service's **`<service>-db` image** (`FROM
+   flyway/flyway` + `COPY migration/main /flyway/sql`) and publishes a **new image
+   tag** to `egovio` on Docker Hub.
+3. **Propagation (the compose step).** Bump the service's image tag in
+   `local-setup/docker-compose.migrations.yml`:
+   ```yaml
+   <service>-migration:
+     image: egovio/<service>-db:<NEW_TAG>   # was <OLD_TAG>
+   ```
+4. **Application (automatic, on boot).** On the next `docker compose up`, the
+   `<service>-migration` container pulls the new image, Flyway compares its files
+   against the recorded history, sees the new version as **pending**, applies it,
+   and exits 0. Only then does the app start (it `depends_on:
+   service_completed_successfully`).
+
+**Propagation is image-version-gated:** a migration reaches the DB *only* when the
+`-db` image tag is bumped. An unchanged tag = no new files = the migrator no-ops.
+This is identical to how K8s bumps `initContainers.dbMigration.image.tag`.
+
+```
+author V…sql ──► CI builds egovio/<svc>-db:<newtag> ──► bump tag in migrations.yml
+                                                              │
+                                                    docker compose up
+                                                              │
+                          <svc>-migration pulls image ► applies pending ► exits 0 ► app starts
+```
+
+---
+
+## Conditions for it to work
+
+These are the invariants. If one breaks, boot fails (usually `42P07 relation already
+exists`) or the migration silently doesn't apply.
+
+1. **Image is pullable.** `egovio/<service>-db:<tag>` must exist on Docker Hub
+   (all current core `-db` images do). Compose only pulls from public registries.
+2. **History-table name matches the dump.** The migrator's `SCHEMA_TABLE` must equal
+   the history table the dump ships for that service (the K8s `<service>_schema`
+   name). If they differ, Flyway sees an empty history and re-runs everything →
+   `42P07`. **Enforced in CI** by `.github/scripts/check-flyway-dump-alignment.py`.
+3. **The dump records *real* applied versions, not just a baseline.** The dump was
+   re-baked so each history table holds the actual applied rows. This is why new
+   migrations read as "pending" and already-applied ones as "done." A baseline-only
+   history would make the `-db` image re-run everything → `42P07`. (If you ever
+   regenerate the dump, keep it consistent with the `-db` images — see Maintenance.)
+4. **Migrator connects to the real Postgres.** `DB_URL` points at `postgres-db:5432`,
+   **not** the `postgres` alias (that is pgbouncer in transaction mode, which breaks
+   Flyway's session locks).
+5. **Lenient Flyway flags.** Migrators run with `-baselineOnMigrate=true
+   -outOfOrder=true` (from the image's `migrate.sh`) plus
+   `FLYWAY_VALIDATE_ON_MIGRATE=false`, so a checksum/ordering difference between the
+   dump's lineage and the image doesn't hard-fail.
+6. **Cross-service ordering, if the migration reads another service's tables.**
+   Most services are self-contained. If a migration `SELECT`s another service's
+   tables (e.g. `pgr-services` analytics reads `boundary_relationship`, `eg_user`),
+   its migrator must `depends_on` those services being healthy — otherwise it fails
+   on a from-empty build. See the `pgr-services-migration` gates for the pattern.
+7. **App has embedded Flyway off.** Each converted app sets `SPRING_FLYWAY_ENABLED:
+   "false"` so the init container is the single source of migration truth.
+
+---
+
+## Procedure — propagate a new migration
+
+1. Confirm the new `egovio/<service>-db:<tag>` is published and pullable:
+   `docker manifest inspect egovio/<service>-db:<tag>`.
+2. Edit `local-setup/docker-compose.migrations.yml` → set the `<service>-migration`
+   `image:` tag to the new one.
+3. Redeploy: `docker compose … up -d`. The migrator applies the new migration; the
+   app restarts after it completes.
+4. Verify: `docker logs <service>-migration` shows `Successfully applied N
+   migration(s)`, and the app comes up healthy.
+5. The CI alignment check must stay green (it runs on any change to the overlay /
+   dump / compose).
+
+---
+
+## Testing — future-migration smoke test
+
+You don't need a real upstream release to test the mechanism. For any service:
+
+```bash
+# 1. Simulate a newer -db image = the real image + one throwaway migration
+mkdir probe && cd probe
+printf 'CREATE TABLE IF NOT EXISTS <svc>_probe (id integer PRIMARY KEY);\n' \
+  > V29990101000000__smoke_probe.sql
+printf 'FROM egovio/<service>-db:<tag>\nCOPY V29990101000000__smoke_probe.sql /flyway/sql/\n' \
+  > Dockerfile
+docker build -t <service>-db:probe .
+
+# 2. Run it against a dump-loaded DB (scratch or the live one)
+docker run --rm --network digit_egov-network \
+  -e DB_URL=jdbc:postgresql://postgres-db:5432/egov -e SCHEMA_NAME=public \
+  -e SCHEMA_TABLE=<service>_schema -e FLYWAY_USER=egov -e FLYWAY_PASSWORD=egov123 \
+  -e FLYWAY_LOCATIONS=filesystem:/flyway/sql -e FLYWAY_VALIDATE_ON_MIGRATE=false \
+  <service>-db:probe
+#   expect: "Successfully applied 1 migration"; re-run → "up to date"
+
+# 3. Clean up
+docker exec docker-postgres psql -U egov -d egov \
+  -c "DROP TABLE IF EXISTS <svc>_probe;" \
+  -c "DELETE FROM <service>_schema WHERE version='29990101000000';"
+docker rmi <service>-db:probe
+```
+
+This exercises the full chain: pull → detect pending → apply → idempotent re-run.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `42P07 relation "X" already exists` on boot | `SCHEMA_TABLE` ≠ the dump's history name, or the dump's history is baseline-only | Align the name (run the alignment check); ensure the dump carries real history (Maintenance) |
+| `relation "…" does not exist` (a *different* service's table) | migration reads another service's tables and ran too early | add `depends_on: { <dep-service>: { condition: service_healthy } }` to the migrator |
+| Migrator no-ops but expected a new migration | image tag wasn't bumped | bump `<service>-migration` `image:` tag |
+| `Migration checksum mismatch` | dump lineage ≠ image lineage | already mitigated by `FLYWAY_VALIDATE_ON_MIGRATE=false`; if it still fails, regenerate the dump |
+| App won't start, migrator `Exited (1)` | migration itself failed | read `docker logs <service>-migration` |
+
+---
+
+## Maintenance — keeping the dump honest
+
+The dump is the fast-path baseline; the migrators apply anything newer on top. The
+further the dump lags the pinned `-db` tags, the more migrations apply at boot and
+the higher the chance of hitting a lineage difference. Periodically **regenerate the
+dump from the `-db` images** so its history matches them:
+
+1. Load the current dump into a scratch DB (preserves seed/master data).
+2. For each service, run its (current-tag) `-db` image on an empty DB, capture its
+   history, and swap it into the dump under the `<service>_schema` name (data tables
+   untouched). *(This is exactly the re-bake procedure from item #10.)*
+3. Round-trip check: fresh-load the new dump, run all migrators → all no-op.
+
+The **CI alignment check** guards naming drift on every PR; the **smoke test** above
+guards the apply path. Regenerating the dump on a cadence guards content drift.

--- a/docs/superpowers/plans/2026-07-10-compose-migration-parity-pilot.md
+++ b/docs/superpowers/plans/2026-07-10-compose-migration-parity-pilot.md
@@ -1,0 +1,385 @@
+# Compose↔K8s Migration Parity — pgr-services Pilot Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove the per-service Flyway init-container model on one service (`pgr-services`) end-to-end in compose, exactly as K8s does it, without breaking the fast-path boot.
+
+**Architecture:** Add a one-shot `pgr-services-migration` compose service (built from the existing in-repo `backend/pgr-services/src/main/resources/db` Dockerfile — the same `-db` image K8s uses), connected directly to the real Postgres. Gate the `pgr-services` app on it and turn the app's embedded Flyway off. All changes live in a new `docker-compose.migrations.yml` overlay so the base stack is untouched and the pilot is reviewable in isolation.
+
+**Tech Stack:** Docker Compose (multi-file overlays), Flyway 10.7.1 (`egovio/flyway`), PostgreSQL 16, pgbouncer, Python 3 (the alignment check).
+
+## Global Constraints
+
+- Canonical stack = `local-setup/docker-compose.egov-digit.yaml` + `local-setup/docker-compose.fast-path.yml`. All compose commands run from `local-setup/` and include both, plus the new overlay.
+- Migrators MUST connect to **`postgres-db:5432`** (the real DB), never `postgres` (that hostname is a pgbouncer alias in `POOL_MODE: transaction`, which breaks Flyway).
+- `pgr-services` history table name is **`pgr_services_schema`** — identical in the dump and in K8s. The pilot performs **no dump rename** (that is deliberately the easiest first service).
+- The `-db` image contract (from `backend/pgr-services/src/main/resources/db/migrate.sh`) is: `DB_URL`, `SCHEMA_TABLE`, `FLYWAY_USER`, `FLYWAY_PASSWORD`, `FLYWAY_LOCATIONS`; it hardcodes `-baselineOnMigrate=true -outOfOrder=true`.
+- Commit messages end with: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+- Work on branch `feat/compose-migration-parity` (already checked out).
+- Repo is PUBLIC — no secrets or exploit detail in commits.
+
+---
+
+### Task 1: Migration overlay + `pgr-services-migration` (no-ops on the dump)
+
+**Files:**
+- Create: `local-setup/docker-compose.migrations.yml`
+
+**Interfaces:**
+- Produces: a compose service `pgr-services-migration` (one-shot, `restart: "no"`) built from `../backend/pgr-services/src/main/resources/db`, that runs Flyway `migrate` against `postgres-db:5432` with `SCHEMA_TABLE=pgr_services_schema`. Later tasks add `depends_on: { pgr-services-migration: { condition: service_completed_successfully } }`.
+
+- [ ] **Step 1: Write the overlay with just the migration service**
+
+Create `local-setup/docker-compose.migrations.yml`:
+
+```yaml
+# Deployment-parity item #10 — per-service Flyway init containers (pilot).
+# Mirrors the K8s db-migration init container: a one-shot Flyway run per
+# service, from the same in-repo <service>-db image, writing history to the
+# K8s <service>_schema table, connected DIRECTLY to postgres-db (never the
+# pgbouncer 'postgres' alias, which runs in transaction mode and breaks Flyway).
+services:
+  pgr-services-migration:
+    build:
+      context: ../backend/pgr-services/src/main/resources/db
+    container_name: pgr-services-migration
+    depends_on:
+      postgres-db:
+        condition: service_healthy
+    environment:
+      DB_URL: jdbc:postgresql://postgres-db:5432/egov
+      SCHEMA_TABLE: pgr_services_schema
+      FLYWAY_USER: egov
+      FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
+      FLYWAY_LOCATIONS: filesystem:/flyway/sql
+      FLYWAY_VALIDATE_ON_MIGRATE: "false"
+    restart: "no"
+    networks:
+      - egov-network
+```
+
+- [ ] **Step 2: Reset to a fresh dump-loaded DB and confirm the "before" state**
+
+Run:
+```bash
+cd local-setup
+export COMPOSE="docker compose -f docker-compose.egov-digit.yaml -f docker-compose.fast-path.yml -f docker-compose.migrations.yml"
+$COMPOSE down -v
+$COMPOSE up -d --wait postgres-db   # --wait blocks until the healthcheck passes,
+                                    # i.e. after the dump finishes loading via initdb
+docker exec docker-postgres psql -U egov -d egov -c \
+  "select count(*) as applied_migrations from pgr_services_schema where success;"
+```
+Expected: a non-zero count (the dump ships an already-populated `pgr_services_schema` history). Record this number — call it **N**.
+
+- [ ] **Step 3: Build the migration image**
+
+Run:
+```bash
+$COMPOSE build pgr-services-migration
+```
+Expected: build succeeds; final image has `/flyway/sql` populated and `migrate.sh` as entrypoint.
+
+- [ ] **Step 4: Run the migrator against the dump-loaded DB**
+
+Run:
+```bash
+$COMPOSE run --rm pgr-services-migration
+echo "exit=$?"
+```
+Expected: `exit=0`. Flyway output reports the schema is already up to date (0 migrations applied), OR applies only migrations newer than the dump's recorded version (any `V2026…` present in the repo but not yet in history). It must NOT error with `relation already exists` (42P07) or a checksum-mismatch failure.
+
+- [ ] **Step 5: Confirm the migrator was a safe no-op / clean incremental**
+
+Run:
+```bash
+docker exec docker-postgres psql -U egov -d egov -c \
+  "select count(*) as applied_migrations from pgr_services_schema where success;"
+```
+Expected: count `>= N` (equal if the repo SQL matches the dump; slightly higher if the repo carries newer migrations — both are correct). No failed rows:
+```bash
+docker exec docker-postgres psql -U egov -d egov -c \
+  "select version, description, success from pgr_services_schema where not success;"
+```
+Expected: **0 rows**.
+
+> **If Step 4 fails on checksum mismatch:** `FLYWAY_VALIDATE_ON_MIGRATE=false` was not honored (migrate.sh builds an explicit CLI without that flag, and env precedence may differ by Flyway version). Fix by making the flag explicit in the image entrypoint — edit `backend/pgr-services/src/main/resources/db/migrate.sh` to add `-validateOnMigrate=false` to the `flyway` command, rebuild (Step 3), and re-run (Step 4). Note this change in the commit; it matches how DIGIT already runs Flyway leniently (baseline + out-of-order).
+
+- [ ] **Step 6: Tear down and commit**
+
+Run:
+```bash
+$COMPOSE down -v
+git add local-setup/docker-compose.migrations.yml backend/pgr-services/src/main/resources/db/migrate.sh 2>/dev/null
+git commit -m "feat(compose): add pgr-services Flyway init-container overlay (item #10 pilot)
+
+One-shot pgr-services-migration built from the in-repo pgr-services-db
+Dockerfile, connected directly to postgres-db (not the pgbouncer alias),
+writing history to pgr_services_schema (same name as the dump and K8s).
+No-ops on the fast-path dump; applies newer migrations incrementally.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Gate `pgr-services` on the migrator, disable embedded Flyway
+
+**Files:**
+- Modify: `local-setup/docker-compose.migrations.yml` (add a `pgr-services` override block)
+
+**Interfaces:**
+- Consumes: `pgr-services-migration` from Task 1.
+- Produces: `pgr-services` now starts only after the migrator completes, with `SPRING_FLYWAY_ENABLED: "false"`.
+
+- [ ] **Step 1: Add the app override to the overlay**
+
+Append to `local-setup/docker-compose.migrations.yml` under `services:`:
+
+```yaml
+  # The app no longer self-migrates; the init container above owns it.
+  pgr-services:
+    environment:
+      SPRING_FLYWAY_ENABLED: "false"
+    depends_on:
+      pgr-services-migration:
+        condition: service_completed_successfully
+```
+
+- [ ] **Step 2: Verify compose merges the override without dropping base deps**
+
+Run:
+```bash
+cd local-setup
+$COMPOSE config | sed -n '/^  pgr-services:/,/^  [a-z]/p' | grep -E "SPRING_FLYWAY_ENABLED|pgr-services-migration|pgbouncer|condition"
+```
+Expected: shows `SPRING_FLYWAY_ENABLED: "false"`, the new `pgr-services-migration` dependency, AND the pre-existing base dependencies (`pgbouncer`, `redpanda`, etc.) — compose merges `depends_on`, it does not replace it.
+
+- [ ] **Step 3: Boot the DB + migrator + app chain and confirm ordering**
+
+Run:
+```bash
+$COMPOSE down -v
+$COMPOSE up -d pgr-services
+$COMPOSE ps
+```
+Expected: `pgr-services-migration` shows `Exited (0)`; `pgr-services` is `Up` (started only after the migrator exited 0). Its dependency infra (pgbouncer, redpanda, mdms, idgen, user, workflow, localization, enc) also came up because they remain in the merged `depends_on`.
+
+- [ ] **Step 4: Confirm the app is healthy and its Flyway stayed off**
+
+Run:
+```bash
+docker logs pgr-services 2>&1 | grep -iE "flyway|migrat" | head
+```
+Expected: **no** Flyway migration lines from the app (embedded Flyway disabled). Then hit the API:
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" \
+  "http://localhost:18080/pgr-services/v2/request/_count?tenantId=pg"
+```
+Expected: `401` or `400` (reachable, auth-gated) — NOT `000`/`502` (which would mean the app never came up).
+
+- [ ] **Step 5: Tear down and commit**
+
+Run:
+```bash
+$COMPOSE down -v
+git add local-setup/docker-compose.migrations.yml
+git commit -m "feat(compose): gate pgr-services on its migrator, disable embedded Flyway
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Prove incremental application (new migration) + slow path (empty DB)
+
+**Files:**
+- Temporary: `backend/pgr-services/src/main/resources/db/migration/main/V20260710000000__parity_probe.sql` (created then removed — never committed)
+
+**Interfaces:**
+- Consumes: `pgr-services-migration` from Task 1.
+
+- [ ] **Step 1: Slow-path — migrator builds the schema from empty**
+
+Prove the migrator works with no dump (the real product bring-up path). Use a scratch database so no volume juggling is needed:
+```bash
+cd local-setup
+$COMPOSE down -v
+$COMPOSE up -d --wait postgres-db   # --wait blocks until the healthcheck passes,
+                                    # i.e. after the dump finishes loading via initdb
+docker exec docker-postgres psql -U egov -d egov -c "CREATE DATABASE egov_slowtest;"
+$COMPOSE run --rm -e DB_URL=jdbc:postgresql://postgres-db:5432/egov_slowtest pgr-services-migration
+echo "exit=$?"
+```
+Expected: `exit=0`; Flyway applies ALL pgr migrations from scratch.
+
+- [ ] **Step 2: Verify the fresh schema exists with the K8s-named history table**
+
+Run:
+```bash
+docker exec docker-postgres psql -U egov -d egov_slowtest -c "\dt" | grep -iE "pgr|eg_pgr|service_request"
+docker exec docker-postgres psql -U egov -d egov_slowtest -c \
+  "select count(*) from pgr_services_schema where success;"
+```
+Expected: pgr tables present; `pgr_services_schema` populated with a full migration history. Then clean up:
+```bash
+docker exec docker-postgres psql -U egov -d egov -c "DROP DATABASE egov_slowtest;"
+```
+
+- [ ] **Step 3: New-migration test — write a probe migration**
+
+Create `backend/pgr-services/src/main/resources/db/migration/main/V20260710000000__parity_probe.sql`:
+```sql
+CREATE TABLE IF NOT EXISTS pgr_parity_probe (id integer PRIMARY KEY);
+```
+
+- [ ] **Step 4: Rebuild the -db image and run it against the dump-loaded DB**
+
+Run:
+```bash
+$COMPOSE down -v
+$COMPOSE up -d --wait postgres-db   # --wait blocks until the healthcheck passes,
+                                    # i.e. after the dump finishes loading via initdb
+$COMPOSE build pgr-services-migration
+$COMPOSE run --rm pgr-services-migration
+echo "exit=$?"
+```
+Expected: `exit=0`; Flyway reports "Successfully applied 1 migration" (the probe), because `V20260710000000` is newer than everything in the dump's history.
+
+- [ ] **Step 5: Verify the probe applied, then remove it**
+
+Run:
+```bash
+docker exec docker-postgres psql -U egov -d egov -c "\dt pgr_parity_probe"
+docker exec docker-postgres psql -U egov -d egov -c \
+  "select version,description,success from pgr_services_schema where version='20260710000000';"
+```
+Expected: the `pgr_parity_probe` table exists; one successful history row for the probe. This empirically proves incremental Flyway on top of the dump. Now remove the probe (it must never be committed):
+```bash
+rm backend/pgr-services/src/main/resources/db/migration/main/V20260710000000__parity_probe.sql
+$COMPOSE down -v
+git status --short   # expect: nothing to commit (probe removed, no tracked changes)
+```
+Expected: clean tree. Nothing to commit for this task — it is a validation-only task.
+
+---
+
+### Task 4: Keep the alignment check green after the migrator move
+
+**Files:**
+- Modify: `.github/scripts/check-flyway-dump-alignment.py`
+- Modify: `.github/workflows/flyway-dump-alignment.yml`
+
+**Interfaces:**
+- Consumes: the `docker-compose.migrations.yml` overlay from Tasks 1–2.
+- Produces: `claimed_tables()` now also reads each `*-migration` service's `SCHEMA_TABLE`, so pgr's table stays "claimed" after its embedded `SPRING_FLYWAY_TABLE` is gone.
+
+**Why:** Task 2 sets `pgr-services` `SPRING_FLYWAY_ENABLED: "false"`, so the current check (which only reads enabled services' `SPRING_FLYWAY_TABLE`) would stop counting `pgr_services_schema` as claimed and fail with `dump_not_claimed`. The check must learn the new source of truth: the migration service's `SCHEMA_TABLE`.
+
+- [ ] **Step 1: Write a failing self-test case**
+
+In `.github/scripts/check-flyway-dump-alignment.py`, inside `self_test()`, after the existing assertions and before the `PENDING_ENABLE, BASELINE_FRESH = saved_p, saved_b` restore line, add:
+```python
+    # A service migrated to an init container claims its table via SCHEMA_TABLE,
+    # not SPRING_FLYWAY_TABLE. That must still count as claimed.
+    PENDING_ENABLE, BASELINE_FRESH = set(), set()
+    migrated = claimed_tables({
+        "pgr-services": {"SPRING_FLYWAY_ENABLED": "false"},
+        "pgr-services-migration": {"SCHEMA_TABLE": "pgr_services_schema"},
+    })
+    assert migrated == {"pgr_services_schema"}, f"migrator SCHEMA_TABLE not claimed: {migrated}"
+```
+
+- [ ] **Step 2: Run the self-test to see it fail**
+
+Run:
+```bash
+cd /home/ubuntu/projects/egov-devops/Citizen-Complaint-Resolution-System
+python3 .github/scripts/check-flyway-dump-alignment.py --self-test
+```
+Expected: FAIL — `AssertionError: migrator SCHEMA_TABLE not claimed: set()` (the current `claimed_tables` ignores `SCHEMA_TABLE`).
+
+- [ ] **Step 3: Teach `claimed_tables` about migration services**
+
+In `claimed_tables()`, replace the loop body so a service claims a table via EITHER an enabled `SPRING_FLYWAY_TABLE` OR a `SCHEMA_TABLE` (the init-container contract):
+```python
+def claimed_tables(services: dict) -> set:
+    """Tables claimed by (a) a Flyway-enabled app via SPRING_FLYWAY_TABLE, or
+    (b) a per-service migration init container via SCHEMA_TABLE."""
+    claimed = set()
+    for env in services.values():
+        # (b) init-container migrator: SCHEMA_TABLE is the authoritative name.
+        schema_table = env.get("SCHEMA_TABLE")
+        if schema_table:
+            claimed.add(schema_table.strip())
+            continue
+        # (a) app with embedded Flyway still enabled.
+        relevant = any(k.startswith("SPRING_FLYWAY") for k in env) or "FLYWAY_ENABLED" in env
+        if not relevant:
+            continue
+        flag = env.get("SPRING_FLYWAY_ENABLED", env.get("FLYWAY_ENABLED", "")).strip().strip("'\"").lower()
+        if flag in _FALSE:
+            continue
+        table = env.get("SPRING_FLYWAY_TABLE")
+        if table:
+            claimed.add(table.strip())
+    return claimed
+```
+
+- [ ] **Step 4: Point the live check at the migrations overlay too**
+
+In `main()`, add the overlay to the merged compose sources. Change:
+```python
+    claimed = claimed_tables(merged_services(COMPOSE.read_text(), FAST_PATH.read_text()))
+```
+to:
+```python
+    claimed = claimed_tables(merged_services(
+        COMPOSE.read_text(), FAST_PATH.read_text(), MIGRATIONS.read_text()))
+```
+And update `merged_services` to accept a third overlay, plus add the constant near the other paths (after `FAST_PATH = ...`):
+```python
+MIGRATIONS = ROOT / "local-setup/docker-compose.migrations.yml"
+```
+Replace `merged_services` with:
+```python
+def merged_services(*compose_texts: str) -> dict:
+    """Per-service env from the base compose with each overlay merged in order."""
+    services = {}
+    for text in compose_texts:
+        data = yaml.safe_load(text) or {}
+        for name, spec in (data.get("services") or {}).items():
+            services.setdefault(name, {}).update(_env(spec))
+    return services
+```
+
+- [ ] **Step 5: Run the self-test and the live check**
+
+Run:
+```bash
+python3 .github/scripts/check-flyway-dump-alignment.py --self-test
+python3 .github/scripts/check-flyway-dump-alignment.py; echo "exit=$?"
+```
+Expected: self-test prints OK; live check prints `OK: ...` with `exit=0` (pgr still counted via the migrator's `SCHEMA_TABLE`).
+
+- [ ] **Step 6: Add the overlay to the workflow trigger paths**
+
+In `.github/workflows/flyway-dump-alignment.yml`, add `local-setup/docker-compose.migrations.yml` to BOTH the `pull_request.paths` and `push.paths` lists (alongside the other compose files).
+
+- [ ] **Step 7: Commit**
+
+Run:
+```bash
+git add .github/scripts/check-flyway-dump-alignment.py .github/workflows/flyway-dump-alignment.yml
+git commit -m "ci: alignment check reads per-service migrator SCHEMA_TABLE (item #10)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Out of scope for this plan (follow-up plans after the pilot proves out)
+
+- **Phase 2** — template the pilot across the other repo-local services (`novu-bridge`, `digit-config-service`, `digit-user-preferences-service`, `xstate-chatbot`, `default-data-handler`).
+- **Phase 3** — core services (`boundary-service`, `egov-hrms`, `egov-idgen`, `egov-user`, `egov-localization`, `egov-enc-service`, `egov-filestore`, `egov-workflow-v2`, `mdms-v2`, `egov-url-shortening`, `egov-otp`) + resolve the `egov-accesscontrol` open item; requires the §6 dump rename+re-bake and the §5 image-sourcing decision.
+- **Phase 4** — retire the `db-migrations` container, remove embedded `SPRING_FLYWAY_*` and the url-shortening override, re-bake the dump with all renames, wire the overlay into the ansible playbook, and flip the alignment check to a three-way (migrator ↔ dump ↔ K8s `schemaTable`) enforcement.

--- a/docs/superpowers/plans/2026-07-13-flyway-history-normalization.md
+++ b/docs/superpowers/plans/2026-07-13-flyway-history-normalization.md
@@ -998,7 +998,12 @@ ok: renamed 10, rebuilt 1, already-aligned 3, skipped 2
 ALL PASS
 ```
 
-Note `egov-otp` now reaches `exit=0 noop`: the normalizer drops the empty orphan `eg_token`, so its migrator builds the table cleanly instead of hitting 42P07.
+**`egov-otp` is expected to APPLY, not no-op.** The normalizer drops its empty orphan
+`eg_token`, so its migrator necessarily rebuilds the table — it exits 0 having applied
+its migrations, instead of hitting 42P07. Demanding a no-op from a service that took
+the rebuild path would be wrong, so the test asserts per path: services named in the
+normalizer's `rebuilt` lines must apply; every other migrator must report
+`No migration necessary`. Both must exit 0.
 
 - [ ] **Step 3: Commit**
 

--- a/docs/superpowers/plans/2026-07-13-flyway-history-normalization.md
+++ b/docs/superpowers/plans/2026-07-13-flyway-history-normalization.md
@@ -1,0 +1,1290 @@
+# Flyway History Normalization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a DIGIT deploy over an operator-supplied Postgres dump either leave existing data untouched or fail loudly — never silently destroy it.
+
+**Architecture:** A one-shot `db-history-normalize` init container runs after `postgres-db` is healthy and before every Flyway migrator. It reads a shared map of canonical (K8s) Flyway history-table names plus their legacy compose aliases, introspects the database, and renames legacy history tables into place so the migrators see their history and no-op. Anything it cannot prove safe aborts the deploy. Compose enforces the ordering via `depends_on`, so Ansible and a bare `docker compose up` are both covered with no playbook change.
+
+**Tech Stack:** Docker Compose, Python 3 (stdlib + PyYAML), `psql`, Flyway (inside the pinned `egovio/*-db` images), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-07-13-ansible-flyway-history-normalization-design.md`
+
+## Global Constraints
+
+- Base branch: `feat/flyway-history-normalize` (stacked on `feat/item10-db-migration-parity` / PR #1142).
+- All paths below are relative to the repo root. Compose paths inside `docker-compose.migrations.yml` are relative to `local-setup/`.
+- The normalizer **must exit non-zero** on any condition it cannot prove safe. No path may silently succeed while modifying data.
+- The normalizer **must be idempotent** — compose re-runs it on every `up`.
+- `postgres:16` ships `psql` but **not** `python3` (verified). The Dockerfile must install `python3` + `python3-yaml`.
+- Base image is referenced through the VPC registry used by the rest of the stack: `registry.preview.egov.theflywheel.in/postgres:16`, exposed as a build ARG.
+- **`psql` writes errors as `psql:<file>:<line>: ERROR: ...`, not `ERROR` at line start.** Any grep for failures must not anchor with `^ERROR` — an anchored grep silently reports success on a failed run. Prefer `-v ON_ERROR_STOP=1` and check the exit code.
+- The canonical name for `egov-url-shortening` is **hyphenated**: `egov-url-shortening_schema`. It must be double-quoted in SQL.
+- Never modify `local-setup/db/full-dump.sql` in this work.
+- No change to `local-setup/ansible/playbook-deploy.yml`.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `local-setup/db/flyway-history-map.yml` | **new** — single source of truth: per service, canonical history table, legacy aliases, owned data tables, and flags (`embedded`, `baseline_fresh`) |
+| `local-setup/db/normalize/normalize.py` | **new** — pure decision layer (`decide()`) + DB introspection + action execution + CLI |
+| `local-setup/db/normalize/Dockerfile` | **new** — `postgres:16` + `python3-yaml`, entrypoint `normalize.py` |
+| `local-setup/db/normalize/test-integration.sh` | **new** — the real proof + the negative test, against a real dump |
+| `local-setup/tests/test_flyway_history_normalize.py` | **new** — decision-table unit tests |
+| `local-setup/docker-compose.migrations.yml` | **modify** — add `db-history-normalize`; gate all 14 migrators on it |
+| `.github/scripts/check-flyway-dump-alignment.py` | **modify** — read the shared map instead of hardcoded name sets |
+| `.github/workflows/flyway-dump-alignment.yml` | **modify** — add the map to trigger paths; run the new unit tests |
+
+### Map schema
+
+```yaml
+<service-name>:
+  canonical:     <str>   # the table Flyway looks for (SCHEMA_TABLE in the compose overlay)
+  aliases:       [<str>] # legacy compose names that mean the same history
+  data_tables:   [<str>] # real tables this service's migrations CREATE (not materialized views)
+  embedded:      <bool>  # optional. true = no migration init container; normalizer skips entirely
+  baseline_fresh: <bool> # optional. true = legitimately absent from the dump; CI must not flag it
+```
+
+**Note on scope (refinement of the spec):** the spec listed 13 services. The CI check's existing `BASELINE_FRESH` set also covers `egov-indexer`, `novu-bridge` and `digit-config-service`. For the map to *replace* those hardcoded sets (spec deliverable 4), it must be able to express them — hence the `baseline_fresh` flag and three extra entries. Their `data_tables` are derived from their own migration SQL, same as everything else.
+
+---
+
+### Task 1: The map and the decision layer
+
+The decision layer is a pure function — no database, no Docker. It is where every safety property lives, so it gets tested first and hardest.
+
+**Files:**
+- Create: `local-setup/db/flyway-history-map.yml`
+- Create: `local-setup/db/normalize/normalize.py`
+- Test: `local-setup/tests/test_flyway_history_normalize.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `load_map(path: str) -> dict[str, dict]`
+  - `Decision` — `NamedTuple(action: str, service: str, canonical: str, alias: str | None, tables: tuple[str, ...], reason: str)`
+  - `decide(service: str, spec: dict, present: set[str], row_counts: dict[str, int]) -> Decision`
+  - Action constants: `NOOP`, `RENAME`, `DROP`, `ABORT`, `SKIP` (module-level strings).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `local-setup/tests/test_flyway_history_normalize.py`:
+
+```python
+#!/usr/bin/env python3
+"""Decision-table tests for the Flyway history normalizer.
+
+The normalizer's safety properties all live in the pure `decide()` function:
+given what is in the database, what should we do? These tests pin every row of
+the decision table, including the two that exist to prevent data loss.
+"""
+import os
+import sys
+
+import pytest
+import yaml
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "db", "normalize")))
+
+from normalize import ABORT, DROP, NOOP, RENAME, SKIP, decide, load_map
+
+MAP_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "db", "flyway-history-map.yml")
+)
+
+SPEC = {
+    "canonical": "egov_user_schema",
+    "aliases": ["egov_user_schema_version"],
+    "data_tables": ["eg_user", "eg_role"],
+}
+
+
+def test_canonical_present_is_noop():
+    d = decide("egov-user", SPEC, {"egov_user_schema", "eg_user"}, {"eg_user": 534})
+    assert d.action == NOOP
+
+
+def test_legacy_alias_is_renamed_to_canonical():
+    d = decide("egov-user", SPEC, {"egov_user_schema_version", "eg_user"}, {"eg_user": 534})
+    assert d.action == RENAME
+    assert d.alias == "egov_user_schema_version"
+    assert d.canonical == "egov_user_schema"
+
+
+def test_both_canonical_and_alias_present_aborts_as_ambiguous():
+    present = {"egov_user_schema", "egov_user_schema_version", "eg_user"}
+    d = decide("egov-user", SPEC, present, {"eg_user": 534})
+    assert d.action == ABORT
+    assert "ambiguous" in d.reason.lower()
+
+
+def test_two_aliases_present_aborts_as_ambiguous():
+    spec = dict(SPEC, aliases=["egov_user_schema_version", "user_schema_version"])
+    present = {"egov_user_schema_version", "user_schema_version", "eg_user"}
+    d = decide("egov-user", spec, present, {"eg_user": 534})
+    assert d.action == ABORT
+    assert "ambiguous" in d.reason.lower()
+
+
+def test_no_history_and_no_data_is_noop_fresh_install():
+    d = decide("egov-user", SPEC, set(), {})
+    assert d.action == NOOP
+
+
+def test_no_history_but_empty_data_tables_are_dropped_for_rebuild():
+    # The egov-otp / eg_token shape: table present, history absent, zero rows.
+    d = decide("egov-user", SPEC, {"eg_user", "eg_role"}, {"eg_user": 0, "eg_role": 0})
+    assert d.action == DROP
+    assert set(d.tables) == {"eg_user", "eg_role"}
+
+
+def test_no_history_but_populated_data_tables_abort():
+    # THE important one: never drop rows we cannot prove are reproducible.
+    d = decide("egov-user", SPEC, {"eg_user", "eg_role"}, {"eg_user": 534, "eg_role": 0})
+    assert d.action == ABORT
+    assert "eg_user" in d.reason
+
+
+def test_embedded_services_are_skipped_entirely():
+    spec = {"canonical": "accesscontrol_schema_version", "embedded": True}
+    d = decide("egov-accesscontrol", spec, {"accesscontrol_schema_version"}, {})
+    assert d.action == SKIP
+
+
+def test_embedded_service_is_skipped_even_when_it_looks_wrong():
+    # No migrator exists for it, so nothing can replay against it. Hands off.
+    spec = {"canonical": "accesscontrol_schema_version", "embedded": True}
+    d = decide("egov-accesscontrol", spec, set(), {})
+    assert d.action == SKIP
+
+
+# ── the shipped map itself ────────────────────────────────────────────────────
+
+def test_shipped_map_parses_and_covers_every_migrator():
+    m = load_map(MAP_PATH)
+    # Every service with a -db migration init container in the compose overlay.
+    for svc in [
+        "boundary-service", "egov-user", "mdms-backend", "egov-idgen",
+        "egov-localization", "egov-enc-service", "egov-filestore",
+        "egov-workflow-v2", "egov-hrms", "egov-url-shortening", "egov-otp",
+        "pgr-services", "novu-bridge", "digit-config-service",
+    ]:
+        assert svc in m, f"{svc} missing from the map"
+        assert m[svc]["canonical"], f"{svc} has no canonical table"
+
+
+def test_shipped_map_carries_the_verified_legacy_aliases():
+    m = load_map(MAP_PATH)
+    # These ten renames were verified to take the team dump to zero data change.
+    assert m["boundary-service"]["aliases"] == ["boundary_schema_version"]
+    assert m["egov-enc-service"]["aliases"] == ["enc_schema_version"]
+    assert m["mdms-backend"]["aliases"] == ["mdms_schema_version"]
+    assert m["egov-workflow-v2"]["aliases"] == ["workflow_schema_version"]
+    assert m["egov-url-shortening"]["canonical"] == "egov-url-shortening_schema"
+
+
+def test_shipped_map_has_no_duplicate_table_names_across_services():
+    m = load_map(MAP_PATH)
+    seen = {}
+    for svc, spec in m.items():
+        for name in [spec["canonical"]] + list(spec.get("aliases") or []):
+            assert name not in seen, f"{name} claimed by both {seen[name]} and {svc}"
+            seen[name] = svc
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd local-setup && python3 -m pytest tests/test_flyway_history_normalize.py -v
+```
+
+Expected: collection error — `ModuleNotFoundError: No module named 'normalize'`.
+
+- [ ] **Step 3: Write the map**
+
+Create `local-setup/db/flyway-history-map.yml`:
+
+```yaml
+# Source of truth for Flyway history-table names (deployment-parity item #10).
+#
+# The compose stack boots from a dump, then each service's -db migration init
+# container runs Flyway on top. Flyway finds "what have I already applied?" by
+# reading the history table named by SCHEMA_TABLE. If that name does not match
+# what the dump actually shipped, Flyway sees an EMPTY history, replays every
+# migration from V1 against a populated database, and — for services whose V1
+# starts with DROP TABLE IF EXISTS (egov-localization, egov-enc-service) —
+# silently destroys the data and exits 0.
+#
+# db-history-normalize reads this file before any migrator runs and renames
+# legacy history tables to their canonical names.
+#
+#   canonical      the table Flyway looks for (== SCHEMA_TABLE in
+#                  docker-compose.migrations.yml). Keep the two in sync.
+#   aliases        legacy compose names for the same history.
+#   data_tables    real tables this service's migrations CREATE. Derived from the
+#                  CREATE TABLE statements in its own migration SQL — NOT guessed.
+#                  Materialized views are excluded: they can always be rebuilt.
+#   embedded       true = no migration init container. The normalizer skips these
+#                  entirely; nothing would replay against them.
+#   baseline_fresh true = legitimately absent from the dump (migrates from empty).
+#                  Consumed by .github/scripts/check-flyway-dump-alignment.py.
+
+boundary-service:
+  canonical: boundary_service_schema
+  aliases: [boundary_schema_version]
+  data_tables: [boundary, boundary_hierarchy, boundary_relationship]
+
+egov-user:
+  canonical: egov_user_schema
+  aliases: [egov_user_schema_version]
+  data_tables:
+    - eg_address
+    - eg_role
+    - eg_user
+    - eg_user_address
+    - eg_user_audit_table
+    - eg_user_login_failed_attempts
+    - eg_userrole
+    - eg_userrole_v1
+
+mdms-backend:
+  canonical: mdms_v2_schema
+  aliases: [mdms_schema_version]
+  data_tables: [eg_mdms_data, eg_mdms_schema_definition]
+
+egov-idgen:
+  canonical: egov_idgen_schema
+  aliases: [egov_idgen_schema_version]
+  data_tables: [id_generator]
+
+egov-localization:
+  canonical: egov_localization_schema
+  aliases: [egov_localization_schema_version]
+  data_tables: [message]
+
+egov-enc-service:
+  canonical: egov_enc_service_schema
+  aliases: [enc_schema_version]
+  data_tables: [eg_enc_asymmetric_keys, eg_enc_symmetric_keys]
+
+egov-filestore:
+  canonical: egov_filestore_schema
+  aliases: [filestore_schema_version]
+  data_tables: [eg_filestoremap]
+
+egov-workflow-v2:
+  canonical: egov_workflow_v2_schema
+  aliases: [workflow_schema_version]
+  data_tables:
+    - eg_wf_action_v2
+    - eg_wf_assignee_v2
+    - eg_wf_businessservice_v2
+    - eg_wf_document_v2
+    - eg_wf_processinstance_v2
+    - eg_wf_state_v2
+
+egov-hrms:
+  canonical: egov_hrms_schema
+  aliases: [hrms_schema_version]
+  data_tables:
+    - eg_hrms_assignment
+    - eg_hrms_deactivationdetails
+    - eg_hrms_departmentaltests
+    - eg_hrms_educationaldetails
+    - eg_hrms_empdocuments
+    - eg_hrms_employee
+    - eg_hrms_jurisdiction
+    - eg_hrms_reactivationdetails
+    - eg_hrms_servicehistory
+
+egov-url-shortening:
+  canonical: "egov-url-shortening_schema"   # hyphenated, as in the K8s chart
+  aliases: [egov_url_shortening_schema_version]
+  data_tables: [eg_url_shortener]
+
+egov-otp:
+  canonical: egov_otp_schema
+  aliases: []              # no legacy otp history exists in any known dump
+  data_tables: [eg_token]
+
+pgr-services:
+  canonical: pgr_services_schema
+  aliases: []              # already canonical in the dump
+  data_tables:
+    - complaint_open_state_daily
+    - eg_pgr_address_v2
+    - eg_pgr_document_v2
+    - eg_pgr_service_v2
+
+novu-bridge:
+  canonical: novu_bridge_schema
+  aliases: []
+  data_tables: [nb_dispatch_log]
+  baseline_fresh: true
+
+digit-config-service:
+  canonical: digit_config_service_schema
+  aliases: []
+  data_tables: [eg_config_data]
+  baseline_fresh: true
+
+egov-indexer:
+  canonical: egov_indexer_schema
+  aliases: []
+  data_tables: []
+  embedded: true           # embedded Flyway; no migration init container
+  baseline_fresh: true
+
+egov-accesscontrol:
+  canonical: accesscontrol_schema_version
+  aliases: []
+  data_tables: []
+  embedded: true           # K8s chart declares no schemaTable; stays embedded
+```
+
+- [ ] **Step 4: Write the decision layer**
+
+Create `local-setup/db/normalize/normalize.py` (decision layer only — the DB layer lands in Task 2):
+
+```python
+#!/usr/bin/env python3
+"""Normalize Flyway history-table names before any migrator runs.
+
+See docs/superpowers/specs/2026-07-13-ansible-flyway-history-normalization-design.md
+
+The database is the input; the decision table below is the entire logic. Keep
+`decide()` pure — every safety property is tested there, without a database.
+"""
+from typing import Dict, NamedTuple, Optional, Set, Tuple
+
+import yaml
+
+NOOP = "noop"
+RENAME = "rename"
+DROP = "drop"
+ABORT = "abort"
+SKIP = "skip"
+
+
+class Decision(NamedTuple):
+    action: str
+    service: str
+    canonical: str
+    alias: Optional[str] = None
+    tables: Tuple[str, ...] = ()
+    reason: str = ""
+
+
+def load_map(path: str) -> Dict[str, dict]:
+    with open(path) as fh:
+        data = yaml.safe_load(fh) or {}
+    if not data:
+        raise SystemExit(f"FATAL: {path} is empty or unparseable")
+    return data
+
+
+def decide(
+    service: str,
+    spec: dict,
+    present: Set[str],
+    row_counts: Dict[str, int],
+) -> Decision:
+    """Pure. What should we do about `service`, given what is in the database?
+
+    present     — every table name in the public schema
+    row_counts  — rows per data table, for the data tables that are present
+    """
+    canonical = spec["canonical"]
+
+    # No migration init container exists for embedded services, so nothing would
+    # replay against their history. Hands off, whatever it looks like.
+    if spec.get("embedded"):
+        return Decision(SKIP, service, canonical, reason="embedded Flyway")
+
+    canonical_present = canonical in present
+    found = [a for a in (spec.get("aliases") or []) if a in present]
+
+    if canonical_present and found:
+        return Decision(
+            ABORT, service, canonical,
+            reason=(f"ambiguous: canonical {canonical!r} AND legacy "
+                    f"{', '.join(repr(a) for a in found)} both exist. "
+                    f"Cannot tell which history is authoritative."),
+        )
+    if len(found) > 1:
+        return Decision(
+            ABORT, service, canonical,
+            reason=(f"ambiguous: multiple legacy history tables exist "
+                    f"({', '.join(repr(a) for a in found)})."),
+        )
+    if canonical_present:
+        return Decision(NOOP, service, canonical, reason="already canonical")
+    if found:
+        return Decision(RENAME, service, canonical, alias=found[0])
+
+    # No history table at all, under any name.
+    data_present = tuple(t for t in (spec.get("data_tables") or []) if t in present)
+    if not data_present:
+        return Decision(NOOP, service, canonical, reason="fresh install")
+
+    populated = {t: row_counts.get(t, 0) for t in data_present if row_counts.get(t, 0) > 0}
+    if populated:
+        detail = ", ".join(f"{t} has {n:,} rows" for t, n in sorted(populated.items()))
+        return Decision(
+            ABORT, service, canonical, tables=data_present,
+            reason=(f"{detail}, but no Flyway history table exists. Cannot prove "
+                    f"which migrations are applied; replaying from V1 would DROP "
+                    f"these tables."),
+        )
+
+    return Decision(
+        DROP, service, canonical, tables=data_present,
+        reason="tables exist but are empty and have no history; migrator will rebuild",
+    )
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+cd local-setup && python3 -m pytest tests/test_flyway_history_normalize.py -v
+```
+
+Expected: **13 passed.**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add local-setup/db/flyway-history-map.yml \
+        local-setup/db/normalize/normalize.py \
+        local-setup/tests/test_flyway_history_normalize.py
+git commit -m "feat(db): Flyway history map + pure decision layer for normalization
+
+Refs #1142"
+```
+
+---
+
+### Task 2: Database layer, CLI and image
+
+Turns the decision into SQL. The `DROP` path is the only destructive operation in the system, so it is guarded by an `ACCESS EXCLUSIVE` lock plus a row re-check inside the same transaction.
+
+**Files:**
+- Modify: `local-setup/db/normalize/normalize.py` (append to Task 1's module)
+- Create: `local-setup/db/normalize/Dockerfile`
+
+**Interfaces:**
+- Consumes: `decide()`, `load_map()`, `Decision`, action constants from Task 1.
+- Produces:
+  - `psql(sql: str, *, capture: bool = True) -> str` — runs SQL via `psql -v ON_ERROR_STOP=1`, raises `CalledProcessError` on failure.
+  - `list_tables() -> set[str]`
+  - `history_tables() -> set[str]` — tables identified as Flyway history by column signature (`installed_rank` + `checksum` + `installed_on`), name-independent.
+  - `count_rows(tables: Iterable[str]) -> dict[str, int]`
+  - `apply(d: Decision) -> None` — executes RENAME / DROP; no-ops otherwise.
+  - `main() -> int` — exit 0 to proceed, 1 to abort.
+
+- [ ] **Step 1: Append the DB layer and CLI to `normalize.py`**
+
+Append to `local-setup/db/normalize/normalize.py`:
+
+```python
+# ── database layer ────────────────────────────────────────────────────────────
+import os
+import subprocess
+import sys
+from typing import Iterable, List
+
+MAP_PATH = os.environ.get("MAP_PATH", "/map.yml")
+
+# Flyway history tables are identified by their column signature, not their name —
+# that is the whole point, since the name is what we cannot trust.
+_HISTORY_SIG = """
+SELECT c.relname
+FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'public' AND c.relkind = 'r'
+  AND EXISTS (SELECT 1 FROM information_schema.columns col
+              WHERE col.table_schema = 'public' AND col.table_name = c.relname
+                AND col.column_name = 'installed_rank')
+  AND EXISTS (SELECT 1 FROM information_schema.columns col
+              WHERE col.table_schema = 'public' AND col.table_name = c.relname
+                AND col.column_name = 'checksum')
+  AND EXISTS (SELECT 1 FROM information_schema.columns col
+              WHERE col.table_schema = 'public' AND col.table_name = c.relname
+                AND col.column_name = 'installed_on');
+"""
+
+
+def psql(sql: str, *, capture: bool = True) -> str:
+    """Run SQL. ON_ERROR_STOP=1 so a failure is a non-zero exit, not a warning.
+
+    (psql prints errors as `psql:<file>:<line>: ERROR: ...` — never grep for a
+    line-anchored ^ERROR to detect failure; check the exit code.)
+    """
+    proc = subprocess.run(
+        ["psql", "-v", "ON_ERROR_STOP=1", "-qtA", "-c", sql],
+        capture_output=capture, text=True,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr or "")
+        raise subprocess.CalledProcessError(proc.returncode, "psql", proc.stdout, proc.stderr)
+    return (proc.stdout or "").strip()
+
+
+def list_tables() -> Set[str]:
+    out = psql("SELECT tablename FROM pg_tables WHERE schemaname = 'public';")
+    return {line.strip() for line in out.splitlines() if line.strip()}
+
+
+def history_tables() -> Set[str]:
+    out = psql(_HISTORY_SIG)
+    return {line.strip() for line in out.splitlines() if line.strip()}
+
+
+def count_rows(tables: Iterable[str]) -> Dict[str, int]:
+    counts: Dict[str, int] = {}
+    for t in tables:
+        counts[t] = int(psql(f'SELECT count(*) FROM public."{t}";') or 0)
+    return counts
+
+
+def apply(d: Decision) -> None:
+    if d.action == RENAME:
+        psql(f'ALTER TABLE public."{d.alias}" RENAME TO "{d.canonical}";')
+        print(f"  renamed  {d.alias} -> {d.canonical}")
+
+    elif d.action == DROP:
+        # The only destructive operation here. Take an ACCESS EXCLUSIVE lock, then
+        # re-count INSIDE the transaction: a table that gained a row between the
+        # decision and now raises and rolls back rather than losing data.
+        # NB: '%' is plpgsql's RAISE placeholder. Python f-strings do not treat '%'
+        # specially, so write exactly one — '%%' would emit a literal '%%' and
+        # plpgsql would try to substitute twice against a single argument.
+        guards = "\n".join(
+            f'  LOCK TABLE public."{t}" IN ACCESS EXCLUSIVE MODE;\n'
+            f'  SELECT count(*) INTO n FROM public."{t}";\n'
+            f"  IF n > 0 THEN RAISE EXCEPTION "
+            f"'{t} gained % rows since the check; refusing to drop', n; END IF;"
+            for t in d.tables
+        )
+        drops = "\n".join(f'DROP TABLE public."{t}" CASCADE;' for t in d.tables)
+        psql(f"""
+BEGIN;
+DO $$
+DECLARE n bigint;
+BEGIN
+{guards}
+END $$;
+{drops}
+COMMIT;
+""")
+        print(f"  rebuilt  dropped empty {', '.join(d.tables)} (migrator will recreate)")
+
+
+def main() -> int:
+    services = load_map(MAP_PATH)
+    present = list_tables()
+
+    # Decide everything first, so an abort happens BEFORE anything is modified.
+    decisions: List[Decision] = []
+    for service, spec in services.items():
+        data_tables = [t for t in (spec.get("data_tables") or []) if t in present]
+        counts = count_rows(data_tables) if data_tables else {}
+        decisions.append(decide(service, spec, present, counts))
+
+    aborts = [d for d in decisions if d.action == ABORT]
+    if aborts:
+        print("\ndb-history-normalize: ABORT\n", file=sys.stderr)
+        for d in aborts:
+            print(f"  {d.service}: {d.reason}\n", file=sys.stderr)
+        print("Refusing to start migrators. No data was modified.", file=sys.stderr)
+        return 1
+
+    print("db-history-normalize: normalizing Flyway history")
+    for d in decisions:
+        apply(d)
+
+    # A history table we do not recognise is harmless: no migrator exists for it,
+    # so nothing would replay against it. Say so, but do not fail.
+    known = set()
+    for spec in services.values():
+        known.add(spec["canonical"])
+        known.update(spec.get("aliases") or [])
+    for orphan in sorted(history_tables() - known):
+        print(f"  warning  unrecognised history table {orphan!r} — no migrator owns it, skipping")
+
+    tally = {a: sum(1 for d in decisions if d.action == a) for a in (NOOP, RENAME, DROP, SKIP)}
+    print(
+        f"ok: renamed {tally[RENAME]}, rebuilt {tally[DROP]}, "
+        f"already-aligned {tally[NOOP]}, skipped {tally[SKIP]}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 2: Verify the unit tests still pass after the append**
+
+```bash
+cd local-setup && python3 -m pytest tests/test_flyway_history_normalize.py -v
+```
+
+Expected: **13 passed.** (The DB layer imports cleanly; `decide()` is unchanged.)
+
+- [ ] **Step 3: Write the Dockerfile**
+
+Create `local-setup/db/normalize/Dockerfile`:
+
+```dockerfile
+# db-history-normalize — see docs/superpowers/specs/2026-07-13-ansible-flyway-history-normalization-design.md
+#
+# postgres:16 gives us psql; it does NOT ship python3, so install it.
+ARG POSTGRES_IMAGE=registry.preview.egov.theflywheel.in/postgres:16
+FROM ${POSTGRES_IMAGE}
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends python3 python3-yaml \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY normalize.py /usr/local/bin/normalize.py
+
+ENTRYPOINT ["python3", "/usr/local/bin/normalize.py"]
+```
+
+- [ ] **Step 4: Build the image and smoke-test it against an empty database**
+
+```bash
+cd local-setup/db/normalize
+docker build -t db-history-normalize:test .
+
+docker network create norm-smoke 2>/dev/null || true
+docker run -d --name norm-pg --network norm-smoke \
+  -e POSTGRES_USER=egov -e POSTGRES_PASSWORD=egov123 -e POSTGRES_DB=egov \
+  registry.preview.egov.theflywheel.in/postgres:16
+until docker exec norm-pg pg_isready -U egov >/dev/null 2>&1; do sleep 2; done
+
+docker run --rm --network norm-smoke \
+  -e PGHOST=norm-pg -e PGUSER=egov -e PGPASSWORD=egov123 -e PGDATABASE=egov \
+  -v "$PWD/../flyway-history-map.yml:/map.yml:ro" \
+  db-history-normalize:test
+echo "exit=$?"
+
+docker rm -f norm-pg >/dev/null && docker network rm norm-smoke >/dev/null
+```
+
+Expected: exit **0**, and a fresh-install tally — every service takes the no-op branch:
+
+```
+db-history-normalize: normalizing Flyway history
+ok: renamed 0, rebuilt 0, already-aligned 14, skipped 2
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add local-setup/db/normalize/normalize.py local-setup/db/normalize/Dockerfile
+git commit -m "feat(db): db-history-normalize DB layer, CLI and image
+
+Guards the only destructive path (DROP of empty orphan tables) with an
+ACCESS EXCLUSIVE lock plus a row re-check inside the same transaction.
+
+Refs #1142"
+```
+
+---
+
+### Task 3: Wire the normalizer into compose
+
+Every migrator becomes unable to start before the normalizer has succeeded. This is what makes the guard unbypassable — including for a bare `docker compose up`.
+
+**Files:**
+- Modify: `local-setup/docker-compose.migrations.yml`
+
+**Interfaces:**
+- Consumes: the `db-history-normalize:test` image built in Task 2 (built here by compose from `./db/normalize`).
+- Produces: a `db-history-normalize` compose service that all 14 migrators gate on.
+
+- [ ] **Step 1: Add the normalizer service**
+
+In `local-setup/docker-compose.migrations.yml`, insert immediately after the `services:` key, before `pgr-services-migration`:
+
+```yaml
+  # ── Guard · runs before EVERY migrator ──────────────────────────────────────
+  # An operator-supplied dump carries the LEGACY compose history-table names
+  # (*_schema_version). The -db migrator images look for the K8s <service>_schema
+  # names. On a mismatch Flyway sees an empty history, replays from V1 against a
+  # populated database, and egov-localization + egov-enc-service DROP+recreate
+  # their tables and exit 0 — silent, unrecoverable data loss (the encryption keys
+  # that decrypt all user PII). This renames them into place first, and aborts the
+  # deploy on anything it cannot prove safe.
+  #   docs/superpowers/specs/2026-07-13-ansible-flyway-history-normalization-design.md
+  db-history-normalize:
+    build:
+      context: ./db/normalize
+    container_name: db-history-normalize
+    depends_on:
+      postgres-db:
+        condition: service_healthy
+    environment:
+      PGHOST: postgres-db
+      PGPORT: "5432"
+      PGUSER: egov
+      PGPASSWORD: ${POSTGRES_PASSWORD:-egov123}
+      PGDATABASE: egov
+      MAP_PATH: /map.yml
+    volumes:
+      - ./db/flyway-history-map.yml:/map.yml:ro
+    restart: "no"
+    networks:
+      - egov-network
+```
+
+- [ ] **Step 2: Gate every migrator on it**
+
+For **each** of the 14 migration services in this file — `pgr-services-migration`, `novu-bridge-migration`, `digit-config-service-migration`, `boundary-service-migration`, `egov-user-migration`, `mdms-backend-migration`, `egov-idgen-migration`, `egov-localization-migration`, `egov-enc-service-migration`, `egov-filestore-migration`, `egov-workflow-v2-migration`, `egov-hrms-migration`, `egov-url-shortening-migration`, `egov-otp-migration` — add `db-history-normalize` to its existing `depends_on`.
+
+The eleven Phase-3 core migrators currently use the inline form. Change each from:
+
+```yaml
+    depends_on: { postgres-db: { condition: service_healthy } }
+```
+
+to:
+
+```yaml
+    depends_on:
+      postgres-db: { condition: service_healthy }
+      db-history-normalize: { condition: service_completed_successfully }
+```
+
+`pgr-services-migration` uses the block form with cross-service gates. Add one key to its existing `depends_on`, leaving the other conditions untouched:
+
+```yaml
+    depends_on:
+      postgres-db:
+        condition: service_healthy
+      db-history-normalize:
+        condition: service_completed_successfully
+      boundary-service:
+        condition: service_healthy
+      egov-user:
+        condition: service_healthy
+      mdms-backend:
+        condition: service_healthy
+      egov-workflow-v2:
+        condition: service_healthy
+```
+
+`novu-bridge-migration` and `digit-config-service-migration` likewise gain the one key alongside their existing `postgres-db` gate. Note both carry `profiles: ["notifications"]`; `db-history-normalize` has **no** profile, so it is always active and satisfies them in every profile combination.
+
+- [ ] **Step 3: Verify compose resolves the graph**
+
+```bash
+cd local-setup
+docker compose -f docker-compose.egov-digit.yaml \
+               -f docker-compose.fast-path.yml \
+               -f docker-compose.migrations.yml config >/dev/null && echo "compose config OK"
+
+# Every migrator must now depend on the normalizer: expect 14.
+docker compose -f docker-compose.egov-digit.yaml \
+               -f docker-compose.fast-path.yml \
+               -f docker-compose.migrations.yml config \
+  | python3 -c "
+import sys, yaml
+c = yaml.safe_load(sys.stdin)
+gated = [n for n, s in c['services'].items()
+         if n.endswith('-migration') and 'db-history-normalize' in (s.get('depends_on') or {})]
+migrators = [n for n in c['services'] if n.endswith('-migration')]
+print(f'{len(gated)}/{len(migrators)} migrators gated on db-history-normalize')
+missing = sorted(set(migrators) - set(gated))
+assert not missing, f'UNGATED: {missing}'
+print('OK')
+"
+```
+
+Expected: `compose config OK`, then `14/14 migrators gated on db-history-normalize` and `OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add local-setup/docker-compose.migrations.yml
+git commit -m "feat(compose): gate every Flyway migrator on db-history-normalize
+
+Ansible inherits the guard — it already runs these compose files — and a bare
+\`docker compose up\` is covered too.
+
+Refs #1142"
+```
+
+---
+
+### Task 4: The proof — integration and negative tests
+
+This is the task that decides whether the whole thing actually works. It runs against a real dump with the real pinned migrator images.
+
+**Files:**
+- Create: `local-setup/db/normalize/test-integration.sh`
+
+**Interfaces:**
+- Consumes: the built normalizer image, `local-setup/db/flyway-history-map.yml`, the eleven pinned `egovio/*-db` images.
+- Produces: an executable proof, runnable on any box with Docker. Exit 0 = both the positive and negative tests held.
+
+- [ ] **Step 1: Write the test script**
+
+Create `local-setup/db/normalize/test-integration.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Proof for db-history-normalize, against a REAL dump and the REAL pinned images.
+#
+#   ./test-integration.sh /path/to/dump.sql
+#
+# A) POSITIVE — dump + normalizer + all 11 migrators:
+#      every migrator reports "No migration necessary", and a row-count +
+#      content-checksum snapshot of every table is byte-identical before/after.
+# B) NEGATIVE — dump + all 11 migrators, normalizer SKIPPED:
+#      data IS destroyed. If this ever stops failing, the guard has been silently
+#      disabled and the positive test alone would not tell us.
+set -euo pipefail
+
+DUMP="${1:?usage: test-integration.sh /path/to/dump.sql}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MAP="$HERE/../flyway-history-map.yml"
+PG_IMAGE="registry.preview.egov.theflywheel.in/postgres:16"
+NET=normalize-it
+WORK="$(mktemp -d)"
+trap 'docker rm -f it-pos it-neg >/dev/null 2>&1 || true; docker network rm $NET >/dev/null 2>&1 || true; rm -rf "$WORK"' EXIT
+
+MIGRATORS=(
+  "boundary-service|boundary-service-db:v2.9.2-4a60f20|boundary_service_schema"
+  "egov-user|egov-user-db:master-d69ce29|egov_user_schema"
+  "mdms-backend|mdms-v2-db:v2.9.2-4a60f20|mdms_v2_schema"
+  "egov-idgen|egov-idgen-db:v2.9.2-4a60f20|egov_idgen_schema"
+  "egov-localization|egov-localization-db:v2.9.2-4a60f20|egov_localization_schema"
+  "egov-enc-service|egov-enc-service-db:v2.9.2-4a60f20|egov_enc_service_schema"
+  "egov-filestore|egov-filestore-db:v2.9.2-4a60f20|egov_filestore_schema"
+  "egov-workflow-v2|egov-workflow-v2-db:v2.9.2-4a60f20|egov_workflow_v2_schema"
+  "egov-hrms|egov-hrms-db:hrms-boundary-0a4e737|egov_hrms_schema"
+  "egov-url-shortening|egov-url-shortening-db:v2.9.2-4a60f20|egov-url-shortening_schema"
+  "egov-otp|egov-otp-db:v2.9.2-4a60f20|egov_otp_schema"
+)
+
+# Row count + content checksum for every table in public.
+cat > "$WORK/snapshot.sql" <<'SQL'
+SELECT c.relname,
+       (xpath('/row/c/text()', query_to_xml(format('select count(*) as c from public.%I', c.relname), false,true,'')))[1]::text::bigint,
+       (xpath('/row/c/text()', query_to_xml(format('select coalesce(md5(string_agg(t::text, E''\n'' ORDER BY t::text)),''EMPTY'') as c from public.%I t', c.relname), false,true,'')))[1]::text
+FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'public' AND c.relkind = 'r'
+ORDER BY 1;
+SQL
+
+start_db() {  # $1 = container name
+  docker rm -f "$1" >/dev/null 2>&1 || true
+  docker run -d --name "$1" --network $NET \
+    -e POSTGRES_USER=egov -e POSTGRES_PASSWORD=egov123 -e POSTGRES_DB=egov \
+    "$PG_IMAGE" >/dev/null
+  until docker exec "$1" pg_isready -U egov >/dev/null 2>&1; do sleep 2; done
+  docker cp "$DUMP" "$1:/tmp/dump.sql" >/dev/null
+  docker cp "$WORK/snapshot.sql" "$1:/tmp/snapshot.sql" >/dev/null
+  # ON_ERROR_STOP: psql errors read "psql:file:line: ERROR:", so never grep ^ERROR.
+  docker exec "$1" psql -U egov -d egov -q -v ON_ERROR_STOP=1 -f /tmp/dump.sql >/dev/null
+}
+snapshot() { docker exec "$1" psql -U egov -d egov -tA -F'|' -f /tmp/snapshot.sql; }
+
+run_migrators() {  # $1 = db container; echoes "<name> <exit> <verdict>" per line
+  for m in "${MIGRATORS[@]}"; do
+    IFS='|' read -r name image table <<< "$m"
+    local log rc
+    log="$WORK/$1-$name.log"
+    docker run --rm --network $NET \
+      -e DB_URL="jdbc:postgresql://$1:5432/egov" -e SCHEMA_NAME=public -e SCHEMA_TABLE="$table" \
+      -e FLYWAY_USER=egov -e FLYWAY_PASSWORD=egov123 \
+      -e FLYWAY_LOCATIONS=filesystem:/flyway/sql -e FLYWAY_VALIDATE_ON_MIGRATE=false \
+      "egovio/$image" > "$log" 2>&1 && rc=0 || rc=$?
+    if grep -q "No migration necessary" "$log"; then echo "$name $rc noop"
+    else echo "$name $rc applied-or-failed"; fi
+  done
+}
+
+docker network create $NET >/dev/null 2>&1 || true
+docker build -q -t db-history-normalize:test "$HERE" >/dev/null
+
+# ── A) POSITIVE ───────────────────────────────────────────────────────────────
+echo "=== A) POSITIVE: dump -> normalize -> migrators ==="
+start_db it-pos
+snapshot it-pos > "$WORK/pos-before.txt"
+
+docker run --rm --network $NET \
+  -e PGHOST=it-pos -e PGUSER=egov -e PGPASSWORD=egov123 -e PGDATABASE=egov \
+  -v "$MAP:/map.yml:ro" db-history-normalize:test
+
+# Idempotency: a second run must change nothing and still exit 0.
+docker run --rm --network $NET \
+  -e PGHOST=it-pos -e PGUSER=egov -e PGPASSWORD=egov123 -e PGDATABASE=egov \
+  -v "$MAP:/map.yml:ro" db-history-normalize:test > "$WORK/second-run.log"
+grep -q "renamed 0" "$WORK/second-run.log" || { echo "FAIL: normalizer is not idempotent"; cat "$WORK/second-run.log"; exit 1; }
+echo "  idempotent: second run renamed 0"
+
+fail=0
+while read -r name rc verdict; do
+  printf "  %-22s exit=%s %s\n" "$name" "$rc" "$verdict"
+  [ "$rc" = "0" ] && [ "$verdict" = "noop" ] || { echo "  FAIL: $name did not cleanly no-op"; fail=1; }
+done < <(run_migrators it-pos)
+[ "$fail" = "0" ] || { echo "FAIL: not every migrator no-opped"; exit 1; }
+
+snapshot it-pos > "$WORK/pos-after.txt"
+# Ignore history tables the migrators legitimately create (e.g. egov_otp_schema);
+# assert every table that EXISTED BEFORE is byte-identical.
+if ! join -t'|' -j1 <(sort -t'|' -k1,1 "$WORK/pos-before.txt") <(sort -t'|' -k1,1 "$WORK/pos-after.txt") \
+     | awk -F'|' '$2!=$4 || $3!=$5 {print; bad=1} END {exit bad?1:0}'; then
+  echo "FAIL: pre-existing data changed"; exit 1
+fi
+echo "  PASS: every pre-existing table byte-identical (rows + checksum)"
+
+# ── B) NEGATIVE ───────────────────────────────────────────────────────────────
+echo "=== B) NEGATIVE: dump -> migrators, normalizer SKIPPED (must destroy data) ==="
+start_db it-neg
+snapshot it-neg > "$WORK/neg-before.txt"
+run_migrators it-neg >/dev/null
+snapshot it-neg > "$WORK/neg-after.txt"
+
+destroyed=0
+for t in message eg_enc_symmetric_keys eg_enc_asymmetric_keys; do
+  before=$(awk -F'|' -v t="$t" '$1==t {print $2}' "$WORK/neg-before.txt")
+  after=$(awk -F'|' -v t="$t" '$1==t {print $2}' "$WORK/neg-after.txt")
+  printf "  %-24s %s -> %s\n" "$t" "${before:-?}" "${after:-?}"
+  [ -n "$before" ] && [ "$before" -gt 0 ] && [ "$after" = "0" ] && destroyed=$((destroyed+1))
+done
+[ "$destroyed" = "3" ] || {
+  echo "FAIL: the unguarded run did NOT destroy data as expected."
+  echo "      Either the migration images changed, or the guard is being applied"
+  echo "      when it should not be. Do not ship until this is understood."
+  exit 1
+}
+echo "  PASS: unguarded run destroys data — the guard is doing real work"
+
+echo
+echo "ALL PASS: normalizer makes the dump safe; without it the data is destroyed."
+```
+
+- [ ] **Step 2: Make it executable and run it against the team dump**
+
+```bash
+chmod +x local-setup/db/normalize/test-integration.sh
+./local-setup/db/normalize/test-integration.sh /home/ubuntu/egov_backup_20260709_082159.sql
+```
+
+Expected (measured on this dump — 57 tables, 97,250 rows):
+
+```
+=== A) POSITIVE: dump -> normalize -> migrators ===
+db-history-normalize: normalizing Flyway history
+  renamed  boundary_schema_version -> boundary_service_schema
+  ... (10 renames)
+  rebuilt  dropped empty eg_token (migrator will recreate)
+ok: renamed 10, rebuilt 1, already-aligned 3, skipped 2
+  idempotent: second run renamed 0
+  boundary-service       exit=0 noop
+  ... (all 11)
+  PASS: every pre-existing table byte-identical (rows + checksum)
+=== B) NEGATIVE: dump -> migrators, normalizer SKIPPED (must destroy data) ===
+  message                  70835 -> 0
+  eg_enc_symmetric_keys    27 -> 0
+  eg_enc_asymmetric_keys   27 -> 0
+  PASS: unguarded run destroys data — the guard is doing real work
+ALL PASS
+```
+
+Note `egov-otp` now reaches `exit=0 noop`: the normalizer drops the empty orphan `eg_token`, so its migrator builds the table cleanly instead of hitting 42P07.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add local-setup/db/normalize/test-integration.sh
+git commit -m "test(db): integration proof + negative test for db-history-normalize
+
+Positive: the team dump survives a full migrator run byte-identical.
+Negative: without the normalizer the same dump loses 73% of its rows —
+if that test ever stops failing, the guard has been silently disabled.
+
+Refs #1142"
+```
+
+---
+
+### Task 5: Point the CI check at the shared map
+
+The CI check currently hardcodes two name sets that must be kept in step with the map by hand. Wire it to the map so they cannot drift.
+
+**Files:**
+- Modify: `.github/scripts/check-flyway-dump-alignment.py`
+- Modify: `.github/workflows/flyway-dump-alignment.yml`
+
+**Interfaces:**
+- Consumes: `local-setup/db/flyway-history-map.yml`.
+- Produces: no new interface; the script keeps its `--self-test` flag and its exit-code contract (0 aligned, 1 misaligned).
+
+- [ ] **Step 1: Replace the hardcoded sets with map-derived ones**
+
+In `.github/scripts/check-flyway-dump-alignment.py`, replace the `BASELINE_FRESH` and `PENDING_ENABLE` literal sets (and their comment block) with:
+
+```python
+MAP = ROOT / "local-setup/db/flyway-history-map.yml"
+
+
+def _load_history_map() -> dict:
+    with open(MAP) as fh:
+        return yaml.safe_load(fh) or {}
+
+
+_HISTORY_MAP = _load_history_map()
+
+# Services that legitimately create their history fresh: their data tables are not
+# in the dump, so Flyway baselines from empty with no 42P07 risk. Declared in the
+# map (`baseline_fresh: true`) so the map and this check cannot drift apart.
+BASELINE_FRESH = {
+    spec["canonical"] for spec in _HISTORY_MAP.values() if spec.get("baseline_fresh")
+}
+
+# Emptied in Phase 3: every core service now has a migration init container
+# claiming its table, so nothing is pending-enable. db-history-normalize renames
+# any legacy names in the dump before the migrators run, so a legacy alias in a
+# dump is no longer a misalignment — it is expected and handled.
+PENDING_ENABLE = set()
+
+# Legacy names the normalizer will rename into canonical form at deploy time.
+# A dump carrying these is fine, so they must not be reported as orphans.
+NORMALIZED_ALIASES = {
+    alias
+    for spec in _HISTORY_MAP.values()
+    for alias in (spec.get("aliases") or [])
+}
+```
+
+Then, in `analyze()`, exclude the aliases from the orphan bucket — a dump carrying a legacy name is now a *handled* case, not a misalignment:
+
+```python
+        "dump_not_claimed": sorted(dump - claimed - PENDING_ENABLE - NORMALIZED_ALIASES),
+```
+
+- [ ] **Step 2: Add a self-test for the map wiring**
+
+In the `self_test()` function of the same file, add before the final restore of the saved allowlists:
+
+```python
+    # The map must claim every canonical name the compose overlay declares, or the
+    # normalizer would not know about a service the migrators do run.
+    claimed_by_compose = claimed_tables(merged_services(
+        COMPOSE.read_text(), FAST_PATH.read_text(), MIGRATIONS.read_text()))
+    canonical_in_map = {spec["canonical"] for spec in _HISTORY_MAP.values()}
+    unmapped = claimed_by_compose - canonical_in_map
+    assert not unmapped, (
+        f"compose declares SCHEMA_TABLE(s) absent from flyway-history-map.yml: "
+        f"{sorted(unmapped)} — add them to the map or db-history-normalize will "
+        f"not protect them"
+    )
+```
+
+- [ ] **Step 3: Run the check and its self-test**
+
+```bash
+pip install pyyaml
+python3 .github/scripts/check-flyway-dump-alignment.py --self-test
+python3 .github/scripts/check-flyway-dump-alignment.py
+```
+
+Expected: the self-test prints its OK line and the map assertion passes; the check prints `OK: Flyway history tables aligned with the dump (...)`.
+
+Then prove the new guard bites — add a fake migrator to the overlay with an unmapped `SCHEMA_TABLE` and confirm the self-test fails:
+
+```bash
+python3 - <<'PY'
+import pathlib
+p = pathlib.Path("local-setup/docker-compose.migrations.yml")
+p.write_text(p.read_text() + """
+  bogus-migration:
+    image: busybox
+    environment:
+      SCHEMA_TABLE: bogus_schema
+""")
+PY
+python3 .github/scripts/check-flyway-dump-alignment.py --self-test; echo "exit=$?"
+git checkout local-setup/docker-compose.migrations.yml
+```
+
+Expected: `AssertionError: compose declares SCHEMA_TABLE(s) absent from flyway-history-map.yml: ['bogus_schema']` and `exit=1`.
+
+- [ ] **Step 4: Add the map and the unit tests to CI**
+
+In `.github/workflows/flyway-dump-alignment.yml`, add `local-setup/db/flyway-history-map.yml` and `local-setup/db/normalize/normalize.py` to **both** the `pull_request` and `push` `paths:` lists, and add a step after the existing self-test step:
+
+```yaml
+      - name: Normalizer decision-table unit tests
+        run: |
+          pip install pytest
+          python3 -m pytest local-setup/tests/test_flyway_history_normalize.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/scripts/check-flyway-dump-alignment.py .github/workflows/flyway-dump-alignment.yml
+git commit -m "ci(flyway): drive the alignment check from the shared history map
+
+The check no longer hardcodes name sets that must be hand-synced with the
+normalizer. A migrator whose SCHEMA_TABLE is missing from the map now fails CI.
+
+Refs #1142"
+```
+
+---
+
+### Task 6: Document the flow and open the PR
+
+**Files:**
+- Modify: `docs/db-migration-flow.md`
+
+- [ ] **Step 1: Document the guard**
+
+Append a section to `docs/db-migration-flow.md`:
+
+```markdown
+## Deploying over a dump you did not build
+
+The stack boots from whatever dump sits at `local-setup/db/full-dump.sql`. A dump
+handed over by a service team, or lifted from a running environment, carries the
+**legacy compose** Flyway history-table names (`*_schema_version`) — but the `-db`
+migrator images look for the **K8s** names (`<service>_schema`).
+
+On a mismatch Flyway sees an empty history and replays every migration from V1
+against a populated database. Nine migrators crash with 42P07. Two do not:
+`egov-localization` and `egov-enc-service` open their V1 with `DROP TABLE IF
+EXISTS`, so they drop, recreate empty, and **exit 0**. Measured on a real team
+dump: 97,250 rows → 26,377, including the encryption keys that decrypt all user
+PII. That loss is unrecoverable.
+
+`db-history-normalize` runs before every migrator and prevents this. It reads
+`local-setup/db/flyway-history-map.yml`, renames legacy history tables to their
+canonical names, rebuilds empty orphan tables, and **aborts the deploy** on
+anything it cannot prove safe. It is idempotent, and it is gated in compose — so
+Ansible and a bare `docker compose up` are both covered.
+
+**Adding a service:** add it to `flyway-history-map.yml` (canonical name matching
+its `SCHEMA_TABLE`, any legacy aliases, and the tables its migrations create). CI
+fails if a migrator's `SCHEMA_TABLE` has no map entry.
+
+**Testing a dump before you trust it:**
+
+```bash
+./local-setup/db/normalize/test-integration.sh /path/to/dump.sql
+```
+```
+
+- [ ] **Step 2: Run everything once more, end to end**
+
+```bash
+cd local-setup && python3 -m pytest tests/test_flyway_history_normalize.py -v && cd ..
+python3 .github/scripts/check-flyway-dump-alignment.py --self-test
+python3 .github/scripts/check-flyway-dump-alignment.py
+./local-setup/db/normalize/test-integration.sh /home/ubuntu/egov_backup_20260709_082159.sql
+```
+
+Expected: 13 unit tests pass, both CI checks pass, and the integration script ends `ALL PASS`.
+
+- [ ] **Step 3: Commit and open the PR**
+
+```bash
+git add docs/db-migration-flow.md
+git commit -m "docs: how migrations flow over an operator-supplied dump
+
+Refs #1142"
+git push -u origin feat/flyway-history-normalize
+gh pr create --base feat/item10-db-migration-parity \
+  --title "fix(db): never let a migrator replay from V1 over a populated dump (#1142 follow-up)" \
+  --body "$(cat <<'EOF'
+## Problem
+
+#1142 re-baked the repo's own dump to the K8s `<service>_schema` history names, and
+assumed every service team would rename theirs at source. They have not, and nothing
+in the deploy checks.
+
+Measured against a team-supplied dump (57 tables, 97,250 rows): the migrators find no
+history under the names they expect, replay from V1 against populated tables, and
+
+**97,250 rows → 26,377. 73% of the data destroyed.**
+
+| Table | Before | After |
+|---|---|---|
+| `message` | 70,835 | **0** |
+| `eg_enc_symmetric_keys` | 27 | **0** |
+| `eg_enc_asymmetric_keys` | 27 | **0** |
+
+Nine migrators crash with 42P07 — that crash is the only reason their data survived.
+The two that do *not* crash are the ones that do the damage: `egov-localization` and
+`egov-enc-service` open their V1 migration with `DROP TABLE IF EXISTS`, so they drop,
+recreate empty, and **exit 0**. A green deploy that ate the data.
+
+The encryption keys are unrecoverable: `eg_user.name` and `mobilenumber` are ciphertext
+and those keys were the only thing that could decrypt them.
+
+## Fix
+
+A `db-history-normalize` init container, gated ahead of every migrator in compose (so
+Ansible and bare `docker compose up` are both covered — no playbook change). It renames
+legacy history tables to canonical names from a shared map, rebuilds empty orphan tables,
+and aborts the deploy on anything it cannot prove safe.
+
+Verified: with it, the same dump comes through a full migrator run **byte-identical** —
+every migrator reports `No migration necessary`.
+
+## Tests
+
+- Integration proof: real dump + the real pinned `egovio/*-db` images → zero data change.
+- Negative test: skip the normalizer → assert the data IS destroyed. If it ever stops
+  failing, the guard has been silently disabled.
+- Decision-table unit tests, idempotency, fresh-install.
+- CI: a migrator whose `SCHEMA_TABLE` is missing from the map now fails the build.
+
+Spec: `docs/superpowers/specs/2026-07-13-ansible-flyway-history-normalization-design.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec requirement | Task |
+|---|---|
+| `flyway-history-map.yml` (canonical + aliases + data_tables) | 1 |
+| Six-row decision table | 1 (pure `decide()`) |
+| Skip `embedded: true` entries | 1 |
+| Warn-not-error on unknown history tables | 2 (`main()`) |
+| `normalize.py` + Dockerfile (`postgres:16` + `python3-yaml`) | 2 |
+| DROP guarded by row re-check in the same transaction | 2 (`apply()`, `LOCK ... ACCESS EXCLUSIVE` + `RAISE EXCEPTION`) |
+| Abort exits non-zero, modifies nothing | 2 (decide-all-then-apply; aborts checked before any `apply()`) |
+| Idempotency | 2 (no-op branch), asserted in 4 |
+| Compose: normalizer gated on `postgres-db` healthy | 3 |
+| Compose: all migrators gated on normalizer | 3 (asserted 14/14) |
+| No `playbook-deploy.yml` change | — (none in any task) |
+| CI check reads the shared map | 5 |
+| Integration proof (byte-identical) | 4 |
+| Negative test (data IS destroyed) | 4 |
+| Decision-table unit tests | 1 |
+| Fresh-install | 2 (Step 4 smoke test on an empty DB) |
+| Known limitation (schema drift) out of scope | — (documented, no task) |
+
+No gaps.
+
+**Deviation from the spec, called out:** the spec's map listed 13 services. To let the map *replace* the CI check's hardcoded `BASELINE_FRESH` (spec deliverable 4), it must also express `egov-indexer`, `novu-bridge` and `digit-config-service` — hence the `baseline_fresh` flag and 16 entries. Their `data_tables` are derived from their own migration SQL, same standard as the rest.
+
+**Type consistency:** `decide()` / `load_map()` / `Decision` / `NOOP|RENAME|DROP|ABORT|SKIP` are defined in Task 1 and used with identical names and signatures in Tasks 1, 2 and the tests. `psql()`, `list_tables()`, `history_tables()`, `count_rows()`, `apply()`, `main()` are defined and used only in Task 2. The map keys (`canonical`, `aliases`, `data_tables`, `embedded`, `baseline_fresh`) are read identically in `normalize.py` (Tasks 1–2) and `check-flyway-dump-alignment.py` (Task 5).
+
+**Placeholder scan:** no TBD/TODO; every code step carries complete code; every command carries expected output.

--- a/docs/superpowers/plans/2026-07-13-flyway-history-normalization.md
+++ b/docs/superpowers/plans/2026-07-13-flyway-history-normalization.md
@@ -451,7 +451,7 @@ def decide(
 cd local-setup && python3 -m pytest tests/test_flyway_history_normalize.py -v
 ```
 
-Expected: **13 passed.**
+Expected: **12 passed.**
 
 - [ ] **Step 6: Commit**
 
@@ -631,7 +631,7 @@ if __name__ == "__main__":
 cd local-setup && python3 -m pytest tests/test_flyway_history_normalize.py -v
 ```
 
-Expected: **13 passed.** (The DB layer imports cleanly; `decide()` is unchanged.)
+Expected: **12 passed.** (The DB layer imports cleanly; `decide()` is unchanged.)
 
 - [ ] **Step 3: Write the Dockerfile**
 
@@ -1192,7 +1192,7 @@ python3 .github/scripts/check-flyway-dump-alignment.py
 ./local-setup/db/normalize/test-integration.sh /home/ubuntu/egov_backup_20260709_082159.sql
 ```
 
-Expected: 13 unit tests pass, both CI checks pass, and the integration script ends `ALL PASS`.
+Expected: 12 unit tests pass, both CI checks pass, and the integration script ends `ALL PASS`.
 
 - [ ] **Step 3: Commit and open the PR**
 

--- a/docs/superpowers/specs/2026-07-10-compose-k8s-migration-parity-design.md
+++ b/docs/superpowers/specs/2026-07-10-compose-k8s-migration-parity-design.md
@@ -1,0 +1,248 @@
+# Compose ↔ K8s DB-migration parity via per-service init containers
+
+**Status:** Design — pending review
+**Date:** 2026-07-10
+**Context:** Deployment-parity Item #10. Follows the team decision to adopt "Option B"
+(mirror the K8s per-service migration model in compose) over the compose-native
+embedded-Flyway approach.
+
+---
+
+## 1. Problem
+
+The two stacks apply DB migrations by different mechanisms, which diverge in
+*structure* and in *history-table naming*:
+
+- **K8s:** one Flyway **init container per service** (`<service>-db` image),
+  running before the app, writing history to `<service>_schema`. The app does not
+  self-migrate.
+- **Compose:** a mix — embedded Spring Flyway in 11 app images, plus one
+  consolidated `db-migrations` container (`tilt-demo-db-migrations`, partial: SQL
+  for only 3 services) for 4 services, plus a fast-path override. History tables
+  are named `*_schema_version` / `pgr_services_schema` — **not** the K8s names.
+
+Consequences:
+- The compose dump carries compose-flavoured history-table names, so it **cannot**
+  be regenerated from a stock K8s DB, and a DB is **not portable** across stacks —
+  a name mismatch produces `42P07 relation already exists` on boot (this is the
+  class of failure behind the impel incident).
+- New migrations propagate through two different code paths that must be reasoned
+  about separately.
+
+## 2. Goal & non-goals
+
+**Goal:** compose applies migrations the *same way K8s does* — one Flyway init step
+per service, from the same SQL, writing to the same `<service>_schema` history
+table — so migrations propagate identically and the dump becomes portable across
+stacks.
+
+**Non-goals:**
+- Changing the K8s stack (it is the reference; we conform to it).
+- Changing seed/master data in the dump (only Flyway history-table *names* change).
+- Changing app runtime behaviour beyond disabling embedded Flyway.
+- Rebuilding the dump from scratch (see §6).
+
+## 3. Reference model — what K8s actually does
+
+The `<service>-db` image is a stock Flyway image plus that service's SQL — confirmed
+by the per-service `db/Dockerfile`s already in this repo (`backend/pgr-services/
+src/main/resources/db/Dockerfile`, `novu-bridge`, `digit-config-service`, …):
+
+```dockerfile
+FROM flyway/flyway:<version>
+COPY ./migration/main /flyway/sql
+```
+
+The init container runs the stock `flyway migrate` with this contract
+(`charts/common/values.yaml`, `charts/core-services/configmaps/values.yaml`):
+
+| Var | Value |
+|---|---|
+| `SCHEMA_TABLE` | `<service>_schema` (per-service, e.g. `egov_hrms_schema`) |
+| `SCHEMA_NAME` | `public` |
+| `FLYWAY_LOCATIONS` | `filesystem:/flyway/sql,filesystem:/flyway/seed,filesystem:/flyway/qa` |
+| `FLYWAY_USER` / `FLYWAY_PASSWORD` | DB creds |
+| baseline-on-migrate | on |
+
+Run as an init container **before** the app; the app has **no** embedded Flyway.
+
+**Key point:** compose already runs this exact recipe today —
+`local-setup/docker/db-migrations/Dockerfile` is `FROM flyway/flyway:9-alpine` +
+`COPY sql /flyway/sql`. We are making an existing, K8s-identical mechanism faithful,
+not inventing a new one.
+
+## 4. Target architecture (compose)
+
+For each Flyway-relevant service, add a one-shot **`<service>-migration`** compose
+service (the init-container equivalent):
+
+```yaml
+<service>-migration:
+  image: <service>-db:<tag>          # see §5 for sourcing
+  depends_on:
+    postgres-db: { condition: service_healthy }
+  environment:
+    FLYWAY_URL: jdbc:postgresql://postgres:5432/egov   # DIRECT to postgres, NOT pgbouncer
+    FLYWAY_USER: egov
+    FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
+    FLYWAY_SCHEMAS: public
+    FLYWAY_TABLE: <service>_schema                      # the K8s name
+    FLYWAY_LOCATIONS: filesystem:/flyway/sql
+    FLYWAY_BASELINE_ON_MIGRATE: "true"
+    FLYWAY_VALIDATE_ON_MIGRATE: "false"                 # lenient — see §8
+    FLYWAY_OUT_OF_ORDER: "true"
+  command: migrate
+  restart: "no"
+
+<service>:                            # the app
+  environment:
+    SPRING_FLYWAY_ENABLED: "false"    # app no longer self-migrates
+  depends_on:
+    <service>-migration: { condition: service_completed_successfully }
+```
+
+**Removed** at the end of rollout:
+- The consolidated `db-migrations` container and its `migrate-all.sh`.
+- All `SPRING_FLYWAY_*` embedded config on app services.
+- The fast-path `egov-url-shortening` `SPRING_FLYWAY_TABLE` override.
+
+**Bonus:** connecting the migrator **directly to `postgres:5432`** (as the current
+`db-migrations` container already does) dissolves the `egov-otp` exception — its
+Flyway-disabled state was due to *pgbouncer transaction mode*, which the direct
+connection bypasses. otp joins the uniform model.
+
+## 5. Image sourcing
+
+The `<service>-db` image = Flyway base + that service's `db/migration/main` SQL.
+Two sources, chosen per service:
+
+- **Repo-local services** (`pgr-services`, `novu-bridge`, `digit-config-service`,
+  `default-data-handler`, `digit-user-preferences-service`, `xstate-chatbot`):
+  build directly from the existing in-repo `db/Dockerfile`. Trivial.
+- **Core services** (`boundary-service`, `egov-hrms`, `egov-idgen`, `egov-user`,
+  `egov-localization`, `egov-enc-service`, `egov-filestore`, `egov-workflow-v2`,
+  `mdms-v2`, `egov-url-shortening`, `egov-otp`): two acceptable paths —
+  - **(preferred)** the platform team publishes the upstream `<service>-db` images
+    to the public proxy `registry.preview.egov.theflywheel.in`; compose pulls them
+    → true image-level parity with K8s.
+  - **(fallback)** build locally: the SQL is already bundled inside each app image
+    at `BOOT-INF/classes/db/migration/main` (verified: boundary=3, pgr=5, idgen=58,
+    localization=4 files). Extract it into the Flyway recipe. No VPC access needed.
+
+The design supports both; the choice is a registry-ownership decision, not a
+technical blocker.
+
+## 6. Naming convergence + dump re-bake
+
+Chosen strategy: **rename in place, re-bake** (preserves all seed/master data;
+one-time, deterministic, reviewable). Procedure:
+
+1. Load current `local-setup/db/full-dump.sql` into a scratch Postgres.
+2. Apply the rename SQL below (history tables only; data tables untouched).
+3. `pg_dump` → new `full-dump.sql`. Commit the diff.
+
+**Rename mapping** (compose/dump name → K8s name):
+
+| Service | Dump table today | → K8s `<service>_schema` |
+|---|---|---|
+| pgr-services | `pgr_services_schema` | `pgr_services_schema` *(no change)* |
+| boundary-service | `boundary_schema_version` | `boundary_service_schema` |
+| egov-hrms | `hrms_schema_version` | `egov_hrms_schema` |
+| egov-enc-service | `enc_schema_version` | `egov_enc_service_schema` |
+| egov-filestore | `filestore_schema_version` | `egov_filestore_schema` |
+| egov-workflow-v2 | `workflow_schema_version` | `egov_workflow_v2_schema` |
+| mdms-v2 | `mdms_schema_version` | `mdms_v2_schema` |
+| egov-user | `egov_user_schema_version` | `egov_user_schema` |
+| egov-idgen | `egov_idgen_schema_version` | `egov_idgen_schema` |
+| egov-localization | `egov_localization_schema_version` | `egov_localization_schema` |
+| egov-url-shortening | `egov_url_shortening_schema_version` | `"egov-url-shortening_schema"` ⚠ hyphens → must be quoted everywhere |
+| egov-accesscontrol | `accesscontrol_schema_version` | **OPEN** (see §9) |
+
+**Baseline-fresh services** (`egov-indexer`, `digit-config-service`, `novu-bridge`):
+already use K8s-matching names and have **no** dump history — nothing to rename;
+their migrators create history fresh on first run.
+
+**`egov-otp`:** no dump history table today; its migrator creates `egov_otp_schema`
+fresh (baseline). Confirm otp data tables in the dump don't collide (§8).
+
+## 7. Rollout — pilot first
+
+- **Phase 0 — tooling.** Rename+re-bake script; update the Flyway-dump alignment
+  check (§10); confirm the Flyway base-image version to match K8s.
+- **Phase 1 — pilot: `pgr-services`.** Repo-local, flagship, and its name needs
+  **no** rename (`pgr_services_schema` already matches K8s). Build `pgr-services-db`
+  from the repo Dockerfile; add `pgr-services-migration`; disable pgr embedded
+  Flyway; gate the app on the migrator. Validate all of §11 on this one service
+  before templating. This de-risks the whole pattern cheaply.
+- **Phase 2 — repo-local services.** Template Phase 1 across `novu-bridge`,
+  `digit-config-service`, `digit-user-preferences-service`, `xstate-chatbot`,
+  `default-data-handler`.
+- **Phase 3 — core services.** Per the §5 sourcing decision. Resolve the
+  `accesscontrol` and `otp` open items here.
+- **Phase 4 — cleanup.** Re-bake the dump with all renames; remove the
+  `db-migrations` container, `migrate-all.sh`, embedded `SPRING_FLYWAY_*`, and the
+  url-shortening override; flip the alignment check to enforce K8s names.
+
+Each phase is independently shippable and leaves the stack bootable.
+
+## 8. Risks & mitigations
+
+- **Checksum mismatch** — the re-baked dump's history rows were written by
+  compose's *old* Flyway build, so a migrator that validates could fail on checksum
+  differences. Mitigation: `FLYWAY_VALIDATE_ON_MIGRATE=false` (+ out-of-order,
+  ignore-missing), consistent with how DIGIT already runs Flyway leniently.
+- **Hyphenated identifier** (`egov-url-shortening_schema`) — must be double-quoted
+  in the rename SQL and passed verbatim as `FLYWAY_TABLE`. Faithful to K8s, which
+  uses the hyphen as-is.
+- **Core-service SQL sourcing** depends on the registry decision (§5); design
+  supports both, so this is not a blocker.
+- **Boot time / noise** — ~14 one-shot containers spin up to no-op on the fast
+  path. They exit immediately and run in parallel (all gated only on postgres
+  health); acceptable.
+- **otp data collision** — confirm the dump's otp data tables don't cause the fresh
+  `egov_otp_schema` migrator to hit `42P07`; if they do, add otp to the rename set.
+
+## 9. Open items to resolve during rollout
+
+- **`egov-accesscontrol`:** its K8s chart has **no** `schemaTable` / `-db` init
+  container, yet compose runs embedded Flyway for it and the dump carries
+  `accesscontrol_schema_version`. Determine how accesscontrol's schema is created in
+  K8s (embedded? another service? no migrations?) and mirror that — don't invent a
+  `-db` step K8s doesn't have. Resolve before Phase 3 touches accesscontrol.
+- **Flyway base version:** pin the `<service>-db` base image to the same Flyway
+  version K8s uses (charts give no explicit tag; the repo's existing `db/Dockerfile`s
+  and the `db-migrations` bundle use `flyway/flyway:9-alpine`). Confirm and
+  standardize.
+- **`/flyway/seed` and `/flyway/qa`:** K8s locations include seed/qa. Confirm
+  whether any service relies on them and include those folders if so.
+
+## 10. Alignment check evolution
+
+The existing `check-flyway-dump-alignment.py` (compose `SPRING_FLYWAY_TABLE` ↔ dump)
+evolves into a **three-way** parity assertion:
+
+> per-service migrator `FLYWAY_TABLE` == dump history-table name == K8s chart
+> `schemaTable`
+
+for every service. The transitional `PENDING_ENABLE` / `BASELINE_FRESH` allowlists
+shrink toward empty as services migrate; a service is "done" when all three names
+agree. This makes cross-stack naming drift a CI failure, permanently.
+
+## 11. Validation / success criteria
+
+- **Fast path:** stack boots; every `<service>-migration` exits 0 and reports Flyway
+  "up to date" (no-op); all apps start.
+- **Slow path:** empty DB → migrators build the full schema with `<service>_schema`
+  names → apps start → Newman suites pass (digit-core-validation + complaints-demo
+  16/16; CRSLoader regression 11/11).
+- **New-migration test:** add a probe migration to a service's SQL, rebuild its
+  `-db` image, boot → migrator applies it (Flyway "migrated 1"), verified in DB.
+- **Naming parity:** the §10 three-way check is green for every migrated service.
+- **Dump portability:** a DB dumped from compose loads into a K8s-shaped schema
+  layout without `42P07` (history-table names match K8s).
+
+## 12. What this deliberately does NOT change
+
+- K8s charts (reference model, unchanged).
+- Seed/master data in the dump (only history-table names change).
+- App business logic or images (beyond disabling embedded Flyway).

--- a/docs/superpowers/specs/2026-07-10-compose-k8s-migration-parity-design.md
+++ b/docs/superpowers/specs/2026-07-10-compose-k8s-migration-parity-design.md
@@ -78,20 +78,23 @@ service (the init-container equivalent):
 
 ```yaml
 <service>-migration:
-  image: <service>-db:<tag>          # see §5 for sourcing
+  build:                              # repo-local: build from the in-repo db/Dockerfile
+    context: ../backend/<service>/src/main/resources/db
+  # image: <service>-db:<tag>         # core services: pull instead (see §5)
   depends_on:
     postgres-db: { condition: service_healthy }
   environment:
-    FLYWAY_URL: jdbc:postgresql://postgres:5432/egov   # DIRECT to postgres, NOT pgbouncer
+    # Contract expected by the -db image's migrate.sh (verified in
+    # backend/pgr-services/src/main/resources/db/migrate.sh):
+    #   flyway -url=$DB_URL -table=$SCHEMA_TABLE -user=$FLYWAY_USER
+    #     -password=$FLYWAY_PASSWORD -locations=$FLYWAY_LOCATIONS
+    #     -baselineOnMigrate=true -outOfOrder=true migrate
+    DB_URL: jdbc:postgresql://postgres-db:5432/egov    # REAL postgres — see note below
+    SCHEMA_TABLE: <service>_schema                      # the K8s name
     FLYWAY_USER: egov
     FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
-    FLYWAY_SCHEMAS: public
-    FLYWAY_TABLE: <service>_schema                      # the K8s name
     FLYWAY_LOCATIONS: filesystem:/flyway/sql
-    FLYWAY_BASELINE_ON_MIGRATE: "true"
     FLYWAY_VALIDATE_ON_MIGRATE: "false"                 # lenient — see §8
-    FLYWAY_OUT_OF_ORDER: "true"
-  command: migrate
   restart: "no"
 
 <service>:                            # the app
@@ -100,6 +103,16 @@ service (the init-container equivalent):
   depends_on:
     <service>-migration: { condition: service_completed_successfully }
 ```
+
+**Host note — `postgres` is NOT the database.** In compose, the hostname
+`postgres` is a network **alias for pgbouncer**, which runs in `POOL_MODE:
+transaction`. The real Postgres is the `postgres-db` service (container
+`docker-postgres`). Flyway needs session-scoped connections (advisory locks,
+multi-statement DDL), which transaction pooling breaks — *this is the actual
+root of the `egov-otp` "Flyway incompatible with pgbouncer" exception.* Every
+migrator therefore connects to **`postgres-db:5432` directly**, bypassing
+pgbouncer, which both mirrors K8s (its init containers hit the DB directly) and
+dissolves the otp exception.
 
 **Removed** at the end of rollout:
 - The consolidated `db-migrations` container and its `migrate-all.sh`.

--- a/docs/superpowers/specs/2026-07-13-ansible-flyway-history-normalization-design.md
+++ b/docs/superpowers/specs/2026-07-13-ansible-flyway-history-normalization-design.md
@@ -1,0 +1,280 @@
+# Flyway history normalization on operator-supplied dumps (item #10 follow-up)
+
+**Status:** design, approved 2026-07-13
+**Extends:** PR #1142 (`feat/item10-db-migration-parity`), spec `2026-07-10-compose-k8s-migration-parity-design.md`
+
+## Problem
+
+PR #1142 replaced compose's embedded Flyway with per-service `-db` migration init
+containers pulled from the same `egovio/<service>-db:<tag>` images K8s runs. Those
+images locate their Flyway history by the K8s table name (`SCHEMA_TABLE`, e.g.
+`boundary_service_schema`). The PR made this work by **re-baking the dump it ships**
+(`local-setup/db/full-dump.sql`) so its history rows sit under those names.
+
+That fix covers the repo's own dump. It does not cover a dump handed over by a
+service team or lifted from a running environment, and the fast-path overlay mounts
+*whatever* file sits at `db/full-dump.sql` into `/docker-entrypoint-initdb.d/`. The
+standing assumption was that every team would rename their history tables at source.
+They have not, and nothing in the deploy checks.
+
+### What actually happens (measured, not predicted)
+
+Verified 2026-07-13 against a team-supplied dump (`egov_backup_20260709_082159.sql`,
+21 MB, 57 tables, 97,250 rows) in throwaway containers. The dump carries the **legacy
+compose history names** (`boundary_schema_version`, `enc_schema_version`, …). Loading
+it and running the eleven pinned `-db` migrators unmodified:
+
+**97,250 rows → 26,377. 73% of the data destroyed.**
+
+| Table | Before | After |
+|---|---|---|
+| `message` (localization) | 70,835 | **0** |
+| `eg_enc_symmetric_keys` | 27 | **0** |
+| `eg_enc_asymmetric_keys` | 27 | **0** |
+
+Each migrator looks for its K8s-named history table, finds none, concludes the
+database is empty, and replays every migration from V1 (2017) against a populated
+database. Nine crash with `42P07 relation already exists` — that crash is the only
+reason their data survived. The two that do **not** crash are the ones that cause the
+damage, because their V1 migration opens with a drop:
+
+- `egov-localization` → `V20170502122717__localization_create_message.sql` begins
+  `DROP TABLE IF EXISTS message;`
+- `egov-enc-service` → `V20180607185601__eg_enc.sql` begins
+  `DROP TABLE IF EXISTS eg_enc_symmetric_keys; DROP TABLE IF EXISTS eg_enc_asymmetric_keys;`
+
+Both drop, recreate empty, and **exit 0**. A green deploy that ate the data.
+
+The encryption keys are the unrecoverable part: `eg_user.name` and `mobilenumber` are
+ciphertext in this dump, and those keys are the only thing that could decrypt them.
+Losing them permanently destroys the PII of 534 users and 496 employees. No re-seed
+recovers it. (`inventory/host_vars/_example.yml:446` already documents that the dump's
+`eg_enc_*_keys` decrypt only under the matching master password — the table is known to
+be load-bearing.)
+
+### Verified remedy
+
+Renaming the ten legacy history tables to their canonical K8s names, then running the
+same eleven migrators against the same dump:
+
+**Zero data change — every pre-existing table byte-identical (rows + checksum).** All
+ten report `Schema "public" is up to date / No migration necessary`.
+
+Renaming is a pure catalog operation. It rewrites no rows.
+
+One service does not resolve by rename. `egov-otp` has `eg_token` in the dump but **no
+history table at all**, so Flyway baselines at v1, replays
+`V20170303153029__otp_create_token_table.sql`, and hits 42P07. It rolls back cleanly and
+`eg_token` is empty here, so nothing is lost — but the migrator exits 1, and under
+`service_completed_successfully` that blocks `egov-otp` from booting.
+
+## Goals
+
+1. A deploy over **any** dump either leaves existing data untouched or fails loudly.
+   No path may silently succeed while destroying data.
+2. Remove the dependency on every service team renaming their history tables.
+3. Protect a bare `docker compose up`, not just an Ansible deploy.
+
+**Non-goal:** verifying that the dump's *schema* matches what its history claims. See
+Known limitation.
+
+## Design
+
+### Components
+
+| File | Change |
+|---|---|
+| `local-setup/db/flyway-history-map.yml` | **new** — source of truth: canonical table, legacy aliases, data tables |
+| `local-setup/db/normalize/` (`normalize.py`, `Dockerfile`) | **new** — the normalizer |
+| `local-setup/docker-compose.migrations.yml` | **edit** — add `db-history-normalize`; gate every migrator on it |
+| `.github/scripts/check-flyway-dump-alignment.py` | **edit** — read the map instead of hardcoding names |
+
+No change to `playbook-deploy.yml`. Ansible already runs these compose files, so it
+inherits the guard.
+
+### Ordering
+
+Compose enforces it, not Ansible task order:
+
+```
+postgres-db  (initdb runs the dump; healthcheck green only after it completes)
+    │  condition: service_healthy
+    ▼
+db-history-normalize   ← one-shot; exit 0 to proceed, non-zero to stop the deploy
+    │  condition: service_completed_successfully
+    ▼
+11 × <service>-migration   → "No migration necessary"
+    │  condition: service_completed_successfully
+    ▼
+apps
+```
+
+Because the migrators are gated on the normalizer, they **cannot** run before it. A
+non-zero normalizer means compose never starts them, never starts the apps, and
+`docker compose up -d` returns non-zero — so the Ansible task fails too.
+
+### Decision table
+
+Applied per service in the map. This is the whole of the logic.
+
+| Canonical | Legacy alias | Data tables | Action |
+|---|---|---|---|
+| present | — | — | no-op |
+| — | present | — | **rename** alias → canonical |
+| present | present | — | **abort** — ambiguous, cannot tell which is authoritative |
+| — | — | absent | no-op — genuine fresh install; migrator builds from scratch |
+| — | — | present, **0 rows** | **drop** them; migrator rebuilds (the `egov-otp` path) |
+| — | — | present, **has rows** | **abort** — cannot prove which migrations are applied |
+
+Entries marked `embedded: true` are **skipped before the table is consulted** — they
+have no migration init container, so nothing would replay against them. They appear in
+the map only so the CI check knows their history table is claimed and does not report
+it as orphaned.
+
+**Unknown history tables are a warning, not an error.** A migrator only exists for a
+service in the map, so a history table we do not recognise has nothing that would
+replay against it. It is logged and skipped. `accesscontrol_schema_version` is exactly
+this case: `egov-accesscontrol` stays on embedded Flyway (its K8s chart declares no
+`schemaTable`), so it is recorded in the map as `embedded: true` and never touched.
+
+### The map
+
+Canonical names are the `SCHEMA_TABLE` values already declared in
+`docker-compose.migrations.yml`. Aliases are the legacy compose names. Data tables are
+derived from the `CREATE TABLE` statements in each `-db` image's own migration SQL, so
+ownership is authoritative rather than guessed.
+
+```yaml
+boundary-service:
+  canonical: boundary_service_schema
+  aliases: [boundary_schema_version]
+  data_tables: [boundary, boundary_hierarchy, boundary_relationship]
+
+egov-user:
+  canonical: egov_user_schema
+  aliases: [egov_user_schema_version]
+  data_tables: [eg_address, eg_role, eg_user, eg_user_address, eg_user_audit_table,
+                eg_user_login_failed_attempts, eg_userrole, eg_userrole_v1]
+
+mdms-backend:
+  canonical: mdms_v2_schema
+  aliases: [mdms_schema_version]
+  data_tables: [eg_mdms_data, eg_mdms_schema_definition]
+
+egov-idgen:
+  canonical: egov_idgen_schema
+  aliases: [egov_idgen_schema_version]
+  data_tables: [id_generator]
+
+egov-localization:
+  canonical: egov_localization_schema
+  aliases: [egov_localization_schema_version]
+  data_tables: [message]
+
+egov-enc-service:
+  canonical: egov_enc_service_schema
+  aliases: [enc_schema_version]
+  data_tables: [eg_enc_asymmetric_keys, eg_enc_symmetric_keys]
+
+egov-filestore:
+  canonical: egov_filestore_schema
+  aliases: [filestore_schema_version]
+  data_tables: [eg_filestoremap]
+
+egov-workflow-v2:
+  canonical: egov_workflow_v2_schema
+  aliases: [workflow_schema_version]
+  data_tables: [eg_wf_action_v2, eg_wf_assignee_v2, eg_wf_businessservice_v2,
+                eg_wf_document_v2, eg_wf_processinstance_v2, eg_wf_state_v2]
+
+egov-hrms:
+  canonical: egov_hrms_schema
+  aliases: [hrms_schema_version]
+  data_tables: [eg_hrms_assignment, eg_hrms_deactivationdetails, eg_hrms_departmentaltests,
+                eg_hrms_educationaldetails, eg_hrms_empdocuments, eg_hrms_employee,
+                eg_hrms_jurisdiction, eg_hrms_reactivationdetails, eg_hrms_servicehistory]
+
+egov-url-shortening:
+  canonical: "egov-url-shortening_schema"    # hyphenated, as in the K8s chart
+  aliases: [egov_url_shortening_schema_version]
+  data_tables: [eg_url_shortener]
+
+egov-otp:
+  canonical: egov_otp_schema
+  aliases: []                                 # no legacy history exists anywhere
+  data_tables: [eg_token]
+
+pgr-services:
+  canonical: pgr_services_schema
+  aliases: []                                 # already canonical in the dump
+  data_tables: [complaint_open_state_daily, eg_pgr_address_v2, eg_pgr_document_v2,
+                eg_pgr_service_v2]            # materialized views are not data tables
+
+egov-accesscontrol:
+  embedded: true                              # stays on embedded Flyway; never touched
+  canonical: accesscontrol_schema_version
+```
+
+`data_tables` lists only real tables. `pgr-services` also creates materialized views
+(`pgr_mv_*`, `complaint_events`, `complaint_facts`); they are excluded because the
+"data tables present but no history" branch reasons about rows that cannot be
+reconstructed, and an MV can always be rebuilt from its sources.
+
+### Image
+
+`FROM postgres:16` plus `python3-yaml`, built from `local-setup/db/normalize/Dockerfile`.
+It needs `psql` and a YAML parser. This same overlay already builds
+`pgr-services-migration`, `novu-bridge-migration` and `digit-config-service-migration`
+from local Dockerfiles, so it introduces no new class of dependency. The eleven core
+migrators keep pulling their pinned `egovio/*-db` images untouched.
+
+## Error handling
+
+Every abort exits non-zero and modifies nothing. The message states what was found,
+what would have happened, and what to do:
+
+```
+db-history-normalize: ABORT
+
+  egov-otp: eg_token has 4,102 rows but no Flyway history table.
+  Cannot prove which migrations are already applied. Replaying from
+  V1 would DROP eg_token.
+
+  Resolve by seeding egov_otp_schema with the applied versions, or
+  confirm the table is disposable and empty it.
+
+Refusing to start migrators. No data was modified.
+```
+
+**The drop path is guarded twice.** The row count is re-checked *inside the same
+transaction* as the `DROP`, so a table that gains rows between check and drop aborts
+rather than proceeds. It only ever touches tables named in that service's
+`data_tables`, and only when the service has no history table whatsoever.
+
+**Idempotency.** Compose re-runs the normalizer on every `up`. The second run finds
+canonical tables present and no aliases, so every service takes the no-op branch and it
+exits 0. That is the steady state after the first deploy.
+
+## Testing
+
+| Test | Asserts |
+|---|---|
+| **Real proof** (integration) | Scratch Postgres + the team's dump → normalizer → 11 migrators. Every migrator reports `No migration necessary`, and a full before/after row-count + content-checksum snapshot of all 57 tables is byte-identical. |
+| **Negative** | Same dump, normalizer skipped → data IS destroyed. If this ever stops failing, the guard has been silently disabled. |
+| **Decision table** (unit) | The six rows above are a pure function of (canonical?, alias?, data tables, row counts). Table-driven, no DB. |
+| **Idempotency** | Run the normalizer twice; the second run is a no-op. |
+| **Fresh install** | No dump → normalizer no-ops, migrators build from scratch, stack comes up. |
+| **CI** | `check-flyway-dump-alignment.py` reads the shared map, so a service added to the overlay without a map entry fails the PR. |
+
+The integration harness already exists — it is what produced the measurements above.
+
+## Known limitation
+
+The rename asserts that the dump's *schema* matches what those migration files would
+have produced. That holds for this dump (all eleven migrators go clean), but the
+normalizer does not independently verify it: a dump whose schema had drifted from its
+history would still be accepted, and a later migration could then fail against an
+unexpected column. Closing that requires a real schema-drift check (build the schema
+from migrations, build it from the dump, diff). Deliberately out of scope here — it is
+a separate piece of work and bolting a half-version of it onto the normalizer would
+give false confidence.

--- a/docs/superpowers/specs/2026-07-13-ansible-flyway-history-normalization-design.md
+++ b/docs/superpowers/specs/2026-07-13-ansible-flyway-history-normalization-design.md
@@ -89,8 +89,14 @@ Known limitation.
 | `local-setup/docker-compose.migrations.yml` | **edit** — add `db-history-normalize`; gate every migrator on it |
 | `.github/scripts/check-flyway-dump-alignment.py` | **edit** — read the map instead of hardcoding names |
 
-No change to `playbook-deploy.yml`. Ansible already runs these compose files, so it
-inherits the guard.
+**Update (final PR scope):** the original design assumed no `playbook-deploy.yml`
+change was needed. That was wrong — Ansible did **not** reference the migration
+overlay at all, so a deploy ran none of the migrators and fell back to embedded
+Flyway. `playbook-deploy.yml` **is** changed in this PR: it now copies
+`docker-compose.migrations.yml` (+ the Ansible build-context overlay
+`docker-compose.migrations.ansible.yml`) to the target and **always** layers them
+into `compose_files`, so an Ansible deploy inherits the `db-history-normalize` guard
+the same way the plain-compose flow does.
 
 ### Ordering
 

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -281,6 +281,40 @@
         src: ../docker-compose.fast-path.yml
         dest: "{{ digit_dir }}/docker-compose.fast-path.yml"
 
+    # ── DB-migration overlay (item #10) ────────────────────────────────────────
+    # Per-service Flyway init containers + the db-history-normalize guard that
+    # runs ahead of them. Always layered: it IS the migration model (it turns the
+    # apps' embedded Flyway off and gates them on their migrator), so a deploy
+    # without it silently falls back to embedded Flyway and, on an
+    # operator-supplied dump, can destroy data. See docs/db-migration-flow.md.
+    #
+    # db/ is already synchronized below (digit_config_dirs), which carries
+    # db/normalize/ (the guard's build context) and db/flyway-history-map.yml.
+    - name: Copy DB-migration overlay
+      copy:
+        src: ../docker-compose.migrations.yml
+        dest: "{{ digit_dir }}/docker-compose.migrations.yml"
+
+    # The overlay's three in-repo migrators (pgr-services, novu-bridge,
+    # digit-config-service) build from ../backend/<svc>/src/main/resources/db.
+    # That path exists in the repo but NOT on a deployed host, so sync those
+    # contexts under docker/ (the existing build-context convention) and repoint
+    # them with an Ansible-only overlay. docker-compose.migrations.yml itself
+    # stays valid for anyone running compose straight from the repo.
+    - name: Synchronize in-repo migrator build contexts
+      synchronize:
+        src: "../../backend/{{ item }}/src/main/resources/db/"
+        dest: "{{ digit_dir }}/docker/{{ item }}-db/"
+      loop:
+        - pgr-services
+        - novu-bridge
+        - digit-config-service
+
+    - name: Copy DB-migration overlay (Ansible build-context paths)
+      copy:
+        src: ../docker-compose.migrations.ansible.yml
+        dest: "{{ digit_dir }}/docker-compose.migrations.ansible.yml"
+
     # Per-tenant compose overlay convention. If a file named
     # local-setup/docker-compose.<inventory_hostname>.yml exists on the
     # controller, copy it to the target and include it in every compose
@@ -551,12 +585,17 @@
     # Tenants opt into the DB fast-path with `db_fast_path: true` in their
     # host_vars. When on, layer the overlay onto every compose invocation
     # below (pull, up, recreate). Default off — never touches live tenants.
-    - name: "Compute compose -f flags (fast-path + per-tenant overlay opt-in)"
+    # The migration overlay is layered ALWAYS (see "Copy DB-migration overlay"):
+    # it is the migration model, not an opt-in extra. It must come BEFORE the
+    # per-tenant overlay so a tenant can still override a migrator if it has to.
+    - name: "Compute compose -f flags (fast-path + migrations + per-tenant overlay)"
       ansible.builtin.set_fact:
         compose_files: >-
           {{
             '-f docker-compose.egov-digit.yaml' +
             (' -f docker-compose.fast-path.yml' if (db_fast_path | default(false)) else '') +
+            ' -f docker-compose.migrations.yml' +
+            ' -f docker-compose.migrations.ansible.yml' +
             (' -f docker-compose.' ~ inventory_hostname ~ '.yml' if per_tenant_overlay.stat.exists else '')
           }}
 

--- a/local-setup/db/flyway-history-map.yml
+++ b/local-setup/db/flyway-history-map.yml
@@ -1,0 +1,135 @@
+# Source of truth for Flyway history-table names (deployment-parity item #10).
+#
+# The compose stack boots from a dump, then each service's -db migration init
+# container runs Flyway on top. Flyway finds "what have I already applied?" by
+# reading the history table named by SCHEMA_TABLE. If that name does not match
+# what the dump actually shipped, Flyway sees an EMPTY history, replays every
+# migration from V1 against a populated database, and — for services whose V1
+# starts with DROP TABLE IF EXISTS (egov-localization, egov-enc-service) —
+# silently destroys the data and exits 0.
+#
+# db-history-normalize reads this file before any migrator runs and renames
+# legacy history tables to their canonical names.
+#
+#   canonical      the table Flyway looks for (== SCHEMA_TABLE in
+#                  docker-compose.migrations.yml). Keep the two in sync.
+#   aliases        legacy compose names for the same history.
+#   data_tables    real tables this service's migrations CREATE. Derived from the
+#                  CREATE TABLE statements in its own migration SQL — NOT guessed.
+#                  Materialized views are excluded: they can always be rebuilt.
+#   embedded       true = no migration init container. The normalizer skips these
+#                  entirely; nothing would replay against them.
+#   baseline_fresh true = legitimately absent from the dump (migrates from empty).
+#                  Consumed by .github/scripts/check-flyway-dump-alignment.py.
+
+boundary-service:
+  canonical: boundary_service_schema
+  aliases: [boundary_schema_version]
+  data_tables: [boundary, boundary_hierarchy, boundary_relationship]
+
+egov-user:
+  canonical: egov_user_schema
+  aliases: [egov_user_schema_version]
+  data_tables:
+    - eg_address
+    - eg_role
+    - eg_user
+    - eg_user_address
+    - eg_user_audit_table
+    - eg_user_login_failed_attempts
+    - eg_userrole
+    - eg_userrole_v1
+
+mdms-backend:
+  canonical: mdms_v2_schema
+  aliases: [mdms_schema_version]
+  data_tables: [eg_mdms_data, eg_mdms_schema_definition]
+
+egov-idgen:
+  canonical: egov_idgen_schema
+  aliases: [egov_idgen_schema_version]
+  data_tables: [id_generator]
+
+egov-localization:
+  canonical: egov_localization_schema
+  aliases: [egov_localization_schema_version]
+  data_tables: [message]
+
+egov-enc-service:
+  canonical: egov_enc_service_schema
+  aliases: [enc_schema_version]
+  data_tables: [eg_enc_asymmetric_keys, eg_enc_symmetric_keys]
+
+egov-filestore:
+  canonical: egov_filestore_schema
+  aliases: [filestore_schema_version]
+  data_tables: [eg_filestoremap]
+
+egov-workflow-v2:
+  canonical: egov_workflow_v2_schema
+  aliases: [workflow_schema_version]
+  data_tables:
+    - eg_wf_action_v2
+    - eg_wf_assignee_v2
+    - eg_wf_businessservice_v2
+    - eg_wf_document_v2
+    - eg_wf_processinstance_v2
+    - eg_wf_state_v2
+
+egov-hrms:
+  canonical: egov_hrms_schema
+  aliases: [hrms_schema_version]
+  data_tables:
+    - eg_hrms_assignment
+    - eg_hrms_deactivationdetails
+    - eg_hrms_departmentaltests
+    - eg_hrms_educationaldetails
+    - eg_hrms_empdocuments
+    - eg_hrms_employee
+    - eg_hrms_jurisdiction
+    - eg_hrms_reactivationdetails
+    - eg_hrms_servicehistory
+
+egov-url-shortening:
+  canonical: "egov-url-shortening_schema"   # hyphenated, as in the K8s chart
+  aliases: [egov_url_shortening_schema_version]
+  data_tables: [eg_url_shortener]
+
+egov-otp:
+  canonical: egov_otp_schema
+  aliases: []              # no legacy otp history exists in any known dump
+  data_tables: [eg_token]
+
+pgr-services:
+  canonical: pgr_services_schema
+  aliases: []              # already canonical in the dump
+  data_tables:
+    - complaint_open_state_daily
+    - eg_pgr_address_v2
+    - eg_pgr_document_v2
+    - eg_pgr_service_v2
+
+novu-bridge:
+  canonical: novu_bridge_schema
+  aliases: []
+  data_tables: [nb_dispatch_log]
+  baseline_fresh: true
+
+digit-config-service:
+  canonical: digit_config_service_schema
+  aliases: []
+  data_tables: [eg_config_data]
+  baseline_fresh: true
+
+egov-indexer:
+  canonical: egov_indexer_schema
+  aliases: []
+  data_tables: []
+  embedded: true           # embedded Flyway; no migration init container
+  baseline_fresh: true
+
+egov-accesscontrol:
+  canonical: accesscontrol_schema_version
+  aliases: []
+  data_tables: []
+  embedded: true           # K8s chart declares no schemaTable; stays embedded

--- a/local-setup/db/normalize/Dockerfile
+++ b/local-setup/db/normalize/Dockerfile
@@ -1,0 +1,13 @@
+# db-history-normalize — see docs/superpowers/specs/2026-07-13-ansible-flyway-history-normalization-design.md
+#
+# postgres:16 gives us psql; it does NOT ship python3, so install it.
+ARG POSTGRES_IMAGE=registry.preview.egov.theflywheel.in/postgres:16
+FROM ${POSTGRES_IMAGE}
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends python3 python3-yaml \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY normalize.py /usr/local/bin/normalize.py
+
+ENTRYPOINT ["python3", "/usr/local/bin/normalize.py"]

--- a/local-setup/db/normalize/normalize.py
+++ b/local-setup/db/normalize/normalize.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Normalize Flyway history-table names before any migrator runs.
+
+See docs/superpowers/specs/2026-07-13-ansible-flyway-history-normalization-design.md
+
+The database is the input; the decision table below is the entire logic. Keep
+`decide()` pure — every safety property is tested there, without a database.
+"""
+from typing import Dict, NamedTuple, Optional, Set, Tuple
+
+import yaml
+
+NOOP = "noop"
+RENAME = "rename"
+DROP = "drop"
+ABORT = "abort"
+SKIP = "skip"
+
+
+class Decision(NamedTuple):
+    action: str
+    service: str
+    canonical: str
+    alias: Optional[str] = None
+    tables: Tuple[str, ...] = ()
+    reason: str = ""
+
+
+def load_map(path: str) -> Dict[str, dict]:
+    with open(path) as fh:
+        data = yaml.safe_load(fh) or {}
+    if not data:
+        raise SystemExit(f"FATAL: {path} is empty or unparseable")
+    return data
+
+
+def decide(
+    service: str,
+    spec: dict,
+    present: Set[str],
+    row_counts: Dict[str, int],
+) -> Decision:
+    """Pure. What should we do about `service`, given what is in the database?
+
+    present     — every table name in the public schema
+    row_counts  — rows per data table, for the data tables that are present
+    """
+    canonical = spec["canonical"]
+
+    # No migration init container exists for embedded services, so nothing would
+    # replay against their history. Hands off, whatever it looks like.
+    if spec.get("embedded"):
+        return Decision(SKIP, service, canonical, reason="embedded Flyway")
+
+    canonical_present = canonical in present
+    found = [a for a in (spec.get("aliases") or []) if a in present]
+
+    if canonical_present and found:
+        return Decision(
+            ABORT, service, canonical,
+            reason=(f"ambiguous: canonical {canonical!r} AND legacy "
+                    f"{', '.join(repr(a) for a in found)} both exist. "
+                    f"Cannot tell which history is authoritative."),
+        )
+    if len(found) > 1:
+        return Decision(
+            ABORT, service, canonical,
+            reason=(f"ambiguous: multiple legacy history tables exist "
+                    f"({', '.join(repr(a) for a in found)})."),
+        )
+    if canonical_present:
+        return Decision(NOOP, service, canonical, reason="already canonical")
+    if found:
+        return Decision(RENAME, service, canonical, alias=found[0])
+
+    # No history table at all, under any name.
+    data_present = tuple(t for t in (spec.get("data_tables") or []) if t in present)
+    if not data_present:
+        return Decision(NOOP, service, canonical, reason="fresh install")
+
+    populated = {t: row_counts.get(t, 0) for t in data_present if row_counts.get(t, 0) > 0}
+    if populated:
+        detail = ", ".join(f"{t} has {n:,} rows" for t, n in sorted(populated.items()))
+        return Decision(
+            ABORT, service, canonical, tables=data_present,
+            reason=(f"{detail}, but no Flyway history table exists. Cannot prove "
+                    f"which migrations are applied; replaying from V1 would DROP "
+                    f"these tables."),
+        )
+
+    return Decision(
+        DROP, service, canonical, tables=data_present,
+        reason="tables exist but are empty and have no history; migrator will rebuild",
+    )

--- a/local-setup/db/normalize/normalize.py
+++ b/local-setup/db/normalize/normalize.py
@@ -120,16 +120,39 @@ WHERE n.nspname = 'public' AND c.relkind = 'r'
 """
 
 
+# Fail LOUDLY instead of hanging the whole deploy. Every migrator and app gates on
+# db-history-normalize completing, so a psql that blocks forever — most likely the
+# DROP branch's `LOCK TABLE ... ACCESS EXCLUSIVE` waiting on another session's lock —
+# would silently deadlock the entire stack. lock_timeout aborts a LOCK that can't be
+# acquired; statement_timeout caps any single statement; the subprocess timeout is a
+# hard backstop that turns a hung psql into a diagnosable non-zero exit.
+LOCK_TIMEOUT = "30s"        # abort a blocked LOCK TABLE
+STATEMENT_TIMEOUT = "300s"  # cap any single statement server-side
+SUBPROCESS_TIMEOUT = 600    # hard client-side backstop on the psql process (seconds)
+
+
 def psql(sql: str, *, capture: bool = True) -> str:
     """Run SQL. ON_ERROR_STOP=1 so a failure is a non-zero exit, not a warning.
 
     (psql prints errors as `psql:<file>:<line>: ERROR: ...` — never grep for a
     line-anchored ^ERROR to detect failure; check the exit code.)
+
+    Runs with lock_timeout/statement_timeout (via PGOPTIONS) and a subprocess
+    timeout so a blocked lock or a wedged connection fails fast instead of
+    hanging every downstream migrator forever.
     """
-    proc = subprocess.run(
-        ["psql", "-v", "ON_ERROR_STOP=1", "-qtA", "-c", sql],
-        capture_output=capture, text=True,
-    )
+    env = {**os.environ, "PGOPTIONS": f"-c lock_timeout={LOCK_TIMEOUT} -c statement_timeout={STATEMENT_TIMEOUT}"}
+    try:
+        proc = subprocess.run(
+            ["psql", "-v", "ON_ERROR_STOP=1", "-qtA", "-c", sql],
+            capture_output=capture, text=True, env=env, timeout=SUBPROCESS_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        sys.stderr.write(
+            f"psql exceeded {SUBPROCESS_TIMEOUT}s (likely a blocked lock) — aborting "
+            "rather than hanging the deploy.\n"
+        )
+        raise
     if proc.returncode != 0:
         sys.stderr.write(proc.stderr or "")
         raise subprocess.CalledProcessError(proc.returncode, "psql", proc.stdout, proc.stderr)

--- a/local-setup/db/normalize/normalize.py
+++ b/local-setup/db/normalize/normalize.py
@@ -92,3 +92,140 @@ def decide(
         DROP, service, canonical, tables=data_present,
         reason="tables exist but are empty and have no history; migrator will rebuild",
     )
+
+
+# ── database layer ────────────────────────────────────────────────────────────
+import os
+import subprocess
+import sys
+from typing import Iterable, List
+
+MAP_PATH = os.environ.get("MAP_PATH", "/map.yml")
+
+# Flyway history tables are identified by their column signature, not their name —
+# that is the whole point, since the name is what we cannot trust.
+_HISTORY_SIG = """
+SELECT c.relname
+FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'public' AND c.relkind = 'r'
+  AND EXISTS (SELECT 1 FROM information_schema.columns col
+              WHERE col.table_schema = 'public' AND col.table_name = c.relname
+                AND col.column_name = 'installed_rank')
+  AND EXISTS (SELECT 1 FROM information_schema.columns col
+              WHERE col.table_schema = 'public' AND col.table_name = c.relname
+                AND col.column_name = 'checksum')
+  AND EXISTS (SELECT 1 FROM information_schema.columns col
+              WHERE col.table_schema = 'public' AND col.table_name = c.relname
+                AND col.column_name = 'installed_on');
+"""
+
+
+def psql(sql: str, *, capture: bool = True) -> str:
+    """Run SQL. ON_ERROR_STOP=1 so a failure is a non-zero exit, not a warning.
+
+    (psql prints errors as `psql:<file>:<line>: ERROR: ...` — never grep for a
+    line-anchored ^ERROR to detect failure; check the exit code.)
+    """
+    proc = subprocess.run(
+        ["psql", "-v", "ON_ERROR_STOP=1", "-qtA", "-c", sql],
+        capture_output=capture, text=True,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr or "")
+        raise subprocess.CalledProcessError(proc.returncode, "psql", proc.stdout, proc.stderr)
+    return (proc.stdout or "").strip()
+
+
+def list_tables() -> Set[str]:
+    out = psql("SELECT tablename FROM pg_tables WHERE schemaname = 'public';")
+    return {line.strip() for line in out.splitlines() if line.strip()}
+
+
+def history_tables() -> Set[str]:
+    out = psql(_HISTORY_SIG)
+    return {line.strip() for line in out.splitlines() if line.strip()}
+
+
+def count_rows(tables: Iterable[str]) -> Dict[str, int]:
+    counts: Dict[str, int] = {}
+    for t in tables:
+        counts[t] = int(psql(f'SELECT count(*) FROM public."{t}";') or 0)
+    return counts
+
+
+def apply(d: Decision) -> None:
+    if d.action == RENAME:
+        psql(f'ALTER TABLE public."{d.alias}" RENAME TO "{d.canonical}";')
+        print(f"  renamed  {d.alias} -> {d.canonical}")
+
+    elif d.action == DROP:
+        # The only destructive operation here. Take an ACCESS EXCLUSIVE lock, then
+        # re-count INSIDE the transaction: a table that gained a row between the
+        # decision and now raises and rolls back rather than losing data.
+        #
+        # NB: '%' is plpgsql's RAISE placeholder. Python f-strings do not treat '%'
+        # specially, so write exactly one — '%%' would emit a literal '%%' and
+        # plpgsql would try to substitute twice against a single argument.
+        guards = "\n".join(
+            f'  LOCK TABLE public."{t}" IN ACCESS EXCLUSIVE MODE;\n'
+            f'  SELECT count(*) INTO n FROM public."{t}";\n'
+            f"  IF n > 0 THEN RAISE EXCEPTION "
+            f"'{t} gained % rows since the check; refusing to drop', n; END IF;"
+            for t in d.tables
+        )
+        drops = "\n".join(f'DROP TABLE public."{t}" CASCADE;' for t in d.tables)
+        psql(f"""
+BEGIN;
+DO $$
+DECLARE n bigint;
+BEGIN
+{guards}
+END $$;
+{drops}
+COMMIT;
+""")
+        print(f"  rebuilt  dropped empty {', '.join(d.tables)} (migrator will recreate)")
+
+
+def main() -> int:
+    services = load_map(MAP_PATH)
+    present = list_tables()
+
+    # Decide everything first, so an abort happens BEFORE anything is modified.
+    decisions: List[Decision] = []
+    for service, spec in services.items():
+        data_tables = [t for t in (spec.get("data_tables") or []) if t in present]
+        counts = count_rows(data_tables) if data_tables else {}
+        decisions.append(decide(service, spec, present, counts))
+
+    aborts = [d for d in decisions if d.action == ABORT]
+    if aborts:
+        print("\ndb-history-normalize: ABORT\n", file=sys.stderr)
+        for d in aborts:
+            print(f"  {d.service}: {d.reason}\n", file=sys.stderr)
+        print("Refusing to start migrators. No data was modified.", file=sys.stderr)
+        return 1
+
+    print("db-history-normalize: normalizing Flyway history")
+    for d in decisions:
+        apply(d)
+
+    # A history table we do not recognise is harmless: no migrator exists for it,
+    # so nothing would replay against it. Say so, but do not fail.
+    known = set()
+    for spec in services.values():
+        known.add(spec["canonical"])
+        known.update(spec.get("aliases") or [])
+    for orphan in sorted(history_tables() - known):
+        print(f"  warning  unrecognised history table {orphan!r} — no migrator owns it, skipping")
+
+    tally = {a: sum(1 for d in decisions if d.action == a) for a in (NOOP, RENAME, DROP, SKIP)}
+    print(
+        f"ok: renamed {tally[RENAME]}, rebuilt {tally[DROP]}, "
+        f"already-aligned {tally[NOOP]}, skipped {tally[SKIP]}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/local-setup/db/normalize/normalize.py
+++ b/local-setup/db/normalize/normalize.py
@@ -156,7 +156,7 @@ def count_rows(tables: Iterable[str]) -> Dict[str, int]:
 def apply(d: Decision) -> None:
     if d.action == RENAME:
         psql(f'ALTER TABLE public."{d.alias}" RENAME TO "{d.canonical}";')
-        print(f"  renamed  {d.alias} -> {d.canonical}")
+        print(f"  renamed  {d.service}: {d.alias} -> {d.canonical}")
 
     elif d.action == DROP:
         # The only destructive operation here. Take an ACCESS EXCLUSIVE lock, then
@@ -184,7 +184,10 @@ END $$;
 {drops}
 COMMIT;
 """)
-        print(f"  rebuilt  dropped empty {', '.join(d.tables)} (migrator will recreate)")
+        # NOTE: a rebuilt service's migrator will APPLY its migrations (it has to —
+        # we just dropped its tables). It will NOT report "No migration necessary".
+        # That is correct, and the integration test asserts it per path.
+        print(f"  rebuilt  {d.service}: dropped empty {', '.join(d.tables)} (migrator will recreate)")
 
 
 def main() -> int:

--- a/local-setup/db/normalize/test-integration.sh
+++ b/local-setup/db/normalize/test-integration.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Proof for db-history-normalize, against a REAL dump and the REAL pinned images.
+#
+#   ./test-integration.sh /path/to/dump.sql
+#
+# A) POSITIVE — dump + normalizer + all 11 migrators:
+#      every migrator reports "No migration necessary", and a row-count +
+#      content-checksum snapshot of every table is byte-identical before/after.
+# B) NEGATIVE — dump + all 11 migrators, normalizer SKIPPED:
+#      data IS destroyed. If this ever stops failing, the guard has been silently
+#      disabled and the positive test alone would not tell us.
+#
+# Runs entirely in throwaway containers on their own network. Never touches a
+# running stack.
+set -euo pipefail
+
+DUMP="${1:?usage: test-integration.sh /path/to/dump.sql}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MAP="$HERE/../flyway-history-map.yml"
+PG_IMAGE="registry.preview.egov.theflywheel.in/postgres:16"
+NET=normalize-it
+WORK="$(mktemp -d)"
+trap 'docker rm -f it-pos it-neg >/dev/null 2>&1 || true; docker network rm $NET >/dev/null 2>&1 || true; rm -rf "$WORK"' EXIT
+
+MIGRATORS=(
+  "boundary-service|boundary-service-db:v2.9.2-4a60f20|boundary_service_schema"
+  "egov-user|egov-user-db:master-d69ce29|egov_user_schema"
+  "mdms-backend|mdms-v2-db:v2.9.2-4a60f20|mdms_v2_schema"
+  "egov-idgen|egov-idgen-db:v2.9.2-4a60f20|egov_idgen_schema"
+  "egov-localization|egov-localization-db:v2.9.2-4a60f20|egov_localization_schema"
+  "egov-enc-service|egov-enc-service-db:v2.9.2-4a60f20|egov_enc_service_schema"
+  "egov-filestore|egov-filestore-db:v2.9.2-4a60f20|egov_filestore_schema"
+  "egov-workflow-v2|egov-workflow-v2-db:v2.9.2-4a60f20|egov_workflow_v2_schema"
+  "egov-hrms|egov-hrms-db:hrms-boundary-0a4e737|egov_hrms_schema"
+  "egov-url-shortening|egov-url-shortening-db:v2.9.2-4a60f20|egov-url-shortening_schema"
+  "egov-otp|egov-otp-db:v2.9.2-4a60f20|egov_otp_schema"
+)
+
+# Row count + content checksum for every table in public.
+cat > "$WORK/snapshot.sql" <<'SQL'
+SELECT c.relname,
+       (xpath('/row/c/text()', query_to_xml(format('select count(*) as c from public.%I', c.relname), false,true,'')))[1]::text::bigint,
+       (xpath('/row/c/text()', query_to_xml(format('select coalesce(md5(string_agg(t::text, E''\n'' ORDER BY t::text)),''EMPTY'') as c from public.%I t', c.relname), false,true,'')))[1]::text
+FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'public' AND c.relkind = 'r'
+ORDER BY 1;
+SQL
+
+start_db() {  # $1 = container name
+  docker rm -f "$1" >/dev/null 2>&1 || true
+  docker run -d --name "$1" --network $NET \
+    -e POSTGRES_USER=egov -e POSTGRES_PASSWORD=egov123 -e POSTGRES_DB=egov \
+    "$PG_IMAGE" >/dev/null
+  until docker exec "$1" pg_isready -U egov >/dev/null 2>&1; do sleep 2; done
+  docker cp "$DUMP" "$1:/tmp/dump.sql" >/dev/null
+  docker cp "$WORK/snapshot.sql" "$1:/tmp/snapshot.sql" >/dev/null
+  # ON_ERROR_STOP: psql errors read "psql:file:line: ERROR:", so never grep ^ERROR.
+  docker exec "$1" psql -U egov -d egov -q -v ON_ERROR_STOP=1 -f /tmp/dump.sql >/dev/null
+}
+snapshot() { docker exec "$1" psql -U egov -d egov -tA -F'|' -f /tmp/snapshot.sql; }
+
+run_migrators() {  # $1 = db container; echoes "<name> <exit> <verdict>" per line
+  local m name image table log rc
+  for m in "${MIGRATORS[@]}"; do
+    IFS='|' read -r name image table <<< "$m"
+    log="$WORK/$1-$name.log"
+    docker run --rm --network $NET \
+      -e DB_URL="jdbc:postgresql://$1:5432/egov" -e SCHEMA_NAME=public -e SCHEMA_TABLE="$table" \
+      -e FLYWAY_USER=egov -e FLYWAY_PASSWORD=egov123 \
+      -e FLYWAY_LOCATIONS=filesystem:/flyway/sql -e FLYWAY_VALIDATE_ON_MIGRATE=false \
+      "egovio/$image" > "$log" 2>&1 && rc=0 || rc=$?
+    if grep -q "No migration necessary" "$log"; then echo "$name $rc noop"
+    else echo "$name $rc applied-or-failed"; fi
+  done
+}
+
+normalize() {  # $1 = db container
+  docker run --rm --network $NET \
+    -e PGHOST="$1" -e PGUSER=egov -e PGPASSWORD=egov123 -e PGDATABASE=egov \
+    -v "$MAP:/map.yml:ro" db-history-normalize:test
+}
+
+docker network create $NET >/dev/null 2>&1 || true
+docker build -q -t db-history-normalize:test "$HERE" >/dev/null
+
+# ── A) POSITIVE ───────────────────────────────────────────────────────────────
+echo "=== A) POSITIVE: dump -> normalize -> migrators ==="
+start_db it-pos
+snapshot it-pos > "$WORK/pos-before.txt"
+
+normalize it-pos | tee "$WORK/first-run.log"
+
+# Services whose empty orphan tables the normalizer dropped. Their migrators MUST
+# apply their migrations (we just removed the tables) — demanding a no-op from
+# them would be wrong. Every other service must no-op.
+REBUILT="$(sed -n 's/^  rebuilt  \([a-z0-9-]*\):.*/\1/p' "$WORK/first-run.log" | tr '\n' ' ')"
+echo "  rebuild path: ${REBUILT:-<none>}"
+
+# Idempotency: a second run must change nothing and still exit 0.
+normalize it-pos > "$WORK/second-run.log"
+grep -q "renamed 0, rebuilt 0" "$WORK/second-run.log" || {
+  echo "FAIL: normalizer is not idempotent"; cat "$WORK/second-run.log"; exit 1; }
+echo "  idempotent: second run renamed 0, rebuilt 0"
+
+fail=0
+while read -r name rc verdict; do
+  expect=noop
+  case " $REBUILT " in *" $name "*) expect=applied-or-failed ;; esac
+  printf "  %-22s exit=%s %-18s (expect %s)\n" "$name" "$rc" "$verdict" "$expect"
+  if [ "$rc" != "0" ]; then
+    echo "    FAIL: $name exited $rc"; fail=1
+  elif [ "$verdict" != "$expect" ]; then
+    echo "    FAIL: $name expected $expect, got $verdict"; fail=1
+  fi
+done < <(run_migrators it-pos)
+[ "$fail" = "0" ] || { echo "FAIL: migrators did not behave as expected"; exit 1; }
+
+snapshot it-pos > "$WORK/pos-after.txt"
+# Assert every table that EXISTED BEFORE is byte-identical. (Tables the migrators
+# legitimately create, e.g. a fresh egov_otp_schema, are simply not in `before`.)
+if ! join -t'|' -j1 <(sort -t'|' -k1,1 "$WORK/pos-before.txt") <(sort -t'|' -k1,1 "$WORK/pos-after.txt") \
+     | awk -F'|' '$2!=$4 || $3!=$5 {print "    CHANGED: "$0; bad=1} END {exit bad?1:0}'; then
+  echo "FAIL: pre-existing data changed"; exit 1
+fi
+echo "  PASS: every pre-existing table byte-identical (rows + checksum)"
+
+# ── B) NEGATIVE ───────────────────────────────────────────────────────────────
+echo "=== B) NEGATIVE: dump -> migrators, normalizer SKIPPED (must destroy data) ==="
+start_db it-neg
+snapshot it-neg > "$WORK/neg-before.txt"
+run_migrators it-neg >/dev/null
+snapshot it-neg > "$WORK/neg-after.txt"
+
+destroyed=0
+for t in message eg_enc_symmetric_keys eg_enc_asymmetric_keys; do
+  before=$(awk -F'|' -v t="$t" '$1==t {print $2}' "$WORK/neg-before.txt")
+  after=$(awk -F'|' -v t="$t" '$1==t {print $2}' "$WORK/neg-after.txt")
+  printf "  %-24s %s -> %s\n" "$t" "${before:-?}" "${after:-?}"
+  if [ -n "$before" ] && [ "$before" -gt 0 ] && [ "$after" = "0" ]; then
+    destroyed=$((destroyed + 1))
+  fi
+done
+[ "$destroyed" = "3" ] || {
+  echo "FAIL: the unguarded run did NOT destroy data as expected."
+  echo "      Either the migration images changed, or the guard is being applied"
+  echo "      when it should not be. Do not ship until this is understood."
+  exit 1
+}
+echo "  PASS: unguarded run destroys data — the guard is doing real work"
+
+echo
+echo "ALL PASS: normalizer makes the dump safe; without it the data is destroyed."

--- a/local-setup/docker-compose.migrations.ansible.yml
+++ b/local-setup/docker-compose.migrations.ansible.yml
@@ -1,0 +1,27 @@
+# Ansible-only companion to docker-compose.migrations.yml.
+#
+# Three migrators (pgr-services, novu-bridge, digit-config-service) build from
+# the in-repo path ../backend/<svc>/src/main/resources/db. That resolves when you
+# run compose from local-setup/ in a repo checkout, but a deployed host has no
+# backend/ tree — so the playbook syncs those contexts to docker/<svc>-db/ and
+# this overlay repoints the builds at them.
+#
+# Layered by the playbook immediately AFTER docker-compose.migrations.yml. Nothing
+# else here: the 11 core migrators pull pinned egovio/*-db images and need no
+# build context, and db-history-normalize builds from ./db/normalize, which is
+# already synced as part of db/.
+#
+# If you are running compose straight from the repo, you do NOT want this file —
+# docker-compose.migrations.yml is already correct on its own.
+services:
+  pgr-services-migration:
+    build:
+      context: ./docker/pgr-services-db
+
+  novu-bridge-migration:
+    build:
+      context: ./docker/novu-bridge-db
+
+  digit-config-service-migration:
+    build:
+      context: ./docker/digit-config-service-db

--- a/local-setup/docker-compose.migrations.yml
+++ b/local-setup/docker-compose.migrations.yml
@@ -1,8 +1,11 @@
-# Deployment-parity item #10 — per-service Flyway init containers (pilot).
+# Deployment-parity item #10 — per-service Flyway init containers.
 # Mirrors the K8s db-migration init container: a one-shot Flyway run per
-# service, from the same in-repo <service>-db image, writing history to the
-# K8s <service>_schema table, connected DIRECTLY to postgres-db (never the
+# service, from the same <service>-db image, writing history to the K8s
+# <service>_schema table, connected DIRECTLY to postgres-db (never the
 # pgbouncer 'postgres' alias, which runs in transaction mode and breaks Flyway).
+#
+# How future migrations flow, conditions, testing & troubleshooting:
+#   docs/db-migration-flow.md
 services:
   pgr-services-migration:
     build:

--- a/local-setup/docker-compose.migrations.yml
+++ b/local-setup/docker-compose.migrations.yml
@@ -7,6 +7,35 @@
 # How future migrations flow, conditions, testing & troubleshooting:
 #   docs/db-migration-flow.md
 services:
+  # ── Guard · runs before EVERY migrator ──────────────────────────────────────
+  # An operator-supplied dump carries the LEGACY compose history-table names
+  # (*_schema_version). The -db migrator images look for the K8s <service>_schema
+  # names. On a mismatch Flyway sees an empty history, replays from V1 against a
+  # populated database, and egov-localization + egov-enc-service DROP+recreate
+  # their tables and exit 0 — silent, unrecoverable data loss (the encryption keys
+  # that decrypt all user PII). This renames them into place first, and aborts the
+  # deploy on anything it cannot prove safe.
+  #   docs/superpowers/specs/2026-07-13-ansible-flyway-history-normalization-design.md
+  db-history-normalize:
+    build:
+      context: ./db/normalize
+    container_name: db-history-normalize
+    depends_on:
+      postgres-db:
+        condition: service_healthy
+    environment:
+      PGHOST: postgres-db
+      PGPORT: "5432"
+      PGUSER: egov
+      PGPASSWORD: ${POSTGRES_PASSWORD:-egov123}
+      PGDATABASE: egov
+      MAP_PATH: /map.yml
+    volumes:
+      - ./db/flyway-history-map.yml:/map.yml:ro
+    restart: "no"
+    networks:
+      - egov-network
+
   pgr-services-migration:
     build:
       context: ../backend/pgr-services/src/main/resources/db
@@ -14,6 +43,8 @@ services:
     depends_on:
       postgres-db:
         condition: service_healthy
+      db-history-normalize:
+        condition: service_completed_successfully
       # pgr's analytics migrations build materialized views that read other
       # services' tables (boundary_relationship/_hierarchy, eg_user, eg_mdms_data,
       # eg_wf_*). Gate on those services being healthy so their schemas exist
@@ -55,6 +86,10 @@ services:
     depends_on:
       postgres-db:
         condition: service_healthy
+      # db-history-normalize carries no profile, so it is always active and
+      # satisfies this gate in every profile combination.
+      db-history-normalize:
+        condition: service_completed_successfully
     environment:
       DB_URL: jdbc:postgresql://postgres-db:5432/egov
       SCHEMA_TABLE: novu_bridge_schema
@@ -81,6 +116,8 @@ services:
     depends_on:
       postgres-db:
         condition: service_healthy
+      db-history-normalize:
+        condition: service_completed_successfully
     environment:
       DB_URL: jdbc:postgresql://postgres-db:5432/egov
       # digit-config-service's migrate.sh sets currentSchema per SCHEMA_NAME.
@@ -110,7 +147,9 @@ services:
   boundary-service-migration:
     image: egovio/boundary-service-db:v2.9.2-4a60f20
     container_name: boundary-service-migration
-    depends_on: { postgres-db: { condition: service_healthy } }
+    depends_on:
+      postgres-db: { condition: service_healthy }
+      db-history-normalize: { condition: service_completed_successfully }
     environment:
       DB_URL: jdbc:postgresql://postgres-db:5432/egov
       SCHEMA_NAME: public
@@ -128,7 +167,9 @@ services:
   egov-user-migration:
     image: egovio/egov-user-db:master-d69ce29
     container_name: egov-user-migration
-    depends_on: { postgres-db: { condition: service_healthy } }
+    depends_on:
+      postgres-db: { condition: service_healthy }
+      db-history-normalize: { condition: service_completed_successfully }
     environment:
       DB_URL: jdbc:postgresql://postgres-db:5432/egov
       SCHEMA_NAME: public
@@ -146,7 +187,9 @@ services:
   mdms-backend-migration:
     image: egovio/mdms-v2-db:v2.9.2-4a60f20
     container_name: mdms-backend-migration
-    depends_on: { postgres-db: { condition: service_healthy } }
+    depends_on:
+      postgres-db: { condition: service_healthy }
+      db-history-normalize: { condition: service_completed_successfully }
     environment:
       DB_URL: jdbc:postgresql://postgres-db:5432/egov
       SCHEMA_NAME: public
@@ -164,7 +207,9 @@ services:
   egov-idgen-migration:
     image: egovio/egov-idgen-db:v2.9.2-4a60f20
     container_name: egov-idgen-migration
-    depends_on: { postgres-db: { condition: service_healthy } }
+    depends_on:
+      postgres-db: { condition: service_healthy }
+      db-history-normalize: { condition: service_completed_successfully }
     environment:
       DB_URL: jdbc:postgresql://postgres-db:5432/egov
       SCHEMA_NAME: public
@@ -182,7 +227,9 @@ services:
   egov-localization-migration:
     image: egovio/egov-localization-db:v2.9.2-4a60f20
     container_name: egov-localization-migration
-    depends_on: { postgres-db: { condition: service_healthy } }
+    depends_on:
+      postgres-db: { condition: service_healthy }
+      db-history-normalize: { condition: service_completed_successfully }
     environment:
       DB_URL: jdbc:postgresql://postgres-db:5432/egov
       SCHEMA_NAME: public
@@ -200,7 +247,9 @@ services:
   egov-enc-service-migration:
     image: egovio/egov-enc-service-db:v2.9.2-4a60f20
     container_name: egov-enc-service-migration
-    depends_on: { postgres-db: { condition: service_healthy } }
+    depends_on:
+      postgres-db: { condition: service_healthy }
+      db-history-normalize: { condition: service_completed_successfully }
     environment:
       DB_URL: jdbc:postgresql://postgres-db:5432/egov
       SCHEMA_NAME: public
@@ -218,7 +267,9 @@ services:
   egov-filestore-migration:
     image: egovio/egov-filestore-db:v2.9.2-4a60f20
     container_name: egov-filestore-migration
-    depends_on: { postgres-db: { condition: service_healthy } }
+    depends_on:
+      postgres-db: { condition: service_healthy }
+      db-history-normalize: { condition: service_completed_successfully }
     environment:
       DB_URL: jdbc:postgresql://postgres-db:5432/egov
       SCHEMA_NAME: public
@@ -236,7 +287,9 @@ services:
   egov-workflow-v2-migration:
     image: egovio/egov-workflow-v2-db:v2.9.2-4a60f20
     container_name: egov-workflow-v2-migration
-    depends_on: { postgres-db: { condition: service_healthy } }
+    depends_on:
+      postgres-db: { condition: service_healthy }
+      db-history-normalize: { condition: service_completed_successfully }
     environment:
       DB_URL: jdbc:postgresql://postgres-db:5432/egov
       SCHEMA_NAME: public
@@ -254,7 +307,9 @@ services:
   egov-hrms-migration:
     image: egovio/egov-hrms-db:hrms-boundary-0a4e737
     container_name: egov-hrms-migration
-    depends_on: { postgres-db: { condition: service_healthy } }
+    depends_on:
+      postgres-db: { condition: service_healthy }
+      db-history-normalize: { condition: service_completed_successfully }
     environment:
       DB_URL: jdbc:postgresql://postgres-db:5432/egov
       SCHEMA_NAME: public
@@ -272,7 +327,9 @@ services:
   egov-url-shortening-migration:
     image: egovio/egov-url-shortening-db:v2.9.2-4a60f20
     container_name: egov-url-shortening-migration
-    depends_on: { postgres-db: { condition: service_healthy } }
+    depends_on:
+      postgres-db: { condition: service_healthy }
+      db-history-normalize: { condition: service_completed_successfully }
     environment:
       DB_URL: jdbc:postgresql://postgres-db:5432/egov
       SCHEMA_NAME: public
@@ -292,7 +349,9 @@ services:
     image: egovio/egov-otp-db:v2.9.2-4a60f20
     container_name: egov-otp-migration
     profiles: ["otp"]
-    depends_on: { postgres-db: { condition: service_healthy } }
+    depends_on:
+      postgres-db: { condition: service_healthy }
+      db-history-normalize: { condition: service_completed_successfully }
     environment:
       DB_URL: jdbc:postgresql://postgres-db:5432/egov
       SCHEMA_NAME: public

--- a/local-setup/docker-compose.migrations.yml
+++ b/local-setup/docker-compose.migrations.yml
@@ -97,3 +97,217 @@ services:
     depends_on:
       digit-config-service-migration:
         condition: service_completed_successfully
+
+  # ── Phase 3 · core services ─────────────────────────────────────────────────
+  # Pull the EXACT egovio/<service>-db:<tag> images K8s pins (image-level parity).
+  # The dump is re-baked so its Flyway history carries these images' real
+  # migration rows under the K8s <service>_schema names → the migrators no-op on
+  # the fast path. Env matches the -db images' migrate.sh contract.
+
+  boundary-service-migration:
+    image: egovio/boundary-service-db:v2.9.2-4a60f20
+    container_name: boundary-service-migration
+    depends_on: { postgres-db: { condition: service_healthy } }
+    environment:
+      DB_URL: jdbc:postgresql://postgres-db:5432/egov
+      SCHEMA_NAME: public
+      SCHEMA_TABLE: boundary_service_schema
+      FLYWAY_USER: egov
+      FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
+      FLYWAY_LOCATIONS: filesystem:/flyway/sql
+      FLYWAY_VALIDATE_ON_MIGRATE: "false"
+    restart: "no"
+    networks: [egov-network]
+  boundary-service:
+    environment: { SPRING_FLYWAY_ENABLED: "false" }
+    depends_on: { boundary-service-migration: { condition: service_completed_successfully } }
+
+  egov-user-migration:
+    image: egovio/egov-user-db:master-d69ce29
+    container_name: egov-user-migration
+    depends_on: { postgres-db: { condition: service_healthy } }
+    environment:
+      DB_URL: jdbc:postgresql://postgres-db:5432/egov
+      SCHEMA_NAME: public
+      SCHEMA_TABLE: egov_user_schema
+      FLYWAY_USER: egov
+      FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
+      FLYWAY_LOCATIONS: filesystem:/flyway/sql
+      FLYWAY_VALIDATE_ON_MIGRATE: "false"
+    restart: "no"
+    networks: [egov-network]
+  egov-user:
+    environment: { SPRING_FLYWAY_ENABLED: "false" }
+    depends_on: { egov-user-migration: { condition: service_completed_successfully } }
+
+  mdms-backend-migration:
+    image: egovio/mdms-v2-db:v2.9.2-4a60f20
+    container_name: mdms-backend-migration
+    depends_on: { postgres-db: { condition: service_healthy } }
+    environment:
+      DB_URL: jdbc:postgresql://postgres-db:5432/egov
+      SCHEMA_NAME: public
+      SCHEMA_TABLE: mdms_v2_schema
+      FLYWAY_USER: egov
+      FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
+      FLYWAY_LOCATIONS: filesystem:/flyway/sql
+      FLYWAY_VALIDATE_ON_MIGRATE: "false"
+    restart: "no"
+    networks: [egov-network]
+  mdms-backend:
+    environment: { SPRING_FLYWAY_ENABLED: "false" }
+    depends_on: { mdms-backend-migration: { condition: service_completed_successfully } }
+
+  egov-idgen-migration:
+    image: egovio/egov-idgen-db:v2.9.2-4a60f20
+    container_name: egov-idgen-migration
+    depends_on: { postgres-db: { condition: service_healthy } }
+    environment:
+      DB_URL: jdbc:postgresql://postgres-db:5432/egov
+      SCHEMA_NAME: public
+      SCHEMA_TABLE: egov_idgen_schema
+      FLYWAY_USER: egov
+      FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
+      FLYWAY_LOCATIONS: filesystem:/flyway/sql
+      FLYWAY_VALIDATE_ON_MIGRATE: "false"
+    restart: "no"
+    networks: [egov-network]
+  egov-idgen:
+    environment: { SPRING_FLYWAY_ENABLED: "false" }
+    depends_on: { egov-idgen-migration: { condition: service_completed_successfully } }
+
+  egov-localization-migration:
+    image: egovio/egov-localization-db:v2.9.2-4a60f20
+    container_name: egov-localization-migration
+    depends_on: { postgres-db: { condition: service_healthy } }
+    environment:
+      DB_URL: jdbc:postgresql://postgres-db:5432/egov
+      SCHEMA_NAME: public
+      SCHEMA_TABLE: egov_localization_schema
+      FLYWAY_USER: egov
+      FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
+      FLYWAY_LOCATIONS: filesystem:/flyway/sql
+      FLYWAY_VALIDATE_ON_MIGRATE: "false"
+    restart: "no"
+    networks: [egov-network]
+  egov-localization:
+    environment: { SPRING_FLYWAY_ENABLED: "false" }
+    depends_on: { egov-localization-migration: { condition: service_completed_successfully } }
+
+  egov-enc-service-migration:
+    image: egovio/egov-enc-service-db:v2.9.2-4a60f20
+    container_name: egov-enc-service-migration
+    depends_on: { postgres-db: { condition: service_healthy } }
+    environment:
+      DB_URL: jdbc:postgresql://postgres-db:5432/egov
+      SCHEMA_NAME: public
+      SCHEMA_TABLE: egov_enc_service_schema
+      FLYWAY_USER: egov
+      FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
+      FLYWAY_LOCATIONS: filesystem:/flyway/sql
+      FLYWAY_VALIDATE_ON_MIGRATE: "false"
+    restart: "no"
+    networks: [egov-network]
+  egov-enc-service:
+    environment: { SPRING_FLYWAY_ENABLED: "false" }
+    depends_on: { egov-enc-service-migration: { condition: service_completed_successfully } }
+
+  egov-filestore-migration:
+    image: egovio/egov-filestore-db:v2.9.2-4a60f20
+    container_name: egov-filestore-migration
+    depends_on: { postgres-db: { condition: service_healthy } }
+    environment:
+      DB_URL: jdbc:postgresql://postgres-db:5432/egov
+      SCHEMA_NAME: public
+      SCHEMA_TABLE: egov_filestore_schema
+      FLYWAY_USER: egov
+      FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
+      FLYWAY_LOCATIONS: filesystem:/flyway/sql
+      FLYWAY_VALIDATE_ON_MIGRATE: "false"
+    restart: "no"
+    networks: [egov-network]
+  egov-filestore:
+    environment: { SPRING_FLYWAY_ENABLED: "false" }
+    depends_on: { egov-filestore-migration: { condition: service_completed_successfully } }
+
+  egov-workflow-v2-migration:
+    image: egovio/egov-workflow-v2-db:v2.9.2-4a60f20
+    container_name: egov-workflow-v2-migration
+    depends_on: { postgres-db: { condition: service_healthy } }
+    environment:
+      DB_URL: jdbc:postgresql://postgres-db:5432/egov
+      SCHEMA_NAME: public
+      SCHEMA_TABLE: egov_workflow_v2_schema
+      FLYWAY_USER: egov
+      FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
+      FLYWAY_LOCATIONS: filesystem:/flyway/sql
+      FLYWAY_VALIDATE_ON_MIGRATE: "false"
+    restart: "no"
+    networks: [egov-network]
+  egov-workflow-v2:
+    environment: { SPRING_FLYWAY_ENABLED: "false" }
+    depends_on: { egov-workflow-v2-migration: { condition: service_completed_successfully } }
+
+  egov-hrms-migration:
+    image: egovio/egov-hrms-db:hrms-boundary-0a4e737
+    container_name: egov-hrms-migration
+    depends_on: { postgres-db: { condition: service_healthy } }
+    environment:
+      DB_URL: jdbc:postgresql://postgres-db:5432/egov
+      SCHEMA_NAME: public
+      SCHEMA_TABLE: egov_hrms_schema
+      FLYWAY_USER: egov
+      FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
+      FLYWAY_LOCATIONS: filesystem:/flyway/sql
+      FLYWAY_VALIDATE_ON_MIGRATE: "false"
+    restart: "no"
+    networks: [egov-network]
+  egov-hrms:
+    environment: { SPRING_FLYWAY_ENABLED: "false" }
+    depends_on: { egov-hrms-migration: { condition: service_completed_successfully } }
+
+  egov-url-shortening-migration:
+    image: egovio/egov-url-shortening-db:v2.9.2-4a60f20
+    container_name: egov-url-shortening-migration
+    depends_on: { postgres-db: { condition: service_healthy } }
+    environment:
+      DB_URL: jdbc:postgresql://postgres-db:5432/egov
+      SCHEMA_NAME: public
+      SCHEMA_TABLE: egov-url-shortening_schema   # hyphenated, as in the K8s chart
+      FLYWAY_USER: egov
+      FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
+      FLYWAY_LOCATIONS: filesystem:/flyway/sql
+      FLYWAY_VALIDATE_ON_MIGRATE: "false"
+    restart: "no"
+    networks: [egov-network]
+  egov-url-shortening:
+    environment: { SPRING_FLYWAY_ENABLED: "false" }
+    depends_on: { egov-url-shortening-migration: { condition: service_completed_successfully } }
+
+  # otp is [otp]-profile-gated; its migrator carries the same profile.
+  egov-otp-migration:
+    image: egovio/egov-otp-db:v2.9.2-4a60f20
+    container_name: egov-otp-migration
+    profiles: ["otp"]
+    depends_on: { postgres-db: { condition: service_healthy } }
+    environment:
+      DB_URL: jdbc:postgresql://postgres-db:5432/egov
+      SCHEMA_NAME: public
+      SCHEMA_TABLE: egov_otp_schema
+      FLYWAY_USER: egov
+      FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
+      FLYWAY_LOCATIONS: filesystem:/flyway/sql
+      FLYWAY_VALIDATE_ON_MIGRATE: "false"
+    restart: "no"
+    networks: [egov-network]
+  egov-otp:
+    environment: { SPRING_FLYWAY_ENABLED: "false" }
+    depends_on: { egov-otp-migration: { condition: service_completed_successfully } }
+
+  # Retire the consolidated db-migrations container. Its migrate-all.sh looks for
+  # the OLD *_schema_version tables, which the re-bake renamed to K8s names — it
+  # would 42P07 and block its dependents (idgen/user/localization), which now have
+  # their own migrators. No-op it so its unremovable service_completed_successfully
+  # gate is satisfied.
+  db-migrations:
+    entrypoint: ["true"]

--- a/local-setup/docker-compose.migrations.yml
+++ b/local-setup/docker-compose.migrations.yml
@@ -1,0 +1,23 @@
+# Deployment-parity item #10 — per-service Flyway init containers (pilot).
+# Mirrors the K8s db-migration init container: a one-shot Flyway run per
+# service, from the same in-repo <service>-db image, writing history to the
+# K8s <service>_schema table, connected DIRECTLY to postgres-db (never the
+# pgbouncer 'postgres' alias, which runs in transaction mode and breaks Flyway).
+services:
+  pgr-services-migration:
+    build:
+      context: ../backend/pgr-services/src/main/resources/db
+    container_name: pgr-services-migration
+    depends_on:
+      postgres-db:
+        condition: service_healthy
+    environment:
+      DB_URL: jdbc:postgresql://postgres-db:5432/egov
+      SCHEMA_TABLE: pgr_services_schema
+      FLYWAY_USER: egov
+      FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
+      FLYWAY_LOCATIONS: filesystem:/flyway/sql
+      FLYWAY_VALIDATE_ON_MIGRATE: "false"
+    restart: "no"
+    networks:
+      - egov-network

--- a/local-setup/docker-compose.migrations.yml
+++ b/local-setup/docker-compose.migrations.yml
@@ -21,3 +21,11 @@ services:
     restart: "no"
     networks:
       - egov-network
+
+  # The app no longer self-migrates; the init container above owns it.
+  pgr-services:
+    environment:
+      SPRING_FLYWAY_ENABLED: "false"
+    depends_on:
+      pgr-services-migration:
+        condition: service_completed_successfully

--- a/local-setup/docker-compose.migrations.yml
+++ b/local-setup/docker-compose.migrations.yml
@@ -11,6 +11,19 @@ services:
     depends_on:
       postgres-db:
         condition: service_healthy
+      # pgr's analytics migrations build materialized views that read other
+      # services' tables (boundary_relationship/_hierarchy, eg_user, eg_mdms_data,
+      # eg_wf_*). Gate on those services being healthy so their schemas exist
+      # before this migrator runs — deterministic ordering, unlike K8s which
+      # relies on init-container retry. (See docs/superpowers/specs item #10.)
+      boundary-service:
+        condition: service_healthy
+      egov-user:
+        condition: service_healthy
+      mdms-backend:
+        condition: service_healthy
+      egov-workflow-v2:
+        condition: service_healthy
     environment:
       DB_URL: jdbc:postgresql://postgres-db:5432/egov
       SCHEMA_TABLE: pgr_services_schema

--- a/local-setup/docker-compose.migrations.yml
+++ b/local-setup/docker-compose.migrations.yml
@@ -42,3 +42,58 @@ services:
     depends_on:
       pgr-services-migration:
         condition: service_completed_successfully
+
+  # ── Phase 2 · repo-local, self-contained services ───────────────────────────
+  novu-bridge-migration:
+    build:
+      context: ../backend/novu-bridge/src/main/resources/db
+    container_name: novu-bridge-migration
+    profiles: ["notifications"]   # active exactly when novu-bridge is
+    depends_on:
+      postgres-db:
+        condition: service_healthy
+    environment:
+      DB_URL: jdbc:postgresql://postgres-db:5432/egov
+      SCHEMA_TABLE: novu_bridge_schema
+      FLYWAY_USER: egov
+      FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
+      FLYWAY_LOCATIONS: filesystem:/flyway/sql
+      FLYWAY_VALIDATE_ON_MIGRATE: "false"
+    restart: "no"
+    networks:
+      - egov-network
+
+  novu-bridge:
+    environment:
+      SPRING_FLYWAY_ENABLED: "false"
+    depends_on:
+      novu-bridge-migration:
+        condition: service_completed_successfully
+
+  digit-config-service-migration:
+    build:
+      context: ../backend/digit-config-service/src/main/resources/db
+    container_name: digit-config-service-migration
+    profiles: ["notifications"]   # active exactly when digit-config-service is
+    depends_on:
+      postgres-db:
+        condition: service_healthy
+    environment:
+      DB_URL: jdbc:postgresql://postgres-db:5432/egov
+      # digit-config-service's migrate.sh sets currentSchema per SCHEMA_NAME.
+      SCHEMA_NAME: public
+      SCHEMA_TABLE: digit_config_service_schema
+      FLYWAY_USER: egov
+      FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
+      FLYWAY_LOCATIONS: filesystem:/flyway/sql
+      FLYWAY_VALIDATE_ON_MIGRATE: "false"
+    restart: "no"
+    networks:
+      - egov-network
+
+  digit-config-service:
+    environment:
+      SPRING_FLYWAY_ENABLED: "false"
+    depends_on:
+      digit-config-service-migration:
+        condition: service_completed_successfully

--- a/local-setup/tests/test_flyway_history_normalize.py
+++ b/local-setup/tests/test_flyway_history_normalize.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Decision-table tests for the Flyway history normalizer.
+
+The normalizer's safety properties all live in the pure `decide()` function:
+given what is in the database, what should we do? These tests pin every row of
+the decision table, including the two that exist to prevent data loss.
+"""
+import os
+import sys
+
+import pytest
+import yaml
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "db", "normalize")))
+
+from normalize import ABORT, DROP, NOOP, RENAME, SKIP, decide, load_map
+
+MAP_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "db", "flyway-history-map.yml")
+)
+
+SPEC = {
+    "canonical": "egov_user_schema",
+    "aliases": ["egov_user_schema_version"],
+    "data_tables": ["eg_user", "eg_role"],
+}
+
+
+def test_canonical_present_is_noop():
+    d = decide("egov-user", SPEC, {"egov_user_schema", "eg_user"}, {"eg_user": 534})
+    assert d.action == NOOP
+
+
+def test_legacy_alias_is_renamed_to_canonical():
+    d = decide("egov-user", SPEC, {"egov_user_schema_version", "eg_user"}, {"eg_user": 534})
+    assert d.action == RENAME
+    assert d.alias == "egov_user_schema_version"
+    assert d.canonical == "egov_user_schema"
+
+
+def test_both_canonical_and_alias_present_aborts_as_ambiguous():
+    present = {"egov_user_schema", "egov_user_schema_version", "eg_user"}
+    d = decide("egov-user", SPEC, present, {"eg_user": 534})
+    assert d.action == ABORT
+    assert "ambiguous" in d.reason.lower()
+
+
+def test_two_aliases_present_aborts_as_ambiguous():
+    spec = dict(SPEC, aliases=["egov_user_schema_version", "user_schema_version"])
+    present = {"egov_user_schema_version", "user_schema_version", "eg_user"}
+    d = decide("egov-user", spec, present, {"eg_user": 534})
+    assert d.action == ABORT
+    assert "ambiguous" in d.reason.lower()
+
+
+def test_no_history_and_no_data_is_noop_fresh_install():
+    d = decide("egov-user", SPEC, set(), {})
+    assert d.action == NOOP
+
+
+def test_no_history_but_empty_data_tables_are_dropped_for_rebuild():
+    # The egov-otp / eg_token shape: table present, history absent, zero rows.
+    d = decide("egov-user", SPEC, {"eg_user", "eg_role"}, {"eg_user": 0, "eg_role": 0})
+    assert d.action == DROP
+    assert set(d.tables) == {"eg_user", "eg_role"}
+
+
+def test_no_history_but_populated_data_tables_abort():
+    # THE important one: never drop rows we cannot prove are reproducible.
+    d = decide("egov-user", SPEC, {"eg_user", "eg_role"}, {"eg_user": 534, "eg_role": 0})
+    assert d.action == ABORT
+    assert "eg_user" in d.reason
+
+
+def test_embedded_services_are_skipped_entirely():
+    spec = {"canonical": "accesscontrol_schema_version", "embedded": True}
+    d = decide("egov-accesscontrol", spec, {"accesscontrol_schema_version"}, {})
+    assert d.action == SKIP
+
+
+def test_embedded_service_is_skipped_even_when_it_looks_wrong():
+    # No migrator exists for it, so nothing can replay against it. Hands off.
+    spec = {"canonical": "accesscontrol_schema_version", "embedded": True}
+    d = decide("egov-accesscontrol", spec, set(), {})
+    assert d.action == SKIP
+
+
+# ── the shipped map itself ────────────────────────────────────────────────────
+
+def test_shipped_map_parses_and_covers_every_migrator():
+    m = load_map(MAP_PATH)
+    # Every service with a -db migration init container in the compose overlay.
+    for svc in [
+        "boundary-service", "egov-user", "mdms-backend", "egov-idgen",
+        "egov-localization", "egov-enc-service", "egov-filestore",
+        "egov-workflow-v2", "egov-hrms", "egov-url-shortening", "egov-otp",
+        "pgr-services", "novu-bridge", "digit-config-service",
+    ]:
+        assert svc in m, f"{svc} missing from the map"
+        assert m[svc]["canonical"], f"{svc} has no canonical table"
+
+
+def test_shipped_map_carries_the_verified_legacy_aliases():
+    m = load_map(MAP_PATH)
+    # These ten renames were verified to take the team dump to zero data change.
+    assert m["boundary-service"]["aliases"] == ["boundary_schema_version"]
+    assert m["egov-enc-service"]["aliases"] == ["enc_schema_version"]
+    assert m["mdms-backend"]["aliases"] == ["mdms_schema_version"]
+    assert m["egov-workflow-v2"]["aliases"] == ["workflow_schema_version"]
+    assert m["egov-url-shortening"]["canonical"] == "egov-url-shortening_schema"
+
+
+def test_shipped_map_has_no_duplicate_table_names_across_services():
+    m = load_map(MAP_PATH)
+    seen = {}
+    for svc, spec in m.items():
+        for name in [spec["canonical"]] + list(spec.get("aliases") or []):
+            assert name not in seen, f"{name} claimed by both {seen[name]} and {svc}"
+            seen[name] = svc


### PR DESCRIPTION
## Plain-English summary

- Our system runs two ways — a **quick local setup** (Docker Compose) and the **real cloud setup** (Kubernetes) — and they applied database changes **differently**, which caused a real incident. This makes the local setup work **exactly like the cloud**.
- Every service now gets its **own "update the database" helper that runs before it starts**, and the local setup **pulls the *same* helper images the cloud uses** — so the two can't drift apart.
- **Future database changes flow in cleanly:** bump a version tag and the helper applies the change on the next startup; if there's nothing new, it does nothing (no risk).
- We had to **rebuild the "what's already applied" record** inside the pre-loaded database snapshot so the cloud helpers understand it (all real data left untouched) — otherwise they'd try to redo everything and crash.
- **Proven, not theory:** rebuilt the whole stack from scratch → every service came up healthy (27 healthy, 0 failed); faked a future change → the helper picked it up and applied it smoothly. Plus an automatic check + a runbook so the team can operate and extend it.

---

## What & why

**Deployment-parity item #10** — make the Docker Compose stack apply DB migrations the **same way Kubernetes does**: one Flyway **init container per service**, run before the app, using the **same `egovio/<service>-db:<pinned-tag>` image K8s pins**, writing to the same `<service>_schema` history table. This replaces compose's previous mix (embedded Flyway in some apps + one shared `db-migrations` container) and closes the gap behind a recent multi-day migration incident.

The whole point: **future migrations propagate cleanly and predictably** — bump a service's `-db` image tag, and its init container applies the pending migration on boot, exactly like K8s.

## What's in here

**Per-service Flyway init containers** (`local-setup/docker-compose.migrations.yml`) for **13 services**:
- **Repo-local** (built from the in-repo `db/Dockerfile`): `pgr-services`, `novu-bridge`, `digit-config-service`.
- **Core** (pull the exact K8s `egovio/<service>-db:<tag>` images): `boundary-service`, `egov-hrms`, `egov-user`, `egov-idgen`, `egov-localization`, `egov-enc-service`, `egov-filestore`, `egov-workflow-v2`, `mdms-v2`, `egov-url-shortening`, `egov-otp`.

Each: a one-shot migrator connected **directly to `postgres-db`** (not the pgbouncer/transaction-mode alias — which also dissolves the old `egov-otp` Flyway incompatibility), the app gated on it, embedded Flyway off. `pgr-services` is additionally **ordered** after the services its analytics views read.

**Dump re-bake** (`local-setup/db/full-dump.sql`) — the dump stored **baseline-only** Flyway history under compose-flavoured names, incompatible with the real K8s `-db` image lineages (they'd re-run migrations → `42P07`). Re-baked so each history table carries the **real** applied rows under the K8s `<service>_schema` names (data tables untouched).

**CI guard** (`.github/scripts/check-flyway-dump-alignment.py` + workflow) — asserts every service's history-table name lines up with the dump, catching the `42P07` naming class in a PR instead of at boot.

**Docs** — design spec, pilot plan, and an operator **runbook** (`docs/db-migration-flow.md`): how future migrations flow, the conditions for it to work, add/test/troubleshoot procedures, and dump-regeneration maintenance.

**Retired** the consolidated `db-migrations` container (no-op entrypoint) — its 3 dependents now self-migrate.

## Validated end-to-end (live)

- **Full-stack boot from the re-baked dump:** all 13 migrators `Exited (0)` (no-op), `pgr-services-migration` ran *after* its gated deps went healthy, all converted apps came up **healthy** — **27 healthy / 0 unhealthy / 0 failed**.
- **Future-migration smoke test:** simulated a newer `-db` image (real image + one new migration) → init container **applied it cleanly** (`Successfully applied 1 migration`), then **no-ops** on re-run (idempotent).
- **CI alignment check green:** 13 aligned / 3 baseline-fresh / 0 pending.

## Deliberately not changed

- `egov-accesscontrol` — kept on embedded Flyway (its K8s chart declares no `schemaTable`).
- `egov-indexer` — baseline-fresh, still embedded.
- `default-data-handler` (no migrations) and `digit-user-preferences-service` (GORM AutoMigrate) — **already at parity**; adding migrators would *create* divergence.

## Follow-ups (out of scope)

- Regenerate the dump from the `-db` images on a cadence (guards content drift — the CI check guards naming, the smoke test guards the apply path). Documented in the runbook.
- Apply the same per-service model to the K8s side is N/A (K8s already does this) — this PR brings compose *to* K8s, not the reverse.

## Draft

Opened as a draft; ready for a review of the approach before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-service migration orchestration that runs before each app starts, with embedded app migrations disabled.
  * Added a pre-migration “history normalization” step to safely align Flyway history tables with the expected canonical naming.
  * Added a dedicated CI workflow to validate dump/migration parity.
* **Bug Fixes**
  * Prevents Flyway from replaying or corrupting migrations when dump history table names don’t match expectations.
* **Documentation**
  * Updated migration parity, rollout, verification, and troubleshooting guidance for Compose and Kubernetes workflows, plus history normalization testing details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->