### PR TITLE
fix(pgr): escape HTML in map ward tooltip — XSS hardening (CCSD-1993)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/GeoLocations.js
+++ b/digit-ui-esbuild/products/pgr/src/components/GeoLocations.js
@@ -136,7 +136,16 @@ const GeoLocations = ({ t, config, onSelect, formData }) => {
     // the raw code rather than blank, and the label re-localizes on language
     // switch (i18n.language is in the dep list).
     const label = (code && trans(code)) || feature?.properties?.name || code;
-    if (label) layer.bindTooltip(label, { sticky: true, direction: "top", className: "ward-tooltip" });
+    // Leaflet bindTooltip renders its content as HTML. `label` derives from
+    // tenant-controlled data (boundary code, localization message, or GeoJSON
+    // `name`), so escape it before binding — otherwise a crafted ward
+    // name/localization value could inject markup/script (CCSD, HTML-escape
+    // audit). Escaped text still displays correctly.
+    if (label) {
+      const safeLabel = String(label).replace(/[&<>"']/g, (ch) =>
+        ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[ch]));
+      layer.bindTooltip(safeLabel, { sticky: true, direction: "top", className: "ward-tooltip" });
+    }
     layer.on({
       mouseover: () => { if (selectedWard !== code) setHoveredWard(code); },
       mouseout:  () => setHoveredWard((c) => (c === code ? null : c)),


### PR DESCRIPTION
## Jira
[CCSD-1993](https://digit-discuss.atlassian.net/browse/CCSD-1993)

P0 HTML-escape audit. React escapes form inputs by default — the audit found **one reachable HTML sink**: the citizen create map binds ward hover tooltips via Leaflet `bindTooltip` (renders as HTML) from tenant-controlled data. Now escaped (`&<>"'`) before binding.

Other audited sinks (utilities IFrameInterface `dangerouslySetInnerHTML`, sandbox ProductDetails) are **not on any CCRS route / unreachable** — documented, no change. Full audit notes in `~/Desktop/CCRS-QA/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CCSD-1993]: https://digit-discuss.atlassian.net/browse/CCSD-1993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ