### PR TITLE
fix(pgr): Moz QA CSS + theme batch (CCSD-1982/1983/1984/1985)

### DIFF
--- a/digit-ui-esbuild/public/vendor/overrides.css
+++ b/digit-ui-esbuild/public/vendor/overrides.css
@@ -6021,3 +6021,21 @@ header.digit-header .digit-dropdown-master {
   background: #fff;
   box-shadow: 0 8px 10px 1px rgba(0,0,0,.14), 0 3px 14px 2px rgba(0,0,0,.12), 0 5px 5px -3px rgba(0,0,0,.2);
 }
+
+/* ============================================================================
+   CCSD-1985 — unify all primary buttons to the Moz brand ORANGE (#c84c0e).
+   The v2 buttons paint inline from var(--color-button-primary-bg-default, …),
+   which the tenant theme had set to yellow (#FEC931), while orange leaked
+   through the legacy paths — two shades on one screen. Force the brand button
+   vars to orange with !important so every path (v2 inline-var buttons, legacy
+   --color-primary-main buttons, submit bars) resolves to one shade. !important
+   on these custom properties beats applyTheme's runtime (non-important) :root
+   values. Text stays dark via --color-text-primary.
+   ========================================================================= */
+:root {
+  --color-button-primary-bg-default: #c84c0e !important;
+  --color-button-primary-bg-hover: #a83d0b !important;
+  --color-button-primary-bg-pressed: #8f340a !important;
+  --color-primary-2: #c84c0e !important;
+  --color-primary-main: #c84c0e !important;
+}

--- a/digit-ui-esbuild/public/vendor/overrides.css
+++ b/digit-ui-esbuild/public/vendor/overrides.css
@@ -5958,3 +5958,66 @@ header.digit-header .digit-dropdown-master {
 .navbar .digit-dropdown-employee-select-wrap:focus-within {
   border-color: revert !important;
 }
+
+/* ============================================================================
+   Moz QA CSS batch (CCSD-1982 / 1983 / 1984)
+   ========================================================================= */
+
+/* CCSD-1982 — text inputs clickable across the full field.
+   The wrapper was made flex but its child container never told to fill it,
+   so the <input> spanned ~60% of the bordered box and the right side didn't
+   place the caret. Stretch the container (and thus the input) to full width. */
+.digit-text-input-field > .input-container {
+  flex: 1 1 auto !important;
+  width: 100% !important;
+  max-width: 100% !important;
+  min-width: 0 !important;
+}
+
+/* CCSD-1983 — header/brand logo must not stretch.
+   The navbar logo had object-fit:fill + min-width:78px, distorting non-square
+   logos. Use contain and drop the min-width. Profile avatars keep cover. */
+.navbar img {
+  object-fit: contain !important;
+  min-width: 0 !important;
+  width: auto !important;
+}
+.profile-section img {
+  object-fit: cover !important;
+  object-position: center !important;
+}
+
+/* CCSD-1984 — employee inbox Date Range: align the box + float the calendar.
+   (a) normalize to the 44px rounded v2 chrome and vertically center contents;
+   (b) render the calendar as an absolute popover so it overlays instead of
+       pushing the page down and leaving empty space. */
+.v2-pgr-inbox .digit-employee-select-wrap .digit-select {
+  height: 44px !important;
+  border: 1px solid var(--color-border, #d6d5d4) !important;
+  border-radius: 6px !important;
+  background: var(--v2-surface-color, var(--color-surface, #fff)) !important;
+  display: flex !important;
+  align-items: center !important;
+}
+.v2-pgr-inbox .digit-employee-select-wrap .digit-select input[type="text"] {
+  position: static !important;
+  height: 100% !important;
+  width: calc(100% - 32px) !important;
+  border: 0 !important;
+}
+.v2-pgr-inbox .digit-employee-select-wrap .digit-select svg {
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  margin: 0 !important;
+  transform: translateY(-50%);
+}
+.v2-pgr-inbox .digit-employee-select-wrap .options-card {
+  position: absolute !important;
+  z-index: 20;
+  margin-top: 4px;
+  width: max-content;
+  max-width: none;
+  background: #fff;
+  box-shadow: 0 8px 10px 1px rgba(0,0,0,.14), 0 3px 14px 2px rgba(0,0,0,.12), 0 5px 5px -3px rgba(0,0,0,.2);
+}


### PR DESCRIPTION
## Jira
- [CCSD-1982](https://digit-discuss.atlassian.net/browse/CCSD-1982) text inputs not clickable mid-to-end (GH #1164)
- [CCSD-1983](https://digit-discuss.atlassian.net/browse/CCSD-1983) header/brand logo stretch
- [CCSD-1984](https://digit-discuss.atlassian.net/browse/CCSD-1984) inbox Date Range box + calendar popover

CSS-only, all in `public/vendor/overrides.css`. Grouped (one file).

### Verified (measured)
```
1982 input fillRatio: 0.60 -> 0.99      1983 logo object-fit: fill -> contain
1984 (a) date-range box aligned to 44px (before/after inbox shots)
1984 (b) calendar popover CSS scoped + classes confirmed present — needs a manual QA click to confirm overlay
```
QA before/after (both viewports) + reports: `~/Desktop/CCRS-QA/CCSD-1982|1983|1984/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CCSD-1982]: https://digit-discuss.atlassian.net/browse/CCSD-1982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CCSD-1983]: https://digit-discuss.atlassian.net/browse/CCSD-1983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CCSD-1984]: https://digit-discuss.atlassian.net/browse/CCSD-1984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---
## Added: CCSD-1985 — unify primary buttons to brand orange
Forced brand button vars to **#c84c0e** in `overrides.css :root` with `!important` (beats the tenant's runtime yellow). Verified inbox Apply/Search `#FEC931 → #c84c0e`. Direction chosen by product (orange, matching sidebar/emblem/default.json). QA data: `~/Desktop/CCRS-QA/CCSD-1985/`.