### PR TITLE
fix(db): register audit_service_schema in flyway-history-map — fixes develop CI

### DIFF
--- a/.github/workflows/flyway-dump-alignment.yml
+++ b/.github/workflows/flyway-dump-alignment.yml
@@ -1,4 +1,4 @@
-name: DB migration — Flyway history-table ↔ dump alignment
+name: DB migration — Flyway history-table NAME match (dump ↔ service config)
 
 # Deployment-parity item #10: the compose stack boots from a prebuilt dump and
 # then runs Flyway incrementally on top. Each Flyway-enabled service must point
@@ -44,7 +44,7 @@ jobs:
         run: pip install pyyaml pytest
       - name: Self-test the alignment check
         run: python3 .github/scripts/check-flyway-dump-alignment.py --self-test
-      - name: Check Flyway ↔ dump history-table alignment
+      - name: Check Flyway history-table NAMES match the dump
         run: python3 .github/scripts/check-flyway-dump-alignment.py
       # The decision table is where every safety property of db-history-normalize
       # lives — including "never drop a populated table". Pin it on every PR.

--- a/.github/workflows/flyway-dump-alignment.yml
+++ b/.github/workflows/flyway-dump-alignment.yml
@@ -1,4 +1,4 @@
-name: Flyway dump alignment
+name: DB migration — Flyway history-table ↔ dump alignment
 
 # Deployment-parity item #10: the compose stack boots from a prebuilt dump and
 # then runs Flyway incrementally on top. Each Flyway-enabled service must point

--- a/local-setup/db/flyway-history-map.yml
+++ b/local-setup/db/flyway-history-map.yml
@@ -121,6 +121,12 @@ digit-config-service:
   data_tables: [eg_config_data]
   baseline_fresh: true
 
+audit-service:
+  canonical: audit_service_schema
+  aliases: []
+  data_tables: [eg_audit_logs]
+  baseline_fresh: true       # new to compose (#1157); migrates from empty, absent from the dump
+
 egov-indexer:
   canonical: egov_indexer_schema
   aliases: []


### PR DESCRIPTION
## Fixes the red `Flyway dump alignment` check on `develop`

`develop` is failing the **Flyway dump alignment** self-test:

```
AssertionError: compose declares SCHEMA_TABLE(s) absent from flyway-history-map.yml:
['audit_service_schema'] — add them to the map or db-history-normalize will not protect them
```

### Cause
#1157 added an `audit-service-migration` to `docker-compose.egov-digit.yaml` declaring
`SCHEMA_TABLE: audit_service_schema`, but the schema was never registered in
`local-setup/db/flyway-history-map.yml`. The alignment check requires every compose-declared
`SCHEMA_TABLE` to be a `canonical` in the map (so `db-history-normalize` knows about and
protects it).

### Fix
Register `audit-service` in the map as `baseline_fresh: true` — audit-service is new to compose
and migrates from empty (no history in the dump), the same category as `novu-bridge` /
`digit-config-service`. The smoke test in #1157 confirmed it baselines from empty.

### Verification (local)
- `python3 .github/scripts/check-flyway-dump-alignment.py --self-test` → **OK** (exit 0)
- `python3 .github/scripts/check-flyway-dump-alignment.py` → **OK: 13 aligned, 4 baseline-fresh, 0 pending-enable**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added local database migration mapping for the audit service.
  * Configured fresh-database migration behavior and audit log table tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->