### PR TITLE
fix(pgr): employee create-complaint — reset fields after any submit attempt (moz)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/employee/CreateComplaint/createComplaintForm.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/CreateComplaint/createComplaintForm.js
@@ -605,12 +605,23 @@ const CreateComplaintForm = ({
    */
   const handleResponseForCreateComplaint = async (payload) => {
 
+    // A submit ATTEMPT (either outcome) invalidates the persisted draft:
+    // coming back to this page must show a blank form. On failure the
+    // IN-MEMORY values stay on screen so the operator can correct and
+    // resubmit immediately — and because draftJsonRef already equals the
+    // current form JSON, the change-guard in onFormValueChange won't
+    // re-persist them until the operator actually edits something.
+    const dropDraft = () => {
+      clearSessionFormData();
+    };
     await CreateComplaintMutation(payload, {
       onError: async () => {
+        dropDraft();
         setToast({ show: true, label: t("FAILED_TO_CREATE_COMPLAINT"), type: "error" });
       },
       onSuccess: async (responseData) => {
         if (responseData?.ResponseInfo?.Errors) {
+          dropDraft();
           setToast({ show: true, label: t("FAILED_TO_CREATE_COMPLAINT"), type: "error" });
         } else {
           // Clear both the sessionStorage cache and the in-memory form


### PR DESCRIPTION
## Employee create-complaint: failed submits also drop the draft

The form persists a session draft on every change (draft feature from #1093). A **successful** submit already cleared it before navigating (CCRS#478) — but a **failed** submit kept the persisted draft, so leaving the page and returning restored the failed attempt's values.

**Change:** any submit attempt (success *or* failure) invalidates the persisted draft — coming back to `/employee/pgr/create-complaint` always starts blank.

Behavior detail on failure: the on-screen values are intentionally kept so the operator can correct and resubmit immediately; the `onFormValueChange` change-guard (the draft-JSON ref already equals the current form JSON) keeps them from being re-persisted until a field is actually edited. The draft feature still works for the type → navigate away → return flow that never submitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> Moz twin (same commit cherry-picked onto `release-v2.12-moz`).