### PR TITLE
fix(pgr): boundary cascade allows NEXT at the deepest EXISTING level (CCSD-1974)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/BoundaryComponent.js
+++ b/digit-ui-esbuild/products/pgr/src/components/BoundaryComponent.js
@@ -214,8 +214,11 @@ useEffect(() => {
     // locality validation was firing only when children happened to
     // be attached, so County-level selections silently passed).
     const deepest = path[path.length - 1];
+    // Childless node = branch ends here in the data → leaf (same rule as
+    // handleSelection below; don't hold NEXT hostage to unseeded levels).
     const isDeepestLevel =
-      deepest?.boundaryType === hierarchy[hierarchy.length - 1];
+      deepest?.boundaryType === hierarchy[hierarchy.length - 1] ||
+      !(Array.isArray(deepest?.children) && deepest.children.length > 0);
     processedHintRef.current = hintKey;
     onSelect(config.key, { ...deepest, isLeaf: isDeepestLevel });
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -302,7 +305,15 @@ useEffect(() => {
     // `isLeaf` so validators can trust hierarchy depth instead of the
     // `.children` array (which isn't reliably preserved on the picked
     // node and let County-level selections pass — egovernments/CCRS#478).
-    const isDeepestLevel = index === boundaryHierarchy.length - 1;
+    // A branch may also END above the deepest configured level (data simply
+    // not seeded that deep — prod Tete→Tsangano has no Municípios): the last
+    // node that exists IS the finest answer for that branch, so a childless
+    // pick counts as leaf too. Safe against #478 because `selectedBoundary`
+    // here is the live tree node (children intact) — only downstream
+    // form-state copies lose `.children`, and those never reach this emit.
+    const isDeepestLevel =
+      index === boundaryHierarchy.length - 1 ||
+      !(Array.isArray(selectedBoundary.children) && selectedBoundary.children.length > 0);
     onSelect(config.key, { ...selectedBoundary, isLeaf: isDeepestLevel });
 
     // Load child boundaries


### PR DESCRIPTION
## Jira
[CCSD-1974](https://digit-discuss.atlassian.net/browse/CCSD-1974) — Moz: boundary cascade blocks NEXT when a branch has no deeper data (partial hierarchy)

## Problem (prod repro)
On digit.mctd.gov.mz citizen create: Província **Tete** → Distrito **Tsangano** has no Municípios seeded — NEXT stays disabled forever. The picked node was tagged `isLeaf` only when it sat at the **deepest configured hierarchy level**, so any branch whose data ends earlier could never validate.

## Fix
`BoundaryComponent.js` (shared by the citizen wizard and employee create): both `isLeaf` emit sites (manual pick + map auto-fill) now also tag a **childless node** as leaf — the last node that exists is the finest answer for that branch. Dropdowns already stopped rendering where data ends; only the validation tag was wrong.

- Full depth still enforced where children exist (non-leaf pick keeps NEXT disabled).
- Safe vs CCRS#478 (county-level selections silently passing): the emitter reads the **live tree node** with `.children` intact — only downstream form-state copies lose them, and those never reach the emit.

## Verification (headless Playwright, local)
Seeded a 2-level branch in `mz.ige` (`MAPUTO_PROVINCE > TESTE_DISTRITO`, no municípios):
- childless Distrito → **no** Município dropdown rendered, **NEXT enabled**, advances to Details ✅
- control MATOLA (has municípios) → NEXT stays **disabled** until the Município is picked, then enables ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CCSD-1974]: https://digit-discuss.atlassian.net/browse/CCSD-1974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---
## QA verification (before/after)
Full report + screenshots (desktop 1440×900 + mobile 390×844) in the shared QA folder:
`~/Desktop/CCRS-QA/CCSD-1974/` (TEST-REPORT.md, before-/after-desktop.png, before-/after-mobile.png).

Real flow driven headless (citizen login → IGE authority → type → Província Maputo → Distrito *Teste Distrito (sem municípios)*), NEXT-button state asserted:
```
before/desktop: NEXT disabled=true      after/desktop: NEXT disabled=false
before/mobile:  NEXT disabled=true      after/mobile:  NEXT disabled=false
```
Negative control: MATOLA (Distrito with Municípios) keeps NEXT disabled until the Município is picked — full depth still enforced.