### PR TITLE
feat(dashboard): resolve the route/card role gate from MDMS (dss.DashboardConfig) with code fallback

### DIFF
--- a/ansible/nairobi-mdms/mdms/dss/DashboardConfig.json
+++ b/ansible/nairobi-mdms/mdms/dss/DashboardConfig.json
@@ -1,0 +1,17 @@
+[
+  {
+    "tenantId": "ke",
+    "data": {
+      "id": "default",
+      "allowedRoles": [
+        "SUPERVISOR",
+        "PGR_SUPERVISOR",
+        "GRO",
+        "DGRO",
+        "PGR_LME",
+        "PGR_ADMIN",
+        "SUPERUSER"
+      ]
+    }
+  }
+]

--- a/digit-ui-esbuild/products/dashboard/DashboardCard.js
+++ b/digit-ui-esbuild/products/dashboard/DashboardCard.js
@@ -1,14 +1,17 @@
 import { EmployeeModuleCard } from "@egovernments/digit-ui-react-components";
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { DASHBOARD_ROLES } from "./roles";
+import { useDashboardAccess } from "./roles";
 
 const DashboardCard = () => {
   const { t } = useTranslation();
 
-  // Same tenant-agnostic check as the DashboardModule route guard (roles live
-  // at the state root tenant), so the card and the route always agree.
-  if (!Digit.UserService.hasAccess(DASHBOARD_ROLES)) {
+  // Same MDMS-resolved, tenant-agnostic check as the DashboardModule route
+  // guard (shared useDashboardAccess hook — one react-query cache entry), so
+  // the card and the route always agree. Render nothing while it resolves so
+  // the card doesn't flash in or out.
+  const { allowed, loading } = useDashboardAccess();
+  if (loading || !allowed) {
     return null;
   }
 

--- a/digit-ui-esbuild/products/dashboard/Module.js
+++ b/digit-ui-esbuild/products/dashboard/Module.js
@@ -3,15 +3,17 @@ import { Redirect } from "react-router-dom";
 import { Loader } from "@egovernments/digit-ui-react-components";
 import AdminDashboard from "./src/AdminDashboard";
 import DashboardCard from "./DashboardCard";
-import { DASHBOARD_ROLES } from "./roles";
+import { DASHBOARD_ROLES, useDashboardAccess } from "./roles";
 
 export { DASHBOARD_ROLES };
 
 // Mounted by core AppModules at /{contextPath}/employee/dashboard INSIDE the
 // employee chrome (topbar + sidebar). AppModules already guarantees a logged-in
-// session, so the only guard needed here is the role check — tenant-agnostic
-// (see roles.js) — before rendering the dashboard in embedded mode (which
-// suppresses its standalone shell: internal sidebar, login gate, 100dvh layout).
+// session, so the only guard needed here is the role check — resolved from
+// MDMS (dss.DashboardConfig) with the roles.js list as fallback, checked
+// tenant-agnostically (see roles.js) — before rendering the dashboard in
+// embedded mode (which suppresses its standalone shell: internal sidebar,
+// login gate, 100dvh layout).
 const DashboardModule = ({ stateCode }) => {
   // Lazy-load this module's localization bundles into the host i18next
   // (same pattern as PGRModule): rainmaker-dashboard for the dashboard's own
@@ -24,11 +26,14 @@ const DashboardModule = ({ stateCode }) => {
     language: Digit.StoreData.getCurrentLanguage(),
     modulePrefix: "rainmaker",
   });
-  if (!Digit.UserService.hasAccess(DASHBOARD_ROLES)) {
-    return <Redirect to={`/${window?.contextPath}/employee`} />;
-  }
-  if (isLoading) {
+  const { allowed, loading: accessLoading } = useDashboardAccess();
+  // While the MDMS-backed gate resolves, hold on the Loader (never the
+  // Redirect) so an eventually-allowed role doesn't flash away from the route.
+  if (accessLoading || isLoading) {
     return <Loader />;
+  }
+  if (!allowed) {
+    return <Redirect to={`/${window?.contextPath}/employee`} />;
   }
   return <AdminDashboard embedded />;
 };

--- a/digit-ui-esbuild/products/dashboard/roles.js
+++ b/digit-ui-esbuild/products/dashboard/roles.js
@@ -1,6 +1,64 @@
-// Roles allowed to open the supervisor dashboard. Checked tenant-agnostically
-// (role CODE only, via Digit.UserService.hasAccess) because employee roles live
-// at the state root tenant ("ke") while the working tenant may be a city tenant —
-// Digit.Utils.didEmployeeHasAtleastOneRole filters by current tenant and would
-// wrongly hide the dashboard there.
+// FALLBACK roles allowed to open the supervisor dashboard, used whenever the
+// dss.DashboardConfig MDMS record is absent or unreadable (fresh tenants,
+// MDMS down, schema not registered) so existing deployments keep working
+// unchanged. Deployments with a custom role taxonomy (e.g. CMS_* roles)
+// override this via MDMS instead of a rebuild — see useDashboardAccess below.
+//
+// Checked tenant-agnostically (role CODE only, via Digit.UserService.hasAccess)
+// because employee roles live at the state root tenant ("ke") while the working
+// tenant may be a city tenant — Digit.Utils.didEmployeeHasAtleastOneRole filters
+// by current tenant and would wrongly hide the dashboard there.
 export const DASHBOARD_ROLES = ["SUPERVISOR", "PGR_SUPERVISOR", "GRO", "DGRO", "PGR_LME", "PGR_ADMIN", "SUPERUSER"];
+
+/**
+ * useDashboardAccess — resolves the dashboard's nav/route role gate from MDMS.
+ *
+ * Master: dss.DashboardConfig at the STATE ROOT tenant (same owning tenant as
+ * the dss.KpiDefinition / dss.DashboardPack catalog), single record:
+ *   { "id": "default", "allowedRoles": ["SUPERVISOR", ...] }
+ *
+ * Resolution:
+ *   - record present with a non-empty allowedRoles array → those role codes
+ *   - record absent / fetch error / malformed shape → DASHBOARD_ROLES fallback
+ *     (silent — a tenant that never seeds the master behaves exactly as before)
+ *
+ * Fetched through the same MDMS v1-compat search the rest of the UI uses
+ * (Digit.Hooks.useCustomMDMS → /egov-mdms-service/v1/_search; mdms-v2 serves it
+ * as schemaCode "dss.DashboardConfig"). react-query caches it for the session
+ * (staleTime/cacheTime Infinity), so the gate costs one request per login, and
+ * both consumers (route guard + home card) share the one cache entry.
+ *
+ * This is deliberately NOT a security boundary: the data plane is enforced
+ * server-side by the analytics catalog + scope RBAC. This hook only decides
+ * whether the nav surfaces (home card, /employee/dashboard route) show.
+ *
+ * @returns {{ allowed: boolean, loading: boolean }} — consumers must render
+ *   nothing while `loading` so the gate never flashes a redirect/card.
+ */
+export const useDashboardAccess = () => {
+  const stateId = Digit.ULBService.getStateId();
+
+  const { data, isLoading } = Digit.Hooks.useCustomMDMS(
+    stateId,
+    "dss",
+    [{ name: "DashboardConfig" }],
+    {
+      cacheTime: Infinity,
+      staleTime: Infinity,
+      retry: false,
+      select: (res) => res?.dss?.DashboardConfig,
+    }
+  );
+
+  // Shape-guard everything: Kong's cjson pre-function can flatten an empty
+  // array to {}, and a hand-seeded master may carry extra records — prefer the
+  // "default" record, tolerate anything else by falling back.
+  const records = Array.isArray(data) ? data : [];
+  const record = records.find((r) => r?.id === "default") || records[0];
+  const configured = Array.isArray(record?.allowedRoles)
+    ? record.allowedRoles.filter((role) => typeof role === "string" && role)
+    : [];
+  const roles = configured.length ? configured : DASHBOARD_ROLES;
+
+  return { allowed: !!Digit.UserService.hasAccess(roles), loading: isLoading };
+};

--- a/docs/dashboard-configuration/20-packs-and-rbac.md
+++ b/docs/dashboard-configuration/20-packs-and-rbac.md
@@ -144,11 +144,11 @@ emits `scope_incomplete`, which currently falls through to the raw-code default 
 | role R sees only its own department's numbers | give the user an HRMS assignment with that department; keep R out of `TENANT_WIDE_ROLES` | HRMS + (code constant, deploy) |
 | role R sees the whole tenant | grant one of the `TENANT_WIDE_ROLES` (e.g. `PGR_SUPERVISOR`) | HRMS/user roles |
 | anonymous/public page shows KPI X | add `"PUBLIC"` to X's `visibleTo` | `dss.KpiDefinition` (MDMS) |
-| role R can *open the dashboard view at all* (home card, deep-link route) | add R to `DASHBOARD_ROLES` (FE gate) **and** a `Dashboard` `tenant.citymodule` row (home card) — **a different system entirely** | `70-esbuild-embedding.md` §4, `30-view-access.md` |
+| role R can *open the dashboard view at all* (home card, deep-link route) | add R to `dss.DashboardConfig` `allowedRoles` (MDMS; the FE falls back to its built-in `DASHBOARD_ROLES` when the record is absent) **and** a `Dashboard` `tenant.citymodule` row (home card) — **a different system entirely** | `70-esbuild-embedding.md` §4, `30-view-access.md` |
 | role R gets a *sidebar* entry for the dashboard | ACCESSCONTROL actions/roleactions | `30-view-access.md` §2 (note the live bomet sidebar outage, `80-live-bomet-state.md` §5) |
 
 The last rows are the classic confusion: `visibleTo`/packs govern *what renders inside* the
-dashboard; whether the user can *navigate to* it is a different stack — the FE `DASHBOARD_ROLES`
-gate + home card + always-on deep-link route (`70-esbuild-embedding.md`), plus the optional
+dashboard; whether the user can *navigate to* it is a different stack — the FE gate resolved from
+`dss.DashboardConfig` + home card + always-on deep-link route (`70-esbuild-embedding.md`), plus the optional
 digit-ui sidebar access-control surface (`30-view-access.md`). Three independent gates; align all
 that apply.

--- a/docs/dashboard-configuration/30-view-access.md
+++ b/docs/dashboard-configuration/30-view-access.md
@@ -43,7 +43,8 @@ first-class product with an **always-on route fallback** (`70-esbuild-embedding.
 - The **route** `/employee/dashboard` is mounted by `AppModules.js` from the registered
   `DashboardModule` **whether or not** a `Dashboard` citymodule row exists — so the dashboard is
   always reachable by **deep link**. Role-gating is inside `DashboardModule`
-  (`DASHBOARD_ROLES`, `70` §4).
+  (MDMS `dss.DashboardConfig` `allowedRoles`, falling back to the built-in
+  `DASHBOARD_ROLES` when the record is absent — `70` §4).
 - The **home card** *does* follow the citymodule rule: the employee home renders one card per
   entry in `initData.modules`, so the card appears only when a `Dashboard` citymodule row is
   present **and** `"Dashboard"` is in the build's `enabledModules` (it is — `App.js`).

--- a/docs/dashboard-configuration/70-esbuild-embedding.md
+++ b/docs/dashboard-configuration/70-esbuild-embedding.md
@@ -110,13 +110,27 @@ card and route are self-contained in the dashboard product; the sidebar is a sep
 `digit-ui-esbuild/products/dashboard/roles.js`:
 
 ```js
-export const DASHBOARD_ROLES =
+export const DASHBOARD_ROLES = // the FALLBACK
   ["SUPERVISOR", "PGR_SUPERVISOR", "GRO", "DGRO", "PGR_LME", "PGR_ADMIN", "SUPERUSER"];
+export const useDashboardAccess = () => { /* MDMS-resolved gate */ };
 ```
 
-Both `DashboardModule` (route) and `DashboardCard` (home card) gate on
-`Digit.UserService.hasAccess(DASHBOARD_ROLES)` — the card returns `null`, the route `Redirect`s to
-`/employee`, when the check fails. They therefore **always agree**.
+Both `DashboardModule` (route) and `DashboardCard` (home card) gate on the shared
+`useDashboardAccess()` hook — the card returns `null`, the route `Redirect`s to
+`/employee`, when the check fails; both render nothing while it resolves. They
+therefore **always agree**.
+
+The role list itself is **MDMS data, not code**: the hook fetches
+`dss.DashboardConfig` (single record `{ "id": "default", "allowedRoles": [...] }`,
+state-root tenant, same v1-compat `/egov-mdms-service/v1/_search` path as every
+other UI master, cached per session via react-query). Record present with a
+non-empty `allowedRoles` → those role codes; absent / error / malformed →
+`DASHBOARD_ROLES` fallback, silently — a deployment that never seeds the master
+behaves exactly as before. Deployments with a custom role taxonomy (e.g. `CMS_*`)
+seed the record instead of rebuilding the bundle. It is a **nav/route gate
+only, not a security boundary** — the data plane stays enforced server-side by
+the catalog + scope RBAC. Seed shape: `ansible/nairobi-mdms/mdms/dss/DashboardConfig.json`;
+schema: `local-setup/db/notif-mdms-seed/schemas/dss.DashboardConfig.json`.
 
 The check is **tenant-agnostic by design** (role *code* only). The rationale is load-bearing:
 employee roles live at the **state-root** tenant (`ke`) while the working tenant is usually a city
@@ -237,12 +251,13 @@ Key files and behaviours:
 | add/retire a KPI tile, its query, thresholds, params | `dss.KpiDefinition` (MDMS) | no |
 | default tiles + layout for a role | `dss.DashboardPack` (MDMS) | no |
 | a brand-new `viz.kind` render behaviour | `products/dashboard/src/components/KpiTile.jsx` (+ a component) | **yes** (FE bundle) |
-| which roles can *open* the view | `products/dashboard/roles.js` `DASHBOARD_ROLES` | **yes** (FE bundle) |
+| which roles can *open* the view | `dss.DashboardConfig` `allowedRoles` (MDMS; code fallback `products/dashboard/roles.js`) | no |
 | analytics base / tenant / MDMS path | host `globalConfigs` (`STATE_LEVEL_TENANT_ID`, `MDMS_V1_CONTEXT_PATH`, `REACT_APP_ANALYTICS_BASE`) | no (config) |
 | home card visibility | `tenant.citymodule` `Dashboard` row (`30-view-access.md`) | no |
 | card/menu labels | localization `DASHBOARD_CARD_HEADER`, `ACTION_TEST_DASHBOARD` (`30-view-access.md`) | no |
 
-Note that `DASHBOARD_ROLES` and any new `viz.kind` are the **only** two everyday dashboard knobs
-that require an FE rebuild — everything else is MDMS/config. A redeploy overwrites the served
+Note that a new `viz.kind` is the **only** everyday dashboard knob that requires an FE rebuild —
+everything else is MDMS/config (the open-the-view role gate moved to `dss.DashboardConfig`;
+`DASHBOARD_ROLES` in code is now only the fallback when that record is absent). A redeploy overwrites the served
 bundle (`60-operations.md` §4), so FE edits must land in `products/dashboard/` → PR → image, never
 as a hand-patch to `/opt/*/build/`.

--- a/docs/dashboard-configuration/README.md
+++ b/docs/dashboard-configuration/README.md
@@ -19,7 +19,7 @@ frontend. Two audiences:
 | expose a KPI to anonymous/public | add `"PUBLIC"` to `visibleTo` | **No** | [20](20-packs-and-rbac.md) §2 |
 | which rows a user's tiles aggregate (department scoping) | HRMS assignments (+ role choice) | **No** | [20](20-packs-and-rbac.md) layer 1 |
 | home card for the dashboard | MDMS `tenant.citymodule` (`Dashboard` row) | **No** | [30-view-access.md](30-view-access.md) §1a |
-| which roles can *open* the view (card + deep-link route) | `products/dashboard/roles.js` `DASHBOARD_ROLES` | **Yes** (FE bundle) | [70-esbuild-embedding.md](70-esbuild-embedding.md) §4 |
+| which roles can *open* the view (card + deep-link route) | MDMS `dss.DashboardConfig` `allowedRoles` (fallback: `products/dashboard/roles.js` `DASHBOARD_ROLES`) | **No** | [70-esbuild-embedding.md](70-esbuild-embedding.md) §4 |
 | how the dashboard is mounted inside digit-ui | esbuild product module + always-on route fallback | — | [70-esbuild-embedding.md](70-esbuild-embedding.md) |
 | sidebar entry + role gating of the view | MDMS `ACCESSCONTROL-ACTIONS-TEST` + `ACCESSCONTROL-ROLEACTIONS` | **No** | [30-view-access.md](30-view-access.md) |
 | menu/card labels | localization `_upsert` + cache bust | **No** | [30](30-view-access.md) §3–4 |

--- a/local-setup/db/notif-mdms-seed/schemas/dss.DashboardConfig.json
+++ b/local-setup/db/notif-mdms-seed/schemas/dss.DashboardConfig.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DashboardConfig",
+  "type": "object",
+  "required": ["id", "allowedRoles"],
+  "properties": {
+    "id": { "type": "string", "description": "Config record key; the UI reads the \"default\" record (single-record master)" },
+    "allowedRoles": {
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 1,
+      "description": "Role codes allowed to see the dashboard home card and open /employee/dashboard. Nav/route gate only — NOT a security boundary: the data plane is enforced server-side by the analytics catalog + scope RBAC. Absent record → the UI falls back to its built-in DASHBOARD_ROLES list."
+    }
+  },
+  "x-unique": ["id"]
+}


### PR DESCRIPTION
## Motivation

The supervisor dashboard's nav gate is hardcoded: `digit-ui-esbuild/products/dashboard/roles.js` ships `DASHBOARD_ROLES = ["SUPERVISOR","PGR_SUPERVISOR","GRO","DGRO","PGR_LME","PGR_ADMIN","SUPERUSER"]`, and both `Module.js` (route guard) and `DashboardCard.js` (home card) gate on it. Deployments with a custom role taxonomy — e.g. the `CMS_*` roles on moz — are locked out of the dashboard entirely unless they rebuild the FE bundle. Discussion #784 ("Frontend gates") flagged exactly this. Moving the list to MDMS also gives the G7 configurator a natural editing surface for it later.

## What changes

- **New MDMS master `dss.DashboardConfig`** (state root tenant, single record):
  ```json
  { "id": "default", "allowedRoles": ["SUPERVISOR", "PGR_SUPERVISOR", "GRO", "DGRO", "PGR_LME", "PGR_ADMIN", "SUPERUSER"] }
  ```
  Schema: `local-setup/db/notif-mdms-seed/schemas/dss.DashboardConfig.json` (follows the `dss.KpiDefinition`/`dss.DashboardPack` conventions). Seed data: `ansible/nairobi-mdms/mdms/dss/DashboardConfig.json` — mirrors today's hardcoded list, so seeded deployments behave identically.
- **FE:** `roles.js` keeps `DASHBOARD_ROLES` as the **fallback** and gains `useDashboardAccess()` — fetches `dss.DashboardConfig` at the state root (`Digit.ULBService.getStateId()`) via the same MDMS v1-compat search the rest of the UI uses (`Digit.Hooks.useCustomMDMS` → `POST /egov-mdms-service/v1/_search`), cached per session via react-query (`staleTime/cacheTime: Infinity`, shared cache entry across both consumers).
- Both `Module.js` and `DashboardCard.js` gate on the shared hook, so route and card keep agreeing. While the gate resolves, the route holds on the `Loader` and the card renders nothing — no flash of redirect/card.
- Docs (`docs/dashboard-configuration/`) updated: the open-the-view knob is now MDMS, no rebuild.

## Semantics

- Record present with a non-empty `allowedRoles` array → those role codes.
- Record absent / fetch error / malformed shape → the built-in `DASHBOARD_ROLES`, **silently**. A deployment that never seeds the master is byte-for-byte backward compatible.

## Explicitly NOT a security boundary

This gates navigation surfaces only (home card + `/employee/dashboard` route). The data plane is already enforced server-side by the analytics catalog RBAC (`rbac.visibleTo`) and scope RBAC — a user who deep-links past this gate still sees only what the API grants their token.

## Deployment notes

- Backend untouched.
- Validated live on bomet: schema registered + `default` record seeded at tenant `ke`, branch temp-deployed, bundle serves the MDMS-resolved gate.
- moz applicability: once its dashboard port lands (#1169), seeding a `dss.DashboardConfig` record with the `CMS_*` roles unlocks the dashboard there with no rebuild.
- **Fresh compose installs** (review follow-up): `local-setup/db/full-dump.sql` now seeds the `dss.DashboardConfig` schema definition + the `default` record at tenant `ke` (`dashboard-config-schema-001` / `dashboard-config-data-001`, matching the hand-seed idiom of `theme-config-*-001`), so new deployments get the master out of the box. Validated by loading the dump into a scratch postgres:14 container (`ON_ERROR_STOP=1`) — both rows land and the JSON parses.
- The record shape is additive: `numberFormat` arrives via #1272, which extends the same `default` record — per the seed-convergence rule, whichever PR merges later updates the dump row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard view access roles can now be configured via MDMS (`dss.DashboardConfig.allowedRoles`) without frontend rebuild.
  * Added a tenant default dashboard configuration (`id: "default"`) with role allowlisting.
  * Route and card access checks now share the same MDMS-driven authorization logic.

* **Bug Fixes**
  * Prevented dashboard card/route UI from flashing while access permissions are still resolving.
  * Added fallback to built-in dashboard roles when MDMS config is missing or malformed.

* **Documentation**
  * Updated dashboard configuration, access, embedding, and setup guidance to match MDMS-based gating.
  * Added/clarified schema validation rules for `dss.DashboardConfig`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
