### PR TITLE
fix(dashboard): locale-refresh for picker titles + header title/date and CSV-export i18n

### DIFF
--- a/digit-mcp/src/tools/dashboard-l10n-seed.ts
+++ b/digit-mcp/src/tools/dashboard-l10n-seed.ts
@@ -493,6 +493,11 @@ export const DASHBOARD_L10N_MESSAGES: { code: string; message: string; module: s
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "DASHBOARD_HEADER_TITLE",
+    "message": "Complaint Resolution Operations",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "DASHBOARD_HEADER_TYPE_CHART",
     "message": "CHART",
     "module": "rainmaker-dashboard"

--- a/digit-mcp/src/tools/dashboard-l10n-seed.ts
+++ b/digit-mcp/src/tools/dashboard-l10n-seed.ts
@@ -288,6 +288,26 @@ export const DASHBOARD_L10N_MESSAGES: { code: string; message: string; module: s
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "DASHBOARD_EXPORT_COL_KPI",
+    "message": "KPI",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_EXPORT_COL_TITLE",
+    "message": "Title",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_EXPORT_COL_VALUE",
+    "message": "Value",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_EXPORT_ROWS",
+    "message": "rows",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "DASHBOARD_FILTERS_ALL_TYPES",
     "message": "All types",
     "module": "rainmaker-dashboard"

--- a/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
@@ -502,11 +502,19 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
         assembled?.value != null
           ? assembled.value
           : assembled?.rows
-          ? `${assembled.rows.length} rows`
+          ? `${assembled.rows.length} ${t("DASHBOARD_EXPORT_ROWS", "rows")}`
           : "";
       return [resolveTitle(def) || item.i, item.i, value];
     });
-    const csv = ["Title,KPI,Value", ...rows.map((r) => r.map(csvEscape).join(","))].join("\n");
+    // Column headers go through t() like the tile titles (resolveTitle above);
+    // the filename stays ASCII-English on purpose — a stable machine-facing
+    // identifier, not display copy.
+    const header = [
+      t("DASHBOARD_EXPORT_COL_TITLE", "Title"),
+      t("DASHBOARD_EXPORT_COL_KPI", "KPI"),
+      t("DASHBOARD_EXPORT_COL_VALUE", "Value"),
+    ];
+    const csv = [header, ...rows].map((r) => r.map(csvEscape).join(",")).join("\n");
     const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
@@ -514,7 +522,7 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
     a.download = "dashboard-export.csv";
     a.click();
     URL.revokeObjectURL(url);
-  }, [layout, kpis, batch.results]);
+  }, [layout, kpis, batch.results, t]);
 
   const showEmpty = !catalogLoading && pack && layout.length === 0;
 

--- a/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
@@ -334,7 +334,7 @@ function seriesToPoints(rows, viz, valueKey, columns) {
 /* -------------------------------------------------------------------------- */
 
 const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
-  const { t, language } = useDashboardT();
+  const { t, language, i18nTick } = useDashboardT();
   const { filters, setFilter, clearFilters, applyFilterOptions } =
     useDashboardFilters();
   const { options: filterOptions, loading: filterOptionsLoading } =
@@ -383,12 +383,16 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
       const title = (resolveTitle(kpis[kpiId]) || kpiId).toLowerCase();
       return title.includes(q);
     },
-    [searchQuery, kpis]
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- i18nTick re-resolves titles on late bundle arrival
+    [searchQuery, kpis, i18nTick]
   );
 
   // Add-KPI picker source: every role-visible catalog tile (already filtered
   // server-side), shaped to the picker's { id, metric, type, itemType } contract.
-  // `language` is a dep so the resolved metric names re-localize on a language switch.
+  // `language` re-localizes the resolved names on a language switch; `i18nTick`
+  // covers the async gap behind it — the host fires i18next.changeLanguage
+  // BEFORE the new locale's bundles finish fetching, so the names must also
+  // re-resolve when the messages actually land ("added" store event).
   const catalogItems = useMemo(
     () =>
       Object.values(kpis)
@@ -399,7 +403,8 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
           type: def.viz?.kind,
           itemType: isCardKind(def.viz?.kind) ? "kpi" : "widget",
         })),
-    [kpis, language]
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- i18nTick re-resolves titles on late bundle arrival
+    [kpis, language, i18nTick]
   );
 
   // Re-run the batch whenever the catalog resolves or the filters change.

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardHeader.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardHeader.jsx
@@ -37,14 +37,28 @@ function buildRowScope(scope) {
   return { deptLabel, areaLabel, hasDepartments: departments.length > 0 };
 }
 
-function formatDisplayDate(iso) {
+/**
+ * Render a filter ISO date (yyyy-mm-dd) in the ACTIVE locale's numeric order —
+ * hardcoding `${m}/${d}/${y}` printed US dates under every locale (06/13/2026
+ * where French expects 13/06/2026). `language` is the DIGIT locale
+ * (en_IN / fr_FR); underscore→hyphen makes it a BCP 47 tag.
+ */
+function formatDisplayDate(iso, language) {
   if (!iso) return "";
   const [y, m, d] = iso.split("-");
   if (!y || !m || !d) return iso;
-  return `${m}/${d}/${y}`;
+  const date = new Date(Number(y), Number(m) - 1, Number(d));
+  if (Number.isNaN(date.getTime())) return iso;
+  const opts = { day: "2-digit", month: "2-digit", year: "numeric" };
+  try {
+    return date.toLocaleDateString(language?.replace("_", "-"), opts);
+  } catch (e) {
+    // Malformed stored locale tag — let the browser default decide.
+    return date.toLocaleDateString(undefined, opts);
+  }
 }
 
-function buildSubtitle(filters, filterOptions, t) {
+function buildSubtitle(filters, filterOptions, t, language) {
   const geoOptions = filterOptions?.geography ?? GEOGRAPHY_OPTIONS;
   const geoId = filters?.geography;
   // The geography chip is a raw boundary code — route it through the
@@ -56,10 +70,8 @@ function buildSubtitle(filters, filterOptions, t) {
         t("DASHBOARD_HEADER_ALL_LOCALITIES", "All Localities");
 
   let period = t("DASHBOARD_HEADER_LAST_7_DAYS", "Last 7 days");
-  if (filters?.dateRangeActive && filters?.dateFrom && filters?.dateTo) {
-    period = `${formatDisplayDate(filters.dateFrom)} – ${formatDisplayDate(filters.dateTo)}`;
-  } else if (filters?.dateFrom && filters?.dateTo) {
-    period = `${formatDisplayDate(filters.dateFrom)} – ${formatDisplayDate(filters.dateTo)}`;
+  if (filters?.dateFrom && filters?.dateTo) {
+    period = `${formatDisplayDate(filters.dateFrom, language)} – ${formatDisplayDate(filters.dateTo, language)}`;
   }
 
   return `${geo} · ${period}`;
@@ -106,7 +118,7 @@ const DashboardHeader = ({
   // `language` re-keys the memos on language switch (t itself is stable).
   const rowScope = useMemo(() => buildRowScope(scope), [scope, language]);
   const subtitle = useMemo(
-    () => buildSubtitle(filters, filterOptions, t),
+    () => buildSubtitle(filters, filterOptions, t, language),
     [filters, filterOptions, t, language]
   );
   // ONE full-phrase key wins when seeded — splicing the DASHBOARD_PRODUCT_LABEL

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardHeader.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardHeader.jsx
@@ -113,13 +113,14 @@ const DashboardHeader = ({
 }) => {
   const [addKpiOpen, setAddKpiOpen] = useState(false);
   const addKpiRef = useRef(null);
-  const { t, exists, language } = useDashboardT();
+  const { t, exists, language, i18nTick } = useDashboardT();
   const productLabel = useMemo(() => getProductLabel(), []);
-  // `language` re-keys the memos on language switch (t itself is stable).
-  const rowScope = useMemo(() => buildRowScope(scope), [scope, language]);
+  // `language` re-keys the memos on language switch; `i18nTick` re-keys them
+  // when a locale bundle arrives asynchronously after the switch (t is stable).
+  const rowScope = useMemo(() => buildRowScope(scope), [scope, language, i18nTick]);
   const subtitle = useMemo(
     () => buildSubtitle(filters, filterOptions, t, language),
-    [filters, filterOptions, t, language]
+    [filters, filterOptions, t, language, i18nTick]
   );
   // ONE full-phrase key wins when seeded — splicing the DASHBOARD_PRODUCT_LABEL
   // globalConfig onto a translated "Operations" produced mixed-language titles

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardHeader.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardHeader.jsx
@@ -101,7 +101,7 @@ const DashboardHeader = ({
 }) => {
   const [addKpiOpen, setAddKpiOpen] = useState(false);
   const addKpiRef = useRef(null);
-  const { t, language } = useDashboardT();
+  const { t, exists, language } = useDashboardT();
   const productLabel = useMemo(() => getProductLabel(), []);
   // `language` re-keys the memos on language switch (t itself is stable).
   const rowScope = useMemo(() => buildRowScope(scope), [scope, language]);
@@ -109,7 +109,16 @@ const DashboardHeader = ({
     () => buildSubtitle(filters, filterOptions, t),
     [filters, filterOptions, t, language]
   );
-  const title = productLabel.toLowerCase().includes("pgr")
+  // ONE full-phrase key wins when seeded — splicing the DASHBOARD_PRODUCT_LABEL
+  // globalConfig onto a translated "Operations" produced mixed-language titles
+  // ("Complaint Resolution Opérations"); word order/agreement can't survive
+  // per-word translation. The legacy composition stays as the unseeded fallback,
+  // so tenants that brand via DASHBOARD_PRODUCT_LABEL and don't seed
+  // DASHBOARD_HEADER_TITLE keep their branded English title; branded tenants
+  // that localize should carry the brand inside the seeded message itself.
+  const title = exists("DASHBOARD_HEADER_TITLE")
+    ? t("DASHBOARD_HEADER_TITLE", "Complaint Resolution Operations")
+    : productLabel.toLowerCase().includes("pgr")
     ? t("DASHBOARD_HEADER_PGR_OPERATIONS", "PGR Operations")
     : `${productLabel} ${t("DASHBOARD_HEADER_OPERATIONS", "Operations")}`;
 

--- a/digit-ui-esbuild/products/dashboard/src/i18n/useDashboardT.js
+++ b/digit-ui-esbuild/products/dashboard/src/i18n/useDashboardT.js
@@ -8,12 +8,19 @@ import { translate, exists, getLanguage, subscribe, ensureMessages } from "./loc
  * (which exists only as the seed pack's extraction source). `language` is
  * included so imperatively-drawn surfaces (Leaflet layers, ApexCharts
  * instances) can re-key on it — the #882 ward-tooltip pattern.
+ *
+ * `i18nTick` increments on EVERY store event (language change AND late bundle
+ * arrival). The host's ChangeLanguage fires i18next.changeLanguage without
+ * awaiting the new locale's bundle fetch, so `language` alone is not a safe
+ * memo dep for derivations that bake resolved strings (the Add-KPI picker's
+ * catalogItems): they'd compute against a half-loaded store and never refresh
+ * when the messages land. Dep on `i18nTick` wherever resolve* output is memoized.
  */
 export default function useDashboardT() {
-  const [, bump] = useReducer((x) => x + 1, 0);
+  const [tick, bump] = useReducer((x) => x + 1, 0);
   useEffect(() => {
     ensureMessages();
     return subscribe(bump);
   }, []);
-  return { t: translate, exists, language: getLanguage() };
+  return { t: translate, exists, language: getLanguage(), i18nTick: tick };
 }


### PR DESCRIPTION
Follow-up to #1159 — dashboard i18n fixes: the picker locale-refresh commit that missed the #1159 train, plus the header title/date and CSV-export localization bugs seen on bomet under French.

## 1. Picker titles re-resolve when locale bundles land late
`ChangeLanguage` fires `i18next.changeLanguage` without awaiting the new locale's bundle fetch, so the Add-KPI picker's `catalogItems`/`matchesSearch` memos (dep'd only on `[kpis, language]`) bake titles against a half-loaded store and never refresh when the messages arrive — KPI names stay in the previous language until a full re-render.

**Fix:** `useDashboardT` exposes an `i18nTick` counter that bumps on every i18next store event (including async resource arrival); both memo sites in `AdminDashboard.jsx` depend on it.

## 2. Mixed-language header title ("Complaint Resolution Opérations")
`DashboardHeader.jsx` composed the title as `${DASHBOARD_PRODUCT_LABEL globalConfig} ${t("DASHBOARD_HEADER_OPERATIONS")}` — an untranslatable config constant spliced onto a translated word. No per-word composition can produce grammatical French/Portuguese (word order and agreement don't survive splicing).

**Fix:** one full-phrase `DASHBOARD_HEADER_TITLE` key wins when seeded (same `exists()`/fallback idiom as textResolver); unseeded tenants keep the exact previous composed-English behavior, including `DASHBOARD_PRODUCT_LABEL` branding. **Tradeoff:** a tenant that both brands via `DASHBOARD_PRODUCT_LABEL` and localizes must carry the brand inside the seeded message itself — the single-key approach was preferred over a branded interpolation because interpolating a config constant into a translated phrase reintroduces the splicing problem.

## 3. US date order in the header range under fr ("06/13/2026")
`formatDisplayDate` hardcoded `${m}/${d}/${y}`. It now formats via `toLocaleDateString` with the active DIGIT locale from `useDashboardT` (`fr_FR` → `fr-FR`), numeric 2-digit day/month; French renders `13/06/2026`. All other dashboard dates (tiles, map hover, last-updated stamp) were already locale-driven.

## 4. CSV export localization
KPI titles in the export already route through `resolveTitle` (#1159), but the header row (`Title,KPI,Value`) and the `N rows` value were raw English — now `t()` with `DASHBOARD_EXPORT_COL_*` / `DASHBOARD_EXPORT_ROWS`, seeded in the en_IN pack. Deliberately left English: the `dashboard-export.csv` filename (machine-facing identifier, not display copy).

## Seeds
`digit-mcp/src/tools/dashboard-l10n-seed.ts` gains `DASHBOARD_HEADER_TITLE` ("Complaint Resolution Operations" — the current default composition verbatim) and the four export keys. en_IN + fr_FR messages for the new keys upserted live on bomet (module `rainmaker-dashboard`, tenant `ke`).

## Verification
- Picker commit cherry-picked verbatim from the branch commit already built and verified live on bomet 2026-07-11 (picker re-verified rendering French after a cold language switch).
- Header/date/export commits built green (`npm run build` in digit-ui-esbuild; digit-mcp `tsc` clean) and temp-deployed to bomet from this branch (served `/digit-ui/index.js` sha256 equals the new artifact; bundle contains the new keys).
- New-key messages verified live via Kong `_search` in both locales: fr_FR `DASHBOARD_HEADER_TITLE` = "Opérations de résolution des réclamations"; the fr date range formats as `13/06/2026 – 13/07/2026` per `toLocaleDateString("fr-FR")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
