### PR TITLE
feat(ddh): tenant.citymodule schema allows bannerImage (CCSD-1959)

### DIFF
--- a/utilities/default-data-handler/src/main/resources/schema/tenant.json
+++ b/utilities/default-data-handler/src/main/resources/schema/tenant.json
@@ -31,6 +31,9 @@
         "module": {
           "type": "string"
         },
+        "bannerImage": {
+          "type": "string"
+        },
         "tenants": {
           "type": "array",
           "items": {


### PR DESCRIPTION
## Jira
[CCSD-1959](https://digit-discuss.atlassian.net/browse/CCSD-1959)

The citizen `/pgr-home` banner reads `tenant.citymodule.bannerImage` (falling back to `StateInfo.bannerUrl`), and the configurator's **Advanced → City Modules** editor exposes the field — but the seeded schema (`additionalProperties: false`) didn't include it, so saving failed with *extraneous key [bannerImage] is not permitted*.

One-property addition to the DDH schema seed: `bannerImage: string`. New tenants get it automatically; existing tenants need the same schema addition once (done on local mz; prod/209 pending — operator step, since MDMS schema rows aren't editable via plain API).

Current mz value: `https://egov-dev-assets.s3.ap-south-1.amazonaws.com/ccrs_logo.png` (S3-hosted, so no per-env asset hosting needed). Renders per PR #1181's sizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CCSD-1959]: https://digit-discuss.atlassian.net/browse/CCSD-1959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ