### PR TITLE
feat(db): every schema-owning service gets a Flyway init container (Phase 4)

### DIFF
--- a/docs/db-migration-flow.md
+++ b/docs/db-migration-flow.md
@@ -222,7 +222,7 @@ migrator's `SCHEMA_TABLE` has no map entry.
 ./local-setup/db/normalize/test-integration.sh /path/to/dump.sql
 ```
 
-It loads the dump into a throwaway database, normalizes, runs all fourteen pinned `-db`
+It loads the dump into a throwaway database, normalizes, runs all fifteen pinned `-db`
 migrators, and asserts every pre-existing table is byte-identical afterwards. It also
 runs the same dump *without* the normalizer and asserts the data IS destroyed — if
 that half ever stops failing, the guard has been silently disabled.

--- a/docs/db-migration-flow.md
+++ b/docs/db-migration-flow.md
@@ -223,6 +223,21 @@ migrator's `SCHEMA_TABLE` has no map entry.
 ```
 
 It loads the dump into a throwaway database, normalizes, runs all fifteen pinned `-db`
-migrators, and asserts every pre-existing table is byte-identical afterwards. It also
-runs the same dump *without* the normalizer and asserts the data IS destroyed — if
-that half ever stops failing, the guard has been silently disabled.
+migrators, and asserts every pre-existing **data** table is byte-identical afterwards
+(Flyway history tables are excluded — they legitimately gain a row when a migration
+newer than the dump applies). It also runs the same dump *without* the normalizer and
+asserts the data IS destroyed — if that half ever stops failing, the guard has been
+silently disabled.
+
+It then runs the **convergence** check: build the schema a second time from an EMPTY
+database with every migrator, and assert the two paths end at an identical schema —
+same columns, indexes, and matview definitions.
+
+> **Why this matters.** The dump is a shortcut for DATA and TIME. It is never a source
+> of schema truth. Anything the dump has that the migrations cannot reproduce is drift,
+> and it fails *silently*: from-empty builds lack it while the fast path keeps working
+> by accident. Neither the positive test (which only proves existing data survives) nor
+> the CI alignment check (which only compares history-table *names*) can see it.
+> This is not hypothetical — it caught `eg_user.countrycode`, which existed only in the
+> dump because the app ran `egov-user:mobilevalidation-*` while its migrator was pinned
+> to `master-d69ce29`, a lineage that predates the countrycode migration.

--- a/docs/db-migration-flow.md
+++ b/docs/db-migration-flow.md
@@ -89,6 +89,14 @@ exists`) or the migration silently doesn't apply.
    on a from-empty build. See the `pgr-services-migration` gates for the pattern.
 7. **App has embedded Flyway off.** Each converted app sets `SPRING_FLYWAY_ENABLED:
    "false"` so the init container is the single source of migration truth.
+8. **No exceptions.** Every service that owns a schema has a migration init
+   container — there is no `embedded` opt-out in `flyway-history-map.yml` any more
+   (Phase 4). An app that migrates itself can silently *not* migrate and still
+   report healthy (novu-bridge's Flyway pointed at a hardcoded `localhost` and
+   applied nothing for months), and a service with no mechanism at all is worse
+   still: `egov-bndry-mgmnt`'s tables existed only because the dump shipped them,
+   so a from-empty build produced no schema and nothing noticed. If you are adding
+   a service, it gets a migrator.
 
 ---
 
@@ -214,7 +222,7 @@ migrator's `SCHEMA_TABLE` has no map entry.
 ./local-setup/db/normalize/test-integration.sh /path/to/dump.sql
 ```
 
-It loads the dump into a throwaway database, normalizes, runs all eleven pinned `-db`
+It loads the dump into a throwaway database, normalizes, runs all fourteen pinned `-db`
 migrators, and asserts every pre-existing table is byte-identical afterwards. It also
 runs the same dump *without* the normalizer and asserts the data IS destroyed — if
 that half ever stops failing, the guard has been silently disabled.

--- a/docs/db-migration-flow.md
+++ b/docs/db-migration-flow.md
@@ -229,6 +229,20 @@ newer than the dump applies). It also runs the same dump *without* the normalize
 asserts the data IS destroyed — if that half ever stops failing, the guard has been
 silently disabled.
 
+It also proves the guard on a **synthesised operator dump** (our dump with its history
+tables renamed back to the legacy names — our own dump is already canonical, so it is
+the *safe* input and proves nothing here): without the normalizer the data is destroyed
+(so the guard is needed); with it, the renames happen and every row survives (so the
+guard works). That second half is the only test that exercises the rename path against
+a real database.
+
+> Note the simulation renames each history table's **indexes** too. Flyway names them
+> after the table (`<table>_pk`, `<table>_s_idx`) and Postgres's `ALTER TABLE ... RENAME`
+> does not touch them. Renaming only the table yields a state that cannot occur
+> naturally, and Flyway then dies on `relation <x>_pk already exists` instead of
+> replaying — the run fails rather than destroying data, and the test reads as
+> "the guard isn't needed" for entirely the wrong reason.
+
 It then runs the **convergence** check: build the schema a second time from an EMPTY
 database with every migrator, and assert the two paths end at an identical schema —
 same columns, indexes, and matview definitions.

--- a/local-setup/db/flyway-history-map.yml
+++ b/local-setup/db/flyway-history-map.yml
@@ -17,10 +17,14 @@
 #   data_tables    real tables this service's migrations CREATE. Derived from the
 #                  CREATE TABLE statements in its own migration SQL — NOT guessed.
 #                  Materialized views are excluded: they can always be rebuilt.
-#   embedded       true = no migration init container. The normalizer skips these
-#                  entirely; nothing would replay against them.
 #   baseline_fresh true = legitimately absent from the dump (migrates from empty).
 #                  Consumed by .github/scripts/check-flyway-dump-alignment.py.
+#
+# INVARIANT: every service with a schema has a migration init container. There is
+# no `embedded` escape hatch — if you are tempted to add one, you are re-opening
+# the failure mode this file exists to close (an app that silently does not
+# migrate, e.g. novu-bridge's hardcoded-localhost Flyway URL, or a service with no
+# mechanism at all, e.g. egov-bndry-mgmnt before Phase 4).
 
 boundary-service:
   canonical: boundary_service_schema
@@ -130,12 +134,20 @@ audit-service:
 egov-indexer:
   canonical: egov_indexer_schema
   aliases: []
-  data_tables: []
-  embedded: true           # embedded Flyway; no migration init container
-  baseline_fresh: true
+  data_tables: [eg_indexer_job]
+  baseline_fresh: true     # [search]-gated; absent from the dump, migrates from empty
 
 egov-accesscontrol:
   canonical: accesscontrol_schema_version
-  aliases: []
-  data_tables: []
-  embedded: true           # K8s chart declares no schemaTable; stays embedded
+  aliases: []              # legacy name IS the canonical here — the dump ships it
+  data_tables: [eg_action, eg_ms_role, eg_roleaction, service]
+
+egov-bndry-mgmnt:
+  canonical: "egov-bndry-mgmnt_schema"   # hyphenated, as in the K8s chart
+  aliases: []              # no history exists under ANY name — see baseline_fresh
+  data_tables: [eg_bm_generated_template, eg_bm_processed_template]
+  # The dump ships both tables but NO history for them under any name (compose
+  # never ran this migrator; K8s always did). Both are empty in the dump, so
+  # normalize takes the DROP branch and the migrator rebuilds them with a real
+  # history — i.e. it does migrate from empty, hence baseline_fresh.
+  baseline_fresh: true

--- a/local-setup/db/normalize/normalize.py
+++ b/local-setup/db/normalize/normalize.py
@@ -14,7 +14,6 @@ NOOP = "noop"
 RENAME = "rename"
 DROP = "drop"
 ABORT = "abort"
-SKIP = "skip"
 
 
 class Decision(NamedTuple):
@@ -46,11 +45,6 @@ def decide(
     row_counts  — rows per data table, for the data tables that are present
     """
     canonical = spec["canonical"]
-
-    # No migration init container exists for embedded services, so nothing would
-    # replay against their history. Hands off, whatever it looks like.
-    if spec.get("embedded"):
-        return Decision(SKIP, service, canonical, reason="embedded Flyway")
 
     canonical_present = canonical in present
     found = [a for a in (spec.get("aliases") or []) if a in present]
@@ -245,10 +239,10 @@ def main() -> int:
     for orphan in sorted(history_tables() - known):
         print(f"  warning  unrecognised history table {orphan!r} — no migrator owns it, skipping")
 
-    tally = {a: sum(1 for d in decisions if d.action == a) for a in (NOOP, RENAME, DROP, SKIP)}
+    tally = {a: sum(1 for d in decisions if d.action == a) for a in (NOOP, RENAME, DROP)}
     print(
         f"ok: renamed {tally[RENAME]}, rebuilt {tally[DROP]}, "
-        f"already-aligned {tally[NOOP]}, skipped {tally[SKIP]}"
+        f"already-aligned {tally[NOOP]}"
     )
     return 0
 

--- a/local-setup/db/normalize/test-integration.sh
+++ b/local-setup/db/normalize/test-integration.sh
@@ -23,6 +23,10 @@ WORK="$(mktemp -d)"
 trap 'docker rm -f it-pos it-neg >/dev/null 2>&1 || true; docker network rm $NET >/dev/null 2>&1 || true; rm -rf "$WORK"' EXIT
 
 MIGRATORS=(
+  # audit-service was never covered here: its migrator used to live in the base
+  # compose rather than the overlay, so it fell outside this list. Both now live
+  # in docker-compose.migrations.yml.
+  "audit-service|audit-service-db:v2.9.2-4a60f20|audit_service_schema"
   "boundary-service|boundary-service-db:v2.9.2-4a60f20|boundary_service_schema"
   "egov-user|egov-user-db:master-d69ce29|egov_user_schema"
   "mdms-backend|mdms-v2-db:v2.9.2-4a60f20|mdms_v2_schema"
@@ -107,7 +111,7 @@ echo "  rebuild path: ${REBUILT:-<none>}"
 # install"), so they are not in REBUILT — but their migrator still legitimately
 # applies from empty. Demanding a no-op from them would be wrong for the same
 # reason it is wrong for REBUILT, just via a different path.
-BASELINE_FRESH="egov-indexer"
+BASELINE_FRESH="egov-indexer audit-service"
 echo "  baseline-fresh: ${BASELINE_FRESH:-<none>}"
 
 # Idempotency: a second run must change nothing and still exit 0.

--- a/local-setup/db/normalize/test-integration.sh
+++ b/local-setup/db/normalize/test-integration.sh
@@ -7,9 +7,21 @@
 #      each reports "No migration necessary" (except services that legitimately
 #      migrate from empty), and a row-count + content-checksum snapshot of every
 #      table is byte-identical before/after.
-# B) NEGATIVE — dump + migrators, normalizer SKIPPED:
-#      data IS destroyed. If this ever stops failing, the guard has been silently
-#      disabled and the positive test alone would not tell us.
+# B) THE GUARD — on an OPERATOR-style dump (legacy history names):
+#      B1 without the normalizer, data IS destroyed  -> the guard is NEEDED
+#      B2 with it, the renames happen and data survives -> the guard WORKS
+#
+#      Flyway finds its logbook BY NAME. Our shipped dump files its logbooks under
+#      the CURRENT names (item #10 re-baked it), so on our dump the normalizer has
+#      nothing to rename — part A reports "renamed 0". The input this component
+#      exists for is an OPERATOR's dump, still using the LEGACY names: Flyway does
+#      not find the logbook, concludes it has never run, and replays from V1 —
+#      whose first statement, for egov-localization and egov-enc-service, is
+#      DROP TABLE IF EXISTS. 23k messages and the PII encryption keys, exit 0.
+#
+#      So B synthesises that dump by renaming our logbooks BACKWARDS. Testing this
+#      against our own dump proves nothing (it is the safe input) — that is exactly
+#      how this section silently rotted after the re-bake.
 # C) CONVERGENCE — fast path (dump + migrators) vs slow path (EMPTY + migrators):
 #      both must end at an IDENTICAL schema — same columns, indexes, and
 #      materialized-view definitions. The dump is a shortcut for DATA and TIME; it
@@ -34,7 +46,7 @@ REPO="$(cd "$HERE/../../.." && pwd)"
 PG_IMAGE="registry.preview.egov.theflywheel.in/postgres:16"
 NET=normalize-it
 WORK="$(mktemp -d)"
-trap 'docker rm -f it-pos it-neg it-slow >/dev/null 2>&1 || true; docker network rm $NET >/dev/null 2>&1 || true; rm -rf "$WORK"' EXIT
+trap 'docker rm -f it-pos it-neg it-slow it-grd >/dev/null 2>&1 || true; docker network rm $NET >/dev/null 2>&1 || true; rm -rf "$WORK"' EXIT
 
 # Migrators built from the repo rather than pulled. Part C needs them: without
 # them the slow path would lack pgr/novu/config tables that the dump HAS, and the
@@ -269,29 +281,109 @@ echo "  PASS: fast and slow paths converge to an identical schema"
 
 echo
 
-# ── B) NEGATIVE ───────────────────────────────────────────────────────────────
-echo "=== B) NEGATIVE: dump -> migrators, normalizer SKIPPED (must destroy data) ==="
-start_db it-neg
-snapshot it-neg > "$WORK/neg-before.txt"
-run_migrators it-neg >/dev/null
-snapshot it-neg > "$WORK/neg-after.txt"
+# ── B) THE GUARD ──────────────────────────────────────────────────────────────
+# See the header. Both halves run against a SYNTHESISED operator dump, because our
+# own dump is the safe input and proves nothing here.
+echo "=== B) THE GUARD: against an OPERATOR-style dump (legacy history names) ==="
 
+# canonical -> legacy pairs, straight from the map. Never hardcode them: the map is
+# the single source of truth, and a hardcoded copy would drift out of sync silently.
+alias_pairs() {
+  docker run --rm -v "$MAP:/map.yml:ro" --entrypoint python3 db-history-normalize:test -c '
+import yaml
+for spec in (yaml.safe_load(open("/map.yml")) or {}).values():
+    a = spec.get("aliases") or []
+    if a:
+        print(spec["canonical"], a[0])
+'
+}
+
+# Turn our (canonical) dump back into the operator dump we protect against.
+#
+# The indexes MUST be renamed alongside the table. Flyway names a history table's
+# constraint/index after the table (<table>_pk, <table>_s_idx), and Postgres's
+# ALTER TABLE ... RENAME does NOT rename them. Renaming only the table produces a
+# state that cannot occur naturally — table "x_version" whose PK is still "x_pk" —
+# and Flyway then dies on "relation x_pk already exists" while trying to baseline,
+# rather than replaying. The run FAILS instead of destroying data, and the test
+# reads as "the guard isn't needed" for entirely the wrong reason.
+#
+# A genuine legacy dump has no such collision: Flyway created the table AS
+# "x_version", so its PK is "x_version_pk".
+legacy_ify() {  # $1 = db container
+  local canon alias n=0
+  while read -r canon alias; do
+    [ -z "${canon:-}" ] && continue
+    docker exec "$1" psql -U egov -d egov -q -v ON_ERROR_STOP=1 \
+      -c "ALTER TABLE public.\"$canon\" RENAME TO \"$alias\";" \
+      -c "ALTER INDEX IF EXISTS public.\"${canon}_pk\" RENAME TO \"${alias}_pk\";" \
+      -c "ALTER INDEX IF EXISTS public.\"${canon}_s_idx\" RENAME TO \"${alias}_s_idx\";" \
+      || { echo "FAIL: could not rename $canon -> $alias"; exit 1; }
+    n=$((n + 1))
+  done < <(alias_pairs)
+  [ "$n" -gt 0 ] || { echo "FAIL: the map yielded no aliases — nothing to synthesise"; exit 1; }
+  echo "  synthesised operator dump: $n history tables (+ their indexes) renamed to legacy names"
+}
+
+rows() {  # $1 = db, $2 = table -> row count, or "GONE" if the table no longer exists
+  docker exec "$1" psql -U egov -d egov -tAc "SELECT count(*) FROM public.$2" 2>/dev/null || echo GONE
+}
+
+# The two services whose V1 starts with DROP TABLE IF EXISTS. If a replay happens,
+# these die first — and eg_enc_* are the keys that decrypt every user's PII.
+CANARIES="message eg_enc_symmetric_keys eg_enc_asymmetric_keys"
+
+# ── B1) unguarded — the data MUST die ─────────────────────────────────────────
+echo "--- B1) legacy dump + migrators, normalizer SKIPPED (must destroy data) ---"
+start_db it-neg
+legacy_ify it-neg
+for t in $CANARIES; do printf "  before  %-24s %s\n" "$t" "$(rows it-neg "$t")"; done
+run_migrators it-neg >/dev/null
 destroyed=0
-for t in message eg_enc_symmetric_keys eg_enc_asymmetric_keys; do
-  before=$(awk -F'|' -v t="$t" '$1==t {print $2}' "$WORK/neg-before.txt")
-  after=$(awk -F'|' -v t="$t" '$1==t {print $2}' "$WORK/neg-after.txt")
-  printf "  %-24s %s -> %s\n" "$t" "${before:-?}" "${after:-?}"
-  if [ -n "$before" ] && [ "$before" -gt 0 ] && [ "$after" = "0" ]; then
-    destroyed=$((destroyed + 1))
-  fi
+for t in $CANARIES; do
+  after="$(rows it-neg "$t")"
+  printf "  after   %-24s %s\n" "$t" "$after"
+  case "$after" in 0|GONE) destroyed=$((destroyed + 1)) ;; esac
 done
 [ "$destroyed" = "3" ] || {
   echo "FAIL: the unguarded run did NOT destroy data as expected."
-  echo "      Either the migration images changed, or the guard is being applied"
-  echo "      when it should not be. Do not ship until this is understood."
+  echo "      Either the migration images changed, or legacy_ify no longer produces"
+  echo "      the dangerous input. Do not ship until this is understood — this test"
+  echo "      passing is the only evidence the guard is worth running."
   exit 1
 }
-echo "  PASS: unguarded run destroys data — the guard is doing real work"
+echo "  PASS: unguarded run destroys data — the guard is NEEDED"
 
-echo "ALL PASS: normalizer makes the dump safe; without it the data is destroyed;"
-echo "          and dump-built and empty-built schemas are identical."
+# ── B2) guarded — the renames happen and the data survives ────────────────────
+# This is the case the whole component exists for, and the ONLY test that executes
+# its rename path against a real database (part A's dump is already canonical, so
+# it reports "renamed 0").
+echo "--- B2) legacy dump + normalizer + migrators (must rename, must preserve) ---"
+start_db it-grd
+legacy_ify it-grd
+snapshot it-grd > "$WORK/grd-before.txt"
+normalize it-grd | tee "$WORK/grd-normalize.log"
+renamed="$(sed -n 's/^ok: renamed \([0-9]*\).*/\1/p' "$WORK/grd-normalize.log")"
+[ "${renamed:-0}" -ge 1 ] || {
+  echo "FAIL: normalizer renamed NOTHING on a legacy dump. Its rename path did not"
+  echo "      run, so this test proves nothing about the code it exists to cover."
+  exit 1
+}
+echo "  normalizer renamed $renamed history table(s)"
+fail=0
+while read -r name rc verdict; do
+  [ "$rc" = "0" ] || { echo "    FAIL: $name exited $rc after normalization"; fail=1; }
+done < <(run_migrators it-grd)
+[ "$fail" = "0" ] || { echo "FAIL: a migrator failed on a normalized legacy dump"; exit 1; }
+for t in $CANARIES; do printf "  survived %-24s %s\n" "$t" "$(rows it-grd "$t")"; done
+snapshot it-grd > "$WORK/grd-after.txt"
+if ! join -t'|' -j1 <(sort -t'|' -k1,1 "$WORK/grd-before.txt") <(sort -t'|' -k1,1 "$WORK/grd-after.txt") \
+     | awk -F'|' '$2!=$4 || $3!=$5 {print "    CHANGED: "$0; bad=1} END {exit bad?1:0}'; then
+  echo "FAIL: the guarded run changed pre-existing data — the guard did not protect it"
+  exit 1
+fi
+echo "  PASS: guarded run renames and preserves every row — the guard WORKS"
+
+echo "ALL PASS: on an operator dump the guard is both NEEDED (B1) and WORKS (B2);"
+echo "          our own dump is safe (A); and dump-built and empty-built schemas"
+echo "          are identical (C)."

--- a/local-setup/db/normalize/test-integration.sh
+++ b/local-setup/db/normalize/test-integration.sh
@@ -34,6 +34,12 @@ MIGRATORS=(
   "egov-hrms|egov-hrms-db:hrms-boundary-0a4e737|egov_hrms_schema"
   "egov-url-shortening|egov-url-shortening-db:v2.9.2-4a60f20|egov-url-shortening_schema"
   "egov-otp|egov-otp-db:v2.9.2-4a60f20|egov_otp_schema"
+  # Phase 4 — the last self-migrating services. These three -db images are pinned
+  # to the SAME tag as their app image in docker-compose.migrations.yml, not to
+  # the K8s v2.9.2 release tag, so keep the two in sync.
+  "egov-indexer|egov-indexer-db:maven-jdk21-9f83afb|egov_indexer_schema"
+  "egov-accesscontrol|egov-accesscontrol-db:maven-jdk21-9f83afb|accesscontrol_schema_version"
+  "egov-bndry-mgmnt|egov-bndry-mgmnt-db:bndry-mgmnt-3794b8c|egov-bndry-mgmnt_schema"
 )
 
 # Row count + content checksum for every table in public.
@@ -96,6 +102,14 @@ normalize it-pos | tee "$WORK/first-run.log"
 REBUILT="$(sed -n 's/^  rebuilt  \([a-z0-9-]*\):.*/\1/p' "$WORK/first-run.log" | tr '\n' ' ')"
 echo "  rebuild path: ${REBUILT:-<none>}"
 
+# Services the dump carries NEITHER history NOR tables for (`baseline_fresh: true`
+# in flyway-history-map.yml). The normalizer correctly leaves them alone ("fresh
+# install"), so they are not in REBUILT — but their migrator still legitimately
+# applies from empty. Demanding a no-op from them would be wrong for the same
+# reason it is wrong for REBUILT, just via a different path.
+BASELINE_FRESH="egov-indexer"
+echo "  baseline-fresh: ${BASELINE_FRESH:-<none>}"
+
 # Idempotency: a second run must change nothing and still exit 0.
 normalize it-pos > "$WORK/second-run.log"
 grep -q "renamed 0, rebuilt 0" "$WORK/second-run.log" || {
@@ -105,7 +119,7 @@ echo "  idempotent: second run renamed 0, rebuilt 0"
 fail=0
 while read -r name rc verdict; do
   expect=noop
-  case " $REBUILT " in *" $name "*) expect=applied-or-failed ;; esac
+  case " $REBUILT $BASELINE_FRESH " in *" $name "*) expect=applied-or-failed ;; esac
   printf "  %-22s exit=%s %-18s (expect %s)\n" "$name" "$rc" "$verdict" "$expect"
   if [ "$rc" != "0" ]; then
     echo "    FAIL: $name exited $rc"; fail=1

--- a/local-setup/db/normalize/test-integration.sh
+++ b/local-setup/db/normalize/test-integration.sh
@@ -3,12 +3,25 @@
 #
 #   ./test-integration.sh /path/to/dump.sql
 #
-# A) POSITIVE — dump + normalizer + all 11 migrators:
-#      every migrator reports "No migration necessary", and a row-count +
-#      content-checksum snapshot of every table is byte-identical before/after.
-# B) NEGATIVE — dump + all 11 migrators, normalizer SKIPPED:
+# A) POSITIVE — dump + normalizer + every pinned migrator:
+#      each reports "No migration necessary" (except services that legitimately
+#      migrate from empty), and a row-count + content-checksum snapshot of every
+#      table is byte-identical before/after.
+# B) NEGATIVE — dump + migrators, normalizer SKIPPED:
 #      data IS destroyed. If this ever stops failing, the guard has been silently
 #      disabled and the positive test alone would not tell us.
+# C) CONVERGENCE — fast path (dump + migrators) vs slow path (EMPTY + migrators):
+#      both must end at an IDENTICAL schema — same columns, indexes, and
+#      materialized-view definitions. The dump is a shortcut for DATA and TIME; it
+#      is never a source of schema truth. Anything the dump has that the migrations
+#      cannot reproduce is drift, and it breaks from-empty builds silently while the
+#      fast path keeps working by accident.
+#      This caught a real one: eg_user.countrycode existed only in the dump because
+#      the app was on egov-user:mobilevalidation-* while its migrator was pinned to
+#      master-d69ce29, which predates the countrycode migration. Neither (A), (B),
+#      nor the CI alignment check can see that class of bug — (A) only proves
+#      existing data survives, and the alignment check only compares history-table
+#      NAMES.
 #
 # Runs entirely in throwaway containers on their own network. Never touches a
 # running stack.
@@ -17,10 +30,20 @@ set -euo pipefail
 DUMP="${1:?usage: test-integration.sh /path/to/dump.sql}"
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MAP="$HERE/../flyway-history-map.yml"
+REPO="$(cd "$HERE/../../.." && pwd)"
 PG_IMAGE="registry.preview.egov.theflywheel.in/postgres:16"
 NET=normalize-it
 WORK="$(mktemp -d)"
-trap 'docker rm -f it-pos it-neg >/dev/null 2>&1 || true; docker network rm $NET >/dev/null 2>&1 || true; rm -rf "$WORK"' EXIT
+trap 'docker rm -f it-pos it-neg it-slow >/dev/null 2>&1 || true; docker network rm $NET >/dev/null 2>&1 || true; rm -rf "$WORK"' EXIT
+
+# Migrators built from the repo rather than pulled. Part C needs them: without
+# them the slow path would lack pgr/novu/config tables that the dump HAS, and the
+# comparison would report false drift.
+BUILT_MIGRATORS=(
+  "pgr-services|$REPO/backend/pgr-services/src/main/resources/db|pgr_services_schema|"
+  "novu-bridge|$REPO/backend/novu-bridge/src/main/resources/db|novu_bridge_schema|"
+  "digit-config-service|$REPO/backend/digit-config-service/src/main/resources/db|digit_config_service_schema|public"
+)
 
 MIGRATORS=(
   # audit-service was never covered here: its migrator used to live in the base
@@ -28,7 +51,10 @@ MIGRATORS=(
   # in docker-compose.migrations.yml.
   "audit-service|audit-service-db:v2.9.2-4a60f20|audit_service_schema"
   "boundary-service|boundary-service-db:v2.9.2-4a60f20|boundary_service_schema"
-  "egov-user|egov-user-db:master-d69ce29|egov_user_schema"
+  # Lineage fix: the app is egov-user:mobilevalidation-*, so the migrator must be
+  # from that lineage too. master-d69ce29 predates the countrycode migration and
+  # left from-empty builds without eg_user.countrycode. See docker-compose.migrations.yml.
+  "egov-user|egov-user-db:mobile-validation-user-otp-9883730|egov_user_schema"
   "mdms-backend|mdms-v2-db:v2.9.2-4a60f20|mdms_v2_schema"
   "egov-idgen|egov-idgen-db:v2.9.2-4a60f20|egov_idgen_schema"
   "egov-localization|egov-localization-db:v2.9.2-4a60f20|egov_localization_schema"
@@ -46,13 +72,27 @@ MIGRATORS=(
   "egov-bndry-mgmnt|egov-bndry-mgmnt-db:bndry-mgmnt-3794b8c|egov-bndry-mgmnt_schema"
 )
 
-# Row count + content checksum for every table in public.
+# Row count + content checksum for every DATA table in public.
+#
+# Flyway history tables are EXCLUDED. This assertion is about data survival, and a
+# history table is bookkeeping: when a migrator legitimately applies a migration
+# newer than the dump (egov-user's countrycode), its history GAINS a row — correct
+# behaviour that would otherwise read as "pre-existing data changed". What each
+# migrator did is already reported above, per service, so nothing is lost by
+# leaving history out of this comparison.
+#
+# Identified by column signature, not by name — the name is precisely what we
+# cannot trust here (same rule as normalize.py).
 cat > "$WORK/snapshot.sql" <<'SQL'
 SELECT c.relname,
        (xpath('/row/c/text()', query_to_xml(format('select count(*) as c from public.%I', c.relname), false,true,'')))[1]::text::bigint,
        (xpath('/row/c/text()', query_to_xml(format('select coalesce(md5(string_agg(t::text, E''\n'' ORDER BY t::text)),''EMPTY'') as c from public.%I t', c.relname), false,true,'')))[1]::text
 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
 WHERE n.nspname = 'public' AND c.relkind = 'r'
+  AND NOT EXISTS (
+    SELECT 1 FROM pg_attribute a
+    WHERE a.attrelid = c.oid AND a.attname = 'installed_rank'
+  )
 ORDER BY 1;
 SQL
 
@@ -114,6 +154,15 @@ echo "  rebuild path: ${REBUILT:-<none>}"
 BASELINE_FRESH="egov-indexer audit-service"
 echo "  baseline-fresh: ${BASELINE_FRESH:-<none>}"
 
+# Services whose PINNED image carries migrations NEWER than the dump. They apply on
+# top; that is the fast path working exactly as designed (dump = baseline, Flyway
+# applies the delta), not a failure. egov-user is here because its migrator is now
+# pinned to the mobilevalidation lineage, whose countrycode migration postdates the
+# dump. Keep this list honest: an entry that stops applying means the dump has
+# caught up and the entry should go.
+NEWER_THAN_DUMP="egov-user"
+echo "  newer-than-dump: ${NEWER_THAN_DUMP:-<none>}"
+
 # Idempotency: a second run must change nothing and still exit 0.
 normalize it-pos > "$WORK/second-run.log"
 grep -q "renamed 0, rebuilt 0" "$WORK/second-run.log" || {
@@ -123,7 +172,7 @@ echo "  idempotent: second run renamed 0, rebuilt 0"
 fail=0
 while read -r name rc verdict; do
   expect=noop
-  case " $REBUILT $BASELINE_FRESH " in *" $name "*) expect=applied-or-failed ;; esac
+  case " $REBUILT $BASELINE_FRESH $NEWER_THAN_DUMP " in *" $name "*) expect=applied-or-failed ;; esac
   printf "  %-22s exit=%s %-18s (expect %s)\n" "$name" "$rc" "$verdict" "$expect"
   if [ "$rc" != "0" ]; then
     echo "    FAIL: $name exited $rc"; fail=1
@@ -141,6 +190,84 @@ if ! join -t'|' -j1 <(sort -t'|' -k1,1 "$WORK/pos-before.txt") <(sort -t'|' -k1,
   echo "FAIL: pre-existing data changed"; exit 1
 fi
 echo "  PASS: every pre-existing table byte-identical (rows + checksum)"
+
+# ── C) CONVERGENCE ────────────────────────────────────────────────────────────
+# Both paths must arrive at the SAME schema. See the header for why this exists.
+echo "=== C) CONVERGENCE: fast path (dump) vs slow path (empty) must match ==="
+
+build_migrator() {  # $1 = name, $2 = context -> echoes the built tag
+  docker build -q -t "it-$1-db:test" "$2" >/dev/null
+  echo "it-$1-db:test"
+}
+
+run_built() {  # $1 = db container
+  local m name ctx table schema img
+  for m in "${BUILT_MIGRATORS[@]}"; do
+    IFS='|' read -r name ctx table schema <<< "$m"
+    img="$(build_migrator "$name" "$ctx")"
+    docker run --rm --network $NET \
+      -e DB_URL="jdbc:postgresql://$1:5432/egov" ${schema:+-e SCHEMA_NAME=$schema} \
+      -e SCHEMA_TABLE="$table" -e FLYWAY_USER=egov -e FLYWAY_PASSWORD=egov123 \
+      -e FLYWAY_LOCATIONS=filesystem:/flyway/sql -e FLYWAY_VALIDATE_ON_MIGRATE=false \
+      "$img" > "$WORK/$1-$name.log" 2>&1 || {
+        echo "    FAIL: $name migrator exited non-zero on $1"; tail -5 "$WORK/$1-$name.log"; exit 1; }
+  done
+}
+
+# Snapshot the SHAPE of the schema (not the data): columns, indexes, and matview
+# definitions. Data is expected to differ — the dump has rows, an empty build does not.
+cat > "$WORK/shape.sql" <<'SQL'
+SELECT 'col|'||table_name||'.'||column_name||'|'||data_type||'|'
+       ||coalesce(character_maximum_length::text,'-')||'|'||is_nullable
+FROM information_schema.columns WHERE table_schema='public'
+UNION ALL
+SELECT 'idx|'||indexname||'|'||md5(indexdef) FROM pg_indexes WHERE schemaname='public'
+UNION ALL
+SELECT 'mv|'||matviewname||'|'||md5(definition) FROM pg_matviews WHERE schemaname='public'
+ORDER BY 1;
+SQL
+shape() { docker cp "$WORK/shape.sql" "$1:/tmp/shape.sql" >/dev/null
+          docker exec "$1" psql -U egov -d egov -tA -f /tmp/shape.sql | sed 's/ *$//' | sort; }
+
+# it-pos already has: dump + normalize + every PULLED migrator. Finish the fast
+# path by running the in-repo built ones on it too.
+run_built it-pos
+shape it-pos > "$WORK/shape-fast.txt"
+
+# Slow path: virgin DB, normalize (must be a no-op), then every migrator.
+docker rm -f it-slow >/dev/null 2>&1 || true
+docker run -d --name it-slow --network $NET \
+  -e POSTGRES_USER=egov -e POSTGRES_PASSWORD=egov123 -e POSTGRES_DB=egov "$PG_IMAGE" >/dev/null
+until docker exec it-slow pg_isready -U egov >/dev/null 2>&1; do sleep 2; done
+# pg_isready answers from initdb's TEMPORARY server first; wait for the real one.
+until docker logs it-slow 2>&1 | grep -q "PostgreSQL init process complete"; do sleep 1; done
+normalize it-slow > "$WORK/slow-normalize.log"
+grep -q "renamed 0, rebuilt 0" "$WORK/slow-normalize.log" || {
+  echo "FAIL: normalizer touched an EMPTY database — it must be a pure no-op there"
+  cat "$WORK/slow-normalize.log"; exit 1; }
+echo "  normalizer on empty DB: no-op (as required)"
+run_migrators it-slow > "$WORK/slow-migrators.txt"
+while read -r name rc verdict; do
+  [ "$rc" = "0" ] || { echo "    FAIL: $name exited $rc building from empty"; exit 1; }
+done < "$WORK/slow-migrators.txt"
+run_built it-slow
+shape it-slow > "$WORK/shape-slow.txt"
+
+echo "  fast path: $(grep -c '^col|' "$WORK/shape-fast.txt") columns, $(grep -c '^idx|' "$WORK/shape-fast.txt") indexes, $(grep -c '^mv|' "$WORK/shape-fast.txt") matviews"
+echo "  slow path: $(grep -c '^col|' "$WORK/shape-slow.txt") columns, $(grep -c '^idx|' "$WORK/shape-slow.txt") indexes, $(grep -c '^mv|' "$WORK/shape-slow.txt") matviews"
+
+if ! diff -u "$WORK/shape-fast.txt" "$WORK/shape-slow.txt" > "$WORK/shape.diff"; then
+  echo "FAIL: the two paths do NOT converge to the same schema."
+  echo "      '-' = in the dump but NOT reproducible from migrations (drift: from-empty"
+  echo "            builds silently lack it while the fast path works by accident)."
+  echo "      '+' = built from migrations but absent from the dump (the dump is stale;"
+  echo "            usually fine — it applies on top — but check it is intentional)."
+  grep -E '^[-+][^-+]' "$WORK/shape.diff" | head -30
+  exit 1
+fi
+echo "  PASS: fast and slow paths converge to an identical schema"
+
+echo
 
 # ── B) NEGATIVE ───────────────────────────────────────────────────────────────
 echo "=== B) NEGATIVE: dump -> migrators, normalizer SKIPPED (must destroy data) ==="
@@ -166,5 +293,5 @@ done
 }
 echo "  PASS: unguarded run destroys data — the guard is doing real work"
 
-echo
-echo "ALL PASS: normalizer makes the dump safe; without it the data is destroyed."
+echo "ALL PASS: normalizer makes the dump safe; without it the data is destroyed;"
+echo "          and dump-built and empty-built schemas are identical."

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -574,31 +574,12 @@ services:
   # via configs/egov-persister/audit-service-persister.yml. K8s runs this too
   # (coreservices-helmfile: audit-service installed:true). Compose previously lacked
   # it, so audit capture was non-functional (no eg_audit_logs table). This restores
-  # cross-stack parity. Schema is created by the audit-service-db Flyway image below.
-  audit-service-migration:
-    image: egovio/audit-service-db:v2.9.2-4a60f20
-    container_name: audit-service-migration
-    depends_on:
-      # DIRECT to postgres-db (never the pgbouncer 'postgres' alias, which runs in
-      # transaction mode and breaks Flyway's session locks).
-      postgres-db:
-        condition: service_healthy
-    environment:
-      DB_URL: jdbc:postgresql://postgres-db:5432/egov
-      SCHEMA_TABLE: audit_service_schema
-      FLYWAY_USER: egov
-      FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
-      FLYWAY_LOCATIONS: filesystem:/flyway/sql
-      FLYWAY_VALIDATE_ON_MIGRATE: "false"
-    restart: "no"
-    networks:
-      - egov-network
-
+  # cross-stack parity. Its schema is owned by an audit-service-db Flyway init
+  # container, declared with every other migrator in docker-compose.migrations.yml
+  # (which the playbook always layers) — this file stays free of migration wiring.
   audit-service:
     image: egovio/audit-service:v2.9.2-4a60f20
     depends_on:
-      audit-service-migration:
-        condition: service_completed_successfully
       pgbouncer:
         condition: service_healthy
       redpanda:
@@ -611,7 +592,8 @@ services:
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/egov
       SPRING_DATASOURCE_USERNAME: egov
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
-      # Flyway disabled on the app — the audit-service-migration init ran it.
+      # Flyway disabled on the app — its migration init container owns the schema
+      # (docker-compose.migrations.yml). Also set there, alongside the migrator.
       SPRING_FLYWAY_ENABLED: 'false'
       KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SPRING_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092

--- a/local-setup/docker-compose.migrations.yml
+++ b/local-setup/docker-compose.migrations.yml
@@ -189,8 +189,31 @@ services:
     environment: { SPRING_FLYWAY_ENABLED: "false" }
     depends_on: { boundary-service-migration: { condition: service_completed_successfully } }
 
+  # Lineage fix (NOT a routine bump). The app runs egov-user:mobilevalidation-*,
+  # which USES eg_user.countrycode, but this migrator was pinned to master-d69ce29,
+  # which predates V20260309120000__alter_eg_user_add_countrycode.sql. App and
+  # migrator were from different lineages — the exact thing the per-service pin is
+  # supposed to prevent.
+  #
+  # The fast path hid it: the dump was baked from an environment that had already
+  # run that migration, so `countrycode` is baked into the dump's CREATE TABLE while
+  # its history does NOT record the migration. A from-empty build therefore produced
+  # an eg_user with no countrycode under an app that expects one.
+  #
+  # mobile-validation-user-otp-9883730 is a strict superset of master-d69ce29
+  # (28 migrations = the same 27 + countrycode, no regressions) and the migration is
+  # ADD COLUMN IF NOT EXISTS, so it is safe both ways: on the dump it no-ops the
+  # ALTER and records the history row (26 eg_user rows verified untouched); on empty
+  # it creates the column. Verified: both paths then agree at 766 columns.
+  #
+  # K8s is NOT affected and needs no change — its chart pins the app AND the db to
+  # master-d69ce29, so it is self-consistent (on an older feature set). Only compose
+  # bumped the app without its -db.
+  #
+  # There is no -db tag matching the app's exact tag (the app is a custom preview
+  # build); this is the closest published tag in the same lineage.
   egov-user-migration:
-    image: egovio/egov-user-db:master-d69ce29
+    image: egovio/egov-user-db:mobile-validation-user-otp-9883730
     container_name: egov-user-migration
     depends_on:
       postgres-db: { condition: service_healthy }

--- a/local-setup/docker-compose.migrations.yml
+++ b/local-setup/docker-compose.migrations.yml
@@ -144,6 +144,31 @@ services:
   # migration rows under the K8s <service>_schema names → the migrators no-op on
   # the fast path. Env matches the -db images' migrate.sh contract.
 
+  # audit-service (item #13) arrived with its migrator declared in the BASE compose
+  # rather than here — the same pattern in two homes, which is exactly the kind of
+  # split that makes "where does this service's schema come from?" unanswerable by
+  # grep. Moved here verbatim so every migrator lives in one file. Note it takes no
+  # SCHEMA_NAME (its migrate.sh does not read one); that is preserved from the
+  # original, not an omission.
+  audit-service-migration:
+    image: egovio/audit-service-db:v2.9.2-4a60f20
+    container_name: audit-service-migration
+    depends_on:
+      postgres-db: { condition: service_healthy }
+      db-history-normalize: { condition: service_completed_successfully }
+    environment:
+      DB_URL: jdbc:postgresql://postgres-db:5432/egov
+      SCHEMA_TABLE: audit_service_schema
+      FLYWAY_USER: egov
+      FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
+      FLYWAY_LOCATIONS: filesystem:/flyway/sql
+      FLYWAY_VALIDATE_ON_MIGRATE: "false"
+    restart: "no"
+    networks: [egov-network]
+  audit-service:
+    environment: { SPRING_FLYWAY_ENABLED: "false" }
+    depends_on: { audit-service-migration: { condition: service_completed_successfully } }
+
   boundary-service-migration:
     image: egovio/boundary-service-db:v2.9.2-4a60f20
     container_name: boundary-service-migration

--- a/local-setup/docker-compose.migrations.yml
+++ b/local-setup/docker-compose.migrations.yml
@@ -366,6 +366,99 @@ services:
     environment: { SPRING_FLYWAY_ENABLED: "false" }
     depends_on: { egov-otp-migration: { condition: service_completed_successfully } }
 
+  # ── Phase 4 · the last self-migrating services ──────────────────────────────
+  # Closes the invariant: no service manages its own schema. Each -db image is
+  # pinned to the SAME tag as its app image, so the migrations that run are the
+  # ones that app was built against — not a different release's.
+
+  # indexer is [search]-profile-gated; its migrator carries the same profile.
+  # K8s has always run this as an init container (charts/core-services/egov-indexer
+  # values.yaml: initContainers.dbMigration.enabled=true, egov_indexer_schema).
+  # Compose was the outlier, so this closes a real divergence rather than adding
+  # one. Nothing is in the dump for it (baseline_fresh) — it migrates from empty.
+  egov-indexer-migration:
+    image: egovio/egov-indexer-db:maven-jdk21-9f83afb
+    container_name: egov-indexer-migration
+    profiles: ["search"]
+    depends_on:
+      postgres-db: { condition: service_healthy }
+      db-history-normalize: { condition: service_completed_successfully }
+    environment:
+      DB_URL: jdbc:postgresql://postgres-db:5432/egov
+      SCHEMA_NAME: public
+      SCHEMA_TABLE: egov_indexer_schema
+      FLYWAY_USER: egov
+      FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
+      FLYWAY_LOCATIONS: filesystem:/flyway/sql
+      FLYWAY_VALIDATE_ON_MIGRATE: "false"
+    restart: "no"
+    networks: [egov-network]
+  egov-indexer:
+    environment: { SPRING_FLYWAY_ENABLED: "false" }
+    depends_on: { egov-indexer-migration: { condition: service_completed_successfully } }
+
+  # egov-bndry-mgmnt had NO schema mechanism on compose at all: it is a Node
+  # service (no embedded Flyway), no migrator was ever wired, and its two tables
+  # existed ONLY because the dump ships them — with no Flyway history under any
+  # name. A fresh/empty compose DB therefore got no bndry schema at all. K8s has
+  # run this as an init container all along (charts/urban/egov-bndry-mgmnt
+  # values.yaml: egov-bndry-mgmnt_schema). The app does not self-migrate — its
+  # image bundles migration/main + migrate.sh purely to build the -db image.
+  #
+  # The dump's copies of both tables are EMPTY, so db-history-normalize takes the
+  # DROP branch (tables present, no history, zero rows -> "migrator will rebuild")
+  # and this migrator recreates them with a real history. If a deployment ever has
+  # rows in them and no history, normalize ABORTs by design rather than guess.
+  egov-bndry-mgmnt-migration:
+    image: egovio/egov-bndry-mgmnt-db:bndry-mgmnt-3794b8c
+    container_name: egov-bndry-mgmnt-migration
+    depends_on:
+      postgres-db: { condition: service_healthy }
+      db-history-normalize: { condition: service_completed_successfully }
+    environment:
+      DB_URL: jdbc:postgresql://postgres-db:5432/egov
+      SCHEMA_NAME: public
+      SCHEMA_TABLE: egov-bndry-mgmnt_schema
+      FLYWAY_USER: egov
+      FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
+      FLYWAY_LOCATIONS: filesystem:/flyway/sql
+      FLYWAY_VALIDATE_ON_MIGRATE: "false"
+    restart: "no"
+    networks: [egov-network]
+  egov-bndry-mgmnt:
+    depends_on: { egov-bndry-mgmnt-migration: { condition: service_completed_successfully } }
+
+  # accesscontrol was the last embedded-Flyway service. Its four tables are the
+  # legacy pre-MDMS role/action path: the service reads roles/actions from MDMS
+  # (EGOV_MDMS_HOST + mdms.*.path in its application.properties), and all four sit
+  # at 0 rows on a fully seeded, working stack.
+  #
+  # NOTE the asymmetry this preserves: upstream ships spring.flyway.enabled=false
+  # and the K8s chart declares no dbMigration, so K8s NEVER creates these tables —
+  # compose alone enabled embedded Flyway. Converting keeps compose's current state
+  # exactly (history + tables already exist -> the migrator no-ops) while removing
+  # the last self-migrating service. Whether compose should create them at all is a
+  # separate decision; see docs/db-migration-flow.md.
+  egov-accesscontrol-migration:
+    image: egovio/egov-accesscontrol-db:maven-jdk21-9f83afb
+    container_name: egov-accesscontrol-migration
+    depends_on:
+      postgres-db: { condition: service_healthy }
+      db-history-normalize: { condition: service_completed_successfully }
+    environment:
+      DB_URL: jdbc:postgresql://postgres-db:5432/egov
+      SCHEMA_NAME: public
+      SCHEMA_TABLE: accesscontrol_schema_version
+      FLYWAY_USER: egov
+      FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
+      FLYWAY_LOCATIONS: filesystem:/flyway/sql
+      FLYWAY_VALIDATE_ON_MIGRATE: "false"
+    restart: "no"
+    networks: [egov-network]
+  egov-accesscontrol:
+    environment: { SPRING_FLYWAY_ENABLED: "false" }
+    depends_on: { egov-accesscontrol-migration: { condition: service_completed_successfully } }
+
   # Retire the consolidated db-migrations container. Its migrate-all.sh looks for
   # the OLD *_schema_version tables, which the re-bake renamed to K8s names — it
   # would 42P07 and block its dependents (idgen/user/localization), which now have

--- a/local-setup/tests/test_flyway_history_normalize.py
+++ b/local-setup/tests/test_flyway_history_normalize.py
@@ -13,7 +13,7 @@ import yaml
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "db", "normalize")))
 
-from normalize import ABORT, DROP, NOOP, RENAME, SKIP, decide, load_map
+from normalize import ABORT, DROP, NOOP, RENAME, decide, load_map
 
 MAP_PATH = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "db", "flyway-history-map.yml")
@@ -72,17 +72,28 @@ def test_no_history_but_populated_data_tables_abort():
     assert "eg_user" in d.reason
 
 
-def test_embedded_services_are_skipped_entirely():
-    spec = {"canonical": "accesscontrol_schema_version", "embedded": True}
-    d = decide("egov-accesscontrol", spec, {"accesscontrol_schema_version"}, {})
-    assert d.action == SKIP
+def test_no_service_opts_out_of_normalization():
+    # Phase 4 removed the `embedded` escape hatch: every service with a schema now
+    # has a migration init container, so every entry must be normalized. A stray
+    # `embedded: true` would silently skip a service whose migrator DOES run —
+    # exactly the replay-against-populated-tables case decide() exists to catch.
+    m = load_map(MAP_PATH)
+    opted_out = [svc for svc, spec in m.items() if spec.get("embedded")]
+    assert not opted_out, f"`embedded` is no longer supported; found on: {opted_out}"
 
 
-def test_embedded_service_is_skipped_even_when_it_looks_wrong():
-    # No migrator exists for it, so nothing can replay against it. Hands off.
-    spec = {"canonical": "accesscontrol_schema_version", "embedded": True}
-    d = decide("egov-accesscontrol", spec, set(), {})
-    assert d.action == SKIP
+def test_bndry_mgmnt_empty_dump_tables_are_rebuilt_not_aborted():
+    # The dump ships both bndry tables with NO history under any name. They are
+    # empty, so the migrator may safely rebuild them. If they are ever populated,
+    # the ABORT branch must win instead (covered by the eg_user test above).
+    m = load_map(MAP_PATH)
+    spec = m["egov-bndry-mgmnt"]
+    present = {"eg_bm_generated_template", "eg_bm_processed_template"}
+    d = decide("egov-bndry-mgmnt", spec, present, {})
+    assert d.action == DROP
+
+    d = decide("egov-bndry-mgmnt", spec, present, {"eg_bm_generated_template": 12})
+    assert d.action == ABORT
 
 
 # ── the shipped map itself ────────────────────────────────────────────────────
@@ -94,7 +105,9 @@ def test_shipped_map_parses_and_covers_every_migrator():
         "boundary-service", "egov-user", "mdms-backend", "egov-idgen",
         "egov-localization", "egov-enc-service", "egov-filestore",
         "egov-workflow-v2", "egov-hrms", "egov-url-shortening", "egov-otp",
-        "pgr-services", "novu-bridge", "digit-config-service",
+        "pgr-services", "novu-bridge", "digit-config-service", "audit-service",
+        # Phase 4 — the last three to get init containers.
+        "egov-indexer", "egov-accesscontrol", "egov-bndry-mgmnt",
     ]:
         assert svc in m, f"{svc} missing from the map"
         assert m[svc]["canonical"], f"{svc} has no canonical table"


### PR DESCRIPTION
## Goal

**No service manages its own schema.** This closes the last three exceptions and deletes the `embedded` escape hatch from `flyway-history-map.yml`, so the rule is enforced structurally rather than documented.

Before this PR, "all services use init containers" was true for 15 of 19 schema-owning services. The other four were invisible unless you went looking — two of them are real defects.

It also consolidates **all 18 migrators into one file**: `audit-service`'s lived in the base compose, the other 17 in the overlay.

## What changed

| Service | Before | After | Why |
|---|---|---|---|
| `egov-indexer` | embedded Flyway | init container | **K8s already ran an init container** for it (`charts/core-services/egov-indexer`, `egov_indexer_schema`). Compose was the outlier — this closes a divergence, not adds one. |
| `egov-bndry-mgmnt` | **nothing at all** | init container | See below — this is the serious one. |
| `egov-accesscontrol` | embedded Flyway | init container | Last self-migrating service. Conversion is a no-op (see open question). |
| `audit-service` | init container **in base compose** | init container **in overlay** | Same pattern, two homes. Also now gates on `db-history-normalize` (it could previously race it) and is covered by `test-integration.sh` for the first time. |

Each `-db` image is pinned to the **same tag as its app image**, not the K8s `v2.9.2` release tag, so the migrations that run match the app that runs.

### egov-bndry-mgmnt had no schema mechanism

It's a Node service (no embedded Flyway), no migrator was ever wired, and its two tables existed **only because the dump ships them** — with no Flyway history under any name. A from-empty build produced no bndry schema and nothing noticed, because the fast-path dump always papered over it. It was also **absent from `flyway-history-map.yml` entirely**, so the CI alignment guard couldn't see it.

K8s has run its init container all along (`charts/urban/egov-bndry-mgmnt`). The app does not self-migrate — its image bundles `migration/main` + `migrate.sh` purely to build the `-db` image.

### `data_tables: []` was silently disabling the safety net

`indexer` and `accesscontrol` both had `data_tables: []`. `normalize.decide()` uses `data_tables` for its **ABORT** branch — the one that refuses to let Flyway replay V1 against populated tables. An empty list means that net can never fire. Both are now derived from the images' own `CREATE TABLE` statements, per the map's stated contract ("NOT guessed").

## Verification

Run end-to-end against the **real dump** on a scratch DB (not the live stack):

```
normalize:            rebuilt 1 (bndry's empty tables dropped), already-aligned 17
accesscontrol:        "Schema is up to date. No migration necessary."   <- no-op
indexer:              baselined + applied 2 migrations
bndry-mgmnt:          baselined + applied 1 migration
second run of all:    renamed 0, rebuilt 0, all migrators "up to date"  <- idempotent
base compose alone:   valid, 0 migrator references (after the audit move)
```

- `test-integration.sh` **part A**: all 15 migrators behave as expected; every pre-existing data table byte-identical (rows + checksum)
- `test-integration.sh` **part C**: fast and slow paths converge to an identical schema (766 columns / 175 indexes / 6 matviews)
- `test-integration.sh` **part B1/B2**: on a synthesised operator dump, the guard is proven both NEEDED and WORKING — harness fully green
- `check-flyway-dump-alignment.py`: **13 aligned, 5 baseline-fresh, 0 pending** ✅
- `test_flyway_history_normalize.py`: **12/12** ✅
- `docker compose config` validates with no profiles and with `search,otp,notifications,mcp,keycloak`


## 🐛 Bonus: a real bug the new convergence check found

While verifying that the dump path and the empty path agree, the comparison turned up **`eg_user.countrycode` existing only on the fast path**.

**Root cause — mismatched lineage.** The app runs `egov-user:mobilevalidation-jdk8-4984479` (which *uses* `countrycode`), but its migrator was pinned to `egov-user-db:master-d69ce29`, which predates `V20260309120000__alter_eg_user_add_countrycode.sql`. Someone bumped the app image without its paired `-db` — exactly what per-service pinning is supposed to prevent.

**The dump hid it.** The dump was baked from an environment that had already run that migration, so `countrycode` is baked into its `CREATE TABLE` while its history does *not* record the migration. Net effect: the dump had a column no pinned migration could produce, so **from-empty builds silently produced an `eg_user` with no `countrycode` under an app that expects one** — while the fast path kept working by accident. This is live functionality (#1264 `country_code_override_fix`; Maputo's `countryCode: "+258"`).

**Fix:** pin to `mobile-validation-user-otp-9883730` — a strict superset (28 = the same 27 + countrycode, no regressions). The migration is `ADD COLUMN IF NOT EXISTS`, so it's safe both ways:

| | Result |
|---|---|
| Fast path (dump) | applies 1 → `column already exists, skipping` → history records it → **26 `eg_user` rows untouched** |
| Slow path (empty) | applies 1 → creates the column |
| After | **766 = 766 columns** ✅ |

**K8s is not affected** — its chart pins app *and* db to `master-d69ce29`, so it's self-consistent on an older feature set. No chart change.

## 🛡️ New: part C — path convergence

Nothing could have caught the above. The CI alignment check compares only history-table **names**; part A only proves pre-existing data **survives**. Neither can see a column the migrations can't reproduce.

`test-integration.sh` now builds the schema **from the dump** and **from empty**, and asserts both converge — columns, indexes, and matview definitions:

```
fast path: 766 columns, 175 indexes, 6 matviews
slow path: 766 columns, 175 indexes, 6 matviews
PASS: fast and slow paths converge to an identical schema
```

**Verified the test has teeth:** reverting the pin makes it fail and name the defect exactly — `-col|eg_user.countrycode|character varying|10|YES`, 766 vs 765.

Supporting changes worth reviewer attention:
- Part C needs the three in-repo built migrators (pgr/novu-bridge/config), else the slow path would lack tables the dump *has* and report false drift.
- **Sections reordered A, C, B** — part B fails pre-existing (below) and `exit 1`s, which would have stopped part C from ever running.
- **Part A's snapshot now excludes Flyway history tables.** It asserts *data* survival, and a history table legitimately gains a row when a migration newer than the dump applies (now true for egov-user). Identified by column signature, not name — same rule as `normalize.py`.

## ✅ Part B rebuilt — the guard is now actually proven

Part B claimed to prove *"without the normalizer, data is destroyed"* — but it ran that test against **our** dump, which item #10 re-baked to canonical history names. That's the **safe** input: migrators find their history, no-op, destroy nothing. So it failed, reporting *"the guard isn't doing real work"* when the guard was fine and the **input** was wrong. The re-bake fixed the dump and silently invalidated the test. (Verified pre-existing: it fails identically on clean `develop`.)

The input this component exists for is an **operator's dump**, still on the legacy `*_schema_version` names. Part B now synthesises one by renaming our history tables backwards, and proves both halves:

```
B1) legacy dump, normalizer SKIPPED
  message                23061 → 0
  eg_enc_symmetric_keys      5 → 0        ← the keys that decrypt all user PII
  eg_enc_asymmetric_keys     5 → 0
  PASS: unguarded run destroys data — the guard is NEEDED

B2) legacy dump + normalizer
  renamed 10 history tables → canonical
  survived message               23061
  survived eg_enc_symmetric_keys     5
  PASS: guarded run renames and preserves every row — the guard WORKS
```

**B2 is the one that matters.** It's the *only* test that runs the rename path against a real database. Part A's dump is already canonical, so it reports `renamed 0` — meaning this component's central code path was covered by unit tests of `decide()` alone, and never executed as SQL in any test.

⚠️ **Reviewer note — the subtle bit.** The simulation renames each history table's **indexes** too. Flyway names them after the table (`<table>_pk`, `<table>_s_idx`) and Postgres's `ALTER TABLE ... RENAME` doesn't touch them. Renaming only the table produces a state that **cannot occur naturally** — table `x_version` whose PK is still `x_pk` — and Flyway then dies on `relation x_pk already exists` while baselining, *instead of replaying*. The run fails rather than destroys, and the test passes/fails for entirely the wrong reason. I hit exactly this on the first cut. A real legacy dump has no collision, because Flyway created the table *as* `x_version`.

**The harness is now fully green for the first time** (A, C, B1, B2).

## 🔴 Open question — accesscontrol

I converted it to satisfy the invariant, but the evidence says its schema may not belong on compose *at all*:

- Its own image ships `spring.flyway.enabled=false` in `application.properties`
- The K8s common chart sets `SPRING_FLYWAY_ENABLED: "false"` for every `java-spring` app, and `egov-accesscontrol/values.yaml` has `initContainers: {}` → **K8s has never created these four tables**
- All four (`service`, `eg_action`, `eg_roleaction`, `eg_ms_role`) sit at **0 rows** on a fully seeded, working stack — roles/actions are served from **MDMS** (`mdms.roleaction.path=$.MdmsRes.ACCESSCONTROL-ROLEACTIONS.roleactions`), seeded by default-data-handler
- The JDBC repositories are the legacy pre-MDMS path; `ActionService` calls `mdmsRepository`

So **compose alone enabled embedded Flyway here** — an unintentional local divergence. This PR preserves current behaviour (the migrator no-ops on any existing dump), but the alternative is to stop migrating it entirely and match upstream + K8s. That trades an orphaned `accesscontrol_schema_version` in the dump (which the CI check would flag) for honesty about a dead schema. **Happy to switch if reviewers prefer.**

## CI status — read before judging the reds

| Check | Status | |
|---|---|---|
| **flyway-dump-alignment** | ✅ **pass** | The check that actually covers this PR |
| `test` (Local Setup CI) | ❌ fail | **Pre-existing, repo-wide** |
| `tilt-test` | ⚠️ flaky | Alternates pass/fail across this branch's own commits |

`test` fails at *"Run Node.js smoke tests"* on **every branch** right now — `feat/whatsapp-contentsid-pipeline`, `feat/dashboard-number-format`, `feat/dashboard-metrics-client`, and others, all unrelated to this work. I verified an unrelated branch's run fails at the identical step. It is red before this PR and stays red after; nothing here touches it.

`tilt-test` passed on commits 1 and 3 of this branch and failed on 2 and 4, with unrelated changes between — i.e. flaky, not a signal.

Everything this PR *is* about was verified locally and is reproducible on demand:

```
./local-setup/db/normalize/test-integration.sh local-setup/db/full-dump.sql
  A  … PASS: every pre-existing table byte-identical
  C  … PASS: fast and slow paths converge to an identical schema
  B1 … PASS: unguarded run destroys data — the guard is NEEDED
  B2 … PASS: guarded run renames and preserves every row — the guard WORKS
  ALL PASS
```

## Still outstanding

`digit-user-preferences-service` self-migrates via **GORM AutoMigrate** — the purest violation of the invariant. Its K8s chart sets `dbMigration.enabled: false` deliberately ("Uses GORM AutoMigrate instead"). `egovio/digit-user-preferences-service-db` does exist, but adding a Flyway migrator without disabling AutoMigrate in the Go service would have both racing. That's an upstream architectural call, not a compose one — left out on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




