### PR TITLE
feat(dashboard): per-widget "Group by" hierarchy-level control (#1111 PR2)

### DIFF
--- a/digit-mcp/src/tools/dashboard-l10n-seed.ts
+++ b/digit-mcp/src/tools/dashboard-l10n-seed.ts
@@ -390,6 +390,26 @@ export const DASHBOARD_L10N_MESSAGES: { code: string; message: string; module: s
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "DASHBOARD_GROUPBY_LABEL",
+    "message": "Group by",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_GROUPBY_LEAF",
+    "message": "Leaf",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_GROUPBY_LEVEL_CATEGORY",
+    "message": "Category",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_GROUPBY_LEVEL_SUB_TYPE",
+    "message": "Sub-type",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "DASHBOARD_HEADER_ADD",
     "message": "Add",
     "module": "rainmaker-dashboard"
@@ -1557,7 +1577,7 @@ export const DASHBOARD_L10N_MESSAGES: { code: string; message: string; module: s
 ];
 
 /**
- * pt_PT (European Portuguese) pack — same 308 codes as the en_IN pack, 1:1.
+ * pt_PT (European Portuguese) pack — same 312 codes as the en_IN pack, 1:1.
  * Translations follow European/Mozambique conventions (bairro/distrito geo
  * terms, "reclamações" agreement); placeholder tokens verified identical to
  * the en_IN messages.
@@ -1936,6 +1956,26 @@ export const DASHBOARD_L10N_MESSAGES_PT_PT: { code: string; message: string; mod
   {
     "code": "DASHBOARD_GEO_LEVEL_3",
     "message": "Reclamações",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_GROUPBY_LABEL",
+    "message": "Agrupar por",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_GROUPBY_LEAF",
+    "message": "Folha",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_GROUPBY_LEVEL_CATEGORY",
+    "message": "Categoria",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_GROUPBY_LEVEL_SUB_TYPE",
+    "message": "Subtipo",
     "module": "rainmaker-dashboard"
   },
   {

--- a/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
@@ -9,6 +9,7 @@ import KpiTile from "./components/KpiTile";
 import CardUpdatedStamp from "./components/CardUpdatedStamp";
 import ResizeGrip from "./components/ResizeGrip";
 import SubtleScroll from "./components/SubtleScroll";
+import GroupByLevelSelect, { levelDisplayLabel } from "./components/GroupByLevelSelect";
 import {
   VIZ_TYPE,
   SHARED_CHROME,
@@ -28,7 +29,20 @@ import { useFilterOptions } from "./hooks/useFilterOptions";
 import { useCatalog } from "./hooks/useCatalog";
 import { useCatalogLayout } from "./hooks/useCatalogLayout";
 import { runKpiBatch, getTenantId } from "./services/analyticsService";
+import { fetchComplaintHierarchyLevels } from "./services/complaintHierarchyService";
 import { GRID_COLS, KPI_ROW_HEIGHT } from "./constants/layoutConfig";
+import {
+  isCardKind,
+  isSparklineKind,
+  isMapKind,
+  buildRefs,
+  buildRefsKey,
+} from "./utils/queryPlan";
+import {
+  hierLevelParam,
+  effectiveHierLevel,
+  buildGroupByOptions,
+} from "./utils/hierLevelGrouping";
 
 // Map the catalog's viz.kind onto the reference dashboard's VIZ_TYPE so each widget
 // gets its type-specific header/body chrome (padding, insets, legend tuning) instead
@@ -131,88 +145,37 @@ const AdminDashboard = ({ embedded = false }) => {
 /* -------------------------------------------------------------------------- */
 /* Query-plan helpers                                                          */
 /* -------------------------------------------------------------------------- */
-
-const CARD_KINDS = new Set([
-  "number-tile-delta",
-  "number-tile",
-  "scalar",
-  "number-tile-sparkline",
-  "sparkline-card",
-]);
-const SPARKLINE_KINDS = new Set(["number-tile-sparkline", "sparkline-card"]);
-const MAP_KINDS = new Set(["map", "choropleth-map"]);
-
-// The internal pin source: map tiles fetch this alongside their ward aggregates
-// to overlay per-complaint pins (the FE map widget has the pin layer; this feeds it).
-const PIN_KPI_ID = "cl_map_complaint_pins";
-
-function isCardKind(kind) {
-  return CARD_KINDS.has(kind);
-}
-function isSparklineKind(kind) {
-  return SPARKLINE_KINDS.has(kind);
-}
-function isMapKind(kind) {
-  return MAP_KINDS.has(kind);
-}
+// globalParams / buildRefs / buildRefsKey and the kind sets live in
+// utils/queryPlan.js (pure, unit-tested); this file owns the React state that
+// feeds them.
 
 /**
- * Map the dashboard filter bar -> the KpiQueryComposer param names.
- * Mirrors config/kpiQueries.js buildGlobalApiFilters: an active date range maps
- * to dateFrom/dateTo (yyyy-MM-dd, which the composer turns into a gte/lt on the
- * grain's time column and which drops the def's base window); a non-"all"
- * geography/complaintType narrows via ward/serviceCode. No global `window` is
- * emitted, so each def keeps its own baked window when no range is active —
- * exactly the reference path's behaviour.
+ * Per-widget "Group by" hierarchy-level overrides (#1111 PR2), persisted like
+ * the saved layout: localStorage, kpiId-keyed. NOT part of `filters` state on
+ * purpose — a Group-by level is structurally NOT a filter: it changes the
+ * widget's own aggregation dimension (which hierarchy level the service_code
+ * buckets roll up to), never which complaints qualify. Hierarchy FILTERS were
+ * built and deliberately abandoned; this control must stay out of the filter
+ * store so it can never be mistaken for (or grow into) one.
  */
-function globalParams(filters) {
-  const params = {};
-  if (filters?.geography && filters.geography !== "all") {
-    params.ward = filters.geography;
+const HIER_OVERRIDES_STORAGE_KEY = "ccrs.dashboard.hier-level-overrides.v1";
+
+function readHierOverrides() {
+  try {
+    const raw = window.localStorage?.getItem(HIER_OVERRIDES_STORAGE_KEY);
+    const parsed = raw ? JSON.parse(raw) : null;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
   }
-  if (filters?.complaintType && filters.complaintType !== "all") {
-    params.serviceCode = filters.complaintType;
-  }
-  if (filters?.dateRangeActive && filters?.dateFrom && filters?.dateTo) {
-    params.dateFrom = filters.dateFrom; // yyyy-MM-dd
-    params.dateTo = filters.dateTo; // yyyy-MM-dd
-  }
-  return params;
 }
 
-/**
- * Build the per-tile refs map for runKpiBatch. The tileKey convention is:
- *   <kpiId>           base query (global params applied)
- *   <kpiId>__prior    delta cards: same params + compare:'prior'
- *   <kpiId>__series   sparkline cards: same params + series:'daily'
- *
- * The prior/series refs are gated on viz.kind (the only series signal exposed by
- * the catalog tile — supportsSeries is not serialised), so non-card tiles only
- * issue the single base query.
- */
-function buildRefs(tiles, kpis, filters) {
-  const gp = globalParams(filters);
-  const refs = {};
-  for (const tile of tiles) {
-    const kpiId = tile.kpiId;
-    const def = kpis[kpiId];
-    if (!def) continue;
-    const kind = def.viz?.kind;
-
-    refs[kpiId] = { kpiId, params: { ...gp } };
-
-    if (isCardKind(kind)) {
-      refs[`${kpiId}__prior`] = { kpiId, params: { ...gp, compare: "prior" } };
-    }
-    if (isSparklineKind(kind)) {
-      refs[`${kpiId}__series`] = { kpiId, params: { ...gp, series: "daily" } };
-    }
-    if (isMapKind(kind)) {
-      // Per-complaint pins (same filters/scope) overlaid on the ward choropleth.
-      refs[`${kpiId}__pins`] = { kpiId: PIN_KPI_ID, params: { ...gp } };
-    }
+function persistHierOverrides(overrides) {
+  try {
+    window.localStorage?.setItem(HIER_OVERRIDES_STORAGE_KEY, JSON.stringify(overrides));
+  } catch {
+    /* ignore quota/serialisation errors — override state is non-critical */
   }
-  return refs;
 }
 
 /**
@@ -350,6 +313,30 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
   const { loading: catalogLoading, kpis, pack, error: catalogError } =
     useCatalog(tenantId);
 
+  // Deployment complaint-hierarchy levels for the per-widget "Group by"
+  // control. NO_HIERARCHY-shaped until the fetch resolves (control hidden).
+  const [hierarchy, setHierarchy] = useState(null);
+  useEffect(() => {
+    let cancelled = false;
+    fetchComplaintHierarchyLevels().then((h) => {
+      if (!cancelled) setHierarchy(h);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Per-widget hierLevel overrides — see the module comment on
+  // HIER_OVERRIDES_STORAGE_KEY for why this is NOT in `filters`.
+  const [hierOverrides, setHierOverrides] = useState(readHierOverrides);
+  const setHierLevelOverride = useCallback((kpiId, value) => {
+    setHierOverrides((prev) => {
+      const next = { ...prev, [kpiId]: value };
+      persistHierOverrides(next);
+      return next;
+    });
+  }, []);
+
   const [batch, setBatch] = useState({
     loading: true,
     results: {},
@@ -407,18 +394,14 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
     [kpis, language, i18nTick]
   );
 
-  // Re-run the batch whenever the catalog resolves or the filters change.
-  // Include each tile's viz.kind: it drives buildRefs' __prior/__series companion
-  // refs, so a def flipping card<->chart (or gaining sparkline) must re-trigger the
-  // batch even when the id set and global params are unchanged.
+  // Re-run the batch whenever the catalog resolves, the filters change, or a
+  // per-widget "Group by" override changes. buildRefsKey includes each tile's
+  // viz.kind (a def flipping card<->chart must re-trigger even when ids/params
+  // are unchanged) AND the applied hierLevel overrides (R7c — without them a
+  // Group-by change would never refire this effect).
   const refsKey = useMemo(
-    () =>
-      JSON.stringify({
-        ids: tiles.map((t) => t.kpiId),
-        kinds: tiles.map((t) => kpis[t.kpiId]?.viz?.kind),
-        gp: globalParams(filters),
-      }),
-    [tiles, filters, kpis]
+    () => buildRefsKey(tiles, kpis, filters, hierOverrides),
+    [tiles, filters, kpis, hierOverrides]
   );
 
   useEffect(() => {
@@ -426,7 +409,7 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
       setBatch({ loading: false, results: {}, errors: null, partial: false });
       return;
     }
-    const refs = buildRefs(tiles, kpis, filters);
+    const refs = buildRefs(tiles, kpis, filters, hierOverrides);
     const reqId = ++reqIdRef.current;
     setBatch((prev) => ({ ...prev, loading: true }));
 
@@ -468,7 +451,7 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
   // viz.kind-derived constraints), so the grid layout passes items through verbatim.
   const gridLayout = useMemo(() => layout, [layout]);
 
-  const renderTile = (kpiId) => {
+  const renderTile = (kpiId, groupBy = null) => {
     const def = kpis[kpiId];
     if (!def) return null;
 
@@ -483,8 +466,31 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
         results={batch.results}
         error={tileError}
         loading={batch.loading && !assembled}
+        groupBy={groupBy}
       />
     );
+  };
+
+  /**
+   * Group-by state for one widget: select options (null hides the control),
+   * the effective level shown in the select, and — when the effective level is
+   * non-leaf — the { level, label } info table tiles need to hide the
+   * service_group ("Type") column and relabel service_code (R4). The effective
+   * level mirrors the def's declared default even before the user touches the
+   * control, because the backend applies that default server-side.
+   */
+  const groupByStateFor = (kpiId) => {
+    const def = kpis[kpiId];
+    const param = hierLevelParam(def);
+    if (!param || !hierarchy?.hasHierarchy) return { options: null, value: null, info: null };
+    const options = buildGroupByOptions(hierarchy.levels, param);
+    if (!options) return { options: null, value: null, info: null };
+    const value = effectiveHierLevel(def, hierOverrides);
+    const level = value !== "leaf" ? hierarchy.levels[Number(value) - 1] : null;
+    const info = level
+      ? { level: value, label: levelDisplayLabel(level, hierarchy.hierarchyType) }
+      : null;
+    return { options, value, info };
   };
 
   // CSV export of the laid-out tiles (title + scalar value, or row count for
@@ -623,6 +629,11 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
             // the card tiles' KpiTile resolvers.
             const headerTitle = resolveTitle(kpis[item.i]) || item.i;
             const headerSubtitle = resolveSubtitle(viz);
+            // Per-widget "Group by" hierarchy-level control (#1111 PR2). Table
+            // kinds share this same header chrome (they are not selfHeaders),
+            // so one placement covers charts AND tables; card tiles never
+            // declare hierLevel and KpiTile carries no header of its own (R7b).
+            const groupBy = groupByStateFor(item.i);
             return (
               <section
                 key={item.i}
@@ -639,6 +650,14 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
                         <p className={SHARED_CHROME.dragHandleSubtitle}>{headerSubtitle}</p>
                       )}
                     </div>
+                    {groupBy.options && (
+                      <GroupByLevelSelect
+                        value={groupBy.value}
+                        options={groupBy.options}
+                        hierarchyType={hierarchy?.hierarchyType}
+                        onChange={(value) => setHierLevelOverride(item.i, value)}
+                      />
+                    )}
                   </header>
                 )}
                 <div
@@ -650,10 +669,10 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
                 >
                   {isTable ? (
                     <SubtleScroll className={getWidgetScrollClassName()}>
-                      {renderTile(item.i)}
+                      {renderTile(item.i, groupBy.info)}
                     </SubtleScroll>
                   ) : (
-                    renderTile(item.i)
+                    renderTile(item.i, groupBy.info)
                   )}
                 </div>
                 <CardUpdatedStamp label={lastUpdatedLabel} />

--- a/digit-ui-esbuild/products/dashboard/src/components/GroupByLevelSelect.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/GroupByLevelSelect.jsx
@@ -1,0 +1,66 @@
+import React from "react";
+import useDashboardT from "../i18n/useDashboardT";
+import { translate as t, exists } from "../i18n/localeRuntime";
+
+/**
+ * Per-widget "Group by" hierarchy-level control (#1111 PR2).
+ *
+ * A compact select rendered in the widget header's title row (right-aligned)
+ * for tiles whose KPI def declares the `hierLevel` param on a tenant with a
+ * usable complaint hierarchy. Options come from buildGroupByOptions
+ * (definition levels + Leaf); the RGL draggableCancel whitelist already
+ * covers `select`, so interacting with it never starts a widget drag.
+ *
+ * This is deliberately NOT a dashboard filter: it changes the widget's own
+ * aggregation dimension (which level the service_code buckets roll up to),
+ * never which complaints qualify.
+ */
+
+/**
+ * Localized display name for a hierarchy level. Resolution mirrors the
+ * dashboard's key-wins-else-data-owned convention:
+ *   1. dashboard-owned DASHBOARD_GROUPBY_LEVEL_<LEVELCODE> (seeded pack)
+ *   2. the PGR pages' <HIERARCHYTYPE>_<LEVELCODE> convention (operator-seeded)
+ *   3. the definition's data-owned label (when it isn't just the raw code)
+ *   4. the raw levelCode — a visible localisation gap, not a humanised guess
+ */
+export function levelDisplayLabel(level, hierarchyType) {
+  if (!level) return "";
+  const code = String(level.levelCode || "");
+  const own = `DASHBOARD_GROUPBY_LEVEL_${code.toUpperCase()}`;
+  if (exists(own)) return t(own);
+  if (hierarchyType) {
+    const pgrKey = `${String(hierarchyType)}_${code}`.toUpperCase();
+    if (exists(pgrKey)) return t(pgrKey);
+  }
+  if (level.label && level.label !== code) return level.label;
+  return code;
+}
+
+const GroupByLevelSelect = ({ value, options, hierarchyType, onChange }) => {
+  // Subscribes the control to language/bundle changes so option labels
+  // re-resolve on a language switch.
+  const { t: tt } = useDashboardT();
+  const label = tt("DASHBOARD_GROUPBY_LABEL", "Group by");
+  return (
+    <span className="dashboard-filter-inline-select-wrap tw-ml-2 tw-mr-6">
+      <select
+        className="dashboard-filter-inline-select tw-min-w-0"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        aria-label={label}
+        title={label}
+      >
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.leaf
+              ? tt("DASHBOARD_GROUPBY_LEAF", "Leaf")
+              : levelDisplayLabel(opt.level, hierarchyType)}
+          </option>
+        ))}
+      </select>
+    </span>
+  );
+};
+
+export default GroupByLevelSelect;

--- a/digit-ui-esbuild/products/dashboard/src/components/KpiTile.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/KpiTile.jsx
@@ -10,6 +10,7 @@ import DashboardTable from './DashboardTable';
 import ComplaintsAtRiskTable from './ComplaintsAtRiskTable';
 import OpenComplaintsByGeographyWidget from './OpenComplaintsByGeographyWidget';
 import { evaluateCompose } from '../utils/composeKpi';
+import { applyGroupByToColumns } from '../utils/hierLevelGrouping';
 import { getNumberTileDeltaClass, formatOfficerLabel, dimensionKindForName } from '../config/kpiDisplay';
 import {
   resolveSlaRiskPresentation,
@@ -57,8 +58,13 @@ import { resolveTitle, resolveSubtitle, seriesEntryLabel, resolveSeriesLabel } f
  * - vizOverride: optional user-chosen viz kind
  * - loading: pass-through loading flag for the child components
  * - onRemove: pass-through remove handler for card chrome
+ * - groupBy: { level, label } | null — the widget's effective non-leaf
+ *   "Group by" hierarchy level (#1111 PR2). The backend already aliases the
+ *   level code back AS service_code, so charts need nothing; table kinds use
+ *   this to drop the now-redundant service_group column and relabel the
+ *   service_code column to the level's name.
  */
-export function KpiTile({ def, result, results, error, vizOverride, loading = false, onRemove }) {
+export function KpiTile({ def, result, results, error, vizOverride, loading = false, onRemove, groupBy = null }) {
   // Subscribes the whole tile to language/bundle changes so every label
   // computed below re-renders on a language switch.
   const { language } = useDashboardT();
@@ -82,7 +88,7 @@ export function KpiTile({ def, result, results, error, vizOverride, loading = fa
   }
 
   const kind = vizOverride || viz.kind || 'scalar';
-  const ctx = { def, viz, result, results, title, loading, onRemove, locale: language?.replace('_', '-') };
+  const ctx = { def, viz, result, results, title, loading, onRemove, groupBy, locale: language?.replace('_', '-') };
 
   const content = renderByKind(kind, ctx);
 
@@ -740,8 +746,13 @@ function renderLine(ctx) {
 // ---------------------------------------------------------------------------
 
 function renderTable(ctx) {
-  const { viz, result, loading } = ctx;
-  const columns = viz.columns || deriveColumnsFromResult(result);
+  const { viz, result, loading, groupBy } = ctx;
+  // #1111 PR2 (R4): at a non-leaf "Group by" level, drop the redundant
+  // service_group ("Type") column and relabel service_code to the level's
+  // name — see applyGroupByToColumns. The ideal_sla_ms avg-of-heterogeneous-
+  // SLAs caveat at non-leaf levels is documented in the KPI catalog docs
+  // (PR1), not surfaced in-cell.
+  const columns = applyGroupByToColumns(viz.columns || deriveColumnsFromResult(result), groupBy);
   const rows = result.rows || [];
   if (loading && !rows.length) return <Placeholder message={t("DASHBOARD_COMMON_LOADING", "Loading…")} />;
   return <DashboardTable columns={columns} rows={rows} emptyMessage={viz.emptyMessage || t("DASHBOARD_COMMON_NO_DATA", "No data")} />;

--- a/digit-ui-esbuild/products/dashboard/src/services/complaintHierarchyService.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/complaintHierarchyService.js
@@ -1,4 +1,5 @@
 import { getTenantId, hasAuth } from "./analyticsService";
+import { selectHierarchyDefinition, orderedLevels } from "../utils/hierLevelGrouping";
 
 /**
  * MDMS context path from globalConfigs (deployments serve MDMS under
@@ -145,5 +146,86 @@ export async function fetchComplaintTypeIndex() {
   } catch (error) {
     console.warn("egov-mdms-service ComplaintHierarchy _search error", error);
     return null;
+  }
+}
+
+/**
+ * The deployment's complaint hierarchyType pin. Optional globalConfigs key —
+ * ke's MDMS carries BOTH a "PGR" (2-level) and a "PGR_TEST" (4-level)
+ * ComplaintHierarchyDefinition, and only the deployment knows which one its
+ * complaints are coded against. Unset → selectHierarchyDefinition falls back
+ * to the rows-backed heuristic the PGR complaint pages use.
+ */
+function getComplaintHierarchyTypePin() {
+  const get = window.globalConfigs?.getConfig?.bind(window.globalConfigs);
+  const pin = get?.("COMPLAINT_HIERARCHY_TYPE");
+  return pin ? String(pin) : "";
+}
+
+const NO_HIERARCHY = Object.freeze({ hasHierarchy: false, hierarchyType: null, levels: [] });
+
+/**
+ * Fetch the deployment's complaint-hierarchy LEVELS for the per-widget
+ * "Group by" control (#1111 PR2): ComplaintHierarchyDefinition (level order +
+ * names) scoped to the deployment's hierarchyType, alongside the
+ * ComplaintHierarchy rows needed to pick the live definition when no
+ * COMPLAINT_HIERARCHY_TYPE pin is configured.
+ *
+ * Returns { hasHierarchy, hierarchyType, levels:[{ levelCode, label, order,
+ * isLeafServiceCode }] }; hasHierarchy is false when the tenant has no usable
+ * definition (flat/legacy tenant) so callers hide the control. Resolves the
+ * NO_HIERARCHY shape on any failure (never rejects).
+ */
+export async function fetchComplaintHierarchyLevels() {
+  if (!hasAuth()) return NO_HIERARCHY;
+
+  try {
+    const response = await fetch(getMdmsSearchUrl(), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "omit",
+      body: JSON.stringify({
+        RequestInfo: buildRequestInfo(),
+        MdmsCriteria: {
+          tenantId: getTenantId(),
+          moduleDetails: [
+            {
+              moduleName: "RAINMAKER-PGR",
+              masterDetails: [
+                { name: "ComplaintHierarchyDefinition" },
+                { name: "ComplaintHierarchy" },
+              ],
+            },
+          ],
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      console.warn(
+        `egov-mdms-service ComplaintHierarchyDefinition _search failed (${response.status})`
+      );
+      return NO_HIERARCHY;
+    }
+
+    const payload = await response.json();
+    const pgr = payload?.MdmsRes?.["RAINMAKER-PGR"] || {};
+    const definition = selectHierarchyDefinition(
+      pgr.ComplaintHierarchyDefinition,
+      pgr.ComplaintHierarchy,
+      getComplaintHierarchyTypePin()
+    );
+    if (!definition) return NO_HIERARCHY;
+
+    const levels = orderedLevels(definition);
+    if (!levels.length) return NO_HIERARCHY;
+    return {
+      hasHierarchy: true,
+      hierarchyType: definition.hierarchyType ?? null,
+      levels,
+    };
+  } catch (error) {
+    console.warn("egov-mdms-service ComplaintHierarchyDefinition _search error", error);
+    return NO_HIERARCHY;
   }
 }

--- a/digit-ui-esbuild/products/dashboard/src/utils/hierLevelGrouping.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/hierLevelGrouping.js
@@ -1,0 +1,165 @@
+/**
+ * Pure helpers for the per-widget "Group by" hierarchy-level control (#1111 PR2).
+ *
+ * A KPI definition opts into hierarchy grouping by declaring a `hierLevel`
+ * params entry ({ name:"hierLevel", allowed:["leaf","1",...], default }) — the
+ * backend KpiQueryComposer rewrites the `service_code` dimension to the chosen
+ * hierarchy level at query time and aliases the level code back AS
+ * `service_code`, so the FE viz contract (dimensionKey, columns, sort) is
+ * unchanged. These helpers own the FE side of that contract:
+ *
+ *   - which ComplaintHierarchyDefinition applies to this deployment,
+ *   - which "Group by" options a tile offers,
+ *   - which hierLevel value is in effect / must be sent for a tile.
+ *
+ * Everything here is pure (no fetch, no window) so it is unit-testable with
+ * node --test; complaintHierarchyService.js does the MDMS fetch and
+ * AdminDashboard.jsx owns the override state.
+ */
+
+/** The tile's declared hierLevel params entry, or null when it doesn't opt in. */
+export function hierLevelParam(def) {
+  const params = Array.isArray(def?.params) ? def.params : [];
+  return params.find((p) => p && p.name === "hierLevel") || null;
+}
+
+function allowedList(param) {
+  return Array.isArray(param?.allowed) && param.allowed.length
+    ? param.allowed.map(String)
+    : null;
+}
+
+function overrideFor(def, overrides) {
+  const param = hierLevelParam(def);
+  if (!param) return null;
+  const kpiId = def?.kpiId ?? def?.id;
+  const raw = overrides && kpiId != null ? overrides[kpiId] : null;
+  if (raw == null || raw === "") return null;
+  const value = String(raw);
+  // Drop stale saved values the def no longer allows (seed drift) instead of
+  // sending a param the backend's allowed-list validation would reject.
+  const allowed = allowedList(param);
+  if (allowed && !allowed.includes(value)) return null;
+  return value;
+}
+
+/**
+ * The hierLevel value to SEND for this tile: the user's valid override, else
+ * null (the backend applies the def's declared default itself — sending
+ * nothing keeps the wire identical to today for untouched tiles).
+ */
+export function appliedHierLevel(def, overrides) {
+  return overrideFor(def, overrides);
+}
+
+/**
+ * The hierLevel value in EFFECT for this tile (what the select shows and what
+ * the table columns must reflect): the valid override, else the def's declared
+ * default, else "leaf". Null when the def doesn't declare hierLevel.
+ */
+export function effectiveHierLevel(def, overrides) {
+  const param = hierLevelParam(def);
+  if (!param) return null;
+  return overrideFor(def, overrides) || (param.default != null ? String(param.default) : "leaf");
+}
+
+/**
+ * Pick the ComplaintHierarchyDefinition this deployment's dashboard groups by.
+ *
+ * `pinnedType` (globalConfigs COMPLAINT_HIERARCHY_TYPE) wins when set — ke
+ * carries BOTH a "PGR" 2-level and a "PGR_TEST" 4-level definition, and only
+ * the deployment knows which one its complaints are actually coded against.
+ * Without a pin, prefer the definition whose hierarchyType has the most
+ * ComplaintHierarchy rows behind it (the live tree, not a test stub) — the
+ * same rows-backed heuristic the PGR complaint pages use — else the first
+ * active definition.
+ */
+export function selectHierarchyDefinition(definitions, rows, pinnedType) {
+  const defs = (Array.isArray(definitions) ? definitions : []).filter(
+    (d) => d && d.active !== false
+  );
+  if (!defs.length) return null;
+  if (pinnedType) {
+    return defs.find((d) => String(d.hierarchyType) === String(pinnedType)) || null;
+  }
+  const allRows = Array.isArray(rows) ? rows : [];
+  const counts = new Map();
+  for (const n of allRows) {
+    if (!n || n.active === false) continue;
+    const type = n.hierarchyType;
+    counts.set(type, (counts.get(type) || 0) + 1);
+  }
+  let best = null;
+  let bestCount = 0;
+  for (const d of defs) {
+    const c = counts.get(d.hierarchyType) || 0;
+    if (c > bestCount) {
+      best = d;
+      bestCount = c;
+    }
+  }
+  return best || defs[0];
+}
+
+/** Ordered levels [{ levelCode, label, order, isLeafServiceCode }] of a definition. */
+export function orderedLevels(definition) {
+  return [...(definition?.levels || [])]
+    .filter((l) => l && l.levelCode != null)
+    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+    .map((l) => ({
+      levelCode: String(l.levelCode),
+      label: l.label,
+      order: l.order,
+      isLeafServiceCode: !!l.isLeafServiceCode,
+    }));
+}
+
+/**
+ * Build the "Group by" select options for one tile:
+ *   [{ value:"1", level }, ..., { value:"leaf", leaf:true }]
+ *
+ * - Only non-leaf levels are offered by level number: the leaf service-code
+ *   level (isLeafServiceCode, else the deepest level) IS what "Leaf" means —
+ *   listing it again would duplicate the Leaf option (bomet's live 2-level
+ *   PGR tree: level 2 == leaf, so the demo contrast is level 1 vs Leaf).
+ * - Each level number must pass the def's allowed list (when declared) so the
+ *   select never offers a value the backend would reject.
+ *
+ * Returns null when there is nothing to choose (no param, <2 usable options).
+ */
+export function buildGroupByOptions(levels, param) {
+  if (!param || !Array.isArray(levels) || levels.length < 2) return null;
+  const allowed = allowedList(param);
+  const leafFlagIdx = levels.findIndex((l) => l.isLeafServiceCode);
+  const cut = leafFlagIdx >= 0 ? leafFlagIdx : levels.length - 1;
+
+  const options = [];
+  for (let i = 0; i < cut; i++) {
+    const value = String(i + 1);
+    if (allowed && !allowed.includes(value)) continue;
+    options.push({ value, level: levels[i] });
+  }
+  if (!allowed || allowed.includes("leaf")) {
+    options.push({ value: "leaf", leaf: true });
+  }
+  return options.length >= 2 ? options : null;
+}
+
+/**
+ * Table-kind column shaping at a non-leaf "Group by" level (R4). Every row is
+ * then a hierarchy-level bucket (the backend aliases the level code back AS
+ * `service_code`), so the service_group ("Type") column would duplicate
+ * (level 1) or cross-cut (deeper levels) the grouped dimension — drop it, and
+ * relabel the service_code column to the selected level's display name
+ * (labelKey stripped so the computed label wins in TableSortHeader).
+ *
+ * `groupBy` is { level, label } or null (leaf/no grouping → columns untouched).
+ */
+export function applyGroupByToColumns(columns, groupBy) {
+  if (!groupBy || !Array.isArray(columns)) return columns;
+  return columns
+    .filter((c) => c.id !== "service_group")
+    .map((c) =>
+      c.id === "service_code" ? { ...c, label: groupBy.label, labelKey: undefined } : c
+    );
+}

--- a/digit-ui-esbuild/products/dashboard/src/utils/hierLevelGrouping.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/hierLevelGrouping.test.js
@@ -1,0 +1,284 @@
+// Unit tests for the per-widget "Group by" hierarchy-level control (#1111 PR2).
+// Run from digit-ui-esbuild/:  node --test products/dashboard/src/utils/hierLevelGrouping.test.js
+//
+// The modules under test are ESM (like the rest of products/), so the test
+// bundles them to CJS with the repo's own esbuild — the same idiom as
+// src/theme/applyTheme.test.js and dashboardMetrics.test.js (#1110).
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const esbuild = require("esbuild");
+
+function bundle(entry) {
+  const out = path.join(
+    os.tmpdir(),
+    `${path.basename(entry, ".js")}.cjs.${process.pid}.js`
+  );
+  esbuild.buildSync({
+    entryPoints: [path.join(__dirname, entry)],
+    bundle: true,
+    format: "cjs",
+    platform: "neutral",
+    outfile: out,
+  });
+  process.on("exit", () => {
+    try {
+      fs.unlinkSync(out);
+    } catch (e) {
+      /* already gone */
+    }
+  });
+  return require(out);
+}
+
+const {
+  hierLevelParam,
+  appliedHierLevel,
+  effectiveHierLevel,
+  selectHierarchyDefinition,
+  orderedLevels,
+  buildGroupByOptions,
+  applyGroupByToColumns,
+} = bundle("hierLevelGrouping.js");
+
+const { buildRefs, buildRefsKey, globalParams } = bundle("queryPlan.js");
+
+/* ------------------------------------------------------------------ */
+/* Fixtures                                                            */
+/* ------------------------------------------------------------------ */
+
+const HIER_PARAM = { name: "hierLevel", allowed: ["leaf", "1", "2", "3", "4"], default: "1" };
+
+const chartDef = (kpiId, extra = {}) => ({
+  kpiId,
+  viz: { kind: "stacked-bar", dimensionKey: "service_code" },
+  params: [{ name: "window", default: "last_7d", allowed: ["last_7d"] }, HIER_PARAM],
+  ...extra,
+});
+
+const cardDef = (kpiId) => ({
+  kpiId,
+  viz: { kind: "number-tile-sparkline" },
+  params: [{ name: "window", default: "last_7d", allowed: ["last_7d"] }],
+});
+
+const LEVELS_3 = [
+  { levelCode: "CATEGORY", label: "Category", order: 1, isLeafServiceCode: false },
+  { levelCode: "SECTOR", label: "SECTOR", order: 2, isLeafServiceCode: false },
+  { levelCode: "SUB_TYPE", label: "Sub-Type", order: 3, isLeafServiceCode: true },
+];
+
+/* ------------------------------------------------------------------ */
+/* Param declaration + effective/applied value                         */
+/* ------------------------------------------------------------------ */
+
+test("hierLevelParam: only defs declaring the param opt in", () => {
+  assert.equal(hierLevelParam(cardDef("c1")), null);
+  assert.deepEqual(hierLevelParam(chartDef("t1")), HIER_PARAM);
+  assert.equal(hierLevelParam(null), null);
+});
+
+test("appliedHierLevel: sends only a valid stored override, never the default", () => {
+  const def = chartDef("t1");
+  // no override -> nothing sent (backend applies the def default itself)
+  assert.equal(appliedHierLevel(def, {}), null);
+  assert.equal(appliedHierLevel(def, null), null);
+  // valid override -> sent verbatim (including an explicit "leaf" that must
+  // beat the def's non-leaf default server-side)
+  assert.equal(appliedHierLevel(def, { t1: "2" }), "2");
+  assert.equal(appliedHierLevel(def, { t1: "leaf" }), "leaf");
+  // stale override outside the allowed list -> dropped, not sent
+  assert.equal(appliedHierLevel(def, { t1: "9" }), null);
+  // overrides for OTHER tiles never leak
+  assert.equal(appliedHierLevel(def, { other: "2" }), null);
+  // defs without the param ignore overrides entirely (stale key after a seed change)
+  assert.equal(appliedHierLevel(cardDef("c1"), { c1: "2" }), null);
+});
+
+test("effectiveHierLevel: override wins, else declared default, else leaf", () => {
+  const def = chartDef("t1");
+  assert.equal(effectiveHierLevel(def, { t1: "2" }), "2");
+  assert.equal(effectiveHierLevel(def, {}), "1"); // declared default mirrors the server
+  const noDefault = chartDef("t2");
+  noDefault.params = [{ name: "hierLevel", allowed: ["leaf", "1"] }];
+  assert.equal(effectiveHierLevel(noDefault, {}), "leaf");
+  assert.equal(effectiveHierLevel(cardDef("c1"), {}), null);
+});
+
+/* ------------------------------------------------------------------ */
+/* Definition selection (R7a)                                          */
+/* ------------------------------------------------------------------ */
+
+const DEF_PGR = { hierarchyType: "PGR", active: true, levels: LEVELS_3.slice(0, 2) };
+const DEF_TEST = { hierarchyType: "PGR_TEST", active: true, levels: LEVELS_3 };
+
+test("selectHierarchyDefinition: globalConfigs pin wins over everything", () => {
+  const rows = [{ hierarchyType: "PGR_TEST" }]; // rows would pick PGR_TEST
+  assert.equal(selectHierarchyDefinition([DEF_PGR, DEF_TEST], rows, "PGR"), DEF_PGR);
+  // pinned type absent from MDMS -> no hierarchy (control stays hidden)
+  assert.equal(selectHierarchyDefinition([DEF_PGR, DEF_TEST], rows, "NOPE"), null);
+});
+
+test("selectHierarchyDefinition: without a pin the rows-backed definition wins (most rows)", () => {
+  const rows = [
+    { hierarchyType: "PGR" },
+    { hierarchyType: "PGR" },
+    { hierarchyType: "PGR_TEST" },
+  ];
+  assert.equal(selectHierarchyDefinition([DEF_TEST, DEF_PGR], rows, ""), DEF_PGR);
+  // no rows at all -> first active definition
+  assert.equal(selectHierarchyDefinition([DEF_TEST, DEF_PGR], [], ""), DEF_TEST);
+  // inactive definitions are never picked
+  assert.equal(
+    selectHierarchyDefinition([{ ...DEF_PGR, active: false }], rows, ""),
+    null
+  );
+  assert.equal(selectHierarchyDefinition([], rows, ""), null);
+});
+
+test("orderedLevels: sorted by order, codes stringified", () => {
+  const shuffled = [LEVELS_3[2], LEVELS_3[0], LEVELS_3[1]];
+  const levels = orderedLevels({ levels: shuffled });
+  assert.deepEqual(
+    levels.map((l) => l.levelCode),
+    ["CATEGORY", "SECTOR", "SUB_TYPE"]
+  );
+  assert.equal(levels[2].isLeafServiceCode, true);
+  assert.deepEqual(orderedLevels(null), []);
+});
+
+/* ------------------------------------------------------------------ */
+/* Control visibility / options                                        */
+/* ------------------------------------------------------------------ */
+
+test("buildGroupByOptions: non-leaf levels by number + Leaf; leaf level never duplicated", () => {
+  const opts = buildGroupByOptions(orderedLevels({ levels: LEVELS_3 }), HIER_PARAM);
+  assert.deepEqual(
+    opts.map((o) => o.value),
+    ["1", "2", "leaf"]
+  );
+  assert.equal(opts[0].level.levelCode, "CATEGORY");
+  assert.equal(opts[2].leaf, true);
+});
+
+test("buildGroupByOptions: bomet-shaped 2-level tree offers level 1 vs Leaf", () => {
+  const twoLevels = orderedLevels({ levels: LEVELS_3.filter((l) => l.levelCode !== "SECTOR") });
+  const opts = buildGroupByOptions(twoLevels, HIER_PARAM);
+  assert.deepEqual(
+    opts.map((o) => o.value),
+    ["1", "leaf"]
+  );
+});
+
+test("buildGroupByOptions: hidden when there is nothing to choose", () => {
+  // no param declared
+  assert.equal(buildGroupByOptions(orderedLevels({ levels: LEVELS_3 }), null), null);
+  // flat/one-level tenant
+  assert.equal(buildGroupByOptions([], HIER_PARAM), null);
+  assert.equal(buildGroupByOptions([LEVELS_3[2]], HIER_PARAM), null);
+  // allowed list excludes every non-leaf level -> only Leaf would remain
+  const leafOnly = { name: "hierLevel", allowed: ["leaf"] };
+  assert.equal(buildGroupByOptions(orderedLevels({ levels: LEVELS_3 }), leafOnly), null);
+});
+
+test("buildGroupByOptions: allowed list filters level numbers", () => {
+  const param = { name: "hierLevel", allowed: ["leaf", "2"] };
+  const opts = buildGroupByOptions(orderedLevels({ levels: LEVELS_3 }), param);
+  assert.deepEqual(
+    opts.map((o) => o.value),
+    ["2", "leaf"]
+  );
+});
+
+/* ------------------------------------------------------------------ */
+/* Table columns at a non-leaf level (R4)                              */
+/* ------------------------------------------------------------------ */
+
+const TABLE_COLUMNS = [
+  { id: "service_code", label: "Subtype", labelKey: "DASHBOARD_COL_SUBTYPE", align: "left" },
+  { id: "service_group", label: "Type", labelKey: "DASHBOARD_COL_TYPE", align: "left" },
+  { id: "avg_resolution_ms", label: "Avg resolution time", align: "left" },
+];
+
+test("applyGroupByToColumns: drops service_group and relabels service_code (labelKey stripped)", () => {
+  const cols = applyGroupByToColumns(TABLE_COLUMNS, { level: "1", label: "Category" });
+  assert.deepEqual(
+    cols.map((c) => c.id),
+    ["service_code", "avg_resolution_ms"]
+  );
+  assert.equal(cols[0].label, "Category");
+  assert.equal(cols[0].labelKey, undefined); // else the old key would win in TableSortHeader
+  // measure columns pass through untouched (same object)
+  assert.equal(cols[1], TABLE_COLUMNS[2]);
+});
+
+test("applyGroupByToColumns: leaf/no grouping leaves columns untouched", () => {
+  assert.equal(applyGroupByToColumns(TABLE_COLUMNS, null), TABLE_COLUMNS);
+});
+
+/* ------------------------------------------------------------------ */
+/* Override merge into refs + refsKey refire (R7c)                     */
+/* ------------------------------------------------------------------ */
+
+const FILTERS = { geography: "WARD1", complaintType: "all", dateRangeActive: false };
+
+test("buildRefs: override merges into the tile's params BEFORE the companion spreads", () => {
+  const kpis = {
+    chart: chartDef("chart"),
+    spark: { ...cardDef("spark"), params: [HIER_PARAM] }, // hypothetical card declaring hierLevel
+    map: { kpiId: "map", viz: { kind: "map" }, params: [HIER_PARAM] },
+  };
+  const tiles = [{ kpiId: "chart" }, { kpiId: "spark" }, { kpiId: "map" }];
+  const overrides = { chart: "2", spark: "2", map: "2" };
+  const refs = buildRefs(tiles, kpis, FILTERS, overrides);
+
+  assert.deepEqual(refs.chart.params, { ward: "WARD1", hierLevel: "2" });
+  // companions AUTO-INHERIT the override (spread comes after the merge)…
+  assert.deepEqual(refs.spark__prior.params, { ward: "WARD1", hierLevel: "2", compare: "prior" });
+  assert.deepEqual(refs.spark__series.params, { ward: "WARD1", hierLevel: "2", series: "daily" });
+  assert.deepEqual(refs.map__pins.params, { ward: "WARD1", hierLevel: "2" });
+  // …and the companion's own marker can never be clobbered by the merge
+  assert.equal(refs.spark__prior.params.compare, "prior");
+});
+
+test("buildRefs: tiles without the param (or without an override) send no hierLevel", () => {
+  const kpis = { chart: chartDef("chart"), card: cardDef("card") };
+  const tiles = [{ kpiId: "chart" }, { kpiId: "card" }];
+  // stale override for a def that does not declare the param
+  const refs = buildRefs(tiles, kpis, FILTERS, { card: "2" });
+  assert.deepEqual(refs.chart.params, { ward: "WARD1" }); // default is server-side
+  assert.deepEqual(refs.card.params, { ward: "WARD1" });
+  assert.equal("hierLevel" in refs.card__prior.params, false);
+});
+
+test("buildRefsKey: a Group-by change refires the batch effect; unrelated overrides don't", () => {
+  const kpis = { chart: chartDef("chart"), card: cardDef("card") };
+  const tiles = [{ kpiId: "chart" }, { kpiId: "card" }];
+  const before = buildRefsKey(tiles, kpis, FILTERS, {});
+  const after = buildRefsKey(tiles, kpis, FILTERS, { chart: "2" });
+  assert.notEqual(before, after); // R7c: without this the effect never refires
+  // explicit "leaf" override beats a non-leaf default -> must also refire
+  const leaf = buildRefsKey(tiles, kpis, FILTERS, { chart: "leaf" });
+  assert.notEqual(before, leaf);
+  // an override on a tile that can't use it does not thrash the batch
+  const stale = buildRefsKey(tiles, kpis, FILTERS, { card: "2" });
+  assert.equal(before, stale);
+});
+
+test("globalParams: unchanged filter mapping (regression guard for the extraction)", () => {
+  assert.deepEqual(globalParams(null), {});
+  assert.deepEqual(
+    globalParams({
+      geography: "W2",
+      complaintType: "CT",
+      dateRangeActive: true,
+      dateFrom: "2026-07-01",
+      dateTo: "2026-07-10",
+    }),
+    { ward: "W2", serviceCode: "CT", dateFrom: "2026-07-01", dateTo: "2026-07-10" }
+  );
+  assert.deepEqual(globalParams({ geography: "all", complaintType: "all" }), {});
+});

--- a/digit-ui-esbuild/products/dashboard/src/utils/queryPlan.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/queryPlan.js
@@ -1,0 +1,122 @@
+import { appliedHierLevel } from "./hierLevelGrouping";
+
+/**
+ * Query-plan helpers for the catalog dashboard (extracted from
+ * AdminDashboard.jsx so the ref-building logic is pure and unit-testable).
+ *
+ * The tileKey convention for runKpiBatch refs:
+ *   <kpiId>           base query (global params applied)
+ *   <kpiId>__prior    delta cards: same params + compare:'prior'
+ *   <kpiId>__series   sparkline cards: same params + series:'daily'
+ *   <kpiId>__pins     map tiles: the per-complaint pin companion source
+ */
+
+export const CARD_KINDS = new Set([
+  "number-tile-delta",
+  "number-tile",
+  "scalar",
+  "number-tile-sparkline",
+  "sparkline-card",
+]);
+export const SPARKLINE_KINDS = new Set(["number-tile-sparkline", "sparkline-card"]);
+export const MAP_KINDS = new Set(["map", "choropleth-map"]);
+
+// The internal pin source: map tiles fetch this alongside their ward aggregates
+// to overlay per-complaint pins (the FE map widget has the pin layer; this feeds it).
+export const PIN_KPI_ID = "cl_map_complaint_pins";
+
+export function isCardKind(kind) {
+  return CARD_KINDS.has(kind);
+}
+export function isSparklineKind(kind) {
+  return SPARKLINE_KINDS.has(kind);
+}
+export function isMapKind(kind) {
+  return MAP_KINDS.has(kind);
+}
+
+/**
+ * Map the dashboard filter bar -> the KpiQueryComposer param names.
+ * Mirrors config/kpiQueries.js buildGlobalApiFilters: an active date range maps
+ * to dateFrom/dateTo (yyyy-MM-dd, which the composer turns into a gte/lt on the
+ * grain's time column and which drops the def's base window); a non-"all"
+ * geography/complaintType narrows via ward/serviceCode. No global `window` is
+ * emitted, so each def keeps its own baked window when no range is active —
+ * exactly the reference path's behaviour.
+ */
+export function globalParams(filters) {
+  const params = {};
+  if (filters?.geography && filters.geography !== "all") {
+    params.ward = filters.geography;
+  }
+  if (filters?.complaintType && filters.complaintType !== "all") {
+    params.serviceCode = filters.complaintType;
+  }
+  if (filters?.dateRangeActive && filters?.dateFrom && filters?.dateTo) {
+    params.dateFrom = filters.dateFrom; // yyyy-MM-dd
+    params.dateTo = filters.dateTo; // yyyy-MM-dd
+  }
+  return params;
+}
+
+/**
+ * Per-tile base params: the global filter params plus — for tiles whose def
+ * declares the hierLevel param — the user's per-widget "Group by" override
+ * (#1111 PR2). The override merges HERE, before the companion-ref spreads in
+ * buildRefs, so __prior/__series/__pins inherit it automatically. When there
+ * is no (valid) override nothing is sent and the backend applies the def's
+ * declared default itself.
+ */
+export function tileParams(def, filters, hierOverrides) {
+  const gp = globalParams(filters);
+  const hierLevel = appliedHierLevel(def, hierOverrides);
+  return hierLevel ? { ...gp, hierLevel } : gp;
+}
+
+/**
+ * Build the per-tile refs map for runKpiBatch.
+ *
+ * The prior/series refs are gated on viz.kind (the only series signal exposed by
+ * the catalog tile — supportsSeries is not serialised), so non-card tiles only
+ * issue the single base query.
+ */
+export function buildRefs(tiles, kpis, filters, hierOverrides) {
+  const refs = {};
+  for (const tile of tiles) {
+    const kpiId = tile.kpiId;
+    const def = kpis[kpiId];
+    if (!def) continue;
+    const kind = def.viz?.kind;
+    const base = tileParams(def, filters, hierOverrides);
+
+    refs[kpiId] = { kpiId, params: { ...base } };
+
+    if (isCardKind(kind)) {
+      refs[`${kpiId}__prior`] = { kpiId, params: { ...base, compare: "prior" } };
+    }
+    if (isSparklineKind(kind)) {
+      refs[`${kpiId}__series`] = { kpiId, params: { ...base, series: "daily" } };
+    }
+    if (isMapKind(kind)) {
+      // Per-complaint pins (same filters/scope) overlaid on the ward choropleth.
+      refs[`${kpiId}__pins`] = { kpiId: PIN_KPI_ID, params: { ...base } };
+    }
+  }
+  return refs;
+}
+
+/**
+ * Serialisable fingerprint of everything buildRefs reads, used as the batch
+ * effect's dependency key. Includes each tile's viz.kind (a def flipping
+ * card<->chart must re-trigger even when ids/params are unchanged) AND each
+ * tile's applied hierLevel override — without the latter the batch effect
+ * would never refire on a "Group by" change (R7c).
+ */
+export function buildRefsKey(tiles, kpis, filters, hierOverrides) {
+  return JSON.stringify({
+    ids: tiles.map((t) => t.kpiId),
+    kinds: tiles.map((t) => kpis[t.kpiId]?.viz?.kind),
+    gp: globalParams(filters),
+    hier: tiles.map((t) => appliedHierLevel(kpis[t.kpiId], hierOverrides)),
+  });
+}

--- a/local-setup/ansible/templates/globalConfigs.js.j2
+++ b/local-setup/ansible/templates/globalConfigs.js.j2
@@ -45,6 +45,13 @@ var globalConfigs = (function () {
   var pgrBoundaryLowestLevel = {{ pgr_boundary_lowest_level | to_json }};
   var boundaryType = {{ boundary_type | to_json }};
   var hierarchyType = {{ hierarchy_type | default('ADMIN') | to_json }};
+  // COMPLAINT hierarchy pin (distinct from the boundary hierarchyType above):
+  // which RAINMAKER-PGR.ComplaintHierarchyDefinition the dashboard's per-widget
+  // "Group by" control enumerates. Optional — when empty the SPA resolves the
+  // definition whose hierarchyType actually has ComplaintHierarchy rows behind
+  // it. Set `complaint_hierarchy_type: PGR` in host_vars when the tenant
+  // carries multiple definitions (e.g. a live tree plus a test one).
+  var complaintHierarchyType = {{ complaint_hierarchy_type | default('') | to_json }};
   var mapCenter = {{ map_center | to_json }};
   // Tenant whose boundary tree the SPA's map/boundary code resolves
   // against (Turbopass/OSM boundary resolution). Mirrors the build-time
@@ -129,6 +136,8 @@ var globalConfigs = (function () {
       return boundaryType;
     } else if (key === "HIERARCHY_TYPE") {
       return hierarchyType;
+    } else if (key === "COMPLAINT_HIERARCHY_TYPE") {
+      return complaintHierarchyType;
     } else if (key === "CORE_MOBILE_CONFIGS") {
       return coreMobileConfigs;
     } else if (key === "CORE_POSTAL_CONFIGS") {


### PR DESCRIPTION
PR2 of #1111 — the FE half of the hierarchy-level rollup. Pairs with PR1 (backend composer + catalog seeds), but is **independently mergeable in either order**: the "Group by" control renders only for tiles whose KPI def declares the `hierLevel` params entry, so this PR is inert until PR1's catalog params land (and PR1's level-1 defaults render fine without this PR — the FE already labels any node code via `COMPLAINT_HIERARCHY.<code>`).

## What it does

Each hierarchy-aware widget gets a compact right-aligned **"Group by"** select in its header title row: the deployment's complaint-hierarchy levels (from `ComplaintHierarchyDefinition`) plus **Leaf**. Picking a level sends `params.hierLevel` on that tile's `_query` ref; the backend re-aggregates over the raw rows and aliases the level code back as `service_code`, so charts/sort/labels need no per-widget code.

- **Where the control lands per widget kind**: chart AND table widgets share the AdminDashboard header chrome (`!selfHeaders`), so a single header placement covers both. Card tiles never declare `hierLevel` and `KpiTile` has no header of its own (R7b). Map tiles render their own internal header and are excluded (row-grain pins — no aggregation). Note: the plan's `DataTableChrome.headerActions` placement doesn't exist on develop — `DataTableChrome` is an orphaned legacy component with no importers; the shared widget header is the live equivalent.
- **Definition source (R7a)**: `ComplaintHierarchyDefinition` scoped to the deployment's hierarchyType — new optional `COMPLAINT_HIERARCHY_TYPE` globalConfigs pin (ke carries BOTH a live "PGR" 2-level and a "PGR_TEST" 4-level definition; a naive fetch could enumerate the wrong dropdown), falling back to the rows-backed-definition heuristic the PGR complaint pages already use. No records → `hasHierarchy:false` → control hidden (flat/legacy tenants unchanged).
- **Persistence + refire (R7c)**: per-widget overrides live in localStorage (kpiId-keyed, same pattern as the saved layout) and merge into the tile's params **before** the `__prior`/`__series`/`__pins` companion spreads, so companions auto-inherit; the applied overrides are fingerprinted into `refsKey`, else the batch effect would never refire on a Group-by change.
- **Non-leaf tables (R4)**: the `service_group` ("Type") column is hidden and the `service_code` column relabels to the selected level's name. The `ideal_sla_ms` avg-of-heterogeneous-SLAs caveat is left to the PR1 catalog docs (simpler than an in-cell tooltip).
- **Localization (R7d)**: level names resolve `DASHBOARD_GROUPBY_LEVEL_<LEVELCODE>` → the PGR pages' `<HIERARCHYTYPE>_<LEVELCODE>` convention → the definition's data-owned label → the raw code (visible gap, never a humanised guess). New `DASHBOARD_GROUPBY_*` codes seeded in BOTH the en_IN and pt_PT packs of the digit-mcp dashboard l10n seed (312 codes each, 1:1).

## NOT a filter

Hierarchy **filters** were built and deliberately abandoned by the project owner. This control is structurally different and must stay that way: it changes a widget's **own aggregation dimension** (which level its `service_code` buckets roll up to), never which complaints qualify. It therefore lives outside the `filters` state entirely (enforced by comment + module layout), and there is no click-to-filter/drilldown here.

## Tests / build

- `node --test products/dashboard/src/utils/hierLevelGrouping.test.js` — 16 tests: override merge (companion auto-inherit), refsKey refire incl. explicit-leaf-over-default, definition selection (pin wins / rows-backed fallback), control visibility (flat, 1-level, leaf-only-allowed all hide), allowed-list filtering of stale saved values, R4 column shaping, and a `globalParams` regression guard for the queryPlan extraction. Same node:test + esbuild-bundle idiom as `applyTheme.test.js`.
- `npm run build` (digit-ui-esbuild) green.
- digit-mcp `tsc --noEmit` green after the seed edit.

## QA / screenshots note

On the bomet demo the live PGR tree is 2-level, and level 2 **is** the leaf service-code level — so the demo contrast is **level 1 ("Category") vs Leaf** on `cl_chart_complaints_by_type` / the type tables (bucket sums at level 1 must equal the sum of leaf buckets, with no limit-8 truncation at level 1). A 3+-level tenant (e.g. a PGR_TEST-pinned env) exercises the intermediate levels. Screenshots to follow once PR1's catalog params are live on a demo box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
