### PR TITLE
feat(ansible): cap Docker container logs at 1GB, max-size configurable

### DIFF
--- a/.github/workflows/local-setup-ci.yaml
+++ b/.github/workflows/local-setup-ci.yaml
@@ -71,6 +71,14 @@ jobs:
       - name: preflight — tracked example must pass
         run: python3 local-setup/scripts/preflight.py local-setup/ansible/inventory/host_vars/_example.yml
 
+      # Renders the daemon.json the deploy would write across a matrix of
+      # docker_log_* combinations and asserts three things per case: it parses
+      # as JSON, `dockerd --validate` accepts it, and max-size * max-file stays
+      # within docker_log_total_size. The last check is the point — dockerd
+      # will happily accept a config allowing 10GB per container.
+      - name: daemon.json render matrix
+        run: local-setup/scripts/test-daemon-json.sh
+
       # Cross-file contracts lint can't see: compose -f stack discipline,
       # :latest pin freeze, overlay-service existence.
       - name: infra contract tests

--- a/local-setup/ansible/inventory/group_vars/digit.yml
+++ b/local-setup/ansible/inventory/group_vars/digit.yml
@@ -159,7 +159,9 @@ docker_log_total_size: "1g"
 # Escape hatch: set docker_log_max_file to pin the file count directly. This
 # BYPASSES the derivation and the cap check, so the effective ceiling becomes
 # docker_log_max_size * docker_log_max_file. Only use it if you need Docker's
-# native two-knob behaviour.
+# native two-knob behaviour. It is a file COUNT, not a size — a unit on it
+# ('10m') is rejected by preflight. Uncommenting it and leaving the value blank
+# is treated as unset, so the derivation still applies.
 # docker_log_max_file: 10
 
 # On-target directory for digit-mcp when build_mcp is true. Vendored deploys

--- a/local-setup/ansible/inventory/group_vars/digit.yml
+++ b/local-setup/ansible/inventory/group_vars/digit.yml
@@ -142,6 +142,26 @@ docker_registry: 10.0.0.4:5000
 insecure_registries:
   - "{{ docker_registry }}"
 
+# Docker log rotation (daemon.json log-opts). Without these the json-file
+# driver grows a container's log without bound; a chatty JVM service can fill
+# the disk on a long-running tenant.
+#
+# Docker's real per-container ceiling is max-size * max-file, so these are not
+# independent. docker_log_total_size is the INVARIANT — the most any single
+# container may consume — and docker_log_max_size is the tunable slice size.
+# The file count is derived (total / max-size) so changing the slice size
+# cannot breach the cap. The deploy fails fast if max-size exceeds the total.
+#
+# 100m x 10 = 1g per container by default.
+docker_log_max_size: "100m"
+docker_log_total_size: "1g"
+#
+# Escape hatch: set docker_log_max_file to pin the file count directly. This
+# BYPASSES the derivation and the cap check, so the effective ceiling becomes
+# docker_log_max_size * docker_log_max_file. Only use it if you need Docker's
+# native two-knob behaviour.
+# docker_log_max_file: 10
+
 # On-target directory for digit-mcp when build_mcp is true. Vendored deploys
 # rsync CCRS digit-mcp/ here; a git mcp_repo_url clones/updates here instead.
 mcp_repo: "{{ digit_dir }}/digit-mcp"

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -320,20 +320,54 @@
         # NOTE: daemon-level log-opts apply to containers CREATED after the
         # daemon restart. Containers already running keep the settings they
         # were created with until they are recreated.
-        - name: Configure Docker daemon (log rotation + insecure registries)
-          copy:
-            dest: /etc/docker/daemon.json
-            content: >-
-              {{ ({'log-driver': 'json-file',
-                   'log-opts': {'max-size': docker_log_max_size,
-                                'max-file': docker_log_max_file_effective | string}}
-                  | combine(
-                      {'insecure-registries': insecure_registries}
-                      if (insecure_registries | default([]) | length > 0) else {}
-                    )) | to_nice_json }}
+        # Read any existing daemon.json so operator-set keys survive. This task
+        # used to be gated on insecure_registries being non-empty, so hosts on
+        # a TLS registry were never touched at all. Now that it always runs, a
+        # blind overwrite would silently discard whatever else is in the file —
+        # storage-driver, data-root, live-restore, registry-mirrors,
+        # default-address-pools. Merge instead: our keys win, everything else
+        # is preserved.
+        - name: "Docker daemon — read existing daemon.json (if any)"
+          ansible.builtin.slurp:
+            src: /etc/docker/daemon.json
+          register: daemon_json_existing
+          failed_when: false
+          changed_when: false
 
-            mode: '0644'
-          register: daemon_json
+        # An unparseable existing file makes from_json raise inside the
+        # template, which surfaces as a bare traceback. block/rescue turns it
+        # into something an operator can act on. The file is left untouched
+        # either way — we refuse to overwrite what we could not read.
+        - name: "Docker daemon — write merged daemon.json"
+          block:
+            - name: "Docker daemon — merge log rotation + insecure registries"
+              vars:
+                _existing: >-
+                  {{ (daemon_json_existing.content | default('') | b64decode | from_json)
+                     if (daemon_json_existing.content is defined
+                         and (daemon_json_existing.content | b64decode | trim | length) > 0)
+                     else {} }}
+                _ours: >-
+                  {{ {'log-driver': 'json-file',
+                      'log-opts': {'max-size': docker_log_max_size,
+                                   'max-file': docker_log_max_file_effective | string}}
+                     | combine(
+                         {'insecure-registries': insecure_registries}
+                         if (insecure_registries | default([]) | length > 0) else {}
+                       ) }}
+              ansible.builtin.copy:
+                dest: /etc/docker/daemon.json
+                content: "{{ _existing | combine(_ours, recursive=True) | to_nice_json }}\n"
+                mode: '0644'
+              register: daemon_json
+          rescue:
+            - name: "Docker daemon — existing daemon.json is unreadable"
+              ansible.builtin.fail:
+                msg: >-
+                  /etc/docker/daemon.json exists but could not be parsed as
+                  JSON, so the log-rotation settings were not merged in. Fix or
+                  remove that file and re-run — it has been left untouched
+                  rather than overwritten.
 
         - name: Restart docker if daemon.json changed
           service:

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -274,18 +274,66 @@
             enabled: yes
 
         # ==================== Docker Configuration ====================
-        # The Hetzner VPC registry at {{ docker_registry }} (egov-ci) hosts every
-        # custom-built DIGIT image (digit-mcp, sb35-rebuilt egov-* services)
-        # over plain HTTP. Without this entry Docker refuses to pull with
-        # `http: server gave HTTP response to HTTPS client`. Restart the
-        # daemon when the file changes so the new config takes effect.
-        - name: Configure Docker insecure-registries for VPC registry
+        # Log rotation. Docker's json-file driver keeps growing a container's
+        # log forever unless max-size/max-file are set, and a chatty JVM
+        # service can fill a disk over a long-running deploy.
+        #
+        # The per-container ceiling is max-size * max-file, so the two settings
+        # cannot be chosen independently. docker_log_total_size is the
+        # invariant (1g) and docker_log_max_size is the knob; the file count is
+        # derived so raising or lowering the slice size cannot breach the cap.
+        # Set docker_log_max_file explicitly only to override that derivation.
+        - name: "Docker logging — reject a max-size larger than the total cap"
+          vars:
+            _u: {k: 1024, m: 1048576, g: 1073741824}
+            _sz: "{{ (docker_log_max_size | regex_search('^([0-9.]+)', '\\1') | first | float)
+                     * _u[(docker_log_max_size | regex_search('([kmgKMG])[bB]?$', '\\1') | first | lower)] }}"
+            _tt: "{{ (docker_log_total_size | regex_search('^([0-9.]+)', '\\1') | first | float)
+                     * _u[(docker_log_total_size | regex_search('([kmgKMG])[bB]?$', '\\1') | first | lower)] }}"
+          ansible.builtin.fail:
+            msg: >-
+              docker_log_max_size ({{ docker_log_max_size }}) exceeds
+              docker_log_total_size ({{ docker_log_total_size }}). Docker keeps
+              at least one log file per container, so this would allow
+              {{ docker_log_max_size }} per container — above the cap.
+          when:
+            - docker_log_max_file is not defined
+            - (_sz | float) > (_tt | float)
+
+        - name: "Docker logging — derive max-file from the total cap"
+          vars:
+            _u: {k: 1024, m: 1048576, g: 1073741824}
+            _sz: "{{ (docker_log_max_size | regex_search('^([0-9.]+)', '\\1') | first | float)
+                     * _u[(docker_log_max_size | regex_search('([kmgKMG])[bB]?$', '\\1') | first | lower)] }}"
+            _tt: "{{ (docker_log_total_size | regex_search('^([0-9.]+)', '\\1') | first | float)
+                     * _u[(docker_log_total_size | regex_search('([kmgKMG])[bB]?$', '\\1') | first | lower)] }}"
+          ansible.builtin.set_fact:
+            docker_log_max_file_effective: >-
+              {{ docker_log_max_file | default([1, ((_tt | float) / (_sz | float)) | int] | max) }}
+
+        # daemon.json is written unconditionally now. It used to be gated on
+        # insecure_registries being non-empty, which meant hosts on a TLS
+        # registry never got a daemon.json at all — and would therefore never
+        # get log rotation either. insecure-registries is now merged in only
+        # when the list is non-empty, so TLS hosts still get a clean file.
+        #
+        # NOTE: daemon-level log-opts apply to containers CREATED after the
+        # daemon restart. Containers already running keep the settings they
+        # were created with until they are recreated.
+        - name: Configure Docker daemon (log rotation + insecure registries)
           copy:
             dest: /etc/docker/daemon.json
-            content: "{{ {'insecure-registries': insecure_registries | default([])} | to_nice_json }}\n"
+            content: >-
+              {{ ({'log-driver': 'json-file',
+                   'log-opts': {'max-size': docker_log_max_size,
+                                'max-file': docker_log_max_file_effective | string}}
+                  | combine(
+                      {'insecure-registries': insecure_registries}
+                      if (insecure_registries | default([]) | length > 0) else {}
+                    )) | to_nice_json }}
+
             mode: '0644'
           register: daemon_json
-          when: insecure_registries | default([]) | length > 0
 
         - name: Restart docker if daemon.json changed
           service:

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -283,6 +283,14 @@
         # invariant (1g) and docker_log_max_size is the knob; the file count is
         # derived so raising or lowering the slice size cannot breach the cap.
         # Set docker_log_max_file explicitly only to override that derivation.
+        #
+        # "Override" means a truthy value. `default()` without boolean=true only
+        # substitutes for an *undefined* variable, so an operator who uncomments
+        # the escape hatch in group_vars and leaves it blank (docker_log_max_file:
+        # -> YAML null) would be treated as having opted in: the cap guard below
+        # would skip, the derivation would pass None through, and daemon.json
+        # would get the literal "max-file": "None", which dockerd refuses. Both
+        # tasks therefore test the value, not its mere definedness.
         - name: "Docker logging — reject a max-size larger than the total cap"
           vars:
             _u: {k: 1024, m: 1048576, g: 1073741824}
@@ -297,7 +305,7 @@
               at least one log file per container, so this would allow
               {{ docker_log_max_size }} per container — above the cap.
           when:
-            - docker_log_max_file is not defined
+            - not (docker_log_max_file | default('', true))
             - (_sz | float) > (_tt | float)
 
         - name: "Docker logging — derive max-file from the total cap"
@@ -309,13 +317,13 @@
                      * _u[(docker_log_total_size | regex_search('([kmgKMG])[bB]?$', '\\1') | first | lower)] }}"
           ansible.builtin.set_fact:
             docker_log_max_file_effective: >-
-              {{ docker_log_max_file | default([1, ((_tt | float) / (_sz | float)) | int] | max) }}
+              {{ docker_log_max_file
+                 | default([1, ((_tt | float) / (_sz | float)) | int] | max, true) }}
 
         # daemon.json is written unconditionally now. It used to be gated on
         # insecure_registries being non-empty, which meant hosts on a TLS
         # registry never got a daemon.json at all — and would therefore never
-        # get log rotation either. insecure-registries is now merged in only
-        # when the list is non-empty, so TLS hosts still get a clean file.
+        # get log rotation either.
         #
         # NOTE: daemon-level log-opts apply to containers CREATED after the
         # daemon restart. Containers already running keep the settings they
@@ -347,14 +355,20 @@
                      if (daemon_json_existing.content is defined
                          and (daemon_json_existing.content | b64decode | trim | length) > 0)
                      else {} }}
+                # insecure-registries is always present, never conditionally
+                # omitted. combine() only adds and overwrites — a key that
+                # exists solely in _existing survives untouched. Omitting the
+                # key when the list is empty would therefore leave a stale
+                # entry on disk forever for exactly the host that needs it
+                # gone: one that deployed with the default non-empty list and
+                # later migrated to a TLS registry (insecure_registries: []).
+                # Writing [] clears it, because combine's list_merge defaults
+                # to replace.
                 _ours: >-
                   {{ {'log-driver': 'json-file',
                       'log-opts': {'max-size': docker_log_max_size,
-                                   'max-file': docker_log_max_file_effective | string}}
-                     | combine(
-                         {'insecure-registries': insecure_registries}
-                         if (insecure_registries | default([]) | length > 0) else {}
-                       ) }}
+                                   'max-file': docker_log_max_file_effective | string},
+                      'insecure-registries': insecure_registries | default([])} }}
               ansible.builtin.copy:
                 dest: /etc/docker/daemon.json
                 content: "{{ _existing | combine(_ours, recursive=True) | to_nice_json }}\n"

--- a/local-setup/scripts/preflight.py
+++ b/local-setup/scripts/preflight.py
@@ -268,7 +268,9 @@ def _parse_size(val):
     "('100'), a non-size ('abc') or an empty string raises an unhandled "
     "templating error mid-deploy; '0m' divides by zero. A max-size larger than "
     "the total silently allows more than the cap, because Docker always keeps "
-    "at least one log file per container.",
+    "at least one log file per container. docker_log_max_file is a file count, "
+    "not a size — a unit on it ('10m') reaches daemon.json and dockerd refuses "
+    "to start.",
 )
 def r_docker_log_rotation(cfg):
     raw_size = get(cfg, "docker_log_max_size")
@@ -295,14 +297,32 @@ def r_docker_log_rotation(cfg):
                f"({raw_total}). Docker keeps at least one file per container, so "
                f"the effective cap would be {raw_size}, not {raw_total}.")
 
-    if get(cfg, "docker_log_max_file") is not None and size and total:
-        eff = size * float(get(cfg, "docker_log_max_file"))
-        if eff > total:
-            yield (WARN,
-                   f"docker_log_max_file pins the count directly, so the cap is "
-                   f"{raw_size} x {get(cfg, 'docker_log_max_file')} = "
-                   f"{eff / 1048576:.0f} MB, above docker_log_total_size "
-                   f"({raw_total}).")
+    # A falsy value (null, 0, '') is treated as unset: the playbook derives the
+    # count with `default(..., true)`, which substitutes for those too. Anything
+    # truthy is an explicit override and has to be a positive integer — it is a
+    # file count, not a size, but it sits between two size-string vars in both
+    # this rule and group_vars, so 'docker_log_max_file: 10m' is an easy slip.
+    # Convert it defensively: an unguarded float() would kill preflight with a
+    # traceback instead of the actionable message this tool exists to print.
+    raw_count = get(cfg, "docker_log_max_file")
+    if raw_count:
+        try:
+            count = int(str(raw_count).strip())
+            if count < 1:
+                raise ValueError(raw_count)
+        except (TypeError, ValueError):
+            yield (FAIL,
+                   f"docker_log_max_file: {raw_count!r} is not a positive "
+                   f"integer. It is a file count, not a size — Docker rejects "
+                   f"anything else. Drop the unit, or unset it and let "
+                   f"docker_log_total_size derive the count.")
+        else:
+            eff = size * count if (size and total) else None
+            if eff is not None and eff > total:
+                yield (WARN,
+                       f"docker_log_max_file pins the count directly, so the "
+                       f"cap is {raw_size} x {count} = {eff / 1048576:.0f} MB, "
+                       f"above docker_log_total_size ({raw_total}).")
 
 
 # ── Self-test: each rule gets a firing and a non-firing case ────────────────
@@ -324,6 +344,24 @@ SELF_TEST_CASES = [
      {"docker_log_max_size": "500m", "docker_log_total_size": "1g",
       "docker_log_max_file": 10},
      {"docker-log-rotation"}),
+    ("max-file written as a size string fires (would crash on float())",
+     {"docker_log_max_size": "100m", "docker_log_total_size": "1g",
+      "docker_log_max_file": "10m"},
+     {"docker-log-rotation"}),
+    ("max-file that is not a number fires",
+     {"docker_log_max_size": "100m", "docker_log_total_size": "1g",
+      "docker_log_max_file": "abc"},
+     {"docker-log-rotation"}),
+    ("zero max-file fires",
+     {"docker_log_max_size": "100m", "docker_log_total_size": "1g",
+      "docker_log_max_file": -1},
+     {"docker-log-rotation"}),
+    ("max-file left blank is clean — the playbook derives it",
+     {"docker_log_max_size": "100m", "docker_log_total_size": "1g",
+      "docker_log_max_file": None}, set()),
+    ("max-file as a string integer is clean",
+     {"docker_log_max_size": "100m", "docker_log_total_size": "1g",
+      "docker_log_max_file": "10"}, set()),
     ("defaults are clean",
      {"docker_log_max_size": "100m", "docker_log_total_size": "1g"}, set()),
     ("uppercase units are clean",

--- a/local-setup/scripts/preflight.py
+++ b/local-setup/scripts/preflight.py
@@ -247,9 +247,90 @@ def report(path, findings, strict):
     return bad
 
 
+_SIZE_RE = re.compile(r"^(\d+(?:\.\d+)?)([kmg])b?$", re.IGNORECASE)
+_UNITS = {"k": 1024, "m": 1048576, "g": 1073741824}
+
+
+def _parse_size(val):
+    """Return bytes for '100m'/'1G'/'512k', or None if unparseable."""
+    if not isinstance(val, str):
+        return None
+    m = _SIZE_RE.match(val.strip())
+    if not m:
+        return None
+    return float(m.group(1)) * _UNITS[m.group(2).lower()]
+
+
+@rule(
+    "docker-log-rotation",
+    "docker_log_max_size / docker_log_total_size are fed straight into a Jinja "
+    "size parser that builds daemon.json log-opts. A value without a unit "
+    "('100'), a non-size ('abc') or an empty string raises an unhandled "
+    "templating error mid-deploy; '0m' divides by zero. A max-size larger than "
+    "the total silently allows more than the cap, because Docker always keeps "
+    "at least one log file per container.",
+)
+def r_docker_log_rotation(cfg):
+    raw_size = get(cfg, "docker_log_max_size")
+    raw_total = get(cfg, "docker_log_total_size")
+
+    for key, raw in (("docker_log_max_size", raw_size),
+                     ("docker_log_total_size", raw_total)):
+        if raw is None:
+            continue  # unset is fine — group_vars supplies the default
+        if _parse_size(raw) is None:
+            yield (FAIL,
+                   f"{key}: {raw!r} is not a valid Docker size. Use a number "
+                   f"with a k/m/g unit, e.g. '100m' or '1g'.")
+        elif _parse_size(raw) == 0:
+            yield (FAIL,
+                   f"{key}: {raw!r} is zero. Docker would reject it and the "
+                   f"file-count derivation divides by it.")
+
+    size = _parse_size(raw_size) if raw_size is not None else None
+    total = _parse_size(raw_total) if raw_total is not None else None
+    if size and total and size > total:
+        yield (FAIL,
+               f"docker_log_max_size ({raw_size}) exceeds docker_log_total_size "
+               f"({raw_total}). Docker keeps at least one file per container, so "
+               f"the effective cap would be {raw_size}, not {raw_total}.")
+
+    if get(cfg, "docker_log_max_file") is not None and size and total:
+        eff = size * float(get(cfg, "docker_log_max_file"))
+        if eff > total:
+            yield (WARN,
+                   f"docker_log_max_file pins the count directly, so the cap is "
+                   f"{raw_size} x {get(cfg, 'docker_log_max_file')} = "
+                   f"{eff / 1048576:.0f} MB, above docker_log_total_size "
+                   f"({raw_total}).")
+
+
 # ── Self-test: each rule gets a firing and a non-firing case ────────────────
 
 SELF_TEST_CASES = [
+    # ── docker log rotation ──
+    ("log size without a unit fires", {"docker_log_max_size": "100"},
+     {"docker-log-rotation"}),
+    ("log size that is not a size fires", {"docker_log_max_size": "abc"},
+     {"docker-log-rotation"}),
+    ("empty log size fires", {"docker_log_max_size": ""},
+     {"docker-log-rotation"}),
+    ("zero log size fires", {"docker_log_max_size": "0m"},
+     {"docker-log-rotation"}),
+    ("log max-size above the total cap fires",
+     {"docker_log_max_size": "2g", "docker_log_total_size": "1g"},
+     {"docker-log-rotation"}),
+    ("explicit max-file breaching the cap warns",
+     {"docker_log_max_size": "500m", "docker_log_total_size": "1g",
+      "docker_log_max_file": 10},
+     {"docker-log-rotation"}),
+    ("defaults are clean",
+     {"docker_log_max_size": "100m", "docker_log_total_size": "1g"}, set()),
+    ("uppercase units are clean",
+     {"docker_log_max_size": "100M", "docker_log_total_size": "1G"}, set()),
+    ("size equal to the total is clean",
+     {"docker_log_max_size": "1g", "docker_log_total_size": "1g"}, set()),
+    ("unset log vars are clean (group_vars supplies defaults)", {}, set()),
     # (description, cfg, expected rule ids that FAIL/WARN)
     ("fastpath without ack fires", {"db_fast_path": True,
       "bootstrap_secrets": {"elasticsearch_master_password": DUMP_MASTER_PASSWORD}},

--- a/local-setup/scripts/test-daemon-json.sh
+++ b/local-setup/scripts/test-daemon-json.sh
@@ -31,7 +31,11 @@ else
   echo
 fi
 
-render() {  # size total registries_json -> daemon.json on stdout
+# The var block below mirrors playbook-deploy.yml's daemon.json tasks. Keep the
+# two in step — a divergence here means the matrix stops testing the deploy.
+# EXISTING (optional) is the daemon.json already on the host, so the merge path
+# is exercised too, not just a first-ever write.
+render() {  # size total registries_json [max_file_extra_var] -> daemon.json on stdout
   cat > "$WORK/render.yml" <<'PLAYBOOK'
 - hosts: localhost
   gather_facts: false
@@ -41,41 +45,50 @@ render() {  # size total registries_json -> daemon.json on stdout
              * _u[(docker_log_max_size | regex_search('([kmgKMG])[bB]?$', '\\1') | first | lower)] }}"
     _tt: "{{ (docker_log_total_size | regex_search('^([0-9.]+)', '\\1') | first | float)
              * _u[(docker_log_total_size | regex_search('([kmgKMG])[bB]?$', '\\1') | first | lower)] }}"
-    _cnt: "{{ docker_log_max_file | default([1, ((_tt | float) / (_sz | float)) | int] | max) }}"
+    _cnt: "{{ docker_log_max_file
+              | default([1, ((_tt | float) / (_sz | float)) | int] | max, true) }}"
+    _existing: >-
+      {{ (lookup('file', existing) | from_json) if existing else {} }}
+    _ours: >-
+      {{ {'log-driver': 'json-file',
+          'log-opts': {'max-size': docker_log_max_size,
+                       'max-file': _cnt | string},
+          'insecure-registries': insecure_registries | default([])} }}
   tasks:
     - copy:
         dest: "{{ out }}"
-        content: >-
-          {{ ({'log-driver': 'json-file',
-               'log-opts': {'max-size': docker_log_max_size,
-                            'max-file': _cnt | string}}
-              | combine({'insecure-registries': insecure_registries}
-                        if (insecure_registries | length > 0) else {})) | to_nice_json }}
+        content: "{{ _existing | combine(_ours, recursive=True) | to_nice_json }}\n"
 PLAYBOOK
+  local extra=()
+  if [ -n "${4:-}" ]; then extra=(-e "$4"); fi
   ansible-playbook -i localhost, -c local "$WORK/render.yml" \
     -e "docker_log_max_size=$1" -e "docker_log_total_size=$2" \
     -e "{\"insecure_registries\": $3}" -e "out=$WORK/daemon.json" \
+    -e "existing=${EXISTING:-}" "${extra[@]}" \
     >"$WORK/ansible.log" 2>&1 || { sed -n "1,40p" "$WORK/ansible.log" >&2; return 1; }
   cat "$WORK/daemon.json"
 }
 
-check() {  # label size total registries
-  local label="$1" size="$2" total="$3" regs="$4"
+check() {  # label size total registries expected_max_file [extra_vars_json]
+  local label="$1" size="$2" total="$3" regs="$4" want="$5" extra="${6:-}"
   local json ok=1 detail=""
 
-  if ! json="$(render "$size" "$total" "$regs")"; then
+  if ! json="$(render "$size" "$total" "$regs" "$extra")"; then
     echo "FAIL  $label — render failed"; fail=$((fail+1)); return
   fi
 
-  # 1. valid JSON, and max-file must be a string
-  if ! detail="$(python3 - "$json" <<'PY'
+  # 1. valid JSON, max-file a string, and the count is the one we expect.
+  #    Asserting the count matters: a case whose extra vars silently fail to
+  #    apply otherwise renders the default and passes, testing nothing.
+  if ! detail="$(python3 - "$json" "$want" <<'PY'
 import json, sys
 d = json.loads(sys.argv[1])
 mf = d["log-opts"]["max-file"]
 assert isinstance(mf, str), f"max-file is {type(mf).__name__}, Docker requires a string"
+assert mf == sys.argv[2], f"max-file is {mf}, expected {sys.argv[2]}"
 print(f'max-size={d["log-opts"]["max-size"]} max-file={mf} registries={len(d.get("insecure-registries", []))}')
 PY
-  )"; then ok=0; detail="invalid JSON or bad max-file type"; fi
+  )"; then ok=0; detail="invalid JSON, bad max-file type, or wrong count"; fi
 
   # 2. dockerd accepts it
   if [ "$ok" = 1 ] && [ "$have_dockerd" = 1 ]; then
@@ -111,15 +124,65 @@ PY
 }
 
 echo "=== daemon.json render matrix ==="
-check "defaults (100m/1g) + insecure registry" 100m 1g '["10.0.0.4:5000"]'
-check "TLS registry — insecure-registries omitted" 100m 1g '[]'
-check "small slice (50m/1g) -> 20 files"          50m  1g '[]'
-check "large slice (250m/1g) -> 4 files"          250m 1g '[]'
-check "slice equals cap (1g/1g) -> 1 file"        1g   1g '[]'
-check "uppercase units (100M/1G)"                 100M 1G '[]'
-check "non-integer division (300m/1g) -> 3 files" 300m 1g '[]'
-check "sub-megabyte slice (512k/1g)"              512k 1g '[]'
-check "smaller cap (10m/500m)"                    10m  500m '[]'
+check "defaults (100m/1g) + insecure registry" 100m 1g '["10.0.0.4:5000"]' 10
+check "TLS registry — insecure-registries empty"  100m 1g '[]'   10
+check "small slice (50m/1g) -> 20 files"          50m  1g '[]'   20
+check "large slice (250m/1g) -> 4 files"          250m 1g '[]'   4
+check "slice equals cap (1g/1g) -> 1 file"        1g   1g '[]'   1
+check "uppercase units (100M/1G)"                 100M 1G '[]'   10
+check "non-integer division (300m/1g) -> 3 files" 300m 1g '[]'   3
+check "sub-megabyte slice (512k/1g)"              512k 1g '[]'   2048
+check "smaller cap (10m/500m)"                    10m  500m '[]' 50
+
+# The escape hatch, uncommented and left blank -> YAML null. Without
+# `default(..., true)` this renders "max-file": "None", which dockerd refuses.
+check "blank max-file falls back to the derivation" 100m 1g '[]' 10 \
+  '{"docker_log_max_file": null}'
+check "explicit max-file overrides the derivation"  100m 1g '[]' 5 \
+  '{"docker_log_max_file": 5}'
+
+# ── Merging into an existing daemon.json ────────────────────────────────────
+# Everything above renders onto an empty host. These start from a file already
+# on disk, which is where the merge can go wrong in ways a fresh write cannot.
+
+merge_check() {  # label existing_json assertion_py
+  local label="$1"
+  printf '%s' "$2" > "$WORK/existing.json"
+  local json
+  if ! json="$(EXISTING="$WORK/existing.json" render 100m 1g "${4:-[]}")"; then
+    echo "FAIL  $label — render failed"; fail=$((fail+1)); return
+  fi
+  if printf '%s' "$3" | python3 - "$json"; then
+    echo "ok    $label"; pass=$((pass+1))
+  else
+    echo "FAIL  $label"; fail=$((fail+1))
+  fi
+}
+
+# combine() only adds and overwrites; it never drops a key the overlay omits.
+# So insecure-registries has to be written unconditionally — omitting it when
+# the list is empty would strand the old value on a host migrating to TLS.
+merge_check "migrating to a TLS registry clears insecure-registries" \
+  '{"insecure-registries": ["10.0.0.4:5000"]}' '
+import json, sys
+d = json.loads(sys.argv[1])
+assert d.get("insecure-registries") == [], d.get("insecure-registries")
+'
+
+# The clobber this PR would otherwise have introduced by making the write
+# unconditional: operator keys the deploy knows nothing about must survive.
+merge_check "operator-set daemon keys survive the merge" \
+  '{"storage-driver": "overlay2", "data-root": "/mnt/docker", "live-restore": true,
+    "registry-mirrors": ["https://mirror.example"], "log-opts": {"max-size": "5m"}}' '
+import json, sys
+d = json.loads(sys.argv[1])
+assert d["storage-driver"] == "overlay2"
+assert d["data-root"] == "/mnt/docker"
+assert d["live-restore"] is True
+assert d["registry-mirrors"] == ["https://mirror.example"]
+assert d["log-opts"]["max-size"] == "100m", d["log-opts"]   # ours wins
+assert d["log-opts"]["max-file"] == "10"
+'
 
 echo
 echo "passed=$pass failed=$fail"

--- a/local-setup/scripts/test-daemon-json.sh
+++ b/local-setup/scripts/test-daemon-json.sh
@@ -70,10 +70,12 @@ PLAYBOOK
 }
 
 check() {  # label size total registries expected_max_file [extra_vars_json]
-  local label="$1" size="$2" total="$3" regs="$4" want="$5" extra="${6:-}"
+  # Not named `extra`: render() has a local array by that name, and shellcheck
+  # tracks the name globally — it would read this scalar as SC2178/SC2128.
+  local label="$1" size="$2" total="$3" regs="$4" want="$5" extra_vars="${6:-}"
   local json ok=1 detail=""
 
-  if ! json="$(render "$size" "$total" "$regs" "$extra")"; then
+  if ! json="$(render "$size" "$total" "$regs" "$extra_vars")"; then
     echo "FAIL  $label — render failed"; fail=$((fail+1)); return
   fi
 
@@ -145,7 +147,7 @@ check "explicit max-file overrides the derivation"  100m 1g '[]' 5 \
 # Everything above renders onto an empty host. These start from a file already
 # on disk, which is where the merge can go wrong in ways a fresh write cannot.
 
-merge_check() {  # label existing_json assertion_py
+merge_check() {  # label existing_json assertion_py [registries_json]
   local label="$1"
   printf '%s' "$2" > "$WORK/existing.json"
   local json

--- a/local-setup/scripts/test-daemon-json.sh
+++ b/local-setup/scripts/test-daemon-json.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Render the daemon.json that the deploy would write, across a matrix of
+# variable combinations, and check each one three ways:
+#
+#   1. it parses as JSON
+#   2. `dockerd --validate` accepts it (catches type errors the JSON parser
+#      cannot — e.g. max-file as an integer, which Docker rejects but JSON
+#      considers perfectly valid)
+#   3. the 1GB-per-container invariant actually holds: max-size * max-file
+#      must not exceed docker_log_total_size
+#
+# Check 3 is the one that matters. dockerd will happily accept a config that
+# allows 10GB per container; only arithmetic catches that.
+#
+# Usage: local-setup/scripts/test-daemon-json.sh
+# Requires: ansible-playbook, python3. dockerd is optional — checks 1 and 3
+# still run without it, and the script says so rather than silently skipping.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0; fail=0
+have_dockerd=0
+if command -v dockerd >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+  have_dockerd=1
+else
+  echo "NOTE: dockerd --validate unavailable (missing binary or passwordless sudo)."
+  echo "      JSON-parse and cap-invariant checks still run; daemon acceptance does not."
+  echo
+fi
+
+render() {  # size total registries_json -> daemon.json on stdout
+  cat > "$WORK/render.yml" <<'PLAYBOOK'
+- hosts: localhost
+  gather_facts: false
+  vars:
+    _u: {k: 1024, m: 1048576, g: 1073741824}
+    _sz: "{{ (docker_log_max_size | regex_search('^([0-9.]+)', '\\1') | first | float)
+             * _u[(docker_log_max_size | regex_search('([kmgKMG])[bB]?$', '\\1') | first | lower)] }}"
+    _tt: "{{ (docker_log_total_size | regex_search('^([0-9.]+)', '\\1') | first | float)
+             * _u[(docker_log_total_size | regex_search('([kmgKMG])[bB]?$', '\\1') | first | lower)] }}"
+    _cnt: "{{ docker_log_max_file | default([1, ((_tt | float) / (_sz | float)) | int] | max) }}"
+  tasks:
+    - copy:
+        dest: "{{ out }}"
+        content: >-
+          {{ ({'log-driver': 'json-file',
+               'log-opts': {'max-size': docker_log_max_size,
+                            'max-file': _cnt | string}}
+              | combine({'insecure-registries': insecure_registries}
+                        if (insecure_registries | length > 0) else {})) | to_nice_json }}
+PLAYBOOK
+  ansible-playbook -i localhost, -c local "$WORK/render.yml" \
+    -e "docker_log_max_size=$1" -e "docker_log_total_size=$2" \
+    -e "{\"insecure_registries\": $3}" -e "out=$WORK/daemon.json" \
+    >"$WORK/ansible.log" 2>&1 || { sed -n "1,40p" "$WORK/ansible.log" >&2; return 1; }
+  cat "$WORK/daemon.json"
+}
+
+check() {  # label size total registries
+  local label="$1" size="$2" total="$3" regs="$4"
+  local json ok=1 detail=""
+
+  if ! json="$(render "$size" "$total" "$regs")"; then
+    echo "FAIL  $label — render failed"; fail=$((fail+1)); return
+  fi
+
+  # 1. valid JSON, and max-file must be a string
+  if ! detail="$(python3 - "$json" <<'PY'
+import json, sys
+d = json.loads(sys.argv[1])
+mf = d["log-opts"]["max-file"]
+assert isinstance(mf, str), f"max-file is {type(mf).__name__}, Docker requires a string"
+print(f'max-size={d["log-opts"]["max-size"]} max-file={mf} registries={len(d.get("insecure-registries", []))}')
+PY
+  )"; then ok=0; detail="invalid JSON or bad max-file type"; fi
+
+  # 2. dockerd accepts it
+  if [ "$ok" = 1 ] && [ "$have_dockerd" = 1 ]; then
+    printf '%s' "$json" > "$WORK/candidate.json"
+    if ! sudo -n dockerd --validate --config-file="$WORK/candidate.json" >/dev/null 2>&1; then
+      ok=0; detail="dockerd rejected the config"
+    fi
+  fi
+
+  # 3. the cap invariant holds
+  if [ "$ok" = 1 ]; then
+    if ! python3 - "$json" "$total" <<'PY'
+import json, re, sys
+U = {"k": 1024, "m": 1048576, "g": 1073741824}
+def b(v):
+    m = re.match(r"^(\d+(?:\.\d+)?)([kmg])b?$", v.strip(), re.I)
+    return float(m.group(1)) * U[m.group(2).lower()]
+d = json.loads(sys.argv[1])
+eff = b(d["log-opts"]["max-size"]) * int(d["log-opts"]["max-file"])
+cap = b(sys.argv[2])
+if eff > cap:
+    print(f"effective {eff/1048576:.0f}MB exceeds cap {cap/1048576:.0f}MB", file=sys.stderr)
+    sys.exit(1)
+PY
+    then ok=0; detail="cap invariant breached"; fi
+  fi
+
+  if [ "$ok" = 1 ]; then
+    echo "ok    $label — $detail"; pass=$((pass+1))
+  else
+    echo "FAIL  $label — $detail"; fail=$((fail+1))
+  fi
+}
+
+echo "=== daemon.json render matrix ==="
+check "defaults (100m/1g) + insecure registry" 100m 1g '["10.0.0.4:5000"]'
+check "TLS registry — insecure-registries omitted" 100m 1g '[]'
+check "small slice (50m/1g) -> 20 files"          50m  1g '[]'
+check "large slice (250m/1g) -> 4 files"          250m 1g '[]'
+check "slice equals cap (1g/1g) -> 1 file"        1g   1g '[]'
+check "uppercase units (100M/1G)"                 100M 1G '[]'
+check "non-integer division (300m/1g) -> 3 files" 300m 1g '[]'
+check "sub-megabyte slice (512k/1g)"              512k 1g '[]'
+check "smaller cap (10m/500m)"                    10m  500m '[]'
+
+echo
+echo "passed=$pass failed=$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #1342.

Caps Docker container logs so a chatty service can't fill the disk on a
long-running tenant. The json-file driver grows a container's log without
bound unless `max-size`/`max-file` are set, and nothing set them.

## Design point worth a look before this leaves draft

Docker's real per-container ceiling is `max-size × max-file`, so the two
cannot be chosen independently and still guarantee a cap. I made the **total
the invariant** and derived the file count, so tuning the slice size can never
breach 1 GB:

| `docker_log_max_size` | derived `max-file` | effective |
|---|---|---|
| `100m` (default) | 10 | 1000 MB |
| `50m` | 20 | 1000 MB |
| `250m` | 4 | 1000 MB |

```yaml
docker_log_max_size: "100m"   # the tunable slice
docker_log_total_size: "1g"   # the invariant — per-container ceiling
# docker_log_max_file: 10     # escape hatch; bypasses derivation AND the cap check
```

If the team would rather have Docker's conventional two-knob interface
(`max-size` + `max-file` set independently, cap implicit), say so and I'll
flip which is primary — `docker_log_max_file` already exists as the override,
it would just become the documented path.

## Guard

`max-size` larger than the total is rejected at deploy time:

```
docker_log_max_size (2g) exceeds docker_log_total_size (1g). Docker keeps at
least one log file per container, so this would allow 2g per container —
above the cap.
```

Without it, `2g`/`1g` derives `max-file=1` and silently allows **double** the
intended cap. Found by testing the derivation, not by reading it.

## Pre-existing bug fixed in the same task

`daemon.json` was written only `when: insecure_registries | length > 0`. Hosts
on a TLS registry (`insecure_registries: []` — e.g. `maputo.yml.example`)
therefore **never got a daemon.json at all**, and would have silently missed
log rotation. It is now written unconditionally, with `insecure-registries`
merged in only when the list is non-empty.

## Verification

- playbook syntax-check passes (237 tasks)
- `daemon.json` renders correctly for: defaults + insecure registry, TLS
  registry (key omitted entirely), custom `max-size` at 50m and 250m
- the oversized guard fails with the message above, and is skipped when
  `docker_log_max_file` is set
- output is valid JSON with `max-file` as a **string** — Docker rejects an
  integer here
- a real container accepts `--log-opt max-size=100m --log-opt max-file=10`

Not verified: no run against a real tenant host. The rendering and arithmetic
were tested locally with `ansible-playbook`, not by deploying.

## Known limitation

Daemon-level `log-opts` apply to containers **created after** the daemon
restart. Containers already running keep the settings they were created with
until recreated, so on an existing tenant the cap takes effect gradually. The
playbook restarts Docker when `daemon.json` changes but does not force-recreate
the stack — that seemed too disruptive to do implicitly. Worth deciding whether
a follow-up should recreate, or whether gradual rollout is fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Testing (added in 9f68b0d0)

Three layers, because the failure modes are different in kind.

**1. `preflight.py` — bad values, before a deploy runs.** The size vars feed a
Jinja parser; testing it found inputs that crash mid-deploy with an opaque
templating error — `'100'` (no unit), `'abc'`, `''` — and `'0m'`, which
divides by zero. New `docker-log-rotation` rule rejects those plus
`max-size > total`, and warns when an explicit `docker_log_max_file` breaches
the cap. 10 self-test cases; suite is 26/26.

**2. `local-setup/scripts/test-daemon-json.sh` — the generated config.**
Renders what the deploy would write across 9 combinations, checking each:
parses as JSON with `max-file` a string; `dockerd --validate` accepts it; and
`max-size × max-file` stays within the cap. Wired into `local-setup-ci.yaml`.

The third check is the point — **dockerd accepts a config allowing 10GB per
container without complaint.** Confirmed by mutation testing: emitting
`max-file` as an int fails 9/9 on checks 1–2, and pinning `max-file=100` fails
8/9 on check 3 *while dockerd accepts every one of them*.

Matrix: defaults, TLS registry (key omitted), 50m/250m/1g slices, uppercase
units, non-integer division (300m → 3 files, 900MB, under cap), sub-megabyte
slices, smaller cap.

**3. Merge instead of overwrite — a clobber risk this PR itself introduced.**
The task wrote `daemon.json` with `copy:`, replacing the whole file. That was
survivable while it only ran `when: insecure_registries | length > 0`; making
it unconditional in 0abeb805 meant hosts previously never touched would now
have operator-set keys silently discarded — `storage-driver`, `data-root`,
`live-restore`, `registry-mirrors`, `default-address-pools`.

It now slurps and merges recursively, ours winning. Verified a file carrying
all four of those keeps them while `log-opts.max-size` updates 5m → 100m. An
unparseable existing file gets an actionable message via `block`/`rescue` and
is **left untouched** rather than overwritten.

## Caveats

- `dockerd --validate` accepts a path-bearing `insecure-registries` entry that
  the daemon then refuses to start on. Validation is necessary, not
  sufficient; the existing `group_vars` warning about that still stands.
- Still no run against a real tenant host. Everything above is rendering,
  arithmetic, and daemon-level config validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Docker daemon container log rotation defaults, capping both per-file and total retained log sizes.
* **Bug Fixes**
  * Deployment now preserves existing `daemon.json` settings while applying the validated logging policy.
  * Fails safely when `daemon.json` is not valid JSON, avoiding risky overwrites.
  * Ensures registry-related settings are applied consistently, including when the list is empty.
* **Tests**
  * Added preflight and CI validation to verify daemon rendering, JSON correctness, daemon validation, merge behavior, and log size invariants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->