### PR TITLE
fix(dashboard): resolve all widget text through the i18n pipeline + catalog/seed reconciliation

### DIFF
--- a/ansible/nairobi-mdms/mdms/dss/KpiDefinition.json
+++ b/ansible/nairobi-mdms/mdms/dss/KpiDefinition.json
@@ -807,6 +807,7 @@
         "orientation": "horizontal",
         "measureKey": "total",
         "seriesLabel": "Filed",
+        "seriesLabelKey": "DASHBOARD_SERIES_FILED",
         "limit": 8,
         "subtitle": "Complaints filed, by type",
         "subtitleKey": "RAINMAKER-PGR.DASHBOARD_KPI_CL_CHART_COMPLAINTS_BY_TYPE_SUBTITLE",
@@ -1774,18 +1775,21 @@
         "seriesDefs": [
           {
             "name": "Created",
+            "labelKey": "DASHBOARD_SERIES_CREATED",
             "measureKey": "created",
             "color": "var(--chart-1)",
             "yAxisGroup": "count"
           },
           {
             "name": "Resolved",
+            "labelKey": "DASHBOARD_SERIES_RESOLVED",
             "measureKey": "resolved",
             "color": "var(--chart-2)",
             "yAxisGroup": "count"
           },
           {
             "name": "Resolution rate",
+            "labelKey": "DASHBOARD_SERIES_RESOLUTION_RATE",
             "numeratorKey": "resolved",
             "denominatorKey": "created",
             "color": "var(--chart-3)",
@@ -1794,6 +1798,7 @@
           },
           {
             "name": "SLA compliance rate",
+            "labelKey": "DASHBOARD_SERIES_SLA_COMPLIANCE_RATE",
             "numeratorKey": "on_time",
             "denominatorKey": "created",
             "color": "var(--chart-4)",
@@ -2312,6 +2317,1046 @@
       "rbac": {
         "visibleTo": []
       }
+    }
+  },
+  {
+    "tenantId": "ke",
+    "data": {
+      "id": "cl_total_complaints_count",
+      "viz": {
+        "pii": false,
+        "kind": "scalar",
+        "delta": {
+          "mode": "percent",
+          "compare": "prior"
+        },
+        "group": "complaint-landscape",
+        "title": "Total complaints",
+        "accent": "teal",
+        "format": "integer",
+        "compose": null,
+        "dateKey": "created_date",
+        "subtitle": "Complaints filed in period",
+        "subtitleKey": "RAINMAKER-PGR.DASHBOARD_KPI_CL_TOTAL_COMPLAINTS_COUNT_SUBTITLE",
+        "titleKey": "RAINMAKER-PGR.DASHBOARD_KPI_CL_TOTAL_COMPLAINTS_COUNT",
+        "valueKey": "total",
+        "deltaLabel": "vs prior period",
+        "sparklineMeasureKey": "total"
+      },
+      "rbac": {
+        "visibleTo": [
+          "SUPERVISOR",
+          "PGR_SUPERVISOR",
+          "GRO",
+          "DGRO",
+          "PGR_LME",
+          "PGR_ADMIN",
+          "SUPERUSER",
+          "TICKET_REPORT_VIEWER",
+          "PGR_VIEWER"
+        ]
+      },
+      "query": {
+        "grain": "facts",
+        "measures": [
+          {
+            "agg": "count",
+            "name": "total"
+          }
+        ]
+      },
+      "params": [
+        {
+          "name": "window",
+          "allowed": [
+            "last_1d",
+            "last_7d",
+            "last_30d",
+            "wtd",
+            "mtd"
+          ],
+          "default": "last_7d"
+        }
+      ],
+      "status": "published",
+      "version": "1.0.0",
+      "supportsSeries": true
+    }
+  },
+  {
+    "tenantId": "ke",
+    "data": {
+      "id": "cl_flow_ratio_count",
+      "viz": {
+        "pii": false,
+        "kind": "scalar",
+        "delta": {
+          "mode": "rating",
+          "compare": "prior"
+        },
+        "group": "complaint-landscape",
+        "title": "Flow ratio",
+        "accent": "teal",
+        "format": "decimalTwo",
+        "compose": null,
+        "subtitle": "Resolved in period ÷ created in period",
+        "subtitleKey": "RAINMAKER-PGR.DASHBOARD_KPI_CL_FLOW_RATIO_COUNT_SUBTITLE",
+        "titleKey": "RAINMAKER-PGR.DASHBOARD_KPI_CL_FLOW_RATIO_COUNT",
+        "valueKey": "ratio",
+        "deltaLabel": "vs prior period"
+      },
+      "rbac": {
+        "visibleTo": [
+          "TICKET_REPORT_VIEWER",
+          "PGR_VIEWER"
+        ]
+      },
+      "query": {
+        "grain": "facts",
+        "measures": [
+          {
+            "agg": "ratio",
+            "name": "ratio",
+            "numerator": {
+              "agg": "count",
+              "filter": {
+                "is_resolved": true
+              },
+              "window": {
+                "timeRole": "resolved_at"
+              }
+            },
+            "denominator": {
+              "agg": "count"
+            }
+          }
+        ]
+      },
+      "params": [
+        {
+          "name": "window",
+          "allowed": [
+            "last_1d",
+            "last_7d",
+            "last_30d",
+            "wtd",
+            "mtd"
+          ],
+          "default": "last_7d"
+        }
+      ],
+      "status": "published",
+      "version": "1.0.0",
+      "supportsSeries": false
+    }
+  },
+  {
+    "tenantId": "ke",
+    "data": {
+      "id": "cl_chart_complaints_over_time",
+      "viz": {
+        "pii": false,
+        "kind": "line",
+        "group": "complaint-landscape",
+        "title": "Complaints over time",
+        "accent": "teal",
+        "format": "integer",
+        "compose": null,
+        "subtitle": "Created, resolved and open per day",
+        "subtitleKey": "RAINMAKER-PGR.DASHBOARD_KPI_CL_CHART_COMPLAINTS_OVER_TIME_SUBTITLE",
+        "titleKey": "RAINMAKER-PGR.DASHBOARD_KPI_CL_CHART_COMPLAINTS_OVER_TIME",
+        "valueKey": "created",
+        "seriesDefs": [
+          {
+            "name": "Created",
+            "labelKey": "DASHBOARD_SERIES_CREATED",
+            "color": "var(--chart-1)",
+            "chartType": "column",
+            "measureKey": "created",
+            "yAxisGroup": "count"
+          },
+          {
+            "name": "Resolved",
+            "labelKey": "DASHBOARD_SERIES_RESOLVED",
+            "color": "var(--chart-2)",
+            "chartType": "column",
+            "measureKey": "resolved",
+            "yAxisGroup": "count"
+          },
+          {
+            "name": "Open",
+            "labelKey": "DASHBOARD_SERIES_OPEN",
+            "color": "var(--chart-3)",
+            "chartType": "column",
+            "measureKey": "open",
+            "yAxisGroup": "count"
+          },
+          {
+            "name": "On-time %",
+            "color": "var(--chart-4)",
+            "chartType": "line",
+            "yAxisGroup": "percent",
+            "numeratorKey": "on_time",
+            "denominatorKey": "resolved"
+          }
+        ],
+        "labelFormat": "date-dow",
+        "measureKeys": [
+          "created",
+          "resolved",
+          "open",
+          "on_time"
+        ],
+        "dimensionKey": "created_date"
+      },
+      "rbac": {
+        "visibleTo": [
+          "TICKET_REPORT_VIEWER",
+          "PGR_VIEWER"
+        ]
+      },
+      "query": {
+        "sort": [
+          {
+            "by": "created_date",
+            "dir": "asc"
+          }
+        ],
+        "grain": "facts",
+        "limit": 366,
+        "measures": [
+          {
+            "agg": "count",
+            "name": "created"
+          }
+        ],
+        "dimensions": [
+          "created_date"
+        ]
+      },
+      "params": [
+        {
+          "name": "window",
+          "allowed": [
+            "last_1d",
+            "last_7d",
+            "last_30d",
+            "wtd",
+            "mtd"
+          ],
+          "default": "last_7d"
+        }
+      ],
+      "status": "published",
+      "version": "1.0.0",
+      "supportsSeries": false
+    }
+  },
+  {
+    "tenantId": "ke",
+    "data": {
+      "id": "cl_chart_over_time_open_daily",
+      "viz": {
+        "pii": false,
+        "kind": "line",
+        "group": "complaint-landscape",
+        "title": "Open complaints over time (daily)",
+        "accent": "teal",
+        "format": "integer",
+        "compose": null,
+        "titleKey": "RAINMAKER-PGR.DASHBOARD_KPI_CL_CHART_OVER_TIME_OPEN_DAILY",
+        "valueKey": "open",
+        "dimensionKey": "snapshot_date"
+      },
+      "rbac": {
+        "visibleTo": [
+          "TICKET_REPORT_VIEWER"
+        ]
+      },
+      "query": {
+        "sort": [
+          {
+            "by": "snapshot_date",
+            "dir": "asc"
+          }
+        ],
+        "grain": "daily",
+        "limit": 366,
+        "filters": {
+          "is_open": true
+        },
+        "measures": [
+          {
+            "agg": "count",
+            "name": "open"
+          }
+        ],
+        "dimensions": [
+          "snapshot_date"
+        ]
+      },
+      "params": [
+        {
+          "name": "window",
+          "allowed": [
+            "last_1d",
+            "last_7d",
+            "last_30d",
+            "wtd",
+            "mtd"
+          ],
+          "default": "last_7d"
+        }
+      ],
+      "status": "published",
+      "version": "1.0.0",
+      "supportsSeries": false
+    }
+  },
+  {
+    "tenantId": "ke",
+    "data": {
+      "id": "cl_chart_wards_by_sla",
+      "viz": {
+        "pii": false,
+        "kind": "bar",
+        "group": "complaint-landscape",
+        "limit": 12,
+        "title": "Complaints by Wards",
+        "accent": "teal",
+        "format": "integer",
+        "compose": null,
+        "stackKey": "sla_status_bucket",
+        "subtitle": "All complaints by SLA state — per ward",
+        "subtitleKey": "RAINMAKER-PGR.DASHBOARD_KPI_CL_CHART_WARDS_BY_SLA_SUBTITLE",
+        "titleKey": "RAINMAKER-PGR.DASHBOARD_KPI_CL_CHART_WARDS_BY_SLA",
+        "valueKey": "total",
+        "measureKey": "total",
+        "labelFormat": "dimension",
+        "measureKeys": [
+          "total"
+        ],
+        "orientation": "horizontal",
+        "stackSeries": [
+          {
+            "key": "resolved",
+            "color": "var(--status-resolved-bg)",
+            "label": "Resolved",
+            "labelKey": "DASHBOARD_SERIES_RESOLVED"
+          },
+          {
+            "key": "within",
+            "color": "var(--chart-1)",
+            "label": "On track",
+            "labelKey": "DASHBOARD_SLA_WITHIN"
+          },
+          {
+            "key": "approaching",
+            "color": "var(--chart-2)",
+            "label": "Nearing breach",
+            "labelKey": "DASHBOARD_SLA_APPROACHING"
+          },
+          {
+            "key": "breached",
+            "color": "var(--status-breach)",
+            "label": "Breached",
+            "labelKey": "DASHBOARD_SLA_BREACHED"
+          }
+        ],
+        "dimensionKey": "ward_code",
+        "sortBySegment": "breached"
+      },
+      "rbac": {
+        "visibleTo": [
+          "TICKET_REPORT_VIEWER",
+          "PGR_VIEWER"
+        ]
+      },
+      "query": {
+        "grain": "daily",
+        "limit": 120,
+        "measures": [
+          {
+            "agg": "count",
+            "name": "total"
+          }
+        ],
+        "dimensions": [
+          "ward_code",
+          "sla_status_bucket"
+        ]
+      },
+      "params": [
+        {
+          "name": "window",
+          "allowed": [
+            "last_1d",
+            "last_7d",
+            "last_30d",
+            "wtd",
+            "mtd"
+          ],
+          "default": "last_7d"
+        }
+      ],
+      "status": "published",
+      "version": "1.0.0",
+      "supportsSeries": false
+    }
+  },
+  {
+    "tenantId": "ke",
+    "data": {
+      "id": "cl_chart_department_breach_scatter",
+      "viz": {
+        "pii": false,
+        "kind": "line",
+        "group": "complaint-landscape",
+        "title": "Breach rate vs caseload by department",
+        "accent": "teal",
+        "format": "percentOneDecimal",
+        "compose": null,
+        "subtitle": "Open caseload vs breach rate at period end",
+        "subtitleKey": "RAINMAKER-PGR.DASHBOARD_KPI_CL_CHART_DEPARTMENT_BREACH_SCATTER_SUBTITLE",
+        "titleKey": "RAINMAKER-PGR.DASHBOARD_KPI_CL_CHART_DEPARTMENT_BREACH_SCATTER",
+        "valueKey": "open",
+        "xAxisLabel": "Caseload (open)",
+        "yAxisLabel": "Breach rate (%)",
+        "labelFormat": "department",
+        "measureKeys": [
+          "open",
+          "breached",
+          "sla_elapsed"
+        ],
+        "xMeasureKey": "open",
+        "dimensionKey": "department_code",
+        "numeratorKey": "breached",
+        "denominatorKey": "sla_elapsed",
+        "scatterProfile": "departmentBreachCaseload"
+      },
+      "rbac": {
+        "visibleTo": [
+          "TICKET_REPORT_VIEWER",
+          "PGR_VIEWER"
+        ]
+      },
+      "query": {
+        "sort": [
+          {
+            "by": "open",
+            "dir": "desc"
+          }
+        ],
+        "grain": "daily",
+        "limit": 50,
+        "filters": {
+          "is_open": true
+        },
+        "measures": [
+          {
+            "agg": "count",
+            "name": "open"
+          },
+          {
+            "agg": "count",
+            "name": "breached",
+            "filter": {
+              "sla_status_bucket": "breached"
+            }
+          },
+          {
+            "agg": "count",
+            "name": "sla_elapsed",
+            "filter": {
+              "sla_status_bucket": {
+                "in": [
+                  "within",
+                  "approaching",
+                  "breached"
+                ]
+              }
+            }
+          }
+        ],
+        "dimensions": [
+          "department_code"
+        ]
+      },
+      "params": [
+        {
+          "name": "window",
+          "allowed": [
+            "last_1d",
+            "last_7d",
+            "last_30d",
+            "wtd",
+            "mtd"
+          ],
+          "default": "last_7d"
+        }
+      ],
+      "status": "published",
+      "version": "1.0.0",
+      "supportsSeries": false
+    }
+  },
+  {
+    "tenantId": "ke",
+    "data": {
+      "id": "cl_table_ward_performance",
+      "viz": {
+        "pii": false,
+        "kind": "rankedList",
+        "group": "complaint-landscape",
+        "title": "Ward performance",
+        "accent": "teal",
+        "format": "integer",
+        "columns": [
+          {
+            "id": "wardLabel",
+            "type": "text",
+            "align": "left",
+            "label": "Ward",
+            "width": "24%"
+          },
+          {
+            "id": "created",
+            "type": "integer",
+            "align": "left",
+            "label": "Created",
+            "width": "14%"
+          },
+          {
+            "id": "open",
+            "type": "integer",
+            "align": "left",
+            "label": "Open",
+            "width": "14%"
+          },
+          {
+            "id": "reopenRate",
+            "type": "percent",
+            "align": "left",
+            "label": "Reopen %",
+            "width": "16%"
+          },
+          {
+            "id": "ontimeRate",
+            "type": "percent",
+            "align": "left",
+            "label": "On-time %",
+            "width": "16%"
+          },
+          {
+            "id": "avgCsat",
+            "type": "rating",
+            "align": "left",
+            "label": "CSAT",
+            "width": "16%"
+          }
+        ],
+        "compose": null,
+        "subtitle": "Created, open, reopen, on-time and CSAT by ward",
+        "subtitleKey": "RAINMAKER-PGR.DASHBOARD_KPI_CL_TABLE_WARD_PERFORMANCE_SUBTITLE",
+        "titleKey": "RAINMAKER-PGR.DASHBOARD_KPI_CL_TABLE_WARD_PERFORMANCE",
+        "valueKey": "created",
+        "measureKeys": [
+          "created",
+          "open",
+          "reopen_rate",
+          "ontime_rate",
+          "avg_csat"
+        ],
+        "dimensionKey": "ward_code",
+        "tableProfile": "wardPerformance"
+      },
+      "rbac": {
+        "visibleTo": [
+          "TICKET_REPORT_VIEWER",
+          "PGR_VIEWER"
+        ]
+      },
+      "query": {
+        "sort": [
+          {
+            "by": "created",
+            "dir": "desc"
+          }
+        ],
+        "grain": "facts",
+        "limit": 200,
+        "measures": [
+          {
+            "agg": "count",
+            "name": "created"
+          },
+          {
+            "agg": "ratio",
+            "name": "reopen_rate",
+            "numerator": {
+              "agg": "count",
+              "filter": {
+                "is_reopened": true,
+                "is_resolved": true
+              },
+              "window": {
+                "timeRole": "resolved_at"
+              }
+            },
+            "denominator": {
+              "agg": "count",
+              "filter": {
+                "is_resolved": true
+              },
+              "window": {
+                "timeRole": "resolved_at"
+              }
+            }
+          },
+          {
+            "agg": "ratio",
+            "name": "ontime_rate",
+            "numerator": {
+              "agg": "count",
+              "filter": {
+                "is_resolved": true,
+                "sla_breached": false
+              },
+              "window": {
+                "timeRole": "resolved_at"
+              }
+            },
+            "denominator": {
+              "agg": "count",
+              "filter": {
+                "is_resolved": true
+              },
+              "window": {
+                "timeRole": "resolved_at"
+              }
+            }
+          },
+          {
+            "agg": "avg",
+            "name": "avg_csat",
+            "column": "rating",
+            "filter": {
+              "has_rating": true,
+              "is_resolved": true
+            },
+            "window": {
+              "timeRole": "resolved_at"
+            }
+          }
+        ],
+        "dimensions": [
+          "ward_code"
+        ]
+      },
+      "params": [
+        {
+          "name": "window",
+          "allowed": [
+            "last_1d",
+            "last_7d",
+            "last_30d",
+            "wtd",
+            "mtd"
+          ],
+          "default": "last_7d"
+        }
+      ],
+      "status": "published",
+      "version": "1.0.0",
+      "supportsSeries": false
+    }
+  },
+  {
+    "tenantId": "ke",
+    "data": {
+      "id": "cl_table_ward_open_daily",
+      "viz": {
+        "pii": false,
+        "kind": "line",
+        "group": "complaint-landscape",
+        "title": "Open complaints by ward (daily)",
+        "accent": "teal",
+        "format": "integer",
+        "compose": null,
+        "titleKey": "RAINMAKER-PGR.DASHBOARD_KPI_CL_TABLE_WARD_OPEN_DAILY",
+        "valueKey": "open",
+        "dimensionKey": "ward_code"
+      },
+      "rbac": {
+        "visibleTo": [
+          "TICKET_REPORT_VIEWER"
+        ]
+      },
+      "query": {
+        "sort": [
+          {
+            "by": "open",
+            "dir": "desc"
+          }
+        ],
+        "grain": "daily",
+        "limit": 200,
+        "filters": {
+          "is_open": true
+        },
+        "measures": [
+          {
+            "agg": "count",
+            "name": "open"
+          }
+        ],
+        "dimensions": [
+          "ward_code"
+        ]
+      },
+      "params": [
+        {
+          "name": "window",
+          "allowed": [
+            "last_1d",
+            "last_7d",
+            "last_30d",
+            "wtd",
+            "mtd"
+          ],
+          "default": "last_7d"
+        }
+      ],
+      "status": "published",
+      "version": "1.0.0",
+      "supportsSeries": false
+    }
+  },
+  {
+    "tenantId": "ke",
+    "data": {
+      "id": "cl_table_service_quality_by_channel",
+      "viz": {
+        "pii": false,
+        "kind": "rankedList",
+        "group": "complaint-landscape",
+        "title": "Service quality by channel",
+        "accent": "teal",
+        "format": "integer",
+        "columns": [
+          {
+            "id": "channelLabel",
+            "type": "text",
+            "align": "left",
+            "label": "Channel",
+            "width": "28%"
+          },
+          {
+            "id": "volume",
+            "type": "integer",
+            "align": "left",
+            "label": "Volume",
+            "width": "20%"
+          },
+          {
+            "id": "resolutionRate",
+            "type": "percent",
+            "align": "left",
+            "label": "Resolution",
+            "width": "26%"
+          },
+          {
+            "id": "avgCsat",
+            "type": "rating",
+            "align": "left",
+            "label": "CSAT",
+            "width": "26%"
+          }
+        ],
+        "compose": null,
+        "subtitle": "Volume, resolution rate and CSAT by intake channel",
+        "subtitleKey": "RAINMAKER-PGR.DASHBOARD_KPI_CL_TABLE_SERVICE_QUALITY_BY_CHANNEL_SUBTITLE",
+        "titleKey": "RAINMAKER-PGR.DASHBOARD_KPI_CL_TABLE_SERVICE_QUALITY_BY_CHANNEL",
+        "valueKey": "volume",
+        "measureKeys": [
+          "volume",
+          "resolved",
+          "avg_csat"
+        ],
+        "dimensionKey": "source",
+        "tableProfile": "serviceQualityByChannel"
+      },
+      "rbac": {
+        "visibleTo": [
+          "TICKET_REPORT_VIEWER",
+          "PGR_VIEWER"
+        ]
+      },
+      "query": {
+        "sort": [
+          {
+            "by": "volume",
+            "dir": "desc"
+          }
+        ],
+        "grain": "facts",
+        "limit": 100,
+        "measures": [
+          {
+            "agg": "count",
+            "name": "volume"
+          },
+          {
+            "agg": "count",
+            "name": "resolved",
+            "filter": {
+              "is_resolved": true
+            },
+            "window": {
+              "timeRole": "resolved_at"
+            }
+          },
+          {
+            "agg": "avg",
+            "name": "avg_csat",
+            "column": "rating",
+            "filter": {
+              "has_rating": true,
+              "is_resolved": true
+            },
+            "window": {
+              "timeRole": "resolved_at"
+            }
+          }
+        ],
+        "dimensions": [
+          "source"
+        ]
+      },
+      "params": [
+        {
+          "name": "window",
+          "allowed": [
+            "last_1d",
+            "last_7d",
+            "last_30d",
+            "wtd",
+            "mtd"
+          ],
+          "default": "last_7d"
+        }
+      ],
+      "status": "published",
+      "version": "1.0.0",
+      "supportsSeries": false
+    }
+  },
+  {
+    "tenantId": "ke",
+    "data": {
+      "id": "cl_table_subtype_performance",
+      "viz": {
+        "pii": false,
+        "kind": "rankedList",
+        "group": "complaint-landscape",
+        "title": "Complaint sub-type performance",
+        "accent": "teal",
+        "format": "hoursDays",
+        "columns": [
+          {
+            "id": "subtypeLabel",
+            "type": "text",
+            "align": "left",
+            "label": "Subtype",
+            "width": "30%"
+          },
+          {
+            "id": "share_pct",
+            "type": "percent",
+            "align": "left",
+            "label": "% of complaints",
+            "width": "18%"
+          },
+          {
+            "id": "avgResolutionMs",
+            "type": "hoursDays",
+            "align": "left",
+            "label": "Avg resolution",
+            "width": "22%"
+          },
+          {
+            "id": "idealSlaMs",
+            "type": "hoursDays",
+            "align": "left",
+            "label": "SLA",
+            "width": "18%"
+          }
+        ],
+        "compose": null,
+        "subtitle": "Share, resolution time and SLA by subtype",
+        "subtitleKey": "RAINMAKER-PGR.DASHBOARD_KPI_CL_TABLE_SUBTYPE_PERFORMANCE_SUBTITLE",
+        "titleKey": "RAINMAKER-PGR.DASHBOARD_KPI_CL_TABLE_SUBTYPE_PERFORMANCE",
+        "valueKey": "avg_resolution_ms",
+        "measureKeys": [
+          "total",
+          "avg_resolution_ms",
+          "ideal_sla_ms"
+        ],
+        "dimensionKey": "service_code",
+        "tableProfile": "subtypePerformance"
+      },
+      "rbac": {
+        "visibleTo": [
+          "TICKET_REPORT_VIEWER",
+          "PGR_VIEWER"
+        ]
+      },
+      "query": {
+        "sort": [
+          {
+            "by": "total",
+            "dir": "desc"
+          }
+        ],
+        "grain": "facts",
+        "limit": 30,
+        "measures": [
+          {
+            "agg": "count",
+            "name": "total"
+          },
+          {
+            "agg": "avg",
+            "name": "avg_resolution_ms",
+            "column": "resolution_ms",
+            "filter": {
+              "is_resolved": true
+            }
+          },
+          {
+            "agg": "avg",
+            "name": "ideal_sla_ms",
+            "column": "sla_target_ms"
+          }
+        ],
+        "dimensions": [
+          "service_code"
+        ]
+      },
+      "params": [
+        {
+          "name": "window",
+          "allowed": [
+            "last_1d",
+            "last_7d",
+            "last_30d",
+            "wtd",
+            "mtd"
+          ],
+          "default": "last_7d"
+        }
+      ],
+      "status": "published",
+      "version": "1.0.0",
+      "supportsSeries": false
+    }
+  },
+  {
+    "tenantId": "ke",
+    "data": {
+      "id": "cl_table_recurring_ward_subtype",
+      "viz": {
+        "pii": false,
+        "kind": "rankedList",
+        "group": "complaint-landscape",
+        "title": "Recurring complaints by ward & sub-type",
+        "accent": "teal",
+        "format": "integer",
+        "columns": [
+          {
+            "id": "wardLabel",
+            "type": "text",
+            "align": "left",
+            "label": "Ward",
+            "width": "28%"
+          },
+          {
+            "id": "subtypeLabel",
+            "type": "text",
+            "align": "left",
+            "label": "Sub-type",
+            "width": "32%"
+          },
+          {
+            "id": "total",
+            "type": "integer",
+            "align": "left",
+            "label": "Total",
+            "width": "18%"
+          },
+          {
+            "id": "trendPct",
+            "type": "trend",
+            "align": "left",
+            "label": "Trend",
+            "width": "22%"
+          }
+        ],
+        "compose": null,
+        "minCount": 3,
+        "subtitle": "Ward × subtype pairs with ≥ 3 complaints in period",
+        "subtitleKey": "RAINMAKER-PGR.DASHBOARD_KPI_CL_TABLE_RECURRING_WARD_SUBTYPE_SUBTITLE",
+        "titleKey": "RAINMAKER-PGR.DASHBOARD_KPI_CL_TABLE_RECURRING_WARD_SUBTYPE",
+        "valueKey": "total",
+        "needsPrior": true,
+        "measureKeys": [
+          "total"
+        ],
+        "dimensionKey": "ward_code",
+        "tableProfile": "wardSubtypeRecurring"
+      },
+      "rbac": {
+        "visibleTo": [
+          "TICKET_REPORT_VIEWER",
+          "PGR_VIEWER"
+        ]
+      },
+      "query": {
+        "sort": [
+          {
+            "by": "total",
+            "dir": "desc"
+          }
+        ],
+        "grain": "facts",
+        "limit": 200,
+        "measures": [
+          {
+            "agg": "count",
+            "name": "total"
+          }
+        ],
+        "dimensions": [
+          "ward_code",
+          "service_code"
+        ]
+      },
+      "params": [
+        {
+          "name": "window",
+          "allowed": [
+            "last_1d",
+            "last_7d",
+            "last_30d",
+            "wtd",
+            "mtd"
+          ],
+          "default": "last_7d"
+        }
+      ],
+      "status": "published",
+      "version": "1.0.0",
+      "supportsSeries": false
     }
   }
 ]

--- a/digit-mcp/src/tools/dashboard-l10n-seed.ts
+++ b/digit-mcp/src/tools/dashboard-l10n-seed.ts
@@ -5,8 +5,9 @@
  * workstream: every entry is either a two-arg t("KEY", "English") literal in
  * digit-ui-esbuild/products/dashboard/, a titleKey/subtitleKey/labelKey ↔
  * title/subtitle/label pair in ansible/nairobi-mdms/mdms/dss/KpiDefinition.json,
- * or a seam-implied dimensionLabel key. DASHBOARD_GEO_LEVEL_* keys are
- * deliberately NOT seeded (per-call-site English variants; see #1111).
+ * or a seam-implied dimensionLabel key. DASHBOARD_GEO_LEVEL_* keys ARE
+ * seeded below with one canonical English message per level (#1111's
+ * per-call-site English variants were canonicalised when they landed).
  */
 export const DASHBOARD_L10N_MODULE = 'rainmaker-dashboard';
 export const DASHBOARD_L10N_LOCALE = 'en_IN';
@@ -962,6 +963,36 @@ export const DASHBOARD_L10N_MESSAGES: { code: string; message: string; module: s
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "DASHBOARD_SERIES_CREATED",
+    "message": "Created",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_SERIES_FILED",
+    "message": "Filed",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_SERIES_OPEN",
+    "message": "Open",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_SERIES_RESOLUTION_RATE",
+    "message": "Resolution rate",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_SERIES_RESOLVED",
+    "message": "Resolved",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_SERIES_SLA_COMPLIANCE_RATE",
+    "message": "SLA compliance rate",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "DASHBOARD_SIDEBAR_DASHBOARD",
     "message": "Dashboard",
     "module": "rainmaker-dashboard"
@@ -1192,6 +1223,26 @@ export const DASHBOARD_L10N_MESSAGES: { code: string; message: string; module: s
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "RAINMAKER-PGR.DASHBOARD_KPI_CL_CHART_COMPLAINTS_OVER_TIME",
+    "message": "Complaints over time",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "RAINMAKER-PGR.DASHBOARD_KPI_CL_CHART_COMPLAINTS_OVER_TIME_SUBTITLE",
+    "message": "Created, resolved and open per day",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "RAINMAKER-PGR.DASHBOARD_KPI_CL_CHART_DEPARTMENT_BREACH_SCATTER",
+    "message": "Breach rate vs caseload by department",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "RAINMAKER-PGR.DASHBOARD_KPI_CL_CHART_DEPARTMENT_BREACH_SCATTER_SUBTITLE",
+    "message": "Open caseload vs breach rate at period end",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "RAINMAKER-PGR.DASHBOARD_KPI_CL_CHART_DEPARTMENT_FLOW_RATIO",
     "message": "Flow ratio by department",
     "module": "rainmaker-dashboard"
@@ -1262,6 +1313,21 @@ export const DASHBOARD_L10N_MESSAGES: { code: string; message: string; module: s
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "RAINMAKER-PGR.DASHBOARD_KPI_CL_CHART_OVER_TIME_OPEN_DAILY",
+    "message": "Open complaints over time (daily)",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "RAINMAKER-PGR.DASHBOARD_KPI_CL_CHART_WARDS_BY_SLA",
+    "message": "Complaints by Wards",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "RAINMAKER-PGR.DASHBOARD_KPI_CL_CHART_WARDS_BY_SLA_SUBTITLE",
+    "message": "All complaints by SLA state — per ward",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "RAINMAKER-PGR.DASHBOARD_KPI_CL_CREATED_TODAY_COUNT",
     "message": "Complaints created today",
     "module": "rainmaker-dashboard"
@@ -1284,6 +1350,16 @@ export const DASHBOARD_L10N_MESSAGES: { code: string; message: string; module: s
   {
     "code": "RAINMAKER-PGR.DASHBOARD_KPI_CL_FIRST_ASSIGNMENT_RATE_COUNT_SUBTITLE",
     "message": "Never reassigned ÷ assigned",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "RAINMAKER-PGR.DASHBOARD_KPI_CL_FLOW_RATIO_COUNT",
+    "message": "Flow ratio",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "RAINMAKER-PGR.DASHBOARD_KPI_CL_FLOW_RATIO_COUNT_SUBTITLE",
+    "message": "Resolved in period ÷ created in period",
     "module": "rainmaker-dashboard"
   },
   {
@@ -1379,6 +1455,61 @@ export const DASHBOARD_L10N_MESSAGES: { code: string; message: string; module: s
   {
     "code": "RAINMAKER-PGR.DASHBOARD_KPI_CL_TABLE_COMPLAINTS_AT_RISK_SUBTITLE",
     "message": "Open complaints nearing or past SLA",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "RAINMAKER-PGR.DASHBOARD_KPI_CL_TABLE_RECURRING_WARD_SUBTYPE",
+    "message": "Recurring complaints by ward & sub-type",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "RAINMAKER-PGR.DASHBOARD_KPI_CL_TABLE_RECURRING_WARD_SUBTYPE_SUBTITLE",
+    "message": "Ward × subtype pairs with ≥ 3 complaints in period",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "RAINMAKER-PGR.DASHBOARD_KPI_CL_TABLE_SERVICE_QUALITY_BY_CHANNEL",
+    "message": "Service quality by channel",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "RAINMAKER-PGR.DASHBOARD_KPI_CL_TABLE_SERVICE_QUALITY_BY_CHANNEL_SUBTITLE",
+    "message": "Volume, resolution rate and CSAT by intake channel",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "RAINMAKER-PGR.DASHBOARD_KPI_CL_TABLE_SUBTYPE_PERFORMANCE",
+    "message": "Complaint sub-type performance",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "RAINMAKER-PGR.DASHBOARD_KPI_CL_TABLE_SUBTYPE_PERFORMANCE_SUBTITLE",
+    "message": "Share, resolution time and SLA by subtype",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "RAINMAKER-PGR.DASHBOARD_KPI_CL_TABLE_WARD_OPEN_DAILY",
+    "message": "Open complaints by ward (daily)",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "RAINMAKER-PGR.DASHBOARD_KPI_CL_TABLE_WARD_PERFORMANCE",
+    "message": "Ward performance",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "RAINMAKER-PGR.DASHBOARD_KPI_CL_TABLE_WARD_PERFORMANCE_SUBTITLE",
+    "message": "Created, open, reopen, on-time and CSAT by ward",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "RAINMAKER-PGR.DASHBOARD_KPI_CL_TOTAL_COMPLAINTS_COUNT",
+    "message": "Total complaints",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "RAINMAKER-PGR.DASHBOARD_KPI_CL_TOTAL_COMPLAINTS_COUNT_SUBTITLE",
+    "message": "Complaints filed in period",
     "module": "rainmaker-dashboard"
   },
   {

--- a/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
@@ -22,6 +22,7 @@ import DashboardLogin, {
 } from "./components/DashboardLogin";
 
 import useDashboardT from "./i18n/useDashboardT";
+import { resolveTitle, resolveSubtitle } from "./i18n/textResolver";
 import { useDashboardFilters } from "./hooks/useDashboardFilters";
 import { useFilterOptions } from "./hooks/useFilterOptions";
 import { useCatalog } from "./hooks/useCatalog";
@@ -374,11 +375,12 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
   );
 
   // Title-based tile search: dim tiles whose title doesn't match the query.
+  // Matches against the LOCALIZED title (what the user sees on the tile).
   const matchesSearch = useCallback(
     (kpiId) => {
       const q = searchQuery.trim().toLowerCase();
       if (!q) return true;
-      const title = (kpis[kpiId]?.viz?.title || kpiId).toLowerCase();
+      const title = (resolveTitle(kpis[kpiId]) || kpiId).toLowerCase();
       return title.includes(q);
     },
     [searchQuery, kpis]
@@ -386,17 +388,18 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
 
   // Add-KPI picker source: every role-visible catalog tile (already filtered
   // server-side), shaped to the picker's { id, metric, type, itemType } contract.
+  // `language` is a dep so the resolved metric names re-localize on a language switch.
   const catalogItems = useMemo(
     () =>
       Object.values(kpis)
         .filter((def) => !def.viz?.internal) // hide internal companion sources (e.g. map pins)
         .map((def) => ({
           id: def.kpiId,
-          metric: def.viz?.title || def.kpiId,
+          metric: resolveTitle(def) || def.kpiId,
           type: def.viz?.kind,
           itemType: isCardKind(def.viz?.kind) ? "kpi" : "widget",
         })),
-    [kpis]
+    [kpis, language]
   );
 
   // Re-run the batch whenever the catalog resolves or the filters change.
@@ -496,7 +499,7 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
           : assembled?.rows
           ? `${assembled.rows.length} rows`
           : "";
-      return [def?.viz?.title || item.i, item.i, value];
+      return [resolveTitle(def) || item.i, item.i, value];
     });
     const csv = ["Title,KPI,Value", ...rows.map((r) => r.map(csvEscape).join(","))].join("\n");
     const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
@@ -573,7 +576,7 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
             const dimClass = matchesSearch(item.i) ? "" : " dashboard-search-dimmed";
             const removeBtn = (
               <WidgetRemoveButton
-                label={`${t("DASHBOARD_COMMON_REMOVE", "Remove")} ${kpis[item.i]?.viz?.title || item.i}`}
+                label={`${t("DASHBOARD_COMMON_REMOVE", "Remove")} ${resolveTitle(kpis[item.i]) || item.i}`}
                 onClick={(e) => {
                   e.preventDefault();
                   e.stopPropagation();
@@ -602,6 +605,11 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
             const vizType = KIND_TO_VIZTYPE[kind] || kind;
             const isTable = TABLE_KINDS.has(kind);
             const selfHeaders = kind === "map" || kind === "choropleth-map";
+            // Header text resolves through the i18n seam (titleKey/subtitleKey
+            // win when seeded, else the catalog's English) — same pipeline as
+            // the card tiles' KpiTile resolvers.
+            const headerTitle = resolveTitle(kpis[item.i]) || item.i;
+            const headerSubtitle = resolveSubtitle(viz);
             return (
               <section
                 key={item.i}
@@ -612,10 +620,10 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
                   <header className={`${buildWidgetHeaderClassName(vizType)} tw-min-w-0`}>
                     <div className="tw-min-w-0 tw-flex-1">
                       <h2 className={`${SHARED_CHROME.dragHandleTitle} tw-truncate`}>
-                        {viz.title || item.i}
+                        {headerTitle}
                       </h2>
-                      {viz.subtitle && (
-                        <p className={SHARED_CHROME.dragHandleSubtitle}>{viz.subtitle}</p>
+                      {headerSubtitle && (
+                        <p className={SHARED_CHROME.dragHandleSubtitle}>{headerSubtitle}</p>
                       )}
                     </div>
                   </header>

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardTable.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardTable.jsx
@@ -8,7 +8,8 @@ import { buildRedSeverityStyle } from "../config/tablePresentation";
 import { formatOfficerLabel, dimensionKindForName } from "../config/kpiDisplay";
 import useDashboardT from "../i18n/useDashboardT";
 import { dimensionLabel } from "../i18n/dimensionLabel";
-import { translate as t, exists } from "../i18n/localeRuntime";
+import { translate as t } from "../i18n/localeRuntime";
+import { seriesEntryLabel } from "../i18n/textResolver";
 import useTableSort from "../hooks/useTableSort";
 import TableSortHeader from "./TableSortHeader";
 
@@ -179,8 +180,10 @@ function annotateRowsFromThresholds(rows, columns) {
       cellTones[c.id] = tone;
       // threshold.tagKey.{watch,breach} (DASHBOARD_BADGE_*) wins when seeded,
       // else the descriptor's literal threshold.tag.{watch,breach}.
-      const labelKey = c.threshold.tagKey?.[tone];
-      const label = labelKey && exists(labelKey) ? t(labelKey) : c.threshold.tag?.[tone];
+      const label = seriesEntryLabel(
+        { labelKey: c.threshold.tagKey?.[tone] },
+        c.threshold.tag?.[tone]
+      );
       if (label) tags.push({ label, tone });
     }
     if (!Object.keys(cellTones).length && !hasTagsCol) return row;

--- a/digit-ui-esbuild/products/dashboard/src/components/KpiTile.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/KpiTile.jsx
@@ -21,7 +21,7 @@ import {
 import useDashboardT from '../i18n/useDashboardT';
 import { dimensionLabel } from '../i18n/dimensionLabel';
 import { translate as t } from '../i18n/localeRuntime';
-import { resolveTitle, resolveSubtitle, seriesEntryLabel } from '../i18n/textResolver';
+import { resolveTitle, resolveSubtitle, seriesEntryLabel, resolveSeriesLabel } from '../i18n/textResolver';
 
 /**
  * Generic viz-kind-driven tile renderer (the dashboard RENDERING ENGINE).
@@ -537,7 +537,7 @@ function adaptStacked(ctx) {
     if (viz.limit) rows = rows.slice(0, viz.limit);
     return {
       categories: rows.map((r) => r.label),
-      series: [{ name: viz.seriesLabel || t("DASHBOARD_COMMON_COUNT", "Count"), data: rows.map((r) => r.value) }],
+      series: [{ name: resolveSeriesLabel(viz, viz.seriesLabel || t("DASHBOARD_COMMON_COUNT", "Count")), data: rows.map((r) => r.value) }],
       colors: viz.colors || ['var(--chart-1)'],
     };
   }

--- a/digit-ui-esbuild/products/dashboard/src/components/KpiTile.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/KpiTile.jsx
@@ -20,7 +20,8 @@ import {
 } from '../config/complaintsAtRiskPresentation';
 import useDashboardT from '../i18n/useDashboardT';
 import { dimensionLabel } from '../i18n/dimensionLabel';
-import { translate as t, exists } from '../i18n/localeRuntime';
+import { translate as t } from '../i18n/localeRuntime';
+import { resolveTitle, resolveSubtitle, seriesEntryLabel } from '../i18n/textResolver';
 
 /**
  * Generic viz-kind-driven tile renderer (the dashboard RENDERING ENGINE).
@@ -1074,54 +1075,6 @@ function epochOrIsoToDateKey(value) {
 
 function normalizeSeg(value) {
   return String(value ?? '').toUpperCase();
-}
-
-/**
- * Title resolution for the inverted catalog. `titleKey` (a raw
- * RAINMAKER-PGR.DASHBOARD_KPI_* localization code) wins when its message is
- * seeded; otherwise the human `viz.title` from the MDMS def is the source of
- * truth, and the prettified key remains the last-resort fallback — never
- * rendered verbatim.
- */
-function resolveTitle(def) {
-  const titleKey = def?.viz?.titleKey || def?.titleKey;
-  if (titleKey && exists(titleKey)) return t(titleKey);
-  return (
-    def?.viz?.title ||
-    def?.title ||
-    def?.name ||
-    prettifyTitleKey(titleKey) ||
-    ''
-  );
-}
-
-/**
- * Subtitle: `viz.subtitleKey` (RAINMAKER-PGR.DASHBOARD_KPI_<ID>_SUBTITLE) wins
- * when seeded, else the legacy viz.subtitle / description / contextLabel chain.
- */
-function resolveSubtitle(viz) {
-  const subtitle = viz.subtitleKey && exists(viz.subtitleKey) ? t(viz.subtitleKey) : viz.subtitle;
-  return subtitle || viz.description || viz.contextLabel || '';
-}
-
-/**
- * stackSeries / seriesDefs / channelMap / measure-column entries: a `labelKey`
- * (DASHBOARD_WF_STAGE_* / DASHBOARD_CHANNEL_* / DASHBOARD_SLA_* / DASHBOARD_COL_*)
- * wins when seeded, else the descriptor's literal label.
- */
-function seriesEntryLabel(entry, fallback) {
-  return entry?.labelKey && exists(entry.labelKey) ? t(entry.labelKey) : fallback;
-}
-
-function prettifyTitleKey(key) {
-  if (!key) return '';
-  const tail = String(key).split('.').pop().replace(/^DASHBOARD_KPI_/, '');
-  if (!tail) return '';
-  return tail
-    .toLowerCase()
-    .replace(/_/g, ' ')
-    .replace(/\b\w/g, (c) => c.toUpperCase())
-    .trim();
 }
 
 function errorLabel(code) {

--- a/digit-ui-esbuild/products/dashboard/src/components/TableSortHeader.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/TableSortHeader.jsx
@@ -1,15 +1,16 @@
 import React from "react";
 import useDashboardT from "../i18n/useDashboardT";
+import { seriesEntryLabel } from "../i18n/textResolver";
 
 const TableSortHeader = ({ column, sortState, onSort }) => {
-  const { t, exists } = useDashboardT();
+  const { t } = useDashboardT();
   const active = sortState.key === column.id;
   const nextDirection =
     active && sortState.direction === "asc"
       ? t("DASHBOARD_TABLE_SORT_DESCENDING", "descending")
       : t("DASHBOARD_TABLE_SORT_ASCENDING", "ascending");
   // Column descriptors may carry a labelKey (DASHBOARD_COL_*) that wins when seeded.
-  const label = column.labelKey && exists(column.labelKey) ? t(column.labelKey) : column.label;
+  const label = seriesEntryLabel(column, column.label);
 
   return (
     <button

--- a/digit-ui-esbuild/products/dashboard/src/i18n/textResolver.js
+++ b/digit-ui-esbuild/products/dashboard/src/i18n/textResolver.js
@@ -1,0 +1,71 @@
+import { translate as t, exists } from "./localeRuntime";
+
+/**
+ * THE single seam between catalog-descriptor text and display text — the
+ * companion of dimensionLabel.js (which covers data VALUES; this file covers
+ * the descriptor's own titles, subtitles and series labels). Every place the
+ * dashboard renders `viz.title` / `viz.subtitle` / a seriesDefs / stackSeries /
+ * channelMap / column label must route through here.
+ *
+ * Resolution rule (shared with dimensionLabel): a localization KEY wins when
+ * its message is seeded; otherwise the DATA-OWNED English from the MDMS
+ * KpiDefinition descriptor renders verbatim — a localisation gap surfaces as
+ * readable English, and the client never invents translations.
+ */
+
+/**
+ * Title resolution for the inverted catalog. `titleKey` (a raw
+ * RAINMAKER-PGR.DASHBOARD_KPI_* localization code) wins when its message is
+ * seeded; otherwise the human `viz.title` from the MDMS def is the source of
+ * truth, and the prettified key remains the last-resort fallback — never
+ * rendered verbatim.
+ */
+export function resolveTitle(def) {
+  const titleKey = def?.viz?.titleKey || def?.titleKey;
+  if (titleKey && exists(titleKey)) return t(titleKey);
+  return (
+    def?.viz?.title ||
+    def?.title ||
+    def?.name ||
+    prettifyTitleKey(titleKey) ||
+    ''
+  );
+}
+
+/**
+ * Subtitle: `viz.subtitleKey` (RAINMAKER-PGR.DASHBOARD_KPI_<ID>_SUBTITLE) wins
+ * when seeded, else the legacy viz.subtitle / description / contextLabel chain.
+ */
+export function resolveSubtitle(viz) {
+  const subtitle = viz?.subtitleKey && exists(viz.subtitleKey) ? t(viz.subtitleKey) : viz?.subtitle;
+  return subtitle || viz?.description || viz?.contextLabel || '';
+}
+
+/**
+ * stackSeries / seriesDefs / channelMap / measure-column entries: a `labelKey`
+ * (DASHBOARD_SERIES_* / DASHBOARD_WF_STAGE_* / DASHBOARD_CHANNEL_* /
+ * DASHBOARD_SLA_* / DASHBOARD_COL_*) wins when seeded, else the descriptor's
+ * literal label.
+ */
+export function seriesEntryLabel(entry, fallback) {
+  return entry?.labelKey && exists(entry.labelKey) ? t(entry.labelKey) : fallback;
+}
+
+/**
+ * Single-series bar charts name their one series via `viz.seriesLabel`
+ * ("Filed"); `viz.seriesLabelKey` (DASHBOARD_SERIES_*) wins when seeded.
+ */
+export function resolveSeriesLabel(viz, fallback) {
+  return seriesEntryLabel({ labelKey: viz?.seriesLabelKey }, fallback);
+}
+
+function prettifyTitleKey(key) {
+  if (!key) return '';
+  const tail = String(key).split('.').pop().replace(/^DASHBOARD_KPI_/, '');
+  if (!tail) return '';
+  return tail
+    .toLowerCase()
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .trim();
+}


### PR DESCRIPTION
## Problem

Supervisor-dashboard text was only partially localized because it left the i18n pipeline in four places:

1. **AdminDashboard rendered non-card widget chrome raw.** Chart/table headers used `viz.title` / `viz.subtitle` directly (plus raw titles in the search-dimming match, the Add-KPI picker item names, the remove-button labels and the CSV export), so seeded `titleKey`/`subtitleKey` translations never applied — e.g. "Open Complaints by Workflow Stage" and "Employees with most open complaints" stayed English after a language switch even though their French messages are seeded. Only card tiles (via KpiTile's private resolvers) localized correctly.
2. **The repo MDMS catalog was stale.** `ansible/nairobi-mdms/mdms/dss/KpiDefinition.json` had 28 entries; the live catalog has 39 — the 11 second-wave KPIs (`cl_total_complaints_count`, `cl_flow_ratio_count`, `cl_chart_complaints_over_time`, `cl_chart_over_time_open_daily`, `cl_chart_wards_by_sla`, `cl_chart_department_breach_scatter`, and five `cl_table_*` widgets) were never folded back.
3. **`seriesDefs` entries were keyless** (and `viz.seriesLabel` had no key counterpart), so line-chart legend labels ("Created", "Resolved", …) could never localize.
4. **The seed pack lagged the catalog**: no messages for the second-wave titleKeys/subtitles, no `DASHBOARD_SERIES_*` keys, and a stale doc-header claiming `DASHBOARD_GEO_LEVEL_*` keys are unseeded when the array contains them.

## What changed

- **`products/dashboard/src/i18n/textResolver.js` (new):** `resolveTitle` / `resolveSubtitle` / `seriesEntryLabel` / `resolveSeriesLabel` extracted from KpiTile into a shared module — the descriptor-text companion of `dimensionLabel.js`. Rule unchanged: a localization key wins when its message is seeded, else the catalog's data-owned English renders; the client never invents translations.
- **KpiTile, DashboardTable (threshold tag labels), TableSortHeader (column labels)** consume the shared module (pure refactor).
- **AdminDashboard** routes all six raw call sites through the resolvers: widget header title + subtitle, search match, Add-KPI picker names (re-localized on language switch), remove-button aria labels, CSV export titles.
- **KpiTile single-series charts** honour a new `viz.seriesLabelKey` over the literal `seriesLabel`.
- **`dss/KpiDefinition.json`:** folded the 11 second-wave KPIs with full key fields (`titleKey`, `subtitleKey` where a subtitle exists, series labelKeys); added `labelKey` to every `seriesDefs` entry per the `DASHBOARD_SERIES_*` canon and `seriesLabelKey: DASHBOARD_SERIES_FILED` to `cl_chart_complaints_by_type`; `cl_chart_wards_by_sla` stack segments reuse the existing `DASHBOARD_SLA_*` keys (+ `DASHBOARD_SERIES_RESOLVED` for its resolved segment). `cl_chart_department_flow_ratio` already carried its titleKey in the repo copy (verified against the orphaned seeded key).
- **`digit-mcp/src/tools/dashboard-l10n-seed.ts`:** +26 en_IN messages — 11 second-wave titles + 9 subtitles (English verbatim from the live catalog) + 6 `DASHBOARD_SERIES_*` keys; fixed the stale `DASHBOARD_GEO_LEVEL_*` doc-header.

## Known gap (left deliberately)

The "On-time %" series of `cl_chart_complaints_over_time` stays keyless: it computes `on_time ÷ resolved`, which is not the `DASHBOARD_SERIES_SLA_COMPLIANCE_RATE` ("SLA compliance rate", `on_time ÷ created`) canon message, so mapping it would silently change the English copy. It falls back to its English label until a key is canonised. Similarly, the folded tables' column labels that have no exactly-matching seeded `DASHBOARD_COL_*` message (Channel, Volume, Ward, Trend, …) keep their English `label` fallback.

## Verification

- `npm run build` in `digit-ui-esbuild` — green (563ms, same warnings as develop).
- `npm run build` in `digit-mcp` (workspace + `tsc`) — green.
- Resolver smoke test with a mocked host i18next: seeded titleKey → translation; unseeded subtitleKey → English catalog fallback; seeded `seriesLabelKey` → translation; unseeded `labelKey` → English label; keyless def → `viz.title`. All pass.
- `KpiDefinition.json` round-trips `json.loads`/`dumps` byte-identical to the repo formatting; the diff is pure insertions.

## Rollout note

Live bomet MDMS (`dss.KpiDefinition` series labelKeys) and the corresponding localization messages are being updated **in parallel** on the box by a separate workstream, using the same `DASHBOARD_SERIES_*` canon as this PR — repo and live stay reconciled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new complaint and service-performance dashboard KPIs, including charts, tables, ratios, SLA metrics, ward views, and department analysis.
  * Added localized titles, subtitles, chart series labels, table headers, and threshold labels.
  * Dashboard search, KPI selection, widget controls, and CSV exports now display translated text.
  * Added canonical English dashboard geography labels for localization.

* **Improvements**
  * Improved consistency and fallback behavior for dashboard titles and labels across visualizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->