### PR TITLE
fix: mobile number validation consistency and i18n across configurator + PGR

### DIFF
--- a/configurator/src/admin/DigitCreate.tsx
+++ b/configurator/src/admin/DigitCreate.tsx
@@ -91,7 +91,10 @@ function DigitCreateContent({
 
       <DigitCard className="max-w-none">
         <MutationErrorBanner info={errorInfo} onDismiss={onDismissError} />
-        <Form>
+        {/* mode="onChange": ra-core's <Form> defaults to react-hook-form's
+            "onSubmit" mode, which leaves fieldState.invalid unset (and thus
+            no red/error styling) until the first submit attempt. */}
+        <Form mode="onChange">
           <div className="space-y-4">
             {children}
           </div>

--- a/configurator/src/admin/DigitEdit.tsx
+++ b/configurator/src/admin/DigitEdit.tsx
@@ -130,7 +130,10 @@ function DigitEditContent({
       {/* Form card */}
       <DigitCard className="max-w-none">
         <MutationErrorBanner info={errorInfo} onDismiss={onDismissError} />
-        <Form>
+        {/* mode="onChange": see matching note in DigitCreate.tsx — without
+            it, fieldState.invalid stays unset (no red/error styling) until
+            the first submit attempt. */}
+        <Form mode="onChange">
           <div className="space-y-4">
             {children}
           </div>

--- a/configurator/src/admin/DigitFormInput.tsx
+++ b/configurator/src/admin/DigitFormInput.tsx
@@ -42,7 +42,10 @@ export function DigitFormInput({
     isRequired,
   } = useInput(parseProps);
 
-  const hasError = fieldState.invalid && fieldState.isTouched;
+  // `isTouched` only flips on blur, so gating on it alone leaves the field
+  // showing no error while the user is still typing an invalid value.
+  // `isDirty` flips on the first change, giving immediate feedback.
+  const hasError = fieldState.invalid && (fieldState.isDirty || fieldState.isTouched);
   // ra-core v5 wraps validator errors as `@@react-admin@@${JSON.stringify(msg)}`
   // before storing them in react-hook-form state. Strip the prefix and unwrap
   // the JSON string so the raw human-readable message is rendered.

--- a/configurator/src/providers/i18nProvider.ts
+++ b/configurator/src/providers/i18nProvider.ts
@@ -144,6 +144,7 @@ const customEnglishMessages: TranslationMessages = {
       request_id: 'Request ID',
       citizen: 'Citizen',
       locality: 'Locality',
+      mobile_login_username_help: "Used as the citizen's login username.",
     },
     list: {
       refresh: 'Refresh',

--- a/configurator/src/resources/users/UserCreate.tsx
+++ b/configurator/src/resources/users/UserCreate.tsx
@@ -1,4 +1,6 @@
+import { useTranslate } from 'ra-core';
 import { DigitCreate, DigitFormInput, DigitFormSelect, v } from '@/admin';
+import { useMobileValidator } from '@/admin/hrms/useMobileValidator';
 
 const GENDER_CHOICES = [
   { value: 'MALE', label: 'Male' },
@@ -23,14 +25,21 @@ const transform = (data: Record<string, unknown>) => {
 };
 
 export function UserCreate() {
+  const { validator: mobileValidate, rules: mobileRules } = useMobileValidator();
+  const translate = useTranslate();
+  const loginUsernameHelp = translate('app.fields.mobile_login_username_help', {
+    _: "Used as the citizen's login username.",
+  });
+
   return (
     <DigitCreate title="Create User" record={defaultRecord} transform={transform}>
       <DigitFormInput source="name" label="Name" validate={v.name} />
       <DigitFormInput
         source="mobileNumber"
         label="Mobile Number"
-        validate={v.mobileKERequired}
-        help="9 digits starting with 7 or 1 (e.g. 712345678). Used as the citizen's login username."
+        validate={mobileValidate}
+        maxLength={mobileRules.maxLength}
+        help={loginUsernameHelp}
       />
       <DigitFormInput source="emailId" label="Email" validate={v.emailOptional} />
       <DigitFormSelect

--- a/digit-ui-esbuild/packages/digit-ui-components/src/atoms/SearchComponent.js
+++ b/digit-ui-esbuild/packages/digit-ui-components/src/atoms/SearchComponent.js
@@ -57,6 +57,11 @@ const SearchComponent = ({ uiConfig, header = "", screenType = "search", fullCon
     clearErrors,
     unregister,
   } = useForm({
+    // mode: "onChange" — without it RHF v6 defaults to "onSubmit", so
+    // `errors` (and therefore errorStyle/red-border on fields like the PGR
+    // inbox mobile number search) stays empty until the first Enter/Search
+    // submit attempt, even while the typed value already fails validation.
+    mode: "onChange",
     defaultValues: uiConfig?.defaultValues,
     // defaultValues: {...uiConfig?.defaultValues,...defValuesFromSession}
     // defaultValues:defaultValuesFromSession

--- a/digit-ui-esbuild/products/pgr/src/hooks/pgr/useMobileValidation.js
+++ b/digit-ui-esbuild/products/pgr/src/hooks/pgr/useMobileValidation.js
@@ -5,6 +5,7 @@ import {
   DEFAULT_MOBILE_PATTERN,
   DEFAULT_MOBILE_PREFIX,
 } from "@egovernments/digit-ui-libraries";
+import { useTranslation } from "react-i18next";
 
 /**
  * Custom hook that returns the mobile-number validation config for the
@@ -34,6 +35,7 @@ import {
  * @returns {object} - Returns validation rules and loading state
  */
 const useMobileValidation = (tenantId, validationName = "defaultMobileValidation") => {
+  const { t } = useTranslation();
   const reqCriteria = {
     url: `/${window?.globalConfigs?.getConfig?.("MDMS_V1_CONTEXT_PATH") || "mdms-v2"}/v1/_search`,
     params: {
@@ -107,7 +109,10 @@ const useMobileValidation = (tenantId, validationName = "defaultMobileValidation
     minLength: resolvedMin,
     maxLength: resolvedMax > 0 ? resolvedMax : 15,
 
-    errorMessage: buildMobileErrorMessage(resolvedPattern),
+    // `t` from react-i18next resolves ERR_INVALID_MOBILE_NUMBER / MOBILE_VALIDATION_*
+    // against the active locale (module: rainmaker-common) — without it this
+    // message is hardcoded English regardless of the selected language.
+    errorMessage: buildMobileErrorMessage(resolvedPattern, t),
 
     isActive: mdmsConfig?.isActive !== undefined ? mdmsConfig.isActive : true,
   };

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRInbox.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRInbox.js
@@ -65,6 +65,16 @@ const PGRSearchInbox = () => {
   // Inject mobile validation rules from MDMS into the search config
   if (configs && validationRules && configs.sections?.search?.uiConfig?.fields) {
     const { min, max } = getMinMaxValues();
+    // react-hook-form@6's pattern rule only runs when `pattern.value` (or
+    // `pattern` itself) is an actual RegExp instance — a plain string is
+    // silently skipped with no error and no console warning, so the field
+    // never validates. `validationRules.pattern` is always a string here.
+    let compiledPattern = null;
+    try {
+      compiledPattern = new RegExp(validationRules.pattern);
+    } catch {
+      compiledPattern = null;
+    }
     configs = {
       ...configs,
       sections: {
@@ -85,7 +95,7 @@ const PGRSearchInbox = () => {
                       maxlength: validationRules.maxLength,
                       min: min,
                       max: max,
-                      pattern: validationRules.pattern,
+                      pattern: compiledPattern,
                     },
                     error: validationRules.errorMessage || field.populators.error,
                   },

--- a/local-setup/ansible/files/configurator-localization/configurator-ui.json
+++ b/local-setup/ansible/files/configurator-localization/configurator-ui.json
@@ -4774,5 +4774,149 @@
     "message": "Assunto",
     "module": "configurator-ui",
     "locale": "pt_BR"
+  },
+  {
+    "code": "app.fields.mobile_login_username_help",
+    "message": "Used as the citizen's login username.",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "app.fields.mobile_login_username_help",
+    "message": "नागरिक के लॉगिन उपयोगकर्ता नाम के रूप में उपयोग किया जाता है।",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "app.fields.mobile_login_username_help",
+    "message": "Utilisé comme nom d'utilisateur de connexion du citoyen.",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "app.fields.mobile_login_username_help",
+    "message": "Usado como o nome de usuário de login do cidadão.",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "ERR_INVALID_MOBILE_NUMBER",
+    "message": "Please enter a valid mobile number",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "ERR_INVALID_MOBILE_NUMBER",
+    "message": "अमान्य मोबाइल नंबर",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "ERR_INVALID_MOBILE_NUMBER",
+    "message": "Veuillez saisir un numéro de mobile valide",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "ERR_INVALID_MOBILE_NUMBER",
+    "message": "Por favor, insira um número de celular válido",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "MOBILE_VALIDATION_DIGITS",
+    "message": "digits",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "MOBILE_VALIDATION_DIGITS",
+    "message": "अंक",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "MOBILE_VALIDATION_DIGITS",
+    "message": "chiffres",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "MOBILE_VALIDATION_DIGITS",
+    "message": "dígitos",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "MOBILE_VALIDATION_AT_LEAST",
+    "message": "at least",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "MOBILE_VALIDATION_AT_LEAST",
+    "message": "कम से कम",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "MOBILE_VALIDATION_AT_LEAST",
+    "message": "au moins",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "MOBILE_VALIDATION_AT_LEAST",
+    "message": "pelo menos",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "MOBILE_VALIDATION_STARTING_WITH",
+    "message": "starting with",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "MOBILE_VALIDATION_STARTING_WITH",
+    "message": "से शुरू होकर",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "MOBILE_VALIDATION_STARTING_WITH",
+    "message": "commençant par",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "MOBILE_VALIDATION_STARTING_WITH",
+    "message": "começando com",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
+  },
+  {
+    "code": "MOBILE_VALIDATION_OR",
+    "message": "or",
+    "module": "configurator-ui",
+    "locale": "en_IN"
+  },
+  {
+    "code": "MOBILE_VALIDATION_OR",
+    "message": "या",
+    "module": "configurator-ui",
+    "locale": "hi_IN"
+  },
+  {
+    "code": "MOBILE_VALIDATION_OR",
+    "message": "ou",
+    "module": "configurator-ui",
+    "locale": "fr_FR"
+  },
+  {
+    "code": "MOBILE_VALIDATION_OR",
+    "message": "ou",
+    "module": "configurator-ui",
+    "locale": "pt_BR"
   }
 ]


### PR DESCRIPTION
## Summary
- **Configurator**: the mobile number field now turns red and shows an error live while typing an invalid number, instead of only after blur/submit (`DigitFormInput`'s error gate + `mode="onChange"` on `DigitCreate`/`DigitEdit`).
- **Configurator**: Create User's mobile help text no longer duplicates the validation error message — shows just the login-username note, consistent with Employee/Complaint screens.
- **Employee PGR search (`inbox-v2`)**: the MDMS-driven mobile regex was injected as a plain string into react-hook-form's `pattern` rule, which v6 silently skips unless given an actual `RegExp` — the field never validated regardless of input. Fixed by compiling it to a `RegExp` before injecting.
- **Employee PGR search**: `SearchComponent`'s form defaulted to react-hook-form's `"onSubmit"` mode, so the mobile field never turned red while typing. Added `mode="onChange"` for live validation, matching the configurator fix.
- `useMobileValidation` never passed a translate function into `buildMobileErrorMessage`, so the validation message was hardcoded English regardless of locale. Wired `useTranslation()`'s `t` through.
- Seeded the mobile-validation error message keys (`ERR_INVALID_MOBILE_NUMBER`, `MOBILE_VALIDATION_*`) for `en_IN`/`hi_IN`/`fr_FR`/`pt_BR` under the `configurator-ui` localization module.

## Test plan
- [x] Configurator Create User: typed an invalid mobile number, confirmed red border + error message appear live (no blur/submit needed); confirmed help text no longer duplicates the error text.
- [x] Employee PGR search screen: typed too-short, wrong-starting-digit, and fully valid mobile numbers via both Enter and the Search button; confirmed invalid values are blocked with a live red error and valid values search correctly.
- [x] Switched locale to Hindi in the configurator and confirmed the mobile validation error message translates.
- [x] Regression-checked English behavior on both screens after the fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized guidance explaining how mobile numbers are used as login usernames.
  * Added translated mobile-number validation messages across supported locales.
  * Search validation now supports configured patterns more reliably.

* **Bug Fixes**
  * Form validation and error styling now update while users type or after fields are changed or touched.
  * Invalid mobile-number patterns no longer interrupt the search experience.
  * Mobile validation errors now reflect the selected language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->