### PR TITLE
fix(enc): disable embedded Flyway on egov-enc-service (external migrator owns schema)

### DIFF
--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -414,7 +414,14 @@ services:
       SPRING_FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
       SPRING_FLYWAY_BASELINE_ON_MIGRATE: 'true'
       SPRING_FLYWAY_VALIDATE_ON_MIGRATE: 'false'
-      SPRING_FLYWAY_ENABLED: 'true'
+      # Schema is owned by the external egov-enc-service-migration container
+      # (like every other service — egov-user/filestore/localization all set
+      # this false). enc was the lone service still running embedded Flyway;
+      # on an existing DB the app's Flyway then fights the migrator's history
+      # table (enc_schema_version vs the standard egov_enc_service_schema) and
+      # the service crash-loops on "relation enc_schema_version_pk already
+      # exists". Disable it so the external migrator is the single source.
+      SPRING_FLYWAY_ENABLED: 'false'
       SPRING_FLYWAY_TABLE: enc_schema_version
       SERVER_PORT: 1234
       OTEL_TRACES_EXPORTER: otlp


### PR DESCRIPTION
## Problem
`egov-enc-service` is the **only** core service still running **embedded Flyway** (`SPRING_FLYWAY_ENABLED: 'true'` in `docker-compose.egov-digit.yaml`). Every other service — egov-user, filestore, localization, workflow, mdms, pgr… — sets it `false` and lets its external `<svc>-migration` container own the schema.

On an **existing** database this is not just redundant, it **breaks the service**:
- the app's embedded Flyway uses history table `enc_schema_version`
- the external `egov-enc-service-migration` uses the DIGIT-standard `egov_enc_service_schema` (matching `egov_user_schema`, `egov_filestore_schema`, `boundary_service_schema`, …)

The v2.12 enc image reconciles toward the standard name, so the app boot-loops on:
```
ERROR: relation "enc_schema_version_pk" already exists
```
→ `egov-enc-service` goes unhealthy → **encryption/decryption is down for the whole stack** (500 on `/egov-enc-service/crypto/*`, logins fail).

## Fix
Set `SPRING_FLYWAY_ENABLED: 'false'` for `egov-enc-service`, so the external migrator is the single source of Flyway truth — exactly like every other service. (The `SPRING_FLYWAY_*` lines are left in place but inert, for symmetry with the other service blocks.)

## Verified on Bomet (Ubuntu, existing DB)
- `egovio/egov-enc-service:2.12-87e13fe` with embedded Flyway off → **boots clean**, no Flyway history-table conflict.
- Employee `POST /user/oauth/token` (which exercises enc **decryption** of stored PII with the box's existing asymmetric keys) → **200**.
- Keys untouched; the external `egov-enc-service-migration` (`egov-enc-service-db:2.12-87e13fe`, table `egov_enc_service_schema`) reports schema up to date.

## Note for existing installs
An existing box that ran embedded enc Flyway will have a history table named `enc_schema_version`. Align it to the standard once:
```sql
ALTER TABLE enc_schema_version RENAME TO egov_enc_service_schema;
```
Fresh installs are unaffected — the external migrator creates `egov_enc_service_schema` from the start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented encryption service startup failures caused by conflicting database schema migrations.
  * Ensured database migration history is managed consistently by the dedicated migration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->