### PR TITLE
fix(pgr): restore consent checkboxes on citizen create — explicit opt-in (CCSD-1979 revisited)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
@@ -263,9 +263,9 @@ function fieldsFromSchema(schema: any): TemplateField[] {
 }
 
 // Complaint-level declarations confirmed before submit (BRD).
-const REQUIRED_CONSENTS: ReadonlyArray<{ code: string; label: string }> = [
-  { code: "TRUTHFULNESS", label: "I declare that the information provided is true and accurate." },
-  { code: "DATA_PROCESSING", label: "I consent to my data being processed to handle this complaint." },
+const REQUIRED_CONSENTS: ReadonlyArray<{ code: string; labelKey: string; label: string }> = [
+  { code: "TRUTHFULNESS", labelKey: "PGR_CONSENT_TRUTHFULNESS_LABEL", label: "I declare that the information provided is true and accurate." },
+  { code: "DATA_PROCESSING", labelKey: "PGR_CONSENT_DATA_PROCESSING_LABEL", label: "I consent to my data being processed to handle this complaint." },
 ];
 
 // Consistent checkbox styling: fixed-size box with a theme-accent (centered native
@@ -407,9 +407,9 @@ function mapFormDataToRequest(formData: FormData, tenantId: string, user: any, d
       ...(formData.complainantName ? { complainantName: formData.complainantName } : {}),
       ...(formData.complainantAddress ? { complainantAddress: formData.complainantAddress } : {}),
       ...(formData.email ? { email: formData.email } : {}),
-      // Consent UI removed (QA) — submitting the complaint is implicit
-      // acceptance, so the codes are always sent to keep the backend contract.
-      consents: REQUIRED_CONSENTS.map((c) => c.code),
+      // Consent checkboxes are shown at create (explicit opt-in, gated on
+      // submit); the codes recorded here are the ones the citizen ticked.
+      consents: formData.consents || [],
       ...(formData.dynamicFields || {}),
     };
   }
@@ -1057,6 +1057,9 @@ function Step3Description({ data, patch, templateFields, t }: StepBodyProps) {
   const dyn = data.dynamicFields || {};
   const extended = !!data.caseRelatedTo; // dispatcher flow active
   const setDyn = (key: string, value: unknown) => patch({ dynamicFields: { ...dyn, [key]: value } });
+  const consents = data.consents || [];
+  const toggleConsent = (code: string, on: boolean) =>
+    patch({ consents: on ? [...consents, code] : consents.filter((c) => c !== code) });
 
   return (
     <StepShell
@@ -1160,11 +1163,26 @@ function Step3Description({ data, patch, templateFields, t }: StepBodyProps) {
 
         {extended ? (
           <div className="space-y-2">
-            {/* QA (Moz): the TRUTHFULNESS / DATA_PROCESSING consent checkboxes
-                are hidden — submitting the complaint carries them as implicitly
-                accepted (see mapFormDataToRequest). Only the confidential toggle
-                remains a visible choice. */}
-            <label className="flex items-start gap-2 text-sm">
+            {/* Consents are EXPLICIT at create (CCSD-1979 revisited: show at
+                create; hidden only on the details/view screens — CCSD-1988). */}
+            {REQUIRED_CONSENTS.map((c) => (
+              <label key={c.code} className="flex items-start gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  style={CHECKBOX_STYLE}
+                  checked={consents.includes(c.code)}
+                  onChange={(e) => toggleConsent(c.code, e.target.checked)}
+                />
+                <span>
+                  {tr(t, c.labelKey, c.label)}
+                  {/* Same required marker the design-system Label renders. */}
+                  <span className="ml-0.5 text-destructive" style={{ color: "var(--color-error, #d4351c)" }} aria-hidden>
+                    *
+                  </span>
+                </span>
+              </label>
+            ))}
+            <label className="flex items-start gap-2 text-sm pt-2 border-t border-border">
               <input
                 type="checkbox"
                 style={CHECKBOX_STYLE}
@@ -1799,8 +1817,11 @@ const CreatePGRFlowV2: React.FC = () => {
         for (const f of templateFields) {
           if (f.mandatory && !String((formData.dynamicFields || {})[f.fieldKey] ?? "").trim()) return false;
         }
-        // Consent checkboxes are hidden (QA) — acceptance is implicit on
-        // submit, so there is no consent gate here anymore.
+        // Both consents are required once an authority/template is in play
+        // (checkboxes restored at create — CCSD-1979 revisited).
+        if (formData.caseRelatedTo && REQUIRED_CONSENTS.some((c) => !(formData.consents || []).includes(c.code))) {
+          return false;
+        }
         return true;
       }
       default:

--- a/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
@@ -3624,6 +3624,18 @@
         "locale": "en_IN"
     },
     {
+        "code": "PGR_CONSENT_DATA_PROCESSING_LABEL",
+        "message": "I consent to my data being processed to handle this complaint.",
+        "module": "rainmaker-pgr",
+        "locale": "en_IN"
+    },
+    {
+        "code": "PGR_CONSENT_TRUTHFULNESS_LABEL",
+        "message": "I declare that the information provided is true and accurate.",
+        "module": "rainmaker-pgr",
+        "locale": "en_IN"
+    },
+    {
         "code": "PGR_DEFAULT_CITIZEN_SMS_MESSAGE",
         "message": "Your current complaint status is {status}. You can track your complaint status on the mSeva app or your local government web portal.\n\nEGOVS",
         "module": "rainmaker-pgr",

--- a/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
@@ -24,6 +24,18 @@
         "locale": "pt_PT"
     },
     {
+        "code": "PGR_CONSENT_DATA_PROCESSING_LABEL",
+        "message": "Autorizo o tratamento dos meus dados pessoais para a tramitação desta manifestação.",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "PGR_CONSENT_TRUTHFULNESS_LABEL",
+        "message": "Declaro que as informações prestadas são verdadeiras e exactas.",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
         "code": "PGR_INBOX",
         "message": "Caixa de Reclamações",
         "module": "rainmaker-pgr",


### PR DESCRIPTION
## Requirement clarified

Consents must be **shown at citizen create** (explicit opt-in); they are hidden **only on the details/view screens** (CCSD-1988 — untouched by this PR). The earlier CCSD-1979 change removed them from create per the product decision recorded on that ticket; this restores them per the clarified requirement.

## What's restored (and improved)

- The two consent checkboxes (TRUTHFULNESS, DATA_PROCESSING) back on step 3, above the confidential toggle, with required markers — now **localized** via `PGR_CONSENT_TRUTHFULNESS_LABEL` / `PGR_CONSENT_DATA_PROCESSING_LABEL` (en + pt seeds added; PT: *"Declaro que as informações prestadas são verdadeiras e exactas."* / *"Autorizo o tratamento dos meus dados pessoais para a tramitação desta manifestação."*) instead of the old hardcoded English.
- **Submit gate restored**: both consents required once an authority/template is in play.
- Payload now records the consents the citizen actually ticked (was: implicit auto-accept of both).

## Browser-verified (local, full citizen wizard walk)

- Step 3 renders both checkboxes with `*`; Submit stays disabled until description + mandatory dynamic field (`Institute Name`) + **both consents**.
- Unchecking either consent re-disables Submit; re-checking enables it.
- Details/view screens unchanged — consents still hidden there.

## Env note

The two new localization keys ride the DDH seeds for new tenants; existing envs get them from the migration runner (seeds missing keys only) or a one-off upsert.

Jira: CCSD-1979

🤖 Generated with [Claude Code](https://claude.com/claude-code)