### PR TITLE
fix(pgr,core): hide consents on view screens; strict profile email validation (CCSD-1988/1989)

### DIFF
--- a/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Home/UserProfile.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Home/UserProfile.js
@@ -459,11 +459,16 @@ const UserProfile = ({ stateCode, userType, cityDetails }) => {
     }
   };
 
+  // Same rule as the complaint form (CCSD-1978): blank is fine, a typed value
+  // must be a well-formed address. The old check (has "@" AND has ".") passed
+  // shapes like "a@b." which then failed the SAVE round-trip with an
+  // unlocalized backend error (CCSD-1989).
+  const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   const setUserEmailAddress = (value) => {
     if (userInfo?.userName !== value) {
       setEmail(value);
 
-      if (value.length && !(value.includes("@") && value.includes("."))) {
+      if (value.length && !EMAIL_RE.test(value.trim())) {
         setErrors({
           ...errors,
           emailAddress: {
@@ -586,7 +591,7 @@ const UserProfile = ({ stateCode, userType, cityDetails }) => {
         });
       }
 
-      if (email.length && !(email.includes("@") && email.includes("."))) {
+      if (email.length && !EMAIL_RE.test(email.trim())) {
         throw JSON.stringify({
           type: "error",
           message: t("CORE_COMMON_PROFILE_EMAIL_INVALID"),

--- a/digit-ui-esbuild/products/pgr/src/components/PgrExtendedAttributesView.js
+++ b/digit-ui-esbuild/products/pgr/src/components/PgrExtendedAttributesView.js
@@ -21,6 +21,9 @@ const SKIP_KEYS = new Set([
   "hierarchyLevel2",
   "complainantAddress",
   "email",
+  // Moz QA (CCSD-1988): consents are an internal acceptance record, not a
+  // user-facing data row — never show them on the view screens.
+  "consents",
 ]);
 
 function formatValue(v) {


### PR DESCRIPTION
## Jira
[CCSD-1988](https://digit-discuss.atlassian.net/browse/CCSD-1988) · [CCSD-1989](https://digit-discuss.atlassian.net/browse/CCSD-1989)

- **1988**: `consents` added to the extended-attributes SKIP_KEYS — the "Consents ****" row no longer renders on citizen/employee details (completes the QA ask *remove consent fields from the view screens*; create-screen checkboxes were removed in CCSD-1979).
- **1989**: citizen profile email check upgraded from `includes("@") && includes(".")` (let `a@b.` reach SAVE → unlocalized failure) to the same strict pattern as CCSD-1978, in both the inline check and the save gate.

Verified driven on local: details page shows no Consents row (witness rows intact); `a@b.` flags the localized inline error before any save. QA data: `~/Desktop/CCRS-QA/CCSD-1988|1989/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CCSD-1988]: https://digit-discuss.atlassian.net/browse/CCSD-1988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CCSD-1989]: https://digit-discuss.atlassian.net/browse/CCSD-1989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ