### PR TITLE
fix(pgr-inbox): warn when MDMS mobile regex fails to compile

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRInbox.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRInbox.js
@@ -5,6 +5,22 @@ import _ from "lodash";
 import PGRSearchInboxConfig from "../../configs/PGRSearchInboxConfig";
 import { useLocation } from "react-router-dom";
 
+// Defense-in-depth against a misconfigured MDMS regex causing catastrophic
+// backtracking (ReDoS, CWE-1333) when compiled below. Mobile-number patterns
+// are always short and simple (e.g. `^66[0-9]{6}$`), so a generous length cap
+// plus a check for the classic nested-quantifier shape (e.g. `(a+)+`) catches
+// realistic failure modes without a full regex-safety analyzer.
+const MOBILE_PATTERN_MAX_LENGTH = 100;
+const NESTED_QUANTIFIER_RE = /\([^()]*[+*][^()]*\)[+*]/;
+function isSafeMobilePattern(pattern) {
+  return (
+    typeof pattern === "string" &&
+    pattern.length > 0 &&
+    pattern.length <= MOBILE_PATTERN_MAX_LENGTH &&
+    !NESTED_QUANTIFIER_RE.test(pattern)
+  );
+}
+
 /**
  * PGRSearchInbox - Complaint Search Inbox Screen
  * 
@@ -70,13 +86,17 @@ const PGRSearchInbox = () => {
     // silently skipped with no error and no console warning, so the field
     // never validates. `validationRules.pattern` is always a string here.
     let compiledPattern = null;
-    try {
-      compiledPattern = new RegExp(validationRules.pattern);
-    } catch (e) {
-      // A misconfigured MDMS regex disables pattern validation with no other
-      // signal (RHF just skips a null pattern) — surface it so it gets fixed.
-      console.warn("PGRInbox: invalid mobile validation regex from MDMS, pattern validation disabled:", validationRules.pattern, e);
-      compiledPattern = null;
+    if (isSafeMobilePattern(validationRules.pattern)) {
+      try {
+        compiledPattern = new RegExp(validationRules.pattern);
+      } catch (e) {
+        // A misconfigured MDMS regex disables pattern validation with no other
+        // signal (RHF just skips a null pattern) — surface it so it gets fixed.
+        console.warn("PGRInbox: invalid mobile validation regex from MDMS, pattern validation disabled:", validationRules.pattern, e);
+        compiledPattern = null;
+      }
+    } else {
+      console.warn("PGRInbox: mobile validation regex from MDMS rejected as unsafe or oversized, pattern validation disabled:", validationRules.pattern);
     }
     configs = {
       ...configs,

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRInbox.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRInbox.js
@@ -72,7 +72,10 @@ const PGRSearchInbox = () => {
     let compiledPattern = null;
     try {
       compiledPattern = new RegExp(validationRules.pattern);
-    } catch {
+    } catch (e) {
+      // A misconfigured MDMS regex disables pattern validation with no other
+      // signal (RHF just skips a null pattern) — surface it so it gets fixed.
+      console.warn("PGRInbox: invalid mobile validation regex from MDMS, pattern validation disabled:", validationRules.pattern, e);
       compiledPattern = null;
     }
     configs = {


### PR DESCRIPTION
## Summary
Follow-up to the CodeRabbit review on #1152, which flagged one comment with two parts:

1. **Silent validation disablement**: `PGRInbox.js` compiles the MDMS-driven mobile regex to a `RegExp` before injecting it into react-hook-form's `pattern` rule. If that regex is malformed, the `catch` silently left `compiledPattern` as `null` — react-hook-form v6 just skips a null pattern rule, so the mobile field's pattern validation goes silently missing with no signal to anyone. Added a `console.warn` logging the offending pattern.
2. **ReDoS (CWE-1333)**: the static analyzer flagged `new RegExp(validationRules.pattern)` as a potential ReDoS vector since the pattern is dynamic (MDMS-sourced) rather than a literal. Risk is low in practice (admin-configured MDMS data, not user input), but added a cheap defense-in-depth check before compiling: reject patterns over 100 chars or containing the classic nested-quantifier catastrophic-backtracking shape (e.g. `(a+)+`, `(a*)*`), falling back to the same "pattern validation disabled + warning" path as a malformed regex.

## Test plan
- [x] `node esbuild.build.js` builds cleanly with the change.
- [x] Verified the safety heuristic against the tenant's live MDMS patterns (`^66[0-9]{6}$`, `^0?[17][0-9]{8}$`) — both pass unaffected.
- [x] Verified the heuristic rejects known-pathological patterns (`(a+)+`, `(a*)*`, oversized/empty/null).
- [x] Redeployed to the running local-setup stack and re-ran the mobile-field validation Playwright checks — invalid numbers still flagged live, valid numbers still pass, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)