### PR TITLE
fix(configurator): Branding rename, Role-Action create/edit, Decryption ABAC id (CCSD-1996/1997/1999)

### DIFF
--- a/configurator/packages/data-provider/src/providers/resourceRegistry.ts
+++ b/configurator/packages/data-provider/src/providers/resourceRegistry.ts
@@ -108,7 +108,7 @@ export const REGISTRY: Record<string, ResourceConfig> = {
   // (RAINMAKER-PGR.ClassificationNode is gone — interior nodes now live in the
   // ComplaintHierarchy master alongside the leaves; cascade pickers read it
   // directly. No standalone classification-nodes resource anymore.)
-  'state-info': { type: 'mdms', label: 'State Info', schema: 'common-masters.StateInfo', idField: 'code', nameField: 'name' },
+  'state-info': { type: 'mdms', label: 'Branding', schema: 'common-masters.StateInfo', idField: 'code', nameField: 'name' }, // CCSD-1997: renamed State Info -> Branding
   'city-modules': { type: 'mdms', label: 'City Modules', schema: 'tenant.citymodule', idField: 'code', nameField: 'module' },
   'id-formats': { type: 'mdms', label: 'ID Formats', schema: 'common-masters.IdFormat', idField: 'idname', nameField: 'idname' },
   'workflow-services': { type: 'mdms', label: 'Business Services', schema: 'Workflow.BusinessService', idField: 'businessService', nameField: 'business' },
@@ -119,7 +119,7 @@ export const REGISTRY: Record<string, ResourceConfig> = {
   roles: { type: 'mdms', label: 'Roles', schema: MDMS_SCHEMAS.ROLES, idField: 'code', nameField: 'name', descriptionField: 'description' },
   'action-mappings': { type: 'mdms', label: 'Action Mappings', schema: 'ACCESSCONTROL-ACTIONS-TEST.actions-test', idField: 'id', nameField: 'displayName', descriptionField: 'url' },
   'encryption-policy': { type: 'mdms', label: 'Encryption Policy', schema: 'DataSecurity.EncryptionPolicy', idField: 'key', nameField: 'key' },
-  'decryption-abac': { type: 'mdms', label: 'Decryption ABAC', schema: 'DataSecurity.DecryptionABAC', idField: 'model', nameField: 'model' },
+  'decryption-abac': { type: 'mdms', label: 'Decryption ABAC', schema: 'DataSecurity.DecryptionABAC', idField: 'key', nameField: 'key' }, // CCSD-1999: schema id is 'key', not 'model'
   'masking-patterns': { type: 'mdms', label: 'Masking Patterns', schema: 'DataSecurity.MaskingPatterns', idField: 'patternId', nameField: 'patternId' },
   'security-policy': { type: 'mdms', label: 'Security Policy', schema: 'DataSecurity.SecurityPolicy', idField: 'model', nameField: 'model' },
   'inbox-config': { type: 'mdms', label: 'Inbox Config', schema: 'INBOX.InboxQueryConfiguration', idField: 'module', nameField: 'module' },

--- a/configurator/src/App.tsx
+++ b/configurator/src/App.tsx
@@ -129,7 +129,10 @@ function ManagementAdmin() {
         {/* Read-only entities with List/Show */}
         <Resource name="access-roles" list={AccessRoleList} show={AccessRoleShow} />
         <Resource name="access-actions" list={AccessActionList} show={AccessActionShow} />
-        <Resource name="role-actions" list={RoleActionList} show={RoleActionShow} />
+        {/* CCSD-1996: role-actions had list/show only. Add the schema-driven
+            generic Edit/Create so a Role-Action mapping can be created/edited
+            from the UI (dedicated List/Show kept). */}
+        <Resource name="role-actions" list={RoleActionList} show={RoleActionShow} edit={MdmsResourceEdit} create={MdmsResourceCreate} />
         <Resource name="workflow-business-services" list={WorkflowServiceList} show={WorkflowServiceShow} />
         <Resource name="workflow-processes" list={WorkflowProcessList} show={WorkflowProcessShow} />
         <Resource name="mdms-schemas" list={MdmsSchemaList} show={MdmsSchemaShow} />

--- a/configurator/src/admin/themeEditor/StateInfoEditor.tsx
+++ b/configurator/src/admin/themeEditor/StateInfoEditor.tsx
@@ -216,12 +216,12 @@ export function StateInfoEditor() {
         record.isActive,
       );
       toast({
-        title: 'State Info updated',
+        title: 'Branding updated',
         description: data.name ?? record.uniqueIdentifier,
       });
       navigate('/manage/state-info');
     } catch (e) {
-      const msg = (e as Error)?.message || 'Failed to save State Info.';
+      const msg = (e as Error)?.message || 'Failed to save Branding.';
       setSaveError(msg);
     } finally {
       setSaving(false);
@@ -235,7 +235,7 @@ export function StateInfoEditor() {
           <ArrowLeft className="w-4 h-4" /> Back
         </Button>
         <DigitCard className="p-8 text-center text-muted-foreground">
-          <RefreshCw className="w-5 h-5 animate-spin inline-block mr-2" /> Loading State Info…
+          <RefreshCw className="w-5 h-5 animate-spin inline-block mr-2" /> Loading Branding…
         </DigitCard>
       </div>
     );
@@ -261,7 +261,7 @@ export function StateInfoEditor() {
           <ArrowLeft className="w-4 h-4" /> Back
         </Button>
         <h1 className="text-2xl sm:text-3xl font-bold font-condensed text-foreground">
-          Edit State Info: {record.uniqueIdentifier}
+          Edit Branding: {record.uniqueIdentifier}
         </h1>
         {saving && <RefreshCw className="w-4 h-4 animate-spin text-muted-foreground" />}
       </div>

--- a/configurator/src/providers/i18nProvider.ts
+++ b/configurator/src/providers/i18nProvider.ts
@@ -95,6 +95,8 @@ const customEnglishMessages: TranslationMessages = {
       workflow_processes: 'Workflow Processes',
       mdms_schemas: 'MDMS Schemas',
       boundary_hierarchies: 'Boundary Hierarchies',
+      // CCSD-1997: StateInfo master is surfaced as "Branding".
+      state_info: 'Branding',
     },
     fields: {
       code: 'Code',


### PR DESCRIPTION
## Jira
[CCSD-1997](https://digit-discuss.atlassian.net/browse/CCSD-1997) · [CCSD-1996](https://digit-discuss.atlassian.net/browse/CCSD-1996) · [CCSD-1999](https://digit-discuss.atlassian.net/browse/CCSD-1999)

Configurator batch (data-provider sub-package + src):
- **1997** StateInfo master renamed to **Branding** (i18n + registry fallback + editor header/toasts). Verified on the master list. *Follow-up:* create-from-scratch (StateInfoEditor is edit-only) + missing `qrCodeURL` input — tracked on the ticket.
- **1996** role-actions gains schema-driven **Edit + Create** (was list/show only) — a Role-Action mapping can now be created/edited. *Enhancement follow-up:* reference-select widgets for rolecode/actionid (currently free-text/number).
- **1999** decryption-abac `idField/nameField` **'model' → 'key'** (schema has no 'model'; 'key' is the identifier).

Build: `packages/data-provider` (tsc) + `vite build --base=/configurator/` → `rsync` to `/var/www/configurator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CCSD-1997]: https://digit-discuss.atlassian.net/browse/CCSD-1997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CCSD-1996]: https://digit-discuss.atlassian.net/browse/CCSD-1996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CCSD-1999]: https://digit-discuss.atlassian.net/browse/CCSD-1999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ