### PR TITLE
fix(pgr): employee create — checkbox at bottom + aligned under uploader (moz)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/employee/CreateComplaint/createComplaintForm.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/CreateComplaint/createComplaintForm.js
@@ -299,6 +299,12 @@ const CreateComplaintForm = ({
       key: "isConfidential",
       type: "checkbox",
       isMandatory: false,
+      // withoutLabel drops the empty left label column and gives the field
+      // width:100% (FormComposerV2), so the checkbox + its own title sit at the
+      // LEFT edge instead of being indented into the right-hand control column.
+      // The checkbox renders its own label via populators.title, so no field
+      // label column is needed.
+      withoutLabel: true,
       populators: { name: "isConfidential", title: "PGR_EXT_IS_CONFIDENTIAL_LABEL" },
     });
     return cfgs;
@@ -382,13 +388,16 @@ const CreateComplaintForm = ({
       populators: { name: "SelectedDocuments", tenantId, maxWidth: "600px" },
     };
 
-    // Append the per-category dynamic fields (when present) AND the attachment
-    // uploader (always) to the "Additional details" section holding the
-    // description. extFieldConfigs is empty for non-mapped tenants — the
-    // uploader still shows.
+    // Append the per-category dynamic fields (when present) + the attachment
+    // uploader to the "Additional details" section. The uploader goes BEFORE
+    // the isConfidential checkbox (last element of extFieldConfigs) so the
+    // checkbox stays at the very bottom of the section.
+    const confIdx = extFieldConfigs.findIndex((c) => c.key === "isConfidential");
+    const extBeforeConf = confIdx >= 0 ? extFieldConfigs.slice(0, confIdx) : extFieldConfigs;
+    const extConfField = confIdx >= 0 ? extFieldConfigs.slice(confIdx) : [];
     const withExt = (updatedForm || []).map((section) =>
       section?.head === "CS_COMPLAINT_DETAILS_ADDITIONAL_DETAILS"
-        ? { ...section, body: [...section.body, ...extFieldConfigs, uploadFieldConfig] }
+        ? { ...section, body: [...section.body, ...extBeforeConf, uploadFieldConfig, ...extConfField] }
         : section
     );
 

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/CreateComplaint/createComplaintForm.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/CreateComplaint/createComplaintForm.js
@@ -299,12 +299,9 @@ const CreateComplaintForm = ({
       key: "isConfidential",
       type: "checkbox",
       isMandatory: false,
-      // withoutLabel drops the empty left label column and gives the field
-      // width:100% (FormComposerV2), so the checkbox + its own title sit at the
-      // LEFT edge instead of being indented into the right-hand control column.
-      // The checkbox renders its own label via populators.title, so no field
-      // label column is needed.
-      withoutLabel: true,
+      // Left edge sits in the control column (~x698), i.e. directly beneath the
+      // upload drop zone above it — NOT pulled to the extreme left. This is the
+      // default label-column layout, so no withoutLabel/inline override.
       populators: { name: "isConfidential", title: "PGR_EXT_IS_CONFIDENTIAL_LABEL" },
     });
     return cfgs;


### PR DESCRIPTION
## What
Follow-up to the merged #1346/#1347, which landed at only 2 commits (upload feature + width alignment). These two layout commits merged after that and were dropped when the branches auto-deleted — re-delivering them:

1. **Order** — the attachment uploader is placed **before** the `isConfidential` checkbox, so the **"Keep details confidential" checkbox sits at the very bottom** of the Additional-details section.
2. **Alignment** — the checkbox returns to the control-column position, lining up directly **beneath the upload drop zone** (not pulled to the extreme left).

Employee create-complaint form only; additive. Verified on local: uploader above checkbox; checkbox left edge ≈ upload-zone left edge (desktop).

Note: a residual ~30px drift remains on very narrow/mobile widths (the checkbox box centers within its 38px hit-area); closing that fully needs a scoped tweak to the shared checkbox atom — deliberately not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)