### PR TITLE
feat(novu-bridge): resolve per-tenant WhatsApp sender from MDMS ProviderDetail

### DIFF
--- a/backend/novu-bridge/schemas/ProviderDetail.json
+++ b/backend/novu-bridge/schemas/ProviderDetail.json
@@ -35,6 +35,10 @@
       "type": "integer",
       "description": "Provider priority (lower = higher priority)",
       "default": 0
+    },
+    "senderNumber": {
+      "type": "string",
+      "description": "Provider-specific sender/from identity (e.g. the Twilio WhatsApp sender number)"
     }
   },
   "required": ["tenantId", "providerName", "channel"],

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/service/DispatchPipelineService.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/service/DispatchPipelineService.java
@@ -33,7 +33,6 @@ import java.util.*;
 public class DispatchPipelineService {
 
     private static final Set<String> KNOWN_CHANNELS = Set.of("SMS", "WHATSAPP", "EMAIL");
-    private static final String WHATSAPP_PREFIX = "whatsapp:";
 
     private final EnvelopeValidator envelopeValidator;
     private final PreferenceServiceClient preferenceServiceClient;
@@ -151,59 +150,12 @@ public class DispatchPipelineService {
                     .build();
         }
 
-        // For WHATSAPP: normalize 'to' phone (adds whatsapp: prefix) and build 'from' override.
-        Contact finalContact = contact;
-        Map<String, Object> overrides = null;
-
-        if ("WHATSAPP".equalsIgnoreCase(channel) && StringUtils.hasText(contact.getPhone())) {
-            try {
-                String toPhone = formatRecipientPhone(
-                        contact.getPhone(), event.getTenantId(), channel, null);
-                finalContact = Contact.builder()
-                        .userId(contact.getUserId()).type(contact.getType())
-                        .name(contact.getName()).phone(toPhone)
-                        .email(contact.getEmail()).locale(contact.getLocale())
-                        .build();
-            } catch (Exception e) {
-                log.warn("Phone normalization failed for eventId={}, tenantId={}: {}",
-                        event.getEventId(), event.getTenantId(), e.getMessage());
-            }
-
-            String senderNumber = mdmsServiceClient.getWhatsappSenderNumber(event.getTenantId());
-            if (StringUtils.hasText(senderNumber)) {
-                if (!senderNumber.startsWith(WHATSAPP_PREFIX)) {
-                    senderNumber = WHATSAPP_PREFIX + senderNumber;
-                }
-                Map<String, Object> twilioConfig = new HashMap<>();
-                twilioConfig.put("from", senderNumber);
-                Map<String, Object> providers = new HashMap<>();
-                providers.put("twilio", twilioConfig);
-                overrides = new HashMap<>();
-                overrides.put("providers", providers);
-                log.debug("WHATSAPP dispatch: from override={}", senderNumber);
-            } else {
-                log.warn("WHATSAPP dispatch: no senderNumber in MDMS ProviderDetail for tenantId={}; " +
-                        "Novu will fall back to integration credentials.from", event.getTenantId());
-            }
-        }
-
         NovuClient.NovuResponse response;
         try {
-            if ("WHATSAPP".equalsIgnoreCase(channel)) {
-                String workflowId = config.getNovuWorkflowId(channel);
-                Map<String, Object> payload = new HashMap<>();
-                if (event.getData() != null) payload.putAll(event.getData());
-                payload.put("body", context.getRenderedBody());
-                if (context.getRenderedSubject() != null) payload.put("subject", context.getRenderedSubject());
-                novuClient.identify(subscriberId, finalContact);
-                response = novuClient.trigger(workflowId, subscriberId, finalContact.getPhone(),
-                        payload, context.getTransactionId(), overrides);
-            } else {
-                response = novuClient.identifyThenTrigger(
-                        subscriberId, finalContact, channel,
-                        context.getRenderedBody(), context.getRenderedSubject(),
-                        context.getTransactionId(), event.getData());
-            }
+            response = novuClient.identifyThenTrigger(
+                    subscriberId, contact, channel,
+                    context.getRenderedBody(), context.getRenderedSubject(),
+                    context.getTransactionId(), event.getData(), event.getTenantId());
         } catch (CustomException ce) {
             persist(event, context, "FAILED", ce.getCode(), ce.getMessage(), null, 1);
             throw ce;   // consumer logs + DLQs as before

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/service/DispatchPipelineService.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/service/DispatchPipelineService.java
@@ -33,6 +33,7 @@ import java.util.*;
 public class DispatchPipelineService {
 
     private static final Set<String> KNOWN_CHANNELS = Set.of("SMS", "WHATSAPP", "EMAIL");
+    private static final String WHATSAPP_PREFIX = "whatsapp:";
 
     private final EnvelopeValidator envelopeValidator;
     private final PreferenceServiceClient preferenceServiceClient;
@@ -150,12 +151,59 @@ public class DispatchPipelineService {
                     .build();
         }
 
+        // For WHATSAPP: normalize 'to' phone (adds whatsapp: prefix) and build 'from' override.
+        Contact finalContact = contact;
+        Map<String, Object> overrides = null;
+
+        if ("WHATSAPP".equalsIgnoreCase(channel) && StringUtils.hasText(contact.getPhone())) {
+            try {
+                String toPhone = formatRecipientPhone(
+                        contact.getPhone(), event.getTenantId(), channel, null);
+                finalContact = Contact.builder()
+                        .userId(contact.getUserId()).type(contact.getType())
+                        .name(contact.getName()).phone(toPhone)
+                        .email(contact.getEmail()).locale(contact.getLocale())
+                        .build();
+            } catch (Exception e) {
+                log.warn("Phone normalization failed for eventId={}, tenantId={}: {}",
+                        event.getEventId(), event.getTenantId(), e.getMessage());
+            }
+
+            String senderNumber = mdmsServiceClient.getWhatsappSenderNumber(event.getTenantId());
+            if (StringUtils.hasText(senderNumber)) {
+                if (!senderNumber.startsWith(WHATSAPP_PREFIX)) {
+                    senderNumber = WHATSAPP_PREFIX + senderNumber;
+                }
+                Map<String, Object> twilioConfig = new HashMap<>();
+                twilioConfig.put("from", senderNumber);
+                Map<String, Object> providers = new HashMap<>();
+                providers.put("twilio", twilioConfig);
+                overrides = new HashMap<>();
+                overrides.put("providers", providers);
+                log.debug("WHATSAPP dispatch: from override={}", senderNumber);
+            } else {
+                log.warn("WHATSAPP dispatch: no senderNumber in MDMS ProviderDetail for tenantId={}; " +
+                        "Novu will fall back to integration credentials.from", event.getTenantId());
+            }
+        }
+
         NovuClient.NovuResponse response;
         try {
-            response = novuClient.identifyThenTrigger(
-                    subscriberId, contact, channel,
-                    context.getRenderedBody(), context.getRenderedSubject(),
-                    context.getTransactionId(), event.getData());
+            if ("WHATSAPP".equalsIgnoreCase(channel)) {
+                String workflowId = config.getNovuWorkflowId(channel);
+                Map<String, Object> payload = new HashMap<>();
+                if (event.getData() != null) payload.putAll(event.getData());
+                payload.put("body", context.getRenderedBody());
+                if (context.getRenderedSubject() != null) payload.put("subject", context.getRenderedSubject());
+                novuClient.identify(subscriberId, finalContact);
+                response = novuClient.trigger(workflowId, subscriberId, finalContact.getPhone(),
+                        payload, context.getTransactionId(), overrides);
+            } else {
+                response = novuClient.identifyThenTrigger(
+                        subscriberId, finalContact, channel,
+                        context.getRenderedBody(), context.getRenderedSubject(),
+                        context.getTransactionId(), event.getData());
+            }
         } catch (CustomException ce) {
             persist(event, context, "FAILED", ce.getCode(), ce.getMessage(), null, 1);
             throw ce;   // consumer logs + DLQs as before

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/service/MdmsServiceClient.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/service/MdmsServiceClient.java
@@ -32,11 +32,17 @@ public class MdmsServiceClient {
     /** Schema that carries the mobile number validation config. */
     private static final String SCHEMA_CODE = "common-masters.MobileNumberValidation";
 
+    /** Schema that carries per-tenant provider delivery config (WhatsApp sender number etc.). */
+    private static final String PROVIDER_DETAIL_SCHEMA = "ProviderDetail";
+
     private final RestTemplate restTemplate;
     private final NovuBridgeConfiguration config;
 
     /** Cache: tenantId → country-code prefix (e.g. "+91") */
     private final Map<String, String> prefixCache = new ConcurrentHashMap<>();
+
+    /** Cache: tenantId → WhatsApp sender number from ProviderDetail MDMS */
+    private final Map<String, String> senderCache = new ConcurrentHashMap<>();
 
     public MdmsServiceClient(RestTemplate restTemplate, NovuBridgeConfiguration config) {
         this.restTemplate = restTemplate;
@@ -69,6 +75,63 @@ public class MdmsServiceClient {
         config.setMobileNumberRegex((String) data.get("mobileNumberRegex"));
 
         return config;
+    }
+
+    /**
+     * Returns the WhatsApp sender number for the given tenant from the
+     * {@code ProviderDetail} MDMS schema. Returns {@code null} if not configured;
+     * the pipeline then falls back to the Novu integration's own credentials.from.
+     */
+    @SuppressWarnings("unchecked")
+    public String getWhatsappSenderNumber(String tenantId) {
+        if (senderCache.containsKey(tenantId)) {
+            return senderCache.get(tenantId);
+        }
+        try {
+            String url = config.getMdmsHost() + config.getMdmsSearchPath();
+
+            Map<String, Object> mdmsCriteria = new HashMap<>();
+            mdmsCriteria.put("tenantId", tenantId);
+            mdmsCriteria.put("schemaCode", PROVIDER_DETAIL_SCHEMA);
+
+            Map<String, Object> body = new HashMap<>();
+            body.put("MdmsCriteria", mdmsCriteria);
+            body.put("RequestInfo", buildMinimalRequestInfo());
+
+            ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                    url, HttpMethod.POST, new HttpEntity<>(body),
+                    (Class<Map<String, Object>>) (Class<?>) Map.class);
+
+            if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+                log.warn("MDMS returned non-2xx or empty body for ProviderDetail tenantId={}", tenantId);
+                return null;
+            }
+
+            List<Map<String, Object>> mdmsList =
+                    (List<Map<String, Object>>) response.getBody().get("mdms");
+            if (mdmsList == null || mdmsList.isEmpty()) {
+                log.warn("No ProviderDetail records in MDMS for tenantId={}", tenantId);
+                return null;
+            }
+
+            String senderNumber = mdmsList.stream()
+                    .map(r -> (Map<String, Object>) r.get("data"))
+                    .filter(d -> d != null
+                            && "whatsapp".equalsIgnoreCase((String) d.get("channel"))
+                            && Boolean.TRUE.equals(d.get("isActive")))
+                    .map(d -> (String) d.get("senderNumber"))
+                    .filter(s -> s != null && !s.isBlank())
+                    .findFirst().orElse(null);
+
+            if (senderNumber != null) {
+                senderCache.put(tenantId, senderNumber);
+            }
+            return senderNumber;
+        } catch (Exception e) {
+            log.warn("Failed to fetch WhatsApp senderNumber from MDMS for tenantId={}: {}",
+                    tenantId, e.getMessage());
+            return null;
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/service/MdmsServiceClient.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/service/MdmsServiceClient.java
@@ -35,13 +35,16 @@ public class MdmsServiceClient {
     /** Schema that carries per-tenant provider delivery config (WhatsApp sender number etc.). */
     private static final String PROVIDER_DETAIL_SCHEMA = "ProviderDetail";
 
+    /** Sentinel senderCache value meaning "looked up, confirmed not configured" (ConcurrentHashMap rejects null values). */
+    private static final String NO_SENDER_CONFIGURED = "";
+
     private final RestTemplate restTemplate;
     private final NovuBridgeConfiguration config;
 
     /** Cache: tenantId → country-code prefix (e.g. "+91") */
     private final Map<String, String> prefixCache = new ConcurrentHashMap<>();
 
-    /** Cache: tenantId → WhatsApp sender number from ProviderDetail MDMS */
+    /** Cache: tenantId → WhatsApp sender number from ProviderDetail MDMS, or {@link #NO_SENDER_CONFIGURED}. */
     private final Map<String, String> senderCache = new ConcurrentHashMap<>();
 
     public MdmsServiceClient(RestTemplate restTemplate, NovuBridgeConfiguration config) {
@@ -85,7 +88,8 @@ public class MdmsServiceClient {
     @SuppressWarnings("unchecked")
     public String getWhatsappSenderNumber(String tenantId) {
         if (senderCache.containsKey(tenantId)) {
-            return senderCache.get(tenantId);
+            String cached = senderCache.get(tenantId);
+            return NO_SENDER_CONFIGURED.equals(cached) ? null : cached;
         }
         try {
             String url = config.getMdmsHost() + config.getMdmsSearchPath();
@@ -104,6 +108,7 @@ public class MdmsServiceClient {
 
             if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
                 log.warn("MDMS returned non-2xx or empty body for ProviderDetail tenantId={}", tenantId);
+                senderCache.put(tenantId, NO_SENDER_CONFIGURED);
                 return null;
             }
 
@@ -111,6 +116,7 @@ public class MdmsServiceClient {
                     (List<Map<String, Object>>) response.getBody().get("mdms");
             if (mdmsList == null || mdmsList.isEmpty()) {
                 log.warn("No ProviderDetail records in MDMS for tenantId={}", tenantId);
+                senderCache.put(tenantId, NO_SENDER_CONFIGURED);
                 return null;
             }
 
@@ -118,18 +124,17 @@ public class MdmsServiceClient {
                     .map(r -> (Map<String, Object>) r.get("data"))
                     .filter(d -> d != null
                             && "whatsapp".equalsIgnoreCase((String) d.get("channel"))
+                            && "twilio".equalsIgnoreCase((String) d.get("providerName"))
                             && Boolean.TRUE.equals(d.get("isActive")))
                     .map(d -> (String) d.get("senderNumber"))
                     .filter(s -> s != null && !s.isBlank())
                     .findFirst().orElse(null);
 
-            if (senderNumber != null) {
-                senderCache.put(tenantId, senderNumber);
-            }
+            senderCache.put(tenantId, senderNumber != null ? senderNumber : NO_SENDER_CONFIGURED);
             return senderNumber;
         } catch (Exception e) {
-            log.warn("Failed to fetch WhatsApp senderNumber from MDMS for tenantId={}: {}",
-                    tenantId, e.getMessage());
+            log.warn("Failed to fetch WhatsApp senderNumber from MDMS for tenantId={}", tenantId, e);
+            senderCache.put(tenantId, NO_SENDER_CONFIGURED);
             return null;
         }
     }

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/service/MdmsServiceClient.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/service/MdmsServiceClient.java
@@ -133,8 +133,11 @@ public class MdmsServiceClient {
             senderCache.put(tenantId, senderNumber != null ? senderNumber : NO_SENDER_CONFIGURED);
             return senderNumber;
         } catch (Exception e) {
+            // Do NOT cache: unlike a clean non-2xx/empty-result response, an exception here
+            // (timeout, connection reset, transient 5xx) is not a stable "not configured" fact —
+            // senderCache has no TTL, so caching it would permanently disable this tenant's
+            // sender override until process restart, even after MDMS recovers.
             log.warn("Failed to fetch WhatsApp senderNumber from MDMS for tenantId={}", tenantId, e);
-            senderCache.put(tenantId, NO_SENDER_CONFIGURED);
             return null;
         }
     }

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/service/NovuClient.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/service/NovuClient.java
@@ -91,7 +91,7 @@ public class NovuClient {
                 providers.put("twilio", twilioConfig);
                 overrides = new HashMap<>();
                 overrides.put("providers", providers);
-                log.debug("WHATSAPP dispatch: from override={}", senderNumber);
+                log.debug("WHATSAPP dispatch: from override={}", PiiMask.mask(senderNumber));
             } else {
                 log.warn("WHATSAPP dispatch: no senderNumber in MDMS for tenantId={}; " +
                         "falling back to integration credentials.from", tenantId);

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/service/NovuClient.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/service/NovuClient.java
@@ -23,16 +23,21 @@ import java.util.concurrent.ConcurrentHashMap;
 @Slf4j
 public class NovuClient {
 
+    private static final String WHATSAPP_PREFIX = "whatsapp:";
+
     private final RestTemplate restTemplate;
     private final NovuBridgeConfiguration config;
+    private final MdmsServiceClient mdmsServiceClient;
 
     // Hand-rolled subscriberId -> last-identified epoch-ms TTL cache (no guava/caffeine);
     // skips redundant POST /v1/subscribers calls within the configured TTL window.
     private final Map<String, Long> identifiedAt = new ConcurrentHashMap<>();
 
-    public NovuClient(RestTemplate restTemplate, NovuBridgeConfiguration config) {
+    public NovuClient(RestTemplate restTemplate, NovuBridgeConfiguration config,
+                      MdmsServiceClient mdmsServiceClient) {
         this.restTemplate = restTemplate;
         this.config = config;
+        this.mdmsServiceClient = mdmsServiceClient;
     }
 
     /**
@@ -47,10 +52,12 @@ public class NovuClient {
      * @param renderedSubject EMAIL subject, else null
      * @param transactionId   stable idempotency key
      * @param data            structured payload echoed alongside body/subject
+     * @param tenantId        used to resolve the per-tenant WhatsApp sender override from MDMS
      */
     public NovuResponse identifyThenTrigger(String subscriberId, Contact contact, String channel,
                                             String renderedBody, String renderedSubject,
-                                            String transactionId, Map<String, Object> data) {
+                                            String transactionId, Map<String, Object> data,
+                                            String tenantId) {
         identify(subscriberId, contact);
 
         String workflowId = config.getNovuWorkflowId(channel);
@@ -64,6 +71,32 @@ public class NovuClient {
         payload.put("body", renderedBody);
         if (renderedSubject != null) {
             payload.put("subject", renderedSubject);
+        }
+
+        if ("WHATSAPP".equalsIgnoreCase(channel)) {
+            // Twilio Programmable WhatsApp requires whatsapp: prefix on both To and From.
+            if (StringUtils.hasText(phone) && !phone.startsWith(WHATSAPP_PREFIX)) {
+                phone = WHATSAPP_PREFIX + phone;
+            }
+            Map<String, Object> overrides = null;
+            String senderNumber = StringUtils.hasText(tenantId)
+                    ? mdmsServiceClient.getWhatsappSenderNumber(tenantId) : null;
+            if (StringUtils.hasText(senderNumber)) {
+                if (!senderNumber.startsWith(WHATSAPP_PREFIX)) {
+                    senderNumber = WHATSAPP_PREFIX + senderNumber;
+                }
+                Map<String, Object> twilioConfig = new HashMap<>();
+                twilioConfig.put("from", senderNumber);
+                Map<String, Object> providers = new HashMap<>();
+                providers.put("twilio", twilioConfig);
+                overrides = new HashMap<>();
+                overrides.put("providers", providers);
+                log.debug("WHATSAPP dispatch: from override={}", senderNumber);
+            } else {
+                log.warn("WHATSAPP dispatch: no senderNumber in MDMS for tenantId={}; " +
+                        "falling back to integration credentials.from", tenantId);
+            }
+            return trigger(workflowId, subscriberId, phone, payload, transactionId, overrides);
         }
 
         return trigger(workflowId, subscriberId, phone, email, payload, transactionId);

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/service/DispatchPipelineFailureRowTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/service/DispatchPipelineFailureRowTest.java
@@ -100,7 +100,7 @@ class DispatchPipelineFailureRowTest {
 
     @Test
     void providerThrowsCustomException_persistsFailedWithPropagatedCode_thenRethrows() {
-        when(novuClient.identifyThenTrigger(anyString(), any(), anyString(), anyString(), any(), anyString(), any()))
+        when(novuClient.identifyThenTrigger(anyString(), any(), anyString(), anyString(), any(), anyString(), any(), anyString()))
                 .thenThrow(new CustomException("NB_NOVU_RATE_LIMITED", "429 from Novu"));
 
         CustomException ex = assertThrows(CustomException.class, () -> service.process(smsEvent(), true, null));
@@ -114,7 +114,7 @@ class DispatchPipelineFailureRowTest {
 
     @Test
     void providerThrowsGenericException_persistsFailedWithDeliveryError_thenRethrows() {
-        when(novuClient.identifyThenTrigger(anyString(), any(), anyString(), anyString(), any(), anyString(), any()))
+        when(novuClient.identifyThenTrigger(anyString(), any(), anyString(), anyString(), any(), anyString(), any(), anyString()))
                 .thenThrow(new RuntimeException("connection reset"));
 
         assertThrows(RuntimeException.class, () -> service.process(smsEvent(), true, null));
@@ -126,7 +126,7 @@ class DispatchPipelineFailureRowTest {
 
     @Test
     void novuNon2xxResponse_recordsFailed_noRethrow() {
-        when(novuClient.identifyThenTrigger(anyString(), any(), anyString(), anyString(), any(), anyString(), any()))
+        when(novuClient.identifyThenTrigger(anyString(), any(), anyString(), anyString(), any(), anyString(), any(), anyString()))
                 .thenReturn(NovuClient.NovuResponse.builder().statusCode(500)
                         .response(Map.of("message", "internal error")).build());
 
@@ -141,7 +141,7 @@ class DispatchPipelineFailureRowTest {
 
     @Test
     void novuNullResponse_recordsFailed_noRethrow() {
-        when(novuClient.identifyThenTrigger(anyString(), any(), anyString(), anyString(), any(), anyString(), any()))
+        when(novuClient.identifyThenTrigger(anyString(), any(), anyString(), anyString(), any(), anyString(), any(), anyString()))
                 .thenReturn(null);
 
         DispatchResult result = service.process(smsEvent(), true, null);

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/service/DispatchPipelineIdempotencyTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/service/DispatchPipelineIdempotencyTest.java
@@ -57,7 +57,7 @@ class DispatchPipelineIdempotencyTest {
 
         when(preferenceServiceClient.isChannelAllowed(anyString(), any(), any(), anyString()))
                 .thenReturn(true);
-        when(novuClient.identifyThenTrigger(anyString(), any(), anyString(), anyString(), any(), anyString(), any()))
+        when(novuClient.identifyThenTrigger(anyString(), any(), anyString(), anyString(), any(), anyString(), any(), anyString()))
                 .thenReturn(NovuClient.NovuResponse.builder().statusCode(201).response(Map.of("acknowledged", true)).build());
 
         service = new DispatchPipelineService(envelopeValidator, preferenceServiceClient, novuClient,
@@ -90,7 +90,7 @@ class DispatchPipelineIdempotencyTest {
 
         // Current behavior: no pre-send SENT-row dedupe in process(); both passes trigger.
         verify(novuClient, times(2))
-                .identifyThenTrigger(anyString(), any(), anyString(), anyString(), any(), anyString(), any());
+                .identifyThenTrigger(anyString(), any(), anyString(), anyString(), any(), anyString(), any(), anyString());
 
         ArgumentCaptor<DispatchLogEntry> captor = ArgumentCaptor.forClass(DispatchLogEntry.class);
         verify(dispatchLogRepository, times(2)).upsert(captor.capture());

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/service/DispatchPipelinePassThroughTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/service/DispatchPipelinePassThroughTest.java
@@ -60,7 +60,7 @@ class DispatchPipelinePassThroughTest {
 
         when(preferenceServiceClient.isChannelAllowed(anyString(), any(), any(), anyString()))
                 .thenReturn(true);
-        when(novuClient.identifyThenTrigger(anyString(), any(), anyString(), anyString(), any(), anyString(), any()))
+        when(novuClient.identifyThenTrigger(anyString(), any(), anyString(), anyString(), any(), anyString(), any(), anyString()))
                 .thenReturn(NovuClient.NovuResponse.builder().statusCode(201).response(Map.of("acknowledged", true)).build());
 
         service = new DispatchPipelineService(envelopeValidator, preferenceServiceClient, novuClient,
@@ -103,7 +103,7 @@ class DispatchPipelinePassThroughTest {
         ArgumentCaptor<String> body = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> txn = ArgumentCaptor.forClass(String.class);
         verify(novuClient).identifyThenTrigger(subId.capture(), contact.capture(), eq("SMS"),
-                body.capture(), any(), txn.capture(), any());
+                body.capture(), any(), txn.capture(), any(), eq("ke.bomet"));
 
         // subscriberId, contact profile, renderedBody, transactionId all come straight from the event.
         assertEquals("ke.bomet:uuid-123", subId.getValue());
@@ -151,7 +151,7 @@ class DispatchPipelinePassThroughTest {
 
         assertFalse(result.getNovuTriggered());
         // No Novu trigger at all — in particular NOT the SMS workflow.
-        verify(novuClient, never()).identifyThenTrigger(any(), any(), any(), any(), any(), any(), any());
+        verify(novuClient, never()).identifyThenTrigger(any(), any(), any(), any(), any(), any(), any(), any());
         // Explicit SKIPPED/NB_NO_PROVIDER dispatch row.
         ArgumentCaptor<DispatchLogEntry> captor = ArgumentCaptor.forClass(DispatchLogEntry.class);
         verify(dispatchLogRepository).upsert(captor.capture());
@@ -169,7 +169,7 @@ class DispatchPipelinePassThroughTest {
         DispatchResult result = service.process(event, true, null);
 
         assertFalse(result.getNovuTriggered());
-        verify(novuClient, never()).identifyThenTrigger(any(), any(), any(), any(), any(), any(), any());
+        verify(novuClient, never()).identifyThenTrigger(any(), any(), any(), any(), any(), any(), any(), any());
         ArgumentCaptor<DispatchLogEntry> captor = ArgumentCaptor.forClass(DispatchLogEntry.class);
         verify(dispatchLogRepository).upsert(captor.capture());
         assertEquals("SKIPPED", captor.getValue().getStatus());
@@ -188,13 +188,13 @@ class DispatchPipelinePassThroughTest {
         assertTrue(result.getNovuTriggered());
         ArgumentCaptor<String> body = ArgumentCaptor.forClass(String.class);
         verify(novuClient).identifyThenTrigger(eq("ke.bomet:uuid-123"), any(), eq("EMAIL"),
-                body.capture(), any(), eq("PGR-001:ASSIGN:PENDINGATLME:ke.bomet:uuid-123:EMAIL"), any());
+                body.capture(), any(), eq("PGR-001:ASSIGN:PENDINGATLME:ke.bomet:uuid-123:EMAIL"), any(), eq("ke.bomet"));
         assertEquals("Dear Jane, your complaint PGR-001 is assigned.", body.getValue());
     }
 
     @Test
     void novuTriggerThrows_persistsFailed_thenRethrows() {
-        when(novuClient.identifyThenTrigger(anyString(), any(), anyString(), anyString(), any(), anyString(), any()))
+        when(novuClient.identifyThenTrigger(anyString(), any(), anyString(), anyString(), any(), anyString(), any(), anyString()))
                 .thenThrow(new CustomException("NB_NOVU_TRIGGER_FAILED", "boom"));
 
         assertThrows(CustomException.class, () -> service.process(smsEvent(), true, null));
@@ -219,7 +219,7 @@ class DispatchPipelinePassThroughTest {
         DispatchResult result = service.process(event, true, null);
 
         assertFalse(result.getNovuTriggered());
-        verify(novuClient, never()).identifyThenTrigger(any(), any(), any(), any(), any(), any(), any());
+        verify(novuClient, never()).identifyThenTrigger(any(), any(), any(), any(), any(), any(), any(), any());
         ArgumentCaptor<DispatchLogEntry> captor = ArgumentCaptor.forClass(DispatchLogEntry.class);
         verify(dispatchLogRepository).upsert(captor.capture());
         assertEquals("SKIPPED", captor.getValue().getStatus());
@@ -235,7 +235,7 @@ class DispatchPipelinePassThroughTest {
 
         assertEquals(Boolean.FALSE, result.getPreferenceAllowed());
         assertEquals(Boolean.FALSE, result.getNovuTriggered());
-        verify(novuClient, never()).identifyThenTrigger(anyString(), any(), anyString(), anyString(), any(), anyString(), any());
+        verify(novuClient, never()).identifyThenTrigger(anyString(), any(), anyString(), anyString(), any(), anyString(), any(), anyString());
     }
 
     @Test

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/service/DispatchPipelineWhatsappNoProviderTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/service/DispatchPipelineWhatsappNoProviderTest.java
@@ -22,7 +22,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -69,9 +68,7 @@ class DispatchPipelineWhatsappNoProviderTest {
 
         when(preferenceServiceClient.isChannelAllowed(anyString(), any(), any(), anyString()))
                 .thenReturn(true);
-        when(novuClient.identifyThenTrigger(anyString(), any(), anyString(), anyString(), any(), anyString(), any()))
-                .thenReturn(NovuClient.NovuResponse.builder().statusCode(201).response(Map.of("acknowledged", true)).build());
-        when(novuClient.trigger(anyString(), anyString(), any(), any(), anyString(), any()))
+        when(novuClient.identifyThenTrigger(anyString(), any(), anyString(), anyString(), any(), anyString(), any(), anyString()))
                 .thenReturn(NovuClient.NovuResponse.builder().statusCode(201).response(Map.of("acknowledged", true)).build());
 
         service = new DispatchPipelineService(envelopeValidator, preferenceServiceClient, novuClient,
@@ -113,64 +110,20 @@ class DispatchPipelineWhatsappNoProviderTest {
     }
 
     @Test
-    void whatsappEvent_gateEnabled_noSenderConfigured_triggersNovuWithoutOverrides() {
+    void whatsappEvent_gateEnabled_dispatchesViaIdentifyThenTrigger_withTenantId() {
         config.setChannelsEnabled(List.of("SMS", "EMAIL", "WHATSAPP"));
-        // No ProviderDetail configured for this tenant: getWhatsappSenderNumber() returns null.
-        when(mdmsServiceClient.getWhatsappSenderNumber(anyString())).thenReturn(null);
 
         DispatchResult result = service.process(whatsappEvent(), true, null);
 
         assertTrue(result.getNovuTriggered());
-        // WHATSAPP now goes through identify() + the pass-through trigger() overload
-        // (rather than identifyThenTrigger) because it needs the option to attach a
-        // per-tenant "from" override — with no senderNumber configured, overrides is null
-        // and Novu falls back to the integration's own credentials.from.
-        verify(novuClient).identify(eq("ke.bomet:uuid-123"), any());
-        ArgumentCaptor<Map> payload = ArgumentCaptor.forClass(Map.class);
-        ArgumentCaptor<Map> overrides = ArgumentCaptor.forClass(Map.class);
-        // formatRecipientPhone() also normalizes the recipient's "to" phone for WHATSAPP:
-        // it is already E.164, so it is only prefixed with "whatsapp:".
-        verify(novuClient).trigger(eq("complaints-whatsapp"), eq("ke.bomet:uuid-123"), eq("whatsapp:+254712345678"),
-                payload.capture(), eq("PGR-001:ASSIGN:PENDINGATLME:ke.bomet:uuid-123:WHATSAPP"),
-                overrides.capture());
-        assertEquals("Dear Jane, your complaint PGR-001 is assigned.", payload.getValue().get("body"));
-        assertEquals(null, overrides.getValue());
-        verify(novuClient, never()).identifyThenTrigger(any(), any(), any(), any(), any(), any(), any());
-    }
-
-    @Test
-    void whatsappEvent_gateEnabled_senderConfigured_triggersNovuWithFromOverride() {
-        config.setChannelsEnabled(List.of("SMS", "EMAIL", "WHATSAPP"));
-        // ProviderDetail in MDMS carries a raw (unprefixed) Twilio WhatsApp sender number.
-        when(mdmsServiceClient.getWhatsappSenderNumber("ke.bomet")).thenReturn("+14155550123");
-
-        DispatchResult result = service.process(whatsappEvent(), true, null);
-
-        assertTrue(result.getNovuTriggered());
-        ArgumentCaptor<Map> overrides = ArgumentCaptor.forClass(Map.class);
-        // formatRecipientPhone() also normalizes the recipient's "to" phone for WHATSAPP:
-        // it is already E.164, so it is only prefixed with "whatsapp:".
-        verify(novuClient).trigger(eq("complaints-whatsapp"), eq("ke.bomet:uuid-123"), eq("whatsapp:+254712345678"),
-                any(), eq("PGR-001:ASSIGN:PENDINGATLME:ke.bomet:uuid-123:WHATSAPP"), overrides.capture());
-
-        Map<String, Object> providers = (Map<String, Object>) overrides.getValue().get("providers");
-        Map<String, Object> twilio = (Map<String, Object>) providers.get("twilio");
-        // The bare MDMS number is prefixed with "whatsapp:" before being sent as the override.
-        assertEquals("whatsapp:+14155550123", twilio.get("from"));
-    }
-
-    @Test
-    void whatsappEvent_gateEnabled_senderAlreadyPrefixed_isNotDoublePrefixed() {
-        config.setChannelsEnabled(List.of("SMS", "EMAIL", "WHATSAPP"));
-        when(mdmsServiceClient.getWhatsappSenderNumber("ke.bomet")).thenReturn("whatsapp:+14155550123");
-
-        service.process(whatsappEvent(), true, null);
-
-        ArgumentCaptor<Map> overrides = ArgumentCaptor.forClass(Map.class);
-        verify(novuClient).trigger(anyString(), anyString(), any(), any(), anyString(), overrides.capture());
-        Map<String, Object> providers = (Map<String, Object>) overrides.getValue().get("providers");
-        Map<String, Object> twilio = (Map<String, Object>) providers.get("twilio");
-        assertEquals("whatsapp:+14155550123", twilio.get("from"));
+        // The per-tenant WhatsApp sender-override wiring (MDMS lookup, "whatsapp:" phone
+        // prefixing, Twilio provider override) now lives inside NovuClient.identifyThenTrigger
+        // — see NovuClientTest. The pipeline's only remaining contract here is to route an
+        // enabled WHATSAPP event through identifyThenTrigger with the event's tenantId, so
+        // that wiring has what it needs to run.
+        verify(novuClient).identifyThenTrigger(eq("ke.bomet:uuid-123"), any(), eq("WHATSAPP"),
+                eq("Dear Jane, your complaint PGR-001 is assigned."), any(),
+                eq("PGR-001:ASSIGN:PENDINGATLME:ke.bomet:uuid-123:WHATSAPP"), any(), eq("ke.bomet"));
     }
 
     @Test

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/service/DispatchPipelineWhatsappNoProviderTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/service/DispatchPipelineWhatsappNoProviderTest.java
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -62,11 +63,15 @@ class DispatchPipelineWhatsappNoProviderTest {
         config.setDefaultLocale("en_IN");
         // Default enabled set ships SMS,EMAIL — WHATSAPP is deliberately absent.
         config.setChannelsEnabled(List.of("SMS", "EMAIL"));
+        // @Value defaults only apply under Spring; set explicitly for this plain-POJO config.
+        config.setNovuWorkflowWhatsapp("complaints-whatsapp");
         mdmsServiceClient = mock(MdmsServiceClient.class);
 
         when(preferenceServiceClient.isChannelAllowed(anyString(), any(), any(), anyString()))
                 .thenReturn(true);
         when(novuClient.identifyThenTrigger(anyString(), any(), anyString(), anyString(), any(), anyString(), any()))
+                .thenReturn(NovuClient.NovuResponse.builder().statusCode(201).response(Map.of("acknowledged", true)).build());
+        when(novuClient.trigger(anyString(), anyString(), any(), any(), anyString(), any()))
                 .thenReturn(NovuClient.NovuResponse.builder().statusCode(201).response(Map.of("acknowledged", true)).build());
 
         service = new DispatchPipelineService(envelopeValidator, preferenceServiceClient, novuClient,
@@ -108,18 +113,64 @@ class DispatchPipelineWhatsappNoProviderTest {
     }
 
     @Test
-    void whatsappEvent_gateEnabled_triggersNovuWhatsappWorkflow() {
+    void whatsappEvent_gateEnabled_noSenderConfigured_triggersNovuWithoutOverrides() {
         config.setChannelsEnabled(List.of("SMS", "EMAIL", "WHATSAPP"));
+        // No ProviderDetail configured for this tenant: getWhatsappSenderNumber() returns null.
+        when(mdmsServiceClient.getWhatsappSenderNumber(anyString())).thenReturn(null);
 
         DispatchResult result = service.process(whatsappEvent(), true, null);
 
         assertTrue(result.getNovuTriggered());
-        // The bridge asks NovuClient to deliver on the WHATSAPP channel; NovuClient owns
-        // resolving the complaints-whatsapp workflow id internally.
-        ArgumentCaptor<String> body = ArgumentCaptor.forClass(String.class);
-        verify(novuClient).identifyThenTrigger(eq("ke.bomet:uuid-123"), any(), eq("WHATSAPP"),
-                body.capture(), any(), eq("PGR-001:ASSIGN:PENDINGATLME:ke.bomet:uuid-123:WHATSAPP"), any());
-        assertEquals("Dear Jane, your complaint PGR-001 is assigned.", body.getValue());
+        // WHATSAPP now goes through identify() + the pass-through trigger() overload
+        // (rather than identifyThenTrigger) because it needs the option to attach a
+        // per-tenant "from" override — with no senderNumber configured, overrides is null
+        // and Novu falls back to the integration's own credentials.from.
+        verify(novuClient).identify(eq("ke.bomet:uuid-123"), any());
+        ArgumentCaptor<Map> payload = ArgumentCaptor.forClass(Map.class);
+        ArgumentCaptor<Map> overrides = ArgumentCaptor.forClass(Map.class);
+        // formatRecipientPhone() also normalizes the recipient's "to" phone for WHATSAPP:
+        // it is already E.164, so it is only prefixed with "whatsapp:".
+        verify(novuClient).trigger(eq("complaints-whatsapp"), eq("ke.bomet:uuid-123"), eq("whatsapp:+254712345678"),
+                payload.capture(), eq("PGR-001:ASSIGN:PENDINGATLME:ke.bomet:uuid-123:WHATSAPP"),
+                overrides.capture());
+        assertEquals("Dear Jane, your complaint PGR-001 is assigned.", payload.getValue().get("body"));
+        assertEquals(null, overrides.getValue());
+        verify(novuClient, never()).identifyThenTrigger(any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void whatsappEvent_gateEnabled_senderConfigured_triggersNovuWithFromOverride() {
+        config.setChannelsEnabled(List.of("SMS", "EMAIL", "WHATSAPP"));
+        // ProviderDetail in MDMS carries a raw (unprefixed) Twilio WhatsApp sender number.
+        when(mdmsServiceClient.getWhatsappSenderNumber("ke.bomet")).thenReturn("+14155550123");
+
+        DispatchResult result = service.process(whatsappEvent(), true, null);
+
+        assertTrue(result.getNovuTriggered());
+        ArgumentCaptor<Map> overrides = ArgumentCaptor.forClass(Map.class);
+        // formatRecipientPhone() also normalizes the recipient's "to" phone for WHATSAPP:
+        // it is already E.164, so it is only prefixed with "whatsapp:".
+        verify(novuClient).trigger(eq("complaints-whatsapp"), eq("ke.bomet:uuid-123"), eq("whatsapp:+254712345678"),
+                any(), eq("PGR-001:ASSIGN:PENDINGATLME:ke.bomet:uuid-123:WHATSAPP"), overrides.capture());
+
+        Map<String, Object> providers = (Map<String, Object>) overrides.getValue().get("providers");
+        Map<String, Object> twilio = (Map<String, Object>) providers.get("twilio");
+        // The bare MDMS number is prefixed with "whatsapp:" before being sent as the override.
+        assertEquals("whatsapp:+14155550123", twilio.get("from"));
+    }
+
+    @Test
+    void whatsappEvent_gateEnabled_senderAlreadyPrefixed_isNotDoublePrefixed() {
+        config.setChannelsEnabled(List.of("SMS", "EMAIL", "WHATSAPP"));
+        when(mdmsServiceClient.getWhatsappSenderNumber("ke.bomet")).thenReturn("whatsapp:+14155550123");
+
+        service.process(whatsappEvent(), true, null);
+
+        ArgumentCaptor<Map> overrides = ArgumentCaptor.forClass(Map.class);
+        verify(novuClient).trigger(anyString(), anyString(), any(), any(), anyString(), overrides.capture());
+        Map<String, Object> providers = (Map<String, Object>) overrides.getValue().get("providers");
+        Map<String, Object> twilio = (Map<String, Object>) providers.get("twilio");
+        assertEquals("whatsapp:+14155550123", twilio.get("from"));
     }
 
     @Test

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/service/EnvelopePipelineNegativesTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/service/EnvelopePipelineNegativesTest.java
@@ -136,7 +136,7 @@ class EnvelopePipelineNegativesTest {
         // suite where every event happens to be rejected for an unrelated reason).
         org.mockito.Mockito.when(preferenceServiceClient.isChannelAllowed(anyString(), any(), any(), anyString()))
                 .thenReturn(true);
-        org.mockito.Mockito.when(novuClient.identifyThenTrigger(anyString(), any(), anyString(), anyString(), any(), anyString(), any()))
+        org.mockito.Mockito.when(novuClient.identifyThenTrigger(anyString(), any(), anyString(), anyString(), any(), anyString(), any(), anyString()))
                 .thenReturn(NovuClient.NovuResponse.builder().statusCode(201).response(Map.of()).build());
         org.junit.jupiter.api.Assertions.assertDoesNotThrow(() -> service.process(validEvent(), true, null));
     }

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/service/MdmsServiceClientWhatsappSenderTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/service/MdmsServiceClientWhatsappSenderTest.java
@@ -52,9 +52,13 @@ class MdmsServiceClientWhatsappSenderTest {
     }
 
     private Map<String, Object> providerRecord(String channel, boolean isActive, String senderNumber) {
+        return providerRecord("twilio", channel, isActive, senderNumber);
+    }
+
+    private Map<String, Object> providerRecord(String providerName, String channel, boolean isActive, String senderNumber) {
         Map<String, Object> data = new HashMap<>();
         data.put("tenantId", "ke.bomet");
-        data.put("providerName", "twilio");
+        data.put("providerName", providerName);
         data.put("channel", channel);
         data.put("isActive", isActive);
         data.put("senderNumber", senderNumber);
@@ -91,9 +95,19 @@ class MdmsServiceClientWhatsappSenderTest {
         stubMdmsResponse(List.of(
                 providerRecord("sms", true, "+14155550999"),
                 providerRecord("whatsapp", false, "+14155550001"),
+                providerRecord("meta", "whatsapp", true, "+14155550777"),
                 providerRecord("whatsapp", true, "+14155550123")));
 
         assertEquals("+14155550123", mdmsServiceClient.getWhatsappSenderNumber("ke.bomet"));
+    }
+
+    @Test
+    void activeNonTwilioWhatsappRecord_isIgnored_returnsNull() {
+        // Only a non-Twilio active WhatsApp provider is configured; the sender is always
+        // sent as overrides.providers.twilio.from, so a non-Twilio record must not be picked.
+        stubMdmsResponse(List.of(providerRecord("meta", "whatsapp", true, "+14155550777")));
+
+        assertNull(mdmsServiceClient.getWhatsappSenderNumber("ke.bomet"));
     }
 
     @Test
@@ -125,6 +139,50 @@ class MdmsServiceClientWhatsappSenderTest {
 
         assertEquals("+14155550123", mdmsServiceClient.getWhatsappSenderNumber("ke.bomet"));
         assertEquals("+14155550123", mdmsServiceClient.getWhatsappSenderNumber("ke.bomet"));
+
+        verify(restTemplate, times(1)).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class));
+    }
+
+    @Test
+    void secondLookupForTenantWithNoActiveRecord_isServedFromCache_doesNotCallMdmsAgain() {
+        // The "not configured" outcome must be cached too, else every WHATSAPP dispatch for a
+        // tenant with no ProviderDetail sender re-issues a synchronous MDMS HTTP call forever.
+        stubMdmsResponse(List.of(providerRecord("whatsapp", false, "+14155550001")));
+
+        assertNull(mdmsServiceClient.getWhatsappSenderNumber("ke.bomet"));
+        assertNull(mdmsServiceClient.getWhatsappSenderNumber("ke.bomet"));
+
+        verify(restTemplate, times(1)).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class));
+    }
+
+    @Test
+    void secondLookupAfterNoRecordsAtAll_isServedFromCache_doesNotCallMdmsAgain() {
+        stubMdmsResponse(List.of());
+
+        assertNull(mdmsServiceClient.getWhatsappSenderNumber("ke.bomet"));
+        assertNull(mdmsServiceClient.getWhatsappSenderNumber("ke.bomet"));
+
+        verify(restTemplate, times(1)).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class));
+    }
+
+    @Test
+    void secondLookupAfterNon2xxResponse_isServedFromCache_doesNotCallMdmsAgain() {
+        when(restTemplate.exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+
+        assertNull(mdmsServiceClient.getWhatsappSenderNumber("ke.bomet"));
+        assertNull(mdmsServiceClient.getWhatsappSenderNumber("ke.bomet"));
+
+        verify(restTemplate, times(1)).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class));
+    }
+
+    @Test
+    void secondLookupAfterRestTemplateThrows_isServedFromCache_doesNotCallMdmsAgain() {
+        when(restTemplate.exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class)))
+                .thenThrow(new RuntimeException("MDMS unreachable"));
+
+        assertNull(mdmsServiceClient.getWhatsappSenderNumber("ke.bomet"));
+        assertNull(mdmsServiceClient.getWhatsappSenderNumber("ke.bomet"));
 
         verify(restTemplate, times(1)).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class));
     }

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/service/MdmsServiceClientWhatsappSenderTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/service/MdmsServiceClientWhatsappSenderTest.java
@@ -1,0 +1,131 @@
+package org.egov.novubridge.service;
+
+import org.egov.novubridge.config.NovuBridgeConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * getWhatsappSenderNumber() reads the per-tenant Twilio WhatsApp sender number
+ * from the {@code ProviderDetail} MDMS schema, used by DispatchPipelineService
+ * to build the Novu {@code overrides.providers.twilio.from} override.
+ */
+class MdmsServiceClientWhatsappSenderTest {
+
+    private RestTemplate restTemplate;
+    private NovuBridgeConfiguration config;
+    private MdmsServiceClient mdmsServiceClient;
+
+    @BeforeEach
+    void setUp() {
+        restTemplate = mock(RestTemplate.class);
+        config = new NovuBridgeConfiguration();
+        config.setMdmsHost("http://localhost:8082");
+        config.setMdmsSearchPath("/egov-mdms-service/v2/_search");
+        mdmsServiceClient = new MdmsServiceClient(restTemplate, config);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void stubMdmsResponse(List<Map<String, Object>> mdmsRecords) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("mdms", mdmsRecords);
+        when(restTemplate.exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(new ResponseEntity<>(body, HttpStatus.OK));
+    }
+
+    private Map<String, Object> providerRecord(String channel, boolean isActive, String senderNumber) {
+        Map<String, Object> data = new HashMap<>();
+        data.put("tenantId", "ke.bomet");
+        data.put("providerName", "twilio");
+        data.put("channel", channel);
+        data.put("isActive", isActive);
+        data.put("senderNumber", senderNumber);
+        Map<String, Object> record = new HashMap<>();
+        record.put("data", data);
+        return record;
+    }
+
+    @Test
+    void activeWhatsappRecord_returnsSenderNumber() {
+        stubMdmsResponse(List.of(providerRecord("whatsapp", true, "+14155550123")));
+
+        String senderNumber = mdmsServiceClient.getWhatsappSenderNumber("ke.bomet");
+
+        assertEquals("+14155550123", senderNumber);
+    }
+
+    @Test
+    void inactiveWhatsappRecord_isIgnored_returnsNull() {
+        stubMdmsResponse(List.of(providerRecord("whatsapp", false, "+14155550123")));
+
+        assertNull(mdmsServiceClient.getWhatsappSenderNumber("ke.bomet"));
+    }
+
+    @Test
+    void nonWhatsappChannelRecord_isIgnored_returnsNull() {
+        stubMdmsResponse(List.of(providerRecord("sms", true, "+14155550999")));
+
+        assertNull(mdmsServiceClient.getWhatsappSenderNumber("ke.bomet"));
+    }
+
+    @Test
+    void mixedRecords_picksTheActiveWhatsappOne() {
+        stubMdmsResponse(List.of(
+                providerRecord("sms", true, "+14155550999"),
+                providerRecord("whatsapp", false, "+14155550001"),
+                providerRecord("whatsapp", true, "+14155550123")));
+
+        assertEquals("+14155550123", mdmsServiceClient.getWhatsappSenderNumber("ke.bomet"));
+    }
+
+    @Test
+    void noRecords_returnsNull() {
+        stubMdmsResponse(List.of());
+
+        assertNull(mdmsServiceClient.getWhatsappSenderNumber("ke.bomet"));
+    }
+
+    @Test
+    void non2xxResponse_returnsNull_doesNotThrow() {
+        when(restTemplate.exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+
+        assertNull(mdmsServiceClient.getWhatsappSenderNumber("ke.bomet"));
+    }
+
+    @Test
+    void restTemplateThrows_returnsNull_doesNotThrow() {
+        when(restTemplate.exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class)))
+                .thenThrow(new RuntimeException("MDMS unreachable"));
+
+        assertNull(mdmsServiceClient.getWhatsappSenderNumber("ke.bomet"));
+    }
+
+    @Test
+    void secondLookupForSameTenant_isServedFromCache_doesNotCallMdmsAgain() {
+        stubMdmsResponse(List.of(providerRecord("whatsapp", true, "+14155550123")));
+
+        assertEquals("+14155550123", mdmsServiceClient.getWhatsappSenderNumber("ke.bomet"));
+        assertEquals("+14155550123", mdmsServiceClient.getWhatsappSenderNumber("ke.bomet"));
+
+        verify(restTemplate, times(1)).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class));
+    }
+}

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/service/MdmsServiceClientWhatsappSenderTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/service/MdmsServiceClientWhatsappSenderTest.java
@@ -177,13 +177,28 @@ class MdmsServiceClientWhatsappSenderTest {
     }
 
     @Test
-    void secondLookupAfterRestTemplateThrows_isServedFromCache_doesNotCallMdmsAgain() {
+    void secondLookupAfterRestTemplateThrows_isNotCached_retriesMdms() {
+        // Unlike a clean "not configured" outcome, a thrown exception (timeout, connection
+        // reset, transient 5xx) must NOT be cached: senderCache has no TTL, so caching it would
+        // permanently disable this tenant's sender override until process restart even after
+        // MDMS recovers. Each lookup after a failure must retry MDMS.
         when(restTemplate.exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class)))
                 .thenThrow(new RuntimeException("MDMS unreachable"));
 
         assertNull(mdmsServiceClient.getWhatsappSenderNumber("ke.bomet"));
         assertNull(mdmsServiceClient.getWhatsappSenderNumber("ke.bomet"));
 
-        verify(restTemplate, times(1)).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class));
+        verify(restTemplate, times(2)).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class));
+    }
+
+    @Test
+    void lookupRecoversAfterTransientException_onNextCall() {
+        when(restTemplate.exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(Map.class)))
+                .thenThrow(new RuntimeException("MDMS unreachable"))
+                .thenReturn(new ResponseEntity<>(
+                        Map.of("mdms", List.of(providerRecord("whatsapp", true, "+14155550123"))), HttpStatus.OK));
+
+        assertNull(mdmsServiceClient.getWhatsappSenderNumber("ke.bomet"));
+        assertEquals("+14155550123", mdmsServiceClient.getWhatsappSenderNumber("ke.bomet"));
     }
 }

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/service/NovuClientTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/service/NovuClientTest.java
@@ -1,6 +1,7 @@
 package org.egov.novubridge.service;
 
 import org.egov.novubridge.config.NovuBridgeConfiguration;
+import org.egov.novubridge.web.models.Contact;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -14,10 +15,12 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -25,11 +28,16 @@ import static org.mockito.Mockito.when;
  * Coverage of the two new {@link NovuClient} methods used by provider management:
  * {@code createIntegration} (bootstrap-shaped {@code POST /v1/integrations} payload,
  * ApiKey applied server-side) and {@code listWorkflows} ({@code GET /v2/workflows}).
+ *
+ * <p>Also covers the WHATSAPP branch of {@code identifyThenTrigger}: this is where the
+ * per-tenant Twilio "from" sender override (resolved from MDMS ProviderDetail) and the
+ * "whatsapp:" recipient-phone prefixing now live, moved out of DispatchPipelineService.
  */
 class NovuClientTest {
 
     private RestTemplate restTemplate;
     private NovuBridgeConfiguration config;
+    private MdmsServiceClient mdmsServiceClient;
     private NovuClient novuClient;
 
     @BeforeEach
@@ -38,7 +46,105 @@ class NovuClientTest {
         config = new NovuBridgeConfiguration();
         config.setNovuBaseUrl("http://novu:3000");
         config.setNovuApiKey("secret-key");
-        novuClient = new NovuClient(restTemplate, config);
+        config.setNovuWorkflowWhatsapp("complaints-whatsapp");
+        mdmsServiceClient = mock(MdmsServiceClient.class);
+        novuClient = new NovuClient(restTemplate, config, mdmsServiceClient);
+    }
+
+    private Contact whatsappContact() {
+        return Contact.builder()
+                .userId("uuid-123").type("CITIZEN").name("Jane Doe")
+                .phone("+254712345678").email("jane@example.com").locale("en_IN")
+                .build();
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Test
+    void identifyThenTrigger_whatsapp_noSenderConfigured_triggersWithoutOverrides() {
+        when(restTemplate.exchange(anyString(), eq(HttpMethod.POST), any(), eq(Map.class)))
+                .thenReturn((ResponseEntity) ResponseEntity.ok(Map.of("acknowledged", true)));
+        // No ProviderDetail configured for this tenant: getWhatsappSenderNumber() returns null.
+        when(mdmsServiceClient.getWhatsappSenderNumber("ke.bomet")).thenReturn(null);
+
+        NovuClient.NovuResponse res = novuClient.identifyThenTrigger("ke.bomet:uuid-123", whatsappContact(),
+                "WHATSAPP", "Dear Jane, your complaint PGR-001 is assigned.", null,
+                "PGR-001:ASSIGN:PENDINGATLME:ke.bomet:uuid-123:WHATSAPP", Map.of(), "ke.bomet");
+
+        assertEquals(200, res.getStatusCode());
+
+        // identify() (subscribers) then trigger() (events/trigger) — in that order.
+        ArgumentCaptor<HttpEntity> entities = ArgumentCaptor.forClass(HttpEntity.class);
+        verify(restTemplate, times(2)).exchange(anyString(), eq(HttpMethod.POST), entities.capture(), eq(Map.class));
+        Map<String, Object> triggerBody = (Map<String, Object>) entities.getAllValues().get(1).getBody();
+
+        assertEquals("complaints-whatsapp", triggerBody.get("name"));
+        Map<String, Object> to = (Map<String, Object>) triggerBody.get("to");
+        // The recipient's "to" phone is E.164-already, so it is only prefixed with "whatsapp:".
+        assertEquals("whatsapp:+254712345678", to.get("phone"));
+        assertFalse(triggerBody.containsKey("overrides"));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Test
+    void identifyThenTrigger_whatsapp_senderConfigured_triggersWithFromOverride() {
+        when(restTemplate.exchange(anyString(), eq(HttpMethod.POST), any(), eq(Map.class)))
+                .thenReturn((ResponseEntity) ResponseEntity.ok(Map.of("acknowledged", true)));
+        // ProviderDetail in MDMS carries a raw (unprefixed) Twilio WhatsApp sender number.
+        when(mdmsServiceClient.getWhatsappSenderNumber("ke.bomet")).thenReturn("+14155550123");
+
+        NovuClient.NovuResponse res = novuClient.identifyThenTrigger("ke.bomet:uuid-123", whatsappContact(),
+                "WHATSAPP", "Dear Jane, your complaint PGR-001 is assigned.", null,
+                "PGR-001:ASSIGN:PENDINGATLME:ke.bomet:uuid-123:WHATSAPP", Map.of(), "ke.bomet");
+
+        assertEquals(200, res.getStatusCode());
+
+        ArgumentCaptor<HttpEntity> entities = ArgumentCaptor.forClass(HttpEntity.class);
+        verify(restTemplate, times(2)).exchange(anyString(), eq(HttpMethod.POST), entities.capture(), eq(Map.class));
+        Map<String, Object> triggerBody = (Map<String, Object>) entities.getAllValues().get(1).getBody();
+
+        Map<String, Object> overrides = (Map<String, Object>) triggerBody.get("overrides");
+        Map<String, Object> providers = (Map<String, Object>) overrides.get("providers");
+        Map<String, Object> twilio = (Map<String, Object>) providers.get("twilio");
+        // The bare MDMS number is prefixed with "whatsapp:" before being sent as the override.
+        assertEquals("whatsapp:+14155550123", twilio.get("from"));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Test
+    void identifyThenTrigger_whatsapp_senderAlreadyPrefixed_isNotDoublePrefixed() {
+        when(restTemplate.exchange(anyString(), eq(HttpMethod.POST), any(), eq(Map.class)))
+                .thenReturn((ResponseEntity) ResponseEntity.ok(Map.of("acknowledged", true)));
+        when(mdmsServiceClient.getWhatsappSenderNumber("ke.bomet")).thenReturn("whatsapp:+14155550123");
+
+        novuClient.identifyThenTrigger("ke.bomet:uuid-123", whatsappContact(), "WHATSAPP",
+                "Dear Jane, your complaint PGR-001 is assigned.", null,
+                "PGR-001:ASSIGN:PENDINGATLME:ke.bomet:uuid-123:WHATSAPP", Map.of(), "ke.bomet");
+
+        ArgumentCaptor<HttpEntity> entities = ArgumentCaptor.forClass(HttpEntity.class);
+        verify(restTemplate, times(2)).exchange(anyString(), eq(HttpMethod.POST), entities.capture(), eq(Map.class));
+        Map<String, Object> triggerBody = (Map<String, Object>) entities.getAllValues().get(1).getBody();
+
+        Map<String, Object> overrides = (Map<String, Object>) triggerBody.get("overrides");
+        Map<String, Object> providers = (Map<String, Object>) overrides.get("providers");
+        Map<String, Object> twilio = (Map<String, Object>) providers.get("twilio");
+        assertEquals("whatsapp:+14155550123", twilio.get("from"));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Test
+    void identifyThenTrigger_whatsapp_blankTenantId_skipsMdmsLookup_triggersWithoutOverrides() {
+        when(restTemplate.exchange(anyString(), eq(HttpMethod.POST), any(), eq(Map.class)))
+                .thenReturn((ResponseEntity) ResponseEntity.ok(Map.of("acknowledged", true)));
+
+        novuClient.identifyThenTrigger("ke.bomet:uuid-123", whatsappContact(), "WHATSAPP",
+                "Dear Jane, your complaint PGR-001 is assigned.", null,
+                "PGR-001:ASSIGN:PENDINGATLME:ke.bomet:uuid-123:WHATSAPP", Map.of(), null);
+
+        verify(mdmsServiceClient, times(0)).getWhatsappSenderNumber(any());
+        ArgumentCaptor<HttpEntity> entities = ArgumentCaptor.forClass(HttpEntity.class);
+        verify(restTemplate, times(2)).exchange(anyString(), eq(HttpMethod.POST), entities.capture(), eq(Map.class));
+        Map<String, Object> triggerBody = (Map<String, Object>) entities.getAllValues().get(1).getBody();
+        assertFalse(triggerBody.containsKey("overrides"));
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/local-setup/db/notif-mdms-seed/schemas/ProviderDetail.json
+++ b/local-setup/db/notif-mdms-seed/schemas/ProviderDetail.json
@@ -35,6 +35,10 @@
       "type": "integer",
       "description": "Provider priority (lower = higher priority)",
       "default": 0
+    },
+    "senderNumber": {
+      "type": "string",
+      "description": "Provider-specific sender/from identity (e.g. the Twilio WhatsApp sender number)"
     }
   },
   "required": ["tenantId", "providerName", "channel"],

--- a/utilities/default-data-handler/src/main/resources/schema/ProviderDetail.json
+++ b/utilities/default-data-handler/src/main/resources/schema/ProviderDetail.json
@@ -43,6 +43,10 @@
         "providerName": {
           "type": "string",
           "description": "Provider name (e.g., twilio, sendgrid, etc.)"
+        },
+        "senderNumber": {
+          "type": "string",
+          "description": "Provider-specific sender/from identity (e.g. the Twilio WhatsApp sender number)"
         }
       },
       "x-security": [


### PR DESCRIPTION
## Summary
- Adds `MdmsServiceClient.getWhatsappSenderNumber(tenantId)` to resolve the active Twilio WhatsApp `senderNumber` for a tenant from the `ProviderDetail` MDMS schema, cached per tenant.
- `NovuClient.identifyThenTrigger` now owns the WHATSAPP-specific wiring directly: it prefixes the recipient's `to` phone with `whatsapp:`, and when a sender number is configured for the tenant it attaches it as a Novu `overrides.providers.twilio.from` override; falls back to the Novu integration's own `credentials.from` when no `ProviderDetail` is configured. This replaced an earlier version of the change that special-cased WHATSAPP inside `DispatchPipelineService` (calling `identify()`/`trigger()` directly) — that responsibility has since moved into `NovuClient` so every channel now dispatches through the same `identifyThenTrigger` call, parameterized by the event's `tenantId`.

## Test plan
- [x] Updated `NovuClientTest` to cover the WHATSAPP branch of `identifyThenTrigger` directly (where the sender-override wiring now lives): no sender configured (no override, falls back), sender configured (override built with `whatsapp:` prefix), sender already prefixed (not double-prefixed), and blank tenantId (skips the MDMS lookup entirely).
- [x] Updated `DispatchPipelineWhatsappNoProviderTest`, `DispatchPipelinePassThroughTest`, `DispatchPipelineIdempotencyTest`, `DispatchPipelineFailureRowTest`, and `EnvelopePipelineNegativesTest` for the `identifyThenTrigger` signature change (added `tenantId`); the WHATSAPP gate-enabled test in `DispatchPipelineWhatsappNoProviderTest` now just asserts the pipeline routes WHATSAPP through `identifyThenTrigger` with the event's tenantId, since the override-wiring detail moved to `NovuClientTest`.
- [x] Added `MdmsServiceClientWhatsappSenderTest` covering the MDMS lookup: active/inactive filtering, non-whatsapp channel filtering, empty results, non-2xx response, client exception, and per-tenant caching (single HTTP call across repeat lookups).
- [x] `mvn test` on `novu-bridge`: 100 tests, 0 failures, 0 errors.

## Notes for reviewers
Two follow-up items were identified during review but intentionally left out of this PR's scope (flagged, not fixed):
- The recipient's `to` phone is now only prefixed with `whatsapp:` (no MDMS-based E.164 normalization) — it assumes the contact phone PGR sends is already E.164. If that assumption doesn't hold for some tenant, a malformed number reaches Twilio.
- The Twilio override-building logic here duplicates `TwilioProviderStrategy.buildProviderConfig`; could be unified in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tenant-aware WhatsApp sender overrides via MDMS (provider-specific sender number).
  * Routed WhatsApp dispatch through an identify-then-trigger flow that includes tenant context.
* **Bug Fixes**
  * Enforced correct `whatsapp:` prefix handling for recipients and sender numbers (prevents double-prefixing).
  * If no valid MDMS sender is available or MDMS fails, dispatch continues without overrides.
  * Added per-tenant caching for sender lookups to reduce repeated MDMS calls.
* **Tests**
  * Updated and expanded unit tests to verify tenant-aware WhatsApp behavior and MDMS override/caching scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->