### PR TITLE
feat(pgr): config-driven landing P1 — runtime LandingRenderer (CCSD-2006)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/LandingRenderer.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/LandingRenderer.tsx
@@ -1,0 +1,134 @@
+// Generic, config-driven renderer for the PGR public landing (P1, CCSD-2006).
+//
+// It consumes a ResolvedLandingConfig (LandingPageConfig + ordered, filtered,
+// role-gated LandingSection rows — see useLandingConfig) and assembles the page
+// through the type->component registry. It reproduces the pre-P1 shell
+// byte-for-byte: the .v2-scope token wrapper, the .pgr-landing column, the skip
+// link, the scroll-padding effect, and the header/main/footer DOM slots. When
+// the config is the built-in default (MDMS absent) every section falls back to
+// its own content defaults, so the output is identical to the static page.
+//
+// Config is untrusted input: unknown section types have no registry entry and
+// are skipped; page toggles gate the two chrome pieces; all links still flow
+// through CtaLink/LandingLink so the overrides.css anchor !important defence is
+// preserved.
+
+import * as React from "react";
+import { cn } from "@egovernments/digit-ui-components-v2";
+
+import { LandingRoutes, mergeRoutes } from "./routes";
+import { buildTokenStyle, LandingTokens, FOCUS_RING } from "./tokens";
+import { NewsItem, DEFAULT_NEWS } from "./content";
+import { useLandingCopy } from "./useLandingCopy";
+import { UtilityBar, LanguageOption, DEFAULT_LANGUAGES } from "./components/UtilityBar";
+import { WhatsAppFab } from "./components/WhatsAppFab";
+
+import { getEntry, RenderCtx, Slot } from "./config/sectionRegistry";
+import type { LandingSectionConfig, ResolvedLandingConfig } from "./config/types";
+
+export interface LandingRendererProps {
+  config: ResolvedLandingConfig;
+  routes?: Partial<LandingRoutes>;
+  news?: NewsItem[];
+  heroImageUrl?: string;
+  emblemUrl?: string;
+  languages?: LanguageOption[];
+  onLanguageChange?: (code: string) => void;
+  tokens?: Partial<LandingTokens>;
+  /** Explicit override; when undefined the LandingPageConfig toggle governs. */
+  showWhatsAppFab?: boolean;
+  showUtilityBar?: boolean;
+  className?: string;
+}
+
+export function LandingRenderer({
+  config,
+  routes: routeOverrides,
+  news = DEFAULT_NEWS,
+  heroImageUrl,
+  emblemUrl,
+  languages = DEFAULT_LANGUAGES,
+  onLanguageChange,
+  tokens,
+  showWhatsAppFab,
+  showUtilityBar,
+  className,
+}: LandingRendererProps) {
+  const { c } = useLandingCopy();
+  const routes = React.useMemo(() => mergeRoutes(routeOverrides), [routeOverrides]);
+  const tokenStyle = React.useMemo(() => buildTokenStyle(tokens), [tokens]);
+
+  // Sticky nav (48px) vs keyboard-focus / skip-link jumps (WCAG 2.4.11); the
+  // scroll container is <html>, so set for the page's lifetime and restore.
+  React.useEffect(() => {
+    const el = document.documentElement;
+    const prev = el.style.scrollPaddingTop;
+    el.style.scrollPaddingTop = "4rem";
+    return () => {
+      el.style.scrollPaddingTop = prev;
+    };
+  }, []);
+
+  const page = config.page || {};
+  const utilityOn = showUtilityBar ?? page.showUtilityBar ?? true;
+  const fabOn = showWhatsAppFab ?? page.showWhatsAppFab ?? true;
+
+  const ctx: RenderCtx = React.useMemo(
+    () => ({ routes, news, heroImageUrl, emblemUrl }),
+    [routes, news, heroImageUrl, emblemUrl]
+  );
+
+  // Group the ordered, visible sections into DOM slots; unknown types (no
+  // registry entry) are dropped here.
+  const slots = React.useMemo(() => {
+    const out: Record<Slot, LandingSectionConfig[]> = { header: [], main: [], footer: [] };
+    (config.sections || []).forEach((s) => {
+      const entry = getEntry(s.type);
+      if (entry) out[entry.slot].push(s);
+    });
+    return out;
+  }, [config.sections]);
+
+  const renderSection = (s: LandingSectionConfig, i: number) => {
+    const entry = getEntry(s.type);
+    if (!entry) return null;
+    const { Component, buildProps } = entry;
+    return <Component key={s.code ?? `${s.type}-${i}`} {...buildProps(s, ctx)} />;
+  };
+
+  return (
+    <div className="v2-scope" style={tokenStyle}>
+      <div
+        className={cn(
+          "pgr-landing flex min-h-screen flex-col bg-[hsl(var(--pgrl-page))] text-[hsl(var(--pgrl-ink))]",
+          className
+        )}
+      >
+        <a
+          href="#pgr-landing-main"
+          className={cn(
+            "sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[60] focus:rounded-[var(--pgrl-radius)]",
+            "focus:bg-[hsl(var(--pgrl-surface))] focus:px-4 focus:py-2 focus:font-semibold focus:text-[hsl(var(--pgrl-deep))] focus:shadow-lg",
+            FOCUS_RING
+          )}
+        >
+          {c("SKIP_LINK")}
+        </a>
+
+        {utilityOn && (
+          <UtilityBar routes={routes} languages={languages} onLanguageChange={onLanguageChange} />
+        )}
+        {slots.header.map(renderSection)}
+
+        <main id="pgr-landing-main" className="flex-1">
+          {slots.main.map(renderSection)}
+        </main>
+
+        {slots.footer.map(renderSection)}
+        {fabOn && <WhatsAppFab href={routes.WHATSAPP} />}
+      </div>
+    </div>
+  );
+}
+
+export default LandingRenderer;

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/components/ChannelsSection.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/components/ChannelsSection.tsx
@@ -12,20 +12,29 @@ import { CtaLink } from "./CtaLink";
 import { CHANNELS } from "../content";
 import { useLandingCopy } from "../useLandingCopy";
 import { LandingRoutes } from "../routes";
+import type { LandingSectionConfig } from "../config/types";
 
 export interface ChannelsSectionProps {
   routes: LandingRoutes;
+  /** Config-driven overrides; absent => the built-in deck (unchanged). */
+  section?: LandingSectionConfig;
 }
 
-export function ChannelsSection({ routes }: ChannelsSectionProps) {
+export function ChannelsSection({ routes, section }: ChannelsSectionProps) {
   const { c } = useLandingCopy();
+  const items: any[] = (section?.items as any[]) ?? CHANNELS;
 
   return (
-    <Section id="pgr-landing-channels" title={c("CHANNELS_TITLE")} intro={c("CHANNELS_INTRO")} tone="page">
+    <Section
+      id="pgr-landing-channels"
+      title={c(section?.titleKey, "CHANNELS_TITLE")}
+      intro={c(section?.subtitleKey, "CHANNELS_INTRO")}
+      tone="page"
+    >
       <ul className="m-0 grid list-none grid-cols-1 gap-5 p-0 sm:grid-cols-2 xl:grid-cols-4">
-        {CHANNELS.map((channel) => {
+        {items.map((channel) => {
           const Icon = channel.icon;
-          const to = routes[channel.route];
+          const to = channel.href ?? routes[channel.route];
           const external = Boolean(channel.external) && to !== "#";
           return (
             <li key={channel.id} className="m-0 p-0">

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/components/FinalCtaSection.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/components/FinalCtaSection.tsx
@@ -7,12 +7,15 @@ import { CtaLink } from "./CtaLink";
 import { useLandingCopy } from "../useLandingCopy";
 import { LandingRoutes } from "../routes";
 import { CONTAINER } from "../tokens";
+import type { LandingSectionConfig } from "../config/types";
 
 export interface FinalCtaSectionProps {
   routes: LandingRoutes;
+  /** Config-driven overrides; absent => the built-in deck (unchanged). */
+  section?: LandingSectionConfig;
 }
 
-export function FinalCtaSection({ routes }: FinalCtaSectionProps) {
+export function FinalCtaSection({ routes, section }: FinalCtaSectionProps) {
   const { c } = useLandingCopy();
 
   return (
@@ -31,10 +34,10 @@ export function FinalCtaSection({ routes }: FinalCtaSectionProps) {
             id="pgr-landing-final-title"
             className="mb-0 mt-4 text-2xl font-bold leading-tight text-[hsl(var(--pgrl-on-primary))] md:text-3xl"
           >
-            {c("FINAL_TITLE")}
+            {c(section?.titleKey, "FINAL_TITLE")}
           </h2>
           <p className="mb-0 mt-3 text-base leading-relaxed text-[hsl(var(--pgrl-on-primary))]">
-            {c("FINAL_TEXT")}
+            {c(section?.subtitleKey ?? section?.bodyKey, "FINAL_TEXT")}
           </p>
         </div>
 

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/components/HeroSection.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/components/HeroSection.tsx
@@ -18,14 +18,17 @@ import { CtaLink } from "./CtaLink";
 import { useLandingCopy } from "../useLandingCopy";
 import { LandingRoutes } from "../routes";
 import { CONTAINER, FOCUS_RING_DARK } from "../tokens";
+import type { LandingSectionConfig } from "../config/types";
 
 export interface HeroSectionProps {
   routes: LandingRoutes;
   /** Optional photographic background, rendered under the brand scrim. */
   imageUrl?: string;
+  /** Config-driven overrides; absent => the built-in deck (unchanged). */
+  section?: LandingSectionConfig;
 }
 
-export function HeroSection({ routes, imageUrl }: HeroSectionProps) {
+export function HeroSection({ routes, imageUrl, section }: HeroSectionProps) {
   const { c } = useLandingCopy();
 
   const trust = [
@@ -69,19 +72,19 @@ export function HeroSection({ routes, imageUrl }: HeroSectionProps) {
       <div className={cn(CONTAINER, "py-14 md:py-20")}>
         <div className="max-w-3xl">
           <p className="m-0 inline-flex items-center rounded-full bg-[hsl(var(--pgrl-on-primary)/0.12)] px-3 py-1 text-xs font-semibold uppercase tracking-widest text-[hsl(var(--pgrl-accent))]">
-            {c("HERO_EYEBROW")}
+            {c(section?.bodyKey, "HERO_EYEBROW")}
           </p>
 
           <h1
             id="pgr-landing-hero-title"
             className="mb-0 mt-4 text-3xl font-bold leading-tight text-[hsl(var(--pgrl-on-primary))] sm:text-4xl lg:text-5xl"
           >
-            {c("HERO_TITLE")}
+            {c(section?.titleKey, "HERO_TITLE")}
           </h1>
 
           {/* Solid white: /0.9 dims below 4.5:1 over the gradient's light end. */}
           <p className="mb-0 mt-4 max-w-2xl text-base leading-relaxed text-[hsl(var(--pgrl-on-primary))] sm:text-lg">
-            {c("HERO_LEDE")}
+            {c(section?.subtitleKey, "HERO_LEDE")}
           </p>
 
           <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/components/HowItWorksSection.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/components/HowItWorksSection.tsx
@@ -9,20 +9,27 @@ import { Bell, Check } from "lucide-react";
 import { Section } from "./Section";
 import { HOW_STEPS } from "../content";
 import { useLandingCopy } from "../useLandingCopy";
+import type { LandingSectionConfig } from "../config/types";
 
-export function HowItWorksSection() {
+export interface HowItWorksSectionProps {
+  /** Config-driven overrides; absent => the built-in deck (unchanged). */
+  section?: LandingSectionConfig;
+}
+
+export function HowItWorksSection({ section }: HowItWorksSectionProps = {}) {
   const { c } = useLandingCopy();
+  const items: any[] = (section?.items as any[]) ?? HOW_STEPS;
 
   const notes = [c("HOW_NOTE_NOTIFY"), c("HOW_NOTE_RECORD"), c("HOW_NOTE_CHANNELS")];
 
   return (
-    <Section id="pgr-landing-how" title={c("HOW_TITLE")} tone="surface">
+    <Section id="pgr-landing-how" title={c(section?.titleKey, "HOW_TITLE")} tone="surface">
       <ol className="m-0 grid list-none grid-cols-1 gap-4 p-0 sm:grid-cols-2 lg:grid-cols-3">
-        {HOW_STEPS.map((step, i) => {
+        {items.map((step, i) => {
           const Icon = step.icon;
           return (
             <li
-              key={step.titleKey}
+              key={step.id ?? step.titleKey ?? i}
               className="m-0 flex items-start gap-4 rounded-[var(--pgrl-radius)] border border-solid border-[hsl(var(--pgrl-line))] bg-[hsl(var(--pgrl-page))] p-5"
             >
               <span

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/components/InstitutionsSection.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/components/InstitutionsSection.tsx
@@ -4,17 +4,24 @@ import * as React from "react";
 import { Section } from "./Section";
 import { INSTITUTIONS } from "../content";
 import { useLandingCopy } from "../useLandingCopy";
+import type { LandingSectionConfig } from "../config/types";
 
-export function InstitutionsSection() {
+export interface InstitutionsSectionProps {
+  /** Config-driven overrides; absent => the built-in deck (unchanged). */
+  section?: LandingSectionConfig;
+}
+
+export function InstitutionsSection({ section }: InstitutionsSectionProps = {}) {
   const { c } = useLandingCopy();
+  const items: any[] = (section?.items as any[]) ?? INSTITUTIONS;
 
   return (
-    <Section id="pgr-landing-institutions" title={c("INST_TITLE")} tone="surface">
+    <Section id="pgr-landing-institutions" title={c(section?.titleKey, "INST_TITLE")} tone="surface">
       <ul className="m-0 grid list-none grid-cols-1 gap-5 p-0 md:grid-cols-2">
-        {INSTITUTIONS.map((inst) => {
+        {items.map((inst) => {
           const Icon = inst.icon;
           return (
-            <li key={inst.titleKey} className="m-0 p-0">
+            <li key={inst.id ?? inst.titleKey} className="m-0 p-0">
               <article className="flex h-full flex-col gap-4 rounded-[var(--pgrl-radius)] border border-solid border-[hsl(var(--pgrl-line))] bg-[hsl(var(--pgrl-page))] p-6 sm:flex-row sm:items-start">
                 <span
                   aria-hidden

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/components/LandingHeader.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/components/LandingHeader.tsx
@@ -33,11 +33,14 @@ export interface LandingHeaderProps {
   routes: LandingRoutes;
   /** Emblem/crest image URL; falls back to a Landmark glyph when absent. */
   emblemUrl?: string;
+  /** Config-driven nav items; absent => the built-in NAV_ITEMS (unchanged). */
+  navItems?: any[];
 }
 
 const MENU_ID = "pgr-landing-nav-menu";
 
-export function LandingHeader({ routes, emblemUrl }: LandingHeaderProps) {
+export function LandingHeader({ routes, emblemUrl, navItems }: LandingHeaderProps) {
+  const items: any[] = navItems ?? NAV_ITEMS;
   const { c } = useLandingCopy();
   const router = React.useContext(__RouterContext as React.Context<any>);
   const [open, setOpen] = React.useState(false);
@@ -135,11 +138,11 @@ export function LandingHeader({ routes, emblemUrl }: LandingHeaderProps) {
             open ? "flex" : "hidden"
           )}
         >
-          {NAV_ITEMS.map((item) => {
-            const to = routes[item.route];
+          {items.map((item) => {
+            const to = item.href ?? routes[item.route];
             const active = isActive(to);
             return (
-              <li key={item.labelKey} className="m-0 p-0">
+              <li key={item.code ?? item.labelKey} className="m-0 p-0">
                 <LandingLink
                   to={to}
                   aria-current={active ? "page" : undefined}

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/components/NewsSection.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/components/NewsSection.tsx
@@ -13,22 +13,27 @@ import { NewsItem } from "../content";
 import { useLandingCopy } from "../useLandingCopy";
 import { LandingRoutes } from "../routes";
 import { FOCUS_RING } from "../tokens";
+import type { LandingSectionConfig } from "../config/types";
 
 export interface NewsSectionProps {
   routes: LandingRoutes;
   items: NewsItem[];
+  /** Config-driven overrides; absent => the built-in deck (unchanged).
+   *  Note: news CARDS stay prop-driven (their raw CMS fields don't fit the
+   *  key-based item schema) — only the heading is config-driven in v1. */
+  section?: LandingSectionConfig;
 }
 
 const isExternal = (href: string) => /^https?:\/\//i.test(href);
 
-export function NewsSection({ routes, items }: NewsSectionProps) {
+export function NewsSection({ routes, items, section }: NewsSectionProps) {
   const { c } = useLandingCopy();
-  if (!items.length) return null;
+  if (!items || !items.length) return null;
 
   return (
     <Section
       id="pgr-landing-news"
-      title={c("NEWS_TITLE")}
+      title={c(section?.titleKey, "NEWS_TITLE")}
       tone="page"
       action={
         <CtaLink

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/components/PrivacySection.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/components/PrivacySection.tsx
@@ -7,16 +7,19 @@ import { Section } from "./Section";
 import { CtaLink } from "./CtaLink";
 import { useLandingCopy } from "../useLandingCopy";
 import { LandingRoutes } from "../routes";
+import type { LandingSectionConfig } from "../config/types";
 
 export interface PrivacySectionProps {
   routes: LandingRoutes;
+  /** Config-driven overrides; absent => the built-in deck (unchanged). */
+  section?: LandingSectionConfig;
 }
 
-export function PrivacySection({ routes }: PrivacySectionProps) {
+export function PrivacySection({ routes, section }: PrivacySectionProps) {
   const { c } = useLandingCopy();
 
   return (
-    <Section id="pgr-landing-privacy" title={c("PRIVACY_TITLE")} tone="surface">
+    <Section id="pgr-landing-privacy" title={c(section?.titleKey, "PRIVACY_TITLE")} tone="surface">
       <div className="flex flex-col gap-6 rounded-[var(--pgrl-radius)] border border-solid border-[hsl(var(--pgrl-line))] border-l-4 border-l-[hsl(var(--pgrl-primary))] bg-[hsl(var(--pgrl-page))] p-6 sm:flex-row sm:items-start md:p-8">
         <span
           aria-hidden
@@ -25,8 +28,8 @@ export function PrivacySection({ routes }: PrivacySectionProps) {
           <Lock className="h-7 w-7" />
         </span>
         <div className="max-w-3xl">
-          <p className="m-0 text-base font-semibold leading-relaxed text-[hsl(var(--pgrl-ink))]">{c("PRIVACY_P1")}</p>
-          <p className="mb-0 mt-3 text-sm leading-relaxed text-[hsl(var(--pgrl-ink-soft))]">{c("PRIVACY_P2")}</p>
+          <p className="m-0 text-base font-semibold leading-relaxed text-[hsl(var(--pgrl-ink))]">{c(section?.bodyKey, "PRIVACY_P1")}</p>
+          <p className="mb-0 mt-3 text-sm leading-relaxed text-[hsl(var(--pgrl-ink-soft))]">{c(section?.subtitleKey, "PRIVACY_P2")}</p>
           <CtaLink
             to={routes.PRIVACY}
             variant="subtle"

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/components/TypesSection.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/components/TypesSection.tsx
@@ -13,18 +13,27 @@ import { MANIFESTATION_TYPES } from "../content";
 import { useLandingCopy } from "../useLandingCopy";
 import { LandingRoutes } from "../routes";
 import { FOCUS_RING } from "../tokens";
+import type { LandingSectionConfig } from "../config/types";
 
 export interface TypesSectionProps {
   routes: LandingRoutes;
+  /** Config-driven overrides; absent => the built-in deck (unchanged). */
+  section?: LandingSectionConfig;
 }
 
-export function TypesSection({ routes }: TypesSectionProps) {
+export function TypesSection({ routes, section }: TypesSectionProps) {
   const { c } = useLandingCopy();
+  const items: any[] = (section?.items as any[]) ?? MANIFESTATION_TYPES;
 
   return (
-    <Section id="pgr-landing-types" title={c("TYPES_TITLE")} intro={c("TYPES_INTRO")} tone="page">
+    <Section
+      id="pgr-landing-types"
+      title={c(section?.titleKey, "TYPES_TITLE")}
+      intro={c(section?.subtitleKey, "TYPES_INTRO")}
+      tone="page"
+    >
       <ul className="m-0 grid list-none grid-cols-1 gap-5 p-0 sm:grid-cols-2 xl:grid-cols-4">
-        {MANIFESTATION_TYPES.map((type) => {
+        {items.map((type) => {
           const Icon = type.icon;
           const accent = `hsl(var(${type.accentVar}))`;
           return (
@@ -44,7 +53,7 @@ export function TypesSection({ routes }: TypesSectionProps) {
                 <h3 className="mb-0 mt-4 text-lg font-bold text-[hsl(var(--pgrl-ink))]">
                   {/* Stretched link: one big click target, single tab stop. */}
                   <LandingLink
-                    to={routes[type.route]}
+                    to={type.href ?? routes[type.route]}
                     className={
                       "!text-inherit no-underline after:absolute after:inset-0 after:content-[''] " +
                       "rounded-[var(--pgrl-radius)] " +

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/config/defaults.ts
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/config/defaults.ts
@@ -1,0 +1,45 @@
+// Built-in fallback config for the config-driven landing (P1, CCSD-2006).
+//
+// Deliberately STRUCTURE-ONLY: it declares which sections exist, their order,
+// and the page-level toggles — but carries NO content (no titleKey/items). Each
+// section component supplies its own content defaults (section?.x ?? LITERAL,
+// section?.items ?? DECK_ARRAY), so rendering from this fallback is byte-
+// identical to the pre-P1 hardcoded page. useLandingConfig returns this when
+// MDMS is missing, empty, disabled, or errors — the backward-compat guarantee.
+//
+// Order values mirror the Phase 0 seed (RAINMAKER-PGR.LandingSection):
+// navigation 10, hero 30, types 40, steps 50, channels 60, privacy 70,
+// news 80, institutions 90, cta 100, footer 110.
+
+import type { LandingSectionConfig, ResolvedLandingConfig } from "./types";
+
+const row = (code: string, type: string, order: number): LandingSectionConfig => ({
+  code,
+  type,
+  order,
+  enabled: true,
+  status: "PUBLISHED",
+});
+
+export const DEFAULT_LANDING_SECTIONS: LandingSectionConfig[] = [
+  row("navigation", "navigation", 10),
+  row("hero", "hero", 30),
+  row("types", "types", 40),
+  row("steps", "steps", 50),
+  row("channels", "channels", 60),
+  row("privacy", "privacy", 70),
+  row("news", "news", 80),
+  row("institutions", "institutions", 90),
+  row("cta", "cta", 100),
+  row("footer", "footer", 110),
+];
+
+export const DEFAULT_LANDING_CONFIG: ResolvedLandingConfig = {
+  page: {
+    code: "default",
+    enabled: true,
+    showUtilityBar: true,
+    showWhatsAppFab: true,
+  },
+  sections: DEFAULT_LANDING_SECTIONS,
+};

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/config/iconRegistry.ts
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/config/iconRegistry.ts
@@ -1,0 +1,57 @@
+// Icon whitelist for config-driven items (P1, CCSD-2006).
+//
+// MDMS items carry an `iconId` STRING (JSON can't hold a React component); the
+// adapter maps it to a lucide component through this closed whitelist. Unknown
+// / missing ids resolve to a safe fallback rather than crashing — config is
+// untrusted input. Ids are the lucide export names, matching the icons the
+// built-in content deck already uses (content.ts), so a seed row that mirrors a
+// default renders the identical glyph.
+
+import {
+  FileText,
+  Megaphone,
+  Scale,
+  ShieldAlert,
+  Send,
+  Hash,
+  FileSearch,
+  UserCheck,
+  Search,
+  CheckCircle2,
+  Globe,
+  Smartphone,
+  MessageCircle,
+  Phone,
+  Landmark,
+  Store,
+} from "lucide-react";
+import type { IconComponent } from "../content";
+
+export const ICON_REGISTRY: Record<string, IconComponent> = {
+  FileText,
+  Megaphone,
+  Scale,
+  ShieldAlert,
+  Send,
+  Hash,
+  FileSearch,
+  UserCheck,
+  Search,
+  CheckCircle2,
+  Globe,
+  Smartphone,
+  MessageCircle,
+  Phone,
+  Landmark,
+  Store,
+};
+
+/** Fallback glyph for an unknown/absent iconId. */
+export const FALLBACK_ICON: IconComponent = FileText;
+
+/** Resolve an iconId string to a component; `fallback` (usually the matching
+ *  default item's icon) wins over the generic FALLBACK_ICON. */
+export function resolveIcon(iconId?: string, fallback?: IconComponent): IconComponent {
+  if (iconId && ICON_REGISTRY[iconId]) return ICON_REGISTRY[iconId];
+  return fallback ?? FALLBACK_ICON;
+}

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/config/resolve.ts
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/config/resolve.ts
@@ -1,0 +1,164 @@
+// Pure resolution helpers for the config-driven landing (P1, CCSD-2006).
+//
+// MDMS config is untrusted, tenant-authored input, so everything here is
+// defensive: bad types are ignored, unsafe URLs are neutralised, unknown
+// section types are dropped by the caller, and every path has a sane default.
+
+import { resolveIcon } from "./iconRegistry";
+import type { IconComponent } from "../content";
+import type { LandingItemConfig, LandingSectionConfig } from "./types";
+
+// ---------------------------------------------------------------------------
+// Links
+// ---------------------------------------------------------------------------
+
+/** Allow only in-app ("/", "#"), http(s), tel and mailto/wa targets. Anything
+ *  else (javascript:, data:, vbscript: …) collapses to the inert "#". */
+export function safeHref(url?: string): string {
+  if (!url || typeof url !== "string") return "#";
+  const u = url.trim();
+  if (u === "#" || u.startsWith("/") || u.startsWith("#")) return u;
+  if (/^(https?:|tel:|mailto:|wa:)/i.test(u)) return u;
+  // wa.me / plain domain without scheme -> treat cautiously as external https
+  if (/^wa\.me\//i.test(u) || /^www\./i.test(u)) return "https://" + u;
+  return "#";
+}
+
+/** A LandingRoutes key (resolved against the routes map) OR a literal URL. */
+export function resolveNavTarget(
+  navigationUrl: string | undefined,
+  routes: Record<string, string>,
+  fallbackRouteKey?: string
+): { route?: string; href?: string } {
+  if (navigationUrl && Object.prototype.hasOwnProperty.call(routes, navigationUrl)) {
+    return { route: navigationUrl };
+  }
+  if (navigationUrl) return { href: safeHref(navigationUrl) };
+  if (fallbackRouteKey) return { route: fallbackRouteKey };
+  return { href: "#" };
+}
+
+// ---------------------------------------------------------------------------
+// Items — build the rich runtime shape section components iterate
+// ---------------------------------------------------------------------------
+
+/** Rich item: superset of every default-array element shape (content.ts).
+ *  Cosmetic-only fields absent from the MDMS item schema (accentVar, external,
+ *  badgeKey, ctaKey) are inherited from the matching default by `code`. */
+export interface RichItem {
+  id?: string;
+  code?: string;
+  icon?: IconComponent;
+  labelKey?: string;
+  titleKey?: string;
+  descKey?: string;
+  ctaKey?: string;
+  badgeKey?: string;
+  accentVar?: string;
+  external?: boolean;
+  route?: string;
+  href?: string;
+  order?: number;
+}
+
+const defaultKey = (d: any): string | undefined => d?.id ?? d?.code ?? d?.labelKey;
+
+/** Build the runtime item list. When `rawItems` is empty/absent the caller uses
+ *  its built-in default array instead (see section components) — so an
+ *  unconfigured section is byte-identical to today. When present, each config
+ *  item is normalised: icon string -> component, nav target -> route-key|url,
+ *  and cosmetic fields inherited from the default of the same `code`. */
+export function buildRichItems(
+  rawItems: LandingItemConfig[] | undefined,
+  defaultArray: any[],
+  routes: Record<string, string>
+): RichItem[] | undefined {
+  if (!Array.isArray(rawItems) || rawItems.length === 0) return undefined;
+  const byKey = new Map<string, any>();
+  (defaultArray || []).forEach((d) => {
+    const k = defaultKey(d);
+    if (k) byKey.set(k, d);
+  });
+
+  const items = rawItems
+    .filter((it) => it && it.enabled !== false)
+    .map((it, i): RichItem => {
+      const base = (it.code && byKey.get(it.code)) || {};
+      const target = resolveNavTarget(it.navigationUrl, routes, base.route);
+      return {
+        id: it.code ?? base.id ?? `item-${i}`,
+        code: it.code,
+        icon: resolveIcon(it.iconId, base.icon),
+        // Key-based sections read titleKey/labelKey/descKey through c().
+        labelKey: it.labelKey ?? base.labelKey,
+        titleKey: it.labelKey ?? base.titleKey,
+        descKey: it.descKey ?? base.descKey,
+        ctaKey: base.ctaKey,
+        badgeKey: base.badgeKey,
+        accentVar: base.accentVar ?? "--pgrl-primary",
+        external: base.external,
+        route: target.route,
+        href: target.href,
+        order: typeof it.order === "number" ? it.order : i,
+      };
+    });
+
+  items.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+  return items;
+}
+
+// ---------------------------------------------------------------------------
+// Sections — order, visibility, role-gating, tenant overlay
+// ---------------------------------------------------------------------------
+
+/** City rows override state rows by `code` (tenant override). Rows without a
+ *  code fall through unchanged. */
+export function mergeSectionsByCode(
+  stateRows: LandingSectionConfig[],
+  cityRows: LandingSectionConfig[]
+): LandingSectionConfig[] {
+  if (!cityRows || cityRows.length === 0) return stateRows || [];
+  const merged = new Map<string, LandingSectionConfig>();
+  (stateRows || []).forEach((r, i) => merged.set(r.code ?? `s-${i}`, r));
+  cityRows.forEach((r, i) => merged.set(r.code ?? `c-${i}`, r));
+  return Array.from(merged.values());
+}
+
+/** A section is visible when: enabled !== false, not DRAFT (unless preview),
+ *  and either public (no roles) or the user holds one of its roles. */
+export function isSectionVisible(
+  s: LandingSectionConfig,
+  userRoles: string[],
+  opts: { preview?: boolean } = {}
+): boolean {
+  if (!s || s.enabled === false) return false;
+  if (!opts.preview && s.status === "DRAFT") return false;
+  if (Array.isArray(s.roles) && s.roles.length > 0) {
+    const set = new Set(userRoles || []);
+    if (!s.roles.some((r) => set.has(r))) return false;
+  }
+  return true;
+}
+
+/** Order sections: an explicit page.sectionOrder (list of codes) wins; else the
+ *  numeric `order`; ties keep input order. Filters to visible sections first. */
+export function orderSections(
+  sections: LandingSectionConfig[],
+  sectionOrder: string[] | undefined,
+  userRoles: string[],
+  opts: { preview?: boolean } = {}
+): LandingSectionConfig[] {
+  const visible = (sections || []).filter((s) => isSectionVisible(s, userRoles, opts));
+  if (Array.isArray(sectionOrder) && sectionOrder.length > 0) {
+    const rank = new Map(sectionOrder.map((code, i) => [code, i]));
+    return visible
+      .slice()
+      .sort((a, b) => {
+        const ra = rank.has(a.code!) ? rank.get(a.code!)! : Number.MAX_SAFE_INTEGER;
+        const rb = rank.has(b.code!) ? rank.get(b.code!)! : Number.MAX_SAFE_INTEGER;
+        if (ra !== rb) return ra - rb;
+        return (a.order ?? 0) - (b.order ?? 0);
+      });
+  }
+  return visible.slice().sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+}

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/config/sectionRegistry.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/config/sectionRegistry.tsx
@@ -1,0 +1,137 @@
+// type -> component registry + config->props adapter (P1, CCSD-2006).
+//
+// The frozen v1 catalog (scope A) is enforced HERE, not by the MDMS schema: an
+// unknown `type` simply has no entry and is skipped by the renderer (config is
+// untrusted). Each entry declares a DOM `slot` so the renderer reproduces the
+// exact page structure — navigation sits above <main>, footer below it, every
+// other section inside <main> — while still honouring per-section ordering.
+//
+// buildProps performs the two adapter responsibilities the leaf components must
+// NOT know about: (1) icon-id string -> lucide component + cosmetic-field
+// inheritance (via buildRichItems), (2) media-id -> url. When a section carries
+// no items, buildRichItems returns undefined and the leaf falls back to its
+// built-in deck array — so an unconfigured section renders identically to today.
+
+import { HeroSection } from "../components/HeroSection";
+import { TypesSection } from "../components/TypesSection";
+import { HowItWorksSection } from "../components/HowItWorksSection";
+import { ChannelsSection } from "../components/ChannelsSection";
+import { PrivacySection } from "../components/PrivacySection";
+import { NewsSection } from "../components/NewsSection";
+import { InstitutionsSection } from "../components/InstitutionsSection";
+import { FinalCtaSection } from "../components/FinalCtaSection";
+import { LandingHeader } from "../components/LandingHeader";
+import { LandingFooter } from "../components/LandingFooter";
+
+import {
+  MANIFESTATION_TYPES,
+  HOW_STEPS,
+  CHANNELS,
+  INSTITUTIONS,
+  NAV_ITEMS,
+  NewsItem,
+} from "../content";
+import { LandingRoutes } from "../routes";
+import { buildRichItems, safeHref } from "./resolve";
+import type { LandingMediaConfig, LandingSectionConfig } from "./types";
+
+export type Slot = "header" | "main" | "footer";
+
+export interface RenderCtx {
+  routes: LandingRoutes;
+  news: NewsItem[];
+  heroImageUrl?: string;
+  emblemUrl?: string;
+}
+
+export interface SectionEntry {
+  Component: React.ComponentType<any>;
+  slot: Slot;
+  buildProps: (section: LandingSectionConfig, ctx: RenderCtx) => Record<string, any>;
+}
+
+/** media.imageId as a direct URL passes through (safe-guarded); a bare
+ *  filestore id is left for the P2 media phase (signed-URL resolver) and
+ *  ignored here so the section falls back to its default (no image). */
+function mediaUrl(media?: LandingMediaConfig): string | undefined {
+  const id = media?.imageId;
+  if (!id) return undefined;
+  if (/^(https?:)?\/\//i.test(id) || id.startsWith("/")) return safeHref(id);
+  return undefined;
+}
+
+/** section with its items normalised to the rich runtime shape (or left absent
+ *  so the leaf uses its default array). */
+const withItems = (s: LandingSectionConfig, def: any[], routes: LandingRoutes): LandingSectionConfig => ({
+  ...s,
+  items: buildRichItems(s.items, def, routes as unknown as Record<string, string>) as any,
+});
+
+export const SECTION_REGISTRY: Record<string, SectionEntry> = {
+  navigation: {
+    Component: LandingHeader,
+    slot: "header",
+    buildProps: (s, ctx) => ({
+      routes: ctx.routes,
+      emblemUrl: mediaUrl(s.media) ?? ctx.emblemUrl,
+      navItems: buildRichItems(s.items, NAV_ITEMS, ctx.routes as unknown as Record<string, string>),
+    }),
+  },
+  hero: {
+    Component: HeroSection,
+    slot: "main",
+    buildProps: (s, ctx) => ({
+      routes: ctx.routes,
+      imageUrl: mediaUrl(s.media) ?? ctx.heroImageUrl,
+      section: s,
+    }),
+  },
+  types: {
+    Component: TypesSection,
+    slot: "main",
+    buildProps: (s, ctx) => ({ routes: ctx.routes, section: withItems(s, MANIFESTATION_TYPES, ctx.routes) }),
+  },
+  steps: {
+    Component: HowItWorksSection,
+    slot: "main",
+    buildProps: (s, ctx) => ({ section: withItems(s, HOW_STEPS, ctx.routes) }),
+  },
+  channels: {
+    Component: ChannelsSection,
+    slot: "main",
+    buildProps: (s, ctx) => ({ routes: ctx.routes, section: withItems(s, CHANNELS, ctx.routes) }),
+  },
+  privacy: {
+    Component: PrivacySection,
+    slot: "main",
+    buildProps: (s, ctx) => ({ routes: ctx.routes, section: s }),
+  },
+  news: {
+    Component: NewsSection,
+    slot: "main",
+    buildProps: (s, ctx) => ({ routes: ctx.routes, items: ctx.news, section: s }),
+  },
+  institutions: {
+    Component: InstitutionsSection,
+    slot: "main",
+    buildProps: (s, ctx) => ({ section: withItems(s, INSTITUTIONS, ctx.routes) }),
+  },
+  cta: {
+    Component: FinalCtaSection,
+    slot: "main",
+    buildProps: (s, ctx) => ({ routes: ctx.routes, section: s }),
+  },
+  footer: {
+    Component: LandingFooter,
+    slot: "footer",
+    // Footer columns (GROUPS) stay the component default in v1 — their nested
+    // group shape isn't expressible in the flat item schema; destinations are
+    // already config-driven via `routes` and labels via PGR_LANDING_* keys.
+    buildProps: (s, ctx) => ({ routes: ctx.routes }),
+  },
+};
+
+export function getEntry(type?: string): SectionEntry | undefined {
+  if (!type) return undefined;
+  return SECTION_REGISTRY[type];
+}

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/config/types.ts
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/config/types.ts
@@ -1,0 +1,87 @@
+// Runtime config model for the config-driven landing page (P1, CCSD-2006).
+//
+// These interfaces mirror the two MDMS masters shipped in Phase 0
+// (RAINMAKER-PGR.LandingSection + RAINMAKER-PGR.LandingPageConfig, see
+// utilities/default-data-handler/.../schema/rainmaker-pgr-landing.json). MDMS is
+// untrusted, tenant-authored input, so every field is optional here and the
+// renderer defends against missing/garbage values (see useLandingConfig +
+// sectionRegistry). Text is carried as PGR_LANDING_* localization *keys*, never
+// inline strings — resolved through useLandingCopy (store, then bundled deck).
+
+/** The frozen v1 section catalog (scope A). Enforced here + in the registry,
+ *  NOT by the MDMS schema (type is a free string there so new types can be
+ *  added without a schema recreation). */
+export type LandingSectionType =
+  | "hero"
+  | "navigation"
+  | "types"
+  | "steps"
+  | "channels"
+  | "privacy"
+  | "news"
+  | "institutions"
+  | "cta"
+  | "footer";
+
+export type LandingStatus = "DRAFT" | "PUBLISHED";
+
+/** One card / link / step inside a section. Matches the MDMS items[] schema
+ *  (additionalProperties:false: code/labelKey/descKey/iconId/navigationUrl/
+ *  enabled/order). Cosmetic-only fields the schema can't express (accent,
+ *  external, badge, icon component) are inherited from the matching default
+ *  item by `code` during resolution. */
+export interface LandingItemConfig {
+  code?: string;
+  labelKey?: string;
+  descKey?: string;
+  iconId?: string;
+  navigationUrl?: string;
+  enabled?: boolean;
+  order?: number;
+}
+
+export interface LandingMediaConfig {
+  imageId?: string;
+  altKey?: string;
+}
+
+export interface LandingSectionConfig {
+  code?: string;
+  type?: string;
+  order?: number;
+  enabled?: boolean;
+  status?: LandingStatus;
+  version?: number;
+  /** When non-empty, only users holding one of these roles see the section.
+   *  Empty/absent => public (the common case for this pre-login page). */
+  roles?: string[];
+  titleKey?: string;
+  subtitleKey?: string;
+  bodyKey?: string;
+  media?: LandingMediaConfig;
+  items?: LandingItemConfig[];
+  theme?: { accent?: string; bg?: string };
+}
+
+export interface LandingPageConfig {
+  code?: string;
+  enabled?: boolean;
+  defaultLocale?: string;
+  showWhatsAppFab?: boolean;
+  showUtilityBar?: boolean;
+  /** Optional global order override (list of section codes). When present it
+   *  wins over each section's numeric `order`. */
+  sectionOrder?: string[];
+  seo?: { titleKey?: string; descriptionKey?: string };
+  theme?: Record<string, string>;
+  publish?: { status?: string; publishedVersion?: number; publishedAt?: number };
+}
+
+/** The fully-resolved config the renderer consumes: a page config plus the
+ *  ordered, enabled, role-filtered list of sections. Produced by
+ *  useLandingConfig from MDMS, or from DEFAULT_LANDING_CONFIG on
+ *  missing/incomplete data. */
+export interface ResolvedLandingConfig {
+  page: LandingPageConfig;
+  sections: LandingSectionConfig[];
+}

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/config/useLandingConfig.ts
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/config/useLandingConfig.ts
@@ -1,0 +1,117 @@
+// Runtime config fetch for the landing page (P1, CCSD-2006).
+//
+// Reads RAINMAKER-PGR.LandingSection + LandingPageConfig from MDMS at the state
+// tenant (where Phase 0 seeds them), with an optional city overlay (tenant
+// override: city rows win by `code`). Everything degrades gracefully — while
+// loading, on error, on empty data, or when the page is disabled, it returns
+// the built-in DEFAULT_LANDING_CONFIG, which reproduces today's layout. So the
+// page NEVER renders blank and is backward-compatible by construction.
+//
+// The fetch is anonymous/pre-login (this is a public page); MDMS _search is
+// exposed publicly via Kong. useCustomMDMS (v1 _search branch) reads the
+// v2-seeded rows — verified against the local stack.
+
+import * as React from "react";
+import { DEFAULT_LANDING_CONFIG, DEFAULT_LANDING_SECTIONS } from "./defaults";
+import { mergeSectionsByCode, orderSections } from "./resolve";
+import type {
+  LandingPageConfig,
+  LandingSectionConfig,
+  ResolvedLandingConfig,
+} from "./types";
+
+// `Digit` is the app-global runtime (same access pattern as the rest of
+// products/pgr). The landing only ever mounts inside the DIGIT shell, so it is
+// always present; typed loose to avoid coupling to the libraries' d.ts.
+declare const Digit: any;
+
+interface LandingFetch {
+  sections: LandingSectionConfig[];
+  page?: LandingPageConfig;
+}
+
+const selectLanding = (raw: any): LandingFetch => ({
+  sections: (raw?.["RAINMAKER-PGR"]?.LandingSection as LandingSectionConfig[]) || [],
+  page: (raw?.["RAINMAKER-PGR"]?.LandingPageConfig as LandingPageConfig[])?.[0],
+});
+
+function safe<T>(fn: () => T): T | undefined {
+  try {
+    return fn();
+  } catch {
+    return undefined;
+  }
+}
+
+export interface UseLandingConfigResult extends ResolvedLandingConfig {
+  isLoading: boolean;
+  /** true when the resolved config came from MDMS (vs the built-in fallback). */
+  fromConfig: boolean;
+}
+
+export function useLandingConfig(): UseLandingConfigResult {
+  const stateId: string | undefined = safe(() => Digit.ULBService.getStateId());
+  const currentTenant: string | undefined =
+    safe(() => Digit.ULBService.getCurrentTenantId()) || stateId;
+
+  const userRoles: string[] =
+    safe(() => (Digit.UserService.getUser()?.info?.roles || []).map((r: any) => r.code)) || [];
+
+  const isAdmin = userRoles.includes("ADMIN") || userRoles.includes("SUPERUSER");
+  const preview =
+    isAdmin && typeof window !== "undefined" && /[?&]preview=1\b/.test(window.location.search || "");
+
+  const commonOpts = { cacheTime: Infinity, staleTime: Infinity, select: selectLanding } as const;
+
+  // State-tenant rows (where the config lives).
+  const { data: stateData, isLoading } = Digit.Hooks.useCustomMDMS(
+    stateId,
+    "RAINMAKER-PGR",
+    [{ name: "LandingSection" }, { name: "LandingPageConfig" }],
+    { ...commonOpts, enabled: !!stateId }
+  );
+
+  // City overlay — only when a distinct city tenant is in context.
+  const cityEnabled = !!currentTenant && currentTenant !== stateId;
+  const { data: cityData } = Digit.Hooks.useCustomMDMS(
+    currentTenant,
+    "RAINMAKER-PGR",
+    [{ name: "LandingSection" }, { name: "LandingPageConfig" }],
+    { ...commonOpts, enabled: cityEnabled }
+  );
+
+  return React.useMemo<UseLandingConfigResult>(() => {
+    const state: LandingFetch = stateData || { sections: [], page: undefined };
+    const city: LandingFetch = cityData || { sections: [], page: undefined };
+
+    const page: LandingPageConfig | undefined = city.page || state.page;
+    const rawSections = mergeSectionsByCode(state.sections, city.sections);
+
+    // Fall back to the built-in layout when MDMS is empty, the page is
+    // explicitly disabled, or nothing survives filtering.
+    const pageDisabled = page && page.enabled === false;
+    if (pageDisabled || !rawSections || rawSections.length === 0) {
+      return { ...DEFAULT_LANDING_CONFIG, isLoading: !!isLoading, fromConfig: false };
+    }
+
+    const ordered = orderSections(rawSections, page?.sectionOrder, userRoles, { preview });
+    if (ordered.length === 0) {
+      // Config present but nothing visible (e.g. all role-gated away) — keep the
+      // structural default rather than a blank page.
+      return {
+        page: page || DEFAULT_LANDING_CONFIG.page,
+        sections: DEFAULT_LANDING_SECTIONS,
+        isLoading: !!isLoading,
+        fromConfig: false,
+      };
+    }
+
+    return {
+      page: page || DEFAULT_LANDING_CONFIG.page,
+      sections: ordered,
+      isLoading: !!isLoading,
+      fromConfig: true,
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stateData, cityData, isLoading, preview, userRoles.join(",")]);
+}

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/index.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/index.tsx
@@ -16,26 +16,13 @@
 // colors resolve from --pgrl-*-brand CSS vars with Mozambique gov defaults.
 
 import * as React from "react";
-import { cn } from "@egovernments/digit-ui-components-v2";
 
-import { LandingRoutes, mergeRoutes, DEFAULT_LANDING_ROUTES } from "./routes";
-import { buildTokenStyle, LandingTokens, DEFAULT_LANDING_TOKENS } from "./tokens";
-import { NewsItem, DEFAULT_NEWS } from "./content";
-import { useLandingCopy } from "./useLandingCopy";
-
-import { UtilityBar, LanguageOption, DEFAULT_LANGUAGES } from "./components/UtilityBar";
-import { LandingHeader } from "./components/LandingHeader";
-import { HeroSection } from "./components/HeroSection";
-import { TypesSection } from "./components/TypesSection";
-import { HowItWorksSection } from "./components/HowItWorksSection";
-import { ChannelsSection } from "./components/ChannelsSection";
-import { PrivacySection } from "./components/PrivacySection";
-import { NewsSection } from "./components/NewsSection";
-import { InstitutionsSection } from "./components/InstitutionsSection";
-import { FinalCtaSection } from "./components/FinalCtaSection";
-import { LandingFooter } from "./components/LandingFooter";
-import { WhatsAppFab } from "./components/WhatsAppFab";
-import { FOCUS_RING } from "./tokens";
+import { LandingRoutes } from "./routes";
+import { LandingTokens } from "./tokens";
+import { NewsItem } from "./content";
+import { LanguageOption } from "./components/UtilityBar";
+import { useLandingConfig } from "./config/useLandingConfig";
+import { LandingRenderer } from "./LandingRenderer";
 
 export interface PGRLandingPageProps {
   /** Override any destination — see LandingRoutes for the full map. */
@@ -52,79 +39,25 @@ export interface PGRLandingPageProps {
   onLanguageChange?: (code: string) => void;
   /** Design-token overrides (HSL triples — see LandingTokens). */
   tokens?: Partial<LandingTokens>;
-  /** Show the floating WhatsApp action. Default true. */
+  /** Force the floating WhatsApp action on/off (else the LandingPageConfig
+   *  toggle governs; default on). */
   showWhatsAppFab?: boolean;
+  /** Force the top utility bar on/off (else the LandingPageConfig toggle
+   *  governs; default on). */
+  showUtilityBar?: boolean;
   className?: string;
 }
 
-export function PGRLandingPage({
-  routes: routeOverrides,
-  news = DEFAULT_NEWS,
-  heroImageUrl,
-  emblemUrl,
-  languages = DEFAULT_LANGUAGES,
-  onLanguageChange,
-  tokens,
-  showWhatsAppFab = true,
-  className,
-}: PGRLandingPageProps) {
-  const { c } = useLandingCopy();
-  const routes = React.useMemo(() => mergeRoutes(routeOverrides), [routeOverrides]);
-  const tokenStyle = React.useMemo(() => buildTokenStyle(tokens), [tokens]);
-
-  // The sticky nav (48px) would otherwise fully obscure elements the browser
-  // scrolls into view on keyboard focus / skip-link jumps (WCAG 2.2 SC 2.4.11).
-  // scroll-padding must live on the scroll container (html), so set it for the
-  // page's lifetime and restore on unmount.
-  React.useEffect(() => {
-    const el = document.documentElement;
-    const prev = el.style.scrollPaddingTop;
-    el.style.scrollPaddingTop = "4rem";
-    return () => {
-      el.style.scrollPaddingTop = prev;
-    };
-  }, []);
-
-  return (
-    // Outer div carries .v2-scope (activates the scoped Tailwind layer) and
-    // seeds the --pgrl-* design tokens; utilities apply to descendants only.
-    <div className="v2-scope" style={tokenStyle}>
-      <div
-        className={cn(
-          "pgr-landing flex min-h-screen flex-col bg-[hsl(var(--pgrl-page))] text-[hsl(var(--pgrl-ink))]",
-          className
-        )}
-      >
-        <a
-          href="#pgr-landing-main"
-          className={cn(
-            "sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[60] focus:rounded-[var(--pgrl-radius)]",
-            "focus:bg-[hsl(var(--pgrl-surface))] focus:px-4 focus:py-2 focus:font-semibold focus:text-[hsl(var(--pgrl-deep))] focus:shadow-lg",
-            FOCUS_RING
-          )}
-        >
-          {c("SKIP_LINK")}
-        </a>
-
-        <UtilityBar routes={routes} languages={languages} onLanguageChange={onLanguageChange} />
-        <LandingHeader routes={routes} emblemUrl={emblemUrl} />
-
-        <main id="pgr-landing-main" className="flex-1">
-          <HeroSection routes={routes} imageUrl={heroImageUrl} />
-          <TypesSection routes={routes} />
-          <HowItWorksSection />
-          <ChannelsSection routes={routes} />
-          <PrivacySection routes={routes} />
-          <NewsSection routes={routes} items={news} />
-          <InstitutionsSection />
-          <FinalCtaSection routes={routes} />
-        </main>
-
-        <LandingFooter routes={routes} />
-        {showWhatsAppFab && <WhatsAppFab href={routes.WHATSAPP} />}
-      </div>
-    </div>
-  );
+/**
+ * Config-driven entry point. Fetches the landing config from MDMS
+ * (RAINMAKER-PGR.LandingSection + LandingPageConfig) with a built-in fallback
+ * that reproduces the previous static layout, then renders it generically via
+ * LandingRenderer. Props remain as integrator overrides layered on top of the
+ * config. Backward-compatible: with no/empty config the page is unchanged.
+ */
+export function PGRLandingPage(props: PGRLandingPageProps) {
+  const config = useLandingConfig();
+  return <LandingRenderer config={config} {...props} />;
 }
 
 export default PGRLandingPage;

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/useLandingCopy.ts
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/useLandingCopy.ts
@@ -13,8 +13,10 @@ import { LANDING_COPY, LandingCopyKey } from "./content";
 export const LANDING_KEY_PREFIX = "PGR_LANDING_";
 
 export interface LandingCopyApi {
-  /** Resolve a landing copy key to display text. */
-  c: (key: LandingCopyKey) => string;
+  /** Resolve a landing copy key to display text. Accepts the built-in short
+   *  keys and fully-qualified PGR_LANDING_* config keys alike; the optional
+   *  second arg is the fallback key used when the first is empty/unresolved. */
+  c: (key?: LandingCopyKey | string, fallbackKey?: LandingCopyKey | string) => string;
   /** "pt" | "en" — resolved from the active i18n language. */
   lang: "pt" | "en";
   /** Raw i18n handle for integrators (language switching etc.). */
@@ -30,11 +32,29 @@ export function useLandingCopy(): LandingCopyApi {
     : "pt";
 
   const c = React.useCallback(
-    (key: LandingCopyKey): string => {
-      const fullKey = LANDING_KEY_PREFIX + key;
-      const translated = t(fullKey);
-      if (translated && translated !== fullKey) return translated;
-      return LANDING_COPY[key]?.[lang] ?? key;
+    // Resolve a copy key to text. Accepts BOTH the built-in short keys
+    // ("HERO_TITLE") and fully-qualified config/MDMS keys
+    // ("PGR_LANDING_HERO_TITLE") — config rows carry the prefixed form, so
+    // re-prefixing would double it. The optional `fallbackKey` is the component's
+    // canonical default: when the primary key is empty OR unresolved (missing
+    // from both the i18n store and the built-in deck — e.g. a bad/typo'd config
+    // key), we resolve the fallback instead, so untrusted/incomplete config
+    // never surfaces a raw key.
+    (key?: LandingCopyKey | string, fallbackKey?: LandingCopyKey | string): string => {
+      const resolveOne = (k?: string): string | undefined => {
+        if (!k) return undefined;
+        const hasPrefix = k.startsWith(LANDING_KEY_PREFIX);
+        const fullKey = hasPrefix ? k : LANDING_KEY_PREFIX + k;
+        const shortKey = hasPrefix ? k.slice(LANDING_KEY_PREFIX.length) : k;
+        const translated = t(fullKey);
+        if (translated && translated !== fullKey) return translated;
+        return (LANDING_COPY as Record<string, { pt: string; en: string }>)[shortKey]?.[lang];
+      };
+      return (
+        resolveOne(key as string) ??
+        resolveOne(fallbackKey as string) ??
+        String(key ?? fallbackKey ?? "")
+      );
     },
     [t, lang]
   );


### PR DESCRIPTION
## What & why
**Phase 1** of the config-driven landing (parent CCSD-2004). The public landing now renders **entirely from MDMS configuration** (`RAINMAKER-PGR.LandingSection` + `LandingPageConfig`, seeded in Phase 0 / PR #1186) via a generic renderer + type→component registry — while **preserving the exact UI** and remaining **fully backward-compatible**.

FE-only; no backend. Builds on Phase 0's data foundation.

## How it works
- **`useLandingConfig`** fetches both masters (`Digit.Hooks.useCustomMDMS`, v1 read path) at the **state tenant** with a **city overlay** (tenant override, city wins by `code`), then orders / enable-disable / DRAFT-gates / **role-gates** the sections. On missing/empty/disabled/error it returns a built-in **`DEFAULT_LANDING_CONFIG`** (structure-only) so the page never renders blank.
- **`sectionRegistry`** enforces the frozen v1 catalog (scope A) as a `type → { Component, slot, buildProps }` map (not a schema enum). `slot` (header/main/footer) preserves the exact DOM structure; `buildProps` resolves `iconId → component`, `media-id → url`, and `navigationUrl → route-key|url` with a `safeHref` guard. Unknown types are skipped.
- **`LandingRenderer`** reproduces the shell byte-for-byte (`.v2-scope` token wrapper, `.pgr-landing` column, skip link, scroll-padding effect, header/main/footer slots) and gates `UtilityBar` / `WhatsAppFab` on the page toggles.
- **Section components** each gained one **optional** `section`/`navItems` prop (`section?.items ?? DECK_ARRAY`, title/subtitle/body via config keys). Absent prop ⇒ byte-identical to before.
- **`useLandingCopy.c()`** now accepts short *or* fully-qualified `PGR_LANDING_*` keys **plus a fallback key** — a bad/typo'd config key resolves to the component default instead of surfacing a raw key (untrusted/incomplete config stays safe).

## Requirements coverage (per the P1 ask)
| Requirement | Status |
|---|---|
| Generic LandingRenderer consuming both masters | ✅ |
| type → component registry (scope-A catalog) | ✅ |
| Item-level content from config | ✅ (overlay on deck defaults; full seeding = rollout script) |
| Preserve existing appearance exactly | ✅ (verified 1440×900 + 390×844) |
| Ordering, enable/disable, localization, page toggles, tenant override | ✅ (all verified live) |
| Fallback when config missing/incomplete | ✅ (DEFAULT config + per-field defaults + bad-key fallback) |
| Role-gated sections filtered; config treated as untrusted | ✅ (role filter + safeHref + unknown-type skip + no `dangerouslySetInnerHTML`) |

## Testing (local, `mz`, `/digit-ui/landing`, against the live Phase 0 seed)
- Renders entirely from config at **1440×900** and **390×844**, byte-faithful to the static page; **no console errors, no raw keys**.
- **Config-drives-behavior** confirmed by mutating MDMS and reloading: **reorder** (order change moved `institutions` up), **disable** (`news` hidden), **page toggle** (`showWhatsAppFab=false` hid the FAB), **role-gate** (`EMPLOYEE`-only `privacy` hidden for the anonymous visitor) — then restored.
- No FE test harness in this repo (QA-owned).

## Scope / follow-ups
- Full item-level content seeding (nav/type/step arrays) is a **data** task for the rollout/migration script — deliberately **not** in this FE-only PR.
- Filestore-id → signed-URL media resolution and per-item theming land in **P2** (CCSD-2007). Configurator CRUD / Builder / Draft-Publish are P3–P5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)