### PR TITLE
fix(config-service): serialize jsonb criteria filter values with Jackson

### DIFF
--- a/backend/digit-config-service/src/main/java/org/egov/config/utils/QueryUtil.java
+++ b/backend/digit-config-service/src/main/java/org/egov/config/utils/QueryUtil.java
@@ -1,11 +1,15 @@
 package org.egov.config.utils;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 
 public class QueryUtil {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private QueryUtil() {}
 
@@ -29,29 +33,25 @@ public class QueryUtil {
         preparedStmtList.addAll(values);
     }
 
+    /**
+     * Serializes the criteria filter map to a JSON object string suitable for binding
+     * into a {@code data @> CAST(? AS jsonb)} containment predicate.
+     *
+     * <p>{@code ConfigDataCriteria.criteria} / {@code ResolveParams.criteria} are typed
+     * {@code Map<String, Object>}, so a filter value may be a scalar (String/Number/Boolean),
+     * or a nested Map/List. Jackson is used for serialization so nested values are emitted as
+     * valid JSON (e.g. {@code {"a":1}}) rather than Java's {@code Object.toString()} form
+     * (e.g. {@code {a=1}}), which would produce invalid JSON and fail the jsonb cast at query
+     * time.
+     */
     public static String preparePartialJsonStringFromFilterMap(Map<String, Object> filterMap) {
         if (filterMap == null || filterMap.isEmpty()) {
             return "{}";
         }
-        StringBuilder sb = new StringBuilder("{");
-        boolean first = true;
-        for (Map.Entry<String, Object> entry : filterMap.entrySet()) {
-            if (!first) sb.append(",");
-            sb.append("\"").append(escapeJson(entry.getKey())).append("\":");
-            Object val = entry.getValue();
-            if (val instanceof String) {
-                sb.append("\"").append(escapeJson((String) val)).append("\"");
-            } else {
-                sb.append(val);
-            }
-            first = false;
+        try {
+            return OBJECT_MAPPER.writeValueAsString(filterMap);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialize criteria filter map to JSON", e);
         }
-        sb.append("}");
-        return sb.toString();
-    }
-
-    private static String escapeJson(String value) {
-        if (value == null) return "";
-        return value.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 }

--- a/backend/digit-config-service/src/test/java/org/egov/config/utils/QueryUtilTest.java
+++ b/backend/digit-config-service/src/test/java/org/egov/config/utils/QueryUtilTest.java
@@ -1,0 +1,68 @@
+package org.egov.config.utils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class QueryUtilTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void emptyOrNullMapReturnsEmptyObject() {
+        assertEquals("{}", QueryUtil.preparePartialJsonStringFromFilterMap(null));
+        assertEquals("{}", QueryUtil.preparePartialJsonStringFromFilterMap(new LinkedHashMap<>()));
+    }
+
+    @Test
+    void scalarValuesProduceValidJson() throws Exception {
+        Map<String, Object> filter = new LinkedHashMap<>();
+        filter.put("tenantId", "pg");
+        filter.put("count", 3);
+        filter.put("enabled", true);
+
+        String json = QueryUtil.preparePartialJsonStringFromFilterMap(filter);
+        JsonNode node = MAPPER.readTree(json); // parses => valid JSON
+        assertEquals("pg", node.get("tenantId").asText());
+        assertEquals(3, node.get("count").asInt());
+        assertTrue(node.get("enabled").asBoolean());
+    }
+
+    @Test
+    void stringValueWithQuotesIsEscaped() throws Exception {
+        Map<String, Object> filter = new LinkedHashMap<>();
+        filter.put("name", "a\"b");
+        JsonNode node = MAPPER.readTree(QueryUtil.preparePartialJsonStringFromFilterMap(filter));
+        assertEquals("a\"b", node.get("name").asText());
+    }
+
+    @Test
+    void nestedObjectAndArrayProduceValidJson() throws Exception {
+        // Regression: criteria was widened to Map<String,Object>. A nested Map/List value
+        // previously fell through to Object.toString() (e.g. "{nested=1}"), producing invalid
+        // JSON and failing the `data @> CAST(? AS jsonb)` cast at query time.
+        Map<String, Object> nested = new LinkedHashMap<>();
+        nested.put("nested", 1);
+
+        Map<String, Object> filter = new LinkedHashMap<>();
+        filter.put("tenantId", "pg");
+        filter.put("config", nested);
+        filter.put("tags", List.of("a", "b"));
+
+        String json = assertDoesNotThrow(() -> QueryUtil.preparePartialJsonStringFromFilterMap(filter));
+        JsonNode node = MAPPER.readTree(json); // must be parseable as valid JSON
+        assertEquals(1, node.get("config").get("nested").asInt());
+        assertEquals("a", node.get("tags").get(0).asText());
+        assertEquals("b", node.get("tags").get(1).asText());
+        // Explicitly assert the old broken rendering is gone.
+        assertTrue(!json.contains("nested=1"));
+    }
+}


### PR DESCRIPTION
## Context
Surfaced by the Claude bot review on the **v2.12 release PR #1316** (CodeRabbit skipped that PR for exceeding its file-count limit). Fixing on `develop` so it flows into the release.

## 🔴 Bug: nested criteria filter values crash the jsonb cast
This release widened `ConfigDataCriteria.criteria` and `ConfigDataResolveRequest.ResolveParams.criteria` from `Map<String,String>` to `Map<String,Object>` so filter values can be numbers, booleans, or nested objects/arrays for jsonb containment queries.

But `QueryUtil.preparePartialJsonStringFromFilterMap` built the JSON string by hand and only special-cased `String` values (`val instanceof String`); every other type fell through to `sb.append(val)` → `Object.toString()`. Jackson deserializes a nested JSON object into a `LinkedHashMap` and an array into an `ArrayList`, whose `toString()` renders **Java** syntax (`{a=1}`, `[a, b]`), not JSON.

That malformed literal is bound into `data @> CAST(? AS jsonb)`, so a request like:

```json
POST /config/data/_search
{ "criteria": { "tenantId": "pg", "config": { "nested": 1 } } }
```

produces `{"tenantId":"pg","config":{nested=1}}` → Postgres `invalid input syntax for type json` → an unhandled **500** on both `/config/data/_search` and `/config/data/_resolve`, for exactly the value shapes the `Object` widening was meant to support. Scalar filters (string/number/boolean) happen to render valid tokens, so most existing callers are unaffected.

## Fix
Replace the hand-rolled string building with `ObjectMapper.writeValueAsString(filterMap)` (mirroring `ConfigDataRepository.toJsonString`), which serializes nested Map/List values as valid JSON at any depth. Empty/null map still short-circuits to `{}`.

## Test plan
- [ ] CI green
- Added `QueryUtilTest`: scalars, quote-escaping, and the nested object/array regression (asserts parseable JSON and that the old `nested=1` rendering is gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)