### PR TITLE
fix(configurator): admin PGR create/list/assign/workflow bugs (two-level tenant)

### DIFF
--- a/configurator/packages/data-provider/src/client/DigitApiClient.ts
+++ b/configurator/packages/data-provider/src/client/DigitApiClient.ts
@@ -491,7 +491,10 @@ export class DigitApiClient {
   async pgrUpdate(service: Record<string, unknown>, action: string, options?: {
     comment?: string; assignees?: string[]; rating?: number;
   }): Promise<Record<string, unknown>> {
-    const workflow: Record<string, unknown> = { action, assignees: options?.assignees || [], comments: options?.comment };
+    // The PGR workflow POJO binds `assignes` (single-e), NOT `assignees`. Sending
+    // `assignees` silently drops the assignee, so an ASSIGN runs with no target and
+    // pgr-services 400s with a NullPointerException. Send the key the server reads.
+    const workflow: Record<string, unknown> = { action, assignes: options?.assignees || [], comments: options?.comment };
     if (options?.rating !== undefined) workflow.rating = options.rating;
 
     const data = await this.request<{ ServiceWrappers?: Record<string, unknown>[] }>(this.endpoint('PGR_UPDATE'), {

--- a/configurator/packages/data-provider/src/client/DigitApiClient.ts
+++ b/configurator/packages/data-provider/src/client/DigitApiClient.ts
@@ -187,11 +187,16 @@ export class DigitApiClient {
   // --- MDMS v2 ---
 
   async mdmsSearch(tenantId: string, schemaCode: string, options?: {
-    limit?: number; offset?: number; uniqueIdentifiers?: string[];
+    limit?: number; offset?: number; uniqueIdentifiers?: string[]; isActive?: boolean;
   }): Promise<MdmsRecord[]> {
     const criteria: Record<string, unknown> = { tenantId, limit: options?.limit || 100, offset: options?.offset || 0 };
     if (schemaCode) criteria.schemaCode = schemaCode;
     if (options?.uniqueIdentifiers) criteria.uniqueIdentifiers = options.uniqueIdentifiers;
+    // Push isActive to the server so limit/offset paginate over the FILTERED set.
+    // Filtering active rows client-side after a raw page is fetched drops rows the
+    // page already spent, so a window of soft-deleted rows renders empty under a
+    // "showing 1-N of M" footer (MDMS v2 honors this criterion).
+    if (options?.isActive !== undefined) criteria.isActive = options.isActive;
 
     const data = await this.request<{ mdms?: MdmsRecord[] }>(this.endpoint('MDMS_SEARCH'), {
       RequestInfo: this.buildRequestInfo(), MdmsCriteria: criteria,

--- a/configurator/packages/data-provider/src/providers/dataProvider.ts
+++ b/configurator/packages/data-provider/src/providers/dataProvider.ts
@@ -870,7 +870,11 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
         return { data: normalizeRecord(users[0], config) };
       }
       if (config.type === 'workflow-bs') {
-        const services = await client.workflowBusinessServiceSearch(tenantId, [String(params.id)]);
+        // Honor a meta.tenantId override — a complaint's PGR workflow (actions
+        // like ESCALATE) lives at the CITY tenant; the root/session tenant's PGR
+        // config differs, so reading it there hides city-only actions.
+        const wfTenant = (params.meta as Record<string, unknown> | undefined)?.tenantId as string | undefined;
+        const services = await client.workflowBusinessServiceSearch(wfTenant || tenantId, [String(params.id)]);
         if (!services.length) throw new Error(`Workflow business service not found: ${params.id}`);
         return { data: normalizeRecord(services[0], config) };
       }

--- a/configurator/packages/data-provider/src/providers/dataProvider.ts
+++ b/configurator/packages/data-provider/src/providers/dataProvider.ts
@@ -794,7 +794,10 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
         if (!hasClientFilter) {
           const tenant = pickTenant(tenantId, filter);
           const offset = (page - 1) * perPage;
-          const raw = await client.mdmsSearch(tenant, config.schema!, { limit: perPage, offset });
+          // isActive:true so the server paginates over active rows only. The
+          // client-side .filter below stays as a defensive fallback for any MDMS
+          // that ignores the criterion (degrades to old behavior, never worse).
+          const raw = await client.mdmsSearch(tenant, config.schema!, { limit: perPage, offset, isActive: true });
           const data = raw.filter((r) => r.isActive).map((r) => normalizeMdmsRecord(r, config));
           const sorted = clientSort(data, field, order);
           const total = raw.length >= perPage ? offset + perPage + 1 : offset + data.length;
@@ -984,8 +987,13 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
           tenantId,
           typeof localityCode === 'string' ? localityCode : undefined,
         );
+        // The complaint's service.tenantId must be the boundary's CITY tenant
+        // (same as address.tenantId, resolved above), NOT the session/root tenant:
+        // pgr-services validates the picked locality against service.tenantId, and
+        // root has no boundaries → INVALID_BOUNDARY_CODE. A root-`mz` admin session
+        // previously passed `mz` here and every create 400'd.
         const wrapper = await client.pgrCreate(
-          tenantId,
+          String(address.tenantId || tenantId),
           String(data.serviceCode),
           String(data.description || ''),
           address,

--- a/configurator/packages/data-provider/src/providers/dataProvider.ts
+++ b/configurator/packages/data-provider/src/providers/dataProvider.ts
@@ -203,16 +203,19 @@ async function mdmsGetList(client: DigitApiClient, config: ResourceConfig, tenan
   return records.filter((r) => r.isActive).map((r) => normalizeMdmsRecord(r, config));
 }
 
-async function hrmsGetList(client: DigitApiClient, config: ResourceConfig, tenantId: string): Promise<RaRecord[]> {
-  // First try searching the given tenant
-  const employees = await client.employeeSearch(tenantId, { limit: 500 });
+async function hrmsGetList(client: DigitApiClient, config: ResourceConfig, tenantId: string, filter?: Record<string, unknown>): Promise<RaRecord[]> {
+  // Honor a __tenantId override (e.g. the assignee picker on a city complaint
+  // must list the CITY's employees, not the root/session tenant's).
+  const tenant = pickTenant(tenantId, filter);
+  // First try searching the resolved tenant
+  const employees = await client.employeeSearch(tenant, { limit: 500 });
   if (employees.length > 0) return employees.map((e) => normalizeRecord(e, config));
 
   // If root tenant returned 0 results, search all city-level sub-tenants
-  if (!tenantId.includes('.')) {
-    const tenantRecords = await client.mdmsSearch(tenantId, 'tenant.tenants', { limit: 200 });
+  if (!tenant.includes('.')) {
+    const tenantRecords = await client.mdmsSearch(tenant, 'tenant.tenants', { limit: 200 });
     const cityTenants = tenantRecords
-      .filter((r) => r.isActive && r.data?.code && String(r.data.code).startsWith(`${tenantId}.`))
+      .filter((r) => r.isActive && r.data?.code && String(r.data.code).startsWith(`${tenant}.`))
       .map((r) => String(r.data.code));
 
     if (cityTenants.length > 0) {
@@ -660,7 +663,7 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
     const config = resolveConfig(resource);
     switch (config.type) {
       case 'mdms': return mdmsGetList(client, config, tenantId, filter);
-      case 'hrms': return hrmsGetList(client, config, tenantId);
+      case 'hrms': return hrmsGetList(client, config, tenantId, filter);
       case 'boundary': return boundaryGetList(client, config, tenantId);
       case 'pgr': return pgrGetList(client, config, tenantId, filter);
       case 'localization': return localizationGetList(client, config, tenantId, filter);
@@ -1160,7 +1163,13 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
         // and only the workflow action, comment, assignees, and rating survived.
         const editableTop = ['serviceCode', 'description', 'source', 'additionalDetail'];
         for (const key of editableTop) {
-          if (key in data) service[key] = data[key];
+          // Only overwrite when the form actually carries a value. A complaint
+          // edit that only changes the description leaves serviceCode null on the
+          // form (the hierarchy cascade doesn't repopulate it), and blindly
+          // merging that null clobbers the real serviceCode → pgr-services NPEs on
+          // ASSIGN (it needs the type to validate the assignee's department).
+          const val = data[key];
+          if (key in data && val != null && val !== '') service[key] = val;
         }
         if (data.address && typeof data.address === 'object') {
           service.address = {

--- a/configurator/packages/data-provider/src/providers/dataProvider.ts
+++ b/configurator/packages/data-provider/src/providers/dataProvider.ts
@@ -21,6 +21,81 @@ function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
   return current;
 }
 
+/**
+ * Re-project nested filter values onto their dotted paths.
+ *
+ * react-admin's `<FilterLiveForm>` drives react-hook-form, and RHF treats a
+ * dotted input name as a PATH: a filter declared `source="additionalDetail.department"`
+ * reaches the data provider as `{ additionalDetail: { department: 'x' } }`, never
+ * as `{ 'additionalDetail.department': 'x' }`. Every branch in this provider reads
+ * filters by their flat, declared key, so any dotted-source filter silently
+ * evaporated (verified at runtime on /manage/complaints, 2026-07-27).
+ *
+ * This normalises generically rather than special-casing one field: every leaf of
+ * every nested filter object is also published under its full dotted path, while
+ * the original nested shape is left intact so fetchers that read nested objects
+ * (and `clientFilter`, which compares them stringified) keep behaving as before.
+ * Existing flat keys always win — a caller that passed `'a.b'` explicitly is not
+ * overwritten by the walk.
+ */
+function flattenFilterSources(filter?: Record<string, unknown>): Record<string, unknown> {
+  if (!filter) return {};
+  const out: Record<string, unknown> = { ...filter };
+  const walk = (value: unknown, path: string): void => {
+    if (
+      value == null ||
+      typeof value !== 'object' ||
+      Array.isArray(value) ||
+      value instanceof Date
+    ) {
+      if (!(path in out)) out[path] = value;
+      return;
+    }
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      walk(child, path ? `${path}.${key}` : key);
+    }
+  };
+  for (const [key, value] of Object.entries(filter)) walk(value, key);
+  return out;
+}
+
+/**
+ * Coerce a filter date into the epoch-ms that DIGIT services expect.
+ *
+ * pgr-services types `RequestSearchCriteria.fromDate/toDate` as `Long` and runs
+ * `ser.createdtime BETWEEN ? AND ?` (PGRQueryBuilder), and the rest of the estate
+ * (digit-ui inbox, the v2 dashboard) sends epoch-ms too. But `<input type="date">`
+ * hands react-hook-form a date-ONLY string ("2026-07-20"), which the provider used
+ * to drop on a `typeof === 'number'` guard.
+ *
+ * The Y-M-D parts are parsed explicitly in LOCAL time: `new Date('2026-07-20')`
+ * is specified as UTC midnight, which is the wrong day for any tenant east of UTC.
+ * `edge` widens a bare day to the boundary the caller means — 'start' takes local
+ * 00:00:00.000, 'end' takes local 23:59:59.999 so an inclusive "To 20 Jul" still
+ * matches complaints filed on 20 Jul.
+ */
+function toEpochMs(value: unknown, edge: 'start' | 'end'): number | undefined {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : undefined;
+  if (value instanceof Date) {
+    const t = value.getTime();
+    return Number.isNaN(t) ? undefined : t;
+  }
+  if (typeof value !== 'string') return undefined;
+  const raw = value.trim();
+  if (!raw) return undefined;
+  // Already an epoch-ms value round-tripped through the URL query string.
+  if (/^\d{10,}$/.test(raw)) return Number(raw);
+  const ymd = /^(\d{4})-(\d{2})-(\d{2})$/.exec(raw);
+  if (ymd) {
+    const [, y, m, d] = ymd;
+    return edge === 'end'
+      ? new Date(Number(y), Number(m) - 1, Number(d), 23, 59, 59, 999).getTime()
+      : new Date(Number(y), Number(m) - 1, Number(d), 0, 0, 0, 0).getTime();
+  }
+  const parsed = Date.parse(raw);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
 function extractId(record: Record<string, unknown>, config: ResourceConfig): string {
   const value = getNestedValue(record, config.idField);
   return value == null ? '' : String(value);
@@ -347,6 +422,63 @@ async function boundaryGetList(client: DigitApiClient, config: ResourceConfig, t
   }
 
   return rootFlat;
+}
+
+/**
+ * Drop UI-private sidecar keys from a PGR `address.locality`.
+ *
+ * A form control that keeps navigation state under a dotted source rooted at the
+ * field it drives (`address.locality.code` → `address.locality.code__h`) has
+ * react-hook-form build those keys INSIDE the locality object, so they ride out
+ * on the wire as part of PGR's address contract. pgr-services tolerates them
+ * (they vanish when the payload is bound to the Boundary POJO), but they are not
+ * ours to send, and a stricter service would reject the whole write. `__` is the
+ * codebase's synthetic-key marker (cf. the localization grid's `msg__<locale>`)
+ * and no field of Boundary contains it.
+ */
+function stripLocalitySidecars(locality: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(locality)) {
+    if (key.includes('__')) continue;
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Merge a complaint-edit form's `address` onto the address loaded from PGR.
+ *
+ * `eg_pgr_address_v2.locality` is NOT NULL, and egov-persister applies the
+ * address and service UPDATEs in ONE transaction. So an address whose
+ * `locality.code` is null does not merely lose the locality: pgr-services
+ * returns 200 and advances the workflow, the persister then dies on
+ * `null value in column "locality" of relation "eg_pgr_address_v2"`, and the
+ * service UPDATE rolls back with it — nine retries, message dropped, the
+ * complaint left untouched while its workflow state says otherwise. A write the
+ * persister cannot apply must never be sent, whatever the form hands us: an
+ * empty incoming code is always restored from the record that was just loaded.
+ * (Clearing a complaint's locality is not a supported edit — the column forbids
+ * it — so there is no legitimate intent to preserve here.)
+ *
+ * Every other address field merges as before: nulling a landmark or a pincode is
+ * a real edit the schema allows.
+ */
+function mergePgrAddress(
+  current: Record<string, unknown>,
+  incoming: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = { ...current, ...incoming };
+  const currentLocality = current.locality as Record<string, unknown> | undefined;
+  const incomingLocality = incoming.locality as Record<string, unknown> | undefined;
+  if (currentLocality || incomingLocality) {
+    const locality = stripLocalitySidecars({ ...(currentLocality ?? {}), ...(incomingLocality ?? {}) });
+    const loadedCode = currentLocality?.code;
+    if ((locality.code == null || locality.code === '') && loadedCode != null && loadedCode !== '') {
+      locality.code = loadedCode;
+    }
+    merged.locality = locality;
+  }
+  return merged;
 }
 
 /** Resolve the tenant that a complaint's `address.tenantId` must carry.
@@ -686,6 +818,10 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
     async getList(resource, params): Promise<GetListResult> {
       const { page = 1, perPage = 25 } = params.pagination ?? {};
       const { field = 'id', order = 'ASC' } = params.sort ?? {};
+      // Filters declared with a dotted source arrive nested from react-hook-form;
+      // normalise once here so every branch below can read them by their declared
+      // key. See flattenFilterSources.
+      const filterValues = flattenFilterSources(params.filter as Record<string, unknown> | undefined);
 
       // PGR complaints: push pagination + server-supported filters to the
       // API. The old behavior pulled the first 100 records and paginated
@@ -693,10 +829,14 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
       // returns the real total so react-admin's paginator stays honest.
       const config = resolveConfig(resource);
       if (config.type === 'pgr') {
-        const filter = (params.filter ?? {}) as Record<string, unknown>;
+        const filter = filterValues;
         const status = filter.applicationStatus ?? filter.status;
-        const fromDate = typeof filter.fromDate === 'number' ? filter.fromDate : undefined;
-        const toDate = typeof filter.toDate === 'number' ? filter.toDate : undefined;
+        // <input type="date"> yields a "YYYY-MM-DD" string; pgr-services wants epoch-ms.
+        let fromDate = toEpochMs(filter.fromDate, 'start');
+        const toDate = toEpochMs(filter.toDate, 'end');
+        // PGRQueryBuilder throws INVALID_SEARCH ("Cannot specify to-Date without a
+        // from-Date") when only toDate is given, so anchor an open-ended "To" at the epoch.
+        if (toDate !== undefined && fromDate === undefined) fromDate = 0;
         const department =
           typeof filter['additionalDetail.department'] === 'string'
             ? filter['additionalDetail.department']
@@ -762,7 +902,7 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
       // proxy (which returns the real total); notification-provider returns the
       // full integration list, so we paginate/filter/sort it client-side.
       if (config.type === 'custom') {
-        const filter = (params.filter ?? {}) as Record<string, unknown>;
+        const filter = filterValues;
         if (resource === 'notification-log') {
           const { records, total } = await customFetchList(client, config, tenantId, {
             referenceNumber: typeof filter.referenceNumber === 'string' ? filter.referenceNumber : undefined,
@@ -779,7 +919,7 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
         // Generic custom list (e.g. notification-provider): fetch-all then
         // filter/sort/paginate in memory.
         const { records } = await customFetchList(client, config, tenantId, {});
-        const filtered = clientFilter(records, params.filter);
+        const filtered = clientFilter(records, filterValues);
         const sorted = clientSort(filtered, field, order);
         const data = clientPaginate(sorted, page, perPage);
         return { data, total: filtered.length };
@@ -792,7 +932,7 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
       // count, so we use a heuristic: a full page means "there may be more"
       // (next button enabled), a partial page means "last page".
       if (config.type === 'mdms' && !config.leafServiceDefAdapter) {
-        const filter = (params.filter ?? {}) as Record<string, unknown>;
+        const filter = filterValues;
         const hasClientFilter = Object.keys(filter).some((k) => k !== TENANT_OVERRIDE_KEY);
         if (!hasClientFilter) {
           const tenant = pickTenant(tenantId, filter);
@@ -808,8 +948,8 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
         }
       }
 
-      const all = await fetchAll(resource, params.filter);
-      const filtered = clientFilter(all, params.filter);
+      const all = await fetchAll(resource, filterValues);
+      const filtered = clientFilter(all, filterValues);
       const sorted = clientSort(filtered, field, order);
       const data = clientPaginate(sorted, page, perPage);
       return { data, total: filtered.length };
@@ -983,6 +1123,11 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
         const address: Record<string, unknown> = { ...formAddress };
         if (!address.locality && typeof data['address.locality.code'] === 'string') {
           address.locality = { code: data['address.locality.code'] };
+        }
+        // Never ship the picker's private navigation state as part of the
+        // address — see stripLocalitySidecars.
+        if (address.locality && typeof address.locality === 'object') {
+          address.locality = stripLocalitySidecars(address.locality as Record<string, unknown>);
         }
         // address.tenantId must be the boundary's CITY tenant (e.g.
         // `mz.maputo`), NOT the session tenant. A root-`mz` admin session
@@ -1176,10 +1321,10 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
           if (key in data && val != null && val !== '') service[key] = val;
         }
         if (data.address && typeof data.address === 'object') {
-          service.address = {
-            ...(service.address as Record<string, unknown> | undefined ?? {}),
-            ...(data.address as Record<string, unknown>),
-          };
+          service.address = mergePgrAddress(
+            (service.address as Record<string, unknown> | undefined) ?? {},
+            data.address as Record<string, unknown>,
+          );
         }
 
         // Normalize assignees: accept a single string (from form select) or an array

--- a/configurator/src/admin/DigitFormSelect.tsx
+++ b/configurator/src/admin/DigitFormSelect.tsx
@@ -34,6 +34,8 @@ export interface DigitFormSelectProps extends InputProps {
   optionValue?: string;
   /** Field to use as the option label when using reference (default: 'name') */
   optionText?: string;
+  /** Optional filter passed to the reference getList (e.g. a tenant override). */
+  filter?: Record<string, unknown>;
   /** Optional helper text shown below the select (muted) */
   help?: string;
 }
@@ -47,6 +49,7 @@ export function DigitFormSelect({
   reference,
   optionValue = 'code',
   optionText = 'name',
+  filter,
   help,
   ...inputProps
 }: DigitFormSelectProps) {
@@ -60,7 +63,7 @@ export function DigitFormSelect({
   // Auto-fetch choices from a resource when `reference` is provided
   const { data, isLoading } = useGetList(
     reference ?? '_unused',
-    { pagination: { page: 1, perPage: 1000 }, sort: { field: optionText, order: 'ASC' as const } },
+    { pagination: { page: 1, perPage: 1000 }, sort: { field: optionText, order: 'ASC' as const }, filter },
     { enabled: !!reference },
   );
 

--- a/configurator/src/admin/WorkflowActionSelect.tsx
+++ b/configurator/src/admin/WorkflowActionSelect.tsx
@@ -98,6 +98,14 @@ export function WorkflowActionSelect({
   // Watch the current application status in the form
   const currentStatus = useWatch({ name: statusSource }) as string | undefined;
 
+  // The record's CITY tenant (address.tenantId, else the record tenantId).
+  // The assignee list must come from the complaint's city, not the root/session
+  // tenant — a root admin editing a city complaint otherwise gets the root's
+  // employees (none valid for a city ASSIGN), so pgr-services 400s.
+  const recordTenant =
+    (useWatch({ name: 'address.tenantId' }) as string | undefined) ||
+    (useWatch({ name: 'tenantId' }) as string | undefined);
+
   // Fetch the workflow business service definition
   const { data: workflowDef, isLoading } = useGetOne(
     'workflow-business-services',
@@ -244,6 +252,7 @@ export function WorkflowActionSelect({
               optionValue="uuid"
               optionText="user.name"
               placeholder="Select employee..."
+              filter={recordTenant ? { __tenantId: recordTenant } : undefined}
             />
           )}
 

--- a/configurator/src/admin/WorkflowActionSelect.tsx
+++ b/configurator/src/admin/WorkflowActionSelect.tsx
@@ -106,10 +106,12 @@ export function WorkflowActionSelect({
     (useWatch({ name: 'address.tenantId' }) as string | undefined) ||
     (useWatch({ name: 'tenantId' }) as string | undefined);
 
-  // Fetch the workflow business service definition
+  // Fetch the workflow business service definition — from the complaint's CITY
+  // tenant (recordTenant), not the session/root tenant, so city-only actions
+  // (e.g. ESCALATE) are offered. Falls back to the session tenant when unknown.
   const { data: workflowDef, isLoading } = useGetOne(
     'workflow-business-services',
-    { id: businessService },
+    { id: businessService, meta: recordTenant ? { tenantId: recordTenant } : undefined },
     { enabled: !!businessService },
   );
 

--- a/configurator/src/api/services/mdms.ts
+++ b/configurator/src/api/services/mdms.ts
@@ -17,12 +17,43 @@ import type {
 const MAP_CONFIG_KEY = 'DEFAULT';
 
 export const mdmsService = {
-  // Generic MDMS search
+  /**
+   * Generic MDMS search. **Returns ACTIVE records only** unless
+   * `options.includeInactive` is set.
+   *
+   * mdms-v2 soft-deletes: a "removed" record keeps its row and its `data`
+   * verbatim (including `data.active: true`, which is a *business* flag owned by
+   * the schema and has nothing to do with deletion) and only flips the
+   * record-level `isActive` to false. This function used to send no `isActive`
+   * criterion AND then throw the flag away by mapping straight down to
+   * `record.data`, so every caller silently received deleted records with no way
+   * to tell — the complaint-type cascade offered four soft-deleted
+   * `*_CTPARITY` sub-types, and picking one got the operator an opaque
+   * `400 INVALID_SERVICECODE: … not present in MDMS` from pgr-services, which
+   * resolves the hierarchy with `isActive = true`.
+   *
+   * The filter is pushed to the SERVER (verified: 263 active of 267 rows on
+   * mz/RAINMAKER-PGR.ComplaintHierarchy) so paging stays honest, and re-applied
+   * client-side as a defensive fallback for any MDMS build that ignores the
+   * criterion. The record-level flag is also preserved on each result as
+   * `_isActive` (the `_`-prefixed metadata convention the data-provider already
+   * uses) so a caller that opts into inactive rows can still tell them apart.
+   *
+   * Need the raw records (uniqueIdentifier / id / auditDetails / isActive)?
+   * Use `searchRecords()` — it is deliberately unfiltered.
+   */
   async search<T>(
     tenantId: string,
     schemaCode: string,
-    options?: { limit?: number; offset?: number; uniqueIdentifiers?: string[] }
+    options?: {
+      limit?: number;
+      offset?: number;
+      uniqueIdentifiers?: string[];
+      /** Opt in to soft-deleted records (e.g. an admin list with a "show removed" toggle). */
+      includeInactive?: boolean;
+    }
   ): Promise<T[]> {
+    const includeInactive = options?.includeInactive === true;
     const response = await apiClient.post(ENDPOINTS.MDMS_SEARCH, {
       RequestInfo: apiClient.buildRequestInfo(),
       MdmsCriteria: {
@@ -31,11 +62,18 @@ export const mdmsService = {
         limit: options?.limit || 100,
         offset: options?.offset || 0,
         uniqueIdentifiers: options?.uniqueIdentifiers,
+        ...(includeInactive ? {} : { isActive: true }),
       },
     });
 
     const mdmsRecords = (response.mdms || []) as MdmsRecord[];
-    return mdmsRecords.map((record) => record.data as T);
+    const kept = includeInactive
+      ? mdmsRecords
+      : mdmsRecords.filter((record) => record.isActive !== false);
+    return kept.map(
+      (record) =>
+        ({ ...(record.data as Record<string, unknown>), _isActive: record.isActive !== false }) as T
+    );
   },
 
   // Generic MDMS create
@@ -59,9 +97,11 @@ export const mdmsService = {
     return response.Mdms as MdmsRecord;
   },
 
-  // Raw search: keeps `uniqueIdentifier` / `id` / `auditDetails`, which the
-  // generic search() drops when it maps records down to their `data`. An update
-  // has to round-trip all three.
+  // Raw search: keeps `uniqueIdentifier` / `id` / `auditDetails` / `isActive`,
+  // which the generic search() drops when it maps records down to their `data`.
+  // An update has to round-trip the first three. Deliberately UNFILTERED — this
+  // is the escape hatch for the flows that must see soft-deleted rows
+  // (upsertMapConfig has to know a uid is occupied before it mints a new one).
   async searchRecords(
     tenantId: string,
     schemaCode: string,

--- a/configurator/src/api/services/tenantBootstrap.ts
+++ b/configurator/src/api/services/tenantBootstrap.ts
@@ -156,19 +156,47 @@ async function createData(record: MdmsRecordRaw): Promise<void> {
 
 // --- Step 3.5: register the tenant with egov-enc-service -----------------
 
-// egov-enc-service discovers tenants via an MDMS search scoped to its own
-// STATE_LEVEL_TENANT_ID env var — a brand-new state root is invisible to it
-// until this is called, so provisionAdmin()'s _createnovalidate (which
-// encrypts the user's PII) would otherwise fail with "Tenant Id not found"
-// even though every step above succeeded. Idempotent (created:false when a
-// key already exists). Non-fatal: swallow failures here and let Step 4
-// surface the real error if enc-service is genuinely unreachable.
+export interface EncKeyResult {
+  tenantId: string;
+  /** true when this call inserted a new key; false when one already existed. */
+  created: boolean;
+  keyId?: number;
+}
+
+// egov-enc-service holds ONE symmetric key per tenant, and every PII column it
+// wrote is sealed with that key. Without a key row the tenant cannot accept any
+// encrypted write: egov-user's _create / HRMS employee create fail with
+// "Unknown error occurred in encryption process" (or "Tenant Id not found" for a
+// brand-new state root, because enc-service discovers tenants via an MDMS search
+// scoped to its own STATE_LEVEL_TENANT_ID env var and doesn't know the new root).
+//
+// POST /crypto/v1/_generatekey is CREATE-IF-MISSING, never a rotation:
+// re-calling it for a tenant that already has a key returns `created:false` with
+// the SAME keyId and leaves the stored secret untouched (verified against a
+// throwaway tenant — one row, unchanged key_id/secret_key across three calls).
+// That property is what makes it safe to call from the wizard: it can never
+// strand already-encrypted data. It is nonetheless only ever called on the
+// tenant-creation path, and the UI exposes no "regenerate key" affordance —
+// rotating a live tenant's key is a deliberate ops action, not a button.
+//
+// Throws on transport/API failure; callers decide how fatal that is.
+export async function ensureEncKey(tenantId: string): Promise<EncKeyResult> {
+  const response = await apiClient.post(ENDPOINTS.ENC_GENERATE_KEY, {
+    RequestInfo: apiClient.buildRequestInfo(),
+    tenantId,
+  });
+  return {
+    tenantId,
+    created: (response as { created?: boolean } | undefined)?.created === true,
+    keyId: (response as { keyId?: number } | undefined)?.keyId,
+  };
+}
+
+/** Bootstrap-path wrapper: non-fatal: swallow failures here and let Step 4
+ *  surface the real error if enc-service is genuinely unreachable. */
 async function registerEncKey(target: string): Promise<void> {
   try {
-    await apiClient.post(ENDPOINTS.ENC_GENERATE_KEY, {
-      RequestInfo: apiClient.buildRequestInfo(),
-      tenantId: target,
-    });
+    await ensureEncKey(target);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.warn(`[bootstrap] enc-service key generation for ${target} failed: ${msg}`);

--- a/configurator/src/pages/Phase1Page.tsx
+++ b/configurator/src/pages/Phase1Page.tsx
@@ -27,7 +27,7 @@ import { Banner } from '@/components/digit/Banner';
 import { parseExcelFile, parseTenantExcel } from '@/utils/excelParser';
 import * as XLSX from 'xlsx';
 import { mdmsService, localizationService, apiClient, ApiClientError } from '@/api';
-import { bootstrapStateRoot, bootstrapLocalization, stateNeedsBootstrap, type BootstrapProgress } from '@/api/services/tenantBootstrap';
+import { bootstrapStateRoot, bootstrapLocalization, stateNeedsBootstrap, ensureEncKey, type BootstrapProgress } from '@/api/services/tenantBootstrap';
 import type { TenantExcelRow, Tenant, ValidationResult } from '@/api/types';
 
 type Step = 'landing' | 'upload' | 'preview' | 'branding' | 'complete' | 'select-existing';
@@ -76,6 +76,11 @@ export default function Phase1Page() {
   const [step, setStep] = useState<Step>('landing');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Non-blocking problems: the step SUCCEEDED but something the operator needs
+  // to know about degraded (e.g. the enc-service key registration below, which
+  // only bites later in Phase 4). Kept separate from `error` so it doesn't read
+  // as "this failed, go back".
+  const [warning, setWarning] = useState<string | null>(null);
   const [uploadedFile, setUploadedFile] = useState<File | null>(null);
   // Bootstrap progress (only set when we detect a brand-new state root).
   // The new tenant.tenants record will be written at parentState (derived from the
@@ -175,6 +180,7 @@ export default function Phase1Page() {
 
     setLoading(true);
     setError(null);
+    setWarning(null);
 
     try {
       // Build tenant object for MDMS
@@ -215,11 +221,51 @@ export default function Phase1Page() {
       // definitely has the tenant.tenants schema, either pre-existing or just
       // registered by bootstrap). This replaces the previous `state.tenant`
       // target — that was a localStorage value, not a deliberate write target.
+      let tenantAlreadyExisted = false;
       try {
         await mdmsService.createTenant(parentState, tenant);
       } catch (err) {
         const msg = err instanceof ApiClientError ? err.firstError : (err instanceof Error ? err.message : '');
         if (!/duplicate|already exists|unique|NON_UNIQUE/i.test(msg)) throw err;
+        tenantAlreadyExisted = true;
+      }
+
+      // Give the brand-new tenant its egov-enc-service symmetric key.
+      //
+      // Every write that carries PII — Phase 4's employees (mobile/email), and
+      // any citizen user later — is encrypted per tenant. A tenant with no key
+      // row rejects all of them with
+      //   400 UNKNOWN_ERROR "Unknown error occurred in encryption process"
+      // which is what made UI-created tenants unusable in Phase 4. The ansible
+      // deploy does this for the tenants it provisions (playbook-deploy.yml,
+      // "pre-bootstrap — generate enc-service key"); the wizard has to do it for
+      // the tenants IT creates.
+      //
+      // Deliberately narrow, so this can never rotate a live tenant's key:
+      //   - only here, on the tenant-CREATION path;
+      //   - skipped entirely when the tenant already existed (duplicate above),
+      //     and skipped for a fresh state root because bootstrapStateRoot()
+      //     already registered the key for it;
+      //   - the endpoint itself is create-if-missing (returns created:false and
+      //     the same keyId when a key exists) — see ensureEncKey();
+      //   - and there is no standalone "regenerate key" control anywhere in the UI.
+      //
+      // Non-fatal: the tenant itself is created and usable for Phases 2-3, so
+      // don't roll the operator back to the upload step. Warn instead — Phase 4
+      // surfaces the underlying encryption error if this really didn't take.
+      if (!tenantAlreadyExisted) {
+        try {
+          await ensureEncKey(tenant.code);
+        } catch (encErr) {
+          const msg = encErr instanceof ApiClientError
+            ? encErr.firstError
+            : (encErr instanceof Error ? encErr.message : String(encErr));
+          console.warn(`[phase1] enc-service key generation for ${tenant.code} failed: ${msg}`);
+          setWarning(
+            `Tenant created, but registering it with the encryption service failed (${msg}). ` +
+            `Employee creation in Phase 4 will fail until this is resolved.`
+          );
+        }
       }
 
       // Create localization for tenant name, also at the parent state.
@@ -437,6 +483,19 @@ export default function Phase1Page() {
           <AlertDescription className="flex items-center justify-between">
             <span>{error}</span>
             <Button variant="ghost" size="sm" onClick={() => setError(null)} className="h-6 w-6 p-0">
+              <X className="h-4 w-4" />
+            </Button>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {/* Non-blocking warning display (step succeeded, something degraded) */}
+      {warning && (
+        <Alert variant="warning">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription className="flex items-start justify-between gap-2">
+            <span>{warning}</span>
+            <Button variant="ghost" size="sm" onClick={() => setWarning(null)} className="h-6 w-6 p-0 flex-shrink-0">
               <X className="h-4 w-4" />
             </Button>
           </AlertDescription>

--- a/configurator/src/pages/Phase4Page.tsx
+++ b/configurator/src/pages/Phase4Page.tsx
@@ -86,6 +86,12 @@ export default function Phase4Page() {
   const [createdCount, setCreatedCount] = useState(0);
   const [failedCount, setFailedCount] = useState(0);
   const [createdEmployees, setCreatedEmployees] = useState<Employee[]>([]);
+  // Per-row failure reasons. The loop below creates employees one at a time and
+  // keeps going past a failure, so the enclosing try/catch never sees those
+  // errors — without this the complete screen could only say "0 created, 1
+  // failed" and the actual API message (e.g. "Unknown error occurred in
+  // encryption process") was console-only.
+  const [failures, setFailures] = useState<{ name: string; reason: string }[]>([]);
 
   useEffect(() => {
     async function fetchReferenceData() {
@@ -275,6 +281,7 @@ export default function Phase4Page() {
     setProgress(0);
     setCreatedCount(0);
     setFailedCount(0);
+    setFailures([]);
     setCreatedEmployees([]);
 
     const validEmployees = employees.filter((e) => e.status === 'valid');
@@ -353,6 +360,15 @@ export default function Phase4Page() {
           setCreatedCount((prev) => prev + 1);
         } catch (err) {
           console.error(`Failed to create employee ${emp.name}:`, err);
+          // Surface the reason, don't just count it. ApiClientError.firstError
+          // carries the DIGIT error message ("Unknown error occurred in
+          // encryption process", "INVALID_ROLE", …) — that string is the whole
+          // difference between an operator who can fix the row and one staring
+          // at "1 failed".
+          const reason = err instanceof ApiClientError
+            ? err.firstError
+            : (err instanceof Error ? err.message : String(err));
+          setFailures((prev) => [...prev, { name: emp.name, reason }]);
           setFailedCount((prev) => prev + 1);
         }
 
@@ -881,6 +897,26 @@ export default function Phase4Page() {
               </TableBody>
             </Table>
           </div>
+
+          {/* Why each row failed. The Banner above already promises a
+              "failure list below" — this is it. */}
+          {failures.length > 0 && (
+            <Alert variant="destructive" className="text-left mt-4 sm:mt-6">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription className="text-xs sm:text-sm">
+                <p className="mb-2">
+                  <strong>Failed rows:</strong>
+                </p>
+                <ul className="space-y-1">
+                  {failures.map((f, idx) => (
+                    <li key={`${f.name}-${idx}`}>
+                      <span className="font-medium">{f.name}</span>: {f.reason}
+                    </li>
+                  ))}
+                </ul>
+              </AlertDescription>
+            </Alert>
+          )}
 
           <Alert variant="info" className="text-left mt-4 sm:mt-6 max-w-md mx-auto">
             <AlertDescription className="text-xs sm:text-sm">

--- a/configurator/src/resources/complaint-hierarchies/ComplaintHierarchyShow.tsx
+++ b/configurator/src/resources/complaint-hierarchies/ComplaintHierarchyShow.tsx
@@ -54,7 +54,11 @@ export function ComplaintHierarchyShow() {
             { limit: PAGE, offset },
           );
           acc.push(...page);
-          if (page.length < PAGE || offset > 100000) break; // last page (or safety cap)
+          // Stop on an EMPTY page, not a short one. mdmsService.search() drops
+          // soft-deleted records, so a short page no longer implies "last page" —
+          // it can just mean this window contained a removed row. Costs one extra
+          // (empty) request per tenant and can never truncate the tree.
+          if (page.length === 0 || offset > 100000) break; // exhausted (or safety cap)
         }
         return acc;
       };

--- a/configurator/src/resources/complaint-types/ComplaintTypeList.tsx
+++ b/configurator/src/resources/complaint-types/ComplaintTypeList.tsx
@@ -1,7 +1,29 @@
-import { DigitList, DigitDatagrid } from '@/admin';
+import {
+  DigitList,
+  DigitDatagrid,
+  SearchFilterInput,
+  ReferenceFilterInput,
+} from '@/admin';
 import type { DigitColumn } from '@/admin';
 import { StatusChip } from '@/admin/fields';
 import { EntityLink } from '@/components/ui/EntityLink';
+
+// Department is the axis admins actually slice this list by ("what does Public
+// Works own?"), and it is already a rendered column — mirrors the Department
+// filter DesignationList declares, but alwaysOn so it is visible without going
+// through the Add-filter popover. Passing `filters` swaps DigitList's built-in
+// search box for the FilterBar, so SearchFilterInput has to be re-declared here
+// or free-text search disappears from the page.
+const filters = [
+  <SearchFilterInput key="q" source="q" alwaysOn />,
+  <ReferenceFilterInput
+    key="department"
+    source="department"
+    reference="departments"
+    label="Department"
+    alwaysOn
+  />,
+];
 
 const columns: DigitColumn[] = [
   // Grouping key — the leaf's parent node code in the hierarchy (was menuPath).
@@ -43,7 +65,12 @@ const columns: DigitColumn[] = [
 
 export function ComplaintTypeList() {
   return (
-    <DigitList title="app.resources.complaint_types" hasCreate sort={{ field: 'serviceCode', order: 'ASC' }}>
+    <DigitList
+      title="app.resources.complaint_types"
+      hasCreate
+      sort={{ field: 'serviceCode', order: 'ASC' }}
+      filters={filters}
+    >
       <DigitDatagrid columns={columns} rowClick="show" />
     </DigitList>
   );

--- a/configurator/src/resources/complaints/ComplaintCreate.tsx
+++ b/configurator/src/resources/complaints/ComplaintCreate.tsx
@@ -30,7 +30,7 @@ export function ComplaintCreate() {
   };
 
   return (
-    <DigitCreate title="File Complaint" record={{}} transform={transform}>
+    <DigitCreate title="File Complaint" record={{}} transform={transform} redirect="show">
       <FieldSection title="Complaint">
         <div className="space-y-4">
           <ComplaintHierarchyCascade

--- a/configurator/src/resources/complaints/ComplaintHierarchyCascade.tsx
+++ b/configurator/src/resources/complaints/ComplaintHierarchyCascade.tsx
@@ -20,6 +20,8 @@ interface HierNode {
   levelCode?: string;
   order?: number;
   active?: boolean;
+  /** Record-level mdms-v2 soft-delete flag, stamped by mdmsService.search(). */
+  _isActive?: boolean;
   hierarchyType?: string;
   department?: string;
   slaHours?: number;
@@ -37,8 +39,17 @@ interface Level {
  * (MAIN_CATEGORY → SECTOR → SUB_TYPE …). The form field (`source`, e.g.
  * serviceCode) is set to the DEEPEST node the operator selects. A branch that
  * has no children at the next level is terminal — its own code becomes the
- * serviceCode (pgr-services accepts any ComplaintHierarchy code). Levels deeper
- * than a terminal selection are hidden.
+ * serviceCode. Levels deeper than a terminal selection are hidden.
+ *
+ * Only rows pgr-services will actually accept may be offered. It resolves a
+ * complaint's serviceCode against ComplaintHierarchy with `isActive = true` and
+ * rejects anything else with `400 INVALID_SERVICECODE: The service code: X is
+ * not present in MDMS`, so BOTH gates apply here:
+ *   - `_isActive` — the mdms-v2 record-level soft-delete flag (a "removed" row
+ *     keeps `data.active: true`, so this is the only thing that reveals it).
+ *     `mdmsService.search()` already filters these out server-side; the check
+ *     below is the local restatement of the contract.
+ *   - `active` — the schema's own business flag, set by the operator.
  */
 export function ComplaintHierarchyCascade(props: InputProps & { label?: string }) {
   const { label } = props;
@@ -61,7 +72,9 @@ export function ComplaintHierarchyCascade(props: InputProps & { label?: string }
         ),
         mdmsService.search<HierNode>(tenant, 'RAINMAKER-PGR.ComplaintHierarchy', { limit: 2000 }),
       ]);
-      const allRows = (nodes || []).filter((n) => n.active !== false && n.code);
+      const allRows = (nodes || []).filter(
+        (n) => n._isActive !== false && n.active !== false && n.code,
+      );
       const def =
         (defs || []).find(
           (d) => Array.isArray(d.levels) && d.levels!.length && allRows.some((n) => n.hierarchyType === d.hierarchyType),
@@ -113,14 +126,19 @@ export function ComplaintHierarchyCascade(props: InputProps & { label?: string }
   };
 
   const handleChange = (i: number, value: string) => {
+    // Radix's hidden form-bubble <select> echoes an EMPTY onValueChange whenever
+    // the controlled `value` changes while the dropdown is closed: its options
+    // are only mounted with the (portalled) content, so assigning a value it has
+    // no <option> for leaves the native select at "" and the synthetic `change`
+    // it dispatches reports "". Rehydrating the cascade from an existing
+    // serviceCode does exactly that, so an unguarded handler wiped the very
+    // value it had just restored. A real pick is never empty — Radix forbids an
+    // empty SelectItem value — so an empty payload is always the echo. Ignore it.
+    if (!value) return;
     const next = sel.slice();
-    next[i] = value || null;
+    next[i] = value;
     for (let j = i + 1; j < next.length; j++) next[j] = null;
     setSel(next);
-    if (!value) {
-      field.onChange('');
-      return;
-    }
     // Terminal when this is the declared leaf level OR the next level has no
     // options for this selection → its code is the serviceCode. Otherwise clear
     // (force the operator to drill deeper).

--- a/configurator/src/resources/complaints/ComplaintList.tsx
+++ b/configurator/src/resources/complaints/ComplaintList.tsx
@@ -42,6 +42,7 @@ const filters = [
     source="additionalDetail.department"
     reference="departments"
     label="Department"
+    alwaysOn
   />,
   <TextFilterInput key="srid" source="serviceRequestId" label="Request ID" />,
 ];

--- a/configurator/src/resources/complaints/LocalityPicker.tsx
+++ b/configurator/src/resources/complaints/LocalityPicker.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useInput, useGetList, type RaRecord } from 'ra-core';
 import {
   Select,
@@ -51,14 +51,23 @@ export function LocalityPicker({
 }: LocalityPickerProps) {
   const { id, field, fieldState } = useInput({ source, validate: required ? requiredV : undefined });
 
+  // Same story as `boundaries` below: client-side slicing only, so don't truncate.
   const { data: hierarchies, isLoading: hierarchiesLoading } = useGetList<HierarchyRecord>(
     'boundary-hierarchies',
-    { pagination: { page: 1, perPage: 100 }, sort: { field: 'hierarchyType', order: 'ASC' } },
+    { pagination: { page: 1, perPage: 100_000 }, sort: { field: 'hierarchyType', order: 'ASC' } },
   );
 
+  // `boundaries` has no server-side pagination in the data provider — it fetches
+  // every tenant tree and then slices `perPage` off the front — so `perPage` is
+  // a pure TRUNCATION knob here, not a cost control. The old 1000 silently cut a
+  // 1256-node deployment (mz.maputo) off at the knees: any complaint whose
+  // locality fell past the cut had no matching record, so `currentBoundary` came
+  // back undefined, the ancestor selects fell back to some unrelated hierarchy,
+  // and the Boundary control rendered its bare "Boundary" placeholder instead of
+  // the complaint's real locality. Ask for the whole set.
   const { data: boundaries, isLoading: boundariesLoading } = useGetList<BoundaryRecord>(
     'boundaries',
-    { pagination: { page: 1, perPage: 1000 }, sort: { field: 'name', order: 'ASC' } },
+    { pagination: { page: 1, perPage: 100_000 }, sort: { field: 'name', order: 'ASC' } },
   );
 
   // Seed the navigation selects from the *current* boundary code (if the form
@@ -136,17 +145,18 @@ export function LocalityPicker({
     (boundaryTypesByHierarchy.get(hierarchyType) ?? [])[0] ??
     '';
 
-  // Navigation state that the operator *actually* manipulates: we keep the
-  // hierarchy + type in form-local sidecars so changing them doesn't fire an
-  // immediate `field.onChange` of a broken code.
-  const { hSource, tSource } = {
-    hSource: `${source}__h`,
-    tSource: `${source}__t`,
-  };
-  const hInput = useInput({ source: hSource, defaultValue: hierarchyType });
-  const tInput = useInput({ source: tSource, defaultValue: boundaryType });
-  const activeHierarchy = String(hInput.field.value || hierarchyType);
-  const activeType = String(tInput.field.value || boundaryType);
+  // Navigation state that the operator *actually* manipulates. This is COMPONENT
+  // state, never form state: the previous version registered `useInput` on
+  // `${source}__h` / `${source}__t`, and because `source` is `address.locality.code`
+  // those paths resolve INSIDE the locality object — so react-hook-form built
+  // `address.locality.code__h` / `code__t` and the form posted this picker's
+  // private navigation into PGR's address contract. pgr-services tolerates the
+  // extra keys (they're dropped when the payload is bound to the Boundary POJO),
+  // but they are not ours to send.
+  const [navHierarchy, setNavHierarchy] = useState<string | null>(null);
+  const [navType, setNavType] = useState<string | null>(null);
+  const activeHierarchy = navHierarchy ?? hierarchyType;
+  const activeType = navType ?? boundaryType;
 
   const typesForHierarchy =
     boundaryTypesByHierarchy.get(activeHierarchy) ?? [];
@@ -173,8 +183,9 @@ export function LocalityPicker({
         <Select
           value={activeHierarchy}
           onValueChange={(v) => {
-            hInput.field.onChange(v);
-            tInput.field.onChange('');
+            if (!v) return; // Radix echo — see the note on the Boundary select below.
+            setNavHierarchy(v);
+            setNavType(null);
             field.onChange('');
           }}
           disabled={hierarchiesLoading}
@@ -192,7 +203,8 @@ export function LocalityPicker({
         <Select
           value={activeType}
           onValueChange={(v) => {
-            tInput.field.onChange(v);
+            if (!v) return; // Radix echo — see the note on the Boundary select below.
+            setNavType(v);
             field.onChange('');
           }}
           disabled={!activeHierarchy || typesForHierarchy.length === 0}
@@ -207,9 +219,34 @@ export function LocalityPicker({
           </SelectContent>
         </Select>
 
+        {/* THE LOCALITY WIPE. Radix renders a hidden form-bubble <select> to make
+            the control submittable, and its <option>s are contributed by the
+            SelectItems — which live in the portalled content and are therefore
+            NOT mounted while the dropdown is closed. Its effect fires on every
+            change of the controlled `value`: it assigns the new value to the
+            native select and dispatches a synthetic `change`. With no options
+            mounted the assignment can't take, the native value stays "", and the
+            event reports "" back through `onValueChange`.
+
+            On an edit form that happens unprompted: the hierarchy/type selects
+            go from "" to their resolved defaults the moment the boundary queries
+            settle, each echoes "", and the handlers dutifully cleared the code.
+            `useInput`'s default parse turns "" into null, so the form posted
+            `address.locality.code: null`. pgr-services accepted it (200) and
+            published to `update-pgr-request`, then egov-persister died on
+            `null value in column "locality" of relation "eg_pgr_address_v2"` —
+            and because the address and service UPDATEs share one transaction,
+            the description/status edit rolled back with it. Nine retries, message
+            dropped, complaint silently unchanged with its workflow advanced.
+
+            Radix rejects an empty SelectItem value, so an empty payload is ALWAYS
+            the echo and never an operator choice. Drop it. */}
         <Select
           value={typeof field.value === 'string' ? field.value : ''}
-          onValueChange={(v) => field.onChange(v)}
+          onValueChange={(v) => {
+            if (!v) return;
+            field.onChange(v);
+          }}
           disabled={!activeType || boundariesLoading}
         >
           <SelectTrigger

--- a/utilities/default-data-handler/src/main/resources/PgrWorkflowConfig.json
+++ b/utilities/default-data-handler/src/main/resources/PgrWorkflowConfig.json
@@ -273,7 +273,7 @@
               "tenantId": "{tenantid}",
               "currentState": "PENDINGATLME",
               "action": "FORWARD",
-              "nextState": "04752227-e267-43e3-bfd8-6e48bdbfd97a",
+              "nextState": "PENDINGATSUPERVISOR",
               "roles": [
                 "AUTO_ESCALATE"
               ],
@@ -420,9 +420,9 @@
           "actions": [
             {
               "tenantId": "{tenantid}",
-              "currentState": "04752227-e267-43e3-bfd8-6e48bdbfd97a",
+              "currentState": "PENDINGATSUPERVISOR",
               "action": "RESOLVEBYSUPERVISOR",
-              "nextState": "e80e3dd6-8336-4586-b84a-c191dcd80c98",
+              "nextState": "RESOLVED",
               "roles": [
                 "SUPERVISOR"
               ],


### PR DESCRIPTION
## Admin (configurator) + PGR seed bug fixes

Bugs surfaced by the integration test suite on a two-level (root/city) deployment
(Maputo). Most are in the admin SPA / its data-provider, plus one fix to the
shipped PGR workflow seed. Verified locally.

Test-suite changes are **not** in this PR — they are in #1376.

---

### 1. Complaint create stamped the wrong tenant

**What:** `service.tenantId` was set to the session/root tenant rather than the
tenant that owns the selected boundary.
**Why it mattered:** a root admin creating a complaint against a city boundary got
`INVALID_BOUNDARY_CODE`, because the boundary does not exist at the root.
**Fix:** derive the city tenant from the boundary and stamp that.

### 2. Department / tenant lists filtered `isActive` after pagination

**What:** the data provider requested a page of rows and *then* dropped inactive
ones client-side.
**Why it mattered:** on a tenant with soft-deleted rows the whole page could be
inactive, so the grid rendered empty under a "showing 1–N of M" header.
**Fix:** push `isActive` to the server so pagination runs over the filtered set.

### 3. Assign-to-employee sent the wrong key and merged a null `serviceCode`

**What:** the assignee was sent under `assignees`; PGR binds `assignes`. Separately,
a text-only edit merged a `null` `serviceCode` into the update payload.
**Why it mattered:** the assignment silently did nothing, and the null `serviceCode`
caused an NPE in pgr-services.
**Fix:** correct key name, plus a null guard on the edit merge.

### 4. Assignee dropdown listed the root tenant's employees

**What:** the employee picker searched HRMS at the session tenant.
**Why it mattered:** for a root admin working a city complaint, the list contained
people who cannot act on it, and omitted the ones who can.
**Fix:** `DigitFormSelect` gains a tenant filter and hrms `getOne` honors it, so the
picker lists the **complaint's city** employees.

### 5. Workflow actions read from the root tenant's PGR config (#521)

**What:** available actions were fetched against the session tenant.
**Why it mattered:** city-only actions (e.g. `ESCALATE`) were missing from the action
bar.
**Fix:** read the workflow from the complaint's city tenant.

### 6. Wizard-created tenants had no egov-enc-service key

**Files:** `configurator/src/api/services/tenantBootstrap.ts`,
`configurator/src/pages/Phase1Page.tsx`, `configurator/src/pages/Phase4Page.tsx`

**What:** egov-enc-service holds exactly one symmetric key per tenant, and every
write carrying PII is sealed with it. `bootstrapStateRoot()` generated a key for a
brand-new state root, but the wizard's normal path creates a city under an
**existing** root and skips bootstrap entirely — so no key was ever generated.

**Why it mattered:** every tenant the wizard created was structurally incapable of
accepting employees. Phase 4 always failed on it with
`400 UNKNOWN_ERROR "Unknown error occurred in encryption process"`.

**Fix:** `registerEncKey` is extracted and exported as `ensureEncKey()`, and Phase 1
calls it on the tenant-creation path. Deliberately narrow so it can never rotate a
live tenant's key:

- called only on the creation path — skipped on the duplicate branch, and for a
  fresh state root bootstrap has already done it;
- `POST /crypto/v1/_generatekey` is create-if-missing, not rotation. Verified against
  a throwaway tenant: three calls returned `created: true / false / false` with a
  single DB row whose `key_id` and `secret_key` never changed;
- no "regenerate key" affordance is exposed anywhere in the UI. Rotation would strand
  already-encrypted data (#622) and remains a deliberate ops action.

Failure is non-fatal — the tenant is created and Phases 2–3 work — so it raises a
non-blocking warning rather than rolling the operator back.

Also in `Phase4Page.tsx`: the employee-create loop continues past a row failure, so
the enclosing try/catch never observed per-row errors and the complete screen could
only report "0 created, 1 failed" with no reason (the Banner even promised a "failure
list below" that did not exist). Per-row `ApiClientError.firstError` is now recorded
and rendered.

### 7. PGR workflow seed referenced per-tenant state UUIDs

**File:** `utilities/default-data-handler/src/main/resources/PgrWorkflowConfig.json`

**What:** three transitions referenced workflow **state UUIDs** captured from the
tenant the seed was originally taken from.

**Why it mattered:** state UUIDs are minted per tenant, so on any other tenant those
references resolve to nothing. `PENDINGATLME --FORWARD--> 04752227-…` was a dangling
transition — confirmed live on `mz.maputo` before the fix.

**Fix:** reference the state **names**, which the workflow service resolves per
tenant:

| was | now | where |
| --- | --- | --- |
| `04752227-e267-43e3-bfd8-6e48bdbfd97a` | `PENDINGATSUPERVISOR` | the `FORWARD` `nextState`, and a `currentState` |
| `e80e3dd6-8336-4586-b84a-c191dcd80c98` | `RESOLVED` | the `RESOLVEBYSUPERVISOR` `nextState` |

The `ESCALATE` row already used a name and is unchanged.

### 8. Complaint-types list had no Department filter

**File:** `configurator/src/resources/complaint-types/ComplaintTypeList.tsx`

**What:** the list rendered a Department column but offered no way to filter by it,
unlike `DepartmentList` and `DesignationList`, which both ship a `FilterBar`.

**Why it mattered:** Department is the axis admins actually slice this list by
("what does Public Works own?"), and there was no way to do it.

**Fix:** added a `filters` array with a `ReferenceFilterInput` for department,
declared `alwaysOn` so it is visible without going through the Add-filter popover.
Note that passing `filters` to `DigitList` swaps out its built-in search box for the
`FilterBar`, so `SearchFilterInput` is re-declared alongside it — otherwise free-text
search would have disappeared from the page.

### 9. Minor UX

Create → Show redirect after creating a record.

### 10. Complaint edits silently discarded themselves — data loss

**Files:** `configurator/src/resources/complaints/LocalityPicker.tsx`,
`configurator/src/resources/complaints/ComplaintHierarchyCascade.tsx`,
`configurator/packages/data-provider/src/providers/dataProvider.ts`

Editing a complaint returned `200`, advanced the workflow, and left the record
untouched — description, status, everything. `egov-persister` logged **825**
`null value in column "locality" of relation "eg_pgr_address_v2"` rows in 24 hours; the
address and service UPDATEs share one transaction, so the service row rolled back with
the address, and after nine retries the message was dropped. This affected real
operators, not only tests.

**Why:** a Radix Select interaction, not our state handling. Inside a `<form>`, Radix
renders a hidden form-bubble `<select>` whose `<option>`s are contributed by
`SelectItem`s living in the *portalled content* — not mounted while the dropdown is
closed. Its effect runs on every controlled-value change; with no options mounted the
assignment cannot take and it emits `onValueChange("")`. On the edit form the
hierarchy/type selects go `"" → resolved default` as soon as the boundary queries
settle, so both echo `""` unprompted on **every page load**, and ra-core's
`defaultParse` turns `''` into `null`.

- Both components now ignore an empty `onValueChange` payload (Radix forbids an empty
  `SelectItem` value, so `""` is only ever the echo).
- `dataProvider` gains `mergePgrAddress()` — defence in depth: `locality.code` is
  restored from the loaded record when the incoming one is empty, since the column
  forbids null and clearing a locality is not a supported edit. Other address fields
  merge as before, because nulling a landmark *is* a real edit.
- `stripLocalitySidecars()` drops the picker's `__h`/`__t` navigation keys, which were
  leaking into PGR's address contract via `useInput` on `` `${source}__h` ``.
- `perPage` raised for boundaries/hierarchies. The provider fetches everything and
  slices client-side, so `perPage: 1000` against 1256 nodes was a pure truncation knob.
  This produced the visible tell (the Boundary control showing its placeholder) but was
  **not** the null source — a competing hypothesis that the evidence refuted.

**Verified:** an edit persists through a re-search, pgr and `egov-wf` agree on the
state, and `egov-persister` logs zero errors over the window.

### 11. The configurator offered soft-deleted complaint types

**Files:** `configurator/src/api/services/mdms.ts`,
`configurator/src/resources/complaints/ComplaintHierarchyCascade.tsx`,
`configurator/src/resources/complaint-hierarchies/ComplaintHierarchyShow.tsx`

Selecting one produced an opaque `400 INVALID_SERVICECODE ... not present in MDMS`.
`mdmsService.search()` never sent `isActive: true` and then did
`.map(record => record.data)`, discarding the record-level flag entirely — so no caller
could filter on it. The cascade filtered on `data.active`, a *different* field, still
`true` on deleted rows. Four deleted types sorted **first** (`order: 1`) ahead of the two
real ones.

`search()` now requests active rows (opt out via `includeInactive`), re-filters
client-side as a fallback, and preserves the flag as `_isActive`. Every caller was
reviewed: none legitimately wants inactive rows — migrating or verifying against a
deleted ServiceDef would be a false pass. **Behaviour change worth noting:** the bulk
importers use these lists for duplicate detection, so a soft-deleted department is no
longer treated as a duplicate; the create then surfaces MDMS's own "uid taken" error
instead of being silently skipped. `ComplaintHierarchyShow`'s pager assumed a short page
meant the last page, which stops holding once `search()` can drop rows — it now breaks on
an empty page.

### 12. The complaints Department filter did not filter

**File:** `configurator/packages/data-provider/src/providers/dataProvider.ts`

Selecting a department left the grid byte-identical and the outbound request unchanged.
`ComplaintList` declares `source="additionalDetail.department"`; react-hook-form nests
the dotted path, while the provider read the flat key and found `undefined`.

Fixed **generically** rather than by renaming the source: `flattenFilterSources()`
additionally publishes every nested leaf under its dotted path, so any future dotted
source works too. The nested shape is kept intact (ra-core's filter-form reset depends on
it) and a flat key passed by a caller is never overwritten. The declaration is
deliberately left dotted so the path stays exercised as a regression guard.

### 13. Date filters were discarded before the request was built

**File:** `configurator/packages/data-provider/src/providers/dataProvider.ts`

`DateFilterInput` drives an `<input type="date">`, so the value is the string
`"2026-07-20"`; the provider gated on `typeof === 'number'` and dropped it silently.

`toEpochMs()` coerces `number | Date | YYYY-MM-DD | epoch-string`, parsing the date parts
in **local** time — `new Date(str)` is spec'd as UTC midnight and lands on the wrong day
east of UTC. `'end'` resolves to `23:59:59.999` so an inclusive To date still matches
same-day complaints. `fromDate` is anchored to `0` when only `toDate` is set, because
`PGRQueryBuilder` throws `INVALID_SEARCH` on a to-without-from — latent before, since both
values were always dropped.

---

## Known-open, diagnosed, **not** addressed by this PR

Investigated in the same pass and understood, but each needs a decision or a fix that is
out of scope here. Their tests in #1376 are **deliberately red** rather than skipped, so
they stay visible.

- **Complaint-type create is broken.** `ComplaintTypeCreate.tsx` omits `hierarchyType`
  and `levelCode`, both of which the schema requires → `400 INVALID_REQUEST_REQUIRED`.
  The fix is ~2 lines, but needs a product decision on what `levelCode` should default to,
  or whether it should derive from the selected parent.
- **`_search` silently caps at 200 rows** while `_count` reports the true total (e.g. 203).
  Requesting 250 or 300 still yields exactly 200. Backend; needs a decision on whether the
  cap is intended and, if so, on making the counter agree with it.
- **A ward-scoped CSR receives the full boundary tree.** `boundary-service` ignores the
  jurisdiction when resolving boundary-relationships. Backend, outside the configurator.
- **pgr-services accepts an `ASSIGN` with an empty `assignes` array** and moves the
  complaint to `PENDINGATLME`. Backend validation gap, noticed while diagnosing the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
