### PR TITLE
feat(pgr): file/attachment upload on employee create-complaint

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/ActionUploadComponent.js
+++ b/digit-ui-esbuild/products/pgr/src/components/ActionUploadComponent.js
@@ -29,7 +29,11 @@ const ActionUploadComponent = ({ config, onSelect, formData }) => {
   const existing = formData?.[config?.key];
   const value = Array.isArray(existing) ? existing.map((d) => d?.fileStoreId).filter(Boolean) : [];
 
-  return (
+  // Optional width cap (populators.maxWidth) so the drop zone lines up with the
+  // capped input column when embedded in a full-page FormComposerV2 form.
+  // Absent in the action modal → unchanged there.
+  const maxWidth = config?.populators?.maxWidth;
+  const uploader = (
     <PgrFileUpload
       t={t}
       tenantId={tenantId}
@@ -39,6 +43,7 @@ const ActionUploadComponent = ({ config, onSelect, formData }) => {
       onSelect={(key, ids) => onSelect(key, ids.map(toDocument))}
     />
   );
+  return maxWidth ? <div style={{ maxWidth, width: "100%" }}>{uploader}</div> : uploader;
 };
 
 export default ActionUploadComponent;

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/CreateComplaint/createComplaintForm.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/CreateComplaint/createComplaintForm.js
@@ -359,13 +359,18 @@ const CreateComplaintForm = ({
     // `SelectedDocuments`. tenantId is the create tenant so files land on the
     // right (tenant-scoped) filestore. Optional — never gates submit.
     const uploadFieldConfig = {
-      inline: false,
+      // inline:true → same label-left / control-right row as the fields above,
+      // so the uploader's width:100% fills the capped control column instead of
+      // spanning the full card (was overflowing to the right).
+      inline: true,
       type: "component",
       component: "PGRActionUploadComponent",
       key: "SelectedDocuments",
       label: "CS_ADDCOMPLAINT_UPLOAD_PHOTO",
       isMandatory: false,
-      populators: { name: "SelectedDocuments", tenantId },
+      // maxWidth caps the drop zone to the same width as the text-input control
+      // column (600px) so its right edge lines up with the fields above.
+      populators: { name: "SelectedDocuments", tenantId, maxWidth: "600px" },
     };
 
     // Append the per-category dynamic fields (when present) AND the attachment

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/CreateComplaint/createComplaintForm.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/CreateComplaint/createComplaintForm.js
@@ -353,11 +353,28 @@ const CreateComplaintForm = ({
       };
     });
 
-    // Append the per-category dynamic fields to the "Additional details" section
-    // (the one holding the description). No-op when extFieldConfigs is empty.
+    // Attachment uploader — reuses the SAME component the assign/action modals
+    // use (PGRActionUploadComponent → PgrFileUpload: drag-drop, previews,
+    // 5MB/file), emitting already-shaped {documentType, fileStoreId} docs under
+    // `SelectedDocuments`. tenantId is the create tenant so files land on the
+    // right (tenant-scoped) filestore. Optional — never gates submit.
+    const uploadFieldConfig = {
+      inline: false,
+      type: "component",
+      component: "PGRActionUploadComponent",
+      key: "SelectedDocuments",
+      label: "CS_ADDCOMPLAINT_UPLOAD_PHOTO",
+      isMandatory: false,
+      populators: { name: "SelectedDocuments", tenantId },
+    };
+
+    // Append the per-category dynamic fields (when present) AND the attachment
+    // uploader (always) to the "Additional details" section holding the
+    // description. extFieldConfigs is empty for non-mapped tenants — the
+    // uploader still shows.
     const withExt = (updatedForm || []).map((section) =>
-      section?.head === "CS_COMPLAINT_DETAILS_ADDITIONAL_DETAILS" && extFieldConfigs.length
-        ? { ...section, body: [...section.body, ...extFieldConfigs] }
+      section?.head === "CS_COMPLAINT_DETAILS_ADDITIONAL_DETAILS"
+        ? { ...section, body: [...section.body, ...extFieldConfigs, uploadFieldConfig] }
         : section
     );
 
@@ -379,7 +396,7 @@ const CreateComplaintForm = ({
     }));
 
     return { ...baseConfig, form: withOptional };
-  }, [createComplaintConfig, serviceDefs, t, disabledFields, subType, loggedInUserDepartments, hasHierarchy, departmentGate, extFieldConfigs]);
+  }, [createComplaintConfig, serviceDefs, t, disabledFields, subType, loggedInUserDepartments, hasHierarchy, departmentGate, extFieldConfigs, tenantId]);
 
 
 

--- a/digit-ui-esbuild/products/pgr/src/utils/index.js
+++ b/digit-ui-esbuild/products/pgr/src/utils/index.js
@@ -217,6 +217,15 @@ export const formPayloadToCreateComplaint = (formData, tenantId, user, extOpts) 
     }
   }
 
+  // Attachments (parity with the citizen create flow + the action-modal
+  // uploader): SelectedDocuments is already an array of
+  // {documentType, fileStoreId, ...} shaped by ActionUploadComponent, so
+  // forward it verbatim as workflow.verificationDocuments. Additive — absent
+  // when no file was attached, so existing behaviour is unchanged.
+  if (Array.isArray(formData?.SelectedDocuments) && formData.SelectedDocuments.length > 0) {
+    complaint.workflow.verificationDocuments = formData.SelectedDocuments;
+  }
+
   // Additive: attach a FLAT top-level service.extendedAttributes when the
   // employee's tenant mapped to a category (extOpts.caseRelatedTo). Backward
   // compatible — existing 3-arg callers and non-mapped tenants are unchanged.


### PR DESCRIPTION
## What
Adds a file/document upload section to the **employee** create-complaint form (\`/employee/pgr/create-complaint\`), matching the citizen flow — so a Reception Officer can attach evidence when logging a complaint.

Reuses the **exact component the assign/action modals already use** (\`PGRActionUploadComponent\` → \`PgrFileUpload\`): drag-drop zone, preview cards, remove, 5 MB/file, ≤5 files. **No new component, no backend change** (the backend already accepts \`workflow.verificationDocuments\`).

## Changes (2 files, additive)
- **createComplaintForm.js** — inject a \`type:"component"\` field (\`PGRActionUploadComponent\`, key \`SelectedDocuments\`, \`populators.tenantId\` = create tenant) into the "Additional details" section. Always present, optional, never gates submit.
- **utils/index.js** — \`formPayloadToCreateComplaint\` forwards \`SelectedDocuments\` (already \`{documentType,fileStoreId}\`-shaped by the component) as \`workflow.verificationDocuments\` — the same contract the citizen create flow and action modals use. Absent when no file is attached, so existing behaviour is unchanged.

## Verified (live, local mz.ige employee)
Uploader renders after the witness/confidential fields as **"Carregar fotos / anexos (Opcional)"** with the drag-drop zone and file input (screenshot-confirmed). pt_PT label \`CS_ADDCOMPLAINT_UPLOAD_PHOTO\` upserted (was en_IN-only) — needs the same upsert on pilot/mctd.

QA note: worth one end-to-end pass (attach → submit → confirm the file shows on the complaint timeline/details), though the payload path is identical to the already-proven action-modal upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (twin of the moz PR — same commit cherry-picked)