### PR TITLE
feat(migration): --update-masters overwrites a differing bannerImage

### DIFF
--- a/docs/migration/ccrs-migrate.cjs
+++ b/docs/migration/ccrs-migrate.cjs
@@ -832,13 +832,22 @@ async function phaseBanner() {
   }
 
   // 3) PGR bannerImage: opt-in via --banner-url, and ONLY filled when empty —
-  //    an existing value is never overwritten (differences are reported).
+  //    an existing value is never overwritten (differences are reported)
+  //    UNLESS --update-masters is passed, which makes the flag value win.
   const pgr = byCode.get('PGR');
   const current = pgr && pgr.data ? pgr.data.bannerImage : undefined;
+  const wantOverwrite = !!(CFG.bannerUrl && current && current !== CFG.bannerUrl && CFG.updateMasters);
   if (!CFG.bannerUrl) {
     info(`PGR bannerImage: ${current ? truncate(current, 70) : '(not set)'} — pass --banner-url to fill when empty`);
+  } else if (wantOverwrite && CFG.dryRun) {
+    info(`dry-run: would UPDATE PGR bannerImage → ${CFG.bannerUrl} (--update-masters)`);
+  } else if (wantOverwrite) {
+    pgr.data.bannerImage = CFG.bannerUrl;
+    const r = await mdmsUpdate(SCHEMA, pgr);
+    if (!r.ok) failures.push(`bannerImage update: HTTP ${r.code} ${truncate(r.body, 80)}`);
+    else ok(`PGR bannerImage UPDATED = ${CFG.bannerUrl} (--update-masters)`);
   } else if (current) {
-    info(`PGR bannerImage already set — untouched${current === CFG.bannerUrl ? '' : ' (DIFFERS from --banner-url)'}`);
+    info(`PGR bannerImage already set — untouched${current === CFG.bannerUrl ? '' : ' (DIFFERS from --banner-url; pass --update-masters to overwrite)'}`);
   } else if (schemaDrift) {
     warn('cannot set bannerImage while the schema lacks the property');
   } else if (!pgr) {


### PR DESCRIPTION
## What
The banner phase filled `bannerImage` only when empty — rebranding an env (logo → landscape hero) reported `already set — untouched (DIFFERS from --banner-url)` and changed nothing. With `--update-masters`, the `--banner-url` value now wins: dry-run announces `would UPDATE`, real run rewrites the PGR citymodule row, re-run is a no-op. Without the flag, behavior is unchanged (and the message now hints at the flag).

## Verified (live, local)
`ccrs_logo.png` → `mozambique-landscape.jpg`: dry-run announcement, applied update, MDMS v1 read-back serves the new URL, idempotent re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (twin of the moz PR — same commit cherry-picked)