### PR TITLE
feat(ddh): pt_PT localization seeds — inbox/filter labels + locale list (CCSD-1987)

### DIFF
--- a/utilities/default-data-handler/src/main/resources/application.properties
+++ b/utilities/default-data-handler/src/main/resources/application.properties
@@ -60,7 +60,7 @@ egov.localization.host=http://localhost:8087
 egov.localization.default.data.create.endpoint=/localization/defaultdata/_create
 egov.localization.upsert.path=/localization/messages/v1/_upsert
 
-default.localization.locale.list=en_IN,hi_IN
+default.localization.locale.list=en_IN,hi_IN,pt_PT
 default.localization.module.create.list=digit-ui,digit-sandbox,rainmaker-common,digit-privacy-policy,rainmaker-pgr,rainmaker-hr,rainmaker-workbench,rainmaker-mdms,rainmaker-schema
 tenant.localization.module=digit-tenants
 

--- a/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
@@ -6970,5 +6970,11 @@
         "message": "Companies and Commercial Establishments (Private Entities)",
         "module": "rainmaker-pgr",
         "locale": "en_IN"
+    },
+    {
+        "code": "ROWS_PER_PAGE",
+        "message": "Rows per page",
+        "module": "rainmaker-pgr",
+        "locale": "en_IN"
     }
 ]

--- a/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-common.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-common.json
@@ -1,0 +1,38 @@
+[
+    {
+        "code": "EVENTS_DATERANGE_LABEL",
+        "message": "Intervalo de Datas",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "ES_COMMON_APPLY",
+        "message": "Aplicar",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "ES_CLEAR_ALL",
+        "message": "Limpar Tudo",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CORE_COMMON_PROFILE_EMAIL_INVALID",
+        "message": "Endereço de email inválido",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CORE_COMMON_CITY",
+        "message": "Instituição",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CORE_COMMON_SELECT_CITY",
+        "message": "Selecionar instituição",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    }
+]

--- a/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
@@ -1,0 +1,188 @@
+[
+    {
+        "code": "CS_COMMON_COMPLAINT_NO",
+        "message": "N.º da Reclamação",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_COMMON_MOBILE_NO",
+        "message": "N.º de Telemóvel",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "ACTION_TEST_SEARCH",
+        "message": "Pesquisar",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "ACTION_TEST_HOME",
+        "message": "Início",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "PGR_INBOX",
+        "message": "Caixa de Reclamações",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "ASSIGNED_TO_ME",
+        "message": "Atribuídas a mim",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "ASSIGNED_TO_ALL",
+        "message": "Todas",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "ES_PGR_FILTER_STATUS",
+        "message": "Estado",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_COMPLAINT_DETAILS_COMPLAINT_SUBTYPE",
+        "message": "Subtipo de Reclamação",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "WF_INBOX_HEADER_LOCALITY",
+        "message": "Localidade",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "WF_INBOX_HEADER_CURRENT_OWNER",
+        "message": "Responsável Atual",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "ROWS_PER_PAGE",
+        "message": "Linhas por página",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_COMMON_PGR_STATE_PENDINGFORASSIGNMENT",
+        "message": "Pendente de Atribuição",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_COMMON_PGR_STATE_REFERRED",
+        "message": "Encaminhada",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_COMMON_PGR_STATE_INVESTIGATION",
+        "message": "Em Investigação",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_COMMON_PGR_STATE_INFOFROMCITIZEN",
+        "message": "Aguarda Informação do Cidadão",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_COMMON_PGR_STATE_PENDINGFORREASSIGNMENT",
+        "message": "Pendente de Reatribuição",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_COMMON_PGR_STATE_REJECTED",
+        "message": "Rejeitada",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_COMMON_PGR_STATE_RESOLVED",
+        "message": "Resolvida",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_COMMON_PGR_STATE_CLOSEDAFTERREJECTION",
+        "message": "Fechada após Rejeição",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_COMMON_PGR_STATE_CLOSEDAFTERRESOLUTION",
+        "message": "Fechada após Resolução",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_COMMON_PGR_STATE_CANCELLED",
+        "message": "Cancelada",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_COMMON_PENDINGFORASSIGNMENT",
+        "message": "Pendente de Atribuição",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_COMMON_INVESTIGATION",
+        "message": "Em Investigação",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_COMMON_AWAITINGINFORMATION",
+        "message": "Aguarda Informação",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_COMMON_RESOLVED",
+        "message": "Resolvida",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_COMMON_REJECTED",
+        "message": "Rejeitada",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_DESC_MIN_CHARS",
+        "message": "Descreva o problema em 20 a 1000 caracteres (use palavras, nao apenas numeros).",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_DESC_NEEDS_WORDS",
+        "message": "Descreva o problema por palavras, nao apenas numeros.",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "PGR_RELATEDTO_NAME_IGE",
+        "message": "Serviços do Governo (Entidades Públicas)",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "PGR_RELATEDTO_NAME_IGSAE",
+        "message": "Empresas e Estabelecimentos Comerciais (Entidades Privadas)",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    }
+]


### PR DESCRIPTION
## Jira
[CCSD-1987](https://digit-discuss.atlassian.net/browse/CCSD-1987)

Employee inbox showed raw keys in Portuguese sessions: **en_IN had the catalog, pt_PT had none** (pt_PT is the default locale on Moz). This PR makes new tenants seed pt_PT too:
- `localisations/pt_PT/rainmaker-pgr.json` (31 keys) + `rainmaker-common.json` (6 keys)
- `default.localization.locale.list` += `pt_PT`
- en_IN gap: `ROWS_PER_PAGE`

Existing tenants seeded directly via API on local (verified driven: rawKeysLeft=0, labels render "N.º da Reclamação / Intervalo de Datas / Pesquisar"). Prod/209 need the same upserts — curl set kept with the QA data (`~/Desktop/CCRS-QA/CCSD-1987/`).

Deliberately excluded: the local-only `pgr.workflow.variant` hold in application.properties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CCSD-1987]: https://digit-discuss.atlassian.net/browse/CCSD-1987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ