### PR TITLE
fix(pgr): stop reverse-geocode infinite loop when nominatim is unreachable

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/GeoLocations.js
+++ b/digit-ui-esbuild/products/pgr/src/components/GeoLocations.js
@@ -116,6 +116,12 @@ const GeoLocations = ({ t, config, onSelect, formData }) => {
   const mapRef = useRef(null);
   const searchInputRef = useRef(null);
   const hasInitialized = useRef(false);
+  // Coordinate we've already attempted a reverse-geocode for. Guards the
+  // formData-driven effect below: a FAILED reverse call re-writes formData
+  // (lat/lng, no address), which re-fires the effect; without this guard it
+  // would re-fetch → fail → re-write → loop forever (thousands of nominatim
+  // hits, self-inflicted rate-limiting). One attempt per unique coordinate.
+  const geocodeAttemptRef = useRef(null);
 
   // Leaflet writes the stroke as an SVG DOM attribute, which doesn't resolve
   // CSS `var()`. Read the runtime accent at mount so the user-drawn polygon
@@ -190,13 +196,23 @@ const GeoLocations = ({ t, config, onSelect, formData }) => {
           setAddress(savedAddress);
           setSearchQuery(savedAddress);
         } else if (!address) {
-          fetchAddress(lat, lng);
+          // Only reverse-geocode a coordinate once. A failed lookup re-writes
+          // formData with no address, which re-enters this effect — without the
+          // guard that becomes an infinite fetch loop.
+          const key = `${lat},${lng}`;
+          if (geocodeAttemptRef.current !== key) {
+            geocodeAttemptRef.current = key;
+            fetchAddress(lat, lng);
+          }
         }
       }
     }
   }, [formData, config.key]);
 
   const fetchAddress = async (lat, lng) => {
+    // Record the attempt so the formData-driven effect won't re-fire this for
+    // the same coordinate after a failure (loop guard).
+    geocodeAttemptRef.current = `${lat},${lng}`;
     // QA #12: resolveWard ran OUTSIDE the try below — a bad point (turf throws
     // on non-finite coordinates) aborted fetchAddress before any onSelect, so
     // the click errored in the console and the location was never captured.


### PR DESCRIPTION
## What
GeoLocations reverse-geocode entered an **infinite loop** whenever the nominatim `/reverse` lookup failed (offline, blocked, or rate-limited). The formData-driven effect re-calls `fetchAddress` when the location value has no address yet; the failure path re-writes formData with lat/lng but no address → the effect re-fires → re-fetches → fails → repeats. Observed **1850+ requests and climbing**, self-inflicted rate-limiting, and the location step stuck "not loading" (grey map).

## Fix
A `geocodeAttemptRef` records the last coordinate a reverse-geocode was attempted for (set at the top of `fetchAddress`, checked in the effect) → each unique coordinate is looked up **at most once**. A genuine new pin drop (different coordinate) still fetches; a failure no longer spirals.

## Impact
Shared component — fixes both the **citizen** and **employee** PGR create-complaint location step. Relates to QA feedback #12/#13 (map/location errors).

## Verified (local)
Steady-state reverse calls dropped from continuous (1850+) to **0 over 18s idle**; the guard caps it at one call per unique pin position.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (twin of the moz PR — same commit cherry-picked)