### PR TITLE
feat(pgr): show per-step attachments in the complaint timeline (CCSD-1965)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/TimeLineWrapper.js
+++ b/digit-ui-esbuild/products/pgr/src/components/TimeLineWrapper.js
@@ -34,6 +34,83 @@ const TimelineWrapper = ({ businessId, isWorkFlowLoading, workflowData, labelPre
 
     // Manage timeline data
     const [timelineSteps, setTimelineSteps] = useState([]);
+    // CCSD-1965: fileStoreId -> viewable URL, resolved once per workflow load.
+    const [docUrls, setDocUrls] = useState({});
+
+    // Resolve viewable URLs for EVERY document across ALL workflow steps in one
+    // pass. Attachments live under the complaint's (city) tenant and Filefetch
+    // is tenant-scoped, so group by each instance's tenantId before fetching.
+    useEffect(() => {
+        const instances = workflowData?.ProcessInstances || [];
+        const byTenant = {};
+        instances.forEach((inst) => {
+            (inst?.documents || []).forEach((d) => {
+                if (!d?.fileStoreId) return;
+                const tid = inst?.tenantId || tenantId;
+                (byTenant[tid] = byTenant[tid] || []).push(d.fileStoreId);
+            });
+        });
+        const tenants = Object.keys(byTenant);
+        if (!tenants.length) { setDocUrls({}); return; }
+        let cancelled = false;
+        (async () => {
+            const map = {};
+            for (const tid of tenants) {
+                try {
+                    const res = await Digit.UploadServices.Filefetch(byTenant[tid], tid);
+                    const entries = Array.isArray(res?.data?.fileStoreIds) ? res.data.fileStoreIds : [];
+                    entries.forEach((e) => {
+                        // url is a comma-joined variant list; first = full file.
+                        const first = typeof e?.url === "string" ? e.url.split(",")[0].trim() : "";
+                        if (e?.id && first) map[e.id] = first;
+                    });
+                } catch (e) {
+                    /* leave those ids unresolved — chip still renders as a plain link */
+                }
+            }
+            if (!cancelled) setDocUrls(map);
+        })();
+        return () => { cancelled = true; };
+    }, [workflowData, tenantId]);
+
+    // A compact per-step attachments row (thumbnails for images, a labelled
+    // chip otherwise). Returns null when the step has no documents.
+    const renderStepDocs = (documents) => {
+        if (!Array.isArray(documents) || documents.length === 0) return null;
+        const isImage = (url, doc) =>
+            /\.(png|jpe?g|gif|webp|bmp|svg)(\?|$)/i.test(url || "") ||
+            (doc?.documentType || "").toUpperCase() === "PHOTO";
+        return (
+            <div key="docs" style={{ display: "flex", flexWrap: "wrap", gap: "0.4rem", marginTop: "0.25rem" }}>
+                <span style={{ fontSize: "0.78rem", color: "var(--color-text-secondary, #64748b)", width: "100%" }}>
+                    {t("CS_TIMELINE_ATTACHMENTS")}
+                </span>
+                {documents.map((doc, i) => {
+                    const url = docUrls[doc?.fileStoreId];
+                    const label = `${t("CS_TIMELINE_ATTACHMENT")} ${i + 1}`;
+                    if (url && isImage(url, doc)) {
+                        return (
+                            <a key={i} href={url} target="_blank" rel="noopener noreferrer" title={label}>
+                                <img src={url} alt={label}
+                                    style={{ width: 44, height: 44, objectFit: "cover", borderRadius: 6, border: "1px solid var(--color-border, #e2e8f0)" }} />
+                            </a>
+                        );
+                    }
+                    return (
+                        <a key={i} href={url || undefined} target="_blank" rel="noopener noreferrer"
+                            style={{
+                                display: "inline-flex", alignItems: "center", gap: "0.3rem",
+                                fontSize: "0.78rem", padding: "0.2rem 0.5rem", borderRadius: 6,
+                                border: "1px solid var(--color-border, #cbd5e1)", color: "var(--color-primary-1, #c84c0e)",
+                                pointerEvents: url ? "auto" : "none", opacity: url ? 1 : 0.6,
+                            }}>
+                            📎 {label}
+                        </a>
+                    );
+                })}
+            </div>
+        );
+    };
 
     useEffect(() => {
         if (workflowData && workflowData.ProcessInstances) {
@@ -115,6 +192,12 @@ const TimelineWrapper = ({ businessId, isWorkFlowLoading, workflowData, labelPre
                         contactLine,
                         formatComment(instance?.comment),
                     ].filter(Boolean),
+                    // CCSD-1965: the attachments uploaded AT this workflow step
+                    // (verificationDocuments persist per transition). Rendered
+                    // per-step below so the timeline keeps the FULL history, not
+                    // just the latest upload — same on citizen + employee UIs.
+                    documents: Array.isArray(instance?.documents) ? instance.documents : [],
+                    documentTenantId: instance?.tenantId || tenantId,
                     showConnector: true,
                 };
             });
@@ -125,18 +208,25 @@ const TimelineWrapper = ({ businessId, isWorkFlowLoading, workflowData, labelPre
     return (
         isWorkFlowLoading ? <Loader /> :
             <TimelineMolecule key="timeline" initialVisibleCount={4} hidePastLabel={timelineSteps.length < 5}>
-                {timelineSteps.map((step, index) => (
-                    <Timeline
-                        key={index}
-                        label={step.label}
-                        // currentStateChildren renders inside the FIRST (current-state) row —
-                        // the citizen action links/rating live in the timeline, like the
-                        // legacy checkpoints did.
-                        subElements={index === 0 && currentStateChildren ? [...step.subElements, currentStateChildren] : step.subElements}
-                        variant={step.variant}
-                        showConnector={step.showConnector}
-                    />
-                ))}
+                {timelineSteps.map((step, index) => {
+                    // Base sub-elements + this step's attachments (CCSD-1965) +
+                    // current-state children on the first row.
+                    const docsNode = renderStepDocs(step.documents);
+                    const subElements = [
+                        ...step.subElements,
+                        ...(docsNode ? [docsNode] : []),
+                        ...(index === 0 && currentStateChildren ? [currentStateChildren] : []),
+                    ];
+                    return (
+                        <Timeline
+                            key={index}
+                            label={step.label}
+                            subElements={subElements}
+                            variant={step.variant}
+                            showConnector={step.showConnector}
+                        />
+                    );
+                })}
             </TimelineMolecule>
     );
 };

--- a/digit-ui-esbuild/products/pgr/src/components/TimeLineWrapper.js
+++ b/digit-ui-esbuild/products/pgr/src/components/TimeLineWrapper.js
@@ -60,9 +60,24 @@ const TimelineWrapper = ({ businessId, isWorkFlowLoading, workflowData, labelPre
                     const res = await Digit.UploadServices.Filefetch(byTenant[tid], tid);
                     const entries = Array.isArray(res?.data?.fileStoreIds) ? res.data.fileStoreIds : [];
                     entries.forEach((e) => {
-                        // url is a comma-joined variant list; first = full file.
-                        const first = typeof e?.url === "string" ? e.url.split(",")[0].trim() : "";
-                        if (e?.id && first) map[e.id] = first;
+                        // `url` is a comma-joined variant list. The filestore emits
+                        // several variants (full,large,medium,small,…) ONLY for
+                        // images; non-image files (PDF/doc/…) come back as a single
+                        // URL. So multiple variants ⟹ image, and we can pick a
+                        // "small" variant for the 44x44 thumbnail (mirrors
+                        // ComplaintPhotos.js). We deliberately do NOT trust the
+                        // document's `documentType` here — the generic action
+                        // uploader (ActionUploadComponent) stamps every file as
+                        // "PHOTO" regardless of its real type.
+                        const variants = typeof e?.url === "string"
+                            ? e.url.split(",").map((u) => u.trim()).filter(Boolean)
+                            : [];
+                        const full = variants[0] || "";
+                        if (!e?.id || !full) return;
+                        const thumb = variants.find((u) => /small/i.test(u)) || full;
+                        const isImage = variants.length > 1 ||
+                            /\.(png|jpe?g|gif|webp|bmp|svg)(\?|$)/i.test(full);
+                        map[e.id] = { full, thumb, isImage };
                     });
                 } catch (e) {
                     /* leave those ids unresolved — chip still renders as a plain link */
@@ -77,21 +92,19 @@ const TimelineWrapper = ({ businessId, isWorkFlowLoading, workflowData, labelPre
     // chip otherwise). Returns null when the step has no documents.
     const renderStepDocs = (documents) => {
         if (!Array.isArray(documents) || documents.length === 0) return null;
-        const isImage = (url, doc) =>
-            /\.(png|jpe?g|gif|webp|bmp|svg)(\?|$)/i.test(url || "") ||
-            (doc?.documentType || "").toUpperCase() === "PHOTO";
         return (
             <div key="docs" style={{ display: "flex", flexWrap: "wrap", gap: "0.4rem", marginTop: "0.25rem" }}>
                 <span style={{ fontSize: "0.78rem", color: "var(--color-text-secondary, #64748b)", width: "100%" }}>
                     {t("CS_TIMELINE_ATTACHMENTS")}
                 </span>
                 {documents.map((doc, i) => {
-                    const url = docUrls[doc?.fileStoreId];
+                    const entry = docUrls[doc?.fileStoreId];
+                    const url = entry?.full;
                     const label = `${t("CS_TIMELINE_ATTACHMENT")} ${i + 1}`;
-                    if (url && isImage(url, doc)) {
+                    if (url && entry?.isImage) {
                         return (
                             <a key={i} href={url} target="_blank" rel="noopener noreferrer" title={label}>
-                                <img src={url} alt={label}
+                                <img src={entry.thumb || url} alt={label}
                                     style={{ width: 44, height: 44, objectFit: "cover", borderRadius: 6, border: "1px solid var(--color-border, #e2e8f0)" }} />
                             </a>
                         );

--- a/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
@@ -2898,6 +2898,18 @@
         "locale": "en_IN"
     },
     {
+        "code": "CS_TIMELINE_ATTACHMENT",
+        "message": "Attachment",
+        "module": "rainmaker-pgr",
+        "locale": "en_IN"
+    },
+    {
+        "code": "CS_TIMELINE_ATTACHMENTS",
+        "message": "Attachments",
+        "module": "rainmaker-pgr",
+        "locale": "en_IN"
+    },
+    {
         "code": "CS_UPLOAD_RESTRICTIONS",
         "message": "**Upload restrictions",
         "module": "rainmaker-pgr",

--- a/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
@@ -24,6 +24,18 @@
         "locale": "pt_PT"
     },
     {
+        "code": "CS_TIMELINE_ATTACHMENT",
+        "message": "Anexo",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_TIMELINE_ATTACHMENTS",
+        "message": "Anexos",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
         "code": "PGR_INBOX",
         "message": "Caixa de Reclamações",
         "module": "rainmaker-pgr",


### PR DESCRIPTION
## What (QA follow-up on CCSD-1965)

The workflow timeline showed **no attachment history** — only the details page's *Attachments* section, which lists the current/latest set. So a doc uploaded at each workflow step (reject-with-doc, reopen-with-doc, etc.) wasn't visible per step. Product decision (Gurjeet/Priyanshu, 2026-07-14): **show all attachments, per step, on both citizen and employee UIs.**

## Approach — FE-only, data already present

`verificationDocuments` persist per transition and `process/_search?history=true` already returns them per `ProcessInstance` (verified live). The shared `TimeLineWrapper` (used by both citizen `ComplaintDetails` and employee `PGRDetails`) now:
- resolves viewable URLs for **every** step's documents in one pass, grouped by each instance's tenant (attachments live under the complaint's *city* tenant and `Filefetch` is tenant-scoped);
- renders a per-step **Attachments** row — image thumbnails (click → full) or a labelled chip for other types — in step order, so the full upload history is visible.

One shared component → both UIs, as the product ask requires. No backend or schema change.

## Localization
`CS_TIMELINE_ATTACHMENTS` / `CS_TIMELINE_ATTACHMENT` (en + pt) seeded and **upserted to local + cms-pilot + mctd**.

## Verified
- Live: the APPLY-step document on `PG-PGR-2026-07-09-002999` (mz.igsae) resolves to a filestore URL via `Filefetch`; build carries the change.
- Visual browser pass (thumbnails render per step, multi-step history) — pending, will confirm on the ticket.

Jira: CCSD-1965

🤖 Generated with [Claude Code](https://claude.com/claude-code)