### PR TITLE
fix(ansible): force /bin/bash for shell tasks via ansible.cfg

### DIFF
--- a/local-setup/ansible/ansible.cfg
+++ b/local-setup/ansible/ansible.cfg
@@ -1,0 +1,9 @@
+[defaults]
+# ansible.builtin.shell tasks run via /bin/sh by default. On Debian/Ubuntu
+# controllers /bin/sh is dash, which rejects `set -o pipefail` — so every
+# task that starts with `set -o pipefail` fails immediately with
+# "set: Illegal option -o pipefail" (rc=2). deploy.sh runs from this
+# directory, so ansible loads this file and forces bash for all shell
+# tasks — pipefail (and other bashisms) then work uniformly, instead of
+# needing `args: { executable: /bin/bash }` pinned on each task.
+executable = /bin/bash


### PR DESCRIPTION
## Summary
`ansible.builtin.shell` runs via `/bin/sh` by default. On Debian/Ubuntu controllers `/bin/sh` is **dash**, which does not support `set -o pipefail`. Every task that starts with `set -o pipefail` therefore fails immediately with `set: Illegal option -o pipefail` (rc=2), aborting the play.

This is latent today because the nightly/redeploy fast path only does `docker compose up -d`, but a full `./deploy.sh <tenant>` converge on a dash host dies at the first such task. Observed live on a Bomet full converge: the play failed at **"Lay digit-ui from-source build into the container"** — the exact `set -eo pipefail` tar-sync task — with `failed=1`.

## Fix
`deploy.sh` runs `ansible-playbook` from `local-setup/ansible/`, so ansible loads an `ansible.cfg` placed there. This PR adds one with:

```ini
[defaults]
executable = /bin/bash
```

That makes ansible run **every** shell task under bash, so `pipefail` (and other bashisms) work uniformly.

## Relationship to #1344
[#1344](https://github.com/egovernments/Citizen-Complaint-Resolution-System/pull/1344) fixed this per-task on `master-2.12-fixes` by adding `args: { executable: /bin/bash }` to ~16 tasks. That is correct but has to be repeated on every new `pipefail` task. This global setting is the **root-cause fix** and covers future tasks automatically; the per-task pins remain harmless and can be removed as follow-up cleanup.

## Test plan
- [x] `ansible-playbook --syntax-check` still passes (config is `[defaults]` only).
- [x] On a dash-`/bin/sh` host (Bomet, Ubuntu 24.04), a full `./deploy.sh` converge that previously aborted at the pipefail tar-sync task runs to completion after this change (configurator build + digit-ui lay-in + validation all execute).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local setup reliability on Debian- and Ubuntu-based systems by ensuring Ansible tasks use Bash, preventing failures with supported shell options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->