### PR TITLE
fix(ansible): post-bootstrap survives a pre-seeded (live-dump) database

### DIFF
--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -2354,9 +2354,12 @@
         status_code: [200]
         timeout: 60
       register: mcp_rekey_root
-      failed_when: >-
-        mcp_rekey_root.status != 200 or
-        not (mcp_rekey_root.json.admin_user_provisioned | default(false))
+      # A DB pre-seeded from a LIVE environment dump (instead of the stock pg
+      # dump) already carries ADMIN under the state key — the shim then errors
+      # on the existing row and `admin_user_provisioned` stays false even
+      # though login works. Only require the shim to be reachable here; the
+      # configurator-i18n ADMIN login below (6 retries) is the real gate.
+      failed_when: mcp_rekey_root.status != 200
       when: state_root != 'pg'
       no_log: true
 
@@ -2377,11 +2380,41 @@
         status_code: [200]
         timeout: 60
       register: mcp_rekey_city
-      failed_when: >-
-        mcp_rekey_city.status != 200 or
-        not (mcp_rekey_city.json.admin_user_provisioned | default(false))
+      # Same pre-seeded-dump tolerance as the state_root task above.
+      failed_when: mcp_rekey_city.status != 200
       when: state_root != 'pg' and tenant_id != state_root
       no_log: true
+
+    # The authoritative check the softened asserts above rely on: ADMIN must
+    # actually authenticate at the city tenant (covers both the stock-dump
+    # re-key path and the pre-seeded-dump path).
+    - name: "post-bootstrap — verify ADMIN authenticates at the city tenant"
+      ansible.builtin.uri:
+        url: "{{ 'https://' + domain if (tls_enabled | default(true)) else 'http://127.0.0.1' }}/user/oauth/token"
+        method: POST
+        headers: >-
+          {{
+            {'Authorization': 'Basic ZWdvdi11c2VyLWNsaWVudDo=',
+             'Content-Type': 'application/x-www-form-urlencoded'}
+            | combine({'Host': domain} if not (tls_enabled | default(true)) else {})
+          }}
+        body_format: form-urlencoded
+        body:
+          grant_type: password
+          username: "{{ bootstrap_user | default('ADMIN') }}"
+          password: "{{ bootstrap_password | default('eGov@123') }}"
+          scope: read
+          tenantId: "{{ tenant_id }}"
+          userType: EMPLOYEE
+        status_code: [200]
+        timeout: 15
+        validate_certs: "{{ tls_enabled | default(true) }}"
+      register: admin_login_city
+      retries: 6
+      delay: 10
+      until: admin_login_city.status == 200
+      no_log: true
+      when: state_root != 'pg' and tenant_id != state_root
 
     # ────────────────────────────────────────────────────────────────
     # Configurator UI localization seed. The configurator's own chrome —


### PR DESCRIPTION
## What
The documented 0→1 clone flow swaps `local-setup/db/full-dump.sql` for a live environment's dump. On such a deploy, ADMIN already exists under the state enc key, so the MCP `user_only` re-provision errors on the existing row — and the old `failed_when` asserts killed an otherwise healthy deploy at the very last stage.

## Changes (playbook-deploy.yml only)
- The two **post-bootstrap ADMIN re-provision** tasks now only require the provisioning shim to be reachable (HTTP 200), instead of asserting `admin_user_provisioned`.
- The authoritative gate is a **real ADMIN login**: the existing configurator-i18n login already covers the state root, and a new probe task now verifies ADMIN authenticates at the **city tenant** (retries 6×10s, `no_log`), which previously had no login verification at all.

## Verified
Fresh local 0→1 with the pilot dump pre-seeded: recap `ok=113 failed=0`, ADMIN+SUPERUSER and pilot employees log in, 9.6k pt_PT localization keys, 84-node IGE hierarchy, P-2026-* complaints present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)