### PR TITLE
fix(pgr): citizen create wizard — clean entry + Moz QA validation batch (CCSD-1969/1978/1979/1980)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
@@ -306,12 +306,14 @@ const STEPS = [
 // key, which Module.js clears on every citizen-home mount.
 const CREATE_DRAFT_KEY = "PGR_CREATE_CITIZEN_DRAFT";
 
-// The saved step POSITION may only be restored when the document itself was
-// RELOADED (mid-flow F5) — and only by the first wizard mount after it. Any
-// other entry (SPA links, and sidebar items that hard-navigate like "Citizen
-// Complaint Resolution System") starts at step 1 with the answers kept. The
-// flag is consumed on first use so later SPA re-entries within the same
-// document also start at step 1.
+// The saved draft (answers AND step position) may only be restored when the
+// document itself was RELOADED (mid-flow F5) — and only by the first wizard
+// mount after it. Any other entry (SPA links, and sidebar items that
+// hard-navigate like "Citizen Complaint Resolution System") is a FRESH start:
+// the stored draft is discarded entirely — answers included (user feedback:
+// re-entering via "File a Complaint" with pre-filled fields reads as stale
+// state, matching the pre-draft behaviour). The flag is consumed on first use
+// so later SPA re-entries within the same document also start clean.
 let RESTORE_STEP_ARMED = (() => {
   try {
     const nav = performance.getEntriesByType("navigation")[0] as PerformanceNavigationTiming | undefined;
@@ -1542,19 +1544,26 @@ const CreatePGRFlowV2: React.FC = () => {
     (baseTenant ? String(baseTenant).split(".")[0] : baseTenant);
   const tenants: any = Digit.Hooks.pgr.useTenants();
 
-  // Seed from the session draft (if any) so refresh / re-entry restores both
-  // the answers and the step the citizen was on. The draft is stamped with the
-  // tenant + user it was written under and DISCARDED on mismatch — a home-city
-  // switch or a re-login must never restore another tenant's serviceCode /
-  // boundary (they would submit under the new tenant with blank pickers).
+  // Seed from the session draft ONLY on a document reload (mid-flow F5) so the
+  // citizen doesn't lose their answers to an accidental refresh. Every other
+  // entry ("File a Complaint", sidebar, deep link) starts completely clean and
+  // deletes the stored draft. The draft is also stamped with the tenant + user
+  // it was written under and DISCARDED on mismatch — a home-city switch or a
+  // re-login must never restore another tenant's serviceCode / boundary (they
+  // would submit under the new tenant with blank pickers).
   const draftUserUuid = Digit.UserService.getUser()?.info?.uuid;
   const savedDraftRef = React.useRef<any>(null);
   if (savedDraftRef.current === null) {
-    const d = Digit.SessionStorage.get(CREATE_DRAFT_KEY) || {};
-    savedDraftRef.current =
-      d.formData && typeof d.formData === "object" && d.tenant === baseTenant && d.user === draftUserUuid
-        ? d
-        : {};
+    if (RESTORE_STEP_ARMED) {
+      const d = Digit.SessionStorage.get(CREATE_DRAFT_KEY) || {};
+      savedDraftRef.current =
+        d.formData && typeof d.formData === "object" && d.tenant === baseTenant && d.user === draftUserUuid
+          ? d
+          : {};
+    } else {
+      Digit.SessionStorage.del(CREATE_DRAFT_KEY);
+      savedDraftRef.current = {};
+    }
   }
   const [stepIndex, setStepIndex] = React.useState(() => {
     // Position restores ONLY right after a document reload (see
@@ -1574,20 +1583,8 @@ const CreatePGRFlowV2: React.FC = () => {
     Digit.SessionStorage.set(CREATE_DRAFT_KEY, { formData, stepIndex, tenant: baseTenant, user: draftUserUuid });
   }, [formData, stepIndex, baseTenant, draftUserUuid]);
 
-  // Leaving the wizard via IN-APP navigation (sidebar Home, back, links) resets
-  // the saved POSITION to step 1 while keeping the answers — re-entering from
-  // "File a Complaint" should read as a fresh start, not resume on page 3
-  // (user feedback on the draft-persistence feature). A hard refresh tears the
-  // page down without running this cleanup, so mid-flow F5 still restores the
-  // exact step. Successful create deletes the key before navigating, and the
-  // formData guard keeps this cleanup from resurrecting it.
-  React.useEffect(
-    () => () => {
-      const d = Digit.SessionStorage.get(CREATE_DRAFT_KEY);
-      if (d && d.formData) Digit.SessionStorage.set(CREATE_DRAFT_KEY, { ...d, stepIndex: 0 });
-    },
-    []
-  );
+  // (No unmount cleanup needed: any non-reload mount deletes the draft up
+  // front, so in-app re-entry can never see stale answers or position.)
 
   // Authority dispatcher (RAINMAKER-PGR.ComplaintRelatedToMap @ state tenant).
   // Empty (the default for any tenant that hasn't seeded it) => the legacy flow:


### PR DESCRIPTION
## Jira
[CCSD-1975](https://digit-discuss.atlassian.net/browse/CCSD-1975)

Fresh wizard entries (services menu / sidebar / deep link) restored previously typed answers from the session draft. Now the **entire** draft (answers + step) restores only after an actual page reload (mid-flow F5 — what the draft feature was built for); any other mount deletes the stored draft and starts blank, matching pre-draft behaviour. Unmount step-reset cleanup removed (redundant under the new rule). Tenant/user stamping + delete-on-create unchanged.

Verified on local: menu re-entry → blank step 1; mid-flow F5 → answers + step restored; create → draft cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CCSD-1975]: https://digit-discuss.atlassian.net/browse/CCSD-1975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---
## Added: Moz QA validation batch (stacked on the clean-entry change)
- **CCSD-1978** email: optional field validates format when filled (blank passes); inline error + NEXT gated.
- **CCSD-1979** consents: TRUTHFULNESS / DATA_PROCESSING checkboxes hidden; implicit acceptance on submit (payload `extendedAttributes.consents` unchanged).
- **CCSD-1980** description: 20–1000 chars AND ≥3 letters (rejects `000…`); citizen wizard + employee `CreateComplaintConfig` pattern; clearer message (DDH en_IN seed: CS_DESC_MIN_CHARS + CS_DESC_NEEDS_WORDS).

### QA (before/after, both viewports) — shared folder
`~/Desktop/CCRS-QA/CCSD-1978|1979|1980/` (TEST-REPORT.md + before/after desktop+mobile). Driven signals:
```
1978 email '@':  before NEXT enabled/no error   →  after NEXT disabled + 'valid email' error
1979 consents:   before both checkboxes shown    →  after both removed (confidential kept)
1980 desc 000…:  before accepted                 →  after words-hint + Submit disabled
```
Grouped into this PR (not 3 PRs) because all three edit the same `CreatePGRFlowV2.tsx`.