### PR TITLE
feat(pgr): ship visibility tabs without notification numbers

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/PGRInboxTabs.js
+++ b/digit-ui-esbuild/products/pgr/src/components/PGRInboxTabs.js
@@ -11,6 +11,12 @@ import { useTranslation } from "react-i18next";
  * the tab since the user last opened it (high-water-mark cursor, see
  * useTabCounts) — not the tab's total. The red dot accompanies a non-zero
  * count.
+ *
+ * NOTE: the count badge + dot are currently DISABLED (commented out below,
+ * together with the useTabCounts wiring in PGRInbox.js) — product call to
+ * ship the tabs without notification numbers for now. To re-enable, restore
+ * the commented blocks in both files; the hook and its localization keys are
+ * untouched.
  */
 const TABS = [
   { key: "MY", label: "PGR_INBOX_TAB_MY", fallback: "My Complaints" },
@@ -28,7 +34,10 @@ const PGRInboxTabs = ({ activeTab, onChange, counts = {} }) => {
     <div className="pgr-inbox-tabs" role="tablist">
       {TABS.map((tab) => {
         const active = activeTab === tab.key;
-        const count = counts[tab.key] || 0;
+        // Notification numbers disabled — see the class-doc NOTE. Re-enable by
+        // restoring the two commented lines below (and the useTabCounts wiring
+        // in PGRInbox.js) and rendering `${label(tab)} (${count})`.
+        // const count = counts[tab.key] || 0;
         return (
           <button
             key={tab.key}
@@ -38,8 +47,8 @@ const PGRInboxTabs = ({ activeTab, onChange, counts = {} }) => {
             className={`pgr-inbox-tab${active ? " active" : ""}`}
             onClick={() => onChange(tab.key)}
           >
-            <span>{`${label(tab)} (${count})`}</span>
-            {count > 0 && <span className="pgr-inbox-tab-dot" aria-hidden="true" />}
+            <span>{label(tab)}</span>
+            {/* {count > 0 && <span className="pgr-inbox-tab-dot" aria-hidden="true" />} */}
           </button>
         );
       })}

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRInbox.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRInbox.js
@@ -5,7 +5,7 @@ import _ from "lodash";
 import PGRSearchInboxConfig from "../../configs/PGRSearchInboxConfig";
 import { useLocation } from "react-router-dom";
 import useBusinessServiceStates from "../../hooks/pgr/useBusinessServiceStates";
-import useTabCounts from "../../hooks/pgr/useTabCounts";
+// import useTabCounts from "../../hooks/pgr/useTabCounts"; // badges disabled — see PGRInboxTabs.js NOTE
 import useInboxVisibility from "../../hooks/pgr/useInboxVisibility";
 import PGRInboxTabs from "../../components/PGRInboxTabs";
 import Urls from "../../utils/urls";
@@ -82,14 +82,17 @@ const PGRSearchInbox = () => {
     enabled: visibilityEnabled,
   });
 
-  const { counts, markSeen } = useTabCounts({ tenantId, allStates, enabled: visibilityEnabled, serverSide: visibilityServerSide });
+  // Tab notification numbers DISABLED (product call — see the NOTE in
+  // PGRInboxTabs.js). Restoring the two commented blocks below re-enables the
+  // alert-count badges and their _count polling; useTabCounts itself is kept.
+  // const { counts, markSeen } = useTabCounts({ tenantId, allStates, enabled: visibilityEnabled, serverSide: visibilityServerSide });
 
   // A tab is "seen" once it's the visible tab -> its badge clears, and the other
   // tab's badge keeps surfacing newly-arrived complaints.
-  useEffect(() => {
-    if (visibilityEnabled && !bsLoading) markSeen(activeTab);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeTab, bsLoading, visibilityEnabled]);
+  // useEffect(() => {
+  //   if (visibilityEnabled && !bsLoading) markSeen(activeTab);
+  //   // eslint-disable-next-line react-hooks/exhaustive-deps
+  // }, [activeTab, bsLoading, visibilityEnabled]);
 
   // Fetch mobile validation config from MDMS
   const { validationRules, isLoading: isValidationLoading, getMinMaxValues } = Digit.Hooks.pgr.useMobileValidation(tenantId);
@@ -268,7 +271,7 @@ const PGRSearchInbox = () => {
           <InboxSearchComposer
             key={activeTab}
             configs={tabConfig}
-            resultsHeader={<PGRInboxTabs activeTab={activeTab} onChange={setActiveTab} counts={counts} />}
+            resultsHeader={<PGRInboxTabs activeTab={activeTab} onChange={setActiveTab} /* counts={counts} */ />}
           />
         ) : (
           <InboxSearchComposer configs={updatedConfig} />


### PR DESCRIPTION
Follow-up to #1052 (merged): product call to ship the My/All Complaints tabs **without the alert-count badges** for now.

**What changes**
- `PGRInboxTabs` renders the plain localized tab labels — no `(##)` count, no red dot.
- `PGRInbox` no longer wires `useTabCounts`, which also stops the per-tab `_count` polling and the mark-seen cursor writes — the feature is fully quiesced, not just visually hidden.

**What's kept (commented out, not deleted)**
- `useTabCounts`, its high-water-mark cursor logic, and the localization keys are untouched.
- Both disable points carry a NOTE marker; restoring the two commented blocks re-enables the badges exactly as designed (PRD alert-count semantics).

Validation: changed files esbuild-parse clean; no backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)