### PR TITLE
fix(migration): review follow-ups from #1328 (moz)

### DIFF
--- a/docs/migration/ccrs-migrate.cjs
+++ b/docs/migration/ccrs-migrate.cjs
@@ -64,10 +64,20 @@ function parseArgs(argv) {
     if (!a.startsWith('--')) continue;
     const key = a.slice(2);
     const flag = ['dry-run', 'cms', 'update-wf', 'gzip', 'no-color', 'help', 'update-masters'].includes(key);
-    // Never let a value-taking arg swallow a following --flag (a missing
-    // allowlist entry once made `--update-masters --dry-run` eat the dry-run).
     const next = argv[i + 1];
-    out[key] = flag || next === undefined || String(next).startsWith('--') ? true : argv[++i];
+    if (flag) {
+      out[key] = true;
+    } else if (next === undefined || String(next).startsWith('--')) {
+      // Value-taking arg with no value (trailing typo, or followed by another
+      // --flag): leave it undefined so required-arg guards fail fast with the
+      // Usage message — never a boolean `true` leaking into CFG (e.g.
+      // CFG.tenant === 'true'), and never consuming the following --flag
+      // (a missing allowlist entry once made `--update-masters --dry-run`
+      // eat the dry-run). Boolean flags belong in the allowlist above.
+      out[key] = undefined;
+    } else {
+      out[key] = argv[++i];
+    }
   }
   return out;
 }
@@ -1035,6 +1045,9 @@ async function phaseVerify() {
   // Tenant list: state-level phases run once (against tenants[0] / the state
   // root); only the city-scoped cms phase repeats for the additional tenants.
   const extraCmsTenants = CFG.tenants.length > 1 && CFG.phases.includes('cms') ? CFG.tenants.slice(1) : [];
+  // The loop below mutates CFG.tenant per city — snapshot the full list now so
+  // the --report JSON reflects the run's real scope, not the last loop value.
+  const tenantList = CFG.tenants.join(',');
   const total = enabled.length + extraCmsTenants.length;
   for (const [id, fn] of enabled) {
     section(++n, total, id);
@@ -1072,7 +1085,7 @@ async function phaseVerify() {
   console.log(`${failedCount ? C.y(`${failedCount} phase(s) need attention`) : C.g('All phases clean')} · ${((Date.now() - started) / 1000).toFixed(1)}s · safe to re-run any time (completed work is skipped)`);
 
   if (CFG.report) {
-    fs.writeFileSync(CFG.report, JSON.stringify({ host: CFG.base, tenant: CFG.tenant, dryRun: CFG.dryRun, startedAt: new Date(started).toISOString(), results }, null, 2));
+    fs.writeFileSync(CFG.report, JSON.stringify({ host: CFG.base, tenant: tenantList, dryRun: CFG.dryRun, startedAt: new Date(started).toISOString(), results }, null, 2));
     console.log(C.d(`report written: ${CFG.report}`));
   }
   process.exit(Math.min(failedCount, 125));


### PR DESCRIPTION
Moz twin of the two review fixes applied to #1328 (which is not yet merged on release; moz already merged #1327 so these land as a follow-up):
1. `parseArgs`: dangling value-args (trailing `--tenant`, or `--tenant --dry-run`) resolve `undefined` → clean Usage error, instead of boolean `true` leaking into CFG (e.g. `CFG.tenant === 'true'` slipping past the guard, or `bannerImage` being written as `true`).
2. `--report` + tenant list: the report's `tenant` field now records the full run scope (`mz,mz.ige`) instead of whatever city the per-tenant cms loop ended on.

Verified: Usage fail-fast for both dangling forms; `--update-masters --dry-run` still honors both flags; report field = `mz,mz.ige`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)