### PR TITLE
fix(pgr): remove tenant/city token from the complaint address line (CCSD-1981)

### DIFF
--- a/digit-ui-esbuild/packages/libraries/src/hooks/pgr/useComplaintDetails.js
+++ b/digit-ui-esbuild/packages/libraries/src/hooks/pgr/useComplaintDetails.js
@@ -20,10 +20,12 @@ const getDetailsRow = ({ id, service, complaintType }) => ({
   CS_ADDCOMPLAINT_COMPLAINT_SUB_TYPE: `COMPLAINT_HIERARCHY.${service.serviceCode.toUpperCase()}`,
   CS_COMPLAINT_ADDTIONAL_DETAILS: service.description,
   CS_COMPLAINT_FILED_DATE: Digit.DateUtils.ConvertTimestampToDate(service.auditDetails.createdTime),
+  // Address = real location parts only. The tenant/city token
+  // (TENANT_TENANTS_<tenantId>) used to be appended here and printed as part of
+  // the address (e.g. "…, Namaacha Sede, IGE") — wrong at Moz level; removed.
   ES_CREATECOMPLAINT_ADDRESS: [
     service.address.landmark,
     Digit.Utils.getMultiRootTenant() ? `ADMIN_${service.address.locality.code}` : Digit.Utils.locale.getLocalityCode(service.address.locality, service.tenantId),
-    `TENANT_TENANTS_${service?.tenantId?.toUpperCase?.()?.replace(".", "_")}`,
     service.address.pincode,
   ],
 });


### PR DESCRIPTION
## Jira
[CCSD-1981](https://digit-discuss.atlassian.net/browse/CCSD-1981)

The complaint-details address printed the tenant/city token, e.g. **"SDADADS, Namaacha Sede, IGE"** (QA: "…, Ribaue, IGSE"). Removed the `TENANT_TENANTS_<tenantId>` element from `ES_CREATECOMPLAINT_ADDRESS` in `useComplaintDetails.js`. Landmark / locality / pincode unchanged. Employee details page builds its address separately and was unaffected.

### QA (before/after, both viewports)
`~/Desktop/CCRS-QA/CCSD-1981/` — driven text read:
```
before: 'SDADADS, Namaacha Sede, IGE'   after: 'SDADADS, Namaacha Sede'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CCSD-1981]: https://digit-discuss.atlassian.net/browse/CCSD-1981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ