### PR TITLE
feat(migration): tenant-list runs, arg-parser hardening, guided gzip script

### DIFF
--- a/docs/migration/ccrs-migrate.cjs
+++ b/docs/migration/ccrs-migrate.cjs
@@ -63,8 +63,11 @@ function parseArgs(argv) {
     const a = argv[i];
     if (!a.startsWith('--')) continue;
     const key = a.slice(2);
-    const flag = ['dry-run', 'cms', 'update-wf', 'gzip', 'no-color', 'help'].includes(key);
-    out[key] = flag ? true : argv[++i];
+    const flag = ['dry-run', 'cms', 'update-wf', 'gzip', 'no-color', 'help', 'update-masters'].includes(key);
+    // Never let a value-taking arg swallow a following --flag (a missing
+    // allowlist entry once made `--update-masters --dry-run` eat the dry-run).
+    const next = argv[i + 1];
+    out[key] = flag || next === undefined || String(next).startsWith('--') ? true : argv[++i];
   }
   return out;
 }
@@ -97,6 +100,11 @@ const CFG = {
   gzip: !!ARGS.gzip || truthy(process.env.GZIP),
   nginxConf: ARGS['nginx-conf'] || process.env.NGINX_CONF || '',
 };
+// --tenant accepts a comma-separated list (e.g. mz,mz.ige,mz.igsae): the
+// state-level phases run ONCE against the shared state root; only the
+// city-scoped cms phase repeats for each additional tenant in the list.
+CFG.tenants = String(CFG.tenant).split(',').map((s) => s.trim()).filter(Boolean);
+CFG.tenant = CFG.tenants[0] || '';
 CFG.state = CFG.tenant.includes('.') ? CFG.tenant.split('.')[0] : CFG.tenant;
 // OAUTH_BASIC: legacy scripts disagreed (plaintext vs base64) — accept both.
 CFG.basic = /^[A-Za-z0-9+/]+=*$/.test(CFG.basicRaw) && !CFG.basicRaw.includes(':')
@@ -105,6 +113,10 @@ CFG.basic = /^[A-Za-z0-9+/]+=*$/.test(CFG.basicRaw) && !CFG.basicRaw.includes(':
 
 if (!CFG.base || !CFG.tenant) {
   console.error('Usage: node ccrs-migrate.cjs --host <BASE_URL> --tenant <TENANT> [options]   (--help for all options)');
+  process.exit(2);
+}
+if (CFG.tenants.some((t) => (t.includes('.') ? t.split('.')[0] : t) !== CFG.state)) {
+  console.error(`All --tenant entries must share one state root (got: ${CFG.tenants.join(', ')})`);
   process.exit(2);
 }
 
@@ -624,7 +636,7 @@ async function phasePgrMasters() {
     return record('pgr-masters', failed ? OUTCOME.FAILED : OUTCOME.PARTIAL, detail,
       empty.length ? 'MASTER_EMPTY_AFTER_SEED' : 'ROW_CREATE_FAILED', failures.slice(0, 6).join(' | ') || `Empty after seed: ${empty.join(', ')}`);
   }
-  return record('pgr-masters', created ? OUTCOME.OK : OUTCOME.SKIPPED, detail);
+  return record('pgr-masters', (created || updated) ? OUTCOME.OK : OUTCOME.SKIPPED, detail);
 }
 
 /* ═══════════════════════════ PHASE: landing ═══════════════════════════ */
@@ -713,11 +725,20 @@ async function cmsSearchAll(schemaCode, tenantId = CFG.state) {
 }
 const cmsUserInfo = () => ({ id: 1, uuid: 'cms-migration', userName: CFG.user, type: 'EMPLOYEE', tenantId: CFG.state, roles: [{ code: 'SUPERUSER', name: 'Super User', tenantId: CFG.state }] });
 
+// One summary row per tenant when a tenant LIST was passed.
+const CMS_PH = () => (CFG.tenants.length > 1 ? `cms@${CFG.tenant}` : 'cms');
+
 async function phaseCms() {
-  if (!CFG.cms) return record('cms', OUTCOME.SKIPPED, 'opt-in phase — pass --cms to run');
+  if (!CFG.cms) return record(CMS_PH(), OUTCOME.SKIPPED, 'opt-in phase — pass --cms to run');
   const city = CFG.tenant.includes('.') ? CFG.tenant : null;
-  if (!city) return record('cms', OUTCOME.FAILED, 'CMS workflow needs a city tenant (e.g. mz.igsae), got a state root', 'CMS_TENANT_REQUIRED',
-    'Re-run with --tenant <state.city> --phases cms --cms');
+  if (!city) {
+    // A state-root entry in a tenant list legitimately has no cms run of its
+    // own — the city entries that follow carry it. Only a SINGLE state-root
+    // tenant is an operator error.
+    if (CFG.tenants.length > 1) return record(CMS_PH(), OUTCOME.SKIPPED, 'state root — cms runs at the city tenants in the list');
+    return record('cms', OUTCOME.FAILED, 'CMS workflow needs a city tenant (e.g. mz.igsae), got a state root', 'CMS_TENANT_REQUIRED',
+      'Re-run with --tenant <state.city> --phases cms --cms');
+  }
   const failures = [];
   try {
     // 1: roles — at the STATE root and the CITY tenant. MDMS v1 role lookups
@@ -769,11 +790,11 @@ async function phaseCms() {
       info('workflow BusinessService already present — in-place diff/patch requires the legacy UPDATE_WF path; differences (if any) are not fatal');
     }
   } catch (e) {
-    return record('cms', OUTCOME.FAILED, `unexpected: ${e.message}`, 'CMS_UNEXPECTED', e.stack ? truncate(e.stack, 300) : null);
+    return record(CMS_PH(), OUTCOME.FAILED, `unexpected: ${e.message}`, 'CMS_UNEXPECTED', e.stack ? truncate(e.stack, 300) : null);
   }
-  if (CFG.dryRun) return record('cms', OUTCOME.SKIPPED, 'dry-run: plan printed above');
-  if (failures.length) return record('cms', OUTCOME.PARTIAL, `${failures.length} step(s) failed`, 'CMS_STEP_FAILED', failures.slice(0, 6).join(' | '));
-  return record('cms', OUTCOME.OK, 'roles, actions, grants, workflow ensured');
+  if (CFG.dryRun) return record(CMS_PH(), OUTCOME.SKIPPED, 'dry-run: plan printed above');
+  if (failures.length) return record(CMS_PH(), OUTCOME.PARTIAL, `${failures.length} step(s) failed`, 'CMS_STEP_FAILED', failures.slice(0, 6).join(' | '));
+  return record(CMS_PH(), OUTCOME.OK, 'roles, actions, grants, workflow ensured');
 }
 
 /* ═══════════════════════════ PHASE: banner ════════════════════════════ */
@@ -980,7 +1001,7 @@ async function phaseVerify() {
 (async () => {
   const started = Date.now();
   console.log(C.b(`\nCCRS unified migration${CFG.dryRun ? '  [DRY-RUN — no writes]' : ''}`));
-  console.log(C.d(`host=${CFG.base}  tenant=${CFG.tenant} (state=${CFG.state})  phases=${CFG.phases.join(',')}\n${'═'.repeat(64)}`));
+  console.log(C.d(`host=${CFG.base}  tenant=${CFG.tenants.join(',')} (state=${CFG.state})  phases=${CFG.phases.join(',')}\n${'═'.repeat(64)}`));
 
   const PIPELINE = [
     ['auth', async () => {
@@ -1002,13 +1023,28 @@ async function phaseVerify() {
 
   let n = 0;
   const enabled = PIPELINE.filter(([id]) => CFG.phases.includes(id));
+  // Tenant list: state-level phases run once (against tenants[0] / the state
+  // root); only the city-scoped cms phase repeats for the additional tenants.
+  const extraCmsTenants = CFG.tenants.length > 1 && CFG.phases.includes('cms') ? CFG.tenants.slice(1) : [];
+  const total = enabled.length + extraCmsTenants.length;
   for (const [id, fn] of enabled) {
-    section(++n, enabled.length, id);
+    section(++n, total, id);
     if (id !== 'auth' && !RI) { record(id, OUTCOME.SKIPPED, 'skipped: no authentication', 'NO_AUTH'); warn('skipped (auth failed)'); continue; }
     try {
       await fn();
     } catch (e) {
       record(id, OUTCOME.FAILED, `unexpected error: ${e.message}`, 'UNEXPECTED', e.stack ? truncate(e.stack, 400) : null);
+      bad(`unexpected: ${e.message}`);
+    }
+  }
+  for (const t of extraCmsTenants) {
+    CFG.tenant = t;
+    section(++n, total, `cms (${t})`);
+    if (!RI) { record(`cms@${t}`, OUTCOME.SKIPPED, 'skipped: no authentication', 'NO_AUTH'); warn('skipped (auth failed)'); continue; }
+    try {
+      await phaseCms();
+    } catch (e) {
+      record(`cms@${t}`, OUTCOME.FAILED, `unexpected error: ${e.message}`, 'UNEXPECTED', e.stack ? truncate(e.stack, 400) : null);
       bad(`unexpected: ${e.message}`);
     }
   }

--- a/docs/migration/ccrs-migrate.cjs
+++ b/docs/migration/ccrs-migrate.cjs
@@ -64,10 +64,20 @@ function parseArgs(argv) {
     if (!a.startsWith('--')) continue;
     const key = a.slice(2);
     const flag = ['dry-run', 'cms', 'update-wf', 'gzip', 'no-color', 'help', 'update-masters'].includes(key);
-    // Never let a value-taking arg swallow a following --flag (a missing
-    // allowlist entry once made `--update-masters --dry-run` eat the dry-run).
     const next = argv[i + 1];
-    out[key] = flag || next === undefined || String(next).startsWith('--') ? true : argv[++i];
+    if (flag) {
+      out[key] = true;
+    } else if (next === undefined || String(next).startsWith('--')) {
+      // Value-taking arg with no value (trailing typo, or followed by another
+      // --flag): leave it undefined so required-arg guards fail fast with the
+      // Usage message — never a boolean `true` leaking into CFG (e.g.
+      // CFG.tenant === 'true'), and never consuming the following --flag
+      // (a missing allowlist entry once made `--update-masters --dry-run`
+      // eat the dry-run). Boolean flags belong in the allowlist above.
+      out[key] = undefined;
+    } else {
+      out[key] = argv[++i];
+    }
   }
   return out;
 }
@@ -1026,6 +1036,9 @@ async function phaseVerify() {
   // Tenant list: state-level phases run once (against tenants[0] / the state
   // root); only the city-scoped cms phase repeats for the additional tenants.
   const extraCmsTenants = CFG.tenants.length > 1 && CFG.phases.includes('cms') ? CFG.tenants.slice(1) : [];
+  // The loop below mutates CFG.tenant per city — snapshot the full list now so
+  // the --report JSON reflects the run's real scope, not the last loop value.
+  const tenantList = CFG.tenants.join(',');
   const total = enabled.length + extraCmsTenants.length;
   for (const [id, fn] of enabled) {
     section(++n, total, id);
@@ -1063,7 +1076,7 @@ async function phaseVerify() {
   console.log(`${failedCount ? C.y(`${failedCount} phase(s) need attention`) : C.g('All phases clean')} · ${((Date.now() - started) / 1000).toFixed(1)}s · safe to re-run any time (completed work is skipped)`);
 
   if (CFG.report) {
-    fs.writeFileSync(CFG.report, JSON.stringify({ host: CFG.base, tenant: CFG.tenant, dryRun: CFG.dryRun, startedAt: new Date(started).toISOString(), results }, null, 2));
+    fs.writeFileSync(CFG.report, JSON.stringify({ host: CFG.base, tenant: tenantList, dryRun: CFG.dryRun, startedAt: new Date(started).toISOString(), results }, null, 2));
     console.log(C.d(`report written: ${CFG.report}`));
   }
   process.exit(Math.min(failedCount, 125));

--- a/docs/migration/enable-gzip.sh
+++ b/docs/migration/enable-gzip.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# enable-gzip.sh — guided, single-run gzip enablement for /digit-ui.
+#
+# RUN THIS ON THE BOX THAT SERVES THE SITE (the gzip phase edits that
+# machine's nginx — running it anywhere else edits the wrong machine).
+#
+#   bash enable-gzip.sh                      # host defaults to http://127.0.0.1
+#   HOST=http://localhost bash enable-gzip.sh
+#   OAUTH_USER=ADMIN OAUTH_PASS='secret' bash enable-gzip.sh   # non-default creds
+#
+# Safe by design: shows a dry-run plan and waits for Enter before writing;
+# the apply step itself takes a timestamped backup and auto-rolls-back if
+# `nginx -t` rejects the change. Re-running any number of times is safe.
+
+HOST="${HOST:-http://127.0.0.1}"
+RUNNER="$(dirname "$0")/ccrs-migrate.cjs"
+PROBE_URL="$HOST/digit-ui/index.js"
+
+say()  { printf '\n\033[1m%s\033[0m\n' "$*"; }
+pause(){ printf '\n'; read -r -p ">>> $1 — press Enter to continue (Ctrl+C to abort) "; }
+
+say "═══ CCRS gzip enablement — $(hostname) ═══"
+
+# ── 0. sanity: right machine? right files? ──────────────────────────────
+if [ ! -f "$RUNNER" ]; then
+  echo "✖ ccrs-migrate.cjs not found next to this script — run from the repo's docs/migration/ directory."
+  exit 1
+fi
+if [ -e /etc/nginx/sites-enabled/localhost ] && [ "$(hostname)" != "${EXPECTED_HOSTNAME:-}" ]; then
+  echo "⚠ This machine has an nginx site named 'localhost' — that usually means a LOCAL dev box."
+  read -r -p ">>> Type YES if you are sure this is the serving box for $HOST: " ok
+  [ "$ok" = "YES" ] || { echo "aborted."; exit 1; }
+fi
+
+# ── 1. baseline ─────────────────────────────────────────────────────────
+say "[1/5] Baseline — current state of $PROBE_URL"
+enc=$(curl -sI --max-time 15 -H 'Accept-Encoding: gzip' "$PROBE_URL" | grep -i '^content-encoding' | tr -d '\r')
+size=$(curl -s --max-time 60 -o /dev/null -w '%{size_download}' -H 'Accept-Encoding: gzip' --compressed "$PROBE_URL")
+echo "    content-encoding: ${enc:-'(none)'}"
+echo "    transferred:      ${size:-?} bytes"
+if [ -n "$enc" ]; then
+  echo "✔ gzip already active — nothing to do. (Re-run after a redeploy if it ever regresses.)"
+  exit 0
+fi
+echo "→ gzip is OFF (raw transfer). Proceeding will enable it."
+
+# ── 2. sudo prime (the runner shells out with sudo for nginx edits) ─────
+say "[2/5] Priming sudo (nginx edit + test + reload need it)"
+sudo -v || { echo "✖ sudo required"; exit 1; }
+
+# ── 3. dry-run plan ──────────────────────────────────────────────────────
+say "[3/5] Dry-run — plan only, no writes"
+node "$RUNNER" --host "$HOST" --tenant "${TENANT:-mz}" --phases auth,gzip --gzip --dry-run --no-color || {
+  echo "✖ dry-run failed (see AUTH_FAILED detail above: ENOTFOUND = wrong host; 400 = wrong creds — set OAUTH_USER/OAUTH_PASS; 500 JDBC = env DB down)"; exit 1; }
+pause "Apply the plan above (backup → insert gzip block → nginx -t → reload)"
+
+# ── 4. apply ─────────────────────────────────────────────────────────────
+say "[4/5] Applying"
+node "$RUNNER" --host "$HOST" --tenant "${TENANT:-mz}" --phases auth,gzip --gzip --no-color || { echo "✖ apply failed"; exit 1; }
+# keep runner backups out of nginx's include glob (they confuse re-runs and get include-loaded)
+sudo mkdir -p /etc/nginx/ccrs-backups
+sudo mv /etc/nginx/sites-enabled/*.ccrs-gzip.bak* /etc/nginx/ccrs-backups/ 2>/dev/null || true
+
+# ── 5. verify ────────────────────────────────────────────────────────────
+say "[5/5] Verify"
+enc=$(curl -sI --max-time 15 -H 'Accept-Encoding: gzip' "$PROBE_URL" | grep -i '^content-encoding' | tr -d '\r')
+cc=$(curl -sI --max-time 15 -H 'Accept-Encoding: gzip' "$PROBE_URL" | grep -i '^cache-control' | head -1 | tr -d '\r')
+size=$(curl -s --max-time 60 -o /dev/null -w '%{size_download}' -H 'Accept-Encoding: gzip' --compressed "$PROBE_URL")
+echo "    ${enc:-content-encoding: (none)}"
+echo "    ${cc:-cache-control: (none)}"
+echo "    transferred: ${size:-?} bytes"
+case "$enc" in
+  *gzip*) say "✔ SUCCESS — gzip active (expect ~2.1–2.5MB instead of ~8MB). Backups in /etc/nginx/ccrs-backups/." ;;
+  *)      say "✖ still not compressed — send the [4/5] output to the team; backup untouched in /etc/nginx/ccrs-backups/." ; exit 1 ;;
+esac


### PR DESCRIPTION
## What
1. **`--tenant` accepts a comma-separated list** (`mz,mz.ige,mz.igsae`): state-level phases run once against the shared state root; the city-scoped **cms** phase repeats for each additional tenant with per-tenant summary rows (`cms@mz.ige`). A state-root entry in a list is reported SKIPPED ("cms runs at the city tenants in the list") instead of failing the run; a single state-root tenant still errors; mixed state roots are rejected up front.
2. **Arg-parser hardening**: `--update-masters` registered as a boolean flag, and no value-taking arg can swallow a following `--flag` anymore (this made `--update-masters --dry-run` silently apply writes — caught live on mctd). Cosmetic: pgr-masters reports OK instead of SKIPPED when rows were updated.
3. **`enable-gzip.sh`**: guided single-run gzip enablement — wrong-machine guard, baseline probe (short-circuits when already enabled), dry-run plan with press-Enter confirmation, apply via the runner's backup/nginx-t/auto-rollback path, moves backups out of nginx's include glob, final verify.

## Verified (live, local env)
Tenant-list dry-run and real run (`cms@mz` SKIPPED / `cms@mz.ige` OK), DRY-RUN banner now shows after `--update-masters`, mixed-root rejection, single-root error preserved, gzip script guard + already-enabled short-circuit.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (twin of the moz PR — same commit cherry-picked)