### PR TITLE
fix(novu-bridge): gate /dispatch diagnostics behind ProxyAuthFilter + wire MdmsServiceClient cache

### DIFF
--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/service/MdmsServiceClient.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/service/MdmsServiceClient.java
@@ -35,8 +35,8 @@ public class MdmsServiceClient {
     private final RestTemplate restTemplate;
     private final NovuBridgeConfiguration config;
 
-    /** Cache: tenantId → country-code prefix (e.g. "+91") */
-    private final Map<String, String> prefixCache = new ConcurrentHashMap<>();
+    /** Cache: tenantId → resolved mobile-number validation config. */
+    private final Map<String, MobileValidationConfig> configCache = new ConcurrentHashMap<>();
 
     public MdmsServiceClient(RestTemplate restTemplate, NovuBridgeConfiguration config) {
         this.restTemplate = restTemplate;
@@ -60,15 +60,19 @@ public class MdmsServiceClient {
             String tenantId,
             RequestInfo requestInfo) {
 
+        return configCache.computeIfAbsent(tenantId, t -> resolveMobileValidationConfig(t, requestInfo));
+    }
+
+    private MobileValidationConfig resolveMobileValidationConfig(String tenantId, RequestInfo requestInfo) {
         Map<String, Object> record = fetchDefaultRecord(tenantId, requestInfo);
 
         Map<String, Object> data = (Map<String, Object>) record.get("data");
 
-        MobileValidationConfig config = new MobileValidationConfig();
-        config.setCountryCode((String) data.get("countryCode"));
-        config.setMobileNumberRegex((String) data.get("mobileNumberRegex"));
+        MobileValidationConfig resolved = new MobileValidationConfig();
+        resolved.setCountryCode((String) data.get("countryCode"));
+        resolved.setMobileNumberRegex((String) data.get("mobileNumberRegex"));
 
-        return config;
+        return resolved;
     }
 
     // -------------------------------------------------------------------------

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/service/MdmsServiceClient.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/service/MdmsServiceClient.java
@@ -35,6 +35,13 @@ public class MdmsServiceClient {
     private final RestTemplate restTemplate;
     private final NovuBridgeConfiguration config;
 
+    /**
+     * Safety cap on the tenant→config cache. The key space is the set of provisioned
+     * tenants (a small, bounded set), but this guards against unbounded growth if a
+     * caller ever supplies arbitrary tenantIds.
+     */
+    private static final int MAX_CACHE_ENTRIES = 1000;
+
     /** Cache: tenantId → resolved mobile-number validation config. */
     private final Map<String, MobileValidationConfig> configCache = new ConcurrentHashMap<>();
 
@@ -60,7 +67,20 @@ public class MdmsServiceClient {
             String tenantId,
             RequestInfo requestInfo) {
 
-        return configCache.computeIfAbsent(tenantId, t -> resolveMobileValidationConfig(t, requestInfo));
+        // Resolve the cache miss OUTSIDE the map so the blocking MDMS call never runs
+        // inside a ConcurrentHashMap bin lock (which would serialize unrelated keys).
+        MobileValidationConfig cached = configCache.get(tenantId);
+        if (cached != null) {
+            return cached;
+        }
+        MobileValidationConfig resolved = resolveMobileValidationConfig(tenantId, requestInfo);
+        if (configCache.size() < MAX_CACHE_ENTRIES) {
+            MobileValidationConfig existing = configCache.putIfAbsent(tenantId, resolved);
+            if (existing != null) {
+                return existing;
+            }
+        }
+        return resolved;
     }
 
     private MobileValidationConfig resolveMobileValidationConfig(String tenantId, RequestInfo requestInfo) {

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/web/filters/ProxyAuthFilter.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/web/filters/ProxyAuthFilter.java
@@ -28,8 +28,9 @@ import java.util.stream.Collectors;
 /**
  * Server-side authentication for the configurator proxy endpoints
  * ({@code GET /novu-adapter/v1/logs}, {@code /novu-adapter/v1/integrations},
- * {@code /novu-adapter/v1/preferences} and the {@code /novu-adapter/v1/providers}
- * self-service management paths — GET/POST).
+ * {@code /novu-adapter/v1/preferences}, the {@code /novu-adapter/v1/providers}
+ * self-service management paths — GET/POST — and the {@code /novu-adapter/v1/dispatch}
+ * diagnostic endpoints).
  *
  * <p>DIGIT access tokens are opaque OAuth tokens minted by egov-user. This filter
  * introspects the incoming {@code Authorization: Bearer <token>} against egov-user
@@ -72,7 +73,8 @@ public class ProxyAuthFilter extends OncePerRequestFilter {
         return !(path.startsWith("/novu-adapter/v1/logs")
                 || path.startsWith("/novu-adapter/v1/integrations")
                 || path.startsWith("/novu-adapter/v1/preferences")
-                || path.startsWith("/novu-adapter/v1/providers"));
+                || path.startsWith("/novu-adapter/v1/providers")
+                || path.startsWith("/novu-adapter/v1/dispatch"));
     }
 
     @Override

--- a/backend/novu-bridge/src/test/java/org/egov/novubridge/web/filters/ProxyAuthFilterTest.java
+++ b/backend/novu-bridge/src/test/java/org/egov/novubridge/web/filters/ProxyAuthFilterTest.java
@@ -69,6 +69,14 @@ class ProxyAuthFilterTest {
         return req;
     }
 
+    private MockHttpServletRequest dispatchTestTriggerRequest() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setMethod("POST");
+        req.setServletPath("/novu-adapter/v1/dispatch/_test-trigger");
+        req.setRequestURI("/novu-bridge/novu-adapter/v1/dispatch/_test-trigger");
+        return req;
+    }
+
     @Test
     void noAuthHeader_returns401_chainNotInvoked() throws Exception {
         MockHttpServletResponse res = new MockHttpServletResponse();
@@ -101,6 +109,21 @@ class ProxyAuthFilterTest {
         MockFilterChain chain = new MockFilterChain();
 
         filter.doFilter(providersCreateRequest(), res, chain);
+
+        assertEquals(401, res.getStatus());
+        assertNull(chain.getRequest());
+    }
+
+    @Test
+    void dispatchTestTriggerWithoutToken_isGated_returns401() throws Exception {
+        // Regression: the POST /dispatch diagnostics (_validate/_dry-run/_test-trigger)
+        // must be auth-gated like the other /novu-adapter/v1 endpoints. _test-trigger
+        // sends a real Novu SMS/WhatsApp/Email, so it must never run unauthenticated.
+        // (shouldNotFilter previously excluded /dispatch, serving it unauthenticated.)
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(dispatchTestTriggerRequest(), res, chain);
 
         assertEquals(401, res.getStatus());
         assertNull(chain.getRequest());


### PR DESCRIPTION
## Context
Surfaced by the Claude bot review on the **v2.12 release PR #1316** (CodeRabbit skipped that PR for exceeding its file-count limit, so these were the only automated findings). Fixing on `develop` so the fixes flow into the release.

## 🔴 Security: `/dispatch` diagnostics were unauthenticated
`ProxyAuthFilter.shouldNotFilter()` kept only `/logs`, `/integrations`, `/preferences`, `/providers` under the auth filter. Every other path — including the POST diagnostics `POST /novu-adapter/v1/dispatch/{_validate,_dry-run,_test-trigger}` — returned `shouldNotFilter() == true` and skipped the bearer-token + EMPLOYEE-role check entirely.

`_test-trigger` calls `dispatchPipelineService.testTrigger(...)` and sends a **real** Novu SMS/WhatsApp/Email to a caller-supplied subscriber/phone. Kong deliberately does not route `/dispatch/*` publicly *on the assumption novu-bridge gates it internally* — and both the `ProxyAuthFilter` and `MainConfiguration` Javadoc already (incorrectly) asserted these endpoints were gated. So the only thing standing between an internal caller and a real send was Kong's routing table, not auth.

**Fix:** add `/novu-adapter/v1/dispatch` to the `shouldNotFilter()` allowlist, correct the Javadoc, and add a regression test for `_test-trigger` gating. The Postman collection (the only caller) already sends `authToken`, so no legitimate caller breaks.

## 🟡 Perf/docs: `MdmsServiceClient` cache was dead
The class + method Javadoc claimed the mobile-validation config is cached per tenant for the JVM lifetime, but `prefixCache` was declared and never read/written — `getMobileValidationConfig()` issued a fresh MDMS `_search` on **every** SMS/WhatsApp dispatch needing country-code formatting (via `DispatchPipelineService.formatRecipientPhone()`). Wired up the cache the Javadoc describes (per-tenant `MobileValidationConfig`, `computeIfAbsent`).

## Test plan
- [ ] CI green (no local JDK to build; changes are minimal/surgical)
- New `dispatchTestTriggerWithoutToken_isGated_returns401` regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved mobile validation configuration retrieval by caching resolved settings for reuse.

* **Bug Fixes**
  * Added authentication protection for the dispatch test-trigger endpoint, returning an unauthorized response when no token is provided.

* **Tests**
  * Added coverage verifying that unauthenticated dispatch test-trigger requests are blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->