### PR TITLE
fix(ansible): rewrite egov-user mobile-validation defaults per tenant

### DIFF
--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -554,6 +554,30 @@
         regexp: '^(\s+)DEFAULT_TENANT_ID: pg$'
         replace: '\1DEFAULT_TENANT_ID: {{ state_root }}'
 
+    # egov-user's OWN mobile-number-validation fallback (Spring env vars,
+    # baked into the image's application.properties as India's +91 /
+    # 10-digit regex). Distinct from the MDMS common-masters
+    # .MobileNumberValidation config that mcp-bootstrap seeds later from
+    # this same core_mobile_configs — that MDMS config only governs
+    # UI-driven, MDMS-aware validation. egov-user itself falls back to
+    # THIS env var whenever a request doesn't carry a country code (e.g.
+    # a direct /user/citizen/_create call that bypasses the UI), so
+    # without this rewrite every tenant silently validates against India's
+    # format regardless of its actual mobileNumberRegex/countryCode. No
+    # bootstrap-order dependency here (unlike STATE_LEVEL_TENANT_ID above),
+    # so this runs pre-boot alongside the other tenant-shaped literals.
+    - name: Set EGOV_MOBILE_VALIDATION_DEFAULT_COUNTRY_CODE (egov-user) in compose
+      replace:
+        path: "{{ digit_dir }}/docker-compose.egov-digit.yaml"
+        regexp: "^(\\s+)EGOV_MOBILE_VALIDATION_DEFAULT_COUNTRY_CODE: '\\+91'$"
+        replace: "\\1EGOV_MOBILE_VALIDATION_DEFAULT_COUNTRY_CODE: '{{ core_mobile_configs.countryCode | default('+91') }}'"
+
+    - name: Set EGOV_MOBILE_VALIDATION_DEFAULT_REGEX (egov-user) in compose
+      replace:
+        path: "{{ digit_dir }}/docker-compose.egov-digit.yaml"
+        regexp: "^(\\s+)EGOV_MOBILE_VALIDATION_DEFAULT_REGEX: '\\^\\[6-9\\]\\[0-9\\]\\{9\\}\\$'$"
+        replace: "\\1EGOV_MOBILE_VALIDATION_DEFAULT_REGEX: '{{ core_mobile_configs.mobileNumberRegex | default('^[6-9][0-9]{9}$') }}'"
+
     # ==================== Publish digit-mcp image ====================
     # digit-mcp ships from the same registry as every other DIGIT image
     # ({{ docker_registry }}/digit-mcp:latest). Compose `pull` picks it

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -572,11 +572,17 @@
         regexp: "^(\\s+)EGOV_MOBILE_VALIDATION_DEFAULT_COUNTRY_CODE: '\\+91'$"
         replace: "\\1EGOV_MOBILE_VALIDATION_DEFAULT_COUNTRY_CODE: '{{ core_mobile_configs.countryCode | default('+91') }}'"
 
+    # The `replace:` value below is fed straight into Python's re.sub() as
+    # the replacement string, which treats backslash specially (\1, \g<...>
+    # are backreferences; any other \<letter> — e.g. a tenant's regex using
+    # \d or \w shorthand instead of [0-9]/[A-Za-z0-9_] — raises "bad escape").
+    # Double every backslash in the tenant's mobileNumberRegex first so it
+    # survives re.sub() and lands in the compose file unchanged.
     - name: Set EGOV_MOBILE_VALIDATION_DEFAULT_REGEX (egov-user) in compose
       replace:
         path: "{{ digit_dir }}/docker-compose.egov-digit.yaml"
-        regexp: "^(\\s+)EGOV_MOBILE_VALIDATION_DEFAULT_REGEX: '\\^\\[6-9\\]\\[0-9\\]\\{9\\}\\$'$"
-        replace: "\\1EGOV_MOBILE_VALIDATION_DEFAULT_REGEX: '{{ core_mobile_configs.mobileNumberRegex | default('^[6-9][0-9]{9}$') }}'"
+        regexp: '^(\s+)EGOV_MOBILE_VALIDATION_DEFAULT_REGEX: ''\^\[6-9\]\[0-9\]\{9\}\$''$'
+        replace: '\1EGOV_MOBILE_VALIDATION_DEFAULT_REGEX: ''{{ core_mobile_configs.mobileNumberRegex | default(''^[6-9][0-9]{9}$'') | replace(''\\'', ''\\\\'') }}'''
 
     # ==================== Publish digit-mcp image ====================
     # digit-mcp ships from the same registry as every other DIGIT image

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -566,11 +566,15 @@
     # format regardless of its actual mobileNumberRegex/countryCode. No
     # bootstrap-order dependency here (unlike STATE_LEVEL_TENANT_ID above),
     # so this runs pre-boot alongside the other tenant-shaped literals.
+    # Same re.sub()-as-replacement-template hazard as the REGEX task below —
+    # double any backslashes in countryCode before it reaches `replace:`.
+    # A backslash in a country code is unlikely in practice, but the fix is
+    # free, so apply it here too for consistency.
     - name: Set EGOV_MOBILE_VALIDATION_DEFAULT_COUNTRY_CODE (egov-user) in compose
       replace:
         path: "{{ digit_dir }}/docker-compose.egov-digit.yaml"
-        regexp: "^(\\s+)EGOV_MOBILE_VALIDATION_DEFAULT_COUNTRY_CODE: '\\+91'$"
-        replace: "\\1EGOV_MOBILE_VALIDATION_DEFAULT_COUNTRY_CODE: '{{ core_mobile_configs.countryCode | default('+91') }}'"
+        regexp: '^(\s+)EGOV_MOBILE_VALIDATION_DEFAULT_COUNTRY_CODE: ''\+91''$'
+        replace: '\1EGOV_MOBILE_VALIDATION_DEFAULT_COUNTRY_CODE: ''{{ core_mobile_configs.countryCode | default(''+91'') | replace(''\\'', ''\\\\'') }}'''
 
     # The `replace:` value below is fed straight into Python's re.sub() as
     # the replacement string, which treats backslash specially (\1, \g<...>


### PR DESCRIPTION
Fixes #1263

## Summary
- `egov-user`'s own mobile-number-validation fallback env vars (`EGOV_MOBILE_VALIDATION_DEFAULT_COUNTRY_CODE` / `EGOV_MOBILE_VALIDATION_DEFAULT_REGEX`) were hardcoded in `docker-compose.egov-digit.yaml`, so any request bypassing the MDMS-aware UI validation (e.g. a direct citizen-creation API call) was validated against the wrong country's mobile number format regardless of the tenant's own configuration.
- Each tenant already defines its intended format via `core_mobile_configs` (`countryCode`, `mobileNumberRegex`) in `host_vars/<tenant>.yml`, and that value is seeded into MDMS for UI-driven validation — but it never reached `egov-user`'s own internal default.
- Added two pre-boot `ansible.builtin.replace` tasks in `playbook-deploy.yml` that rewrite both env vars from `core_mobile_configs` before the stack first boots, following the same pattern already used for `PARENT_LEVEL_TENANT_ID` / `DIGIT_TENANT` / `DEFAULT_TENANT_ID`. No bootstrap-ordering dependency here (unlike `STATE_LEVEL_TENANT_ID`, which must defer to post-bootstrap), so this runs alongside the other pre-boot tenant-literal rewrites.
- Defaults to the existing hardcoded values when a tenant doesn't set `core_mobile_configs`, so behavior is unchanged for tenants that don't override it.

## Test plan
- [x] `ansible-playbook` syntax/YAML validity confirmed for `playbook-deploy.yml`.
- [x] New regexes verified against the live compose file's exact lines (Python `re` match + substitution check).
- [x] Applied the equivalent rewrite to a live deployed tenant stack, force-recreated `egov-user`, and confirmed via `docker exec ... env` that the container picked up the tenant-specific country code/regex instead of the hardcoded default.
- [x] Replayed a citizen-creation API call end-to-end post-fix and confirmed it still succeeds with the tenant's own mobile number format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mobile number validation fallback settings now use the configured country code and validation pattern when available.
  * Existing default validation behavior remains in place when custom settings are not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->