### PR TITLE
fix(enc): wait for db-migrations before egov-enc-service starts

### DIFF
--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -397,6 +397,11 @@ services:
     depends_on:
       egov-mdms-service:
         condition: service_healthy
+      # Flyway is disabled for this service, so the external db-migrations
+      # container must finish before enc starts — otherwise it races an
+      # unmigrated schema on a cold start (matches egov-user et al.).
+      db-migrations:
+        condition: service_completed_successfully
       otel-collector:
         condition: service_started
     volumes:


### PR DESCRIPTION
## Context
Follow-up to #1354 (disabled embedded Flyway on `egov-enc-service`). That PR merged before this dependency was added, so it's a small standalone fix.

## Why
With `SPRING_FLYWAY_ENABLED: 'false'`, `egov-enc-service` no longer migrates its own schema — the external `db-migrations` container owns it. But enc's `depends_on` didn't wait for it, so on a **cold start** enc can boot against an unmigrated schema. Every other flyway-off service (`egov-user`, …) already declares this dependency.

## Change
```yaml
egov-enc-service:
  depends_on:
    egov-mdms-service: { condition: service_healthy }
    db-migrations: { condition: service_completed_successfully }   # added
    otel-collector: { condition: service_started }
```

Originally flagged by CodeRabbit on #1354; verified the same guard exists on `egov-user`. No behavior change on warm starts (db-migrations already completed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local service startup reliability by ensuring database migrations complete before the encryption service starts.
  * Clarified database schema readiness requirements for local deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->