### PR TITLE
fix(pgr): '(Optional)' suffix on workflow-action modals + citizen reopen (CCSD-1955)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/PGRWorkflowModal.js
+++ b/digit-ui-esbuild/products/pgr/src/components/PGRWorkflowModal.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FormComposerV2,} from '@egovernments/digit-ui-components';
 import PropTypes from 'prop-types';
@@ -45,6 +45,25 @@ const PGRWorkflowModal = ({
     }
   }
 
+  // Non-mandatory fields carry the localized "(Optional)" suffix (CCSD-1955),
+  // same convention as the create forms. Labels arrive as localization KEYS;
+  // suffixed ones become final strings — FormComposer's t() echoes unknown
+  // strings back, so pre-localizing here is safe.
+  const optionalSuffix = (() => {
+    const v = t("CS_OPTIONAL_SUFFIX");
+    return v === "CS_OPTIONAL_SUFFIX" ? "(Optional)" : v;
+  })();
+  const form = useMemo(
+    () =>
+      (config?.form || []).map((section) => ({
+        ...section,
+        body: (section.body || []).map((f) =>
+          f.isMandatory || !f.label ? f : { ...f, label: `${t(f.label)} ${optionalSuffix}` }
+        ),
+      })),
+    [config, t, optionalSuffix]
+  );
+
   if (!config || !selectedAction) return null;
 
   return (
@@ -60,7 +79,7 @@ const PGRWorkflowModal = ({
       formId="modal-action"
     >
       <FormComposerV2
-        config={config.form}
+        config={form}
         noBoxShadow
         inline
         childrenAtTheBottom

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ReopenComplaint/AddtionalDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ReopenComplaint/AddtionalDetails.js
@@ -83,7 +83,11 @@ const AddtionalDetails = (props) => {
   return (
     <React.Fragment>
       <Card>
-        <CardHeader>{t(`${LOCALIZATION_KEY.CS_ADDCOMPLAINT}_PROVIDE_ADDITIONAL_DETAILS`)}</CardHeader>
+        <CardHeader>
+          {t(`${LOCALIZATION_KEY.CS_ADDCOMPLAINT}_PROVIDE_ADDITIONAL_DETAILS`) +
+            // Free-text details are not required to reopen (CCSD-1955)
+            " " + (t("CS_OPTIONAL_SUFFIX") === "CS_OPTIONAL_SUFFIX" ? "(Optional)" : t("CS_OPTIONAL_SUFFIX"))}
+        </CardHeader>
         <CardText>{t(`${LOCALIZATION_KEY.CS_ADDCOMPLAINT}_ADDITIONAL_DETAILS_TEXT`)}</CardText>
         <TextArea name={"AdditionalDetails"} onChange={textInput}></TextArea>
         <div onClick={reopenComplaint}>

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ReopenComplaint/UploadPhoto.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ReopenComplaint/UploadPhoto.js
@@ -50,7 +50,11 @@ const UploadPhoto = (props) => {
     <React.Fragment>
       <Card>
         <ImageUploadHandler
-          header={t(`${LOCALIZATION_KEY.CS_ADDCOMPLAINT}_UPLOAD_PHOTO`)}
+          header={
+            t(`${LOCALIZATION_KEY.CS_ADDCOMPLAINT}_UPLOAD_PHOTO`) +
+            // Photos are skippable on reopen — label them optional (CCSD-1955)
+            (props.skip ? " " + (t("CS_OPTIONAL_SUFFIX") === "CS_OPTIONAL_SUFFIX" ? "(Optional)" : t("CS_OPTIONAL_SUFFIX")) : "")
+          }
           tenantId={props?.complaintDetails?.service?.tenantId}
           cardText=""
           onPhotoChange={handleUpload}

--- a/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
@@ -24,6 +24,12 @@
         "locale": "pt_PT"
     },
     {
+        "code": "CS_OPTIONAL_SUFFIX",
+        "message": "(Opcional)",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
         "code": "PGR_INBOX",
         "message": "Caixa de Reclamações",
         "module": "rainmaker-pgr",


### PR DESCRIPTION
Counterpart of the release-v2.12 PR (clean cherry-pick) — see that PR for the browser-verified matrix. This is the pilot's deploy branch.

Jira: CCSD-1955

🤖 Generated with [Claude Code](https://claude.com/claude-code)