### PR TITLE
fix(ui): QA feedback batch 2 — citizen/employee UX + localization fixes (moz)

### DIFF
--- a/digit-ui-esbuild/packages/modules/core/src/components/TopBarSideBar/SideBar/CitizenSideBar.js
+++ b/digit-ui-esbuild/packages/modules/core/src/components/TopBarSideBar/SideBar/CitizenSideBar.js
@@ -417,22 +417,16 @@ export const CitizenSideBar = ({
     icon: "Language",
   }));
 
+  // QA #10: the city (tenant-name) and Modules entries are removed from the
+  // citizen hamburger — neither leads anywhere useful for a citizen here.
+  // HOME stays, localized via COMMON_BOTTOM_NAVIGATION_HOME.
   const hamburgerItems = [
     {
       label: t("COMMON_BOTTOM_NAVIGATION_HOME"),
       value: "HOME",
       icon: "Home",
-      // children: transformedSelectedCityData?.length>0 ? transformedSelectedCityData : undefined,
       type: "custom",
       key: "home",
-    },
-    {
-      label: city,
-      value: city,
-      children: transformedSelectedCityData?.length > 0 ? transformedSelectedCityData : undefined,
-      type: "custom",
-      icon: "LocationCity",
-      key: "city",
     },
     {
       label: t("Language"),
@@ -451,11 +445,6 @@ export const CitizenSideBar = ({
         },
       ]
     : []),
-    {
-      label: t("Modules"),
-      icon: "DriveFileMove",
-      children: transformedMenuItems,
-    },
   ];
   return isMobile ? (
     <Hamburger

--- a/digit-ui-esbuild/packages/modules/core/src/components/TopBarSideBar/SideBar/CitizenSideBar.js
+++ b/digit-ui-esbuild/packages/modules/core/src/components/TopBarSideBar/SideBar/CitizenSideBar.js
@@ -418,8 +418,11 @@ export const CitizenSideBar = ({
   }));
 
   // QA #10: the city (tenant-name) and Modules entries are removed from the
-  // citizen hamburger — neither leads anywhere useful for a citizen here.
+  // CITIZEN hamburger — neither leads anywhere useful for a citizen here.
   // HOME stays, localized via COMMON_BOTTOM_NAVIGATION_HOME.
+  // The same drawer renders the EMPLOYEE mobile navigation (isEmployee) —
+  // EmployeeSideBar is desktop-only, so Modules is an employee's ONLY mobile
+  // nav surface. Both entries stay for employees.
   const hamburgerItems = [
     {
       label: t("COMMON_BOTTOM_NAVIGATION_HOME"),
@@ -428,6 +431,18 @@ export const CitizenSideBar = ({
       type: "custom",
       key: "home",
     },
+    ...(isEmployee
+      ? [
+          {
+            label: city,
+            value: city,
+            children: transformedSelectedCityData?.length > 0 ? transformedSelectedCityData : undefined,
+            type: "custom",
+            icon: "LocationCity",
+            key: "city",
+          },
+        ]
+      : []),
     {
       label: t("Language"),
       children: transformedLanguageData?.length > 0 ? transformedLanguageData : undefined,
@@ -445,6 +460,15 @@ export const CitizenSideBar = ({
         },
       ]
     : []),
+    ...(isEmployee
+      ? [
+          {
+            label: t("Modules"),
+            icon: "DriveFileMove",
+            children: transformedMenuItems,
+          },
+        ]
+      : []),
   ];
   return isMobile ? (
     <Hamburger

--- a/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Home/UserProfile.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Home/UserProfile.js
@@ -100,7 +100,9 @@ const defaultValidationConfig = {
       // client-side with the localized name error instead of an unhandled
       // backend UserProfileUpdateDeniedException; O'Brien / Mary-Anne / John Jr.
       // / mobile-number names still pass.
-      name: "/^(?![ .'\\-])[a-zA-Z0-9 .'\\-]+$/i",
+      // QA #21: admit accented Latin letters (À-ÖØ-öø-ÿ) so Portuguese names
+      // like "Manhiça" / "Conceição" pass on both citizen and employee profiles.
+      name: "/^(?![ .'\\-])[a-zA-Z0-9À-ÖØ-öø-ÿ .'\\-]+$/i",
       // Fallback mobile pattern for when the MDMS ValidationConfigs master
       // isn't seeded for the tenant. Pull the tenant's pattern from
       // globalConfigs.CORE_MOBILE_CONFIGS (e.g. Mozambique "^8[0-9]{8}$")

--- a/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Login/SelectMobileNumber.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Login/SelectMobileNumber.js
@@ -74,12 +74,13 @@ const SelectMobileNumber = ({
     return v === key ? fallback : v;
   };
 
-  const headerText = config?.texts?.header
-    ? tr(config.texts.header, "Sign in")
-    : "Sign in";
-  const cardText = config?.texts?.cardText
-    ? tr(config.texts.cardText, "We'll send you a one-time password to verify your number.")
-    : null;
+  // QA #2: config.texts.* arrive ALREADY translated (Login/index.js runs every
+  // texts value through t() when building stepItems). Re-running them through
+  // tr() made the `v === key` guard always true for translated strings, so the
+  // hardcoded English fallback rendered even when the PT translation existed.
+  // Consume the pre-translated values directly.
+  const headerText = config?.texts?.header || "Sign in";
+  const cardText = config?.texts?.cardText || null;
 
   return (
     <V2LoginShell>
@@ -207,7 +208,7 @@ const SelectMobileNumber = ({
             disabled={!isMobileValid || !canSubmit}
             width="full"
           >
-            {tr(config?.texts?.nextText || "CS_COMMONS_NEXT", "Continue")}
+            {config?.texts?.nextText || tr("CS_COMMONS_NEXT", "Continue")}
           </V2Button>
         </form>
 

--- a/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Login/SelectMobileNumber.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Login/SelectMobileNumber.js
@@ -78,9 +78,13 @@ const SelectMobileNumber = ({
   // texts value through t() when building stepItems). Re-running them through
   // tr() made the `v === key` guard always true for translated strings, so the
   // hardcoded English fallback rendered even when the PT translation existed.
-  // Consume the pre-translated values directly.
-  const headerText = config?.texts?.header || "Sign in";
-  const cardText = config?.texts?.cardText || null;
+  // Consume the pre-translated values directly — but when a tenant/locale has
+  // a seeding gap, t() echoes the raw ALL_CAPS key back; treat that as missing
+  // so the English fallback still renders instead of the key.
+  const looksLikeRawKey = (s) => typeof s === "string" && /^[A-Z0-9_]{3,}$/.test(s.trim());
+  const pick = (v, fb) => (v && !looksLikeRawKey(v) ? v : fb);
+  const headerText = pick(config?.texts?.header, "Sign in");
+  const cardText = pick(config?.texts?.cardText, null);
 
   return (
     <V2LoginShell>
@@ -208,7 +212,7 @@ const SelectMobileNumber = ({
             disabled={!isMobileValid || !canSubmit}
             width="full"
           >
-            {config?.texts?.nextText || tr("CS_COMMONS_NEXT", "Continue")}
+            {pick(config?.texts?.nextText, null) || tr("CS_COMMONS_NEXT", "Continue")}
           </V2Button>
         </form>
 

--- a/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Login/SelectOtp.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Login/SelectOtp.js
@@ -185,9 +185,12 @@ const SelectOtp = ({
 
   // QA #2: config.texts.* arrive ALREADY translated (see SelectMobileNumber) —
   // and cardText is even composed with the phone number upstream. Consume
-  // directly instead of re-translating into the English fallback.
-  const headerText = config?.texts?.header || "Verify your number";
-  const cardText = config?.texts?.cardText || null;
+  // directly instead of re-translating into the English fallback; raw
+  // ALL_CAPS keys (unseeded tenant/locale) still fall back to English.
+  const looksLikeRawKey = (s) => typeof s === "string" && /^[A-Z0-9_]{3,}$/.test(s.trim());
+  const pick = (v, fb) => (v && !looksLikeRawKey(v) ? v : fb);
+  const headerText = pick(config?.texts?.header, "Verify your number");
+  const cardText = pick(config?.texts?.cardText, null);
 
   const isReady = otp?.length === OTP_LENGTH && canSubmit;
 
@@ -251,7 +254,7 @@ const SelectOtp = ({
             </p>
           ) : null}
           <V2Button type="submit" disabled={!isReady} width="full">
-            {config?.texts?.nextText || tr("CS_COMMONS_NEXT", "Continue")}
+            {pick(config?.texts?.nextText, null) || tr("CS_COMMONS_NEXT", "Continue")}
           </V2Button>
         </form>
 

--- a/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Login/SelectOtp.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Login/SelectOtp.js
@@ -183,12 +183,11 @@ const SelectOtp = ({
     );
   }
 
-  const headerText = config?.texts?.header
-    ? tr(config.texts.header, "Verify your number")
-    : "Verify your number";
-  const cardText = config?.texts?.cardText
-    ? tr(config.texts.cardText, "Enter the 6-digit code we just sent.")
-    : null;
+  // QA #2: config.texts.* arrive ALREADY translated (see SelectMobileNumber) —
+  // and cardText is even composed with the phone number upstream. Consume
+  // directly instead of re-translating into the English fallback.
+  const headerText = config?.texts?.header || "Verify your number";
+  const cardText = config?.texts?.cardText || null;
 
   const isReady = otp?.length === OTP_LENGTH && canSubmit;
 
@@ -252,7 +251,7 @@ const SelectOtp = ({
             </p>
           ) : null}
           <V2Button type="submit" disabled={!isReady} width="full">
-            {tr(config?.texts?.nextText || "CS_COMMONS_NEXT", "Continue")}
+            {config?.texts?.nextText || tr("CS_COMMONS_NEXT", "Continue")}
           </V2Button>
         </form>
 

--- a/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Login/SelectOtp.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Login/SelectOtp.js
@@ -190,7 +190,16 @@ const SelectOtp = ({
   const looksLikeRawKey = (s) => typeof s === "string" && /^[A-Z0-9_]{3,}$/.test(s.trim());
   const pick = (v, fb) => (v && !looksLikeRawKey(v) ? v : fb);
   const headerText = pick(config?.texts?.header, "Verify your number");
-  const cardText = pick(config?.texts?.cardText, null);
+  // cardText is composed upstream as "<translated> <mobileNumber>", so an
+  // unseeded key yields "CS_LOGIN_OTP_TEXT 2588…" — whole-string matching
+  // misses it. Test only the FIRST token; on a raw key fall back to the
+  // English default (the pre-existing tr() behaviour).
+  const cardTextValue = config?.texts?.cardText;
+  const cardText = cardTextValue
+    ? looksLikeRawKey(String(cardTextValue).trim().split(/\s+/)[0])
+      ? "Enter the 6-digit code we just sent."
+      : cardTextValue
+    : null;
 
   const isReady = otp?.length === OTP_LENGTH && canSubmit;
 

--- a/digit-ui-esbuild/packages/react-components/src/atoms/TopBar.js
+++ b/digit-ui-esbuild/packages/react-components/src/atoms/TopBar.js
@@ -45,13 +45,15 @@ const TopBar = ({
 
         <div className="RightMostTopBarOptions">
           {!hideNotificationIconOnSomeUrlsWhenNotLoggedIn ? changeLanguage : null}
-          {!hideNotificationIconOnSomeUrlsWhenNotLoggedIn ? (
+          {/* QA #16: the bell renders only when there ARE unread notifications.
+              When the count query is disabled (no notification service for the
+              tenant) notificationCountLoaded stays false, so the bell — and its
+              dead-end empty page — never shows. */}
+          {!hideNotificationIconOnSomeUrlsWhenNotLoggedIn && notificationCountLoaded && notificationCount > 0 ? (
             <div className="EventNotificationWrapper" onClick={onNotificationIconClick}>
-              {notificationCountLoaded && notificationCount ? (
-                <span>
-                  <p>{notificationCount}</p>
-                </span>
-              ) : null}
+              <span>
+                <p>{notificationCount}</p>
+              </span>
               <NotificationBell />
             </div>
           ) : null}

--- a/digit-ui-esbuild/products/pgr/src/components/GeoLocations.js
+++ b/digit-ui-esbuild/products/pgr/src/components/GeoLocations.js
@@ -225,13 +225,25 @@ const GeoLocations = ({ t, config, onSelect, formData }) => {
   }, [formData, config.key]);
 
   const fetchAddress = async (lat, lng) => {
-    const ward = resolveWard(lat, lng, tenantBoundaries);
+    // QA #12: resolveWard ran OUTSIDE the try below — a bad point (turf throws
+    // on non-finite coordinates) aborted fetchAddress before any onSelect, so
+    // the click errored in the console and the location was never captured.
+    // A ward-resolution failure must never lose the location.
+    let ward = null;
+    try {
+      ward = resolveWard(lat, lng, tenantBoundaries);
+    } catch (e) {
+      console.error("Ward resolution failed:", e);
+    }
     setSelectedWard(ward?.code || null);
     try {
       const response = await fetch(
         `https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lng}&zoom=18&addressdetails=1${nominatimCountry}`,
         { headers: { "Accept-Language": nominatimLang } }
       );
+      // Rate-limited/blocked responses (429/403) return non-JSON bodies —
+      // bail to the coords-only fallback instead of throwing in json().
+      if (!response.ok) throw new Error(`reverse geocode HTTP ${response.status}`);
       const data = await response.json();
       if (data && data.display_name) {
         setAddress(data.display_name);

--- a/digit-ui-esbuild/products/pgr/src/components/TimeLineWrapper.js
+++ b/digit-ui-esbuild/products/pgr/src/components/TimeLineWrapper.js
@@ -27,7 +27,11 @@ const maskPhone = (phone) => {
 const isCitizenActor = (person) =>
   Array.isArray(person?.roles) && person.roles.some((r) => (r?.code || r) === "CITIZEN");
 
-const TimelineWrapper = ({ businessId, isWorkFlowLoading, workflowData, labelPrefix = "", currentStateChildren = null, maskConfidential = false }) => {
+// QA #19: maskEmployeeContacts — set by the EMPLOYEE details page only —
+// masks every non-citizen actor's name and mobile in the timeline (the
+// requirement is mask, not remove). The citizen page never passes it, so
+// citizen-side behaviour is driven by maskConfidential/backend masking alone.
+const TimelineWrapper = ({ businessId, isWorkFlowLoading, workflowData, labelPrefix = "", currentStateChildren = null, maskConfidential = false, maskEmployeeContacts = false }) => {
     const { t } = useTranslation();
 
     const tenantId = Digit.ULBService.getCurrentTenantId();
@@ -179,7 +183,9 @@ const TimelineWrapper = ({ businessId, isWorkFlowLoading, workflowData, labelPre
                 const personRecord = isAssigningAction(instance?.action) ? assignee : instance?.assigner;
                 // Confidential complaints: mask the CITIZEN actor's identity
                 // (employees stay visible — accountability is intact).
-                const maskThis = maskConfidential && isCitizenActor(personRecord);
+                const maskThis =
+                  (maskConfidential && isCitizenActor(personRecord)) ||
+                  (maskEmployeeContacts && personRecord && !isCitizenActor(personRecord));
                 const mobile = isAssigningAction(instance?.action) ? assignee?.mobileNumber : instance?.assigner?.mobileNumber;
                 // The backend already masks the mobile per viewer privilege
                 // ("Contact Details: *****0104"). Mirror that decision onto the

--- a/digit-ui-esbuild/products/pgr/src/configs/PGRSearchInboxConfig.js
+++ b/digit-ui-esbuild/products/pgr/src/configs/PGRSearchInboxConfig.js
@@ -210,33 +210,11 @@ const PGRSearchInboxConfig = (visibilityEnabled = true) => {
 
                     },
                     fields: [
-                        // Legacy assigned-to-me / assigned-to-all radio,
-                        // restored only when the visibility tabs are OFF.
-                        ...(visibilityEnabled
-                            ? []
-                            : [
-                                  {
-                                      label: "",
-                                      type: "radio",
-                                      isMandatory: false,
-                                      disable: false,
-                                      populators: {
-                                          name: "assignedToMe",
-                                          options: [
-                                              { code: "ASSIGNED_TO_ME", name: "ASSIGNED_TO_ME" },
-                                              { code: "ASSIGNED_TO_ALL", name: "ASSIGNED_TO_ALL" },
-                                          ],
-                                          optionsKey: "name",
-                                          styles: {
-                                              "gap": "1rem",
-                                              "flexDirection": "column"
-                                          },
-                                          innerStyles: {
-                                              "display": "flex"
-                                          }
-                                      },
-                                  },
-                              ]),
+                        // QA #18: the assigned-to-me / assigned-to-all radio is
+                        // gone from the left panel. The defaultValues block above
+                        // keeps assignedToMe=ASSIGNED_TO_ALL, and preProcess only
+                        // narrows to the logged-in user on ASSIGNED_TO_ME — so
+                        // with no control the inbox always searches ALL.
                         {
 
                             label: "CS_COMPLAINT_DETAILS_COMPLAINT_SUBTYPE",

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintsList.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintsList.js
@@ -59,9 +59,20 @@ const TONE_STYLES = {
 function StatusPill({ status, t }) {
   const tone = statusToTone(status);
   const palette = TONE_STYLES[tone];
-  const labelKey = `CS_COMMON_${palette.label}`;
-  const translated = t(labelKey);
-  const label = translated === labelKey ? palette.label : translated.toUpperCase();
+  // QA #17: label with the FULL workflow status (same CS_COMMON_<status> key
+  // the details page header uses) so the card and the opened complaint always
+  // agree. The 3-way tone bucket now drives the pill COLOR only. Falls back to
+  // the bucket label when the status key isn't localized.
+  const statusKey = `CS_COMMON_${status}`;
+  const translatedStatus = t(statusKey);
+  let label;
+  if (translatedStatus !== statusKey) {
+    label = translatedStatus.toUpperCase();
+  } else {
+    const labelKey = `CS_COMMON_${palette.label}`;
+    const translated = t(labelKey);
+    label = translated === labelKey ? palette.label : translated.toUpperCase();
+  }
   return (
     <span
       style={{
@@ -118,11 +129,6 @@ function ComplaintRow({ data, onClick, t, typeName }) {
   const dateStr = auditDetails?.createdTime
     ? Digit.DateUtils.ConvertTimestampToDate(auditDetails.createdTime)
     : "";
-  const stageKey = `${LOCALIZATION_KEY.CS_COMMON}_${applicationStatus}`;
-  const stage = (() => {
-    const v = t(stageKey);
-    return v === stageKey ? applicationStatus : v;
-  })();
   return (
     <Card
       role="button"
@@ -187,7 +193,9 @@ function ComplaintRow({ data, onClick, t, typeName }) {
               {serviceRequestId}
             </span>
             {dateStr ? <span>{dateStr}</span> : null}
-            {stage && stage !== title ? <span>{stage}</span> : null}
+            {/* QA #17: bottom state line removed — the title pill now carries
+                the full workflow status, so this duplicate (and previously
+                contradictory) line is gone. */}
           </div>
         </div>
         <ChevronRight

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
@@ -827,7 +827,8 @@ function Step0Type({ data, patch, serviceDefs, hierarchyDef, nodes, t }: StepBod
   }, [data.SelectComplaintType?.menuPath, serviceDefs]);
 
   return (
-    <StepShell title={tr(t, "CS_COMPLAINT_CATEGORY", "Complaint Category")} collapsible>
+    // QA #11: collapsible removed — the section is always expanded.
+    <StepShell title={tr(t, "CS_COMPLAINT_CATEGORY", "Complaint Category")}>
       <div className="space-y-5">
         {hierarchyActive ? (
           <ComplaintHierarchyPicker

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
@@ -56,7 +56,10 @@ const buildActionFormConfig = ({ action, assigneeRoles = [], isTerminal = false,
       },
     });
   }
-  if (!isTerminal && (assigneeRoles?.length || 0) > 0) {
+  // QA #23: rejecting a complaint must not offer an assignee — REJECT is a
+  // verdict, not a hand-off (the CMS workflow's REJECT target state is not
+  // terminal and has assignable roles, which is why the dropdown appeared).
+  if (action !== "REJECT" && !isTerminal && (assigneeRoles?.length || 0) > 0) {
     body.push({
       type: "component",
       // Callers pass assigneeMandatory (dept-mapping + actor aware); default
@@ -685,6 +688,9 @@ const PGRDetails = () => {
                         // CCSD-1971 (B4): confidential complaints hide the
                         // citizen's identity from the employee timeline.
                         maskConfidential={!!pgrData?.ServiceWrappers?.[0]?.service?.extendedAttributes?.isConfidential}
+                        // QA #19: employee-side timeline masks employee names +
+                        // contact numbers (mask, not remove).
+                        maskEmployeeContacts
                       />
                     ),
                   },

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRInbox.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRInbox.js
@@ -74,7 +74,8 @@ const PGRSearchInbox = () => {
   // assigned-to-me radio restored, OPEN_STATES default — and skips the
   // workflow/_count requests entirely.
   const { enabled: visibilityEnabled, serverSide: visibilityServerSide, isLoading: visLoading } = useInboxVisibility();
-  const [activeTab, setActiveTab] = useState("MY");
+  // QA #18: default scope is "everyone's complaints" — in tabs mode too.
+  const [activeTab, setActiveTab] = useState("ALL");
   // Both tabs share the same status scope (all open/actionable states); they
   // differ on the assignee axis — My = assigned to me, All = everyone's
   // (PO decision 2026-07-15; the tabs replaced the assigned-to-me radio).


### PR DESCRIPTION
## What

Moz-branch delivery of the **Feedback of PGR Moz** QA batch — same change set as #1363 (master-2.12-fixes), applied to this branch's newer component flavor. This is the branch the local stack build was smoke-tested from.

| # | Issue | Fix on this branch |
|---|-------|-----|
| 2 | Citizen login shows English despite pt_PT existing | `SelectMobileNumber`/`SelectOtp` consume the pre-translated `config.texts` directly instead of re-translating into the English fallback |
| 10 | Sidebar: HOME untranslated; Presidência/Modules unwanted | City + Modules entries removed from the citizen hamburger; HOME localized via `COMMON_BOTTOM_NAVIGATION_HOME` |
| 11 | Collapse/Expand on create form | `collapsible` prop dropped from the Complaint Category `StepShell` — always expanded |
| 12 | Map region click errors, location not captured | `resolveWard` guarded (turf throw degrades to coords-only capture); reverse-geocode bails on non-OK responses |
| 16 | Bell icon leads to empty notifications page | Bell renders only when unread notifications exist |
| 17 | Card status ≠ opened-complaint status | Card pill shows the FULL `CS_COMMON_<status>` (parity with details header), tone bucket = color only; duplicate bottom state line removed |
| 18 | Assigned-to-Me/All radio on inbox left panel | Radio removed (default ASSIGNED_TO_ALL); tabs mode also defaults to ALL |
| 19 | Employee timeline exposes employee names + numbers | `maskEmployeeContacts` prop on the employee details page: names → `R*** M***`, numbers → `******1234`; citizen timeline unchanged |
| 21 | Name fields reject Portuguese characters | Profile name default admits accented Latin letters (À-ÖØ-öø-ÿ) |
| 23 | Reject modal offers assignee | `buildActionFormConfig` now excludes the assignee block for REJECT explicitly |

## Localization

`CS_COMPLAINT_CLASSIFICATION` (en+pt), `COMMON_BOTTOM_NAVIGATION_HOME` pt@mz.igsae, `CS_COMMONS_NEXT` "Continuar" already upserted directly to local, 20.40.49.209 and mctd — no seed changes in this PR.

## Verification

- Full esbuild build passes from this change set; deployed to the local stack's digit-ui container and smoke-checked
- Twin PR for master-2.12-fixes: #1363 (same items; #11/#23 resolve there via fresh build since that branch's components predate the collapse/assignee code paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)