### PR TITLE
perf(digit-ui): gzip + Cache-Control on the /digit-ui bundle (~7MB → ~2MB)

### DIFF
--- a/docs/ops/digit-ui-compression.md
+++ b/docs/ops/digit-ui-compression.md
@@ -42,17 +42,29 @@ sudo grep -RnE "location .*/digit-ui|alias|proxy_pass" /etc/nginx/ | grep -i dig
 
 ## Deploy — ansible-managed box (recommended)
 
-```bash
-# 1. on your workstation / CI: merge this PR, then on the box:
-cd ~/Citizen-Complaint-Resolution-System && git pull
+Use `deploy.sh` — it regenerates the inventory (`inventory/hosts.yml`, which is
+NOT checked in) from `inventory/host_vars/` and then runs the playbook. The
+host-nginx render tasks carry a `nginx` tag, so a surgical reload is:
 
-# 2. re-render the host nginx site + reload (regenerates from nginx-site.conf.j2):
-#    run the site-config play (adjust inventory/limit to the target host)
-ansible-playbook -i local-setup/ansible/inventory.yml \
-  local-setup/ansible/playbook-deploy.yml --tags nginx --limit <host>
-#    (if the play has no nginx tag, run the nginx template task or the relevant play;
-#     it ends with `nginx -t && systemctl reload nginx`.)
+```bash
+# 1. pull the merged change onto wherever you run ansible from:
+cd <repo> && git pull
+
+# 2. re-render just the host nginx site config + reload, for one host:
+cd local-setup/ansible
+./deploy.sh <host> --tags nginx
+#   deploy.sh → ansible-playbook -i inventory/hosts.yml --limit <host> \
+#               playbook-deploy.yml --tags nginx
+#   the tagged tasks render templates/nginx-site.conf.j2 and notify the
+#   `Reload nginx` handler (which runs `nginx -t` then reloads).
 ```
+
+> ⚠️ **`nginx_preserve_vhost` hosts skip this.** On any host with
+> `nginx_preserve_vhost: true` in its `host_vars` (hand-crafted vhost — e.g.
+> Bomet), the render task is `when: not nginx_preserve_vhost`, so ansible will
+> report `ok=0 changed=0` and touch nothing. Confirm with
+> `grep -r nginx_preserve_vhost local-setup/ansible/inventory/host_vars/<host>.yml`;
+> if it's set, use the **manual** path below.
 
 ## Deploy — manual (if the box's nginx isn't ansible-rendered)
 

--- a/docs/ops/digit-ui-compression.md
+++ b/docs/ops/digit-ui-compression.md
@@ -84,6 +84,16 @@ sudo cp /etc/nginx/sites-available/<file> /root/<file>.$(date +%F).bak
 sudo nginx -t && sudo systemctl reload nginx      # or: sudo docker exec <nginx> nginx -s reload
 ```
 
+> ⚠️ **`add_header` does not merge across scopes.** When a block declares its
+> own `add_header`, nginx **replaces** the entire inherited set for that block
+> rather than adding to it. If this box sets security headers at `server`/`http`
+> scope (e.g. `X-Frame-Options`, CSP, HSTS, `X-Content-Type-Options`), dropping
+> `add_header Cache-Control` into `location /digit-ui/ {}` silently strips **all**
+> of them for that location — and `nginx -t` gives no warning. Re-declare any
+> such outer-level headers inside the block alongside `Cache-Control`. (The
+> repo's own `nginx-site.conf.j2` sets no server-scope headers, so
+> ansible-rendered boxes are unaffected — this only bites hand-configured hosts.)
+
 ## Verify
 
 ```bash

--- a/docs/ops/digit-ui-compression.md
+++ b/docs/ops/digit-ui-compression.md
@@ -1,0 +1,113 @@
+# digit-ui: gzip + cache-control (perf) — deploy runbook
+
+The digit-ui SPA ships as a single non-code-split bundle (`index.js`, ~7–8 MB)
+plus ~1.5 MB of CSS, served **uncompressed** with **no `Cache-Control`**. Cold
+loads (fresh WebView / new device) pull the whole thing raw over the wire.
+
+This change adds, **scoped to the `/digit-ui` location only** (never to any
+Kong/API route):
+
+- **gzip** for JS/CSS/JSON/SVG → the bundle ships ~3–4× smaller
+  (measured local: 7.2 MB → 2.1 MB).
+- **`Cache-Control: no-cache`** → the browser revalidates with its `ETag` and
+  gets a cheap `304` when unchanged, instead of heuristically serving a stale
+  bundle after a redeploy. (Not `immutable`/long-max-age — the filename is not
+  content-hashed, so long caching would strand users on an old build.)
+
+Pure nginx config change: **no bundle rebuild, no app redeploy, reversible with
+a reload.** `sub_filter` (globalConfigs.js injection) runs before gzip, so the
+config injection the SPA depends on is unaffected.
+
+## Which file, per serving mode
+
+There are two ways a box serves `/digit-ui`; check yours first:
+
+```bash
+sudo grep -RnE "location .*/digit-ui|alias|proxy_pass" /etc/nginx/ | grep -i digit-ui
+```
+
+- **Disk-serve (ansible static/vendored mode — pilot & prod):** the host nginx
+  serves the bundle directly (`location /digit-ui/ { alias /opt/digit-ui-esbuild/build/; }`).
+  Source of truth: `local-setup/ansible/templates/nginx-site.conf.j2` — this PR
+  puts the `gzip`/`add_header` **inside that location**. gzip compresses the
+  on-disk file directly; no proxy trick needed.
+- **Proxy-to-container (local compose / some boxes):** the host nginx
+  `proxy_pass`es `/digit-ui` to the digit-ui container. In that case the host
+  must fetch identity from the container and gzip at the edge:
+  add `proxy_set_header Accept-Encoding "";` alongside the `gzip` block in the
+  host's `/digit-ui/` location. (The container-side config —
+  `local-setup/nginx/digit-ui.conf` / the `playbook-deploy.yml` block — also
+  carries gzip in this PR, but with a proxy in front the edge directive is what
+  reaches the client.)
+
+## Deploy — ansible-managed box (recommended)
+
+```bash
+# 1. on your workstation / CI: merge this PR, then on the box:
+cd ~/Citizen-Complaint-Resolution-System && git pull
+
+# 2. re-render the host nginx site + reload (regenerates from nginx-site.conf.j2):
+#    run the site-config play (adjust inventory/limit to the target host)
+ansible-playbook -i local-setup/ansible/inventory.yml \
+  local-setup/ansible/playbook-deploy.yml --tags nginx --limit <host>
+#    (if the play has no nginx tag, run the nginx template task or the relevant play;
+#     it ends with `nginx -t && systemctl reload nginx`.)
+```
+
+## Deploy — manual (if the box's nginx isn't ansible-rendered)
+
+```bash
+# find the live host config that serves /digit-ui
+sudo grep -Rl "digit-ui" /etc/nginx/
+# back it up
+sudo cp /etc/nginx/sites-available/<file> /root/<file>.$(date +%F).bak
+# inside `location /digit-ui/ { ... }` add:
+#   gzip on;
+#   gzip_vary on;
+#   gzip_min_length 1024;
+#   gzip_comp_level 5;
+#   gzip_types text/css application/javascript text/javascript application/json image/svg+xml;
+#   add_header Cache-Control "no-cache" always;
+# (proxy mode only) also add:  proxy_set_header Accept-Encoding "";
+sudo nginx -t && sudo systemctl reload nginx      # or: sudo docker exec <nginx> nginx -s reload
+```
+
+## Verify
+
+```bash
+# gzip + revalidation on the bundle:
+curl -sI -H 'Accept-Encoding: gzip' http://<host>/digit-ui/index.js \
+  | grep -iE 'content-encoding|cache-control'
+#   → content-encoding: gzip   +   cache-control: no-cache
+
+# bytes actually transferred (should be ~2 MB, not ~7 MB):
+curl -s -H 'Accept-Encoding: gzip' http://<host>/digit-ui/index.js -o /dev/null -w '%{size_download}\n'
+
+# app still boots — globalConfigs injection intact:
+curl -s http://<host>/digit-ui/index.html | grep -c globalConfigs.js      # → ≥1
+
+# 304 on second load:
+ET=$(curl -sI http://<host>/digit-ui/index.js | awk '/[Ee]-?[Tt]ag/{print $2}' | tr -d '\r')
+curl -s -o /dev/null -w '%{http_code}\n' -H "If-None-Match: $ET" http://<host>/digit-ui/index.js  # → 304
+```
+
+Then hard-refresh the UI in a browser (Ctrl+Shift+R) and confirm it loads.
+
+## Rollback
+
+```bash
+sudo cp /root/<file>.<date>.bak /etc/nginx/sites-available/<file>
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+No rebuild involved either way.
+
+## Notes / prod specifics
+
+- **mctd prod is HTTP-only** (HTTPS broken) — use `http://digit.mctd.gov.mz` in
+  the verify curls.
+- This is the safe, high-impact slice. The structural follow-up (esbuild
+  content-hashing `entryNames: '[name]-[hash]'` + `immutable` on hashed files,
+  and eventually code-splitting) is a separate, build-level change that needs a
+  full browser regression pass — do **not** switch this location to
+  `immutable`/long-max-age until filenames are hashed.

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -1856,6 +1856,7 @@
           mode: '0644'
         notify: Reload nginx
         when: not (nginx_preserve_vhost | default(false))
+        tags: ['nginx']
 
       - name: "Host nginx — enable site"
         ansible.builtin.file:
@@ -1865,6 +1866,7 @@
           force: yes   # convert pre-existing regular-file copies (older deploys) into a symlink
         notify: Reload nginx
         when: not (nginx_preserve_vhost | default(false))
+        tags: ['nginx']
 
       - name: "Host nginx — remove default site"
         ansible.builtin.file:
@@ -1872,9 +1874,11 @@
           state: absent
         notify: Reload nginx
         when: not (nginx_preserve_vhost | default(false))
+        tags: ['nginx']
 
       - name: "Host nginx — flush handlers so reload happens before validation"
         ansible.builtin.meta: flush_handlers
+        tags: ['nginx']
 
     # macOS thin path: run nginx as a container instead of host nginx.
     # Renders the same template (upstream host -> host.docker.internal so

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -450,6 +450,24 @@
               try_files $uri $uri/ /digit-ui/index.html;
 
               sub_filter '</head>' '<script src="/digit-ui/globalConfigs.js"></script></head>';
+
+              # gzip SCOPED to this static-UI location only (not server-level),
+              # so the Kong proxy in `location /` below is byte-identical to
+              # before. Serves files from disk; ~4x smaller over the wire.
+              # sub_filter runs before gzip, so the globalConfigs.js injection
+              # is unaffected.
+              gzip on;
+              gzip_vary on;
+              gzip_min_length 1024;
+              gzip_comp_level 5;
+              gzip_types text/css application/javascript text/javascript application/json image/svg+xml;
+
+              # The bundle filename is NOT content-hashed (fixed index.js), so
+              # revalidate on every load: a cheap ETag round-trip returns 304
+              # when unchanged, and picks up a redeploy immediately instead of
+              # serving a heuristically-cached stale bundle. Do NOT switch to
+              # immutable/long max-age until filenames are content-hashed.
+              add_header Cache-Control "no-cache" always;
             }
 
             # globalConfigs.js + silent-check-sso.html are served from /host-nginx,

--- a/local-setup/ansible/templates/nginx-site.conf.j2
+++ b/local-setup/ansible/templates/nginx-site.conf.j2
@@ -410,6 +410,22 @@ server {
   location /digit-ui/ {
     alias /opt/digit-ui-esbuild/build/;
     try_files $uri $uri/ /digit-ui/index.html;
+
+    # gzip is SCOPED to this static-UI location ONLY (not server-level), so no
+    # Kong-proxied API route is affected — this location serves files from disk
+    # (the ~7-8 MB bundle + CSS), never proxies. ~4x smaller over the wire.
+    # sub_filter runs before gzip, so the globalConfigs.js/theme HTML injection
+    # is unaffected. text/html is gzip's built-in default (not re-listed).
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_comp_level 5;
+    gzip_types text/css application/javascript text/javascript application/json image/svg+xml;
+
+    # Non-hashed bundle (fixed index.js): revalidate every load (cheap ETag
+    # 304), so a redeploy is picked up immediately with no stale-cache risk.
+    # Do NOT switch to immutable/long max-age until filenames are hashed.
+    add_header Cache-Control "no-cache" always;
     sub_filter_once on;
     sub_filter_types text/html;
     # Inject globalConfigs.js + (optional) tenant theme tokens into <head>. Theme

--- a/local-setup/nginx/digit-ui.conf
+++ b/local-setup/nginx/digit-ui.conf
@@ -15,6 +15,18 @@ server
 
     # Inject globalConfigs.js script tag before </head>
     sub_filter '</head>' '<script src="/digit-ui/globalConfigs.js"></script></head>';
+
+    # gzip SCOPED here (not server-level) so no proxied route is affected.
+    # Static files from disk; ~4x smaller. sub_filter runs before gzip.
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_comp_level 5;
+    gzip_types text/css application/javascript text/javascript application/json image/svg+xml;
+
+    # Non-hashed bundle (fixed index.js): revalidate every load (cheap 304),
+    # so a redeploy is picked up immediately with no stale-cache risk.
+    add_header Cache-Control "no-cache" always;
   }
 
   # Serve globalConfigs.js


### PR DESCRIPTION
> This is the branch the Moz **pilot & prod (mctd)** deploy from — the counterpart of #1243 (clean cherry-pick).

## What & why

The digit-ui SPA ships as a single, non-code-split bundle (`index.js` ~7-8 MB) plus ~1.5 MB CSS, served **uncompressed** with **no `Cache-Control`**. Cold loads (fresh WebView / new device / after a deploy) pull the whole thing raw over HTTP/1.1 — the reported "app takes 15-20s but browser 2s" gap is exactly this (browser has it warm-cached; a cold client re-downloads ~9 MB).

This adds, **scoped to the `/digit-ui` location only** (no Kong / API route touched):

| | Before | After |
|---|---|---|
| `index.js` on the wire | 7.2 MB | **2.1 MB** — `Content-Encoding: gzip` (3.3×) |
| Cache-Control | *(none)* | `no-cache` → ETag revalidation, cheap `304` |
| Stale-bundle-after-deploy risk | present (heuristic caching) | removed |

`Cache-Control` is deliberately `no-cache`, **not** `immutable`/long-max-age: the filename is not content-hashed, so long caching would strand users on an old build. Pure nginx config — **no bundle rebuild, no app redeploy, reload-reversible.**

## Verified locally, end-to-end (this session)

Confirmed on the running local stack at `:80`, not just in theory:
- `content-encoding: gzip` + `cache-control: no-cache` at the edge; **7.2 MB → 2.1 MB** transferred.
- Conditional GET returns **`HTTP 304`, 0 bytes** (no re-download when unchanged).
- **globalConfigs.js injection intact** — `sub_filter` runs before gzip, so the config the SPA depends on is unaffected (verified in served `index.html`).
- **Kong / API untouched** — gzip lives inside `location /digit-ui` only; proxied API responses are byte-identical (an earlier draft had it server-level + `application/json`, which *would* have compressed API JSON — corrected to location-scoped).
- CSS in the same location also compresses.

## Two serving modes (discovered during local testing — important for deploy)

- **Disk-serve** (ansible static/vendored mode — **pilot & prod**): host nginx serves `/digit-ui` from disk (`alias /opt/digit-ui-esbuild/build/`). gzip goes **inside that location** — this PR’s `nginx-site.conf.j2` change. No proxy trick needed.
- **Proxy-to-container** (local compose, and any box where the host `proxy_pass`es `/digit-ui`): the container gzips fine, but the host must fetch identity and gzip at the edge — add `proxy_set_header Accept-Encoding "";` alongside the gzip block. This is spelled out in the runbook; the container-side configs in this PR (`playbook-deploy.yml`, `local-setup/nginx/digit-ui.conf`) carry gzip for that path.

## Files
- `local-setup/ansible/templates/nginx-site.conf.j2` — **pilot/prod (disk-serve) path**
- `local-setup/ansible/playbook-deploy.yml` + `local-setup/nginx/digit-ui.conf` — container-mode, kept consistent
- `docs/ops/digit-ui-compression.md` — **full deploy / verify / rollback runbook** (mode detection, ansible + manual paths, mctd HTTP-only note)

## Deploy (summary; full version in the runbook)
1. Merge → `git pull` on the box.
2. `sudo grep -RnE "location .*/digit-ui|alias|proxy_pass" /etc/nginx/` → confirm disk-serve vs proxy.
3. Re-render via ansible (`--tags nginx`) **or** hand-add the gzip block to the live `/digit-ui` location.
4. `nginx -t && systemctl reload nginx` — no rebuild.
5. Verify with the runbook curls; hard-refresh the UI. Rollback = restore backup + reload.

Follow-up (separate, build-level, needs a browser regression pass): esbuild content-hashing (`[name]-[hash]`) + `immutable`, then code-splitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
