### PR TITLE
feat(analytics): query duration/row metrics + trace-correlated slow-query log (#1110 PR2)

### DIFF
--- a/backend/pgr-services/pom.xml
+++ b/backend/pgr-services/pom.xml
@@ -127,6 +127,14 @@
             <artifactId>opentelemetry-api</artifactId>
             <version>1.45.0</version>
         </dependency>
+        <!-- SDK + in-memory reader, tests only: lets AnalyticsMetricsTest assert the
+             exact instrument names/units the collector's prometheus exporter surfaces. -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+            <version>1.45.0</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/backend/pgr-services/pom.xml
+++ b/backend/pgr-services/pom.xml
@@ -117,6 +117,16 @@
             <version>2.9.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
+        <!-- #1110: analytics query metrics. API-only — the OTEL javaagent (v2.11.0, see
+             otel/download-agent.sh) bridges GlobalOpenTelemetry to its SDK at runtime;
+             without the agent every call is a no-op (tests/CI safe). Version pinned to
+             the SDK bundled by javaagent 2.11.0. Boot 3.2.2 manages an older otel BOM,
+             so the explicit version here is required. -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <version>1.45.0</version>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsController.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsController.java
@@ -113,8 +113,14 @@ public class AnalyticsController {
             // (tenant corpus on complaint_facts, NOT the caller's ABAC-visible subset).
             out.put("packId", pack.map(DashboardPack::getId).orElse(null));
             out.put("persona", pack.map(p -> matchingRole(p, callerRoles)).orElse(null));
+            // recordCount is live tenant data, so it takes the same coarse pack-match
+            // gate as packId/persona: no matching pack (e.g. the anonymous PUBLIC floor
+            // on a tenant with no public pack) -> null. Without this gate an
+            // unauthenticated caller could POST arbitrary tenantIds and enumerate every
+            // tenant's complaint volume. The corpus-not-ABAC-subset semantics (R9-C9)
+            // are unchanged for callers that do match a pack.
             int stateLen = config.getStateLevelTenantIdLength() == null ? 1 : config.getStateLevelTenantIdLength();
-            out.put("recordCount", service.recordCount(tenantId, stateLen));
+            out.put("recordCount", pack.isPresent() ? service.recordCount(tenantId, stateLen) : null);
             return ResponseEntity.ok(out);
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(error(e));

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsController.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsController.java
@@ -47,13 +47,16 @@ public class AnalyticsController {
     }
 
     @PostMapping("/_query")
-    public ResponseEntity<Map<String,Object>> query(@RequestBody JsonNode body){
+    public ResponseEntity<Map<String,Object>> query(@RequestBody JsonNode body,
+            // #1110: correlation FALLBACK only — when the OTEL javaagent is attached, the
+            // active span's trace id (W3C traceparent, propagated by Kong) takes precedence.
+            @RequestHeader(value = "x-trace-id", required = false) String xTraceId){
         try {
             RequestInfo requestInfo = body.has("RequestInfo")
                     ? mapper.convertValue(body.get("RequestInfo"), RequestInfo.class) : null;
             String tenantId = body.hasNonNull("tenantId") ? body.get("tenantId").asText() : null;
             int stateLen = config.getStateLevelTenantIdLength() == null ? 1 : config.getStateLevelTenantIdLength();
-            Map<String,Object> result = service.query(body, requestInfo, tenantId, stateLen);
+            Map<String,Object> result = service.query(body, requestInfo, tenantId, stateLen, xTraceId);
             return ResponseEntity.ok(result);
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(error(e));
@@ -103,6 +106,15 @@ public class AnalyticsController {
             out.put("tiles", tiles);
             out.put("defaultLayout", pack.map(DashboardPack::getLayout).orElse(Collections.emptyList()));
             out.put("asOf", System.currentTimeMillis());
+            // #1110: additive fields the dashboard reads defensively (null until data exists).
+            // packId -> layout_id tag; persona -> the server's ACTUAL pack-match decision
+            // (first pack-role the caller holds, in the pack's declared role order — same
+            // semantics as DashboardPack.matchesRoles); recordCount -> record_count_tier tag
+            // (tenant corpus on complaint_facts, NOT the caller's ABAC-visible subset).
+            out.put("packId", pack.map(DashboardPack::getId).orElse(null));
+            out.put("persona", pack.map(p -> matchingRole(p, callerRoles)).orElse(null));
+            int stateLen = config.getStateLevelTenantIdLength() == null ? 1 : config.getStateLevelTenantIdLength();
+            out.put("recordCount", service.recordCount(tenantId, stateLen));
             return ResponseEntity.ok(out);
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(error(e));
@@ -144,6 +156,17 @@ public class AnalyticsController {
     }
 
     // ---- helpers ----
+
+    /**
+     * The role that made the pack match (#1110/R9-C7): first role in the PACK's declared
+     * roles list that the caller holds. Deterministic (pack order, not set order) and
+     * consistent with {@link DashboardPack#matchesRoles} — a non-null result is exactly
+     * "this pack matched". Returned as the {@code persona} tag source for the FE.
+     */
+    private String matchingRole(DashboardPack pack, Set<String> callerRoles) {
+        if (pack.getRoles() == null || callerRoles == null) return null;
+        return pack.getRoles().stream().filter(callerRoles::contains).findFirst().orElse(null);
+    }
 
     /** Serializes a KpiDefinition for external consumption: includes viz/params but NEVER query or rbac. */
     private Map<String,Object> safeTile(KpiDefinition def) {

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsMetrics.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsMetrics.java
@@ -75,7 +75,7 @@ public class AnalyticsMetrics {
             queryDuration.record(tookMs, attrs);
             queryRows.add(rowCount, attrs);
         } catch (RuntimeException e) {
-            log.debug("analytics metrics record failed (ignored): {}", e.toString());
+            log.debug("analytics metrics record failed (ignored)", e);
         }
     }
 

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsMetrics.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsMetrics.java
@@ -46,14 +46,22 @@ public class AnalyticsMetrics {
     private final LongCounter queryRows;
 
     public AnalyticsMetrics() {
-        Meter meter = GlobalOpenTelemetry.getMeter(METER_NAME);
+        this(GlobalOpenTelemetry.getMeter(METER_NAME));
+    }
+
+    /** Visible for tests: lets a test pass an SDK meter to assert instrument shape. */
+    AnalyticsMetrics(Meter meter) {
+        // NOTE: no unit on purpose. The metric NAMES already carry their unit (.ms),
+        // and the collector's prometheus exporter appends a unit-derived suffix when
+        // unit is set — validated live on bomet: unit "ms" surfaced as
+        // pgr_analytics_query_duration_ms_milliseconds_*. Omitting the unit keeps the
+        // scraped names exactly pgr_analytics_query_duration_ms_* /
+        // pgr_analytics_query_rows_total (same fix as the client's dashboardMetrics.js, #1268).
         this.queryDuration = meter.histogramBuilder("pgr.analytics.query.duration.ms")
                 .setDescription("Duration of one executed analytics SQL query (per batch entry / compose source)")
-                .setUnit("ms")
                 .build();
         this.queryRows = meter.counterBuilder("pgr.analytics.query.rows")
                 .setDescription("Rows returned by executed analytics SQL queries")
-                .setUnit("{row}")
                 .build();
     }
 

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsMetrics.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsMetrics.java
@@ -29,8 +29,10 @@ import org.springframework.stereotype.Component;
  *   <li>{@code pgr.analytics.query.rows} — counter of rows returned.</li>
  * </ul>
  * Attributes: {@code kpi_id} (the KPI id, {@code inline} for inline-grammar queries),
- * {@code grain}, {@code tenant}. Cardinality is bounded: kpi_id by the MDMS catalog
- * (tens), grain by the 3 grains, tenant by the tenant tree.
+ * {@code grain}, {@code tenant} (the STATE-ROOT tenant, never the raw request
+ * tenantId — see {@link QueryTelemetry#stateRootOf}). Cardinality is bounded: kpi_id
+ * by the MDMS catalog (tens), grain by the 3 grains, tenant by the deployment's
+ * state roots.
  */
 @Component
 @Slf4j
@@ -72,7 +74,9 @@ public class AnalyticsMetrics {
      * @param kpiId  the KPI id the query was resolved from, or {@code "inline"} for
      *               inline-grammar queries
      * @param grain  the grain the planner resolved ({@code facts|events|daily})
-     * @param tenant the request tenantId (scope tenant, not per-row)
+     * @param tenant the STATE-ROOT tenant (callers must pre-normalize via
+     *               {@link QueryTelemetry#stateRootOf} — the raw request tenantId is
+     *               attacker-controlled and would blow up label cardinality)
      */
     public void recordQuery(String kpiId, String grain, String tenant, long tookMs, long rowCount) {
         try {

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsMetrics.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsMetrics.java
@@ -1,0 +1,85 @@
+package org.egov.pgr.analytics;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.Meter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * OTEL metrics for the dynamic analytics endpoints (#1110 — dashboard render-lag
+ * instrumentation, server half).
+ *
+ * <p>Thin wrapper over {@link GlobalOpenTelemetry}: when the service runs under the
+ * OpenTelemetry javaagent (the deploy.sh stack attaches it and sets
+ * {@code OTEL_METRICS_EXPORTER=otlp}), the agent bridges this to its SDK and the
+ * instruments export to the collector → Prometheus. Without the agent (unit tests, CI,
+ * bare {@code java -jar}) {@code GlobalOpenTelemetry} is a no-op and every call here is
+ * free and side-effect-less — no config or conditional wiring needed.
+ *
+ * <p>Instruments (OTLP names; Prometheus surfaces them as
+ * {@code pgr_analytics_query_duration_ms_bucket/_sum/_count} and
+ * {@code pgr_analytics_query_rows_total}):
+ * <ul>
+ *   <li>{@code pgr.analytics.query.duration.ms} — histogram, one point per executed SQL
+ *       query (each batch entry, and each SOURCE query of a backend-composed KPI).</li>
+ *   <li>{@code pgr.analytics.query.rows} — counter of rows returned.</li>
+ * </ul>
+ * Attributes: {@code kpi_id} (the KPI id, {@code inline} for inline-grammar queries),
+ * {@code grain}, {@code tenant}. Cardinality is bounded: kpi_id by the MDMS catalog
+ * (tens), grain by the 3 grains, tenant by the tenant tree.
+ */
+@Component
+@Slf4j
+public class AnalyticsMetrics {
+
+    static final String METER_NAME = "pgr-analytics";
+
+    static final AttributeKey<String> ATTR_KPI_ID = AttributeKey.stringKey("kpi_id");
+    static final AttributeKey<String> ATTR_GRAIN  = AttributeKey.stringKey("grain");
+    static final AttributeKey<String> ATTR_TENANT = AttributeKey.stringKey("tenant");
+
+    private final DoubleHistogram queryDuration;
+    private final LongCounter queryRows;
+
+    public AnalyticsMetrics() {
+        Meter meter = GlobalOpenTelemetry.getMeter(METER_NAME);
+        this.queryDuration = meter.histogramBuilder("pgr.analytics.query.duration.ms")
+                .setDescription("Duration of one executed analytics SQL query (per batch entry / compose source)")
+                .setUnit("ms")
+                .build();
+        this.queryRows = meter.counterBuilder("pgr.analytics.query.rows")
+                .setDescription("Rows returned by executed analytics SQL queries")
+                .setUnit("{row}")
+                .build();
+    }
+
+    /**
+     * Record one executed analytics query. Never throws — telemetry must not be able to
+     * break the query path.
+     *
+     * @param kpiId  the KPI id the query was resolved from, or {@code "inline"} for
+     *               inline-grammar queries
+     * @param grain  the grain the planner resolved ({@code facts|events|daily})
+     * @param tenant the request tenantId (scope tenant, not per-row)
+     */
+    public void recordQuery(String kpiId, String grain, String tenant, long tookMs, long rowCount) {
+        try {
+            Attributes attrs = Attributes.of(
+                    ATTR_KPI_ID, orDash(kpiId),
+                    ATTR_GRAIN, orDash(grain),
+                    ATTR_TENANT, orDash(tenant));
+            queryDuration.record(tookMs, attrs);
+            queryRows.add(rowCount, attrs);
+        } catch (RuntimeException e) {
+            log.debug("analytics metrics record failed (ignored): {}", e.toString());
+        }
+    }
+
+    private static String orDash(String v) {
+        return (v == null || v.isEmpty()) ? "-" : v;
+    }
+}

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
@@ -95,7 +95,7 @@ public class AnalyticsService {
      */
     public Map<String,Object> query(JsonNode body, RequestInfo requestInfo, String tenantId,
                                     int stateLevelLen, String headerTraceId){
-        QueryTelemetry tel = new QueryTelemetry(metrics, tenantId);
+        QueryTelemetry tel = new QueryTelemetry(metrics, tenantId, stateLevelLen);
         try {
             return doQuery(body, requestInfo, tenantId, stateLevelLen, tel);
         } finally {

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
@@ -68,17 +68,44 @@ public class AnalyticsService {
     private final KpiCatalogService kpiCatalogService;
     private final PrincipalScopeResolver scopeResolver;
     private final KpiQueryComposer queryComposer;
+    private final AnalyticsMetrics metrics;
 
     @Autowired
     public AnalyticsService(AnalyticsPlanner planner, AnalyticsCatalog catalog, JdbcTemplate jdbc,
                             KpiCatalogService kpiCatalogService, PrincipalScopeResolver scopeResolver,
-                            KpiQueryComposer queryComposer){
+                            KpiQueryComposer queryComposer, AnalyticsMetrics metrics){
         this.planner = planner; this.catalog = catalog; this.jdbc = jdbc;
         this.kpiCatalogService = kpiCatalogService; this.scopeResolver = scopeResolver;
-        this.queryComposer = queryComposer;
+        this.queryComposer = queryComposer; this.metrics = metrics;
     }
 
+    /** Back-compat entry point (no trace correlation header). */
     public Map<String,Object> query(JsonNode body, RequestInfo requestInfo, String tenantId, int stateLevelLen){
+        return query(body, requestInfo, tenantId, stateLevelLen, null);
+    }
+
+    /**
+     * #1110: instrumented entry point. Every executed SQL query (batch entry, single query,
+     * compose SOURCE query) records an OTEL duration/rows point via {@link QueryTelemetry};
+     * one {@code analytics.slow_queries} line (top-{@value QueryTelemetry#TOP_N} by tookMs)
+     * is logged per request — also on partial failure, covering whatever did execute.
+     *
+     * @param headerTraceId the literal {@code x-trace-id} header — correlation FALLBACK only;
+     *                      the active span's trace id (javaagent + Kong w3c propagation) wins.
+     */
+    public Map<String,Object> query(JsonNode body, RequestInfo requestInfo, String tenantId,
+                                    int stateLevelLen, String headerTraceId){
+        QueryTelemetry tel = new QueryTelemetry(metrics, tenantId);
+        try {
+            return doQuery(body, requestInfo, tenantId, stateLevelLen, tel);
+        } finally {
+            if (!tel.isEmpty())
+                log.info(tel.slowQueryLine(QueryTelemetry.resolveTraceId(headerTraceId)));
+        }
+    }
+
+    private Map<String,Object> doQuery(JsonNode body, RequestInfo requestInfo, String tenantId,
+                                       int stateLevelLen, QueryTelemetry tel){
         if (tenantId == null || tenantId.isEmpty()) throw new IllegalArgumentException("invalid_param: tenantId is required");
         AnalyticsScope scope = scopeResolver.resolve(requestInfo, tenantId, stateLevelLen);
         Set<String> callerRoles = extractRoles(requestInfo);
@@ -107,7 +134,7 @@ public class AnalyticsService {
                         continue;
                     }
                     // D1a: backend-composed defs (query:null + viz.compose) resolve recursively here.
-                    Map<String,Object> composed = maybeComposeResult(queryNode, scope, tenantId, callerRoles);
+                    Map<String,Object> composed = maybeComposeResult(queryNode, scope, tenantId, callerRoles, tel, name);
                     if (composed != null) { results.put(name, composed); continue; }
 
                     JsonNode actualQueryNode = resolveKpiRef(queryNode, tenantId, callerRoles);
@@ -126,7 +153,7 @@ public class AnalyticsService {
                                 "message", "inline query projects officer-PII dimension(s); role not authorized"));
                         continue;
                     }
-                    results.put(name, runOne(actualQueryNode, scope));
+                    results.put(name, runOne(actualQueryNode, scope, tel, name, kpiContext(queryNode)));
                 } catch (Exception ex) {
                     partial = true;
                     results.put(name, err(ex));
@@ -138,14 +165,14 @@ public class AnalyticsService {
             JsonNode queryNode = body.get("query");
             if (publicFloor && !queryNode.has("kpiId"))
                 throw new IllegalArgumentException("kpi_forbidden: public access is limited to published PUBLIC KPIs");
-            Map<String,Object> composed = maybeComposeResult(queryNode, scope, tenantId, callerRoles);
+            Map<String,Object> composed = maybeComposeResult(queryNode, scope, tenantId, callerRoles, tel, "query");
             if (composed != null) { out.putAll(composed); return out; }
             JsonNode actualQueryNode = resolveKpiRef(queryNode, tenantId, callerRoles);
             if (actualQueryNode == null)
                 throw new IllegalArgumentException("kpi_forbidden: KPI not found or not authorized");
             if (!queryNode.has("kpiId") && projectsForbiddenPii(actualQueryNode, callerRoles))
                 throw new IllegalArgumentException("pii_forbidden: inline query projects officer-PII dimension(s); role not authorized");
-            out.putAll(runOne(actualQueryNode, scope));
+            out.putAll(runOne(actualQueryNode, scope, tel, "query", kpiContext(queryNode)));
         } else {
             throw new IllegalArgumentException("invalid_param: body must contain 'query' or 'queries'");
         }
@@ -253,7 +280,8 @@ public class AnalyticsService {
      * {@code hourlyAvgFromDaily}, {@code openRateComplement}, {@code netBacklogDaily}.
      */
     private Map<String,Object> maybeComposeResult(JsonNode queryNode, AnalyticsScope scope,
-                                                  String tenantId, Set<String> callerRoles) {
+                                                  String tenantId, Set<String> callerRoles,
+                                                  QueryTelemetry tel, String entryName) {
         if (queryNode == null || !queryNode.has("kpiId")) return null;
         String kpiId = queryNode.get("kpiId").asText();
         Optional<KpiDefinition> defOpt = kpiCatalogService.getDef(kpiId, tenantId);
@@ -274,13 +302,15 @@ public class AnalyticsService {
         String type = compose.get("type").asText();
 
         // Resolve + run each source kpiId with the same params, RBAC and row-scope.
+        // #1110/R9: each SOURCE query records its own metric point and joins the per-request
+        // slow-query pool (attributed to its own kpiId, under the composed entry's name).
         List<Map<String,Object>> sourceRows = new ArrayList<>();
         for (JsonNode srcId : compose.get("sourceKpiIds")) {
             JsonNode srcRef = synthRef(srcId.asText(), params);
             JsonNode srcQuery = resolveKpiRef(srcRef, tenantId, callerRoles);
             if (srcQuery == null)
                 throw new IllegalArgumentException("kpi_forbidden: compose source '" + srcId.asText() + "' not authorized");
-            Map<String,Object> r = runOne(srcQuery, scope);
+            Map<String,Object> r = runOne(srcQuery, scope, tel, entryName, srcId.asText());
             sourceRows.add(firstRow(r));
         }
 
@@ -412,17 +442,35 @@ public class AnalyticsService {
         return callerRoles == null || callerRoles.stream().noneMatch(OFFICER_PII_ROLES::contains);
     }
 
-    private Map<String,Object> runOne(JsonNode q, AnalyticsScope scope){
+    /**
+     * Execute one planned query. THE choke point for every analytics SQL execution
+     * (batch entries, the single-query arm, compose SOURCE queries) — each successful run
+     * records one OTEL metric point + one slow-query-pool entry (#1110).
+     *
+     * @param entryName the batch dict key this run belongs to ({@code "query"} on the
+     *                  single arm); compose sources share their composed entry's name
+     * @param kpiId     the resolved KPI id, or {@code "inline"} for inline-grammar queries
+     */
+    private Map<String,Object> runOne(JsonNode q, AnalyticsScope scope, QueryTelemetry tel,
+                                      String entryName, String kpiId){
         AnalyticsPlanner.Planned p = planner.plan(q, scope);
         long t0 = System.currentTimeMillis();
         List<Map<String,Object>> rows = jdbc.queryForList(p.sql, p.params.toArray());
+        long tookMs = System.currentTimeMillis() - t0;
+        if (tel != null) tel.record(entryName, kpiId, p.grain, tookMs, rows.size());
         Map<String,Object> r = new LinkedHashMap<>();
         r.put("grain", p.grain);
         r.put("columns", p.columns);
         r.put("rows", rows);
         r.put("rowCount", rows.size());
-        r.put("tookMs", System.currentTimeMillis() - t0);
+        r.put("tookMs", tookMs);
         return r;
+    }
+
+    /** Metric attribution for a request query node: its kpiId, or {@code "inline"}. */
+    private static String kpiContext(JsonNode queryNode) {
+        return queryNode != null && queryNode.hasNonNull("kpiId")
+                ? queryNode.get("kpiId").asText() : "inline";
     }
 
     /** /_schema capabilities — lets the FE build the KPI editor dynamically. */
@@ -462,6 +510,48 @@ public class AnalyticsService {
     private Long asOf(){
         try { return jdbc.queryForObject("SELECT max(facts_built_at) FROM complaint_facts", Long.class); }
         catch (Exception e) { return System.currentTimeMillis(); }
+    }
+
+    // ---- #1110: tenant record-count for /packs (record_count_tier tag source) ----
+
+    private static final long RECORD_COUNT_TTL_MS = 5 * 60_000L;
+    /** tenantId -> [count, expiresAtMs]. Concurrent; a stale entry is simply recomputed. */
+    private final java.util.concurrent.ConcurrentHashMap<String, long[]> recordCountCache =
+            new java.util.concurrent.ConcurrentHashMap<>();
+    /** Injectable clock for cache-expiry tests (see AnalyticsServiceRecordCountTest). */
+    private java.util.function.LongSupplier recordCountClock = System::currentTimeMillis;
+
+    /**
+     * TENANT-CORPUS size of {@code complaint_facts} — how many fact rows exist for the
+     * tenant subtree, using {@link AnalyticsPlanner#applyScope}'s tenant semantics
+     * (state level: {@code tenant_id LIKE 'ke%'}; city level: exact match). This is
+     * deliberately NOT the caller's ABAC-visible subset: the dashboard uses it as the
+     * {@code record_count_tier} tag, which must describe the tenant's data volume so
+     * render-lag comparisons across personas share a denominator (#1110/R9-C9).
+     *
+     * <p>Cached in-memory for 5 minutes per tenant; errors return null (additive,
+     * never fails the /packs response) and are not cached.
+     */
+    public Long recordCount(String tenantId, int stateLevelLen) {
+        if (tenantId == null || tenantId.isEmpty()) return null;
+        long now = recordCountClock.getAsLong();
+        long[] cached = recordCountCache.get(tenantId);
+        if (cached != null && cached[1] > now) return cached[0];
+        // same state-level test as PrincipalScopeResolver.resolve()
+        boolean stateLevel = tenantId.split("\\.").length == stateLevelLen;
+        try {
+            Long count = stateLevel
+                    ? jdbc.queryForObject("SELECT count(*) FROM complaint_facts WHERE tenant_id LIKE ?",
+                                          Long.class, tenantId + "%")
+                    : jdbc.queryForObject("SELECT count(*) FROM complaint_facts WHERE tenant_id = ?",
+                                          Long.class, tenantId);
+            if (count == null) return null;
+            recordCountCache.put(tenantId, new long[]{count, now + RECORD_COUNT_TTL_MS});
+            return count;
+        } catch (Exception e) {
+            log.debug("recordCount for tenant {} failed (returning null): {}", tenantId, e.toString());
+            return null;
+        }
     }
 
     private Map<String,Object> scopeInfo(AnalyticsScope s){

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
@@ -549,7 +549,7 @@ public class AnalyticsService {
             recordCountCache.put(tenantId, new long[]{count, now + RECORD_COUNT_TTL_MS});
             return count;
         } catch (Exception e) {
-            log.debug("recordCount for tenant {} failed (returning null): {}", tenantId, e.toString());
+            log.debug("recordCount for tenant {} failed (returning null)", tenantId, e);
             return null;
         }
     }

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/QueryTelemetry.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/QueryTelemetry.java
@@ -44,17 +44,43 @@ final class QueryTelemetry {
 
     private final AnalyticsMetrics metrics;
     private final String tenantId;
+    private final String metricTenant;
     private final List<Execution> executions = new ArrayList<>();
 
-    QueryTelemetry(AnalyticsMetrics metrics, String tenantId) {
+    QueryTelemetry(AnalyticsMetrics metrics, String tenantId, int stateLevelLen) {
         this.metrics = metrics;
         this.tenantId = tenantId;
+        this.metricTenant = stateRootOf(tenantId, stateLevelLen);
     }
 
-    /** Record one successfully executed query (metric point + slow-query pool entry). */
+    /**
+     * Record one successfully executed query (metric point + slow-query pool entry).
+     * The metric point is tagged with the STATE-ROOT tenant, not the raw request
+     * tenantId: the request string is never validated against real tenants, so tagging
+     * it raw would let an unauthenticated caller mint a new Prometheus series per
+     * request ({@code ke.attack0001}, {@code ke.attack0002}, ...) — a cardinality bomb
+     * on the collector. The full tenantId still appears (sanitized) in the
+     * slow-query log line, which is unbounded-safe.
+     */
     void record(String name, String kpiId, String grain, long tookMs, long rowCount) {
-        if (metrics != null) metrics.recordQuery(kpiId, grain, tenantId, tookMs, rowCount);
+        if (metrics != null) metrics.recordQuery(kpiId, grain, metricTenant, tookMs, rowCount);
         executions.add(new Execution(name, kpiId, tookMs, rowCount));
+    }
+
+    /**
+     * First {@code stateLevelLen} dot-segments of the tenant — same state-level
+     * semantics as PrincipalScopeResolver/AnalyticsService.recordCount. Bounds the
+     * metric label to the deployment's state roots: a fabricated sub-tenant suffix
+     * collapses to its real root, and a fabricated ROOT never reaches
+     * {@link #record} because KPI-by-reference resolution fails at a root with no
+     * published catalog (and inline queries are blocked for the public floor).
+     */
+    static String stateRootOf(String tenantId, int stateLevelLen) {
+        if (tenantId == null || tenantId.isEmpty()) return tenantId;
+        String[] parts = tenantId.split("\\.");
+        int keep = Math.max(1, stateLevelLen);
+        if (parts.length <= keep) return tenantId;
+        return String.join(".", java.util.Arrays.asList(parts).subList(0, keep));
     }
 
     boolean isEmpty() {

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/QueryTelemetry.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/QueryTelemetry.java
@@ -1,0 +1,120 @@
+package org.egov.pgr.analytics;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Per-request recorder of executed analytics SQL queries (#1110).
+ *
+ * <p>One instance is created per {@code /_query} request and threaded through
+ * {@code AnalyticsService.runOne()} — the single choke point every SQL execution passes
+ * through (plain batch entries, the single-query arm, AND each SOURCE query of a
+ * backend-composed KPI). Each execution is (a) exported as an OTEL histogram/counter
+ * point via {@link AnalyticsMetrics} and (b) pooled for the per-request top-N
+ * slow-query log line. Errored entries never reach {@link #record} (the exception fires
+ * before/at execution), so they are naturally excluded from the pool.
+ *
+ * <p>Not thread-safe by design: request-scoped, single thread.
+ */
+final class QueryTelemetry {
+
+    static final int TOP_N = 3;
+
+    /** One executed query: batch-entry name + resolved kpiId (or "inline") + timings. */
+    static final class Execution {
+        final String name;
+        final String kpiId;
+        final long tookMs;
+        final long rowCount;
+
+        Execution(String name, String kpiId, long tookMs, long rowCount) {
+            this.name = name;
+            this.kpiId = kpiId;
+            this.tookMs = tookMs;
+            this.rowCount = rowCount;
+        }
+    }
+
+    private final AnalyticsMetrics metrics;
+    private final String tenantId;
+    private final List<Execution> executions = new ArrayList<>();
+
+    QueryTelemetry(AnalyticsMetrics metrics, String tenantId) {
+        this.metrics = metrics;
+        this.tenantId = tenantId;
+    }
+
+    /** Record one successfully executed query (metric point + slow-query pool entry). */
+    void record(String name, String kpiId, String grain, long tookMs, long rowCount) {
+        if (metrics != null) metrics.recordQuery(kpiId, grain, tenantId, tookMs, rowCount);
+        executions.add(new Execution(name, kpiId, tookMs, rowCount));
+    }
+
+    boolean isEmpty() {
+        return executions.isEmpty();
+    }
+
+    int total() {
+        return executions.size();
+    }
+
+    /** The n slowest executions, descending by tookMs (fewer when fewer ran). */
+    List<Execution> topSlowest(int n) {
+        return executions.stream()
+                .sorted(Comparator.comparingLong((Execution e) -> e.tookMs).reversed())
+                .limit(n)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * The ONE structured line logged per request:
+     * {@code analytics.slow_queries traceId=<id> tenant=<t> total=<n> top=[{...},...]}.
+     * Promtail ships it to Loki; the traceId pivots to Tempo (and to the FE's
+     * {@code dashboard.load} log record, which carries the same id).
+     */
+    String slowQueryLine(String traceId) {
+        String top = topSlowest(TOP_N).stream()
+                .map(e -> "{name=" + sanitize(e.name) + ", kpiId=" + sanitize(e.kpiId)
+                        + ", tookMs=" + e.tookMs + ", rowCount=" + e.rowCount + "}")
+                .collect(Collectors.joining(", ", "[", "]"));
+        return "analytics.slow_queries traceId=" + sanitize(traceId)
+                + " tenant=" + sanitize(tenantId)
+                + " total=" + total()
+                + " top=" + top;
+    }
+
+    /**
+     * Trace id for correlation. Preference order:
+     * <ol>
+     *   <li>the current span's trace id when valid — under the javaagent + Kong's
+     *       {@code opentelemetry} plugin (w3c) this IS the browser's per-load trace id;</li>
+     *   <li>the literal {@code x-trace-id} request header (agent-less deployments);</li>
+     *   <li>{@code "-"}.</li>
+     * </ol>
+     */
+    static String resolveTraceId(String headerTraceId) {
+        try {
+            SpanContext sc = Span.current().getSpanContext();
+            if (sc.isValid()) return sc.getTraceId();
+        } catch (RuntimeException ignored) {
+            // no agent / API misbehaviour — fall through to the header
+        }
+        if (headerTraceId != null && !headerTraceId.isBlank()) return headerTraceId.trim();
+        return "-";
+    }
+
+    /**
+     * Log-injection hygiene for caller-controlled strings (batch-entry names, header
+     * trace ids): allow only word chars plus {@code . : # / -}, cap at 64 chars.
+     */
+    static String sanitize(String v) {
+        if (v == null || v.isEmpty()) return "-";
+        String cleaned = v.replaceAll("[^\\w.:#/\\-]", "_");
+        return cleaned.length() > 64 ? cleaned.substring(0, 64) : cleaned;
+    }
+}

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/QueryTelemetry.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/QueryTelemetry.java
@@ -2,6 +2,7 @@ package org.egov.pgr.analytics;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -21,6 +22,7 @@ import java.util.stream.Collectors;
  *
  * <p>Not thread-safe by design: request-scoped, single thread.
  */
+@Slf4j
 final class QueryTelemetry {
 
     static final int TOP_N = 3;
@@ -101,8 +103,9 @@ final class QueryTelemetry {
         try {
             SpanContext sc = Span.current().getSpanContext();
             if (sc.isValid()) return sc.getTraceId();
-        } catch (RuntimeException ignored) {
-            // no agent / API misbehaviour — fall through to the header
+        } catch (RuntimeException e) {
+            // no agent / API misbehaviour — fall through to the header (but keep the root cause)
+            log.trace("Span.current() unavailable; falling back to x-trace-id header", e);
         }
         if (headerTraceId != null && !headerTraceId.isBlank()) return headerTraceId.trim();
         return "-";

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsControllerPacksTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsControllerPacksTest.java
@@ -1,0 +1,79 @@
+package org.egov.pgr.analytics;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.egov.pgr.analytics.model.DashboardPack;
+import org.egov.pgr.config.PGRConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.ResponseEntity;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Pins the /packs recordCount authorization gate: recordCount is live tenant data
+ * (complaint_facts corpus size) and must take the same coarse pack-match gate as
+ * packId/persona. Without it, an anonymous caller (degraded to the PUBLIC floor)
+ * could POST arbitrary tenantIds and enumerate every tenant's complaint volume
+ * even when every sibling field correctly collapses to null/empty.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class AnalyticsControllerPacksTest {
+
+    @Mock private AnalyticsService service;
+    @Mock private KpiCatalogService kpiCatalogService;
+    @Mock private PGRConfiguration config;
+
+    private AnalyticsController controller;
+
+    @BeforeEach
+    public void setUp() {
+        controller = new AnalyticsController(service, kpiCatalogService, new ObjectMapper(), config);
+        when(config.getStateLevelTenantIdLength()).thenReturn(1);
+    }
+
+    @Test
+    public void noMatchingPackReturnsNullRecordCountAndNeverCounts() {
+        // anonymous caller (no RequestInfo -> PUBLIC floor) on a tenant with no public pack
+        when(kpiCatalogService.getVisibleDefs(eq("ke.othercity"), any())).thenReturn(Collections.emptyList());
+        when(kpiCatalogService.getBestPack(eq("ke.othercity"), any(), any())).thenReturn(Optional.empty());
+
+        Map<String,Object> body = new HashMap<>();
+        body.put("tenantId", "ke.othercity");
+        ResponseEntity<Map<String,Object>> resp = controller.getPacks(body);
+
+        assertEquals(200, resp.getStatusCodeValue());
+        assertNull(resp.getBody().get("recordCount"),
+                "recordCount must not leak to a caller no pack matched for");
+        // the count query (and its cache) must not even run for unmatched callers
+        verify(service, never()).recordCount(anyString(), anyInt());
+    }
+
+    @Test
+    public void matchingPackStillGetsTheTenantCorpusCount() {
+        DashboardPack pack = new DashboardPack();
+        pack.setId("supervisor-pack");
+        pack.setRoles(Collections.singletonList("PGR_ADMIN"));
+        pack.setTiles(Collections.emptyList());
+        when(kpiCatalogService.getVisibleDefs(eq("ke.bomet"), any())).thenReturn(Collections.emptyList());
+        when(kpiCatalogService.getBestPack(eq("ke.bomet"), any(), any())).thenReturn(Optional.of(pack));
+        when(service.recordCount("ke.bomet", 1)).thenReturn(1234L);
+
+        Map<String,Object> body = new HashMap<>();
+        body.put("tenantId", "ke.bomet");
+        ResponseEntity<Map<String,Object>> resp = controller.getPacks(body);
+
+        assertEquals(200, resp.getStatusCodeValue());
+        assertEquals(1234L, resp.getBody().get("recordCount"));
+        assertEquals("supervisor-pack", resp.getBody().get("packId"));
+    }
+}

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsMetricsTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsMetricsTest.java
@@ -1,8 +1,15 @@
 package org.egov.pgr.analytics;
 
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * #1110: the metrics component must be a total no-op — and in particular must never
@@ -23,5 +30,40 @@ public class AnalyticsMetricsTest {
         AnalyticsMetrics metrics = new AnalyticsMetrics();
         assertDoesNotThrow(() -> metrics.recordQuery(null, null, null, 0L, 0L));
         assertDoesNotThrow(() -> metrics.recordQuery("", "", "", -1L, 0L));
+    }
+
+    /**
+     * The collector's prometheus exporter appends a unit-derived suffix to the metric
+     * name when the OTLP unit field is set (validated live: unit "ms" surfaced as
+     * pgr_analytics_query_duration_ms_milliseconds_*). The documented scrape names
+     * (docs/observability/dashboard-metrics-server.md) require the instruments to carry
+     * their unit in the NAME only — this pins name and empty-unit for both instruments.
+     */
+    @Test
+    public void instrumentNamesCarryUnitAndUnitFieldStaysEmpty() {
+        InMemoryMetricReader reader = InMemoryMetricReader.create();
+        SdkMeterProvider provider = SdkMeterProvider.builder().registerMetricReader(reader).build();
+        try {
+            AnalyticsMetrics metrics =
+                    new AnalyticsMetrics(provider.get(AnalyticsMetrics.METER_NAME));
+            metrics.recordQuery("open-complaints", "facts", "ke", 42L, 7L);
+
+            Collection<MetricData> collected = reader.collectAllMetrics();
+            assertEquals("", metricByName(collected, "pgr.analytics.query.duration.ms").getUnit(),
+                    "duration histogram must not set an OTLP unit (exporter would append _milliseconds)");
+            assertEquals("", metricByName(collected, "pgr.analytics.query.rows").getUnit(),
+                    "rows counter must not set an OTLP unit");
+        } finally {
+            provider.close();
+        }
+    }
+
+    private static MetricData metricByName(Collection<MetricData> collected, String name) {
+        MetricData found = collected.stream()
+                .filter(m -> name.equals(m.getName()))
+                .findFirst()
+                .orElse(null);
+        assertTrue(found != null, "expected instrument " + name + " in " + collected);
+        return found;
     }
 }

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsMetricsTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsMetricsTest.java
@@ -1,0 +1,27 @@
+package org.egov.pgr.analytics;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * #1110: the metrics component must be a total no-op — and in particular must never
+ * throw — when the OpenTelemetry javaagent is NOT attached (unit tests, CI, bare
+ * java -jar). GlobalOpenTelemetry returns its no-op implementation here, so these
+ * calls exercise exactly the agent-less production path.
+ */
+public class AnalyticsMetricsTest {
+
+    @Test
+    public void constructsAndRecordsWithoutAgent() {
+        AnalyticsMetrics metrics = new AnalyticsMetrics();
+        assertDoesNotThrow(() -> metrics.recordQuery("open-complaints", "facts", "ke", 42L, 7L));
+    }
+
+    @Test
+    public void toleratesNullAndEmptyAttributes() {
+        AnalyticsMetrics metrics = new AnalyticsMetrics();
+        assertDoesNotThrow(() -> metrics.recordQuery(null, null, null, 0L, 0L));
+        assertDoesNotThrow(() -> metrics.recordQuery("", "", "", -1L, 0L));
+    }
+}

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsServiceRecordCountTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsServiceRecordCountTest.java
@@ -1,0 +1,120 @@
+package org.egov.pgr.analytics;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * #1110: pins /packs recordCount semantics — the tenant-CORPUS count on complaint_facts
+ * with AnalyticsPlanner's tenant LIKE-prefix semantics (state level 'ke%' LIKE, city
+ * exact), the 5-minute per-tenant cache (including expiry), and error -> null (never
+ * cached, never thrown).
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class AnalyticsServiceRecordCountTest {
+
+    private static final int STATE_LEN = 1;   // "ke" is state root; "ke.bomet" is a city
+
+    @Mock private JdbcTemplate jdbc;
+
+    private AnalyticsService service;
+    private final AtomicLong clock = new AtomicLong(1_000_000L);
+
+    @BeforeEach
+    public void setUp() {
+        service = new AnalyticsService(null, null, jdbc, null, null, null, new AnalyticsMetrics());
+        ReflectionTestUtils.setField(service, "recordCountClock", (LongSupplier) clock::get);
+    }
+
+    @Test
+    public void stateLevelTenantUsesLikePrefix() {
+        when(jdbc.queryForObject(contains("LIKE"), eq(Long.class), eq("ke%"))).thenReturn(1234L);
+
+        assertEquals(1234L, service.recordCount("ke", STATE_LEN));
+
+        verify(jdbc).queryForObject(
+                eq("SELECT count(*) FROM complaint_facts WHERE tenant_id LIKE ?"),
+                eq(Long.class), eq("ke%"));
+        verify(jdbc, never()).queryForObject(contains("tenant_id = ?"), eq(Long.class), any());
+    }
+
+    @Test
+    public void cityTenantUsesExactMatch() {
+        when(jdbc.queryForObject(contains("tenant_id = ?"), eq(Long.class), eq("ke.bomet"))).thenReturn(55L);
+
+        assertEquals(55L, service.recordCount("ke.bomet", STATE_LEN));
+
+        verify(jdbc).queryForObject(
+                eq("SELECT count(*) FROM complaint_facts WHERE tenant_id = ?"),
+                eq(Long.class), eq("ke.bomet"));
+        verify(jdbc, never()).queryForObject(contains("LIKE"), eq(Long.class), any());
+    }
+
+    @Test
+    public void secondCallWithinTtlServesFromCache() {
+        when(jdbc.queryForObject(anyString(), eq(Long.class), any())).thenReturn(10L);
+
+        assertEquals(10L, service.recordCount("ke", STATE_LEN));
+        clock.addAndGet(4 * 60_000L + 59_000L);   // 4m59s later — still inside the 5m TTL
+        assertEquals(10L, service.recordCount("ke", STATE_LEN));
+
+        verify(jdbc, times(1)).queryForObject(anyString(), eq(Long.class), any());
+    }
+
+    @Test
+    public void cacheExpiresAfterFiveMinutes() {
+        when(jdbc.queryForObject(anyString(), eq(Long.class), any())).thenReturn(10L, 20L);
+
+        assertEquals(10L, service.recordCount("ke", STATE_LEN));
+        clock.addAndGet(5 * 60_000L + 1L);        // past the TTL
+        assertEquals(20L, service.recordCount("ke", STATE_LEN));
+
+        verify(jdbc, times(2)).queryForObject(anyString(), eq(Long.class), any());
+    }
+
+    @Test
+    public void cacheIsKeyedByTenant() {
+        when(jdbc.queryForObject(contains("LIKE"), eq(Long.class), eq("ke%"))).thenReturn(100L);
+        when(jdbc.queryForObject(contains("tenant_id = ?"), eq(Long.class), eq("ke.bomet"))).thenReturn(7L);
+
+        assertEquals(100L, service.recordCount("ke", STATE_LEN));
+        assertEquals(7L, service.recordCount("ke.bomet", STATE_LEN));
+        assertEquals(100L, service.recordCount("ke", STATE_LEN));   // still cached
+
+        verify(jdbc, times(2)).queryForObject(anyString(), eq(Long.class), any());
+    }
+
+    @Test
+    public void errorReturnsNullAndIsNotCached() {
+        when(jdbc.queryForObject(anyString(), eq(Long.class), any()))
+                .thenThrow(new DataAccessResourceFailureException("db down"))
+                .thenReturn(33L);
+
+        assertNull(service.recordCount("ke", STATE_LEN));           // failure -> null, no throw
+        assertEquals(33L, service.recordCount("ke", STATE_LEN));    // retried, not a cached null
+
+        verify(jdbc, times(2)).queryForObject(anyString(), eq(Long.class), any());
+    }
+
+    @Test
+    public void nullOrEmptyTenantReturnsNullWithoutQuerying() {
+        assertNull(service.recordCount(null, STATE_LEN));
+        assertNull(service.recordCount("", STATE_LEN));
+        verifyNoInteractions(jdbc);
+    }
+}

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/QueryTelemetryTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/QueryTelemetryTest.java
@@ -1,7 +1,11 @@
 package org.egov.pgr.analytics;
 
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -9,14 +13,51 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * #1110: pins the per-request slow-query pool semantics — top-3 selection (descending
  * tookMs), fewer-than-3 handling, the exclusion of errored entries (they are simply
- * never recorded), the single structured log line, and the trace-id fallback chain
- * (valid span > x-trace-id header > "-").
+ * never recorded), the single structured log line, the trace-id fallback chain
+ * (valid span > x-trace-id header > "-"), and the state-root normalization of the
+ * metric tenant label (raw request tenantIds are attacker-controlled and must never
+ * become Prometheus series).
  */
 public class QueryTelemetryTest {
 
     @Test
+    public void stateRootOfTruncatesToTheStateSegments() {
+        assertEquals("ke", QueryTelemetry.stateRootOf("ke", 1));
+        assertEquals("ke", QueryTelemetry.stateRootOf("ke.bomet", 1));
+        assertEquals("ke", QueryTelemetry.stateRootOf("ke.attack0001", 1));
+        assertEquals("ke.bomet", QueryTelemetry.stateRootOf("ke.bomet.ward1", 2));
+        assertNull(QueryTelemetry.stateRootOf(null, 1));
+        assertEquals("", QueryTelemetry.stateRootOf("", 1));
+        // defensive: a broken stateLevelLen still keeps at least one segment
+        assertEquals("zz", QueryTelemetry.stateRootOf("zz.a.b", 0));
+    }
+
+    @Test
+    public void metricPointsCarryTheStateRootNotTheRawRequestTenant() {
+        InMemoryMetricReader reader = InMemoryMetricReader.create();
+        SdkMeterProvider provider = SdkMeterProvider.builder().registerMetricReader(reader).build();
+        try {
+            AnalyticsMetrics metrics = new AnalyticsMetrics(provider.get(AnalyticsMetrics.METER_NAME));
+            QueryTelemetry tel = new QueryTelemetry(metrics, "ke.attack0001", 1);
+            tel.record("tiles", "open-complaints", "facts", 5, 1);
+
+            Collection<MetricData> collected = reader.collectAllMetrics();
+            assertFalse(collected.isEmpty());
+            for (MetricData md : collected) {
+                md.getData().getPoints().forEach(p -> assertEquals("ke",
+                        p.getAttributes().get(AnalyticsMetrics.ATTR_TENANT),
+                        md.getName() + " must be tagged with the state root"));
+            }
+            // ...while the log line keeps the full request tenant for debugging
+            assertTrue(tel.slowQueryLine("-").contains("tenant=ke.attack0001"));
+        } finally {
+            provider.close();
+        }
+    }
+
+    @Test
     public void topSlowestSortsDescendingAndLimitsToThree() {
-        QueryTelemetry tel = new QueryTelemetry(null, "ke");
+        QueryTelemetry tel = new QueryTelemetry(null, "ke", 1);
         tel.record("a", "kpi-a", "facts", 10, 1);
         tel.record("b", "kpi-b", "facts", 500, 2);
         tel.record("c", "kpi-c", "events", 250, 3);
@@ -33,7 +74,7 @@ public class QueryTelemetryTest {
 
     @Test
     public void fewerThanThreeEntriesReturnsWhatRan() {
-        QueryTelemetry tel = new QueryTelemetry(null, "ke.bomet");
+        QueryTelemetry tel = new QueryTelemetry(null, "ke.bomet", 1);
         tel.record("only", "kpi-x", "facts", 77, 0);
         List<QueryTelemetry.Execution> top = tel.topSlowest(QueryTelemetry.TOP_N);
         assertEquals(1, top.size());
@@ -44,7 +85,7 @@ public class QueryTelemetryTest {
     public void erroredEntriesAreExcludedBecauseNeverRecorded() {
         // The service records ONLY successful runOne() executions; an entry that threw
         // (plan error, kpi_forbidden, SQL failure) has no tookMs and never enters the pool.
-        QueryTelemetry tel = new QueryTelemetry(null, "ke");
+        QueryTelemetry tel = new QueryTelemetry(null, "ke", 1);
         tel.record("ok-1", "kpi-a", "facts", 5, 1);
         // "boom" entry errored -> no record() call
         tel.record("ok-2", "kpi-b", "facts", 9, 1);
@@ -55,13 +96,13 @@ public class QueryTelemetryTest {
 
     @Test
     public void emptyPoolMeansNoLogLine() {
-        QueryTelemetry tel = new QueryTelemetry(null, "ke");
+        QueryTelemetry tel = new QueryTelemetry(null, "ke", 1);
         assertTrue(tel.isEmpty());
     }
 
     @Test
     public void slowQueryLineCarriesTraceTenantTotalAndTop() {
-        QueryTelemetry tel = new QueryTelemetry(null, "ke.bomet");
+        QueryTelemetry tel = new QueryTelemetry(null, "ke.bomet", 1);
         tel.record("tiles", "open-complaints", "facts", 120, 42);
         String line = tel.slowQueryLine("abc123def456");
         assertTrue(line.startsWith("analytics.slow_queries traceId=abc123def456 tenant=ke.bomet total=1 top=["));
@@ -70,7 +111,7 @@ public class QueryTelemetryTest {
 
     @Test
     public void callerControlledNamesAreSanitizedInTheLogLine() {
-        QueryTelemetry tel = new QueryTelemetry(null, "ke");
+        QueryTelemetry tel = new QueryTelemetry(null, "ke", 1);
         tel.record("evil\nname \"quoted\"", "kpi", "facts", 1, 0);
         String line = tel.slowQueryLine("-");
         assertFalse(line.contains("\n"));

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/QueryTelemetryTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/QueryTelemetryTest.java
@@ -1,0 +1,97 @@
+package org.egov.pgr.analytics;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * #1110: pins the per-request slow-query pool semantics — top-3 selection (descending
+ * tookMs), fewer-than-3 handling, the exclusion of errored entries (they are simply
+ * never recorded), the single structured log line, and the trace-id fallback chain
+ * (valid span > x-trace-id header > "-").
+ */
+public class QueryTelemetryTest {
+
+    @Test
+    public void topSlowestSortsDescendingAndLimitsToThree() {
+        QueryTelemetry tel = new QueryTelemetry(null, "ke");
+        tel.record("a", "kpi-a", "facts", 10, 1);
+        tel.record("b", "kpi-b", "facts", 500, 2);
+        tel.record("c", "kpi-c", "events", 250, 3);
+        tel.record("d", "kpi-d", "facts", 999, 4);
+        tel.record("e", "kpi-e", "daily", 1, 5);
+
+        List<QueryTelemetry.Execution> top = tel.topSlowest(QueryTelemetry.TOP_N);
+        assertEquals(3, top.size());
+        assertEquals("d", top.get(0).name);
+        assertEquals("b", top.get(1).name);
+        assertEquals("c", top.get(2).name);
+        assertEquals(5, tel.total());
+    }
+
+    @Test
+    public void fewerThanThreeEntriesReturnsWhatRan() {
+        QueryTelemetry tel = new QueryTelemetry(null, "ke.bomet");
+        tel.record("only", "kpi-x", "facts", 77, 0);
+        List<QueryTelemetry.Execution> top = tel.topSlowest(QueryTelemetry.TOP_N);
+        assertEquals(1, top.size());
+        assertEquals(77, top.get(0).tookMs);
+    }
+
+    @Test
+    public void erroredEntriesAreExcludedBecauseNeverRecorded() {
+        // The service records ONLY successful runOne() executions; an entry that threw
+        // (plan error, kpi_forbidden, SQL failure) has no tookMs and never enters the pool.
+        QueryTelemetry tel = new QueryTelemetry(null, "ke");
+        tel.record("ok-1", "kpi-a", "facts", 5, 1);
+        // "boom" entry errored -> no record() call
+        tel.record("ok-2", "kpi-b", "facts", 9, 1);
+
+        assertEquals(2, tel.total());
+        assertTrue(tel.topSlowest(QueryTelemetry.TOP_N).stream().noneMatch(e -> "boom".equals(e.name)));
+    }
+
+    @Test
+    public void emptyPoolMeansNoLogLine() {
+        QueryTelemetry tel = new QueryTelemetry(null, "ke");
+        assertTrue(tel.isEmpty());
+    }
+
+    @Test
+    public void slowQueryLineCarriesTraceTenantTotalAndTop() {
+        QueryTelemetry tel = new QueryTelemetry(null, "ke.bomet");
+        tel.record("tiles", "open-complaints", "facts", 120, 42);
+        String line = tel.slowQueryLine("abc123def456");
+        assertTrue(line.startsWith("analytics.slow_queries traceId=abc123def456 tenant=ke.bomet total=1 top=["));
+        assertTrue(line.contains("{name=tiles, kpiId=open-complaints, tookMs=120, rowCount=42}"));
+    }
+
+    @Test
+    public void callerControlledNamesAreSanitizedInTheLogLine() {
+        QueryTelemetry tel = new QueryTelemetry(null, "ke");
+        tel.record("evil\nname \"quoted\"", "kpi", "facts", 1, 0);
+        String line = tel.slowQueryLine("-");
+        assertFalse(line.contains("\n"));
+        assertFalse(line.contains("\""));
+    }
+
+    @Test
+    public void traceIdFallsBackToHeaderThenDash() {
+        // No agent in unit tests -> Span.current() is invalid -> header wins.
+        assertEquals("deadbeef", QueryTelemetry.resolveTraceId("deadbeef"));
+        assertEquals("deadbeef", QueryTelemetry.resolveTraceId("  deadbeef  "));
+        assertEquals("-", QueryTelemetry.resolveTraceId(null));
+        assertEquals("-", QueryTelemetry.resolveTraceId("   "));
+    }
+
+    @Test
+    public void sanitizeCapsLengthAndStripsUnsafeChars() {
+        assertEquals("-", QueryTelemetry.sanitize(null));
+        assertEquals("-", QueryTelemetry.sanitize(""));
+        assertEquals("a_b_c", QueryTelemetry.sanitize("a b\nc"));
+        assertEquals(64, QueryTelemetry.sanitize("x".repeat(200)).length());
+        assertEquals("ke.bomet", QueryTelemetry.sanitize("ke.bomet"));
+    }
+}

--- a/docs/observability/dashboard-metrics-server.md
+++ b/docs/observability/dashboard-metrics-server.md
@@ -104,7 +104,10 @@ defensively; older clients ignore them):
 - **`recordCount`** — the **tenant corpus** size of `complaint_facts`, computed with the
   planner's tenant scope semantics: state-level tenant → `tenant_id LIKE 'ke%'`, city
   tenant → exact match. Cached in-memory for 5 minutes per tenant; `null` on error
-  (never fails the response).
+  (never fails the response). Gated by the same pack-match check as `packId`/`persona`:
+  when no pack matched the caller's roles (e.g. the anonymous PUBLIC floor on a tenant
+  with no public pack) it is `null` — otherwise any caller could enumerate every
+  tenant's complaint volume.
 
   **Semantics — read this:** `recordCount` is the **tenant's data volume**, deliberately
   **NOT the caller's ABAC-visible subset** (department/citizen/boundary scope is not

--- a/docs/observability/dashboard-metrics-server.md
+++ b/docs/observability/dashboard-metrics-server.md
@@ -1,0 +1,121 @@
+# Dashboard metrics — server side (#1110, PR2)
+
+> **Merge note:** PR1 of #1110 introduces `docs/observability/dashboard-metrics.md`
+> (client-side metrics, delivery path, feature gate). This file is the **server section**
+> of that page, kept separate only to avoid cross-PR conflicts — fold it into
+> `dashboard-metrics.md` once both PRs have landed.
+
+## What the server emits
+
+`pgr-services` measures every analytics SQL execution behind
+`POST /pgr-services/v2/analytics/_query` — each **batch entry**, each **single query**,
+and each **SOURCE query of a backend-composed KPI** (composed KPIs like
+`dailyAvgFromWeekly` run 1..n source queries; each records its own point, attributed to
+its own `kpi_id`).
+
+Instrumentation is `io.opentelemetry:opentelemetry-api` over `GlobalOpenTelemetry`
+(no micrometer/actuator). The OTEL **javaagent** the deploy stack attaches
+(`JAVA_TOOL_OPTIONS: -javaagent:...`, `OTEL_METRICS_EXPORTER: otlp`,
+`OTEL_SERVICE_NAME: pgr-services`) bridges it to its SDK and exports OTLP to the
+collector, which Prometheus scrapes on `otel-collector:8889`. **Without the agent every
+call is a no-op** — no config change, no compose change, safe in tests/CI.
+
+## Metric names as scraped (Prometheus)
+
+| OTLP instrument | Prometheus series | Type |
+|---|---|---|
+| `pgr.analytics.query.duration.ms` | `pgr_analytics_query_duration_ms_bucket` / `_sum` / `_count` | histogram |
+| `pgr.analytics.query.rows` | `pgr_analytics_query_rows_total` | counter |
+
+Labels on both: `kpi_id` (the KPI id, or `inline` for inline-grammar queries), `grain`
+(`facts`/`events`/`daily`/`compose` never appears — sources record their real grain),
+`tenant` (the request tenantId). Resource attributes (`service.name="pgr-services"` →
+`job`) come from the agent; `resource_to_telemetry_conversion` is enabled on the
+collector's prometheus exporter.
+
+Example queries:
+
+```promql
+# p95 duration per KPI over 15m
+histogram_quantile(0.95,
+  sum by (kpi_id, le) (rate(pgr_analytics_query_duration_ms_bucket[15m])))
+
+# slowest KPIs by mean duration
+topk(5, sum by (kpi_id) (rate(pgr_analytics_query_duration_ms_sum[15m]))
+      / sum by (kpi_id) (rate(pgr_analytics_query_duration_ms_count[15m])))
+```
+
+## Per-request slow-query log (Loki)
+
+After every `_query` request, pgr-services logs **one** structured line with the top-3
+slowest executed queries of that request (errored entries never execute, so they are
+excluded — they have no `tookMs`):
+
+```
+analytics.slow_queries traceId=<32-hex-or-header-or--> tenant=<t> total=<n> top=[{name=..., kpiId=..., tookMs=..., rowCount=...}, ...]
+```
+
+Promtail ships all container stdout to Loki. Query:
+
+```logql
+{compose_service="pgr-services"} |= "analytics.slow_queries"
+# only slow loads:
+{compose_service="pgr-services"} |= "analytics.slow_queries" | pattern "<_>tookMs=<took>,<_>" | took > 2000
+```
+
+## Trace correlation recipe
+
+The trace id in the log line is resolved in this order:
+
+1. **Active span's trace id** — Kong runs the `opentelemetry` plugin (`header_type: w3c`)
+   and pgr-services runs the javaagent, so the browser's `traceparent` (PR1 emits one per
+   dashboard load) is continued end-to-end. This is the normal case.
+2. The literal **`x-trace-id` request header** — fallback for agent-less deployments
+   (the `_query` handler accepts it as an optional header; it changes no behaviour).
+3. `-` when neither exists.
+
+To go from "the dashboard felt slow" to the exact query:
+
+1. **Prometheus** — find the offending aggregate (p95 spike on
+   `pgr_analytics_query_duration_ms` for a `kpi_id`/`tenant`).
+2. **Loki** — find affected loads: the FE's `dashboard.load` record (PR1) and the
+   server's `analytics.slow_queries` line carry the **same trace id** for one dashboard
+   load. Grep either, copy `traceId`.
+3. **Tempo** — search that trace id: the full span tree (Kong → pgr-services → JDBC
+   spans from the agent's auto-instrumentation) shows exactly where the time went.
+
+## `/packs` additions (`packId`, `persona`, `recordCount`)
+
+`POST /v2/analytics/packs` now returns three additive fields (the FE reads them
+defensively; older clients ignore them):
+
+- **`packId`** — the matched `DashboardPack.id`, the FE's `layout_id` tag. `null` when no
+  pack matched.
+- **`persona`** — the role that made the pack match: the first role in the **pack's**
+  declared `roles` list that the caller holds (the server's actual `matchesRoles`
+  decision, deterministic in pack order). The FE prefers this over its client-side
+  derivation for the `persona` tag.
+- **`recordCount`** — the **tenant corpus** size of `complaint_facts`, computed with the
+  planner's tenant scope semantics: state-level tenant → `tenant_id LIKE 'ke%'`, city
+  tenant → exact match. Cached in-memory for 5 minutes per tenant; `null` on error
+  (never fails the response).
+
+  **Semantics — read this:** `recordCount` is the **tenant's data volume**, deliberately
+  **NOT the caller's ABAC-visible subset** (department/citizen/boundary scope is not
+  applied). It feeds the `record_count_tier` metric tag, which must give render-lag
+  comparisons a shared denominator across personas — a department-scoped officer on a
+  100k-row tenant is in the `gt100k` tier even if they can see 2k rows. Do not use it as
+  a "rows you can query" indicator.
+
+## Validation cheat-sheet
+
+```bash
+# metrics appear within one scrape interval of a _query
+curl -s http://otel-collector:8889/metrics | grep pgr_analytics_query_duration_ms_count
+
+# slow-query line with a propagated trace id
+curl -s -X POST https://<host>/pgr-services/v2/analytics/_query \
+  -H 'Content-Type: application/json' -H 'x-trace-id: cafebabecafebabecafebabecafebabe' \
+  -d '{"tenantId":"ke","queries":{"open":{"kpiId":"<a PUBLIC kpiId>"}}}'
+docker logs pgr-services 2>&1 | grep analytics.slow_queries | tail -1
+```

--- a/docs/observability/dashboard-metrics-server.md
+++ b/docs/observability/dashboard-metrics-server.md
@@ -35,7 +35,10 @@ Same convention as the client-side `dashboardMetrics.js` (#1268).
 
 Labels on both: `kpi_id` (the KPI id, or `inline` for inline-grammar queries), `grain`
 (`facts`/`events`/`daily`/`compose` never appears — sources record their real grain),
-`tenant` (the request tenantId). Resource attributes (`service.name="pgr-services"` →
+`tenant` (the **state-root** tenant, e.g. `ke` — never the raw request tenantId,
+which is caller-controlled and unvalidated: tagging it raw would let an anonymous
+caller mint a new Prometheus series per request. The full request tenantId still
+appears, sanitized, in the `analytics.slow_queries` log line). Resource attributes (`service.name="pgr-services"` →
 `job`) come from the agent; `resource_to_telemetry_conversion` is enabled on the
 collector's prometheus exporter.
 

--- a/docs/observability/dashboard-metrics-server.md
+++ b/docs/observability/dashboard-metrics-server.md
@@ -27,6 +27,12 @@ call is a no-op** — no config change, no compose change, safe in tests/CI.
 | `pgr.analytics.query.duration.ms` | `pgr_analytics_query_duration_ms_bucket` / `_sum` / `_count` | histogram |
 | `pgr.analytics.query.rows` | `pgr_analytics_query_rows_total` | counter |
 
+The instruments deliberately set **no OTLP `unit`** — the unit lives in the name
+(`.ms`). The collector's prometheus exporter appends a unit-derived suffix whenever
+`unit` is set (validated live on bomet: `unit: "ms"` scraped as
+`pgr_analytics_query_duration_ms_milliseconds_*`), which would break the names above.
+Same convention as the client-side `dashboardMetrics.js` (#1268).
+
 Labels on both: `kpi_id` (the KPI id, or `inline` for inline-grammar queries), `grain`
 (`facts`/`events`/`daily`/`compose` never appears — sources record their real grain),
 `tenant` (the request tenantId). Resource attributes (`service.name="pgr-services"` →


### PR DESCRIPTION
Server half of #1110 (PR2 of 2) — per the implementation plan in https://github.com/egovernments/Citizen-Complaint-Resolution-System/issues/1110#issuecomment-4987649750 (REVISION 2, esp. R9).

## What

- **Per-query OTEL metrics** — every executed analytics SQL query records `pgr.analytics.query.duration.ms` (histogram) + `pgr.analytics.query.rows` (counter), attributes `kpi_id`/`grain`/`tenant`, via `io.opentelemetry:opentelemetry-api` 1.45.0 over `GlobalOpenTelemetry` (pinned to the SDK bundled by the deployed javaagent v2.11.0). Instrumented at `runOne()` — the single choke point — with the KPI context passed in, so **backend-composed KPIs' SOURCE queries each record their own point** and join the slow-query pool (R9/C6).
- **Trace-correlated slow-query log** — one structured line per `_query` request: `analytics.slow_queries traceId=<id> tenant=<t> total=<n> top=[{name,kpiId,tookMs,rowCount}×3]` (top-3 by `tookMs`; errored entries never execute, so they're excluded; emitted from a `finally` so partial failures still log what ran). Trace id: active span (javaagent + Kong w3c propagation → the browser's per-load trace id) > literal `x-trace-id` header (new optional header on `_query`, fallback only) > `-`.
- **`/packs` additive fields** — `packId` (matched `DashboardPack.id` → FE `layout_id` tag), `persona` (the role that made the pack match: first pack-declared role the caller holds — the server's actual `matchesRoles` decision, R9/C7), `recordCount` (see below).
- **Docs** — `docs/observability/dashboard-metrics-server.md`: scraped metric names, Loki query, Prometheus→Loki→Tempo correlation recipe, `recordCount` semantics. Kept as a separate file to avoid cross-PR conflicts; fold into PR1's `dashboard-metrics.md` once both land.

## `recordCount` semantics (read before reviewing)

**Tenant corpus, NOT the caller's ABAC scope**: `count(*)` on `complaint_facts` with the planner's tenant scope semantics (state level `tenant_id LIKE 'ke%'`, city exact — R9/F7), cached in-memory 5 min per tenant, `null` on error (additive, never fails the response). It feeds the `record_count_tier` metric tag, which needs a shared denominator across personas — deliberately independent of department/citizen/boundary scoping (R9/C9).

## Independence / scope

- **Independent of PR1** (client half): all additions are defensive/optional — the new header is optional, the `/packs` fields are additive, the metrics are a no-op without the javaagent. Mergeable in either order.
- **No compose/config changes needed**: pgr-services already runs the OTEL javaagent with `OTEL_METRICS_EXPORTER: otlp`; the collector→Prometheus scrape path and Promtail→Loki shipping already exist.
- **AC deviation (owner-acked on the issue)**: server metric scope is the `/v2/analytics/*` endpoints that actually feed this dashboard, not PGR `_search`/MDMS/DSS (D14 — those are already visible as javaagent spans).

## Validation

- `mvn package` clean (JDK 17 / Boot 3.2.2, via `maven:3.9-eclipse-temurin-17`).
- Full unit suite green: **84 tests, 0 failures** (17 new: no-agent no-op, top-3 selection incl. `<3`/errored entries, log-line shape + injection sanitizer, trace-id fallback chain, recordCount LIKE-vs-exact, cache hit/expiry/keying, error→null).

## Found in integration (bomet deploy)

- **OTLP unit → exporter name suffix**: the collector's prometheus exporter appends a unit-derived suffix when the OTLP `unit` field is set — the duration histogram scraped as `pgr_analytics_query_duration_ms_milliseconds_*` instead of the documented `pgr_analytics_query_duration_ms_*`. Fixed by dropping the `unit` fields (names carry their unit already) — the identical gotcha #1268 fixed on the client. New SDK-backed test pins the instrument names + empty units; docs note the convention. Suite: **85 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenTelemetry-backed analytics observability: query duration and returned-row metrics, plus per-request structured slow-query logs (top 3).
  * Added optional trace correlation via the `x-trace-id` header.
  * Enhanced analytics pack responses with `packId`, deterministic `persona`, and `recordCount` (tenant corpus count, null when no matching pack).
  * Added short-term caching for tenant record counts to reduce repeat lookups.
* **Documentation**
  * Documented server metrics, slow-query log format, trace correlation, and updated pack response fields.
* **Tests**
  * Added/expanded tests covering telemetry behavior, trace/tenant normalization, caching semantics, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
