### PR TITLE
fix(deploy): close Compose/k8s dual-deploy parity gaps (charts + test harness)

### DIFF
--- a/devops/deploy-as-code/charts/backbone-services/postgresql/values.yaml
+++ b/devops/deploy-as-code/charts/backbone-services/postgresql/values.yaml
@@ -94,7 +94,7 @@ diagnosticMode:
 ##
 image:
   registry: docker.io
-  repository: bitnami/postgresql
+  repository: bitnamilegacy/postgresql
   tag: 14.5.0-debian-11-r35
   digest: ""
   ## Specify a imagePullPolicy
@@ -1117,7 +1117,7 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/bitnami-shell
+    repository: bitnamilegacy/bitnami-shell
     tag: 11-debian-11-r45
     digest: ""
     pullPolicy: IfNotPresent
@@ -1204,7 +1204,7 @@ metrics:
   ##
   image:
     registry: docker.io
-    repository: bitnami/postgres-exporter
+    repository: bitnamilegacy/postgres-exporter
     tag: 0.11.1-debian-11-r22
     digest: ""
     pullPolicy: IfNotPresent

--- a/devops/deploy-as-code/charts/common-services/egov-hrms/values.yaml
+++ b/devops/deploy-as-code/charts/common-services/egov-hrms/values.yaml
@@ -19,9 +19,17 @@ initContainers:
       tag: "hrms-boundary-0a4e737"
 
 # Container Configs
+# PARITY / IMAGE NOTE — why this is NOT the chart-default tag:
+#   egov-hrms wasn't deployed on k8s at all (refs #1160); the base chart tag
+#   (hrms-boundary-0a4e737) differs from what Compose runs. Compose pins
+#   registry.preview…/egov-hrms:800-preview (local-setup/docker-compose.egov-digit.yaml)
+#   and the restored HRMS DB was seeded by it — pinned the same here so k8s matches
+#   Compose. Reverting would re-diverge. Keep both on this tag; revisit when a
+#   released egovio/egov-hrms tag is chosen.
 image:
-  repository: "egov-hrms"
-  tag: "hrms-boundary-0a4e737"
+  repository: "registry.preview.egov.theflywheel.in/egovio/egov-hrms"
+  tag: "800-preview"
+  pullPolicy: "IfNotPresent"
 replicas: "1"
 healthChecks:
   enabled: true

--- a/devops/deploy-as-code/charts/core-services/boundary-service/values.yaml
+++ b/devops/deploy-as-code/charts/core-services/boundary-service/values.yaml
@@ -36,7 +36,7 @@ kafka-topics-create-boundary-hierarchy: "save-boundary-hierarchy-definition"
 kafka-topics-update-boundary-hierarchy: "update-boundary-hierarchy-definition"
 kafka-topics-create-boundary-relationship: "save-boundary-relationship"
 kafka-topics-update-boundary-relationship: "update-boundary-relationship"
-memory_limits: "512Mi"
+memory_limits: "1024Mi"
 cpu_limits: "200m"
 
 # Additional Container Envs

--- a/devops/deploy-as-code/charts/core-services/egov-user/values.yaml
+++ b/devops/deploy-as-code/charts/core-services/egov-user/values.yaml
@@ -19,9 +19,23 @@ initContainers:
       tag: master-d69ce29
 
 # Container Configs
+# PARITY / IMAGE NOTE — why this is NOT the stock egov-user tag:
+#   The stock image (`egov-user:master-d69ce29`) HARDCODES the mobile-number
+#   validation regex (a Kenya/India format). Maputo's rule (MDMS
+#   common-masters.MobileNumberValidation) is +258 / numbers starting with 8, so
+#   the stock image REJECTS every valid Maputo number → citizen register/create/
+#   provisioning fails. The `mobilevalidation-jdk8-4984479` build reads the
+#   per-tenant MDMS rule at runtime instead of hardcoding, so it works for any tenant.
+#   PARITY: Compose already pins this EXACT image (local-setup/docker-compose.egov-digit.yaml)
+#   — reverting to the stock tag would make k8s diverge from Compose (mobile validation
+#   would fail on k8s only). Keep them on the same tag.
+#   PENDING (product decision): get the MDMS-driven mobile-validation fix into a
+#   PUBLISHED egovio/egov-user image, then repin BOTH stacks to that tag. Also fix the
+#   twin frontend bug: digit-ui UserCreate.tsx hardcodes a Kenyan regex (v.mobileKERequired).
 image:
-  repository: "egov-user"
-  tag: master-d69ce29
+  repository: "registry.preview.egov.theflywheel.in/egovio/egov-user"
+  tag: "mobilevalidation-jdk8-4984479"
+  pullPolicy: "IfNotPresent"
 replicas: "1"
 healthChecks:
   enabled: true

--- a/devops/deploy-as-code/charts/core-services/mdms-v2/values.yaml
+++ b/devops/deploy-as-code/charts/core-services/mdms-v2/values.yaml
@@ -18,9 +18,20 @@ initContainers:
       tag: "v2.9.2-4a60f20"
 
 # Container Configs
+# PARITY / IMAGE NOTE — why this is NOT the chart-default v2.9.2 tag:
+#   v2.9.2 STRICTLY rejects string-valued RequestInfo.userInfo.roles (e.g. ["DGRO"])
+#   with a 500 (Cannot construct Role from String) — which the configurator SPA sends
+#   — so configurator writes fail on k8s. The maven-jdk21-9f83afb build tolerates it.
+#   Image drift, not app logic.
+#   PARITY: Compose pins the SAME image (egovio/mdms-v2:maven-jdk21-9f83afb,
+#   local-setup/docker-compose.egov-digit.yaml) — reverting to v2.9.2 would make k8s
+#   diverge from Compose. Keep both on this tag.
+#   Repo normalized to egovio/ so k8s pulls the same published image Compose does
+#   (was bare "mdms-v2", which relied on a local containerd import during the parity run).
 image:
-  repository: "mdms-v2"
-  tag: "v2.9.2-4a60f20"
+  repository: "egovio/mdms-v2"
+  tag: "maven-jdk21-9f83afb"
+  pullPolicy: "IfNotPresent"
 replicas: "1"
 healthChecks:
   enabled: true
@@ -28,7 +39,7 @@ healthChecks:
   readinessProbePath: "/mdms-v2/health"
 appType: "java-spring"
 tracing-enabled: true
-memory_limits: 512Mi
+memory_limits: 1024Mi
 heap: "-Xmx512m -Xms512m"
 java-args: "-Dspring.profiles.active=monitoring"
 egov-mdms-schema-definition-save-topic: "save-mdms-schema-definition"

--- a/devops/deploy-as-code/charts/core-services/user-otp/values.yaml
+++ b/devops/deploy-as-code/charts/core-services/user-otp/values.yaml
@@ -30,6 +30,14 @@ java-args: ""
 env: |
   - name: SERVER_PORT
     value: "8080"
+  - name: SPRING_REDIS_HOST
+    value: redis.backbone
+  - name: SPRING_REDIS_PORT
+    value: "6379"
+  - name: SPRING_DATA_REDIS_HOST
+    value: redis.backbone
+  - name: SPRING_DATA_REDIS_PORT
+    value: "6379"
   - name: OTP_HOST
     value: http://egov-otp:8080/otp
   - name: SECURITY_BASIC_ENABLED

--- a/devops/deploy-as-code/charts/environments/env.yaml
+++ b/devops/deploy-as-code/charts/environments/env.yaml
@@ -98,7 +98,7 @@ egov-notification-sms:
 egov-user:
   replicas: 1
   heap: "-Xmx256m -Xms256m"
-  memory_limits: 512Mi
+  memory_limits: 1024Mi
   otp-validation: "true"
   citizen-otp-enabled: "true"
   employee-otp-enabled: "false"
@@ -201,7 +201,7 @@ gateway:
   server-tomcat-max-connections: "1500"
   #egov-statelevel-tenant-map: "{'kenya-demo.digit.org':'ke','unified-demo.digit.org':'pg','central-instance.digit.org':'in'}"
   egov-open-endpoints-whitelist: "/user/oauth/token,/user-otp/v1/_send,/otp/v1/_validate,/user/citizen/_create,/localization/messages,/localization/messages/v1/_search,/user/password/nologin/_update,/tenant/v1/tenant/_search,/egov-location/boundarys,/egov-location/boundarys/boundariesByBndryTypeNameAndHierarchyTypeName,/egov-location/boundarys/getLocationByLocationName,/egov-location/boundarys/isshapefileexist,/pgr/services/v1/_search,/egov-mdms-service/v1/_search,/egov-mdms-service/v1/_get,/egov-mdms-service/v1/_reload,/egov-mdms-service/v1/_reloadobj,/egov-location/boundarys/getshapefile,/egov-indexer/index-operations/_index,/egov-indexer/index-operations/_reload,/egov-mdms-service-test/v1/_search,/filestore/v1/files/url,/egov-url-shortening,/mdms-v2/schema/v1/_search,/mdms-v2/v2/_search,/mdms-v2/v1/_search,/filestore/v1/file,/default-data-handler/tenant/new,/filestore/v1/files/id,/filestore/v1/files"
-  egov-mixed-mode-endpoints-whitelist: "/workflow/history/v1/_search,/filestore/v1/files/tag,/egov-idgen/id/_generate,/user/_search,/access/v1/actions/mdms/_get,/egov-location/location/v11/boundarys/_search"
+  egov-mixed-mode-endpoints-whitelist: "/workflow/history/v1/_search,/filestore/v1/files/tag,/egov-idgen/id/_generate,/user/_search,/access/v1/actions/mdms/_get,/egov-location/location/v11/boundarys/_search,/boundary-service/boundary-relationships/_search,/boundary-service/boundary-hierarchy-definition/_search,/boundary-service/boundary/_search"
 # <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   
@@ -215,7 +215,7 @@ pgr-services:
   notification-allowed-status: "open,assigned,rejected,resolved"
   java-enable-debug: "true"
   time-before-closing-complaint: "3600000"
-  memory_limits: 386Mi
+  memory_limits: 768Mi
   egov.mdms.search.endpoint: "/mdms-v2/v1/_search"
 
 egov-workflow-v2:
@@ -225,7 +225,7 @@ egov-workflow-v2:
   heap: "-Xmx192m -Xms192m"
   workflow-statelevel: "true"
   wf-max-limit: "10000"
-  memory_limits: 386Mi
+  memory_limits: 768Mi
 
 egov-hrms:
   java-args: -Dspring.profiles.active=monitoring
@@ -236,24 +236,24 @@ egov-hrms:
 default-data-handler:
   java-args: -Dspring.profiles.active=monitoring
   heap: "-Xmx192m -Xms192m"
-  memory_limits: 386Mi
+  memory_limits: 640Mi
   ### make it false in production
   dev-enabled: "true"
 
 boundary-service:
   replicas: 1
   heap: '-Xmx512m -Xms512m'
-  memory_limits: 512Mi
+  memory_limits: 1024Mi
 
 digit-config-service:
-  memory_limits: 512Mi
+  memory_limits: 1024Mi
 
 digit-user-preferences-service:
   memory_limits: 256Mi
   db-ssl-mode: "require"
 
 novu-bridge:
-  memory_limits: 512Mi
+  memory_limits: 1024Mi
   preference-check-path: "/user-preference/v1/_search"
   config-resolve-path: "/config-service/config/v1/_resolve"
   config-search-path: "/config-service/config/v1/_search"

--- a/devops/deploy-as-code/charts/urban/digit-ui/values.yaml
+++ b/devops/deploy-as-code/charts/urban/digit-ui/values.yaml
@@ -12,6 +12,11 @@ ingress:
 initContainers: {}
 
 # Container Configs
+# PARITY / BUILD NOTE: digit-ui has FRONTEND source changes that the stock
+# `v2.11-a520687` image predates. Rebuild + repin the image from a branch that
+# contains, at minimum:
+#   #1098 (fix/egov-location-boundary-migration) — digit-ui-v2/packages/data-provider/src/client/endpoints.ts
+# Without a rebuild the boundary/location UI wiring is stale. Refs #1160.
 image:
   repository: "digit-ui"
   tag: "v2.11-a520687"

--- a/devops/deploy-as-code/charts/urban/pgr-services/values.yaml
+++ b/devops/deploy-as-code/charts/urban/pgr-services/values.yaml
@@ -47,6 +47,12 @@ initContainers:
                 key: flyway-locations
 
 # Container Configs
+# PARITY / BUILD NOTE: pgr-services has BACKEND source changes that the stock
+# `v2.11-a520687` image predates. Rebuild + repin the image from a branch that
+# contains, at minimum:
+#   #1100 (fix/pgr-search-citizen-scoping) — PrincipalScopeResolver.java, EnrichmentService.java
+#     (the citizen-scoping / search-IDOR fix). Without a rebuild, PGR search is not
+#     citizen-scoped. Refs #1160.
 image:
   repository: "pgr-services"
   tag: "v2.11-a520687"

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -763,7 +763,12 @@ services:
       EGOV_MDMS_HOST: http://egov-mdms-service:8094/
       EGOV_MDMS_SEARCH_ENDPOINT: mdms-v2/v1/_search
       EGOV_USER_HOST: http://egov-user-proxy:8107/
-      STATE_LEVEL_TENANT_ID: pg.citya
+      # STATE_LEVEL_TENANT_ID MUST be the state ROOT (pg → rewritten to state_root),
+      # NOT the city tier. egov-workflow-v2 resolves the businessservice (PGR) at this
+      # tenant, and the businessservice is seeded at the state root. Grouping this with
+      # enc-service on `pg.citya` (city) makes workflow look for PGR at the city, find
+      # nothing, and fail every complaint APPLY. Refs #1160.
+      STATE_LEVEL_TENANT_ID: pg
       EGOV_STATE_LEVEL_TENANT_ID: pg
       # Disable schema-per-tenant mode - use public schema for all tenants
       IS_ENVIRONMENT_CENTRAL_INSTANCE: 'false'

--- a/tests/integration-tests/deploy/otp-mock.k8s.yaml
+++ b/tests/integration-tests/deploy/otp-mock.k8s.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otp-mock-conf
+  namespace: egov
+data:
+  default.conf: |
+    server {
+      listen 8080;
+      # OTP validate -> rubber-stamp success (mirrors compose otp-validate-mock)
+      location ~* _validate {
+        default_type application/json;
+        return 200 '{"ResponseInfo":{"apiId":"Rainmaker","ver":".01","ts":"","resMsgId":"uief87324","msgId":"","status":"successful"},"otp":{"otp":"","UUID":"mock","isValidationSuccessful":true}}';
+      }
+      # everything else (/_send, etc.) -> success (mirrors compose user-otp-mock)
+      location / {
+        default_type application/json;
+        return 200 '{"ResponseInfo":{"apiId":"Rainmaker","ver":null,"ts":null,"resMsgId":"uief87324","msgId":null,"status":"successful"},"otp":{"identity":"","tenantId":"","type":"","otp":"","expiryTime":0}}';
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otp-mock
+  namespace: egov
+  labels: { app: otp-mock }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: otp-mock }
+  template:
+    metadata:
+      labels: { app: otp-mock }
+    spec:
+      containers:
+      - name: nginx
+        image: docker.io/library/nginx:alpine
+        imagePullPolicy: IfNotPresent
+        ports: [{ containerPort: 8080 }]
+        volumeMounts:
+        - { name: conf, mountPath: /etc/nginx/conf.d }
+      volumes:
+      - name: conf
+        configMap: { name: otp-mock-conf }

--- a/tests/integration-tests/deploy/parity/gateway-behavior-parity.py
+++ b/tests/integration-tests/deploy/parity/gateway-behavior-parity.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# Gateway BEHAVIOR parity probe (companion to .github/scripts/check-gateway-whitelist-parity.py).
+#
+# The whitelist check proves the RULES match; this proves the DECISIONS match.
+# Fires identical requests at the compose Kong gateway and the k3s Spring gateway
+# and diffs the HTTP auth outcome (pass / 401 / 403). Every mismatch is a parity gap.
+#
+# Usage:  KONG=http://localhost:18000  K3S=https://<k3s-ingress>  python3 gateway-behavior-parity.py
+# Requires both stacks up + reachable. Excludes the bodyless-GET row (k3s gateway bug — Kong is
+# correctly better there; do NOT "fix" Kong to match k3s's 500).
+"""Gateway parity probe: fire identical requests at compose-Kong and k3s-Spring
+gateways, diff the HTTP status outcomes. Every mismatch is a parity gap."""
+import json, os, subprocess, sys
+
+# Endpoints are environment-specific — pass them in (see the usage note above).
+KONG = os.environ.get("KONG", "http://localhost:18000")
+K3S  = os.environ.get("K3S",  "https://<k3s-ingress>")
+
+def curl(base, method, path, token=None, body=None, insecure=False):
+    cmd = ["curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", "-X", method, base+path]
+    if insecure: cmd.insert(1, "-k")
+    cmd += ["-H", "Content-Type: application/json"]
+    if token:
+        cmd += ["-H", f"Authorization: Bearer {token}", "-H", f"auth-token: {token}"]
+        # real DIGIT clients also carry the token in RequestInfo.authToken
+        if body is not None:
+            try:
+                b = json.loads(body); b.setdefault("RequestInfo", {})["authToken"] = token
+                body = json.dumps(b)
+            except Exception: pass
+    if body is not None: cmd += ["-d", body]
+    try: return subprocess.run(cmd, capture_output=True, text=True, timeout=20).stdout.strip()
+    except Exception as e: return f"ERR"
+
+def login(base, insecure):
+    cmd = ["curl","-s","-X","POST",base+"/user/oauth/token",
+           "-H","Authorization: Basic ZWdvdi11c2VyLWNsaWVudDo=",
+           "-H","Content-Type: application/x-www-form-urlencoded",
+           "--data","username=ADMIN&password=eGov@123&grant_type=password&scope=read&tenantId=mz&userType=EMPLOYEE"]
+    if insecure: cmd.insert(1,"-k")
+    try: return json.loads(subprocess.run(cmd,capture_output=True,text=True,timeout=20).stdout)["access_token"]
+    except Exception: return None
+
+OP_KONG = login(KONG, False)
+OP_K3S  = login(K3S, True)
+print(f"tokens: kong={'ok' if OP_KONG else 'FAIL'} k3s={'ok' if OP_K3S else 'FAIL'}\n")
+
+DEPT = json.dumps({"RequestInfo":{},"Mdms":{"tenantId":"mz","schemaCode":"common-masters.Department","uniqueIdentifier":"PARITY_PROBE","data":{"code":"PARITY_PROBE","name":"x","active":True},"isActive":True}})
+SEARCH = json.dumps({"RequestInfo":{}})
+
+# (label, method, path, token-kind, body)  token-kind: none|operator
+PROBES = [
+ ("open: mdms search (no auth)",        "POST","/egov-mdms-service/v1/_search","none",SEARCH),
+ ("open: localization search",          "POST","/localization/messages/v1/_search","none",SEARCH),
+ ("protected write, NO token",          "POST","/mdms-v2/v2/_create/common-masters.Department","none",DEPT),
+ ("protected write, operator",          "POST","/mdms-v2/v2/_create/common-masters.Department","operator",DEPT),
+ ("mdms ACCESSCONTROL write, operator", "POST","/mdms-v2/v2/_create/ACCESSCONTROL-ROLES.roles","operator",SEARCH),
+ ("user _search, NO token",             "POST","/user/_search","none",SEARCH),
+ ("user _search, operator",             "POST","/user/_search","operator",SEARCH),
+ ("pgr request _search, NO token",      "POST","/pgr-services/v2/request/_search","none",SEARCH),
+ ("pgr request _search, operator",      "POST","/pgr-services/v2/request/_search","operator",SEARCH),
+ ("workflow bs _search, NO token",      "POST","/egov-workflow-v2/egov-wf/businessservice/_search?tenantId=mz","none",SEARCH),
+ ("hrms _search, operator",             "POST","/egov-hrms/employees/_search?tenantId=mz","operator",SEARCH),
+ ("bodyless GET dashboard, operator",   "GET","/pgr-services/v2/dashboard?tenantId=mz","operator",None),
+ ("idgen generate, NO token (mixed)",   "POST","/egov-idgen/id/_generate","none",SEARCH),
+ ("filestore url GET, operator",        "GET","/filestore/v1/files/url?tenantId=mz&fileStoreIds=zzz","operator",None),
+]
+
+print(f"{'probe':<38}{'kong':>7}{'k3s':>7}  parity")
+print("-"*64)
+gaps=[]
+for label,method,path,tk,body in PROBES:
+    tkK = OP_KONG if tk=="operator" else None
+    tkS = OP_K3S  if tk=="operator" else None
+    ck = curl(KONG, method, path, tkK, body, False)
+    cs = curl(K3S,  method, path, tkS, body, True)
+    match = "OK" if ck==cs else "◄ DIVERGE"
+    if ck!=cs: gaps.append((label,ck,cs))
+    print(f"{label:<38}{ck:>7}{cs:>7}  {match}")
+print(f"\n{len(gaps)} divergences / {len(PROBES)} probes")
+for l,ck,cs in gaps: print(f"  - {l}: kong={ck} k3s={cs}")

--- a/tests/integration-tests/playwright.config.ts
+++ b/tests/integration-tests/playwright.config.ts
@@ -33,6 +33,8 @@ export default defineConfig({
   ],
   use: {
     baseURL: BASE_URL,
+    // Opt-in for self-signed clusters (e.g. local k3s ingress); secure by default.
+    ignoreHTTPSErrors: process.env.IGNORE_HTTPS_ERRORS === '1',
     headless: true,
     screenshot: 'on',
     trace: 'on',

--- a/tests/integration-tests/tests/admin/users.spec.ts
+++ b/tests/integration-tests/tests/admin/users.spec.ts
@@ -19,7 +19,7 @@
  * doesn't implement.
  */
 import { test, expect } from '@playwright/test';
-import { loadAuth, type AuthInfo } from '../utils/manage/api';
+import { apiAuth, type AuthInfo } from '../utils/manage/api';
 import { testCode } from '../utils/manage/codes';
 import { TENANT, ROOT_TENANT } from '../utils/env';
 import { getMobileValidationRule, generateValidMobile, type MobileRule } from '../utils/mdms-mobile';
@@ -51,7 +51,23 @@ function requestInfo(auth: AuthInfo, action = '_search'): Record<string, unknown
     action,
     msgId: `${Date.now()}|en_IN`,
     authToken: auth.token,
-    userInfo: auth.user || undefined,
+    // Roles come from the configurator storageState as bare code strings; expand
+    // to Role objects so services can deserialize them. Kong (compose) re-resolves
+    // userInfo from the token and tolerates strings; the stock k8s gateway forwards
+    // them verbatim → 401/500 "Cannot construct Role from String". See manage/api.ts.
+    userInfo: auth.user
+      ? {
+          ...auth.user,
+          roles: (Array.isArray((auth.user as { roles?: unknown }).roles)
+            ? ((auth.user as { roles: unknown[] }).roles)
+            : []
+          ).map((r) =>
+            typeof r === 'string'
+              ? { code: r, name: r, tenantId: (auth.user as { tenantId?: string }).tenantId }
+              : r,
+          ),
+        }
+      : undefined,
   };
 }
 
@@ -99,7 +115,7 @@ async function softDeleteUser(auth: AuthInfo, userName: string): Promise<void> {
 
 test.afterAll(async () => {
   if (createdUsernames.size === 0) return;
-  const auth = loadAuth();
+  const auth = await apiAuth();
   const failed: Array<{ userName: string; reason: string }> = [];
   for (const u of createdUsernames) {
     try { await softDeleteUser(auth, u); } catch (e) {
@@ -205,7 +221,7 @@ Teardown is API-only — egov-user has no UI delete affordance for users; the af
       .catch(() => {});
 
     // API sanity — user exists and is active. userName is derived from mobile.
-    const auth = loadAuth();
+    const auth = await apiAuth();
     const res = await postJson(auth, USER_SEARCH, {
       RequestInfo: requestInfo(auth),
       tenantId: TENANT_CODE,
@@ -251,7 +267,7 @@ Tolerant of show-vs-edit routing differences — works whether /:id lands on Sho
     const mobile = generateValidMobile(mobileRule);
     createdUsernames.add(uname);
 
-    const auth = loadAuth();
+    const auth = await apiAuth();
     await postJson(auth, '/user/users/_createnovalidate', {
       RequestInfo: requestInfo(auth, '_create'),
       user: {
@@ -345,7 +361,7 @@ Pairs with the edit test — together they cover the two read-only routes (show 
     const mobile = generateValidMobile(mobileRule);
     createdUsernames.add(uname);
 
-    const auth = loadAuth();
+    const auth = await apiAuth();
     await postJson(auth, '/user/users/_createnovalidate', {
       RequestInfo: requestInfo(auth, '_create'),
       user: {

--- a/tests/integration-tests/tests/utils/manage/api.ts
+++ b/tests/integration-tests/tests/utils/manage/api.ts
@@ -75,6 +75,49 @@ export function loadAuth(authFile: string = DEFAULT_AUTH_FILE): AuthInfo {
   );
 }
 
+/**
+ * Obtain a FRESH, fully-resolved API token via a direct OAuth password grant
+ * (ADMIN@ROOT_TENANT). Use this — not loadAuth() — for API assertions/teardown
+ * that hit RBAC-ENFORCED endpoints (e.g. /user/_search, /user/users/_*).
+ *
+ * Why: the configurator storageState token (loadAuth) resolves to INSUFFICIENT
+ * roles on a fail-closed gateway. The k8s Spring gateway RBAC-checks /user/_search
+ * against the token's *resolved* roles and returns 401 ("not authorized"), so the
+ * `create — citizen user` verify step fails on k3s while passing on Compose (whose
+ * Kong treats /user/_search as auth-optional). A password-grant login resolves the
+ * operator's real roles (SUPERUSER/EMPLOYEE — both granted /user/_search), so the
+ * check passes on BOTH stacks. The UI create flow still uses the configurator
+ * session; only the API verify/teardown uses this token. Refs #1160.
+ */
+export async function apiAuth(): Promise<AuthInfo> {
+  const baseUrl = process.env.BASE_URL || 'http://localhost';
+  const digitTenant = process.env.DIGIT_TENANT;
+  const rootTenant =
+    process.env.ROOT_TENANT ||
+    (digitTenant && digitTenant.includes('.') ? digitTenant.split('.')[0] : digitTenant) ||
+    'ke';
+  const body = new URLSearchParams({
+    username: process.env.DIGIT_USERNAME || 'ADMIN',
+    password: process.env.DIGIT_PASSWORD || 'eGov@123',
+    grant_type: 'password',
+    scope: 'read',
+    tenantId: rootTenant,
+    userType: 'EMPLOYEE',
+  });
+  const res = await fetch(`${baseUrl}/user/oauth/token`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      // egov-user-client:(no secret) — the stock DIGIT OAuth basic header
+      Authorization: 'Basic ZWdvdi11c2VyLWNsaWVudDo=',
+    },
+    body,
+  });
+  if (!res.ok) throw new Error(`apiAuth OAuth login failed (${res.status}): ${await res.text()}`);
+  const j = (await res.json()) as { access_token: string; UserRequest?: Record<string, unknown> };
+  return { token: j.access_token, user: j.UserRequest || null, tenant: rootTenant, baseUrl };
+}
+
 function buildRequestInfo(auth: AuthInfo, action?: string): Record<string, unknown> {
   return {
     apiId: 'Rainmaker',
@@ -83,7 +126,25 @@ function buildRequestInfo(auth: AuthInfo, action?: string): Record<string, unkno
     action,
     msgId: `${Date.now()}|en_IN`,
     authToken: auth.token,
-    userInfo: auth.user || undefined,
+    // The configurator storageState stores roles as bare code strings; services
+    // deserialize RequestInfo.userInfo.roles into Role objects. Compose's Kong
+    // re-resolves userInfo from the token so string roles are tolerated, but the
+    // stock k8s gateway forwards the body verbatim → mdms/tenant/user 500
+    // ("Cannot construct Role from String"). Expand to Role objects so the harness
+    // sends a well-formed request to either gateway.
+    userInfo: auth.user
+      ? {
+          ...auth.user,
+          roles: (Array.isArray((auth.user as { roles?: unknown }).roles)
+            ? ((auth.user as { roles: unknown[] }).roles)
+            : []
+          ).map((r) =>
+            typeof r === 'string'
+              ? { code: r, name: r, tenantId: (auth.user as { tenantId?: string }).tenantId }
+              : r,
+          ),
+        }
+      : undefined,
   };
 }
 


### PR DESCRIPTION
## Goal

The same code deployed via **Docker-Compose (Kong)** and **k3s (Spring gateway)** did not behave the same. This closes the gaps that are **config and harness**, not app logic. Refs #1160.

Every change is annotated in-file with *why it is not the chart default*, so the next person doesn't revert it back into a divergence.

## Scope — what this PR is *not*

- **The PGR search IDOR fix is deliberately excluded.** It belongs to #1100, which is open and strictly ahead of the copy that was on the working branch. This PR only carries the *deploy-side* note that `pgr-services`' pinned image predates it.
- **The parity investigation docs are excluded** — internal knowledge work, tracked in #1160.

## Charts / config

| Change | Why |
|---|---|
| `egov-user`, `mdms-v2`, `egov-hrms` image pins | Pin what **Compose already runs**. Stock `egov-user` hardcodes a mobile-validation regex (Kenya/India) and rejects every valid Maputo `+258` number; stock `mdms-v2` v2.9.2 rejects string-valued `RequestInfo.userInfo.roles` with a 500; `egov-hrms` wasn't deployed on k8s at all. Reverting either side re-diverges the stacks. |
| `postgresql`: `bitnami/*` → `bitnamilegacy/*` | The pinned Debian tags were relocated to `bitnamilegacy` and no longer pull from the original repos. |
| `user-otp`: Redis host | Points at `redis.backbone`, under **both** the Spring Boot 2 (`SPRING_REDIS_*`) and 3 (`SPRING_DATA_REDIS_*`) property names. |
| `env.yaml`: boundary-service endpoints | Adds the three `boundary-service/*_search` paths to the mixed-mode whitelist. |
| `env.yaml`: memory right-sizing | Services OOM-kill (`Exited 137`) at their current caps. |
| `docker-compose`: `STATE_LEVEL_TENANT_ID: pg` | **One-line, highest-impact fix.** It was grouped with `enc-service` on the city tier, so `egov-workflow-v2` resolved the PGR businessservice at the city, found nothing (it's seeded at the state root), and **failed every complaint APPLY**. This is a Compose-side gap — k3s was already correct. |

## Test harness

The suite encoded assumptions that only held on Kong, so tests failed on the k8s gateway for harness reasons rather than product ones.

- **`apiAuth()`** — a fresh OAuth password grant for RBAC-enforced endpoints. The configurator `storageState` token resolves to insufficient roles on a fail-closed gateway, so `/user/_search` 401s on k3s while passing on Kong. The UI flow still uses the configurator session; only API verify/teardown uses this token.
- **Role expansion** — bare string roles → `Role` objects. Kong re-resolves `userInfo` from the token and tolerates strings; the Spring gateway forwards them verbatim → `Cannot construct Role from String`.
- **`ignoreHTTPSErrors`** behind `IGNORE_HTTPS_ERRORS` — opt-in for self-signed cluster ingress, **secure by default**.
- **`otp-mock.k8s.yaml`** — mirrors Compose's OTP mock so citizen OTP tests can run on k8s.
- **`gateway-behavior-parity.py`** — probes both gateways with identical requests, to tell config drift apart from product bugs.

## Reviewer attention 🔴

**The `egov-user` and `egov-hrms` pins point at `registry.preview.egov.theflywheel.in`.** This matches Compose exactly (so it *closes* a divergence rather than adding one), but a preview registry in a shared chart is a real call to make. The in-file note records the pending product decision: get the MDMS-driven mobile-validation fix into a **published** `egovio/egov-user` image, then repin **both** stacks. There's a twin frontend bug too — `digit-ui` `UserCreate.tsx` hardcodes a Kenyan regex.

`memory_limits` bumps in `env.yaml` affect every deployment using this template, not just local — worth a sanity check against your cluster sizing.

## Verification

- `docker compose -f docker-compose.egov-digit.yaml config` → validates
- All 9 chart values + `otp-mock.k8s.yaml` → parse as YAML
- `gateway-behavior-parity.py` → compiles
- `manage/api.ts`, `users.spec.ts` → typecheck clean (only pre-existing `@types/node` resolution noise)
- Branches off current `develop` (incl. #1273) — **single merge base, zero conflicts**

🤖 Generated with [Claude Code](https://claude.com/claude-code)