### PR TITLE
feat(configurator): City Modules descriptor — Banner Image editable on existing rows (CCSD-1959)

### DIFF
--- a/configurator/src/admin/schemaDescriptors/city-module.ts
+++ b/configurator/src/admin/schemaDescriptors/city-module.ts
@@ -1,0 +1,33 @@
+import type { SchemaDescriptor } from './types';
+
+/**
+ * Descriptor for `tenant.citymodule` — which DIGIT modules are enabled per
+ * city, plus module-home presentation (CCSD-1959).
+ *
+ * Needed because the generic Edit form derives its fields from the keys the
+ * RECORD already has: optional properties a row doesn't carry yet (like
+ * `bannerImage` on rows created before the schema gained it) never get an
+ * input, so operators can't set them at all. Declaring them here makes the
+ * field render regardless of the record's current shape.
+ *
+ * `code` and `tenants` are intentionally not listed: `code` stays on the
+ * generic loop (rendered disabled as the row identifier) and `tenants` keeps
+ * its existing JSON/complex-field handling.
+ */
+export const cityModuleDescriptor: SchemaDescriptor = {
+  schema: 'tenant.citymodule',
+  groups: [
+    { title: 'Module', fields: ['module', 'order', 'active'] },
+    { title: 'Presentation', fields: ['bannerImage'] },
+  ],
+  fields: [
+    { path: 'module', widget: 'text', label: 'Module', required: true,
+      help: 'DIGIT module code this entry enables (e.g. "PGR").' },
+    { path: 'order', widget: 'integer', label: 'Order',
+      help: 'Position of the module on the citizen home page.' },
+    { path: 'active', widget: 'boolean', label: 'Active',
+      help: 'Inactive modules are hidden from the citizen home page.' },
+    { path: 'bannerImage', widget: 'text', label: 'Banner image',
+      help: 'URL of the banner shown on the citizen module home page. Falls back to StateInfo.bannerUrl when empty.' },
+  ],
+};

--- a/configurator/src/admin/schemaDescriptors/index.ts
+++ b/configurator/src/admin/schemaDescriptors/index.ts
@@ -10,6 +10,7 @@ import { notificationRoutingDescriptor } from './notification-routing';
 import { notificationTemplateDescriptor } from './notification-template';
 import { landingSectionDescriptor } from './landing-section';
 import { landingPageConfigDescriptor } from './landing-page-config';
+import { cityModuleDescriptor } from './city-module';
 
 /** Map of schema code -> descriptor. Add new entries as we cover more schemas. */
 const DESCRIPTORS: Record<string, SchemaDescriptor> = {
@@ -24,6 +25,7 @@ const DESCRIPTORS: Record<string, SchemaDescriptor> = {
   [notificationTemplateDescriptor.schema]: notificationTemplateDescriptor,
   [landingSectionDescriptor.schema]: landingSectionDescriptor,
   [landingPageConfigDescriptor.schema]: landingPageConfigDescriptor,
+  [cityModuleDescriptor.schema]: cityModuleDescriptor,
 };
 
 export function getDescriptor(schemaCode?: string): SchemaDescriptor | undefined {


### PR DESCRIPTION
## Why the field wasn't showing on the pilot (even after the schema fix)

Two different form engines:
- **Add** (`MdmsResourceCreate`) is **schema-driven** — after the pilot's `tenant.citymodule` schema was fixed, Add shows Banner Image (hard refresh needed).
- **Edit** (`MdmsResourceEdit`) derives fields from **the keys the record already has** — rows created before the schema gained `bannerImage` can never be given the field. Chicken-and-egg: the input only appears once the row has the key, and the row can only get the key through the input.

## Fix

Schema descriptor for `tenant.citymodule` (the established pattern — same as `landing-section.ts`, `mobile-validation.ts`): declares Module / Order / Active / **Banner image** explicitly, so Edit renders them regardless of the record's shape. `code` (disabled identifier) and `tenants` (complex field) keep their existing generic handling.

## Verified (local)

Edit on a row **without** the `bannerImage` key (`Workbench`): form now shows Module, Order, Active, Banner image, Code. Save path already validated by the schema (`bannerImage: string`).

## Pilot prerequisite (already done)

The `tenant.citymodule` schema on the box must allow `bannerImage` — the SQL fix has been applied there (verified via schema search). This PR only needs a configurator rebuild on the box.

Jira: CCSD-1959

🤖 Generated with [Claude Code](https://claude.com/claude-code)