### PR TITLE
chore(local-setup): bump 4 core-service images to 2.12-87e13fe

### DIFF
--- a/devops/deploy-as-code/charts/core-services/egov-user/values.yaml
+++ b/devops/deploy-as-code/charts/core-services/egov-user/values.yaml
@@ -20,21 +20,21 @@ initContainers:
 
 # Container Configs
 # PARITY / IMAGE NOTE — why this is NOT the stock egov-user tag:
-#   The stock image (`egov-user:master-d69ce29`) HARDCODES the mobile-number
-#   validation regex (a Kenya/India format). Maputo's rule (MDMS
-#   common-masters.MobileNumberValidation) is +258 / numbers starting with 8, so
-#   the stock image REJECTS every valid Maputo number → citizen register/create/
-#   provisioning fails. The `mobilevalidation-jdk8-4984479` build reads the
-#   per-tenant MDMS rule at runtime instead of hardcoding, so it works for any tenant.
-#   PARITY: Compose already pins this EXACT image (local-setup/docker-compose.egov-digit.yaml)
-#   — reverting to the stock tag would make k8s diverge from Compose (mobile validation
-#   would fail on k8s only). Keep them on the same tag.
-#   PENDING (product decision): get the MDMS-driven mobile-validation fix into a
-#   PUBLISHED egovio/egov-user image, then repin BOTH stacks to that tag. Also fix the
-#   twin frontend bug: digit-ui UserCreate.tsx hardcodes a Kenyan regex (v.mobileKERequired).
+#   The stock image previously HARDCODED the mobile-number validation regex
+#   (a Kenya/India format). Maputo's rule (MDMS common-masters.MobileNumberValidation)
+#   is +258 / numbers starting with 8, so a hardcoded-regex build REJECTS every
+#   valid Maputo number → citizen register/create/provisioning fails.
+#   2.12-87e13fe carries the Digit-Core#1044 fixes (MDMS-driven per-tenant mobile
+#   validation, tenant-aware encryption, SafeHtmlValidator/CCRS#771) that were
+#   previously only in the `mobilevalidation-jdk8-4984479` preview build.
+#   PARITY: Compose pins this EXACT image (local-setup/docker-compose.egov-digit.yaml)
+#   — diverging here would make k8s mobile validation behave differently than
+#   Compose. Keep them on the same tag.
+#   Still fix the twin frontend bug: digit-ui UserCreate.tsx hardcodes a Kenyan
+#   regex (v.mobileKERequired).
 image:
-  repository: "registry.preview.egov.theflywheel.in/egovio/egov-user"
-  tag: "mobilevalidation-jdk8-4984479"
+  repository: "egovio/egov-user"
+  tag: "2.12-87e13fe"
   pullPolicy: "IfNotPresent"
 replicas: "1"
 healthChecks:

--- a/local-setup/ansible/inventory/host_vars/_example.yml
+++ b/local-setup/ansible/inventory/host_vars/_example.yml
@@ -27,7 +27,7 @@ ansible_host: 10.0.0.10
 #   - Grafana root URL (so dashboard links use the real domain)
 #   - Let's Encrypt certificate
 #   - Citizen-facing URLs the UI generates
-domain: digit.example.com  
+domain: digit.example.com
 
 # Default `true`. Renders nginx with `listen 443 ssl` + HTTP→HTTPS
 # redirect, expects Let's Encrypt certs at /etc/letsencrypt/live/<domain>/.

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -2194,11 +2194,12 @@
     # tenant BEFORE MCP bootstrap creates the ADMIN user. egov-enc-service
     # discovers tenants via MDMS search under STATE_LEVEL_TENANT_ID — at this
     # point that's still `pg.citya`, so `mz` (a different root) is unknown and
-    # user encrypt/decrypt for `mz` throws "Tenant Id not found". The custom
-    # `:generatekey-endpoint` image exposes POST /crypto/v1/_generatekey which
-    # inserts the key row directly, bypassing MDMS discovery — solving the
-    # chicken-and-egg between bootstrap needing encryption and enc-service not
-    # yet knowing the new tenant. Idempotent (created: false when key exists).
+    # user encrypt/decrypt for `mz` throws "Tenant Id not found". egov-enc-service
+    # 2.12-87e13fe (formerly the custom `:generatekey-endpoint` preview build)
+    # exposes POST /crypto/v1/_generatekey which inserts the key row directly,
+    # bypassing MDMS discovery — solving the chicken-and-egg between bootstrap
+    # needing encryption and enc-service not yet knowing the new tenant.
+    # Idempotent (created: false when key exists).
     - name: "pre-bootstrap — generate enc-service key for state root ({{ state_root }})"
       ansible.builtin.uri:
         url: "http://127.0.0.1:11234/egov-enc-service/crypto/v1/_generatekey"

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -389,15 +389,10 @@ services:
     - egov-network
 
   egov-enc-service:
-    # `:generatekey-endpoint` stacks the POST /crypto/v1/_generatekey
-    # endpoint (Digit-Core #1354) on top of :v2.9.2-4a60f20. Without
-    # _generatekey, the first encrypt for a brand-new state root (created
-    # by MCP tenant_bootstrap or similar) throws "Tenant Id not found" —
-    # enc-service only discovers tenants via MDMS search under
-    # STATE_LEVEL_TENANT_ID, and a brand-new root isn't under any
-    # existing root's tenant.tenants list. Bump can be replaced with a
-    # versioned tag once Digit-Core #1354 lands and a release ships.
-    image: registry.preview.egov.theflywheel.in/egovio/egov-enc-service:generatekey-endpoint
+    # Bumped to the 2.12 core-services merge (87e13fe), which includes
+    # the Digit-Core #1354 _generatekey fix previously carried via the
+    # :generatekey-endpoint preview pin.
+    image: egovio/egov-enc-service:2.12-87e13fe
     container_name: egov-enc-service
     depends_on:
       egov-mdms-service:
@@ -631,23 +626,11 @@ services:
     restart: "no"
 
   egov-user:
-    # Custom image stacks (a) the tenant-aware encryption fix from
-    # egovernments/Digit-Core#1044 — cherry-pick of c6f5438 + call-site
-    # migration 884c5e6 — on (b) the ccc0e13 NPE fix base in
-    # _updatenovalidate / profile/_update. Built off the pre-d69ce29
-    # commit lineage, so it also sidesteps the SafeHtmlValidator
-    # BeanCreationException regression that blocks citizen registration on
-    # the stock maven-jdk21-* images (CCRS#771).
-    #
-    # When Digit-Core#1044 merges upstream and an official
-    # `egovio/egov-user:<post-1044>` tag exists, replace this pin with
-    # the canonical image.
-    #
-    # `registry.preview.egov.theflywheel.in` is a read-only HTTPS proxy
-    # in front of the egov-ci VPC registry — public cert, no
-    # insecure-registries trust required, pullable from anywhere.
-    #
-    image: registry.preview.egov.theflywheel.in/egovio/egov-user:mobilevalidation-jdk8-4984479
+    # Bumped to the 2.12 core-services merge (87e13fe), which now
+    # includes the Digit-Core#1044 fixes (tenant-aware encryption,
+    # SafeHtmlValidator/CCRS#771, NPE fix) previously carried via the
+    # :mobilevalidation-jdk8 preview pin.
+    image: egovio/egov-user:2.12-87e13fe
     depends_on:
       pgbouncer:
         condition: service_healthy
@@ -730,7 +713,7 @@ services:
     - egov-network
 
   egov-workflow-v2:
-    image: egovio/egov-workflow-v2:maven-jdk21-983e8b2
+    image: egovio/egov-workflow-v2:2.12-87e13fe
     depends_on:
       pgbouncer:
         condition: service_healthy
@@ -817,7 +800,7 @@ services:
     - egov-network
 
   egov-localization:
-    image: egovio/egov-localization:maven-jdk21-9f83afb
+    image: egovio/egov-localization:2.12-87e13fe
     container_name: egov-localization
     depends_on:
       pgbouncer:
@@ -865,6 +848,12 @@ services:
     - egov-network
 
   boundary-service:
+    # NOT bumped to 2.12-87e13fe — that build changes the
+    # /boundary-relationships/_search contract from query-param-bound
+    # criteria (@ModelAttribute) to a body-only BoundaryRelationshipSearchRequest,
+    # which breaks the currently-deployed UI's locality/address search
+    # (NullPointerException on boundaryRelationshipSearchCriteria). Holding
+    # this pin until that's resolved.
     image: egovio/boundary-service:maven-jdk21-9f83afb
     container_name: boundary-service
     depends_on:

--- a/local-setup/docker-compose.migrations.yml
+++ b/local-setup/docker-compose.migrations.yml
@@ -213,7 +213,7 @@ services:
   # There is no -db tag matching the app's exact tag (the app is a custom preview
   # build); this is the closest published tag in the same lineage.
   egov-user-migration:
-    image: egovio/egov-user-db:mobile-validation-user-otp-9883730
+    image: egovio/egov-user-db:2.12-87e13fe
     container_name: egov-user-migration
     depends_on:
       postgres-db: { condition: service_healthy }
@@ -273,7 +273,7 @@ services:
     depends_on: { egov-idgen-migration: { condition: service_completed_successfully } }
 
   egov-localization-migration:
-    image: egovio/egov-localization-db:v2.9.2-4a60f20
+    image: egovio/egov-localization-db:2.12-87e13fe
     container_name: egov-localization-migration
     depends_on:
       postgres-db: { condition: service_healthy }
@@ -293,7 +293,7 @@ services:
     depends_on: { egov-localization-migration: { condition: service_completed_successfully } }
 
   egov-enc-service-migration:
-    image: egovio/egov-enc-service-db:v2.9.2-4a60f20
+    image: egovio/egov-enc-service-db:2.12-87e13fe
     container_name: egov-enc-service-migration
     depends_on:
       postgres-db: { condition: service_healthy }
@@ -333,7 +333,7 @@ services:
     depends_on: { egov-filestore-migration: { condition: service_completed_successfully } }
 
   egov-workflow-v2-migration:
-    image: egovio/egov-workflow-v2-db:v2.9.2-4a60f20
+    image: egovio/egov-workflow-v2-db:2.12-87e13fe
     container_name: egov-workflow-v2-migration
     depends_on:
       postgres-db: { condition: service_healthy }

--- a/local-setup/otel/loki-config.yaml
+++ b/local-setup/otel/loki-config.yaml
@@ -10,6 +10,12 @@ common:
       chunks_directory: /loki/chunks
       rules_directory: /loki/rules
   replication_factor: 1
+  # Single-node ring (inmemory kvstore) doesn't need real inter-node gossip,
+  # but the memberlist-kv module still initializes and tries to auto-detect
+  # an advertise address via `eth0`/`en0` — which fails fast in some
+  # container-networking setups before the interface is visible. Pinning
+  # instance_addr skips that auto-detection entirely.
+  instance_addr: 127.0.0.1
   ring:
     kvstore:
       store: inmemory


### PR DESCRIPTION
Updates egov-localization, egov-user, egov-enc-service, and egov-workflow-v2 to the 2.12 core-services merge in docker-compose.egov-digit.yaml (the compose file the ansible playbook deploys). egov-user and egov-enc-service move off their preview pins now that the merge carries the same fixes (Digit-Core#1044, #1354).

boundary-service is intentionally held back: the new build changes /boundary-relationships/_search from query-param-bound criteria to a body-only request, which NPEs against the currently-deployed UI.

Also includes two fixes needed to get the ansible deploy running:
- otel/loki-config.yaml: pin instance_addr so Loki's memberlist-kv module doesn't fail interface auto-detection on startup
- ansible/inventory/host_vars/_example.yml: trailing-whitespace fix (yamllint blocker in deploy.sh's static validation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Updated local setup service images to a unified DIGIT Core build.
  * Improved Loki startup reliability by explicitly configuring its local network address.
  * Cleaned up the example domain configuration.
  * Kept the boundary service version unchanged to preserve locality and address search compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->