### PR TITLE
feat(configurator): Builder v2 polish — full-canvas workspace + mockup parity (CCSD-2009)

### DIFF
--- a/configurator/src/admin/DigitLayout.tsx
+++ b/configurator/src/admin/DigitLayout.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useLocaleState, useLocales, useTranslate } from 'ra-core';
 import { useApp } from '../App';
@@ -99,6 +99,21 @@ export function DigitLayout({ children }: { children?: ReactNode }) {
   const location = useLocation();
   const translate = useTranslate();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  // CCSD-2009 (Builder v2 polish): the Builder is a full-canvas workspace —
+  // auto-collapse the nav sidebar and hide the docs pane while it's open,
+  // restoring the user's previous state on leave.
+  const isBuilderRoute = location.pathname.includes('/landing-builder');
+  const preBuilderCollapsed = useRef<boolean | null>(null);
+  useEffect(() => {
+    if (isBuilderRoute) {
+      if (preBuilderCollapsed.current === null) preBuilderCollapsed.current = sidebarCollapsed;
+      setSidebarCollapsed(true);
+    } else if (preBuilderCollapsed.current !== null) {
+      setSidebarCollapsed(preBuilderCollapsed.current);
+      preBuilderCollapsed.current = null;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isBuilderRoute]);
   const [collapsedGroups, setCollapsedGroups] = useState<Record<string, boolean>>(() => {
     // Auto-expand groups that contain the active route, collapse others
     const initial: Record<string, boolean> = {};
@@ -402,7 +417,7 @@ export function DigitLayout({ children }: { children?: ReactNode }) {
       </div>
 
       {/* Documentation Pane */}
-      <DocsPane />
+      {!isBuilderRoute && <DocsPane />}
     </div>
   );
 }

--- a/configurator/src/admin/landingBuilder/BuilderToolbar.tsx
+++ b/configurator/src/admin/landingBuilder/BuilderToolbar.tsx
@@ -65,7 +65,7 @@ export function BuilderToolbar({
   };
 
   return (
-    <div className="flex items-center gap-2 border-b border-border bg-card px-3 py-1.5">
+    <div className="flex items-center gap-2 border-b border-border bg-card px-4 py-2">
       {/* Breadcrumb */}
       <div className="flex min-w-0 items-center gap-1 text-sm">
         <span className="font-semibold">Landing Page Builder</span>
@@ -80,8 +80,8 @@ export function BuilderToolbar({
         {state.selected === 'page' && <span className="text-muted-foreground">/ Page Settings</span>}
       </div>
       {dirty
-        ? <Badge variant="outline" className="border-amber-500 text-amber-600">Unsaved changes</Badge>
-        : <Badge variant="outline" className="border-emerald-600 text-emerald-700">All changes saved</Badge>}
+        ? <span className="whitespace-nowrap rounded-full bg-amber-100 px-2.5 py-0.5 text-[11px] font-medium text-amber-700">● Unsaved changes</span>
+        : <span className="whitespace-nowrap rounded-full bg-emerald-100 px-2.5 py-0.5 text-[11px] font-medium text-emerald-700">✓ All changes saved</span>}
 
       <div className="mx-2 flex-1" />
 
@@ -111,16 +111,17 @@ export function BuilderToolbar({
       </Select>
 
       {/* Draft / Published preview */}
-      <div className="flex overflow-hidden rounded-md border border-border text-xs">
+      <span className="text-[11px] text-muted-foreground">Preview:</span>
+      <div className="flex overflow-hidden rounded-full border border-border text-xs">
         <button
           type="button"
           onClick={() => dispatch({ type: 'setPreviewMode', mode: 'draft' })}
-          className={`px-2 py-1 ${state.previewMode === 'draft' ? 'bg-amber-500 text-white' : 'hover:bg-accent'}`}
+          className={`px-2.5 py-1 ${state.previewMode === 'draft' ? 'bg-amber-500 text-white' : 'hover:bg-accent'}`}
         >Draft</button>
         <button
           type="button"
           onClick={() => dispatch({ type: 'setPreviewMode', mode: 'published' })}
-          className={`px-2 py-1 ${state.previewMode === 'published' ? 'bg-emerald-600 text-white' : 'hover:bg-accent'}`}
+          className={`px-2.5 py-1 ${state.previewMode === 'published' ? 'bg-emerald-600 text-white' : 'hover:bg-accent'}`}
         >Published</button>
       </div>
 
@@ -142,7 +143,7 @@ export function BuilderToolbar({
       </Button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button size="sm" className="h-7" disabled={state.saving}>
+          <Button size="sm" className="h-7 bg-emerald-600 text-white hover:bg-emerald-700" disabled={state.saving}>
             <UploadCloud className="mr-1 h-3.5 w-3.5" /> Publish <ChevronDown className="ml-1 h-3 w-3" />
           </Button>
         </DropdownMenuTrigger>

--- a/configurator/src/admin/landingBuilder/Inspector.tsx
+++ b/configurator/src/admin/landingBuilder/Inspector.tsx
@@ -69,7 +69,7 @@ function LocTextField({ def, sectionCode, draft }: { def: BuilderFieldDef; secti
           className="w-full rounded-md border border-input bg-background px-2 py-1.5 text-sm"
         />
       ) : (
-        <Input value={value} disabled={!key} onChange={(e) => onChange(e.target.value)} className="h-8 text-sm" />
+        <Input value={value} disabled={!key} onChange={(e) => onChange(e.target.value)} className="h-9 text-sm" />
       )}
       <div className="flex items-center justify-between">
         <span className="truncate text-[10px] text-muted-foreground" title={key}>{key ?? 'No localization key set (Advanced tab)'}</span>
@@ -213,7 +213,7 @@ function GenericField({ def, code, draft }: { def: BuilderFieldDef; code: string
       <div className="space-y-1" data-field={def.path}>
         <Label className="text-xs font-medium">{def.label}</Label>
         <Select value={(value as string) ?? ''} onValueChange={patch}>
-          <SelectTrigger className="h-8 text-sm"><SelectValue placeholder="—" /></SelectTrigger>
+          <SelectTrigger className="h-9 text-sm"><SelectValue placeholder="—" /></SelectTrigger>
           <SelectContent>{(def.options ?? []).map((o) => <SelectItem key={o} value={o}>{o}</SelectItem>)}</SelectContent>
         </Select>
         {def.help && <p className="m-0 text-[10px] text-muted-foreground">{def.help}</p>}
@@ -231,7 +231,7 @@ function GenericField({ def, code, draft }: { def: BuilderFieldDef; code: string
             const roles = e.target.value.split(',').map((r) => r.trim()).filter(Boolean);
             dispatch({ type: 'patchSection', code, patch: { roles: roles.length ? roles : undefined }, coalesce: `f:${code}:roles` });
           }}
-          className="h-8 text-sm"
+          className="h-9 text-sm"
         />
         {def.help && <p className="m-0 text-[10px] text-muted-foreground">{def.help}</p>}
       </div>
@@ -249,6 +249,27 @@ function GenericField({ def, code, draft }: { def: BuilderFieldDef; code: string
       />
       {def.help && <p className="m-0 text-[10px] text-muted-foreground">{def.help}</p>}
     </div>
+  );
+}
+
+/** Boolean that lives on LandingPageConfig, surfaced inside a section tab
+ *  (e.g. the Navigation section's "Show top bar"). */
+function PageToggleField({ def }: { def: BuilderFieldDef }) {
+  const { state, dispatch } = useBuilder();
+  const value = (state.page?.draft as Record<string, unknown> | undefined)?.[def.path];
+  return (
+    <label className="flex cursor-pointer items-center justify-between gap-2 text-sm" data-field={def.path}>
+      {def.label}
+      <button
+        type="button"
+        role="switch"
+        aria-checked={value !== false}
+        onClick={(e) => { e.preventDefault(); dispatch({ type: 'patchPage', patch: { [def.path]: value === false } }); }}
+        className={`relative h-5 w-9 rounded-full transition-colors ${value === false ? 'bg-muted-foreground/30' : 'bg-emerald-500'}`}
+      >
+        <span className="absolute top-0.5 h-4 w-4 rounded-full bg-white transition-all" style={{ left: value === false ? 2 : 18 }} />
+      </button>
+    </label>
   );
 }
 
@@ -306,7 +327,7 @@ export function Inspector() {
                   <Input
                     value={((draft as Record<string, unknown>)[def.path] as string) ?? ''}
                     onChange={(e) => dispatch({ type: 'patchPage', patch: { [def.path]: e.target.value }, coalesce: `p:${def.path}` })}
-                    className="h-8 text-sm"
+                    className="h-9 text-sm"
                   />
                   {def.help && <p className="m-0 text-[10px] text-muted-foreground">{def.help}</p>}
                 </div>
@@ -333,6 +354,7 @@ export function Inspector() {
   return (
     <Pane
       title={entry.label}
+      meta={`Section ID: ${code} · Version: ${section.draft.status === 'PUBLISHED' ? 'Published' : 'Draft'}`}
       subtitle={entry.description}
       header={
         <div className="flex items-center gap-2">
@@ -358,21 +380,38 @@ export function Inspector() {
       }
     >
       <Tabs value={tab} onValueChange={(v) => dispatch({ type: 'setTab', tab: v as InspectorTab })} className="flex min-h-0 flex-1 flex-col">
-        <TabsList className="mx-3 mt-2 grid h-8 grid-cols-6">
+        <TabsList className="h-9 w-full justify-start gap-1 rounded-none border-b border-border bg-transparent px-2">
           {INSPECTOR_TABS.map((t) => (
-            <TabsTrigger key={t.id} value={t.id} className="px-1 text-[10px]">{t.label}</TabsTrigger>
+            <TabsTrigger
+              key={t.id}
+              value={t.id}
+              className="rounded-none border-b-2 border-transparent px-2 pb-1.5 text-[11px] data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+            >
+              {t.label}
+            </TabsTrigger>
           ))}
         </TabsList>
         <div ref={paneRef} className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4">
           {tabFields.length === 0 && !itemsHere && (
             <p className="m-0 text-xs text-muted-foreground">Nothing to configure in this tab for {entry.label}.</p>
           )}
-          {tabFields.map((def) => {
-            if (def.widget === 'loctext') return <LocTextField key={def.path} def={def} sectionCode={code} draft={section.draft} />;
-            if (def.widget === 'action') return <ActionField key={def.path} def={def} />;
-            if (def.widget === 'theme') return <ThemeField key={def.path} def={def} code={code} draft={section.draft} />;
-            if (def.widget === 'media') return <MediaLibraryDialog key={def.path} def={def} code={code} draft={section.draft} />;
-            return <GenericField key={def.path} def={def} code={code} draft={section.draft} />;
+          {tabFields.map((def, i) => {
+            const groupHeader = def.group && def.group !== tabFields[i - 1]?.group ? (
+              <h3 className="mb-0 mt-2 border-t border-border pt-3 text-xs font-semibold">{def.group}</h3>
+            ) : null;
+            let field: React.ReactNode;
+            if (def.widget === 'loctext') field = <LocTextField def={def} sectionCode={code} draft={section.draft} />;
+            else if (def.widget === 'action') field = <ActionField def={def} />;
+            else if (def.widget === 'theme') field = <ThemeField def={def} code={code} draft={section.draft} />;
+            else if (def.widget === 'media') field = <MediaLibraryDialog def={def} code={code} draft={section.draft} />;
+            else if (def.widget === 'pagetoggle') field = <PageToggleField def={def} />;
+            else field = <GenericField def={def} code={code} draft={section.draft} />;
+            return (
+              <div key={def.path} className="contents">
+                {groupHeader}
+                {field}
+              </div>
+            );
           })}
           {itemsHere && <ItemsEditor cfg={itemsHere} code={code} draft={section.draft} />}
         </div>
@@ -381,12 +420,13 @@ export function Inspector() {
   );
 }
 
-function Pane({ title, subtitle, header, children }: { title: string; subtitle?: string; header?: React.ReactNode; children: React.ReactNode }) {
+function Pane({ title, subtitle, meta, header, children }: { title: string; subtitle?: string; meta?: string; header?: React.ReactNode; children: React.ReactNode }) {
   return (
     <div className="flex h-full w-80 shrink-0 flex-col border-l border-border bg-card">
       <div className="flex items-start justify-between gap-2 border-b border-border px-4 py-3">
         <div className="min-w-0">
           <h2 className="m-0 truncate text-sm font-semibold">{title}</h2>
+          {meta && <p className="mb-0 mt-0.5 text-[10px] text-muted-foreground">{meta}</p>}
           {subtitle && <p className="mb-0 mt-0.5 line-clamp-2 text-[10px] leading-snug text-muted-foreground">{subtitle}</p>}
         </div>
         {header}

--- a/configurator/src/admin/landingBuilder/LandingBuilder.tsx
+++ b/configurator/src/admin/landingBuilder/LandingBuilder.tsx
@@ -7,9 +7,11 @@
  * enabled sections to PUBLISHED. Keyboard: Ctrl+S save · Ctrl+Z / Ctrl+Y
  * undo/redo. Live validation runs on every change.
  */
-import { useCallback, useEffect, useMemo } from 'react';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { HelpCircle, History, LayoutList, Palette, PanelRight, X } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
 import { toast } from '@/hooks/use-toast';
 import { useApp } from '../../App';
 import {
@@ -24,6 +26,11 @@ import { Inspector } from './Inspector';
 function BuilderInner() {
   const { state, dispatch } = useBuilder();
   const { state: app } = useApp();
+  const navigate = useNavigate();
+  // Workspace pane toggles (right icon rail): more canvas on demand.
+  const [showLeft, setShowLeft] = useState(true);
+  const [showRight, setShowRight] = useState(true);
+  const [showHelp, setShowHelp] = useState(false);
   const params = useParams<{ id?: string }>();
   const [search] = useSearchParams();
   const tenantId = app.tenant ?? '';
@@ -126,13 +133,80 @@ function BuilderInner() {
       {state.loading ? (
         <p className="p-6 text-sm text-muted-foreground">Loading landing configuration…</p>
       ) : (
-        <div className="flex min-h-0 flex-1">
-          <SectionListPane />
+        <div className="relative flex min-h-0 flex-1">
+          {showLeft && <SectionListPane />}
           <PreviewFrame />
-          <Inspector />
+          {showRight && <Inspector />}
+
+          {/* Right icon rail (mockup): Inspector / Structure / Theme / History / Help */}
+          <div className="flex w-12 shrink-0 flex-col items-center gap-1 border-l border-border bg-card py-2">
+            <RailButton
+              label="Inspector"
+              active={showRight}
+              icon={<PanelRight className="h-4 w-4" />}
+              onClick={() => setShowRight((v) => !v)}
+            />
+            <RailButton
+              label="Structure"
+              active={showLeft}
+              icon={<LayoutList className="h-4 w-4" />}
+              onClick={() => setShowLeft((v) => !v)}
+            />
+            <RailButton
+              label="Theme"
+              icon={<Palette className="h-4 w-4" />}
+              onClick={() => navigate('/manage/theme-config')}
+            />
+            <RailButton label="History (P5)" disabled icon={<History className="h-4 w-4" />} />
+            <RailButton
+              label="Help"
+              active={showHelp}
+              icon={<HelpCircle className="h-4 w-4" />}
+              onClick={() => setShowHelp((v) => !v)}
+            />
+          </div>
+
+          {showHelp && (
+            <div className="absolute bottom-4 right-14 z-40 w-64 rounded-lg border border-border bg-card p-4 shadow-xl">
+              <div className="mb-2 flex items-center justify-between">
+                <h3 className="m-0 text-xs font-semibold">Tips & Shortcuts</h3>
+                <Button variant="ghost" size="icon" className="h-5 w-5" onClick={() => setShowHelp(false)} aria-label="Close help">
+                  <X className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+              <p className="m-0 mb-3 text-[11px] leading-snug text-muted-foreground">
+                Use localization keys to manage content in multiple languages. Click any element in
+                the preview to edit it. Drag section cards to reorder.
+              </p>
+              <dl className="m-0 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-[11px]">
+                <dt className="font-mono text-muted-foreground">Ctrl+S</dt><dd className="m-0">Save Draft</dd>
+                <dt className="font-mono text-muted-foreground">Ctrl+Z</dt><dd className="m-0">Undo</dd>
+                <dt className="font-mono text-muted-foreground">Ctrl+Y</dt><dd className="m-0">Redo</dd>
+              </dl>
+            </div>
+          )}
         </div>
       )}
     </div>
+  );
+}
+
+function RailButton({ label, icon, onClick, active, disabled }: {
+  label: string; icon: React.ReactNode; onClick?: () => void; active?: boolean; disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      title={label}
+      aria-label={label}
+      disabled={disabled}
+      onClick={onClick}
+      className={`flex h-9 w-9 flex-col items-center justify-center rounded-md text-muted-foreground transition-colors ${
+        disabled ? 'opacity-40' : 'hover:bg-accent hover:text-foreground'
+      } ${active ? 'bg-accent text-primary' : ''}`}
+    >
+      {icon}
+    </button>
   );
 }
 

--- a/configurator/src/admin/landingBuilder/SectionListPane.tsx
+++ b/configurator/src/admin/landingBuilder/SectionListPane.tsx
@@ -39,7 +39,7 @@ export function SectionListPane() {
   };
 
   return (
-    <div className="flex h-full w-64 shrink-0 flex-col border-r border-border bg-card">
+    <div className="flex h-full w-72 shrink-0 flex-col border-r border-border bg-card">
       <div className="flex items-center gap-2 border-b border-border px-3 py-2">
         <span className="flex-1 text-sm font-semibold">Sections</span>
         <Button variant="outline" size="sm" className="h-7 px-2 text-xs" onClick={() => setAddOpen(true)}>
@@ -48,7 +48,7 @@ export function SectionListPane() {
       </div>
       <p className="m-0 px-3 py-1.5 text-[10px] text-muted-foreground">Drag to reorder sections</p>
 
-      <ul className="m-0 flex-1 list-none overflow-y-auto p-2 pt-0">
+      <ul className="m-0 flex-1 list-none overflow-y-auto p-3 pt-0">
         {ordered.map((s, i) => {
           const entry = getEditorEntry(s.draft.type);
           const Icon = entry?.icon ?? Settings;
@@ -78,8 +78,12 @@ export function SectionListPane() {
                 onMouseLeave={() => dispatch({ type: 'hover', code: null })}
                 onClick={() => dispatch({ type: 'select', id: code })}
                 onKeyDown={(e) => e.key === 'Enter' && dispatch({ type: 'select', id: code })}
-                className={`group mb-1.5 cursor-pointer rounded-md border px-2 py-2 text-sm transition-colors ${
-                  selected ? 'border-primary bg-accent' : hovered ? 'border-primary/50 bg-accent/60' : 'border-border bg-background hover:bg-accent/40'
+                className={`group mb-2 cursor-pointer rounded-lg border px-3 py-2.5 text-sm shadow-sm transition-all ${
+                  selected
+                    ? 'border-emerald-500 bg-emerald-50/60 ring-1 ring-emerald-500/30'
+                    : hovered
+                      ? 'border-emerald-400/60 bg-accent/60'
+                      : 'border-border bg-background hover:border-emerald-300/60 hover:shadow'
                 } ${off ? 'opacity-55' : ''}`}
               >
                 <div className="flex items-center gap-1.5">

--- a/configurator/src/admin/landingBuilder/sectionEditorRegistry.tsx
+++ b/configurator/src/admin/landingBuilder/sectionEditorRegistry.tsx
@@ -23,7 +23,8 @@ export type BuilderWidget =
   | 'select'
   | 'media'     // media.imageId via the media library
   | 'theme'     // theme token selects
-  | 'action';   // CTA row: editable label (loctext) + fixed destination
+  | 'action'    // CTA row: editable label (loctext) + fixed destination
+  | 'pagetoggle'; // boolean living on LandingPageConfig (e.g. showUtilityBar)
 
 export interface BuilderFieldDef {
   /** dot-path into LandingSectionData; for fixedKey loctext fields the path is
@@ -42,6 +43,8 @@ export interface BuilderFieldDef {
   fixedKey?: string;
   /** for widget 'action': human description of the fixed destination. */
   destination?: string;
+  /** Optional group heading rendered above this field (e.g. "Top Bar Settings"). */
+  group?: string;
 }
 
 export interface ItemsEditorConfig {
@@ -135,7 +138,20 @@ const newItem = (prefix: string) => () => {
 export const SECTION_EDITOR_REGISTRY: Record<string, SectionEditorEntry> = {
   navigation: entry('navigation', 'Navigation', Navigation,
     'Masthead + sticky primary navigation.',
-    [mediaField('Emblem image'), themeField],
+    [
+      mediaField('Emblem image'),
+      // Top bar (utility strip) — texts are fixed deck keys; the visibility
+      // toggle lives on LandingPageConfig (surfaced here for convenience).
+      { path: 'showUtilityBar', label: 'Show top bar', tab: 'content', widget: 'pagetoggle',
+        group: 'Top Bar Settings' },
+      { path: 'topbar.left', label: 'Top bar text (Left)', tab: 'content', widget: 'loctext',
+        fixedKey: 'PGR_LANDING_GOV_NAME', group: 'Top Bar Settings' },
+      { path: 'topbar.center', label: 'Top bar text (Center)', tab: 'content', widget: 'loctext',
+        fixedKey: 'PGR_LANDING_UTILITY_GREEN_LINE', group: 'Top Bar Settings' },
+      { path: 'topbar.right', label: 'Login link text (Right)', tab: 'content', widget: 'loctext',
+        fixedKey: 'PGR_LANDING_LOGIN', group: 'Top Bar Settings' },
+      themeField,
+    ],
     {
       items: {
         label: 'Menu items', tab: 'content', withIcons: false, withDesc: false, withUrl: true,


### PR DESCRIPTION
## ⚠️ Stacked PR
Chain: #1187 → #1188 → #1189 → #1190 → **this** (+183 −33, 6 files). Retarget after the chain merges.

## What (per the updated mockup + "feels congested" feedback)
- **Auto-collapse app chrome**: entering the Builder collapses the configurator nav sidebar and hides the docs pane (previous state restored on leave) → the preview now renders at **full device width**.
- **Right icon rail** (mockup): **Inspector** / **Structure** toggles (collapse either side pane for max canvas), **Theme** (jump to Theme Config), **History** (P5 placeholder), **Help** (Tips + Shortcuts popover — moved out of the panel).
- **Navigation Inspector = mockup's "Top Bar Settings"**: Show-top-bar toggle (surfaces `showUtilityBar` in context) + Left/Center/Right texts as localized fields with Edit Translations; grouped-field headings; Menu Items editor below.
- **Modern restyle**: roomier cards (rounded, shadow, green selection ring), pill save-state chips, "Preview:" Draft/Published pills, green Publish, underline Inspector tabs, Section ID + Version meta, larger inputs.

## Verified live (local, mz)
Sidebar auto-collapses on entry and restores on leave; docs pane hidden; rail toggles work; Top Bar texts resolve (República de Moçambique / Linha Verde 1490 / Entrar); preview at full 1280px device width; screenshot attached to the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)