### PR TITLE
fix(landing): Builder text edits now reflect on the live landing page

### DIFF
--- a/configurator/src/admin/landingBuilder/PreviewFrame.tsx
+++ b/configurator/src/admin/landingBuilder/PreviewFrame.tsx
@@ -9,7 +9,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { useBuilder, buildPreviewConfig, isDirty } from './builderStore';
-import { resolveText } from './localization';
+import { BUILDER_LOCALES, getLoadedMessages } from './localization';
 import type { InspectorTab, LocEdits } from './types';
 
 const LANDING_PATH = '/digit-ui/landing?builderPreview=1';
@@ -20,10 +20,6 @@ export function PreviewFrame() {
   const frameRef = useRef<HTMLIFrameElement>(null);
   const [ready, setReady] = useState(false);
   const debounceRef = useRef<number>();
-  // Keys ever overridden in the iframe's i18n store: when an edit is undone /
-  // cleared we must push the ORIGINAL store text back, or the stale override
-  // sticks (i18n addResources has no "remove").
-  const sentKeysRef = useRef<Record<string, Set<string>>>({});
 
   const post = (payload: Record<string, unknown>) =>
     frameRef.current?.contentWindow?.postMessage(payload, window.location.origin);
@@ -55,22 +51,22 @@ export function PreviewFrame() {
     if (!ready || state.loading) return;
     window.clearTimeout(debounceRef.current);
     debounceRef.current = window.setTimeout(() => {
-      // Merge staged edits with reset-to-original for retracted keys.
+      // Push the FULL loaded message map with staged edits layered on top —
+      // the iframe's i18n store never loads the rainmaker-pgr module, so
+      // partial pushes would leave saved-but-unedited custom text rendering
+      // as deck fallbacks (and this also makes retracted edits revert
+      // naturally, since the original text is always in the map).
       const messages: LocEdits = {};
       const locales = new Set([
+        ...BUILDER_LOCALES.map((l) => l.code),
         ...Object.keys(state.locEdits),
-        ...Object.keys(sentKeysRef.current),
       ]);
       locales.forEach((lng) => {
-        const staged = state.locEdits[lng] ?? {};
-        const sent = sentKeysRef.current[lng] ?? new Set<string>();
-        const out: Record<string, string> = {};
-        new Set([...Object.keys(staged), ...sent]).forEach((key) => {
-          const v = staged[key] ?? resolveText(key, lng, {});
-          if (v !== undefined) out[key] = v;
-        });
+        const out: Record<string, string> = {
+          ...getLoadedMessages(lng),
+          ...(state.locEdits[lng] ?? {}),
+        };
         if (Object.keys(out).length) messages[lng] = out;
-        sentKeysRef.current[lng] = new Set([...sent, ...Object.keys(staged)]);
       });
       post({
         type: 'pgrl-preview-config',

--- a/configurator/src/admin/landingBuilder/localization.ts
+++ b/configurator/src/admin/landingBuilder/localization.ts
@@ -33,6 +33,14 @@ export async function loadMessages(tenantId: string, locale: string): Promise<Re
   return map;
 }
 
+/** Everything loaded from the store for a locale (empty until loadMessages).
+ *  The preview pushes this WHOLE map (staged edits layered on top) so the
+ *  iframe renders saved-but-unedited custom text too — its i18n store never
+ *  loads the module itself. */
+export function getLoadedMessages(locale: string): Record<string, string> {
+  return cache.get(locale) ?? {};
+}
+
 /** Staged edit wins, then the store; undefined when the key is unknown. */
 export function resolveText(
   key: string | undefined,
@@ -47,6 +55,7 @@ export function resolveText(
 
 /** Persist staged edits (per-locale batches) and fold them into the cache. */
 export async function persistLocEdits(tenantId: string, locEdits: LocEdits): Promise<void> {
+  let wrote = false;
   for (const [locale, byKey] of Object.entries(locEdits)) {
     const messages = Object.entries(byKey).map(([code, message]) => ({
       code,
@@ -55,8 +64,21 @@ export async function persistLocEdits(tenantId: string, locEdits: LocEdits): Pro
     }));
     if (!messages.length) continue;
     await digitClient.localizationUpsert(tenantId, locale, messages);
+    wrote = true;
     const map = cache.get(locale);
     if (map) messages.forEach((m) => { map[m.code] = m.message; });
+  }
+  if (wrote) {
+    // The localization service caches search responses; without a bust, other
+    // clients (the live landing page) can keep reading the pre-save text.
+    // Best-effort — the write above already succeeded.
+    try {
+      await digitClient.request('/localization/messages/cache-bust', {
+        RequestInfo: digitClient.buildRequestInfo(),
+      });
+    } catch {
+      /* non-fatal */
+    }
   }
 }
 

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/config/useLandingMessages.ts
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/config/useLandingMessages.ts
@@ -1,0 +1,76 @@
+// Live localization for the landing page (Builder text edits).
+//
+// The Builder saves text edits as PGR_LANDING_* messages in the localization
+// service (module rainmaker-pgr) — but nothing on the public landing route
+// loads that module into i18next, so `t()` always missed and useLandingCopy
+// fell through to the built-in copy deck: saved edits never reflected on the
+// live page. This hook is the missing link. It fetches the module bundle for
+// the active locale (anonymously — this is a pre-login page, same exposure as
+// the MDMS config fetch) and injects it with addResources, then re-renders.
+//
+// Deliberately uncached: the whole point is that a Builder save shows up on
+// the next reload. One small POST per page load / locale switch.
+
+import * as React from "react";
+
+declare const Digit: any;
+
+const LOC_MODULE = "rainmaker-pgr";
+const SEARCH_PATH = "/localization/messages/v1/_search";
+
+function safe<T>(fn: () => T): T | undefined {
+  try {
+    return fn();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Loads the rainmaker-pgr localization bundle for the active i18n language
+ * into the i18n store. Returns a version counter that bumps when new messages
+ * land, so the caller re-renders and `t()` resolves the fresh text.
+ * Fail-open: on any error the page keeps rendering the built-in copy deck.
+ */
+export function useLandingMessages(i18n: any): number {
+  const [version, setVersion] = React.useState(0);
+  const locale: string = String(i18n?.language || "");
+  const stateId: string | undefined = safe(() => Digit.ULBService.getStateId());
+
+  React.useEffect(() => {
+    if (!locale || !stateId) return undefined;
+    let cancelled = false;
+    const params = new URLSearchParams({ tenantId: stateId, module: LOC_MODULE, locale });
+    fetch(`${SEARCH_PATH}?${params.toString()}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ RequestInfo: { apiId: "pgr-landing", ver: "1.0" } }),
+    })
+      .then((r) => (r.ok ? r.json() : undefined))
+      .then((data) => {
+        const rows: Array<{ code?: string; message?: string }> = data?.messages || [];
+        if (cancelled || !rows.length) return;
+        const res: Record<string, string> = {};
+        rows.forEach((m) => {
+          if (m?.code && typeof m.message === "string") res[m.code] = m.message;
+        });
+        try {
+          // Both namespace spellings used across the app (same as the
+          // Builder's preview bridge).
+          i18n?.addResources?.(locale, "translations", res);
+          i18n?.addResources?.(locale, "translation", res);
+        } catch {
+          /* ignore — deck fallback still renders */
+        }
+        setVersion((v) => v + 1);
+      })
+      .catch(() => {
+        /* public page — network/API failure just means deck fallback */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [locale, stateId, i18n]);
+
+  return version;
+}

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/index.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/index.tsx
@@ -23,6 +23,7 @@ import { NewsItem } from "./content";
 import { LanguageOption } from "./components/UtilityBar";
 import { useLandingCopy } from "./useLandingCopy";
 import { useLandingConfig } from "./config/useLandingConfig";
+import { useLandingMessages } from "./config/useLandingMessages";
 import { usePreviewBridge, PreviewBridge } from "./config/usePreviewBridge";
 import { LandingRenderer } from "./LandingRenderer";
 
@@ -73,6 +74,12 @@ export function PGRLandingPage(props: PGRLandingPageProps) {
 function ConfiguredLanding(props: PGRLandingPageProps) {
   const config = useLandingConfig();
   const { i18n } = useLandingCopy();
+
+  // Load the rainmaker-pgr message bundle for the active locale so Builder
+  // text edits (PGR_LANDING_* keys) reflect on the live page; the returned
+  // version bump re-renders this subtree once the messages land. The preview
+  // path doesn't need this — the Builder pushes messages over the bridge.
+  useLandingMessages(i18n);
 
   // Language switching must go through the platform's localization service:
   // it FETCHES the target locale's message bundles (LocalizationService


### PR DESCRIPTION
Counterpart of the release-v2.12 PR (clean cherry-pick) — see that PR for the root cause, the 3-layer fix, and the browser-verified round-trip. This is the branch the pilot box deploys from.

Jira: CCSD-2009

🤖 Generated with [Claude Code](https://claude.com/claude-code)