### PR TITLE
fix(local-setup): backport OTP mock default + per-tenant mobile validation from develop

### DIFF
--- a/local-setup/ansible/inventory/host_vars/_example.yml
+++ b/local-setup/ansible/inventory/host_vars/_example.yml
@@ -208,11 +208,14 @@ enable_integration_tests_runner: false
 
 # Start the real OTP stack: egov-otp (stores OTPs), user-otp (orchestrates
 # send/validate), egov-notification-sms (delivers via SMS gateway).
-# Default true — real OTP services run by default.
-# Set false before deploying if you want to skip the OTP stack (lean/offline
-# environments); egov-user's fixed OTP (CITIZEN_LOGIN_PASSWORD_OTP_FIXED_VALUE=123456)
-# still allows login, but /user-otp/* requests will fail without a mock in kong.yml.
-enable_otp_services: true
+# Default false — local-setup/kong/kong.yml mocks /user-otp/* with a canned
+# 200 response so login/register work via the fixed OTP (123456, see
+# CITIZEN_LOGIN_PASSWORD_OTP_FIXED_VALUE) without any SMS infra.
+# Set true for production, AND follow the "TO ENABLE REAL OTP FOR PRODUCTION"
+# steps in local-setup/kong/kong.yml (remove the mock plugin there, and wire
+# up a real SMS_PROVIDER_CLASS in docker-compose.egov-digit.yaml — it
+# defaults to Console, which only logs OTP SMS instead of sending it).
+enable_otp_services: false
 
 # Bring up Elasticsearch + egov-indexer + inbox-v2. Heavy (~3GB RAM
 # extra). Off by default; only enable if you actually use the inbox.

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -491,11 +491,15 @@
     # format regardless of its actual mobileNumberRegex/countryCode. No
     # bootstrap-order dependency here (unlike STATE_LEVEL_TENANT_ID above),
     # so this runs pre-boot alongside the other tenant-shaped literals.
+    # Same re.sub()-as-replacement-template hazard as the REGEX task below —
+    # double any backslashes in countryCode before it reaches `replace:`.
+    # A backslash in a country code is unlikely in practice, but the fix is
+    # free, so apply it here too for consistency.
     - name: Set EGOV_MOBILE_VALIDATION_DEFAULT_COUNTRY_CODE (egov-user) in compose
       replace:
         path: "{{ digit_dir }}/docker-compose.egov-digit.yaml"
-        regexp: "^(\\s+)EGOV_MOBILE_VALIDATION_DEFAULT_COUNTRY_CODE: '\\+91'$"
-        replace: "\\1EGOV_MOBILE_VALIDATION_DEFAULT_COUNTRY_CODE: '{{ core_mobile_configs.countryCode | default('+91') }}'"
+        regexp: '^(\s+)EGOV_MOBILE_VALIDATION_DEFAULT_COUNTRY_CODE: ''\+91''$'
+        replace: '\1EGOV_MOBILE_VALIDATION_DEFAULT_COUNTRY_CODE: ''{{ core_mobile_configs.countryCode | default(''+91'') | replace(''\\'', ''\\\\'') }}'''
 
     # The `replace:` value below is fed straight into Python's re.sub() as
     # the replacement string, which treats backslash specially (\1, \g<...>

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -497,11 +497,17 @@
         regexp: "^(\\s+)EGOV_MOBILE_VALIDATION_DEFAULT_COUNTRY_CODE: '\\+91'$"
         replace: "\\1EGOV_MOBILE_VALIDATION_DEFAULT_COUNTRY_CODE: '{{ core_mobile_configs.countryCode | default('+91') }}'"
 
+    # The `replace:` value below is fed straight into Python's re.sub() as
+    # the replacement string, which treats backslash specially (\1, \g<...>
+    # are backreferences; any other \<letter> — e.g. a tenant's regex using
+    # \d or \w shorthand instead of [0-9]/[A-Za-z0-9_] — raises "bad escape").
+    # Double every backslash in the tenant's mobileNumberRegex first so it
+    # survives re.sub() and lands in the compose file unchanged.
     - name: Set EGOV_MOBILE_VALIDATION_DEFAULT_REGEX (egov-user) in compose
       replace:
         path: "{{ digit_dir }}/docker-compose.egov-digit.yaml"
-        regexp: "^(\\s+)EGOV_MOBILE_VALIDATION_DEFAULT_REGEX: '\\^\\[6-9\\]\\[0-9\\]\\{9\\}\\$'$"
-        replace: "\\1EGOV_MOBILE_VALIDATION_DEFAULT_REGEX: '{{ core_mobile_configs.mobileNumberRegex | default('^[6-9][0-9]{9}$') }}'"
+        regexp: '^(\s+)EGOV_MOBILE_VALIDATION_DEFAULT_REGEX: ''\^\[6-9\]\[0-9\]\{9\}\$''$'
+        replace: '\1EGOV_MOBILE_VALIDATION_DEFAULT_REGEX: ''{{ core_mobile_configs.mobileNumberRegex | default(''^[6-9][0-9]{9}$'') | replace(''\\'', ''\\\\'') }}'''
 
     # ==================== Publish digit-mcp image ====================
     # digit-mcp ships from the same registry as every other DIGIT image

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -479,6 +479,30 @@
         regexp: '^(\s+)DEFAULT_TENANT_ID: pg$'
         replace: '\1DEFAULT_TENANT_ID: {{ state_root }}'
 
+    # egov-user's OWN mobile-number-validation fallback (Spring env vars,
+    # baked into the image's application.properties as India's +91 /
+    # 10-digit regex). Distinct from the MDMS common-masters
+    # .MobileNumberValidation config that mcp-bootstrap seeds later from
+    # this same core_mobile_configs — that MDMS config only governs
+    # UI-driven, MDMS-aware validation. egov-user itself falls back to
+    # THIS env var whenever a request doesn't carry a country code (e.g.
+    # a direct /user/citizen/_create call that bypasses the UI), so
+    # without this rewrite every tenant silently validates against India's
+    # format regardless of its actual mobileNumberRegex/countryCode. No
+    # bootstrap-order dependency here (unlike STATE_LEVEL_TENANT_ID above),
+    # so this runs pre-boot alongside the other tenant-shaped literals.
+    - name: Set EGOV_MOBILE_VALIDATION_DEFAULT_COUNTRY_CODE (egov-user) in compose
+      replace:
+        path: "{{ digit_dir }}/docker-compose.egov-digit.yaml"
+        regexp: "^(\\s+)EGOV_MOBILE_VALIDATION_DEFAULT_COUNTRY_CODE: '\\+91'$"
+        replace: "\\1EGOV_MOBILE_VALIDATION_DEFAULT_COUNTRY_CODE: '{{ core_mobile_configs.countryCode | default('+91') }}'"
+
+    - name: Set EGOV_MOBILE_VALIDATION_DEFAULT_REGEX (egov-user) in compose
+      replace:
+        path: "{{ digit_dir }}/docker-compose.egov-digit.yaml"
+        regexp: "^(\\s+)EGOV_MOBILE_VALIDATION_DEFAULT_REGEX: '\\^\\[6-9\\]\\[0-9\\]\\{9\\}\\$'$"
+        replace: "\\1EGOV_MOBILE_VALIDATION_DEFAULT_REGEX: '{{ core_mobile_configs.mobileNumberRegex | default('^[6-9][0-9]{9}$') }}'"
+
     # ==================== Publish digit-mcp image ====================
     # digit-mcp ships from the same registry as every other DIGIT image
     # ({{ docker_registry }}/digit-mcp:latest). Compose `pull` picks it

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -1292,7 +1292,9 @@ services:
     deploy:
       resources:
         limits:
-          memory: 256M
+          # 256M OOM-kills (Exited 137) this Spring Boot 3.2 / Java 17 service — heap
+          # (Xmx192m) + metaspace/threads/off-heap exceeds the container cap. 512M is headroom.
+          memory: 512M
           cpus: '0.2'
     networks:
       - egov-network
@@ -1334,7 +1336,8 @@ services:
     deploy:
       resources:
         limits:
-          memory: 256M
+          # 256M OOM-kills (Exited 137) this Spring Boot 3.2 / Java 17 service — see egov-otp above.
+          memory: 512M
           cpus: '0.2'
     networks:
       - egov-network
@@ -1368,7 +1371,8 @@ services:
     deploy:
       resources:
         limits:
-          memory: 256M
+          # Bumped 256M→512M with the other otp-profile services for headroom (Spring Boot 3.2 / Java 17).
+          memory: 512M
           cpus: '0.1'
     networks:
       - egov-network

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -1359,6 +1359,11 @@ services:
       OTEL_METRICS_EXPORTER: none
       OTEL_LOGS_EXPORTER: none
       JAVA_TOOL_OPTIONS: -Xms64m -Xmx128m
+      # Console only logs the OTP SMS to this container's stdout — no SMS is
+      # actually sent. For production, set enable_otp_services: true in the
+      # tenant's Ansible host_vars AND replace this with a real provider
+      # class + credentials (e.g. an SMSCountry/Twilio/MSG91 provider class
+      # supported by this image) before relying on real OTP delivery.
       SMS_PROVIDER_CLASS: Console
     deploy:
       resources:

--- a/local-setup/kong/kong.yml
+++ b/local-setup/kong/kong.yml
@@ -495,9 +495,20 @@ services:
     paths:
     - /kc
     strip_path: true
-# OTP validate mock — returns success for citizen OTP login flow
+# OTP validate — real upstream (egov-otp:8089) fronted by a default request-termination MOCK.
+# Mirrors /user-otp: the mock rubber-stamps every OTP validation as successful, so citizen
+# login works with the fixed OTP (123456) without the `otp` profile running.
+#
+# TO ENABLE REAL OTP VALIDATION FOR PRODUCTION, before deploying:
+#   1. Delete the `plugins:` block below (the request-termination mock).
+#   2. Set enable_otp_services: true in the tenant's Ansible host_vars so compose
+#      starts the `otp` profile (egov-otp, user-otp, egov-notification-sms).
+#   3. Configure a real SMS gateway (see egov-notification-sms SMS_PROVIDER_CLASS).
+# With the mock removed and the otp profile running, /otp reaches egov-otp for real
+# validation (an incorrect OTP is rejected instead of rubber-stamped). The upstream was
+# previously a dead localhost:9999, so de-mocking alone returned HTTP 502 — now fixed.
 - name: otp-validate-mock
-  url: http://localhost:9999
+  url: http://egov-otp:8089
   tags:
   - core
   - auth

--- a/local-setup/kong/kong.yml
+++ b/local-setup/kong/kong.yml
@@ -138,6 +138,30 @@ services:
     paths:
     - /user-otp
     strip_path: false
+    # MOCK (default): request-termination short-circuits every /user-otp/*
+    # call with a canned success response, so login/register work using the
+    # fixed OTP (123456, see CITIZEN_LOGIN_PASSWORD_OTP_FIXED_VALUE in
+    # docker-compose.egov-digit.yaml) without the real egov-otp/user-otp/
+    # egov-notification-sms stack running or any SMS gateway integrated.
+    #
+    # TO ENABLE REAL OTP FOR PRODUCTION, before deploying:
+    #   1. Delete the `plugins:` block below (the request-termination mock).
+    #   2. Set enable_otp_services: true in the tenant's Ansible host_vars
+    #      (local-setup/ansible/inventory/host_vars/<tenant>.yml) so compose
+    #      starts the `otp` profile (egov-otp, user-otp, egov-notification-sms).
+    #   3. Configure a real SMS gateway: egov-notification-sms defaults to
+    #      SMS_PROVIDER_CLASS: Console (logs OTP SMS to container stdout only)
+    #      in docker-compose.egov-digit.yaml — point it at a real provider
+    #      class + credentials before relying on SMS delivery.
+    # Without all three, the first OTP request has nothing to answer it
+    # (real stack down or SMS not actually sent), and only the fixed
+    # 123456 fallback keeps working.
+    plugins:
+    - name: request-termination
+      config:
+        status_code: 200
+        content_type: application/json
+        body: '{"ResponseInfo":{"apiId":"Rainmaker","ver":null,"ts":null,"resMsgId":"uief87324","msgId":null,"status":"successful"},"otp":{"identity":"","tenantId":"","type":"","otp":"","expiryTime":0}}'
 - name: enc-service
   url: http://egov-enc-service:1234
   tags:


### PR DESCRIPTION
## Why
A fresh 0→1 ansible deploy from **release-v2.12** reproduced two bugs already fixed on develop (and partially on release-v2.12-moz): citizen OTP dies in Kong with `name resolution failed` (kong.yml routes /user-otp to a container the default profiles never start), and egov-user falls back to India's +91 / 10-digit mobile validation, stamping `countryCode: +91` on new citizens and rejecting Mozambican numbers (INVALID_MOBILE_NUMBER).

## What (5 clean cherry-picks from develop, `-x` stamped)
- `03767cbc` fix(local-setup): default to OTP mock, document real-OTP production steps
- `d4b3e40a` fix(otp): repair the real-OTP enablement path on compose (#7)
- `7bac0da9` fix(ansible): rewrite egov-user mobile-validation defaults per tenant (PR #1264)
- `0577de0c` + `4ae3d9ca` — backslash-escaping follow-ups to the replace tasks

Note: the replace tasks read `core_mobile_configs.countryCode` / `.mobileNumberRegex` — host_vars that only define the frontend keys (mobilePrefix/mobileNumberPattern) must add these two.

## Verified (live, fresh local 0→1 env)
- `/user-otp/v1/_send` → 200 canned mock response; citizen login with fixed OTP 123456 → token issued.
- New citizen `_create` with 9-digit 8-prefix number accepted; record stamped `countryCode: +258`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)