### PR TITLE
fix(ui): QA feedback batch 2 — citizen/employee UX + localization fixes

### DIFF
--- a/backend/pgr-services/src/main/resources/application.properties
+++ b/backend/pgr-services/src/main/resources/application.properties
@@ -128,7 +128,9 @@ citizen.allowed.search.params=serviceRequestId,ids,mobileNumber,applicationStatu
 employee.allowed.search.params=serviceRequestId,ids,mobileNumber,serviceCode,applicationStatus,tenantId
 
 #Sources
-allowed.source=whatsapp,web,mobile,RB Bot
+# QA #26: Reception Officer channel-of-receipt codes (email/inperson/letter/
+# linhaverde) ride service.source — the employee create form sends them.
+allowed.source=whatsapp,web,mobile,RB Bot,email,inperson,letter,linhaverde
 
 #Migration
 persister.save.transition.wf.topic=save-wf-transitions

--- a/digit-ui-esbuild/packages/modules/core/src/components/TopBarSideBar/SideBar/CitizenSideBar.js
+++ b/digit-ui-esbuild/packages/modules/core/src/components/TopBarSideBar/SideBar/CitizenSideBar.js
@@ -418,8 +418,11 @@ export const CitizenSideBar = ({
   }));
 
   // QA #10: the city (tenant-name) and Modules entries are removed from the
-  // citizen hamburger — neither leads anywhere useful for a citizen here.
+  // CITIZEN hamburger — neither leads anywhere useful for a citizen here.
   // HOME stays, localized via COMMON_BOTTOM_NAVIGATION_HOME.
+  // The same drawer renders the EMPLOYEE mobile navigation (isEmployee) —
+  // EmployeeSideBar is desktop-only, so Modules is an employee's ONLY mobile
+  // nav surface. Both entries stay for employees.
   const hamburgerItems = [
     {
       label: "HOME",
@@ -428,6 +431,18 @@ export const CitizenSideBar = ({
       type: "custom",
       key: "home",
     },
+    ...(isEmployee
+      ? [
+          {
+            label: city,
+            value: city,
+            children: transformedSelectedCityData?.length > 0 ? transformedSelectedCityData : undefined,
+            type: "custom",
+            icon: "LocationCity",
+            key: "city",
+          },
+        ]
+      : []),
     {
       label: t("Language"),
       children: transformedLanguageData?.length > 0 ? transformedLanguageData : undefined,
@@ -445,6 +460,15 @@ export const CitizenSideBar = ({
         },
       ]
     : []),
+    ...(isEmployee
+      ? [
+          {
+            label: t("Modules"),
+            icon: "DriveFileMove",
+            children: transformedMenuItems,
+          },
+        ]
+      : []),
   ];
   return isMobile ? (
     <Hamburger

--- a/digit-ui-esbuild/packages/modules/core/src/components/TopBarSideBar/SideBar/CitizenSideBar.js
+++ b/digit-ui-esbuild/packages/modules/core/src/components/TopBarSideBar/SideBar/CitizenSideBar.js
@@ -417,22 +417,16 @@ export const CitizenSideBar = ({
     icon: "Language",
   }));
 
+  // QA #10: the city (tenant-name) and Modules entries are removed from the
+  // citizen hamburger — neither leads anywhere useful for a citizen here.
+  // HOME stays, localized via COMMON_BOTTOM_NAVIGATION_HOME.
   const hamburgerItems = [
     {
       label: "HOME",
       value: "HOME",
       icon: "Home",
-      // children: transformedSelectedCityData?.length>0 ? transformedSelectedCityData : undefined,
       type: "custom",
       key: "home",
-    },
-    {
-      label: city,
-      value: city,
-      children: transformedSelectedCityData?.length > 0 ? transformedSelectedCityData : undefined,
-      type: "custom",
-      icon: "LocationCity",
-      key: "city",
     },
     {
       label: t("Language"),
@@ -451,11 +445,6 @@ export const CitizenSideBar = ({
         },
       ]
     : []),
-    {
-      label: t("Modules"),
-      icon: "DriveFileMove",
-      children: transformedMenuItems,
-    },
   ];
   return isMobile ? (
     <Hamburger

--- a/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Home/UserProfile.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Home/UserProfile.js
@@ -100,7 +100,9 @@ const defaultValidationConfig = {
       // client-side with the localized name error instead of an unhandled
       // backend UserProfileUpdateDeniedException; O'Brien / Mary-Anne / John Jr.
       // / mobile-number names still pass.
-      name: "/^(?![ .'\\-])[a-zA-Z0-9 .'\\-]+$/i",
+      // QA #21: admit accented Latin letters (À-ÖØ-öø-ÿ) so Portuguese names
+      // like "Manhiça" / "Conceição" pass on both citizen and employee profiles.
+      name: "/^(?![ .'\\-])[a-zA-Z0-9À-ÖØ-öø-ÿ .'\\-]+$/i",
       // Fallback mobile pattern for when the MDMS ValidationConfigs master
       // isn't seeded for the tenant. Pull the tenant's pattern from
       // globalConfigs.CORE_MOBILE_CONFIGS (e.g. Mozambique "^8[0-9]{8}$")

--- a/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Login/SelectMobileNumber.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Login/SelectMobileNumber.js
@@ -74,12 +74,13 @@ const SelectMobileNumber = ({
     return v === key ? fallback : v;
   };
 
-  const headerText = config?.texts?.header
-    ? tr(config.texts.header, "Sign in")
-    : "Sign in";
-  const cardText = config?.texts?.cardText
-    ? tr(config.texts.cardText, "We'll send you a one-time password to verify your number.")
-    : null;
+  // QA #2: config.texts.* arrive ALREADY translated (Login/index.js runs every
+  // texts value through t() when building stepItems). Re-running them through
+  // tr() made the `v === key` guard always true for translated strings, so the
+  // hardcoded English fallback rendered even when the PT translation existed.
+  // Consume the pre-translated values directly.
+  const headerText = config?.texts?.header || "Sign in";
+  const cardText = config?.texts?.cardText || null;
 
   return (
     <V2LoginShell>
@@ -207,7 +208,7 @@ const SelectMobileNumber = ({
             disabled={!isMobileValid || !canSubmit}
             width="full"
           >
-            {tr(config?.texts?.nextText || "CS_COMMONS_NEXT", "Continue")}
+            {config?.texts?.nextText || tr("CS_COMMONS_NEXT", "Continue")}
           </V2Button>
         </form>
 

--- a/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Login/SelectMobileNumber.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Login/SelectMobileNumber.js
@@ -78,9 +78,13 @@ const SelectMobileNumber = ({
   // texts value through t() when building stepItems). Re-running them through
   // tr() made the `v === key` guard always true for translated strings, so the
   // hardcoded English fallback rendered even when the PT translation existed.
-  // Consume the pre-translated values directly.
-  const headerText = config?.texts?.header || "Sign in";
-  const cardText = config?.texts?.cardText || null;
+  // Consume the pre-translated values directly — but when a tenant/locale has
+  // a seeding gap, t() echoes the raw ALL_CAPS key back; treat that as missing
+  // so the English fallback still renders instead of the key.
+  const looksLikeRawKey = (s) => typeof s === "string" && /^[A-Z0-9_]{3,}$/.test(s.trim());
+  const pick = (v, fb) => (v && !looksLikeRawKey(v) ? v : fb);
+  const headerText = pick(config?.texts?.header, "Sign in");
+  const cardText = pick(config?.texts?.cardText, null);
 
   return (
     <V2LoginShell>
@@ -208,7 +212,7 @@ const SelectMobileNumber = ({
             disabled={!isMobileValid || !canSubmit}
             width="full"
           >
-            {config?.texts?.nextText || tr("CS_COMMONS_NEXT", "Continue")}
+            {pick(config?.texts?.nextText, null) || tr("CS_COMMONS_NEXT", "Continue")}
           </V2Button>
         </form>
 

--- a/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Login/SelectOtp.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Login/SelectOtp.js
@@ -185,9 +185,12 @@ const SelectOtp = ({
 
   // QA #2: config.texts.* arrive ALREADY translated (see SelectMobileNumber) —
   // and cardText is even composed with the phone number upstream. Consume
-  // directly instead of re-translating into the English fallback.
-  const headerText = config?.texts?.header || "Verify your number";
-  const cardText = config?.texts?.cardText || null;
+  // directly instead of re-translating into the English fallback; raw
+  // ALL_CAPS keys (unseeded tenant/locale) still fall back to English.
+  const looksLikeRawKey = (s) => typeof s === "string" && /^[A-Z0-9_]{3,}$/.test(s.trim());
+  const pick = (v, fb) => (v && !looksLikeRawKey(v) ? v : fb);
+  const headerText = pick(config?.texts?.header, "Verify your number");
+  const cardText = pick(config?.texts?.cardText, null);
 
   const isReady = otp?.length === OTP_LENGTH && canSubmit;
 
@@ -251,7 +254,7 @@ const SelectOtp = ({
             </p>
           ) : null}
           <V2Button type="submit" disabled={!isReady} width="full">
-            {config?.texts?.nextText || tr("CS_COMMONS_NEXT", "Continue")}
+            {pick(config?.texts?.nextText, null) || tr("CS_COMMONS_NEXT", "Continue")}
           </V2Button>
         </form>
 

--- a/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Login/SelectOtp.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Login/SelectOtp.js
@@ -183,12 +183,11 @@ const SelectOtp = ({
     );
   }
 
-  const headerText = config?.texts?.header
-    ? tr(config.texts.header, "Verify your number")
-    : "Verify your number";
-  const cardText = config?.texts?.cardText
-    ? tr(config.texts.cardText, "Enter the 6-digit code we just sent.")
-    : null;
+  // QA #2: config.texts.* arrive ALREADY translated (see SelectMobileNumber) —
+  // and cardText is even composed with the phone number upstream. Consume
+  // directly instead of re-translating into the English fallback.
+  const headerText = config?.texts?.header || "Verify your number";
+  const cardText = config?.texts?.cardText || null;
 
   const isReady = otp?.length === OTP_LENGTH && canSubmit;
 
@@ -252,7 +251,7 @@ const SelectOtp = ({
             </p>
           ) : null}
           <V2Button type="submit" disabled={!isReady} width="full">
-            {tr(config?.texts?.nextText || "CS_COMMONS_NEXT", "Continue")}
+            {config?.texts?.nextText || tr("CS_COMMONS_NEXT", "Continue")}
           </V2Button>
         </form>
 

--- a/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Login/SelectOtp.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Login/SelectOtp.js
@@ -190,7 +190,16 @@ const SelectOtp = ({
   const looksLikeRawKey = (s) => typeof s === "string" && /^[A-Z0-9_]{3,}$/.test(s.trim());
   const pick = (v, fb) => (v && !looksLikeRawKey(v) ? v : fb);
   const headerText = pick(config?.texts?.header, "Verify your number");
-  const cardText = pick(config?.texts?.cardText, null);
+  // cardText is composed upstream as "<translated> <mobileNumber>", so an
+  // unseeded key yields "CS_LOGIN_OTP_TEXT 2588…" — whole-string matching
+  // misses it. Test only the FIRST token; on a raw key fall back to the
+  // English default (the pre-existing tr() behaviour).
+  const cardTextValue = config?.texts?.cardText;
+  const cardText = cardTextValue
+    ? looksLikeRawKey(String(cardTextValue).trim().split(/\s+/)[0])
+      ? "Enter the 6-digit code we just sent."
+      : cardTextValue
+    : null;
 
   const isReady = otp?.length === OTP_LENGTH && canSubmit;
 

--- a/digit-ui-esbuild/packages/react-components/src/atoms/TopBar.js
+++ b/digit-ui-esbuild/packages/react-components/src/atoms/TopBar.js
@@ -45,13 +45,15 @@ const TopBar = ({
 
         <div className="RightMostTopBarOptions">
           {!hideNotificationIconOnSomeUrlsWhenNotLoggedIn ? changeLanguage : null}
-          {!hideNotificationIconOnSomeUrlsWhenNotLoggedIn ? (
+          {/* QA #16: the bell renders only when there ARE unread notifications.
+              When the count query is disabled (no notification service for the
+              tenant) notificationCountLoaded stays false, so the bell — and its
+              dead-end empty page — never shows. */}
+          {!hideNotificationIconOnSomeUrlsWhenNotLoggedIn && notificationCountLoaded && notificationCount > 0 ? (
             <div className="EventNotificationWrapper" onClick={onNotificationIconClick}>
-              {notificationCountLoaded && notificationCount ? (
-                <span>
-                  <p>{notificationCount}</p>
-                </span>
-              ) : null}
+              <span>
+                <p>{notificationCount}</p>
+              </span>
               <NotificationBell />
             </div>
           ) : null}

--- a/digit-ui-esbuild/products/pgr/src/Module.js
+++ b/digit-ui-esbuild/products/pgr/src/Module.js
@@ -10,6 +10,7 @@ import ComplaintHierarchyComponent from "./components/ComplaintHierarchyComponen
 import PGRDetails from "./pages/employee/PGRDetails";
 import TimelineWrapper from "./components/TimeLineWrapper";
 import AssigneeComponent from "./components/AssigneeComponent";
+import ChannelChipsComponent from "./components/ChannelChipsComponent";
 import PGRSearchInbox from "./pages/employee/PGRInbox";
 import CreateComplaint from "./pages/employee/CreateComplaint";
 import Response from "./components/Response";
@@ -107,6 +108,7 @@ const componentsToRegister = {
   PGRComplaintDetails: PGRDetails,
   PGRTimeLineWrapper: TimelineWrapper,
   PGRAssigneeComponent: AssigneeComponent,
+  PGRChannelChipsComponent: ChannelChipsComponent,
   PGRSearchInbox,
   PGRCreateComplaint: CreateComplaint,
   PGRResponse: Response,

--- a/digit-ui-esbuild/products/pgr/src/components/ChannelChipsComponent.js
+++ b/digit-ui-esbuild/products/pgr/src/components/ChannelChipsComponent.js
@@ -1,0 +1,98 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+// QA #26 — Canal de Recepção as a CHIP selector (radio-style pills with an
+// icon + label + check circle), rendered at the top of the employee create
+// form. The selected option's CODE rides service.source at submit
+// (email / inperson / letter / linhaverde — kept in pgr-services'
+// allowed.source list).
+const OPTIONS = [
+  { code: "email", name: "PGR_CHANNEL_EMAIL", icon: "mail" },
+  { code: "inperson", name: "PGR_CHANNEL_IN_PERSON", icon: "person" },
+  { code: "letter", name: "PGR_CHANNEL_LETTER", icon: "letter" },
+  { code: "linhaverde", name: "PGR_CHANNEL_LINHA_VERDE", icon: "phone" },
+];
+
+const ICONS = {
+  mail: (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+      <rect x="3" y="5" width="18" height="14" rx="2" />
+      <path d="m3 7 9 6 9-6" />
+    </svg>
+  ),
+  person: (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+      <circle cx="12" cy="8" r="4" />
+      <path d="M4 21c0-4 4-6 8-6s8 2 8 6" />
+    </svg>
+  ),
+  letter: (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+      <path d="M6 3h9l4 4v14a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1Z" />
+      <path d="M15 3v4h4" />
+      <path d="M9 12h6M9 16h6" />
+    </svg>
+  ),
+  phone: (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+      <path d="M5 4h4l2 5-2.5 1.5a11 11 0 0 0 5 5L15 13l5 2v4a2 2 0 0 1-2 2A16 16 0 0 1 3 6a2 2 0 0 1 2-2Z" />
+    </svg>
+  ),
+};
+
+const ACCENT = "var(--color-success, #00703C)";
+const ACCENT_BG = "var(--color-success-bg, #E8F3EE)";
+
+const ChannelChipsComponent = ({ config, onSelect, formData }) => {
+  const { t } = useTranslation();
+  const key = config?.key || "ReceivedChannel";
+  const selected = formData?.[key]?.code;
+
+  return (
+    <div style={{ marginBottom: "16px" }}>
+      <div role="radiogroup" aria-label={t("ES_CREATECOMPLAINT_RECEIVED_CHANNEL")} style={{ display: "flex", flexWrap: "wrap", gap: "12px" }}>
+        {OPTIONS.map((opt) => {
+          const isSelected = selected === opt.code;
+          return (
+            <button
+              key={opt.code}
+              type="button"
+              role="radio"
+              aria-checked={isSelected}
+              onClick={() => onSelect(key, { code: opt.code, name: opt.name })}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: "8px",
+                padding: "8px 14px",
+                borderRadius: "10px",
+                border: `1px solid ${isSelected ? ACCENT : "var(--color-border, #E0E0E0)"}`,
+                backgroundColor: isSelected ? ACCENT_BG : "var(--color-background-secondary, #F6F6F6)",
+                color: isSelected ? ACCENT : "var(--color-text-heading, #363636)",
+                fontWeight: 600,
+                fontSize: "0.875rem",
+                cursor: "pointer",
+                transition: "background-color 0.12s ease-out, border-color 0.12s ease-out",
+              }}
+            >
+              {ICONS[opt.icon]}
+              <span>{t(opt.name)}</span>
+              {isSelected ? (
+                <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden>
+                  <circle cx="12" cy="12" r="10" fill={ACCENT.startsWith("var") ? "#00703C" : ACCENT} />
+                  <path d="m8 12 3 3 5-6" fill="none" stroke="#fff" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              ) : (
+                <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden>
+                  <circle cx="12" cy="12" r="9" fill="none" stroke="var(--color-border, #C5C5C5)" strokeWidth="2" />
+                </svg>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default ChannelChipsComponent;

--- a/digit-ui-esbuild/products/pgr/src/components/ChannelChipsComponent.js
+++ b/digit-ui-esbuild/products/pgr/src/components/ChannelChipsComponent.js
@@ -59,8 +59,10 @@ const ChannelChipsComponent = ({ config, onSelect, formData }) => {
   const pick = (opt) => onSelect(key, { code: opt.code, name: opt.name });
 
   return (
-    <div style={{ width: "100%" }}>
-      <div role="radiogroup" aria-label={t("ES_CREATECOMPLAINT_RECEIVED_CHANNEL")} style={{ display: "flex", flexWrap: "wrap", gap: "10px" }}>
+    // Same width cap as the inputs below (the platform caps field controls at
+    // ~600px) so the chip row's right edge lines up with the mobile number.
+    <div style={{ width: "100%", maxWidth: "600px" }}>
+      <div role="radiogroup" aria-label={t("ES_CREATECOMPLAINT_RECEIVED_CHANNEL")} style={{ display: "flex", flexWrap: "wrap", gap: "8px" }}>
         {OPTIONS.map((opt) => {
           const isSelected = selected === opt.code;
           return (
@@ -79,14 +81,22 @@ const ChannelChipsComponent = ({ config, onSelect, formData }) => {
               style={{
                 display: "inline-flex",
                 alignItems: "center",
+                // Fill the control column: 140px basis + grow → all 4 chips
+                // share one row on desktop (4×140 + gaps < 600px cap) and the
+                // row's right edge lines up with the inputs below; on phones
+                // they wrap into a tidy 2×2 grid instead of overflowing.
+                flex: "1 1 140px",
+                minWidth: "140px",
+                whiteSpace: "nowrap",
+                justifyContent: "space-between",
                 gap: "8px",
-                padding: "8px 14px",
+                padding: "8px 10px",
                 borderRadius: "8px",
                 border: `1px solid ${isSelected ? ACCENT : "#E0E0E0"}`,
                 backgroundColor: isSelected ? ACCENT_BG : "#F7F7F7",
                 color: isSelected ? ACCENT : "#363636",
                 fontWeight: 600,
-                fontSize: "0.875rem",
+                fontSize: "0.8125rem",
                 lineHeight: 1,
                 cursor: "pointer",
                 userSelect: "none",
@@ -94,8 +104,10 @@ const ChannelChipsComponent = ({ config, onSelect, formData }) => {
                 transition: "background-color 0.12s ease-out, border-color 0.12s ease-out",
               }}
             >
-              {ICONS[opt.icon]}
-              <span>{t(opt.name)}</span>
+              <span style={{ display: "inline-flex", alignItems: "center", gap: "8px" }}>
+                {ICONS[opt.icon]}
+                <span>{t(opt.name)}</span>
+              </span>
               {isSelected ? (
                 <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden>
                   <circle cx="12" cy="12" r="10" style={{ fill: ACCENT }} />

--- a/digit-ui-esbuild/products/pgr/src/components/ChannelChipsComponent.js
+++ b/digit-ui-esbuild/products/pgr/src/components/ChannelChipsComponent.js
@@ -1,93 +1,109 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 
-// QA #26 — Canal de Recepção as a CHIP selector (radio-style pills with an
-// icon + label + check circle), rendered at the top of the employee create
-// form. The selected option's CODE rides service.source at submit
-// (email / inperson / letter / linhaverde — kept in pgr-services'
+// QA #26 — Canal de Recepção as a CHIP selector (card-style pills with an
+// icon + label + radio circle), rendered just above the mobile number on the
+// employee create form. The selected option's CODE rides service.source at
+// submit (email / inperson / letter / linhaverde — kept in pgr-services'
 // allowed.source list).
+//
+// Rendered as SPANs, not <button>: the platform stylesheet resets buttons
+// with !important rules that beat inline styles (same lesson as the admin
+// search chips), which flattened the pills into bare text.
 const OPTIONS = [
-  { code: "email", name: "PGR_CHANNEL_EMAIL", icon: "mail" },
+  // In Person first (product call) — it is also the pre-selected default.
   { code: "inperson", name: "PGR_CHANNEL_IN_PERSON", icon: "person" },
+  { code: "email", name: "PGR_CHANNEL_EMAIL", icon: "mail" },
   { code: "letter", name: "PGR_CHANNEL_LETTER", icon: "letter" },
   { code: "linhaverde", name: "PGR_CHANNEL_LINHA_VERDE", icon: "phone" },
 ];
 
 const ICONS = {
   mail: (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
       <rect x="3" y="5" width="18" height="14" rx="2" />
       <path d="m3 7 9 6 9-6" />
     </svg>
   ),
   person: (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
       <circle cx="12" cy="8" r="4" />
       <path d="M4 21c0-4 4-6 8-6s8 2 8 6" />
     </svg>
   ),
   letter: (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
       <path d="M6 3h9l4 4v14a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1Z" />
       <path d="M15 3v4h4" />
       <path d="M9 12h6M9 16h6" />
     </svg>
   ),
   phone: (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
       <path d="M5 4h4l2 5-2.5 1.5a11 11 0 0 0 5 5L15 13l5 2v4a2 2 0 0 1-2 2A16 16 0 0 1 3 6a2 2 0 0 1 2-2Z" />
     </svg>
   ),
 };
 
-const ACCENT = "var(--color-success, #00703C)";
-const ACCENT_BG = "var(--color-success-bg, #E8F3EE)";
+const ACCENT = "#00703C";
+const ACCENT_BG = "#E8F3EE";
 
 const ChannelChipsComponent = ({ config, onSelect, formData }) => {
   const { t } = useTranslation();
   const key = config?.key || "ReceivedChannel";
   const selected = formData?.[key]?.code;
 
+  const pick = (opt) => onSelect(key, { code: opt.code, name: opt.name });
+
   return (
-    <div style={{ marginBottom: "16px" }}>
-      <div role="radiogroup" aria-label={t("ES_CREATECOMPLAINT_RECEIVED_CHANNEL")} style={{ display: "flex", flexWrap: "wrap", gap: "12px" }}>
+    <div style={{ width: "100%" }}>
+      <div role="radiogroup" aria-label={t("ES_CREATECOMPLAINT_RECEIVED_CHANNEL")} style={{ display: "flex", flexWrap: "wrap", gap: "14px" }}>
         {OPTIONS.map((opt) => {
           const isSelected = selected === opt.code;
           return (
-            <button
+            <span
               key={opt.code}
-              type="button"
               role="radio"
               aria-checked={isSelected}
-              onClick={() => onSelect(key, { code: opt.code, name: opt.name })}
+              tabIndex={0}
+              onClick={() => pick(opt)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  pick(opt);
+                }
+              }}
               style={{
                 display: "inline-flex",
                 alignItems: "center",
-                gap: "8px",
-                padding: "8px 14px",
-                borderRadius: "10px",
-                border: `1px solid ${isSelected ? ACCENT : "var(--color-border, #E0E0E0)"}`,
-                backgroundColor: isSelected ? ACCENT_BG : "var(--color-background-secondary, #F6F6F6)",
-                color: isSelected ? ACCENT : "var(--color-text-heading, #363636)",
+                gap: "12px",
+                padding: "14px 20px",
+                borderRadius: "12px",
+                border: `1px solid ${isSelected ? ACCENT : "#E0E0E0"}`,
+                backgroundColor: isSelected ? ACCENT_BG : "#F7F7F7",
+                color: isSelected ? ACCENT : "#363636",
                 fontWeight: 600,
-                fontSize: "0.875rem",
+                fontSize: "1rem",
+                lineHeight: 1,
                 cursor: "pointer",
+                userSelect: "none",
+                boxShadow: "0 1px 3px rgba(0,0,0,0.08)",
                 transition: "background-color 0.12s ease-out, border-color 0.12s ease-out",
               }}
             >
               {ICONS[opt.icon]}
               <span>{t(opt.name)}</span>
               {isSelected ? (
-                <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden>
-                  <circle cx="12" cy="12" r="10" fill={ACCENT.startsWith("var") ? "#00703C" : ACCENT} />
+                <svg width="22" height="22" viewBox="0 0 24 24" aria-hidden>
+                  <circle cx="12" cy="12" r="10" fill={ACCENT} />
                   <path d="m8 12 3 3 5-6" fill="none" stroke="#fff" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
                 </svg>
               ) : (
-                <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden>
-                  <circle cx="12" cy="12" r="9" fill="none" stroke="var(--color-border, #C5C5C5)" strokeWidth="2" />
+                <svg width="22" height="22" viewBox="0 0 24 24" aria-hidden>
+                  <circle cx="12" cy="12" r="9" fill="#fff" stroke="#C5C5C5" strokeWidth="2" />
                 </svg>
               )}
-            </button>
+            </span>
           );
         })}
       </div>

--- a/digit-ui-esbuild/products/pgr/src/components/ChannelChipsComponent.js
+++ b/digit-ui-esbuild/products/pgr/src/components/ChannelChipsComponent.js
@@ -20,33 +20,36 @@ const OPTIONS = [
 
 const ICONS = {
   mail: (
-    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
       <rect x="3" y="5" width="18" height="14" rx="2" />
       <path d="m3 7 9 6 9-6" />
     </svg>
   ),
   person: (
-    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
       <circle cx="12" cy="8" r="4" />
       <path d="M4 21c0-4 4-6 8-6s8 2 8 6" />
     </svg>
   ),
   letter: (
-    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
       <path d="M6 3h9l4 4v14a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1Z" />
       <path d="M15 3v4h4" />
       <path d="M9 12h6M9 16h6" />
     </svg>
   ),
   phone: (
-    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
       <path d="M5 4h4l2 5-2.5 1.5a11 11 0 0 0 5 5L15 13l5 2v4a2 2 0 0 1-2 2A16 16 0 0 1 3 6a2 2 0 0 1 2-2Z" />
     </svg>
   ),
 };
 
-const ACCENT = "#00703C";
-const ACCENT_BG = "#E8F3EE";
+// Same theme tokens the rest of the PGR UI uses (StatusPill, links):
+// primary accent with the platform fallback chain; selected bg = the
+// theme's selected-pill tint.
+const ACCENT = "var(--color-primary-1, var(--color-primary-main, #c84c0e))";
+const ACCENT_BG = "var(--color-primary-selected-bg, #FFF4D7)";
 
 const ChannelChipsComponent = ({ config, onSelect, formData }) => {
   const { t } = useTranslation();
@@ -57,7 +60,7 @@ const ChannelChipsComponent = ({ config, onSelect, formData }) => {
 
   return (
     <div style={{ width: "100%" }}>
-      <div role="radiogroup" aria-label={t("ES_CREATECOMPLAINT_RECEIVED_CHANNEL")} style={{ display: "flex", flexWrap: "wrap", gap: "14px" }}>
+      <div role="radiogroup" aria-label={t("ES_CREATECOMPLAINT_RECEIVED_CHANNEL")} style={{ display: "flex", flexWrap: "wrap", gap: "10px" }}>
         {OPTIONS.map((opt) => {
           const isSelected = selected === opt.code;
           return (
@@ -76,30 +79,30 @@ const ChannelChipsComponent = ({ config, onSelect, formData }) => {
               style={{
                 display: "inline-flex",
                 alignItems: "center",
-                gap: "12px",
-                padding: "14px 20px",
-                borderRadius: "12px",
+                gap: "8px",
+                padding: "8px 14px",
+                borderRadius: "8px",
                 border: `1px solid ${isSelected ? ACCENT : "#E0E0E0"}`,
                 backgroundColor: isSelected ? ACCENT_BG : "#F7F7F7",
                 color: isSelected ? ACCENT : "#363636",
                 fontWeight: 600,
-                fontSize: "1rem",
+                fontSize: "0.875rem",
                 lineHeight: 1,
                 cursor: "pointer",
                 userSelect: "none",
-                boxShadow: "0 1px 3px rgba(0,0,0,0.08)",
+                boxShadow: "0 1px 2px rgba(0,0,0,0.05)",
                 transition: "background-color 0.12s ease-out, border-color 0.12s ease-out",
               }}
             >
               {ICONS[opt.icon]}
               <span>{t(opt.name)}</span>
               {isSelected ? (
-                <svg width="22" height="22" viewBox="0 0 24 24" aria-hidden>
-                  <circle cx="12" cy="12" r="10" fill={ACCENT} />
+                <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden>
+                  <circle cx="12" cy="12" r="10" style={{ fill: ACCENT }} />
                   <path d="m8 12 3 3 5-6" fill="none" stroke="#fff" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
                 </svg>
               ) : (
-                <svg width="22" height="22" viewBox="0 0 24 24" aria-hidden>
+                <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden>
                   <circle cx="12" cy="12" r="9" fill="#fff" stroke="#C5C5C5" strokeWidth="2" />
                 </svg>
               )}

--- a/digit-ui-esbuild/products/pgr/src/components/GeoLocations.js
+++ b/digit-ui-esbuild/products/pgr/src/components/GeoLocations.js
@@ -224,13 +224,25 @@ const GeoLocations = ({ t, config, onSelect, formData }) => {
   }, [formData, config.key]);
 
   const fetchAddress = async (lat, lng) => {
-    const ward = resolveWard(lat, lng, tenantBoundaries);
+    // QA #12: resolveWard ran OUTSIDE the try below — a bad point (turf throws
+    // on non-finite coordinates) aborted fetchAddress before any onSelect, so
+    // the click errored in the console and the location was never captured.
+    // A ward-resolution failure must never lose the location.
+    let ward = null;
+    try {
+      ward = resolveWard(lat, lng, tenantBoundaries);
+    } catch (e) {
+      console.error("Ward resolution failed:", e);
+    }
     setSelectedWard(ward?.code || null);
     try {
       const response = await fetch(
         `https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lng}&zoom=18&addressdetails=1${nominatimCountry}`,
         { headers: { "Accept-Language": nominatimLang } }
       );
+      // Rate-limited/blocked responses (429/403) return non-JSON bodies —
+      // bail to the coords-only fallback instead of throwing in json().
+      if (!response.ok) throw new Error(`reverse geocode HTTP ${response.status}`);
       const data = await response.json();
       if (data && data.display_name) {
         setAddress(data.display_name);

--- a/digit-ui-esbuild/products/pgr/src/components/TimeLineWrapper.js
+++ b/digit-ui-esbuild/products/pgr/src/components/TimeLineWrapper.js
@@ -4,7 +4,27 @@ import { PopUp, Timeline, TimelineMolecule, Loader } from '@egovernments/digit-u
 import { useMyContext } from "../utils/context";
 import { convertEpochFormateToDate } from '../utils';
 
-const TimelineWrapper = ({ businessId, isWorkFlowLoading, workflowData, labelPrefix = "" }) => {
+// QA #19 (employee timeline): mask, don't remove, people details.
+// Fixed-shape masks so real lengths don't leak: names keep the first letter of
+// each word ("Roberta Manhica" -> "R*** M***"), numbers keep the last 4 digits.
+const maskName = (name) => {
+  if (!name || name.length < 2) return name;
+  return String(name)
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0) + "***")
+    .join(" ");
+};
+const maskPhone = (phone) => {
+  if (!phone || phone.length < 4) return phone;
+  return "******" + String(phone).slice(-4);
+};
+const isCitizenActor = (person) =>
+  Array.isArray(person?.roles) && person.roles.some((r) => (r?.code || r) === "CITIZEN");
+
+// maskEmployeeContacts is passed by the EMPLOYEE details page only — the
+// citizen page never sets it, so citizen-side rendering is unchanged.
+const TimelineWrapper = ({ businessId, isWorkFlowLoading, workflowData, labelPrefix = "", maskEmployeeContacts = false }) => {
     const { state } = useMyContext();
     const { t } = useTranslation();
 
@@ -65,9 +85,13 @@ const TimelineWrapper = ({ businessId, isWorkFlowLoading, workflowData, labelPre
             const steps = workflowData.ProcessInstances.map((instance, index) => {
                 const assignee = instance?.assignes?.[0];
                 const personRecord = isAssigningAction(instance?.action) ? assignee : instance?.assigner;
-                const personLine = formatPerson(personRecord);
                 const mobile = isAssigningAction(instance?.action) ? assignee?.mobileNumber : instance?.assigner?.mobileNumber;
-                const contactLine = mobile ? `${t("ES_COMMON_CONTACT_DETAILS")}: ${mobile}` : null;
+                // QA #19: on the employee page, employee (non-citizen) actors'
+                // name and contact number are masked — visible shape, hidden value.
+                const maskThis = maskEmployeeContacts && personRecord && !isCitizenActor(personRecord);
+                const personLine = maskThis ? maskName(formatPerson(personRecord)) : formatPerson(personRecord);
+                const shownMobile = maskThis ? maskPhone(mobile) : mobile;
+                const contactLine = shownMobile ? `${t("ES_COMMON_CONTACT_DETAILS")}: ${shownMobile}` : null;
 
                 return {
                     label: t(`${labelPrefix}${instance?.action}`),

--- a/digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
+++ b/digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
@@ -278,12 +278,36 @@ export const CreateComplaintConfig = {
                 maxLength: 1000,
                 validation: {
                   required: true,
-                  // CCSD-1980: reject numbers-only / whitespace-only descriptions
-                  // (e.g. "000000000000") — require at least 3 letters (any
-                  // language). Non-empty is implied.
-                  pattern: /^(?=(?:[\s\S]*?\p{L}){3})[\s\S]+$/u,
+                  // CCSD-1956 + QA #27: 20-1000 chars AND at least 3 letters, so
+                  // "00000000000000000000" (20 digits) and all-whitespace are
+                  // both rejected. The single error message covers both rules.
+                  minLength: 20,
+                  pattern: /^(?=[\s\S]{20,1000}$)(?=(?:[\s\S]*?\p{L}){3})[\s\S]*$/u,
                 },
-                error: "CORE_COMMON_REQUIRED_ERRMSG",
+                error: "CS_DESC_MIN_CHARS",
+              },
+            },
+            {
+              // QA #26: how the complaint reached the Reception Officer
+              // (email / in-person / letter / linha verde). Optional; travels
+              // as extendedAttributes.receivedChannel and shows on the details
+              // pages via the generic extended-attributes card. The stored
+              // value is the human-readable option code — the viewer renders
+              // values verbatim by design.
+              isMandatory: false,
+              key: "ReceivedChannel",
+              type: "dropdown",
+              label: "ES_CREATECOMPLAINT_RECEIVED_CHANNEL",
+              disable: false,
+              populators: {
+                name: "ReceivedChannel",
+                optionsKey: "name",
+                options: [
+                  { code: "E-mail", name: "PGR_CHANNEL_EMAIL" },
+                  { code: "Presencial", name: "PGR_CHANNEL_IN_PERSON" },
+                  { code: "Carta", name: "PGR_CHANNEL_LETTER" },
+                  { code: "Linha Verde", name: "PGR_CHANNEL_LINHA_VERDE" },
+                ],
               },
             },
           ],

--- a/digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
+++ b/digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
@@ -8,16 +8,18 @@ export const CreateComplaintConfig = {
           head: "ES_CREATECOMPLAINT_PROVIDE_COMPLAINANT_DETAILS",
           body: [
             {
-              // QA #26 (product call): channel-of-receipt CHIP selector at the
-              // top of the form (above the mobile number). The selected CODE
-              // becomes service.source at submit (email / inperson / letter /
-              // linhaverde — kept in pgr-services' allowed.source list).
-              // Defaults to "inperson" via the mount-time draft seed.
+              // QA #26 (product call): channel-of-receipt CHIP selector just
+              // above the mobile number — label in the LEFT column, chips in
+              // the control column (inline row, same as the fields below).
+              // The selected CODE becomes service.source at submit (email /
+              // inperson / letter / linhaverde — kept in pgr-services'
+              // allowed.source list). "In Person" is first and pre-selected.
+              inline: true,
               isMandatory: false,
               type: "component",
               component: "PGRChannelChipsComponent",
               key: "ReceivedChannel",
-              withoutLabel: true,
+              label: "ES_CREATECOMPLAINT_RECEIVED_CHANNEL",
               populators: { name: "ReceivedChannel" },
             },
             {

--- a/digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
+++ b/digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
@@ -8,6 +8,19 @@ export const CreateComplaintConfig = {
           head: "ES_CREATECOMPLAINT_PROVIDE_COMPLAINANT_DETAILS",
           body: [
             {
+              // QA #26 (product call): channel-of-receipt CHIP selector at the
+              // top of the form (above the mobile number). The selected CODE
+              // becomes service.source at submit (email / inperson / letter /
+              // linhaverde — kept in pgr-services' allowed.source list).
+              // Defaults to "inperson" via the mount-time draft seed.
+              isMandatory: false,
+              type: "component",
+              component: "PGRChannelChipsComponent",
+              key: "ReceivedChannel",
+              withoutLabel: true,
+              populators: { name: "ReceivedChannel" },
+            },
+            {
               inline: true,
               label: "COMPLAINTS_COMPLAINANT_CONTACT_NUMBER",
               isMandatory: true,
@@ -285,28 +298,6 @@ export const CreateComplaintConfig = {
                   pattern: /^(?=[\s\S]{20,1000}$)(?=(?:[\s\S]*?\p{L}){3})[\s\S]*$/u,
                 },
                 error: "CS_DESC_MIN_CHARS",
-              },
-            },
-            {
-              // QA #26 (product call): how the complaint reached the Reception
-              // Officer. The selected CODE becomes the complaint's
-              // service.source (replacing the hardcoded "web") — codes must
-              // stay in pgr-services' allowed.source list. Not displayed on
-              // the details pages.
-              isMandatory: false,
-              key: "ReceivedChannel",
-              type: "dropdown",
-              label: "ES_CREATECOMPLAINT_RECEIVED_CHANNEL",
-              disable: false,
-              populators: {
-                name: "ReceivedChannel",
-                optionsKey: "name",
-                options: [
-                  { code: "email", name: "PGR_CHANNEL_EMAIL" },
-                  { code: "inperson", name: "PGR_CHANNEL_IN_PERSON" },
-                  { code: "letter", name: "PGR_CHANNEL_LETTER" },
-                  { code: "linhaverde", name: "PGR_CHANNEL_LINHA_VERDE" },
-                ],
               },
             },
           ],

--- a/digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
+++ b/digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
@@ -288,12 +288,11 @@ export const CreateComplaintConfig = {
               },
             },
             {
-              // QA #26: how the complaint reached the Reception Officer
-              // (email / in-person / letter / linha verde). Optional; travels
-              // as extendedAttributes.receivedChannel and shows on the details
-              // pages via the generic extended-attributes card. The stored
-              // value is the human-readable option code — the viewer renders
-              // values verbatim by design.
+              // QA #26 (product call): how the complaint reached the Reception
+              // Officer. The selected CODE becomes the complaint's
+              // service.source (replacing the hardcoded "web") — codes must
+              // stay in pgr-services' allowed.source list. Not displayed on
+              // the details pages.
               isMandatory: false,
               key: "ReceivedChannel",
               type: "dropdown",
@@ -303,10 +302,10 @@ export const CreateComplaintConfig = {
                 name: "ReceivedChannel",
                 optionsKey: "name",
                 options: [
-                  { code: "E-mail", name: "PGR_CHANNEL_EMAIL" },
-                  { code: "Presencial", name: "PGR_CHANNEL_IN_PERSON" },
-                  { code: "Carta", name: "PGR_CHANNEL_LETTER" },
-                  { code: "Linha Verde", name: "PGR_CHANNEL_LINHA_VERDE" },
+                  { code: "email", name: "PGR_CHANNEL_EMAIL" },
+                  { code: "inperson", name: "PGR_CHANNEL_IN_PERSON" },
+                  { code: "letter", name: "PGR_CHANNEL_LETTER" },
+                  { code: "linhaverde", name: "PGR_CHANNEL_LINHA_VERDE" },
                 ],
               },
             },

--- a/digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
+++ b/digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
@@ -16,6 +16,9 @@ export const CreateComplaintConfig = {
               // allowed.source list). "In Person" is first and pre-selected.
               inline: true,
               isMandatory: false,
+              // Always carries a value (defaults to inperson) — suppress the
+              // generic "(Optional)" label suffix.
+              noOptionalSuffix: true,
               type: "component",
               component: "PGRChannelChipsComponent",
               key: "ReceivedChannel",

--- a/digit-ui-esbuild/products/pgr/src/configs/PGRSearchInboxConfig.js
+++ b/digit-ui-esbuild/products/pgr/src/configs/PGRSearchInboxConfig.js
@@ -210,33 +210,11 @@ const PGRSearchInboxConfig = (visibilityEnabled = true) => {
 
                     },
                     fields: [
-                        // Legacy assigned-to-me / assigned-to-all radio,
-                        // restored only when the visibility tabs are OFF.
-                        ...(visibilityEnabled
-                            ? []
-                            : [
-                                  {
-                                      label: "",
-                                      type: "radio",
-                                      isMandatory: false,
-                                      disable: false,
-                                      populators: {
-                                          name: "assignedToMe",
-                                          options: [
-                                              { code: "ASSIGNED_TO_ME", name: "ASSIGNED_TO_ME" },
-                                              { code: "ASSIGNED_TO_ALL", name: "ASSIGNED_TO_ALL" },
-                                          ],
-                                          optionsKey: "name",
-                                          styles: {
-                                              "gap": "1rem",
-                                              "flexDirection": "column"
-                                          },
-                                          innerStyles: {
-                                              "display": "flex"
-                                          }
-                                      },
-                                  },
-                              ]),
+                        // QA #18: the assigned-to-me / assigned-to-all radio is
+                        // gone from the left panel. The defaultValues block above
+                        // keeps assignedToMe=ASSIGNED_TO_ALL, and preProcess only
+                        // narrows to the logged-in user on ASSIGNED_TO_ME — so
+                        // with no control the inbox always searches ALL.
                         {
 
                             label: "CS_COMPLAINT_DETAILS_COMPLAINT_SUBTYPE",

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintDetails.js
@@ -207,31 +207,13 @@ const ComplaintDetailsPage = () => {
 
   const geoLocation = complaintDetails?.service?.address?.geoLocation;
   const address = complaintDetails?.service?.address;
-  // QA #31: complaints store only the lowercase boundary CODE (name is null),
-  // so the Endereço line rendered raw codes like "zumbo". Resolve through the
-  // boundary localization (module rainmaker-boundary-*) when loaded; otherwise
-  // title-case the code — always readable, never a raw identifier.
-  const localityLabel = (() => {
-    const loc = address?.locality;
-    if (!loc) return null;
-    if (loc.name) return loc.name;
-    if (!loc.code) return null;
-    const viaT = t(loc.code);
-    if (viaT && viaT !== loc.code) return viaT;
-    // QA #25/#31 (sheet v4): some environments prefix boundary codes with the
-    // tenant/hierarchy chain (e.g. "MZ_IGE_ADMIN_hungaro") — strip the leading
-    // ALL-CAPS segments so the citizen sees "Hungaro", not the raw chain.
-    // Bare codes ("zumbo", "vila_de_sena") pass through untouched.
-    const bare = String(loc.code).replace(/^(?:[A-Z0-9]+_)+(?=[^A-Z])/, "");
-    return bare
-      .replace(/[_-]+/g, " ")
-      .replace(/\b\w/g, (c) => c.toUpperCase());
-  })();
+  // QA #31/#25: show ONLY what the complainant typed — no boundary code, no
+  // tenant/authority name (those rendered as raw identifiers like
+  // "MZ_IGE_ADMIN_hungaro" or appended "…, IGSAE").
   const displayAddress = [
     address?.buildingName,
     address?.street,
     address?.landmark,
-    localityLabel,
     address?.pincode,
   ]
     .filter(Boolean)

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintDetails.js
@@ -207,11 +207,26 @@ const ComplaintDetailsPage = () => {
 
   const geoLocation = complaintDetails?.service?.address?.geoLocation;
   const address = complaintDetails?.service?.address;
+  // QA #31: complaints store only the lowercase boundary CODE (name is null),
+  // so the Endereço line rendered raw codes like "zumbo". Resolve through the
+  // boundary localization (module rainmaker-boundary-*) when loaded; otherwise
+  // title-case the code — always readable, never a raw identifier.
+  const localityLabel = (() => {
+    const loc = address?.locality;
+    if (!loc) return null;
+    if (loc.name) return loc.name;
+    if (!loc.code) return null;
+    const viaT = t(loc.code);
+    if (viaT && viaT !== loc.code) return viaT;
+    return String(loc.code)
+      .replace(/[_-]+/g, " ")
+      .replace(/\b\w/g, (c) => c.toUpperCase());
+  })();
   const displayAddress = [
     address?.buildingName,
     address?.street,
     address?.landmark,
-    address?.locality?.name || address?.locality?.code,
+    localityLabel,
     address?.pincode,
   ]
     .filter(Boolean)

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintDetails.js
@@ -218,7 +218,12 @@ const ComplaintDetailsPage = () => {
     if (!loc.code) return null;
     const viaT = t(loc.code);
     if (viaT && viaT !== loc.code) return viaT;
-    return String(loc.code)
+    // QA #25/#31 (sheet v4): some environments prefix boundary codes with the
+    // tenant/hierarchy chain (e.g. "MZ_IGE_ADMIN_hungaro") — strip the leading
+    // ALL-CAPS segments so the citizen sees "Hungaro", not the raw chain.
+    // Bare codes ("zumbo", "vila_de_sena") pass through untouched.
+    const bare = String(loc.code).replace(/^(?:[A-Z0-9]+_)+(?=[^A-Z])/, "");
+    return bare
       .replace(/[_-]+/g, " ")
       .replace(/\b\w/g, (c) => c.toUpperCase());
   })();

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintsList.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintsList.js
@@ -57,9 +57,20 @@ const TONE_STYLES = {
 function StatusPill({ status, t }) {
   const tone = statusToTone(status);
   const palette = TONE_STYLES[tone];
-  const labelKey = `CS_COMMON_${palette.label}`;
-  const translated = t(labelKey);
-  const label = translated === labelKey ? palette.label : translated.toUpperCase();
+  // QA #17: label with the FULL workflow status (same CS_COMMON_<status> key
+  // the details page header uses) so the card and the opened complaint always
+  // agree. The 3-way tone bucket now drives the pill COLOR only. Falls back to
+  // the bucket label when the status key isn't localized.
+  const statusKey = `CS_COMMON_${status}`;
+  const translatedStatus = t(statusKey);
+  let label;
+  if (translatedStatus !== statusKey) {
+    label = translatedStatus.toUpperCase();
+  } else {
+    const labelKey = `CS_COMMON_${palette.label}`;
+    const translated = t(labelKey);
+    label = translated === labelKey ? palette.label : translated.toUpperCase();
+  }
   return (
     <span
       style={{
@@ -88,11 +99,6 @@ function ComplaintRow({ data, onClick, t, typeCode, typeName }) {
   const dateStr = auditDetails?.createdTime
     ? Digit.DateUtils.ConvertTimestampToDate(auditDetails.createdTime)
     : "";
-  const stageKey = `${LOCALIZATION_KEY.CS_COMMON}_${applicationStatus}`;
-  const stage = (() => {
-    const v = t(stageKey);
-    return v === stageKey ? applicationStatus : v;
-  })();
   return (
     <Card
       role="button"
@@ -157,7 +163,9 @@ function ComplaintRow({ data, onClick, t, typeCode, typeName }) {
               {serviceRequestId}
             </span>
             {dateStr ? <span>{dateStr}</span> : null}
-            {stage && stage !== title ? <span>{stage}</span> : null}
+            {/* QA #17: bottom state line removed — the title pill now carries
+                the full workflow status, so this duplicate (and previously
+                contradictory) line is gone. */}
           </div>
         </div>
         <ChevronRight

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
@@ -245,7 +245,13 @@ function mapFormDataToRequest(formData: FormData, tenantId: string, user: any) {
       rowVersion: 1,
       address: {
         landmark: validateString(formData?.landmark),
-        buildingName: "",
+        // Product call (sheet-v4 review): the typed complainant address ALSO
+        // travels as the complaint's plain address so the details Address row
+        // can show it (the extendedAttributes copy is withheld by the backend
+        // DataSecurity pipeline on read). Skipped on CONFIDENTIAL complaints —
+        // there the complainant's address must stay hidden, and the details
+        // row falls back to the administrative chain.
+        buildingName: formData?.isConfidential ? "" : validateString(formData?.complainantAddress) || "",
         street: "",
         pincode: validateString(formData?.postalCode),
         locality: {

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
@@ -245,13 +245,7 @@ function mapFormDataToRequest(formData: FormData, tenantId: string, user: any) {
       rowVersion: 1,
       address: {
         landmark: validateString(formData?.landmark),
-        // Product call (sheet-v4 review): the typed complainant address ALSO
-        // travels as the complaint's plain address so the details Address row
-        // can show it (the extendedAttributes copy is withheld by the backend
-        // DataSecurity pipeline on read). Skipped on CONFIDENTIAL complaints —
-        // there the complainant's address must stay hidden, and the details
-        // row falls back to the administrative chain.
-        buildingName: formData?.isConfidential ? "" : validateString(formData?.complainantAddress) || "",
+        buildingName: "",
         street: "",
         pincode: validateString(formData?.postalCode),
         locality: {

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/CreateComplaint/createComplaintForm.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/CreateComplaint/createComplaintForm.js
@@ -495,11 +495,20 @@ const CreateComplaintForm = ({
 
 
 
+  // QA #26: channel-of-receipt defaults to "Presencial" (in person) — the
+  // Reception Officer's most common case. A session-persisted choice wins
+  // (spread order); memoized so the defaultValues reference only changes
+  // when the session data does (FormComposerV2 resets on reference change).
+  const defaultValuesWithChannel = useMemo(
+    () => ({ ReceivedChannel: { code: "inperson", name: "PGR_CHANNEL_IN_PERSON" }, ...(sessionFormData || {}) }),
+    [sessionFormData]
+  );
+
   return (
     <React.Fragment>
       <FormComposerV2
         onSubmit={onFormSubmit}
-        defaultValues={sessionFormData}
+        defaultValues={defaultValuesWithChannel}
         heading={t("")}
         config={updatedConfig?.form}
         className="custom-form"

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
@@ -677,6 +677,18 @@ const PGRDetails = () => {
                     label: t("CS_COMPLAINT_LANDMARK__DETAILS"),
                     value: pgrData?.ServiceWrappers[0].service?.address?.landmark || "NA",
                   },
+                  // Typed address (product call, sheet-v4 review): the
+                  // complainant-entered address shows as its own row —
+                  // arrives masked ("****") on confidential complaints.
+                  ...(pgrData?.ServiceWrappers?.[0]?.service?.extendedAttributes?.complainantAddress
+                    ? [
+                        {
+                          inline: true,
+                          label: t("ES_CREATECOMPLAINT_ADDRESS"),
+                          value: pgrData.ServiceWrappers[0].service.extendedAttributes.complainantAddress,
+                        },
+                      ]
+                    : []),
                   // Pincode is optional in this deployment; only show it when set.
                   ...(pgrData?.ServiceWrappers[0].service?.address?.pincode
                     ? [

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
@@ -100,23 +100,8 @@ const ACTION_CONFIGS = [
       form: [
         {
           body: [
-            {
-              isMandatory: false,
-              key: "SelectedReason",
-              type: "dropdown",
-              label: "CS_REJECT_COMPLAINT",
-              disable: false,
-              populators: {
-                name: "SelectedReason",
-                optionsKey: "name",
-                error: "Required",
-                mdmsConfig: {
-                  masterName: "RejectionReasons",
-                  moduleName: "RAINMAKER-PGR",
-                  localePrefix: "CS_REJECTION_",
-                },
-              },
-            },
+            // QA #23 follow-up: REJECT offers NO dropdowns — the officer's
+            // justification goes in the mandatory comments field.
             {
               type: "textarea",
               isMandatory: true,

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
@@ -677,15 +677,19 @@ const PGRDetails = () => {
                     label: t("CS_COMPLAINT_LANDMARK__DETAILS"),
                     value: pgrData?.ServiceWrappers[0].service?.address?.landmark || "NA",
                   },
-                  // Typed address (product call, sheet-v4 review): the
-                  // complainant-entered address shows as its own row —
-                  // arrives masked ("****") on confidential complaints.
-                  ...(pgrData?.ServiceWrappers?.[0]?.service?.extendedAttributes?.complainantAddress
+                  // Typed address (product call, sheet-v4 review): the backend
+                  // persists the complainant-entered address into the User
+                  // Service and returns it as citizen.correspondenceAddress —
+                  // masked/absent per backend policy on confidential complaints.
+                  ...((pgrData?.ServiceWrappers?.[0]?.service?.citizen?.correspondenceAddress ||
+                      pgrData?.ServiceWrappers?.[0]?.service?.extendedAttributes?.complainantAddress)
                     ? [
                         {
                           inline: true,
                           label: t("ES_CREATECOMPLAINT_ADDRESS"),
-                          value: pgrData.ServiceWrappers[0].service.extendedAttributes.complainantAddress,
+                          value:
+                            pgrData.ServiceWrappers[0].service.citizen?.correspondenceAddress ||
+                            pgrData.ServiceWrappers[0].service.extendedAttributes?.complainantAddress,
                         },
                       ]
                     : []),

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
@@ -771,7 +771,7 @@ const PGRDetails = () => {
                     inline: false,
                     type: "custom",
                     renderCustomContent: () => (
-                      <TimelineWrapper isWorkFlowLoading={isWorkflowLoading} workflowData={workflowData} businessId={id} labelPrefix="WF_PGR_" />
+                      <TimelineWrapper isWorkFlowLoading={isWorkflowLoading} workflowData={workflowData} businessId={id} labelPrefix="WF_PGR_" maskEmployeeContacts />
                     ),
                   },
                 ],

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRInbox.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRInbox.js
@@ -74,7 +74,8 @@ const PGRSearchInbox = () => {
   // assigned-to-me radio restored, OPEN_STATES default — and skips the
   // workflow/_count requests entirely.
   const { enabled: visibilityEnabled, serverSide: visibilityServerSide, isLoading: visLoading } = useInboxVisibility();
-  const [activeTab, setActiveTab] = useState("MY");
+  // QA #18: default scope is "everyone's complaints" — in tabs mode too.
+  const [activeTab, setActiveTab] = useState("ALL");
   // Both tabs share the same status scope (all open/actionable states); they
   // differ on the assignee axis — My = assigned to me, All = everyone's
   // (PO decision 2026-07-15; the tabs replaced the assigned-to-me radio).

--- a/digit-ui-esbuild/products/pgr/src/utils/index.js
+++ b/digit-ui-esbuild/products/pgr/src/utils/index.js
@@ -189,7 +189,12 @@ export const formPayloadToCreateComplaint = (formData, tenantId, user) => {
       "rowVersion": 1,
       "address": {
         "landmark": formData?.landmark,
-        "buildingName": formData?.AddressOne,
+        // Product call (sheet-v4 review): the typed complainant address ALSO
+        // travels as the complaint's plain address (the extendedAttributes
+        // copy is withheld by the backend on read). Confidential complaints
+        // skip the copy so the complainant's address stays hidden. AddressOne
+        // (legacy building field) wins when a caller ever supplies it.
+        "buildingName": formData?.AddressOne || (!formData?.isConfidential && formData?.ComplainantAddress?.trim()) || "",
         "street": formData?.AddressTwo,
         "pincode": formData?.postalCode,
         // `SelectedBoundary` is the deepest node the operator picked

--- a/digit-ui-esbuild/products/pgr/src/utils/index.js
+++ b/digit-ui-esbuild/products/pgr/src/utils/index.js
@@ -217,6 +217,16 @@ export const formPayloadToCreateComplaint = (formData, tenantId, user) => {
     }
   }
 
+  // QA #26: receipt channel picked by the Reception Officer. Additive —
+  // attached only when the officer picked one, so existing payloads are
+  // unchanged.
+  const receivedChannel = formData?.ReceivedChannel?.code;
+  if (receivedChannel) {
+    complaint.service.extendedAttributes = {
+      ...(complaint.service.extendedAttributes || {}),
+      receivedChannel,
+    };
+  }
   return complaint;
 };
 

--- a/digit-ui-esbuild/products/pgr/src/utils/index.js
+++ b/digit-ui-esbuild/products/pgr/src/utils/index.js
@@ -183,7 +183,11 @@ export const formPayloadToCreateComplaint = (formData, tenantId, user) => {
       "serviceCode": getEffectiveServiceCode(formData?.SelectComplaintType,formData?.SelectSubComplaintType),
       "description": formData?.description,
       "applicationStatus": "CREATED",
-      "source": "web",
+      // QA #26 (product call): the Reception Officer's channel-of-receipt IS
+      // the complaint's source (was hardcoded "web"). Codes must exist in
+      // pgr-services' allowed.source list (email/inperson/letter/linhaverde
+      // added there). Employee flow only — the citizen wizard stays "web".
+      "source": formData?.ReceivedChannel?.code || "web",
       "citizen": userInfo,
       "isDeleted": false,
       "rowVersion": 1,
@@ -217,16 +221,6 @@ export const formPayloadToCreateComplaint = (formData, tenantId, user) => {
     }
   }
 
-  // QA #26: receipt channel picked by the Reception Officer. Additive —
-  // attached only when the officer picked one, so existing payloads are
-  // unchanged.
-  const receivedChannel = formData?.ReceivedChannel?.code;
-  if (receivedChannel) {
-    complaint.service.extendedAttributes = {
-      ...(complaint.service.extendedAttributes || {}),
-      receivedChannel,
-    };
-  }
   return complaint;
 };
 

--- a/digit-ui-esbuild/products/pgr/src/utils/index.js
+++ b/digit-ui-esbuild/products/pgr/src/utils/index.js
@@ -189,12 +189,7 @@ export const formPayloadToCreateComplaint = (formData, tenantId, user) => {
       "rowVersion": 1,
       "address": {
         "landmark": formData?.landmark,
-        // Product call (sheet-v4 review): the typed complainant address ALSO
-        // travels as the complaint's plain address (the extendedAttributes
-        // copy is withheld by the backend on read). Confidential complaints
-        // skip the copy so the complainant's address stays hidden. AddressOne
-        // (legacy building field) wins when a caller ever supplies it.
-        "buildingName": formData?.AddressOne || (!formData?.isConfidential && formData?.ComplainantAddress?.trim()) || "",
+        "buildingName": formData?.AddressOne,
         "street": formData?.AddressTwo,
         "pincode": formData?.postalCode,
         // `SelectedBoundary` is the deepest node the operator picked


### PR DESCRIPTION
## What

Fixes 10 items from the **Feedback of PGR Moz** QA sheet (verification env: 20.40.49.209). Landing-page items (#3–9) are excluded per scope; #13 (HTTP geolocation) and #14 (witness fields) are deliberately parked.

| # | Issue | Fix |
|---|-------|-----|
| 2 | Citizen login shows English ("Sign in", OTP text, "Continue") despite pt_PT existing | Double-translation bug: `Login/index.js` pre-translates `config.texts`, then the leaf components re-ran the *translated string* through `tr()` whose `v === key` guard always failed over to the English fallback. `SelectMobileNumber`/`SelectOtp` now consume the pre-translated values directly |
| 10 | Sidebar: HOME untranslated; Presidência/Modules unwanted | City (tenant-name) + Modules entries removed from the citizen hamburger; HOME stays via `COMMON_BOTTOM_NAVIGATION_HOME` (pt rows upserted) |
| 12 | Map region click errors in console, location not captured | `resolveWard` ran outside try/catch (turf throws on bad coords) aborting before `onSelect`; now guarded — ward failure degrades to coords-only capture. Reverse-geocode also bails on non-OK responses instead of throwing in `json()` |
| 16 | Bell icon leads to empty notifications page | Bell renders only when unread notifications exist (also hidden when the count query is disabled for the tenant) |
| 17 | Card status ≠ opened-complaint status | Card pill now shows the FULL workflow status (same `CS_COMMON_<status>` key as the details header); tone bucket drives color only; duplicate bottom state line removed |
| 18 | Assigned-to-Me/All radio on inbox left panel | Radio removed; default stays ASSIGNED_TO_ALL (preProcess only narrows on ASSIGNED_TO_ME); tabs mode (if enabled) also defaults to ALL |
| 19 | Employee timeline exposes employee names + numbers | New `maskEmployeeContacts` prop (employee details page only): names → `R*** M***`, numbers → `******1234`. Mask, not remove; citizen timeline unchanged |
| 21 | Name fields reject Portuguese characters | Profile name validation admits accented Latin letters (À-ÖØ-öø-ÿ) — citizen + employee profiles |
| 23 | Reject modal offers assignee | Already absent from this branch's REJECT config — resolved on the box by shipping a fresh build of this branch |
| 11 | Collapse/Expand on create form | Not present in this branch's `StepShell` — resolved on the box by a fresh build |

## Localization (already live, no seed changes)

`CS_COMPLAINT_CLASSIFICATION` (en+pt), `COMMON_BOTTOM_NAVIGATION_HOME` pt@mz.igsae, `CS_COMMONS_NEXT` "Continuar" (was literal "Next") upserted directly to local, 20.40.49.209 (+ cache-bust) and mctd prod.

## Verification

- esbuild build passes (moz-flavor build deployed + smoke-checked on the local stack); every file parse-checked on this branch
- The live bundle on 20.40.49.209 was fingerprinted to confirm it runs this branch's lineage — deploying a fresh build of this branch resolves #11/#23 there without further code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional received-channel field for complaint submissions.
  - Added configurable employee timeline masking for contact names and phone numbers.
- **Bug Fixes**
  - Improved multilingual handling for OTP and mobile-number steps with safer translated-text fallback.
  - Notification bell rendering no longer leads to empty-page states.
  - Location capture is more resilient to ward/reverse-geocoding failures.
  - Citizen profile name validation now accepts accented Latin characters.
- **Improvements**
  - Citizen menus are now role-appropriate on mobile (HOME only; employee adds city and modules).
  - Inbox defaults to “All,” and removed the assigned-to control.
  - Complaint status/pill text and address/locality display are more accurate.
  - Complaint creation/details validations and payload address handling were refined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->