### PR TITLE
fix(pgr-services): HTML-escape user values in EMAIL notification body

### DIFF
--- a/backend/pgr-services/src/main/java/org/egov/pgr/service/notification/TemplateRenderer.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/service/notification/TemplateRenderer.java
@@ -6,6 +6,7 @@ import org.egov.pgr.util.MDMSUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
+import org.springframework.web.util.HtmlUtils;
 
 import java.util.Map;
 
@@ -62,7 +63,29 @@ public class TemplateRenderer {
                         audience, action, toState, channel, locale, tenantId);
             return null;
         }
-        return substitute(raw, values);
+        // The EMAIL body is delivered through Novu with editorType=html and
+        // disableOutputSanitization=true, so the rendered string is treated as raw
+        // HTML by the recipient's mail client. Placeholder VALUES (citizen name,
+        // workflow comments, ...) are user-controlled, so HTML-escape them before
+        // substitution to prevent HTML/link injection into the email. The template
+        // body itself is admin-authored MDMS and may legitimately contain HTML, so
+        // only the substituted values are escaped, not the template. The subject is
+        // rendered as plain text by Novu, so it is left unescaped.
+        Map<String, String> effectiveValues = values;
+        if ("body".equals(field) && "EMAIL".equalsIgnoreCase(channel)) {
+            effectiveValues = escapeValuesForHtml(values);
+        }
+        return substitute(raw, effectiveValues);
+    }
+
+    /** Returns a copy of {@code values} with every value HTML-escaped. */
+    private Map<String, String> escapeValuesForHtml(Map<String, String> values) {
+        if (values == null) return null;
+        Map<String, String> escaped = new java.util.LinkedHashMap<>(values.size());
+        for (Map.Entry<String, String> e : values.entrySet()) {
+            escaped.put(e.getKey(), e.getValue() == null ? null : HtmlUtils.htmlEscape(e.getValue()));
+        }
+        return escaped;
     }
 
     @SuppressWarnings("unchecked")

--- a/backend/pgr-services/src/test/java/org/egov/pgr/service/notification/TemplateRendererTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/service/notification/TemplateRendererTest.java
@@ -105,4 +105,27 @@ public class TemplateRendererTest {
         String out = renderer.render(TENANT, "CITIZEN", "ASSIGN", "PENDINGATLME", "SMS", "en_IN", v);
         assertTrue(out.contains("{emp_name}"));
     }
+
+    @Test
+    void emailBodyHtmlEscapesUserValuesButKeepsTemplateHtml() {
+        // The EMAIL body is delivered as raw HTML (Novu editorType=html,
+        // disableOutputSanitization=true), so user-controlled values must be escaped
+        // to prevent HTML/link injection, while the admin-authored template markup
+        // (here, the <b> wrapper) is preserved verbatim.
+        seed(tmpl("CITIZEN", "ASSIGN", "PENDINGATLME", "EMAIL", "en_IN", "Hello <b>{citizen_name}</b>"));
+        Map<String, String> v = new HashMap<>();
+        v.put("citizen_name", "Jane<a href=\"http://evil.example/phish\">Doe</a>");
+        String out = renderer.render(TENANT, "CITIZEN", "ASSIGN", "PENDINGATLME", "EMAIL", "en_IN", v);
+        assertEquals("Hello <b>Jane&lt;a href=&quot;http://evil.example/phish&quot;&gt;Doe&lt;/a&gt;</b>", out);
+    }
+
+    @Test
+    void smsBodyDoesNotEscapeUserValues() {
+        // Non-EMAIL channels are plain text, so escaping would leak visible entities.
+        seed(tmpl("CITIZEN", "ASSIGN", "PENDINGATLME", "SMS", "en_IN", "Hello {citizen_name}"));
+        Map<String, String> v = new HashMap<>();
+        v.put("citizen_name", "Tom & Jerry");
+        String out = renderer.render(TENANT, "CITIZEN", "ASSIGN", "PENDINGATLME", "SMS", "en_IN", v);
+        assertEquals("Hello Tom & Jerry", out);
+    }
 }


### PR DESCRIPTION
## Context
Surfaced by the Claude bot review on the **v2.12 release PR #1316** (CodeRabbit skipped that PR for exceeding its file-count limit). Fixing on `develop` so it flows into the release.

## 🔴 Security: HTML injection into transactional emails
The bootstrapped Novu **complaints-email** workflow renders `payload.body` with `editorType=html` + `disableOutputSanitization=true` (`backend/novu-bridge/config/bootstrap-novu-whatsapp.sh`), i.e. the email body is treated as **raw HTML** by the recipient's mail client with Novu's own sanitizer turned off.

That body is built in pgr-services by `TemplateRenderer.substitute()` using plain unescaped `String.replace`, and its placeholder values are user-controlled with no escaping anywhere in the pipeline:
- `citizen_name` — the citizen's own profile display name
- `additional_comments` — free-text workflow comment enterable by any citizen/employee

So a citizen or employee can set their name/comment to `Jane<a href="http://evil.example/phish">Doe</a>` and have it render as a live, clickable link inside a transactional government email sent to another party (e.g. the assigned GRO) — a phishing/spoofing vector on a trusted channel. Mail clients strip `<script>`, so the realistic exploit is HTML/link injection, not JS execution.

## Fix
HTML-escape placeholder **values** (`HtmlUtils.htmlEscape`) before substitution, scoped to the **EMAIL body**:
- The admin-authored MDMS template body may legitimately contain HTML, so only the substituted values are escaped — **not** the template.
- The **subject** is rendered as plain text by Novu, so it is left unescaped (escaping would leak visible `&amp;`/`&lt;` entities).
- **SMS/WHATSAPP** bodies are plain text and unaffected.

## Test plan
- [ ] CI green
- Added `emailBodyHtmlEscapesUserValuesButKeepsTemplateHtml` (injection escaped, `<b>` template markup preserved) and `smsBodyDoesNotEscapeUserValues`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)