### PR TITLE
fix(core): restore the employee topbar language selector — reverts B1 (CCSD-1977)

### DIFF
--- a/digit-ui-esbuild/packages/modules/core/src/pages/employee/index.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/employee/index.js
@@ -80,10 +80,10 @@ const EmployeeApp = ({
               logoUrl={logoUrl}
               logoUrlWhite={logoUrlWhite}
               showSidebar={isUserProfile ? true : false}
-              // CCSD-1971 (Moz feedback B1): the language selector is removed
-              // from the EMPLOYEE surface entirely (was hidden only on the
-              // language-selection route before). Citizen keeps its selector.
-              showLanguageChange={false}
+              // Language selector restored on the employee surface (reverts
+              // CCSD-1971 B1 per user request) — hidden only on the
+              // language-selection route, as before the feedback batch.
+              showLanguageChange={!showLanguageChange}
             />
           )}
           <div
@@ -144,11 +144,10 @@ const EmployeeApp = ({
               logoUrl={logoUrl}
               logoUrlWhite={logoUrlWhite}
               modules={modules}
-              // CCSD-1971 (B1): no language selector on the employee surface.
-              // This is the MAIN employee wrapper — the prop defaulted to true
-              // here, which kept the dropdown alive despite the other wrapper
-              // passing false.
-              showLanguageChange={false}
+              // Language selector restored on the employee surface (reverts
+              // CCSD-1971 B1 per user request). This is the MAIN employee
+              // wrapper — the prop defaults to true here.
+              showLanguageChange={true}
             />}
             <div className={!noTopBar ? `${(isSuperUserWithMultipleRootTenant) ? "" : "main"} ${DSO ? "m-auto" : ""} digit-home-main` : ""}>
 


### PR DESCRIPTION
## Jira
[CCSD-1977](https://digit-discuss.atlassian.net/browse/CCSD-1977)

Change request: feedback item B1 (delivered in #1121 under CCSD-1971) removed the employee language selector; it's needed back. Both TopBarSideBar sites restored to pre-B1 behaviour (visible everywhere except the language-selection route). Citizen surface untouched. A note about the B1 rollback is on CCSD-1971 for the reviewer.

Verified headless on local: employee session shows the ENGLISH/PORTUGUÊS dropdown after login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CCSD-1977]: https://digit-discuss.atlassian.net/browse/CCSD-1977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ