### PR TITLE
feat(novu-bridge): Ozeki SMS Gateway provider via generic-sms (design)

### DIFF
--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/config/NovuBridgeConfiguration.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/config/NovuBridgeConfiguration.java
@@ -103,6 +103,21 @@ public class NovuBridgeConfiguration {
     @Value("${novu.bridge.workflow.id.email:complaints-email}")
     private String novuWorkflowEmail;
 
+    // ---- SMS provider envelope ----
+    // Empty (default) = plain trigger; Novu's primary SMS integration delivers.
+    // "ozeki" = attach the Ozeki generic-sms overrides envelope to SMS triggers
+    // (OzekiOverridesBuilder); requires a generic-sms Novu integration whose
+    // identifier matches novu.bridge.ozeki.integration.identifier.
+    @Value("${novu.bridge.sms.provider:}")
+    private String smsProvider;
+
+    @Value("${novu.bridge.ozeki.integration.identifier:ozeki-sms}")
+    private String ozekiIntegrationIdentifier;
+
+    public boolean isOzekiSmsEnabled() {
+        return smsProvider != null && "ozeki".equalsIgnoreCase(smsProvider.trim());
+    }
+
     // ---- Subscriber identify (upsert) TTL cache ----
     @Value("${novu.bridge.identify.cache.ttl.ms:300000}")
     private Long identifyCacheTtlMs;

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/service/NovuClient.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/service/NovuClient.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.egov.novubridge.config.NovuBridgeConfiguration;
+import org.egov.novubridge.service.provider.OzekiOverridesBuilder;
 import org.egov.novubridge.util.PiiMask;
 import org.egov.tracer.model.CustomException;
 import org.springframework.http.*;
@@ -66,7 +67,18 @@ public class NovuClient {
             payload.put("subject", renderedSubject);
         }
 
-        return trigger(workflowId, subscriberId, phone, email, payload, transactionId);
+        // Ozeki delivery (opt-in): reshape the SMS send for an Ozeki gateway
+        // behind a generic-sms integration. Overrides are sent raw (Novu never
+        // templates them), which is exactly why this envelope can only be built
+        // here — the pass-through path is the one place that has the final
+        // renderedBody, recipient phone and transactionId together.
+        Map<String, Object> overrides = null;
+        if ("SMS".equalsIgnoreCase(channel) && config.isOzekiSmsEnabled()) {
+            overrides = OzekiOverridesBuilder.build(
+                    config.getOzekiIntegrationIdentifier(), transactionId, phone, renderedBody);
+        }
+
+        return trigger(workflowId, subscriberId, phone, email, payload, transactionId, overrides);
     }
 
     /**
@@ -152,6 +164,12 @@ public class NovuClient {
      */
     public NovuResponse trigger(String workflowId, String subscriberId, String phone, String email,
                                 Map<String, Object> payload, String transactionId) {
+        return trigger(workflowId, subscriberId, phone, email, payload, transactionId, null);
+    }
+
+    public NovuResponse trigger(String workflowId, String subscriberId, String phone, String email,
+                                Map<String, Object> payload, String transactionId,
+                                Map<String, Object> overrides) {
         try {
             Map<String, Object> request = new HashMap<>();
             request.put("name", workflowId);
@@ -168,6 +186,9 @@ public class NovuClient {
             request.put("payload", payload);
             if (StringUtils.hasText(transactionId)) {
                 request.put("transactionId", transactionId);
+            }
+            if (overrides != null && !overrides.isEmpty()) {
+                request.put("overrides", overrides);
             }
 
             HttpHeaders headers = new HttpHeaders();

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/service/provider/OzekiOverridesBuilder.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/service/provider/OzekiOverridesBuilder.java
@@ -1,0 +1,73 @@
+package org.egov.novubridge.service.provider;
+
+import org.springframework.util.StringUtils;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds the Novu trigger {@code overrides} envelope that delivers an SMS
+ * through an <a href="https://ozeki-sms-gateway.com/p_5667-http-sms-api.html">Ozeki
+ * SMS Gateway</a> behind Novu's built-in {@code generic-sms} provider — no
+ * forked Novu images, no shim service. Full design:
+ * {@code docs/Novu_Adapter/OZEKI-GENERIC-SMS-PROVIDER.md}.
+ *
+ * <p>Shape constraints (verified against Novu v2.3.0 source):
+ * <ul>
+ *   <li>The provider-overrides key must be the Novu provider id
+ *       {@code generic-sms} — the worker's {@code combineOverrides} looks up
+ *       {@code overrides.providers[integration.providerId]}; a key like
+ *       {@code ozeki} would be silently ignored.</li>
+ *   <li>{@code _passthrough.body} is deep-merged into the outgoing JSON with
+ *       highest priority and is exempt from the provider's key-casing
+ *       transform, so Ozeki's snake_case {@code messages[]} fields survive
+ *       verbatim.</li>
+ *   <li>Overrides are sent raw — Novu never templates them — so {@code text}
+ *       must be the final pre-rendered body, which the pass-through pipeline
+ *       has at trigger time.</li>
+ *   <li>{@code overrides.sms.integrationIdentifier} pins the (possibly
+ *       non-primary) generic-sms integration, letting Ozeki coexist with e.g.
+ *       a primary Twilio integration.</li>
+ * </ul>
+ */
+public final class OzekiOverridesBuilder {
+
+    /** Novu provider id backing the Ozeki integration — NOT "ozeki". */
+    public static final String NOVU_PROVIDER_ID = "generic-sms";
+
+    private OzekiOverridesBuilder() {
+    }
+
+    /**
+     * @param integrationIdentifier identifier of the generic-sms Novu
+     *                              integration pointing at the Ozeki gateway;
+     *                              blank = omit (Novu falls back to the
+     *                              primary SMS integration)
+     * @param transactionId         echoed back by the gateway as
+     *                              {@code message_id} — the correlation key
+     *                              across nb_dispatch_log, the Novu activity
+     *                              feed (via the integration's idPath) and the
+     *                              Ozeki message store
+     * @param toAddress             recipient in +E.164 (already formatted by
+     *                              the dispatch pipeline)
+     * @param text                  final localized message body
+     */
+    public static Map<String, Object> build(String integrationIdentifier, String transactionId,
+                                            String toAddress, String text) {
+        Map<String, Object> message = new LinkedHashMap<>();
+        message.put("message_id", transactionId);
+        message.put("to_address", toAddress);
+        message.put("text", text);
+
+        Map<String, Object> overrides = new LinkedHashMap<>();
+        if (StringUtils.hasText(integrationIdentifier)) {
+            overrides.put("sms", Map.of("integrationIdentifier", integrationIdentifier));
+        }
+        overrides.put("providers", Map.of(NOVU_PROVIDER_ID,
+                Map.of("_passthrough",
+                        Map.of("body",
+                                Map.of("messages", List.of(message))))));
+        return overrides;
+    }
+}

--- a/backend/novu-bridge/src/main/resources/application.properties
+++ b/backend/novu-bridge/src/main/resources/application.properties
@@ -43,6 +43,12 @@ novu.bridge.proxy.allowed.roles=${NOVU_BRIDGE_PROXY_ALLOWED_ROLES:EMPLOYEE,SUPER
 novu.bridge.workflow.id.sms=${NOVU_BRIDGE_WORKFLOW_ID_SMS:complaints-sms}
 novu.bridge.workflow.id.whatsapp=${NOVU_BRIDGE_WORKFLOW_ID_WHATSAPP:complaints-whatsapp}
 novu.bridge.workflow.id.email=${NOVU_BRIDGE_WORKFLOW_ID_EMAIL:complaints-email}
+# SMS provider envelope: empty = whatever Novu integration is primary for SMS;
+# "ozeki" = route SMS through an Ozeki SMS Gateway via a generic-sms Novu
+# integration (identifier below), reshaping the request with a _passthrough
+# overrides envelope (docs/Novu_Adapter/OZEKI-GENERIC-SMS-PROVIDER.md).
+novu.bridge.sms.provider=${NOVU_BRIDGE_SMS_PROVIDER:}
+novu.bridge.ozeki.integration.identifier=${NOVU_BRIDGE_OZEKI_INTEGRATION_IDENTIFIER:ozeki-sms}
 # Subscriber identify (upsert) TTL cache window.
 novu.bridge.identify.cache.ttl.ms=${NOVU_BRIDGE_IDENTIFY_CACHE_TTL_MS:300000}
 # Channels actually delivered. WHATSAPP is intentionally absent until a

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/service/NovuClientOzekiTriggerTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/service/NovuClientOzekiTriggerTest.java
@@ -1,0 +1,121 @@
+package org.egov.novubridge.service;
+
+import org.egov.novubridge.config.NovuBridgeConfiguration;
+import org.egov.novubridge.service.provider.OzekiOverridesBuilder;
+import org.egov.novubridge.web.models.Contact;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Coverage of the Ozeki gate in {@link NovuClient#identifyThenTrigger}: the
+ * generic-sms overrides envelope must be attached to the trigger request only
+ * when {@code novu.bridge.sms.provider=ozeki} AND the channel is SMS — never
+ * for other channels, never with the default (empty) provider.
+ */
+class NovuClientOzekiTriggerTest {
+
+    private static final String TXN = "txn-42";
+    private static final String PHONE = "+254712345678";
+    private static final String BODY = "Your complaint PGR-1 was resolved";
+
+    private RestTemplate restTemplate;
+    private NovuBridgeConfiguration config;
+    private NovuClient novuClient;
+
+    @BeforeEach
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void setUp() {
+        restTemplate = mock(RestTemplate.class);
+        config = new NovuBridgeConfiguration();
+        config.setNovuBaseUrl("http://novu:3000");
+        config.setNovuApiKey("secret-key");
+        config.setNovuWorkflowSms("complaints-sms");
+        config.setNovuWorkflowEmail("complaints-email");
+        config.setIdentifyCacheTtlMs(0L);
+        config.setOzekiIntegrationIdentifier("ozeki-sms");
+        novuClient = new NovuClient(restTemplate, config);
+
+        // identifyThenTrigger POSTs /v1/subscribers (identify) then /v1/events/trigger.
+        when(restTemplate.exchange(anyString(), eq(HttpMethod.POST), any(), eq(Map.class)))
+                .thenReturn((ResponseEntity) ResponseEntity.ok(Map.of("data", Map.of("acknowledged", true))));
+    }
+
+    /** Captures every POST exchange and returns the body of the LAST one (the trigger). */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private Map<String, Object> lastRequestBody() {
+        ArgumentCaptor<HttpEntity> ent = ArgumentCaptor.forClass(HttpEntity.class);
+        verify(restTemplate, atLeast(1))
+                .exchange(anyString(), eq(HttpMethod.POST), ent.capture(), eq(Map.class));
+        List<HttpEntity> all = ent.getAllValues();
+        return (Map<String, Object>) all.get(all.size() - 1).getBody();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void smsWithOzekiProvider_attachesOverridesEnvelope() {
+        config.setSmsProvider("ozeki");
+        Contact contact = Contact.builder().phone(PHONE).name("Jane Doe").build();
+
+        novuClient.identifyThenTrigger("ke.bomet:u1", contact, "SMS", BODY, null, TXN, null);
+
+        Map<String, Object> request = lastRequestBody();
+        assertEquals("complaints-sms", request.get("name"));
+        assertTrue(request.containsKey("overrides"), "SMS + ozeki must attach overrides");
+
+        Map<String, Object> overrides = (Map<String, Object>) request.get("overrides");
+        Map<String, Object> sms = (Map<String, Object>) overrides.get("sms");
+        assertEquals("ozeki-sms", sms.get("integrationIdentifier"));
+
+        Map<String, Object> providers = (Map<String, Object>) overrides.get("providers");
+        Map<String, Object> generic =
+                (Map<String, Object>) providers.get(OzekiOverridesBuilder.NOVU_PROVIDER_ID);
+        Map<String, Object> passthroughBody =
+                (Map<String, Object>) ((Map<String, Object>) generic.get("_passthrough")).get("body");
+        List<Map<String, Object>> messages = (List<Map<String, Object>>) passthroughBody.get("messages");
+        assertEquals(1, messages.size());
+        assertEquals(Map.of("message_id", TXN, "to_address", PHONE, "text", BODY), messages.get(0));
+    }
+
+    @Test
+    void emailWithOzekiProvider_hasNoOverrides() {
+        config.setSmsProvider("ozeki");
+        Contact contact = Contact.builder().email("jane@example.org").name("Jane Doe").build();
+
+        novuClient.identifyThenTrigger("ke.bomet:u1", contact, "EMAIL", BODY, "Subject", TXN, null);
+
+        Map<String, Object> request = lastRequestBody();
+        assertEquals("complaints-email", request.get("name"));
+        assertFalse(request.containsKey("overrides"), "Ozeki envelope is SMS-only");
+    }
+
+    @Test
+    void smsWithDefaultProvider_hasNoOverrides() {
+        config.setSmsProvider(""); // @Value default: novu.bridge.sms.provider unset
+        Contact contact = Contact.builder().phone(PHONE).build();
+
+        novuClient.identifyThenTrigger("ke.bomet:u1", contact, "SMS", BODY, null, TXN, null);
+
+        Map<String, Object> request = lastRequestBody();
+        assertEquals("complaints-sms", request.get("name"));
+        assertFalse(request.containsKey("overrides"), "default provider must not attach overrides");
+    }
+}

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/service/provider/OzekiOverridesBuilderTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/service/provider/OzekiOverridesBuilderTest.java
@@ -1,0 +1,81 @@
+package org.egov.novubridge.service.provider;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Shape coverage for {@link OzekiOverridesBuilder}: the Novu trigger overrides
+ * envelope that routes an SMS through an Ozeki gateway behind Novu's built-in
+ * {@code generic-sms} provider. The exact key shapes are load-bearing — Novu's
+ * worker looks up {@code overrides.providers[providerId]} and deep-merges
+ * {@code _passthrough.body} verbatim into the outgoing gateway request.
+ */
+class OzekiOverridesBuilderTest {
+
+    private static final String TXN = "txn-123";
+    private static final String PHONE = "+254712345678";
+    private static final String TEXT = "Your complaint PGR-1 was resolved";
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> messageAt(Map<String, Object> overrides) {
+        Map<String, Object> providers = (Map<String, Object>) overrides.get("providers");
+        Map<String, Object> generic = (Map<String, Object>) providers.get(OzekiOverridesBuilder.NOVU_PROVIDER_ID);
+        Map<String, Object> passthrough = (Map<String, Object>) generic.get("_passthrough");
+        Map<String, Object> body = (Map<String, Object>) passthrough.get("body");
+        List<Map<String, Object>> messages = (List<Map<String, Object>>) body.get("messages");
+        assertEquals(1, messages.size(), "messages must be a 1-element list");
+        return messages.get(0);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void build_withIdentifier_pinsIntegrationViaSmsKey() {
+        Map<String, Object> overrides = OzekiOverridesBuilder.build("ozeki-sms", TXN, PHONE, TEXT);
+
+        assertTrue(overrides.containsKey("sms"), "sms key must pin the integration");
+        Map<String, Object> sms = (Map<String, Object>) overrides.get("sms");
+        assertEquals("ozeki-sms", sms.get("integrationIdentifier"));
+    }
+
+    @Test
+    void build_withNullOrBlankIdentifier_omitsSmsKeyEntirely() {
+        assertFalse(OzekiOverridesBuilder.build(null, TXN, PHONE, TEXT).containsKey("sms"),
+                "null identifier must omit the sms key");
+        assertFalse(OzekiOverridesBuilder.build("", TXN, PHONE, TEXT).containsKey("sms"),
+                "empty identifier must omit the sms key");
+        assertFalse(OzekiOverridesBuilder.build("   ", TXN, PHONE, TEXT).containsKey("sms"),
+                "blank identifier must omit the sms key");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void build_providersKeyIsGenericSms_neverOzeki() {
+        Map<String, Object> overrides = OzekiOverridesBuilder.build("ozeki-sms", TXN, PHONE, TEXT);
+
+        Map<String, Object> providers = (Map<String, Object>) overrides.get("providers");
+        assertEquals("generic-sms", OzekiOverridesBuilder.NOVU_PROVIDER_ID);
+        assertEquals(Set.of(OzekiOverridesBuilder.NOVU_PROVIDER_ID), providers.keySet(),
+                "providers must be keyed by the Novu provider id only");
+        assertFalse(providers.containsKey("ozeki"),
+                "an 'ozeki' key would be silently ignored by Novu's combineOverrides");
+    }
+
+    @Test
+    void build_passthroughMessage_hasExactlyMessageIdToAddressText() {
+        Map<String, Object> overrides = OzekiOverridesBuilder.build("ozeki-sms", TXN, PHONE, TEXT);
+
+        Map<String, Object> message = messageAt(overrides);
+        assertEquals(Set.of("message_id", "to_address", "text"), message.keySet(),
+                "message must carry exactly Ozeki's snake_case fields");
+        assertEquals(TXN, message.get("message_id"));
+        assertEquals(PHONE, message.get("to_address"));
+        assertEquals(TEXT, message.get("text"));
+    }
+}

--- a/docs/Novu_Adapter/OZEKI-GENERIC-SMS-PROVIDER.md
+++ b/docs/Novu_Adapter/OZEKI-GENERIC-SMS-PROVIDER.md
@@ -1,6 +1,6 @@
 # Ozeki SMS Gateway via Novu `generic-sms` — Design
 
-**Status**: DESIGN — draft for review, not implemented. Mechanics verified 2026-07-17 against Novu v2.3.0 source (the self-hosted tag we deploy) and both novu-bridge variants (develop + the pass-through `feat/whatsapp-contentsid-pipeline` branch).
+**Status**: bridge implementation included in this PR (`OzekiOverridesBuilder` + `NovuClient` SMS-leg wiring + `NOVU_BRIDGE_SMS_PROVIDER` / `NOVU_BRIDGE_OZEKI_INTEGRATION_IDENTIFIER` knobs, default off). The R1 empirical gate (§4) against a live Ozeki gateway is still outstanding — do not enable in a deployment before running it. Mechanics verified 2026-07-17 against Novu v2.3.0 source (the self-hosted tag we deploy).
 **Goal**: send SMS through a customer-hosted [Ozeki SMS Gateway](https://ozeki-sms-gateway.com/p_5667-http-sms-api.html) (HTTP REST, common in on-prem installs) from the DIGIT notification pipeline, with the provider visible in the Novu dashboard (integration store + activity feed), **without forking Novu images** and **without a standalone shim service**.
 
 ---

--- a/docs/Novu_Adapter/OZEKI-GENERIC-SMS-PROVIDER.md
+++ b/docs/Novu_Adapter/OZEKI-GENERIC-SMS-PROVIDER.md
@@ -1,6 +1,6 @@
 # Ozeki SMS Gateway via Novu `generic-sms` — Design
 
-**Status**: bridge implementation included in this PR (`OzekiOverridesBuilder` + `NovuClient` SMS-leg wiring + `NOVU_BRIDGE_SMS_PROVIDER` / `NOVU_BRIDGE_OZEKI_INTEGRATION_IDENTIFIER` knobs, default off). The R1 empirical gate (§4) against a live Ozeki gateway is still outstanding — do not enable in a deployment before running it. Mechanics verified 2026-07-17 against Novu v2.3.0 source (the self-hosted tag we deploy).
+**Status**: bridge implementation included in this PR (`OzekiOverridesBuilder` + `NovuClient` SMS-leg wiring + `NOVU_BRIDGE_SMS_PROVIDER` / `NOVU_BRIDGE_OZEKI_INTEGRATION_IDENTIFIER` knobs, default off). Mechanics verified 2026-07-17 against Novu v2.3.0 source (the self-hosted tag we deploy). **R1 and R3 (§4) verified 2026-07-18 against a real Ozeki 10.4.16 trial gateway — see `ozeki-gateway-probe-2026-07-18.md`**: unknown top-level fields ignored (R1 pass, no shim needed), auth failure = HTTP 200 with a messages-less envelope that `idPath` correctly turns into a Novu failure (R3). Per-deployment: rerun the two probe curls against the customer's gateway before enabling.
 **Goal**: send SMS through a customer-hosted [Ozeki SMS Gateway](https://ozeki-sms-gateway.com/p_5667-http-sms-api.html) (HTTP REST, common in on-prem installs) from the DIGIT notification pipeline, with the provider visible in the Novu dashboard (integration store + activity feed), **without forking Novu images** and **without a standalone shim service**.
 
 ---

--- a/docs/Novu_Adapter/OZEKI-GENERIC-SMS-PROVIDER.md
+++ b/docs/Novu_Adapter/OZEKI-GENERIC-SMS-PROVIDER.md
@@ -1,0 +1,136 @@
+# Ozeki SMS Gateway via Novu `generic-sms` — Design
+
+**Status**: DESIGN — draft for review, not implemented. Mechanics verified 2026-07-17 against Novu v2.3.0 source (the self-hosted tag we deploy) and both novu-bridge variants (develop + the pass-through `feat/whatsapp-contentsid-pipeline` branch).
+**Goal**: send SMS through a customer-hosted [Ozeki SMS Gateway](https://ozeki-sms-gateway.com/p_5667-http-sms-api.html) (HTTP REST, common in on-prem installs) from the DIGIT notification pipeline, with the provider visible in the Novu dashboard (integration store + activity feed), **without forking Novu images** and **without a standalone shim service**.
+
+---
+
+## 1. Decision summary
+
+| Concern | Decision |
+|---|---|
+| Novu-side provider | Built-in **`generic-sms`** integration (present in v2.3.0; no image rebuild) |
+| Request reshaping (the `messages[]` body Ozeki expects) | **`_passthrough.body`** provider override attached by novu-bridge at trigger time |
+| Auth | generic-sms credentials: `apiKeyRequestHeader = "Authorization"`, `apiKey = "Basic <base64(user:pass)>"` |
+| Message id / correlation | Bridge `transactionId` → Ozeki `message_id` (echoed by the gateway) → Novu message `identifier` via `idPath` |
+| Integration selection | `overrides.sms.integrationIdentifier` (works even when another SMS integration stays primary) |
+| Delivery status | v1 = submit-level only (Ozeki's JSON API has no status webhook); folder-polling poller is a possible v2 |
+| Branded "Ozeki" tile | Out of scope; optional upstream PR to novuhq/novu (separate track) |
+
+## 2. Verified mechanics (from source, file:line)
+
+**Ozeki wire contract** (vendor docs + official Java client `ozekisms/java-send-sms-http-rest-ozeki`):
+- `POST http://<gw>:9509/api?action=sendmsg` (HTTPS :9508), Basic auth (gateway "HTTP API user"), JSON.
+- Body: `{"messages":[{"message_id":"<any-string>","to_address":"+E164","text":"..."}]}` — one object per recipient; other fields optional (the official client serializes omit-if-null).
+- Response: `{"http_code":200,"response_code":"SUCCESS","response_msg":"...","data":{"total_count":1,"success_count":1,"failed_count":0,"messages":[{"message_id":"<echoed>","status":"SUCCESS",...}]}}`.
+- Failure `response_code` values are **undocumented**; there is no status-query action and no JSON-API delivery webhook (only `sent`/`notsent` folder polling via `receivemsg`, or the legacy GET API's `reporturl`).
+
+**Novu v2.3.0 `generic-sms`** (`packages/providers/src/lib/sms/generic-sms/generic-sms.provider.ts`):
+- POSTs to `baseUrl` verbatim (query string allowed → put `?action=sendmsg` inside `baseUrl`); body = `transform(bridgeProviderData, {...options, sender})`.
+- `base.provider.ts:74-88`: `_passthrough.body` is **not case-transformed** (`to_address` survives) and deep-merges with **highest priority** over trigger data.
+- Headers = `{[apiKeyRequestHeader]: apiKey}` (+ optional secret pair) → Basic auth works natively. `_passthrough.headers` are **ignored** on the non-token path — do not rely on them.
+- `idPath` resolver is a dot-path reduce (`generic-sms.provider.ts:86-90`) → **`data.messages.0.message_id` resolves** (JS numeric-string indexing). If the response lacks `data.messages`, the reduce throws → Novu marks the message failed (an accidental but useful guard against malformed/error envelopes).
+- No SSRF guard in 2.3.0 (added upstream later) → private-network gateway URLs work; re-check on Novu upgrades.
+
+**Worker plumbing** (`apps/worker/src/app/workflow/usecases/send-message/`):
+- `send-message.base.ts:52-63` `combineOverrides`: provider data = `overrides.providers[<novuProviderId>]` → the overrides key **must be `generic-sms`**, not `ozeki`.
+- `send-message-sms.usecase.ts:53`: `overrides.sms.integrationIdentifier` pins the integration per trigger → Ozeki sends work while e.g. Twilio remains the primary SMS integration.
+- `send-message-sms.usecase.ts:298-300`: `options.to = phone`, `options.content =` rendered step body. These leak into the JSON body alongside our `messages[]` (deepMerge only adds) — see Risk R1.
+
+**Bridge reality check**: trigger `overrides` are sent **raw** — Novu does not handlebars-compile them. Therefore `messages[0].text` must be a concrete string at trigger time.
+- develop (`backend/novu-bridge`, `NovuClient.java:98`): the bridge never holds the final text (Novu renders the workflow step body) → **this design is NOT implementable on develop's render flow as-is**.
+- pass-through D4/D6 (`feat/whatsapp-contentsid-pipeline`, `NovuClient.identifyThenTrigger`): receives `renderedBody`, `contact.phone`, `transactionId` — everything the envelope needs, in one scope. The WhatsApp contentSid override (`buildProviderTemplateOverrides`) is the exact precedent for attaching a provider envelope there.
+
+**⇒ Hard dependency: this design targets the pass-through pipeline.** (Fallback for a Novu-rendered pipeline would be a forked native provider — out of scope.)
+
+## 3. Design
+
+### 3.1 Novu integration (config-only; dashboard-visible)
+
+Create via dashboard, `POST /v1/integrations`, or the configurator's Notification Providers screen (`NovuClient.createIntegration` already supports arbitrary providerIds):
+
+```json
+{
+  "name": "Ozeki SMS Gateway",
+  "identifier": "ozeki-sms",
+  "providerId": "generic-sms",
+  "channel": "sms",
+  "active": true,
+  "check": false,
+  "credentials": {
+    "baseUrl": "http://<gateway-host>:9509/api?action=sendmsg",
+    "apiKeyRequestHeader": "Authorization",
+    "apiKey": "Basic <base64(httpapiuser:password)>",
+    "from": "<default-sender>",
+    "idPath": "data.messages.0.message_id"
+  }
+}
+```
+
+Leave `datePath` unset (a missing `date` key returns undefined → provider falls back to `new Date()`; a wrong path could throw). Single-provider installs may simply make this the primary SMS integration; multi-provider installs rely on the identifier override below.
+
+### 3.2 Bridge change (the only code change; pass-through NovuClient)
+
+New `OzekiOverridesBuilder` (mirror of `buildProviderTemplateOverrides`) producing:
+
+```json
+{
+  "sms": { "integrationIdentifier": "<configured id>" },
+  "providers": { "generic-sms": { "_passthrough": { "body": {
+    "messages": [{
+      "message_id": "<transactionId>",
+      "to_address": "<contact.phone (+E164, already formatted)>",
+      "text": "<renderedBody>"
+    }]
+  }}}}
+}
+```
+
+Wire-in point: the `identifyThenTrigger` SMS leg — when Ozeki is enabled, call the existing overrides-accepting `trigger(...)` overload instead of the plain one.
+
+Enablement knob (holistic, no per-deployment values in code): env/config `NOVU_BRIDGE_SMS_PROVIDER=ozeki` + `NOVU_BRIDGE_OZEKI_INTEGRATION_IDENTIFIER=ozeki-sms` on the bridge container, defaulting off. If/when the develop strategy pipeline and the pass-through design are reconciled, the same builder wraps into an `OzekiProviderStrategy`; that needs two small interface tweaks — an overrides-key hook (develop's `NovuClient.java:98` keys overrides by `ProviderDetail.providerName`, but the worker requires `generic-sms`) and a delivery-context overload carrying `{phone, renderedBody, transactionId}`.
+
+Optional per-message sender: add `"from_address": "<sender>"` to the message object — the wire field exists in the official client, but gateway/SMSC honoring is route-dependent (unconfirmed; test).
+
+### 3.3 Resulting wire request (what Ozeki actually receives)
+
+```
+POST http://<gw>:9509/api?action=sendmsg
+Authorization: Basic <b64>            ← from integration credentials
+Content-Type: application/json
+
+{
+  "to": "+254700000001",              ← Novu options leak-through (expected ignored — R1)
+  "content": "Complaint KE-123 ...",  ← ditto
+  "sender": "<from>",                 ← ditto
+  "id": "<novu message id>",          ← ditto
+  "customData": {},                   ← ditto
+  "messages": [{                      ← ours, via _passthrough (highest merge priority)
+    "message_id": "<txn>",
+    "to_address": "+254700000001",
+    "text": "Complaint KE-123 ..."
+  }]
+}
+```
+
+Correlation chain: `nb_dispatch_log.transactionId` = Ozeki `message_id` = Novu activity-feed message `identifier` (via `idPath`).
+
+## 4. Risks / empirical gates (test in this order, before writing bridge code)
+
+- **R1 (gate #1)**: Ozeki must tolerate the unknown top-level fields (`to`, `content`, `sender`, `id`, `customData`). Ozeki 10 is .NET (typically tolerant deserialization) and the official client omits-if-null, but this is unconfirmed. One curl against a real/trial gateway settles it. If it rejects → fall back to a native-provider fork (or a rewrite proxy, previously rejected).
+- **R2**: HTTP 200 + `response_code != "SUCCESS"` (or `failed_count > 0`) with a well-formed envelope would still be marked sent (generic-sms only extracts `idPath`). Accepted v1 limitation — same class as Novu's fire-and-forget providers (e.g. Kannel). Mitigation path: v2 poller on `receivemsg&folder=notsent` matching `message_id`, writing back to `nb_dispatch_log`.
+- **R3**: Auth-failure behavior of the gateway (401 vs 200-with-error) is undocumented; probe once and record.
+- **R4**: Novu versions past 2.3.0 add SSRF protection to generic-sms — a private-IP `baseUrl` may need the SSRF guard disabled in self-hosted env.
+- **R5**: Datetime fields, if ever added (`time_to_send`, `valid_until`), are `yyyy-MM-dd HH:mm:ss` gateway-local — not ISO-8601.
+
+## 5. Validation plan (mechanism-level)
+
+1. **Gate R1/R3**: curl the canonical envelope + leak-through fields at a trial Ozeki install (free vendor download) or the target gateway. No bridge code before this passes.
+2. Mock-gateway container (records the request, replies the canonical SUCCESS envelope) → point a generic-sms integration at it in a repro environment → trigger a real PGR complaint event → assert: mock received the correct `messages[]`; Novu activity feed shows the message with `identifier == transactionId`; `nb_dispatch_log` row SENT.
+3. Real-gateway smoke: one complaint → phone receives the SMS.
+
+## 6. Out of scope / future
+
+- **Delivery-report poller** (`receivemsg` sent/notsent folders) — v2.
+- **Branded Ozeki tile**: upstream `ozeki` provider PR to novuhq/novu (`pnpm run generate:provider`; ~7 files across @novu/providers, @novu/shared, application-generic, @novu/framework + dashboard SVG). Parallel track; self-hosted deployments pick it up on a future version bump.
+- **Inbound SMS** (`receivemsg` folder=inbox) — not a notification concern.

--- a/docs/Novu_Adapter/ozeki-gateway-probe-2026-07-18.md
+++ b/docs/Novu_Adapter/ozeki-gateway-probe-2026-07-18.md
@@ -1,0 +1,70 @@
+# Ozeki gateway probe — R1/R3 gate results (2026-07-18)
+
+Probes from `OZEKI-GENERIC-SMS-PROVIDER.md` §4/§5, run against a real trial
+**Ozeki SMS Gateway 10.4.16** (vendor Linux .deb in an Ubuntu 22.04/mono
+container, amd64; HTTP API user created via the gateway GUI; no SMS route
+installed — probes verify API parse/response behavior, which is all the R1/R3
+gates require).
+
+## R1 — leak-through tolerance: **PASS**
+
+Request (exactly what Novu generic-sms will emit — our `_passthrough`
+`messages[]` plus the unavoidable top-level leak-through fields):
+
+```
+POST /api?action=sendmsg
+Authorization: Basic base64(apiuser:******)
+Content-Type: application/json
+
+{"to":"+254700000001","content":"Complaint KE-123 status update","sender":"EGOV",
+ "id":"novu-msg-id-1","customData":{},
+ "messages":[{"message_id":"txn-r1-0001","to_address":"+254700000001",
+              "text":"Complaint KE-123 status update"}]}
+```
+
+Response — HTTP 200, byte-identical in shape to the clean-envelope control
+(same run, `messages[]` only):
+
+```json
+{"http_code":200,"response_code":"SUCCESS","response_msg":"Messages queued for delivery.",
+ "data":{"total_count":1,"success_count":1,"failed_count":0,
+  "messages":[{"message_id":"txn-r1-0001","from_station":"%","to_address":"+254700000001",
+   "to_station":"%","text":"Complaint KE-123 status update",
+   "create_date":"2026-07-18 08:45:49","valid_until":"2026-07-25 08:45:49",
+   "time_to_send":"2026-07-18 08:45:49","submit_report_requested":true,
+   "delivery_report_requested":false,"view_report_requested":false,
+   "tags":[{"name":"Type","value":"SMS:TEXT"}],"status":"SUCCESS"}]}}
+```
+
+Conclusions:
+- Unknown top-level fields are **ignored** — no shim or fork needed.
+- `message_id` is echoed at `data.messages.0.message_id`, validating the
+  integration's `idPath` credential exactly as designed.
+- `valid_until` defaults to now+7d; `delivery_report_requested` defaults false.
+
+## R3 — auth failure behavior: **ANSWERED**
+
+Wrong password → **HTTP 200** (not 401) with a *different* envelope:
+
+```json
+{"response":{"action":"commandresult","data":{"errorcode":1157,"errormessage":"Invalid username or password"}}}
+```
+
+Consequence for the design: generic-sms resolves `idPath`
+(`data.messages.0.message_id`) with a dot-path reduce; on this envelope
+`data.messages` is absent, the reduce throws, and Novu marks the message
+**failed**. Auth failures therefore surface as failures despite the 200 —
+the accidental guard described in the design doc §2 is confirmed real.
+
+## Can the trial gateway be a standing CI check? — assessed, NO
+
+Technically it works (the container builds on amd64, boots headless in ~8s,
+and a GUI-provisioned `/var/lib/ozeki/Data` could be baked into a reusable
+image). But the trial license is time-limited (7–14 days) and mangles every
+6th message to "Ozeki SMS Trial"; a CI job that perpetually reinstalls or
+rebakes a trial to keep it fresh would be circumventing the trial terms, and
+an aging baked image rots the check. So:
+- the **real-gateway probe stays a one-time/per-deployment step** (rerun the
+  two curls above against the customer's licensed gateway before enabling);
+- the **responses recorded here are the canonical fixtures** for any future
+  mock-based contract test in CI.

--- a/local-setup/ansible/templates/digit.env.j2
+++ b/local-setup/ansible/templates/digit.env.j2
@@ -77,6 +77,10 @@ NOVU_BRIDGE_CHANNELS_ENABLED={{ novu_bridge_channels_enabled | default('SMS,EMAI
 NOVU_BRIDGE_WORKFLOW_ID_SMS={{ novu_bridge_workflow_id_sms | default('complaints-sms') }}
 NOVU_BRIDGE_WORKFLOW_ID_WHATSAPP={{ novu_bridge_workflow_id_whatsapp | default('complaints-whatsapp') }}
 NOVU_BRIDGE_WORKFLOW_ID_EMAIL={{ novu_bridge_workflow_id_email | default('complaints-email') }}
+# SMS provider envelope: empty = Novu primary SMS integration; "ozeki" =
+# deliver via an Ozeki SMS Gateway behind a generic-sms Novu integration.
+NOVU_BRIDGE_SMS_PROVIDER={{ novu_bridge_sms_provider | default('') }}
+NOVU_BRIDGE_OZEKI_INTEGRATION_IDENTIFIER={{ novu_bridge_ozeki_integration_identifier | default('ozeki-sms') }}
 NOVU_BRIDGE_IDENTIFY_CACHE_TTL_MS={{ novu_bridge_identify_cache_ttl_ms | default(300000) }}
 # Channel the bridge dispatches (sms|whatsapp|email). SMS-first per §3 phasing.
 NOVU_BRIDGE_CHANNEL={{ novu_bridge_channel | default('sms') }}

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -2262,6 +2262,11 @@ services:
       NOVU_BRIDGE_WORKFLOW_ID_SMS: ${NOVU_BRIDGE_WORKFLOW_ID_SMS:-complaints-sms}
       NOVU_BRIDGE_WORKFLOW_ID_WHATSAPP: ${NOVU_BRIDGE_WORKFLOW_ID_WHATSAPP:-complaints-whatsapp}
       NOVU_BRIDGE_WORKFLOW_ID_EMAIL: ${NOVU_BRIDGE_WORKFLOW_ID_EMAIL:-complaints-email}
+      # SMS provider envelope: empty = Novu's primary SMS integration; "ozeki"
+      # = deliver via an Ozeki SMS Gateway behind a generic-sms Novu
+      # integration (docs/Novu_Adapter/OZEKI-GENERIC-SMS-PROVIDER.md).
+      NOVU_BRIDGE_SMS_PROVIDER: ${NOVU_BRIDGE_SMS_PROVIDER:-}
+      NOVU_BRIDGE_OZEKI_INTEGRATION_IDENTIFIER: ${NOVU_BRIDGE_OZEKI_INTEGRATION_IDENTIFIER:-ozeki-sms}
       # TTL cache (ms) skips redundant identifies for the same subscriberId.
       NOVU_BRIDGE_IDENTIFY_CACHE_TTL_MS: ${NOVU_BRIDGE_IDENTIFY_CACHE_TTL_MS:-300000}
       # Channels actually delivered. WHATSAPP stays OFF until a legitimate


### PR DESCRIPTION
Sends SMS through a customer-hosted [Ozeki SMS Gateway](https://ozeki-sms-gateway.com/p_5667-http-sms-api.html) using Novu's built-in `generic-sms` provider + a trigger-time `_passthrough` envelope from novu-bridge — no forked Novu images, no standalone shim service, provider visible in the Novu dashboard (integration store + activity feed).

**Contents**
- Design doc `docs/Novu_Adapter/OZEKI-GENERIC-SMS-PROVIDER.md` (full text also in the first comment below for inline discussion).
- Implementation: `OzekiOverridesBuilder` (the overrides envelope, with the two non-obvious Novu constraints documented in its javadoc) + `NovuClient` pass-through SMS-leg wiring + an overrides-accepting `trigger` overload.
- Config: `NOVU_BRIDGE_SMS_PROVIDER` (empty default = current behavior, `ozeki` = enable) and `NOVU_BRIDGE_OZEKI_INTEGRATION_IDENTIFIER` (default `ozeki-sms`), surfaced in `application.properties`, compose, and `digit.env.j2`.
- Tests: `OzekiOverridesBuilderTest` (4) + `NovuClientOzekiTriggerTest` (3). Full novu-bridge suite: **95 run, 0 failures**.

**Key points for reviewers**
- Novu never templates trigger `overrides`, so the envelope is built on the pass-through SMS leg — the one place holding the final `renderedBody`, recipient phone, and `transactionId` together.
- The worker keys provider overrides by Novu providerId → the envelope key must be `generic-sms`, not `ozeki`.
- `overrides.sms.integrationIdentifier` lets Ozeki sends coexist with a different primary SMS integration.
- Correlation chain: `nb_dispatch_log.transactionId` = Ozeki `message_id` (echoed) = Novu activity-feed `identifier` (via the integration's `idPath`).
- v1 is submit-level delivery status only (Ozeki's JSON API has no status webhook); a notsent-folder poller is sketched as v2.

**Pre-enablement gate (not a review blocker)**: the feature ships dark (`NOVU_BRIDGE_SMS_PROVIDER` empty = zero behavior change). Before flipping it on in any deployment, run the R1 probe — one curl against the target Ozeki gateway confirming it tolerates the leak-through JSON fields (`to`/`content`/`sender`/`id`/`customData` deep-merge in beside `messages[]`). Design doc §4/§5 has the exact probe; results will be posted on this PR when run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Ozeki SMS Gateway support for SMS notifications.
  * SMS delivery can be configured through provider and integration settings, while existing routing remains unchanged by default.
  * Ozeki requests now include the required message details and integration information.

* **Documentation**
  * Added setup and configuration guidance for integrating Ozeki with the notification pipeline.

* **Tests**
  * Added coverage for Ozeki SMS routing, configuration behavior, and request payload formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->