### PR TITLE
fix(pgr): timeline masks actor name in step with the masked contact number (CCSD-1976)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/TimeLineWrapper.js
+++ b/digit-ui-esbuild/products/pgr/src/components/TimeLineWrapper.js
@@ -9,9 +9,16 @@ import { convertEpochFormateToDate } from '../utils';
 // identity must not surface in the employee timeline. Names show first char +
 // asterisks; contact numbers keep the last 4 digits (the backend already
 // masks the mobile, this covers the name and any unmasked residue).
+// Fixed-shape mask, mirroring the number convention (*****0104): first letter
+// of each word + exactly three stars — "CMS Case Manager" → "C*** C*** M***".
+// Fixed star count so the mask doesn't leak the real name's length.
 const maskName = (name) => {
   if (!name || name.length < 2) return name;
-  return name.charAt(0) + "*".repeat(Math.max(2, name.length - 1));
+  return String(name)
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0) + "***")
+    .join(" ");
 };
 const maskPhone = (phone) => {
   if (!phone || phone.length < 4) return phone;
@@ -83,8 +90,14 @@ const TimelineWrapper = ({ businessId, isWorkFlowLoading, workflowData, labelPre
                 // Confidential complaints: mask the CITIZEN actor's identity
                 // (employees stay visible — accountability is intact).
                 const maskThis = maskConfidential && isCitizenActor(personRecord);
-                const personLine = maskThis ? maskName(formatPerson(personRecord)) : formatPerson(personRecord);
                 const mobile = isAssigningAction(instance?.action) ? assignee?.mobileNumber : instance?.assigner?.mobileNumber;
+                // The backend already masks the mobile per viewer privilege
+                // ("Contact Details: *****0104"). Mirror that decision onto the
+                // NAME: a viewer the backend won't show the number to shouldn't
+                // see the person's identity either.
+                const backendMasked = typeof mobile === "string" && mobile.includes("*");
+                const personLine =
+                  maskThis || backendMasked ? maskName(formatPerson(personRecord)) : formatPerson(personRecord);
                 const shownMobile = maskThis ? maskPhone(mobile) : mobile;
                 const contactLine = shownMobile ? `${t("ES_COMMON_CONTACT_DETAILS")}: ${shownMobile}` : null;
 


### PR DESCRIPTION
## Jira
[CCSD-1976](https://digit-discuss.atlassian.net/browse/CCSD-1976) (related: CCSD-1962)

The backend masks mobile numbers per viewer privilege — the timeline now mirrors that decision onto the **name**: masked contact ⇒ masked name. Fixed-shape mask matching the number convention (`CMS Case Manager` → `C*** C*** M***`, no length leak). Privileged viewers unaffected; B4 confidential-citizen masking unchanged.

Verified headless on PG-PGR-2026-07-06-001275 (local): masked pairs render `C*** C*** M*** / *****0104`; no plain assignee names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CCSD-1976]: https://digit-discuss.atlassian.net/browse/CCSD-1976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ