### PR TITLE
feat(dashboard): tree-traversal complaint-type filter (one-widget subtree navigation)

### DIFF
--- a/digit-mcp/src/tools/dashboard-l10n-seed.ts
+++ b/digit-mcp/src/tools/dashboard-l10n-seed.ts
@@ -390,11 +390,6 @@ export const DASHBOARD_L10N_MESSAGES: { code: string; message: string; module: s
     "module": "rainmaker-dashboard"
   },
   {
-    "code": "DASHBOARD_GROUPBY_CHIP",
-    "message": "Group",
-    "module": "rainmaker-dashboard"
-  },
-  {
     "code": "DASHBOARD_GROUPBY_LABEL",
     "message": "Group by",
     "module": "rainmaker-dashboard"
@@ -1592,7 +1587,7 @@ export const DASHBOARD_L10N_MESSAGES: { code: string; message: string; module: s
 ];
 
 /**
- * pt_PT (European Portuguese) pack — same 315 codes as the en_IN pack, 1:1.
+ * pt_PT (European Portuguese) pack — same 314 codes as the en_IN pack, 1:1.
  * Translations follow European/Mozambique conventions (bairro/distrito geo
  * terms, "reclamações" agreement); placeholder tokens verified identical to
  * the en_IN messages.
@@ -1971,11 +1966,6 @@ export const DASHBOARD_L10N_MESSAGES_PT_PT: { code: string; message: string; mod
   {
     "code": "DASHBOARD_GEO_LEVEL_3",
     "message": "Reclamações",
-    "module": "rainmaker-dashboard"
-  },
-  {
-    "code": "DASHBOARD_GROUPBY_CHIP",
-    "message": "Agrupar",
     "module": "rainmaker-dashboard"
   },
   {

--- a/digit-mcp/src/tools/dashboard-l10n-seed.ts
+++ b/digit-mcp/src/tools/dashboard-l10n-seed.ts
@@ -1185,6 +1185,21 @@ export const DASHBOARD_L10N_MESSAGES: { code: string; message: string; module: s
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "DASHBOARD_TYPE_FILTER_ALL_IN",
+    "message": "All in",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_TYPE_FILTER_NOT_APPLIED",
+    "message": "Type filter not applied",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_TYPE_FILTER_UP",
+    "message": "Up one level",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "DASHBOARD_UNIT_D",
     "message": "d",
     "module": "rainmaker-dashboard"
@@ -1577,7 +1592,7 @@ export const DASHBOARD_L10N_MESSAGES: { code: string; message: string; module: s
 ];
 
 /**
- * pt_PT (European Portuguese) pack — same 312 codes as the en_IN pack, 1:1.
+ * pt_PT (European Portuguese) pack — same 315 codes as the en_IN pack, 1:1.
  * Translations follow European/Mozambique conventions (bairro/distrito geo
  * terms, "reclamações" agreement); placeholder tokens verified identical to
  * the en_IN messages.
@@ -2751,6 +2766,21 @@ export const DASHBOARD_L10N_MESSAGES_PT_PT: { code: string; message: string; mod
   {
     "code": "DASHBOARD_TILE_SERIES_RESOLUTION_RATE",
     "message": "Taxa de resolução",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_TYPE_FILTER_ALL_IN",
+    "message": "Tudo em",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_TYPE_FILTER_NOT_APPLIED",
+    "message": "Filtro de tipo não aplicado",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_TYPE_FILTER_UP",
+    "message": "Subir um nível",
     "module": "rainmaker-dashboard"
   },
   {

--- a/digit-mcp/src/tools/dashboard-l10n-seed.ts
+++ b/digit-mcp/src/tools/dashboard-l10n-seed.ts
@@ -390,6 +390,11 @@ export const DASHBOARD_L10N_MESSAGES: { code: string; message: string; module: s
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "DASHBOARD_GROUPBY_CHIP",
+    "message": "Group",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "DASHBOARD_GROUPBY_LABEL",
     "message": "Group by",
     "module": "rainmaker-dashboard"
@@ -1195,11 +1200,6 @@ export const DASHBOARD_L10N_MESSAGES: { code: string; message: string; module: s
     "module": "rainmaker-dashboard"
   },
   {
-    "code": "DASHBOARD_TYPE_FILTER_UP",
-    "message": "Up one level",
-    "module": "rainmaker-dashboard"
-  },
-  {
     "code": "DASHBOARD_UNIT_D",
     "message": "d",
     "module": "rainmaker-dashboard"
@@ -1971,6 +1971,11 @@ export const DASHBOARD_L10N_MESSAGES_PT_PT: { code: string; message: string; mod
   {
     "code": "DASHBOARD_GEO_LEVEL_3",
     "message": "Reclamações",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_GROUPBY_CHIP",
+    "message": "Agrupar",
     "module": "rainmaker-dashboard"
   },
   {
@@ -2776,11 +2781,6 @@ export const DASHBOARD_L10N_MESSAGES_PT_PT: { code: string; message: string; mod
   {
     "code": "DASHBOARD_TYPE_FILTER_NOT_APPLIED",
     "message": "Filtro de tipo não aplicado",
-    "module": "rainmaker-dashboard"
-  },
-  {
-    "code": "DASHBOARD_TYPE_FILTER_UP",
-    "message": "Subir um nível",
     "module": "rainmaker-dashboard"
   },
   {

--- a/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
@@ -154,9 +154,12 @@ const AdminDashboard = ({ embedded = false }) => {
  * the saved layout: localStorage, kpiId-keyed. NOT part of `filters` state on
  * purpose — a Group-by level is structurally NOT a filter: it changes the
  * widget's own aggregation dimension (which hierarchy level the service_code
- * buckets roll up to), never which complaints qualify. Hierarchy FILTERS were
- * built and deliberately abandoned; this control must stay out of the filter
- * store so it can never be mistaken for (or grow into) one.
+ * buckets roll up to), never which complaints qualify. Hierarchy FILTERING
+ * lives where filters live: the global complaint-type TREE filter
+ * (ComplaintTypeTreeFilter, the sanctioned revival of the abandoned July
+ * demo) is part of `filters`/globalParams; this per-widget control must stay
+ * out of the filter store so the two axes never blur — they compose at the
+ * query level (subtree WHERE × level GROUP BY).
  */
 const HIER_OVERRIDES_STORAGE_KEY = "ccrs.dashboard.hier-level-overrides.v1";
 

--- a/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
@@ -10,6 +10,7 @@ import CardUpdatedStamp from "./components/CardUpdatedStamp";
 import ResizeGrip from "./components/ResizeGrip";
 import SubtleScroll from "./components/SubtleScroll";
 import GroupByLevelSelect, { levelDisplayLabel } from "./components/GroupByLevelSelect";
+import TypeFilterIgnoredNote, { typeFilterIgnored } from "./components/TypeFilterIgnoredNote";
 import {
   VIZ_TYPE,
   SHARED_CHROME,
@@ -596,6 +597,12 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
           {layout.map((item) => {
             const isKpi = isCardKind(kpis[item.i]?.viz?.kind);
             const dimClass = matchesSearch(item.i) ? "" : " dashboard-search-dimmed";
+            // Subtle per-tile note when the backend ignored the subtree
+            // complaint-type filter on this KPI's grain (daily has no
+            // complaint_node_path) — the field is ABSENT unless it happened.
+            const ignoredNote = typeFilterIgnored(batch.results?.[item.i]) ? (
+              <TypeFilterIgnoredNote />
+            ) : null;
             const removeBtn = (
               <WidgetRemoveButton
                 label={`${t("DASHBOARD_COMMON_REMOVE", "Remove")} ${resolveTitle(kpis[item.i]) || item.i}`}
@@ -614,6 +621,7 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
                 >
                   {removeBtn}
                   {renderTile(item.i)}
+                  {ignoredNote}
                   <CardUpdatedStamp label={lastUpdatedLabel} />
                 </div>
               );
@@ -678,6 +686,7 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
                     renderTile(item.i, groupBy.info)
                   )}
                 </div>
+                {ignoredNote}
                 <CardUpdatedStamp label={lastUpdatedLabel} />
                 <ResizeGrip />
               </section>

--- a/digit-ui-esbuild/products/dashboard/src/components/ComplaintTypeTreeFilter.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/ComplaintTypeTreeFilter.jsx
@@ -211,13 +211,13 @@ const ComplaintTypeTreeFilter = ({ tree, filters, onFilterChange, t: tProp }) =>
   };
 
   const chip = (
-    <span className="dashboard-popover-chip-trail">
+    <span className="dashboard-popover-trigger-trail">
       {elided && (
         <>
-          <span className="dashboard-popover-chip-seg dashboard-popover-chip-seg--muted" aria-hidden>
+          <span className="dashboard-popover-trigger-seg dashboard-popover-trigger-seg--muted" aria-hidden>
             …
           </span>
-          <span className="dashboard-popover-chip-sep" aria-hidden>
+          <span className="dashboard-popover-trigger-sep" aria-hidden>
             ›
           </span>
         </>
@@ -225,13 +225,13 @@ const ComplaintTypeTreeFilter = ({ tree, filters, onFilterChange, t: tProp }) =>
       {segments.map((segment, index) => (
         <React.Fragment key={`${index}-${segment}`}>
           {index > 0 && (
-            <span className="dashboard-popover-chip-sep" aria-hidden>
+            <span className="dashboard-popover-trigger-sep" aria-hidden>
               ›
             </span>
           )}
           <span
-            className={`dashboard-popover-chip-seg${
-              index < segments.length - 1 ? " dashboard-popover-chip-seg--muted" : ""
+            className={`dashboard-popover-trigger-seg${
+              index < segments.length - 1 ? " dashboard-popover-trigger-seg--muted" : ""
             }`}
           >
             {segment}

--- a/digit-ui-esbuild/products/dashboard/src/components/ComplaintTypeTreeFilter.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/ComplaintTypeTreeFilter.jsx
@@ -68,14 +68,19 @@ export function ComplaintTypeTreePanel({ tree, appliedCode, onApply, t }) {
   const mountedRef = useRef(false);
 
   // After an in-panel browse hop the clicked row unmounts and DOM focus dies
-  // on <body>; hand it to the new level's first row so arrow keys keep
+  // on <body>; hand it to the new level's first LIST row (not the trail's
+  // root crumb, which is first in document order) so arrow keys keep
   // working. Initial focus on open is the primitive's job, not ours.
   useEffect(() => {
     if (!mountedRef.current) {
       mountedRef.current = true;
       return;
     }
-    rootRef.current?.querySelector("[data-menu-item]:not(:disabled)")?.focus();
+    const root = rootRef.current;
+    const target =
+      root?.querySelector(".dashboard-popover-list [data-menu-item]:not(:disabled)") ||
+      root?.querySelector("[data-menu-item]:not(:disabled)");
+    target?.focus();
   }, [browseCode]);
 
   const allTypesLabel = t("DASHBOARD_FILTERS_ALL_TYPES", "All types");

--- a/digit-ui-esbuild/products/dashboard/src/components/ComplaintTypeTreeFilter.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/ComplaintTypeTreeFilter.jsx
@@ -1,0 +1,173 @@
+import React from "react";
+import useDashboardT from "../i18n/useDashboardT";
+import { dimensionLabel } from "../i18n/dimensionLabel";
+import {
+  ALL,
+  ancestorsOf,
+  childrenOf,
+  humanizeTypeCode,
+  nodeOf,
+  parentOf,
+  selectionFromCode,
+  clearedSelection,
+} from "../utils/complaintTypeTree";
+
+/**
+ * ONE compact tree-traversal widget for the complaint-type filter — replaces
+ * the flat leaf <select> in the filter bar (owner design; the exhumed July
+ * demo's growing chain-of-selects is deliberately NOT reproduced).
+ *
+ * From the current node:
+ *   - breadcrumb-ish label: clickable ancestors ("All types" at root) — a
+ *     click applies the filter AT that level (the up/back affordance),
+ *   - one dropdown listing the CHILDREN of the current node — selecting a
+ *     child descends AND applies (interior child → subtree filter, leaf
+ *     child → exact type filter),
+ *   - an up-chevron that applies the parent level (root clears).
+ *
+ * APPLY-ON-SELECT everywhere (validation required-change #3): traversal IS
+ * application; there is no staged state and no Apply button — consistent with
+ * the instant date/geography controls beside it.
+ *
+ * When a LEAF is applied, the dropdown shows the parent's children with the
+ * leaf selected (a leaf has no children), so switching between sibling leaves
+ * stays a one-click operation — exactly the old flat-select ergonomics at
+ * that level. The dropdown's first option re-applies the current interior
+ * level itself ("All types" at root / "All in <node>"), which is also how a
+ * leaf selection steps back up without hunting for the chevron.
+ *
+ * Labels resolve through the dimensionLabel seam (COMPLAINT_HIERARCHY.<code>
+ * first, then the master's data-owned name); interior nodes whose MDMS name
+ * is just the code fall back to a humanised last-segment — never a raw
+ * dotted code in the breadcrumb (validation risk #3ii).
+ */
+
+export function nodeDisplayLabel(tree, code) {
+  const node = nodeOf(tree, code);
+  const resolved = dimensionLabel(code, "complaintType", node?.label);
+  return resolved === String(code) ? humanizeTypeCode(code) : resolved;
+}
+
+const UpIcon = () => (
+  <svg
+    width="12"
+    height="12"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden
+  >
+    <path d="m18 15-6-6-6 6" />
+  </svg>
+);
+
+const CRUMB_STYLE = {
+  maxWidth: "9rem",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+};
+
+const ComplaintTypeTreeFilter = ({ tree, filters, onFilterChange, t: tProp }) => {
+  const { t: tHook } = useDashboardT();
+  const t = tProp || tHook;
+
+  const code = filters?.complaintType ?? ALL;
+  const current = nodeOf(tree, code); // null at root (or stale code pre-repair)
+  const atRoot = !current;
+
+  // The level the dropdown lists: the current node when it can be descended
+  // into (root/interior), else the applied leaf's parent (sibling switching).
+  const baseCode = atRoot || !current.isLeaf ? (atRoot ? ALL : code) : parentOf(tree, code);
+  const children = childrenOf(tree, baseCode);
+
+  const allTypesLabel = t("DASHBOARD_FILTERS_ALL_TYPES", "All types");
+  const label = (c) => nodeDisplayLabel(tree, c);
+
+  const apply = (nextCode) => {
+    onFilterChange(
+      "complaintType",
+      nextCode === ALL ? clearedSelection() : selectionFromCode(tree, nextCode)
+    );
+  };
+
+  // Breadcrumb trail: root sentinel + ancestors (clickable = applies at that
+  // level), then the current node as plain text. At root only the sentinel
+  // shows (as text — nothing to go back to).
+  const trail = atRoot ? [] : [ALL, ...ancestorsOf(tree, code)];
+
+  return (
+    <div
+      className="dashboard-type-tree-filter"
+      role="group"
+      aria-label={t("DASHBOARD_FILTERS_COMPLAINT_TYPE_FILTER", "Complaint type filter")}
+    >
+      <button
+        type="button"
+        className="dashboard-filters-clear-inline dashboard-type-tree-up"
+        onClick={() => apply(atRoot ? ALL : parentOf(tree, code))}
+        disabled={atRoot}
+        aria-disabled={atRoot}
+        title={t("DASHBOARD_TYPE_FILTER_UP", "Up one level")}
+        aria-label={t("DASHBOARD_TYPE_FILTER_UP", "Up one level")}
+      >
+        <UpIcon />
+      </button>
+
+      <span className="dashboard-type-tree-crumbs">
+        {trail.map((crumbCode) => (
+          <React.Fragment key={crumbCode}>
+            <button
+              type="button"
+              className="dashboard-type-tree-crumb"
+              style={CRUMB_STYLE}
+              onClick={() => apply(crumbCode)}
+              title={crumbCode === ALL ? allTypesLabel : label(crumbCode)}
+            >
+              {crumbCode === ALL ? allTypesLabel : label(crumbCode)}
+            </button>
+            <span className="dashboard-type-tree-sep" aria-hidden>
+              ›
+            </span>
+          </React.Fragment>
+        ))}
+        <span
+          className="dashboard-type-tree-current"
+          style={CRUMB_STYLE}
+          title={atRoot ? allTypesLabel : label(code)}
+        >
+          {atRoot ? allTypesLabel : label(code)}
+        </span>
+      </span>
+
+      {children.length > 0 && (
+        <span className="dashboard-filter-inline-select-wrap">
+          <select
+            className="dashboard-filter-inline-select"
+            // Leaf applied → the leaf (a sibling pick); else the base level itself.
+            value={current?.isLeaf ? code : baseCode}
+            onChange={(e) => apply(e.target.value)}
+            aria-label={t("DASHBOARD_FILTERS_COMPLAINT_TYPE_FILTER", "Complaint type filter")}
+          >
+            <option value={baseCode}>
+              {baseCode === ALL
+                ? allTypesLabel
+                : `${t("DASHBOARD_TYPE_FILTER_ALL_IN", "All in")} ${label(baseCode)}`}
+            </option>
+            {children.map((child) => (
+              <option key={child.code} value={child.code}>
+                {label(child.code)}
+                {!child.isLeaf ? " ›" : ""}
+              </option>
+            ))}
+          </select>
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default ComplaintTypeTreeFilter;

--- a/digit-ui-esbuild/products/dashboard/src/components/ComplaintTypeTreeFilter.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/ComplaintTypeTreeFilter.jsx
@@ -1,45 +1,50 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import useDashboardT from "../i18n/useDashboardT";
 import { dimensionLabel } from "../i18n/dimensionLabel";
+import PopoverMenu, { PopoverMenuItem } from "./ui/PopoverMenu";
 import {
   ALL,
+  TRAIL_ELLIPSIS,
   ancestorsOf,
+  browseBaseCode,
   childrenOf,
+  clearedSelection,
   humanizeTypeCode,
   nodeOf,
-  parentOf,
   selectionFromCode,
-  clearedSelection,
+  truncateTrail,
 } from "../utils/complaintTypeTree";
 
 /**
- * ONE compact tree-traversal widget for the complaint-type filter — replaces
- * the flat leaf <select> in the filter bar (owner design; the exhumed July
- * demo's growing chain-of-selects is deliberately NOT reproduced).
+ * The complaint-type filter as ONE compact chip + ONE traversal panel (owner
+ * design pass: "tree traversing clean widget", no native <select>).
  *
- * From the current node:
- *   - breadcrumb-ish label: clickable ancestors ("All types" at root) — a
- *     click applies the filter AT that level (the up/back affordance),
- *   - one dropdown listing the CHILDREN of the current node — selecting a
- *     child descends AND applies (interior child → subtree filter, leaf
- *     child → exact type filter),
- *   - an up-chevron that applies the parent level (root clears).
+ * CHIP (filter bar anchor): shows the applied selection — "All types" at
+ * root, the node's label at depth 1, "Parent › Node" deeper (prefixed with
+ * "… ›" when more ancestors are elided). Clicking opens the panel.
  *
- * APPLY-ON-SELECT everywhere (validation required-change #3): traversal IS
- * application; there is no staged state and no Apply button — consistent with
- * the instant date/geography controls beside it.
+ * PANEL (the whole traversal, via the shared PopoverMenu primitive):
+ *   - ancestor TRAIL across the top — clickable crumbs BROWSE to that level
+ *     (middle-truncated with an ellipsis for deep trees, endpoints kept);
+ *   - the current node's CHILDREN as a scrollable list — an interior child
+ *     (chevron) DESCENDS within the panel, a leaf click APPLIES + closes;
+ *   - an explicit "All in <current>" first row applies the subtree + closes;
+ *   - an "All types" reset row pinned at the bottom.
  *
- * When a LEAF is applied, the dropdown shows the parent's children with the
- * leaf selected (a leaf has no children), so switching between sibling leaves
- * stays a one-click operation — exactly the old flat-select ergonomics at
- * that level. The dropdown's first option re-applies the current interior
- * level itself ("All types" at root / "All in <node>"), which is also how a
- * leaf selection steps back up without hunting for the chevron.
+ * Interaction choice — BROWSE-THEN-APPLY for interior traversal: descending
+ * is navigation-in-progress, and applying every intermediate hop would fire
+ * a full dashboard refetch per step of a drill-down; the subtree apply stays
+ * one deliberate click ("All in <X>"), leaves apply instantly. Persistence
+ * is untouched: applies still emit the { code, path, leaf } trio through
+ * onFilterChange (leaf → serviceCode, interior → complaintPath) and browse
+ * state lives only inside the open panel (it resets to the applied node on
+ * every open, leaf selections opening at their parent so sibling switching
+ * stays one click — the old flat-select ergonomics at that level).
  *
  * Labels resolve through the dimensionLabel seam (COMPLAINT_HIERARCHY.<code>
  * first, then the master's data-owned name); interior nodes whose MDMS name
  * is just the code fall back to a humanised last-segment — never a raw
- * dotted code in the breadcrumb (validation risk #3ii).
+ * dotted code in the chip or trail (validation risk #3ii).
  */
 
 export function nodeDisplayLabel(tree, code) {
@@ -48,45 +53,151 @@ export function nodeDisplayLabel(tree, code) {
   return resolved === String(code) ? humanizeTypeCode(code) : resolved;
 }
 
-const UpIcon = () => (
-  <svg
-    width="12"
-    height="12"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2.5"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden
-  >
-    <path d="m18 15-6-6-6 6" />
-  </svg>
-);
+/** Max rendered trail entries (root + ellipsis + 2 nearest) — ke's PGR_TEST
+ *  4-level tree browses at depth 4 as: All types › … › <parent> › <node>. */
+const TRAIL_MAX = 4;
 
-const CRUMB_STYLE = {
-  maxWidth: "9rem",
-  overflow: "hidden",
-  textOverflow: "ellipsis",
-  whiteSpace: "nowrap",
-};
+/**
+ * The panel body. Exported (also for the ReactDOMServer render smoke): pure
+ * React against the tree + applied code, owns only the transient browse
+ * location. Mounted fresh on every open, so browse state self-resets.
+ */
+export function ComplaintTypeTreePanel({ tree, appliedCode, onApply, t }) {
+  const [browseCode, setBrowseCode] = useState(() => browseBaseCode(tree, appliedCode));
+  const rootRef = useRef(null);
+  const mountedRef = useRef(false);
+
+  // After an in-panel browse hop the clicked row unmounts and DOM focus dies
+  // on <body>; hand it to the new level's first row so arrow keys keep
+  // working. Initial focus on open is the primitive's job, not ours.
+  useEffect(() => {
+    if (!mountedRef.current) {
+      mountedRef.current = true;
+      return;
+    }
+    rootRef.current?.querySelector("[data-menu-item]:not(:disabled)")?.focus();
+  }, [browseCode]);
+
+  const allTypesLabel = t("DASHBOARD_FILTERS_ALL_TYPES", "All types");
+  const label = (c) => (c === ALL ? allTypesLabel : nodeDisplayLabel(tree, c));
+
+  const atRoot = browseCode === ALL || !nodeOf(tree, browseCode);
+  const browse = atRoot ? ALL : browseCode;
+  const children = childrenOf(tree, browse);
+  const trailCodes = atRoot ? [ALL] : [ALL, ...ancestorsOf(tree, browse), browse];
+  const trail = truncateTrail(trailCodes, TRAIL_MAX);
+  const elided =
+    trail === trailCodes ? [] : trailCodes.filter((c) => !trail.includes(c));
+
+  return (
+    <div ref={rootRef} className="dashboard-popover-tree">
+      <div className="dashboard-popover-trail" role="presentation">
+        {trail.map((crumb, index) => {
+          const isCurrent = index === trail.length - 1;
+          if (crumb === TRAIL_ELLIPSIS) {
+            return (
+              <React.Fragment key={TRAIL_ELLIPSIS}>
+                <span
+                  className="dashboard-popover-trail-ellipsis"
+                  title={elided.map(label).join(" › ")}
+                  aria-hidden
+                >
+                  …
+                </span>
+                <span className="dashboard-popover-trail-sep" aria-hidden>
+                  ›
+                </span>
+              </React.Fragment>
+            );
+          }
+          if (isCurrent) {
+            return (
+              <span key={crumb} className="dashboard-popover-trail-current" title={label(crumb)}>
+                {label(crumb)}
+              </span>
+            );
+          }
+          return (
+            <React.Fragment key={crumb}>
+              <button
+                type="button"
+                role="menuitem"
+                data-menu-item=""
+                className="dashboard-popover-trail-crumb"
+                title={label(crumb)}
+                onClick={() => setBrowseCode(crumb)}
+              >
+                {label(crumb)}
+              </button>
+              <span className="dashboard-popover-trail-sep" aria-hidden>
+                ›
+              </span>
+            </React.Fragment>
+          );
+        })}
+      </div>
+
+      <div className="dashboard-popover-list">
+        {!atRoot && (
+          <PopoverMenuItem
+            selected={appliedCode === browse}
+            title={`${t("DASHBOARD_TYPE_FILTER_ALL_IN", "All in")} ${label(browse)}`}
+            onSelect={() => onApply(browse)}
+          >
+            {`${t("DASHBOARD_TYPE_FILTER_ALL_IN", "All in")} ${label(browse)}`}
+          </PopoverMenuItem>
+        )}
+        {children.map((child) => (
+          <PopoverMenuItem
+            key={child.code}
+            selected={appliedCode === child.code ? true : child.isLeaf ? false : undefined}
+            descend={!child.isLeaf}
+            title={label(child.code)}
+            onSelect={() =>
+              child.isLeaf ? onApply(child.code) : setBrowseCode(child.code)
+            }
+          >
+            {label(child.code)}
+          </PopoverMenuItem>
+        ))}
+      </div>
+
+      <div className="dashboard-popover-footer">
+        <PopoverMenuItem
+          muted
+          selected={appliedCode === ALL || !nodeOf(tree, appliedCode)}
+          onSelect={() => onApply(ALL)}
+        >
+          {allTypesLabel}
+        </PopoverMenuItem>
+      </div>
+    </div>
+  );
+}
+
+/** Chip content for the applied code: trailing segments + elision marker. */
+function chipModel(tree, code, allTypesLabel) {
+  const node = nodeOf(tree, code);
+  if (!node) return { segments: [allTypesLabel], elided: false, title: allTypesLabel };
+  const chain = [...ancestorsOf(tree, code), code].map((c) => nodeDisplayLabel(tree, c));
+  const segments = chain.slice(-2);
+  return {
+    segments,
+    elided: chain.length > 2,
+    title: chain.join(" › "),
+  };
+}
 
 const ComplaintTypeTreeFilter = ({ tree, filters, onFilterChange, t: tProp }) => {
   const { t: tHook } = useDashboardT();
   const t = tProp || tHook;
 
   const code = filters?.complaintType ?? ALL;
-  const current = nodeOf(tree, code); // null at root (or stale code pre-repair)
-  const atRoot = !current;
-
-  // The level the dropdown lists: the current node when it can be descended
-  // into (root/interior), else the applied leaf's parent (sibling switching).
-  const baseCode = atRoot || !current.isLeaf ? (atRoot ? ALL : code) : parentOf(tree, code);
-  const children = childrenOf(tree, baseCode);
-
   const allTypesLabel = t("DASHBOARD_FILTERS_ALL_TYPES", "All types");
-  const label = (c) => nodeDisplayLabel(tree, c);
+  const { segments, elided, title } = chipModel(tree, code, allTypesLabel);
 
+  // UNCHANGED wire/persistence contract: applies emit the selection trio
+  // (leaf → serviceCode, interior → complaintPath) through onFilterChange.
   const apply = (nextCode) => {
     onFilterChange(
       "complaintType",
@@ -94,79 +205,56 @@ const ComplaintTypeTreeFilter = ({ tree, filters, onFilterChange, t: tProp }) =>
     );
   };
 
-  // Breadcrumb trail: root sentinel + ancestors (clickable = applies at that
-  // level), then the current node as plain text. At root only the sentinel
-  // shows (as text — nothing to go back to).
-  const trail = atRoot ? [] : [ALL, ...ancestorsOf(tree, code)];
-
-  return (
-    <div
-      className="dashboard-type-tree-filter"
-      role="group"
-      aria-label={t("DASHBOARD_FILTERS_COMPLAINT_TYPE_FILTER", "Complaint type filter")}
-    >
-      <button
-        type="button"
-        className="dashboard-filters-clear-inline dashboard-type-tree-up"
-        onClick={() => apply(atRoot ? ALL : parentOf(tree, code))}
-        disabled={atRoot}
-        aria-disabled={atRoot}
-        title={t("DASHBOARD_TYPE_FILTER_UP", "Up one level")}
-        aria-label={t("DASHBOARD_TYPE_FILTER_UP", "Up one level")}
-      >
-        <UpIcon />
-      </button>
-
-      <span className="dashboard-type-tree-crumbs">
-        {trail.map((crumbCode) => (
-          <React.Fragment key={crumbCode}>
-            <button
-              type="button"
-              className="dashboard-type-tree-crumb"
-              style={CRUMB_STYLE}
-              onClick={() => apply(crumbCode)}
-              title={crumbCode === ALL ? allTypesLabel : label(crumbCode)}
-            >
-              {crumbCode === ALL ? allTypesLabel : label(crumbCode)}
-            </button>
-            <span className="dashboard-type-tree-sep" aria-hidden>
+  const chip = (
+    <span className="dashboard-popover-chip-trail">
+      {elided && (
+        <>
+          <span className="dashboard-popover-chip-seg dashboard-popover-chip-seg--muted" aria-hidden>
+            …
+          </span>
+          <span className="dashboard-popover-chip-sep" aria-hidden>
+            ›
+          </span>
+        </>
+      )}
+      {segments.map((segment, index) => (
+        <React.Fragment key={`${index}-${segment}`}>
+          {index > 0 && (
+            <span className="dashboard-popover-chip-sep" aria-hidden>
               ›
             </span>
-          </React.Fragment>
-        ))}
-        <span
-          className="dashboard-type-tree-current"
-          style={CRUMB_STYLE}
-          title={atRoot ? allTypesLabel : label(code)}
-        >
-          {atRoot ? allTypesLabel : label(code)}
-        </span>
-      </span>
-
-      {children.length > 0 && (
-        <span className="dashboard-filter-inline-select-wrap">
-          <select
-            className="dashboard-filter-inline-select"
-            // Leaf applied → the leaf (a sibling pick); else the base level itself.
-            value={current?.isLeaf ? code : baseCode}
-            onChange={(e) => apply(e.target.value)}
-            aria-label={t("DASHBOARD_FILTERS_COMPLAINT_TYPE_FILTER", "Complaint type filter")}
+          )}
+          <span
+            className={`dashboard-popover-chip-seg${
+              index < segments.length - 1 ? " dashboard-popover-chip-seg--muted" : ""
+            }`}
           >
-            <option value={baseCode}>
-              {baseCode === ALL
-                ? allTypesLabel
-                : `${t("DASHBOARD_TYPE_FILTER_ALL_IN", "All in")} ${label(baseCode)}`}
-            </option>
-            {children.map((child) => (
-              <option key={child.code} value={child.code}>
-                {label(child.code)}
-                {!child.isLeaf ? " ›" : ""}
-              </option>
-            ))}
-          </select>
-        </span>
+            {segment}
+          </span>
+        </React.Fragment>
+      ))}
+    </span>
+  );
+
+  return (
+    <PopoverMenu
+      ariaLabel={t("DASHBOARD_FILTERS_COMPLAINT_TYPE_FILTER", "Complaint type filter")}
+      chipTitle={title}
+      chip={chip}
+      panelWidth={288}
+    >
+      {({ close }) => (
+        <ComplaintTypeTreePanel
+          tree={tree}
+          appliedCode={code}
+          t={t}
+          onApply={(nextCode) => {
+            apply(nextCode);
+            close();
+          }}
+        />
       )}
-    </div>
+    </PopoverMenu>
   );
 };
 

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardFilters.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardFilters.jsx
@@ -6,6 +6,7 @@ import {
   hasActiveFilters,
 } from "../config/globalFilterGroups";
 import ComplaintTypeTreeFilter from "./ComplaintTypeTreeFilter";
+import PopoverMenu, { PopoverMenuItem, PopoverMenuGroupLabel } from "./ui/PopoverMenu";
 import useDashboardT from "../i18n/useDashboardT";
 
 const FunnelIcon = () => (
@@ -26,48 +27,53 @@ const FunnelIcon = () => (
 );
 
 /**
- * Render a flat {id,label,group?} option list, batching consecutive same-group
- * runs into native <optgroup>s. The list arrives group-contiguous (sentinel
- * first, grouped options sorted by group, strays last), so a single pass
- * yields: plain sentinel option → one <optgroup> per root complaint category →
- * plain trailing options for codes missing from the hierarchy master. Lists
- * without any `group` (wards; hierarchy-fetch failure) render exactly as the
- * old flat <option> list.
+ * Degrade path for the complaint-type filter when no usable/pruned hierarchy
+ * exists (flat tenant, MDMS fetch failure, empty scoped distincts): the same
+ * flat {id,label,group?} option list the old native <select> showed, now
+ * rendered through the shared PopoverMenu primitive (owner design pass — no
+ * native selects). Consecutive same-group runs get a non-interactive group
+ * label, exactly where the old <optgroup>s sat; the wire contract is
+ * untouched (a bare leaf-code string through onFilterChange).
  */
-function renderGroupedOptions(options) {
-  const rendered = [];
-  let run = null; // { group, items } — current <optgroup> being accumulated
-
-  const flushRun = () => {
-    if (!run) return;
-    rendered.push(
-      <optgroup key={`group-${run.group}`} label={run.group}>
-        {run.items}
-      </optgroup>
-    );
-    run = null;
-  };
-
-  for (const opt of options) {
-    const node = (
-      <option key={opt.id} value={opt.id}>
-        {opt.label}
-      </option>
-    );
-    if (opt.group) {
-      if (!run || run.group !== opt.group) {
-        flushRun();
-        run = { group: opt.group, items: [] };
-      }
-      run.items.push(node);
-    } else {
-      flushRun();
-      rendered.push(node);
-    }
-  }
-  flushRun();
-  return rendered;
-}
+const FlatComplaintTypeMenu = ({ options, value, loading, onChange, t }) => {
+  const selected = options.find((opt) => opt.id === value);
+  return (
+    <PopoverMenu
+      ariaLabel={t("DASHBOARD_FILTERS_COMPLAINT_TYPE_FILTER", "Complaint type filter")}
+      chip={loading ? t("DASHBOARD_COMMON_LOADING", "Loading…") : selected?.label ?? String(value)}
+      chipTitle={selected?.label}
+      disabled={loading}
+      panelWidth={272}
+    >
+      {({ close }) => {
+        const rows = [];
+        let lastGroup = null;
+        for (const opt of options) {
+          if (opt.group && opt.group !== lastGroup) {
+            rows.push(
+              <PopoverMenuGroupLabel key={`group-${opt.group}`}>{opt.group}</PopoverMenuGroupLabel>
+            );
+          }
+          lastGroup = opt.group || null;
+          rows.push(
+            <PopoverMenuItem
+              key={opt.id}
+              selected={opt.id === value}
+              title={opt.label}
+              onSelect={() => {
+                onChange(opt.id);
+                close();
+              }}
+            >
+              {opt.label}
+            </PopoverMenuItem>
+          );
+        }
+        return <div className="dashboard-popover-list">{rows}</div>;
+      }}
+    </PopoverMenu>
+  );
+};
 
 const DashboardFilters = ({
   filters,
@@ -158,8 +164,8 @@ const DashboardFilters = ({
         </div>
 
         {complaintTypeTree ? (
-          // ONE-widget tree traversal (breadcrumb + children dropdown + up),
-          // ABAC-pruned; leaf selection → serviceCode, interior → complaintPath.
+          // ONE chip + traversal panel (trail, descend-in-place, "All in <X>",
+          // reset), ABAC-pruned; leaf → serviceCode, interior → complaintPath.
           <ComplaintTypeTreeFilter
             tree={complaintTypeTree}
             filters={filters}
@@ -167,23 +173,13 @@ const DashboardFilters = ({
             t={t}
           />
         ) : (
-          // Degrade: no usable/pruned hierarchy (flat tenant, MDMS fetch
-          // failure, empty scoped distincts) → the previous flat leaf select.
-          <div className="dashboard-filter-inline-select-wrap">
-            <select
-              value={filterOptionsLoading && complaintTypeOptions.length <= 1 ? "" : complaintType}
-              disabled={filterOptionsLoading && complaintTypeOptions.length <= 1}
-              onChange={(e) => onFilterChange("complaintType", e.target.value)}
-              aria-label={t("DASHBOARD_FILTERS_COMPLAINT_TYPE_FILTER", "Complaint type filter")}
-              className="dashboard-filter-inline-select"
-            >
-              {filterOptionsLoading && complaintTypeOptions.length <= 1 ? (
-                <option value="">{t("DASHBOARD_COMMON_LOADING", "Loading…")}</option>
-              ) : (
-                renderGroupedOptions(complaintTypeOptions)
-              )}
-            </select>
-          </div>
+          <FlatComplaintTypeMenu
+            options={complaintTypeOptions}
+            value={complaintType}
+            loading={filterOptionsLoading && complaintTypeOptions.length <= 1}
+            onChange={(id) => onFilterChange("complaintType", id)}
+            t={t}
+          />
         )}
 
         <button

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardFilters.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardFilters.jsx
@@ -5,6 +5,7 @@ import {
   GLOBAL_FILTER_FIELDS,
   hasActiveFilters,
 } from "../config/globalFilterGroups";
+import ComplaintTypeTreeFilter from "./ComplaintTypeTreeFilter";
 import useDashboardT from "../i18n/useDashboardT";
 
 const FunnelIcon = () => (
@@ -81,6 +82,7 @@ const DashboardFilters = ({
   const geographyOptions = filterOptions?.geography ?? GEOGRAPHY_OPTIONS;
   const complaintTypeOptions =
     filterOptions?.complaintType ?? COMPLAINT_TYPE_OPTIONS;
+  const complaintTypeTree = filterOptions?.complaintTypeTree ?? null;
 
   const dateFrom = filters?.dateFrom ?? GLOBAL_FILTER_FIELDS.find((f) => f.id === "dateFrom")?.defaultValue;
   const dateTo = filters?.dateTo ?? GLOBAL_FILTER_FIELDS.find((f) => f.id === "dateTo")?.defaultValue;
@@ -155,21 +157,34 @@ const DashboardFilters = ({
           </select>
         </div>
 
-        <div className="dashboard-filter-inline-select-wrap">
-          <select
-            value={filterOptionsLoading && complaintTypeOptions.length <= 1 ? "" : complaintType}
-            disabled={filterOptionsLoading && complaintTypeOptions.length <= 1}
-            onChange={(e) => onFilterChange("complaintType", e.target.value)}
-            aria-label={t("DASHBOARD_FILTERS_COMPLAINT_TYPE_FILTER", "Complaint type filter")}
-            className="dashboard-filter-inline-select"
-          >
-            {filterOptionsLoading && complaintTypeOptions.length <= 1 ? (
-              <option value="">{t("DASHBOARD_COMMON_LOADING", "Loading…")}</option>
-            ) : (
-              renderGroupedOptions(complaintTypeOptions)
-            )}
-          </select>
-        </div>
+        {complaintTypeTree ? (
+          // ONE-widget tree traversal (breadcrumb + children dropdown + up),
+          // ABAC-pruned; leaf selection → serviceCode, interior → complaintPath.
+          <ComplaintTypeTreeFilter
+            tree={complaintTypeTree}
+            filters={filters}
+            onFilterChange={onFilterChange}
+            t={t}
+          />
+        ) : (
+          // Degrade: no usable/pruned hierarchy (flat tenant, MDMS fetch
+          // failure, empty scoped distincts) → the previous flat leaf select.
+          <div className="dashboard-filter-inline-select-wrap">
+            <select
+              value={filterOptionsLoading && complaintTypeOptions.length <= 1 ? "" : complaintType}
+              disabled={filterOptionsLoading && complaintTypeOptions.length <= 1}
+              onChange={(e) => onFilterChange("complaintType", e.target.value)}
+              aria-label={t("DASHBOARD_FILTERS_COMPLAINT_TYPE_FILTER", "Complaint type filter")}
+              className="dashboard-filter-inline-select"
+            >
+              {filterOptionsLoading && complaintTypeOptions.length <= 1 ? (
+                <option value="">{t("DASHBOARD_COMMON_LOADING", "Loading…")}</option>
+              ) : (
+                renderGroupedOptions(complaintTypeOptions)
+              )}
+            </select>
+          </div>
+        )}
 
         <button
           type="button"

--- a/digit-ui-esbuild/products/dashboard/src/components/GeographyChoroplethMap.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/GeographyChoroplethMap.jsx
@@ -872,7 +872,7 @@ const GeographyChoroplethMap = ({
         />
 
         {activeFilterLabel ? (
-          <div className="dashboard-map-filter-chip tw-pointer-events-auto tw-absolute tw-right-3 tw-top-3 tw-z-[1000] tw-flex tw-items-center tw-gap-2 tw-rounded-sm tw-border tw-border-border tw-bg-surface/95 tw-px-2.5 tw-py-1.5 tw-text-[10px] tw-shadow-sm">
+          <div className="dashboard-map-filter-badge tw-pointer-events-auto tw-absolute tw-right-3 tw-top-3 tw-z-[1000] tw-flex tw-items-center tw-gap-2 tw-rounded-sm tw-border tw-border-border tw-bg-surface/95 tw-px-2.5 tw-py-1.5 tw-text-[10px] tw-shadow-sm">
             <span className="tw-text-muted-foreground">{t("DASHBOARD_MAP_FILTER", "Filter:")}</span>
             <span className="tw-font-semibold tw-text-foreground">{activeFilterLabel}</span>
             <button

--- a/digit-ui-esbuild/products/dashboard/src/components/GroupByLevelSelect.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/GroupByLevelSelect.jsx
@@ -1,24 +1,48 @@
 import React from "react";
 import useDashboardT from "../i18n/useDashboardT";
 import { translate as t, exists } from "../i18n/localeRuntime";
-import PopoverMenu, { PopoverMenuItem } from "./ui/PopoverMenu";
+import PopoverMenu, { PopoverMenuItem, PopoverMenuGroupLabel } from "./ui/PopoverMenu";
 
 /**
- * Per-widget "Group by" hierarchy-level control (#1111 PR2), design pass:
- * a small labeled chip ("Group: Category") in the widget header's title row
- * opening the level menu through the shared PopoverMenu primitive — no
- * native <select>. The compact chip keeps to one line (prefix fixed, value
- * truncates) so it never wraps narrow widgets, and end-aligns its panel so
- * the menu stays on-screen for tiles hugging the right edge.
+ * Per-widget "Group by" hierarchy-level control (#1111 PR2), owner design
+ * round 2: per-widget options live behind a small SETTINGS (gear) icon in
+ * the widget header's title row — muted, 16px, the same icon-button idiom
+ * as the widget remove control — so every header looks identical whether
+ * or not a widget has options (the icon is simply absent when it has
+ * none; the earlier labeled text chip made headers with it read
+ * differently from headers without). Clicking opens the shared
+ * PopoverMenu panel with "Group by" as the menu's section label above the
+ * level options; the panel end-aligns so it stays on-screen for tiles
+ * hugging the right edge.
  *
- * RGL: the chip is a <button> (already in AdminDashboard's draggableCancel
- * list) and the panel portals to document.body, outside the grid item — so
- * using the menu can never start a widget drag.
+ * RGL: the anchor is a <button> (already in AdminDashboard's
+ * draggableCancel list) and the panel portals to document.body, outside
+ * the grid item — so using the menu can never start a widget drag.
  *
  * This is deliberately NOT a dashboard filter: it changes the widget's own
  * aggregation dimension (which level the service_code buckets roll up to),
  * never which complaints qualify.
  */
+
+/** lucide "settings" gear — stroke/currentColor family of the header's
+ *  remove (x) icon; 16px per the header icon sizing. */
+const SettingsIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+    <circle cx="12" cy="12" r="3" />
+  </svg>
+);
 
 /**
  * Localized display name for a hierarchy level. Resolution mirrors the
@@ -51,20 +75,20 @@ const GroupByLevelSelect = ({ value, options, hierarchyType, onChange }) => {
       ? tt("DASHBOARD_GROUPBY_LEAF", "Leaf")
       : levelDisplayLabel(opt.level, hierarchyType);
   const current = options.find((opt) => opt.value === value);
+  const currentLabel = current ? optionLabel(current) : String(value);
 
   return (
-    <span className="dashboard-groupby-chip-wrap">
+    <span className="dashboard-widget-settings-wrap">
       <PopoverMenu
-        compact
         align="end"
         panelWidth={200}
         ariaLabel={label}
-        chipTitle={label}
-        chipPrefix={tt("DASHBOARD_GROUPBY_CHIP", "Group")}
-        chip={current ? optionLabel(current) : String(value)}
+        chipTitle={`${label}: ${currentLabel}`}
+        icon={<SettingsIcon />}
       >
         {({ close }) => (
           <div className="dashboard-popover-list">
+            <PopoverMenuGroupLabel>{label}</PopoverMenuGroupLabel>
             {options.map((opt) => (
               <PopoverMenuItem
                 key={opt.value}

--- a/digit-ui-esbuild/products/dashboard/src/components/GroupByLevelSelect.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/GroupByLevelSelect.jsx
@@ -1,15 +1,19 @@
 import React from "react";
 import useDashboardT from "../i18n/useDashboardT";
 import { translate as t, exists } from "../i18n/localeRuntime";
+import PopoverMenu, { PopoverMenuItem } from "./ui/PopoverMenu";
 
 /**
- * Per-widget "Group by" hierarchy-level control (#1111 PR2).
+ * Per-widget "Group by" hierarchy-level control (#1111 PR2), design pass:
+ * a small labeled chip ("Group: Category") in the widget header's title row
+ * opening the level menu through the shared PopoverMenu primitive — no
+ * native <select>. The compact chip keeps to one line (prefix fixed, value
+ * truncates) so it never wraps narrow widgets, and end-aligns its panel so
+ * the menu stays on-screen for tiles hugging the right edge.
  *
- * A compact select rendered in the widget header's title row (right-aligned)
- * for tiles whose KPI def declares the `hierLevel` param on a tenant with a
- * usable complaint hierarchy. Options come from buildGroupByOptions
- * (definition levels + Leaf); the RGL draggableCancel whitelist already
- * covers `select`, so interacting with it never starts a widget drag.
+ * RGL: the chip is a <button> (already in AdminDashboard's draggableCancel
+ * list) and the panel portals to document.body, outside the grid item — so
+ * using the menu can never start a widget drag.
  *
  * This is deliberately NOT a dashboard filter: it changes the widget's own
  * aggregation dimension (which level the service_code buckets roll up to),
@@ -42,23 +46,40 @@ const GroupByLevelSelect = ({ value, options, hierarchyType, onChange }) => {
   // re-resolve on a language switch.
   const { t: tt } = useDashboardT();
   const label = tt("DASHBOARD_GROUPBY_LABEL", "Group by");
+  const optionLabel = (opt) =>
+    opt.leaf
+      ? tt("DASHBOARD_GROUPBY_LEAF", "Leaf")
+      : levelDisplayLabel(opt.level, hierarchyType);
+  const current = options.find((opt) => opt.value === value);
+
   return (
-    <span className="dashboard-filter-inline-select-wrap tw-ml-2 tw-mr-6">
-      <select
-        className="dashboard-filter-inline-select tw-min-w-0"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        aria-label={label}
-        title={label}
+    <span className="dashboard-groupby-chip-wrap">
+      <PopoverMenu
+        compact
+        align="end"
+        panelWidth={200}
+        ariaLabel={label}
+        chipTitle={label}
+        chipPrefix={tt("DASHBOARD_GROUPBY_CHIP", "Group")}
+        chip={current ? optionLabel(current) : String(value)}
       >
-        {options.map((opt) => (
-          <option key={opt.value} value={opt.value}>
-            {opt.leaf
-              ? tt("DASHBOARD_GROUPBY_LEAF", "Leaf")
-              : levelDisplayLabel(opt.level, hierarchyType)}
-          </option>
-        ))}
-      </select>
+        {({ close }) => (
+          <div className="dashboard-popover-list">
+            {options.map((opt) => (
+              <PopoverMenuItem
+                key={opt.value}
+                selected={opt.value === value}
+                onSelect={() => {
+                  onChange(opt.value);
+                  close();
+                }}
+              >
+                {optionLabel(opt)}
+              </PopoverMenuItem>
+            ))}
+          </div>
+        )}
+      </PopoverMenu>
     </span>
   );
 };

--- a/digit-ui-esbuild/products/dashboard/src/components/TypeFilterIgnoredNote.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/TypeFilterIgnoredNote.jsx
@@ -1,0 +1,35 @@
+import React from "react";
+import useDashboardT from "../i18n/useDashboardT";
+
+/**
+ * Subtle per-tile note shown when the backend reports it could NOT honour the
+ * subtree complaint-type filter on this KPI's grain (response envelope
+ * `paramsIgnored: ["complaintPath"]` — the daily grain has `service_code` but
+ * no `complaint_node_path`, so interior-node filters silently no-op there,
+ * #1282). Without this the tile would look filtered while showing unfiltered
+ * numbers (validation risk #1). Leaf selections still filter everywhere via
+ * `serviceCode`, so the note only ever appears for interior-node selections.
+ *
+ * Mirrors CardUpdatedStamp's chrome (bottom-LEFT, same type scale) so it
+ * reads as tile metadata, not an error.
+ */
+
+/** True when this tile's base result reports the subtree filter was ignored. */
+export function typeFilterIgnored(result) {
+  return (
+    Array.isArray(result?.paramsIgnored) &&
+    result.paramsIgnored.includes("complaintPath")
+  );
+}
+
+const TypeFilterIgnoredNote = () => {
+  const { t } = useDashboardT();
+  const text = t("DASHBOARD_TYPE_FILTER_NOT_APPLIED", "Type filter not applied");
+  return (
+    <span className="dashboard-type-filter-ignored" title={text}>
+      {text}
+    </span>
+  );
+};
+
+export default TypeFilterIgnoredNote;

--- a/digit-ui-esbuild/products/dashboard/src/components/treeControls.rendersmoke.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/components/treeControls.rendersmoke.test.js
@@ -1,7 +1,7 @@
 // ReactDOMServer render smoke for the design-pass controls: the
-// complaint-type chip + traversal panel and the "Group by" chip, at root /
-// interior / leaf / 4-level-deep states (ke's PGR_TEST-shaped hierarchy, not
-// just the 2-level live PGR tree).
+// complaint-type chip + traversal panel and the per-widget settings gear
+// ("Group by" menu), at root / interior / leaf / 4-level-deep states (ke's
+// PGR_TEST-shaped hierarchy, not just the 2-level live PGR tree).
 //
 // Run from digit-ui-esbuild/:
 //   node --test products/dashboard/src/components/treeControls.rendersmoke.test.js
@@ -202,7 +202,7 @@ const OPTIONS = [
   { value: "leaf", leaf: true },
 ];
 
-test("group-by chip smoke: labeled chip, no native select, menu semantics", () => {
+test("group-by smoke: settings gear icon button, no native select, menu semantics", () => {
   const html = renderGroupBy({
     value: "1",
     options: OPTIONS,
@@ -210,9 +210,16 @@ test("group-by chip smoke: labeled chip, no native select, menu semantics", () =
     onChange: noop,
   });
   assert.doesNotMatch(html, /<select/);
-  assert.match(html, /dashboard-popover-chip--compact/);
-  assert.match(html, /dashboard-popover-chip-prefix/);
-  assert.match(html, /Category/);
+  // icon-only anchor in the remove-button idiom — NOT a text chip
+  assert.match(html, /dashboard-popover-iconbtn/);
+  assert.doesNotMatch(html, /dashboard-popover-chip/);
+  assert.match(html, /<svg/);
   assert.match(html, /aria-haspopup="menu"/);
-  assert.match(html, /dashboard-groupby-chip-wrap/);
+  assert.match(html, /aria-expanded="false"/);
+  // accessible name + tooltip carry the label and the current value (the
+  // unseeded smoke runtime echoes the KEY for the label — copy is not what
+  // this smoke verifies; "Category" resolves from the level's own label)
+  assert.match(html, /aria-label="DASHBOARD_GROUPBY_LABEL"/);
+  assert.match(html, /title="DASHBOARD_GROUPBY_LABEL: Category"/);
+  assert.match(html, /dashboard-widget-settings-wrap/);
 });

--- a/digit-ui-esbuild/products/dashboard/src/components/treeControls.rendersmoke.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/components/treeControls.rendersmoke.test.js
@@ -25,6 +25,7 @@ import React from "react";
 import ReactDOMServer from "react-dom/server";
 import ComplaintTypeTreeFilter, { ComplaintTypeTreePanel } from "./ComplaintTypeTreeFilter.jsx";
 import GroupByLevelSelect from "./GroupByLevelSelect.jsx";
+import { PopoverMenuItem } from "./ui/PopoverMenu.jsx";
 import { buildComplaintTree } from "../utils/complaintTypeTree";
 
 export { buildComplaintTree };
@@ -34,6 +35,8 @@ export const renderPanel = (props) =>
   ReactDOMServer.renderToStaticMarkup(React.createElement(ComplaintTypeTreePanel, props));
 export const renderGroupBy = (props) =>
   ReactDOMServer.renderToStaticMarkup(React.createElement(GroupByLevelSelect, props));
+export const renderMenuItem = (props, label) =>
+  ReactDOMServer.renderToStaticMarkup(React.createElement(PopoverMenuItem, props, label));
 `;
 
 function bundleEntry() {
@@ -63,7 +66,8 @@ function bundleEntry() {
   return require(out);
 }
 
-const { renderFilter, renderPanel, renderGroupBy, buildComplaintTree } = bundleEntry();
+const { renderFilter, renderPanel, renderGroupBy, renderMenuItem, buildComplaintTree } =
+  bundleEntry();
 
 // t: echo the seed English so assertions read naturally (the real runtime
 // echoes the KEY when unseeded — copy is not what this smoke verifies).
@@ -189,6 +193,27 @@ test("panel smoke: deeper than TRAIL_MAX — trail middle-truncates with ellipsi
   // elided levels stay recoverable from the ellipsis title
   assert.match(html, /title="Infrastructure › Water supply"/);
   assert.match(html, /All in Muddy water/);
+});
+
+/* ---------------- menu-row semantics ---------------- */
+
+test("menu-item smoke: applied descend row announces via aria-current", () => {
+  // An interior child that IS the applied subtree (ComplaintTypeTreePanel
+  // passes selected=true + descend when browsing the applied node's parent):
+  // plain menuitem (navigation row), no aria-checked, aria-current instead.
+  const html = renderMenuItem({ selected: true, descend: true, onSelect: noop }, "Water supply");
+  assert.match(html, /role="menuitem"/);
+  assert.match(html, /aria-current="true"/);
+  assert.doesNotMatch(html, /aria-checked/);
+  // unselected descend rows carry neither state
+  const off = renderMenuItem({ descend: true, onSelect: noop }, "Roads");
+  assert.doesNotMatch(off, /aria-current/);
+  assert.doesNotMatch(off, /aria-checked/);
+  // checkable rows keep their radio semantics untouched
+  const radio = renderMenuItem({ selected: true, onSelect: noop }, "Pothole");
+  assert.match(radio, /role="menuitemradio"/);
+  assert.match(radio, /aria-checked="true"/);
+  assert.doesNotMatch(radio, /aria-current/);
 });
 
 /* ---------------- Group-by chip ---------------- */

--- a/digit-ui-esbuild/products/dashboard/src/components/treeControls.rendersmoke.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/components/treeControls.rendersmoke.test.js
@@ -124,7 +124,7 @@ test("chip smoke: deep leaf shows parent › leaf with elision marker", () => {
   // "… › Water quality › Muddy water" — nearest ancestor + leaf, middle elided.
   assert.match(html, /Water quality/);
   assert.match(html, /Muddy water/);
-  assert.match(html, /dashboard-popover-chip-seg--muted/);
+  assert.match(html, /dashboard-popover-trigger-seg--muted/);
   // full trail is recoverable from the title
   assert.match(html, /title="Infrastructure › Water supply › Water quality › Muddy water"/);
 });
@@ -212,7 +212,7 @@ test("group-by smoke: settings gear icon button, no native select, menu semantic
   assert.doesNotMatch(html, /<select/);
   // icon-only anchor in the remove-button idiom — NOT a text chip
   assert.match(html, /dashboard-popover-iconbtn/);
-  assert.doesNotMatch(html, /dashboard-popover-chip/);
+  assert.doesNotMatch(html, /dashboard-popover-trigger/);
   assert.match(html, /<svg/);
   assert.match(html, /aria-haspopup="menu"/);
   assert.match(html, /aria-expanded="false"/);

--- a/digit-ui-esbuild/products/dashboard/src/components/treeControls.rendersmoke.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/components/treeControls.rendersmoke.test.js
@@ -1,0 +1,218 @@
+// ReactDOMServer render smoke for the design-pass controls: the
+// complaint-type chip + traversal panel and the "Group by" chip, at root /
+// interior / leaf / 4-level-deep states (ke's PGR_TEST-shaped hierarchy, not
+// just the 2-level live PGR tree).
+//
+// Run from digit-ui-esbuild/:
+//   node --test products/dashboard/src/components/treeControls.rendersmoke.test.js
+//
+// The components are ESM/JSX, so the test bundles a small render entry with
+// the repo's own esbuild (React included in the bundle so the hooks
+// dispatcher matches the server renderer — no external duplicates), the same
+// idiom as the utils suites. renderToStaticMarkup exercises the closed chip
+// for the full widgets and the panel body directly (it is portal-free by
+// design; the PopoverMenu portal itself only mounts client-side).
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const esbuild = require("esbuild");
+
+const ENTRY = `
+import React from "react";
+import ReactDOMServer from "react-dom/server";
+import ComplaintTypeTreeFilter, { ComplaintTypeTreePanel } from "./ComplaintTypeTreeFilter.jsx";
+import GroupByLevelSelect from "./GroupByLevelSelect.jsx";
+import { buildComplaintTree } from "../utils/complaintTypeTree";
+
+export { buildComplaintTree };
+export const renderFilter = (props) =>
+  ReactDOMServer.renderToStaticMarkup(React.createElement(ComplaintTypeTreeFilter, props));
+export const renderPanel = (props) =>
+  ReactDOMServer.renderToStaticMarkup(React.createElement(ComplaintTypeTreePanel, props));
+export const renderGroupBy = (props) =>
+  ReactDOMServer.renderToStaticMarkup(React.createElement(GroupByLevelSelect, props));
+`;
+
+function bundleEntry() {
+  const out = path.join(os.tmpdir(), `tree-controls-smoke.${process.pid}.cjs.js`);
+  esbuild.buildSync({
+    stdin: {
+      contents: ENTRY,
+      resolveDir: __dirname,
+      loader: "jsx",
+      sourcefile: "smoke-entry.jsx",
+    },
+    bundle: true,
+    format: "cjs",
+    platform: "node",
+    loader: { ".jsx": "jsx", ".js": "jsx" },
+    outfile: out,
+    logLevel: "silent",
+    define: { "process.env.NODE_ENV": '"test"' },
+  });
+  process.on("exit", () => {
+    try {
+      fs.unlinkSync(out);
+    } catch (e) {
+      /* already gone */
+    }
+  });
+  return require(out);
+}
+
+const { renderFilter, renderPanel, renderGroupBy, buildComplaintTree } = bundleEntry();
+
+// t: echo the seed English so assertions read naturally (the real runtime
+// echoes the KEY when unseeded — copy is not what this smoke verifies).
+const t = (key, seedEnglish) => seedEnglish || key;
+
+const rec = (code, parentCode, name) => ({ code, name: name || code, parentCode, active: true });
+
+// ke PGR_TEST-shaped 4-level hierarchy: Category → Type → SubType → leaf.
+// (WaterMuddy additionally carries a 5th-level child so a browse position
+// DEEPER than TRAIL_MAX exists — the trail-elision render case.)
+const DEEP_TREE = buildComplaintTree([
+  rec("Infra", null, "Infrastructure"),
+  rec("Water", "Infra", "Water supply"),
+  rec("WaterQuality", "Water", "Water quality"),
+  rec("WaterMuddy", "WaterQuality", "Muddy water"),
+  rec("WaterMuddySource", "WaterMuddy", "Muddy at source"),
+  rec("WaterSmelly", "WaterQuality", "Smelly water"),
+  rec("WaterPressure", "Water", "Low pressure"),
+  rec("Roads", null, "Roads"),
+  rec("Pothole", "Roads", "Pothole"),
+]);
+
+const noop = () => {};
+
+/* ---------------- chip (closed widget) states ---------------- */
+
+test("chip smoke: root state shows All types with menu semantics", () => {
+  const html = renderFilter({
+    tree: DEEP_TREE,
+    filters: { complaintType: "all" },
+    onFilterChange: noop,
+    t,
+  });
+  assert.match(html, /aria-haspopup="menu"/);
+  assert.match(html, /aria-expanded="false"/);
+  assert.match(html, /All types/);
+  assert.doesNotMatch(html, /<select/);
+});
+
+test("chip smoke: depth-1 interior selection shows its label", () => {
+  const html = renderFilter({
+    tree: DEEP_TREE,
+    filters: { complaintType: "Infra" },
+    onFilterChange: noop,
+    t,
+  });
+  assert.match(html, /Infrastructure/);
+  assert.doesNotMatch(html, /<select/);
+});
+
+test("chip smoke: deep leaf shows parent › leaf with elision marker", () => {
+  const html = renderFilter({
+    tree: DEEP_TREE,
+    filters: { complaintType: "WaterMuddy" },
+    onFilterChange: noop,
+    t,
+  });
+  // "… › Water quality › Muddy water" — nearest ancestor + leaf, middle elided.
+  assert.match(html, /Water quality/);
+  assert.match(html, /Muddy water/);
+  assert.match(html, /dashboard-popover-chip-seg--muted/);
+  // full trail is recoverable from the title
+  assert.match(html, /title="Infrastructure › Water supply › Water quality › Muddy water"/);
+});
+
+/* ---------------- panel states ---------------- */
+
+test("panel smoke: root — categories listed, no All-in row, reset pinned", () => {
+  const html = renderPanel({ tree: DEEP_TREE, appliedCode: "all", onApply: noop, t });
+  assert.match(html, /role="menuitem"/);
+  assert.match(html, /Infrastructure/);
+  assert.match(html, /Roads/);
+  assert.doesNotMatch(html, /All in/);
+  assert.match(html, /dashboard-popover-footer/);
+  assert.match(html, /All types/);
+  // interior children carry the descend chevron slot
+  assert.match(html, /dashboard-menu-item-trailing/);
+});
+
+test("panel smoke: interior — trail, All-in row, children", () => {
+  const html = renderPanel({ tree: DEEP_TREE, appliedCode: "Water", onApply: noop, t });
+  // browse opens AT the applied interior node
+  assert.match(html, /dashboard-popover-trail/);
+  assert.match(html, /All in Water supply/);
+  // the applied subtree row renders checked
+  assert.match(html, /aria-checked="true"/);
+  assert.match(html, /Water quality/);
+  assert.match(html, /Low pressure/);
+});
+
+test("panel smoke: leaf — opens at parent with the leaf checked among siblings", () => {
+  const html = renderPanel({ tree: DEEP_TREE, appliedCode: "WaterSmelly", onApply: noop, t });
+  assert.match(html, /All in Water quality/);
+  assert.match(html, /Muddy water/);
+  assert.match(html, /data-selected="true"[^>]*>[\s\S]*?Smelly water/);
+  assert.match(html, /aria-checked="true"/);
+});
+
+test("panel smoke: 4-level-deep leaf — full trail fits, every level labeled", () => {
+  const html = renderPanel({ tree: DEEP_TREE, appliedCode: "WaterSmelly", onApply: noop, t });
+  // browse opens at WaterQuality (depth 3): all › Infrastructure › Water
+  // supply › Water quality — exactly TRAIL_MAX, no elision needed.
+  assert.match(html, /All types/);
+  assert.match(html, /Water supply/);
+  assert.match(html, /Water quality/);
+  assert.doesNotMatch(html, /dashboard-popover-trail-ellipsis/);
+  // labels, never raw codes, in the trail text
+  assert.doesNotMatch(html, />WaterQuality</);
+});
+
+test("panel smoke: deeper than TRAIL_MAX — trail middle-truncates with ellipsis", () => {
+  const html = renderPanel({
+    tree: DEEP_TREE,
+    appliedCode: "WaterMuddySource",
+    onApply: noop,
+    t,
+  });
+  // browse opens at WaterMuddy (depth 4): all › … › Water quality › Muddy water
+  assert.match(html, /dashboard-popover-trail-ellipsis/);
+  assert.match(html, /All types/); // root endpoint kept clickable
+  assert.match(html, /Water quality/); // nearest ancestors kept
+  assert.match(html, /Muddy water/);
+  // elided levels stay recoverable from the ellipsis title
+  assert.match(html, /title="Infrastructure › Water supply"/);
+  assert.match(html, /All in Muddy water/);
+});
+
+/* ---------------- Group-by chip ---------------- */
+
+const LEVELS = [
+  { levelCode: "CATEGORY", label: "Category", order: 1 },
+  { levelCode: "TYPE", label: "Type", order: 2 },
+];
+const OPTIONS = [
+  { value: "1", level: LEVELS[0] },
+  { value: "leaf", leaf: true },
+];
+
+test("group-by chip smoke: labeled chip, no native select, menu semantics", () => {
+  const html = renderGroupBy({
+    value: "1",
+    options: OPTIONS,
+    hierarchyType: "PGR_TEST",
+    onChange: noop,
+  });
+  assert.doesNotMatch(html, /<select/);
+  assert.match(html, /dashboard-popover-chip--compact/);
+  assert.match(html, /dashboard-popover-chip-prefix/);
+  assert.match(html, /Category/);
+  assert.match(html, /aria-haspopup="menu"/);
+  assert.match(html, /dashboard-groupby-chip-wrap/);
+});

--- a/digit-ui-esbuild/products/dashboard/src/components/ui/PopoverMenu.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/ui/PopoverMenu.jsx
@@ -14,7 +14,13 @@ import { createPortal } from "react-dom";
  *   - PANEL: a fixed-position, body-portaled surface mirroring
  *     .dashboard-add-kpi-panel (border-border, 6px radius, the same soft
  *     shadow), position-synced on scroll/resize, flipped above the anchor
- *     when the viewport below is too short, clamped horizontally.
+ *     when the viewport below is too short, clamped horizontally. Because
+ *     the portal target (document.body) sits OUTSIDE .dashboard-root — the
+ *     element every dashboard design token (--border/--muted/--ring/…) and
+ *     the Inter font stack hang off — the panel carries the dashboard-root
+ *     class itself, so its contents resolve the exact same tokens as
+ *     in-tree dashboard chrome instead of inheriting the host app's
+ *     body-level styling.
  *
  * Behavior owned here so consumers stay declarative:
  *   - open/close state, click-outside close, Escape/Tab close (refocusing the
@@ -306,7 +312,7 @@ const PopoverMenu = ({
               ref={panelRef}
               role="menu"
               aria-label={ariaLabel}
-              className={`dashboard-popover-panel${panelClassName ? ` ${panelClassName}` : ""}`}
+              className={`dashboard-root dashboard-popover-panel${panelClassName ? ` ${panelClassName}` : ""}`}
               style={{
                 position: "fixed",
                 top: pos?.top ?? -9999,

--- a/digit-ui-esbuild/products/dashboard/src/components/ui/PopoverMenu.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/ui/PopoverMenu.jsx
@@ -49,6 +49,7 @@ import { createPortal } from "react-dom";
 
 const GAP_PX = 6;
 const VIEWPORT_PAD_PX = 8;
+const MIN_PANEL_MAX_PX = 64;
 const ITEM_SELECTOR = "[data-menu-item]:not(:disabled)";
 
 const CaretIcon = () => (
@@ -179,9 +180,12 @@ const PopoverMenu = ({
   }, []);
 
   // Position: below the anchor (start- or end-aligned), clamped to the
-  // viewport, flipped above when there is no room below but there is above.
-  // Re-synced on scroll/resize and (when supported) on panel size changes —
-  // the tree panel grows/shrinks as the user descends.
+  // viewport, flipped above when there is no room below but more above; when
+  // NEITHER side fits (very short viewports) the roomier side wins and the
+  // panel's max height is capped to that side's space so every option stays
+  // reachable (the item list scrolls internally). Re-synced on scroll/resize
+  // and (when supported) on panel size changes — the tree panel grows/shrinks
+  // as the user descends.
   useLayoutEffect(() => {
     if (!open) return undefined;
     const sync = () => {
@@ -196,15 +200,24 @@ const PopoverMenu = ({
         VIEWPORT_PAD_PX,
         Math.min(left, window.innerWidth - width - VIEWPORT_PAD_PX)
       );
-      let top = rect.bottom + GAP_PX;
-      if (
-        height &&
-        top + height > window.innerHeight - VIEWPORT_PAD_PX &&
-        rect.top - GAP_PX - height >= VIEWPORT_PAD_PX
-      ) {
-        top = rect.top - GAP_PX - height;
-      }
-      setPos((prev) => (prev && prev.top === top && prev.left === left ? prev : { top, left }));
+      // Floored so a sub-pixel space difference can't flip sides between
+      // ResizeObserver passes (offsetHeight is integral).
+      const spaceBelow = Math.floor(
+        window.innerHeight - VIEWPORT_PAD_PX - (rect.bottom + GAP_PX)
+      );
+      const spaceAbove = Math.floor(rect.top - GAP_PX - VIEWPORT_PAD_PX);
+      const above = !!height && height > spaceBelow && spaceAbove > spaceBelow;
+      // Never below MIN_PANEL_MAX_PX: a degenerate viewport gets a slightly
+      // anchor-overlapping panel rather than an unusably thin one.
+      const maxHeight = Math.max(above ? spaceAbove : spaceBelow, MIN_PANEL_MAX_PX);
+      const top = above
+        ? Math.max(VIEWPORT_PAD_PX, rect.top - GAP_PX - Math.min(height, maxHeight))
+        : rect.bottom + GAP_PX;
+      setPos((prev) =>
+        prev && prev.top === top && prev.left === left && prev.maxHeight === maxHeight
+          ? prev
+          : { top, left, maxHeight }
+      );
     };
     sync();
     window.addEventListener("resize", sync);
@@ -325,7 +338,7 @@ const PopoverMenu = ({
                 top: pos?.top ?? -9999,
                 left: pos?.left ?? -9999,
                 width: panelWidth,
-                maxHeight: "min(22rem, 70vh)",
+                maxHeight: pos ? `min(22rem, 70vh, ${pos.maxHeight}px)` : "min(22rem, 70vh)",
                 zIndex: 9999,
                 visibility: pos ? "visible" : "hidden",
               }}

--- a/digit-ui-esbuild/products/dashboard/src/components/ui/PopoverMenu.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/ui/PopoverMenu.jsx
@@ -3,14 +3,19 @@ import { createPortal } from "react-dom";
 
 /**
  * Shared styled popover/menu primitive for the dashboard's compact controls
- * (the complaint-type tree filter in the filter bar, the per-widget "Group by"
- * chip) — the design-pass replacement for the browser-native <select>s.
+ * (the complaint-type tree filter in the filter bar, the per-widget settings
+ * gear's "Group by" menu) — the design-pass replacement for the
+ * browser-native <select>s.
  *
  * Anatomy:
  *   - anchor CHIP: a real <button> styled like the inline filter controls
  *     (.dashboard-popover-chip — same h-7/rounded-sm/border-border/bg-surface
  *     language as .dashboard-filter-inline-select), with aria-haspopup/
- *     aria-expanded and a caret;
+ *     aria-expanded and a caret; OR, when `icon` is passed, an ICON-ONLY
+ *     anchor (.dashboard-popover-iconbtn — the muted 1.5rem-square idiom of
+ *     .dashboard-widget-remove-btn) for widget-header placement, where a
+ *     text chip would make headers with options look different from headers
+ *     without;
  *   - PANEL: a fixed-position, body-portaled surface mirroring
  *     .dashboard-add-kpi-panel (border-border, 6px radius, the same soft
  *     shadow), position-synced on scroll/resize, flipped above the anchor
@@ -150,10 +155,9 @@ export const PopoverMenuGroupLabel = ({ children }) => (
 
 const PopoverMenu = ({
   chip,
-  chipPrefix,
   chipTitle,
   ariaLabel,
-  compact = false,
+  icon = null,
   disabled = false,
   align = "start",
   panelWidth = 240,
@@ -294,17 +298,18 @@ const PopoverMenu = ({
         aria-expanded={open}
         aria-label={ariaLabel}
         title={chipTitle}
-        className={`dashboard-popover-chip${compact ? " dashboard-popover-chip--compact" : ""}${
+        className={`${icon ? "dashboard-popover-iconbtn" : "dashboard-popover-chip"}${
           chipClassName ? ` ${chipClassName}` : ""
         }`}
         onClick={() => (open ? close() : setOpen(true))}
         onKeyDown={handleAnchorKeyDown}
       >
-        {chipPrefix != null && (
-          <span className="dashboard-popover-chip-prefix">{chipPrefix}</span>
+        {icon ?? (
+          <>
+            <span className="dashboard-popover-chip-value">{chip}</span>
+            <CaretIcon />
+          </>
         )}
-        <span className="dashboard-popover-chip-value">{chip}</span>
-        <CaretIcon />
       </button>
       {open && canPortal
         ? createPortal(

--- a/digit-ui-esbuild/products/dashboard/src/components/ui/PopoverMenu.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/ui/PopoverMenu.jsx
@@ -106,7 +106,8 @@ const ChevronRightIcon = () => (
  * rows. `descend` marks an interior tree row: trailing chevron, always a
  * plain menuitem (activating it navigates within the panel, it is not a
  * checkable option itself — but it still shows the selected treatment when
- * `selected` is passed, e.g. the applied subtree's own row).
+ * `selected` is passed, e.g. the applied subtree's own row, announced via
+ * aria-current since menuitem carries no aria-checked).
  */
 export const PopoverMenuItem = ({
   selected,
@@ -123,6 +124,7 @@ export const PopoverMenuItem = ({
       type="button"
       role={checkable ? "menuitemradio" : "menuitem"}
       aria-checked={checkable ? !!selected : undefined}
+      aria-current={!checkable && selected ? "true" : undefined}
       data-menu-item=""
       data-selected={selected ? "true" : undefined}
       title={title}

--- a/digit-ui-esbuild/products/dashboard/src/components/ui/PopoverMenu.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/ui/PopoverMenu.jsx
@@ -1,0 +1,330 @@
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+/**
+ * Shared styled popover/menu primitive for the dashboard's compact controls
+ * (the complaint-type tree filter in the filter bar, the per-widget "Group by"
+ * chip) — the design-pass replacement for the browser-native <select>s.
+ *
+ * Anatomy:
+ *   - anchor CHIP: a real <button> styled like the inline filter controls
+ *     (.dashboard-popover-chip — same h-7/rounded-sm/border-border/bg-surface
+ *     language as .dashboard-filter-inline-select), with aria-haspopup/
+ *     aria-expanded and a caret;
+ *   - PANEL: a fixed-position, body-portaled surface mirroring
+ *     .dashboard-add-kpi-panel (border-border, 6px radius, the same soft
+ *     shadow), position-synced on scroll/resize, flipped above the anchor
+ *     when the viewport below is too short, clamped horizontally.
+ *
+ * Behavior owned here so consumers stay declarative:
+ *   - open/close state, click-outside close, Escape/Tab close (refocusing the
+ *     anchor), body-portal + positioning;
+ *   - keyboard navigation: ArrowUp/ArrowDown/Home/End rove DOM focus across
+ *     every [data-menu-item] inside the panel (Enter/Space activate natively —
+ *     items are real <button>s); ArrowDown/ArrowUp on the closed chip opens;
+ *   - initial focus: the selected item when there is one (which also scrolls
+ *     it into view in long lists), else the first item.
+ *
+ * Dependency-free and SSR-safe: the panel only portals when `document`
+ * exists, and a closed chip renders fine under ReactDOMServer. RGL note: the
+ * chip is a <button> (already in AdminDashboard's draggableCancel list) and
+ * the panel is portaled to document.body — outside any grid item — so
+ * opening/using a menu can never start a widget drag.
+ *
+ * Consumers render panel content via function-as-children ({ close }) using
+ * PopoverMenuItem / PopoverMenuGroupLabel (or any elements carrying
+ * data-menu-item for custom rows, e.g. the tree filter's trail crumbs).
+ */
+
+const GAP_PX = 6;
+const VIEWPORT_PAD_PX = 8;
+const ITEM_SELECTOR = "[data-menu-item]:not(:disabled)";
+
+const CaretIcon = () => (
+  <svg
+    className="dashboard-popover-chip-caret"
+    width="12"
+    height="12"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden
+  >
+    <path d="m6 9 6 6 6-6" />
+  </svg>
+);
+
+const CheckIcon = () => (
+  <svg
+    width="12"
+    height="12"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden
+  >
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+);
+
+const ChevronRightIcon = () => (
+  <svg
+    width="12"
+    height="12"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden
+  >
+    <path d="m9 18 6-6-6-6" />
+  </svg>
+);
+
+/**
+ * One menu row. `selected` (true/false) makes it a menuitemradio with a
+ * trailing check when on; leave it undefined for plain action/navigation
+ * rows. `descend` marks an interior tree row: trailing chevron, always a
+ * plain menuitem (activating it navigates within the panel, it is not a
+ * checkable option itself — but it still shows the selected treatment when
+ * `selected` is passed, e.g. the applied subtree's own row).
+ */
+export const PopoverMenuItem = ({
+  selected,
+  descend = false,
+  muted = false,
+  title,
+  className = "",
+  onSelect,
+  children,
+}) => {
+  const checkable = !descend && selected !== undefined;
+  return (
+    <button
+      type="button"
+      role={checkable ? "menuitemradio" : "menuitem"}
+      aria-checked={checkable ? !!selected : undefined}
+      data-menu-item=""
+      data-selected={selected ? "true" : undefined}
+      title={title}
+      className={`dashboard-menu-item${muted ? " dashboard-menu-item--muted" : ""}${
+        className ? ` ${className}` : ""
+      }`}
+      onClick={onSelect}
+    >
+      <span className="dashboard-menu-item-label">{children}</span>
+      {selected ? (
+        <span className="dashboard-menu-item-trailing dashboard-menu-item-check">
+          <CheckIcon />
+        </span>
+      ) : null}
+      {descend ? (
+        <span className="dashboard-menu-item-trailing" aria-hidden>
+          <ChevronRightIcon />
+        </span>
+      ) : null}
+    </button>
+  );
+};
+
+/** Non-interactive section label between runs of related items. */
+export const PopoverMenuGroupLabel = ({ children }) => (
+  <div role="presentation" className="dashboard-menu-group-label">
+    {children}
+  </div>
+);
+
+const PopoverMenu = ({
+  chip,
+  chipPrefix,
+  chipTitle,
+  ariaLabel,
+  compact = false,
+  disabled = false,
+  align = "start",
+  panelWidth = 240,
+  chipClassName = "",
+  panelClassName = "",
+  children,
+}) => {
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState(null);
+  const anchorRef = useRef(null);
+  const panelRef = useRef(null);
+
+  const close = useCallback((opts = {}) => {
+    setOpen(false);
+    setPos(null);
+    if (opts.refocus !== false) anchorRef.current?.focus();
+  }, []);
+
+  // Position: below the anchor (start- or end-aligned), clamped to the
+  // viewport, flipped above when there is no room below but there is above.
+  // Re-synced on scroll/resize and (when supported) on panel size changes —
+  // the tree panel grows/shrinks as the user descends.
+  useLayoutEffect(() => {
+    if (!open) return undefined;
+    const sync = () => {
+      const anchor = anchorRef.current;
+      if (!anchor) return;
+      const rect = anchor.getBoundingClientRect();
+      const panelEl = panelRef.current;
+      const width = panelEl?.offsetWidth || panelWidth;
+      const height = panelEl?.offsetHeight || 0;
+      let left = align === "end" ? rect.right - width : rect.left;
+      left = Math.max(
+        VIEWPORT_PAD_PX,
+        Math.min(left, window.innerWidth - width - VIEWPORT_PAD_PX)
+      );
+      let top = rect.bottom + GAP_PX;
+      if (
+        height &&
+        top + height > window.innerHeight - VIEWPORT_PAD_PX &&
+        rect.top - GAP_PX - height >= VIEWPORT_PAD_PX
+      ) {
+        top = rect.top - GAP_PX - height;
+      }
+      setPos((prev) => (prev && prev.top === top && prev.left === left ? prev : { top, left }));
+    };
+    sync();
+    window.addEventListener("resize", sync);
+    window.addEventListener("scroll", sync, true);
+    let observer;
+    if (typeof ResizeObserver !== "undefined" && panelRef.current) {
+      observer = new ResizeObserver(sync);
+      observer.observe(panelRef.current);
+    }
+    return () => {
+      window.removeEventListener("resize", sync);
+      window.removeEventListener("scroll", sync, true);
+      observer?.disconnect();
+    };
+  }, [open, align, panelWidth]);
+
+  // Click-outside close (mousedown, like AddKpiDropdown) — without stealing
+  // focus back to the anchor. Clicks on the anchor itself are left to the
+  // chip's own toggle handler.
+  useEffect(() => {
+    if (!open) return undefined;
+    const handleMouseDown = (event) => {
+      const insideAnchor = anchorRef.current && anchorRef.current.contains(event.target);
+      const insidePanel = panelRef.current && panelRef.current.contains(event.target);
+      if (insideAnchor || insidePanel) return;
+      close({ refocus: false });
+    };
+    document.addEventListener("mousedown", handleMouseDown);
+    return () => document.removeEventListener("mousedown", handleMouseDown);
+  }, [open, close]);
+
+  // Initial focus: selected item (scrolled into view) else first item.
+  useEffect(() => {
+    if (!open) return undefined;
+    const id = requestAnimationFrame(() => {
+      const root = panelRef.current;
+      if (!root) return;
+      const target =
+        root.querySelector('[data-menu-item][data-selected="true"]') ||
+        root.querySelector(ITEM_SELECTOR);
+      target?.focus();
+    });
+    return () => cancelAnimationFrame(id);
+  }, [open]);
+
+  const handlePanelKeyDown = (event) => {
+    if (event.key === "Escape" || event.key === "Tab") {
+      event.preventDefault();
+      close();
+      return;
+    }
+    if (
+      event.key !== "ArrowDown" &&
+      event.key !== "ArrowUp" &&
+      event.key !== "Home" &&
+      event.key !== "End"
+    ) {
+      return;
+    }
+    event.preventDefault();
+    const root = panelRef.current;
+    if (!root) return;
+    const items = Array.from(root.querySelectorAll(ITEM_SELECTOR));
+    if (!items.length) return;
+    const current = items.indexOf(document.activeElement);
+    let next = 0;
+    if (event.key === "ArrowDown") next = current < 0 ? 0 : (current + 1) % items.length;
+    else if (event.key === "ArrowUp")
+      next = current < 0 ? items.length - 1 : (current - 1 + items.length) % items.length;
+    else if (event.key === "End") next = items.length - 1;
+    items[next].focus();
+  };
+
+  const handleAnchorKeyDown = (event) => {
+    if (!open && (event.key === "ArrowDown" || event.key === "ArrowUp")) {
+      event.preventDefault();
+      setOpen(true);
+    } else if (open && event.key === "Escape") {
+      event.preventDefault();
+      close();
+    }
+  };
+
+  const canPortal = typeof document !== "undefined" && !!document.body;
+
+  return (
+    <>
+      <button
+        type="button"
+        ref={anchorRef}
+        disabled={disabled}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+        title={chipTitle}
+        className={`dashboard-popover-chip${compact ? " dashboard-popover-chip--compact" : ""}${
+          chipClassName ? ` ${chipClassName}` : ""
+        }`}
+        onClick={() => (open ? close() : setOpen(true))}
+        onKeyDown={handleAnchorKeyDown}
+      >
+        {chipPrefix != null && (
+          <span className="dashboard-popover-chip-prefix">{chipPrefix}</span>
+        )}
+        <span className="dashboard-popover-chip-value">{chip}</span>
+        <CaretIcon />
+      </button>
+      {open && canPortal
+        ? createPortal(
+            <div
+              ref={panelRef}
+              role="menu"
+              aria-label={ariaLabel}
+              className={`dashboard-popover-panel${panelClassName ? ` ${panelClassName}` : ""}`}
+              style={{
+                position: "fixed",
+                top: pos?.top ?? -9999,
+                left: pos?.left ?? -9999,
+                width: panelWidth,
+                maxHeight: "min(22rem, 70vh)",
+                zIndex: 9999,
+                visibility: pos ? "visible" : "hidden",
+              }}
+              onKeyDown={handlePanelKeyDown}
+            >
+              {typeof children === "function" ? children({ close }) : children}
+            </div>,
+            document.body
+          )
+        : null}
+    </>
+  );
+};
+
+export default PopoverMenu;

--- a/digit-ui-esbuild/products/dashboard/src/components/ui/PopoverMenu.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/ui/PopoverMenu.jsx
@@ -9,7 +9,7 @@ import { createPortal } from "react-dom";
  *
  * Anatomy:
  *   - anchor CHIP: a real <button> styled like the inline filter controls
- *     (.dashboard-popover-chip — same h-7/rounded-sm/border-border/bg-surface
+ *     (.dashboard-popover-trigger — same h-7/rounded-sm/border-border/bg-surface
  *     language as .dashboard-filter-inline-select), with aria-haspopup/
  *     aria-expanded and a caret; OR, when `icon` is passed, an ICON-ONLY
  *     anchor (.dashboard-popover-iconbtn — the muted 1.5rem-square idiom of
@@ -53,7 +53,7 @@ const ITEM_SELECTOR = "[data-menu-item]:not(:disabled)";
 
 const CaretIcon = () => (
   <svg
-    className="dashboard-popover-chip-caret"
+    className="dashboard-popover-trigger-caret"
     width="12"
     height="12"
     viewBox="0 0 24 24"
@@ -298,7 +298,7 @@ const PopoverMenu = ({
         aria-expanded={open}
         aria-label={ariaLabel}
         title={chipTitle}
-        className={`${icon ? "dashboard-popover-iconbtn" : "dashboard-popover-chip"}${
+        className={`${icon ? "dashboard-popover-iconbtn" : "dashboard-popover-trigger"}${
           chipClassName ? ` ${chipClassName}` : ""
         }`}
         onClick={() => (open ? close() : setOpen(true))}
@@ -306,7 +306,7 @@ const PopoverMenu = ({
       >
         {icon ?? (
           <>
-            <span className="dashboard-popover-chip-value">{chip}</span>
+            <span className="dashboard-popover-trigger-value">{chip}</span>
             <CaretIcon />
           </>
         )}

--- a/digit-ui-esbuild/products/dashboard/src/config/dashboardFilters.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/dashboardFilters.js
@@ -60,6 +60,10 @@ export function reconcileFiltersWithOptions(filters, filterOptions) {
   const changed =
     next.geography !== safe.geography ||
     next.complaintType !== safe.complaintType ||
+    // The tree filter's companions can be repaired (path backfilled, leaf
+    // re-derived) even when the code survives — must propagate too.
+    next.complaintTypePath !== safe.complaintTypePath ||
+    next.complaintTypeLeaf !== safe.complaintTypeLeaf ||
     next.dateFrom !== safe.dateFrom ||
     next.dateTo !== safe.dateTo;
 

--- a/digit-ui-esbuild/products/dashboard/src/config/globalFilterGroups.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/globalFilterGroups.js
@@ -180,7 +180,11 @@ export function sanitizeFilters(raw, dynamicOptions = {}) {
  *   nearest surviving ancestor (repairSelection); nothing valid → cleared.
  * - Flat scoped option list only (tree fetch failed / flat tenant): leaf
  *   codes validate against the list exactly like before; interior selections
- *   can't be verified without a tree → cleared.
+ *   can't be verified without a tree, so they are HELD as-is (never cleared)
+ *   — a transient MDMS hiccup must not permanently forget a persisted subtree
+ *   filter (persistDashboardFilters runs this sanitizer on every filter
+ *   change, so a destructive clear here would outlive the hiccup). The trio
+ *   is repaired-or-cleared by the tree branch on the next successful load.
  * - No dynamic options at all (initial localStorage load): trust the
  *   persisted trio and let reconcileFiltersWithOptions repair it when the
  *   tree arrives — clearing here would forget the selection on every reload.
@@ -195,11 +199,10 @@ function sanitizeComplaintTypeSelection(raw, options) {
 
   if (options.complaintTypeTree) {
     selection = repairSelection(options.complaintTypeTree, stored);
-  } else if (options.complaintType) {
-    selection =
-      stored.leaf && options.complaintType.some((opt) => opt.id === stored.code)
-        ? stored
-        : clearedSelection();
+  } else if (options.complaintType && stored.leaf) {
+    selection = options.complaintType.some((opt) => opt.id === stored.code)
+      ? stored
+      : clearedSelection();
   }
 
   return {

--- a/digit-ui-esbuild/products/dashboard/src/config/globalFilterGroups.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/globalFilterGroups.js
@@ -1,4 +1,9 @@
 import { translate } from "../i18n/localeRuntime";
+import {
+  clearedSelection,
+  normalizeComplaintTypeValue,
+  repairSelection,
+} from "../utils/complaintTypeTree";
 
 function todayISO() {
   const d = new Date();
@@ -95,6 +100,13 @@ export function buildDefaultFilters() {
   );
   defaults.timeWindow = "weekly";
   defaults.dateRangeActive = true;
+  // Tree-traversal complaint-type filter companions: `complaintType` stays the
+  // selected node's code ("all" = cleared, back-compat with every consumer);
+  // path + leaf make the persisted selection self-describing so the very first
+  // batch (before the MDMS tree loads) already sends the right param shape
+  // (leaf → serviceCode, interior → complaintPath).
+  defaults.complaintTypePath = null;
+  defaults.complaintTypeLeaf = false;
   return defaults;
 }
 
@@ -139,13 +151,16 @@ export function sanitizeFilters(raw, dynamicOptions = {}) {
     if (field.type === "date" && isValidISODate(value)) {
       next[field.id] = value;
     }
-    if (field.type === "select") {
+    // complaintType is a tree node, not a flat option — handled below.
+    if (field.type === "select" && field.id !== "complaintType") {
       const fieldOptions = options[field.id] ?? field.options;
       if (fieldOptions.some((opt) => opt.id === value)) {
         next[field.id] = value;
       }
     }
   }
+
+  Object.assign(next, sanitizeComplaintTypeSelection(raw, options));
 
   if (["daily", "weekly", "monthly", "wow", "mom"].includes(raw.timeWindow)) {
     next.timeWindow = raw.timeWindow;
@@ -154,4 +169,42 @@ export function sanitizeFilters(raw, dynamicOptions = {}) {
   next.dateRangeActive = raw.dateRangeActive === true;
 
   return next;
+}
+
+/**
+ * Sanitize/repair the complaint-type node selection ({ complaintType,
+ * complaintTypePath, complaintTypeLeaf }):
+ *
+ * - Pruned tree available (options.complaintTypeTree) — the authority:
+ *   exact node wins; a vanished node walks UP its stored dot-path to the
+ *   nearest surviving ancestor (repairSelection); nothing valid → cleared.
+ * - Flat scoped option list only (tree fetch failed / flat tenant): leaf
+ *   codes validate against the list exactly like before; interior selections
+ *   can't be verified without a tree → cleared.
+ * - No dynamic options at all (initial localStorage load): trust the
+ *   persisted trio and let reconcileFiltersWithOptions repair it when the
+ *   tree arrives — clearing here would forget the selection on every reload.
+ */
+function sanitizeComplaintTypeSelection(raw, options) {
+  const stored = normalizeComplaintTypeValue({
+    code: raw.complaintType,
+    path: raw.complaintTypePath,
+    leaf: raw.complaintTypeLeaf,
+  });
+  let selection = stored;
+
+  if (options.complaintTypeTree) {
+    selection = repairSelection(options.complaintTypeTree, stored);
+  } else if (options.complaintType) {
+    selection =
+      stored.leaf && options.complaintType.some((opt) => opt.id === stored.code)
+        ? stored
+        : clearedSelection();
+  }
+
+  return {
+    complaintType: selection.code,
+    complaintTypePath: selection.path,
+    complaintTypeLeaf: selection.leaf,
+  };
 }

--- a/digit-ui-esbuild/products/dashboard/src/hooks/useDashboardFilters.js
+++ b/digit-ui-esbuild/products/dashboard/src/hooks/useDashboardFilters.js
@@ -6,6 +6,7 @@ import {
   reconcileFiltersWithOptions,
   resolveSubMetricId as resolveSubMetricIdForMetric,
 } from "../config/dashboardFilters";
+import { normalizeComplaintTypeValue } from "../utils/complaintTypeTree";
 
 export function useDashboardFilters() {
   const [filters, setFilters] = useState(loadDashboardFilters);
@@ -29,7 +30,23 @@ export function useDashboardFilters() {
   const setFilter = useCallback(
     (groupId, value) => {
       setFilters((prev) => {
-        const next = { ...prev, [groupId]: value };
+        let next;
+        if (groupId === "complaintType") {
+          // Tree-traversal type filter: the widget sends the { code, path,
+          // leaf } node selection (APPLY-ON-SELECT); the flat fallback select
+          // still sends a bare leaf-code string. Persist the trio atomically
+          // so leaf → serviceCode / interior → complaintPath resolves without
+          // waiting for the MDMS tree.
+          const selection = normalizeComplaintTypeValue(value);
+          next = {
+            ...prev,
+            complaintType: selection.code,
+            complaintTypePath: selection.path,
+            complaintTypeLeaf: selection.leaf,
+          };
+        } else {
+          next = { ...prev, [groupId]: value };
+        }
         if (groupId === "dateFrom" || groupId === "dateTo") {
           next.dateRangeActive = true;
         }

--- a/digit-ui-esbuild/products/dashboard/src/hooks/useFilterOptions.js
+++ b/digit-ui-esbuild/products/dashboard/src/hooks/useFilterOptions.js
@@ -1,6 +1,13 @@
 import { useEffect, useMemo, useState } from "react";
 import { runBatchQueries } from "../services/analyticsService";
-import { fetchComplaintTypeIndex } from "../services/complaintHierarchyService";
+import {
+  buildComplaintTypeIndex,
+  fetchComplaintHierarchyRecords,
+} from "../services/complaintHierarchyService";
+import {
+  buildComplaintTree,
+  pruneComplaintTree,
+} from "../utils/complaintTypeTree";
 import { dimensionLabel } from "../i18n/dimensionLabel";
 import useDashboardT from "../i18n/useDashboardT";
 import {
@@ -92,7 +99,7 @@ function toComplaintTypeDecorator(hierarchyIndex) {
 export function useFilterOptions() {
   // Raw fetch payload and derived labels are split so a language switch
   // re-labels from the cached rows without re-querying the backend.
-  const [raw, setRaw] = useState({ results: null, hierarchyIndex: null, loading: true });
+  const [raw, setRaw] = useState({ results: null, hierarchyRecords: null, loading: true });
   const { language } = useDashboardT();
 
   useEffect(() => {
@@ -101,15 +108,15 @@ export function useFilterOptions() {
       runBatchQueries(OPTION_QUERIES),
       // Resolves null on any failure (never rejects) — labels then fall back
       // to the humanizer and the list stays flat, exactly the old behavior.
-      fetchComplaintTypeIndex(),
+      fetchComplaintHierarchyRecords(),
     ])
-      .then(([res, hierarchyIndex]) => {
+      .then(([res, hierarchyRecords]) => {
         if (cancelled) return;
-        setRaw({ results: res?.results || {}, hierarchyIndex, loading: false });
+        setRaw({ results: res?.results || {}, hierarchyRecords, loading: false });
       })
       .catch(() => {
         // Never block the dashboard — the selects keep their placeholder lists.
-        if (!cancelled) setRaw({ results: null, hierarchyIndex: null, loading: false });
+        if (!cancelled) setRaw({ results: null, hierarchyRecords: null, loading: false });
       });
     return () => {
       cancelled = true;
@@ -118,13 +125,16 @@ export function useFilterOptions() {
 
   return useMemo(() => {
     if (!raw.results) return { options: null, loading: raw.loading };
+    const hierarchyIndex = raw.hierarchyRecords
+      ? buildComplaintTypeIndex(raw.hierarchyRecords)
+      : null;
     // Per-entry failures come back as { error } (no rows) — treated as empty.
     const complaintType = toOptionList(
       raw.results.complaintTypes?.rows,
       "service_code",
       COMPLAINT_TYPE_OPTIONS,
       "complaintType",
-      toComplaintTypeDecorator(raw.hierarchyIndex)
+      toComplaintTypeDecorator(hierarchyIndex?.size ? hierarchyIndex : null)
     );
     const geography = toOptionList(
       raw.results.wards?.rows,
@@ -132,9 +142,21 @@ export function useFilterOptions() {
       GEOGRAPHY_OPTIONS,
       "boundary"
     );
+    // Tree-traversal complaint-type filter: the MDMS tree intersected with the
+    // ABAC-scoped DISTINCT service_code list above (pruneComplaintTree). Both
+    // inputs must exist — no scoped distincts (query failed / zero rows) or no
+    // master → null, and the widget degrades to the flat leaf select.
+    const scopedLeafCodes = (raw.results.complaintTypes?.rows || [])
+      .map((row) => String(row?.service_code ?? "").trim())
+      .filter(Boolean);
+    const complaintTypeTree = pruneComplaintTree(
+      buildComplaintTree(raw.hierarchyRecords),
+      scopedLeafCodes
+    );
     const options = {
       ...(geography && { geography }),
       ...(complaintType && { complaintType }),
+      ...(complaintTypeTree && { complaintTypeTree }),
     };
     return {
       options: Object.keys(options).length ? options : null,

--- a/digit-ui-esbuild/products/dashboard/src/services/complaintHierarchyService.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/complaintHierarchyService.js
@@ -103,14 +103,16 @@ export function buildComplaintTypeIndex(records) {
 }
 
 /**
- * Fetch the PGR complaint hierarchy master (state-root tenant, same-origin
- * MDMS v1 — same auth/tenant conventions as boundaryService) and return the
- * code → { label, rootCode, rootLabel } index.
+ * Fetch the raw PGR complaint hierarchy records (state-root tenant,
+ * same-origin MDMS v1 — same auth/tenant conventions as boundaryService).
+ * ONE fetch feeds both derived shapes the dashboard needs: the flat
+ * code → label/root index (buildComplaintTypeIndex) and the traversal tree
+ * (utils/complaintTypeTree.js buildComplaintTree).
  *
  * Resolves null on any failure (never rejects) so callers can fall back to
  * humanized flat labels without blocking the dashboard.
  */
-export async function fetchComplaintTypeIndex() {
+export async function fetchComplaintHierarchyRecords() {
   if (!hasAuth()) return null;
 
   try {
@@ -139,14 +141,22 @@ export async function fetchComplaintTypeIndex() {
 
     const payload = await response.json();
     const records = payload?.MdmsRes?.["RAINMAKER-PGR"]?.ComplaintHierarchy;
-    if (!Array.isArray(records) || !records.length) return null;
-
-    const indexed = buildComplaintTypeIndex(records);
-    return indexed.size ? indexed : null;
+    return Array.isArray(records) && records.length ? records : null;
   } catch (error) {
     console.warn("egov-mdms-service ComplaintHierarchy _search error", error);
     return null;
   }
+}
+
+/**
+ * Fetch + index in one step (code → { label, rootCode, rootLabel }).
+ * Resolves null on any failure (never rejects).
+ */
+export async function fetchComplaintTypeIndex() {
+  const records = await fetchComplaintHierarchyRecords();
+  if (!records) return null;
+  const indexed = buildComplaintTypeIndex(records);
+  return indexed.size ? indexed : null;
 }
 
 /**

--- a/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
@@ -1075,19 +1075,45 @@
   cursor: default;
 }
 
-/* Compact variant for widget-header placement (the "Group by" chip). */
+/* Icon-only anchor for widget-header placement (per-widget settings
+     gear): the .dashboard-widget-remove-btn idiom — 1.5rem square, muted,
+     transparent resting, bg-muted on hover/open — minus the absolute
+     positioning (this one sits in the title-row flex flow). */
 
-.dashboard-popover-chip--compact{
+.dashboard-popover-iconbtn{
+  margin: 0px;
+  box-sizing: border-box;
+  display: inline-flex;
   height: 1.5rem;
-  gap: 0.25rem;
-  padding-left: 0.375rem;
-  padding-right: 0.375rem;
-  font-size: 11px;
+  width: 1.5rem;
+  flex-shrink: 0;
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  border-width: 0px;
+  background-color: transparent;
+  padding: 0px;
+  color: var(--muted-foreground);
+  font: inherit;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+       appearance: none;
 }
 
-.dashboard-popover-chip-prefix{
-  flex-shrink: 0;
-  color: var(--muted-foreground);
+.dashboard-popover-iconbtn:hover:not(:disabled),
+  .dashboard-popover-iconbtn[aria-expanded="true"]{
+  background-color: var(--muted);
+  color: var(--foreground);
+}
+
+.dashboard-popover-iconbtn:focus{
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+.dashboard-popover-iconbtn:focus-visible {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 30%, transparent);
 }
 
 .dashboard-popover-chip-value{
@@ -1350,16 +1376,15 @@
   color: var(--muted-foreground);
 }
 
-/* Widget-header wrapper for the compact "Group by" chip: right-aligned in
-     the title row, shrinkable (the chip value truncates) so it never wraps
-     narrow widgets; mr-6 clears the hover remove button. */
+/* Widget-header wrapper for the per-widget settings gear: right-aligned
+     in the title row (same slot on every header that has options; absent
+     otherwise); mr-6 clears the absolute remove button. */
 
-.dashboard-groupby-chip-wrap{
+.dashboard-widget-settings-wrap{
   margin-left: 0.5rem;
   margin-right: 1.5rem;
   display: inline-flex;
-  min-width: 0px;
-  flex-shrink: 1;
+  flex-shrink: 0;
   align-items: center;
   align-self: center;
 }

--- a/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
@@ -3754,3 +3754,18 @@
 .dashboard-root.dashboard-embedded > div > main {
   overflow: visible;
 }
+
+/* The host app's vendor/overrides.css forces height:44px !important on all
+   text inputs/selects via a high-specificity :not() chain. The dashboard uses
+   compact 1.75rem controls (owner preference). Stacked-class specificity +
+   !important re-asserts the compact size; both !important -> specificity wins.
+   Scoped to the wards select only (calendars keep the host size by owner choice). */
+.dashboard-filter-inline-select.dashboard-filter-inline-select.dashboard-filter-inline-select.dashboard-filter-inline-select.dashboard-filter-inline-select.dashboard-filter-inline-select {
+  height: 1.75rem !important;
+  min-height: 1.75rem !important;
+  max-height: 1.75rem !important;
+  font-size: 12px !important;
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+  line-height: 1 !important;
+}

--- a/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
@@ -1017,15 +1017,18 @@
 
 /* ── Shared popover/menu primitive (chip anchor + portaled panel) ───── */
 
-/* Anchor chip: the inline filter-control language (h-7 / rounded-sm /
-     border-border / bg-surface / 12px), as a real button. */
+/* Anchor chip: a strict visual PEER of .dashboard-filter-inline-select —
+     same h-7 / min-w-[7.5rem] / rounded-sm / border-border / bg-surface /
+     12px metrics, no resting hover treatment (the select has none), the
+     select's focus treatment (border-foreground + 15% ring); the only
+     divergence is aria-expanded reusing the focus border while open. */
 
 .dashboard-popover-chip{
   margin: 0px;
   box-sizing: border-box;
   display: inline-flex;
   height: 1.75rem;
-  min-width: 0px;
+  min-width: 7.5rem;
   max-width: 100%;
   flex-shrink: 1;
   cursor: pointer;
@@ -1051,10 +1054,6 @@
   -webkit-appearance: none;
   -moz-appearance: none;
        appearance: none;
-}
-
-.dashboard-popover-chip:hover:not(:disabled){
-  border-color: var(--foreground);
 }
 
 .dashboard-popover-chip:focus{
@@ -1096,10 +1095,15 @@
   min-width: 0px;
   align-items: center;
   overflow: hidden;
-  font-weight: 500;
+  font-weight: 400;
 }
 
+/* ml-auto pins the caret to the chip's right edge (px-2, like the
+     select-wrap's ::after caret at right: 0.5rem) when the label is
+     shorter than the shared 7.5rem min width. */
+
 .dashboard-popover-chip-caret{
+  margin-left: auto;
   flex-shrink: 0;
   color: var(--muted-foreground);
 }
@@ -1323,8 +1327,12 @@
   color: var(--muted-foreground);
 }
 
+/* currentColor, not --primary: selection reads as weight + check in the
+     row's own neutral foreground — the filter bar has no brand accent and
+     the menus don't introduce one. */
+
 .dashboard-menu-item-check {
-  color: var(--primary, #1a1917);
+  color: currentColor;
 }
 
 /* Non-interactive section label between runs of related items (the flat

--- a/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
@@ -1051,6 +1051,23 @@
   color: var(--foreground);
 }
 
+/* Per-tile note when the backend reports the subtree filter could not be
+   honoured on a grain (paramsIgnored: complaintPath — daily-grain KPIs). */
+.dashboard-type-filter-ignored{
+  pointer-events: none;
+  position: absolute;
+  bottom: 0.25rem;
+  left: 1.25rem;
+  z-index: 2;
+  border-radius: 0.25rem;
+  background-color: var(--surface);
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+  font-size: 10px;
+  font-style: italic;
+  line-height: 1.25;
+  color: var(--muted-foreground);
+}
 
 /* ── Responsive layout ─────────────────────────────────────────────── */
 

--- a/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
@@ -996,63 +996,9 @@
   pointer-events: none;
 }
 
-/* ── Complaint-type tree-traversal filter (one-widget subtree nav) ──── */
-
-.dashboard-type-tree-filter{
-  display: inline-flex;
-  height: 1.75rem;
-  flex-shrink: 0;
-  align-items: center;
-  gap: 0.25rem;
-  align-self: center;
-}
-
-.dashboard-type-tree-up{
-  padding-left: 0.25rem;
-  padding-right: 0.25rem;
-}
-
-.dashboard-type-tree-crumbs{
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  font-size: 11px;
-  line-height: 1;
-  color: var(--muted-foreground);
-}
-
-.dashboard-type-tree-crumb{
-  margin: 0px;
-  cursor: pointer;
-  border-width: 0px;
-  background-color: transparent;
-  padding: 0px;
-  font-size: 11px;
-  line-height: 1;
-  color: var(--muted-foreground);
-  font-family: inherit;
-}
-
-.dashboard-type-tree-crumb:hover{
-  color: var(--foreground);
-  text-decoration-line: underline;
-}
-
-.dashboard-type-tree-sep{
-  -webkit-user-select: none;
-     -moz-user-select: none;
-          user-select: none;
-}
-
-.dashboard-type-tree-current{
-  font-size: 11px;
-  font-weight: 500;
-  line-height: 1;
-  color: var(--foreground);
-}
-
 /* Per-tile note when the backend reports the subtree filter could not be
-   honoured on a grain (paramsIgnored: complaintPath — daily-grain KPIs). */
+     honoured on a grain (paramsIgnored: complaintPath — daily-grain KPIs). */
+
 .dashboard-type-filter-ignored{
   pointer-events: none;
   position: absolute;
@@ -1067,6 +1013,347 @@
   font-style: italic;
   line-height: 1.25;
   color: var(--muted-foreground);
+}
+
+/* ── Shared popover/menu primitive (chip anchor + portaled panel) ───── */
+
+/* Anchor chip: the inline filter-control language (h-7 / rounded-sm /
+     border-border / bg-surface / 12px), as a real button. */
+
+.dashboard-popover-chip{
+  margin: 0px;
+  box-sizing: border-box;
+  display: inline-flex;
+  height: 1.75rem;
+  min-width: 0px;
+  max-width: 100%;
+  flex-shrink: 1;
+  cursor: pointer;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+          user-select: none;
+  align-items: center;
+  gap: 0.375rem;
+  align-self: center;
+  white-space: nowrap;
+  border-radius: 4px;
+  border-width: 1px;
+  border-color: var(--border);
+  background-color: var(--surface);
+  padding-top: 0px;
+  padding-bottom: 0px;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  font-size: 12px;
+  line-height: 1;
+  color: var(--foreground);
+  font-family: inherit;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+       appearance: none;
+}
+
+.dashboard-popover-chip:hover:not(:disabled){
+  border-color: var(--foreground);
+}
+
+.dashboard-popover-chip:focus{
+  border-color: var(--foreground);
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+.dashboard-popover-chip:focus-visible {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 15%, transparent);
+}
+
+.dashboard-popover-chip[aria-expanded="true"]{
+  border-color: var(--foreground);
+}
+
+.dashboard-popover-chip:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/* Compact variant for widget-header placement (the "Group by" chip). */
+
+.dashboard-popover-chip--compact{
+  height: 1.5rem;
+  gap: 0.25rem;
+  padding-left: 0.375rem;
+  padding-right: 0.375rem;
+  font-size: 11px;
+}
+
+.dashboard-popover-chip-prefix{
+  flex-shrink: 0;
+  color: var(--muted-foreground);
+}
+
+.dashboard-popover-chip-value{
+  display: inline-flex;
+  min-width: 0px;
+  align-items: center;
+  overflow: hidden;
+  font-weight: 500;
+}
+
+.dashboard-popover-chip-caret{
+  flex-shrink: 0;
+  color: var(--muted-foreground);
+}
+
+/* Chip content for hierarchical selections: "… › Parent › Node" — each
+     segment ellipsizes on its own so deep leaves stay chip-sized. */
+
+.dashboard-popover-chip-trail{
+  display: inline-flex;
+  min-width: 0px;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.dashboard-popover-chip-seg{
+  min-width: 0px;
+  max-width: 9rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dashboard-popover-chip-seg--muted{
+  font-weight: 400;
+  color: var(--muted-foreground);
+}
+
+.dashboard-popover-chip-sep{
+  flex-shrink: 0;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+          user-select: none;
+  color: var(--muted-foreground);
+}
+
+/* Panel: mirrors .dashboard-add-kpi-panel's surface language. */
+
+.dashboard-popover-panel {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--border, #e5e2db);
+  border-radius: 6px;
+  background-color: var(--popover, #ffffff);
+  box-shadow:
+      0 4px 6px -1px rgb(0 0 0 / 0.08),
+      0 2px 4px -2px rgb(0 0 0 / 0.06);
+  color: var(--foreground, #1a1917);
+  isolation: isolate;
+}
+
+/* Tree-traversal panel body (ComplaintTypeTreePanel). */
+
+.dashboard-popover-tree{
+  display: flex;
+  min-height: 0px;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* Ancestor trail across the top of the tree panel. */
+
+.dashboard-popover-trail{
+  display: flex;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem;
+  border-bottom-width: 1px;
+  border-color: var(--border);
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  font-size: 11px;
+  line-height: 1;
+  color: var(--muted-foreground);
+}
+
+.dashboard-popover-trail-crumb{
+  margin: 0px;
+  min-width: 0px;
+  max-width: 7rem;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border-radius: 4px;
+  border-width: 0px;
+  background-color: transparent;
+  padding: 0px;
+  font-size: 11px;
+  line-height: 1;
+  color: var(--muted-foreground);
+}
+
+.dashboard-popover-trail-crumb:hover{
+  color: var(--foreground);
+  text-decoration-line: underline;
+}
+
+.dashboard-popover-trail-crumb {
+  font-family: inherit;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+       appearance: none;
+}
+
+.dashboard-popover-trail-crumb:focus{
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+.dashboard-popover-trail-crumb:focus-visible{
+  color: var(--foreground);
+  text-decoration-line: underline;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 35%, transparent);
+}
+
+.dashboard-popover-trail-sep,
+  .dashboard-popover-trail-ellipsis{
+  flex-shrink: 0;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+          user-select: none;
+}
+
+.dashboard-popover-trail-current{
+  min-width: 0px;
+  max-width: 10rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 500;
+  color: var(--foreground);
+}
+
+/* Scrollable item region (deep trees) and pinned footer (reset row). */
+
+.dashboard-popover-list {
+  -webkit-overflow-scrolling: touch;
+  margin: 0px;
+  min-height: 0px;
+  flex: 1 1 0%;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 0.25rem;
+}
+
+.dashboard-popover-footer{
+  flex-shrink: 0;
+  border-top-width: 1px;
+  border-color: var(--border);
+  padding: 0.25rem;
+}
+
+.dashboard-menu-item{
+  margin: 0px;
+  box-sizing: border-box;
+  display: flex;
+  width: 100%;
+  cursor: pointer;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 4px;
+  border-width: 0px;
+  background-color: transparent;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0.375rem;
+  padding-bottom: 0.375rem;
+  text-align: left;
+  font-size: 12px;
+  line-height: 1.375;
+  color: var(--foreground);
+  font-family: inherit;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+       appearance: none;
+}
+
+.dashboard-menu-item:hover {
+  background-color: var(--muted, #f5f4f1);
+}
+
+.dashboard-menu-item:focus{
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+.dashboard-menu-item:focus-visible {
+  background-color: var(--muted, #f5f4f1);
+  box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--ring) 35%, transparent);
+}
+
+.dashboard-menu-item[data-selected="true"]{
+  font-weight: 500;
+}
+
+.dashboard-menu-item--muted {
+  color: var(--muted-foreground, #6b6860);
+}
+
+.dashboard-menu-item--muted:hover,
+  .dashboard-menu-item--muted:focus-visible {
+  color: var(--foreground, #1a1917);
+}
+
+.dashboard-menu-item-label{
+  min-width: 0px;
+  flex: 1 1 0%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dashboard-menu-item-trailing{
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  color: var(--muted-foreground);
+}
+
+.dashboard-menu-item-check {
+  color: var(--primary, #1a1917);
+}
+
+/* Non-interactive section label between runs of related items (the flat
+     complaint-type degrade path's category groups). */
+
+.dashboard-menu-group-label{
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-bottom: 0.25rem;
+  padding-top: 0.5rem;
+  font-size: 10px;
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted-foreground);
+}
+
+/* Widget-header wrapper for the compact "Group by" chip: right-aligned in
+     the title row, shrinkable (the chip value truncates) so it never wraps
+     narrow widgets; mr-6 clears the hover remove button. */
+
+.dashboard-groupby-chip-wrap{
+  margin-left: 0.5rem;
+  margin-right: 1.5rem;
+  display: inline-flex;
+  min-width: 0px;
+  flex-shrink: 1;
+  align-items: center;
+  align-self: center;
 }
 
 /* ── Responsive layout ─────────────────────────────────────────────── */

--- a/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
@@ -1016,6 +1016,9 @@
 }
 
 /* ── Shared popover/menu primitive (chip anchor + portaled panel) ───── */
+/* Named "trigger" NOT "chip": the host theme (vendor/overrides.css, outside
+   this build) has a [class*="chip"] catch-all that pills ANY class containing
+   that substring — never rename these classes back to *chip*. */
 
 /* Anchor chip: a strict visual PEER of .dashboard-filter-inline-select —
      same h-7 / min-w-[7.5rem] / rounded-sm / border-border / bg-surface /
@@ -1023,7 +1026,7 @@
      select's focus treatment (border-foreground + 15% ring); the only
      divergence is aria-expanded reusing the focus border while open. */
 
-.dashboard-popover-chip{
+.dashboard-popover-trigger{
   margin: 0px;
   box-sizing: border-box;
   display: inline-flex;
@@ -1056,21 +1059,21 @@
        appearance: none;
 }
 
-.dashboard-popover-chip:focus{
+.dashboard-popover-trigger:focus{
   border-color: var(--foreground);
   outline: 2px solid transparent;
   outline-offset: 2px;
 }
 
-.dashboard-popover-chip:focus-visible {
+.dashboard-popover-trigger:focus-visible {
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 15%, transparent);
 }
 
-.dashboard-popover-chip[aria-expanded="true"]{
+.dashboard-popover-trigger[aria-expanded="true"]{
   border-color: var(--foreground);
 }
 
-.dashboard-popover-chip:disabled {
+.dashboard-popover-trigger:disabled {
   opacity: 0.5;
   cursor: default;
 }
@@ -1116,7 +1119,7 @@
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 30%, transparent);
 }
 
-.dashboard-popover-chip-value{
+.dashboard-popover-trigger-value{
   display: inline-flex;
   min-width: 0px;
   align-items: center;
@@ -1128,7 +1131,7 @@
      select-wrap's ::after caret at right: 0.5rem) when the label is
      shorter than the shared 7.5rem min width. */
 
-.dashboard-popover-chip-caret{
+.dashboard-popover-trigger-caret{
   margin-left: auto;
   flex-shrink: 0;
   color: var(--muted-foreground);
@@ -1137,14 +1140,14 @@
 /* Chip content for hierarchical selections: "… › Parent › Node" — each
      segment ellipsizes on its own so deep leaves stay chip-sized. */
 
-.dashboard-popover-chip-trail{
+.dashboard-popover-trigger-trail{
   display: inline-flex;
   min-width: 0px;
   align-items: center;
   gap: 0.25rem;
 }
 
-.dashboard-popover-chip-seg{
+.dashboard-popover-trigger-seg{
   min-width: 0px;
   max-width: 9rem;
   overflow: hidden;
@@ -1152,12 +1155,12 @@
   white-space: nowrap;
 }
 
-.dashboard-popover-chip-seg--muted{
+.dashboard-popover-trigger-seg--muted{
   font-weight: 400;
   color: var(--muted-foreground);
 }
 
-.dashboard-popover-chip-sep{
+.dashboard-popover-trigger-sep{
   flex-shrink: 0;
   -webkit-user-select: none;
      -moz-user-select: none;
@@ -1393,7 +1396,7 @@
      like .dashboard-filter-inline-select in the 639px block below. */
 
 @media (max-width: 639px) {
-  .dashboard-popover-chip {
+  .dashboard-popover-trigger {
     width: 100%;
     min-width: 0;
   }
@@ -2654,7 +2657,7 @@
   pointer-events: auto;
 }
 
-.dashboard-map-filter-chip {
+.dashboard-map-filter-badge {
   z-index: 1000;
 }
 
@@ -2742,7 +2745,7 @@
   padding-right: 0.625rem;
 }
 
-.dashboard-map-filter-chip {
+.dashboard-map-filter-badge {
   -webkit-backdrop-filter: blur(4px);
           backdrop-filter: blur(4px);
 }

--- a/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
@@ -1389,6 +1389,16 @@
   align-self: center;
 }
 
+/* Stacked (mobile) filter bar: the chip stretches full-width, exactly
+     like .dashboard-filter-inline-select in the 639px block below. */
+
+@media (max-width: 639px) {
+  .dashboard-popover-chip {
+    width: 100%;
+    min-width: 0;
+  }
+}
+
 /* ── Responsive layout ─────────────────────────────────────────────── */
 
 .dashboard-grid-wrap .react-grid-layout {

--- a/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
@@ -996,6 +996,62 @@
   pointer-events: none;
 }
 
+/* ── Complaint-type tree-traversal filter (one-widget subtree nav) ──── */
+
+.dashboard-type-tree-filter{
+  display: inline-flex;
+  height: 1.75rem;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 0.25rem;
+  align-self: center;
+}
+
+.dashboard-type-tree-up{
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+}
+
+.dashboard-type-tree-crumbs{
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 11px;
+  line-height: 1;
+  color: var(--muted-foreground);
+}
+
+.dashboard-type-tree-crumb{
+  margin: 0px;
+  cursor: pointer;
+  border-width: 0px;
+  background-color: transparent;
+  padding: 0px;
+  font-size: 11px;
+  line-height: 1;
+  color: var(--muted-foreground);
+  font-family: inherit;
+}
+
+.dashboard-type-tree-crumb:hover{
+  color: var(--foreground);
+  text-decoration-line: underline;
+}
+
+.dashboard-type-tree-sep{
+  -webkit-user-select: none;
+     -moz-user-select: none;
+          user-select: none;
+}
+
+.dashboard-type-tree-current{
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1;
+  color: var(--foreground);
+}
+
+
 /* ── Responsive layout ─────────────────────────────────────────────── */
 
 .dashboard-grid-wrap .react-grid-layout {

--- a/digit-ui-esbuild/products/dashboard/src/styles/input.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/input.css
@@ -643,6 +643,11 @@
     @apply tw-text-[11px] tw-font-medium tw-leading-none tw-text-foreground;
   }
 
+  /* Per-tile note when the backend reports the subtree filter could not be
+     honoured on a grain (paramsIgnored: complaintPath — daily-grain KPIs). */
+  .dashboard-type-filter-ignored {
+    @apply tw-pointer-events-none tw-absolute tw-bottom-1 tw-left-5 tw-z-[2] tw-rounded tw-bg-surface tw-px-1 tw-text-[10px] tw-italic tw-leading-tight tw-text-muted-foreground;
+  }
 
   /* ── Responsive layout ─────────────────────────────────────────────── */
 
@@ -1443,7 +1448,6 @@
   .dashboard-horizontal-bar .apexcharts-svg {
     overflow: visible !important;
   }
-
 
   .dashboard-horizontal-bar .apexcharts-yaxis-texts-g .apexcharts-yaxis-label,
   .dashboard-stacked-bar--horizontal .apexcharts-yaxis-texts-g .apexcharts-yaxis-label {

--- a/digit-ui-esbuild/products/dashboard/src/styles/input.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/input.css
@@ -623,32 +623,35 @@
   }
 
   /* ── Shared popover/menu primitive (chip anchor + portaled panel) ───── */
+  /* Named "trigger" NOT "chip": the host theme (vendor/overrides.css, outside
+     this build) has a [class*="chip"] catch-all that pills ANY class containing
+     that substring — never rename these classes back to *chip*. */
 
   /* Anchor chip: a strict visual PEER of .dashboard-filter-inline-select —
      same h-7 / min-w-[7.5rem] / rounded-sm / border-border / bg-surface /
      12px metrics, no resting hover treatment (the select has none), the
      select's focus treatment (border-foreground + 15% ring); the only
      divergence is aria-expanded reusing the focus border while open. */
-  .dashboard-popover-chip {
+  .dashboard-popover-trigger {
     @apply tw-box-border tw-m-0 tw-inline-flex tw-h-7 tw-min-w-[7.5rem] tw-max-w-full tw-shrink tw-cursor-pointer tw-select-none tw-items-center tw-gap-1.5 tw-self-center tw-whitespace-nowrap tw-rounded-sm tw-border tw-border-border tw-bg-surface tw-py-0 tw-px-2 tw-text-[12px] tw-leading-none tw-text-foreground;
     font-family: inherit;
     -webkit-appearance: none;
     appearance: none;
   }
 
-  .dashboard-popover-chip:focus {
+  .dashboard-popover-trigger:focus {
     @apply tw-border-foreground tw-outline-none;
   }
 
-  .dashboard-popover-chip:focus-visible {
+  .dashboard-popover-trigger:focus-visible {
     box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 15%, transparent);
   }
 
-  .dashboard-popover-chip[aria-expanded="true"] {
+  .dashboard-popover-trigger[aria-expanded="true"] {
     @apply tw-border-foreground;
   }
 
-  .dashboard-popover-chip:disabled {
+  .dashboard-popover-trigger:disabled {
     opacity: 0.5;
     cursor: default;
   }
@@ -677,32 +680,32 @@
     box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 30%, transparent);
   }
 
-  .dashboard-popover-chip-value {
+  .dashboard-popover-trigger-value {
     @apply tw-inline-flex tw-min-w-0 tw-items-center tw-overflow-hidden tw-font-normal;
   }
 
   /* ml-auto pins the caret to the chip's right edge (px-2, like the
      select-wrap's ::after caret at right: 0.5rem) when the label is
      shorter than the shared 7.5rem min width. */
-  .dashboard-popover-chip-caret {
+  .dashboard-popover-trigger-caret {
     @apply tw-ml-auto tw-shrink-0 tw-text-muted-foreground;
   }
 
   /* Chip content for hierarchical selections: "… › Parent › Node" — each
      segment ellipsizes on its own so deep leaves stay chip-sized. */
-  .dashboard-popover-chip-trail {
+  .dashboard-popover-trigger-trail {
     @apply tw-inline-flex tw-min-w-0 tw-items-center tw-gap-1;
   }
 
-  .dashboard-popover-chip-seg {
+  .dashboard-popover-trigger-seg {
     @apply tw-min-w-0 tw-max-w-[9rem] tw-overflow-hidden tw-text-ellipsis tw-whitespace-nowrap;
   }
 
-  .dashboard-popover-chip-seg--muted {
+  .dashboard-popover-trigger-seg--muted {
     @apply tw-font-normal tw-text-muted-foreground;
   }
 
-  .dashboard-popover-chip-sep {
+  .dashboard-popover-trigger-sep {
     @apply tw-shrink-0 tw-select-none tw-text-muted-foreground;
   }
 
@@ -830,7 +833,7 @@
   /* Stacked (mobile) filter bar: the chip stretches full-width, exactly
      like .dashboard-filter-inline-select in the 639px block above. */
   @media (max-width: 639px) {
-    .dashboard-popover-chip {
+    .dashboard-popover-trigger {
       width: 100%;
       min-width: 0;
     }
@@ -1892,7 +1895,7 @@
     pointer-events: auto;
   }
 
-  .dashboard-map-filter-chip {
+  .dashboard-map-filter-badge {
     z-index: 1000;
   }
 
@@ -1951,7 +1954,7 @@
     @apply tw-px-2.5;
   }
 
-  .dashboard-map-filter-chip {
+  .dashboard-map-filter-badge {
     backdrop-filter: blur(4px);
   }
 

--- a/digit-ui-esbuild/products/dashboard/src/styles/input.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/input.css
@@ -624,17 +624,16 @@
 
   /* ── Shared popover/menu primitive (chip anchor + portaled panel) ───── */
 
-  /* Anchor chip: the inline filter-control language (h-7 / rounded-sm /
-     border-border / bg-surface / 12px), as a real button. */
+  /* Anchor chip: a strict visual PEER of .dashboard-filter-inline-select —
+     same h-7 / min-w-[7.5rem] / rounded-sm / border-border / bg-surface /
+     12px metrics, no resting hover treatment (the select has none), the
+     select's focus treatment (border-foreground + 15% ring); the only
+     divergence is aria-expanded reusing the focus border while open. */
   .dashboard-popover-chip {
-    @apply tw-box-border tw-m-0 tw-inline-flex tw-h-7 tw-min-w-0 tw-max-w-full tw-shrink tw-cursor-pointer tw-select-none tw-items-center tw-gap-1.5 tw-self-center tw-whitespace-nowrap tw-rounded-sm tw-border tw-border-border tw-bg-surface tw-py-0 tw-px-2 tw-text-[12px] tw-leading-none tw-text-foreground;
+    @apply tw-box-border tw-m-0 tw-inline-flex tw-h-7 tw-min-w-[7.5rem] tw-max-w-full tw-shrink tw-cursor-pointer tw-select-none tw-items-center tw-gap-1.5 tw-self-center tw-whitespace-nowrap tw-rounded-sm tw-border tw-border-border tw-bg-surface tw-py-0 tw-px-2 tw-text-[12px] tw-leading-none tw-text-foreground;
     font-family: inherit;
     -webkit-appearance: none;
     appearance: none;
-  }
-
-  .dashboard-popover-chip:hover:not(:disabled) {
-    @apply tw-border-foreground;
   }
 
   .dashboard-popover-chip:focus {
@@ -664,11 +663,14 @@
   }
 
   .dashboard-popover-chip-value {
-    @apply tw-inline-flex tw-min-w-0 tw-items-center tw-overflow-hidden tw-font-medium;
+    @apply tw-inline-flex tw-min-w-0 tw-items-center tw-overflow-hidden tw-font-normal;
   }
 
+  /* ml-auto pins the caret to the chip's right edge (px-2, like the
+     select-wrap's ::after caret at right: 0.5rem) when the label is
+     shorter than the shared 7.5rem min width. */
   .dashboard-popover-chip-caret {
-    @apply tw-shrink-0 tw-text-muted-foreground;
+    @apply tw-ml-auto tw-shrink-0 tw-text-muted-foreground;
   }
 
   /* Chip content for hierarchical selections: "… › Parent › Node" — each
@@ -790,8 +792,11 @@
     @apply tw-inline-flex tw-shrink-0 tw-items-center tw-text-muted-foreground;
   }
 
+  /* currentColor, not --primary: selection reads as weight + check in the
+     row's own neutral foreground — the filter bar has no brand accent and
+     the menus don't introduce one. */
   .dashboard-menu-item-check {
-    color: var(--primary, #1a1917);
+    color: currentColor;
   }
 
   /* Non-interactive section label between runs of related items (the flat

--- a/digit-ui-esbuild/products/dashboard/src/styles/input.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/input.css
@@ -616,37 +616,195 @@
     pointer-events: none;
   }
 
-  /* ── Complaint-type tree-traversal filter (one-widget subtree nav) ──── */
-
-  .dashboard-type-tree-filter {
-    @apply tw-inline-flex tw-h-7 tw-shrink-0 tw-items-center tw-gap-1 tw-self-center;
-  }
-
-  .dashboard-type-tree-up {
-    @apply tw-px-1;
-  }
-
-  .dashboard-type-tree-crumbs {
-    @apply tw-inline-flex tw-items-center tw-gap-1 tw-text-[11px] tw-leading-none tw-text-muted-foreground;
-  }
-
-  .dashboard-type-tree-crumb {
-    @apply tw-m-0 tw-cursor-pointer tw-border-0 tw-bg-transparent tw-p-0 tw-text-[11px] tw-leading-none tw-text-muted-foreground hover:tw-text-foreground hover:tw-underline;
-    font-family: inherit;
-  }
-
-  .dashboard-type-tree-sep {
-    @apply tw-select-none;
-  }
-
-  .dashboard-type-tree-current {
-    @apply tw-text-[11px] tw-font-medium tw-leading-none tw-text-foreground;
-  }
-
   /* Per-tile note when the backend reports the subtree filter could not be
      honoured on a grain (paramsIgnored: complaintPath — daily-grain KPIs). */
   .dashboard-type-filter-ignored {
     @apply tw-pointer-events-none tw-absolute tw-bottom-1 tw-left-5 tw-z-[2] tw-rounded tw-bg-surface tw-px-1 tw-text-[10px] tw-italic tw-leading-tight tw-text-muted-foreground;
+  }
+
+  /* ── Shared popover/menu primitive (chip anchor + portaled panel) ───── */
+
+  /* Anchor chip: the inline filter-control language (h-7 / rounded-sm /
+     border-border / bg-surface / 12px), as a real button. */
+  .dashboard-popover-chip {
+    @apply tw-box-border tw-m-0 tw-inline-flex tw-h-7 tw-min-w-0 tw-max-w-full tw-shrink tw-cursor-pointer tw-select-none tw-items-center tw-gap-1.5 tw-self-center tw-whitespace-nowrap tw-rounded-sm tw-border tw-border-border tw-bg-surface tw-py-0 tw-px-2 tw-text-[12px] tw-leading-none tw-text-foreground;
+    font-family: inherit;
+    -webkit-appearance: none;
+    appearance: none;
+  }
+
+  .dashboard-popover-chip:hover:not(:disabled) {
+    @apply tw-border-foreground;
+  }
+
+  .dashboard-popover-chip:focus {
+    @apply tw-border-foreground tw-outline-none;
+  }
+
+  .dashboard-popover-chip:focus-visible {
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 15%, transparent);
+  }
+
+  .dashboard-popover-chip[aria-expanded="true"] {
+    @apply tw-border-foreground;
+  }
+
+  .dashboard-popover-chip:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  /* Compact variant for widget-header placement (the "Group by" chip). */
+  .dashboard-popover-chip--compact {
+    @apply tw-h-6 tw-gap-1 tw-px-1.5 tw-text-[11px];
+  }
+
+  .dashboard-popover-chip-prefix {
+    @apply tw-shrink-0 tw-text-muted-foreground;
+  }
+
+  .dashboard-popover-chip-value {
+    @apply tw-inline-flex tw-min-w-0 tw-items-center tw-overflow-hidden tw-font-medium;
+  }
+
+  .dashboard-popover-chip-caret {
+    @apply tw-shrink-0 tw-text-muted-foreground;
+  }
+
+  /* Chip content for hierarchical selections: "… › Parent › Node" — each
+     segment ellipsizes on its own so deep leaves stay chip-sized. */
+  .dashboard-popover-chip-trail {
+    @apply tw-inline-flex tw-min-w-0 tw-items-center tw-gap-1;
+  }
+
+  .dashboard-popover-chip-seg {
+    @apply tw-min-w-0 tw-max-w-[9rem] tw-overflow-hidden tw-text-ellipsis tw-whitespace-nowrap;
+  }
+
+  .dashboard-popover-chip-seg--muted {
+    @apply tw-font-normal tw-text-muted-foreground;
+  }
+
+  .dashboard-popover-chip-sep {
+    @apply tw-shrink-0 tw-select-none tw-text-muted-foreground;
+  }
+
+  /* Panel: mirrors .dashboard-add-kpi-panel's surface language. */
+  .dashboard-popover-panel {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    border: 1px solid var(--border, #e5e2db);
+    border-radius: 6px;
+    background-color: var(--popover, #ffffff);
+    box-shadow:
+      0 4px 6px -1px rgb(0 0 0 / 0.08),
+      0 2px 4px -2px rgb(0 0 0 / 0.06);
+    color: var(--foreground, #1a1917);
+    isolation: isolate;
+  }
+
+  /* Tree-traversal panel body (ComplaintTypeTreePanel). */
+  .dashboard-popover-tree {
+    @apply tw-flex tw-min-h-0 tw-flex-col tw-overflow-hidden;
+  }
+
+  /* Ancestor trail across the top of the tree panel. */
+  .dashboard-popover-trail {
+    @apply tw-flex tw-shrink-0 tw-flex-wrap tw-items-center tw-gap-1 tw-border-b tw-border-border tw-px-3 tw-py-2 tw-text-[11px] tw-leading-none tw-text-muted-foreground;
+  }
+
+  .dashboard-popover-trail-crumb {
+    @apply tw-m-0 tw-min-w-0 tw-max-w-[7rem] tw-cursor-pointer tw-overflow-hidden tw-text-ellipsis tw-whitespace-nowrap tw-rounded-sm tw-border-0 tw-bg-transparent tw-p-0 tw-text-[11px] tw-leading-none tw-text-muted-foreground hover:tw-text-foreground hover:tw-underline;
+    font-family: inherit;
+    -webkit-appearance: none;
+    appearance: none;
+  }
+
+  .dashboard-popover-trail-crumb:focus {
+    @apply tw-outline-none;
+  }
+
+  .dashboard-popover-trail-crumb:focus-visible {
+    @apply tw-text-foreground tw-underline;
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 35%, transparent);
+  }
+
+  .dashboard-popover-trail-sep,
+  .dashboard-popover-trail-ellipsis {
+    @apply tw-shrink-0 tw-select-none;
+  }
+
+  .dashboard-popover-trail-current {
+    @apply tw-min-w-0 tw-max-w-[10rem] tw-overflow-hidden tw-text-ellipsis tw-whitespace-nowrap tw-font-medium tw-text-foreground;
+  }
+
+  /* Scrollable item region (deep trees) and pinned footer (reset row). */
+  .dashboard-popover-list {
+    -webkit-overflow-scrolling: touch;
+    @apply tw-m-0 tw-min-h-0 tw-flex-1 tw-overflow-y-auto tw-overscroll-contain tw-p-1;
+  }
+
+  .dashboard-popover-footer {
+    @apply tw-shrink-0 tw-border-t tw-border-border tw-p-1;
+  }
+
+  .dashboard-menu-item {
+    @apply tw-box-border tw-m-0 tw-flex tw-w-full tw-cursor-pointer tw-items-center tw-gap-2 tw-rounded-sm tw-border-0 tw-bg-transparent tw-px-2 tw-py-1.5 tw-text-left tw-text-[12px] tw-leading-snug tw-text-foreground;
+    font-family: inherit;
+    -webkit-appearance: none;
+    appearance: none;
+  }
+
+  .dashboard-menu-item:hover {
+    background-color: var(--muted, #f5f4f1);
+  }
+
+  .dashboard-menu-item:focus {
+    @apply tw-outline-none;
+  }
+
+  .dashboard-menu-item:focus-visible {
+    background-color: var(--muted, #f5f4f1);
+    box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--ring) 35%, transparent);
+  }
+
+  .dashboard-menu-item[data-selected="true"] {
+    @apply tw-font-medium;
+  }
+
+  .dashboard-menu-item--muted {
+    color: var(--muted-foreground, #6b6860);
+  }
+
+  .dashboard-menu-item--muted:hover,
+  .dashboard-menu-item--muted:focus-visible {
+    color: var(--foreground, #1a1917);
+  }
+
+  .dashboard-menu-item-label {
+    @apply tw-min-w-0 tw-flex-1 tw-overflow-hidden tw-text-ellipsis tw-whitespace-nowrap;
+  }
+
+  .dashboard-menu-item-trailing {
+    @apply tw-inline-flex tw-shrink-0 tw-items-center tw-text-muted-foreground;
+  }
+
+  .dashboard-menu-item-check {
+    color: var(--primary, #1a1917);
+  }
+
+  /* Non-interactive section label between runs of related items (the flat
+     complaint-type degrade path's category groups). */
+  .dashboard-menu-group-label {
+    @apply tw-px-2 tw-pb-1 tw-pt-2 tw-text-[10px] tw-font-normal tw-uppercase tw-tracking-wider tw-text-muted-foreground;
+  }
+
+  /* Widget-header wrapper for the compact "Group by" chip: right-aligned in
+     the title row, shrinkable (the chip value truncates) so it never wraps
+     narrow widgets; mr-6 clears the hover remove button. */
+  .dashboard-groupby-chip-wrap {
+    @apply tw-ml-2 tw-mr-6 tw-inline-flex tw-min-w-0 tw-shrink tw-items-center tw-self-center;
   }
 
   /* ── Responsive layout ─────────────────────────────────────────────── */

--- a/digit-ui-esbuild/products/dashboard/src/styles/input.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/input.css
@@ -653,13 +653,28 @@
     cursor: default;
   }
 
-  /* Compact variant for widget-header placement (the "Group by" chip). */
-  .dashboard-popover-chip--compact {
-    @apply tw-h-6 tw-gap-1 tw-px-1.5 tw-text-[11px];
+  /* Icon-only anchor for widget-header placement (per-widget settings
+     gear): the .dashboard-widget-remove-btn idiom — 1.5rem square, muted,
+     transparent resting, bg-muted on hover/open — minus the absolute
+     positioning (this one sits in the title-row flex flow). */
+  .dashboard-popover-iconbtn {
+    @apply tw-box-border tw-m-0 tw-inline-flex tw-h-6 tw-w-6 tw-shrink-0 tw-cursor-pointer tw-items-center tw-justify-center tw-rounded-sm tw-border-0 tw-bg-transparent tw-p-0 tw-text-muted-foreground;
+    font: inherit;
+    -webkit-appearance: none;
+    appearance: none;
   }
 
-  .dashboard-popover-chip-prefix {
-    @apply tw-shrink-0 tw-text-muted-foreground;
+  .dashboard-popover-iconbtn:hover:not(:disabled),
+  .dashboard-popover-iconbtn[aria-expanded="true"] {
+    @apply tw-bg-muted tw-text-foreground;
+  }
+
+  .dashboard-popover-iconbtn:focus {
+    @apply tw-outline-none;
+  }
+
+  .dashboard-popover-iconbtn:focus-visible {
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 30%, transparent);
   }
 
   .dashboard-popover-chip-value {
@@ -805,11 +820,11 @@
     @apply tw-px-2 tw-pb-1 tw-pt-2 tw-text-[10px] tw-font-normal tw-uppercase tw-tracking-wider tw-text-muted-foreground;
   }
 
-  /* Widget-header wrapper for the compact "Group by" chip: right-aligned in
-     the title row, shrinkable (the chip value truncates) so it never wraps
-     narrow widgets; mr-6 clears the hover remove button. */
-  .dashboard-groupby-chip-wrap {
-    @apply tw-ml-2 tw-mr-6 tw-inline-flex tw-min-w-0 tw-shrink tw-items-center tw-self-center;
+  /* Widget-header wrapper for the per-widget settings gear: right-aligned
+     in the title row (same slot on every header that has options; absent
+     otherwise); mr-6 clears the absolute remove button. */
+  .dashboard-widget-settings-wrap {
+    @apply tw-ml-2 tw-mr-6 tw-inline-flex tw-shrink-0 tw-items-center tw-self-center;
   }
 
   /* ── Responsive layout ─────────────────────────────────────────────── */

--- a/digit-ui-esbuild/products/dashboard/src/styles/input.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/input.css
@@ -616,6 +616,34 @@
     pointer-events: none;
   }
 
+  /* ── Complaint-type tree-traversal filter (one-widget subtree nav) ──── */
+
+  .dashboard-type-tree-filter {
+    @apply tw-inline-flex tw-h-7 tw-shrink-0 tw-items-center tw-gap-1 tw-self-center;
+  }
+
+  .dashboard-type-tree-up {
+    @apply tw-px-1;
+  }
+
+  .dashboard-type-tree-crumbs {
+    @apply tw-inline-flex tw-items-center tw-gap-1 tw-text-[11px] tw-leading-none tw-text-muted-foreground;
+  }
+
+  .dashboard-type-tree-crumb {
+    @apply tw-m-0 tw-cursor-pointer tw-border-0 tw-bg-transparent tw-p-0 tw-text-[11px] tw-leading-none tw-text-muted-foreground hover:tw-text-foreground hover:tw-underline;
+    font-family: inherit;
+  }
+
+  .dashboard-type-tree-sep {
+    @apply tw-select-none;
+  }
+
+  .dashboard-type-tree-current {
+    @apply tw-text-[11px] tw-font-medium tw-leading-none tw-text-foreground;
+  }
+
+
   /* ── Responsive layout ─────────────────────────────────────────────── */
 
   .dashboard-main {

--- a/digit-ui-esbuild/products/dashboard/src/styles/input.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/input.css
@@ -2332,3 +2332,18 @@
 .dashboard-root.dashboard-embedded > div > main {
   overflow: visible;
 }
+
+/* The host app's vendor/overrides.css forces height:44px !important on all
+   text inputs/selects via a high-specificity :not() chain. The dashboard uses
+   compact 1.75rem controls (owner preference). Stacked-class specificity +
+   !important re-asserts the compact size; both !important -> specificity wins.
+   Scoped to the wards select only (calendars keep the host size by owner choice). */
+.dashboard-filter-inline-select.dashboard-filter-inline-select.dashboard-filter-inline-select.dashboard-filter-inline-select.dashboard-filter-inline-select.dashboard-filter-inline-select {
+  height: 1.75rem !important;
+  min-height: 1.75rem !important;
+  max-height: 1.75rem !important;
+  font-size: 12px !important;
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+  line-height: 1 !important;
+}

--- a/digit-ui-esbuild/products/dashboard/src/styles/input.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/input.css
@@ -827,6 +827,15 @@
     @apply tw-ml-2 tw-mr-6 tw-inline-flex tw-shrink-0 tw-items-center tw-self-center;
   }
 
+  /* Stacked (mobile) filter bar: the chip stretches full-width, exactly
+     like .dashboard-filter-inline-select in the 639px block above. */
+  @media (max-width: 639px) {
+    .dashboard-popover-chip {
+      width: 100%;
+      min-width: 0;
+    }
+  }
+
   /* ── Responsive layout ─────────────────────────────────────────────── */
 
   .dashboard-main {

--- a/digit-ui-esbuild/products/dashboard/src/utils/complaintTypeTree.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/complaintTypeTree.js
@@ -1,0 +1,298 @@
+/**
+ * Pure helpers for the tree-traversal complaint-type filter (one-widget
+ * subtree navigation replacing the flat leaf <select> in the filter bar).
+ *
+ * Model: the applied filter node is a single MDMS ComplaintHierarchy node —
+ *   root ("all")   → no type narrowing at all,
+ *   interior node  → subtree filter, sent as `params.complaintPath` (the
+ *                    node's dot-path; the backend turns it into a
+ *                    starts_with predicate on `complaint_node_path`),
+ *   leaf node      → exact filter, sent as `params.serviceCode` (unchanged
+ *                    wire shape — back-compat with every backend, and the
+ *                    daily grain has service_code but no path column).
+ *
+ * ABAC: the MDMS master is the FULL tenant tree, but the filter must only
+ * ever offer what the caller's row scope can see. pruneComplaintTree
+ * intersects the tree with the ABAC-scoped DISTINCT service_code list the
+ * dashboard already fetches (useFilterOptions), dropping every branch with
+ * zero scoped leaves — a dept-scoped supervisor never sees (or can select)
+ * types outside their scope.
+ *
+ * Everything here is pure (no fetch, no window, no React) so it is
+ * unit-testable with node --test; complaintHierarchyService.js does the MDMS
+ * fetch, useFilterOptions.js the intersection inputs, and
+ * ComplaintTypeTreeFilter.jsx the rendering.
+ */
+
+/** Root sentinel — matches the existing filter-state convention. */
+export const ALL = "all";
+
+/** The cleared selection trio ({ code, path, leaf }) stored in filters. */
+export function clearedSelection() {
+  return { code: ALL, path: null, leaf: false };
+}
+
+/**
+ * Build the complaint-type tree from RAINMAKER-PGR.ComplaintHierarchy records
+ * ({ code, name, path (dot-delimited), parentCode, active, ... }).
+ *
+ * Returns { byCode: Map<code, node>, roots: node[] } or null when no usable
+ * records. Node shape:
+ *   { code, label (data-owned name, undefined when name === code),
+ *     path (dot-path; record.path else derived parent.path + "." + code),
+ *     parentCode (null for roots), children: node[], isLeaf }
+ *
+ * Known data caveat (validation risk #3i): nodes whose CODES contain "." have
+ * NULL complaint_node_path on the analytics MV (#1282 migration), so a
+ * subtree filter rooted above them will not match those rows. The tree still
+ * renders them; the gap is a data/migration concern, not a FE one.
+ */
+export function buildComplaintTree(records) {
+  const byCode = new Map();
+  for (const record of Array.isArray(records) ? records : []) {
+    const code = String(record?.code ?? "").trim();
+    if (!code || record?.active === false) continue;
+    const name = String(record?.name ?? "").trim();
+    byCode.set(code, {
+      code,
+      label: name && name !== code ? name : undefined,
+      recordPath: String(record?.path ?? "").trim() || null,
+      parentCode: String(record?.parentCode ?? "").trim() || null,
+      children: [],
+      isLeaf: true,
+    });
+  }
+  if (!byCode.size) return null;
+
+  const roots = [];
+  for (const node of byCode.values()) {
+    const parent =
+      node.parentCode && node.parentCode !== node.code
+        ? byCode.get(node.parentCode)
+        : null;
+    if (parent) {
+      parent.children.push(node);
+      parent.isLeaf = false;
+    } else {
+      node.parentCode = null;
+      roots.push(node);
+    }
+  }
+
+  // Derive dot-paths root-down (record.path wins when present), cycle-safe:
+  // only nodes reachable from a root get visited; orphan cycles are dropped.
+  const reachable = new Set();
+  const stack = roots.map((r) => [r, null]);
+  while (stack.length) {
+    const [node, parentPath] = stack.pop();
+    if (reachable.has(node.code)) continue;
+    reachable.add(node.code);
+    node.path =
+      node.recordPath || (parentPath ? `${parentPath}.${node.code}` : node.code);
+    delete node.recordPath;
+    for (const child of node.children) stack.push([child, node.path]);
+  }
+  for (const code of [...byCode.keys()]) {
+    if (!reachable.has(code)) byCode.delete(code);
+  }
+
+  return byCode.size ? { byCode, roots } : null;
+}
+
+/**
+ * ABAC pruning (validation required-change #1): intersect the full MDMS tree
+ * with the scoped DISTINCT leaf `service_code` list. A node survives iff its
+ * own code is scoped OR at least one descendant survives. Scoped codes with
+ * no tree record (stray/QA codes — visible in today's flat select) are
+ * attached as root-level leaves so no currently-selectable code is lost.
+ *
+ * Returns a NEW pruned { byCode, roots } (never mutates the input), or null
+ * when there is nothing visible (callers fall back to the flat select /
+ * placeholder — same as an empty distinct list today).
+ */
+export function pruneComplaintTree(tree, scopedLeafCodes) {
+  if (!tree) return null;
+  const scoped = new Set(
+    (Array.isArray(scopedLeafCodes) ? scopedLeafCodes : [...(scopedLeafCodes || [])])
+      .map((c) => String(c ?? "").trim())
+      .filter(Boolean)
+  );
+  if (!scoped.size) return null;
+
+  const byCode = new Map();
+  const pruneNode = (node) => {
+    const children = node.children.map(pruneNode).filter(Boolean);
+    if (!children.length && !scoped.has(node.code)) return null;
+    const copy = { ...node, children, isLeaf: !children.length };
+    byCode.set(copy.code, copy);
+    return copy;
+  };
+  const roots = tree.roots.map(pruneNode).filter(Boolean);
+
+  // Stray scoped codes (rows exist, master record doesn't) → root-level leaves.
+  for (const code of scoped) {
+    if (byCode.has(code)) continue;
+    const stray = {
+      code,
+      label: undefined,
+      path: code,
+      parentCode: null,
+      children: [],
+      isLeaf: true,
+    };
+    byCode.set(code, stray);
+    roots.push(stray);
+  }
+
+  return roots.length ? { byCode, roots } : null;
+}
+
+/** Node for a code, or null ("all" is the virtual root — also null). */
+export function nodeOf(tree, code) {
+  if (!tree || code == null || code === ALL) return null;
+  return tree.byCode.get(String(code)) || null;
+}
+
+/** Children to offer at a node ("all" → the root categories). */
+export function childrenOf(tree, code) {
+  if (!tree) return [];
+  if (code == null || code === ALL) return tree.roots;
+  return nodeOf(tree, code)?.children ?? [];
+}
+
+/** Parent code of a node — "all" when the node is a root (or unknown). */
+export function parentOf(tree, code) {
+  const node = nodeOf(tree, code);
+  if (!node || !node.parentCode) return ALL;
+  return tree.byCode.has(node.parentCode) ? node.parentCode : ALL;
+}
+
+/**
+ * Ancestor chain (codes, topmost first, EXCLUDING the node itself and the
+ * virtual root). Cycle-guarded like buildComplaintTypeIndex.
+ */
+export function ancestorsOf(tree, code) {
+  const chain = [];
+  const seen = new Set([String(code)]);
+  let cur = nodeOf(tree, code);
+  while (cur && cur.parentCode && !seen.has(cur.parentCode)) {
+    seen.add(cur.parentCode);
+    cur = tree.byCode.get(cur.parentCode) || null;
+    if (cur) chain.unshift(cur.code);
+  }
+  return chain;
+}
+
+/**
+ * The persisted selection trio for applying a node: descend/ascend/jump all
+ * funnel through here (APPLY-ON-SELECT — there is no staged state).
+ */
+export function selectionFromCode(tree, code) {
+  if (code == null || code === ALL) return clearedSelection();
+  const node = nodeOf(tree, code);
+  if (!node) return clearedSelection();
+  return { code: node.code, path: node.path, leaf: node.isLeaf };
+}
+
+/**
+ * The backend's complaintPath validation (#1282 @ 33f738c88): charset
+ * [A-Za-z0-9._/-], max 256 chars. Sanitize CLIENT-side — the server rejects
+ * violations with a per-entry 400/invalid_param, which would blank every tile
+ * over one exotic MDMS code.
+ */
+const COMPLAINT_PATH_RE = /^[A-Za-z0-9._/-]{1,256}$/;
+
+export function isValidComplaintPath(path) {
+  return typeof path === "string" && COMPLAINT_PATH_RE.test(path);
+}
+
+/**
+ * Selection → KpiQueryComposer params (merged into every tile's globalParams):
+ *   root     → {}                      (filter cleared — neither param)
+ *   leaf     → { serviceCode }         (exact match, works on ALL grains —
+ *                required-change #4; complaintPath is interior-only)
+ *   interior → { complaintPath }       (the node's dot-path; #1282 matches the
+ *                node itself + dot-descendants on complaint_node_path.
+ *                Pre-#1282 backends silently ignore unknown params, so this
+ *                degrades to "no type narrowing", never an error)
+ * An interior path that fails the backend's charset/length validation is NOT
+ * sent (tiles stay unfiltered rather than erroring) — exotic codes outside
+ * [A-Za-z0-9._/-] can't be subtree-filtered at all (their MV paths are NULL
+ * anyway, see buildComplaintTree's caveat).
+ * Legacy persisted string-only state (leaf flag undefined) behaves exactly
+ * like today: leaf serviceCode.
+ */
+export function complaintTypeParams(selection) {
+  const code = selection?.code;
+  if (!code || code === ALL) return {};
+  if (selection.leaf === false && selection.path) {
+    const path = String(selection.path);
+    return isValidComplaintPath(path) ? { complaintPath: path } : {};
+  }
+  return { serviceCode: String(code) };
+}
+
+/**
+ * Repair a persisted selection against the (pruned) tree: exact node wins;
+ * a vanished node walks UP its stored dot-path to the nearest surviving
+ * ancestor (the exhumed demo's sanitize-and-repair idea); nothing valid →
+ * cleared. Also normalises path/leaf drift (e.g. a node that used to be a
+ * leaf and now has children keeps working as a subtree filter).
+ */
+export function repairSelection(tree, selection) {
+  const code = String(selection?.code ?? "").trim();
+  if (!code || code === ALL) return clearedSelection();
+  if (!tree) return clearedSelection();
+  if (tree.byCode.has(code)) return selectionFromCode(tree, code);
+
+  const path = String(selection?.path ?? "").trim();
+  if (path) {
+    const segments = path.split(".").filter(Boolean);
+    for (let i = segments.length - 1; i >= 0; i--) {
+      if (tree.byCode.has(segments[i])) return selectionFromCode(tree, segments[i]);
+    }
+  }
+  return clearedSelection();
+}
+
+/**
+ * Normalise a filter-change value into the persisted trio. The tree widget
+ * sends the trio itself; the flat fallback <select> (tree unavailable) sends
+ * a bare leaf-code string — exactly today's contract.
+ */
+export function normalizeComplaintTypeValue(value) {
+  if (value && typeof value === "object") {
+    const code = String(value.code ?? "").trim() || ALL;
+    if (code === ALL) return clearedSelection();
+    return {
+      code,
+      path: value.path != null ? String(value.path) : null,
+      leaf: value.leaf !== false,
+    };
+  }
+  const code = String(value ?? "").trim();
+  if (!code || code === ALL) return clearedSelection();
+  return { code, path: null, leaf: true };
+}
+
+/**
+ * Humanised fallback for nodes with no data-owned name and no localization
+ * message (validation risk #3ii: interior category records often have
+ * name === code, e.g. "complaints.categories.sanitation" / "MedicalServices").
+ * Last dot-segment, un-snake/un-camel, title-cased — NEVER a raw dotted code
+ * in the breadcrumb. Display-only: params always carry the raw code/path.
+ */
+export function humanizeTypeCode(code) {
+  const raw = String(code ?? "").trim();
+  if (!raw) return "";
+  const segment = raw.split(".").filter(Boolean).pop() || raw;
+  const spaced = segment
+    .replace(/[_\-]+/g, " ")
+    .replace(/([a-z\d])([A-Z])/g, "$1 $2")
+    .replace(/\s+/g, " ")
+    .trim();
+  return spaced
+    .split(" ")
+    .map((w) => (w ? w.charAt(0).toUpperCase() + w.slice(1) : w))
+    .join(" ");
+}

--- a/digit-ui-esbuild/products/dashboard/src/utils/complaintTypeTree.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/complaintTypeTree.js
@@ -184,8 +184,43 @@ export function ancestorsOf(tree, code) {
 }
 
 /**
- * The persisted selection trio for applying a node: descend/ascend/jump all
- * funnel through here (APPLY-ON-SELECT — there is no staged state).
+ * Where the traversal panel starts browsing for an applied selection:
+ *   root / unknown code → the virtual root ("all"),
+ *   interior node       → the node itself (its children are on show),
+ *   leaf node           → the leaf's PARENT, so the leaf renders selected
+ *                         among its siblings and switching leaves stays a
+ *                         one-click operation.
+ */
+export function browseBaseCode(tree, code) {
+  const node = nodeOf(tree, code);
+  if (!node) return ALL;
+  return node.isLeaf ? parentOf(tree, code) : node.code;
+}
+
+/**
+ * Sentinel marking elided entries in a truncated ancestor trail. A string
+ * that can never be an MDMS code (codes are [A-Za-z0-9._/-], see
+ * COMPLAINT_PATH_RE) so it cannot collide with a real trail entry.
+ */
+export const TRAIL_ELLIPSIS = "…<elided>";
+
+/**
+ * Middle-truncate a trail for DEEP trees: when there are more than `max`
+ * entries, keep the FIRST (the "All types" root) and the LAST `max - 2`
+ * (the nearest ancestors + current node), replacing the middle with
+ * TRAIL_ELLIPSIS — the endpoints matter for orientation, the middle is
+ * recoverable by stepping up. Short trails come back untouched (same array).
+ */
+export function truncateTrail(entries, max = 4) {
+  if (!Array.isArray(entries) || entries.length <= max || max < 3) return entries;
+  return [entries[0], TRAIL_ELLIPSIS, ...entries.slice(entries.length - (max - 2))];
+}
+
+/**
+ * The persisted selection trio for applying a node: leaf pick, "All in <X>"
+ * subtree apply and the "All types" reset all funnel through here. (In-panel
+ * traversal is browse-only local state; nothing is persisted until one of
+ * those explicit applies calls this.)
  */
 export function selectionFromCode(tree, code) {
   if (code == null || code === ALL) return clearedSelection();

--- a/digit-ui-esbuild/products/dashboard/src/utils/complaintTypeTree.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/complaintTypeTree.js
@@ -273,6 +273,12 @@ export function complaintTypeParams(selection) {
  * ancestor (the exhumed demo's sanitize-and-repair idea); nothing valid →
  * cleared. Also normalises path/leaf drift (e.g. a node that used to be a
  * leaf and now has children keeps working as a subtree filter).
+ *
+ * The ancestor walk matches surviving node PATHS as dot-boundary prefixes of
+ * the stored path — never by splitting the stored path into segments, because
+ * codes may themselves contain "." (e.g. "complaints.categories.sanitation")
+ * and would be shredded into non-codes, mis-clearing a repairable selection.
+ * The deepest (longest-path) surviving prefix wins.
  */
 export function repairSelection(tree, selection) {
   const code = String(selection?.code ?? "").trim();
@@ -282,10 +288,13 @@ export function repairSelection(tree, selection) {
 
   const path = String(selection?.path ?? "").trim();
   if (path) {
-    const segments = path.split(".").filter(Boolean);
-    for (let i = segments.length - 1; i >= 0; i--) {
-      if (tree.byCode.has(segments[i])) return selectionFromCode(tree, segments[i]);
+    let ancestor = null;
+    for (const node of tree.byCode.values()) {
+      const nodePath = String(node.path ?? "");
+      if (!nodePath || (nodePath !== path && !path.startsWith(`${nodePath}.`))) continue;
+      if (!ancestor || nodePath.length > String(ancestor.path).length) ancestor = node;
     }
+    if (ancestor) return selectionFromCode(tree, ancestor.code);
   }
   return clearedSelection();
 }

--- a/digit-ui-esbuild/products/dashboard/src/utils/complaintTypeTree.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/complaintTypeTree.test.js
@@ -317,6 +317,48 @@ test("repair: vanished node walks UP its stored path to nearest ancestor", () =>
   });
 });
 
+test("repair: dotted CODES repair to the surviving ancestor, not cleared", () => {
+  // Real MDMS codes contain "." (e.g. "complaints.categories.sanitation") —
+  // the stored path must be matched by node-path prefix, never split into
+  // segments (which would shred one dotted code into several non-codes).
+  const full = buildComplaintTree([
+    rec("complaints.categories.sanitation", null, { name: "Sanitation" }),
+    rec("complaints.types.garbage", "complaints.categories.sanitation", {
+      name: "Garbage",
+    }),
+    rec("complaints.types.sewage", "complaints.categories.sanitation", {
+      name: "Sewage",
+    }),
+  ]);
+  // ABAC re-scope drops the garbage leaf; its stored selection must repair
+  // UP to the surviving dotted-code ancestor.
+  const pruned = pruneComplaintTree(full, ["complaints.types.sewage"]);
+  assert.deepEqual(
+    repairSelection(pruned, {
+      code: "complaints.types.garbage",
+      path: "complaints.categories.sanitation.complaints.types.garbage",
+      leaf: true,
+    }),
+    {
+      code: "complaints.categories.sanitation",
+      path: "complaints.categories.sanitation",
+      leaf: false,
+    }
+  );
+});
+
+test("repair: ancestor prefix match respects dot boundaries (ROADS ≠ ROADSIDE)", () => {
+  const pruned = pruneComplaintTree(tree(), ["Pothole"]); // ROADS branch only
+  assert.deepEqual(
+    repairSelection(pruned, {
+      code: "RoadsideDump",
+      path: "ROADSIDE.RoadsideDump", // "ROADS" is NOT a dot-boundary prefix
+      leaf: true,
+    }),
+    clearedSelection()
+  );
+});
+
 test("repair: nothing on the stored path survives → cleared", () => {
   const pruned = pruneComplaintTree(tree(), ["Pothole"]); // ROADS branch only
   assert.deepEqual(

--- a/digit-ui-esbuild/products/dashboard/src/utils/complaintTypeTree.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/complaintTypeTree.test.js
@@ -1,0 +1,359 @@
+// Unit tests for the tree-traversal complaint-type filter state
+// (descend / ascend / apply / clear / repair / ABAC pruning).
+// Run from digit-ui-esbuild/:  node --test products/dashboard/src/utils/complaintTypeTree.test.js
+//
+// The modules under test are ESM (like the rest of products/), so the test
+// bundles them to CJS with the repo's own esbuild — the same idiom as
+// hierLevelGrouping.test.js.
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const esbuild = require("esbuild");
+
+function bundle(entry) {
+  const out = path.join(
+    os.tmpdir(),
+    `${path.basename(entry, ".js")}.cjs.${process.pid}.js`
+  );
+  esbuild.buildSync({
+    entryPoints: [path.join(__dirname, entry)],
+    bundle: true,
+    format: "cjs",
+    platform: "neutral",
+    outfile: out,
+  });
+  process.on("exit", () => {
+    try {
+      fs.unlinkSync(out);
+    } catch (e) {
+      /* already gone */
+    }
+  });
+  return require(out);
+}
+
+const {
+  ALL,
+  buildComplaintTree,
+  pruneComplaintTree,
+  nodeOf,
+  childrenOf,
+  parentOf,
+  ancestorsOf,
+  selectionFromCode,
+  clearedSelection,
+  complaintTypeParams,
+  isValidComplaintPath,
+  repairSelection,
+  normalizeComplaintTypeValue,
+  humanizeTypeCode,
+} = bundle("complaintTypeTree.js");
+
+const { globalParams, buildRefs } = bundle("queryPlan.js");
+
+/* ------------------------------------------------------------------ */
+/* Fixtures — a 3-level tree (bomet-like Category → SubType → leaf)     */
+/* ------------------------------------------------------------------ */
+
+const rec = (code, parentCode, extra = {}) => ({
+  code,
+  name: code,
+  parentCode,
+  active: true,
+  ...extra,
+});
+
+// SANITATION            (root, name===code → no data-owned label)
+//   GARBAGE             (interior, data-owned name)
+//     GarbageFull       (leaf)
+//     GarbageMissed     (leaf)
+//   SEWAGE              (interior)
+//     SewageOverflow    (leaf)
+// ROADS                 (root)
+//   Pothole             (leaf; record carries explicit path)
+const RECORDS = [
+  rec("SANITATION", null),
+  rec("GARBAGE", "SANITATION", { name: "Garbage collection" }),
+  rec("GarbageFull", "GARBAGE", { name: "Bin overflowing" }),
+  rec("GarbageMissed", "GARBAGE", { name: "Missed pickup" }),
+  rec("SEWAGE", "SANITATION"),
+  rec("SewageOverflow", "SEWAGE", { name: "Sewage overflow" }),
+  rec("ROADS", null),
+  rec("Pothole", "ROADS", { name: "Pothole", path: "ROADS.Pothole" }),
+];
+
+const tree = () => buildComplaintTree(RECORDS);
+
+/* ------------------------------------------------------------------ */
+/* buildComplaintTree                                                   */
+/* ------------------------------------------------------------------ */
+
+test("buildComplaintTree: structure, derived paths, record path wins", () => {
+  const t = tree();
+  assert.equal(t.roots.length, 2);
+  assert.deepEqual(
+    t.roots.map((r) => r.code).sort(),
+    ["ROADS", "SANITATION"]
+  );
+
+  const garbage = nodeOf(t, "GARBAGE");
+  assert.equal(garbage.path, "SANITATION.GARBAGE"); // derived from parent chain
+  assert.equal(garbage.isLeaf, false);
+  assert.equal(garbage.label, "Garbage collection");
+
+  const leaf = nodeOf(t, "GarbageFull");
+  assert.equal(leaf.path, "SANITATION.GARBAGE.GarbageFull");
+  assert.equal(leaf.isLeaf, true);
+
+  // Explicit record path wins over derivation.
+  assert.equal(nodeOf(t, "Pothole").path, "ROADS.Pothole");
+
+  // name === code → no data-owned label (localization/humanizer decides).
+  assert.equal(nodeOf(t, "SANITATION").label, undefined);
+});
+
+test("buildComplaintTree: inactive records and cycles are dropped", () => {
+  const t = buildComplaintTree([
+    ...RECORDS,
+    rec("Inactive", "ROADS", { active: false }),
+    rec("CycleA", "CycleB"),
+    rec("CycleB", "CycleA"),
+  ]);
+  assert.equal(nodeOf(t, "Inactive"), null);
+  assert.equal(nodeOf(t, "CycleA"), null); // orphan cycle unreachable from roots
+  assert.equal(t.roots.length, 2);
+});
+
+test("buildComplaintTree: empty/no records → null", () => {
+  assert.equal(buildComplaintTree([]), null);
+  assert.equal(buildComplaintTree(null), null);
+});
+
+/* ------------------------------------------------------------------ */
+/* ABAC pruning                                                         */
+/* ------------------------------------------------------------------ */
+
+test("prune: branches with zero scoped leaves disappear (dept-scoped view)", () => {
+  // Sanitation-dept supervisor: scoped distincts only cover garbage leaves.
+  const pruned = pruneComplaintTree(tree(), ["GarbageFull", "GarbageMissed"]);
+  assert.deepEqual(pruned.roots.map((r) => r.code), ["SANITATION"]);
+  assert.equal(nodeOf(pruned, "SEWAGE"), null); // zero scoped leaves → gone
+  assert.equal(nodeOf(pruned, "ROADS"), null); // whole other branch → gone
+  assert.equal(nodeOf(pruned, "GARBAGE").isLeaf, false);
+  assert.equal(childrenOf(pruned, "GARBAGE").length, 2);
+});
+
+test("prune: stray scoped codes (no master record) attach as root leaves", () => {
+  const pruned = pruneComplaintTree(tree(), ["Pothole", "QA_STRAY_CODE"]);
+  const stray = nodeOf(pruned, "QA_STRAY_CODE");
+  assert.ok(stray);
+  assert.equal(stray.isLeaf, true);
+  assert.equal(stray.path, "QA_STRAY_CODE");
+  assert.ok(pruned.roots.some((r) => r.code === "QA_STRAY_CODE"));
+});
+
+test("prune: never mutates the input tree; empty scope → null", () => {
+  const full = tree();
+  pruneComplaintTree(full, ["GarbageFull"]);
+  assert.equal(nodeOf(full, "ROADS").code, "ROADS"); // input intact
+  assert.equal(nodeOf(full, "SEWAGE").isLeaf, false);
+  assert.equal(pruneComplaintTree(full, []), null);
+  assert.equal(pruneComplaintTree(null, ["x"]), null);
+});
+
+/* ------------------------------------------------------------------ */
+/* Traversal: descend / ascend / apply / clear                          */
+/* ------------------------------------------------------------------ */
+
+test("descend: root → children are the root categories; child applies", () => {
+  const t = tree();
+  assert.deepEqual(
+    childrenOf(t, ALL).map((n) => n.code).sort(),
+    ["ROADS", "SANITATION"]
+  );
+  // Selecting an interior child applies a subtree selection…
+  const sel = selectionFromCode(t, "SANITATION");
+  assert.deepEqual(sel, { code: "SANITATION", path: "SANITATION", leaf: false });
+  // …and the next level's dropdown lists ITS children (traversal continues).
+  assert.deepEqual(
+    childrenOf(t, sel.code).map((n) => n.code).sort(),
+    ["GARBAGE", "SEWAGE"]
+  );
+});
+
+test("descend to leaf: selection applies as exact leaf", () => {
+  const sel = selectionFromCode(tree(), "GarbageFull");
+  assert.deepEqual(sel, {
+    code: "GarbageFull",
+    path: "SANITATION.GARBAGE.GarbageFull",
+    leaf: true,
+  });
+});
+
+test("ascend: parentOf walks one level up; roots go to ALL", () => {
+  const t = tree();
+  assert.equal(parentOf(t, "GarbageFull"), "GARBAGE");
+  assert.equal(parentOf(t, "GARBAGE"), "SANITATION");
+  assert.equal(parentOf(t, "SANITATION"), ALL);
+  assert.equal(parentOf(t, "does-not-exist"), ALL);
+});
+
+test("breadcrumb: ancestorsOf lists the chain topmost-first", () => {
+  const t = tree();
+  assert.deepEqual(ancestorsOf(t, "GarbageFull"), ["SANITATION", "GARBAGE"]);
+  assert.deepEqual(ancestorsOf(t, "SANITATION"), []);
+});
+
+test("clear: ALL / unknown code → cleared selection", () => {
+  const t = tree();
+  assert.deepEqual(selectionFromCode(t, ALL), clearedSelection());
+  assert.deepEqual(selectionFromCode(t, "nope"), clearedSelection());
+});
+
+/* ------------------------------------------------------------------ */
+/* Param mapping (leaf → serviceCode, interior → complaintPath)         */
+/* ------------------------------------------------------------------ */
+
+test("params: root none, leaf serviceCode, interior complaintPath", () => {
+  const t = tree();
+  assert.deepEqual(complaintTypeParams(clearedSelection()), {});
+  assert.deepEqual(complaintTypeParams(selectionFromCode(t, "GarbageFull")), {
+    serviceCode: "GarbageFull",
+  });
+  assert.deepEqual(complaintTypeParams(selectionFromCode(t, "GARBAGE")), {
+    complaintPath: "SANITATION.GARBAGE",
+  });
+});
+
+test("params: legacy string-only persisted state behaves as leaf", () => {
+  // Pre-tree localStorage: { complaintType: "GarbageFull" } — no path/leaf keys.
+  assert.deepEqual(complaintTypeParams({ code: "GarbageFull" }), {
+    serviceCode: "GarbageFull",
+  });
+});
+
+test("params: complaintPath outside the backend charset/length is NOT sent", () => {
+  assert.equal(isValidComplaintPath("SANITATION.GARBAGE"), true);
+  assert.equal(isValidComplaintPath("has space"), false);
+  assert.equal(isValidComplaintPath("x".repeat(257)), false);
+  assert.equal(isValidComplaintPath(""), false);
+  assert.deepEqual(
+    complaintTypeParams({ code: "WEIRD", path: "weird päth", leaf: false }),
+    {} // unfiltered beats a per-entry 400 blanking the tile
+  );
+});
+
+test("globalParams: filter trio flows into the batch params", () => {
+  const interior = {
+    geography: "all",
+    complaintType: "GARBAGE",
+    complaintTypePath: "SANITATION.GARBAGE",
+    complaintTypeLeaf: false,
+  };
+  assert.deepEqual(globalParams(interior), {
+    complaintPath: "SANITATION.GARBAGE",
+  });
+
+  const leaf = {
+    complaintType: "GarbageFull",
+    complaintTypePath: "SANITATION.GARBAGE.GarbageFull",
+    complaintTypeLeaf: true,
+  };
+  assert.deepEqual(globalParams(leaf), { serviceCode: "GarbageFull" });
+
+  assert.deepEqual(globalParams({ complaintType: "all" }), {});
+  // Legacy persisted shape (no companions) → leaf semantics, exactly today.
+  assert.deepEqual(globalParams({ complaintType: "GarbageFull" }), {
+    serviceCode: "GarbageFull",
+  });
+});
+
+test("buildRefs: every tile ref carries the subtree param", () => {
+  const kpis = {
+    a: { kpiId: "a", viz: { kind: "number-tile" } },
+    b: { kpiId: "b", viz: { kind: "stacked-bar" } },
+  };
+  const refs = buildRefs([{ kpiId: "a" }, { kpiId: "b" }], kpis, {
+    complaintType: "SANITATION",
+    complaintTypePath: "SANITATION",
+    complaintTypeLeaf: false,
+  });
+  assert.equal(refs.a.params.complaintPath, "SANITATION");
+  assert.equal(refs.a__prior.params.complaintPath, "SANITATION");
+  assert.equal(refs.b.params.complaintPath, "SANITATION");
+  assert.equal(refs.a.params.serviceCode, undefined);
+});
+
+/* ------------------------------------------------------------------ */
+/* Persisted-selection repair                                           */
+/* ------------------------------------------------------------------ */
+
+test("repair: valid node survives; path/leaf drift is normalised", () => {
+  const t = tree();
+  assert.deepEqual(
+    repairSelection(t, { code: "GARBAGE", path: "STALE.PATH", leaf: true }),
+    { code: "GARBAGE", path: "SANITATION.GARBAGE", leaf: false }
+  );
+});
+
+test("repair: vanished node walks UP its stored path to nearest ancestor", () => {
+  // e.g. ABAC re-scope or master edit removed the leaf; GARBAGE survives.
+  const pruned = pruneComplaintTree(tree(), ["GarbageMissed"]);
+  const repaired = repairSelection(pruned, {
+    code: "GarbageFull",
+    path: "SANITATION.GARBAGE.GarbageFull",
+    leaf: true,
+  });
+  assert.deepEqual(repaired, {
+    code: "GARBAGE",
+    path: "SANITATION.GARBAGE",
+    leaf: false,
+  });
+});
+
+test("repair: nothing on the stored path survives → cleared", () => {
+  const pruned = pruneComplaintTree(tree(), ["Pothole"]); // ROADS branch only
+  assert.deepEqual(
+    repairSelection(pruned, {
+      code: "GarbageFull",
+      path: "SANITATION.GARBAGE.GarbageFull",
+      leaf: true,
+    }),
+    clearedSelection()
+  );
+  assert.deepEqual(repairSelection(null, { code: "X", path: "X" }), clearedSelection());
+});
+
+/* ------------------------------------------------------------------ */
+/* Filter-change value normalisation (widget trio vs flat-select code)  */
+/* ------------------------------------------------------------------ */
+
+test("normalize: trio passes through, bare string means leaf, all clears", () => {
+  assert.deepEqual(
+    normalizeComplaintTypeValue({ code: "GARBAGE", path: "SANITATION.GARBAGE", leaf: false }),
+    { code: "GARBAGE", path: "SANITATION.GARBAGE", leaf: false }
+  );
+  assert.deepEqual(normalizeComplaintTypeValue("GarbageFull"), {
+    code: "GarbageFull",
+    path: null,
+    leaf: true,
+  });
+  assert.deepEqual(normalizeComplaintTypeValue("all"), clearedSelection());
+  assert.deepEqual(normalizeComplaintTypeValue(null), clearedSelection());
+  assert.deepEqual(normalizeComplaintTypeValue({ code: "all" }), clearedSelection());
+});
+
+/* ------------------------------------------------------------------ */
+/* Label fallback                                                       */
+/* ------------------------------------------------------------------ */
+
+test("humanizeTypeCode: never surfaces a raw dotted code", () => {
+  assert.equal(humanizeTypeCode("complaints.categories.sanitation"), "Sanitation");
+  assert.equal(humanizeTypeCode("MedicalServices"), "Medical Services");
+  assert.equal(humanizeTypeCode("GARBAGE_NEEDS_ATTENTION"), "GARBAGE NEEDS ATTENTION");
+  assert.equal(humanizeTypeCode("streetLight-broken"), "Street Light Broken");
+  assert.equal(humanizeTypeCode(""), "");
+});

--- a/digit-ui-esbuild/products/dashboard/src/utils/complaintTypeTree.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/complaintTypeTree.test.js
@@ -347,6 +347,133 @@ test("normalize: trio passes through, bare string means leaf, all clears", () =>
 });
 
 /* ------------------------------------------------------------------ */
+/* Persist/load round-trip (config/dashboardFilters sanitizer):        */
+/* a tree-fetch failure must NOT forget a persisted interior selection */
+/* ------------------------------------------------------------------ */
+
+const {
+  loadDashboardFilters,
+  persistDashboardFilters,
+  reconcileFiltersWithOptions,
+} = bundle("../config/dashboardFilters.js");
+
+// dashboardFilters reaches for browser globals (localStorage for the persisted
+// filters, window.globalConfigs for the tenant-scoped storage key) — stub the
+// minimum for a node round-trip.
+function stubBrowserGlobals() {
+  const store = new Map();
+  globalThis.localStorage = {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => store.set(k, String(v)),
+    removeItem: (k) => store.delete(k),
+  };
+  globalThis.window = { localStorage: globalThis.localStorage };
+  return () => {
+    delete globalThis.localStorage;
+    delete globalThis.window;
+  };
+}
+
+test("tree-fetch failure: persisted interior selection survives a reload cycle, then repairs", () => {
+  const restore = stubBrowserGlobals();
+  try {
+    const full = tree();
+    const pruned = pruneComplaintTree(full, [
+      "GarbageFull",
+      "GarbageMissed",
+      "SewageOverflow",
+      "Pothole",
+    ]);
+    // What useFilterOptions emits when the MDMS hierarchy fetch failed but the
+    // scoped DISTINCT leaf list loaded: flat complaintType list, NO tree.
+    const flatOnly = {
+      complaintType: [
+        { id: "all", label: "All types" },
+        { id: "GarbageFull", label: "Bin overflowing" },
+        { id: "GarbageMissed", label: "Missed pickup" },
+        { id: "SewageOverflow", label: "Sewage overflow" },
+        { id: "Pothole", label: "Pothole" },
+      ],
+    };
+
+    // Session 1 — tree present: the user applies the interior GARBAGE subtree.
+    persistDashboardFilters(
+      {
+        ...loadDashboardFilters(),
+        complaintType: "GARBAGE",
+        complaintTypePath: "SANITATION.GARBAGE",
+        complaintTypeLeaf: false,
+      },
+      { ...flatOnly, complaintTypeTree: pruned }
+    );
+
+    // Session 2 — transient MDMS hiccup: tree fetch failed, flat list loaded.
+    const reloaded = loadDashboardFilters();
+    assert.equal(reloaded.complaintType, "GARBAGE"); // cold load trusts the trio
+    // A filter change re-persists through the sanitizer's FLAT branch — the
+    // held interior trio must be persisted as-is, not cleared (regression:
+    // storage was wiped here while in-memory state kept the selection).
+    persistDashboardFilters({ ...reloaded, dateFrom: "2026-01-01" }, flatOnly);
+
+    const afterHiccup = loadDashboardFilters();
+    assert.deepEqual(
+      {
+        code: afterHiccup.complaintType,
+        path: afterHiccup.complaintTypePath,
+        leaf: afterHiccup.complaintTypeLeaf,
+      },
+      { code: "GARBAGE", path: "SANITATION.GARBAGE", leaf: false }
+    );
+    // In-memory reconcile against the same flat-only options agrees with
+    // storage (no memory/storage split-brain).
+    assert.equal(
+      reconcileFiltersWithOptions(afterHiccup, flatOnly).complaintType,
+      "GARBAGE"
+    );
+
+    // Session 3 — tree is back: the held selection repairs through the tree
+    // branch. Exact node survives here…
+    const treeBack = reconcileFiltersWithOptions(afterHiccup, {
+      ...flatOnly,
+      complaintTypeTree: pruned,
+    });
+    assert.deepEqual(
+      {
+        code: treeBack.complaintType,
+        path: treeBack.complaintTypePath,
+        leaf: treeBack.complaintTypeLeaf,
+      },
+      { code: "GARBAGE", path: "SANITATION.GARBAGE", leaf: false }
+    );
+    // …and a re-scope that dropped the whole branch repairs to cleared, so
+    // holding through the hiccup never pins a permanently-invalid selection.
+    const rescoped = pruneComplaintTree(full, ["Pothole"]);
+    assert.equal(
+      reconcileFiltersWithOptions(afterHiccup, {
+        ...flatOnly,
+        complaintTypeTree: rescoped,
+      }).complaintType,
+      ALL
+    );
+
+    // Unchanged flat-branch behavior: a persisted LEAF still validates against
+    // the flat list — a vanished leaf clears exactly as before.
+    persistDashboardFilters(
+      {
+        ...reloaded,
+        complaintType: "GhostLeaf",
+        complaintTypePath: null,
+        complaintTypeLeaf: true,
+      },
+      flatOnly
+    );
+    assert.equal(loadDashboardFilters().complaintType, ALL);
+  } finally {
+    restore();
+  }
+});
+
+/* ------------------------------------------------------------------ */
 /* Label fallback                                                       */
 /* ------------------------------------------------------------------ */
 

--- a/digit-ui-esbuild/products/dashboard/src/utils/complaintTypeTree.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/complaintTypeTree.test.js
@@ -50,6 +50,9 @@ const {
   repairSelection,
   normalizeComplaintTypeValue,
   humanizeTypeCode,
+  browseBaseCode,
+  truncateTrail,
+  TRAIL_ELLIPSIS,
 } = bundle("complaintTypeTree.js");
 
 const { globalParams, buildRefs } = bundle("queryPlan.js");
@@ -471,6 +474,73 @@ test("tree-fetch failure: persisted interior selection survives a reload cycle, 
   } finally {
     restore();
   }
+});
+
+/* ------------------------------------------------------------------ */
+/* Traversal-panel browse state (chip + panel design pass)              */
+/* ------------------------------------------------------------------ */
+
+// ke's PGR_TEST-shaped 4-level tree (Category → Type → SubType → leaf),
+// deeper than the 2-level live PGR tree — the trail-truncation case.
+const DEEP_RECORDS = [
+  rec("Infra", null, { name: "Infrastructure" }),
+  rec("Water", "Infra", { name: "Water supply" }),
+  rec("WaterQuality", "Water", { name: "Water quality" }),
+  rec("WaterMuddy", "WaterQuality", { name: "Muddy water" }),
+  rec("WaterSmelly", "WaterQuality", { name: "Smelly water" }),
+  rec("WaterPressure", "Water", { name: "Low pressure" }),
+];
+const deepTree = () => buildComplaintTree(DEEP_RECORDS);
+
+test("browseBaseCode: root/unknown → all, interior → itself, leaf → parent", () => {
+  const t = tree();
+  assert.equal(browseBaseCode(t, ALL), ALL);
+  assert.equal(browseBaseCode(t, "NOPE"), ALL);
+  assert.equal(browseBaseCode(null, "GARBAGE"), ALL);
+  // interior: its children are on show
+  assert.equal(browseBaseCode(t, "GARBAGE"), "GARBAGE");
+  // leaf: siblings on show with the leaf selected (one-click switching)
+  assert.equal(browseBaseCode(t, "GarbageFull"), "GARBAGE");
+  // root-level leaf's parent is the virtual root
+  const pruned = pruneComplaintTree(t, ["GarbageFull", "STRAY"]);
+  assert.equal(browseBaseCode(pruned, "STRAY"), ALL);
+});
+
+test("browseBaseCode: 4-level tree opens a deep leaf at its direct parent", () => {
+  const t = deepTree();
+  assert.equal(browseBaseCode(t, "WaterMuddy"), "WaterQuality");
+  assert.equal(browseBaseCode(t, "WaterQuality"), "WaterQuality");
+});
+
+test("truncateTrail: short trails come back untouched (same array)", () => {
+  const short = ["all", "Infra", "Water"];
+  assert.equal(truncateTrail(short, 4), short);
+  const exact = ["all", "Infra", "Water", "WaterQuality"];
+  assert.equal(truncateTrail(exact, 4), exact);
+});
+
+test("truncateTrail: deep trails keep root + nearest, elide the middle", () => {
+  const t = deepTree();
+  // Browsing at depth 3 of the 4-level tree: all › Infra › Water › WaterQuality
+  const full = [ALL, ...ancestorsOf(t, "WaterQuality"), "WaterQuality"];
+  assert.deepEqual(full, ["all", "Infra", "Water", "WaterQuality"]);
+  assert.equal(truncateTrail(full, 4), full); // depth 3 still fits
+
+  // One level deeper than max: middle elided, endpoints kept.
+  const deeper = [...full, "WaterMuddy"];
+  assert.deepEqual(truncateTrail(deeper, 4), [
+    "all",
+    TRAIL_ELLIPSIS,
+    "WaterQuality",
+    "WaterMuddy",
+  ]);
+
+  // Degenerate max (< 3) can't hold first+ellipsis+last → untouched.
+  assert.equal(truncateTrail(deeper, 2), deeper);
+});
+
+test("TRAIL_ELLIPSIS can never collide with a real code", () => {
+  assert.equal(isValidComplaintPath(TRAIL_ELLIPSIS), false);
 });
 
 /* ------------------------------------------------------------------ */

--- a/digit-ui-esbuild/products/dashboard/src/utils/queryPlan.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/queryPlan.js
@@ -1,4 +1,5 @@
 import { appliedHierLevel } from "./hierLevelGrouping";
+import { complaintTypeParams } from "./complaintTypeTree";
 
 /**
  * Query-plan helpers for the catalog dashboard (extracted from
@@ -40,18 +41,26 @@ export function isMapKind(kind) {
  * Mirrors config/kpiQueries.js buildGlobalApiFilters: an active date range maps
  * to dateFrom/dateTo (yyyy-MM-dd, which the composer turns into a gte/lt on the
  * grain's time column and which drops the def's base window); a non-"all"
- * geography/complaintType narrows via ward/serviceCode. No global `window` is
- * emitted, so each def keeps its own baked window when no range is active —
- * exactly the reference path's behaviour.
+ * geography narrows via ward. The complaint-type node selection narrows via
+ * serviceCode (leaf — unchanged wire shape) or complaintPath (interior node —
+ * subtree prefix on complaint_node_path, #1282; pre-#1282 backends ignore the
+ * unknown param, so the dashboard degrades to leaf-only filtering, never an
+ * error). No global `window` is emitted, so each def keeps its own baked
+ * window when no range is active — exactly the reference path's behaviour.
  */
 export function globalParams(filters) {
   const params = {};
   if (filters?.geography && filters.geography !== "all") {
     params.ward = filters.geography;
   }
-  if (filters?.complaintType && filters.complaintType !== "all") {
-    params.serviceCode = filters.complaintType;
-  }
+  Object.assign(
+    params,
+    complaintTypeParams({
+      code: filters?.complaintType,
+      path: filters?.complaintTypePath,
+      leaf: filters?.complaintTypeLeaf,
+    })
+  );
   if (filters?.dateRangeActive && filters?.dateFrom && filters?.dateTo) {
     params.dateFrom = filters.dateFrom; // yyyy-MM-dd
     params.dateTo = filters.dateTo; // yyyy-MM-dd


### PR DESCRIPTION
## What

Replaces the supervisor dashboard's flat leaf-only complaint-type `<select>` with **one compact tree-traversal widget** — the owner-requested design: from the current node, one dropdown descends into children, an up affordance climbs a level, and the current selection IS the filter (subtree). FE half of the pairing with #1282.

**How traversal works (apply-on-select, no Apply button):**
- **Breadcrumb-ish label** of the current node — "All types" at root; every ancestor crumb is clickable and applies the filter *at that level*.
- **One dropdown of the current node's children** — selecting a child descends AND applies. Interior children are "›"-marked and filter the whole subtree; leaf children filter exactly.
- **Up-chevron** applies the parent level; at root the filter is cleared.
- When a **leaf** is applied, the dropdown shows its siblings (leaves have no children) with an "All in <parent>" first option — sibling switching keeps the old flat-select ergonomics, and the first option doubles as a back affordance.

**Wire shape:** root → neither param · leaf → `serviceCode` (unchanged, works on every grain) · interior → `complaintPath` (dot-path; node + dot-descendants), client-sanitized to #1282's `[A-Za-z0-9._/-]{1,256}` so an exotic code can never 400 a tile batch.

## Exhumed-demo contrast (July `fix/dashboard-hierarchy-filters`, reference only)

Kept from the demo:
- **subtree-vs-leaf predicate split** (eq for leaf, prefix for interior) — proven correct there;
- **ABAC-scoped tree pruning** — a dept-scoped supervisor only ever sees (or can select) their branches;
- **sanitize/repair of persisted selections** — a stored node that vanished (master edit / ABAC re-scope) walks UP its dot-path to the nearest surviving ancestor instead of blanking the filter.

Avoided from the demo:
- the **growing horizontal chain of selects** (4-level hierarchy = 4 selects in the bar) — this is ONE widget that stays one widget at any depth;
- the **bespoke BE tree endpoint** — #1283's `complaintHierarchyService` gives the FE the MDMS tree directly; pruning happens client-side against the ABAC-scoped `DISTINCT service_code` list the filter bar already fetches, so no new endpoint and no full-tree info leak.

## ABAC-pruning guarantee

The MDMS master is the FULL tenant tree; the widget's tree is `pruneComplaintTree(mdmsTree, scopedDistinctLeafCodes)` — a branch survives only with ≥1 row-scope-visible leaf, and stray scoped codes (rows without a master record) stay selectable as root leaves. Visibility is therefore *identical* to today's flat select — nothing widens, nothing selectable is lost.

## Backend pairing (#1282)

- Interior selections send `params.complaintPath`; **until #1282 merges/deploys, the composer silently drops the unknown param** → the dashboard degrades to leaf-only filtering (exactly today's capability), never an error.
- Daily-grain KPIs (`cl_chart_over_time_open_daily`, `cl_chart_wards_by_sla`, `cl_chart_department_breach_scatter`, `cl_table_ward_open_daily`) have no `complaint_node_path`; #1282 skips the filter there and reports `paramsIgnored:["complaintPath"]` per result — those tiles render a subtle localized **"Type filter not applied"** stamp (bottom-left, CardUpdatedStamp chrome) so they never *look* filtered while showing unfiltered numbers.
- Composes with #1282's per-widget Group-by: subtree `WHERE` × level `GROUP BY` are orthogonal; the Group-by control stays param-side (NOT a filter), this widget is the sanctioned filter revival and lives in `useDashboardFilters`/`globalParams` like every other filter (persisted, reconciled, cleared by Clear).

## Labels & l10n

Node labels ride the existing `dimensionLabel` seam (`COMPLAINT_HIERARCHY.<code>` → data-owned MDMS name) with a humanized last-segment fallback for `name === code` interior records — never a raw dotted code in the breadcrumb. New widget strings (`DASHBOARD_TYPE_FILTER_ALL_IN` / `_UP` / `_NOT_APPLIED`) are seeded in digit-mcp's dashboard-l10n packs, en_IN + pt_PT, 1:1 (315 codes each).

## Tests / validation

- `node --test products/dashboard/src/utils/complaintTypeTree.test.js` — **22 cases**: descend / ascend / apply / clear / repair (nearest-ancestor walk-up) / ABAC pruning / param mapping incl. charset sanitizing and legacy string-only persisted state, plus a persist/load round-trip proving an interior selection survives a tree-fetch-failure reload cycle and repairs on the next successful tree load.
- **Known note:** the persisted-leaf cold-load validation asymmetry — a persisted leaf `serviceCode` is sent unvalidated on the very first batch (before the option lists load), and gating it could regress legitimately-selectable stray DISTINCT codes — is a flagged product decision, not silently changed here.
- Existing suites green: hierLevelGrouping (16), applyTheme (30), transform-css (11).
- `npm run build` (esbuild production) green.
- Widget markup smoke-verified for root / interior / leaf states via ReactDOMServer.
- `dashboard.css`: only the new block is appended, hand-mirrored 1:1 from the tailwind output of the `input.css` rules (a full regen re-prefixes ~200 unrelated lines from an older autoprefixer vintage).

**Screenshots:** UI screenshots against a live tenant to follow in a PR comment once this is deployed alongside #1282 on the repro box (the widget also degrades cleanly to the current flat select wherever no hierarchy tree is available, so nothing regresses visually in the meantime).

## Design pass (owner feedback round)

Owner feedback from the live pass: both controls read as raw browser-native `<select>`s — asked for a "tree traversing clean widget". Reworked presentation only; the traversal state machine, ABAC pruning, persistence, `paramsIgnored` stamp and `serviceCode`/`complaintPath` emission are byte-identical in behavior.

**Shared primitive** — `products/dashboard/src/components/ui/PopoverMenu.jsx`: dependency-free styled chip + body-portaled menu panel in the dashboard's existing design language (inline-control chip: h-7 / rounded-sm / border-border / bg-surface; panel mirrors the add-KPI dropdown surface). Click-outside + Escape/Tab close, ArrowUp/Down/Home/End keyboard navigation with focus-visible rings, `role=menu` / `menuitem(radio)` + `aria-expanded` semantics, viewport clamping with flip-above. RGL-safe by construction (chip is a `<button>`, panel portals outside the grid), so `draggableCancel` needed no extension.

**Tree type filter**: a compact chip in the filter bar shows the applied selection ("All types" / "Sanitation" / "… › Sanitation › Blocked drain", full trail in the tooltip). One panel does the whole traversal — clickable ancestor trail across the top, children of the current node as a styled list (interior rows chevroned), explicit "All in <current>" row, "All types" reset pinned at the bottom. **Interaction choice: browse-then-apply** — clicking an interior child descends *within the panel* without applying (apply-on-descend would fire a dashboard-wide refetch per hop of a drill-down); leaf click and "All in <X>" apply + close. Deep trees: the list scrolls inside the panel and the trail middle-truncates ("All types › … › parent › current", elided levels in the ellipsis tooltip) — verified against a ke `PGR_TEST`-shaped 4-level hierarchy and one level deeper. The no-hierarchy degrade path renders the same flat leaf list through the primitive (group labels where the old `<optgroup>`s sat) — zero native selects remain in this control.

**Group-by control** (merged #1283 surface, touching it from here sanctioned): now a small "Group: Category" chip (compact primitive variant) in the widget title row — fixed prefix, truncating value, never wraps narrow widgets; menu end-aligns to stay on-screen for right-edge tiles.

Strings: `DASHBOARD_GROUPBY_CHIP` added en_IN + pt_PT; the dead `DASHBOARD_TYPE_FILTER_UP` (old up-chevron) removed — packs stay 1:1 at 315 codes. CSS stays append-only vs develop in `dashboard.css` (hand-mirrored from the tailwind input, diff-verified: 0 pre-existing lines touched). Validation: esbuild build green; 93 `node --test` cases green incl. new pure-state tests (`browseBaseCode`, `truncateTrail`) and a ReactDOMServer render smoke of chip + panel + group-by chip at root / interior / leaf / 4-level-deep / deeper-than-trail states. **Screenshots of the reworked controls to follow in a PR comment.**

## Design consistency round 2 (owner feedback)

Owner feedback from the live build: *"why is the complaints filter weird and blue — just have consistent designs, the functionality is fine"* and *"headers need to be consistent across KPIs … maybe … behind a settings icon — non-obstructionist, non-regressive, compliant with existing UI."* Presentation only again — the wire contract, traversal state machine, persistence and tests' behavioral assertions are untouched (93 `node --test` cases green, esbuild build green).

**Root cause of the "weird" panel** — the menu panel portals to `document.body`, which sits *outside* `.dashboard-root`, the only element defining the dashboard's design tokens (`--border`/`--muted`/`--ring`/…) and the Inter font stack. Portaled content therefore rendered with the host app's body-level font and broken `var()`s. The panel now carries `dashboard-root` itself (that class sets only custom properties + font rules), so menu content resolves the exact same tokens as in-tree chrome.

**Chip = strict peer of the inline selects** — the complaint-type chip now matches `.dashboard-filter-inline-select` property-for-property: h-7, min-w-[7.5rem] (new), rounded-sm, border-border, bg-surface, 12px/leading-none text at weight 400 (was 500), caret pinned to the right padding edge (like the select-wrap's `::after` caret), **no** resting hover treatment (the selects have none — the border-darken hover is gone), the select's exact focus treatment (border-foreground + 15% ring), and full-width stretch in the stacked ≤639px filter bar. The last brand accent is gone too: menu check marks use `currentColor` instead of `--primary`, so selection reads as weight + check in the same neutral foreground as the rest of the filter bar.

**Uniform KPI headers: Group-by behind a settings gear** — the labeled "Group: Category" chip (round 1) made headers with the control look different from headers without; it's replaced by a muted 16px settings gear in the title row, right-aligned before the remove control, in the exact `.dashboard-widget-remove-btn` icon idiom (1.5rem square, transparent resting, bg-muted on hover/open, 30% focus-visible ring, lucide stroke icon family). The icon is simply *absent* on widgets with no per-widget options — absence keeps headers uniform where a text chip did not. Clicking opens the same PopoverMenu with **"Group by" as the menu's section label**; `draggableCancel` coverage is unchanged (the anchor is a `<button>`, already in the cancel list; the panel portals outside the grid). `DASHBOARD_GROUPBY_CHIP` is now dead and dropped from both l10n packs (314 codes each, still 1:1).

**Deliberately NOT moved into the global filter bar**: the owner floated grouping-as-a-filter as an option, but per-widget grouping is per-widget *state* (it changes a widget's own GROUP BY dimension, never which complaints qualify) — folding it into the global filters would change those semantics and regress per-widget persistence, so the settings-icon route satisfies "non-obstructionist" without touching the filter contract.

**Review sweep (2026-07-17)** — all 7 CodeRabbit inline findings addressed on-thread: 3 fixed (`d40f4fa24` aria-current on applied descend rows, `733f82c97` popover capped to the roomier side when neither side fits, `743f12973` dot-boundary-prefix selection repair for dotted MDMS codes — each with tests), 4 declined with evidence in the reply (2 stylelint nits from a linter this repo doesn't run, 2 findings against the validated-live ABAC-pruning/param-emission semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hierarchical complaint-type filtering with searchable navigation, breadcrumbs, and “All types” reset.
  * Added clearer popover menus for complaint-type and “Group by” selections.
  * Added mobile-friendly filter layouts and improved keyboard accessibility.
  * Dashboard tiles now indicate when a complaint-type filter could not be applied.

* **Localization**
  * Added English and Portuguese translations for new filter states.

* **Bug Fixes**
  * Improved persistence and recovery of complaint-type selections when filter data is unavailable or changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
