### PR TITLE
fix(compose): size postgres /dev/shm from the pgbouncer pool (#1365)

### DIFF
--- a/docker-compose.egov-digit.yaml
+++ b/docker-compose.egov-digit.yaml
@@ -95,6 +95,15 @@ services:
   postgres-db:
     image: registry.preview.egov.theflywheel.in/postgres:16
     container_name: docker-postgres
+    # /dev/shm sizing (issue #1365). Postgres puts the dynamic shared memory
+    # that a parallel query's workers use to exchange tuples here — about 8 MB
+    # per query. Docker's default pad is 64 MB, so the 9th concurrent parallel
+    # query fails with "could not resize shared memory segment ... No space
+    # left on device". pgbouncer runs transaction pooling, so its
+    # DEFAULT_POOL_SIZE (60 below) is what bounds concurrency at the database:
+    # 60 x 8 MB = 480 MB worst case. A tmpfs is a ceiling, not a reservation —
+    # unused pages cost no memory.
+    shm_size: 1gb
     environment:
       POSTGRES_USER: egov
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-egov123}

--- a/docs/superpowers/plans/2026-07-21-postgres-shm-size.md
+++ b/docs/superpowers/plans/2026-07-21-postgres-shm-size.md
@@ -1,0 +1,381 @@
+# Postgres `/dev/shm` Sizing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Set `shm_size` on the `postgres-db` service in all six Compose files so parallel complaint-list queries stop failing with `could not resize shared memory segment`, and document that a hand-run `docker compose up` gets no log rotation.
+
+**Architecture:** Postgres allocates ~8 MB of dynamic shared memory in `/dev/shm` per parallel query. Docker's default pad is 64 MB, capping every stack at ~8 concurrent parallel queries. The pad is sized from pgbouncer's `DEFAULT_POOL_SIZE`, which bounds concurrency at the database under transaction pooling: `1gb` for the three pool=60 files, `256m` for the three pool=20 files. No new services, no query changes.
+
+**Tech Stack:** Docker Compose v2 (YAML), Markdown. Verification via `docker compose config --format json` + Python 3.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-21-postgres-shm-size-design.md`. Read it before starting.
+- Branch: `fix/postgres-shm-size-1365`, already created off `develop`. Do not branch off `master`.
+- Do **not** add a CI guard. The user explicitly declined one; the verification script in Task 1 lives in the scratchpad and is never committed.
+- Do **not** change any `deploy.resources.limits` value. The 768M memory caps stay exactly as they are.
+- Do **not** touch `docker-compose.fast-path.yml`. Its `postgres-db` block overrides only `volumes`, and Compose merges overlays per key, so `shm_size` from the base file survives.
+- Exact values, no substitutions: `1gb` and `256m` (lowercase, as written).
+- Scratchpad directory for temporary files: `/tmp/claude-1000/-home-ubuntu-projects-egov-devops-Citizen-Complaint-Resolution-System/78d2754b-a12a-46f5-bbc0-cd420400bedf/scratchpad`
+
+**The six files and their values** (this mapping is the whole change — get it right):
+
+| Compose file | pool | `shm_size` |
+|---|---|---|
+| `local-setup/docker-compose.egov-digit.yaml` | 60 | `1gb` |
+| `local-setup/docker-compose.registry.yml` | 60 | `1gb` |
+| `docker-compose.egov-digit.yaml` (repo root) | 60 | `1gb` |
+| `local-setup/docker-compose.yml` | 20 | `256m` |
+| `local-setup/docker-compose.db-migrations.yml` | 20 | `256m` |
+| `local-setup/docker-compose.deploy.yaml` | 20 | `256m` |
+
+**Two facts already verified empirically — do not re-derive, but do rely on them:**
+
+1. `docker compose config --format json` normalizes `shm_size` to a **string of bytes**: `1gb` → `"1073741824"`, `256m` → `"268435456"`. Compare against strings, not ints.
+2. `local-setup/docker-compose.egov-digit.yaml` will not parse unless `DDH_IMAGE` is set (otherwise: `service "default-data-handler" has neither an image nor a build context specified`). The other five parse with no env. Set `DDH_IMAGE=placeholder` for that one file only.
+
+---
+
+## File Structure
+
+| File | Change |
+|---|---|
+| `local-setup/docker-compose.yml` | Modify: add `shm_size: 256m` + comment to `postgres-db` (block begins line 3) |
+| `local-setup/docker-compose.egov-digit.yaml` | Modify: add `shm_size: 1gb` + comment to `postgres-db` (block begins line 95) |
+| `local-setup/docker-compose.registry.yml` | Modify: add `shm_size: 1gb` + comment to `postgres-db` (block begins line 70) |
+| `local-setup/docker-compose.db-migrations.yml` | Modify: add `shm_size: 256m` + comment to `postgres-db` |
+| `local-setup/docker-compose.deploy.yaml` | Modify: add `shm_size: 256m` + comment to `postgres-db` |
+| `docker-compose.egov-digit.yaml` | Modify: add `shm_size: 1gb` + comment to `postgres-db` |
+| `local-setup/README.md` | Modify: new `### Disk usage: container logs` under `## Resource Usage` (table ends line 580) |
+| `<scratchpad>/check_shm.py` | Create: verification script. **Not committed.** |
+
+Two tasks. Task 1 is the config change and is gated on the checker going red then green. Task 2 is documentation and is independently reviewable — a reviewer could reasonably accept the sizing and reject the wording, or vice versa.
+
+---
+
+### Task 1: `shm_size` on `postgres-db` in all six Compose files
+
+**Files:**
+- Create: `<scratchpad>/check_shm.py` (temporary, not committed)
+- Modify: `local-setup/docker-compose.yml`, `local-setup/docker-compose.egov-digit.yaml`, `local-setup/docker-compose.registry.yml`, `local-setup/docker-compose.db-migrations.yml`, `local-setup/docker-compose.deploy.yaml`, `docker-compose.egov-digit.yaml`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `services["postgres-db"].shm_size` present in all six rendered configs. Task 2 depends on none of it.
+
+- [ ] **Step 1: Write the failing check**
+
+Write to `<scratchpad>/check_shm.py` (substitute the real scratchpad path from Global Constraints):
+
+```python
+#!/usr/bin/env python3
+"""Assert each Compose file's postgres-db gets the /dev/shm its pgbouncer pool needs.
+
+Run from the repo root. Temporary verification for issue #1365 — not committed.
+"""
+import json
+import os
+import subprocess
+import sys
+
+GB = "1073741824"  # what `compose config` reports for 1gb
+MB256 = "268435456"  # ... and for 256m
+
+# path -> (expected shm_size, extra env needed to make the file parse)
+EXPECTED = {
+    "local-setup/docker-compose.egov-digit.yaml": (GB, {"DDH_IMAGE": "placeholder"}),
+    "local-setup/docker-compose.registry.yml": (GB, {}),
+    "docker-compose.egov-digit.yaml": (GB, {}),
+    "local-setup/docker-compose.yml": (MB256, {}),
+    "local-setup/docker-compose.db-migrations.yml": (MB256, {}),
+    "local-setup/docker-compose.deploy.yaml": (MB256, {}),
+}
+
+failed = False
+for path, (want, extra_env) in EXPECTED.items():
+    env = {**os.environ, **extra_env}
+    proc = subprocess.run(
+        ["docker", "compose", "-f", path, "config", "--format", "json"],
+        capture_output=True, text=True, env=env,
+    )
+    if proc.returncode != 0:
+        err = "\n".join(
+            ln for ln in proc.stderr.splitlines() if "level=warning" not in ln
+        )
+        print(f"FAIL  {path}\n      did not parse: {err.strip()}")
+        failed = True
+        continue
+
+    got = json.loads(proc.stdout)["services"]["postgres-db"].get("shm_size")
+    if got == want:
+        print(f"OK    {path}  shm_size={got}")
+    else:
+        print(f"FAIL  {path}  shm_size={got!r}, want {want!r}")
+        failed = True
+
+sys.exit(1 if failed else 0)
+```
+
+- [ ] **Step 2: Run the check to verify it fails**
+
+Run from the repo root:
+
+```bash
+python3 "<scratchpad>/check_shm.py"
+```
+
+Expected: exit 1, with all six lines reading `FAIL ... shm_size=None, want '...'` — the key is absent everywhere today. If any line already says `OK`, stop: someone has partially applied this change and you need to reconcile before continuing.
+
+- [ ] **Step 3: Add `shm_size` to the three pool=60 files**
+
+In each of these three, insert the comment and key immediately after the `container_name: docker-postgres` line inside the `postgres-db` service, keeping the file's existing 4-space service-key indentation.
+
+`local-setup/docker-compose.egov-digit.yaml` and `docker-compose.egov-digit.yaml` (repo root) — both currently read:
+
+```yaml
+  postgres-db:
+    image: registry.preview.egov.theflywheel.in/postgres:16
+    container_name: docker-postgres
+    environment:
+```
+
+becomes:
+
+```yaml
+  postgres-db:
+    image: registry.preview.egov.theflywheel.in/postgres:16
+    container_name: docker-postgres
+    # /dev/shm sizing (issue #1365). Postgres puts the dynamic shared memory
+    # that a parallel query's workers use to exchange tuples here — about 8 MB
+    # per query. Docker's default pad is 64 MB, so the 9th concurrent parallel
+    # query fails with "could not resize shared memory segment ... No space
+    # left on device". pgbouncer runs transaction pooling, so its
+    # DEFAULT_POOL_SIZE (60 below) is what bounds concurrency at the database:
+    # 60 x 8 MB = 480 MB worst case. A tmpfs is a ceiling, not a reservation —
+    # unused pages cost no memory.
+    shm_size: 1gb
+    environment:
+```
+
+`local-setup/docker-compose.registry.yml` — same `image:`/`container_name:` pair, same insertion, same comment, same `shm_size: 1gb`.
+
+- [ ] **Step 4: Add `shm_size` to the two pool=20 files that cap memory**
+
+`local-setup/docker-compose.yml` currently reads:
+
+```yaml
+  postgres-db:
+    image: postgres:16
+    container_name: docker-postgres
+    environment:
+```
+
+becomes:
+
+```yaml
+  postgres-db:
+    image: postgres:16
+    container_name: docker-postgres
+    # /dev/shm sizing (issue #1365). Postgres puts the dynamic shared memory
+    # that a parallel query's workers use to exchange tuples here — about 8 MB
+    # per query — and Docker's default pad is only 64 MB. pgbouncer's
+    # DEFAULT_POOL_SIZE is 20 on this stack, so 20 x 8 MB = 160 MB covers it.
+    # Not 1gb like the deployed stacks: this container is capped at 768M below,
+    # and /dev/shm is a tmpfs charged to that same cgroup, so a 1 GB pad would
+    # let postgres be OOM-killed by filling shm alone — a worse failure than
+    # the one being fixed.
+    shm_size: 256m
+    environment:
+```
+
+`local-setup/docker-compose.db-migrations.yml` — identical `image:`/`container_name:` pair, identical insertion, identical comment and value.
+
+- [ ] **Step 5: Add `shm_size` to the remaining pool=20 file**
+
+`local-setup/docker-compose.deploy.yaml` has no memory cap, so its comment drops the OOM clause:
+
+```yaml
+  postgres-db:
+    image: postgres:16
+    container_name: docker-postgres
+    # /dev/shm sizing (issue #1365). Postgres puts the dynamic shared memory
+    # that a parallel query's workers use to exchange tuples here — about 8 MB
+    # per query — and Docker's default pad is only 64 MB. pgbouncer's
+    # DEFAULT_POOL_SIZE is 20 on this stack, so 20 x 8 MB = 160 MB covers it.
+    shm_size: 256m
+    environment:
+```
+
+- [ ] **Step 6: Run the check to verify it passes**
+
+```bash
+python3 "<scratchpad>/check_shm.py"
+```
+
+Expected: exit 0, six lines:
+
+```
+OK    local-setup/docker-compose.egov-digit.yaml  shm_size=1073741824
+OK    local-setup/docker-compose.registry.yml  shm_size=1073741824
+OK    docker-compose.egov-digit.yaml  shm_size=1073741824
+OK    local-setup/docker-compose.yml  shm_size=268435456
+OK    local-setup/docker-compose.db-migrations.yml  shm_size=268435456
+OK    local-setup/docker-compose.deploy.yaml  shm_size=268435456
+```
+
+- [ ] **Step 7: Confirm the pad is real inside a running container**
+
+The rendered config proves the YAML; this proves the kernel honours it. On the dev stack:
+
+```bash
+cd local-setup
+docker compose -f docker-compose.yml up -d postgres-db
+docker exec docker-postgres df -h /dev/shm
+```
+
+Expected: the `Size` column reads `256M`. Before this change it read `64M`.
+
+Then tear it down so no stray container is left behind:
+
+```bash
+docker compose -f docker-compose.yml down
+cd ..
+```
+
+If `docker compose up` is not possible in your environment (no daemon, no image pull), record that this step was skipped — do not mark it done.
+
+- [ ] **Step 8: Confirm the memory caps were not touched**
+
+```bash
+git diff -U0 -- local-setup/docker-compose.yml local-setup/docker-compose.db-migrations.yml | grep -E '^[-+].*(memory|cpus)' || echo "clean: no resource-limit lines changed"
+```
+
+Expected: `clean: no resource-limit lines changed`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add local-setup/docker-compose.yml \
+        local-setup/docker-compose.egov-digit.yaml \
+        local-setup/docker-compose.registry.yml \
+        local-setup/docker-compose.db-migrations.yml \
+        local-setup/docker-compose.deploy.yaml \
+        docker-compose.egov-digit.yaml
+git commit -m "fix(compose): size postgres /dev/shm from the pgbouncer pool (#1365)
+
+No compose file set shm_size, so postgres-db ran with Docker's 64 MB
+default. Postgres allocates ~8 MB of dynamic shared memory per parallel
+query, so the complaint-list endpoint failed with 'could not resize
+shared memory segment' past ~8 concurrent queries — 1,412 of 3,831
+requests (36.9%) in a k6 run.
+
+Sizes the pad from DEFAULT_POOL_SIZE, which bounds concurrency at the
+database under transaction pooling: 1gb for the three pool=60 stacks,
+256m for the three pool=20 ones. The two 768M-capped files stay at 256m
+deliberately — /dev/shm is a tmpfs charged to the container's memory
+cgroup, so a 1 GB pad there would make an OOM-kill of postgres reachable.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: README note on log rotation for hand-run Compose
+
+**Files:**
+- Modify: `local-setup/README.md` — insert after the Resource Usage table (ends line 580, `| **Total** | **~3.8 GB** |`) and before the `---` that follows it
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing consumed downstream. Final task.
+
+Context for the writer: the disk-fill half of #1365 is fixed on branch `fix/docker-log-rotation-1342`, which writes `max-size`/`max-file` into `/etc/docker/daemon.json` from `playbook-deploy.yml`. That only reaches hosts deployed by Ansible. Someone running `docker compose up` by hand gets no rotation at all, and unbounded logs filled a host disk, drove Postgres into `PANIC: could not write to file ... No space left on device`, and left it crash-looping — crash recovery must itself write a checkpoint, so a full disk means Postgres does not come back without intervention.
+
+- [ ] **Step 1: Add the section**
+
+Insert this immediately after the `| **Total** | **~3.8 GB** |` row. (The outer fence below is four backticks so the nested JSON block survives; insert only what is *between* them, starting at `### Disk usage`.)
+
+````markdown
+### Disk usage: container logs
+
+Container logs are **not** rotated by Compose. With Docker's default `json-file`
+driver they grow without bound: measured on an idle stack 21 hours after start,
+7.9 GB total — 4.3 GB from the MDMS backend and 2.6 GB from the OTel collector
+alone, roughly 9 GB/day before any load.
+
+This is not cosmetic. When the disk fills, Postgres hits
+`PANIC: could not write to file ... No space left on device` and crash-loops,
+because recovery must itself write a checkpoint. It does not return without
+intervention, and every service then fails on connection acquisition.
+
+The Ansible playbook (Option C) configures rotation for you, in
+`/etc/docker/daemon.json`. **If you started the stack by hand with
+`docker compose up`, you must configure it yourself** — it is a daemon-level
+setting, not a Compose one:
+
+```json
+{
+  "log-driver": "json-file",
+  "log-opts": { "max-size": "100m", "max-file": "10" }
+}
+```
+
+Then `sudo systemctl restart docker`. The limits apply to containers **created
+after** the restart — existing containers keep the settings they were created
+with until recreated, so run `docker compose up -d --force-recreate` if the
+stack is already running.
+````
+
+- [ ] **Step 2: Verify the Markdown renders**
+
+The section contains a fenced JSON block nested inside prose. Confirm the fences are balanced and no heading was orphaned:
+
+```bash
+python3 - <<'PY'
+import re, pathlib
+t = pathlib.Path("local-setup/README.md").read_text()
+assert t.count("```") % 2 == 0, "unbalanced code fences"
+assert "### Disk usage: container logs" in t, "section missing"
+assert t.index("### Disk usage: container logs") > t.index("| **Total** | **~3.8 GB** |"), "section landed above the table"
+assert t.index("### Disk usage: container logs") < t.index("## API Access"), "section landed outside Resource Usage"
+print("README structure OK")
+PY
+```
+
+Expected: `README structure OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add local-setup/README.md
+git commit -m "docs(local-setup): warn that hand-run compose gets no log rotation (#1365)
+
+The daemon.json log-opts written by playbook-deploy.yml only reach hosts
+deployed via Ansible. A bare 'docker compose up' rotates nothing, and
+unbounded json-file logs (~9 GB/day at idle, measured) filled a host disk
+and left Postgres crash-looping — recovery needs to write a checkpoint,
+so a full disk is terminal without intervention.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Done When
+
+- [ ] `check_shm.py` exits 0 with all six `OK` lines
+- [ ] `df -h /dev/shm` in `docker-postgres` reports `256M` on the dev stack (or the step is recorded as skipped)
+- [ ] No `deploy.resources.limits` value changed anywhere in the diff
+- [ ] `docker-compose.fast-path.yml` untouched
+- [ ] No CI workflow file touched
+- [ ] `check_shm.py` was never `git add`ed — confirm with `git status --porcelain` showing a clean tree
+- [ ] Two commits on `fix/postgres-shm-size-1365`, on top of the spec commit `975235bc`
+
+## Out of Scope
+
+Do not implement these even if they look adjacent:
+
+- A CI guard asserting `shm_size` is present — explicitly declined.
+- `max_parallel_workers_per_gather = 0`, or an index for the list query — considered and rejected in the spec.
+- The two unconfirmed failures in #1365 (`Unknown error occurred in decryption process`, `INVALID ACTION`).
+- Changing HTTP 400 to 5xx for server-side exceptions — belongs in `pgr-services`/core, its own issue.

--- a/docs/superpowers/specs/2026-07-21-postgres-shm-size-design.md
+++ b/docs/superpowers/specs/2026-07-21-postgres-shm-size-design.md
@@ -1,0 +1,130 @@
+# Postgres `/dev/shm` sizing in the Compose stacks
+
+Design for [issue #1365](https://github.com/egovernments/Citizen-Complaint-Resolution-System/issues/1365).
+
+## Problem
+
+During PGR load testing, 1,412 of 3,831 concurrent complaint-list requests (36.9%)
+failed with:
+
+```
+ERROR: could not resize shared memory segment "/PostgreSQL.NNNNNNNNNN"
+       to 8388608 bytes: No space left on device
+```
+
+"No space left on device" is `/dev/shm`, not the filesystem. Postgres allocates
+dynamic shared memory (DSM) there so the workers of a parallel query can exchange
+tuples. The unfiltered complaint-list query — a join with `ORDER BY … DESC` and
+`OFFSET/LIMIT` — plans as a parallel query, so each concurrent execution claims its
+own DSM segment.
+
+No Compose file sets `shm_size` on `postgres-db`, so every stack runs with Docker's
+64 MB default. The error names the segment size: 8388608 bytes = 8 MB. That gives a
+ceiling of roughly eight concurrent parallel queries before the ninth fails.
+
+Only the list endpoint is affected. Single-record lookups and single-row writes never
+allocate DSM and showed 0% failure in the same run, which makes the fault look
+endpoint-specific when it is a container resource limit.
+
+## Sizing
+
+The pad must hold `8 MB × (concurrent queries)`. Concurrency at the database is not
+bounded by `MAX_CLIENT_CONN` — pgbouncer runs in transaction pooling mode, so the
+bound is `DEFAULT_POOL_SIZE`. That value differs across the stacks, so the required
+size does too:
+
+| Compose file | `DEFAULT_POOL_SIZE` | Worst-case DSM | `shm_size` | postgres memory cap |
+|---|---|---|---|---|
+| `local-setup/docker-compose.egov-digit.yaml` | 60 | ~480 MB | `1gb` | none |
+| `local-setup/docker-compose.registry.yml` | 60 | ~480 MB | `1gb` | none |
+| `docker-compose.egov-digit.yaml` (repo root) | 60 | ~480 MB | `1gb` | none |
+| `local-setup/docker-compose.yml` | 20 | ~160 MB | `256m` | 768M |
+| `local-setup/docker-compose.db-migrations.yml` | 20 | ~160 MB | `256m` | 768M |
+| `local-setup/docker-compose.deploy.yaml` | 20 | ~160 MB | `256m` | none |
+
+Both values come from the same arithmetic; only the pool size differs.
+
+The worst case overstates real demand — not every query plans as a parallel gather,
+and a segment is released when its query ends. Sizing for it anyway is cheap:
+`/dev/shm` is a tmpfs, so the setting is a ceiling rather than a reservation and
+consumes memory only as pages are written.
+
+### Why not `1gb` uniformly
+
+A tmpfs is charged to the container's memory cgroup, so the pad competes with
+shared_buffers, work_mem and the rest of the backend's memory for one budget.
+`docker-compose.yml` and `docker-compose.db-migrations.yml` cap `postgres-db` at
+768M. A 1 GB pad inside a 768M budget permits postgres to be OOM-killed by filling
+the pad alone — a terminal container failure, strictly worse than the recoverable
+query error being fixed. At `256m` the pad cannot breach the cap on its own and
+~500M remains for the backend's own use.
+
+### Why not `256m` uniformly
+
+It is sufficient for the three pool=20 stacks and insufficient for the three pool=60
+ones, which include `docker-compose.egov-digit.yaml` — the stack the failure was
+measured on. It would raise that stack's breaking point from ~8 concurrent parallel
+queries to ~32 while the pool can still present 60, leaving the reported failure
+reachable under the same load profile.
+
+### Alternatives considered
+
+The issue offers two other remedies, neither adopted here:
+
+- **`max_parallel_workers_per_gather = 0`.** Appropriate for an OLTP workload and it
+  removes the allocation rather than accommodating it. Rejected because other DSM
+  consumers — parallel index build, parallel vacuum — would still meet the 64 MB
+  default, so the class of failure stays open, and it forfeits parallelism for
+  genuinely analytic queries.
+- **An index supporting the list query's ordering.** The narrowest change, but it
+  belongs to `pgr-services` migrations rather than `local-setup`, and the planner may
+  still choose a parallel plan under different filters.
+
+`shm_size` is the change that closes the failure class for every DSM consumer without
+altering query behaviour.
+
+## Changes
+
+### 1. `shm_size` on `postgres-db`
+
+Add the key to the `postgres-db` service in all six Compose files, at the sizes
+tabulated above, each with a comment recording the derivation (8 MB per parallel
+query × the file's pgbouncer pool size).
+
+No change is needed to `docker-compose.fast-path.yml`. Its `postgres-db` block
+overrides only `volumes`, and Compose merges overlays per key, so `shm_size` from the
+base file survives.
+
+### 2. README note on log rotation
+
+The other half of #1365 — unbounded container logs filling the host disk and driving
+Postgres into a PANIC crash-loop — is fixed on branch `fix/docker-log-rotation-1342`,
+which writes `max-size`/`max-file` log-opts into `/etc/docker/daemon.json` from
+`playbook-deploy.yml`.
+
+That fix reaches Ansible-deployed hosts only. A hand-run `docker compose up` gets no
+rotation at all. `local-setup/README.md` gains a note stating this and pointing at
+the daemon-level configuration, citing the measured idle growth from the issue
+(7.9 GB across 21 hours, ≈9 GB/day, before any load).
+
+## Verification
+
+For each of the six files, `docker compose -f <file> config --format json` parses and
+reports the expected `services["postgres-db"].shm_size` in bytes (1073741824 or
+268435456).
+
+Then, on the dev stack, `docker compose up -d postgres-db` followed by
+`docker exec docker-postgres df -h /dev/shm` reports 256M rather than 64M.
+
+## Out of scope
+
+- **A CI guard** asserting `shm_size` is present in every Compose file. Considered and
+  declined as disproportionate.
+- **The two unconfirmed failures in #1365** — `Unknown error occurred in decryption
+  process` and `INVALID ACTION … not found in config for the businessService`. The
+  issue does not claim either as an upstream defect, and the state needed to diagnose
+  them was destroyed by a restore predating the run.
+- **HTTP 400 for server-side exceptions.** A `DataAccessResourceFailureException`
+  being indistinguishable from client validation by status code materially slowed
+  this diagnosis, and 5xx would be correct. It is an exception-handler change in
+  `pgr-services`/core rather than a `local-setup` one, and belongs in its own issue.

--- a/local-setup/README.md
+++ b/local-setup/README.md
@@ -578,6 +578,35 @@ The last 3 lines are the values to pass to Newman.
 | Application (PGR, UI, Kong) | ~0.7 GB |
 | **Total** | **~3.8 GB** |
 
+### Disk usage: container logs
+
+Container logs are **not** rotated by Compose. With Docker's default `json-file`
+driver they grow without bound: measured on an idle stack 21 hours after start,
+7.9 GB total — 4.3 GB from the MDMS backend and 2.6 GB from the OTel collector
+alone, roughly 9 GB/day before any load.
+
+This is not cosmetic. When the disk fills, Postgres hits
+`PANIC: could not write to file ... No space left on device` and crash-loops,
+because recovery must itself write a checkpoint. It does not return without
+intervention, and every service then fails on connection acquisition.
+
+The Ansible playbook (Option C) configures rotation for you, in
+`/etc/docker/daemon.json`. **If you started the stack by hand with
+`docker compose up`, you must configure it yourself** — it is a daemon-level
+setting, not a Compose one:
+
+```json
+{
+  "log-driver": "json-file",
+  "log-opts": { "max-size": "100m", "max-file": "10" }
+}
+```
+
+Then `sudo systemctl restart docker`. The limits apply to containers **created
+after** the restart — existing containers keep the settings they were created
+with until recreated, so run `docker compose up -d --force-recreate` if the
+stack is already running.
+
 ---
 
 ## API Access

--- a/local-setup/docker-compose.db-migrations.yml
+++ b/local-setup/docker-compose.db-migrations.yml
@@ -3,6 +3,15 @@ services:
   postgres-db:
     image: postgres:16
     container_name: docker-postgres
+    # /dev/shm sizing (issue #1365). Postgres puts the dynamic shared memory
+    # that a parallel query's workers use to exchange tuples here — about 8 MB
+    # per query — and Docker's default pad is only 64 MB. pgbouncer's
+    # DEFAULT_POOL_SIZE is 20 on this stack, so 20 x 8 MB = 160 MB covers it.
+    # Not 1gb like the deployed stacks: this container is capped at 768M below,
+    # and /dev/shm is a tmpfs charged to that same cgroup, so a 1 GB pad would
+    # let postgres be OOM-killed by filling shm alone — a worse failure than
+    # the one being fixed.
+    shm_size: 256m
     environment:
       POSTGRES_USER: egov
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-egov123}

--- a/local-setup/docker-compose.deploy.yaml
+++ b/local-setup/docker-compose.deploy.yaml
@@ -9,6 +9,11 @@ services:
   postgres-db:
     image: postgres:16
     container_name: docker-postgres
+    # /dev/shm sizing (issue #1365). Postgres puts the dynamic shared memory
+    # that a parallel query's workers use to exchange tuples here — about 8 MB
+    # per query — and Docker's default pad is only 64 MB. pgbouncer's
+    # DEFAULT_POOL_SIZE is 20 on this stack, so 20 x 8 MB = 160 MB covers it.
+    shm_size: 256m
     environment:
       POSTGRES_USER: egov
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-egov123}

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -95,6 +95,15 @@ services:
   postgres-db:
     image: registry.preview.egov.theflywheel.in/postgres:16
     container_name: docker-postgres
+    # /dev/shm sizing (issue #1365). Postgres puts the dynamic shared memory
+    # that a parallel query's workers use to exchange tuples here — about 8 MB
+    # per query. Docker's default pad is 64 MB, so the 9th concurrent parallel
+    # query fails with "could not resize shared memory segment ... No space
+    # left on device". pgbouncer runs transaction pooling, so its
+    # DEFAULT_POOL_SIZE (60 below) is what bounds concurrency at the database:
+    # 60 x 8 MB = 480 MB worst case. A tmpfs is a ceiling, not a reservation —
+    # unused pages cost no memory.
+    shm_size: 1gb
     environment:
       POSTGRES_USER: egov
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-egov123}

--- a/local-setup/docker-compose.registry.yml
+++ b/local-setup/docker-compose.registry.yml
@@ -70,6 +70,15 @@ services:
   postgres-db:
     image: registry.preview.egov.theflywheel.in/postgres:16
     container_name: docker-postgres
+    # /dev/shm sizing (issue #1365). Postgres puts the dynamic shared memory
+    # that a parallel query's workers use to exchange tuples here — about 8 MB
+    # per query. Docker's default pad is 64 MB, so the 9th concurrent parallel
+    # query fails with "could not resize shared memory segment ... No space
+    # left on device". pgbouncer runs transaction pooling, so its
+    # DEFAULT_POOL_SIZE (60 below) is what bounds concurrency at the database:
+    # 60 x 8 MB = 480 MB worst case. A tmpfs is a ceiling, not a reservation —
+    # unused pages cost no memory.
+    shm_size: 1gb
     environment:
       POSTGRES_USER: egov
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-egov123}

--- a/local-setup/docker-compose.yml
+++ b/local-setup/docker-compose.yml
@@ -3,6 +3,15 @@ services:
   postgres-db:
     image: postgres:16
     container_name: docker-postgres
+    # /dev/shm sizing (issue #1365). Postgres puts the dynamic shared memory
+    # that a parallel query's workers use to exchange tuples here — about 8 MB
+    # per query — and Docker's default pad is only 64 MB. pgbouncer's
+    # DEFAULT_POOL_SIZE is 20 on this stack, so 20 x 8 MB = 160 MB covers it.
+    # Not 1gb like the deployed stacks: this container is capped at 768M below,
+    # and /dev/shm is a tmpfs charged to that same cgroup, so a 1 GB pad would
+    # let postgres be OOM-killed by filling shm alone — a worse failure than
+    # the one being fixed.
+    shm_size: 256m
     environment:
       POSTGRES_USER: egov
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-egov123}


### PR DESCRIPTION
Fixes the `/dev/shm` half of #1365.

## The problem

No Compose file sets `shm_size` on `postgres-db`, so every stack runs with Docker's **64 MB** default. Postgres allocates dynamic shared memory there so a parallel query's workers can exchange tuples — the error in #1365 names the size: `could not resize shared memory segment ... to 8388608 bytes` = **8 MB per query**.

```
64 MB pad  ÷  8 MB per query  =  ~8 concurrent parallel queries
```

The 9th fails. That's the 1,412 of 3,831 complaint-list requests (36.9%) that failed under k6. Nothing is wrong with the query — the pad is too small. Single-record lookups and single-row writes never allocate DSM and showed 0% failure in the same run, which is why it looked endpoint-specific when it's a container resource limit.

## The fix

`shm_size` sized from pgbouncer's `DEFAULT_POOL_SIZE`, which is what actually bounds concurrency at the database under transaction pooling (`MAX_CLIENT_CONN` does not):

| Compose file | pool | worst case | `shm_size` |
|---|---|---|---|
| `local-setup/docker-compose.egov-digit.yaml` | 60 | 480 MB | `1gb` |
| `local-setup/docker-compose.registry.yml` | 60 | 480 MB | `1gb` |
| `docker-compose.egov-digit.yaml` (root) | 60 | 480 MB | `1gb` |
| `local-setup/docker-compose.yml` | 20 | 160 MB | `256m` |
| `local-setup/docker-compose.db-migrations.yml` | 20 | 160 MB | `256m` |
| `local-setup/docker-compose.deploy.yaml` | 20 | 160 MB | `256m` |

Same arithmetic (`8 MB × pool`) in both rows; only the pool differs.

**Why not `1gb` everywhere.** `/dev/shm` is a tmpfs charged to the container's memory cgroup. `docker-compose.yml` and `docker-compose.db-migrations.yml` cap `postgres-db` at 768M, so a 1 GB pad there would let Postgres be OOM-killed by filling shm alone — a terminal container failure, strictly worse than the recoverable query error being fixed.

**Why not `256m` everywhere.** It would leave the three pool=60 stacks — including the one the failure was measured on — breaking at ~32 concurrent queries when the pool can present 60.

The worst case overstates real demand (not every query goes parallel; segments free at query end). Sizing for it anyway is cheap: a tmpfs is a ceiling, not a reservation, so unused pages cost no memory.

## Not in this PR

- **Log rotation**, the other half of #1365 — covered by `fix/docker-log-rotation-1342`, which writes `max-size`/`max-file` into `/etc/docker/daemon.json`. That only reaches Ansible-deployed hosts, so this PR adds a README note telling hand-run `docker compose up` users to configure it themselves.
- `max_parallel_workers_per_gather = 0` and the list-query index — the two other candidates in #1365. Considered and rejected in the spec: the former leaves parallel index build/vacuum still meeting the 64 MB default, the latter belongs to `pgr-services` migrations and the planner may still go parallel under different filters.
- The two unconfirmed failures in #1365 — the issue doesn't claim them as defects.
- Returning 5xx rather than 400 for server-side exceptions. Real (a `DataAccessResourceFailureException` is indistinguishable from client validation by status code, which materially slowed this diagnosis) but it's a `pgr-services`/core change. Worth its own issue.

`docker-compose.fast-path.yml` is deliberately untouched — its `postgres-db` block overrides only `volumes`, and Compose merges per key, so `shm_size` survives. Verified.

## Verification

- `docker compose config --format json` on all six → `shm_size` is `1073741824` / `268435456` as expected
- `docker exec docker-postgres df -h /dev/shm` → **256M** (was 64M); `--shm-size=1gb` → **1.0G**
- Base + `fast-path` overlay merged → `shm_size` preserved
- `infra-contracts.test.ts` 6/6, `preflight.py` 16/16 self-test + fixtures + example, CI telemetry check OK
- Confirmed no `deploy.resources.limits` value changed

⚠️ `static/deployment-contracts.test.ts` has **one failing test** (`seeds INTERNAL_USER on state_root after bootstrap`). It is **pre-existing on `develop`** — the string it greps for is absent there too, and this PR touches neither the playbook nor the tests.

No CI guard was added, by request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)