### PR TITLE
feat(analytics): group KPIs by complaint-hierarchy level — query-time rollup (#1111 PR1)

### DIFF
--- a/ansible/nairobi-mdms/mdms/dss/KpiDefinition.json
+++ b/ansible/nairobi-mdms/mdms/dss/KpiDefinition.json
@@ -764,7 +764,7 @@
     "tenantId": "ke",
     "data": {
       "id": "cl_chart_complaints_by_type",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "status": "published",
       "query": {
         "grain": "facts",
@@ -835,6 +835,9 @@
             "3",
             "4"
           ]
+        },
+        {
+          "name": "complaintPath"
         }
       ],
       "rbac": {
@@ -1071,7 +1074,7 @@
     "tenantId": "ke",
     "data": {
       "id": "cl_chart_open_by_type_stage",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "status": "published",
       "query": {
         "grain": "facts",
@@ -1161,6 +1164,9 @@
             "3",
             "4"
           ]
+        },
+        {
+          "name": "complaintPath"
         }
       ],
       "rbac": {
@@ -1455,7 +1461,7 @@
     "tenantId": "ke",
     "data": {
       "id": "cl_table_complaint_type_details",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "status": "published",
       "query": {
         "grain": "facts",
@@ -1660,6 +1666,9 @@
             "3",
             "4"
           ]
+        },
+        {
+          "name": "complaintPath"
         }
       ],
       "rbac": {
@@ -3301,10 +3310,13 @@
             "3",
             "4"
           ]
+        },
+        {
+          "name": "complaintPath"
         }
       ],
       "status": "published",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "supportsSeries": false
     }
   },
@@ -3410,10 +3422,13 @@
             "3",
             "4"
           ]
+        },
+        {
+          "name": "complaintPath"
         }
       ],
       "status": "published",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "supportsSeries": false
     }
   }

--- a/ansible/nairobi-mdms/mdms/dss/KpiDefinition.json
+++ b/ansible/nairobi-mdms/mdms/dss/KpiDefinition.json
@@ -837,7 +837,9 @@
           ]
         },
         {
-          "name": "complaintPath"
+          "name": "complaintPath",
+          "default": "",
+          "allowed": []
         }
       ],
       "rbac": {
@@ -1166,7 +1168,9 @@
           ]
         },
         {
-          "name": "complaintPath"
+          "name": "complaintPath",
+          "default": "",
+          "allowed": []
         }
       ],
       "rbac": {
@@ -1668,7 +1672,9 @@
           ]
         },
         {
-          "name": "complaintPath"
+          "name": "complaintPath",
+          "default": "",
+          "allowed": []
         }
       ],
       "rbac": {
@@ -3312,7 +3318,9 @@
           ]
         },
         {
-          "name": "complaintPath"
+          "name": "complaintPath",
+          "default": "",
+          "allowed": []
         }
       ],
       "status": "published",
@@ -3424,7 +3432,9 @@
           ]
         },
         {
-          "name": "complaintPath"
+          "name": "complaintPath",
+          "default": "",
+          "allowed": []
         }
       ],
       "status": "published",

--- a/ansible/nairobi-mdms/mdms/dss/KpiDefinition.json
+++ b/ansible/nairobi-mdms/mdms/dss/KpiDefinition.json
@@ -764,7 +764,7 @@
     "tenantId": "ke",
     "data": {
       "id": "cl_chart_complaints_by_type",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "status": "published",
       "query": {
         "grain": "facts",
@@ -823,6 +823,17 @@
             "last_30d",
             "wtd",
             "mtd"
+          ]
+        },
+        {
+          "name": "hierLevel",
+          "default": "1",
+          "allowed": [
+            "leaf",
+            "1",
+            "2",
+            "3",
+            "4"
           ]
         }
       ],
@@ -1060,7 +1071,7 @@
     "tenantId": "ke",
     "data": {
       "id": "cl_chart_open_by_type_stage",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "status": "published",
       "query": {
         "grain": "facts",
@@ -1138,6 +1149,17 @@
             "last_30d",
             "wtd",
             "mtd"
+          ]
+        },
+        {
+          "name": "hierLevel",
+          "default": "1",
+          "allowed": [
+            "leaf",
+            "1",
+            "2",
+            "3",
+            "4"
           ]
         }
       ],
@@ -1433,7 +1455,7 @@
     "tenantId": "ke",
     "data": {
       "id": "cl_table_complaint_type_details",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "status": "published",
       "query": {
         "grain": "facts",
@@ -1623,7 +1645,20 @@
             "last_7d",
             "last_30d",
             "wtd",
-            "mtd"
+            "mtd",
+            "all"
+          ],
+          "default": "all"
+        },
+        {
+          "name": "hierLevel",
+          "default": "leaf",
+          "allowed": [
+            "leaf",
+            "1",
+            "2",
+            "3",
+            "4"
           ]
         }
       ],
@@ -1718,7 +1753,7 @@
     "tenantId": "ke",
     "data": {
       "id": "cl_chart_over_time_created_daily",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "status": "published",
       "query": {
         "grain": "facts",
@@ -1762,6 +1797,7 @@
       "viz": {
         "kind": "line",
         "format": "integer",
+        "valueKey": "created",
         "accent": "teal",
         "group": "complaint-landscape",
         "titleKey": "RAINMAKER-PGR.DASHBOARD_KPI_CL_CHART_OVER_TIME_CREATED_DAILY",
@@ -3254,10 +3290,21 @@
             "mtd"
           ],
           "default": "last_7d"
+        },
+        {
+          "name": "hierLevel",
+          "default": "leaf",
+          "allowed": [
+            "leaf",
+            "1",
+            "2",
+            "3",
+            "4"
+          ]
         }
       ],
       "status": "published",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "supportsSeries": false
     }
   },
@@ -3352,10 +3399,21 @@
             "mtd"
           ],
           "default": "last_7d"
+        },
+        {
+          "name": "hierLevel",
+          "default": "leaf",
+          "allowed": [
+            "leaf",
+            "1",
+            "2",
+            "3",
+            "4"
+          ]
         }
       ],
       "status": "published",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "supportsSeries": false
     }
   }

--- a/backend/pgr-services/ANALYTICS-QUERY-API.md
+++ b/backend/pgr-services/ANALYTICS-QUERY-API.md
@@ -108,6 +108,7 @@ shorthand for `eq`):
 | `gt`/`gte`/`lt`/`lte` | `{ "gte": 1719792000000 }` |
 | `in` | `{ "in": ["web","mobile"] }` |
 | `isnull` | `{ "isnull": false }` |
+| `starts_with` / `subtree` | `{ "starts_with": "BOMET." }` / `{ "subtree": "SANITATION.SEWAGE" }` — allowed ONLY on the grain's prefix-filterable materialized-path columns (`boundary_path`, `complaint_node_path`). `subtree` is the delimiter-guarded form (`col = ? OR col LIKE ?\|\|'.%'`): the node itself plus dot-descendants, so `PGR` never matches a `PGRX` sibling |
 
 UUID/PII-adjacent columns (e.g. `account_id`, `current_assignee_uuid`) are **group-by-able and
 distinct-countable but not filterable** — arbitrary UUID probing is rejected.
@@ -136,7 +137,8 @@ ignored) and every declared param with an `allowed` list is enforced server-side
 | `window` | overrides `query.window.name`, preserving `timeRole`/`timeBucket` |
 | `dateFrom` + `dateTo` | inclusive ISO dates → half-open range on the grain's time column; removes the base window |
 | `ward` | narrows `ward_code = ?` iff filterable on the grain |
-| `serviceCode` | narrows `service_code = ?` iff filterable |
+| `serviceCode` | narrows `service_code = ?` iff filterable — the param for complaint-type **leaf** selections (exact match; works on every grain incl. daily) |
+| `complaintPath` | narrows to a complaint-hierarchy **interior** node's whole subtree: a delimiter-guarded `subtree` predicate on `complaint_node_path` (`= ? OR LIKE ?\|\|'.%'`) iff the grain carries the path column (facts/events). Value = the node's dot-path (`SANITATION.SEWAGE`); validated against `[A-Za-z0-9._/-]` (max 256 chars) — anything else is `invalid_param`. On the daily grain (no path column) the filter cannot apply and the result envelope reports `paramsIgnored:["complaintPath"]` instead of silently serving unfiltered numbers. Leaf selections keep using `serviceCode`; NULL-path rows (node codes containing `.`, flat tenants) never match a subtree |
 | `compare: "prior"` | immediately-preceding equal-duration range — "vs prior period" deltas |
 | `series: "daily"` | scalar → daily time series — sparklines |
 | `hierLevel` | `"leaf"` (no-op) or `"1"`..`"12"`: re-groups every `service_code` dimension by the Nth segment of the materialized `complaint_node_path` (#1111). The derived expression is a fixed server-side template aliased back `AS service_code` — result columns are unchanged, and aggregates recompute over raw rows (weighted). NULL/empty-path rows fall back to their leaf code; a level deeper than a row's depth clamps to its leaf; grains without the path column (daily) no-op. A `service_group` dimension is dropped at non-leaf levels (it duplicates the level bucket). Note: `avg(sla_target_ms)`-style measures average heterogeneous per-subtype SLAs inside a level bucket — indicative, not a category SLA |
@@ -164,6 +166,11 @@ planner and is never widened. Full semantics + catalog cookbook:
 Batch responses wrap each query under `results.<name>` plus a top-level `partial` flag (one failed
 query never blanks the others). `asOf` is the materialized-view refresh instant — data is as fresh
 as the last refresh, not real-time. Durations are epoch-milliseconds.
+
+When a supplied param could not be applied to the def's grain **and the caller must know**
+(today: `complaintPath` on the path-less daily grain), the per-query result additionally carries
+`"paramsIgnored": ["complaintPath"]` — the FE shows a "filter not applied" indicator instead of
+presenting an unfiltered number as filtered. The field is absent when every param applied.
 
 ---
 

--- a/backend/pgr-services/ANALYTICS-QUERY-API.md
+++ b/backend/pgr-services/ANALYTICS-QUERY-API.md
@@ -123,6 +123,28 @@ distinct-countable but not filterable** — arbitrary UUID probing is rejected.
 - `timeRole`: a named time column for the grain (e.g. facts: `filed_at`, `resolved_at`;
   events: `event_at`; daily: `snapshot_date`). Defaults per grain.
 
+### `params` — kpiId-by-reference tuning knobs
+
+Instead of an inline grammar body, a query node may reference a stored KPI definition and tune
+it: `{ "kpiId": "<id>", "params": { … } }`. The server layers the params onto the def's baked
+query (`KpiQueryComposer.mergeParams`); the param vocabulary is fixed (unknown names are
+ignored) and every declared param with an `allowed` list is enforced server-side
+(`invalid_param` when out of list):
+
+| param | effect |
+|---|---|
+| `window` | overrides `query.window.name`, preserving `timeRole`/`timeBucket` |
+| `dateFrom` + `dateTo` | inclusive ISO dates → half-open range on the grain's time column; removes the base window |
+| `ward` | narrows `ward_code = ?` iff filterable on the grain |
+| `serviceCode` | narrows `service_code = ?` iff filterable |
+| `compare: "prior"` | immediately-preceding equal-duration range — "vs prior period" deltas |
+| `series: "daily"` | scalar → daily time series — sparklines |
+| `hierLevel` | `"leaf"` (no-op) or `"1"`..`"12"`: re-groups every `service_code` dimension by the Nth segment of the materialized `complaint_node_path` (#1111). The derived expression is a fixed server-side template aliased back `AS service_code` — result columns are unchanged, and aggregates recompute over raw rows (weighted). NULL/empty-path rows fall back to their leaf code; a level deeper than a row's depth clamps to its leaf; grains without the path column (daily) no-op. A `service_group` dimension is dropped at non-leaf levels (it duplicates the level bucket). Note: `avg(sla_target_ms)`-style measures average heterogeneous per-subtype SLAs inside a level bucket — indicative, not a category SLA |
+
+Params can only narrow/re-group: the server-injected RBAC row-scope is layered on top by the
+planner and is never widened. Full semantics + catalog cookbook:
+`docs/dashboard-configuration/10-kpi-catalog.md` §4.
+
 ---
 
 ## 5. Response shape

--- a/backend/pgr-services/pom.xml
+++ b/backend/pgr-services/pom.xml
@@ -127,6 +127,14 @@
             <artifactId>opentelemetry-api</artifactId>
             <version>1.45.0</version>
         </dependency>
+        <!-- SDK + in-memory reader, tests only: lets AnalyticsMetricsTest assert the
+             exact instrument names/units the collector's prometheus exporter surfaces. -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+            <version>1.45.0</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/backend/pgr-services/pom.xml
+++ b/backend/pgr-services/pom.xml
@@ -117,6 +117,16 @@
             <version>2.9.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
+        <!-- #1110: analytics query metrics. API-only — the OTEL javaagent (v2.11.0, see
+             otel/download-agent.sh) bridges GlobalOpenTelemetry to its SDK at runtime;
+             without the agent every call is a no-op (tests/CI safe). Version pinned to
+             the SDK bundled by javaagent 2.11.0. Boot 3.2.2 manages an older otel BOM,
+             so the explicit version here is required. -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <version>1.45.0</version>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsCatalog.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsCatalog.java
@@ -147,6 +147,53 @@ public class AnalyticsCatalog {
     public static final Set<String> AGG_FNS =
         setOf("count","count_distinct","sum","avg","min","max","percentile","ratio");
 
+    // ---- #1111: complaint-hierarchy level rollup (query-time derived dimension) ----
+
+    /** Max hierarchy level, matching the grain migrations' chwalk recursion guard (depth < 12). */
+    public static final int MAX_HIER_LEVEL = 12;
+
+    /**
+     * #1111/R1: composer-internal derived-dimension marker. The planner accepts an OBJECT
+     * dimension {@code {"__hierLevel": <n>, "__token": <jvm-nonce>}} ONLY when {@code __token}
+     * equals this per-JVM nonce — which only {@link KpiQueryComposer} (in-process, never
+     * serialized) can supply. Request bodies and MDMS defs arrive as parsed JSON and cannot
+     * know the nonce, so the object-dimension form is unreachable from any external input:
+     * there is NO generic expression injection surface, and the inline-query grammar is
+     * unchanged (textual dimensions only).
+     */
+    static final String HIER_DIM_LEVEL_FIELD = "__hierLevel";
+    static final String HIER_DIM_TOKEN_FIELD = "__token";
+    static final String HIER_DIM_TOKEN = UUID.randomUUID().toString();
+
+    /**
+     * #1111: fixed registry of grains carrying {@code complaint_node_path}/{@code complaint_depth}
+     * — the only grains that can serve the hierarchy-level derived dimension (facts + events;
+     * daily has no path column, so a {@code hierLevel} param no-ops there exactly like ward).
+     */
+    private static final Set<String> HIER_LEVEL_GRAINS = setOf("facts","events");
+
+    public boolean supportsHierLevel(String grainName){ return HIER_LEVEL_GRAINS.contains(grainName); }
+
+    /**
+     * The hierarchy-level rollup expression for path segment {@code level} (1-based):
+     * the Nth '.'-segment of {@code complaint_node_path}, clamped to the row's own depth
+     * (a depth-2 complaint asked for level-3 buckets stays under its leaf instead of a NULL
+     * bucket), with the leaf {@code service_code} as fallback for rows with a NULL/empty path
+     * (flat/legacy tenants keep today's leaf buckets — the AC's leaf-only fallback for free).
+     *
+     * <p>The template is FIXED Java — neither MDMS defs nor request JSON can supply an
+     * expression. The only variable is {@code level}, validated here (defense in depth, the
+     * composer/planner validate first) and interpolated as a bare int, never raw input.
+     */
+    public String hierLevelExpr(String grainName, int level){
+        if (!supportsHierLevel(grainName))
+            throw new IllegalArgumentException("invalid_param: hierLevel is not supported on grain " + grainName);
+        if (level < 1 || level > MAX_HIER_LEVEL)
+            throw new IllegalArgumentException("invalid_param: hierLevel must be an integer in 1.." + MAX_HIER_LEVEL);
+        return "coalesce(nullif(split_part(complaint_node_path,'.',least(" + level
+                + ",complaint_depth)),''), service_code)";
+    }
+
     // ---- helpers ----
     @SafeVarargs private static <T> Set<T> setOf(T... a){ return new LinkedHashSet<>(Arrays.asList(a)); }
     private static Map<String,String> mapOf(String... kv){

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsController.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsController.java
@@ -113,8 +113,14 @@ public class AnalyticsController {
             // (tenant corpus on complaint_facts, NOT the caller's ABAC-visible subset).
             out.put("packId", pack.map(DashboardPack::getId).orElse(null));
             out.put("persona", pack.map(p -> matchingRole(p, callerRoles)).orElse(null));
+            // recordCount is live tenant data, so it takes the same coarse pack-match
+            // gate as packId/persona: no matching pack (e.g. the anonymous PUBLIC floor
+            // on a tenant with no public pack) -> null. Without this gate an
+            // unauthenticated caller could POST arbitrary tenantIds and enumerate every
+            // tenant's complaint volume. The corpus-not-ABAC-subset semantics (R9-C9)
+            // are unchanged for callers that do match a pack.
             int stateLen = config.getStateLevelTenantIdLength() == null ? 1 : config.getStateLevelTenantIdLength();
-            out.put("recordCount", service.recordCount(tenantId, stateLen));
+            out.put("recordCount", pack.isPresent() ? service.recordCount(tenantId, stateLen) : null);
             return ResponseEntity.ok(out);
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(error(e));

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsController.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsController.java
@@ -47,13 +47,16 @@ public class AnalyticsController {
     }
 
     @PostMapping("/_query")
-    public ResponseEntity<Map<String,Object>> query(@RequestBody JsonNode body){
+    public ResponseEntity<Map<String,Object>> query(@RequestBody JsonNode body,
+            // #1110: correlation FALLBACK only — when the OTEL javaagent is attached, the
+            // active span's trace id (W3C traceparent, propagated by Kong) takes precedence.
+            @RequestHeader(value = "x-trace-id", required = false) String xTraceId){
         try {
             RequestInfo requestInfo = body.has("RequestInfo")
                     ? mapper.convertValue(body.get("RequestInfo"), RequestInfo.class) : null;
             String tenantId = body.hasNonNull("tenantId") ? body.get("tenantId").asText() : null;
             int stateLen = config.getStateLevelTenantIdLength() == null ? 1 : config.getStateLevelTenantIdLength();
-            Map<String,Object> result = service.query(body, requestInfo, tenantId, stateLen);
+            Map<String,Object> result = service.query(body, requestInfo, tenantId, stateLen, xTraceId);
             return ResponseEntity.ok(result);
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(error(e));
@@ -103,6 +106,15 @@ public class AnalyticsController {
             out.put("tiles", tiles);
             out.put("defaultLayout", pack.map(DashboardPack::getLayout).orElse(Collections.emptyList()));
             out.put("asOf", System.currentTimeMillis());
+            // #1110: additive fields the dashboard reads defensively (null until data exists).
+            // packId -> layout_id tag; persona -> the server's ACTUAL pack-match decision
+            // (first pack-role the caller holds, in the pack's declared role order — same
+            // semantics as DashboardPack.matchesRoles); recordCount -> record_count_tier tag
+            // (tenant corpus on complaint_facts, NOT the caller's ABAC-visible subset).
+            out.put("packId", pack.map(DashboardPack::getId).orElse(null));
+            out.put("persona", pack.map(p -> matchingRole(p, callerRoles)).orElse(null));
+            int stateLen = config.getStateLevelTenantIdLength() == null ? 1 : config.getStateLevelTenantIdLength();
+            out.put("recordCount", service.recordCount(tenantId, stateLen));
             return ResponseEntity.ok(out);
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(error(e));
@@ -144,6 +156,17 @@ public class AnalyticsController {
     }
 
     // ---- helpers ----
+
+    /**
+     * The role that made the pack match (#1110/R9-C7): first role in the PACK's declared
+     * roles list that the caller holds. Deterministic (pack order, not set order) and
+     * consistent with {@link DashboardPack#matchesRoles} — a non-null result is exactly
+     * "this pack matched". Returned as the {@code persona} tag source for the FE.
+     */
+    private String matchingRole(DashboardPack pack, Set<String> callerRoles) {
+        if (pack.getRoles() == null || callerRoles == null) return null;
+        return pack.getRoles().stream().filter(callerRoles::contains).findFirst().orElse(null);
+    }
 
     /** Serializes a KpiDefinition for external consumption: includes viz/params but NEVER query or rbac. */
     private Map<String,Object> safeTile(KpiDefinition def) {

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsMetrics.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsMetrics.java
@@ -75,7 +75,7 @@ public class AnalyticsMetrics {
             queryDuration.record(tookMs, attrs);
             queryRows.add(rowCount, attrs);
         } catch (RuntimeException e) {
-            log.debug("analytics metrics record failed (ignored): {}", e.toString());
+            log.debug("analytics metrics record failed (ignored)", e);
         }
     }
 

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsMetrics.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsMetrics.java
@@ -46,14 +46,22 @@ public class AnalyticsMetrics {
     private final LongCounter queryRows;
 
     public AnalyticsMetrics() {
-        Meter meter = GlobalOpenTelemetry.getMeter(METER_NAME);
+        this(GlobalOpenTelemetry.getMeter(METER_NAME));
+    }
+
+    /** Visible for tests: lets a test pass an SDK meter to assert instrument shape. */
+    AnalyticsMetrics(Meter meter) {
+        // NOTE: no unit on purpose. The metric NAMES already carry their unit (.ms),
+        // and the collector's prometheus exporter appends a unit-derived suffix when
+        // unit is set — validated live on bomet: unit "ms" surfaced as
+        // pgr_analytics_query_duration_ms_milliseconds_*. Omitting the unit keeps the
+        // scraped names exactly pgr_analytics_query_duration_ms_* /
+        // pgr_analytics_query_rows_total (same fix as the client's dashboardMetrics.js, #1268).
         this.queryDuration = meter.histogramBuilder("pgr.analytics.query.duration.ms")
                 .setDescription("Duration of one executed analytics SQL query (per batch entry / compose source)")
-                .setUnit("ms")
                 .build();
         this.queryRows = meter.counterBuilder("pgr.analytics.query.rows")
                 .setDescription("Rows returned by executed analytics SQL queries")
-                .setUnit("{row}")
                 .build();
     }
 

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsMetrics.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsMetrics.java
@@ -29,8 +29,10 @@ import org.springframework.stereotype.Component;
  *   <li>{@code pgr.analytics.query.rows} — counter of rows returned.</li>
  * </ul>
  * Attributes: {@code kpi_id} (the KPI id, {@code inline} for inline-grammar queries),
- * {@code grain}, {@code tenant}. Cardinality is bounded: kpi_id by the MDMS catalog
- * (tens), grain by the 3 grains, tenant by the tenant tree.
+ * {@code grain}, {@code tenant} (the STATE-ROOT tenant, never the raw request
+ * tenantId — see {@link QueryTelemetry#stateRootOf}). Cardinality is bounded: kpi_id
+ * by the MDMS catalog (tens), grain by the 3 grains, tenant by the deployment's
+ * state roots.
  */
 @Component
 @Slf4j
@@ -72,7 +74,9 @@ public class AnalyticsMetrics {
      * @param kpiId  the KPI id the query was resolved from, or {@code "inline"} for
      *               inline-grammar queries
      * @param grain  the grain the planner resolved ({@code facts|events|daily})
-     * @param tenant the request tenantId (scope tenant, not per-row)
+     * @param tenant the STATE-ROOT tenant (callers must pre-normalize via
+     *               {@link QueryTelemetry#stateRootOf} — the raw request tenantId is
+     *               attacker-controlled and would blow up label cardinality)
      */
     public void recordQuery(String kpiId, String grain, String tenant, long tookMs, long rowCount) {
         try {

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsMetrics.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsMetrics.java
@@ -1,0 +1,85 @@
+package org.egov.pgr.analytics;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.Meter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * OTEL metrics for the dynamic analytics endpoints (#1110 — dashboard render-lag
+ * instrumentation, server half).
+ *
+ * <p>Thin wrapper over {@link GlobalOpenTelemetry}: when the service runs under the
+ * OpenTelemetry javaagent (the deploy.sh stack attaches it and sets
+ * {@code OTEL_METRICS_EXPORTER=otlp}), the agent bridges this to its SDK and the
+ * instruments export to the collector → Prometheus. Without the agent (unit tests, CI,
+ * bare {@code java -jar}) {@code GlobalOpenTelemetry} is a no-op and every call here is
+ * free and side-effect-less — no config or conditional wiring needed.
+ *
+ * <p>Instruments (OTLP names; Prometheus surfaces them as
+ * {@code pgr_analytics_query_duration_ms_bucket/_sum/_count} and
+ * {@code pgr_analytics_query_rows_total}):
+ * <ul>
+ *   <li>{@code pgr.analytics.query.duration.ms} — histogram, one point per executed SQL
+ *       query (each batch entry, and each SOURCE query of a backend-composed KPI).</li>
+ *   <li>{@code pgr.analytics.query.rows} — counter of rows returned.</li>
+ * </ul>
+ * Attributes: {@code kpi_id} (the KPI id, {@code inline} for inline-grammar queries),
+ * {@code grain}, {@code tenant}. Cardinality is bounded: kpi_id by the MDMS catalog
+ * (tens), grain by the 3 grains, tenant by the tenant tree.
+ */
+@Component
+@Slf4j
+public class AnalyticsMetrics {
+
+    static final String METER_NAME = "pgr-analytics";
+
+    static final AttributeKey<String> ATTR_KPI_ID = AttributeKey.stringKey("kpi_id");
+    static final AttributeKey<String> ATTR_GRAIN  = AttributeKey.stringKey("grain");
+    static final AttributeKey<String> ATTR_TENANT = AttributeKey.stringKey("tenant");
+
+    private final DoubleHistogram queryDuration;
+    private final LongCounter queryRows;
+
+    public AnalyticsMetrics() {
+        Meter meter = GlobalOpenTelemetry.getMeter(METER_NAME);
+        this.queryDuration = meter.histogramBuilder("pgr.analytics.query.duration.ms")
+                .setDescription("Duration of one executed analytics SQL query (per batch entry / compose source)")
+                .setUnit("ms")
+                .build();
+        this.queryRows = meter.counterBuilder("pgr.analytics.query.rows")
+                .setDescription("Rows returned by executed analytics SQL queries")
+                .setUnit("{row}")
+                .build();
+    }
+
+    /**
+     * Record one executed analytics query. Never throws — telemetry must not be able to
+     * break the query path.
+     *
+     * @param kpiId  the KPI id the query was resolved from, or {@code "inline"} for
+     *               inline-grammar queries
+     * @param grain  the grain the planner resolved ({@code facts|events|daily})
+     * @param tenant the request tenantId (scope tenant, not per-row)
+     */
+    public void recordQuery(String kpiId, String grain, String tenant, long tookMs, long rowCount) {
+        try {
+            Attributes attrs = Attributes.of(
+                    ATTR_KPI_ID, orDash(kpiId),
+                    ATTR_GRAIN, orDash(grain),
+                    ATTR_TENANT, orDash(tenant));
+            queryDuration.record(tookMs, attrs);
+            queryRows.add(rowCount, attrs);
+        } catch (RuntimeException e) {
+            log.debug("analytics metrics record failed (ignored): {}", e.toString());
+        }
+    }
+
+    private static String orDash(String v) {
+        return (v == null || v.isEmpty()) ? "-" : v;
+    }
+}

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java
@@ -55,6 +55,17 @@ public class AnalyticsPlanner {
 
         // ---- dimensions ----
         if (q.has("dimensions")) for (JsonNode d : q.get("dimensions")) {
+            if (d.isObject()) {
+                // #1111/R1: the ONLY object dimension the grammar accepts is the composer-emitted
+                // hierarchy-level marker (nonce-gated; unreachable from request/MDMS JSON). It is
+                // aliased AS service_code so viz/sort/columns keep working unchanged, and grouped
+                // by ordinal below, so an expression dimension is safe.
+                String expr = hierLevelDimExpr(d, grainName);
+                selectExprs.add(expr + " AS service_code");
+                groupExprs.add(expr);
+                columns.add("service_code");
+                continue;
+            }
             String col = d.asText();
             if (!g.groupable.contains(col)) throw new IllegalArgumentException("unknown_column: dimension '" + col + "' not groupable on " + grainName);
             selectExprs.add(col + " AS " + col);
@@ -114,6 +125,31 @@ public class AnalyticsPlanner {
         List<Object> params = new ArrayList<>(selectParams);   // SELECT params precede WHERE params
         params.addAll(whereParams);
         return new Planned(sb.toString(), params, columns, grainName);
+    }
+
+    // ---------- #1111: hierarchy-level derived dimension (composer-internal) ----------
+
+    /**
+     * Validate a composer-emitted hierarchy-level dimension marker and return the fixed SQL
+     * expression from {@link AnalyticsCatalog#hierLevelExpr}. Rejects any object dimension whose
+     * {@code __token} is not this JVM's {@link AnalyticsCatalog#HIER_DIM_TOKEN} — external JSON
+     * (inline queries, MDMS defs) can never carry the nonce, so object dimensions remain outside
+     * the public grammar. The level must strictly parse to an int in 1..{@code MAX_HIER_LEVEL};
+     * it is interpolated by the catalog as a bare int, never string-concatenated raw input.
+     */
+    private String hierLevelDimExpr(JsonNode d, String grainName){
+        String token = d.path(AnalyticsCatalog.HIER_DIM_TOKEN_FIELD).asText(null);
+        if (!AnalyticsCatalog.HIER_DIM_TOKEN.equals(token))
+            throw new IllegalArgumentException("unknown_column: object dimensions are not part of the query grammar");
+        JsonNode lvl = d.get(AnalyticsCatalog.HIER_DIM_LEVEL_FIELD);
+        int level;
+        try {
+            level = Integer.parseInt(lvl == null ? "" : lvl.asText());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    "invalid_param: hierLevel must be an integer in 1.." + AnalyticsCatalog.MAX_HIER_LEVEL);
+        }
+        return catalog.hierLevelExpr(grainName, level);
     }
 
     // ---------- measures ----------

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java
@@ -232,6 +232,20 @@ public class AnalyticsPlanner {
                 parts.add(colKey + " LIKE ? || '%'");
                 continue;
             }
+            // subtree: delimiter-guarded subtree membership on a materialized dot-path column —
+            // the node itself OR any dot-descendant. Unlike a bare starts_with, the '.' guard
+            // prevents sibling-prefix collisions ('PGR' must not match 'PGRX.…'), and the eq arm
+            // keeps mixed interior+serviceable nodes (a complaint filed AT the node) in the
+            // subtree. Same allowlist as starts_with (prefix-filterable path columns only), same
+            // bound-param + LIKE-escape mechanics.
+            if ("subtree".equals(op)) {
+                if (!prefixFilterable) throw new IllegalArgumentException(
+                        "op_not_allowed: 'subtree' is only permitted on prefix-filterable path columns, not '" + colKey + "' on " + g.name);
+                params.add(v.asText());
+                params.add(escapeLike(v.asText()));
+                parts.add("(" + colKey + " = ? OR " + colKey + " LIKE ? || '.%')");
+                continue;
+            }
             if (!plainFilterable) throw new IllegalArgumentException(
                     "op_not_allowed: column '" + colKey + "' on " + g.name + " only supports the 'starts_with' filter op");
             switch (op) {

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
@@ -236,8 +236,11 @@ public class AnalyticsService {
      * > the def's baked query (a defaulted param flows through {@link KpiQueryComposer#mergeParams}
      * exactly like a caller-sent one, and the C1 window allow-list check runs on the EFFECTIVE
      * params). Returns {@code reqParams} untouched (possibly null) when no default applies.
+     * An EMPTY-STRING default is a no-op (skipped like an absent one) — the dss.KpiDefinition
+     * schema requires {@code default} on every params entry, so free-form params (complaintPath)
+     * are seeded with {@code "default":""}. Package-private for tests.
      */
-    private JsonNode withDeclaredDefaults(KpiDefinition def, JsonNode reqParams) {
+    JsonNode withDeclaredDefaults(KpiDefinition def, JsonNode reqParams) {
         List<KpiDefinition.KpiParam> declared = def.getParams();
         if (declared == null || declared.isEmpty()) return reqParams;
         com.fasterxml.jackson.databind.node.ObjectNode merged = null;
@@ -261,7 +264,9 @@ public class AnalyticsService {
      * def's declared params carrying a non-empty {@code allowed} list, an effective (caller-sent or
      * defaulted) value must be in that list. Out-of-list (incl. arbitrary {@code last_Nd} windows,
      * out-of-range {@code hierLevel}s) → {@code invalid_param}. No-op for params the def declares
-     * without an allow-list (open values) and for undeclared params (composer vocabulary applies).
+     * without an allow-list — absent OR empty {@code "allowed":[]} both mean unvalidated free-form
+     * (the dss.KpiDefinition schema requires the key, so complaintPath is seeded with an empty
+     * list) — and for undeclared params (composer vocabulary applies).
      * Runs on BOTH the normal kpiId path and the compose path (each calls this on its own def).
      */
     void validateAllowedParams(KpiDefinition def, JsonNode reqParams) {

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
@@ -268,15 +268,24 @@ public class AnalyticsService {
      * (the dss.KpiDefinition schema requires the key, so complaintPath is seeded with an empty
      * list) — and for undeclared params (composer vocabulary applies).
      * Runs on BOTH the normal kpiId path and the compose path (each calls this on its own def).
+     * Malformed shapes are rejected outright: a non-object {@code params} node, or an object/array
+     * value for a declared allow-listed param, is {@code invalid_param} (never a silent bypass).
      */
     void validateAllowedParams(KpiDefinition def, JsonNode reqParams) {
-        if (reqParams == null || def.getParams() == null) return;
+        if (reqParams == null || reqParams.isNull()) return;
+        if (!reqParams.isObject())
+            throw new IllegalArgumentException("invalid_param: params must be an object");
+        if (def.getParams() == null) return;
         for (KpiDefinition.KpiParam p : def.getParams()) {
             if (p == null || p.getName() == null) continue;
             List<String> allowed = p.getAllowed();
             if (allowed == null || allowed.isEmpty()) continue;
             if (!reqParams.hasNonNull(p.getName())) continue;
-            String requested = reqParams.get(p.getName()).asText();
+            JsonNode value = reqParams.get(p.getName());
+            if (!value.isValueNode())
+                throw new IllegalArgumentException(
+                        "invalid_param: " + p.getName() + " must be a scalar value");
+            String requested = value.asText();
             if (requested.isEmpty()) continue;
             if (!allowed.contains(requested))
                 throw new IllegalArgumentException(

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
@@ -7,6 +7,7 @@ import org.egov.common.contract.request.Role;
 import org.egov.common.contract.request.User;
 import org.egov.pgr.analytics.AnalyticsCatalog.Grain;
 import org.egov.pgr.analytics.model.KpiDefinition;
+import org.egov.pgr.config.PGRConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
@@ -69,14 +70,16 @@ public class AnalyticsService {
     private final PrincipalScopeResolver scopeResolver;
     private final KpiQueryComposer queryComposer;
     private final AnalyticsMetrics metrics;
+    private final PGRConfiguration config;
 
     @Autowired
     public AnalyticsService(AnalyticsPlanner planner, AnalyticsCatalog catalog, JdbcTemplate jdbc,
                             KpiCatalogService kpiCatalogService, PrincipalScopeResolver scopeResolver,
-                            KpiQueryComposer queryComposer, AnalyticsMetrics metrics){
+                            KpiQueryComposer queryComposer, AnalyticsMetrics metrics,
+                            PGRConfiguration config){
         this.planner = planner; this.catalog = catalog; this.jdbc = jdbc;
         this.kpiCatalogService = kpiCatalogService; this.scopeResolver = scopeResolver;
-        this.queryComposer = queryComposer; this.metrics = metrics;
+        this.queryComposer = queryComposer; this.metrics = metrics; this.config = config;
     }
 
     /** Back-compat entry point (no trace correlation header). */
@@ -544,7 +547,6 @@ public class AnalyticsService {
 
     // ---- #1110: tenant record-count for /packs (record_count_tier tag source) ----
 
-    private static final long RECORD_COUNT_TTL_MS = 5 * 60_000L;
     /** tenantId -> [count, expiresAtMs]. Concurrent; a stale entry is simply recomputed. */
     private final java.util.concurrent.ConcurrentHashMap<String, long[]> recordCountCache =
             new java.util.concurrent.ConcurrentHashMap<>();
@@ -559,8 +561,9 @@ public class AnalyticsService {
      * {@code record_count_tier} tag, which must describe the tenant's data volume so
      * render-lag comparisons across personas share a denominator (#1110/R9-C9).
      *
-     * <p>Cached in-memory for 5 minutes per tenant; errors return null (additive,
-     * never fails the /packs response) and are not cached.
+     * <p>Cached in-memory per tenant for {@code pgr.analytics.config-cache-ttl-ms}
+     * (the single TTL shared by every analytics config cache; default 5 minutes);
+     * errors return null (additive, never fails the /packs response) and are not cached.
      */
     public Long recordCount(String tenantId, int stateLevelLen) {
         if (tenantId == null || tenantId.isEmpty()) return null;
@@ -576,12 +579,22 @@ public class AnalyticsService {
                     : jdbc.queryForObject("SELECT count(*) FROM complaint_facts WHERE tenant_id = ?",
                                           Long.class, tenantId);
             if (count == null) return null;
-            recordCountCache.put(tenantId, new long[]{count, now + RECORD_COUNT_TTL_MS});
+            recordCountCache.put(tenantId, new long[]{count, now + configCacheTtlMs()});
             return count;
         } catch (Exception e) {
             log.debug("recordCount for tenant {} failed (returning null)", tenantId, e);
             return null;
         }
+    }
+
+    /**
+     * The shared analytics config-cache TTL ({@code pgr.analytics.config-cache-ttl-ms});
+     * falls back to the 5-minute default when constructed without a Spring config
+     * (tests). Same accessor idiom as KpiCatalogService.configCacheTtlMs().
+     */
+    private long configCacheTtlMs() {
+        Long v = config == null ? null : config.getAnalyticsConfigCacheTtlMs();
+        return v != null ? v : PGRConfiguration.DEFAULT_ANALYTICS_CONFIG_CACHE_TTL_MS;
     }
 
     private Map<String,Object> scopeInfo(AnalyticsScope s){

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
@@ -137,7 +137,8 @@ public class AnalyticsService {
                     Map<String,Object> composed = maybeComposeResult(queryNode, scope, tenantId, callerRoles, tel, name);
                     if (composed != null) { results.put(name, composed); continue; }
 
-                    JsonNode actualQueryNode = resolveKpiRef(queryNode, tenantId, callerRoles);
+                    List<String> paramsIgnored = new ArrayList<>();
+                    JsonNode actualQueryNode = resolveKpiRef(queryNode, tenantId, callerRoles, paramsIgnored);
                     if (actualQueryNode == null) {
                         partial = true;
                         results.put(name, Map.of("error", "kpi_forbidden",
@@ -153,7 +154,9 @@ public class AnalyticsService {
                                 "message", "inline query projects officer-PII dimension(s); role not authorized"));
                         continue;
                     }
-                    results.put(name, runOne(actualQueryNode, scope, tel, name, kpiContext(queryNode)));
+                    Map<String,Object> result = runOne(actualQueryNode, scope, tel, name, kpiContext(queryNode));
+                    if (!paramsIgnored.isEmpty()) result.put("paramsIgnored", paramsIgnored);
+                    results.put(name, result);
                 } catch (Exception ex) {
                     partial = true;
                     results.put(name, err(ex));
@@ -167,12 +170,14 @@ public class AnalyticsService {
                 throw new IllegalArgumentException("kpi_forbidden: public access is limited to published PUBLIC KPIs");
             Map<String,Object> composed = maybeComposeResult(queryNode, scope, tenantId, callerRoles, tel, "query");
             if (composed != null) { out.putAll(composed); return out; }
-            JsonNode actualQueryNode = resolveKpiRef(queryNode, tenantId, callerRoles);
+            List<String> paramsIgnored = new ArrayList<>();
+            JsonNode actualQueryNode = resolveKpiRef(queryNode, tenantId, callerRoles, paramsIgnored);
             if (actualQueryNode == null)
                 throw new IllegalArgumentException("kpi_forbidden: KPI not found or not authorized");
             if (!queryNode.has("kpiId") && projectsForbiddenPii(actualQueryNode, callerRoles))
                 throw new IllegalArgumentException("pii_forbidden: inline query projects officer-PII dimension(s); role not authorized");
             out.putAll(runOne(actualQueryNode, scope, tel, "query", kpiContext(queryNode)));
+            if (!paramsIgnored.isEmpty()) out.put("paramsIgnored", paramsIgnored);
         } else {
             throw new IllegalArgumentException("invalid_param: body must contain 'query' or 'queries'");
         }
@@ -189,8 +194,14 @@ public class AnalyticsService {
      * {@link KpiQueryComposer} so the kpiId-by-reference path honours the global filters. The merge
      * produces only narrowing filters; the server-injected RBAC row-scope ({@code applyScope}) is
      * still layered on top by the planner and is never widened here.
+     *
+     * @param paramsIgnored collector (nullable) for supplied params the composer could not apply
+     *                      to this def's grain and must report (today: {@code complaintPath} on
+     *                      the path-less daily grain) — surfaced on the result envelope as
+     *                      {@code paramsIgnored:[...]}
      */
-    private JsonNode resolveKpiRef(JsonNode queryNode, String tenantId, Set<String> callerRoles) {
+    private JsonNode resolveKpiRef(JsonNode queryNode, String tenantId, Set<String> callerRoles,
+                                   List<String> paramsIgnored) {
         if (!queryNode.has("kpiId")) return queryNode;
 
         String kpiId = queryNode.get("kpiId").asText();
@@ -214,7 +225,7 @@ public class AnalyticsService {
             // D1a backend-composed defs are intercepted by maybeComposeResult before this point;
             // a query:null def WITHOUT a valid compose op is a genuine misconfiguration.
             throw new IllegalArgumentException("invalid_kpi: KPI '" + kpiId + "' has no query defined");
-        return queryComposer.mergeParams(storedQuery, effectiveParams);
+        return queryComposer.mergeParams(storedQuery, effectiveParams, paramsIgnored);
     }
 
     /**
@@ -308,9 +319,10 @@ public class AnalyticsService {
         // #1110/R9: each SOURCE query records its own metric point and joins the per-request
         // slow-query pool (attributed to its own kpiId, under the composed entry's name).
         List<Map<String,Object>> sourceRows = new ArrayList<>();
+        List<String> paramsIgnored = new ArrayList<>();   // deduped in resolveKpiRef/composer
         for (JsonNode srcId : compose.get("sourceKpiIds")) {
             JsonNode srcRef = synthRef(srcId.asText(), params);
-            JsonNode srcQuery = resolveKpiRef(srcRef, tenantId, callerRoles);
+            JsonNode srcQuery = resolveKpiRef(srcRef, tenantId, callerRoles, paramsIgnored);
             if (srcQuery == null)
                 throw new IllegalArgumentException("kpi_forbidden: compose source '" + srcId.asText() + "' not authorized");
             Map<String,Object> r = runOne(srcQuery, scope, tel, entryName, srcId.asText());
@@ -327,6 +339,7 @@ public class AnalyticsService {
         out.put("rows", List.of(row));
         out.put("rowCount", 1);
         out.put("compose", type);
+        if (!paramsIgnored.isEmpty()) out.put("paramsIgnored", paramsIgnored);
         return out;
     }
 
@@ -480,7 +493,7 @@ public class AnalyticsService {
     public Map<String,Object> schema(){
         Map<String,Object> out = new LinkedHashMap<>();
         out.put("aggFns", AnalyticsCatalog.AGG_FNS);
-        out.put("filterOps", Arrays.asList("eq","ne","gt","gte","lt","lte","in","isnull","starts_with"));
+        out.put("filterOps", Arrays.asList("eq","ne","gt","gte","lt","lte","in","isnull","starts_with","subtree"));
         out.put("windows", Arrays.asList("all","live","last_<N>d","wtd","mtd","qtd","ytd"));
         out.put("timeBuckets", Arrays.asList("day","week","month","quarter","year"));
         Map<String,Object> grains = new LinkedHashMap<>();

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
@@ -95,7 +95,7 @@ public class AnalyticsService {
      */
     public Map<String,Object> query(JsonNode body, RequestInfo requestInfo, String tenantId,
                                     int stateLevelLen, String headerTraceId){
-        QueryTelemetry tel = new QueryTelemetry(metrics, tenantId);
+        QueryTelemetry tel = new QueryTelemetry(metrics, tenantId, stateLevelLen);
         try {
             return doQuery(body, requestInfo, tenantId, stateLevelLen, tel);
         } finally {

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
@@ -68,17 +68,44 @@ public class AnalyticsService {
     private final KpiCatalogService kpiCatalogService;
     private final PrincipalScopeResolver scopeResolver;
     private final KpiQueryComposer queryComposer;
+    private final AnalyticsMetrics metrics;
 
     @Autowired
     public AnalyticsService(AnalyticsPlanner planner, AnalyticsCatalog catalog, JdbcTemplate jdbc,
                             KpiCatalogService kpiCatalogService, PrincipalScopeResolver scopeResolver,
-                            KpiQueryComposer queryComposer){
+                            KpiQueryComposer queryComposer, AnalyticsMetrics metrics){
         this.planner = planner; this.catalog = catalog; this.jdbc = jdbc;
         this.kpiCatalogService = kpiCatalogService; this.scopeResolver = scopeResolver;
-        this.queryComposer = queryComposer;
+        this.queryComposer = queryComposer; this.metrics = metrics;
     }
 
+    /** Back-compat entry point (no trace correlation header). */
     public Map<String,Object> query(JsonNode body, RequestInfo requestInfo, String tenantId, int stateLevelLen){
+        return query(body, requestInfo, tenantId, stateLevelLen, null);
+    }
+
+    /**
+     * #1110: instrumented entry point. Every executed SQL query (batch entry, single query,
+     * compose SOURCE query) records an OTEL duration/rows point via {@link QueryTelemetry};
+     * one {@code analytics.slow_queries} line (top-{@value QueryTelemetry#TOP_N} by tookMs)
+     * is logged per request — also on partial failure, covering whatever did execute.
+     *
+     * @param headerTraceId the literal {@code x-trace-id} header — correlation FALLBACK only;
+     *                      the active span's trace id (javaagent + Kong w3c propagation) wins.
+     */
+    public Map<String,Object> query(JsonNode body, RequestInfo requestInfo, String tenantId,
+                                    int stateLevelLen, String headerTraceId){
+        QueryTelemetry tel = new QueryTelemetry(metrics, tenantId);
+        try {
+            return doQuery(body, requestInfo, tenantId, stateLevelLen, tel);
+        } finally {
+            if (!tel.isEmpty())
+                log.info(tel.slowQueryLine(QueryTelemetry.resolveTraceId(headerTraceId)));
+        }
+    }
+
+    private Map<String,Object> doQuery(JsonNode body, RequestInfo requestInfo, String tenantId,
+                                       int stateLevelLen, QueryTelemetry tel){
         if (tenantId == null || tenantId.isEmpty()) throw new IllegalArgumentException("invalid_param: tenantId is required");
         AnalyticsScope scope = scopeResolver.resolve(requestInfo, tenantId, stateLevelLen);
         Set<String> callerRoles = extractRoles(requestInfo);
@@ -107,7 +134,7 @@ public class AnalyticsService {
                         continue;
                     }
                     // D1a: backend-composed defs (query:null + viz.compose) resolve recursively here.
-                    Map<String,Object> composed = maybeComposeResult(queryNode, scope, tenantId, callerRoles);
+                    Map<String,Object> composed = maybeComposeResult(queryNode, scope, tenantId, callerRoles, tel, name);
                     if (composed != null) { results.put(name, composed); continue; }
 
                     JsonNode actualQueryNode = resolveKpiRef(queryNode, tenantId, callerRoles);
@@ -126,7 +153,7 @@ public class AnalyticsService {
                                 "message", "inline query projects officer-PII dimension(s); role not authorized"));
                         continue;
                     }
-                    results.put(name, runOne(actualQueryNode, scope));
+                    results.put(name, runOne(actualQueryNode, scope, tel, name, kpiContext(queryNode)));
                 } catch (Exception ex) {
                     partial = true;
                     results.put(name, err(ex));
@@ -138,14 +165,14 @@ public class AnalyticsService {
             JsonNode queryNode = body.get("query");
             if (publicFloor && !queryNode.has("kpiId"))
                 throw new IllegalArgumentException("kpi_forbidden: public access is limited to published PUBLIC KPIs");
-            Map<String,Object> composed = maybeComposeResult(queryNode, scope, tenantId, callerRoles);
+            Map<String,Object> composed = maybeComposeResult(queryNode, scope, tenantId, callerRoles, tel, "query");
             if (composed != null) { out.putAll(composed); return out; }
             JsonNode actualQueryNode = resolveKpiRef(queryNode, tenantId, callerRoles);
             if (actualQueryNode == null)
                 throw new IllegalArgumentException("kpi_forbidden: KPI not found or not authorized");
             if (!queryNode.has("kpiId") && projectsForbiddenPii(actualQueryNode, callerRoles))
                 throw new IllegalArgumentException("pii_forbidden: inline query projects officer-PII dimension(s); role not authorized");
-            out.putAll(runOne(actualQueryNode, scope));
+            out.putAll(runOne(actualQueryNode, scope, tel, "query", kpiContext(queryNode)));
         } else {
             throw new IllegalArgumentException("invalid_param: body must contain 'query' or 'queries'");
         }
@@ -253,7 +280,8 @@ public class AnalyticsService {
      * {@code hourlyAvgFromDaily}, {@code openRateComplement}, {@code netBacklogDaily}.
      */
     private Map<String,Object> maybeComposeResult(JsonNode queryNode, AnalyticsScope scope,
-                                                  String tenantId, Set<String> callerRoles) {
+                                                  String tenantId, Set<String> callerRoles,
+                                                  QueryTelemetry tel, String entryName) {
         if (queryNode == null || !queryNode.has("kpiId")) return null;
         String kpiId = queryNode.get("kpiId").asText();
         Optional<KpiDefinition> defOpt = kpiCatalogService.getDef(kpiId, tenantId);
@@ -274,13 +302,15 @@ public class AnalyticsService {
         String type = compose.get("type").asText();
 
         // Resolve + run each source kpiId with the same params, RBAC and row-scope.
+        // #1110/R9: each SOURCE query records its own metric point and joins the per-request
+        // slow-query pool (attributed to its own kpiId, under the composed entry's name).
         List<Map<String,Object>> sourceRows = new ArrayList<>();
         for (JsonNode srcId : compose.get("sourceKpiIds")) {
             JsonNode srcRef = synthRef(srcId.asText(), params);
             JsonNode srcQuery = resolveKpiRef(srcRef, tenantId, callerRoles);
             if (srcQuery == null)
                 throw new IllegalArgumentException("kpi_forbidden: compose source '" + srcId.asText() + "' not authorized");
-            Map<String,Object> r = runOne(srcQuery, scope);
+            Map<String,Object> r = runOne(srcQuery, scope, tel, entryName, srcId.asText());
             sourceRows.add(firstRow(r));
         }
 
@@ -412,17 +442,35 @@ public class AnalyticsService {
         return callerRoles == null || callerRoles.stream().noneMatch(OFFICER_PII_ROLES::contains);
     }
 
-    private Map<String,Object> runOne(JsonNode q, AnalyticsScope scope){
+    /**
+     * Execute one planned query. THE choke point for every analytics SQL execution
+     * (batch entries, the single-query arm, compose SOURCE queries) — each successful run
+     * records one OTEL metric point + one slow-query-pool entry (#1110).
+     *
+     * @param entryName the batch dict key this run belongs to ({@code "query"} on the
+     *                  single arm); compose sources share their composed entry's name
+     * @param kpiId     the resolved KPI id, or {@code "inline"} for inline-grammar queries
+     */
+    private Map<String,Object> runOne(JsonNode q, AnalyticsScope scope, QueryTelemetry tel,
+                                      String entryName, String kpiId){
         AnalyticsPlanner.Planned p = planner.plan(q, scope);
         long t0 = System.currentTimeMillis();
         List<Map<String,Object>> rows = jdbc.queryForList(p.sql, p.params.toArray());
+        long tookMs = System.currentTimeMillis() - t0;
+        if (tel != null) tel.record(entryName, kpiId, p.grain, tookMs, rows.size());
         Map<String,Object> r = new LinkedHashMap<>();
         r.put("grain", p.grain);
         r.put("columns", p.columns);
         r.put("rows", rows);
         r.put("rowCount", rows.size());
-        r.put("tookMs", System.currentTimeMillis() - t0);
+        r.put("tookMs", tookMs);
         return r;
+    }
+
+    /** Metric attribution for a request query node: its kpiId, or {@code "inline"}. */
+    private static String kpiContext(JsonNode queryNode) {
+        return queryNode != null && queryNode.hasNonNull("kpiId")
+                ? queryNode.get("kpiId").asText() : "inline";
     }
 
     /** /_schema capabilities — lets the FE build the KPI editor dynamically. */
@@ -462,6 +510,48 @@ public class AnalyticsService {
     private Long asOf(){
         try { return jdbc.queryForObject("SELECT max(facts_built_at) FROM complaint_facts", Long.class); }
         catch (Exception e) { return System.currentTimeMillis(); }
+    }
+
+    // ---- #1110: tenant record-count for /packs (record_count_tier tag source) ----
+
+    private static final long RECORD_COUNT_TTL_MS = 5 * 60_000L;
+    /** tenantId -> [count, expiresAtMs]. Concurrent; a stale entry is simply recomputed. */
+    private final java.util.concurrent.ConcurrentHashMap<String, long[]> recordCountCache =
+            new java.util.concurrent.ConcurrentHashMap<>();
+    /** Injectable clock for cache-expiry tests (see AnalyticsServiceRecordCountTest). */
+    private java.util.function.LongSupplier recordCountClock = System::currentTimeMillis;
+
+    /**
+     * TENANT-CORPUS size of {@code complaint_facts} — how many fact rows exist for the
+     * tenant subtree, using {@link AnalyticsPlanner#applyScope}'s tenant semantics
+     * (state level: {@code tenant_id LIKE 'ke%'}; city level: exact match). This is
+     * deliberately NOT the caller's ABAC-visible subset: the dashboard uses it as the
+     * {@code record_count_tier} tag, which must describe the tenant's data volume so
+     * render-lag comparisons across personas share a denominator (#1110/R9-C9).
+     *
+     * <p>Cached in-memory for 5 minutes per tenant; errors return null (additive,
+     * never fails the /packs response) and are not cached.
+     */
+    public Long recordCount(String tenantId, int stateLevelLen) {
+        if (tenantId == null || tenantId.isEmpty()) return null;
+        long now = recordCountClock.getAsLong();
+        long[] cached = recordCountCache.get(tenantId);
+        if (cached != null && cached[1] > now) return cached[0];
+        // same state-level test as PrincipalScopeResolver.resolve()
+        boolean stateLevel = tenantId.split("\\.").length == stateLevelLen;
+        try {
+            Long count = stateLevel
+                    ? jdbc.queryForObject("SELECT count(*) FROM complaint_facts WHERE tenant_id LIKE ?",
+                                          Long.class, tenantId + "%")
+                    : jdbc.queryForObject("SELECT count(*) FROM complaint_facts WHERE tenant_id = ?",
+                                          Long.class, tenantId);
+            if (count == null) return null;
+            recordCountCache.put(tenantId, new long[]{count, now + RECORD_COUNT_TTL_MS});
+            return count;
+        } catch (Exception e) {
+            log.debug("recordCount for tenant {} failed (returning null): {}", tenantId, e.toString());
+            return null;
+        }
     }
 
     private Map<String,Object> scopeInfo(AnalyticsScope s){

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
@@ -203,10 +203,11 @@ public class AnalyticsService {
         // Precedence: explicit caller param > declared default > the def's baked query.
         JsonNode effectiveParams = withDeclaredDefaults(def.get(), queryNode.get("params"));
 
-        // C1: validate the EFFECTIVE window param against the def's params.allowed allow-list
-        // (the def is in scope here). An out-of-list window must be a per-entry invalid_param,
-        // not silently honoured by the composer/planner (which accept any well-formed window).
-        validateWindowParam(def.get(), effectiveParams);
+        // C1 (generalized in #1111/R3): validate EVERY effective param against the def's declared
+        // params.allowed allow-list (the def is in scope here). An out-of-list value (window,
+        // hierLevel, ...) must be a per-entry invalid_param, not silently honoured by the
+        // composer/planner (which accept any well-formed value).
+        validateAllowedParams(def.get(), effectiveParams);
 
         JsonNode storedQuery = def.get().getQuery();
         if (storedQuery == null || storedQuery.isNull())
@@ -245,25 +246,26 @@ public class AnalyticsService {
     }
 
     /**
-     * C1 — window allow-list enforcement. If the request {@code params} carries a {@code window}
-     * and the def declares a {@code window} param with a non-empty {@code allowed} list, the value
-     * must be in that list. Out-of-list (incl. arbitrary {@code last_Nd}) → {@code invalid_param}.
-     * No-op when the def declares no allow-list for {@code window} (open window).
+     * C1, generalized in #1111/R3 — allow-list enforcement for ANY declared param. For each of the
+     * def's declared params carrying a non-empty {@code allowed} list, an effective (caller-sent or
+     * defaulted) value must be in that list. Out-of-list (incl. arbitrary {@code last_Nd} windows,
+     * out-of-range {@code hierLevel}s) → {@code invalid_param}. No-op for params the def declares
+     * without an allow-list (open values) and for undeclared params (composer vocabulary applies).
+     * Runs on BOTH the normal kpiId path and the compose path (each calls this on its own def).
      */
-    private void validateWindowParam(KpiDefinition def, JsonNode reqParams) {
-        if (reqParams == null || !reqParams.hasNonNull("window")) return;
-        String requested = reqParams.get("window").asText();
-        if (requested.isEmpty()) return;
-        if (def.getParams() == null) return;
+    void validateAllowedParams(KpiDefinition def, JsonNode reqParams) {
+        if (reqParams == null || def.getParams() == null) return;
         for (KpiDefinition.KpiParam p : def.getParams()) {
-            if (p != null && "window".equals(p.getName())) {
-                List<String> allowed = p.getAllowed();
-                if (allowed != null && !allowed.isEmpty() && !allowed.contains(requested))
-                    throw new IllegalArgumentException(
-                            "invalid_param: window '" + requested + "' is not allowed for KPI '" + def.getId()
-                                    + "'; allowed=" + allowed);
-                return;
-            }
+            if (p == null || p.getName() == null) continue;
+            List<String> allowed = p.getAllowed();
+            if (allowed == null || allowed.isEmpty()) continue;
+            if (!reqParams.hasNonNull(p.getName())) continue;
+            String requested = reqParams.get(p.getName()).asText();
+            if (requested.isEmpty()) continue;
+            if (!allowed.contains(requested))
+                throw new IllegalArgumentException(
+                        "invalid_param: " + p.getName() + " '" + requested + "' is not allowed for KPI '"
+                                + def.getId() + "'; allowed=" + allowed);
         }
     }
 
@@ -295,8 +297,9 @@ public class AnalyticsService {
         // so a bare {kpiId} compose ref honours its declared defaults too (explicit caller wins).
         JsonNode params = withDeclaredDefaults(def, queryNode.get("params"));
 
-        // C1: the compose def's window allow-list still applies to the effective params.
-        validateWindowParam(def, params);
+        // C1 (generalized, #1111/R3): the compose def's declared allow-lists still apply to the
+        // effective params before they propagate to every source KPI.
+        validateAllowedParams(def, params);
 
         JsonNode compose = def.getViz().getCompose();
         String type = compose.get("type").asText();

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
@@ -549,7 +549,7 @@ public class AnalyticsService {
             recordCountCache.put(tenantId, new long[]{count, now + RECORD_COUNT_TTL_MS});
             return count;
         } catch (Exception e) {
-            log.debug("recordCount for tenant {} failed (returning null): {}", tenantId, e.toString());
+            log.debug("recordCount for tenant {} failed (returning null)", tenantId, e);
             return null;
         }
     }

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiCatalogService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiCatalogService.java
@@ -150,8 +150,7 @@ public class KpiCatalogService {
         } catch (Exception e) {
             // Fail-safe: any unexpected error means "enforced" (current behavior), never a throw
             // that could flip the caller's HRMS-error path to deny-all.
-            log.warn("departmentScoping lookup failed for tenant {}; treating as enforced. Cause: {}",
-                    tenantId, e.toString());
+            log.warn("departmentScoping lookup failed for tenant {}; treating as enforced", tenantId, e);
             return false;
         }
     }

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiCatalogService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiCatalogService.java
@@ -39,7 +39,6 @@ public class KpiCatalogService {
 
     /** The only departmentScoping value that turns employee department scoping OFF (#1280). */
     private static final String DEPT_SCOPING_DISABLED = "disabled";
-    private static final long CONFIG_TTL_MS = 5 * 60_000L;
     /** stateRoot -> [Boolean disabled, Long expiresAtMs]. Mirrors AnalyticsService.recordCountCache. */
     private final java.util.concurrent.ConcurrentHashMap<String, Object[]> deptScopingCache =
             new java.util.concurrent.ConcurrentHashMap<>();
@@ -123,9 +122,10 @@ public class KpiCatalogService {
      * {@code false} ("enforced", today's behavior). Fail-safe by construction; this method never
      * throws.
      *
-     * <p>Cached in-memory for 5 minutes per state root (both outcomes), mirroring the
-     * {@code recordCount} cache idiom in AnalyticsService — a config flip takes effect within
-     * 5 minutes without a redeploy.
+     * <p>Cached in-memory per state root (both outcomes) for
+     * {@code pgr.analytics.config-cache-ttl-ms} (the single TTL shared by every analytics
+     * config cache; default 5 minutes), mirroring the {@code recordCount} cache idiom in
+     * AnalyticsService — a config flip takes effect within one TTL without a redeploy.
      */
     public boolean isDepartmentScopingDisabled(String tenantId) {
         try {
@@ -145,7 +145,7 @@ public class KpiCatalogService {
             if (disabled)
                 log.info("dss.DashboardConfig.departmentScoping=disabled at {} — employee department scoping OFF",
                         stateRoot);
-            deptScopingCache.put(stateRoot, new Object[]{disabled, now + CONFIG_TTL_MS});
+            deptScopingCache.put(stateRoot, new Object[]{disabled, now + configCacheTtlMs()});
             return disabled;
         } catch (Exception e) {
             // Fail-safe: any unexpected error means "enforced" (current behavior), never a throw
@@ -153,6 +153,16 @@ public class KpiCatalogService {
             log.warn("departmentScoping lookup failed for tenant {}; treating as enforced", tenantId, e);
             return false;
         }
+    }
+
+    /**
+     * The shared analytics config-cache TTL ({@code pgr.analytics.config-cache-ttl-ms});
+     * falls back to the 5-minute default when the config mock/bean has no value.
+     * Same accessor idiom as AnalyticsService.configCacheTtlMs().
+     */
+    private long configCacheTtlMs() {
+        Long v = config == null ? null : config.getAnalyticsConfigCacheTtlMs();
+        return v != null ? v : PGRConfiguration.DEFAULT_ANALYTICS_CONFIG_CACHE_TTL_MS;
     }
 
     // ---- private MDMS helpers ----

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiCatalogService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiCatalogService.java
@@ -35,6 +35,16 @@ public class KpiCatalogService {
     private static final String DSS_MODULE = "dss";
     private static final String MASTER_KPI  = "KpiDefinition";
     private static final String MASTER_PACK = "DashboardPack";
+    private static final String MASTER_CONFIG = "DashboardConfig";
+
+    /** The only departmentScoping value that turns employee department scoping OFF (#1280). */
+    private static final String DEPT_SCOPING_DISABLED = "disabled";
+    private static final long CONFIG_TTL_MS = 5 * 60_000L;
+    /** stateRoot -> [Boolean disabled, Long expiresAtMs]. Mirrors AnalyticsService.recordCountCache. */
+    private final java.util.concurrent.ConcurrentHashMap<String, Object[]> deptScopingCache =
+            new java.util.concurrent.ConcurrentHashMap<>();
+    /** Injectable clock for cache-expiry tests (see KpiCatalogServiceDeptScopingTest). */
+    private java.util.function.LongSupplier configClock = System::currentTimeMillis;
 
     private final PGRConfiguration config;
     private final ServiceRequestRepository serviceRequestRepository;
@@ -101,6 +111,49 @@ public class KpiCatalogService {
         return fetchDefs(stateRoot).stream()
                 .filter(d -> kpiId.equals(d.getId()))
                 .findFirst();
+    }
+
+    /**
+     * Whether {@code dss.DashboardConfig.departmentScoping} is {@code "disabled"} for the tenant's
+     * state root (#1280) — i.e. employees should NOT be department-scoped on the analytics API.
+     *
+     * <p>Returns {@code true} only when a DashboardConfig record exists whose
+     * {@code departmentScoping} equals {@code "disabled"} (case-insensitive, trimmed). Everything
+     * else — module/record/field absent, malformed value, MDMS unreachable — resolves to
+     * {@code false} ("enforced", today's behavior). Fail-safe by construction; this method never
+     * throws.
+     *
+     * <p>Cached in-memory for 5 minutes per state root (both outcomes), mirroring the
+     * {@code recordCount} cache idiom in AnalyticsService — a config flip takes effect within
+     * 5 minutes without a redeploy.
+     */
+    public boolean isDepartmentScopingDisabled(String tenantId) {
+        try {
+            if (tenantId == null || tenantId.isEmpty()) return false;
+            String stateRoot = multiStateInstanceUtil.getStateLevelTenant(tenantId);
+            long now = configClock.getAsLong();
+            Object[] cached = deptScopingCache.get(stateRoot);
+            if (cached != null && (Long) cached[1] > now) return (Boolean) cached[0];
+
+            boolean disabled = false;
+            List<Map<String, Object>> records =
+                    fetchMaster(stateRoot, MASTER_CONFIG, new TypeReference<List<Map<String, Object>>>() {});
+            if (!records.isEmpty()) {
+                Object v = records.get(0).get("departmentScoping");
+                disabled = v instanceof String && DEPT_SCOPING_DISABLED.equalsIgnoreCase(((String) v).trim());
+            }
+            if (disabled)
+                log.info("dss.DashboardConfig.departmentScoping=disabled at {} — employee department scoping OFF",
+                        stateRoot);
+            deptScopingCache.put(stateRoot, new Object[]{disabled, now + CONFIG_TTL_MS});
+            return disabled;
+        } catch (Exception e) {
+            // Fail-safe: any unexpected error means "enforced" (current behavior), never a throw
+            // that could flip the caller's HRMS-error path to deny-all.
+            log.warn("departmentScoping lookup failed for tenant {}; treating as enforced. Cause: {}",
+                    tenantId, e.toString());
+            return false;
+        }
     }
 
     // ---- private MDMS helpers ----

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiQueryComposer.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiQueryComposer.java
@@ -51,6 +51,14 @@ import java.time.temporal.TemporalAdjusters;
  *       {@code priorPeriodCreatedAtFilter()} (~1586) / {@code priorPeriodEndDateIso()} (~1360) and the
  *       no-range {@code priorWeekCreatedAtFilter()} (~1417) fallback. Collapses the ~30 FE
  *       {@code *_prior} query keys into one def + {@code {compare:"prior"}}.</li>
+ *   <li>{@code hierLevel} — complaint-hierarchy rollup level (#1111). {@code "leaf"} / absent /
+ *       empty = no-op (today's per-subtype buckets). {@code "1".."12"} rewrites every
+ *       {@code service_code} dimension to the fixed level expression over
+ *       {@code complaint_node_path} (aliased {@code AS service_code}, so viz/sort/columns are
+ *       unchanged) and drops any {@code service_group} dimension (at a rolled-up level it
+ *       collapses into a duplicate of the level bucket). Grains without the path column (daily)
+ *       no-op gracefully, like {@code ward}. Aggregates recompute over raw rows, so averages and
+ *       ratios are correctly weighted — never an average of leaf averages.</li>
  *   <li>{@code series: "daily"} — turn a scalar tile into a daily time series: add the grain's daily
  *       date dimension (+ ascending sort), apply the selected range, drop the base window, and cap
  *       {@code limit} to {@code min(366, dayCount)}. Mirrors the FE {@code *_sparkline} keys
@@ -153,6 +161,12 @@ public class KpiQueryComposer {
         if (params.hasNonNull("serviceCode")) {
             String svc = params.get("serviceCode").asText();
             if (!svc.isEmpty() && !"all".equals(svc)) applyEqFilter(next, g, "service_code", svc);
+        }
+
+        // ---- hierarchy-level rollup (#1111): rewrite service_code dimensions to the level expr ----
+        if (params.hasNonNull("hierLevel")) {
+            String hierLevel = params.get("hierLevel").asText();
+            if (!hierLevel.isEmpty() && !"leaf".equals(hierLevel)) applyHierLevel(next, g, hierLevel);
         }
 
         return next;
@@ -405,6 +419,73 @@ public class KpiQueryComposer {
         if (window != null && window.hasNonNull("timeRole") && "resolved_at".equals(window.get("timeRole").asText()))
             return "resolved_at";
         return "created_at";
+    }
+
+    // ---- hierarchy-level rollup (#1111) ----
+
+    /**
+     * Rewrite the query's {@code service_code} dimensions to the fixed hierarchy-level expression
+     * (via the composer-internal marker only {@link AnalyticsPlanner} accepts — see
+     * {@link AnalyticsCatalog#HIER_DIM_TOKEN}), grouping the tile by the Nth
+     * {@code complaint_node_path} segment instead of the leaf. Rows with a NULL/empty path
+     * (flat/legacy tenants) fall back to their leaf {@code service_code} inside the SQL expr, and
+     * the level clamps to each row's own depth — both live in {@link AnalyticsCatalog#hierLevelExpr}.
+     *
+     * <p>Grains without the path column (daily) skip gracefully, exactly like {@code ward} on a
+     * ward-less grain: the param is inapplicable, not an error. A malformed level, however, IS an
+     * error ({@code invalid_param}) — silently serving leaf granularity for a level the caller
+     * asked for would be a wrong answer, the same reasoning as C2's unparseable-date hard failure.
+     *
+     * <p>R4: when a rewrite happens, any {@code service_group} dimension (and sort referencing it)
+     * is dropped — at a rolled-up level it collapses into a duplicate of the level bucket itself.
+     * When the query carries no {@code service_code} dimension there is nothing to roll up
+     * (scalar tiles), so the param is a no-op and {@code service_group} is left alone.
+     */
+    private void applyHierLevel(ObjectNode query, Grain g, String hierLevel) {
+        if (!catalog.supportsHierLevel(g.name)) {
+            log.debug("grain '{}' has no complaint_node_path; skipping hierLevel param", g.name);
+            return;
+        }
+        int level;
+        try {
+            level = Integer.parseInt(hierLevel);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("invalid_param: hierLevel must be 'leaf' or an integer in 1.."
+                    + AnalyticsCatalog.MAX_HIER_LEVEL);
+        }
+        if (level < 1 || level > AnalyticsCatalog.MAX_HIER_LEVEL)
+            throw new IllegalArgumentException("invalid_param: hierLevel must be 'leaf' or an integer in 1.."
+                    + AnalyticsCatalog.MAX_HIER_LEVEL);
+
+        JsonNode dims = query.get("dimensions");
+        if (dims == null || !dims.isArray()) return;
+        boolean hasServiceCode = false;
+        for (JsonNode d : dims) if (d.isTextual() && "service_code".equals(d.asText())) { hasServiceCode = true; break; }
+        if (!hasServiceCode) return;   // nothing to roll up (scalar / other-dimension tiles)
+
+        ArrayNode next = query.arrayNode();
+        for (JsonNode d : dims) {
+            if (d.isTextual() && "service_code".equals(d.asText())) {
+                ObjectNode marker = next.addObject();
+                marker.put(AnalyticsCatalog.HIER_DIM_LEVEL_FIELD, level);
+                marker.put(AnalyticsCatalog.HIER_DIM_TOKEN_FIELD, AnalyticsCatalog.HIER_DIM_TOKEN);
+            } else if (d.isTextual() && "service_group".equals(d.asText())) {
+                // R4: dropped — duplicates the level bucket once service_code is rolled up.
+            } else {
+                next.add(d);
+            }
+        }
+        query.set("dimensions", next);
+
+        // Keep sort valid: a dropped service_group can no longer be sorted on.
+        JsonNode sort = query.get("sort");
+        if (sort != null && sort.isArray()) {
+            ArrayNode nextSort = query.arrayNode();
+            for (JsonNode s : sort) if (!"service_group".equals(s.path("by").asText(null))) nextSort.add(s);
+            if (nextSort.size() != sort.size()) {
+                if (nextSort.size() == 0) query.remove("sort"); else query.set("sort", nextSort);
+            }
+        }
     }
 
     // ---- narrowing eq filter ----

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiQueryComposer.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiQueryComposer.java
@@ -15,6 +15,8 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * Param-merge for the kpiId-by-reference analytics path.
@@ -45,7 +47,19 @@ import java.time.temporal.TemporalAdjusters;
  *   <li>{@code ward} — a boundary/ward code; narrows to {@code ward_code = ?} <em>iff</em> the grain
  *       has a filterable {@code ward_code}. A client narrowing WITHIN the user's RBAC scope; it can
  *       never widen (row-scope is still injected on top by {@link AnalyticsPlanner#plan}).</li>
- *   <li>{@code serviceCode} — a complaint type; narrows to {@code service_code = ?} iff filterable.</li>
+ *   <li>{@code serviceCode} — a complaint type LEAF; narrows to {@code service_code = ?} iff
+ *       filterable. This stays the param for leaf selections (exact match, works on every grain
+ *       incl. daily); {@code complaintPath} below is for interior nodes only.</li>
+ *   <li>{@code complaintPath} — a complaint-hierarchy INTERIOR node's dot-path (e.g.
+ *       {@code SANITATION.SEWAGE}); narrows to the node's whole subtree via a delimiter-guarded
+ *       {@code complaint_node_path} subtree predicate ({@code = ? OR LIKE ?||'.%'}) iff the grain
+ *       carries the path column (facts/events). Values are validated against the path alphabet
+ *       ({@code [A-Za-z0-9._/-]}, length-capped) — anything else is {@code invalid_param}. On the
+ *       daily grain (no path column) the param cannot apply; unlike {@code ward}'s silent skip,
+ *       the skip is REPORTED to the caller via the {@code paramsIgnored} collector (surfaced as
+ *       {@code paramsIgnored:["complaintPath"]} on the result envelope) so the FE can flag the
+ *       widget as unfiltered. Rows with a NULL path (nodes whose own code contains '.', see the
+ *       #1111 migration; flat tenants) never match a subtree filter.</li>
  *   <li>{@code compare: "prior"} — instead of the selected/default range, apply the
  *       <em>immediately-preceding equal-duration</em> range on the def's time column. Mirrors the FE
  *       {@code priorPeriodCreatedAtFilter()} (~1586) / {@code priorPeriodEndDateIso()} (~1360) and the
@@ -85,6 +99,15 @@ public class KpiQueryComposer {
     private static final long MS_PER_DAY = 86_400_000L;
     /** Sparkline daily-series safety cap, matching the FE {@code Math.min(366, ...)}. */
     private static final int MAX_SERIES_DAYS = 366;
+    /** {@code complaintPath} length cap — live paths are short dot-joined UPPER_SNAKE codes. */
+    static final int MAX_COMPLAINT_PATH_LENGTH = 256;
+    /**
+     * The complaint-hierarchy path alphabet: dot-joined MDMS node codes (alnum/underscore/dash,
+     * occasionally slash). Anything outside it — quotes, whitespace, LIKE metachars, SQL syntax —
+     * is rejected up front (defense in depth on top of the planner's bound params + LIKE-escape).
+     */
+    private static final Pattern COMPLAINT_PATH_VALUE =
+            Pattern.compile("^[A-Za-z0-9._/\\-]{1," + MAX_COMPLAINT_PATH_LENGTH + "}$");
 
     private final AnalyticsCatalog catalog;
 
@@ -97,6 +120,19 @@ public class KpiQueryComposer {
      * empty. Never mutates {@code baseQuery}.
      */
     public JsonNode mergeParams(JsonNode baseQuery, JsonNode params) {
+        return mergeParams(baseQuery, params, null);
+    }
+
+    /**
+     * As {@link #mergeParams(JsonNode, JsonNode)}, additionally reporting into
+     * {@code paramsIgnoredOut} (nullable) the name of any supplied param that could NOT be applied
+     * to this def's grain and whose skip the FE must be told about. Today only
+     * {@code complaintPath} reports (the daily grain has no {@code complaint_node_path}, so a
+     * subtree selection would otherwise leave those widgets silently unfiltered); the historical
+     * silent no-ops ({@code ward} on ward-less grains, {@code hierLevel} on daily) keep their
+     * behaviour unchanged.
+     */
+    public JsonNode mergeParams(JsonNode baseQuery, JsonNode params, List<String> paramsIgnoredOut) {
         if (baseQuery == null || !baseQuery.isObject()) return baseQuery;
         if (params == null || !params.isObject() || params.size() == 0) return baseQuery;
 
@@ -161,6 +197,10 @@ public class KpiQueryComposer {
         if (params.hasNonNull("serviceCode")) {
             String svc = params.get("serviceCode").asText();
             if (!svc.isEmpty() && !"all".equals(svc)) applyEqFilter(next, g, "service_code", svc);
+        }
+        if (params.hasNonNull("complaintPath")) {
+            String path = params.get("complaintPath").asText();
+            if (!path.isEmpty()) applyComplaintPath(next, g, path, paramsIgnoredOut);
         }
 
         // ---- hierarchy-level rollup (#1111): rewrite service_code dimensions to the level expr ----
@@ -486,6 +526,38 @@ public class KpiQueryComposer {
                 if (nextSort.size() == 0) query.remove("sort"); else query.set("sort", nextSort);
             }
         }
+    }
+
+    // ---- complaint-hierarchy subtree filter (interior nodes) ----
+
+    /**
+     * Narrow to a complaint-hierarchy INTERIOR node's whole subtree: a delimiter-guarded
+     * {@code complaint_node_path} {@code subtree} predicate ({@code = ? OR LIKE ?||'.%'} — the
+     * {@code '.'} guard so {@code PGR} never matches a {@code PGRX} sibling, the eq arm so a
+     * complaint filed AT a mixed interior+serviceable node stays in its own subtree). The
+     * predicate rides {@link AnalyticsPlanner}'s prefix-filterable allowlist with bound params
+     * and LIKE-escaping, exactly like the inline path's {@code starts_with}.
+     *
+     * <p>A malformed value (outside the path alphabet / over the length cap) is a hard
+     * {@code invalid_param} — same reasoning as C2/hierLevel: silently serving the UN-narrowed
+     * number for a subtree the caller asked for would be a wrong answer. A grain without the
+     * path column (daily) skips the filter but REPORTS the skip via {@code paramsIgnoredOut},
+     * so the FE can badge the widget instead of presenting an unfiltered count as filtered.
+     *
+     * <p>Leaf selections must keep using {@code serviceCode} (exact match; also covers the daily
+     * grain, which has a filterable {@code service_code} but no path column).
+     */
+    private void applyComplaintPath(ObjectNode query, Grain g, String path, List<String> paramsIgnoredOut) {
+        if (!COMPLAINT_PATH_VALUE.matcher(path).matches())
+            throw new IllegalArgumentException("invalid_param: complaintPath must be a dot-joined node path over"
+                    + " [A-Za-z0-9._/-], at most " + MAX_COMPLAINT_PATH_LENGTH + " chars");
+        if (!g.prefixFilterable.contains("complaint_node_path")) {
+            log.debug("grain '{}' has no complaint_node_path; ignoring complaintPath param (reported)", g.name);
+            if (paramsIgnoredOut != null && !paramsIgnoredOut.contains("complaintPath"))
+                paramsIgnoredOut.add("complaintPath");
+            return;
+        }
+        mergeableFilterObject(query, "complaint_node_path").put("subtree", path);
     }
 
     // ---- narrowing eq filter ----

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/PrincipalScopeResolver.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/PrincipalScopeResolver.java
@@ -36,6 +36,12 @@ import java.util.Set;
  * closes the prior fail-OPEN hole where an officer with a failed/missing HRMS lookup silently saw
  * every department. Under correct config (officers carry an HRMS department) this is a no-op for
  * them — they resolve to their real department. Pure citizens keep their existing self-scope.
+ *
+ * Tenant-configurable (#1280): {@code dss.DashboardConfig.departmentScoping = "disabled"} turns
+ * the whole department axis OFF for a tenant (deployments whose complaint data carries no
+ * departments). Tenant scoping and citizen self-scope are unaffected. Anything other than an
+ * explicit "disabled" — missing record/field, malformed value, MDMS error — means "enforced",
+ * i.e. exactly the behavior described above (fail-safe).
  */
 @Component
 @Slf4j
@@ -55,12 +61,15 @@ public class PrincipalScopeResolver {
     private final PGRConfiguration config;
     private final RestTemplate restTemplate;
     private final ObjectMapper mapper;
+    private final KpiCatalogService catalog;
 
     @Autowired
-    public PrincipalScopeResolver(PGRConfiguration config, RestTemplate restTemplate, ObjectMapper mapper) {
+    public PrincipalScopeResolver(PGRConfiguration config, RestTemplate restTemplate, ObjectMapper mapper,
+                                  KpiCatalogService catalog) {
         this.config = config;
         this.restTemplate = restTemplate;
         this.mapper = mapper;
+        this.catalog = catalog;
     }
 
     /**
@@ -97,6 +106,18 @@ public class PrincipalScopeResolver {
      * tenant-wide (admin/supervisor) roles — see {@link #unresolvedScope}.
      */
     private AnalyticsScope resolveEmployeeScope(RequestInfo requestInfo, User u, String tenantId, boolean stateLevel) {
+        // #1280: tenant-configurable department scoping. When dss.DashboardConfig.departmentScoping
+        // is "disabled" for this tenant, skip HRMS department resolution entirely — the employee is
+        // scoped by tenant only (no department IN filter, no fail-closed sentinel). Citizen
+        // self-scope is untouched (that path returns before this method); tenant scoping is
+        // untouched (carried by the AnalyticsScope tenant fields as always). The catalog lookup is
+        // fail-safe and never throws: missing record/field, malformed value, or an MDMS error all
+        // resolve to "enforced" — exactly today's behavior below.
+        if (catalog.isDepartmentScopingDisabled(tenantId)) {
+            log.info("department scoping disabled by DashboardConfig for tenant {} — unrestricted employee scope for '{}'",
+                    tenantId, u.getUserName());
+            return new AnalyticsScope(tenantId, stateLevel, null, null, null);
+        }
         try {
             String userName = u.getUserName();
             if (userName == null || userName.isEmpty())

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/QueryTelemetry.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/QueryTelemetry.java
@@ -44,17 +44,43 @@ final class QueryTelemetry {
 
     private final AnalyticsMetrics metrics;
     private final String tenantId;
+    private final String metricTenant;
     private final List<Execution> executions = new ArrayList<>();
 
-    QueryTelemetry(AnalyticsMetrics metrics, String tenantId) {
+    QueryTelemetry(AnalyticsMetrics metrics, String tenantId, int stateLevelLen) {
         this.metrics = metrics;
         this.tenantId = tenantId;
+        this.metricTenant = stateRootOf(tenantId, stateLevelLen);
     }
 
-    /** Record one successfully executed query (metric point + slow-query pool entry). */
+    /**
+     * Record one successfully executed query (metric point + slow-query pool entry).
+     * The metric point is tagged with the STATE-ROOT tenant, not the raw request
+     * tenantId: the request string is never validated against real tenants, so tagging
+     * it raw would let an unauthenticated caller mint a new Prometheus series per
+     * request ({@code ke.attack0001}, {@code ke.attack0002}, ...) — a cardinality bomb
+     * on the collector. The full tenantId still appears (sanitized) in the
+     * slow-query log line, which is unbounded-safe.
+     */
     void record(String name, String kpiId, String grain, long tookMs, long rowCount) {
-        if (metrics != null) metrics.recordQuery(kpiId, grain, tenantId, tookMs, rowCount);
+        if (metrics != null) metrics.recordQuery(kpiId, grain, metricTenant, tookMs, rowCount);
         executions.add(new Execution(name, kpiId, tookMs, rowCount));
+    }
+
+    /**
+     * First {@code stateLevelLen} dot-segments of the tenant — same state-level
+     * semantics as PrincipalScopeResolver/AnalyticsService.recordCount. Bounds the
+     * metric label to the deployment's state roots: a fabricated sub-tenant suffix
+     * collapses to its real root, and a fabricated ROOT never reaches
+     * {@link #record} because KPI-by-reference resolution fails at a root with no
+     * published catalog (and inline queries are blocked for the public floor).
+     */
+    static String stateRootOf(String tenantId, int stateLevelLen) {
+        if (tenantId == null || tenantId.isEmpty()) return tenantId;
+        String[] parts = tenantId.split("\\.");
+        int keep = Math.max(1, stateLevelLen);
+        if (parts.length <= keep) return tenantId;
+        return String.join(".", java.util.Arrays.asList(parts).subList(0, keep));
     }
 
     boolean isEmpty() {

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/QueryTelemetry.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/QueryTelemetry.java
@@ -1,0 +1,120 @@
+package org.egov.pgr.analytics;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Per-request recorder of executed analytics SQL queries (#1110).
+ *
+ * <p>One instance is created per {@code /_query} request and threaded through
+ * {@code AnalyticsService.runOne()} — the single choke point every SQL execution passes
+ * through (plain batch entries, the single-query arm, AND each SOURCE query of a
+ * backend-composed KPI). Each execution is (a) exported as an OTEL histogram/counter
+ * point via {@link AnalyticsMetrics} and (b) pooled for the per-request top-N
+ * slow-query log line. Errored entries never reach {@link #record} (the exception fires
+ * before/at execution), so they are naturally excluded from the pool.
+ *
+ * <p>Not thread-safe by design: request-scoped, single thread.
+ */
+final class QueryTelemetry {
+
+    static final int TOP_N = 3;
+
+    /** One executed query: batch-entry name + resolved kpiId (or "inline") + timings. */
+    static final class Execution {
+        final String name;
+        final String kpiId;
+        final long tookMs;
+        final long rowCount;
+
+        Execution(String name, String kpiId, long tookMs, long rowCount) {
+            this.name = name;
+            this.kpiId = kpiId;
+            this.tookMs = tookMs;
+            this.rowCount = rowCount;
+        }
+    }
+
+    private final AnalyticsMetrics metrics;
+    private final String tenantId;
+    private final List<Execution> executions = new ArrayList<>();
+
+    QueryTelemetry(AnalyticsMetrics metrics, String tenantId) {
+        this.metrics = metrics;
+        this.tenantId = tenantId;
+    }
+
+    /** Record one successfully executed query (metric point + slow-query pool entry). */
+    void record(String name, String kpiId, String grain, long tookMs, long rowCount) {
+        if (metrics != null) metrics.recordQuery(kpiId, grain, tenantId, tookMs, rowCount);
+        executions.add(new Execution(name, kpiId, tookMs, rowCount));
+    }
+
+    boolean isEmpty() {
+        return executions.isEmpty();
+    }
+
+    int total() {
+        return executions.size();
+    }
+
+    /** The n slowest executions, descending by tookMs (fewer when fewer ran). */
+    List<Execution> topSlowest(int n) {
+        return executions.stream()
+                .sorted(Comparator.comparingLong((Execution e) -> e.tookMs).reversed())
+                .limit(n)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * The ONE structured line logged per request:
+     * {@code analytics.slow_queries traceId=<id> tenant=<t> total=<n> top=[{...},...]}.
+     * Promtail ships it to Loki; the traceId pivots to Tempo (and to the FE's
+     * {@code dashboard.load} log record, which carries the same id).
+     */
+    String slowQueryLine(String traceId) {
+        String top = topSlowest(TOP_N).stream()
+                .map(e -> "{name=" + sanitize(e.name) + ", kpiId=" + sanitize(e.kpiId)
+                        + ", tookMs=" + e.tookMs + ", rowCount=" + e.rowCount + "}")
+                .collect(Collectors.joining(", ", "[", "]"));
+        return "analytics.slow_queries traceId=" + sanitize(traceId)
+                + " tenant=" + sanitize(tenantId)
+                + " total=" + total()
+                + " top=" + top;
+    }
+
+    /**
+     * Trace id for correlation. Preference order:
+     * <ol>
+     *   <li>the current span's trace id when valid — under the javaagent + Kong's
+     *       {@code opentelemetry} plugin (w3c) this IS the browser's per-load trace id;</li>
+     *   <li>the literal {@code x-trace-id} request header (agent-less deployments);</li>
+     *   <li>{@code "-"}.</li>
+     * </ol>
+     */
+    static String resolveTraceId(String headerTraceId) {
+        try {
+            SpanContext sc = Span.current().getSpanContext();
+            if (sc.isValid()) return sc.getTraceId();
+        } catch (RuntimeException ignored) {
+            // no agent / API misbehaviour — fall through to the header
+        }
+        if (headerTraceId != null && !headerTraceId.isBlank()) return headerTraceId.trim();
+        return "-";
+    }
+
+    /**
+     * Log-injection hygiene for caller-controlled strings (batch-entry names, header
+     * trace ids): allow only word chars plus {@code . : # / -}, cap at 64 chars.
+     */
+    static String sanitize(String v) {
+        if (v == null || v.isEmpty()) return "-";
+        String cleaned = v.replaceAll("[^\\w.:#/\\-]", "_");
+        return cleaned.length() > 64 ? cleaned.substring(0, 64) : cleaned;
+    }
+}

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/QueryTelemetry.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/QueryTelemetry.java
@@ -2,6 +2,7 @@ package org.egov.pgr.analytics;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -21,6 +22,7 @@ import java.util.stream.Collectors;
  *
  * <p>Not thread-safe by design: request-scoped, single thread.
  */
+@Slf4j
 final class QueryTelemetry {
 
     static final int TOP_N = 3;
@@ -101,8 +103,9 @@ final class QueryTelemetry {
         try {
             SpanContext sc = Span.current().getSpanContext();
             if (sc.isValid()) return sc.getTraceId();
-        } catch (RuntimeException ignored) {
-            // no agent / API misbehaviour — fall through to the header
+        } catch (RuntimeException e) {
+            // no agent / API misbehaviour — fall through to the header (but keep the root cause)
+            log.trace("Span.current() unavailable; falling back to x-trace-id header", e);
         }
         if (headerTraceId != null && !headerTraceId.isBlank()) return headerTraceId.trim();
         return "-";

--- a/backend/pgr-services/src/main/java/org/egov/pgr/config/PGRConfiguration.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/config/PGRConfiguration.java
@@ -219,6 +219,22 @@ public class PGRConfiguration {
     @Value("${state.level.tenantid.length}")
     private Integer stateLevelTenantIdLength;
 
+    // ---- analytics config caches ----
+
+    /**
+     * Fallback for {@code pgr.analytics.config-cache-ttl-ms} when the bean is built
+     * outside Spring (hand-constructed/mocked in tests) and the field is null. 5 minutes.
+     */
+    public static final long DEFAULT_ANALYTICS_CONFIG_CACHE_TTL_MS = 5 * 60_000L;
+
+    /**
+     * The ONE TTL for every analytics in-memory config cache — recordCount in
+     * AnalyticsService and departmentScoping in KpiCatalogService both read THIS
+     * property; per-file hardcoded TTLs are not allowed (#1282 review).
+     */
+    @Value("${pgr.analytics.config-cache-ttl-ms:300000}")
+    private Long analyticsConfigCacheTtlMs;
+
     @Value("${is.environment.central.instance}")
     private Boolean isEnvironmentCentralInstance;
 

--- a/backend/pgr-services/src/main/resources/application.properties
+++ b/backend/pgr-services/src/main/resources/application.properties
@@ -146,6 +146,10 @@ persister.save.transition.wf.migration.topic=save-wf-transitions-batch
 state.level.tenantid.length=1
 is.environment.central.instance=false
 
+# Single TTL for the analytics in-memory config caches (recordCount in
+# AnalyticsService, departmentScoping in KpiCatalogService).
+pgr.analytics.config-cache-ttl-ms=300000
+
 pgr.kafka.notification.topic.pattern=((^[a-zA-Z]+-)?save-pgr-request|(^[a-zA-Z]+-)?update-pgr-request)
 
 management.endpoints.web.base-path=/

--- a/backend/pgr-services/src/main/resources/db/migration/main/V20260716000000__hier_path_null_on_dotted_node_codes.sql
+++ b/backend/pgr-services/src/main/resources/db/migration/main/V20260716000000__hier_path_null_on_dotted_node_codes.sql
@@ -1,0 +1,428 @@
+-- ============================================================================
+-- #1111 (R5, data hygiene for hierarchy-level rollup): NULL complaint_node_path
+-- when the matched hierarchy node's OWN code contains '.'.
+--
+-- The dashboard now rolls complaint-type KPIs up to a hierarchy LEVEL at query
+-- time by splitting complaint_node_path on '.'. Legacy flat imports (e.g. the
+-- 'complaints.categories.*' ServiceDefs-era codes) registered SINGLE hierarchy
+-- nodes whose code itself contains dots, so their "path" splits into fabricated
+-- segments and forms garbage level-1 buckets (a "complaints" bucket that is not
+-- a category). Live exposure at authoring time: 20 of 645 fact rows across 3
+-- tenants (13 further NULL-path rows already take the leaf fallback).
+--
+-- Fix: the cnp CTE now emits NULL complaint_node_path when the matched node's
+-- own code contains '.'; those rows take the SAME leaf fallback the query-time
+-- level expression already has for flat/legacy tenants
+-- (coalesce(nullif(split_part(...)),''), service_code) — i.e. they roll up as
+-- themselves instead of polluting level buckets. complaint_depth and the
+-- path-derived service_group/service_parent_code follow (service_group keeps
+-- its legacy ServiceDefs.menuPath fallback). Everything else is byte-identical
+-- to V20260708000000.
+--
+-- NOTE: this supersedes the events/facts definitions in V20260708000000 (which
+-- superseded V20260629000000, which superseded V20260608000000). Recreate BOTH
+-- MVs in any future shape change (flyway migrations are append-only — the
+-- originals cannot be edited without breaking deployed checksums).
+-- ============================================================================
+
+
+-- ---- grain 1: complaint_events ----------------------------------------------
+DROP MATERIALIZED VIEW IF EXISTS complaint_events CASCADE;
+CREATE MATERIALIZED VIEW complaint_events AS
+WITH RECURSIVE svc AS (
+  SELECT s.servicerequestid, s.id AS pgr_id, s.tenantid, s.servicecode, s.accountid,
+         s.source, s.createdtime AS complaint_created_at, s.createdby AS filed_by_uuid,
+         a.locality AS locality_code, a.latitude, a.longitude,
+         (a.latitude IS NOT NULL AND a.longitude IS NOT NULL) AS has_geo_pin
+  FROM eg_pgr_service_v2 s
+  LEFT JOIN eg_pgr_address_v2 a ON a.parentid = s.id
+),
+bnd0 AS (   -- one row per boundary code: full root->leaf path + the node's own (leaf) type,
+            -- tenant and hierarchy; longest ancestral path wins (as before)
+  SELECT DISTINCT ON (code) code, tenantid, hierarchytype,
+         boundarytype AS leaf_type,
+         (ancestralmaterializedpath || '|' || code) AS boundary_path
+  FROM boundary_relationship
+  ORDER BY code, length(ancestralmaterializedpath) DESC
+),
+btype AS (  -- per-node level type (same dedupe rule), to type every path segment
+  SELECT DISTINCT ON (code) code, boundarytype
+  FROM boundary_relationship
+  ORDER BY code, length(ancestralmaterializedpath) DESC
+),
+wardlvl AS (   -- #1079: the tenant's 'Ward' level and the level directly above it,
+               -- from the boundary_hierarchy level registry
+  SELECT DISTINCT ON (h.tenantid, h.hierarchytype) h.tenantid, h.hierarchytype,
+         lvl->>'boundaryType'       AS ward_type,
+         lvl->>'parentBoundaryType' AS zone_type
+  FROM boundary_hierarchy h
+  CROSS JOIN LATERAL jsonb_array_elements(h.boundaryhierarchy) lvl
+  WHERE lower(lvl->>'boundaryType') = 'ward'
+),
+bnd AS (   -- #1079: registry-resolved named levels per boundary code.
+           -- FALLBACK (no Ward level in the tenant's hierarchy): leaf / parent-of-leaf.
+  SELECT b.code, b.boundary_path,
+         b.code      AS boundary_leaf_code,
+         b.leaf_type AS boundary_leaf_type,
+         CASE WHEN w.ward_type IS NOT NULL THEN seg.ward_seg
+              ELSE segs.arr[array_length(segs.arr,1)] END     AS ward_code,
+         CASE WHEN w.ward_type IS NOT NULL THEN seg.zone_seg
+              ELSE segs.arr[array_length(segs.arr,1)-1] END   AS zone_code
+  FROM bnd0 b
+  LEFT JOIN wardlvl w ON w.tenantid = b.tenantid AND w.hierarchytype = b.hierarchytype
+  CROSS JOIN LATERAL (SELECT string_to_array(b.boundary_path,'|') AS arr) segs
+  LEFT JOIN LATERAL (
+    SELECT max(s.seg) FILTER (WHERE lower(bt.boundarytype) = lower(w.ward_type)) AS ward_seg,
+           max(s.seg) FILTER (WHERE lower(bt.boundarytype) = lower(w.zone_type)) AS zone_seg
+    FROM unnest(segs.arr) s(seg)
+    LEFT JOIN btype bt ON bt.code = s.seg
+  ) seg ON true
+),
+bs AS (
+  SELECT DISTINCT ON (tenantid, businessservice) tenantid, businessservice, businessservicesla
+  FROM eg_wf_businessservice_v2
+),
+asg AS (
+  SELECT processinstanceid, count(*) AS assignee_count,
+         (array_agg(assignee ORDER BY assignee))[1] AS assignee_uuid
+  FROM eg_wf_assignee_v2 GROUP BY processinstanceid
+),
+mdms AS (   -- ServiceDefs; dedupe by serviceCode preferring the root (shortest) tenant
+  SELECT DISTINCT ON (data->>'serviceCode')
+         data->>'serviceCode' AS service_code,
+         data->>'department'  AS department_code
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.ServiceDefs' AND isactive
+  ORDER BY data->>'serviceCode', length(tenantid)
+),
+chlvl AS (   -- #1079: levelCodes flagged isLeafServiceCode in ComplaintHierarchyDefinition
+  SELECT DISTINCT lvl->>'levelCode' AS level_code
+  FROM eg_mdms_data d
+  CROSS JOIN LATERAL jsonb_array_elements(d.data->'levels') lvl
+  WHERE d.schemacode = 'RAINMAKER-PGR.ComplaintHierarchyDefinition' AND d.isactive
+    AND (lvl->>'isLeafServiceCode')::boolean
+),
+ch AS (   -- ComplaintHierarchy nodes; dedupe by code preferring leaf-level records
+          -- (registry leaf detection), then the root (shortest) tenant
+  SELECT DISTINCT ON (data->>'code')
+         data->>'code'                  AS code,
+         NULLIF(data->>'path','')       AS node_path,
+         NULLIF(data->>'parentCode','') AS parent_code
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.ComplaintHierarchy' AND isactive
+  ORDER BY data->>'code',
+           (data->>'levelCode' IN (SELECT level_code FROM chlvl)) DESC,
+           length(tenantid)
+),
+chwalk AS (   -- recursive parentCode walk (robust fallback when path is absent)
+  SELECT code AS leaf_code, code, parent_code, code::text AS built_path, 1 AS depth
+  FROM ch
+  UNION ALL
+  SELECT w.leaf_code, p.code, p.parent_code, (p.code || '.' || w.built_path), w.depth + 1
+  FROM chwalk w
+  JOIN ch p ON p.code = w.parent_code
+  WHERE w.depth < 12
+),
+cnp AS (   -- #1079: complaint_node_path per code = master path, else recursive build.
+           -- #1111/R5: NULL when the matched node's OWN code contains '.' — legacy flat
+           -- imports carry dots INSIDE one code, so any '.'-split of their path would
+           -- fabricate garbage level buckets; NULL path => the query-time level expr
+           -- falls back to the leaf service_code instead.
+  SELECT ch.code,
+         CASE WHEN position('.' IN ch.code) > 0 THEN NULL
+              ELSE coalesce(ch.node_path, walk.built_path) END AS complaint_node_path
+  FROM ch
+  LEFT JOIN LATERAL (
+    SELECT w.built_path FROM chwalk w WHERE w.leaf_code = ch.code
+    ORDER BY w.depth DESC LIMIT 1
+  ) walk ON true
+),
+tx AS (
+  SELECT pi.id AS event_id, pi.businessid AS service_request_id, pi.tenantid,
+         pi.businessservice, pi.action, pi.assigner AS actor_uuid,
+         pi.escalated, pi.rating AS event_rating, pi.comment,
+         pi.createdtime AS entered_at,
+         st.state AS status, st.seq AS status_seq, st.sla AS state_sla_ms,
+         st.isterminatestate AS status_is_terminal,
+         lead(pi.createdtime) OVER w AS exited_at,
+         lag(st.state)        OVER w AS previous_status,
+         lag(st.seq)          OVER w AS previous_status_seq,
+         row_number()         OVER w AS seq_no,
+         (lead(pi.id) OVER w IS NULL) AS is_current_state
+  FROM eg_wf_processinstance_v2 pi
+  LEFT JOIN eg_wf_state_v2 st ON st.uuid = pi.status
+  WINDOW w AS (PARTITION BY pi.businessid ORDER BY pi.createdtime, pi.id)
+)
+SELECT
+  tx.event_id, tx.service_request_id, tx.tenantid AS tenant_id,
+  tx.businessservice AS business_service, tx.seq_no, tx.is_current_state,
+  tx.action, tx.status, tx.previous_status,
+  coalesce(tx.status_is_terminal,false)        AS status_is_terminal,
+  (NOT coalesce(tx.status_is_terminal,false))  AS status_is_open,
+  tx.actor_uuid, asg.assignee_uuid,
+  (ua.type = 'SYSTEM')                         AS actor_is_system,
+  tx.entered_at, tx.exited_at,
+  (tx.exited_at - tx.entered_at)               AS dwell_ms,
+  tx.status_seq, tx.previous_status_seq,
+  (tx.status_seq - tx.previous_status_seq)     AS seq_delta,
+  (tx.status_seq < tx.previous_status_seq)     AS is_backward_transition,
+  tx.state_sla_ms,
+  CASE WHEN tx.state_sla_ms IS NOT NULL AND tx.exited_at IS NOT NULL
+       THEN (tx.exited_at - tx.entered_at) > tx.state_sla_ms END AS state_sla_breached_on_exit,
+  bs.businessservicesla                        AS business_sla_ms,
+  (tx.action IN ('ASSIGN','REASSIGN'))         AS is_assignment,
+  (tx.action = 'REOPEN')                       AS is_reopen,
+  coalesce(tx.escalated,false)                 AS is_escalation,
+  CASE WHEN coalesce(tx.escalated,false)
+       THEN (CASE WHEN ua.type='SYSTEM' THEN 'auto' ELSE 'manual' END) END AS escalation_source,
+  (tx.comment IS NOT NULL AND tx.comment <> '') AS has_comment,
+  length(tx.comment)                           AS comment_length,
+  tx.event_rating,
+  coalesce(asg.assignee_count,0)               AS assignee_count,
+  (coalesce(asg.assignee_count,0) > 1)         AS has_multiple_assignees,
+  svc.accountid AS account_id, svc.source, svc.servicecode AS service_code,
+  m.department_code,                                                      -- S2: department row-scope axis
+  cnp.complaint_node_path,                                                -- #1079: complaint taxonomy axis
+  array_length(string_to_array(cnp.complaint_node_path,'.'),1)::smallint AS complaint_depth,
+  svc.locality_code, svc.has_geo_pin,
+  svc.complaint_created_at,
+  (tx.entered_at - svc.complaint_created_at)   AS complaint_age_at_event_ms,
+  bnd.boundary_path,
+  bnd.zone_code,                               -- #1079: registry-resolved (was split_part pos 2)
+  bnd.ward_code,                               -- #1079: registry-resolved (was split_part pos 3)
+  bnd.boundary_leaf_code,                      -- #1079: leaf node, depth-agnostic
+  bnd.boundary_leaf_type,
+  (to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3')::date AS occurred_date,
+  date_trunc('week',(to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3'))::date AS occurred_week_start,
+  to_char((to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3'),'YYYY-MM') AS occurred_month,
+  extract(hour   FROM (to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3'))::smallint AS occurred_hour,
+  extract(isodow FROM (to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3'))::smallint AS occurred_dow,
+  (extract(isodow FROM (to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3')) IN (6,7)) AS occurred_is_weekend,
+  (extract(hour  FROM (to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3')) BETWEEN 8 AND 17) AS occurred_is_business_hr
+FROM tx
+LEFT JOIN svc ON svc.servicerequestid = tx.service_request_id
+LEFT JOIN bnd ON bnd.code = svc.locality_code
+LEFT JOIN cnp ON cnp.code = svc.servicecode
+LEFT JOIN LATERAL (                          -- #1028 fix 3: exact tenant, else state root
+  SELECT b.businessservicesla
+  FROM bs b
+  WHERE b.businessservice = tx.businessservice
+    AND b.tenantid IN (tx.tenantid, split_part(tx.tenantid,'.',1))
+  ORDER BY length(b.tenantid) DESC
+  LIMIT 1
+) bs ON true
+LEFT JOIN asg ON asg.processinstanceid = tx.event_id
+LEFT JOIN mdms m ON m.service_code = svc.servicecode
+LEFT JOIN eg_user ua ON ua.uuid = tx.actor_uuid;
+
+CREATE UNIQUE INDEX ux_complaint_events ON complaint_events(event_id);
+CREATE INDEX ix_ce_timeline ON complaint_events(service_request_id, seq_no);
+CREATE INDEX ix_ce_status   ON complaint_events(status);
+CREATE INDEX ix_ce_assignee ON complaint_events(assignee_uuid);
+CREATE INDEX ix_ce_week     ON complaint_events(occurred_week_start);
+CREATE INDEX ix_ce_dept     ON complaint_events(department_code);
+
+-- ---- grain 2: complaint_facts (CASCADE dropped by the events recreate) ------
+DROP MATERIALIZED VIEW IF EXISTS complaint_facts CASCADE;
+CREATE MATERIALIZED VIEW complaint_facts AS
+WITH RECURSIVE clock AS (SELECT (extract(epoch FROM now())*1000)::bigint AS now_ms),
+roll AS (
+  SELECT service_request_id,
+         min(entered_at)                                            AS created_at,
+         max(entered_at)                                            AS last_transition_at,
+         count(*)                                                   AS transition_count,
+         count(*) FILTER (WHERE is_assignment)                      AS assignment_count,
+         count(*) FILTER (WHERE is_escalation)                      AS escalation_count,
+         count(*) FILTER (WHERE is_reopen)                          AS reopen_count,
+         count(DISTINCT assignee_uuid)                              AS distinct_assignee_count,
+         count(DISTINCT actor_uuid)                                 AS distinct_actor_count,
+         count(*) FILTER (WHERE actor_is_system)                    AS system_transition_count,
+         count(*) FILTER (WHERE NOT actor_is_system)                AS manual_transition_count,
+         bool_or(status IN ('REJECTED','CLOSEDAFTERREJECTION'))     AS was_rejected,
+         min(entered_at) FILTER (WHERE is_assignment)               AS first_assigned_at,
+         min(entered_at) FILTER (WHERE status IN ('RESOLVED','CLOSEDAFTERRESOLUTION')) AS resolved_at,
+         max(entered_at) FILTER (WHERE is_escalation)               AS last_escalated_at,
+         min(entered_at) FILTER (WHERE is_escalation)               AS first_escalated_at,
+         max(dwell_ms)                                              AS max_dwell_ms,
+         sum(dwell_ms) FILTER (WHERE assignee_uuid IS NOT NULL)     AS assigned_dwell_ms,
+         sum(dwell_ms) FILTER (WHERE assignee_uuid IS NULL)         AS unassigned_dwell_ms
+  FROM complaint_events GROUP BY service_request_id
+),
+cur AS (
+  SELECT service_request_id, status AS application_status, status_seq AS current_state_seq,
+         status_is_open AS is_open, assignee_uuid AS current_assignee_uuid,
+         state_sla_ms AS current_state_sla_ms, business_sla_ms,
+         boundary_path, ward_code, zone_code,
+         boundary_leaf_code, boundary_leaf_type                     -- #1079
+  FROM complaint_events WHERE is_current_state
+),
+mdms AS (
+  SELECT DISTINCT ON (data->>'serviceCode')
+         data->>'serviceCode'            AS service_code,
+         (data->>'slaHours')::int        AS mdms_sla_hours,
+         NULLIF(data->>'menuPath','')    AS legacy_service_group,   -- #1079: fallback only
+         (data->>'order')::smallint      AS service_order,
+         data->>'department'             AS department_code
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.ServiceDefs' AND isactive
+  ORDER BY data->>'serviceCode', length(tenantid)
+),
+chlvl AS (   -- #1079: levelCodes flagged isLeafServiceCode in ComplaintHierarchyDefinition
+  SELECT DISTINCT lvl->>'levelCode' AS level_code
+  FROM eg_mdms_data d
+  CROSS JOIN LATERAL jsonb_array_elements(d.data->'levels') lvl
+  WHERE d.schemacode = 'RAINMAKER-PGR.ComplaintHierarchyDefinition' AND d.isactive
+    AND (lvl->>'isLeafServiceCode')::boolean
+),
+ch AS (   -- ComplaintHierarchy nodes; dedupe by code preferring leaf-level records
+          -- (registry leaf detection), then the root (shortest) tenant
+  SELECT DISTINCT ON (data->>'code')
+         data->>'code'                  AS code,
+         NULLIF(data->>'path','')       AS node_path,
+         NULLIF(data->>'parentCode','') AS parent_code
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.ComplaintHierarchy' AND isactive
+  ORDER BY data->>'code',
+           (data->>'levelCode' IN (SELECT level_code FROM chlvl)) DESC,
+           length(tenantid)
+),
+chwalk AS (   -- recursive parentCode walk (robust fallback when path is absent)
+  SELECT code AS leaf_code, code, parent_code, code::text AS built_path, 1 AS depth
+  FROM ch
+  UNION ALL
+  SELECT w.leaf_code, p.code, p.parent_code, (p.code || '.' || w.built_path), w.depth + 1
+  FROM chwalk w
+  JOIN ch p ON p.code = w.parent_code
+  WHERE w.depth < 12
+),
+cnp AS (   -- #1079: complaint_node_path per code = master path, else recursive build.
+           -- #1111/R5: NULL when the matched node's OWN code contains '.' — legacy flat
+           -- imports carry dots INSIDE one code, so any '.'-split of their path would
+           -- fabricate garbage level buckets; NULL path => the query-time level expr
+           -- falls back to the leaf service_code instead.
+  SELECT ch.code,
+         CASE WHEN position('.' IN ch.code) > 0 THEN NULL
+              ELSE coalesce(ch.node_path, walk.built_path) END AS complaint_node_path
+  FROM ch
+  LEFT JOIN LATERAL (
+    SELECT w.built_path FROM chwalk w WHERE w.leaf_code = ch.code
+    ORDER BY w.depth DESC LIMIT 1
+  ) walk ON true
+),
+esc AS (   -- #1028 fix 2: EscalationConfig ladder source (one record per tenant, at state root)
+  SELECT tenantid,
+         data->'overrides'         AS overrides,
+         data->'defaultSlaByLevel' AS default_levels
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.EscalationConfig' AND isactive
+),
+seq AS (
+  SELECT id, row_number() OVER (PARTITION BY accountid ORDER BY createdtime, id) AS complaint_seq_for_citizen
+  FROM eg_pgr_service_v2
+)
+SELECT
+  s.servicerequestid AS service_request_id, s.id AS pgr_id, s.tenantid AS tenant_id,
+  s.accountid AS account_id, 'PGR'::text AS business_service,
+  s.servicecode AS service_code, cur.application_status, s.source, s.rating AS rating_raw, s.active,
+  length(s.description) AS description_length,
+  (s.description IS NOT NULL AND s.description <> '') AS has_description,
+  s.createdby AS filed_by_uuid, (s.createdby <> s.accountid) AS filed_on_behalf,
+  a.locality AS locality_code, a.pincode, a.city, a.latitude, a.longitude,
+  (a.latitude IS NOT NULL AND a.longitude IS NOT NULL) AS has_geo_pin,
+  (a.parentid IS NOT NULL) AS has_address,
+  cur.boundary_path,
+  (length(coalesce(cur.boundary_path,'')) - length(replace(coalesce(cur.boundary_path,''),'|','')) + 1)::smallint AS boundary_depth,
+  cur.ward_code, cur.zone_code,
+  cur.boundary_leaf_code, cur.boundary_leaf_type,                          -- #1079
+  cnp.complaint_node_path,                                                 -- #1079
+  cx.complaint_depth,                                                      -- #1079
+  coalesce(cx.root_code, m.legacy_service_group) AS service_group,         -- #1079: ROOT category
+  cx.service_parent_code,                                                  -- #1079: immediate parent
+  m.service_order, m.mdms_sla_hours, m.department_code,
+  cur.current_state_seq, cur.current_state_sla_ms, tgt.sla_target_ms,      -- #1028: COALESCE'd target
+  (m.mdms_sla_hours IS NOT NULL AND cur.business_sla_ms IS NOT NULL
+    AND m.mdms_sla_hours::bigint*3600000 <> cur.business_sla_ms) AS sla_config_mismatch,
+  roll.created_at, roll.first_assigned_at, roll.first_assigned_at AS first_response_at,
+  roll.resolved_at, roll.last_transition_at, roll.first_escalated_at, roll.last_escalated_at,
+  roll.transition_count, roll.assignment_count, roll.escalation_count, roll.reopen_count,
+  roll.distinct_assignee_count, roll.distinct_actor_count,
+  roll.system_transition_count, roll.manual_transition_count,
+  roll.was_rejected, (roll.reopen_count > 0) AS is_reopened,
+  cur.is_open, (roll.resolved_at IS NOT NULL) AS is_resolved,
+  roll.max_dwell_ms, roll.assigned_dwell_ms, roll.unassigned_dwell_ms,
+  cur.current_assignee_uuid,
+  (roll.resolved_at - roll.created_at)                            AS resolution_ms,
+  (roll.first_assigned_at - roll.created_at)                      AS time_to_assign_ms,
+  CASE WHEN cur.is_open THEN clock.now_ms - roll.created_at END   AS open_age_ms,
+  CASE WHEN cur.is_open THEN clock.now_ms - roll.last_transition_at END AS current_state_age_ms,
+  (roll.first_escalated_at - roll.created_at)                     AS first_escalation_ms,
+  CASE WHEN cur.is_open  THEN (tgt.sla_target_ms IS NOT NULL AND (clock.now_ms - roll.created_at) > tgt.sla_target_ms)
+       WHEN roll.resolved_at IS NOT NULL THEN (tgt.sla_target_ms IS NOT NULL AND (roll.resolved_at - roll.created_at) > tgt.sla_target_ms)
+       ELSE false END                                            AS sla_breached,
+  (cur.is_open AND cur.current_state_sla_ms IS NOT NULL
+    AND (clock.now_ms - roll.last_transition_at) > cur.current_state_sla_ms) AS current_state_sla_breached,
+  CASE WHEN NOT cur.is_open THEN NULL
+       WHEN (clock.now_ms - roll.created_at) < 86400000  THEN '<1d'
+       WHEN (clock.now_ms - roll.created_at) < 259200000 THEN '1-3d'
+       WHEN (clock.now_ms - roll.created_at) < 604800000 THEN '3-7d'
+       ELSE '>7d' END                                            AS aging_bucket,
+  CASE WHEN NOT cur.is_open OR tgt.sla_target_ms IS NULL THEN NULL
+       WHEN (clock.now_ms - roll.created_at) > tgt.sla_target_ms       THEN 'breached'
+       WHEN (clock.now_ms - roll.created_at) > 0.8*tgt.sla_target_ms   THEN 'approaching'
+       ELSE 'within' END                                         AS sla_status_bucket,
+  (s.rating IS NOT NULL) AS has_rating, s.rating, (s.rating IS NOT NULL AND s.rating <= 2) AS is_negative_rating,
+  seq.complaint_seq_for_citizen, (seq.complaint_seq_for_citizen = 1) AS is_first_time_complainant,
+  (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3')::date AS created_date,
+  date_trunc('week',(to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'))::date AS created_week_start,
+  to_char((to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'),'YYYY-MM') AS created_month,
+  extract(year FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'))::smallint AS created_year,
+  to_char((to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'),'YYYY-"Q"Q') AS created_quarter,
+  extract(hour FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'))::smallint AS created_hour,
+  extract(isodow FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'))::smallint AS created_dow,
+  (extract(isodow FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3')) IN (6,7)) AS created_is_weekend,
+  (extract(hour FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3')) BETWEEN 8 AND 17) AS created_is_business_hr,
+  (to_timestamp(roll.resolved_at/1000) AT TIME ZONE 'Etc/GMT-3')::date AS resolved_date,
+  to_char((to_timestamp(roll.resolved_at/1000) AT TIME ZONE 'Etc/GMT-3'),'YYYY-MM') AS resolved_month,
+  clock.now_ms AS facts_built_at
+FROM eg_pgr_service_v2 s
+CROSS JOIN clock
+LEFT JOIN eg_pgr_address_v2 a ON a.parentid = s.id
+LEFT JOIN roll ON roll.service_request_id = s.servicerequestid
+LEFT JOIN cur  ON cur.service_request_id  = s.servicerequestid
+LEFT JOIN mdms m ON m.service_code = s.servicecode
+LEFT JOIN cnp ON cnp.code = s.servicecode
+CROSS JOIN LATERAL (                         -- #1079: path-derived complaint-axis fields
+  SELECT x.arr[1]                            AS root_code,
+         array_length(x.arr,1)::smallint     AS complaint_depth,
+         x.arr[array_length(x.arr,1)-1]      AS service_parent_code
+  FROM (SELECT string_to_array(cnp.complaint_node_path,'.') AS arr) x
+) cx
+LEFT JOIN LATERAL (                          -- #1028 fix 2: ladder total for this complaint's
+  SELECT CASE                                -- service code, from the nearest EscalationConfig
+           WHEN jsonb_typeof(e.overrides -> s.servicecode) = 'array'   -- (exact tenant, else state root)
+             THEN (SELECT sum(v.value::numeric)::bigint
+                   FROM jsonb_array_elements_text(e.overrides -> s.servicecode) v)
+           WHEN jsonb_typeof(e.default_levels) = 'array'
+             THEN (SELECT sum(v.value::numeric)::bigint
+                   FROM jsonb_array_elements_text(e.default_levels) v)
+         END AS ladder_sla_ms
+  FROM esc e
+  WHERE e.tenantid IN (s.tenantid, split_part(s.tenantid,'.',1))
+  ORDER BY length(e.tenantid) DESC
+  LIMIT 1
+) lad ON true
+CROSS JOIN LATERAL (                         -- #1028: the decided SLA-target precedence
+  SELECT coalesce(m.mdms_sla_hours::bigint * 3600000,   -- 1) ServiceDefs slaHours
+                  lad.ladder_sla_ms,                    -- 2) escalation-ladder total
+                  cur.business_sla_ms                   -- 3) workflow SLA (state-root fallback)
+         ) AS sla_target_ms
+) tgt
+LEFT JOIN seq ON seq.id = s.id
+WHERE s.active = true;
+
+CREATE UNIQUE INDEX ux_complaint_facts ON complaint_facts(service_request_id);
+CREATE INDEX ix_cf_service ON complaint_facts(service_code);
+CREATE INDEX ix_cf_status  ON complaint_facts(application_status);
+CREATE INDEX ix_cf_created ON complaint_facts(created_week_start);
+CREATE INDEX ix_cf_open    ON complaint_facts(is_open) WHERE is_open;
+CREATE INDEX ix_cf_ward    ON complaint_facts(ward_code);

--- a/backend/pgr-services/src/main/resources/db/migration/main/V20260717000000__hier_path_null_on_dotted_parent_codes.sql
+++ b/backend/pgr-services/src/main/resources/db/migration/main/V20260717000000__hier_path_null_on_dotted_parent_codes.sql
@@ -1,0 +1,439 @@
+-- ============================================================================
+-- #1111 R5 widening (found in the bomet integration deploy): ALSO NULL
+-- complaint_node_path when the matched hierarchy node's parentCode contains '.'.
+--
+-- V20260716000000 NULLed the path only when the node's OWN code contains '.'
+-- (legacy flat imports whose single-node code IS a dotted 'complaints.
+-- categories.*' string). Bomet data showed a second pollution shape that
+-- heuristic misses: nodes whose code is CLEAN but whose stored parentCode /
+-- path still carries the legacy pollution — e.g. node 'DamagedRoad' with path
+-- 'complaints.categories.DamagedRoad.DamagedRoad' (depth 4). Splitting those
+-- paths on '.' survives R5 and still fabricates a garbage 'complaints' level-1
+-- bucket (30 live fact rows on bomet at authoring time).
+--
+-- Fix: the cnp CTE now emits NULL complaint_node_path when the matched node's
+-- own code contains '.' OR its parentCode contains '.'; those rows take the
+-- SAME leaf fallback the query-time level expression already has for
+-- flat/legacy tenants (coalesce(nullif(split_part(...)),''), service_code) —
+-- i.e. they roll up as themselves instead of polluting level buckets.
+-- complaint_depth and the path-derived service_group/service_parent_code
+-- follow (service_group keeps its legacy ServiceDefs.menuPath fallback).
+-- Everything else is byte-identical to V20260716000000, which is already
+-- applied on live deployments, hence this NEW migration with the widened
+-- predicate (flyway migrations are append-only).
+--
+-- NOTE: this supersedes the events/facts definitions in V20260716000000 (which
+-- superseded V20260708000000, V20260629000000, V20260608000000 in turn).
+-- Recreate BOTH MVs in any future shape change — the originals cannot be
+-- edited without breaking deployed checksums.
+-- ============================================================================
+
+
+-- ---- grain 1: complaint_events ----------------------------------------------
+DROP MATERIALIZED VIEW IF EXISTS complaint_events CASCADE;
+CREATE MATERIALIZED VIEW complaint_events AS
+WITH RECURSIVE svc AS (
+  SELECT s.servicerequestid, s.id AS pgr_id, s.tenantid, s.servicecode, s.accountid,
+         s.source, s.createdtime AS complaint_created_at, s.createdby AS filed_by_uuid,
+         a.locality AS locality_code, a.latitude, a.longitude,
+         (a.latitude IS NOT NULL AND a.longitude IS NOT NULL) AS has_geo_pin
+  FROM eg_pgr_service_v2 s
+  LEFT JOIN eg_pgr_address_v2 a ON a.parentid = s.id
+),
+bnd0 AS (   -- one row per boundary code: full root->leaf path + the node's own (leaf) type,
+            -- tenant and hierarchy; longest ancestral path wins (as before)
+  SELECT DISTINCT ON (code) code, tenantid, hierarchytype,
+         boundarytype AS leaf_type,
+         (ancestralmaterializedpath || '|' || code) AS boundary_path
+  FROM boundary_relationship
+  ORDER BY code, length(ancestralmaterializedpath) DESC
+),
+btype AS (  -- per-node level type (same dedupe rule), to type every path segment
+  SELECT DISTINCT ON (code) code, boundarytype
+  FROM boundary_relationship
+  ORDER BY code, length(ancestralmaterializedpath) DESC
+),
+wardlvl AS (   -- #1079: the tenant's 'Ward' level and the level directly above it,
+               -- from the boundary_hierarchy level registry
+  SELECT DISTINCT ON (h.tenantid, h.hierarchytype) h.tenantid, h.hierarchytype,
+         lvl->>'boundaryType'       AS ward_type,
+         lvl->>'parentBoundaryType' AS zone_type
+  FROM boundary_hierarchy h
+  CROSS JOIN LATERAL jsonb_array_elements(h.boundaryhierarchy) lvl
+  WHERE lower(lvl->>'boundaryType') = 'ward'
+),
+bnd AS (   -- #1079: registry-resolved named levels per boundary code.
+           -- FALLBACK (no Ward level in the tenant's hierarchy): leaf / parent-of-leaf.
+  SELECT b.code, b.boundary_path,
+         b.code      AS boundary_leaf_code,
+         b.leaf_type AS boundary_leaf_type,
+         CASE WHEN w.ward_type IS NOT NULL THEN seg.ward_seg
+              ELSE segs.arr[array_length(segs.arr,1)] END     AS ward_code,
+         CASE WHEN w.ward_type IS NOT NULL THEN seg.zone_seg
+              ELSE segs.arr[array_length(segs.arr,1)-1] END   AS zone_code
+  FROM bnd0 b
+  LEFT JOIN wardlvl w ON w.tenantid = b.tenantid AND w.hierarchytype = b.hierarchytype
+  CROSS JOIN LATERAL (SELECT string_to_array(b.boundary_path,'|') AS arr) segs
+  LEFT JOIN LATERAL (
+    SELECT max(s.seg) FILTER (WHERE lower(bt.boundarytype) = lower(w.ward_type)) AS ward_seg,
+           max(s.seg) FILTER (WHERE lower(bt.boundarytype) = lower(w.zone_type)) AS zone_seg
+    FROM unnest(segs.arr) s(seg)
+    LEFT JOIN btype bt ON bt.code = s.seg
+  ) seg ON true
+),
+bs AS (
+  SELECT DISTINCT ON (tenantid, businessservice) tenantid, businessservice, businessservicesla
+  FROM eg_wf_businessservice_v2
+),
+asg AS (
+  SELECT processinstanceid, count(*) AS assignee_count,
+         (array_agg(assignee ORDER BY assignee))[1] AS assignee_uuid
+  FROM eg_wf_assignee_v2 GROUP BY processinstanceid
+),
+mdms AS (   -- ServiceDefs; dedupe by serviceCode preferring the root (shortest) tenant
+  SELECT DISTINCT ON (data->>'serviceCode')
+         data->>'serviceCode' AS service_code,
+         data->>'department'  AS department_code
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.ServiceDefs' AND isactive
+  ORDER BY data->>'serviceCode', length(tenantid)
+),
+chlvl AS (   -- #1079: levelCodes flagged isLeafServiceCode in ComplaintHierarchyDefinition
+  SELECT DISTINCT lvl->>'levelCode' AS level_code
+  FROM eg_mdms_data d
+  CROSS JOIN LATERAL jsonb_array_elements(d.data->'levels') lvl
+  WHERE d.schemacode = 'RAINMAKER-PGR.ComplaintHierarchyDefinition' AND d.isactive
+    AND (lvl->>'isLeafServiceCode')::boolean
+),
+ch AS (   -- ComplaintHierarchy nodes; dedupe by code preferring leaf-level records
+          -- (registry leaf detection), then the root (shortest) tenant
+  SELECT DISTINCT ON (data->>'code')
+         data->>'code'                  AS code,
+         NULLIF(data->>'path','')       AS node_path,
+         NULLIF(data->>'parentCode','') AS parent_code
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.ComplaintHierarchy' AND isactive
+  ORDER BY data->>'code',
+           (data->>'levelCode' IN (SELECT level_code FROM chlvl)) DESC,
+           length(tenantid)
+),
+chwalk AS (   -- recursive parentCode walk (robust fallback when path is absent)
+  SELECT code AS leaf_code, code, parent_code, code::text AS built_path, 1 AS depth
+  FROM ch
+  UNION ALL
+  SELECT w.leaf_code, p.code, p.parent_code, (p.code || '.' || w.built_path), w.depth + 1
+  FROM chwalk w
+  JOIN ch p ON p.code = w.parent_code
+  WHERE w.depth < 12
+),
+cnp AS (   -- #1079: complaint_node_path per code = master path, else recursive build.
+           -- #1111/R5: NULL when the matched node's OWN code contains '.' — legacy flat
+           -- imports carry dots INSIDE one code, so any '.'-split of their path would
+           -- fabricate garbage level buckets; NULL path => the query-time level expr
+           -- falls back to the leaf service_code instead.
+           -- R5 widening: ALSO NULL when the node's parentCode contains '.' — clean-code
+           -- nodes parented under a dotted legacy code inherit a polluted path/built_path
+           -- and would otherwise survive as the same garbage buckets.
+  SELECT ch.code,
+         CASE WHEN position('.' IN ch.code) > 0
+                OR position('.' IN coalesce(ch.parent_code, '')) > 0 THEN NULL
+              ELSE coalesce(ch.node_path, walk.built_path) END AS complaint_node_path
+  FROM ch
+  LEFT JOIN LATERAL (
+    SELECT w.built_path FROM chwalk w WHERE w.leaf_code = ch.code
+    ORDER BY w.depth DESC LIMIT 1
+  ) walk ON true
+),
+tx AS (
+  SELECT pi.id AS event_id, pi.businessid AS service_request_id, pi.tenantid,
+         pi.businessservice, pi.action, pi.assigner AS actor_uuid,
+         pi.escalated, pi.rating AS event_rating, pi.comment,
+         pi.createdtime AS entered_at,
+         st.state AS status, st.seq AS status_seq, st.sla AS state_sla_ms,
+         st.isterminatestate AS status_is_terminal,
+         lead(pi.createdtime) OVER w AS exited_at,
+         lag(st.state)        OVER w AS previous_status,
+         lag(st.seq)          OVER w AS previous_status_seq,
+         row_number()         OVER w AS seq_no,
+         (lead(pi.id) OVER w IS NULL) AS is_current_state
+  FROM eg_wf_processinstance_v2 pi
+  LEFT JOIN eg_wf_state_v2 st ON st.uuid = pi.status
+  WINDOW w AS (PARTITION BY pi.businessid ORDER BY pi.createdtime, pi.id)
+)
+SELECT
+  tx.event_id, tx.service_request_id, tx.tenantid AS tenant_id,
+  tx.businessservice AS business_service, tx.seq_no, tx.is_current_state,
+  tx.action, tx.status, tx.previous_status,
+  coalesce(tx.status_is_terminal,false)        AS status_is_terminal,
+  (NOT coalesce(tx.status_is_terminal,false))  AS status_is_open,
+  tx.actor_uuid, asg.assignee_uuid,
+  (ua.type = 'SYSTEM')                         AS actor_is_system,
+  tx.entered_at, tx.exited_at,
+  (tx.exited_at - tx.entered_at)               AS dwell_ms,
+  tx.status_seq, tx.previous_status_seq,
+  (tx.status_seq - tx.previous_status_seq)     AS seq_delta,
+  (tx.status_seq < tx.previous_status_seq)     AS is_backward_transition,
+  tx.state_sla_ms,
+  CASE WHEN tx.state_sla_ms IS NOT NULL AND tx.exited_at IS NOT NULL
+       THEN (tx.exited_at - tx.entered_at) > tx.state_sla_ms END AS state_sla_breached_on_exit,
+  bs.businessservicesla                        AS business_sla_ms,
+  (tx.action IN ('ASSIGN','REASSIGN'))         AS is_assignment,
+  (tx.action = 'REOPEN')                       AS is_reopen,
+  coalesce(tx.escalated,false)                 AS is_escalation,
+  CASE WHEN coalesce(tx.escalated,false)
+       THEN (CASE WHEN ua.type='SYSTEM' THEN 'auto' ELSE 'manual' END) END AS escalation_source,
+  (tx.comment IS NOT NULL AND tx.comment <> '') AS has_comment,
+  length(tx.comment)                           AS comment_length,
+  tx.event_rating,
+  coalesce(asg.assignee_count,0)               AS assignee_count,
+  (coalesce(asg.assignee_count,0) > 1)         AS has_multiple_assignees,
+  svc.accountid AS account_id, svc.source, svc.servicecode AS service_code,
+  m.department_code,                                                      -- S2: department row-scope axis
+  cnp.complaint_node_path,                                                -- #1079: complaint taxonomy axis
+  array_length(string_to_array(cnp.complaint_node_path,'.'),1)::smallint AS complaint_depth,
+  svc.locality_code, svc.has_geo_pin,
+  svc.complaint_created_at,
+  (tx.entered_at - svc.complaint_created_at)   AS complaint_age_at_event_ms,
+  bnd.boundary_path,
+  bnd.zone_code,                               -- #1079: registry-resolved (was split_part pos 2)
+  bnd.ward_code,                               -- #1079: registry-resolved (was split_part pos 3)
+  bnd.boundary_leaf_code,                      -- #1079: leaf node, depth-agnostic
+  bnd.boundary_leaf_type,
+  (to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3')::date AS occurred_date,
+  date_trunc('week',(to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3'))::date AS occurred_week_start,
+  to_char((to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3'),'YYYY-MM') AS occurred_month,
+  extract(hour   FROM (to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3'))::smallint AS occurred_hour,
+  extract(isodow FROM (to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3'))::smallint AS occurred_dow,
+  (extract(isodow FROM (to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3')) IN (6,7)) AS occurred_is_weekend,
+  (extract(hour  FROM (to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3')) BETWEEN 8 AND 17) AS occurred_is_business_hr
+FROM tx
+LEFT JOIN svc ON svc.servicerequestid = tx.service_request_id
+LEFT JOIN bnd ON bnd.code = svc.locality_code
+LEFT JOIN cnp ON cnp.code = svc.servicecode
+LEFT JOIN LATERAL (                          -- #1028 fix 3: exact tenant, else state root
+  SELECT b.businessservicesla
+  FROM bs b
+  WHERE b.businessservice = tx.businessservice
+    AND b.tenantid IN (tx.tenantid, split_part(tx.tenantid,'.',1))
+  ORDER BY length(b.tenantid) DESC
+  LIMIT 1
+) bs ON true
+LEFT JOIN asg ON asg.processinstanceid = tx.event_id
+LEFT JOIN mdms m ON m.service_code = svc.servicecode
+LEFT JOIN eg_user ua ON ua.uuid = tx.actor_uuid;
+
+CREATE UNIQUE INDEX ux_complaint_events ON complaint_events(event_id);
+CREATE INDEX ix_ce_timeline ON complaint_events(service_request_id, seq_no);
+CREATE INDEX ix_ce_status   ON complaint_events(status);
+CREATE INDEX ix_ce_assignee ON complaint_events(assignee_uuid);
+CREATE INDEX ix_ce_week     ON complaint_events(occurred_week_start);
+CREATE INDEX ix_ce_dept     ON complaint_events(department_code);
+
+-- ---- grain 2: complaint_facts (CASCADE dropped by the events recreate) ------
+DROP MATERIALIZED VIEW IF EXISTS complaint_facts CASCADE;
+CREATE MATERIALIZED VIEW complaint_facts AS
+WITH RECURSIVE clock AS (SELECT (extract(epoch FROM now())*1000)::bigint AS now_ms),
+roll AS (
+  SELECT service_request_id,
+         min(entered_at)                                            AS created_at,
+         max(entered_at)                                            AS last_transition_at,
+         count(*)                                                   AS transition_count,
+         count(*) FILTER (WHERE is_assignment)                      AS assignment_count,
+         count(*) FILTER (WHERE is_escalation)                      AS escalation_count,
+         count(*) FILTER (WHERE is_reopen)                          AS reopen_count,
+         count(DISTINCT assignee_uuid)                              AS distinct_assignee_count,
+         count(DISTINCT actor_uuid)                                 AS distinct_actor_count,
+         count(*) FILTER (WHERE actor_is_system)                    AS system_transition_count,
+         count(*) FILTER (WHERE NOT actor_is_system)                AS manual_transition_count,
+         bool_or(status IN ('REJECTED','CLOSEDAFTERREJECTION'))     AS was_rejected,
+         min(entered_at) FILTER (WHERE is_assignment)               AS first_assigned_at,
+         min(entered_at) FILTER (WHERE status IN ('RESOLVED','CLOSEDAFTERRESOLUTION')) AS resolved_at,
+         max(entered_at) FILTER (WHERE is_escalation)               AS last_escalated_at,
+         min(entered_at) FILTER (WHERE is_escalation)               AS first_escalated_at,
+         max(dwell_ms)                                              AS max_dwell_ms,
+         sum(dwell_ms) FILTER (WHERE assignee_uuid IS NOT NULL)     AS assigned_dwell_ms,
+         sum(dwell_ms) FILTER (WHERE assignee_uuid IS NULL)         AS unassigned_dwell_ms
+  FROM complaint_events GROUP BY service_request_id
+),
+cur AS (
+  SELECT service_request_id, status AS application_status, status_seq AS current_state_seq,
+         status_is_open AS is_open, assignee_uuid AS current_assignee_uuid,
+         state_sla_ms AS current_state_sla_ms, business_sla_ms,
+         boundary_path, ward_code, zone_code,
+         boundary_leaf_code, boundary_leaf_type                     -- #1079
+  FROM complaint_events WHERE is_current_state
+),
+mdms AS (
+  SELECT DISTINCT ON (data->>'serviceCode')
+         data->>'serviceCode'            AS service_code,
+         (data->>'slaHours')::int        AS mdms_sla_hours,
+         NULLIF(data->>'menuPath','')    AS legacy_service_group,   -- #1079: fallback only
+         (data->>'order')::smallint      AS service_order,
+         data->>'department'             AS department_code
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.ServiceDefs' AND isactive
+  ORDER BY data->>'serviceCode', length(tenantid)
+),
+chlvl AS (   -- #1079: levelCodes flagged isLeafServiceCode in ComplaintHierarchyDefinition
+  SELECT DISTINCT lvl->>'levelCode' AS level_code
+  FROM eg_mdms_data d
+  CROSS JOIN LATERAL jsonb_array_elements(d.data->'levels') lvl
+  WHERE d.schemacode = 'RAINMAKER-PGR.ComplaintHierarchyDefinition' AND d.isactive
+    AND (lvl->>'isLeafServiceCode')::boolean
+),
+ch AS (   -- ComplaintHierarchy nodes; dedupe by code preferring leaf-level records
+          -- (registry leaf detection), then the root (shortest) tenant
+  SELECT DISTINCT ON (data->>'code')
+         data->>'code'                  AS code,
+         NULLIF(data->>'path','')       AS node_path,
+         NULLIF(data->>'parentCode','') AS parent_code
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.ComplaintHierarchy' AND isactive
+  ORDER BY data->>'code',
+           (data->>'levelCode' IN (SELECT level_code FROM chlvl)) DESC,
+           length(tenantid)
+),
+chwalk AS (   -- recursive parentCode walk (robust fallback when path is absent)
+  SELECT code AS leaf_code, code, parent_code, code::text AS built_path, 1 AS depth
+  FROM ch
+  UNION ALL
+  SELECT w.leaf_code, p.code, p.parent_code, (p.code || '.' || w.built_path), w.depth + 1
+  FROM chwalk w
+  JOIN ch p ON p.code = w.parent_code
+  WHERE w.depth < 12
+),
+cnp AS (   -- #1079: complaint_node_path per code = master path, else recursive build.
+           -- #1111/R5: NULL when the matched node's OWN code contains '.' — legacy flat
+           -- imports carry dots INSIDE one code, so any '.'-split of their path would
+           -- fabricate garbage level buckets; NULL path => the query-time level expr
+           -- falls back to the leaf service_code instead.
+           -- R5 widening: ALSO NULL when the node's parentCode contains '.' — clean-code
+           -- nodes parented under a dotted legacy code inherit a polluted path/built_path
+           -- and would otherwise survive as the same garbage buckets.
+  SELECT ch.code,
+         CASE WHEN position('.' IN ch.code) > 0
+                OR position('.' IN coalesce(ch.parent_code, '')) > 0 THEN NULL
+              ELSE coalesce(ch.node_path, walk.built_path) END AS complaint_node_path
+  FROM ch
+  LEFT JOIN LATERAL (
+    SELECT w.built_path FROM chwalk w WHERE w.leaf_code = ch.code
+    ORDER BY w.depth DESC LIMIT 1
+  ) walk ON true
+),
+esc AS (   -- #1028 fix 2: EscalationConfig ladder source (one record per tenant, at state root)
+  SELECT tenantid,
+         data->'overrides'         AS overrides,
+         data->'defaultSlaByLevel' AS default_levels
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.EscalationConfig' AND isactive
+),
+seq AS (
+  SELECT id, row_number() OVER (PARTITION BY accountid ORDER BY createdtime, id) AS complaint_seq_for_citizen
+  FROM eg_pgr_service_v2
+)
+SELECT
+  s.servicerequestid AS service_request_id, s.id AS pgr_id, s.tenantid AS tenant_id,
+  s.accountid AS account_id, 'PGR'::text AS business_service,
+  s.servicecode AS service_code, cur.application_status, s.source, s.rating AS rating_raw, s.active,
+  length(s.description) AS description_length,
+  (s.description IS NOT NULL AND s.description <> '') AS has_description,
+  s.createdby AS filed_by_uuid, (s.createdby <> s.accountid) AS filed_on_behalf,
+  a.locality AS locality_code, a.pincode, a.city, a.latitude, a.longitude,
+  (a.latitude IS NOT NULL AND a.longitude IS NOT NULL) AS has_geo_pin,
+  (a.parentid IS NOT NULL) AS has_address,
+  cur.boundary_path,
+  (length(coalesce(cur.boundary_path,'')) - length(replace(coalesce(cur.boundary_path,''),'|','')) + 1)::smallint AS boundary_depth,
+  cur.ward_code, cur.zone_code,
+  cur.boundary_leaf_code, cur.boundary_leaf_type,                          -- #1079
+  cnp.complaint_node_path,                                                 -- #1079
+  cx.complaint_depth,                                                      -- #1079
+  coalesce(cx.root_code, m.legacy_service_group) AS service_group,         -- #1079: ROOT category
+  cx.service_parent_code,                                                  -- #1079: immediate parent
+  m.service_order, m.mdms_sla_hours, m.department_code,
+  cur.current_state_seq, cur.current_state_sla_ms, tgt.sla_target_ms,      -- #1028: COALESCE'd target
+  (m.mdms_sla_hours IS NOT NULL AND cur.business_sla_ms IS NOT NULL
+    AND m.mdms_sla_hours::bigint*3600000 <> cur.business_sla_ms) AS sla_config_mismatch,
+  roll.created_at, roll.first_assigned_at, roll.first_assigned_at AS first_response_at,
+  roll.resolved_at, roll.last_transition_at, roll.first_escalated_at, roll.last_escalated_at,
+  roll.transition_count, roll.assignment_count, roll.escalation_count, roll.reopen_count,
+  roll.distinct_assignee_count, roll.distinct_actor_count,
+  roll.system_transition_count, roll.manual_transition_count,
+  roll.was_rejected, (roll.reopen_count > 0) AS is_reopened,
+  cur.is_open, (roll.resolved_at IS NOT NULL) AS is_resolved,
+  roll.max_dwell_ms, roll.assigned_dwell_ms, roll.unassigned_dwell_ms,
+  cur.current_assignee_uuid,
+  (roll.resolved_at - roll.created_at)                            AS resolution_ms,
+  (roll.first_assigned_at - roll.created_at)                      AS time_to_assign_ms,
+  CASE WHEN cur.is_open THEN clock.now_ms - roll.created_at END   AS open_age_ms,
+  CASE WHEN cur.is_open THEN clock.now_ms - roll.last_transition_at END AS current_state_age_ms,
+  (roll.first_escalated_at - roll.created_at)                     AS first_escalation_ms,
+  CASE WHEN cur.is_open  THEN (tgt.sla_target_ms IS NOT NULL AND (clock.now_ms - roll.created_at) > tgt.sla_target_ms)
+       WHEN roll.resolved_at IS NOT NULL THEN (tgt.sla_target_ms IS NOT NULL AND (roll.resolved_at - roll.created_at) > tgt.sla_target_ms)
+       ELSE false END                                            AS sla_breached,
+  (cur.is_open AND cur.current_state_sla_ms IS NOT NULL
+    AND (clock.now_ms - roll.last_transition_at) > cur.current_state_sla_ms) AS current_state_sla_breached,
+  CASE WHEN NOT cur.is_open THEN NULL
+       WHEN (clock.now_ms - roll.created_at) < 86400000  THEN '<1d'
+       WHEN (clock.now_ms - roll.created_at) < 259200000 THEN '1-3d'
+       WHEN (clock.now_ms - roll.created_at) < 604800000 THEN '3-7d'
+       ELSE '>7d' END                                            AS aging_bucket,
+  CASE WHEN NOT cur.is_open OR tgt.sla_target_ms IS NULL THEN NULL
+       WHEN (clock.now_ms - roll.created_at) > tgt.sla_target_ms       THEN 'breached'
+       WHEN (clock.now_ms - roll.created_at) > 0.8*tgt.sla_target_ms   THEN 'approaching'
+       ELSE 'within' END                                         AS sla_status_bucket,
+  (s.rating IS NOT NULL) AS has_rating, s.rating, (s.rating IS NOT NULL AND s.rating <= 2) AS is_negative_rating,
+  seq.complaint_seq_for_citizen, (seq.complaint_seq_for_citizen = 1) AS is_first_time_complainant,
+  (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3')::date AS created_date,
+  date_trunc('week',(to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'))::date AS created_week_start,
+  to_char((to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'),'YYYY-MM') AS created_month,
+  extract(year FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'))::smallint AS created_year,
+  to_char((to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'),'YYYY-"Q"Q') AS created_quarter,
+  extract(hour FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'))::smallint AS created_hour,
+  extract(isodow FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'))::smallint AS created_dow,
+  (extract(isodow FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3')) IN (6,7)) AS created_is_weekend,
+  (extract(hour FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3')) BETWEEN 8 AND 17) AS created_is_business_hr,
+  (to_timestamp(roll.resolved_at/1000) AT TIME ZONE 'Etc/GMT-3')::date AS resolved_date,
+  to_char((to_timestamp(roll.resolved_at/1000) AT TIME ZONE 'Etc/GMT-3'),'YYYY-MM') AS resolved_month,
+  clock.now_ms AS facts_built_at
+FROM eg_pgr_service_v2 s
+CROSS JOIN clock
+LEFT JOIN eg_pgr_address_v2 a ON a.parentid = s.id
+LEFT JOIN roll ON roll.service_request_id = s.servicerequestid
+LEFT JOIN cur  ON cur.service_request_id  = s.servicerequestid
+LEFT JOIN mdms m ON m.service_code = s.servicecode
+LEFT JOIN cnp ON cnp.code = s.servicecode
+CROSS JOIN LATERAL (                         -- #1079: path-derived complaint-axis fields
+  SELECT x.arr[1]                            AS root_code,
+         array_length(x.arr,1)::smallint     AS complaint_depth,
+         x.arr[array_length(x.arr,1)-1]      AS service_parent_code
+  FROM (SELECT string_to_array(cnp.complaint_node_path,'.') AS arr) x
+) cx
+LEFT JOIN LATERAL (                          -- #1028 fix 2: ladder total for this complaint's
+  SELECT CASE                                -- service code, from the nearest EscalationConfig
+           WHEN jsonb_typeof(e.overrides -> s.servicecode) = 'array'   -- (exact tenant, else state root)
+             THEN (SELECT sum(v.value::numeric)::bigint
+                   FROM jsonb_array_elements_text(e.overrides -> s.servicecode) v)
+           WHEN jsonb_typeof(e.default_levels) = 'array'
+             THEN (SELECT sum(v.value::numeric)::bigint
+                   FROM jsonb_array_elements_text(e.default_levels) v)
+         END AS ladder_sla_ms
+  FROM esc e
+  WHERE e.tenantid IN (s.tenantid, split_part(s.tenantid,'.',1))
+  ORDER BY length(e.tenantid) DESC
+  LIMIT 1
+) lad ON true
+CROSS JOIN LATERAL (                         -- #1028: the decided SLA-target precedence
+  SELECT coalesce(m.mdms_sla_hours::bigint * 3600000,   -- 1) ServiceDefs slaHours
+                  lad.ladder_sla_ms,                    -- 2) escalation-ladder total
+                  cur.business_sla_ms                   -- 3) workflow SLA (state-root fallback)
+         ) AS sla_target_ms
+) tgt
+LEFT JOIN seq ON seq.id = s.id
+WHERE s.active = true;
+
+CREATE UNIQUE INDEX ux_complaint_facts ON complaint_facts(service_request_id);
+CREATE INDEX ix_cf_service ON complaint_facts(service_code);
+CREATE INDEX ix_cf_status  ON complaint_facts(application_status);
+CREATE INDEX ix_cf_created ON complaint_facts(created_week_start);
+CREATE INDEX ix_cf_open    ON complaint_facts(is_open) WHERE is_open;
+CREATE INDEX ix_cf_ward    ON complaint_facts(ward_code);

--- a/backend/pgr-services/src/main/resources/db/migration/main/V20260717000000__hier_path_null_on_dotted_parent_codes.sql
+++ b/backend/pgr-services/src/main/resources/db/migration/main/V20260717000000__hier_path_null_on_dotted_parent_codes.sql
@@ -11,8 +11,11 @@
 -- paths on '.' survives R5 and still fabricates a garbage 'complaints' level-1
 -- bucket (30 live fact rows on bomet at authoring time).
 --
--- Fix: the cnp CTE now emits NULL complaint_node_path when the matched node's
--- own code contains '.' OR its parentCode contains '.'; those rows take the
+-- Fix: the cnp CTE now emits NULL complaint_node_path when a dotted code OR
+-- parentCode appears ANYWHERE in the matched node's ancestor chain (the chwalk
+-- rows; the node itself is depth 1, so this contains the node+parent check —
+-- a clean leaf under `legacy.dotted -> CleanParent -> CleanLeaf` is caught
+-- too, review finding on #1282); those rows take the
 -- SAME leaf fallback the query-time level expression already has for
 -- flat/legacy tenants (coalesce(nullif(split_part(...)),''), service_code) —
 -- i.e. they roll up as themselves instead of polluting level buckets.
@@ -131,12 +134,18 @@ cnp AS (   -- #1079: complaint_node_path per code = master path, else recursive 
            -- imports carry dots INSIDE one code, so any '.'-split of their path would
            -- fabricate garbage level buckets; NULL path => the query-time level expr
            -- falls back to the leaf service_code instead.
-           -- R5 widening: ALSO NULL when the node's parentCode contains '.' — clean-code
-           -- nodes parented under a dotted legacy code inherit a polluted path/built_path
-           -- and would otherwise survive as the same garbage buckets.
+           -- R5 widening: ALSO NULL when a dotted code/parentCode appears ANYWHERE in the
+           -- node's ancestor chain (chwalk carries the node itself at depth 1, so this
+           -- strictly contains the old node+parent predicate) — clean-code nodes anywhere
+           -- under a dotted legacy code inherit a polluted path/built_path and would
+           -- otherwise survive as the same garbage buckets.
   SELECT ch.code,
-         CASE WHEN position('.' IN ch.code) > 0
-                OR position('.' IN coalesce(ch.parent_code, '')) > 0 THEN NULL
+         CASE WHEN EXISTS (
+                SELECT 1 FROM chwalk w
+                WHERE w.leaf_code = ch.code
+                  AND (position('.' IN w.code) > 0
+                       OR position('.' IN coalesce(w.parent_code, '')) > 0)
+              ) THEN NULL
               ELSE coalesce(ch.node_path, walk.built_path) END AS complaint_node_path
   FROM ch
   LEFT JOIN LATERAL (
@@ -307,12 +316,18 @@ cnp AS (   -- #1079: complaint_node_path per code = master path, else recursive 
            -- imports carry dots INSIDE one code, so any '.'-split of their path would
            -- fabricate garbage level buckets; NULL path => the query-time level expr
            -- falls back to the leaf service_code instead.
-           -- R5 widening: ALSO NULL when the node's parentCode contains '.' — clean-code
-           -- nodes parented under a dotted legacy code inherit a polluted path/built_path
-           -- and would otherwise survive as the same garbage buckets.
+           -- R5 widening: ALSO NULL when a dotted code/parentCode appears ANYWHERE in the
+           -- node's ancestor chain (chwalk carries the node itself at depth 1, so this
+           -- strictly contains the old node+parent predicate) — clean-code nodes anywhere
+           -- under a dotted legacy code inherit a polluted path/built_path and would
+           -- otherwise survive as the same garbage buckets.
   SELECT ch.code,
-         CASE WHEN position('.' IN ch.code) > 0
-                OR position('.' IN coalesce(ch.parent_code, '')) > 0 THEN NULL
+         CASE WHEN EXISTS (
+                SELECT 1 FROM chwalk w
+                WHERE w.leaf_code = ch.code
+                  AND (position('.' IN w.code) > 0
+                       OR position('.' IN coalesce(w.parent_code, '')) > 0)
+              ) THEN NULL
               ELSE coalesce(ch.node_path, walk.built_path) END AS complaint_node_path
   FROM ch
   LEFT JOIN LATERAL (

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsControllerPacksTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsControllerPacksTest.java
@@ -1,0 +1,79 @@
+package org.egov.pgr.analytics;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.egov.pgr.analytics.model.DashboardPack;
+import org.egov.pgr.config.PGRConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.ResponseEntity;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Pins the /packs recordCount authorization gate: recordCount is live tenant data
+ * (complaint_facts corpus size) and must take the same coarse pack-match gate as
+ * packId/persona. Without it, an anonymous caller (degraded to the PUBLIC floor)
+ * could POST arbitrary tenantIds and enumerate every tenant's complaint volume
+ * even when every sibling field correctly collapses to null/empty.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class AnalyticsControllerPacksTest {
+
+    @Mock private AnalyticsService service;
+    @Mock private KpiCatalogService kpiCatalogService;
+    @Mock private PGRConfiguration config;
+
+    private AnalyticsController controller;
+
+    @BeforeEach
+    public void setUp() {
+        controller = new AnalyticsController(service, kpiCatalogService, new ObjectMapper(), config);
+        when(config.getStateLevelTenantIdLength()).thenReturn(1);
+    }
+
+    @Test
+    public void noMatchingPackReturnsNullRecordCountAndNeverCounts() {
+        // anonymous caller (no RequestInfo -> PUBLIC floor) on a tenant with no public pack
+        when(kpiCatalogService.getVisibleDefs(eq("ke.othercity"), any())).thenReturn(Collections.emptyList());
+        when(kpiCatalogService.getBestPack(eq("ke.othercity"), any(), any())).thenReturn(Optional.empty());
+
+        Map<String,Object> body = new HashMap<>();
+        body.put("tenantId", "ke.othercity");
+        ResponseEntity<Map<String,Object>> resp = controller.getPacks(body);
+
+        assertEquals(200, resp.getStatusCodeValue());
+        assertNull(resp.getBody().get("recordCount"),
+                "recordCount must not leak to a caller no pack matched for");
+        // the count query (and its cache) must not even run for unmatched callers
+        verify(service, never()).recordCount(anyString(), anyInt());
+    }
+
+    @Test
+    public void matchingPackStillGetsTheTenantCorpusCount() {
+        DashboardPack pack = new DashboardPack();
+        pack.setId("supervisor-pack");
+        pack.setRoles(Collections.singletonList("PGR_ADMIN"));
+        pack.setTiles(Collections.emptyList());
+        when(kpiCatalogService.getVisibleDefs(eq("ke.bomet"), any())).thenReturn(Collections.emptyList());
+        when(kpiCatalogService.getBestPack(eq("ke.bomet"), any(), any())).thenReturn(Optional.of(pack));
+        when(service.recordCount("ke.bomet", 1)).thenReturn(1234L);
+
+        Map<String,Object> body = new HashMap<>();
+        body.put("tenantId", "ke.bomet");
+        ResponseEntity<Map<String,Object>> resp = controller.getPacks(body);
+
+        assertEquals(200, resp.getStatusCodeValue());
+        assertEquals(1234L, resp.getBody().get("recordCount"));
+        assertEquals("supervisor-pack", resp.getBody().get("packId"));
+    }
+}

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsMetricsTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsMetricsTest.java
@@ -1,8 +1,15 @@
 package org.egov.pgr.analytics;
 
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * #1110: the metrics component must be a total no-op — and in particular must never
@@ -23,5 +30,40 @@ public class AnalyticsMetricsTest {
         AnalyticsMetrics metrics = new AnalyticsMetrics();
         assertDoesNotThrow(() -> metrics.recordQuery(null, null, null, 0L, 0L));
         assertDoesNotThrow(() -> metrics.recordQuery("", "", "", -1L, 0L));
+    }
+
+    /**
+     * The collector's prometheus exporter appends a unit-derived suffix to the metric
+     * name when the OTLP unit field is set (validated live: unit "ms" surfaced as
+     * pgr_analytics_query_duration_ms_milliseconds_*). The documented scrape names
+     * (docs/observability/dashboard-metrics-server.md) require the instruments to carry
+     * their unit in the NAME only — this pins name and empty-unit for both instruments.
+     */
+    @Test
+    public void instrumentNamesCarryUnitAndUnitFieldStaysEmpty() {
+        InMemoryMetricReader reader = InMemoryMetricReader.create();
+        SdkMeterProvider provider = SdkMeterProvider.builder().registerMetricReader(reader).build();
+        try {
+            AnalyticsMetrics metrics =
+                    new AnalyticsMetrics(provider.get(AnalyticsMetrics.METER_NAME));
+            metrics.recordQuery("open-complaints", "facts", "ke", 42L, 7L);
+
+            Collection<MetricData> collected = reader.collectAllMetrics();
+            assertEquals("", metricByName(collected, "pgr.analytics.query.duration.ms").getUnit(),
+                    "duration histogram must not set an OTLP unit (exporter would append _milliseconds)");
+            assertEquals("", metricByName(collected, "pgr.analytics.query.rows").getUnit(),
+                    "rows counter must not set an OTLP unit");
+        } finally {
+            provider.close();
+        }
+    }
+
+    private static MetricData metricByName(Collection<MetricData> collected, String name) {
+        MetricData found = collected.stream()
+                .filter(m -> name.equals(m.getName()))
+                .findFirst()
+                .orElse(null);
+        assertTrue(found != null, "expected instrument " + name + " in " + collected);
+        return found;
     }
 }

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsMetricsTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsMetricsTest.java
@@ -1,0 +1,27 @@
+package org.egov.pgr.analytics;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * #1110: the metrics component must be a total no-op — and in particular must never
+ * throw — when the OpenTelemetry javaagent is NOT attached (unit tests, CI, bare
+ * java -jar). GlobalOpenTelemetry returns its no-op implementation here, so these
+ * calls exercise exactly the agent-less production path.
+ */
+public class AnalyticsMetricsTest {
+
+    @Test
+    public void constructsAndRecordsWithoutAgent() {
+        AnalyticsMetrics metrics = new AnalyticsMetrics();
+        assertDoesNotThrow(() -> metrics.recordQuery("open-complaints", "facts", "ke", 42L, 7L));
+    }
+
+    @Test
+    public void toleratesNullAndEmptyAttributes() {
+        AnalyticsMetrics metrics = new AnalyticsMetrics();
+        assertDoesNotThrow(() -> metrics.recordQuery(null, null, null, 0L, 0L));
+        assertDoesNotThrow(() -> metrics.recordQuery("", "", "", -1L, 0L));
+    }
+}

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsServiceParamValidationTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsServiceParamValidationTest.java
@@ -84,4 +84,49 @@ public class AnalyticsServiceParamValidationTest {
         service.validateAllowedParams(def(SEEDED_PARAMS), null);
         service.validateAllowedParams(def("null"), json("{\"hierLevel\":\"7\"}"));
     }
+
+    // ------------------------------------------------------------------------------------------
+    // Seed-schema pinning: the registered dss.KpiDefinition schema requires `default` + `allowed`
+    // on EVERY params entry, so free-form params (complaintPath) are seeded as
+    // {"default":"","allowed":[]}. These pin the server semantics that make that encoding safe:
+    // an empty allow-list = unvalidated free-form, an empty-string default = no-op.
+    // ------------------------------------------------------------------------------------------
+
+    private static final String FREE_FORM_PARAMS =
+            "[{\"name\":\"complaintPath\",\"default\":\"\",\"allowed\":[]}]";
+
+    @Test
+    public void emptyAllowedListMeansUnvalidatedFreeForm() {
+        // "allowed":[] must behave exactly like an absent allow-list: any value passes.
+        service.validateAllowedParams(def(FREE_FORM_PARAMS),
+                json("{\"complaintPath\":\"RoadsAndFootpaths.DamagedRoad\"}"));
+        service.validateAllowedParams(def(FREE_FORM_PARAMS),
+                json("{\"complaintPath\":\"anything.at.all\"}"));
+    }
+
+    @Test
+    public void emptyStringDefaultIsNoOp() {
+        // "default":"" must never be injected as an effective param value.
+        assertNull(service.withDeclaredDefaults(def(FREE_FORM_PARAMS), null));
+        JsonNode reqParams = json("{\"window\":\"last_7d\"}");
+        JsonNode effective = service.withDeclaredDefaults(def(FREE_FORM_PARAMS), reqParams);
+        assertSame(reqParams, effective);                       // untouched, nothing merged in
+        assertFalse(effective.has("complaintPath"));
+    }
+
+    @Test
+    public void seededFreeFormEntryAlongsideRealDefaultsAndAllowLists() {
+        // The exact seeded shape on the 5 type-dimension KPIs: window + hierLevel keep their
+        // defaults/allow-lists, complaintPath stays free-form and un-defaulted.
+        String seeded = "[{\"name\":\"window\",\"default\":\"last_7d\",\"allowed\":[\"last_1d\",\"last_7d\"]},"
+                + "{\"name\":\"hierLevel\",\"default\":\"1\",\"allowed\":[\"leaf\",\"1\",\"2\"]},"
+                + "{\"name\":\"complaintPath\",\"default\":\"\",\"allowed\":[]}]";
+        JsonNode effective = service.withDeclaredDefaults(def(seeded), json("{}"));
+        assertEquals("last_7d", effective.get("window").asText());
+        assertEquals("1", effective.get("hierLevel").asText());
+        assertFalse(effective.has("complaintPath"));            // empty default not injected
+        service.validateAllowedParams(def(seeded), effective);  // and the effective set validates
+        service.validateAllowedParams(def(seeded),
+                json("{\"window\":\"last_7d\",\"complaintPath\":\"Roads.Potholes\"}"));
+    }
 }

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsServiceParamValidationTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsServiceParamValidationTest.java
@@ -1,0 +1,87 @@
+package org.egov.pgr.analytics;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.egov.pgr.analytics.model.KpiDefinition;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * #1111/R3: pins the generalized allow-list enforcement (formerly window-only C1) —
+ * ANY declared param with a non-empty {@code allowed} list is validated against it,
+ * out-of-list values are {@code invalid_param}, and the original window behaviour is
+ * unchanged (regression). Declared-without-allow-list and undeclared params stay open.
+ */
+public class AnalyticsServiceParamValidationTest {
+
+    private final ObjectMapper om = new ObjectMapper();
+    private final AnalyticsService service =
+            new AnalyticsService(null, null, null, null, null, null, new AnalyticsMetrics());
+
+    private KpiDefinition def(String paramsJson) {
+        try {
+            return om.readValue("{\"id\":\"cl_test\",\"version\":\"1.0.0\",\"status\":\"published\","
+                    + "\"params\":" + paramsJson + "}", KpiDefinition.class);
+        } catch (Exception e) { throw new RuntimeException(e); }
+    }
+
+    private JsonNode json(String s) {
+        try { return om.readTree(s); } catch (Exception e) { throw new RuntimeException(e); }
+    }
+
+    private static final String SEEDED_PARAMS =
+            "[{\"name\":\"window\",\"default\":\"last_7d\",\"allowed\":[\"last_1d\",\"last_7d\",\"last_30d\",\"wtd\",\"mtd\"]},"
+            + "{\"name\":\"hierLevel\",\"default\":\"1\",\"allowed\":[\"leaf\",\"1\",\"2\",\"3\",\"4\"]}]";
+
+    @Test
+    public void hierLevelOutsideAllowedListIsRejected() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+                service.validateAllowedParams(def(SEEDED_PARAMS), json("{\"hierLevel\":\"7\"}")));
+        assertTrue(ex.getMessage().startsWith("invalid_param"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("hierLevel"), ex.getMessage());
+    }
+
+    @Test
+    public void hierLevelInsideAllowedListPasses() {
+        service.validateAllowedParams(def(SEEDED_PARAMS), json("{\"hierLevel\":\"leaf\"}"));
+        service.validateAllowedParams(def(SEEDED_PARAMS), json("{\"hierLevel\":\"2\"}"));
+    }
+
+    @Test
+    public void windowRegressionStillEnforced() {
+        // The original C1 behaviour, now served by the generalized path.
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+                service.validateAllowedParams(def(SEEDED_PARAMS), json("{\"window\":\"last_999d\"}")));
+        assertTrue(ex.getMessage().startsWith("invalid_param"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("window"), ex.getMessage());
+        service.validateAllowedParams(def(SEEDED_PARAMS), json("{\"window\":\"last_30d\"}"));
+    }
+
+    @Test
+    public void bothParamsValidatedTogether() {
+        // window fine, hierLevel out of list — must still throw.
+        assertThrows(IllegalArgumentException.class, () -> service.validateAllowedParams(
+                def(SEEDED_PARAMS), json("{\"window\":\"last_7d\",\"hierLevel\":\"12\"}")));
+    }
+
+    @Test
+    public void declaredParamWithoutAllowedListIsOpen() {
+        service.validateAllowedParams(def("[{\"name\":\"hierLevel\",\"default\":\"leaf\"}]"),
+                json("{\"hierLevel\":\"anything\"}"));   // no allow-list declared -> open
+    }
+
+    @Test
+    public void undeclaredParamsAreNotValidated() {
+        service.validateAllowedParams(def(SEEDED_PARAMS),
+                json("{\"ward\":\"W1\",\"serviceCode\":\"x\",\"series\":\"daily\"}"));
+    }
+
+    @Test
+    public void emptyAndAbsentValuesPass() {
+        service.validateAllowedParams(def(SEEDED_PARAMS), json("{\"hierLevel\":\"\"}"));
+        service.validateAllowedParams(def(SEEDED_PARAMS), json("{}"));
+        service.validateAllowedParams(def(SEEDED_PARAMS), null);
+        service.validateAllowedParams(def("null"), json("{\"hierLevel\":\"7\"}"));
+    }
+}

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsServiceParamValidationTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsServiceParamValidationTest.java
@@ -17,7 +17,7 @@ public class AnalyticsServiceParamValidationTest {
 
     private final ObjectMapper om = new ObjectMapper();
     private final AnalyticsService service =
-            new AnalyticsService(null, null, null, null, null, null, new AnalyticsMetrics());
+            new AnalyticsService(null, null, null, null, null, null, new AnalyticsMetrics(), null);
 
     private KpiDefinition def(String paramsJson) {
         try {

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsServiceParamValidationTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsServiceParamValidationTest.java
@@ -82,7 +82,37 @@ public class AnalyticsServiceParamValidationTest {
         service.validateAllowedParams(def(SEEDED_PARAMS), json("{\"hierLevel\":\"\"}"));
         service.validateAllowedParams(def(SEEDED_PARAMS), json("{}"));
         service.validateAllowedParams(def(SEEDED_PARAMS), null);
+        service.validateAllowedParams(def(SEEDED_PARAMS), json("null"));
         service.validateAllowedParams(def("null"), json("{\"hierLevel\":\"7\"}"));
+    }
+
+    @Test
+    public void nonObjectParamsNodeIsRejected() {
+        // Malformed shapes must be invalid_param, not a silent allow-list bypass.
+        for (String malformed : new String[]{"[\"last_7d\"]", "\"last_7d\"", "42", "true"}) {
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+                    service.validateAllowedParams(def(SEEDED_PARAMS), json(malformed)));
+            assertTrue(ex.getMessage().startsWith("invalid_param"), ex.getMessage());
+        }
+    }
+
+    @Test
+    public void nonScalarValueForAllowListedParamIsRejected() {
+        // Object/array values would asText() to "" and previously slipped past the allow-list.
+        for (String malformed : new String[]{"{\"hierLevel\":[\"1\"]}", "{\"hierLevel\":{\"v\":\"1\"}}",
+                "{\"window\":[]}"}) {
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+                    service.validateAllowedParams(def(SEEDED_PARAMS), json(malformed)));
+            assertTrue(ex.getMessage().startsWith("invalid_param"), ex.getMessage());
+        }
+    }
+
+    @Test
+    public void nonTextScalarsStillMatchTheAllowListByText() {
+        // A JSON number 2 must keep behaving like "2" (callers legitimately send numbers).
+        service.validateAllowedParams(def(SEEDED_PARAMS), json("{\"hierLevel\":2}"));
+        assertThrows(IllegalArgumentException.class, () ->
+                service.validateAllowedParams(def(SEEDED_PARAMS), json("{\"hierLevel\":7}")));
     }
 
     // ------------------------------------------------------------------------------------------

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsServiceRecordCountTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsServiceRecordCountTest.java
@@ -1,0 +1,120 @@
+package org.egov.pgr.analytics;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * #1110: pins /packs recordCount semantics — the tenant-CORPUS count on complaint_facts
+ * with AnalyticsPlanner's tenant LIKE-prefix semantics (state level 'ke%' LIKE, city
+ * exact), the 5-minute per-tenant cache (including expiry), and error -> null (never
+ * cached, never thrown).
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class AnalyticsServiceRecordCountTest {
+
+    private static final int STATE_LEN = 1;   // "ke" is state root; "ke.bomet" is a city
+
+    @Mock private JdbcTemplate jdbc;
+
+    private AnalyticsService service;
+    private final AtomicLong clock = new AtomicLong(1_000_000L);
+
+    @BeforeEach
+    public void setUp() {
+        service = new AnalyticsService(null, null, jdbc, null, null, null, new AnalyticsMetrics());
+        ReflectionTestUtils.setField(service, "recordCountClock", (LongSupplier) clock::get);
+    }
+
+    @Test
+    public void stateLevelTenantUsesLikePrefix() {
+        when(jdbc.queryForObject(contains("LIKE"), eq(Long.class), eq("ke%"))).thenReturn(1234L);
+
+        assertEquals(1234L, service.recordCount("ke", STATE_LEN));
+
+        verify(jdbc).queryForObject(
+                eq("SELECT count(*) FROM complaint_facts WHERE tenant_id LIKE ?"),
+                eq(Long.class), eq("ke%"));
+        verify(jdbc, never()).queryForObject(contains("tenant_id = ?"), eq(Long.class), any());
+    }
+
+    @Test
+    public void cityTenantUsesExactMatch() {
+        when(jdbc.queryForObject(contains("tenant_id = ?"), eq(Long.class), eq("ke.bomet"))).thenReturn(55L);
+
+        assertEquals(55L, service.recordCount("ke.bomet", STATE_LEN));
+
+        verify(jdbc).queryForObject(
+                eq("SELECT count(*) FROM complaint_facts WHERE tenant_id = ?"),
+                eq(Long.class), eq("ke.bomet"));
+        verify(jdbc, never()).queryForObject(contains("LIKE"), eq(Long.class), any());
+    }
+
+    @Test
+    public void secondCallWithinTtlServesFromCache() {
+        when(jdbc.queryForObject(anyString(), eq(Long.class), any())).thenReturn(10L);
+
+        assertEquals(10L, service.recordCount("ke", STATE_LEN));
+        clock.addAndGet(4 * 60_000L + 59_000L);   // 4m59s later — still inside the 5m TTL
+        assertEquals(10L, service.recordCount("ke", STATE_LEN));
+
+        verify(jdbc, times(1)).queryForObject(anyString(), eq(Long.class), any());
+    }
+
+    @Test
+    public void cacheExpiresAfterFiveMinutes() {
+        when(jdbc.queryForObject(anyString(), eq(Long.class), any())).thenReturn(10L, 20L);
+
+        assertEquals(10L, service.recordCount("ke", STATE_LEN));
+        clock.addAndGet(5 * 60_000L + 1L);        // past the TTL
+        assertEquals(20L, service.recordCount("ke", STATE_LEN));
+
+        verify(jdbc, times(2)).queryForObject(anyString(), eq(Long.class), any());
+    }
+
+    @Test
+    public void cacheIsKeyedByTenant() {
+        when(jdbc.queryForObject(contains("LIKE"), eq(Long.class), eq("ke%"))).thenReturn(100L);
+        when(jdbc.queryForObject(contains("tenant_id = ?"), eq(Long.class), eq("ke.bomet"))).thenReturn(7L);
+
+        assertEquals(100L, service.recordCount("ke", STATE_LEN));
+        assertEquals(7L, service.recordCount("ke.bomet", STATE_LEN));
+        assertEquals(100L, service.recordCount("ke", STATE_LEN));   // still cached
+
+        verify(jdbc, times(2)).queryForObject(anyString(), eq(Long.class), any());
+    }
+
+    @Test
+    public void errorReturnsNullAndIsNotCached() {
+        when(jdbc.queryForObject(anyString(), eq(Long.class), any()))
+                .thenThrow(new DataAccessResourceFailureException("db down"))
+                .thenReturn(33L);
+
+        assertNull(service.recordCount("ke", STATE_LEN));           // failure -> null, no throw
+        assertEquals(33L, service.recordCount("ke", STATE_LEN));    // retried, not a cached null
+
+        verify(jdbc, times(2)).queryForObject(anyString(), eq(Long.class), any());
+    }
+
+    @Test
+    public void nullOrEmptyTenantReturnsNullWithoutQuerying() {
+        assertNull(service.recordCount(null, STATE_LEN));
+        assertNull(service.recordCount("", STATE_LEN));
+        verifyNoInteractions(jdbc);
+    }
+}

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsServiceRecordCountTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsServiceRecordCountTest.java
@@ -37,7 +37,8 @@ public class AnalyticsServiceRecordCountTest {
 
     @BeforeEach
     public void setUp() {
-        service = new AnalyticsService(null, null, jdbc, null, null, null, new AnalyticsMetrics());
+        // null config -> the shared DEFAULT_ANALYTICS_CONFIG_CACHE_TTL_MS (5 minutes)
+        service = new AnalyticsService(null, null, jdbc, null, null, null, new AnalyticsMetrics(), null);
         ReflectionTestUtils.setField(service, "recordCountClock", (LongSupplier) clock::get);
     }
 
@@ -82,6 +83,25 @@ public class AnalyticsServiceRecordCountTest {
 
         assertEquals(10L, service.recordCount("ke", STATE_LEN));
         clock.addAndGet(5 * 60_000L + 1L);        // past the TTL
+        assertEquals(20L, service.recordCount("ke", STATE_LEN));
+
+        verify(jdbc, times(2)).queryForObject(anyString(), eq(Long.class), any());
+    }
+
+    @Test
+    public void ttlIsConfigurableViaTheSharedAnalyticsCacheConfig() {
+        // pgr.analytics.config-cache-ttl-ms — ONE property drives every analytics
+        // config cache; here a 1s TTL instead of the 5m default.
+        org.egov.pgr.config.PGRConfiguration cfg = mock(org.egov.pgr.config.PGRConfiguration.class);
+        when(cfg.getAnalyticsConfigCacheTtlMs()).thenReturn(1_000L);
+        service = new AnalyticsService(null, null, jdbc, null, null, null, new AnalyticsMetrics(), cfg);
+        ReflectionTestUtils.setField(service, "recordCountClock", (LongSupplier) clock::get);
+        when(jdbc.queryForObject(anyString(), eq(Long.class), any())).thenReturn(10L, 20L);
+
+        assertEquals(10L, service.recordCount("ke", STATE_LEN));
+        clock.addAndGet(999L);                     // inside the configured 1s TTL
+        assertEquals(10L, service.recordCount("ke", STATE_LEN));
+        clock.addAndGet(2L);                       // past it
         assertEquals(20L, service.recordCount("ke", STATE_LEN));
 
         verify(jdbc, times(2)).queryForObject(anyString(), eq(Long.class), any());

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiCatalogServiceDeptScopingTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiCatalogServiceDeptScopingTest.java
@@ -47,6 +47,9 @@ public class KpiCatalogServiceDeptScopingTest {
     public void setUp() {
         when(config.getMdmsHost()).thenReturn("http://mdms-v2:8080");
         when(config.getMdmsEndPoint()).thenReturn("/mdms-v2/v1/_search");
+        // the @Value default Spring would inject (an unstubbed mock returns 0 -> cache off)
+        when(config.getAnalyticsConfigCacheTtlMs())
+                .thenReturn(PGRConfiguration.DEFAULT_ANALYTICS_CONFIG_CACHE_TTL_MS);
         // "ke" and "ke.bomet" both resolve to state root "ke"
         when(multiStateInstanceUtil.getStateLevelTenant(anyString()))
                 .thenAnswer(inv -> inv.getArgument(0, String.class).split("\\.")[0]);
@@ -154,6 +157,25 @@ public class KpiCatalogServiceDeptScopingTest {
         assertTrue(service.isDepartmentScopingDisabled("ke.bomet"));
         clock.addAndGet(5 * 60_000L + 1L);        // past the TTL
         assertFalse(service.isDepartmentScopingDisabled("ke.bomet"));   // flip applied
+
+        verify(repo, times(2)).fetchResult(any(), any());
+    }
+
+    @Test
+    public void ttlIsConfigurableViaTheSharedAnalyticsCacheConfig() {
+        // Same single property as the recordCount cache: pgr.analytics.config-cache-ttl-ms.
+        when(config.getAnalyticsConfigCacheTtlMs()).thenReturn(1_000L);
+        service = new KpiCatalogService(config, repo, multiStateInstanceUtil, new ObjectMapper());
+        ReflectionTestUtils.setField(service, "configClock", (LongSupplier) clock::get);
+        when(repo.fetchResult(any(), any()))
+                .thenReturn(mdmsResult(record("disabled")))
+                .thenReturn(mdmsResult(record("enforced")));
+
+        assertTrue(service.isDepartmentScopingDisabled("ke.bomet"));
+        clock.addAndGet(999L);                    // inside the configured 1s TTL
+        assertTrue(service.isDepartmentScopingDisabled("ke.bomet"));
+        clock.addAndGet(2L);                      // past it — flip applied
+        assertFalse(service.isDepartmentScopingDisabled("ke.bomet"));
 
         verify(repo, times(2)).fetchResult(any(), any());
     }

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiCatalogServiceDeptScopingTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiCatalogServiceDeptScopingTest.java
@@ -1,0 +1,181 @@
+package org.egov.pgr.analytics;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.egov.common.utils.MultiStateInstanceUtil;
+import org.egov.pgr.config.PGRConfiguration;
+import org.egov.pgr.repository.ServiceRequestRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * #1280: pins {@code dss.DashboardConfig.departmentScoping} semantics as read by
+ * {@link KpiCatalogService#isDepartmentScopingDisabled}:
+ * only an explicit "disabled" (case-insensitive, trimmed) disables department scoping;
+ * missing module/record/field, malformed values, and MDMS errors ALL resolve to enforced
+ * (fail-safe = today's behavior); resolved at the tenant's state root; cached in-memory
+ * for 5 minutes per state root (including expiry — a config flip applies within 5 minutes).
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class KpiCatalogServiceDeptScopingTest {
+
+    @Mock private PGRConfiguration config;
+    @Mock private ServiceRequestRepository repo;
+    @Mock private MultiStateInstanceUtil multiStateInstanceUtil;
+
+    private KpiCatalogService service;
+    private final AtomicLong clock = new AtomicLong(1_000_000L);
+
+    @BeforeEach
+    public void setUp() {
+        when(config.getMdmsHost()).thenReturn("http://mdms-v2:8080");
+        when(config.getMdmsEndPoint()).thenReturn("/mdms-v2/v1/_search");
+        // "ke" and "ke.bomet" both resolve to state root "ke"
+        when(multiStateInstanceUtil.getStateLevelTenant(anyString()))
+                .thenAnswer(inv -> inv.getArgument(0, String.class).split("\\.")[0]);
+        service = new KpiCatalogService(config, repo, multiStateInstanceUtil, new ObjectMapper());
+        ReflectionTestUtils.setField(service, "configClock", (LongSupplier) clock::get);
+    }
+
+    /** MdmsRes.dss.DashboardConfig = [record] — the shape ServiceRequestRepository returns. */
+    private static Map<String, Object> mdmsResult(Map<String, Object>... records) {
+        Map<String, Object> res = new HashMap<>();
+        res.put("MdmsRes", Map.of("dss", Map.of("DashboardConfig", List.of(records))));
+        return res;
+    }
+
+    private static Map<String, Object> record(Object departmentScoping) {
+        Map<String, Object> r = new HashMap<>();
+        r.put("departmentScoping", departmentScoping);
+        return r;
+    }
+
+    // ---- fail-safe default: everything that is not an explicit "disabled" means enforced ----
+
+    @Test
+    public void noDssModuleMeansEnforced() {
+        // MdmsRes without the dss module at all -> JsonPath miss -> enforced
+        when(repo.fetchResult(any(), any())).thenReturn(Map.of("MdmsRes", Map.of()));
+        assertFalse(service.isDepartmentScopingDisabled("ke.bomet"));
+    }
+
+    @Test
+    public void noRecordMeansEnforced() {
+        when(repo.fetchResult(any(), any())).thenReturn(mdmsResult());
+        assertFalse(service.isDepartmentScopingDisabled("ke.bomet"));
+    }
+
+    @Test
+    public void missingFieldMeansEnforced() {
+        when(repo.fetchResult(any(), any())).thenReturn(mdmsResult(new HashMap<>()));
+        assertFalse(service.isDepartmentScopingDisabled("ke.bomet"));
+    }
+
+    @Test
+    public void malformedValuesMeanEnforced() {
+        for (Object malformed : new Object[]{"off", "none", "true", 42, Boolean.TRUE, null, ""}) {
+            service = new KpiCatalogService(config, repo, multiStateInstanceUtil, new ObjectMapper());
+            ReflectionTestUtils.setField(service, "configClock", (LongSupplier) clock::get);
+            when(repo.fetchResult(any(), any())).thenReturn(mdmsResult(record(malformed)));
+            assertFalse(service.isDepartmentScopingDisabled("ke.bomet"),
+                    "value '" + malformed + "' must fail-safe to enforced");
+        }
+    }
+
+    @Test
+    public void explicitEnforcedMeansEnforced() {
+        when(repo.fetchResult(any(), any())).thenReturn(mdmsResult(record("enforced")));
+        assertFalse(service.isDepartmentScopingDisabled("ke.bomet"));
+    }
+
+    @Test
+    public void mdmsErrorMeansEnforcedAndNeverThrows() {
+        when(repo.fetchResult(any(), any())).thenThrow(new RuntimeException("mdms down"));
+        assertFalse(service.isDepartmentScopingDisabled("ke.bomet"));
+    }
+
+    @Test
+    public void nullOrEmptyTenantMeansEnforcedWithoutFetching() {
+        assertFalse(service.isDepartmentScopingDisabled(null));
+        assertFalse(service.isDepartmentScopingDisabled(""));
+        verifyNoInteractions(repo);
+    }
+
+    // ---- the one shape that disables ----
+
+    @Test
+    public void explicitDisabledDisables() {
+        when(repo.fetchResult(any(), any())).thenReturn(mdmsResult(record("disabled")));
+        assertTrue(service.isDepartmentScopingDisabled("ke.bomet"));
+    }
+
+    @Test
+    public void disabledIsCaseInsensitiveAndTrimmed() {
+        when(repo.fetchResult(any(), any())).thenReturn(mdmsResult(record("  DISABLED ")));
+        assertTrue(service.isDepartmentScopingDisabled("ke.bomet"));
+    }
+
+    // ---- 5-minute per-state-root cache, mirroring the recordCount idiom ----
+
+    @Test
+    public void secondCallWithinTtlServesFromCache() {
+        when(repo.fetchResult(any(), any())).thenReturn(mdmsResult(record("disabled")));
+
+        assertTrue(service.isDepartmentScopingDisabled("ke.bomet"));
+        clock.addAndGet(4 * 60_000L + 59_000L);   // 4m59s later — still inside the 5m TTL
+        assertTrue(service.isDepartmentScopingDisabled("ke.bomet"));
+
+        verify(repo, times(1)).fetchResult(any(), any());
+    }
+
+    @Test
+    public void cacheExpiresAfterFiveMinutesAndPicksUpFlip() {
+        when(repo.fetchResult(any(), any()))
+                .thenReturn(mdmsResult(record("disabled")))
+                .thenReturn(mdmsResult(record("enforced")));
+
+        assertTrue(service.isDepartmentScopingDisabled("ke.bomet"));
+        clock.addAndGet(5 * 60_000L + 1L);        // past the TTL
+        assertFalse(service.isDepartmentScopingDisabled("ke.bomet"));   // flip applied
+
+        verify(repo, times(2)).fetchResult(any(), any());
+    }
+
+    @Test
+    public void cacheIsSharedAcrossTenantsOfOneStateRoot() {
+        // resolved (and fetched) at the state root, so "ke" and "ke.bomet" share one entry
+        when(repo.fetchResult(any(), any())).thenReturn(mdmsResult(record("disabled")));
+
+        assertTrue(service.isDepartmentScopingDisabled("ke"));
+        assertTrue(service.isDepartmentScopingDisabled("ke.bomet"));
+
+        verify(repo, times(1)).fetchResult(any(), any());
+    }
+
+    @Test
+    public void enforcedOutcomeIsCachedToo() {
+        when(repo.fetchResult(any(), any())).thenReturn(mdmsResult(record("enforced")));
+
+        assertFalse(service.isDepartmentScopingDisabled("ke.bomet"));
+        assertFalse(service.isDepartmentScopingDisabled("ke.bomet"));
+
+        verify(repo, times(1)).fetchResult(any(), any());
+    }
+}

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiQueryComposerComplaintPathTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiQueryComposerComplaintPathTest.java
@@ -1,0 +1,231 @@
+package org.egov.pgr.analytics;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Pins the {@code complaintPath} subtree-filter param — the composer's delimiter-guarded
+ * {@code complaint_node_path} {@code subtree} predicate for INTERIOR-node selections, the
+ * path-alphabet sanitizer (hard {@code invalid_param}, never silently unfiltered), the
+ * daily-grain reported skip ({@code paramsIgnored} collector, unlike {@code ward}'s silent
+ * no-op), composition with {@code hierLevel} (WHERE vs GROUP BY — orthogonal), the unchanged
+ * exact-eq {@code serviceCode} leaf semantics, and that the server-injected ABAC row-scope is
+ * still layered on top (params only narrow).
+ */
+public class KpiQueryComposerComplaintPathTest {
+
+    private final ObjectMapper om = new ObjectMapper();
+    private final AnalyticsCatalog catalog = new AnalyticsCatalog();
+    private final KpiQueryComposer composer = new KpiQueryComposer(catalog);
+    private final AnalyticsPlanner planner = new AnalyticsPlanner(catalog);
+    private final AnalyticsScope stateScope = new AnalyticsScope("ke", true, null, null, null);
+
+    private JsonNode json(String s) {
+        try { return om.readTree(s); } catch (Exception e) { throw new RuntimeException(e); }
+    }
+
+    /** The seeded complaints-by-type base query (facts, service_code dimension). */
+    private JsonNode byTypeBase() {
+        return json("{\"grain\":\"facts\",\"window\":{\"name\":\"last_30d\",\"timeRole\":\"filed_at\"},"
+                + "\"dimensions\":[\"service_code\"],"
+                + "\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}],"
+                + "\"sort\":[{\"by\":\"total\",\"dir\":\"desc\"}],\"limit\":8}");
+    }
+
+    private JsonNode dailyBase() {
+        return json("{\"grain\":\"daily\",\"dimensions\":[\"service_code\"],"
+                + "\"measures\":[{\"name\":\"open\",\"agg\":\"count\"}]}");
+    }
+
+    // ---- SQL: the delimiter-guarded subtree predicate ----
+
+    @Test
+    public void sqlSnapshotForSubtreePredicate() {
+        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"complaintPath\":\"SANITATION\"}"));
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope);
+        assertEquals("SELECT service_code AS service_code, count(*) AS total"
+                + " FROM complaint_facts"
+                + " WHERE (complaint_node_path = ? OR complaint_node_path LIKE ? || '.%')"
+                + " AND created_at >= ? AND created_at < ? AND tenant_id LIKE ?"
+                + " GROUP BY 1 ORDER BY total DESC NULLS LAST LIMIT 8", p.sql);
+        // eq arm binds the raw path, the LIKE arm the LIKE-escaped path — '.' guard is in the SQL,
+        // so 'SANITATION' can never match a 'SANITATIONX.…' sibling.
+        assertEquals("SANITATION", p.params.get(0));
+        assertEquals("SANITATION", p.params.get(1));
+    }
+
+    @Test
+    public void eventsGrainAppliesSubtree() {
+        JsonNode base = json("{\"grain\":\"events\",\"dimensions\":[\"service_code\"],"
+                + "\"measures\":[{\"name\":\"n\",\"agg\":\"count\"}]}");
+        JsonNode merged = composer.mergeParams(base, json("{\"complaintPath\":\"SANITATION.SEWAGE\"}"));
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope);
+        assertTrue(p.sql.contains("FROM complaint_events"));
+        assertTrue(p.sql.contains("(complaint_node_path = ? OR complaint_node_path LIKE ? || '.%')"));
+    }
+
+    @Test
+    public void likeMetacharactersInPathAreEscapedInTheLikeArm() {
+        // '_' is a legal path character (UPPER_SNAKE codes) but a LIKE metachar — the LIKE arm
+        // must receive the escaped literal while the eq arm gets the raw path.
+        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"complaintPath\":\"ROAD_WORKS\"}"));
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope);
+        assertEquals("ROAD_WORKS", p.params.get(0));
+        assertEquals("ROAD\\_WORKS", p.params.get(1));
+    }
+
+    // ---- sanitizer: path alphabet + length cap ----
+
+    @Test
+    public void sqlMeaningfulValuesAreRejected() {
+        for (String bad : new String[]{
+                "SAN' OR '1'='1", "a b", "x%y", "a;b", "x)--", "a\\b", "path*", "a,b",
+                "x||'y", "a\"b", "café", "a\tb"}) {
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> composer.mergeParams(byTypeBase(), json(om.createObjectNode()
+                            .put("complaintPath", bad).toString())),
+                    "complaintPath '" + bad + "' must be rejected");
+            assertTrue(ex.getMessage().startsWith("invalid_param"), ex.getMessage());
+        }
+    }
+
+    @Test
+    public void overlongPathIsRejected() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 60; i++) sb.append("NODE.");
+        String tooLong = sb.append("LEAFNODE").toString();   // > 256 chars, alphabet-legal
+        assertTrue(tooLong.length() > KpiQueryComposer.MAX_COMPLAINT_PATH_LENGTH);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> composer.mergeParams(byTypeBase(), json("{\"complaintPath\":\"" + tooLong + "\"}")));
+        assertTrue(ex.getMessage().startsWith("invalid_param"), ex.getMessage());
+    }
+
+    @Test
+    public void livePathShapesAreAccepted() {
+        for (String ok : new String[]{"SANITATION", "SANITATION.SEWAGE",
+                "ROADS-AND-TRANSPORT.POTHOLES_1", "infra/roads.SUB"}) {
+            JsonNode merged = composer.mergeParams(byTypeBase(),
+                    json("{\"complaintPath\":\"" + ok + "\"}"));
+            assertEquals(ok, merged.get("filters").get("complaint_node_path").get("subtree").asText());
+        }
+    }
+
+    @Test
+    public void emptyAndAbsentAreNoOps() {
+        assertEquals(byTypeBase(), composer.mergeParams(byTypeBase(), json("{\"complaintPath\":\"\"}")));
+        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"window\":\"last_7d\"}"));
+        assertFalse(merged.has("filters"));
+    }
+
+    // ---- daily grain: reported skip (NOT ward's silent no-op) ----
+
+    @Test
+    public void dailyGrainSkipsFilterAndReportsParamsIgnored() {
+        List<String> ignored = new ArrayList<>();
+        JsonNode merged = composer.mergeParams(dailyBase(), json("{\"complaintPath\":\"SANITATION\"}"), ignored);
+        assertEquals(dailyBase(), merged);                       // no filter injected — daily has no path column
+        assertEquals(List.of("complaintPath"), ignored);         // …but the skip is reported to the caller
+    }
+
+    @Test
+    public void dailyGrainSkipIsIdempotentInTheCollector() {
+        // The compose path reuses one collector across several source KPIs — no duplicates.
+        List<String> ignored = new ArrayList<>();
+        composer.mergeParams(dailyBase(), json("{\"complaintPath\":\"SANITATION\"}"), ignored);
+        composer.mergeParams(dailyBase(), json("{\"complaintPath\":\"SANITATION\"}"), ignored);
+        assertEquals(List.of("complaintPath"), ignored);
+    }
+
+    @Test
+    public void wardStaysASilentNoOpAndSanitizerStillRunsOnDaily() {
+        // ward has no reporting (unchanged behaviour); only complaintPath lands in the collector.
+        List<String> ignored = new ArrayList<>();
+        JsonNode eventsBase = json("{\"grain\":\"daily\",\"dimensions\":[\"service_code\"],"
+                + "\"measures\":[{\"name\":\"open\",\"agg\":\"count\"}]}");
+        composer.mergeParams(eventsBase, json("{\"ward\":\"W1\",\"complaintPath\":\"SANITATION\"}"), ignored);
+        assertEquals(List.of("complaintPath"), ignored);
+        // a malformed path is invalid_param even on the grain that would skip the filter —
+        // garbage is rejected, never half-applied.
+        assertThrows(IllegalArgumentException.class,
+                () -> composer.mergeParams(dailyBase(), json("{\"complaintPath\":\"x; DROP TABLE y\"}"), new ArrayList<>()));
+    }
+
+    @Test
+    public void legacyTwoArgOverloadStaysSafeWithoutACollector() {
+        JsonNode merged = composer.mergeParams(dailyBase(), json("{\"complaintPath\":\"SANITATION\"}"));
+        assertEquals(dailyBase(), merged);   // no NPE, same skip — reporting is opt-in
+    }
+
+    // ---- composition: hierLevel (GROUP BY) ⊥ complaintPath (WHERE) ----
+
+    @Test
+    public void composesWithHierLevelFilterPlusRollup() {
+        // "Filter the Sanitation subtree, grouped at level 2" — WHERE prefix + GROUP BY level expr.
+        JsonNode merged = composer.mergeParams(byTypeBase(),
+                json("{\"hierLevel\":\"2\",\"complaintPath\":\"SANITATION\"}"));
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope);
+        assertTrue(p.sql.contains("split_part(complaint_node_path,'.',least(2,complaint_depth))"),
+                p.sql);   // the rollup dimension survived
+        assertTrue(p.sql.contains("(complaint_node_path = ? OR complaint_node_path LIKE ? || '.%')"),
+                p.sql);   // …and the subtree WHERE narrows it
+        assertEquals(java.util.Arrays.asList("service_code", "total"), p.columns);
+    }
+
+    @Test
+    public void leafServiceCodeParamStaysAnExactEq() {
+        // Leaf selections keep sending serviceCode (exact match) — complaintPath is additive for
+        // interior nodes, not a replacement.
+        JsonNode merged = composer.mergeParams(byTypeBase(),
+                json("{\"serviceCode\":\"GarbageNeedsTobeCleared\",\"complaintPath\":\"SANITATION\"}"));
+        assertEquals("GarbageNeedsTobeCleared",
+                merged.get("filters").get("service_code").get("eq").asText());
+        assertEquals("SANITATION",
+                merged.get("filters").get("complaint_node_path").get("subtree").asText());
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope);
+        assertTrue(p.sql.contains("service_code = ?"));
+    }
+
+    // ---- ABAC: params only narrow; row-scope is injected on top ----
+
+    @Test
+    public void abacRowScopeIsStillAppliedOnTopOfTheSubtreeFilter() {
+        AnalyticsScope constrained = new AnalyticsScope("ke.nairobi", false, null,
+                "KENYA.NAIROBI", java.util.List.of("DEPT_SANITATION"));
+        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"complaintPath\":\"SANITATION\"}"));
+        AnalyticsPlanner.Planned p = planner.plan(merged, constrained);
+        assertTrue(p.sql.contains("(complaint_node_path = ? OR complaint_node_path LIKE ? || '.%')"), p.sql);
+        assertTrue(p.sql.contains("tenant_id = ?"), p.sql);                 // city tenant scope
+        assertTrue(p.sql.contains("boundary_path LIKE ?"), p.sql);          // jurisdiction subtree scope
+        assertTrue(p.sql.contains("department_code IN (?)"), p.sql);        // department scope
+        // scope literals ride AFTER the param filter literals — injected on top, never replaced
+        assertTrue(p.params.containsAll(java.util.List.of(
+                "SANITATION", "ke.nairobi", "KENYA.NAIROBI%", "DEPT_SANITATION")), p.params.toString());
+    }
+
+    // ---- planner: subtree op is gated to prefix-filterable path columns ----
+
+    @Test
+    public void plannerRejectsSubtreeOnNonPathColumns() {
+        JsonNode inline = json("{\"grain\":\"facts\","
+                + "\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}],"
+                + "\"filters\":{\"service_code\":{\"subtree\":\"SANITATION\"}}}");
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> planner.plan(inline, stateScope));
+        assertTrue(ex.getMessage().startsWith("op_not_allowed"), ex.getMessage());
+    }
+
+    @Test
+    public void plannerRejectsSubtreeOnDailyGrainInlinePath() {
+        // daily's prefix allowlist is boundary_path only; complaint_node_path doesn't exist there.
+        JsonNode inline = json("{\"grain\":\"daily\","
+                + "\"measures\":[{\"name\":\"open\",\"agg\":\"count\"}],"
+                + "\"filters\":{\"complaint_node_path\":{\"subtree\":\"SANITATION\"}}}");
+        assertThrows(IllegalArgumentException.class, () -> planner.plan(inline, stateScope));
+    }
+}

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiQueryComposerHierLevelTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiQueryComposerHierLevelTest.java
@@ -1,0 +1,208 @@
+package org.egov.pgr.analytics;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * #1111: pins the query-time complaint-hierarchy rollup — the composer's {@code hierLevel}
+ * param handling (leaf no-op, level rewrite via the composer-internal marker, R4
+ * service_group drop, strict int parse), the planner's nonce-gated acceptance of the marker
+ * (and rejection of forged object dimensions), and the generated SQL (fixed template, leaf
+ * fallback for NULL-path/flat tenants, depth clamp, ordinal GROUP BY).
+ */
+public class KpiQueryComposerHierLevelTest {
+
+    private final ObjectMapper om = new ObjectMapper();
+    private final AnalyticsCatalog catalog = new AnalyticsCatalog();
+    private final KpiQueryComposer composer = new KpiQueryComposer(catalog);
+    private final AnalyticsPlanner planner = new AnalyticsPlanner(catalog);
+    private final AnalyticsScope stateScope = new AnalyticsScope("ke", true, null, null, null);
+
+    private JsonNode json(String s) {
+        try { return om.readTree(s); } catch (Exception e) { throw new RuntimeException(e); }
+    }
+
+    /** The seeded complaints-by-type base query (facts, service_code dimension). */
+    private JsonNode byTypeBase() {
+        return json("{\"grain\":\"facts\",\"window\":{\"name\":\"last_30d\",\"timeRole\":\"filed_at\"},"
+                + "\"dimensions\":[\"service_code\"],"
+                + "\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}],"
+                + "\"sort\":[{\"by\":\"total\",\"dir\":\"desc\"}],\"limit\":8}");
+    }
+
+    // ---- composer: no-op paths ----
+
+    @Test
+    public void leafIsNoOp() {
+        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"hierLevel\":\"leaf\"}"));
+        assertEquals(byTypeBase(), merged);
+    }
+
+    @Test
+    public void absentIsNoOp() {
+        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"window\":\"last_7d\"}"));
+        assertEquals("service_code", merged.get("dimensions").get(0).asText());
+    }
+
+    @Test
+    public void dailyGrainWithoutPathColumnIsNoOp() {
+        JsonNode base = json("{\"grain\":\"daily\",\"dimensions\":[\"service_code\"],"
+                + "\"measures\":[{\"name\":\"open\",\"agg\":\"count\"}]}");
+        JsonNode merged = composer.mergeParams(base, json("{\"hierLevel\":\"2\"}"));
+        assertEquals(base, merged);   // param inapplicable on daily — graceful skip, like ward
+    }
+
+    @Test
+    public void queryWithoutServiceCodeDimensionIsNoOp() {
+        JsonNode base = json("{\"grain\":\"facts\",\"dimensions\":[\"ward_code\",\"service_group\"],"
+                + "\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}]}");
+        JsonNode merged = composer.mergeParams(base, json("{\"hierLevel\":\"1\"}"));
+        assertEquals(base, merged);   // nothing to roll up; service_group untouched
+    }
+
+    // ---- composer: level rewrite ----
+
+    @Test
+    public void levelRewritesServiceCodeDimensionToInternalMarker() {
+        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"hierLevel\":\"2\"}"));
+        JsonNode dim = merged.get("dimensions").get(0);
+        assertTrue(dim.isObject());
+        assertEquals(2, dim.get(AnalyticsCatalog.HIER_DIM_LEVEL_FIELD).asInt());
+        assertEquals(AnalyticsCatalog.HIER_DIM_TOKEN,
+                dim.get(AnalyticsCatalog.HIER_DIM_TOKEN_FIELD).asText());
+        // measures/sort/limit/window untouched
+        assertEquals(byTypeBase().get("measures"), merged.get("measures"));
+        assertEquals(byTypeBase().get("sort"), merged.get("sort"));
+        assertEquals(8, merged.get("limit").asInt());
+    }
+
+    @Test
+    public void serviceGroupDroppedAtNonLeaf() {
+        JsonNode base = json("{\"grain\":\"facts\",\"dimensions\":[\"service_code\",\"service_group\"],"
+                + "\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}],"
+                + "\"sort\":[{\"by\":\"service_group\",\"dir\":\"asc\"},{\"by\":\"total\",\"dir\":\"desc\"}]}");
+        JsonNode merged = composer.mergeParams(base, json("{\"hierLevel\":\"1\"}"));
+        assertEquals(1, merged.get("dimensions").size());   // service_group gone
+        assertTrue(merged.get("dimensions").get(0).isObject());
+        // sort referencing the dropped dimension is removed; the rest survives
+        assertEquals(1, merged.get("sort").size());
+        assertEquals("total", merged.get("sort").get(0).get("by").asText());
+    }
+
+    @Test
+    public void serviceGroupKeptAtLeaf() {
+        JsonNode base = json("{\"grain\":\"facts\",\"dimensions\":[\"service_code\",\"service_group\"],"
+                + "\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}]}");
+        JsonNode merged = composer.mergeParams(base, json("{\"hierLevel\":\"leaf\"}"));
+        assertEquals(base, merged);
+    }
+
+    @Test
+    public void composesWithWindowWardAndServiceCodeParams() {
+        JsonNode merged = composer.mergeParams(byTypeBase(),
+                json("{\"hierLevel\":\"1\",\"window\":\"last_7d\",\"ward\":\"W1\",\"serviceCode\":\"StreetLightNotWorking\"}"));
+        assertEquals("last_7d", merged.get("window").get("name").asText());
+        assertEquals("W1", merged.get("filters").get("ward_code").get("eq").asText());
+        assertEquals("StreetLightNotWorking", merged.get("filters").get("service_code").get("eq").asText());
+        assertTrue(merged.get("dimensions").get(0).isObject());
+        // ...and the planner accepts the combination (WHERE on raw service_code column,
+        // SELECT/GROUP BY on the aliased level expression — verified non-colliding).
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope);
+        assertTrue(p.sql.contains("service_code = ?"));
+        assertTrue(p.sql.contains("AS service_code"));
+    }
+
+    // ---- composer: strict int parse (R1) ----
+
+    @Test
+    public void malformedLevelsAreRejected() {
+        for (String bad : new String[]{"0", "13", "abc", "-1", "1.5", "1e1", "1; DROP TABLE x"}) {
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> composer.mergeParams(byTypeBase(), json("{\"hierLevel\":\"" + bad + "\"}")),
+                    "hierLevel '" + bad + "' must be rejected");
+            assertTrue(ex.getMessage().startsWith("invalid_param"), ex.getMessage());
+        }
+    }
+
+    @Test
+    public void boundaryLevelsAreAccepted() {
+        for (String ok : new String[]{"1", "12"}) {
+            JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"hierLevel\":\"" + ok + "\"}"));
+            assertTrue(merged.get("dimensions").get(0).isObject());
+        }
+    }
+
+    // ---- planner: SQL generation ----
+
+    @Test
+    public void plannerSqlSnapshotForLevelQuery() {
+        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"hierLevel\":\"1\"}"));
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope);
+        assertEquals("SELECT coalesce(nullif(split_part(complaint_node_path,'.',least(1,complaint_depth)),''),"
+                + " service_code) AS service_code, count(*) AS total"
+                + " FROM complaint_facts"
+                + " WHERE created_at >= ? AND created_at < ? AND tenant_id LIKE ?"
+                + " GROUP BY 1 ORDER BY total DESC NULLS LAST LIMIT 8", p.sql);
+        assertEquals(java.util.Arrays.asList("service_code", "total"), p.columns);
+    }
+
+    @Test
+    public void sqlCarriesLeafFallbackForNullPathRows() {
+        // Flat/legacy tenants materialize complaint_node_path NULL — the expr's
+        // coalesce(nullif(...),''), service_code) makes those rows roll up as themselves.
+        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"hierLevel\":\"2\"}"));
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope);
+        assertTrue(p.sql.contains("coalesce(nullif(split_part(complaint_node_path,'.',"));
+        assertTrue(p.sql.contains(",''), service_code) AS service_code"));
+    }
+
+    @Test
+    public void sqlClampsLevelToRowDepth() {
+        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"hierLevel\":\"4\"}"));
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope);
+        assertTrue(p.sql.contains("least(4,complaint_depth)"));
+    }
+
+    @Test
+    public void eventsGrainSupportsLevelRollup() {
+        JsonNode base = json("{\"grain\":\"events\",\"dimensions\":[\"service_code\"],"
+                + "\"measures\":[{\"name\":\"n\",\"agg\":\"count\"}]}");
+        JsonNode merged = composer.mergeParams(base, json("{\"hierLevel\":\"1\"}"));
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope);
+        assertTrue(p.sql.contains("FROM complaint_events"));
+        assertTrue(p.sql.contains("least(1,complaint_depth)"));
+    }
+
+    // ---- planner: the marker is composer-internal (R1) ----
+
+    @Test
+    public void plannerRejectsObjectDimensionWithoutNonce() {
+        // External JSON (inline query / MDMS def) cannot know the per-JVM nonce — any object
+        // dimension it smuggles in is rejected before SQL assembly.
+        JsonNode forged = json("{\"grain\":\"facts\","
+                + "\"dimensions\":[{\"" + AnalyticsCatalog.HIER_DIM_LEVEL_FIELD + "\":1,"
+                + "\"" + AnalyticsCatalog.HIER_DIM_TOKEN_FIELD + "\":\"forged-token\"}],"
+                + "\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}]}");
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> planner.plan(forged, stateScope));
+        assertTrue(ex.getMessage().startsWith("unknown_column"), ex.getMessage());
+    }
+
+    @Test
+    public void plannerRejectsMarkerWithOutOfRangeLevel() {
+        // Defense in depth: even a genuine-token marker is bounds-checked before interpolation.
+        com.fasterxml.jackson.databind.node.ObjectNode q =
+                (com.fasterxml.jackson.databind.node.ObjectNode) json(
+                        "{\"grain\":\"facts\",\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}]}");
+        com.fasterxml.jackson.databind.node.ObjectNode dim =
+                q.putArray("dimensions").addObject();
+        dim.put(AnalyticsCatalog.HIER_DIM_LEVEL_FIELD, 13);
+        dim.put(AnalyticsCatalog.HIER_DIM_TOKEN_FIELD, AnalyticsCatalog.HIER_DIM_TOKEN);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> planner.plan(q, stateScope));
+        assertTrue(ex.getMessage().startsWith("invalid_param"), ex.getMessage());
+    }
+}

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/PrincipalScopeResolverDeptScopingTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/PrincipalScopeResolverDeptScopingTest.java
@@ -1,0 +1,136 @@
+package org.egov.pgr.analytics;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.egov.common.contract.request.RequestInfo;
+import org.egov.common.contract.request.Role;
+import org.egov.common.contract.request.User;
+import org.egov.pgr.config.PGRConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * #1280: pins how PrincipalScopeResolver consults dss.DashboardConfig.departmentScoping.
+ *
+ * - "enforced" (the fail-safe default, including when no DashboardConfig record exists):
+ *   department scoping works exactly as today — HRMS resolution, department IN scope,
+ *   fail-closed sentinel for unresolvable constrained employees.
+ * - "disabled": the HRMS call is skipped ENTIRELY and the employee gets the unrestricted
+ *   (tenant-only) scope. Citizen self-scope is untouched.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class PrincipalScopeResolverDeptScopingTest {
+
+    private static final int STATE_LEN = 1;   // "ke" state root; "ke.bomet" city
+
+    @Mock private PGRConfiguration config;
+    @Mock private RestTemplate restTemplate;
+    @Mock private KpiCatalogService catalog;
+
+    private PrincipalScopeResolver resolver;
+
+    @BeforeEach
+    public void setUp() {
+        when(config.getHrmsHost()).thenReturn("http://egov-hrms:8080");
+        when(config.getHrmsEndPoint()).thenReturn("/egov-hrms/employees/_search");
+        resolver = new PrincipalScopeResolver(config, restTemplate, new ObjectMapper(), catalog);
+    }
+
+    private static RequestInfo employeeRequest(String userName, String... roleCodes) {
+        User u = User.builder().userName(userName).uuid("emp-uuid").type("EMPLOYEE")
+                .roles(rolesOf(roleCodes)).build();
+        return RequestInfo.builder().userInfo(u).build();
+    }
+
+    private static List<Role> rolesOf(String... codes) {
+        return java.util.Arrays.stream(codes)
+                .map(c -> Role.builder().code(c).build())
+                .collect(java.util.stream.Collectors.toList());
+    }
+
+    /** HRMS /_search response with one employee holding one active WATER assignment. */
+    private void stubHrmsWithDepartment(String dept) {
+        Map<String, Object> resp = Map.of("Employees", List.of(
+                Map.of("assignments", List.of(
+                        Map.of("isCurrentAssignment", true, "department", dept)))));
+        when(restTemplate.postForObject(anyString(), any(), eq(Map.class))).thenReturn(resp);
+    }
+
+    @Test
+    public void enforcedDefaultResolvesDepartmentsFromHrmsAsToday() {
+        when(catalog.isDepartmentScopingDisabled(anyString())).thenReturn(false);
+        stubHrmsWithDepartment("WATER");
+
+        AnalyticsScope s = resolver.resolve(employeeRequest("EMP-1", "PGR_LME"), "ke.bomet", STATE_LEN);
+
+        assertEquals(List.of("WATER"), s.departmentCodes);
+        assertNull(s.citizenUuid);
+        assertEquals("ke.bomet", s.tenantId);
+        verify(restTemplate).postForObject(anyString(), any(), eq(Map.class));
+    }
+
+    @Test
+    public void enforcedDefaultKeepsFailClosedSentinelWhenHrmsHasNoRecord() {
+        when(catalog.isDepartmentScopingDisabled(anyString())).thenReturn(false);
+        when(restTemplate.postForObject(anyString(), any(), eq(Map.class)))
+                .thenReturn(Map.of("Employees", List.of()));
+
+        AnalyticsScope s = resolver.resolve(employeeRequest("EMP-1", "PGR_LME"), "ke.bomet", STATE_LEN);
+
+        assertEquals(List.of("__scope_denied__"), s.departmentCodes);   // fail-closed unchanged
+    }
+
+    @Test
+    public void disabledSkipsHrmsEntirelyAndReturnsUnrestrictedEmployeeScope() {
+        when(catalog.isDepartmentScopingDisabled(anyString())).thenReturn(true);
+
+        AnalyticsScope s = resolver.resolve(employeeRequest("EMP-1", "PGR_LME"), "ke.bomet", STATE_LEN);
+
+        assertNull(s.departmentCodes);          // no department axis
+        assertNull(s.boundaryPrefix);
+        assertNull(s.citizenUuid);
+        assertEquals("ke.bomet", s.tenantId);   // tenant scoping untouched
+        assertFalse(s.tenantStateLevel);
+        verifyNoInteractions(restTemplate);     // HRMS never called
+    }
+
+    @Test
+    public void disabledKeepsStateLevelTenantSemantics() {
+        when(catalog.isDepartmentScopingDisabled(anyString())).thenReturn(true);
+
+        AnalyticsScope s = resolver.resolve(employeeRequest("EMP-1", "PGR_LME"), "ke", STATE_LEN);
+
+        assertTrue(s.tenantStateLevel);
+        assertNull(s.departmentCodes);
+    }
+
+    @Test
+    public void citizenSelfScopeIsUntouchedByDisabled() {
+        when(catalog.isDepartmentScopingDisabled(anyString())).thenReturn(true);
+        User citizen = User.builder().userName("9876543210").uuid("citizen-uuid").type("CITIZEN")
+                .roles(rolesOf("CITIZEN")).build();
+
+        AnalyticsScope s = resolver.resolve(RequestInfo.builder().userInfo(citizen).build(),
+                "ke.bomet", STATE_LEN);
+
+        assertEquals("citizen-uuid", s.citizenUuid);   // still self-scoped
+        assertNull(s.departmentCodes);
+        // pure-citizen path returns before the employee branch — config not even consulted
+        verifyNoInteractions(catalog, restTemplate);
+    }
+}

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/QueryTelemetryTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/QueryTelemetryTest.java
@@ -1,7 +1,11 @@
 package org.egov.pgr.analytics;
 
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -9,14 +13,51 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * #1110: pins the per-request slow-query pool semantics — top-3 selection (descending
  * tookMs), fewer-than-3 handling, the exclusion of errored entries (they are simply
- * never recorded), the single structured log line, and the trace-id fallback chain
- * (valid span > x-trace-id header > "-").
+ * never recorded), the single structured log line, the trace-id fallback chain
+ * (valid span > x-trace-id header > "-"), and the state-root normalization of the
+ * metric tenant label (raw request tenantIds are attacker-controlled and must never
+ * become Prometheus series).
  */
 public class QueryTelemetryTest {
 
     @Test
+    public void stateRootOfTruncatesToTheStateSegments() {
+        assertEquals("ke", QueryTelemetry.stateRootOf("ke", 1));
+        assertEquals("ke", QueryTelemetry.stateRootOf("ke.bomet", 1));
+        assertEquals("ke", QueryTelemetry.stateRootOf("ke.attack0001", 1));
+        assertEquals("ke.bomet", QueryTelemetry.stateRootOf("ke.bomet.ward1", 2));
+        assertNull(QueryTelemetry.stateRootOf(null, 1));
+        assertEquals("", QueryTelemetry.stateRootOf("", 1));
+        // defensive: a broken stateLevelLen still keeps at least one segment
+        assertEquals("zz", QueryTelemetry.stateRootOf("zz.a.b", 0));
+    }
+
+    @Test
+    public void metricPointsCarryTheStateRootNotTheRawRequestTenant() {
+        InMemoryMetricReader reader = InMemoryMetricReader.create();
+        SdkMeterProvider provider = SdkMeterProvider.builder().registerMetricReader(reader).build();
+        try {
+            AnalyticsMetrics metrics = new AnalyticsMetrics(provider.get(AnalyticsMetrics.METER_NAME));
+            QueryTelemetry tel = new QueryTelemetry(metrics, "ke.attack0001", 1);
+            tel.record("tiles", "open-complaints", "facts", 5, 1);
+
+            Collection<MetricData> collected = reader.collectAllMetrics();
+            assertFalse(collected.isEmpty());
+            for (MetricData md : collected) {
+                md.getData().getPoints().forEach(p -> assertEquals("ke",
+                        p.getAttributes().get(AnalyticsMetrics.ATTR_TENANT),
+                        md.getName() + " must be tagged with the state root"));
+            }
+            // ...while the log line keeps the full request tenant for debugging
+            assertTrue(tel.slowQueryLine("-").contains("tenant=ke.attack0001"));
+        } finally {
+            provider.close();
+        }
+    }
+
+    @Test
     public void topSlowestSortsDescendingAndLimitsToThree() {
-        QueryTelemetry tel = new QueryTelemetry(null, "ke");
+        QueryTelemetry tel = new QueryTelemetry(null, "ke", 1);
         tel.record("a", "kpi-a", "facts", 10, 1);
         tel.record("b", "kpi-b", "facts", 500, 2);
         tel.record("c", "kpi-c", "events", 250, 3);
@@ -33,7 +74,7 @@ public class QueryTelemetryTest {
 
     @Test
     public void fewerThanThreeEntriesReturnsWhatRan() {
-        QueryTelemetry tel = new QueryTelemetry(null, "ke.bomet");
+        QueryTelemetry tel = new QueryTelemetry(null, "ke.bomet", 1);
         tel.record("only", "kpi-x", "facts", 77, 0);
         List<QueryTelemetry.Execution> top = tel.topSlowest(QueryTelemetry.TOP_N);
         assertEquals(1, top.size());
@@ -44,7 +85,7 @@ public class QueryTelemetryTest {
     public void erroredEntriesAreExcludedBecauseNeverRecorded() {
         // The service records ONLY successful runOne() executions; an entry that threw
         // (plan error, kpi_forbidden, SQL failure) has no tookMs and never enters the pool.
-        QueryTelemetry tel = new QueryTelemetry(null, "ke");
+        QueryTelemetry tel = new QueryTelemetry(null, "ke", 1);
         tel.record("ok-1", "kpi-a", "facts", 5, 1);
         // "boom" entry errored -> no record() call
         tel.record("ok-2", "kpi-b", "facts", 9, 1);
@@ -55,13 +96,13 @@ public class QueryTelemetryTest {
 
     @Test
     public void emptyPoolMeansNoLogLine() {
-        QueryTelemetry tel = new QueryTelemetry(null, "ke");
+        QueryTelemetry tel = new QueryTelemetry(null, "ke", 1);
         assertTrue(tel.isEmpty());
     }
 
     @Test
     public void slowQueryLineCarriesTraceTenantTotalAndTop() {
-        QueryTelemetry tel = new QueryTelemetry(null, "ke.bomet");
+        QueryTelemetry tel = new QueryTelemetry(null, "ke.bomet", 1);
         tel.record("tiles", "open-complaints", "facts", 120, 42);
         String line = tel.slowQueryLine("abc123def456");
         assertTrue(line.startsWith("analytics.slow_queries traceId=abc123def456 tenant=ke.bomet total=1 top=["));
@@ -70,7 +111,7 @@ public class QueryTelemetryTest {
 
     @Test
     public void callerControlledNamesAreSanitizedInTheLogLine() {
-        QueryTelemetry tel = new QueryTelemetry(null, "ke");
+        QueryTelemetry tel = new QueryTelemetry(null, "ke", 1);
         tel.record("evil\nname \"quoted\"", "kpi", "facts", 1, 0);
         String line = tel.slowQueryLine("-");
         assertFalse(line.contains("\n"));

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/QueryTelemetryTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/QueryTelemetryTest.java
@@ -1,0 +1,97 @@
+package org.egov.pgr.analytics;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * #1110: pins the per-request slow-query pool semantics — top-3 selection (descending
+ * tookMs), fewer-than-3 handling, the exclusion of errored entries (they are simply
+ * never recorded), the single structured log line, and the trace-id fallback chain
+ * (valid span > x-trace-id header > "-").
+ */
+public class QueryTelemetryTest {
+
+    @Test
+    public void topSlowestSortsDescendingAndLimitsToThree() {
+        QueryTelemetry tel = new QueryTelemetry(null, "ke");
+        tel.record("a", "kpi-a", "facts", 10, 1);
+        tel.record("b", "kpi-b", "facts", 500, 2);
+        tel.record("c", "kpi-c", "events", 250, 3);
+        tel.record("d", "kpi-d", "facts", 999, 4);
+        tel.record("e", "kpi-e", "daily", 1, 5);
+
+        List<QueryTelemetry.Execution> top = tel.topSlowest(QueryTelemetry.TOP_N);
+        assertEquals(3, top.size());
+        assertEquals("d", top.get(0).name);
+        assertEquals("b", top.get(1).name);
+        assertEquals("c", top.get(2).name);
+        assertEquals(5, tel.total());
+    }
+
+    @Test
+    public void fewerThanThreeEntriesReturnsWhatRan() {
+        QueryTelemetry tel = new QueryTelemetry(null, "ke.bomet");
+        tel.record("only", "kpi-x", "facts", 77, 0);
+        List<QueryTelemetry.Execution> top = tel.topSlowest(QueryTelemetry.TOP_N);
+        assertEquals(1, top.size());
+        assertEquals(77, top.get(0).tookMs);
+    }
+
+    @Test
+    public void erroredEntriesAreExcludedBecauseNeverRecorded() {
+        // The service records ONLY successful runOne() executions; an entry that threw
+        // (plan error, kpi_forbidden, SQL failure) has no tookMs and never enters the pool.
+        QueryTelemetry tel = new QueryTelemetry(null, "ke");
+        tel.record("ok-1", "kpi-a", "facts", 5, 1);
+        // "boom" entry errored -> no record() call
+        tel.record("ok-2", "kpi-b", "facts", 9, 1);
+
+        assertEquals(2, tel.total());
+        assertTrue(tel.topSlowest(QueryTelemetry.TOP_N).stream().noneMatch(e -> "boom".equals(e.name)));
+    }
+
+    @Test
+    public void emptyPoolMeansNoLogLine() {
+        QueryTelemetry tel = new QueryTelemetry(null, "ke");
+        assertTrue(tel.isEmpty());
+    }
+
+    @Test
+    public void slowQueryLineCarriesTraceTenantTotalAndTop() {
+        QueryTelemetry tel = new QueryTelemetry(null, "ke.bomet");
+        tel.record("tiles", "open-complaints", "facts", 120, 42);
+        String line = tel.slowQueryLine("abc123def456");
+        assertTrue(line.startsWith("analytics.slow_queries traceId=abc123def456 tenant=ke.bomet total=1 top=["));
+        assertTrue(line.contains("{name=tiles, kpiId=open-complaints, tookMs=120, rowCount=42}"));
+    }
+
+    @Test
+    public void callerControlledNamesAreSanitizedInTheLogLine() {
+        QueryTelemetry tel = new QueryTelemetry(null, "ke");
+        tel.record("evil\nname \"quoted\"", "kpi", "facts", 1, 0);
+        String line = tel.slowQueryLine("-");
+        assertFalse(line.contains("\n"));
+        assertFalse(line.contains("\""));
+    }
+
+    @Test
+    public void traceIdFallsBackToHeaderThenDash() {
+        // No agent in unit tests -> Span.current() is invalid -> header wins.
+        assertEquals("deadbeef", QueryTelemetry.resolveTraceId("deadbeef"));
+        assertEquals("deadbeef", QueryTelemetry.resolveTraceId("  deadbeef  "));
+        assertEquals("-", QueryTelemetry.resolveTraceId(null));
+        assertEquals("-", QueryTelemetry.resolveTraceId("   "));
+    }
+
+    @Test
+    public void sanitizeCapsLengthAndStripsUnsafeChars() {
+        assertEquals("-", QueryTelemetry.sanitize(null));
+        assertEquals("-", QueryTelemetry.sanitize(""));
+        assertEquals("a_b_c", QueryTelemetry.sanitize("a b\nc"));
+        assertEquals(64, QueryTelemetry.sanitize("x".repeat(200)).length());
+        assertEquals("ke.bomet", QueryTelemetry.sanitize("ke.bomet"));
+    }
+}

--- a/docs/dashboard-configuration/10-kpi-catalog.md
+++ b/docs/dashboard-configuration/10-kpi-catalog.md
@@ -189,7 +189,13 @@ which expresses "all time by default" explicitly instead of by omission.)*
   (weighted averages, count-FILTER ratios — never an average of leaf averages).
 - **Fallbacks**: rows with a NULL/empty path (flat tenants, legacy dotted-code imports — see the
   `V20260716000000` migration) fall back to their leaf `service_code`; a level deeper than a
-  row's own depth clamps to its leaf segment.
+  row's own depth clamps to its leaf segment. The NULLing heuristic is two-part: the node's own
+  code containing `'.'` (`V20260716000000`) OR its `parentCode` containing `'.'`
+  (`V20260717000000` — bomet integration data had clean-code nodes parented under dotted legacy
+  codes, e.g. `DamagedRoad` with stored path `complaints.categories.DamagedRoad.DamagedRoad`,
+  whose polluted paths survived the first predicate as a garbage `complaints` level-1 bucket).
+  A new migration rather than an edit because `V20260716000000` was already applied on live
+  deployments (flyway is append-only).
 - **`service_group` is dropped** at `hierLevel != leaf`: once `service_code` is rolled up, the
   root-category dimension collapses into a duplicate of (or an ancestor of) the level bucket.
   The FE table simply sees no `service_group` column values for that row shape. Column

--- a/docs/dashboard-configuration/10-kpi-catalog.md
+++ b/docs/dashboard-configuration/10-kpi-catalog.md
@@ -153,10 +153,11 @@ ignored):
 | `window` | overrides `query.window.name`, preserving `timeRole`/`timeBucket` |
 | `dateFrom` + `dateTo` | inclusive ISO dates → half-open `gte`/`lt` range on the grain's time column; removes the base window. Unparseable values are a hard `invalid_param`, not a silent fallback |
 | `ward` | narrows `ward_code = ?` iff filterable on the grain |
-| `serviceCode` | narrows `service_code = ?` iff filterable |
+| `serviceCode` | narrows `service_code = ?` iff filterable — the param for complaint-type **leaf** selections (exact match; works on every grain incl. daily) |
 | `compare: "prior"` | immediately-preceding equal-duration range (prior calendar week when no range is set) — powers "vs prior period" deltas |
 | `series: "daily"` | scalar → daily time series (adds the grain's date dimension + asc sort, caps limit at min(366, days)) — powers sparklines |
 | `hierLevel` | complaint-hierarchy rollup level (#1111). `"leaf"`/absent = today's per-subtype buckets; `"1"`..`"12"` re-groups every `service_code` dimension by the Nth segment of `complaint_node_path` (aliased back `AS service_code`, so `viz.dimensionKey`, sort and columns are untouched). Aggregates recompute over raw rows, so averages/ratios stay correctly weighted. Grains without the path column (daily) no-op, like `ward`. See the rollup notes below |
+| `complaintPath` | complaint-hierarchy **subtree filter** for **interior-node** selections. Value = the node's dot-path (e.g. `SANITATION.SEWAGE`); adds a delimiter-guarded `subtree` predicate on `complaint_node_path` (`= ? OR LIKE ?\|\|'.%'`) on grains carrying the path column (facts/events) — a WHERE, orthogonal to `hierLevel`'s GROUP BY rewrite, so "filter the Sanitation subtree, grouped at level 2" composes. Leaf selections keep sending `serviceCode` (exact match; also covers the daily grain). Free-form validated string: `[A-Za-z0-9._/-]`, ≤ 256 chars, else `invalid_param`; declared on the type-dimension KPIs with **no `allowed` list and no default**. On the daily grain the filter cannot apply: the skip is reported via `paramsIgnored:["complaintPath"]` on the result envelope so the FE badges the widget "filter not applied" instead of silently serving unfiltered numbers. NULL-path rows (node codes containing `.`; flat tenants) never match a subtree |
 
 Rules enforced server-side:
 

--- a/docs/dashboard-configuration/10-kpi-catalog.md
+++ b/docs/dashboard-configuration/10-kpi-catalog.md
@@ -156,11 +156,14 @@ ignored):
 | `serviceCode` | narrows `service_code = ?` iff filterable |
 | `compare: "prior"` | immediately-preceding equal-duration range (prior calendar week when no range is set) — powers "vs prior period" deltas |
 | `series: "daily"` | scalar → daily time series (adds the grain's date dimension + asc sort, caps limit at min(366, days)) — powers sparklines |
+| `hierLevel` | complaint-hierarchy rollup level (#1111). `"leaf"`/absent = today's per-subtype buckets; `"1"`..`"12"` re-groups every `service_code` dimension by the Nth segment of `complaint_node_path` (aliased back `AS service_code`, so `viz.dimensionKey`, sort and columns are untouched). Aggregates recompute over raw rows, so averages/ratios stay correctly weighted. Grains without the path column (daily) no-op, like `ward`. See the rollup notes below |
 
 Rules enforced server-side:
 
-- **`allowed` list** (C1): a requested `window` outside the def's `allowed` list is rejected
-  with `invalid_param` — it is never silently honoured.
+- **`allowed` list** (C1, generalized in #1111): a requested value for ANY declared param with a
+  non-empty `allowed` list (`window`, `hierLevel`, …) outside that list is rejected with
+  `invalid_param` — it is never silently honoured. This applies on both the normal kpiId path
+  and the backend-compose path.
 - **`default`** is applied **server-side** for any declared param the caller omitted, with
   precedence *explicit caller param > declared default > the def's baked query*
   (`AnalyticsService.withDeclaredDefaults`). A bare `{ "kpiId": "..." }` reference therefore
@@ -172,7 +175,33 @@ Rules enforced server-side:
 Design consequence: a KPI that should cover *all time* by default (e.g. the Complaint Type
 Details table) must **not** declare a `window` default — with the server-side default fix, a
 declared default now actually applies. *(Changed in this PR: `cl_table_complaint_type_details`
-dropped its `last_7d` default for exactly this reason — issue #1028 / PR #1074 context.)*
+dropped its `last_7d` default for exactly this reason — issue #1028 / PR #1074 context.
+Superseded since: the def now declares `window` `default: "all"` with `"all"` in `allowed`,
+which expresses "all time by default" explicitly instead of by omission.)*
+
+### Hierarchy-level rollup (`hierLevel`) notes — #1111
+
+- **Where the rollup happens**: in SQL, at query time, over the grains' materialized
+  `complaint_node_path` — `coalesce(nullif(split_part(complaint_node_path,'.',least(N,complaint_depth)),''), service_code)`.
+  Pre-aggregation `limit`s therefore truncate AFTER summing into level buckets (a level-1 view of
+  a 200-leaf tenant is not a truncated leaf list), and every measure is recomputed over raw rows
+  (weighted averages, count-FILTER ratios — never an average of leaf averages).
+- **Fallbacks**: rows with a NULL/empty path (flat tenants, legacy dotted-code imports — see the
+  `V20260716000000` migration) fall back to their leaf `service_code`; a level deeper than a
+  row's own depth clamps to its leaf segment.
+- **`service_group` is dropped** at `hierLevel != leaf`: once `service_code` is rolled up, the
+  root-category dimension collapses into a duplicate of (or an ancestor of) the level bucket.
+  The FE table simply sees no `service_group` column values for that row shape. Column
+  hiding/relabelling reacts in the PR2 FE control.
+- **`ideal_sla_ms` caveat**: measures like `avg(sla_target_ms)` average HETEROGENEOUS per-subtype
+  SLA targets inside a level bucket. The number is a correctly weighted mean of the bucket's
+  complaints' targets, but it is *not* "the SLA" of the category — there is no single category
+  SLA. Treat it as indicative at non-leaf levels; the PR2 FE relabels/hides it accordingly.
+  (`cl_table_complaint_type_details` ships with `hierLevel` default `"leaf"`, so its default UX
+  is unchanged.)
+- **Labels**: level-bucket codes are ordinary `ComplaintHierarchy` node codes; the FE already
+  resolves any node code via `COMPLAINT_HIERARCHY.<code>` localization, so level-1/2 labels need
+  no new work.
 
 ## 5. Status lifecycle
 

--- a/docs/dashboard-configuration/20-packs-and-rbac.md
+++ b/docs/dashboard-configuration/20-packs-and-rbac.md
@@ -69,6 +69,40 @@ Boundary/jurisdiction scope (`boundary_path LIKE '<prefix>%'`) is wired end-to-e
 deliberately disabled in the resolver today (`boundaryPrefix = null` with the enabling block
 commented out in `PrincipalScopeResolver.java` — see the inline rationale).
 
+#### Tenant-configurable department scoping — `dss.DashboardConfig.departmentScoping` (#1280)
+
+The employee department axis above can be switched off per tenant via an OPTIONAL field on the
+`dss.DashboardConfig` MDMS master (the tenant-level dashboard config record introduced by #1258
+and extended by #1272 — this field composes additively with whatever else that record carries):
+
+| value | effect |
+|---|---|
+| `"enforced"` (or the field/record absent — the default) | today's behavior, exactly as the table above: HRMS department resolution, `department_code IN (...)`, fail-closed sentinel for unresolvable constrained employees |
+| `"disabled"` | the resolver skips HRMS department resolution ENTIRELY for employees: no department filter, no fail-closed sentinel. Tenant scoping (always applied) and citizen self-scope are untouched |
+
+**Fail-safe**: anything that is not an explicit `"disabled"` (case-insensitive) — missing
+module/record/field, a malformed value, an MDMS error — resolves to `"enforced"`. The lookup
+never widens scope on failure.
+
+The value is read at the tenant's **state root** (like the rest of the dss module) and cached
+in-memory for 5 minutes per state root, so a config flip takes effect within 5 minutes without
+a redeploy.
+
+**When to use it**: deployments whose complaint data carries no departments (#1280 —
+`ServiceDefs` entries without a `department`, so `department_code` is NULL on every fact row).
+Under `"enforced"`, every department-scoped officer there sees zero rows on every tile; under
+`"disabled"` they see the tenant's real numbers.
+
+**Warning — this widens data visibility**: with `"disabled"`, EVERY employee on the tenant sees
+the tenant-wide aggregates (equivalent to holding a `TENANT_WIDE_ROLES` role for Layer 1). Treat
+it as a temporary bridge until department enrichment lands in the complaint data, then flip back
+to `"enforced"`.
+
+Seed note: the `DashboardConfig` seed file (`ansible/nairobi-mdms/mdms/dss/DashboardConfig.json`)
+lives on the #1258/#1272 branches, not this one; add `"departmentScoping": "enforced"` to that
+record whichever merges first — the master's schema is additive/open, and absence already means
+enforced.
+
 Operator consequences:
 
 - A department-scoped supervisor's dashboard (all tiles, and the filter option lists) shows

--- a/docs/observability/dashboard-metrics-server.md
+++ b/docs/observability/dashboard-metrics-server.md
@@ -104,7 +104,10 @@ defensively; older clients ignore them):
 - **`recordCount`** — the **tenant corpus** size of `complaint_facts`, computed with the
   planner's tenant scope semantics: state-level tenant → `tenant_id LIKE 'ke%'`, city
   tenant → exact match. Cached in-memory for 5 minutes per tenant; `null` on error
-  (never fails the response).
+  (never fails the response). Gated by the same pack-match check as `packId`/`persona`:
+  when no pack matched the caller's roles (e.g. the anonymous PUBLIC floor on a tenant
+  with no public pack) it is `null` — otherwise any caller could enumerate every
+  tenant's complaint volume.
 
   **Semantics — read this:** `recordCount` is the **tenant's data volume**, deliberately
   **NOT the caller's ABAC-visible subset** (department/citizen/boundary scope is not

--- a/docs/observability/dashboard-metrics-server.md
+++ b/docs/observability/dashboard-metrics-server.md
@@ -1,0 +1,121 @@
+# Dashboard metrics — server side (#1110, PR2)
+
+> **Merge note:** PR1 of #1110 introduces `docs/observability/dashboard-metrics.md`
+> (client-side metrics, delivery path, feature gate). This file is the **server section**
+> of that page, kept separate only to avoid cross-PR conflicts — fold it into
+> `dashboard-metrics.md` once both PRs have landed.
+
+## What the server emits
+
+`pgr-services` measures every analytics SQL execution behind
+`POST /pgr-services/v2/analytics/_query` — each **batch entry**, each **single query**,
+and each **SOURCE query of a backend-composed KPI** (composed KPIs like
+`dailyAvgFromWeekly` run 1..n source queries; each records its own point, attributed to
+its own `kpi_id`).
+
+Instrumentation is `io.opentelemetry:opentelemetry-api` over `GlobalOpenTelemetry`
+(no micrometer/actuator). The OTEL **javaagent** the deploy stack attaches
+(`JAVA_TOOL_OPTIONS: -javaagent:...`, `OTEL_METRICS_EXPORTER: otlp`,
+`OTEL_SERVICE_NAME: pgr-services`) bridges it to its SDK and exports OTLP to the
+collector, which Prometheus scrapes on `otel-collector:8889`. **Without the agent every
+call is a no-op** — no config change, no compose change, safe in tests/CI.
+
+## Metric names as scraped (Prometheus)
+
+| OTLP instrument | Prometheus series | Type |
+|---|---|---|
+| `pgr.analytics.query.duration.ms` | `pgr_analytics_query_duration_ms_bucket` / `_sum` / `_count` | histogram |
+| `pgr.analytics.query.rows` | `pgr_analytics_query_rows_total` | counter |
+
+Labels on both: `kpi_id` (the KPI id, or `inline` for inline-grammar queries), `grain`
+(`facts`/`events`/`daily`/`compose` never appears — sources record their real grain),
+`tenant` (the request tenantId). Resource attributes (`service.name="pgr-services"` →
+`job`) come from the agent; `resource_to_telemetry_conversion` is enabled on the
+collector's prometheus exporter.
+
+Example queries:
+
+```promql
+# p95 duration per KPI over 15m
+histogram_quantile(0.95,
+  sum by (kpi_id, le) (rate(pgr_analytics_query_duration_ms_bucket[15m])))
+
+# slowest KPIs by mean duration
+topk(5, sum by (kpi_id) (rate(pgr_analytics_query_duration_ms_sum[15m]))
+      / sum by (kpi_id) (rate(pgr_analytics_query_duration_ms_count[15m])))
+```
+
+## Per-request slow-query log (Loki)
+
+After every `_query` request, pgr-services logs **one** structured line with the top-3
+slowest executed queries of that request (errored entries never execute, so they are
+excluded — they have no `tookMs`):
+
+```
+analytics.slow_queries traceId=<32-hex-or-header-or--> tenant=<t> total=<n> top=[{name=..., kpiId=..., tookMs=..., rowCount=...}, ...]
+```
+
+Promtail ships all container stdout to Loki. Query:
+
+```logql
+{compose_service="pgr-services"} |= "analytics.slow_queries"
+# only slow loads:
+{compose_service="pgr-services"} |= "analytics.slow_queries" | pattern "<_>tookMs=<took>,<_>" | took > 2000
+```
+
+## Trace correlation recipe
+
+The trace id in the log line is resolved in this order:
+
+1. **Active span's trace id** — Kong runs the `opentelemetry` plugin (`header_type: w3c`)
+   and pgr-services runs the javaagent, so the browser's `traceparent` (PR1 emits one per
+   dashboard load) is continued end-to-end. This is the normal case.
+2. The literal **`x-trace-id` request header** — fallback for agent-less deployments
+   (the `_query` handler accepts it as an optional header; it changes no behaviour).
+3. `-` when neither exists.
+
+To go from "the dashboard felt slow" to the exact query:
+
+1. **Prometheus** — find the offending aggregate (p95 spike on
+   `pgr_analytics_query_duration_ms` for a `kpi_id`/`tenant`).
+2. **Loki** — find affected loads: the FE's `dashboard.load` record (PR1) and the
+   server's `analytics.slow_queries` line carry the **same trace id** for one dashboard
+   load. Grep either, copy `traceId`.
+3. **Tempo** — search that trace id: the full span tree (Kong → pgr-services → JDBC
+   spans from the agent's auto-instrumentation) shows exactly where the time went.
+
+## `/packs` additions (`packId`, `persona`, `recordCount`)
+
+`POST /v2/analytics/packs` now returns three additive fields (the FE reads them
+defensively; older clients ignore them):
+
+- **`packId`** — the matched `DashboardPack.id`, the FE's `layout_id` tag. `null` when no
+  pack matched.
+- **`persona`** — the role that made the pack match: the first role in the **pack's**
+  declared `roles` list that the caller holds (the server's actual `matchesRoles`
+  decision, deterministic in pack order). The FE prefers this over its client-side
+  derivation for the `persona` tag.
+- **`recordCount`** — the **tenant corpus** size of `complaint_facts`, computed with the
+  planner's tenant scope semantics: state-level tenant → `tenant_id LIKE 'ke%'`, city
+  tenant → exact match. Cached in-memory for 5 minutes per tenant; `null` on error
+  (never fails the response).
+
+  **Semantics — read this:** `recordCount` is the **tenant's data volume**, deliberately
+  **NOT the caller's ABAC-visible subset** (department/citizen/boundary scope is not
+  applied). It feeds the `record_count_tier` metric tag, which must give render-lag
+  comparisons a shared denominator across personas — a department-scoped officer on a
+  100k-row tenant is in the `gt100k` tier even if they can see 2k rows. Do not use it as
+  a "rows you can query" indicator.
+
+## Validation cheat-sheet
+
+```bash
+# metrics appear within one scrape interval of a _query
+curl -s http://otel-collector:8889/metrics | grep pgr_analytics_query_duration_ms_count
+
+# slow-query line with a propagated trace id
+curl -s -X POST https://<host>/pgr-services/v2/analytics/_query \
+  -H 'Content-Type: application/json' -H 'x-trace-id: cafebabecafebabecafebabecafebabe' \
+  -d '{"tenantId":"ke","queries":{"open":{"kpiId":"<a PUBLIC kpiId>"}}}'
+docker logs pgr-services 2>&1 | grep analytics.slow_queries | tail -1
+```

--- a/docs/observability/dashboard-metrics-server.md
+++ b/docs/observability/dashboard-metrics-server.md
@@ -35,7 +35,10 @@ Same convention as the client-side `dashboardMetrics.js` (#1268).
 
 Labels on both: `kpi_id` (the KPI id, or `inline` for inline-grammar queries), `grain`
 (`facts`/`events`/`daily`/`compose` never appears — sources record their real grain),
-`tenant` (the request tenantId). Resource attributes (`service.name="pgr-services"` →
+`tenant` (the **state-root** tenant, e.g. `ke` — never the raw request tenantId,
+which is caller-controlled and unvalidated: tagging it raw would let an anonymous
+caller mint a new Prometheus series per request. The full request tenantId still
+appears, sanitized, in the `analytics.slow_queries` log line). Resource attributes (`service.name="pgr-services"` →
 `job`) come from the agent; `resource_to_telemetry_conversion` is enabled on the
 collector's prometheus exporter.
 

--- a/docs/observability/dashboard-metrics-server.md
+++ b/docs/observability/dashboard-metrics-server.md
@@ -27,6 +27,12 @@ call is a no-op** — no config change, no compose change, safe in tests/CI.
 | `pgr.analytics.query.duration.ms` | `pgr_analytics_query_duration_ms_bucket` / `_sum` / `_count` | histogram |
 | `pgr.analytics.query.rows` | `pgr_analytics_query_rows_total` | counter |
 
+The instruments deliberately set **no OTLP `unit`** — the unit lives in the name
+(`.ms`). The collector's prometheus exporter appends a unit-derived suffix whenever
+`unit` is set (validated live on bomet: `unit: "ms"` scraped as
+`pgr_analytics_query_duration_ms_milliseconds_*`), which would break the names above.
+Same convention as the client-side `dashboardMetrics.js` (#1268).
+
 Labels on both: `kpi_id` (the KPI id, or `inline` for inline-grammar queries), `grain`
 (`facts`/`events`/`daily`/`compose` never appears — sources record their real grain),
 `tenant` (the request tenantId). Resource attributes (`service.name="pgr-services"` →


### PR DESCRIPTION
Implements #1111 (PR 1 of 2) — dashboard type-dimension KPIs can now be grouped by any complaint-hierarchy level at query time, via a new `hierLevel` KPI param. PR 2 adds the per-widget FE "Group by" control.

> **STACKED ON #1267** (`feat/dashboard-metrics-server`). This branch is cut from that PR's head, so its commits appear in this diff until #1267 merges — at which point this diff collapses to the 7 `#1111` commits. Review from `def2bb91b` onward.

## What changes

A KPI request (or a def's declared default) may now carry `params.hierLevel`:

- `"leaf"` / absent — today's per-subtype buckets, byte-identical queries (no-op).
- `"1"`..`"12"` — every `service_code` dimension is re-grouped by the Nth segment of the materialized `complaint_node_path`, **aliased back `AS service_code`** so `viz.dimensionKey`, sort, columns and FE labels (`COMPLAINT_HIERARCHY.<code>`) all keep working with zero FE change.

The rollup is **backend, query-time, in SQL** — `coalesce(nullif(split_part(complaint_node_path,'.',least(N,complaint_depth)),''), service_code)` — so pre-aggregation `limit`s truncate AFTER summing into level buckets (a level-1 view of a 200-leaf tenant is not a truncated leaf list) and every measure recomputes over raw rows: weighted averages and count-FILTER ratios, never an average of leaf averages (verified for all 6 type-details measures).

## Decisions (from the reviewed plan)

| # | Decision | Choice |
|---|---|---|
| 1 | Rollup location | Backend, query-time — FE rollup is wrong under pre-aggregation `limit` and cannot reconstruct weighted avgs |
| 2 | Mechanism | Derived expr over the existing `complaint_node_path` (no new MV column); N clamps to row depth; NULL path falls back to leaf |
| 3 | Catalog shape | New param `{name:"hierLevel", allowed:[...], default:...}` mirroring `window` — not forked dimension names, not viz-only |
| 4 | Wire protocol | Expression aliased `AS service_code`, grouped by ordinal — FE contract unchanged; `service_group` dim dropped at non-leaf (it collapses into a duplicate of the level bucket) |
| 5 | Level count | `params.allowed` seeded generously (`leaf,1..4`); the PR2 dropdown enumerates `ComplaintHierarchyDefinition.levels` at runtime — never hardcoded |
| 6 | MVP UI | PR1 = catalog defaults only (level-1 on the two overview charts fixes the leaf clutter day one); in-UI control is PR2 |
| 7 | Drilldown (issue AC 4) | **Excluded** — click-to-filter is a hierarchy-FILTER interaction; hierarchy-aware filters were built and deliberately abandoned by the project owner |

## Injection surface (R1)

There is **no generic expression support** in the planner. The level expr template is fixed Java in `AnalyticsCatalog`; `hierLevel` must strictly parse to an int in 1..12 before any SQL assembly. The composer hands the planner an object-dimension marker gated on a **per-JVM nonce** that request bodies and MDMS defs (parsed JSON) can never carry — a forged object dimension is rejected as `unknown_column` before SQL is built. The inline-query grammar and PII gate are untouched.

## R5 — data-hygiene migration (`V20260716000000`)

Legacy flat imports (`complaints.categories.*`) registered single hierarchy nodes whose **code itself contains dots**, so splitting their "path" fabricates a garbage `complaints` level-1 bucket. Live exposure at authoring time: **20 of 645 fact rows across 3 tenants** (13 further NULL-path rows already take the leaf fallback). The migration recreates both grains (MV-recreate idiom, supersedes `V20260708000000`) with one change: `complaint_node_path` is NULL when the matched node's own code contains `'.'` — those rows roll up as themselves via the existing leaf fallback instead of polluting level buckets. Validation criterion: no `complaints` bucket at level 1.

## Seeds (R6) + live-update runbook

Seed changes upstream-first so the repo is a superset of live `ke`: `cl_table_complaint_type_details` window gains `"all"` + `default:"all"`; `cl_chart_over_time_created_daily` gains `viz.valueKey:"created"`. Then `hierLevel` (allowed `["leaf","1","2","3","4"]`): defaults `"1"` on `cl_chart_complaints_by_type` / `cl_chart_open_by_type_stage`, `"leaf"` on `cl_table_complaint_type_details` / `cl_table_subtype_performance` / `cl_table_recurring_ward_subtype`. Row-grain KPIs (at-risk, map pins) excluded. Versions bumped; saved layouts are kpiId-keyed and unaffected.

**Ops runbook for live tenants — never bulk-replace `dss.KpiDefinition`.** Live records carry hand-enrichments in both directions. Per record, for each of the 5 KPIs above (+ the 2 enrichment targets below):

1. `_search` the record by `uniqueIdentifier` (schema `dss.KpiDefinition`, tenant `ke`).
2. **Merge into the fetched JSON** (read-merge-write): append the `hierLevel` param to `data.params`, bump `data.version`; leave every other field exactly as fetched.
3. `_update` the single record with the merged payload.
4. In the same pass, push the seed-only enrichments live: `viz.seriesLabelKey` (`DASHBOARD_SERIES_FILED`) on `cl_chart_complaints_by_type`, and the `channelMap[].labelKey`s on `cl_chart_open_by_channel`.
5. Refresh the MVs after the migration lands so the R5 path change takes effect, then spot-check: level-1 bucket sums == sum of level-2 buckets == sum of leaf buckets on `cl_chart_complaints_by_type`, and no `complaints` bucket at level 1.

## Caveat documented (R4): `ideal_sla_ms` at non-leaf

`avg(sla_target_ms)` inside a level bucket averages heterogeneous per-subtype SLA targets — a correctly weighted mean of the bucket's complaints' targets, but not "the category's SLA" (no such thing exists). Documented in `10-kpi-catalog.md`; the type-details table ships with default `"leaf"` (unchanged UX), and the column relabel/hide reacts in PR2 where the FE can respond to the active level.

## PR2 preview (FE, separate review surface)

Per-widget "Group by" select in the AdminDashboard widget header / `DataTableChrome.headerActions`, options enumerated from `ComplaintHierarchyDefinition` filtered by the deployment's `hierarchyType` (ke carries both `PGR` and `PGR_TEST` — naive fetch shows the wrong dropdown), localized level names, per-tile localStorage overrides merged into that tile's params before companion-ref spreads.

## Tests

`mvn test` (maven:3.9-eclipse-temurin-17): **107 tests, 0 failures, 2 skips** (pre-existing `SeedFixtureDriftTest` skips). New: 16 composer/planner tests (leaf no-op, level rewrite, `service_group` + sort drop, strict int-parse incl. injection strings, NULL-path fallback + depth clamp in generated SQL, SQL snapshot with ordinal GROUP BY, events grain, forged-marker rejection, out-of-range genuine marker) + 7 allow-list validation tests (hierLevel + window regression, open/undeclared params, null edges).

## Also in this PR: tenant-configurable department scoping — `dss.DashboardConfig.departmentScoping` (#1280)

Implements the team-call decision to make the analytics department-scope axis configurable per tenant, for deployments whose complaint data carries no departments (#1280): there, every department-scoped officer resolves a department that matches no fact row (or hits the fail-closed sentinel) and sees zero on every tile.

**What**: `dss.DashboardConfig` gains an OPTIONAL `departmentScoping` field:

| value | effect |
|---|---|
| `"enforced"` (default; field/record absent) | today's behavior — HRMS department resolution, `department_code IN (...)`, fail-closed sentinel for unresolvable constrained employees |
| `"disabled"` | `PrincipalScopeResolver` skips HRMS department resolution entirely for employees — no department filter, no sentinel. Tenant scoping and citizen self-scope untouched |

**Fail-safe default**: anything that is not an explicit `"disabled"` (case-insensitive, trimmed) — missing dss module, missing record, missing field, malformed value, MDMS error — resolves to `"enforced"`. The lookup (`KpiCatalogService.isDepartmentScopingDisabled`) never throws, so it can never flip the resolver's HRMS-error path either way.

**Mechanics**: read at the tenant's state root through the existing `fetchMaster` MDMS path in `KpiCatalogService`, cached in-memory for 5 minutes per state root (same idiom as the `/packs` recordCount cache, injectable clock for expiry tests) — a config flip applies within 5 minutes, no redeploy.

**Warning** (also in `docs/dashboard-configuration/20-packs-and-rbac.md` Layer 1): `"disabled"` widens data visibility — every employee on the tenant sees tenant-wide aggregates. Intended as a temporary bridge until department enrichment lands in the complaint data.

**Seeds**: the `DashboardConfig` seed file lives on #1258/#1272's branches, not this one, so no seed change here — the field composes additively with whichever of those merges first (`"departmentScoping": "enforced"` can be added to that record then; absence already means enforced).

**Tests**: enforced default (no record → dept scoping as today, incl. fail-closed sentinel), disabled skips the HRMS call, cache hit / expiry / flip pickup, malformed values → enforced, citizen self-scope untouched. Suite now **125 tests, 0 failures, 2 skips**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added complaint hierarchy drilldown via `hierLevel` (including non-leaf rollups) and enhanced KPI regrouping.
  * Added `complaintPath` subtree filtering (with `serviceCode` leaf support) and hierarchy-aware regrouping.
  * Improved analytics observability: optional `x-trace-id`, server-side query metrics, and per-request slow-query logging (top slow queries).
  * Extended analytics pack responses with `packId`, `persona`, and `recordCount`.
  * Introduced configurable department-scoping disable mode for Layer 1 row-scope behavior.
* **Bug Fixes**
  * Fixed hierarchy path handling for dotted hierarchy codes (preventing incorrect rollups).
  * Corrected daily “created” chart key mapping.
* **Documentation**
  * Updated KPI catalog docs, parameter validation rules, and server observability/dept-scoping guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Addendum: `complaintPath` subtree filter param (+ `paramsIgnored` envelope) — 33f738c88

Adds the small composer param the FE one-widget complaint-type tree filter needs (pairs with the upcoming FE tree-filter PR; validation verdict "BUILD-WITH-CHANGES", required changes #2 and #4).

**Subtree filter.** `params.complaintPath` = an **interior** hierarchy node's dot-path (e.g. `SANITATION.SEWAGE`). The composer injects a delimiter-guarded `subtree` predicate on `complaint_node_path` — `(complaint_node_path = ? OR complaint_node_path LIKE ? || '.%')` — on the grains that carry the path column (facts/events), riding the same prefix-filterable allowlist, bound params and LIKE-escaping as the inline path's `starts_with`. The `'.'` guard means `PGR` can never match a `PGRX` sibling; the `=` arm keeps complaints filed AT a mixed interior+serviceable node in its own subtree. Values are sanitized against the path alphabet (`[A-Za-z0-9._/-]`, ≤ 256 chars) — anything else is a hard `invalid_param`; empty/absent is a no-op. Composes with `hierLevel` (subtree filter = WHERE, level rollup = GROUP BY — orthogonal, covered by a combined test) and never widens ABAC (row-scope is still injected on top; asserted in tests).

**Daily-grain honesty (`paramsIgnored`).** The daily grain has no `complaint_node_path`, so the filter cannot apply to the 4 daily-grain widgets. Instead of `ward`-style silent skipping, the result envelope now reports it: `"paramsIgnored": ["complaintPath"]` on the per-query result (batch entries, the single arm, and compose refs) whenever a supplied param couldn't be applied and the caller must know. The FE shows a "filter not applied" indicator from this field rather than presenting an unfiltered number as filtered.

**Leaf vs interior split.** `serviceCode` (exact `service_code = ?`) remains the param for **leaf** selections — it works on every grain including daily. `complaintPath` is for interior nodes only; both are documented in `ANALYTICS-QUERY-API.md` §params and `10-kpi-catalog.md` §4.

**Seeds.** `complaintPath` declared (free-form validated string — no default, no `allowed` list) on the same 5 type-dimension KPIs that carry `hierLevel`; versions 1.1.0 → 1.2.0.

**Tests.** 16 new (`KpiQueryComposerComplaintPathTest`): subtree SQL snapshot, LIKE-escape of `_`, sanitizer rejections + live path shapes, daily-grain `paramsIgnored` + collector dedupe + ward-stays-silent, `hierLevel`+`complaintPath` combined, ABAC-still-applied, planner `subtree` op gating. Full pgr-services suite green: 141 tests, 0 failures (maven:3.9-eclipse-temurin-17).


---

## Addendum: two fixes found in integration testing (bomet deploy) — bffe6e039, 885324955

Both surfaced while deploying this PR to the bomet integration environment:

1. **Seed schema violation (blocker) — bffe6e039.** The bare `{"name":"complaintPath"}` params entries violated the live/registered `dss.KpiDefinition` schema, which requires `default` + `allowed` on every params entry — mdms `_update` 400'd (`required key [allowed] not found`) and fresh `tenant_bootstrap` seeding failed identically. All 5 entries are now `{"name":"complaintPath","default":"","allowed":[]}`; verified live that the server treats an empty `allowed` list as unvalidated free-form and an empty-string `default` as a no-op, and new unit tests in `AnalyticsServiceParamValidationTest` pin both semantics. (Supersedes the "no default, no `allowed` list" wording in the previous addendum's Seeds paragraph.)

2. **Migration heuristic widening — 885324955.** Bomet data showed a pollution shape the R5 migration (`V20260716000000`: NULL `complaint_node_path` when the node's own code contains `.`) misses: clean-code nodes parented under dotted legacy codes (e.g. node `DamagedRoad`, stored path `complaints.categories.DamagedRoad.DamagedRoad`, depth 4) — 30 live rows survived as a garbage `complaints` level-1 bucket. Since `V20260716000000` is already applied on bomet, a NEW migration `V20260717000000__hier_path_null_on_dotted_parent_codes.sql` (same MV-recreate idiom, otherwise byte-identical) widens the cnp predicate in both grains: also NULL when the matched node's `parentCode` contains `.`. Migration-rationale note updated in `10-kpi-catalog.md`.

Full pgr-services suite green after both: 144 tests, 0 failures, 0 errors (maven:3.9-eclipse-temurin-17).
