### PR TITLE
fix(ddh): add missing IGE x-no-mask to extended-attribute seed

### DIFF
--- a/utilities/default-data-handler/src/main/resources/mdmsData-dev/RAINMAKER-PGR/RAINMAKER-PGR.ComplaintExtendedAttributeSchema.json
+++ b/utilities/default-data-handler/src/main/resources/mdmsData-dev/RAINMAKER-PGR/RAINMAKER-PGR.ComplaintExtendedAttributeSchema.json
@@ -8,6 +8,7 @@
       "type": "object",
       "required": ["instituteName"],
       "x-security": ["instituteName", "witnessName", "witnessAddress", "witnessNote"],
+      "x-no-mask": ["instituteName"],
       "properties": {
         "instituteName":  { "type": "string", "maxLength": 300,  "x-order": 1, "x-label-key": "PGR_EXT_INSTITUTE_NAME_LABEL" },
         "witnessName":    { "type": "string", "maxLength": 200,  "x-order": 2, "x-label-key": "PGR_EXT_WITNESS_NAME_LABEL" },


### PR DESCRIPTION
One-line completion of #1324: the IGE `"x-no-mask": ["instituteName"]` line reached release-v2.12-moz via #1307 (moz-only PR), so the cherry-pick in #1324 only carried the IGSAE half of the DDH seed. With this, the DDH fresh-env seed, the migration-runner seed, and both release branches are byte-identical for the extended-attribute schemas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)