### PR TITLE
test(integration): deployment-agnostic admin/cross/system suites + de-serialise

### DIFF
--- a/tests/integration-tests/WRITING-TESTS.md
+++ b/tests/integration-tests/WRITING-TESTS.md
@@ -1,0 +1,151 @@
+# Integration tests — how they work & how to add them
+
+End-to-end Playwright tests that run against a **live DIGIT deployment** (no mocking).
+The same suite must pass on **any** deployment — local Maputo (`mz.maputo`), bomet
+Kenya (`ke`), etc. That "deployment-agnostic" rule is the single most important thing
+to understand before writing a test.
+
+See also **`docs/TEST-PREREQUISITES.md`** (repo root) for the data a deployment must
+have and what each setup step does.
+
+---
+
+## 1. Layout
+
+```
+tests/integration-tests/
+  playwright.config.ts        # projects, timeouts, workers
+  tests/
+    citizen/  employee/  admin/   # UI specs, grouped by who uses the screen
+    api/  smoke/                   # API-only specs (token-injection auth)
+    keycloak/  lifecycle/  specs/  onboarding/
+    fixtures/                      # SETUP projects (run before specs) + auth files
+    utils/                         # env, profile, probes, personas, seed, helpers
+  scripts/                    # build-catalog.ts (dashboard), tag-tests.ts (tagging)
+```
+
+## 2. How a run works (the pipeline)
+
+Every `npx playwright test` runs these **setup projects first** (dependencies in
+`playwright.config.ts`), then the spec projects:
+
+1. **`profile-setup`** interrogates the live deployment once and writes
+   `deployment-profile.json` — tenant + label, boundary hierarchy, complaint types,
+   PGR workflow actions, mobile/postal patterns, locales, a seed plan, resolved
+   personas. It hard-fails if the deployment can't be tested at all (no boundaries,
+   no workflow, etc.) so an empty stack fails loudly instead of skipping green.
+2. **`setup`** (UI login → `auth.json`), **`api-setup`** (token injection →
+   `auth-api.json`), **`citizen-setup`** (one fresh citizen → `citizen-fixture.json`),
+   **`lifecycle-setup`** (seeds 3 complaints → `lifecycle-fixtures.json`).
+3. Then **`chromium`** (all UI specs), **`api`**, **`smoke`** run.
+
+`utils/env.ts` reads `deployment-profile.json` **synchronously at import time**, so any
+spec that imports a value from `env.ts` is automatically deployment-correct.
+
+**`workers: 1`** — specs run one at a time. They share the fixture files above
+(`auth.json`, `deployment-profile.json`, …), so **never run two `npx playwright test`
+invocations against the same stack at once** — they clobber each other.
+
+## 3. The golden rule: no hardcoded deployment literals
+
+Every deployment-shaped value resolves through one chain:
+
+```
+explicit env var  →  deployment-profile.json  →  legacy hardcoded default
+```
+
+Do **not** hardcode: tenant (`ke`, `mz.maputo`), phone prefix (`+254`), a complaint
+type (`ContractDispute`, `reparo_buracos`), a postal format, a boundary/ward code, an
+id prefix (`NCCG`), a tenant label ("Bomet County"), a specific SRID, a username
+(`EMP001`). Instead, import from `utils/env.ts`:
+
+```ts
+import { TENANT, ROOT_TENANT, SERVICE_CODE, LOCALITY_CODE, TENANT_LABEL,
+         POSTAL_CODE_PATTERN, LOCALES, PGR_ID_PREFIX, generateCitizenPhone } from '../utils/env';
+```
+
+…or resolve it live (MDMS / boundary / workflow lookups via `utils/probes.ts`,
+`utils/personas.ts`). A test that "passes" only because a hardcoded literal happens to
+match one deployment is a **vacuous pass** — the whole point of this chain is to turn
+those into real, portable assertions.
+
+This extends to **workflow shape**, not just literals: read a feature's actual
+configuration live (e.g. what state `ESCALATE` moves to, whether a filter exists)
+rather than assuming one deployment's behaviour.
+
+## 4. Adding a test — checklist
+
+1. **Put it in the right persona folder** (`tests/admin/`, `tests/citizen/`, …). The
+   folder + filename drive its default dashboard tags.
+2. **Tag it.** Every `test()` takes an options object with a `tag` array:
+   ```ts
+   test('does the thing', {
+     tag: ['@persona:admin', '@area:pgr', '@layer:ui', '@kind:regression'],
+   }, async ({ page }) => { … });
+   ```
+   Facets (used by the dashboard filters): `@persona:` (admin | citizen | employee |
+   cross | system), `@area:` (pgr, hrms, configurator-manage, localization, theme,
+   dashboard, auth, mdms-schema, proxy, keycloak, onboarding, manage-boundaries),
+   `@layer:` (ui | api), `@kind:` (happy-path | edge-case | regression | smoke |
+   lifecycle | validation). Reference a ticket with `@ccrs:NNN` / `@pr:NNN`.
+3. **Pull deployment values from `env.ts`** (§3) — never hardcode.
+4. **Reuse the helpers** instead of rolling your own:
+   - `utils/auth.ts` `getDigitToken`, `loadAuth`; `utils/employee-ui.ts`
+     `loginEmployeeBrowser`, `getPrincipal`, `readInboxRows`, `fetchService`.
+   - `utils/seed.ts` `seedComplaintAsCitizen`, `driveToPendingAtLme`, … (file/assign/
+     resolve a complaint — APPLY is always `[CITIZEN, CSR]`, so file as a citizen).
+   - `utils/manage/api.ts` `pgrSearch`, `pgrCount`, `mdmsSearch`, `employeeSearch`.
+   - `utils/personas.ts` `getPersona`, `resolveSeedPlan` (the exact serviceCode/actor/
+     assignee triple PGR will actually accept on this deployment).
+5. **Skip, don't fail, when a capability or data legitimately isn't present** — with a
+   precise reason (`test.skip(!x, 'no ward-scoped CSR on <tenant>: …')`). Reserve a
+   red for a real regression. Never let a spec pass by asserting nothing.
+6. **Clean up what you create.** Track created records and soft-delete them in
+   `afterAll` (`utils/manage/teardown.ts`); use the `PW_` code prefix
+   (`utils/manage/codes.ts` `testCode`) so leftovers are identifiable and never collide.
+
+## 5. Conventions & gotchas (learned the hard way)
+
+- **Assert on the write's RESPONSE, not an immediate re-search.** pgr-services' search
+  index lags the write by a beat — an immediate `_search` after an update reads the
+  *old* value. Read the value back from the `_update`/`_create` response.
+- **Wait for the XHR before asserting.** Don't race a UI Save:
+  ```ts
+  const [resp] = await Promise.all([
+    page.waitForResponse(r => r.url().includes('/_update') && r.request().method()==='POST'),
+    page.getByRole('button', { name: /^Save$/ }).click(),
+  ]);
+  ```
+- **Default to `mode: 'default'`, not `'serial'`.** With `workers:1` both run in file
+  order, but `serial` cascade-skips every test after the first failure — hiding the
+  real state. Use `serial` only when tests genuinely depend on each other.
+- **Locate custom selects/filters by role + name**, e.g.
+  `getByRole('combobox', { name: /^Status$/i })` — `getByLabel` misses controls that
+  render without a `<label>` association.
+- **Two-level tenants:** a complaint's boundary, assignee, and workflow live at the
+  **city** tenant (`mz.maputo`), while the citizen lives at the **root** (`mz`). File
+  and validate against the correct one.
+- **HRMS `employees/_search` needs `offset=0`** (it 500s without it); its
+  `roles=`/`codes=` filters are unreliable — search then filter in code.
+- **`@local-only`-tagged specs** are excluded unless `LOCAL_STACK=1`.
+
+## 6. Running
+
+```bash
+cd tests/integration-tests
+set -a; source .env; set +a          # deployment target: BASE_URL, DIGIT_TENANT, …
+npx playwright test tests/admin --project=chromium --workers=1
+npx playwright test tests/api   --project=api
+```
+
+Run **one suite / project at a time** (shared fixtures — §2). The runner
+(`runner/run-cycle.sh`) and dashboard (`scripts/build-catalog.ts`,
+`scripts/tag-tests.ts`) publish results; the dashboard groups by the tags above.
+
+## 7. Pass / fail / skip — what each means
+
+- **pass** — the behaviour is correct on this deployment.
+- **fail** — a real regression, OR a genuine app/deployment defect the test correctly
+  catches (keep it red; don't weaken the assertion to go green).
+- **skip** — a capability/data/build feature this deployment legitimately lacks, with a
+  precise reason. A skip must never hide a failure.

--- a/tests/integration-tests/WRITING-TESTS.md
+++ b/tests/integration-tests/WRITING-TESTS.md
@@ -5,9 +5,6 @@ The same suite must pass on **any** deployment — local Maputo (`mz.maputo`), b
 Kenya (`ke`), etc. That "deployment-agnostic" rule is the single most important thing
 to understand before writing a test.
 
-See also **`docs/TEST-PREREQUISITES.md`** (repo root) for the data a deployment must
-have and what each setup step does.
-
 ---
 
 ## 1. Layout
@@ -26,27 +23,68 @@ tests/integration-tests/
 
 ## 2. How a run works (the pipeline)
 
-Every `npx playwright test` runs these **setup projects first** (dependencies in
-`playwright.config.ts`), then the spec projects:
+Every `npx playwright test` runs these **setup projects first** (declared as project
+dependencies in `playwright.config.ts`), then the spec projects:
 
-1. **`profile-setup`** interrogates the live deployment once and writes
-   `deployment-profile.json` — tenant + label, boundary hierarchy, complaint types,
-   PGR workflow actions, mobile/postal patterns, locales, a seed plan, resolved
-   personas. It hard-fails if the deployment can't be tested at all (no boundaries,
-   no workflow, etc.) so an empty stack fails loudly instead of skipping green.
-2. **`setup`** (UI login → `auth.json`), **`api-setup`** (token injection →
-   `auth-api.json`), **`citizen-setup`** (one fresh citizen → `citizen-fixture.json`),
-   **`lifecycle-setup`** (seeds 3 complaints → `lifecycle-fixtures.json`).
-3. Then **`chromium`** (all UI specs), **`api`**, **`smoke`** run.
+1. **`profile-setup`** → writes `deployment-profile.json`. Interrogates the *live*
+   deployment once (`utils/profile.ts` `discoverProfile()`): tenant + label (from
+   localization), boundary hierarchy shape + a proven leaf, complaint types, PGR
+   workflow actions, mobile regex, postal pattern, populated locales, the **seed plan**
+   (serviceCode + localityCode + idPrefix), and the resolved **personas** (logs each in,
+   records which tenant accepted it). It **hard-asserts** the anti-vacuous-pass guards
+   (rows 1, 3, 4, 5, 6 in §3) so an empty stack fails loudly instead of skipping green.
+2. **`setup`** (real UI login at `/configurator/login` as ADMIN → `auth.json`; *skips*
+   if the configurator isn't deployed).
+3. **`api-setup`** (token injection, no UI → `auth-api.json`; used by `api` + `smoke`).
+4. **`citizen-setup`** (one fresh citizen per run → `citizen-fixture.json`).
+5. **`lifecycle-setup`** (seeds 3 complaints → `lifecycle-fixtures.json`: one
+   non-terminal at `PENDINGFORASSIGNMENT`, one assigned at `PENDINGATLME`, one walked
+   ASSIGN→RESOLVE→RATE to `CLOSEDAFTERRESOLUTION` rating=4). Always files as a CITIZEN
+   (APPLY is `[CITIZEN, CSR]` everywhere). If no viable seed triple exists it writes a
+   `status: skipped` marker and **passes** — downstream specs fall back to their own
+   env/historical defaults rather than cascade-failing.
 
-`utils/env.ts` reads `deployment-profile.json` **synchronously at import time**, so any
-spec that imports a value from `env.ts` is automatically deployment-correct.
+Then the spec projects run: **`chromium`** (all UI specs), **`api`** (`tests/api`),
+**`smoke`** (`tests/smoke`). `@local-only` specs run only when `LOCAL_STACK=1`.
 
-**`workers: 1`** — specs run one at a time. They share the fixture files above
-(`auth.json`, `deployment-profile.json`, …), so **never run two `npx playwright test`
-invocations against the same stack at once** — they clobber each other.
+`utils/env.ts` reads `deployment-profile.json` **synchronously at import time** — that
+ordering (a project dependency, not a `beforeAll`) is why any spec that imports a value
+from `env.ts` is automatically deployment-correct.
 
-## 3. The golden rule: no hardcoded deployment literals
+**Fixture files written to the suite root** (shared, per-invocation state):
+`deployment-profile.json`, `auth.json`, `auth-api.json`, `citizen-fixture.json`,
+`lifecycle-fixtures.json`. Because they're shared, **`workers: 1`** and you must **never
+run two `npx playwright test` invocations against the same stack at once** — they
+clobber each other's profile + auth + seed fixtures.
+
+## 3. Data a deployment must have
+
+The suite *discovers* these live (§2) rather than hardcoding them — but discovery can
+only find what the deployment was seeded with. If a row is missing, the paired setup
+step either **hard-fails** (suite stops) or **self-skips** (that capability's specs
+skip, not fail).
+
+| # | Data | Service / MDMS | Missing → | Guard |
+|---|------|----------------|-----------|-------|
+| 1 | Tenant hierarchy: root + city (e.g. `mz` / `mz.maputo`) | tenant-management | can't resolve TENANT | hard-fail |
+| 2 | City display label `TENANT_TENANTS_<CITY>` in `en_IN` | localization | login combobox spins → 120s timeout | warn (falls back to guess) |
+| 3 | Boundary hierarchy, ≥2 levels, ≥1 leaf node | boundary-service + MDMS boundary | no complaint can be filed | **hard-fail** |
+| 4 | PGR `BusinessService` **at the city tenant**, ≥1 action | egov-workflow-v2 | no workflow to drive | **hard-fail** |
+| 5 | Complaint types (`RAINMAKER-PGR.ServiceDefs` / `ComplaintHierarchy`) at city | MDMS v2 | nothing to file | **hard-fail** |
+| 6 | An **employee persona** the seed plan can use: a GRO actor + a PGR_LME assignee whose HRMS department matches a complaint type's department | egov-hrms | ASSIGN 400s `DEPARTMENT_NOT_FOUND`; setup can't seed | **hard-fail** (employee persona), else lifecycle self-skips |
+| 6b | **Escalation suite only:** ≥2 *more* employees in the seed complaint-type's department (≥3 total incl. the assignee), to build the 2-level `reportingTo` chain | egov-hrms | `pgr-escalation` tests 3–12 self-skip | self-skip |
+| 7 | `MobileNumberValidation` regex | common-masters MDMS | phone gen falls back to `7`-lead (Kenya) | degrades |
+| 8 | Postal config `CORE_POSTAL_CONFIGS.postalCodePattern` in SPA globalConfigs | globalConfigs.js | falls back to 5-digit rule | degrades |
+| 9 | PGR id prefix (segment before `-PGR-`) | egov-idgen | falls back to `NCCG` | degrades |
+| 10 | Localization messages for `en_IN` (+ any locale under test), incl. workflow action labels (ESCALATE, …) | localization | label assertions skip/fail | per-spec |
+| 11 | `RejectionReasons`, `Department`, `Designation` masters | MDMS v2 | admin/HRMS specs skip | per-spec |
+| 12 | Citizen self-registration + fixed OTP `123456` | user-service (+ OTP disabled/fixed) | citizen-setup fails | hard-fail (citizen specs) |
+| 13 | **Optional:** Keycloak realm + OIDC discovery | keycloak | `tests/keycloak/*` self-skip | self-skip |
+
+A deployment's onboarding (XLSX + `deploy.sh`) may not seed all of these — close the
+gaps by hand on the test tenant.
+
+## 4. The golden rule: no hardcoded deployment literals
 
 Every deployment-shaped value resolves through one chain:
 
@@ -69,11 +107,18 @@ import { TENANT, ROOT_TENANT, SERVICE_CODE, LOCALITY_CODE, TENANT_LABEL,
 match one deployment is a **vacuous pass** — the whole point of this chain is to turn
 those into real, portable assertions.
 
-This extends to **workflow shape**, not just literals: read a feature's actual
-configuration live (e.g. what state `ESCALATE` moves to, whether a filter exists)
-rather than assuming one deployment's behaviour.
+**This extends to workflow *shape*, not just literals** — read a feature's actual
+configuration live rather than assuming one deployment's behaviour:
+- **ESCALATE model** — Kenya wires it as a **self-loop** on `PENDINGATLME` (status
+  unchanged, an escalation *level* increments); a supervisor-tier deployment (maputo)
+  wires it as a **forward transition** to `PENDINGATSUPERVISOR`. Read the ESCALATE
+  action's configured `nextState` from the businessservice; multi-level self-loop
+  assertions self-skip on the forward model.
+- **Inbox locality sort** — some deployments sort by the raw leaf boundary code, others
+  by a coarser bairro/name key, so a spec cannot assume raw-leaf-code order.
+- **Postal / mobile formats, id prefixes, locales** — always from the profile.
 
-## 4. Adding a test — checklist
+## 5. Adding a test — checklist
 
 1. **Put it in the right persona folder** (`tests/admin/`, `tests/citizen/`, …). The
    folder + filename drive its default dashboard tags.
@@ -88,7 +133,7 @@ rather than assuming one deployment's behaviour.
    dashboard, auth, mdms-schema, proxy, keycloak, onboarding, manage-boundaries),
    `@layer:` (ui | api), `@kind:` (happy-path | edge-case | regression | smoke |
    lifecycle | validation). Reference a ticket with `@ccrs:NNN` / `@pr:NNN`.
-3. **Pull deployment values from `env.ts`** (§3) — never hardcode.
+3. **Pull deployment values from `env.ts`** (§4) — never hardcode.
 4. **Reuse the helpers** instead of rolling your own:
    - `utils/auth.ts` `getDigitToken`, `loadAuth`; `utils/employee-ui.ts`
      `loginEmployeeBrowser`, `getPrincipal`, `readInboxRows`, `fetchService`.
@@ -98,13 +143,13 @@ rather than assuming one deployment's behaviour.
    - `utils/personas.ts` `getPersona`, `resolveSeedPlan` (the exact serviceCode/actor/
      assignee triple PGR will actually accept on this deployment).
 5. **Skip, don't fail, when a capability or data legitimately isn't present** — with a
-   precise reason (`test.skip(!x, 'no ward-scoped CSR on <tenant>: …')`). Reserve a
-   red for a real regression. Never let a spec pass by asserting nothing.
+   precise reason (`test.skip(!x, 'no ward-scoped CSR on <tenant>: …')`). Reserve a red
+   for a real regression. Never let a spec pass by asserting nothing.
 6. **Clean up what you create.** Track created records and soft-delete them in
    `afterAll` (`utils/manage/teardown.ts`); use the `PW_` code prefix
    (`utils/manage/codes.ts` `testCode`) so leftovers are identifiable and never collide.
 
-## 5. Conventions & gotchas (learned the hard way)
+## 6. Conventions & gotchas (learned the hard way)
 
 - **Assert on the write's RESPONSE, not an immediate re-search.** pgr-services' search
   index lags the write by a beat — an immediate `_search` after an update reads the
@@ -129,7 +174,7 @@ rather than assuming one deployment's behaviour.
   `roles=`/`codes=` filters are unreliable — search then filter in code.
 - **`@local-only`-tagged specs** are excluded unless `LOCAL_STACK=1`.
 
-## 6. Running
+## 7. Running
 
 ```bash
 cd tests/integration-tests
@@ -142,7 +187,7 @@ Run **one suite / project at a time** (shared fixtures — §2). The runner
 (`runner/run-cycle.sh`) and dashboard (`scripts/build-catalog.ts`,
 `scripts/tag-tests.ts`) publish results; the dashboard groups by the tags above.
 
-## 7. Pass / fail / skip — what each means
+## 8. Pass / fail / skip — what each means
 
 - **pass** — the behaviour is correct on this deployment.
 - **fail** — a real regression, OR a genuine app/deployment defect the test correctly

--- a/tests/integration-tests/deploy/expectations/maputo-local.json
+++ b/tests/integration-tests/deploy/expectations/maputo-local.json
@@ -12,7 +12,7 @@
     "pgr.citizenCreate": "required",
     "ui.citizen.attachmentDetailRender": "required",
     "personas.gro-with-department": "required",
-    "personas.ward-scoped-csr": "absent",
+    "personas.ward-scoped-csr": "optional",
     "locales.multi": "absent",
     "tenant.citySubTenant": "required"
   },
@@ -20,7 +20,7 @@
     "workflow.pgr.actions.ESCALATE": "REQUIRED, not absent — corrected 2026-07-16. ESCALATE is intended product config (added by PR #635 / commit ce302053: PENDINGATLME -> ESCALATE -> PENDINGATSUPERVISOR with role PGR_LME), and bomet's `ke` has it. mz.maputo lacked it only because tenant_bootstrap copies the PGR businessService from the `pg` demo tenant, which predates that PR — a real seed gap, not an N/A. api/pgr-escalation test 2 self-heals it (it patches the wirings into the live workflow, which is its stated purpose); do NOT gate that test on this capability, since it is the thing that creates it. Declaring this 'absent' would bless the gap and permanently skip #521 here.",
     "mdms.rejectionReasons": "Deliberate red. Neither the schema nor any data exists on any tenant of either deployment, while the GRO reject modal reads this master. Seeded locally on 2026-07-16 (4 rows at mz), so this should now pass — if it goes red again the tenant was wiped (see the fast-path dump trap).",
     "ui.citizen.attachmentDetailRender": "Required so a real regression stays visibly red rather than being hidden behind the old ATTACHMENT_DETAIL_UNSUPPORTED env hatch.",
-    "personas.ward-scoped-csr": "No ward-scoped CSR persona is onboarded here; the bomet-shaped BOMET_CSR_* defaults do not exist.",
+    "personas.ward-scoped-csr": "Was 'absent' — nothing here held the CSR role together with a jurisdiction below the MAPUTO_ADMIN root (EMP001/2/3 are scoped to the root itself and hold no CSR; ADMIN holds CSR but its only jurisdiction is the TENANT id mz.maputo, in hierarchy ADMIN). scripts/seed-deployment.ts now onboards SEED_WARD_CSR (Bairro-scoped, obras_publicas/agente) so boundary-jurisdiction-496 can actually run. 'optional' rather than 'required': the seeder is idempotent but not guaranteed to have been run, and a deployment that legitimately has no ward CSR should still self-skip honestly rather than hard-fail on a persona nobody onboarded.",
     "locales.multi": "Only en_IN is meaningfully seeded (16899 rows). pt_BR/fr_FR/hi_IN exist but are 205-row stubs, not real translations.",
     "tenant.citySubTenant": "Two-level: root mz + city mz.maputo. The configurator tenant-search test is meaningful here."
   }

--- a/tests/integration-tests/playwright.config.ts
+++ b/tests/integration-tests/playwright.config.ts
@@ -128,7 +128,11 @@ export default defineConfig({
       name: 'api',
       testDir: 'tests/api',
       testMatch: /.*\.spec\.ts$/,
-      dependencies: ['api-setup', 'profile-setup'],
+      // lifecycle-setup writes lifecycle-fixtures.json, which api-helpers.spec.ts
+      // reads at module-load time. Without this dependency a `--project=api` run has
+      // no fixture file and that spec self-skips — which read as a data gap but was
+      // purely a missing dependency here.
+      dependencies: ['api-setup', 'profile-setup', 'lifecycle-setup'],
       grepInvert: EXCLUDE_LOCAL_ONLY,
       use: {
         storageState: 'auth-api.json',

--- a/tests/integration-tests/scripts/seed-deployment.ts
+++ b/tests/integration-tests/scripts/seed-deployment.ts
@@ -1,0 +1,265 @@
+/**
+ * seed-deployment.ts — make a FROM-SCRATCH deployment testable, reproducibly.
+ *
+ * This is ENV-DATA-PLAN P0 option (B): seed from version-controlled JSON instead of
+ * relying on a binary DB dump. A teardown-with-volumes + fresh deploy leaves the
+ * stack unable to run the suite at all (`full-dump.sql` carries 108 localization
+ * rows and no ComplaintHierarchy schema). Everything this script seeds was
+ * restored by hand on 2026-07-27; this encodes that runbook so it never has to be
+ * done by hand again.
+ *
+ * Deployment-agnostic by construction:
+ *   - tenants come from env (ROOT_TENANT / DIGIT_TENANT), never hardcoded
+ *   - the mobile rule is derived from the deployment's OWN globalConfigs, so a
+ *     Kenya box gets +254 and a Mozambique box gets +258 (copying the shipped
+ *     Kenya seed onto Maputo is exactly the bug this avoids)
+ *   - every step is idempotent: re-running reports "exists" rather than failing
+ *
+ * Usage:
+ *   cd tests/integration-tests
+ *   set -a; source .env; set +a
+ *   npx tsx scripts/seed-deployment.ts            # seed everything missing
+ *   npx tsx scripts/seed-deployment.ts --check    # report only, change nothing
+ *
+ * NOTE the two traps this script exists to encode:
+ *   1. Localization must be seeded at BOTH the root AND the city tenant — the city
+ *      does not inherit, and the citizen/employee UIs read at the city.
+ *   2. The localization service caches _search per (tenant, locale, module). After
+ *      writing you MUST flush, or every verification reads the stale count.
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { BASE_URL, ROOT_TENANT, TENANT, ADMIN_USER, ADMIN_PASS } from '../tests/utils/env';
+
+const CHECK_ONLY = process.argv.includes('--check');
+/** Where the version-controlled seed lives (a git submodule in this repo). */
+const SEED_ROOT = resolve(__dirname, '../../../local-setup/ansible/nairobi-mdms');
+const LOC_DIR = join(SEED_ROOT, 'localization');
+const MDMS_DIR = join(SEED_ROOT, 'mdms');
+/** Root first: schemas/masters live at the root and the city inherits them. */
+const TENANTS = Array.from(new Set([ROOT_TENANT, TENANT]));
+
+let token = '';
+const log = (s: string) => console.log(s);
+
+async function post<T = any>(path: string, body: unknown): Promise<{ ok: boolean; data?: T; err?: string }> {
+  try {
+    const r = await fetch(`${BASE_URL}${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const text = await r.text();
+    if (!r.ok) return { ok: false, err: `${r.status} ${text.slice(0, 160)}` };
+    return { ok: true, data: text ? (JSON.parse(text) as T) : undefined };
+  } catch (e) {
+    return { ok: false, err: (e as Error).message.slice(0, 160) };
+  }
+}
+
+const requestInfo = () => ({ apiId: 'Rainmaker', ver: '1.0', msgId: `seed|en_IN`, authToken: token });
+
+async function auth(): Promise<void> {
+  const body = new URLSearchParams({
+    grant_type: 'password', username: ADMIN_USER, password: ADMIN_PASS,
+    tenantId: ROOT_TENANT, scope: 'read', userType: 'EMPLOYEE',
+  });
+  const r = await fetch(`${BASE_URL}/user/oauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded', Authorization: 'Basic ZWdvdi11c2VyLWNsaWVudDo=' },
+    body: body.toString(),
+  });
+  if (!r.ok) throw new Error(`admin login failed (${r.status}) — is the stack up?`);
+  token = ((await r.json()) as { access_token: string }).access_token;
+}
+
+// ── localization ────────────────────────────────────────────────────────────
+
+async function locCount(tenant: string, module: string): Promise<number> {
+  const r = await post<{ messages?: unknown[] }>(
+    `/localization/messages/v1/_search?tenantId=${tenant}&locale=en_IN&module=${module}`,
+    { RequestInfo: requestInfo() },
+  );
+  return r.data?.messages?.length ?? 0;
+}
+
+async function seedLocalization(): Promise<void> {
+  const files = ['rainmaker-common.json', 'rainmaker-pgr.json', 'rainmaker-hr.json'];
+  for (const tenant of TENANTS) {
+    for (const f of files) {
+      const p = join(LOC_DIR, f);
+      if (!existsSync(p)) { log(`  ! missing seed file ${f} — is the nairobi-mdms submodule initialised?`); continue; }
+      const msgs = JSON.parse(readFileSync(p, 'utf8')) as Array<{ code: string; message: string; module: string; locale: string }>;
+      const module = msgs[0]?.module ?? f.replace('.json', '');
+      const before = await locCount(tenant, module);
+      if (before >= msgs.length) { log(`  = ${module} @ ${tenant}: ${before} (already seeded)`); continue; }
+      if (CHECK_ONLY) { log(`  ~ ${module} @ ${tenant}: ${before} → would seed ${msgs.length}`); continue; }
+      for (let i = 0; i < msgs.length; i += 300) {
+        const chunk = msgs.slice(i, i + 300).map((m) => ({ code: m.code, message: m.message, module, locale: m.locale || 'en_IN' }));
+        const r = await post(`/localization/messages/v1/_upsert?tenantId=${tenant}&locale=en_IN`,
+          { RequestInfo: requestInfo(), tenantId: tenant, messages: chunk });
+        if (!r.ok) log(`    ! chunk ${i} failed: ${r.err}`);
+      }
+      log(`  + ${module} @ ${tenant}: ${before} → ${msgs.length}`);
+    }
+  }
+}
+
+/**
+ * The city must be at least as complete as the root — `admin/localization` asserts
+ * exactly that, and the bootstrap writes a handful of root-only rows.
+ */
+async function mirrorRootToCity(): Promise<void> {
+  if (ROOT_TENANT === TENANT) return;
+  for (const module of ['rainmaker-common', 'rainmaker-pgr', 'rainmaker-hr']) {
+    const [rootRes, cityRes] = await Promise.all([
+      post<{ messages?: Array<{ code: string; message: string }> }>(`/localization/messages/v1/_search?tenantId=${ROOT_TENANT}&locale=en_IN&module=${module}`, { RequestInfo: requestInfo() }),
+      post<{ messages?: Array<{ code: string; message: string }> }>(`/localization/messages/v1/_search?tenantId=${TENANT}&locale=en_IN&module=${module}`, { RequestInfo: requestInfo() }),
+    ]);
+    const cityCodes = new Set((cityRes.data?.messages ?? []).map((m) => m.code));
+    const missing = (rootRes.data?.messages ?? []).filter((m) => !cityCodes.has(m.code));
+    if (!missing.length) { log(`  = ${module}: root/city in parity`); continue; }
+    if (CHECK_ONLY) { log(`  ~ ${module}: ${missing.length} root-only rows would be mirrored to city`); continue; }
+    for (let i = 0; i < missing.length; i += 300) {
+      const chunk = missing.slice(i, i + 300).map((m) => ({ code: m.code, message: m.message, module, locale: 'en_IN' }));
+      await post(`/localization/messages/v1/_upsert?tenantId=${TENANT}&locale=en_IN`,
+        { RequestInfo: requestInfo(), tenantId: TENANT, messages: chunk });
+    }
+    log(`  + ${module}: mirrored ${missing.length} rows to ${TENANT}`);
+  }
+}
+
+// ── MDMS schemas + masters ──────────────────────────────────────────────────
+
+async function ensureSchema(tenant: string, code: string, definition: unknown): Promise<void> {
+  if (CHECK_ONLY) { log(`  ~ schema ${code} @ ${tenant}: would ensure`); return; }
+  const r = await post('/mdms-v2/schema/v1/_create',
+    { RequestInfo: requestInfo(), SchemaDefinition: { tenantId: tenant, code, description: code, definition, isActive: true } });
+  log(r.ok ? `  + schema ${code} @ ${tenant}` : `  = schema ${code} @ ${tenant} (${/DUPLICATE/.test(r.err ?? '') ? 'exists' : r.err})`);
+}
+
+async function ensureData(tenant: string, schemaCode: string, uid: string, data: unknown): Promise<void> {
+  if (CHECK_ONLY) { log(`  ~ ${schemaCode}/${uid} @ ${tenant}: would ensure`); return; }
+  const r = await post(`/mdms-v2/v2/_create/${schemaCode}`,
+    { RequestInfo: requestInfo(), Mdms: { tenantId: tenant, schemaCode, uniqueIdentifier: uid, data, isActive: true } });
+  log(r.ok ? `  + ${schemaCode}/${uid} @ ${tenant}` : `  = ${schemaCode}/${uid} @ ${tenant} (exists/err)`);
+}
+
+/** ComplaintHierarchy: written by the onboarding wizard, absent from the dump. */
+async function seedComplaintHierarchySchemas(): Promise<void> {
+  const hier = {
+    type: 'object', title: 'RAINMAKER-PGR.ComplaintHierarchy', $schema: 'http://json-schema.org/draft-07/schema#',
+    required: ['code', 'name', 'hierarchyType', 'levelCode', 'active'], 'x-unique': ['code'],
+    properties: {
+      hierarchyType: { type: 'string' }, levelCode: { type: 'string' }, code: { type: 'string' },
+      parentCode: { type: ['string', 'null'] }, name: { type: 'string' }, order: { type: 'number' },
+      active: { type: 'boolean' }, path: { type: 'string' }, department: { type: 'string' },
+      departments: { type: 'array', items: { type: 'string' } },
+      slaHours: { type: 'number' }, keywords: { type: 'string' },
+    },
+    'x-ref-schema': [], additionalProperties: false,
+  };
+  const hdef = {
+    type: 'object', title: 'RAINMAKER-PGR.ComplaintHierarchyDefinition', $schema: 'http://json-schema.org/draft-07/schema#',
+    required: ['hierarchyType', 'levels', 'active'], 'x-unique': ['hierarchyType'],
+    properties: {
+      hierarchyType: { type: 'string' }, active: { type: 'boolean' },
+      levels: { type: 'array', items: { type: 'object', additionalProperties: true } },
+    },
+    'x-ref-schema': [], additionalProperties: false,
+  };
+  await ensureSchema(ROOT_TENANT, 'RAINMAKER-PGR.ComplaintHierarchy', hier);
+  await ensureSchema(ROOT_TENANT, 'RAINMAKER-PGR.ComplaintHierarchyDefinition', hdef);
+}
+
+async function seedRejectionReasons(): Promise<void> {
+  const sp = join(MDMS_DIR, 'schemas/RAINMAKER-PGR/RejectionReasons.json');
+  const dp = join(MDMS_DIR, 'data/ke/RAINMAKER-PGR/RejectionReasons.json');
+  if (existsSync(sp)) {
+    const sd = JSON.parse(readFileSync(sp, 'utf8'));
+    await ensureSchema(ROOT_TENANT, 'RAINMAKER-PGR.RejectionReasons', sd.definition ?? sd);
+  }
+  if (!existsSync(dp)) return;
+  for (const row of JSON.parse(readFileSync(dp, 'utf8')) as Array<Record<string, any>>) {
+    const data = row.data ?? row;
+    await ensureData(ROOT_TENANT, 'RAINMAKER-PGR.RejectionReasons', row.uniqueIdentifier ?? data.code, data);
+  }
+}
+
+/**
+ * The mobile rule MUST reflect this deployment, not the shipped Kenya seed.
+ * Read it from the SPA's own globalConfigs (the rule the UI actually enforces) so
+ * MDMS and the UI can never disagree — the exact mismatch that broke
+ * verify-mobile-validation. Two masters exist; the app/tests read
+ * `common-masters.MobileNumberValidation`.
+ */
+async function seedMobileValidation(): Promise<void> {
+  let pattern = '', countryCode = '';
+  try {
+    const js = await (await fetch(`${BASE_URL}/digit-ui/globalConfigs.js`)).text();
+    pattern = /mobileNumberPattern["']?\s*[:=]\s*["']([^"']+)/.exec(js)?.[1]
+      ?? /mobileNumberRegex["']?\s*[:=]\s*["']([^"']+)/.exec(js)?.[1] ?? '';
+    countryCode = /countryCode["']?\s*[:=]\s*["']([^"']+)/.exec(js)?.[1] ?? '';
+  } catch { /* fall through to the profile below */ }
+  if (!pattern) {
+    const pf = resolve('deployment-profile.json');
+    if (existsSync(pf)) {
+      const p = JSON.parse(readFileSync(pf, 'utf8'));
+      pattern = p?.mobile?.pattern ?? ''; countryCode = countryCode || (p?.mobile?.countryCode ?? '');
+    }
+  }
+  if (!pattern) { log('  ! could not resolve this deployment\'s mobile pattern — skipping (set it by hand)'); return; }
+  const digits = /\{(\d+)\}/.exec(pattern)?.[1];
+  const len = digits ? Number(digits) + 1 : 10; // leading class + {n}
+  const defn = {
+    type: 'object', title: 'common-masters.MobileNumberValidation', $schema: 'http://json-schema.org/draft-07/schema#',
+    required: ['countryCode', 'mobileNumberRegex'], 'x-unique': ['countryCode'],
+    properties: { countryCode: { type: 'string' }, mobileNumberRegex: { type: 'string' }, default: { type: 'boolean' }, errorMessage: { type: 'string' } },
+    'x-ref-schema': [], additionalProperties: false,
+  };
+  const data = { countryCode: countryCode || '+000', mobileNumberRegex: pattern, default: true,
+    errorMessage: `Please enter a valid mobile number (${len} digits)` };
+  await ensureSchema(ROOT_TENANT, 'common-masters.MobileNumberValidation', defn);
+  for (const t of TENANTS) await ensureData(t, 'common-masters.MobileNumberValidation', data.countryCode, data);
+  log(`  → mobile rule: ${data.countryCode} ${pattern} (derived from this deployment)`);
+}
+
+// ── cache ───────────────────────────────────────────────────────────────────
+
+/**
+ * Without this every verification reads stale counts and you conclude the seeding
+ * failed when it didn't. Best-effort: falls back to the localization cache-bust
+ * endpoint when the redis container isn't reachable from here.
+ */
+async function bustCaches(): Promise<void> {
+  if (CHECK_ONLY) return;
+  const { execSync } = await import('node:child_process');
+  try {
+    execSync('docker exec digit-redis redis-cli FLUSHALL', { stdio: 'ignore' });
+    log('  + flushed redis (localization + validationRules)');
+    return;
+  } catch { /* not a local docker stack */ }
+  await post('/localization/messages/v1/_cache-bust', { RequestInfo: requestInfo() });
+  log('  + requested localization cache-bust');
+}
+
+async function main(): Promise<void> {
+  log(`seed-deployment: ${BASE_URL}  root=${ROOT_TENANT} city=${TENANT}${CHECK_ONLY ? '  [CHECK ONLY]' : ''}`);
+  await auth();
+  log('\n── MDMS schemas ──');
+  await seedComplaintHierarchySchemas();
+  log('\n── RejectionReasons ──');
+  await seedRejectionReasons();
+  log('\n── mobile validation ──');
+  await seedMobileValidation();
+  log('\n── localization ──');
+  await seedLocalization();
+  await mirrorRootToCity();
+  log('\n── caches ──');
+  await bustCaches();
+  log('\nDone. Re-run any time — every step is idempotent.');
+  log('Onboarding data (boundaries / complaint types / employees) is NOT handled here:');
+  log('  seed it with the XLSX onboarding (see docs/TEST-PREREQUISITES.md §1b row A).');
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/tests/integration-tests/scripts/seed-deployment.ts
+++ b/tests/integration-tests/scripts/seed-deployment.ts
@@ -29,7 +29,9 @@
  */
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve, join } from 'node:path';
-import { BASE_URL, ROOT_TENANT, TENANT, ADMIN_USER, ADMIN_PASS } from '../tests/utils/env';
+import { BASE_URL, ROOT_TENANT, TENANT, ADMIN_USER, ADMIN_PASS, DEFAULT_PASSWORD } from '../tests/utils/env';
+import { fetchGlobalConfigs, fetchBoundaryTree, type BoundaryNode } from '../tests/utils/probes';
+import { getMobileValidationRule, generateValidMobile } from '../tests/utils/mdms-mobile';
 
 const CHECK_ONLY = process.argv.includes('--check');
 /** Where the version-controlled seed lives (a git submodule in this repo). */
@@ -40,6 +42,8 @@ const MDMS_DIR = join(SEED_ROOT, 'mdms');
 const TENANTS = Array.from(new Set([ROOT_TENANT, TENANT]));
 
 let token = '';
+/** The admin's own UserRequest, kept for the writes whose audit trail needs it. */
+let adminUserInfo: Record<string, any> | null = null;
 const log = (s: string) => console.log(s);
 
 async function post<T = any>(path: string, body: unknown): Promise<{ ok: boolean; data?: T; err?: string }> {
@@ -70,7 +74,9 @@ async function auth(): Promise<void> {
     body: body.toString(),
   });
   if (!r.ok) throw new Error(`admin login failed (${r.status}) — is the stack up?`);
-  token = ((await r.json()) as { access_token: string }).access_token;
+  const body2 = (await r.json()) as { access_token: string; UserRequest?: Record<string, any> };
+  token = body2.access_token;
+  adminUserInfo = body2.UserRequest ?? null;
 }
 
 // ── localization ────────────────────────────────────────────────────────────
@@ -224,6 +230,166 @@ async function seedMobileValidation(): Promise<void> {
   log(`  → mobile rule: ${data.countryCode} ${pattern} (derived from this deployment)`);
 }
 
+// ── personas ────────────────────────────────────────────────────────────────
+
+/**
+ * A CSR narrowed to ONE ward — the persona `personas.ward-scoped-csr` gates
+ * tests/api/boundary-jurisdiction-496.spec.ts on.
+ *
+ * Without it that spec self-skips, because personas.ts's isWardScopedCsr wants
+ * BOTH halves and no shipped employee has them together:
+ *   - the CSR role, and
+ *   - an HRMS jurisdiction in the PGR boundary hierarchy whose boundaryType is
+ *     BELOW the hierarchy root (an employee scoped to the whole root sees the
+ *     entire tree, which would make the jurisdiction-filter assertion vacuous).
+ * On the local stack EMP001/2/3 are scoped to the MAPUTO_ADMIN root itself and
+ * hold no CSR, while ADMIN holds CSR but its lone jurisdiction is `mz.maputo` —
+ * a TENANT id in hierarchy `ADMIN`, not a PGR boundary at all.
+ *
+ * Everything here is derived from the deployment, never from Maputo literals:
+ * the hierarchy comes from the SPA's own globalConfigs, the ward from that
+ * hierarchy's live tree, and the department/designation from an employee who
+ * already exists (the same trick tests/admin/employees.spec.ts uses, so HRMS's
+ * FK validation passes on any tenant). Idempotent: if any active employee
+ * already satisfies the predicate, nothing is written.
+ */
+const WARD_CSR_CODE = process.env.SEED_WARD_CSR_CODE || 'SEED_WARD_CSR';
+
+interface HrmsEmployeeRow {
+  code?: string;
+  user?: { roles?: Array<{ code?: string }> };
+  jurisdictions?: Array<{ hierarchy?: string; boundary?: string; boundaryType?: string; isActive?: boolean }>;
+  assignments?: Array<{ department?: string; designation?: string; isCurrentAssignment?: boolean }>;
+}
+
+/** Active employees at the EXACT complaint tenant — HRMS has no parent fallback. */
+async function employeesAt(tenant: string): Promise<HrmsEmployeeRow[]> {
+  const r = await post<{ Employees?: HrmsEmployeeRow[] }>(
+    `/egov-hrms/employees/_search?tenantId=${encodeURIComponent(tenant)}&isActive=true&limit=500&offset=0`,
+    { RequestInfo: requestInfo() },
+  );
+  return r.data?.Employees ?? [];
+}
+
+/** The boundaryTypes of one root-to-leaf path, root first. */
+function levelsOf(root: BoundaryNode): string[] {
+  const out: string[] = [];
+  for (let n: BoundaryNode | undefined = root; n; n = n.children?.[0]) out.push(n.boundaryType);
+  return [...new Set(out)];
+}
+
+async function seedWardScopedCsr(): Promise<void> {
+  const gc = await fetchGlobalConfigs().catch(() => ({} as Awaited<ReturnType<typeof fetchGlobalConfigs>>));
+  let hierarchyType = gc.hierarchyType ?? '';
+  if (!hierarchyType && existsSync(resolve('deployment-profile.json'))) {
+    hierarchyType = JSON.parse(readFileSync(resolve('deployment-profile.json'), 'utf8'))?.boundary?.hierarchyType ?? '';
+  }
+  if (!hierarchyType) { log('  ! no boundary hierarchy on this deployment — cannot scope a CSR to a ward'); return; }
+
+  const tree = await fetchBoundaryTree(TENANT, hierarchyType, { authToken: token }).catch(() => null);
+  if (!tree) { log(`  ! hierarchy ${hierarchyType} has no boundary tree at ${TENANT} — seed boundaries first`); return; }
+  const levels = levelsOf(tree);
+  if (levels.length < 2) { log(`  ! hierarchy ${hierarchyType} is one level deep — nothing sits BELOW its root`); return; }
+
+  // Already satisfied? Same predicate personas.ts applies, so a deployment that
+  // onboarded its own ward CSR (bomet) is left completely alone.
+  const employees = await employeesAt(TENANT);
+  const existing = employees.find((e) =>
+    (e.user?.roles ?? []).some((r) => r.code === 'CSR') &&
+    (e.jurisdictions ?? []).some(
+      (j) => j.isActive !== false && j.hierarchy === hierarchyType && j.boundaryType !== levels[0],
+    ),
+  );
+  if (existing) { log(`  = ward-scoped CSR @ ${TENANT}: ${existing.code} (already onboarded)`); return; }
+
+  // A "ward" is the level just above the leaf — the smallest area that still
+  // contains several localities — but never the root, which would defeat the
+  // scoping this persona exists to exercise.
+  const wardLevel = levels[Math.max(1, levels.length - 2)];
+  const wards: string[] = [];
+  const collect = (n: BoundaryNode): void => {
+    if (n.boundaryType === wardLevel) wards.push(n.code);
+    for (const c of n.children ?? []) collect(c);
+  };
+  collect(tree);
+  wards.sort();
+  if (wards.length < 2) {
+    log(`  ! only ${wards.length} '${wardLevel}' boundary(ies) exist — #496 needs a sibling ward to be non-vacuous`);
+    return;
+  }
+  const ward = wards[0];
+
+  // HRMS validates department/designation against the tenant's own masters, so
+  // borrow a live pair rather than guessing. `PW_`-prefixed rows are suite
+  // litter and are skipped; a donor scoped to the PGR hierarchy is preferred
+  // because its department is the one the complaint catalogue actually uses.
+  const isLitter = (code = ''): boolean => /(^|_)PW[A-Z_]/i.test(code);
+  const donors = employees
+    .filter((e) => !isLitter(e.code) && (e.assignments ?? []).some((a) => a.department && a.designation))
+    .sort((a, b) => String(a.code).localeCompare(String(b.code)));
+  const donor =
+    donors.find((e) => (e.jurisdictions ?? []).some((j) => j.hierarchy === hierarchyType)) ?? donors[0];
+  const assignment = (donor?.assignments ?? []).find((a) => a.department && a.designation);
+  if (!assignment) {
+    log(`  ! no employee at ${TENANT} carries a department+designation to copy — onboard one employee first`);
+    return;
+  }
+
+  if (CHECK_ONLY) {
+    log(`  ~ ward-scoped CSR ${WARD_CSR_CODE} @ ${TENANT}: would create — ${wardLevel} '${ward}' ` +
+      `in ${hierarchyType}, ${assignment.department}/${assignment.designation} (from ${donor?.code})`);
+    return;
+  }
+
+  // Mobile must satisfy THIS tenant's MDMS rule (Kenya starts 7/1, Maputo 8) —
+  // HRMS rejects the create otherwise.
+  const mobile = generateValidMobile(await getMobileValidationRule(TENANT));
+  const now = Date.now();
+  const r = await post(`/egov-hrms/employees/_create?tenantId=${encodeURIComponent(TENANT)}`, {
+    RequestInfo: { ...requestInfo(), ver: '1.0', ts: now, action: '_create', userInfo: adminUserInfo ?? undefined },
+    Employees: [{
+      tenantId: TENANT,
+      code: WARD_CSR_CODE,
+      employeeStatus: 'EMPLOYED',
+      employeeType: 'PERMANENT',
+      dateOfAppointment: now - 24 * 3600_000,
+      user: {
+        // HRMS overwrites userName with the employee code regardless of what we
+        // send (see EmployeeShow.tsx:39-41), and persona discovery logs in with
+        // the CODE it read back from HRMS — so they must be the same string.
+        userName: WARD_CSR_CODE,
+        name: 'Seeded Ward CSR',
+        mobileNumber: mobile,
+        type: 'EMPLOYEE',
+        active: true,
+        gender: 'MALE',
+        dob: 631152000000,
+        // The password persona discovery guesses (personas.ts passwordGuesses
+        // defaults to this); without it the persona is created but unusable.
+        password: process.env.PERSONA_PASSWORD_GUESSES?.split(',')[0]?.trim() || DEFAULT_PASSWORD,
+        tenantId: TENANT,
+        roles: [
+          { code: 'CSR', name: 'CSR', tenantId: TENANT },
+          { code: 'EMPLOYEE', name: 'Employee', tenantId: TENANT },
+        ],
+      },
+      jurisdictions: [{
+        boundary: ward, boundaryType: wardLevel,
+        hierarchy: hierarchyType, hierarchyType,
+        tenantId: TENANT, isActive: true,
+      }],
+      assignments: [{
+        department: assignment.department, designation: assignment.designation,
+        fromDate: now - 24 * 3600_000, isCurrentAssignment: true,
+      }],
+    }],
+  });
+  log(r.ok
+    ? `  + ward-scoped CSR ${WARD_CSR_CODE} @ ${TENANT}: ${wardLevel} '${ward}' in ${hierarchyType}, ` +
+      `${assignment.department}/${assignment.designation}`
+    : `  ! ward-scoped CSR ${WARD_CSR_CODE} @ ${TENANT} failed: ${r.err}`);
+}
+
 // ── cache ───────────────────────────────────────────────────────────────────
 
 /**
@@ -255,6 +421,8 @@ async function main(): Promise<void> {
   log('\n── localization ──');
   await seedLocalization();
   await mirrorRootToCity();
+  log('\n── personas ──');
+  await seedWardScopedCsr();
   log('\n── caches ──');
   await bustCaches();
   log('\nDone. Re-run any time — every step is idempotent.');

--- a/tests/integration-tests/tests/admin/boundaries-ui.spec.ts
+++ b/tests/integration-tests/tests/admin/boundaries-ui.spec.ts
@@ -161,7 +161,11 @@ Steps:
 Regression (#21 gap D, fixed): the BoundaryList data provider aggregates city sub-tenants at state level — when the session is the root tenant ('ke'), dataProvider.ts concatenates every active 'ke.*' sub-tenant's boundary tree, so boundaries created at the freshly-onboarded child tenant now surface in the admin list viewed from root. This spec asserts that post-fix behaviour and is expected to pass. Teardown is API-only because the configurator has no UI delete affordance for tenants — tracked in CCRS#21.`,
     },
     tag: ['@area:manage-boundaries', '@kind:regression', '@layer:ui', '@persona:admin'] }, async ({ page }) => {
-    test.setTimeout(180_000);
+    // Bumped from 180s: the boundary-create pipeline (create + localizations +
+    // cache-bust + boundary-path repair, Phase2Page.tsx handleUploadBoundaries)
+    // can run past a minute when the shared local stack is under concurrent
+    // load from other suites; give it headroom rather than flake.
+    test.setTimeout(240_000);
 
     // -------- Login (Onboarding mode) --------
     await page.goto('/configurator/login');
@@ -193,15 +197,36 @@ Regression (#21 gap D, fixed): the BoundaryList data provider aggregates city su
 
     // -------- Phase 2: hierarchy + boundaries --------
     await expect(page.getByText('Phase 2: Boundary Setup')).toBeVisible();
+    // Phase 2 now opens with a "Choose Your Data Source" chooser (OSM vs Excel);
+    // the manual hierarchy + xlsx flow lives behind the Excel card (Phase2Page.tsx).
+    const excelCard = page.getByRole('button', { name: /Upload from Excel/i });
+    if (await excelCard.isVisible({ timeout: 5_000 }).catch(() => false)) {
+      await excelCard.click();
+    }
     await page.getByRole('button', { name: /Option 1: Create New Hierarchy/i }).click();
     await expect(page.locator('#hierarchyType')).toBeVisible({ timeout: 15_000 });
     await page.locator('#hierarchyType').fill(HIERARCHY_TYPE);
+    // The wizard's "Define Levels" defaults to 4 levels (Country/State/City/
+    // Ward), but BOUNDARY_FIXTURE only defines 2 (Country -> City directly).
+    // boundary-service enforces strict direct-descendant hierarchy checks —
+    // a relationship whose child boundaryType isn't the parent's immediate
+    // next level is permanently rejected (HIERARCHY_ERROR: "Hierarchy of
+    // child should be the direct descendant of parent's boundary hierarchy
+    // type"), confirmed against the live boundary-relationships/_create API.
+    // Remove the unused "State" and "Ward" levels so the created hierarchy
+    // is exactly [Country, City], matching the fixture.
+    await page.getByText(/^Level 2:$/).locator('..').getByRole('button').click();
+    await page.getByText(/^Level 3:$/).locator('..').getByRole('button').click();
+    await expect(page.getByText(/^Level 3:$/)).toHaveCount(0);
     await page.getByRole('button', { name: /Create Hierarchy/i }).click();
     await expect(page.getByText('Boundary Data Upload')).toBeVisible({ timeout: 60_000 });
     await page.locator('input[type="file"]').first().setInputFiles(BOUNDARY_FIXTURE);
     await expect(page.getByText('Verify Boundary Data')).toBeVisible({ timeout: 30_000 });
     await page.getByRole('button', { name: /Upload \d+ Boundaries/i }).click();
-    await expect(page.getByText('Boundaries Created Successfully!')).toBeVisible({ timeout: 60_000 });
+    // Generous timeout: handleUploadBoundaries (Phase2Page.tsx) chains boundary
+    // create + localizations + cache-bust + boundary-path repair before landing
+    // here, and can run past a minute when the shared local stack is busy.
+    await expect(page.getByText('Boundaries Created Successfully!')).toBeVisible({ timeout: 120_000 });
 
     // -------- Switch to Management via the header button --------
     // The Layout header carries a "Management" button that flips

--- a/tests/integration-tests/tests/admin/complaint-form-validators-2026-05-31.spec.ts
+++ b/tests/integration-tests/tests/admin/complaint-form-validators-2026-05-31.spec.ts
@@ -88,49 +88,73 @@ test.describe('admin complaint create — validator bundle 2026-05-30', () => {
     await page.waitForTimeout(5_000);
 
     // ============ Complaint type — ComplaintHierarchyCascade ============
-    // Drive the "Complaint Type" cascade the same way complaints.spec does:
-    // open it and pick the first available option. The validator assertions
-    // below don't depend on a complaint type being chosen, but we exercise
-    // the real control that replaced the old "Select complaint type" combobox.
-    const typeSelect = page.getByLabel(/^Complaint Type/i).first();
-    if (await typeSelect.isVisible().catch(() => false)) {
-      await typeSelect.click();
-      await page.waitForTimeout(800);
-      const firstType = page.getByRole('option').first();
-      if (await firstType.isVisible().catch(() => false)) {
-        await firstType.click();
-        await page.waitForTimeout(1_000);
-      }
-    }
+    // RC5: none of the Category/Sub-Type/Hierarchy/Locality controls are
+    // htmlFor-associated to their <Label> (getByLabel resolves nothing and
+    // .click() hangs the full 120s). Mirror complaints.spec.ts's
+    // triggerNearLabel + pickComplaintType approach instead — copied locally
+    // rather than imported so the two spec files stay decoupled.
+    await pickComplaintType(page);
 
     // ============ Locality — LocalityPicker cascade (+ #496 dedup) ============
-    // LocalityPicker exposes three cascading selects (Hierarchy → Boundary
-    // Type → Locality). Hierarchy + Boundary Type are best-effort (their
-    // choices may already default); the final Locality select is the one we
-    // must open. Mirror complaints.spec's pickLocality helper.
-    const hierarchy = page.getByLabel(/Hierarchy/i).first();
-    if (await hierarchy.isVisible().catch(() => false)) {
-      await hierarchy.click();
-      await page.getByRole('option').first().click().catch(() => {});
-      await page.waitForTimeout(500);
-    }
-    const boundaryType = page.getByLabel(/Boundary type/i).first();
-    if (await boundaryType.isVisible().catch(() => false)) {
-      await boundaryType.click();
-      await page.getByRole('option').first().click().catch(() => {});
-      await page.waitForTimeout(500);
-    }
+    // LocalityPicker is three radix Selects in one grid (Hierarchy → Boundary
+    // Type → Locality); only the group's help text ("Cascades from
+    // hierarchy…") is a reliable anchor. Walk hierarchy x boundary-type
+    // combos positionally until one actually offers Locality options (the
+    // first hierarchy option, e.g. "ADMIN", can be a tree with zero usable
+    // boundaries while a later one holds the real tree) — this test doesn't
+    // need a SPECIFIC locality, just any valid one, to reach the #496 dedup
+    // check and then the postal/mobile validator assertions.
+    const localityGroup = page
+      .locator('div')
+      .filter({ has: page.getByText(/Cascades from hierarchy/i) })
+      .last();
+    await localityGroup.getByRole('combobox').first().waitFor({ state: 'visible', timeout: 15_000 });
+    const selects = localityGroup.getByRole('combobox');
+    const hierarchy = selects.nth(0);
+    const boundaryType = selects.nth(1);
+    const localityTrigger = selects.nth(2);
 
-    const locality = page.getByLabel(/^Locality$/i).first();
-    await locality.click();
-    await page.waitForTimeout(1_000);
+    const countOptions = async (trigger: import('@playwright/test').Locator): Promise<number> => {
+      if (!(await trigger.isEnabled().catch(() => false))) return 0;
+      await trigger.click();
+      const n = await page.getByRole('option').count();
+      if (n === 0) await page.keyboard.press('Escape').catch(() => {});
+      return n;
+    };
+
+    let localityOpts: string[] = [];
+    const hierN = await countOptions(hierarchy);
+    outer: for (let h = 0; h < Math.max(hierN, 1); h++) {
+      if (hierN > 0) {
+        await page.getByRole('option').nth(h).click();
+      }
+      const typeN = await countOptions(boundaryType);
+      for (let t = 0; t < typeN; t++) {
+        await page.getByRole('option').nth(t).click();
+        if (await localityTrigger.isEnabled().catch(() => false)) {
+          await localityTrigger.click();
+          const opts = (await page.getByRole('option').allInnerTexts())
+            .map((s) => s.trim())
+            .filter(Boolean);
+          if (opts.length > 0) {
+            localityOpts = opts;
+            break outer;
+          }
+          await page.keyboard.press('Escape').catch(() => {});
+        }
+        if (t + 1 < typeN && (await boundaryType.isEnabled().catch(() => false))) {
+          await boundaryType.click();
+        }
+      }
+      if (h + 1 < hierN && (await hierarchy.isEnabled().catch(() => false))) {
+        await hierarchy.click();
+      }
+    }
+    expect(localityOpts.length, 'no hierarchy/type combination yielded a selectable locality').toBeGreaterThan(0);
 
     // #496 (adapted): the locality options must be unique by code. The old
     // flat "Boundary" combobox is gone; assert dedup on the cascade's final
     // Locality options instead.
-    const localityOpts = (await page.getByRole('option').allInnerTexts())
-      .map((s) => s.trim())
-      .filter(Boolean);
     expect(
       new Set(localityOpts).size,
       `#496 — locality options must be unique (got ${localityOpts.length}, ${new Set(localityOpts).size} unique)`,
@@ -184,3 +208,45 @@ test.describe('admin complaint create — validator bundle 2026-05-30', () => {
     ).toHaveCount(0);
   });
 });
+
+// --- Local helpers (copied from complaints.spec.ts; not imported across spec
+// files so the two buckets/specs stay decoupled — see RC5). ---
+
+/** Locate a radix Select trigger sitting in the same wrapper <div> as a given
+ *  field <Label> text. These cascade selects don't associate their label via
+ *  htmlFor, so getByLabel can't reach them — anchor on the label text and
+ *  take the combobox in the innermost enclosing div. */
+function triggerNearLabel(
+  page: import('@playwright/test').Page,
+  labelText: RegExp,
+): import('@playwright/test').Locator {
+  return page
+    .locator('div')
+    .filter({ has: page.getByText(labelText) })
+    .filter({ has: page.getByRole('combobox') })
+    .last()
+    .getByRole('combobox')
+    .first();
+}
+
+async function pickComplaintType(
+  page: import('@playwright/test').Page,
+): Promise<void> {
+  // The complaint-type control is a Category → Sub-Type cascade — one radix
+  // Select per RAINMAKER-PGR.ComplaintHierarchy level. Pick the first option
+  // at each level until the deepest (terminal) level is chosen. Deeper levels
+  // are hidden once a branch is terminal, so a missing/disabled next level
+  // just ends the walk.
+  for (const lbl of [/^Category$/i, /^Sub-?Type$/i]) {
+    const sel = triggerNearLabel(page, lbl);
+    if (!(await sel.isVisible({ timeout: 8_000 }).catch(() => false))) break;
+    if (!(await sel.isEnabled().catch(() => false))) break;
+    await sel.click();
+    const opt = page.getByRole('option').first();
+    if (!(await opt.isVisible({ timeout: 5_000 }).catch(() => false))) {
+      await page.keyboard.press('Escape').catch(() => {});
+      break;
+    }
+    await opt.click();
+  }
+}

--- a/tests/integration-tests/tests/admin/complaint-types.spec.ts
+++ b/tests/integration-tests/tests/admin/complaint-types.spec.ts
@@ -40,22 +40,52 @@ const LIST_PATH = '/configurator/manage/complaint-hierarchy';
 
 const createdCodes = new Set<string>();
 
+// Scratch records this suite (and its predecessors) created are all prefixed
+// PW_ / *_PW* by helpers/manage/codes. A long-lived deployment accumulates
+// thousands of them, so "pick a real record" has to exclude them explicitly.
+const SCRATCH_CODE = /(^|_)PW[A-Z_]/i;
+
+/** Escape a live-resolved label before embedding it in a locator RegExp. */
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 let liveDeptCode: string | null = null;
 
-test.describe.configure({ mode: 'serial' });
+// Default mode (not serial): workers=1 keeps file order, but a failure no
+// longer cascade-skips the rest. Tests 4 and 5 are independent of test 2 —
+// 4 reads pre-existing data, 5 seeds via the API — so serial mode was
+// downgrading their real results to "did not run" whenever the create form
+// broke, which is exactly when their signal matters most.
+test.describe.configure({ mode: 'default' });
 
 test.beforeAll(async () => {
   const auth = loadAuth();
   // Pick an existing active department to use as the `department` FK for
-  // creates / bulk rows. The live tenant carries ~31 seeded departments.
-  const depts = await mdmsSearch(auth, TENANT_CODE, DEPT_SCHEMA, { limit: 50 }).catch(
-    () => [] as MdmsRecord[],
+  // creates / bulk rows.
+  //
+  // This used to page the schema unfiltered (`{ limit: 50 }`) and then look
+  // for the first row with isActive !== false. On a deployment polluted with
+  // soft-deleted PW_ scratch departments — measured 147 rows, only 3 active —
+  // the first 50 rows are ALL inactive, so liveDeptCode stayed null and tests
+  // 2 and 5 skipped forever with "No active department seeded on tenant",
+  // even though the tenant has perfectly good departments. Push isActive to
+  // the server so pagination happens over the ACTIVE set, and prefer a
+  // non-scratch department so the FK points at real tenant data.
+  const depts = await mdmsSearch(auth, TENANT_CODE, DEPT_SCHEMA, {
+    limit: 200,
+    isActive: true,
+  }).catch(() => [] as MdmsRecord[]);
+
+  const codeOf = (d: MdmsRecord) =>
+    ((d.data as Record<string, unknown>)?.code as string | undefined) ||
+    d.uniqueIdentifier;
+  const active = depts.filter((d) => d.isActive !== false && codeOf(d));
+  const real = active.find(
+    (d) => !SCRATCH_CODE.test(codeOf(d)!) && !SCRATCH_CODE.test(String(d.uniqueIdentifier)),
   );
-  for (const d of depts) {
-    if (d.isActive === false) continue;
-    const code = (d.data as Record<string, unknown>).code as string | undefined;
-    if (code) { liveDeptCode = code; break; }
-  }
+  // Fall back to any active department — a scratch one still exercises the FK.
+  liveDeptCode = codeOf(real || active[0]) ?? null;
 });
 
 test.afterAll(async () => {
@@ -209,46 +239,104 @@ Cleanup is API-only — soft-deletes via cleanupMdms in afterAll because there's
   test('4. department reference filter narrows the list', {
     annotation: {
       type: 'description',
-      description: `Validates the Department filter on the complaint-types list: picking a department option must narrow the rendered rows so each row references that department (either label or code). Skips if the filter isn't implemented on the current build.
+      description: `Validates the Department filter on the complaint-types list: picking a department must narrow the rendered rows to exactly the complaint types that reference it.
 
 Steps:
-1. Navigate to /configurator/manage/complaint-types.
-2. Locate getByLabel(/^Department/i); test.skip if not visible.
-3. Click the filter; capture the first option's text label; click it.
-4. Wait for networkidle.
-5. Read row count; if <=1 return early (filter validly returned 0 rows).
-6. For up to 5 sample rows, read text content and assert it (lowercased) includes the dept label (lowercased).
+1. Via MDMS, find an active leaf complaint type carrying a \`department\` (preferring a non-scratch one), then resolve that department's display name from common-masters.Department. Skip only if the deployment has no such pairing at all.
+2. Navigate to /configurator/manage/complaint-hierarchy; count the unfiltered DATA rows (rows containing role=cell).
+3. Open the Department filter (a Radix combobox showing "Department" until a value is picked) and select the resolved department by name.
+4. Assert the known complaint type's row survives the filter.
+5. Assert EVERY rendered row references that department (label or code) — vacuously-true empty results are excluded by step 4.
+6. Assert the row count strictly dropped versus the unfiltered list.
 
-Loose label-match — works whether the row renders the dept code, dept name, or both.`,
+All row reads are auto-retrying expect()/expect.poll() — the grid debounces filter changes, so a bare count() straight after selecting reads the PRE-filter list.
+
+The filter itself did not exist before: ComplaintTypeList passed no \`filters\` to DigitList, so this test skipped unconditionally on "Department filter not present on this build". It is now declared alongside SearchFilterInput, mirroring DesignationList.`,
     },
     tag: ['@area:configurator-manage', '@area:pgr', '@kind:regression', '@layer:ui', '@persona:admin'] }, async ({ page }) => {
+    // Resolve the department to filter by from live data — never a literal.
+    const auth = loadAuth();
+    const [types, depts] = await Promise.all([
+      mdmsSearch(auth, TENANT_CODE, SCHEMA, { limit: 500, isActive: true }),
+      mdmsSearch(auth, TENANT_CODE, DEPT_SCHEMA, { limit: 200, isActive: true }),
+    ]);
+
+    const deptOf = (r: MdmsRecord) => {
+      const raw = (r.data as Record<string, unknown>)?.department;
+      return Array.isArray(raw) ? (raw[0] as string | undefined) : (raw as string | undefined);
+    };
+    // ComplaintHierarchy junk left by previous runs is created ACTIVE, so
+    // isActive alone doesn't separate it from real data here — the PW_ prefix
+    // does. Prefer a real leaf; fall back to any leaf with a department.
+    const leaves = types.filter((r) => deptOf(r));
+    const leaf =
+      leaves.find((r) => !SCRATCH_CODE.test(String(r.uniqueIdentifier))) ?? leaves[0];
+    const deptCode = leaf ? deptOf(leaf) : undefined;
+    const deptRecord = depts.find(
+      (d) =>
+        String(d.uniqueIdentifier) === deptCode ||
+        String((d.data as Record<string, unknown>)?.code ?? '') === deptCode,
+    );
+    test.skip(
+      !leaf || !deptRecord,
+      'No active complaint type linked to an active department on this deployment',
+    );
+
+    // The list renders the department via EntityLink, which shows the
+    // department NAME when it resolves and falls back to the raw code when it
+    // does not — accept either.
+    const deptName = String(
+      (deptRecord!.data as Record<string, unknown>)?.name ?? deptRecord!.uniqueIdentifier,
+    );
+    const serviceCode = String(leaf!.uniqueIdentifier);
+
     await page.goto(LIST_PATH);
 
-    const filter = page.getByLabel(/^Department/i).first();
-    if (!(await filter.isVisible().catch(() => false))) {
-      test.skip(true, 'Department filter not present on this build');
-    }
+    // DATA rows only — the header row holds columnheaders, not cells.
+    const dataRows = page.getByRole('row').filter({ has: page.getByRole('cell') });
+    await expect(dataRows.first()).toBeVisible();
+    const unfilteredCount = await dataRows.count();
+    expect(unfilteredCount).toBeGreaterThan(0);
 
+    // ReferenceFilterInput renders a Radix trigger with no <label> and no
+    // accessible name — its only label is the SelectValue placeholder, so match
+    // on the text it displays (the placeholder before selection, the chosen
+    // department's name after).
+    const filter = page
+      .getByRole('combobox')
+      .filter({ hasText: new RegExp(`^(Department|${escapeRe(deptName)})$`) })
+      .first();
+    await expect(filter).toBeVisible();
     await filter.click();
-    const firstOpt = page.getByRole('option').first();
-    const deptLabel = ((await firstOpt.textContent()) || '').trim();
-    await firstOpt.click();
-    await page.waitForLoadState('networkidle').catch(() => {});
+    await page.getByRole('option', { name: new RegExp(`^${escapeRe(deptName)}$`) }).click();
 
-    const rows = page.getByRole('row');
-    const n = await rows.count();
-    if (n <= 1) return; // filter validly returned 0 rows
+    // The known complaint type must survive the filter — this also rules out a
+    // vacuously-true "every row matches" over an empty result set.
+    await expect(dataRows.filter({ hasText: serviceCode }).first()).toBeVisible();
 
-    // Spot-check up to 5 rows — each should contain either the dept label
-    // or the dept code in its text content.
-    const sample = Math.min(5, n - 1);
-    for (let i = 1; i <= sample; i++) {
-      const t = ((await rows.nth(i).textContent()) || '').toLowerCase();
-      expect(
-        t.includes(deptLabel.toLowerCase()),
-        `row ${i} should match dept filter "${deptLabel}"`,
-      ).toBe(true);
-    }
+    // ...and every row left must reference that department.
+    const needle = deptName.toLowerCase();
+    const codeNeedle = String(deptCode).toLowerCase();
+    await expect
+      .poll(
+        async () => {
+          const texts = await dataRows.allTextContents();
+          return (
+            texts.length > 0 &&
+            texts.every((t) => {
+              const lower = t.toLowerCase();
+              return lower.includes(needle) || lower.includes(codeNeedle);
+            })
+          );
+        },
+        { message: `every row should reference department "${deptName}"` },
+      )
+      .toBe(true);
+
+    // And the list genuinely shrank.
+    await expect
+      .poll(() => dataRows.count(), { message: 'department filter should narrow the list' })
+      .toBeLessThan(unfilteredCount);
   });
 
   test('5. tenant parity — api create at root is visible at city tenant', {

--- a/tests/integration-tests/tests/admin/complaints.spec.ts
+++ b/tests/integration-tests/tests/admin/complaints.spec.ts
@@ -415,7 +415,9 @@ Catches a regression where filters render but only update local state instead of
       if (/\/pgr-services\/v2\/request\/_search/.test(url)) seen.push(url);
     });
 
-    const statusFilter = page.getByLabel(/^Status$/i).first();
+    // The filter renders as a combobox with an accessible name (not a <label>
+    // association), so match by role+name, not getByLabel.
+    const statusFilter = page.getByRole('combobox', { name: /^Status$/i }).first();
     if (!(await statusFilter.isVisible().catch(() => false))) {
       test.skip(true, 'Status filter not present on this build');
     }
@@ -456,7 +458,7 @@ Loose match via text inclusion tolerates whatever the row actually renders (labe
     },
     tag: ['@area:configurator-manage', '@area:pgr', '@kind:regression', '@layer:ui', '@persona:admin'] }, async ({ page }) => {
     await page.goto(LIST_PATH);
-    const filter = page.getByLabel(/^Department/i).first();
+    const filter = page.getByRole('combobox', { name: /^Department/i }).first();
     if (!(await filter.isVisible().catch(() => false))) {
       test.skip(true, 'Department filter not present on this build');
     }

--- a/tests/integration-tests/tests/admin/complaints.spec.ts
+++ b/tests/integration-tests/tests/admin/complaints.spec.ts
@@ -21,7 +21,7 @@ import {
   type AuthInfo,
 } from '../utils/manage/api';
 import { cleanupPgrComplaints } from '../utils/manage/teardown';
-import { generateCitizenPhone, ROOT_TENANT, TENANT, LOCALITY_CODE } from '../utils/env';
+import { generateCitizenPhone, ROOT_TENANT, TENANT, LOCALITY_CODE, SERVICE_CODE } from '../utils/env';
 
 // Tenant identifiers come from env so the suite runs on any deployment.
 // TENANT_CODE is the STATE/root tenant (citizen tenantId); CITY_TENANT is the
@@ -38,7 +38,10 @@ let liveServiceCode: string | null = null;
 let lmeAssigneeUuid: string | null = null;
 let liveBoundaryCode: string | null = null;
 
-test.describe.configure({ mode: 'serial' });
+// Default mode (not serial): with workers=1 the tests still run in file order,
+// but a single failure no longer cascade-skips the rest — each test seeds/finds
+// its own complaint (pickWorkableComplaint) and reports independently.
+test.describe.configure({ mode: 'default' });
 
 test.beforeAll(async () => {
   const auth = loadAuth();
@@ -53,13 +56,19 @@ test.beforeAll(async () => {
     'RAINMAKER-PGR.ComplaintHierarchy',
     { limit: 200 },
   ).catch(() => [] as Awaited<ReturnType<typeof mdmsSearch>>);
+  const leafCodes: string[] = [];
   for (const r of ctRecords) {
     if (r.isActive === false) continue;
     const data = r.data as Record<string, unknown>;
     if (data.department === undefined && data.slaHours === undefined) continue; // interior node
     const code = data.code as string | undefined;
-    if (code) { liveServiceCode = code; break; }
+    if (code) leafCodes.push(code);
   }
+  // Prefer the deployment's SEED serviceCode: resolveSeedPlan picks it precisely
+  // because a PGR_LME employee holds its department, so a complaint filed with it
+  // is actually ASSIGNable. A random first leaf is often a test-junk type whose
+  // department no employee holds — the ASSIGN then 400s and tests 2/12 fail.
+  liveServiceCode = leafCodes.includes(SERVICE_CODE) ? SERVICE_CODE : (leafCodes[0] ?? liveServiceCode);
 
   // --- Pick an HRMS employee with PGR_LME role for ASSIGN test ---
   const employees = await employeeSearch(auth, CITY_TENANT, {
@@ -228,11 +237,11 @@ Catches a regression where description doesn't ride along with the workflow tran
     await page.goto(`${LIST_PATH}/${target}/edit`);
 
     const newDesc = `PW edited at ${Date.now()}`;
-    const desc = page.getByLabel(/^Description/i);
-    await desc.fill('');
-    await desc.fill(newDesc);
 
-    // Pick ASSIGN action.
+    // Pick ASSIGN action FIRST — choosing an action calls setValue() on
+    // assignee/rating and re-renders the Workflow section; the assignee/cascade
+    // widgets can reset sibling inputs on mount, so fill the description LAST
+    // (right before Save) to guarantee its value is what gets submitted.
     const actionSelect = page.getByLabel(/^Action$/i).or(page.getByLabel(/^Workflow/i)).first();
     await actionSelect.click();
     await page.getByRole('option', { name: /ASSIGN/i }).first().click();
@@ -246,14 +255,28 @@ Catches a regression where description doesn't ride along with the workflow tran
       await page.getByRole('option').first().click();
     }
 
-    await page.getByRole('button', { name: /^Save$/i }).click();
+    const desc = page.getByLabel(/^Description/i);
+    await desc.fill('');
+    await desc.fill(newDesc);
+    await desc.blur();
 
-    // Verify both changes landed.
-    const wrappers = await pgrSearch(auth, CITY_TENANT, { serviceRequestId: target! });
-    expect(wrappers.length).toBeGreaterThan(0);
-    const svc = wrappers[0].service as Record<string, unknown>;
-    expect(svc.description).toBe(newDesc);
-    expect(svc.applicationStatus).toBe('PENDINGATLME');
+    // Wait for the _update to actually complete before searching — otherwise the
+    // assertion races the XHR and reads the pre-edit description.
+    const [updResp] = await Promise.all([
+      page.waitForResponse(
+        (r) => r.url().includes('/pgr-services/v2/request/_update') && r.request().method() === 'POST',
+        { timeout: 30_000 },
+      ),
+      page.getByRole('button', { name: /^Save$/i }).click(),
+    ]);
+    expect(updResp.status(), 'PGR _update should succeed').toBe(200);
+    // Assert on the _update RESPONSE (the write's source of truth) rather than a
+    // fresh _search — pgr-services' search index lags the write by a beat, so an
+    // immediate re-search reads the pre-edit value and the test flakes.
+    const updBody = await updResp.json();
+    const svc = (updBody.ServiceWrappers?.[0]?.service ?? {}) as Record<string, unknown>;
+    expect(svc.description, 'edited description merged into the ASSIGN _update').toBe(newDesc);
+    expect(svc.applicationStatus, 'ASSIGN moved it to PENDINGATLME').toBe('PENDINGATLME');
   });
 
   test('3. workflow dropdown labels are human-readable, not UUIDs', {
@@ -347,13 +370,9 @@ Catches the bug class where pagination renders fine but the count number is wron
     await page.goto(LIST_PATH);
     await page.waitForLoadState('networkidle').catch(() => {});
 
-    // Find the page-size selector and pick 10.
-    const perPage = page.getByLabel(/per page|rows per page/i).first();
-    if (await perPage.isVisible().catch(() => false)) {
-      await perPage.click();
-      await page.getByRole('option', { name: '10' }).click();
-      await page.waitForLoadState('networkidle').catch(() => {});
-    }
+    // The footer "of N" reflects the live TOTAL regardless of page size, so we
+    // don't touch the per-page selector (its option widget varies by build and
+    // isn't needed to validate the count).
 
     // Live count via the API.
     const auth = loadAuth();
@@ -687,13 +706,24 @@ Both client-side (single XHR count) and server-side (persistence) checks — tog
     await page.goto(`${LIST_PATH}/${target}/edit`);
 
     const newDesc = `PW single-roundtrip at ${Date.now()}`;
+
+    // A PGR field edit still needs a valid workflow action — the API defaults to
+    // ASSIGN, which is only valid from PENDINGFORASSIGNMENT and needs an assignee.
+    // Drive a real ASSIGN and confirm the description rides along in the SAME
+    // _update round-trip (the point of this test).
+    const actionSelect = page.getByLabel(/^Action$/i).or(page.getByLabel(/^Workflow/i)).first();
+    await actionSelect.click();
+    await page.getByRole('option', { name: /ASSIGN/i }).first().click();
+    const assigneeSelect = page.getByLabel(/Assign(ee)?/i).first();
+    if (await assigneeSelect.isVisible().catch(() => false)) {
+      await assigneeSelect.click();
+      await page.getByRole('option').first().click();
+    }
     const desc = page.getByLabel(/^Description/i);
     await desc.fill('');
     await desc.fill(newDesc);
+    await desc.blur();
 
-    // Don't change the workflow action — we want to be sure the
-    // description alone rides along. (The merge logic wraps both into one
-    // POST /request/_update, see dataProvider.ts:617.)
     const updates: Array<{ body: string }> = [];
     page.on('request', (req) => {
       if (
@@ -704,18 +734,23 @@ Both client-side (single XHR count) and server-side (persistence) checks — tog
       }
     });
 
-    await page.getByRole('button', { name: /^Save$/i }).click();
-    await page.waitForLoadState('networkidle').catch(() => {});
+    const [upd12] = await Promise.all([
+      page.waitForResponse(
+        (r) => r.url().includes('/pgr-services/v2/request/_update') && r.request().method() === 'POST',
+        { timeout: 30_000 },
+      ),
+      page.getByRole('button', { name: /^Save$/i }).click(),
+    ]);
+    expect(upd12.status(), 'PGR _update should succeed').toBe(200);
 
     expect(updates.length, 'expected exactly one _update POST on save').toBe(1);
     // The single POST body should carry the new description under service.description.
     const body = JSON.parse(updates[0].body || '{}');
-    const svc = body.service as Record<string, unknown>;
-    expect(svc?.description).toBe(newDesc);
+    expect((body.service as Record<string, unknown>)?.description).toBe(newDesc);
 
-    // Server round-trip confirmation.
-    const wrappers = await pgrSearch(auth, CITY_TENANT, { serviceRequestId: target ?? undefined });
-    const persisted = (wrappers[0]?.service as Record<string, unknown>)?.description;
+    // Persisted per the _update RESPONSE (source of truth; the search index lags).
+    const respBody = await upd12.json();
+    const persisted = (respBody.ServiceWrappers?.[0]?.service as Record<string, unknown>)?.description;
     expect(persisted).toBe(newDesc);
   });
 
@@ -906,8 +941,16 @@ async function pickLocality(
 async function pickWorkableComplaint(auth: AuthInfo): Promise<string | null> {
   const wrappers = await pgrSearch(auth, CITY_TENANT, {
     status: 'PENDINGFORASSIGNMENT',
-    limit: 5,
+    limit: 50,
   }).catch(() => []);
+  // Prefer a complaint filed under the deployment's SEED serviceCode: its
+  // department is one a PGR_LME employee actually holds, so an ASSIGN succeeds.
+  // A random PFA complaint is often an old test-junk type whose department no
+  // employee holds — ASSIGN then 400s (pgr-services NPEs on the mismatch).
+  const preferred = wrappers.find(
+    (w) => (w.service as Record<string, unknown>)?.serviceCode === SERVICE_CODE,
+  );
+  if (preferred) return (preferred.service as Record<string, unknown>).serviceRequestId as string;
   for (const w of wrappers) {
     const id = (w.service as Record<string, unknown>)?.serviceRequestId as string | undefined;
     if (id) return id;

--- a/tests/integration-tests/tests/admin/complaints.spec.ts
+++ b/tests/integration-tests/tests/admin/complaints.spec.ts
@@ -21,7 +21,7 @@ import {
   type AuthInfo,
 } from '../utils/manage/api';
 import { cleanupPgrComplaints } from '../utils/manage/teardown';
-import { generateCitizenPhone, ROOT_TENANT, TENANT } from '../utils/env';
+import { generateCitizenPhone, ROOT_TENANT, TENANT, LOCALITY_CODE } from '../utils/env';
 
 // Tenant identifiers come from env so the suite runs on any deployment.
 // TENANT_CODE is the STATE/root tenant (citizen tenantId); CITY_TENANT is the
@@ -138,10 +138,15 @@ Citizen tenant must be ROOT — assigning to city would break login flows. Clean
       'PW filed-by-test — complaint description over ten chars',
     );
 
-    // LocalityPicker is three cascading selects. We pick the first hierarchy
-    // option, then the first boundary type, then either liveBoundaryCode
-    // (if known on this tenant) or the first listed boundary.
-    await pickLocality(page, liveBoundaryCode || undefined);
+    // LocalityPicker is three cascading selects. pickLocality does a first
+    // pass across EVERY hierarchy x boundary-type combo looking ONLY for a
+    // boundary matching the known-good code (liveBoundaryCode from a recent
+    // complaint, or the env/profile LOCALITY_CODE floor); only if that comes
+    // up empty everywhere does it fall back to the first combo with any
+    // option (RC6 — the old single-combo-first behavior stamped ROOT tenant
+    // whenever the default hierarchy's tree had no city boundaries).
+    const preferredLocality = liveBoundaryCode || LOCALITY_CODE;
+    const { pickedPreferred } = await pickLocality(page, preferredLocality);
 
     // Citizen mobile — valid for the deployment's MDMS mobile rule
     // (9 digits starting with 7/1). A raw 10-digit 7… fails that rule.
@@ -163,9 +168,20 @@ Citizen tenant must be ROOT — assigning to city would break login flows. Clean
 
     // Citizen tenant must be the STATE tenant, not the city.
     expect((service.citizen as Record<string, unknown>)?.tenantId).toBe(TENANT_CODE);
-    // Address tenant is the city.
+    // Address tenant. When pickLocality found the known-good (city) boundary
+    // in pass 1, the app must stamp CITY — that's the strict contract this
+    // test guards. When pass 1 found nothing anywhere and pass 2 fell back to
+    // whatever combo offered ANY option (e.g. a flat deployment or a
+    // deployment whose only reachable tree is the root hierarchy), the address
+    // tenant must be whichever tenant actually owns the picked boundary —
+    // see resolveComplaintAddressTenant (dataProvider.ts:355-391). On a flat
+    // deployment ROOT === CITY so both branches are equally strict there.
     const address = service.address as Record<string, unknown>;
-    expect(address?.tenantId).toBe(CITY_TENANT);
+    if (pickedPreferred) {
+      expect(address?.tenantId).toBe(CITY_TENANT);
+    } else {
+      expect([TENANT_CODE, CITY_TENANT]).toContain(address?.tenantId);
+    }
     expect(((address?.locality as Record<string, unknown>)?.code) ?? '').toBeTruthy();
 
     // Wait for the redirect to the Show page with a fresh <PREFIX>-PGR-* id
@@ -776,17 +792,35 @@ async function pickComplaintType(
   }
 }
 
+/** Escape regex metacharacters so a live boundary code can be used verbatim
+ *  inside a `getByRole('option', { name: new RegExp(...) })` match. */
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 async function pickLocality(
   page: import('@playwright/test').Page,
   preferredCode?: string,
-): Promise<void> {
+): Promise<{ pickedPreferred: boolean }> {
   // LocalityPicker is three radix Selects in one grid — Hierarchy → Boundary
   // Type → Boundary(locality). Only the last carries a "Locality" label
   // (htmlFor); the first two expose no accessible label, so scope to the grid
   // and drive them positionally. The default hierarchy can be one with no
   // usable city boundaries (e.g. ADMIN 400s on this tenant while MAPUTO_ADMIN
   // holds the real tree), so iterate hierarchy × boundary-type until the
-  // Boundary select actually offers options, then pick preferredCode or first.
+  // Boundary select actually offers options.
+  //
+  // RC6: picking the FIRST combo offering ANY option used to stop the walk
+  // even when that combo was the root-level tree — the app then (correctly)
+  // stamps address.tenantId = ROOT via resolveComplaintAddressTenant
+  // (dataProvider.ts:355-391), breaking the "address tenant = CITY" contract.
+  // So we walk the WHOLE combo space twice: pass 1 looks only for
+  // `preferredCode` (a boundary code known to live under the city tree);
+  // pass 2 — only if pass 1 found nothing anywhere — falls back to today's
+  // original "first combo, first option" behavior. Boundary options render
+  // the raw code (LocalityPicker.tsx: `{b.name ?? b.code}`; relationship
+  // nodes carry no name), so a code-regex match is reliable.
+  //
   // Anchor on the picker's help text (unique) to scope to its 3 selects —
   // the individual Hierarchy/Boundary-Type triggers carry no accessible label.
   const localityGroup = page
@@ -799,20 +833,6 @@ async function pickLocality(
   const boundaryType = selects.nth(1);
   const localityTrigger = selects.nth(2);
 
-  const pickFirstOrPreferred = async (): Promise<boolean> => {
-    const options = page.getByRole('option');
-    if ((await options.count()) === 0) return false;
-    if (preferredCode) {
-      const pref = page.getByRole('option', { name: new RegExp(preferredCode) });
-      if (await pref.first().isVisible().catch(() => false)) {
-        await pref.first().click();
-        return true;
-      }
-    }
-    await options.first().click();
-    return true;
-  };
-
   const countOptions = async (trigger: import('@playwright/test').Locator): Promise<number> => {
     if (!(await trigger.isEnabled().catch(() => false))) return 0;
     await trigger.click();
@@ -821,28 +841,65 @@ async function pickLocality(
     return n;
   };
 
-  const hierN = await countOptions(hierarchy);
-  for (let h = 0; h < Math.max(hierN, 1); h++) {
-    if (hierN > 0) {
-      await page.getByRole('option').nth(h).click();
-    }
-    const typeN = await countOptions(boundaryType);
-    for (let t = 0; t < typeN; t++) {
-      await page.getByRole('option').nth(t).click();
-      if (!(await localityTrigger.isEnabled().catch(() => false))) continue;
-      await localityTrigger.click();
-      if (await pickFirstOrPreferred()) return;
-      await page.keyboard.press('Escape').catch(() => {});
-      // Re-open the type select for the next candidate.
-      if (t + 1 < typeN && (await boundaryType.isEnabled().catch(() => false))) {
-        await boundaryType.click();
+  // Walk every hierarchy x boundary-type combo, opening the locality select
+  // for each one. `onLocalityOpen` decides whether to pick an option for
+  // THIS combo (returning true stops the walk) or to back out (Escape) and
+  // let the walk continue to the next combo (returning false).
+  const walkCombos = async (
+    onLocalityOpen: () => Promise<boolean>,
+  ): Promise<boolean> => {
+    const hierN = await countOptions(hierarchy);
+    for (let h = 0; h < Math.max(hierN, 1); h++) {
+      if (hierN > 0) {
+        await page.getByRole('option').nth(h).click();
+      }
+      const typeN = await countOptions(boundaryType);
+      for (let t = 0; t < typeN; t++) {
+        await page.getByRole('option').nth(t).click();
+        if (await localityTrigger.isEnabled().catch(() => false)) {
+          await localityTrigger.click();
+          if (await onLocalityOpen()) return true;
+          await page.keyboard.press('Escape').catch(() => {});
+        }
+        // Re-open the type select for the next candidate.
+        if (t + 1 < typeN && (await boundaryType.isEnabled().catch(() => false))) {
+          await boundaryType.click();
+        }
+      }
+      // Re-open the hierarchy select for the next candidate.
+      if (h + 1 < hierN && (await hierarchy.isEnabled().catch(() => false))) {
+        await hierarchy.click();
       }
     }
-    // Re-open the hierarchy select for the next candidate.
-    if (h + 1 < hierN && (await hierarchy.isEnabled().catch(() => false))) {
-      await hierarchy.click();
-    }
+    return false;
+  };
+
+  // Pass 1: across ALL combos, look ONLY for preferredCode.
+  if (preferredCode) {
+    const found = await walkCombos(async () => {
+      const options = page.getByRole('option');
+      if ((await options.count()) === 0) return false;
+      const pref = page.getByRole('option', { name: new RegExp(escapeRegex(preferredCode)) });
+      if (await pref.first().isVisible().catch(() => false)) {
+        await pref.first().click();
+        return true;
+      }
+      return false;
+    });
+    if (found) return { pickedPreferred: true };
   }
+
+  // Pass 2: preferredCode not reachable anywhere — fall back to the first
+  // combo that offers ANY option, picking its first option (original
+  // behavior, kept for flat/degenerate deployments).
+  const fellBack = await walkCombos(async () => {
+    const options = page.getByRole('option');
+    if ((await options.count()) === 0) return false;
+    await options.first().click();
+    return true;
+  });
+  if (fellBack) return { pickedPreferred: false };
+
   throw new Error('pickLocality: no hierarchy/type combination yielded a selectable boundary');
 }
 

--- a/tests/integration-tests/tests/admin/complaints.spec.ts
+++ b/tests/integration-tests/tests/admin/complaints.spec.ts
@@ -18,11 +18,12 @@ import {
   pgrSearch,
   pgrCount,
   employeeSearch,
+  buildRequestInfo,
   type AuthInfo,
 } from '../utils/manage/api';
 import { cleanupPgrComplaints } from '../utils/manage/teardown';
 import { seedComplaintAsCitizen } from '../utils/seed';
-import { generateCitizenPhone, ROOT_TENANT, TENANT, LOCALITY_CODE, SERVICE_CODE } from '../utils/env';
+import { BASE_URL, generateCitizenPhone, ROOT_TENANT, TENANT, LOCALITY_CODE, SERVICE_CODE } from '../utils/env';
 
 // Tenant identifiers come from env so the suite runs on any deployment.
 // TENANT_CODE is the STATE/root tenant (citizen tenantId); CITY_TENANT is the
@@ -734,22 +735,47 @@ If the geo link doesn't pop a new tab or doesn't carry the coords, an admin can'
     await page.goto(`${LIST_PATH}/${target!.id}/show`);
 
     // Address-extras rows we expect to render.
-    for (const label of ['Landmark', 'Street', 'Pincode']) {
+    for (const label of ['Landmark', 'Street', 'Pincode', 'Geo']) {
       const row = page.getByText(new RegExp(`^${label}$`, 'i')).first();
       // Some may be blank — just assert the LABEL renders.
       await expect(row).toBeVisible();
     }
 
-    // Geo link — opens new tab to maps.google.com/maps?q=lat,lng.
+    // Geo link — a target="_blank" anchor to google.com/maps?q=lat,lng.
+    //
+    // Located by href, NOT by accessible name. The anchor's accessible name is the
+    // coordinate pair itself ("-25.969200, 32.573200"); the word "Geo" is only the
+    // <dt> label of the FieldRow (admin/fields/FieldSection.tsx), a plain sibling
+    // with no aria association to the <a> in the adjacent <dd>. The previous
+    // `getByRole('link', { name: /map|geo|location/i })` matched ZERO links, so the
+    // click hung on an unresolvable locator and the popup wait timed out first —
+    // reporting a failure identical whether the feature worked or not. It works.
+    const geoLink = page.locator('a[href*="google.com/maps"]').first();
+    await expect(
+      geoLink,
+      'the Geo row must render a maps link for a complaint with coordinates',
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Assert the URL BEFORE clicking, so a placeholder href (e.g. ?q=0,0) fails even
+    // though a tab would still open. Single combined match: two separate substring
+    // checks can both pass on a URL that merely contains each number somewhere.
+    expect(
+      await geoLink.getAttribute('href'),
+      "geo link must point at the complaint's real coordinates",
+    ).toContain(`?q=${target!.lat},${target!.lng}`);
+    expect(
+      await geoLink.getAttribute('target'),
+      'geo link must open in a new tab',
+    ).toBe('_blank');
+
     const [popup] = await Promise.all([
       page.waitForEvent('popup', { timeout: 10_000 }),
-      page.getByRole('link', { name: /map|geo|location/i }).first().click(),
+      geoLink.click(),
     ]);
 
     const popupUrl = popup.url();
     expect(popupUrl).toMatch(/google\.com\/maps/);
-    expect(popupUrl).toContain(String(target!.lat));
-    expect(popupUrl).toContain(String(target!.lng));
+    expect(popupUrl).toContain(`${target!.lat},${target!.lng}`);
   });
 
   test('9. mobile-only citizen heuristic shows suffix on Show page', {
@@ -1290,18 +1316,55 @@ async function pickWorkableComplaint(auth: AuthInfo): Promise<string | null> {
     return id;
   };
 
-  const preferred = wrappers.find(
-    (w) =>
-      (w.service as Record<string, unknown>)?.serviceCode === SERVICE_CODE &&
-      !consumedComplaints.has(String(idOf(w))),
-  );
-  if (preferred) {
-    const id = claim(idOf(preferred));
-    if (id) return id;
+  // Scavenge ONLY a complaint whose live WORKFLOW state agrees with pgr's.
+  //
+  // pgr-services' `applicationStatus` cannot be trusted on this deployment. The
+  // configurator's complaint edit submits `address.locality.code: null`; pgr
+  // answers 200 and publishes, then egov-persister rejects the row on a NOT NULL
+  // constraint and the shared transaction rolls the service row back too. The
+  // result is a "zombie": egov-workflow-v2 has advanced to PENDINGATLME while the
+  // pgr read model still reports PENDINGFORASSIGNMENT, permanently.
+  //
+  // Measured on mz.maputo: 23 of 211 PENDINGFORASSIGNMENT complaints were zombies,
+  // with 15 distinct ids producing `INVALID ACTION` in a five-hour window. Handing
+  // one to a test yields exactly that 400 — the UI loads the stale status, offers
+  // ASSIGN, and workflow (which IS up to date) refuses it.
+  //
+  // Crucially, a PASSING edit test mints a new zombie, so this poisons itself: the
+  // same spec alternates green and red depending on whether the newest candidate
+  // happens to be a fresh seed or a corpse from the previous run.
+  const wfAgrees = async (srid: string): Promise<boolean> => {
+    try {
+      const r = await fetch(
+        `${BASE_URL}/egov-workflow-v2/egov-wf/process/_search?tenantId=${CITY_TENANT}` +
+          `&businessIds=${encodeURIComponent(srid)}&history=false`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ RequestInfo: buildRequestInfo(auth) }),
+        },
+      );
+      if (!r.ok) return false;
+      const j = (await r.json()) as { ProcessInstances?: Array<{ state?: { applicationStatus?: string } }> };
+      const state = j.ProcessInstances?.[0]?.state?.applicationStatus;
+      // No workflow record yet == freshly filed and not desynced.
+      return state === undefined || state === 'PENDINGFORASSIGNMENT';
+    } catch {
+      return false;
+    }
+  };
+
+  for (const w of wrappers) {
+    if ((w.service as Record<string, unknown>)?.serviceCode !== SERVICE_CODE) continue;
+    const id = idOf(w);
+    if (!id || consumedComplaints.has(id)) continue;
+    if (!(await wfAgrees(id))) continue; // zombie — skip it
+    const claimed = claim(id);
+    if (claimed) return claimed;
   }
 
-  // No unconsumed complaint of the seed serviceCode left — file a fresh one
-  // rather than scavenging.
+  // No unconsumed, workflow-consistent complaint of the seed serviceCode — file a
+  // fresh one rather than scavenging.
   //
   // Scavenging is actively harmful here: most PENDINGFORASSIGNMENT complaints on
   // a long-lived box are filed against `PW*` junk complaint types other runs

--- a/tests/integration-tests/tests/admin/complaints.spec.ts
+++ b/tests/integration-tests/tests/admin/complaints.spec.ts
@@ -875,16 +875,44 @@ Product decision (2026-07-26): there is no departments page, so the column is NO
     await page.waitForLoadState('networkidle').catch(() => {});
 
     const auth = loadAuth();
+
+    // Resolve the departments master FIRST so we can prefer a complaint whose
+    // department actually resolves to a display name.
+    //
+    // isActive:true is load-bearing here: this deployment carries 225+
+    // department records of which only 3 are real — the rest are soft-deleted
+    // PW_ scratch rows left by previous suite runs. An unfiltered page of 200
+    // is entirely junk, the real rows sort past the page boundary, and the
+    // lookup below found nothing even though the department exists. Pushing
+    // isActive to the server paginates over the ACTIVE set instead.
+    const deptRecords = await mdmsSearch(auth, TENANT_CODE, 'common-masters.Department', {
+      limit: 500,
+      isActive: true,
+    }).catch(() => [] as Awaited<ReturnType<typeof mdmsSearch>>);
+    const resolveDeptName = (code: string): string | undefined => {
+      const match = deptRecords.find((r) => {
+        const d = r.data as Record<string, unknown>;
+        return d?.code === code || r.uniqueIdentifier === code || d?.name === code;
+      });
+      return (match?.data as Record<string, unknown> | undefined)?.name as string | undefined;
+    };
+
     // Find a complaint whose additionalDetail.department is populated so
-    // we know the column has something to render.
+    // we know the column has something to render. Prefer one whose department
+    // still resolves in the master — scratch complaints from earlier runs can
+    // point at departments that have since been soft-deleted.
     const wrappers = await pgrSearch(auth, CITY_TENANT, { limit: 50 });
     let deptCode: string | null = null;
+    let fallbackDeptCode: string | null = null;
     for (const w of wrappers) {
       const svc = w.service as Record<string, unknown> | undefined;
       const add = svc?.additionalDetail as Record<string, unknown> | undefined;
       const d = add?.department as string | undefined;
-      if (d) { deptCode = d; break; }
+      if (!d) continue;
+      if (fallbackDeptCode === null) fallbackDeptCode = d;
+      if (resolveDeptName(d)) { deptCode = d; break; }
     }
+    if (!deptCode) deptCode = fallbackDeptCode;
     if (!deptCode) test.skip(true, 'No complaint with additionalDetail.department on tenant');
 
     // Product decision (2026-07-26): there is NO departments page to link to, so
@@ -894,16 +922,11 @@ Product decision (2026-07-26): there is no departments page, so the column is NO
     const rowsText = (await page.getByRole('row').allTextContents()).join(' | ');
     expect(rowsText, 'complaints list rendered rows').toBeTruthy();
 
-    // Resolve the department's display name from the departments master, then
-    // assert the grid shows THAT (not the raw code). Deployment-agnostic: the
-    // name comes from the tenant's own master, never a hardcoded literal.
-    const deptRecords = await mdmsSearch(auth, TENANT_CODE, 'common-masters.Department', { limit: 200 })
-      .catch(() => [] as Awaited<ReturnType<typeof mdmsSearch>>);
-    const match = deptRecords.find((r) => {
-      const d = r.data as Record<string, unknown>;
-      return d?.code === deptCode || r.uniqueIdentifier === deptCode || d?.name === deptCode;
-    });
-    const displayName = (match?.data as Record<string, unknown> | undefined)?.name as string | undefined;
+    // Resolve the department's display name from the departments master (read
+    // above), then assert the grid shows THAT (not the raw code).
+    // Deployment-agnostic: the name comes from the tenant's own master, never
+    // a hardcoded literal.
+    const displayName = resolveDeptName(deptCode!);
     if (!displayName) test.skip(true, `department '${deptCode}' not found in common-masters.Department — cannot resolve its display name`);
 
     expect(

--- a/tests/integration-tests/tests/admin/complaints.spec.ts
+++ b/tests/integration-tests/tests/admin/complaints.spec.ts
@@ -21,6 +21,7 @@ import {
   type AuthInfo,
 } from '../utils/manage/api';
 import { cleanupPgrComplaints } from '../utils/manage/teardown';
+import { seedComplaintAsCitizen } from '../utils/seed';
 import { generateCitizenPhone, ROOT_TENANT, TENANT, LOCALITY_CODE, SERVICE_CODE } from '../utils/env';
 
 // Tenant identifiers come from env so the suite runs on any deployment.
@@ -33,6 +34,34 @@ const LIST_PATH = '/configurator/manage/complaints';
 const CREATE_PATH = `${LIST_PATH}/create`;
 
 const createdComplaints = new Set<string>();
+// Complaints already handed out by pickWorkableComplaint(). pgr-services' read
+// model does not reflect a write immediately (and, until the locality-wipe bug
+// is fixed, may never reflect it at all), so a second caller asking the same
+// `status: PENDINGFORASSIGNMENT` query gets the same complaint back, loads a
+// stale status, offers ASSIGN, and egov-workflow-v2 — which IS up to date —
+// rejects it with `INVALID ACTION`. Never hand the same complaint out twice.
+const consumedComplaints = new Set<string>();
+
+/**
+ * Choose the human ASSIGN action in the Take-Action select.
+ *
+ * Anchored deliberately: from PENDINGFORASSIGNMENT the PGR workflow also offers
+ * `ASSIGNEDBYAUTOESCALATION` (roles: [AUTO_ESCALATE]) and the UI lists it BEFORE
+ * `ASSIGN`, so a loose /assign/i picks the system-only transition. No human role
+ * holds AUTO_ESCALATE, so the _update then 400s with `INVALID ROLE`. Anchoring on
+ * ^ also keeps `Reassign to Employee` out.
+ *
+ * Asserts on the option's text so a future label change fails loudly here rather
+ * than silently selecting a neighbouring action.
+ */
+async function chooseAssignAction(page: import('@playwright/test').Page) {
+  const option = page.getByRole('option', { name: /^Assign to Employee/i }).first();
+  await expect(
+    option,
+    'the Take-Action select should offer an "Assign to Employee" option',
+  ).toBeVisible({ timeout: 20_000 });
+  await option.click({ timeout: 20_000 });
+}
 
 let liveServiceCode: string | null = null;
 let lmeAssigneeUuid: string | null = null;
@@ -268,7 +297,7 @@ Catches a regression where description doesn't ride along with the workflow tran
     // force: the trigger is visible but Playwright's actionability check can hang
     // on this custom select (overlay/pointer-events during the record load).
     await actionSelect.click({ timeout: 20_000, force: true });
-    await page.getByRole('option', { name: /assign/i }).first().click({ timeout: 20_000 });
+    await chooseAssignAction(page);
 
     // The assignee picker may render only after ASSIGN is chosen.
     // These custom selects render WITHOUT a <label> association, so getByLabel
@@ -422,26 +451,29 @@ Catches the bug class where pagination renders fine but the count number is wron
     expect(uiCount).toBe(apiCount);
   });
 
-  test('6. status + date filters fire as XHR query params', {
+  test('6. status filter fires as an XHR query param', {
     annotation: {
       type: 'description',
-      description: `Validates server-side filtering on the complaints list: changing the Status filter to PENDINGFORASSIGNMENT and setting From-date to 7 days ago must produce a /pgr-services/v2/request/_search XHR with both applicationStatus= and fromDate= query params.
+      description: `Validates server-side status filtering on the complaints list: changing the Status filter to "Pending Assignment" must produce a /pgr-services/v2/request/_search XHR carrying applicationStatus=PENDINGFORASSIGNMENT.
 
 Steps:
-1. Navigate to /complaints; wait networkidle.
-2. Attach a request listener to capture _search URLs into 'seen'.
-3. Locate Status filter; test.skip if not visible; click; pick PENDINGFORASSIGNMENT.
-4. If From-date input exists, fill ISO date 7 days ago.
-5. Wait networkidle.
-6. Assert seen.length > 0 (at least one search XHR fired).
-7. Assert the latest URL matches /applicationStatus=/.
-8. If From-date was filled, assert the URL also matches /fromDate=/.
+1. Navigate to /complaints; wait for the first data row.
+2. Attach a request listener capturing _search URLs into 'seen'.
+3. Locate the Status filter (radix combobox — matched by its trigger TEXT, see below); assert it is visible.
+4. Click it and pick the option whose id is PENDINGFORASSIGNMENT (label "Pending Assignment").
+5. expect.poll until a _search URL carrying applicationStatus= is observed, then assert the value is PENDINGFORASSIGNMENT.
 
-Catches a regression where filters render but only update local state instead of triggering a server search.`,
+Two selector notes, both learned the hard way:
+- The radix SelectTrigger has NO accessible name, so getByRole('combobox', { name: /^Status$/ }) matches NOTHING. That silently drove this test into test.skip() for its whole life. Match on trigger text instead.
+- waitForLoadState('networkidle') resolves in ~0.2ms after an SPA click (no navigation occurs), so it cannot be used to wait for the refire. Poll the captured URLs instead.
+
+The From/To date half of this test now lives in test 6b — it is a genuinely separate contract and it is currently broken app-side, so bundling the two hid a working assertion behind a failing one.
+
+Catches a regression where the status filter renders but only updates local state instead of triggering a server search.`,
     },
     tag: ['@area:configurator-manage', '@area:pgr', '@kind:regression', '@layer:ui', '@persona:admin'] }, async ({ page }) => {
     await page.goto(LIST_PATH);
-    await page.waitForLoadState('networkidle').catch(() => {});
+    await expect(page.getByRole('row').nth(1)).toBeVisible({ timeout: 30_000 });
 
     const seen: string[] = [];
     page.on('request', (req: Request) => {
@@ -449,76 +481,215 @@ Catches a regression where filters render but only update local state instead of
       if (/\/pgr-services\/v2\/request\/_search/.test(url)) seen.push(url);
     });
 
-    // The filter renders as a combobox with an accessible name (not a <label>
-    // association), so match by role+name, not getByLabel.
-    const statusFilter = page.getByRole('combobox', { name: /^Status$/i }).first();
-    if (!(await statusFilter.isVisible().catch(() => false))) {
-      test.skip(true, 'Status filter not present on this build');
-    }
+    const statusFilter = page.getByRole('combobox').filter({ hasText: /^Status$/ }).first();
+    await expect(
+      statusFilter,
+      'the complaints list must render a Status filter',
+    ).toBeVisible({ timeout: 15_000 });
     await statusFilter.click();
-    await page.getByRole('option', { name: /PENDINGFORASSIGNMENT/i }).click();
 
-    // From-date = 7 days ago. The widget is a date input; we drive it via
-    // its labeled control if present.
-    const fromDate = page.getByLabel(/^From|^From\s*date/i).first();
-    if (await fromDate.isVisible().catch(() => false)) {
-      const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-      const iso = sevenDaysAgo.toISOString().slice(0, 10);
-      await fromDate.fill(iso);
-    }
-    await page.waitForLoadState('networkidle').catch(() => {});
+    // The option LABEL is the human name ("Pending Assignment"); the id it sets
+    // is PENDINGFORASSIGNMENT. Anchor on the label, assert on the emitted param.
+    const pendingOption = page
+      .getByRole('option')
+      .filter({ hasText: /^Pending Assignment$/i })
+      .first();
+    await expect(
+      pendingOption,
+      'the Status filter must offer the PENDINGFORASSIGNMENT state',
+    ).toBeVisible({ timeout: 15_000 });
+    await pendingOption.click();
 
-    expect(seen.length, 'status/date change should trigger _search XHR').toBeGreaterThan(0);
-    const last = seen[seen.length - 1];
-    expect(last).toMatch(/applicationStatus=/);
-    if (await fromDate.isVisible().catch(() => false)) {
-      expect(last).toMatch(/fromDate=/);
-    }
+    await expect
+      .poll(() => seen.filter((u) => /[?&]applicationStatus=/.test(u)).length, {
+        timeout: 25_000,
+        message:
+          'changing Status must refire /pgr-services/v2/request/_search with an applicationStatus= query param',
+      })
+      .toBeGreaterThan(0);
+
+    const filtered = seen.filter((u) => /[?&]applicationStatus=/.test(u));
+    expect(
+      filtered[filtered.length - 1],
+      'the emitted applicationStatus must be the state the operator picked',
+    ).toMatch(/[?&]applicationStatus=PENDINGFORASSIGNMENT(&|$)/);
+  });
+
+  test('6b. From-date filter fires as a fromDate XHR query param', {
+    annotation: {
+      type: 'description',
+      description: `Validates server-side DATE filtering on the complaints list: adding the "From" filter and setting it to 7 days ago must produce a /pgr-services/v2/request/_search XHR carrying a fromDate= query param.
+
+Steps:
+1. Navigate to /complaints; wait for the first data row.
+2. Click "Add filter" and choose "From" (fromDate is NOT alwaysOn in ComplaintList.tsx, so it only exists once added — this is why the old bundled test never exercised it).
+3. Attach a request listener capturing _search URLs.
+4. Fill the date input with ISO(now - 7d). DateFilterInput DOES associate its <label htmlFor>, so getByLabel(/^From$/) reaches it once shown.
+5. expect.poll until _search refires at all (proves the filter form reacted).
+6. Assert one of the refired URLs carries fromDate=.
+
+Split out of test 6 deliberately: the status half passes and the date half does not, and a single bundled test would have masked the working half behind the broken one. Do NOT relax step 6 to make this green — see the failure message for the mechanism.`,
+    },
+    tag: ['@area:configurator-manage', '@area:pgr', '@kind:regression', '@layer:ui', '@persona:admin'] }, async ({ page }) => {
+    await page.goto(LIST_PATH);
+    await expect(page.getByRole('row').nth(1)).toBeVisible({ timeout: 30_000 });
+
+    // fromDate is not alwaysOn — surface it through the Add-filter popover.
+    const addFilter = page.getByRole('button', { name: /^Add filter$/i }).first();
+    await expect(
+      addFilter,
+      'the complaints list must offer an "Add filter" control for the non-alwaysOn filters',
+    ).toBeVisible({ timeout: 15_000 });
+    await addFilter.click();
+    const fromEntry = page
+      .locator('[data-radix-popper-content-wrapper]')
+      .getByRole('button', { name: /^From$/ })
+      .first();
+    await expect(
+      fromEntry,
+      'the Add-filter menu must offer the "From" date filter',
+    ).toBeVisible({ timeout: 15_000 });
+    await fromEntry.click();
+
+    const fromInput = page.getByLabel(/^From$/i).first();
+    await expect(fromInput, 'the From date input must mount once added').toBeVisible({
+      timeout: 15_000,
+    });
+
+    const seen: string[] = [];
+    page.on('request', (req: Request) => {
+      const url = req.url();
+      if (/\/pgr-services\/v2\/request\/_search/.test(url)) seen.push(url);
+    });
+
+    const iso = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    await fromInput.fill(iso);
+
+    // The grid debounces (DigitList setFilters(..., undefined, true)), so never
+    // read immediately — poll until the refire lands.
+    await expect
+      .poll(() => seen.length, {
+        timeout: 25_000,
+        message: 'setting the From date must refire /pgr-services/v2/request/_search',
+      })
+      .toBeGreaterThan(0);
+
+    expect(
+      seen.some((u) => /[?&]fromDate=/.test(u)),
+      `the From date must reach pgr-services as a fromDate= query param, but no refired _search carried one. ` +
+        `Observed: ${JSON.stringify(seen)}. ` +
+        `APP BUG — DateFilterInput drives an <input type="date">, so react-hook-form stores fromDate as the STRING "${iso}", ` +
+        `while dataProvider.ts getList() gates on \`typeof filter.fromDate === 'number'\` and therefore drops it. ` +
+        `Do not weaken this assertion; parse the date input to epoch-ms (or widen the type guard) in the provider.`,
+    ).toBe(true);
   });
 
   test('7. department filter narrows visible rows', {
     annotation: {
       type: 'description',
-      description: `Validates the Department filter on the complaints list: each visible row after filtering must reference the picked department (text match in row content). Picks the first available option to avoid hardcoding tenant-specific dept codes.
+      description: `Validates the Department filter on the complaints list actually NARROWS the grid: after picking a department, the rows still on screen must be exactly the rows that already carried that department.
 
 Steps:
-1. Navigate to /complaints.
-2. Locate Department filter; test.skip if absent.
-3. Click filter; capture first option's text; click it; wait networkidle.
-4. Read row count; if <=1 return early (filter validly returned 0 rows).
-5. Sample up to 5 rows; lower-case row text and assert it contains the option's lowercased text.
+1. Navigate to /complaints; wait for rows and let them settle (the grid debounces).
+2. Read the Department column of every visible row -> deptsBefore.
+3. Open the Department filter and read its options, dropping "All" (that option CLEARS the filter — selecting it can never narrow anything, so iterating it would guarantee a vacuous pass).
+4. Pick the department with the FEWEST rows on the current page — that maximises the observable narrowing. Skip if it would not narrow at all (a real data gap, not a pass).
+5. expect.poll the Department column until it equals exactly the subset of deptsBefore that carried the picked department.
 
-Loose match via text inclusion tolerates whatever the row actually renders (label, code, or both).`,
+Selector note: the radix SelectTrigger has NO accessible name, so getByRole('combobox', { name: /^Department/ }) matched nothing and this test skipped itself for its whole life.
+
+The assertion is an exact array equality against a pre-filter measurement — it cannot pass unless the filter genuinely removed the non-matching rows.`,
     },
     tag: ['@area:configurator-manage', '@area:pgr', '@kind:regression', '@layer:ui', '@persona:admin'] }, async ({ page }) => {
     await page.goto(LIST_PATH);
-    const filter = page.getByRole('combobox', { name: /^Department/i }).first();
-    if (!(await filter.isVisible().catch(() => false))) {
-      test.skip(true, 'Department filter not present on this build');
-    }
-
-    // Pick the FIRST option that has at least one matching row server-side
-    // — querying live data avoids tenant-specific assumptions.
-    await filter.click();
-    const firstOpt = page.getByRole('option').first();
-    const optText = ((await firstOpt.textContent()) || '').trim();
-    await firstOpt.click();
-    await page.waitForLoadState('networkidle').catch(() => {});
-
     const rows = page.getByRole('row');
-    const rowCount = await rows.count();
-    if (rowCount <= 1) return; // header only — filter validly returned 0 rows.
+    await expect(rows.nth(1)).toBeVisible({ timeout: 30_000 });
 
-    // Sample up to 5 rows and check the Department column contains the
-    // selected option's text.
-    const sample = Math.min(5, rowCount - 1);
-    for (let i = 1; i <= sample; i++) {
-      const rowText = (await rows.nth(i).textContent())?.toLowerCase() || '';
-      expect(
-        rowText.includes(optText.toLowerCase()),
-        `row ${i} should match dept filter "${optText}"`,
-      ).toBe(true);
-    }
+    const headers = (await rows.nth(0).getByRole('columnheader').allTextContents()).map((h) =>
+      h.trim(),
+    );
+    const deptCol = headers.findIndex((h) => /^department$/i.test(h));
+    expect(deptCol, `complaints grid must render a Department column, got ${JSON.stringify(headers)}`)
+      .toBeGreaterThanOrEqual(0);
+
+    /** The Department cell of every DATA row, top to bottom. */
+    const readDepartments = async (): Promise<string[]> => {
+      const n = await rows.count();
+      const out: string[] = [];
+      for (let i = 1; i < n; i++) {
+        out.push(((await rows.nth(i).getByRole('cell').nth(deptCol).textContent()) || '').trim());
+      }
+      return out;
+    };
+
+    /** Read until two consecutive reads agree — the grid debounces its refetch,
+     *  so a single immediate read regularly catches a half-rendered page. */
+    const settledDepartments = async (): Promise<string[]> => {
+      let prev = '';
+      await expect
+        .poll(
+          async () => {
+            const cur = JSON.stringify(await readDepartments());
+            const stable = cur === prev && cur !== '[]';
+            prev = cur;
+            return stable;
+          },
+          { timeout: 30_000, intervals: [800], message: 'complaints grid rows must settle' },
+        )
+        .toBe(true);
+      return JSON.parse(prev) as string[];
+    };
+
+    const before = await settledDepartments();
+    expect(before.length, 'need at least one complaint on page 1 to test narrowing').toBeGreaterThan(0);
+
+    const filter = page.getByRole('combobox').filter({ hasText: /^Department$/ }).first();
+    await expect(
+      filter,
+      'the complaints list must render a Department filter',
+    ).toBeVisible({ timeout: 15_000 });
+    await filter.click();
+
+    // "All" is the clear-the-filter sentinel (ReferenceFilterInput maps it to
+    // ''), so it is never a narrowing case — iterating it is a guaranteed
+    // vacuous pass. Drop it.
+    const choices = (await page.getByRole('option').allTextContents())
+      .map((t) => t.trim())
+      .filter(Boolean)
+      .filter((t) => !/^all$/i.test(t));
+    expect(choices.length, 'the departments reference list must offer at least one department')
+      .toBeGreaterThan(0);
+
+    const occurrences = (d: string) => before.filter((v) => v === d).length;
+    const target = choices
+      .slice()
+      .sort((a, b) => occurrences(a) - occurrences(b) || a.localeCompare(b))[0];
+    const expectedAfter = before.filter((v) => v === target);
+    expect(
+      expectedAfter.length,
+      `every department option matches every row on page 1 (${JSON.stringify(before)}) — ` +
+        'no option could narrow anything, so this deployment cannot prove the filter works',
+    ).toBeLessThan(before.length);
+
+    await page
+      .getByRole('option', { name: new RegExp(`^${escapeRegex(target)}$`) })
+      .first()
+      .click();
+
+    await expect
+      .poll(readDepartments, {
+        timeout: 30_000,
+        intervals: [800],
+        message:
+          `selecting Department="${target}" must leave ONLY that department's rows. ` +
+          `Page 1 held ${JSON.stringify(before)}, so the grid must narrow to ${JSON.stringify(expectedAfter)}. ` +
+          'If the grid is byte-identical to the unfiltered one, the filter is not filtering — ' +
+          'ComplaintList.tsx declares source="additionalDetail.department", react-hook-form (inside FilterLiveForm) ' +
+          "NESTS that dotted path into params.filter as { additionalDetail: { department } }, while dataProvider.ts " +
+          "getList() reads the FLAT key filter['additionalDetail.department'] and gets undefined, so the client-side " +
+          'filter never runs. Do not weaken this assertion.',
+      })
+      .toEqual(expectedAfter);
   });
 
   test('8. show page renders address extras and a working geo link', {
@@ -658,10 +829,25 @@ Test data: ke.nairobi has 55 complaints (probed 2026-04-23). The 26 minimum keep
     if (!(await nextBtn.isVisible().catch(() => false))) {
       test.skip(true, 'No Next pagination control rendered');
     }
-    await nextBtn.click();
-    await page.waitForLoadState('networkidle').catch(() => {});
-
-    expect(searches.length, 'paging should trigger a fresh _search XHR').toBeGreaterThan(0);
+    // Wait for the REQUEST, not for a load state. Clicking Next in an SPA performs
+    // no navigation, and the page's `networkidle` already fired during goto(), so
+    // waitForLoadState('networkidle') returns in ~0.2 ms — before React has even
+    // dispatched the refetch. The old assertion was therefore reading `searches`
+    // while it was still empty, and reported "pagination is not server-side" on a
+    // grid that pages perfectly well.
+    await Promise.all([
+      page.waitForRequest(
+        (r) => r.url().includes('/pgr-services/v2/request/_search'),
+        { timeout: 15_000 },
+      ),
+      nextBtn.click(),
+    ]);
+    await expect
+      .poll(() => searches.length, {
+        message: 'paging should trigger a fresh _search XHR',
+        timeout: 15_000,
+      })
+      .toBeGreaterThan(0);
     // The last search's offset should be > 0 — i.e. real server-side paging.
     const last = searches[searches.length - 1];
     const offset = Number(last.searchParams.get('offset') || '0');
@@ -771,7 +957,7 @@ Both client-side (single XHR count) and server-side (persistence) checks — tog
     // force: the trigger is visible but Playwright's actionability check can hang
     // on this custom select (overlay/pointer-events during the record load).
     await actionSelect.click({ timeout: 20_000, force: true });
-    await page.getByRole('option', { name: /assign/i }).first().click({ timeout: 20_000 });
+    await chooseAssignAction(page);
     const assigneeSelect = page.getByRole('combobox').filter({ hasText: /select employee/i }).first();
     if (await assigneeSelect.isVisible().catch(() => false)) {
       await assigneeSelect.click();
@@ -822,32 +1008,93 @@ Both client-side (single XHR count) and server-side (persistence) checks — tog
   test('13. PENDINGFORASSIGNMENT filter returns the expected queue size', {
     annotation: {
       type: 'description',
-      description: `API-level coherence check: pgrCount and pgrSearch must agree on the PENDINGFORASSIGNMENT queue size. Doesn't pin a hard count (seed data drifts) — only that count >= 0, search returns <= count, and search respects the page size limit.
+      description: `API-level check that the PENDINGFORASSIGNMENT status filter returns a REAL, verifiable queue size — not merely a self-consistent one.
+
+The previous version asserted count >= 0, wrappers.length <= count and wrappers.length <= 50. All three are tautologies (counts are always >= 0; 0 <= N always holds; 50 was the limit it had just passed), so despite the title nothing asserted a size and the test could not fail. Note pgrCount() returns 0 for any non-numeric body, so even a broken endpoint kept it green.
 
 Steps:
-1. pgrCount(auth, CITY_TENANT, { status: 'PENDINGFORASSIGNMENT' }).
-2. pgrSearch(auth, CITY_TENANT, { status: 'PENDINGFORASSIGNMENT', limit: 50 }).
-3. Assert count >= 0.
-4. Assert wrappers.length <= count.
-5. Assert wrappers.length <= 50 (page size respected).
+1. total  = pgrCount(CITY_TENANT)                            — every complaint on the tenant.
+2. queue  = pgrCount(CITY_TENANT, { status: PENDINGFORASSIGNMENT }).
+3. Assert 0 < queue <= total. A non-empty queue is a real precondition of this suite: lifecycle.setup.ts seeds a PENDINGFORASSIGNMENT complaint every run and pickWorkableComplaint() consumes them, so an empty queue means the filter (or the seed) is broken.
+4. rows = pgrSearch(status, limit > queue); assert rows.length === queue EXACTLY, and that every row's applicationStatus is PENDINGFORASSIGNMENT — the server must return the whole queue and nothing else.
+5. Assert the page size is honoured EXACTLY: pgrSearch(status, limit 25).length === min(25, queue).
+6. Independent recount: sweep the UNFILTERED complaint list page by page and count PENDINGFORASSIGNMENT locally; assert it equals 'queue'. This is the only assertion here that cannot be satisfied by an internally-consistent-but-wrong server (skipped, with an annotation, on tenants too large to sweep).
 
-Probed 2026-04-23: 11 PENDINGFORASSIGNMENT on ke.nairobi. Hardcoding 11 would drift; this test validates the contract instead.`,
+Mutation-proven: flipping the status to a nonsense state drops 'queue' to 0 and step 3 fails; stubbing pgrSearch to [] fails step 4.`,
     },
     tag: ['@area:configurator-manage', '@area:pgr', '@kind:regression', '@layer:ui', '@persona:admin'] }, async () => {
-    // Probed 2026-04-23: 11 PENDINGFORASSIGNMENT on ke.nairobi. Rather
-    // than hard-code 11 (seed data drifts), we assert the server responds
-    // coherently — both _count and _search agree on a non-negative
-    // number, and _search never returns more than the page size.
     const auth = loadAuth();
-    const count = await pgrCount(auth, CITY_TENANT, {
-      status: 'PENDINGFORASSIGNMENT',
+    const QUEUE_STATUS = 'PENDINGFORASSIGNMENT';
+    const SWEEP_PAGE = 100;
+    // Above this, the unfiltered sweep costs more than it is worth; steps 3-5
+    // still carry the test.
+    const SWEEP_LIMIT = 2_000;
+
+    const total = await pgrCount(auth, CITY_TENANT);
+    const queue = await pgrCount(auth, CITY_TENANT, { status: QUEUE_STATUS });
+
+    expect(total, `tenant ${CITY_TENANT} must hold complaints to measure a queue against`)
+      .toBeGreaterThan(0);
+    expect(
+      queue,
+      `the ${QUEUE_STATUS} queue must be non-empty — lifecycle.setup.ts seeds one every run, ` +
+        'so 0 means either the status filter or the seed is broken',
+    ).toBeGreaterThan(0);
+    expect(queue, 'a filtered queue can never exceed the tenant total').toBeLessThanOrEqual(total);
+
+    // The filtered search must return the WHOLE queue and nothing but the queue.
+    const rows = await pgrSearch(auth, CITY_TENANT, {
+      status: QUEUE_STATUS,
+      limit: queue + 5,
     });
-    const wrappers = await pgrSearch(auth, CITY_TENANT, {
-      status: 'PENDINGFORASSIGNMENT', limit: 50,
-    });
-    expect(count).toBeGreaterThanOrEqual(0);
-    expect(wrappers.length).toBeLessThanOrEqual(count);
-    expect(wrappers.length).toBeLessThanOrEqual(50);
+    expect(
+      rows.length,
+      `_search must return every ${QUEUE_STATUS} complaint _count promised (${queue})`,
+    ).toBe(queue);
+    const returnedStatuses = [
+      ...new Set(
+        rows.map((w) =>
+          String((w.service as Record<string, unknown> | undefined)?.applicationStatus ?? ''),
+        ),
+      ),
+    ];
+    expect(returnedStatuses, `_search must return ONLY ${QUEUE_STATUS} complaints`).toEqual([
+      QUEUE_STATUS,
+    ]);
+
+    // Page size honoured exactly — not "at most".
+    const pageSize = 25;
+    const firstPage = await pgrSearch(auth, CITY_TENANT, { status: QUEUE_STATUS, limit: pageSize });
+    expect(firstPage.length, `limit=${pageSize} must yield exactly min(limit, queue) rows`).toBe(
+      Math.min(pageSize, queue),
+    );
+
+    // Independent recount from the UNFILTERED list — the server's own filter is
+    // not allowed to be the only witness to its own size.
+    if (total > SWEEP_LIMIT) {
+      test.info().annotations.push({
+        type: 'note',
+        description: `unfiltered recount skipped: ${total} complaints on ${CITY_TENANT} exceeds the ${SWEEP_LIMIT} sweep cap`,
+      });
+      return;
+    }
+    let recount = 0;
+    let swept = 0;
+    for (let offset = 0; offset < total; offset += SWEEP_PAGE) {
+      const page = await pgrSearch(auth, CITY_TENANT, { limit: SWEEP_PAGE, offset });
+      if (page.length === 0) break;
+      swept += page.length;
+      for (const w of page) {
+        const status = (w.service as Record<string, unknown> | undefined)?.applicationStatus;
+        if (status === QUEUE_STATUS) recount += 1;
+      }
+    }
+    expect(swept, 'the unfiltered sweep must reach every complaint _count reported').toBe(total);
+    expect(
+      recount,
+      `counting ${QUEUE_STATUS} by hand across all ${total} complaints must reproduce the ` +
+        'size the server reports for the filtered query',
+    ).toBe(queue);
   });
 });
 
@@ -1012,12 +1259,48 @@ async function pickWorkableComplaint(auth: AuthInfo): Promise<string | null> {
   // department is one a PGR_LME employee actually holds, so an ASSIGN succeeds.
   // A random PFA complaint is often an old test-junk type whose department no
   // employee holds — ASSIGN then 400s (pgr-services NPEs on the mismatch).
+  const idOf = (w: { service?: unknown }) =>
+    (w.service as Record<string, unknown> | undefined)?.serviceRequestId as string | undefined;
+  const claim = (id: string | undefined): string | null => {
+    if (!id || consumedComplaints.has(id)) return null;
+    consumedComplaints.add(id);
+    return id;
+  };
+
   const preferred = wrappers.find(
-    (w) => (w.service as Record<string, unknown>)?.serviceCode === SERVICE_CODE,
+    (w) =>
+      (w.service as Record<string, unknown>)?.serviceCode === SERVICE_CODE &&
+      !consumedComplaints.has(String(idOf(w))),
   );
-  if (preferred) return (preferred.service as Record<string, unknown>).serviceRequestId as string;
+  if (preferred) {
+    const id = claim(idOf(preferred));
+    if (id) return id;
+  }
+
+  // No unconsumed complaint of the seed serviceCode left — file a fresh one
+  // rather than scavenging.
+  //
+  // Scavenging is actively harmful here: most PENDINGFORASSIGNMENT complaints on
+  // a long-lived box are filed against `PW*` junk complaint types other runs
+  // created, whose department no employee holds. ASSIGN on one of those 400s in
+  // pgr-services, which reads as a workflow bug and is really just bad test data.
+  // Seeding gives every caller a complaint of the SEED serviceCode, whose
+  // department the resolved PGR_LME assignee actually holds.
+  try {
+    const seeded = await seedComplaintAsCitizen({
+      serviceCode: SERVICE_CODE,
+      localityCode: LOCALITY_CODE,
+      description: `complaints.spec seed — ${new Date().toISOString()}`,
+    });
+    createdComplaints.add(seeded.srid);
+    const id = claim(seeded.srid);
+    if (id) return id;
+  } catch {
+    // Fall through to scavenging — better a flaky complaint than no coverage.
+  }
+
   for (const w of wrappers) {
-    const id = (w.service as Record<string, unknown>)?.serviceRequestId as string | undefined;
+    const id = claim(idOf(w));
     if (id) return id;
   }
   // Fall back to any non-terminal complaint.
@@ -1029,7 +1312,8 @@ async function pickWorkableComplaint(auth: AuthInfo): Promise<string | null> {
       status &&
       !['REJECTED', 'CLOSEDAFTERRESOLUTION', 'CLOSEDAFTERREJECTION'].includes(status)
     ) {
-      return svc?.serviceRequestId as string;
+      const id = claim(svc?.serviceRequestId as string | undefined);
+      if (id) return id;
     }
   }
   return null;

--- a/tests/integration-tests/tests/admin/complaints.spec.ts
+++ b/tests/integration-tests/tests/admin/complaints.spec.ts
@@ -36,6 +36,7 @@ const createdComplaints = new Set<string>();
 
 let liveServiceCode: string | null = null;
 let lmeAssigneeUuid: string | null = null;
+let lmeAssigneeName: string | null = null;
 let liveBoundaryCode: string | null = null;
 
 // Default mode (not serial): with workers=1 the tests still run in file order,
@@ -75,10 +76,27 @@ test.beforeAll(async () => {
     roles: ['PGR_LME'],
     limit: 100,
   }).catch(() => [] as Record<string, unknown>[]);
-  for (const e of employees) {
+  // Prefer an employee whose HRMS department matches the complaint type we file
+  // with. pgr-services validates the assignee's department against the
+  // complaint's, and the configurator's assignee dropdown is NOT yet filtered by
+  // department (product gap — pending the ABAC work), so it happily offers staff
+  // the backend will reject. Picking a department-valid assignee keeps this test
+  // measuring the edit/merge behaviour rather than that known gap.
+  const wantedDept = liveServiceCode
+    ? ((ctRecords.find((r) => (r.data as Record<string, unknown>)?.code === liveServiceCode)
+        ?.data as Record<string, unknown> | undefined)?.department as string | undefined)
+    : undefined;
+  const deptOf = (e: Record<string, unknown>): string[] =>
+    ((e.assignments as Record<string, unknown>[] | undefined) ?? [])
+      .map((a) => String(a.department ?? ''));
+  const preferred = wantedDept
+    ? employees.find((e) => deptOf(e).includes(wantedDept))
+    : undefined;
+  for (const e of [preferred, ...employees].filter(Boolean) as Record<string, unknown>[]) {
     const user = e.user as Record<string, unknown> | undefined;
     const uuid = (user?.uuid as string) || (e.uuid as string);
-    if (uuid) { lmeAssigneeUuid = uuid; break; }
+    const name = (user?.name as string) || (e.code as string);
+    if (uuid) { lmeAssigneeUuid = uuid; lmeAssigneeName = name ?? null; break; }
   }
 
   // --- Pick a live boundary code we know exists on this tenant ---
@@ -242,17 +260,33 @@ Catches a regression where description doesn't ride along with the workflow tran
     // assignee/rating and re-renders the Workflow section; the assignee/cascade
     // widgets can reset sibling inputs on mount, so fill the description LAST
     // (right before Save) to guarantee its value is what gets submitted.
-    const actionSelect = page.getByLabel(/^Action$/i).or(page.getByLabel(/^Workflow/i)).first();
-    await actionSelect.click();
-    await page.getByRole('option', { name: /ASSIGN/i }).first().click();
+    // These custom selects have NO <label> association, so getByLabel never
+    // matches them — locate by the combobox's own visible text instead.
+    const actionSelect = page.getByRole('combobox').filter({ hasText: /select action/i }).first();
+    await actionSelect.waitFor({ state: 'visible', timeout: 20_000 });
+    await actionSelect.scrollIntoViewIfNeeded().catch(() => {});
+    // force: the trigger is visible but Playwright's actionability check can hang
+    // on this custom select (overlay/pointer-events during the record load).
+    await actionSelect.click({ timeout: 20_000, force: true });
+    await page.getByRole('option', { name: /assign/i }).first().click({ timeout: 20_000 });
 
     // The assignee picker may render only after ASSIGN is chosen.
-    const assigneeSelect = page.getByLabel(/Assign(ee)?/i).first();
+    // These custom selects render WITHOUT a <label> association, so getByLabel
+    // never matches them — locate by role + accessible name (same pattern the
+    // Status/Department filters needed).
+    const assigneeSelect = page.getByRole('combobox').filter({ hasText: /select employee/i }).first();
     if (await assigneeSelect.isVisible().catch(() => false)) {
       await assigneeSelect.click();
       // Click the first available employee option — we already validated
       // a PGR_LME exists in beforeAll, so there will be options.
-      await page.getByRole('option').first().click();
+      // Pick the department-valid assignee resolved in beforeAll. The dropdown is
+      // not department-filtered yet (product gap), so 'first option' can be a
+      // employee whose department pgr-services will reject with a 400.
+      const wanted = lmeAssigneeName
+        ? page.getByRole('option', { name: new RegExp(lmeAssigneeName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i') }).first()
+        : null;
+      if (wanted && await wanted.count() > 0) await wanted.click();
+      else await page.getByRole('option').first().click();
     }
 
     const desc = page.getByLabel(/^Description/i);
@@ -634,7 +668,7 @@ Test data: ke.nairobi has 55 complaints (probed 2026-04-23). The 26 minimum keep
     expect(offset, 'offset on second page should be > 0').toBeGreaterThan(0);
   });
 
-  test('11. department column renders via EntityLink — not a raw code', {
+  test('11. department column renders the readable department name, not a raw code', {
     annotation: {
       type: 'description',
       description: `Confirms the Department column in the complaints list renders an EntityLink (anchor pointing at the dept show page), not a raw text code. Catches a regression where the cross-reference is dropped and admins lose the click-through to dept details.
@@ -643,10 +677,10 @@ Steps:
 1. Navigate to /complaints; wait networkidle.
 2. pgrSearch; iterate looking for a complaint with additionalDetail.department populated.
 3. test.skip if none.
-4. Build a lenient locator: look for an <a> linking to /manage/departments/.
-5. Assert at least one such link is visible within 15s.
+4. Resolve that department's display name from common-masters.Department.
+5. Assert the grid's row text contains the readable display name.
 
-Loose check — only requires that SOME row's department renders as a link, not that every row's link points at the seeded dept code (that would require deeper matching).`,
+Product decision (2026-07-26): there is no departments page, so the column is NOT expected to be a link. The requirement is that it reads as a human-readable name rather than a raw identifier — the stored value should be the code, the rendered value the name.`,
     },
     tag: ['@area:configurator-manage', '@area:pgr', '@kind:regression', '@layer:ui', '@persona:admin'] }, async ({
     page,
@@ -667,13 +701,29 @@ Loose check — only requires that SOME row's department renders as a link, not 
     }
     if (!deptCode) test.skip(true, 'No complaint with additionalDetail.department on tenant');
 
-    // EntityLink renders an <a> whose href points at the dept show page.
-    const link = page.getByRole('link').filter({
-      has: page.locator(`text=${deptCode!}`).or(page.locator(`[href*="/departments/"]`)),
-    }).first();
-    // Lenient: at least one departments link should exist in the list body.
-    const anyDeptLink = page.locator('a[href*="/manage/departments/"]').first();
-    await expect(anyDeptLink.or(link)).toBeVisible({ timeout: 15_000 });
+    // Product decision (2026-07-26): there is NO departments page to link to, so
+    // the column is not expected to be an anchor. What it MUST do is render the
+    // department in a human-readable form — the display name, not a raw code —
+    // even though the underlying record should store the code as the identifier.
+    const rowsText = (await page.getByRole('row').allTextContents()).join(' | ');
+    expect(rowsText, 'complaints list rendered rows').toBeTruthy();
+
+    // Resolve the department's display name from the departments master, then
+    // assert the grid shows THAT (not the raw code). Deployment-agnostic: the
+    // name comes from the tenant's own master, never a hardcoded literal.
+    const deptRecords = await mdmsSearch(auth, TENANT_CODE, 'common-masters.Department', { limit: 200 })
+      .catch(() => [] as Awaited<ReturnType<typeof mdmsSearch>>);
+    const match = deptRecords.find((r) => {
+      const d = r.data as Record<string, unknown>;
+      return d?.code === deptCode || r.uniqueIdentifier === deptCode || d?.name === deptCode;
+    });
+    const displayName = (match?.data as Record<string, unknown> | undefined)?.name as string | undefined;
+    if (!displayName) test.skip(true, `department '${deptCode}' not found in common-masters.Department — cannot resolve its display name`);
+
+    expect(
+      rowsText.includes(displayName!),
+      `Department column should show the readable name "${displayName}" (rows: ${rowsText.slice(0, 300)})`,
+    ).toBe(true);
   });
 
   test('12. edit saves description + workflow in a single _update round-trip', {
@@ -713,13 +763,26 @@ Both client-side (single XHR count) and server-side (persistence) checks — tog
     // ASSIGN, which is only valid from PENDINGFORASSIGNMENT and needs an assignee.
     // Drive a real ASSIGN and confirm the description rides along in the SAME
     // _update round-trip (the point of this test).
-    const actionSelect = page.getByLabel(/^Action$/i).or(page.getByLabel(/^Workflow/i)).first();
-    await actionSelect.click();
-    await page.getByRole('option', { name: /ASSIGN/i }).first().click();
-    const assigneeSelect = page.getByLabel(/Assign(ee)?/i).first();
+    // These custom selects have NO <label> association, so getByLabel never
+    // matches them — locate by the combobox's own visible text instead.
+    const actionSelect = page.getByRole('combobox').filter({ hasText: /select action/i }).first();
+    await actionSelect.waitFor({ state: 'visible', timeout: 20_000 });
+    await actionSelect.scrollIntoViewIfNeeded().catch(() => {});
+    // force: the trigger is visible but Playwright's actionability check can hang
+    // on this custom select (overlay/pointer-events during the record load).
+    await actionSelect.click({ timeout: 20_000, force: true });
+    await page.getByRole('option', { name: /assign/i }).first().click({ timeout: 20_000 });
+    const assigneeSelect = page.getByRole('combobox').filter({ hasText: /select employee/i }).first();
     if (await assigneeSelect.isVisible().catch(() => false)) {
       await assigneeSelect.click();
-      await page.getByRole('option').first().click();
+      // Pick the department-valid assignee resolved in beforeAll. The dropdown is
+      // not department-filtered yet (product gap), so 'first option' can be a
+      // employee whose department pgr-services will reject with a 400.
+      const wanted = lmeAssigneeName
+        ? page.getByRole('option', { name: new RegExp(lmeAssigneeName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i') }).first()
+        : null;
+      if (wanted && await wanted.count() > 0) await wanted.click();
+      else await page.getByRole('option').first().click();
     }
     const desc = page.getByLabel(/^Description/i);
     await desc.fill('');

--- a/tests/integration-tests/tests/admin/configurator-mdms-fixes-2026-04-29.spec.ts
+++ b/tests/integration-tests/tests/admin/configurator-mdms-fixes-2026-04-29.spec.ts
@@ -2,7 +2,7 @@
 // tests where we can — the configurator just shells out to mdms-v2 with
 // the same payload shape we're checking here.
 import { test, expect } from '@playwright/test';
-import { loginEmployee, mdmsCreate, mdmsSearch, mdmsUpdate } from '../utils/launch-fixes/api.js';
+import { loginEmployee, mdmsCreate, mdmsUpdate } from '../utils/launch-fixes/api.js';
 import { TENANT, ROOT_TENANT, BASE_URL } from '../utils/env';
 
 test.describe('01-configurator-mdms: Department CRUD (#472 + follow-ups)', () => {
@@ -73,37 +73,57 @@ Teardown is API-only because there's no UI flow inside this spec — it's pure M
 
 Steps:
 1. Log in as the test employee.
-2. mdmsSearch for common-masters.Department; pick the first isActive record.
+2. mdmsCreate a fresh, self-owned active common-masters.Department record (uid DEPT_PW_LEAK_<ts>).
 3. Build a polluted record: spread existing + add data.id, _isActive, _uniqueIdentifier, _auditDetails, _schemaCode, _mdmsId.
 4. mdmsUpdate with the polluted record.
 5. Read response.Errors codes; assert at least one starts with 'INVALID_REQUEST_ADDITIONALPROPERTIES'.
+6. finally: soft-delete the seeded record (isActive=false + mdmsUpdate).
 
-Test relies on at least one active Department existing on the deployment — assert is on existing being truthy.`,
+Hermetic: self-seeds its own active Department record rather than fishing one out of the tenant, so it doesn't depend on any pre-existing active row (deployments with no active common-masters.Department — e.g. bomet's ke — used to fail here with "existing" undefined).`,
     },
     tag: ['@area:configurator-manage', '@area:mdms-schema', '@ccrs:472', '@kind:edge-case', '@kind:regression', '@layer:api', '@persona:admin'] }, async () => {
     // Reproduces what the old dataProvider was sending. PR #40 strips
     // these client-side; this test guards against a regression that
     // re-introduces the leak (or a future change to the configurator's
     // form payload that includes new `_*` fields).
+    //
+    // B4: self-seed the record we pollute-update instead of fishing an
+    // active Department out of the tenant — some deployments (bomet's ke)
+    // have no active common-masters.Department, which used to fail this
+    // test with "existing" undefined. Soft-delete in `finally` so the
+    // probe record doesn't linger.
     const auth = await loginEmployee();
-    const search = await mdmsSearch(auth, TENANT, 'common-masters.Department');
-    const existing = search.mdms?.find((r: any) => r.isActive);
+    const uid = `DEPT_PW_LEAK_${Date.now()}`;
+    const seeded = await mdmsCreate(auth, 'common-masters.Department', {
+      tenantId: TENANT,
+      schemaCode: 'common-masters.Department',
+      uniqueIdentifier: uid,
+      isActive: true,
+      data: { code: uid, name: 'pw leak probe', active: true },
+    });
+    expect(seeded.Errors).toBeUndefined();
+    const existing = seeded.mdms?.[0];
     expect(existing).toBeTruthy();
-    const polluted = {
-      ...existing,
-      data: {
-        ...existing.data,
-        id: existing.id,
-        _isActive: existing.isActive,
-        _uniqueIdentifier: existing.uniqueIdentifier,
-        _auditDetails: existing.auditDetails,
-        _schemaCode: existing.schemaCode,
-        _mdmsId: existing.id,
-      },
-    };
-    const r = await mdmsUpdate(auth, 'common-masters.Department', polluted);
-    const codes = (r.Errors ?? []).map((e: any) => e.code);
-    expect(codes.some((c: string) => c?.startsWith('INVALID_REQUEST_ADDITIONALPROPERTIES'))).toBe(true);
+    try {
+      const polluted = {
+        ...existing,
+        data: {
+          ...existing.data,
+          id: existing.id,
+          _isActive: existing.isActive,
+          _uniqueIdentifier: existing.uniqueIdentifier,
+          _auditDetails: existing.auditDetails,
+          _schemaCode: existing.schemaCode,
+          _mdmsId: existing.id,
+        },
+      };
+      const r = await mdmsUpdate(auth, 'common-masters.Department', polluted);
+      const codes = (r.Errors ?? []).map((e: any) => e.code);
+      expect(codes.some((c: string) => c?.startsWith('INVALID_REQUEST_ADDITIONALPROPERTIES'))).toBe(true);
+    } finally {
+      const m = { ...existing, isActive: false };
+      await mdmsUpdate(auth, 'common-masters.Department', m);
+    }
   });
 });
 

--- a/tests/integration-tests/tests/admin/departments.spec.ts
+++ b/tests/integration-tests/tests/admin/departments.spec.ts
@@ -258,7 +258,11 @@ Loose regex on "department|row" tolerates UI label changes between Create-N-depa
     await createBtn.click();
 
     // Complete screen — should report 5 created / 0 failed.
-    await expect(page.getByText(/5\s*(created|success)/i).first()).toBeVisible({
+    // RC8: completion copy is "Created 5 departments" (number AFTER the
+    // word), not "5 created" — accept either order.
+    await expect(
+      page.getByText(/(?:created\s+5|5\s+(?:created|success))/i).first(),
+    ).toBeVisible({
       timeout: 60_000,
     });
 

--- a/tests/integration-tests/tests/admin/departments.spec.ts
+++ b/tests/integration-tests/tests/admin/departments.spec.ts
@@ -27,7 +27,9 @@ const LIST_PATH = '/configurator/manage/departments';
 
 const createdCodes = new Set<string>();
 
-test.describe.configure({ mode: 'serial' });
+// Default mode (not serial): workers=1 keeps file order, but a failure no longer
+// cascade-skips the rest — each test self-seeds its own department code.
+test.describe.configure({ mode: 'default' });
 
 test.afterAll(async () => {
   if (createdCodes.size === 0) return;
@@ -173,6 +175,13 @@ Guard banner check is loose because exact wording depends on dependency type and
 
     await page.getByRole('button', { name: /^Save$/i }).click();
     await expect(page.getByText(editedName).first()).toBeVisible();
+
+    // After Save the edit form returns to the LIST (DigitEdit redirect default),
+    // so reopen the record's Show page before the deactivate edit — otherwise the
+    // top-level "Edit" button doesn't exist on the list and the click hangs.
+    await page.getByPlaceholder(/search/i).first().fill(code);
+    await page.waitForLoadState('networkidle').catch(() => {});
+    await page.getByRole('row').filter({ hasText: code }).first().click();
 
     // --- Deactivate ---
     await page.getByRole('button', { name: /^Edit$/i }).click();

--- a/tests/integration-tests/tests/admin/departments.spec.ts
+++ b/tests/integration-tests/tests/admin/departments.spec.ts
@@ -14,6 +14,7 @@ import {
   mdmsCreate,
   mdmsSearch,
   type AuthInfo,
+  type MdmsRecord,
 } from '../utils/manage/api';
 import { testCode, testCodeIndexed } from '../utils/manage/codes';
 import { cleanupMdms } from '../utils/manage/teardown';
@@ -26,6 +27,22 @@ const SCHEMA = 'common-masters.Department';
 const LIST_PATH = '/configurator/manage/departments';
 
 const createdCodes = new Set<string>();
+
+// Scratch records this suite (and every previous run) created are prefixed
+// PW_ / *_PW* by utils/manage/codes. A long-lived deployment accumulates
+// thousands of them, so "pick a real record" has to exclude them explicitly —
+// the same pattern the rest of the suite uses.
+const SCRATCH_CODE = /(^|_)PW[A-Z_]/i;
+
+/** First active, non-scratch record — i.e. real tenant data, not our litter. */
+function findRealRecord(records: MdmsRecord[]): MdmsRecord | undefined {
+  return records.find(
+    (r) =>
+      r.isActive !== false &&
+      !SCRATCH_CODE.test(String(r.uniqueIdentifier)) &&
+      !SCRATCH_CODE.test(String((r.data as Record<string, unknown>)?.code ?? '')),
+  );
+}
 
 // Default mode (not serial): workers=1 keeps file order, but a failure no longer
 // cascade-skips the rest — each test self-seeds its own department code.
@@ -52,26 +69,42 @@ test.afterAll(async () => {
 });
 
 test.describe('manage/departments', () => {
-  test('1. list renders with header columns and filter narrows results', {
+  test('1. list renders with header columns and filters narrow to the expected rows', {
     annotation: {
       type: 'description',
-      description: `Asserts /manage/departments renders with the four expected columns (Code, Name, Status, Description), has data, the search filter narrows the row count, and the Status filter switch (if present) doesn't crash. Multi-purpose smoke that exercises the major surface in one pass.
+      description: `Asserts /manage/departments renders with the four expected columns (Code, Name, Status, Description) and that BOTH list filters actually narrow the rendered rows — not merely "don't increase the count".
 
 Steps:
-1. Navigate to /configurator/manage/departments.
-2. Assert role=table is visible.
-3. For each header in ['Code','Name','Status','Description'], assert the matching role=columnheader is visible.
-4. Read initial row count; assert > 1.
-5. Type 'zzz_no_such_dept_string' in the search input; wait networkidle.
-6. Read filtered count; assert filtered <= initial.
-7. Clear search; wait networkidle.
-8. If Status filter exists, click it, pick Inactive option, wait networkidle, assert count >= 0.
+1. Resolve a real active department via mdmsSearch(isActive:true), preferring a non-scratch (non-PW_) code. Skip only if the deployment has no active department at all.
+2. Navigate to /configurator/manage/departments.
+3. Assert role=table is visible and each of ['Code','Name','Status','Description'] renders as a columnheader.
+4. Count DATA rows (rows containing role=cell — excludes the header row); assert > 0.
+5. Search a term that cannot match: assert data rows go to EXACTLY 0 and the empty-state ("No records") renders.
+6. Search the real department's code: assert its row is present AND every rendered row matches the term; when the unfiltered list had more than one row, assert the count strictly dropped.
+7. Clear the search and assert the original row count is restored.
+8. Status filter → Active: assert the list is non-empty and EVERY row is marked Active.
+9. Status filter → Inactive: assert ZERO rows marked Active survive.
 
-Filters should compose; the test resets search before testing status to keep them independent.`,
+Every count read is an auto-retrying expect()/expect.poll() — the grid debounces filter changes (DigitList setFilters(..., undefined, true)), so a bare count() immediately after typing reads the PRE-filter list.
+
+Prior version was vacuous: expect(filteredCount).toBeLessThanOrEqual(initialCount) can never fail (a narrowing filter cannot increase a count) and, thanks to the debounce race, filteredCount === initialCount anyway; expect(inactiveCount).toBeGreaterThanOrEqual(0) is a pure tautology. The Status branch was additionally dead code — getByLabel(/^Status$/i) never matches, because SelectFilterInput renders a Radix trigger with no associated <label>, so the whole if-block was skipped on every run.`,
     },
     tag: ['@area:configurator-manage', '@area:hrms', '@kind:regression', '@layer:ui', '@persona:admin'] }, async ({
     page,
   }) => {
+    // Resolve the search term from live data rather than hardcoding a
+    // deployment literal. isActive:true is load-bearing: this tenant carries
+    // 147 department records of which only 3 are active, so an unfiltered page
+    // is entirely soft-deleted scratch rows.
+    const auth = loadAuth();
+    const activeDepts = await mdmsSearch(auth, TENANT_CODE, SCHEMA, {
+      limit: 200,
+      isActive: true,
+    });
+    const probe = findRealRecord(activeDepts) ?? activeDepts[0];
+    test.skip(!probe, 'No active department on this deployment to filter for');
+    const probeCode = String(probe!.uniqueIdentifier);
+
     await page.goto(LIST_PATH);
 
     // Header columns — Code / Name / Status / Description.
@@ -84,39 +117,84 @@ Filters should compose; the test resets search before testing status to keep the
       ).toBeVisible();
     }
 
-    // At least one data row should render on a healthy tenant.
-    const dataRows = page.getByRole('row');
+    // DATA rows only. getByRole('row') also matches the header row (whose
+    // children are columnheaders, not cells), which is what forced the old
+    // `> 1` / `<= initial` fudge factors. Filtering on `has: cell` gives a
+    // locator whose count is the real record count, so exact assertions work.
+    const dataRows = page.getByRole('row').filter({ has: page.getByRole('cell') });
+    await expect(dataRows.first()).toBeVisible();
     const initialCount = await dataRows.count();
-    expect(initialCount).toBeGreaterThan(1); // header + at least 1
+    expect(initialCount, 'list should render at least one department').toBeGreaterThan(0);
 
-    // Type into the search input — debounced server-side filter narrows.
     const search = page.getByPlaceholder(/search/i).first();
     await expect(search).toBeVisible();
+
+    // --- Search that matches nothing must empty the table ---
     await search.fill('zzz_no_such_dept_string');
-    // Wait for the list to settle after the debounce (~300ms typical).
-    await page.waitForLoadState('networkidle').catch(() => {});
+    // toHaveCount auto-retries, so this rides out the grid's debounce instead
+    // of racing it.
+    await expect(dataRows).toHaveCount(0);
+    await expect(page.getByText(/no records/i).first()).toBeVisible();
 
-    const filteredCount = await dataRows.count();
-    // Either the row count drops or an empty-state replaces the table.
-    expect(filteredCount).toBeLessThanOrEqual(initialCount);
-
-    // Reset search before status filter so the two filters compose
-    // predictably.
-    await search.fill('');
-    await page.waitForLoadState('networkidle').catch(() => {});
-
-    // Toggle Status filter to Inactive — count should change (or empty
-    // state appears).
-    const statusFilter = page.getByLabel(/^Status$/i);
-    if (await statusFilter.isVisible().catch(() => false)) {
-      await statusFilter.click();
-      await page.getByRole('option', { name: /Inactive/i }).click();
-      await page.waitForLoadState('networkidle').catch(() => {});
-      // Just assert the filter applied — we don't know the tenant's
-      // active/inactive split.
-      const inactiveCount = await dataRows.count();
-      expect(inactiveCount).toBeGreaterThanOrEqual(0);
+    // --- Search for a real code must leave ONLY rows that match it ---
+    await search.fill(probeCode);
+    await expect(dataRows.filter({ hasText: probeCode }).first()).toBeVisible();
+    await expect
+      .poll(
+        async () => {
+          const texts = await dataRows.allTextContents();
+          return (
+            texts.length > 0 &&
+            texts.every((t) => t.toLowerCase().includes(probeCode.toLowerCase()))
+          );
+        },
+        { message: `every row left after searching "${probeCode}" should match it` },
+      )
+      .toBe(true);
+    if (initialCount > 1) {
+      // Strict narrowing — a code search cannot leave the full list behind.
+      await expect
+        .poll(() => dataRows.count(), { message: 'search should strictly narrow the list' })
+        .toBeLessThan(initialCount);
     }
+
+    // Reset search before the status filter so the two compose predictably.
+    await search.fill('');
+    await expect(dataRows).toHaveCount(initialCount);
+
+    // --- Status filter ---
+    // SelectFilterInput renders a Radix trigger whose only label is the
+    // SelectValue placeholder, so there is no <label> to target and no
+    // accessible name — getByLabel(/^Status$/i) matched nothing, which is why
+    // the old assertions never ran. Match the trigger by the text it shows in
+    // each of its states instead.
+    const statusFilter = page
+      .getByRole('combobox')
+      .filter({ hasText: /^(Status|Active|Inactive)$/ })
+      .first();
+    await expect(statusFilter).toBeVisible();
+    const rowsMarkedActive = dataRows.filter({
+      has: page.getByRole('cell', { name: /^Active$/ }),
+    });
+
+    // Status = Active → non-empty, and every row is marked Active.
+    await statusFilter.click();
+    await page.getByRole('option', { name: /^Active$/i }).click();
+    await expect(rowsMarkedActive.first()).toBeVisible();
+    await expect
+      .poll(
+        async () => (await dataRows.count()) - (await rowsMarkedActive.count()),
+        { message: 'Status=Active should leave no non-Active rows' },
+      )
+      .toBe(0);
+    const activeCount = await dataRows.count();
+    expect(activeCount).toBeGreaterThan(0);
+
+    // Status = Inactive → not one of those Active rows survives. This is the
+    // assertion the old `inactiveCount >= 0` tautology should have been.
+    await statusFilter.click();
+    await page.getByRole('option', { name: /^Inactive$/i }).click();
+    await expect(rowsMarkedActive).toHaveCount(0);
   });
 
   test('2. single create → edit → deactivate round-trip', {
@@ -363,24 +441,41 @@ Doesn't assert what's INSIDE the related lists — that depends on tenant conten
     tag: ['@area:configurator-manage', '@area:hrms', '@kind:regression', '@layer:ui', '@persona:admin'] }, async ({
     page,
   }) => {
-    // Seeded `ke` tenant has DEPT_7 with employees + complaint-types
-    // pointing at it (Gurjeet Singh's assignment references DEPT_7). Use
-    // that as the fixture — avoids seeding our own reverse-ref graph.
+    // Probe whichever real (non-scratch) department the deployment seeded —
+    // avoids depending on any specific code.
+    //
+    // This used to page the schema unfiltered (`{ limit: 20 }`). On a
+    // deployment polluted with soft-deleted PW_ scratch departments (measured
+    // 147 rows, only 3 active) the first 20 rows are ALL inactive, so the
+    // find() returned undefined and the test skipped permanently — the data
+    // was present, just unreachable behind a page of junk. Push isActive to
+    // the server so pagination runs over the ACTIVE set.
     const auth = loadAuth();
     const deptCandidates = await mdmsSearch(auth, TENANT_CODE, SCHEMA, {
-      limit: 20,
+      limit: 200,
+      isActive: true,
     });
-    const realDept = deptCandidates.find(
-      (r) => r.isActive !== false && !String(r.uniqueIdentifier).startsWith('PW_'),
-    );
+    const realDept = findRealRecord(deptCandidates);
     test.skip(!realDept, 'No seeded department to probe reverse references on');
 
     await page.goto(`${LIST_PATH}/${encodeURIComponent(realDept!.uniqueIdentifier)}/show`);
 
-    // The "Related" section headers; both lists render even when empty.
+    // The "Related" section and both of its sub-lists.
+    //
+    // ReverseReferenceList renders EITHER "<Label>" + a count badge (when the
+    // reverse lookup found rows) OR the sentence "No <label> found" (when it
+    // didn't) — it never renders the bare label in the empty case. The old
+    // assertion anchored on /^Employees$/i, which therefore could not match a
+    // department with no employees assigned to it; it was unreachable rather
+    // than wrong about the feature. Accept either rendering, which is what
+    // "the section structure renders even when empty" actually means.
     await expect(page.getByText(/^Related$/i).first()).toBeVisible();
-    await expect(page.getByText(/Complaint Types/i).first()).toBeVisible();
-    await expect(page.getByText(/^Employees$/i).first()).toBeVisible();
+    await expect(
+      page.getByText(/^(Complaint Types|No complaint types found)$/i).first(),
+    ).toBeVisible();
+    await expect(
+      page.getByText(/^(Employees|No employees found)$/i).first(),
+    ).toBeVisible();
   });
 
   test('5b. deactivation guard probes designation + employee APIs', {

--- a/tests/integration-tests/tests/admin/designations.spec.ts
+++ b/tests/integration-tests/tests/admin/designations.spec.ts
@@ -602,7 +602,11 @@ Critical for tenant onboarding workflows that use comma-list xlsx as their canon
     await page.getByRole('button', {
       name: /Create\s+\d+\s+(designation|row)s?/i,
     }).click();
-    await expect(page.getByText(/1\s*(created|success)/i).first()).toBeVisible({
+    // RC8: completion copy is "Created 1 designations" (number AFTER the
+    // word), not "1 created" — accept either order.
+    await expect(
+      page.getByText(/(?:created\s+1|1\s+(?:created|success))/i).first(),
+    ).toBeVisible({
       timeout: 60_000,
     });
 

--- a/tests/integration-tests/tests/admin/designations.spec.ts
+++ b/tests/integration-tests/tests/admin/designations.spec.ts
@@ -222,73 +222,16 @@ Pairs with create test #1 — together they cover all three mutation paths (crea
     expect(dept).toEqual(expect.arrayContaining([DEPT_A, DEPT_B]));
   });
 
-  test('3. legacy single-string department is coerced to array on save', {
-    annotation: {
-      type: 'description',
-      description: `Handles legacy data: a record with department as a bare string (pre-PR-5 shape) must coerce to a single-element array when the form loads, AND saving without changes must persist the array shape. Critical for migrating in-place data without manual cleanup.
-
-Steps:
-1. Generate a unique code; track for cleanup.
-2. Seed via mdmsCreate with department: DEPT_A (bare string, NOT array).
-3. Navigate to LIST_PATH; search; click row; click Edit.
-4. Assert exactly one chip rendering DEPT_A is visible (legacy string coerced into a one-chip array on form load).
-5. Click Save (no changes).
-6. mdmsSearch; assert dept is now Array.isArray and equals [DEPT_A].
-
-The bare-string seed is required for this test — if the schema later rejects bare strings server-side, this test can't run without bypass and should be migrated.`,
-    },
-    tag: ['@area:configurator-manage', '@area:hrms', '@kind:regression', '@layer:ui', '@persona:admin'] }, async ({
-    page,
-  }, testInfo) => {
-    const code = testCode(testInfo, 'DESIG_LEGACY');
-    createdDesigCodes.add(code);
-
-    const auth = loadAuth();
-    // Pre-PR-5 shape: department is a bare string, not an array. Per this
-    // test's own contingency note, a backend whose Designation schema now
-    // enforces department:array rejects this legacy seed — in which case the
-    // in-place-migration scenario is no longer reproducible and we skip
-    // rather than fail (and rather than block the serial chain).
-    try {
-      await mdmsCreate(auth, TENANT_CODE, DESIG_SCHEMA, code, {
-        code,
-        name: `PW Legacy ${code}`,
-        description: 'Legacy single-string department',
-        department: DEPT_A,
-        active: true,
-      } as Record<string, unknown>);
-    } catch (err) {
-      const msg = String(err);
-      if (/JSONArray|expected type|INVALID_REQUEST/i.test(msg)) {
-        createdDesigCodes.delete(code);
-        test.skip(true, `Backend Designation schema rejects a bare-string department — legacy shape no longer seedable: ${msg}`);
-      }
-      throw err;
-    }
-
-    await page.goto(LIST_PATH);
-    await page.getByPlaceholder(/search/i).first().fill(code);
-    await page.waitForLoadState('networkidle').catch(() => {});
-    await page.getByRole('row').filter({ hasText: code }).click();
-
-    await page.getByRole('button', { name: /^Edit$/i }).click();
-
-    // Exactly one chip should render — the legacy string coerced into
-    // a one-element array on load.
-    const chip = page.getByText(DEPT_A, { exact: true });
-    await expect(chip).toBeVisible();
-
-    // Save without changes.
-    await page.getByRole('button', { name: /^Save$/i }).click();
-
-    // Re-read — now stored as ["DEPT_A"], not "DEPT_A".
-    const records = await mdmsSearch(auth, TENANT_CODE, DESIG_SCHEMA, {
-      uniqueIdentifiers: [code],
-    });
-    const dept = (records[0].data as Record<string, unknown>).department;
-    expect(Array.isArray(dept)).toBe(true);
-    expect(dept).toEqual([DEPT_A]);
-  });
+  // Removed (2026-07-27): test '3. legacy single-string department is coerced
+  // to array on save'. The scenario is unstageable — the live Designation
+  // schema declares `department` as a JSONArray and rejects a bare string at
+  // _create with "expected type: JSONArray, found: String", so the legacy
+  // record it needed cannot be seeded without bypassing the schema. The
+  // pre-migration world it guarded no longer exists. The forward-facing
+  // contract it also happened to cover ("the UI always writes string[]")
+  // remains covered non-vacuously by tests 1 (UI create), 2 (UI edit,
+  // add + remove), 5b (show-page read path) and 6 (bulk import), each of
+  // which asserts Array.isArray on the persisted value.
 
   test('4. department filter narrows list to designations referencing that code', {
     annotation: {

--- a/tests/integration-tests/tests/admin/designations.spec.ts
+++ b/tests/integration-tests/tests/admin/designations.spec.ts
@@ -299,13 +299,14 @@ Steps:
 1. Generate two unique codes (codeA matching DEPT_A, codeOther matching DEPT_C); track for cleanup.
 2. mdmsCreate both designations with the appropriate department arrays.
 3. Navigate to LIST_PATH.
-4. Locate Department filter; test.skip if absent.
-5. Click filter, click DEPT_A option (fall back to typeahead if click fails).
-6. Wait networkidle; type 'PW_' in the search to scope to seeded rows.
-7. Assert codeA row is visible.
-8. Assert codeOther row count === 0.
+4. The Department filter is NOT alwaysOn in DesignationList — open the "Add filter" popover and pick "Department" so the control mounts.
+5. Locate the trigger via getByRole('combobox').filter({ hasText: /department/i }) and open it.
+6. Click the option whose label carries DEPT_A (ReferenceFilterInput labels options by department NAME, which embeds the code).
+7. Type 'PW_' in the search to scope to seeded rows.
+8. Assert codeA row becomes visible (auto-retrying — the grid debounces).
+9. Assert codeOther row count === 0.
 
-Filter-by-array logic — confirms the dataProvider sends the right query for chip values.`,
+Filter-by-array logic — confirms the dataProvider sends the right query for chip values. Previously this used getByLabel(/^Department/i), which matched NOTHING (ReferenceFilterInput renders a Radix SelectTrigger with an id but no <label for>) and additionally never opened "Add filter", so the test self-skipped on every deployment.`,
     },
     tag: ['@area:configurator-manage', '@area:hrms', '@kind:regression', '@layer:ui', '@persona:admin'] }, async ({
     page,
@@ -329,26 +330,35 @@ Filter-by-array logic — confirms the dataProvider sends the right query for ch
 
     await page.goto(LIST_PATH);
 
-    // Filter by DEPT_A. The departments filter is a select; if it's
-    // missing on this build, the test logs and short-circuits — the
-    // filter UI is part of the regression net but a missing widget is a
-    // separate failure surface.
-    const filter = page.getByLabel(/^Department/i).first();
+    // Filter by DEPT_A. The Department filter is NOT `alwaysOn` in
+    // DesignationList's `filters` array, so it doesn't exist in the DOM until
+    // it's picked out of the "Add filter" popover (FilterBar/AddFilterButton).
+    // ReferenceFilterInput then renders a Radix <SelectTrigger id={id}> with no
+    // <label for> anywhere — getByLabel(/^Department/i) matched NOTHING, which
+    // is why the old guard skipped this test on every deployment. Target the
+    // combobox by the placeholder text the trigger renders instead.
+    const filter = page.getByRole('combobox').filter({ hasText: /department/i }).first();
     if (!(await filter.isVisible().catch(() => false))) {
-      test.skip(true, 'Department filter not present on this build');
+      await page.getByRole('button', { name: /^Add filter$/i }).click();
+      await page.getByRole('button', { name: 'Department', exact: true }).click();
     }
+    await expect(filter).toBeVisible();
     await filter.click();
-    await page.getByRole('option', { name: DEPT_A }).click().catch(async () => {
-      // Some builds use a typeahead — fall back to keyboard input.
-      await page.keyboard.type(DEPT_A);
-      await page.getByRole('option', { name: DEPT_A }).click();
-    });
-    await page.waitForLoadState('networkidle').catch(() => {});
 
-    // codeA should appear; codeOther should not.
+    // Options are labelled with the department NAME (ReferenceFilterInput's
+    // displayField), and the seeded names embed the code.
+    const option = page.getByRole('option', { name: new RegExp(DEPT_A) }).first();
+    await option.waitFor({ state: 'visible', timeout: 15_000 });
+    await option.click();
+
+    // codeA should appear; codeOther should not. Scope to the seeded rows.
     await page.getByPlaceholder(/search/i).first().fill('PW_');
-    await page.waitForLoadState('networkidle').catch(() => {});
-    await expect(page.getByRole('row').filter({ hasText: codeA })).toBeVisible();
+    // The grid debounces (setFilters(..., undefined, true)) and neither the
+    // option click nor the keystrokes navigate, so waitForLoadState('networkidle')
+    // resolves in ~0.2 ms. Auto-retrying expect is the honest wait.
+    await expect(
+      page.getByRole('row').filter({ hasText: codeA }),
+    ).toBeVisible({ timeout: 30_000 });
     await expect(page.getByRole('row').filter({ hasText: codeOther })).toHaveCount(0);
   });
 

--- a/tests/integration-tests/tests/admin/employee-create-tenant-459.spec.ts
+++ b/tests/integration-tests/tests/admin/employee-create-tenant-459.spec.ts
@@ -22,7 +22,7 @@ test.describe('admin employee create — tenant + form-clears #459 #471 #476', (
     // so the "Select boundary" combobox is empty and the form can't be
     // completed. Left skipped rather than faked — re-enable on deployments
     // where the root tenant has a populated boundary tree.
-    test.skip(true, 'root tenant has no jurisdiction boundaries to select in the employee-create form');
+    test.skip(true, 'root tenant has no jurisdiction boundaries to select in the employee-create form — boundary-relationships _search at ROOT returns 0 boundaries for every hierarchy (probe-verified)');
     const stamp = Date.now();
     const empCode = `INT_TEST_CSR_${stamp}`;
     // Mobile prefix from env (CITIZEN_PHONE_PREFIX) — no hardcoded Kenya '7'.

--- a/tests/integration-tests/tests/admin/employee-create-tenant-459.spec.ts
+++ b/tests/integration-tests/tests/admin/employee-create-tenant-459.spec.ts
@@ -10,19 +10,64 @@
  *          AuditDetails (proven by the 2xx + post-create state walk).
  */
 import { test, expect } from '@playwright/test';
-import { BASE_URL, ROOT_TENANT, ADMIN_USER, ADMIN_PASS, generateEmployeePhone } from '../utils/env';
+import {
+  BASE_URL,
+  ROOT_TENANT,
+  TENANT,
+  ADMIN_USER,
+  ADMIN_PASS,
+  generateEmployeePhone,
+} from '../utils/env';
 
 const EMPLOYEES_URL = '/configurator/manage/employees';
 
+/** Records this suite created on earlier runs and never cleaned up. Boundary
+ *  hierarchies in particular are 48-to-1 junk on a long-lived deployment, so
+ *  "pick the first option" reliably picks a hierarchy with no boundaries. */
+const PW_JUNK = /(^|_)PW[A-Z_]/i;
+
+/** Escape a live code so it can be matched verbatim inside a RegExp. */
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 test.describe('admin employee create — tenant + form-clears #459 #471 #476', () => {
-  test('fills the create form and submits — tenant correct + form clears', { tag: ['@persona:admin'] }, async ({ page }) => {
-    // Onboarding-data gap: this walk creates an employee AT THE ROOT (state)
-    // tenant, whose jurisdiction picker needs leaf boundaries. Stock state
-    // tenants carry no leaf boundaries (they live under the city sub-tenant),
-    // so the "Select boundary" combobox is empty and the form can't be
-    // completed. Left skipped rather than faked — re-enable on deployments
-    // where the root tenant has a populated boundary tree.
-    test.skip(true, 'root tenant has no jurisdiction boundaries to select in the employee-create form — boundary-relationships _search at ROOT returns 0 boundaries for every hierarchy (probe-verified)');
+  test('fills the create form and submits — tenant correct + form clears', {
+    annotation: {
+      type: 'description',
+      description: `Drives the whole Create Employee form and then checks three post-submit claims.
+
+#459 is the reason the Tenant field is DRIVEN rather than left at its default. EmployeeCreate.tsx seeds \`defaults.tenantId\` from the session tenant (the root, e.g. mz) and its \`transform()\` used to let that session value shadow the form value, so every create landed on the session tenant no matter what the operator picked. Asserting against the DEFAULT therefore proves nothing — root == session tenant, so the regression and the fix look identical. This test picks the CITY tenant (which is NOT the session tenant) and asserts the employee lands there.
+
+Jurisdiction walk: the picker is Hierarchy + one cascading select PER HIERARCHY LEVEL (on MAPUTO_ADMIN: Município -> Distrito Municipal -> Bairro -> Quarteirão), each gated on its parent — NOT the "hierarchy / boundary type / boundary" triple an earlier version looked for. Those three comboboxes never existed, which is what actually blocked this test; the recorded reason ("root tenant has no boundary hierarchy at all") was wrong. boundaryHierarchyGetList unions the root tenant with its children, so the real hierarchy IS offered at the root and its boundaries resolve against the city tenant.
+
+Steps:
+1. Open /manage/employees/create; fill name, code, mobile, dob, dateOfAppointment.
+2. Tenant -> the CITY tenant (deliberately not the session default).
+3. Roles -> PGR_LME via the typeahead.
+4. Assignment -> first department + designation, mark current assignment.
+5. Jurisdiction -> first non-PW_ hierarchy, then walk every enabled level picking the first option.
+6. Submit; assert /egov-hrms/employees/_create returned 2xx.
+7. #471 — URL leaves /create and the form input unmounts.
+8. #459 — employees/_search on the PICKED tenant returns the employee with that tenantId (and user.tenantId), proving the form value beat the session default.`,
+    },
+    tag: ['@persona:admin'] }, async ({ page }) => {
+    test.setTimeout(180_000);
+
+    // The tenant we DRIVE the form to. It must differ from the session tenant
+    // (the root) for #459 to be a real claim rather than a restatement of the
+    // form default — see the annotation above.
+    const targetTenant = TENANT;
+    const discriminating = targetTenant !== ROOT_TENANT;
+    if (!discriminating) {
+      test.info().annotations.push({
+        type: 'note',
+        description:
+          `flat deployment: city tenant (${TENANT}) === root tenant (${ROOT_TENANT}), so the Tenant ` +
+          'field is still driven but #459 cannot distinguish the form value from the session default here',
+      });
+    }
+
     const stamp = Date.now();
     const empCode = `INT_TEST_CSR_${stamp}`;
     // Mobile prefix from env (CITIZEN_PHONE_PREFIX) — no hardcoded Kenya '7'.
@@ -31,7 +76,6 @@ test.describe('admin employee create — tenant + form-clears #459 #471 #476', (
     await page.goto(`${BASE_URL}${EMPLOYEES_URL}/create?cb=${stamp}`);
     await page.waitForLoadState('domcontentloaded');
     await expect(page.locator('input[name="user.name"]').first()).toBeVisible({ timeout: 25_000 });
-    await page.waitForTimeout(2_500);
 
     await page.locator('input[name="user.name"]').first().fill('Integration Test Employee');
     await page.locator('input[name="code"]').first().fill(empCode);
@@ -52,34 +96,63 @@ test.describe('admin employee create — tenant + form-clears #459 #471 #476', (
       setDate('user.dob', '1990-01-01');
       setDate('dateOfAppointment', '2024-01-01');
     });
-    await page.waitForTimeout(1_000);
 
-    // Roles — typeahead.
+    /** Options of whichever radix Select is currently open. */
+    const openOptions = page.locator('[role="listbox"][data-state="open"] [role="option"]');
+
+    // ---- Tenant — the point of #459 ----
+    // The radix SelectTrigger carries no accessible name, so anchor on the
+    // field's <Label> text and take the combobox in the innermost wrapper.
+    const tenantCombo = page
+      .locator('div')
+      .filter({ has: page.getByText(/^Tenant$/) })
+      .filter({ has: page.getByRole('combobox') })
+      .last()
+      .getByRole('combobox')
+      .first();
+    await expect(tenantCombo, 'the create form must offer a Tenant field').toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(
+      tenantCombo,
+      'the Tenant field must default to the session tenant — that default is exactly what #459 must not be mistaken for',
+    ).toHaveText(ROOT_TENANT);
+    await tenantCombo.click();
+    const tenantOption = openOptions
+      .filter({ hasText: new RegExp(`^${escapeRegex(targetTenant)}$`) })
+      .first();
+    await expect(
+      tenantOption,
+      `the Tenant dropdown must offer ${targetTenant}`,
+    ).toBeVisible({ timeout: 15_000 });
+    await tenantOption.click();
+    await expect(tenantCombo, 'the Tenant field must hold the picked tenant').toHaveText(
+      targetTenant,
+    );
+
+    // ---- Roles — typeahead ----
     const rolesCombo = page.locator('input[placeholder*="Search roles" i]');
     await expect(rolesCombo).toBeVisible({ timeout: 15_000 });
     await rolesCombo.click();
     await page.keyboard.type('PGR_LME', { delay: 60 });
-    await page.waitForTimeout(1_500);
-    await page
-      .getByRole('option')
-      .filter({ hasText: /PGR_LME/i })
-      .first()
-      .click();
-    await page.waitForTimeout(600);
+    const roleOption = page.getByRole('option').filter({ hasText: /PGR_LME/i }).first();
+    await expect(roleOption, 'PGR_LME must be offered by the roles typeahead').toBeVisible({
+      timeout: 15_000,
+    });
+    await roleOption.click();
 
-    // Assignment block.
+    // ---- Assignment ----
     await page.getByRole('button', { name: /^Add assignment$/i }).click();
-    await page.waitForTimeout(700);
     const deptCombo = page.getByRole('combobox').filter({ hasText: /Select department/i }).first();
+    await expect(deptCombo).toBeVisible({ timeout: 15_000 });
     await deptCombo.click();
-    await page.waitForTimeout(700);
-    await page.locator('[role="listbox"][data-state="open"] [role="option"]').first().click();
-    await page.waitForTimeout(600);
+    await expect(openOptions.first()).toBeVisible({ timeout: 15_000 });
+    await openOptions.first().click();
     const desigCombo = page.getByRole('combobox').filter({ hasText: /Select designation/i }).first();
+    await expect(desigCombo).toBeVisible({ timeout: 15_000 });
     await desigCombo.click();
-    await page.waitForTimeout(700);
-    await page.locator('[role="listbox"][data-state="open"] [role="option"]').first().click();
-    await page.waitForTimeout(600);
+    await expect(openOptions.first()).toBeVisible({ timeout: 15_000 });
+    await openOptions.first().click();
 
     // Current-assignment radio via native setter.
     await page.evaluate(() => {
@@ -98,49 +171,77 @@ test.describe('admin employee create — tenant + form-clears #459 #471 #476', (
         }
       }
     });
-    await page.waitForTimeout(1_500);
 
-    // Jurisdiction.
+    // ---- Jurisdiction — Hierarchy, then one gated select per hierarchy level ----
     await page.getByRole('button', { name: /^Add jurisdiction$/i }).click();
-    await page.waitForTimeout(700);
-    const hierCombo = page.getByRole('combobox').filter({ hasText: /Select hierarchy/i }).first();
+    const jurisdictionRow = page
+      .locator('div')
+      .filter({ has: page.getByRole('button', { name: /^Remove jurisdiction 1$/i }) })
+      .last();
+    const levelCombos = jurisdictionRow.getByRole('combobox');
+    const hierCombo = levelCombos.first();
+    await expect(hierCombo, 'the jurisdiction row must offer a Hierarchy select').toBeVisible({
+      timeout: 15_000,
+    });
     await hierCombo.click();
-    await page.waitForTimeout(700);
-    await page.locator('[role="listbox"][data-state="open"] [role="option"]').first().click();
-    await page.waitForTimeout(700);
-    const btCombo = page.getByRole('combobox').filter({ hasText: /Select boundary type/i }).first();
-    await btCombo.click();
-    await page.waitForTimeout(700);
-    await page.locator('[role="listbox"][data-state="open"] [role="option"]').first().click();
-    await page.waitForTimeout(800);
-    const boundCombo = page
-      .getByRole('combobox')
-      .filter({ hasText: /Select boundary/i })
-      .filter({ hasNotText: /type/i })
-      .first();
-    await boundCombo.click();
-    await page.waitForTimeout(700);
-    await page.locator('[role="listbox"][data-state="open"] [role="option"]').first().click();
-    await page.waitForTimeout(800);
+    await expect(openOptions.first()).toBeVisible({ timeout: 15_000 });
+    const hierarchyNames = (await openOptions.allTextContents()).map((t) => t.trim()).filter(Boolean);
+    const realHierarchy = hierarchyNames.find((h) => !PW_JUNK.test(h));
+    expect(
+      realHierarchy,
+      `the Hierarchy select must offer a real (non-PW_ test-junk) boundary hierarchy, got ${JSON.stringify(hierarchyNames.slice(0, 10))}`,
+    ).toBeTruthy();
+    await openOptions
+      .filter({ hasText: new RegExp(`^${escapeRegex(realHierarchy!)}$`) })
+      .first()
+      .click();
 
-    // Submit.
+    // Each level is disabled until its parent is chosen; walk down until the
+    // hierarchy runs out of (enabled) levels. The deepest pick is what gets stored.
+    let levelsPicked = 0;
+    for (let level = 1; level < 12; level++) {
+      const combo = levelCombos.nth(level);
+      if ((await combo.count()) === 0) break;
+      const enabled = await expect(combo).toBeEnabled({ timeout: 6_000 }).then(
+        () => true,
+        () => false,
+      );
+      if (!enabled) break;
+      await combo.click();
+      const opened = await expect(openOptions.first())
+        .toBeVisible({ timeout: 8_000 })
+        .then(() => true, () => false);
+      if (!opened) {
+        await page.keyboard.press('Escape').catch(() => {});
+        break;
+      }
+      await openOptions.first().click();
+      levelsPicked += 1;
+    }
+    expect(
+      levelsPicked,
+      `hierarchy "${realHierarchy}" resolved no selectable boundaries — the jurisdiction cascade is empty`,
+    ).toBeGreaterThan(0);
+
+    // ---- Submit ----
     const createBtn = page.getByRole('button', { name: /^Create$/i });
     await createBtn.scrollIntoViewIfNeeded();
-    await page.waitForTimeout(800);
     const hrmsCreatePromise = page
       .waitForResponse(
         (r) => /\/egov-hrms\/employees\/_create/.test(r.url()) && r.status() < 500,
-        { timeout: 25_000 },
+        { timeout: 30_000 },
       )
       .catch(() => null);
     await createBtn.click();
     const createResp = await hrmsCreatePromise;
     expect(createResp, 'Create POST must hit /egov-hrms/employees/_create').not.toBeNull();
-    expect(createResp!.ok(), 'Create must return 2xx').toBeTruthy();
-    await page.waitForTimeout(2_000);
+    expect(
+      createResp!.ok(),
+      `Create must return 2xx, got ${createResp!.status()}: ${await createResp!.text().catch(() => '')}`,
+    ).toBeTruthy();
 
     // ============ #471 — form clears (URL + DOM) ============
-    await page.waitForURL(/\/manage\/employees(?!.*\/create)/, { timeout: 15_000 });
+    await page.waitForURL(/\/manage\/employees(?!.*\/create)/, { timeout: 20_000 });
     expect(page.url(), '#471 — URL must leave /create').not.toMatch(/\/create($|\?)/);
     await expect(
       page.locator('input[name="code"]'),
@@ -158,7 +259,7 @@ test.describe('admin employee create — tenant + form-clears #459 #471 #476', (
     expect(tokenResp.ok()).toBeTruthy();
     const token = (await tokenResp.json()).access_token as string;
     const hrmsResp = await page.request.post(
-      `${BASE_URL}/egov-hrms/employees/_search?tenantId=${ROOT_TENANT}&codes=${empCode}`,
+      `${BASE_URL}/egov-hrms/employees/_search?tenantId=${targetTenant}&codes=${empCode}`,
       {
         headers: { 'Content-Type': 'application/json' },
         data: { RequestInfo: { authToken: token } },
@@ -166,11 +267,18 @@ test.describe('admin employee create — tenant + form-clears #459 #471 #476', (
     );
     expect(hrmsResp.ok()).toBeTruthy();
     const employees = (await hrmsResp.json()).Employees as Array<Record<string, unknown>>;
-    expect(employees.length).toBeGreaterThan(0);
+    expect(
+      employees.length,
+      `#459 — the employee must be findable on the tenant the form picked (${targetTenant}); ` +
+        `finding nothing here means the create landed on the session tenant (${ROOT_TENANT}) instead`,
+    ).toBeGreaterThan(0);
     expect(
       employees[0].tenantId,
-      `#459 — Employee.tenantId must match the form's tenant (${ROOT_TENANT})`,
-    ).toBe(ROOT_TENANT);
-    expect((employees[0].user as Record<string, unknown>).tenantId).toBe(ROOT_TENANT);
+      `#459 — Employee.tenantId must match the form's Tenant field (${targetTenant}), not the session tenant (${ROOT_TENANT})`,
+    ).toBe(targetTenant);
+    expect(
+      (employees[0].user as Record<string, unknown>).tenantId,
+      `#459 — the backing user must land on ${targetTenant} too`,
+    ).toBe(targetTenant);
   });
 });

--- a/tests/integration-tests/tests/admin/employees.spec.ts
+++ b/tests/integration-tests/tests/admin/employees.spec.ts
@@ -65,6 +65,13 @@ let SEED_DESIG = process.env.SEED_DESIG || 'DESIG_58';
 let SEED_HIERARCHY = process.env.SEED_HIERARCHY || 'ADMIN';
 let SEED_BOUNDARY_TYPE = process.env.SEED_BOUNDARY_TYPE || 'County';
 
+// Tracks whether resolveSeedFks() found a live employee to derive FKs from.
+// Tests that API-seed employees (4a/5/6) need a real boundary/dept/designation
+// combo; without live resolution AND without an explicit env override they'd
+// silently fall back to the Kenya literals above, which fail (or worse,
+// silently mis-seed) on any non-Kenya tenant. See B6 in ADMIN-SUITE-PLAN.md.
+let seedFksResolved = false;
+
 /**
  * Derive boundary / department / designation FKs from a real employee on the
  * deployment so HRMS _create seeds validate. Env overrides take precedence;
@@ -88,6 +95,7 @@ async function resolveSeedFks(): Promise<void> {
         if (!process.env.SEED_BOUNDARY_TYPE) SEED_BOUNDARY_TYPE = boundaryType;
         if (!process.env.SEED_DEPT) SEED_DEPT = dept;
         if (!process.env.SEED_DESIG) SEED_DESIG = desig;
+        seedFksResolved = true;
         return;
       }
     }
@@ -288,17 +296,25 @@ Cleanup uses the inline softDeleteEmployee helper because HRMS has no DELETE end
     await page.goto(`${LIST_PATH}/create`);
 
     // --- Pre-assertions (CCRS#404 / #419 + CCRS#416) ---
-    // CCRS#404 / #419: DOB must be marked required on the Create form. We
-    // prefer the HTML `required` attribute because the red-asterisk copy
-    // depends on a FormLabel CSS class that can shift across shadcn upgrades.
+    // CCRS#404 / #419: DOB must be marked required on the Create form.
+    // DigitFormInput never sets the HTML `required` attribute — required-ness
+    // renders as the label's `aria-label="required"` asterisk marker instead
+    // (configurator/src/admin/DigitFormInput.tsx:69-73). Assert that marker.
     const dobInput = page.getByLabel(/^Date of Birth/i);
     await expect(dobInput).toBeVisible();
-    await expect(dobInput).toHaveAttribute('required', '');
+    const dobLabel = page.locator('label', { hasText: /^Date of Birth/i }).first();
+    await expect(dobLabel.locator('[aria-label="required"]')).toBeVisible();
 
     // CCRS#416 (UI): Tenant picker is present on Create and defaults to the
     // session tenant. We accept either a native input (read via `value`) or a
     // combobox trigger whose rendered text contains the tenant code.
-    const tenantField = page.getByLabel(/^Tenant$/i).first();
+    // Tenant is required (v.codeRequired), so its Label's computed accessible
+    // name includes the aria-label="required" asterisk marker's text
+    // ("Tenant required", not a bare "Tenant") — anchoring with a trailing
+    // `$` (as employees#1's Status label does, where the field is optional
+    // and unmarked) never matches. Use a prefix match like every other label
+    // lookup in this spec (Name, Mobile Number, Date of Birth, ...).
+    const tenantField = page.getByLabel(/^Tenant/i).first();
     await expect(tenantField).toBeVisible();
     const tenantTag = await tenantField.evaluate((el) => el.tagName.toLowerCase());
     if (tenantTag === 'input' || tenantTag === 'select') {
@@ -320,6 +336,23 @@ Cleanup uses the inline softDeleteEmployee helper because HRMS has no DELETE end
     await page.getByLabel(/^Email/i).fill(`${code.toLowerCase()}@example.com`);
     await page.getByLabel(/^Date of Birth/i).fill('1990-05-14');
     await page.getByLabel(/^Date of Appointment/i).fill('2026-01-15');
+
+    // Follow-on locator gap surfaced once the DOB pre-assertion (above) was
+    // fixed and the flow could actually reach Create: HRMS's _create rejects
+    // employees with zero roles (ERR_HRMS_MISSING_ROLES) and the create
+    // form's default is an empty user.roles array — nothing auto-selects
+    // one. Pick EMPLOYEE via the RolesEditor combobox (same pattern as
+    // test 4a's CITIZEN pick) so the happy path actually reaches HRMS.
+    const roleCombobox = page.getByRole('combobox', { name: /^Roles?$/i }).first();
+    await roleCombobox.click();
+    await roleCombobox.fill('EMPLOYEE');
+    // The option's accessible name concatenates code + name with no
+    // separator ("EMPLOYEEEmployee") so a `\b`-anchored regex never finds a
+    // word boundary there — match on the code PREFIX only. The query also
+    // substring-matches on role name (e.g. "Auto Escalation Employee"), so a
+    // plain "contains" match would be ambiguous; anchoring at `^` picks only
+    // the row whose code itself starts with EMPLOYEE.
+    await page.getByRole('option', { name: /^EMPLOYEE/i }).first().click();
 
     // Submit. List path is `/configurator/manage/employees`.
     await Promise.all([
@@ -381,8 +414,19 @@ Pairs with the happy-path test (#2) — together they bracket valid + invalid mo
     // The validator error copy is sourced from HRMS clamping the MDMS rule.
     // Assert on the rule.errorMessage substring (escaped for regex) with a
     // loose fallback to tolerate minor copy variants across HRMS releases.
+    //
+    // The live form's own useMobileValidator (configurator/src/admin/hrms/
+    // useMobileValidator.ts buildErrorMessage) composes a DIFFERENT string
+    // than this test util's mdms-mobile.ts errorMessage: the app renders
+    // "Please enter a valid mobile number (9 digits, starting with 8)"
+    // (base phrase + parenthetical), not "Please enter a valid 9-digit
+    // mobile number". The two also punctuate the digits/starting clause
+    // differently ("9 digits, starting with 8" has a comma the old
+    // `digits starting` alternative didn't tolerate). Add both a
+    // comma-tolerant variant and the app's own generic (deployment-agnostic
+    // — no tenant literal) base phrase as fallbacks.
     const ruleMsgRe = new RegExp(
-      `${escapeRegex(mobileRule.errorMessage)}|MobileNumber|must be \\d+|digits starting`,
+      `${escapeRegex(mobileRule.errorMessage)}|MobileNumber|must be \\d+|digits,?\\s*starting|valid mobile number`,
       'i',
     );
     const errorText = page.getByText(ruleMsgRe).first();
@@ -422,6 +466,15 @@ Code and Username are write-once because HRMS doesn't allow mutating either afte
     await codeInput.fill(code);
     await page.getByLabel(/^Mobile Number/i).fill(mobile);
     await page.getByLabel(/^Date of Birth/i).fill('1985-07-20');
+    // Date of Appointment is required (v.required, EmployeeCreate.tsx) — was
+    // missing here, which silently blocked the form from ever submitting.
+    await page.getByLabel(/^Date of Appointment/i).fill('2026-01-15');
+    // HRMS _create rejects a zero-role employee (ERR_HRMS_MISSING_ROLES) —
+    // see test 2's comment for the full explanation.
+    const roleCombobox = page.getByRole('combobox', { name: /^Roles?$/i }).first();
+    await roleCombobox.click();
+    await roleCombobox.fill('EMPLOYEE');
+    await page.getByRole('option', { name: /^EMPLOYEE/i }).first().click();
 
     await Promise.all([
       page.waitForURL(LIST_PATH, { timeout: 45_000 }),
@@ -441,9 +494,15 @@ Code and Username are write-once because HRMS doesn't allow mutating either afte
     const dobInput = page.getByLabel(/^Date of Birth/i);
     await expect(dobInput).toHaveValue('1985-07-20');
 
-    // Code + Username are disabled on edit.
+    // Code + Username are write-once. Employee Code is disabled on edit;
+    // Username has no separate field at all any more (CCRS#460 —
+    // EmployeeShow.tsx:39-41 documents that HRMS always overwrites userName
+    // with the employee code, so a distinct "Username" input/display would
+    // just duplicate Employee Code under a misleading label). Its absence
+    // from the DOM is an even stronger write-once guarantee than `disabled`
+    // would be, so assert that instead of a stale `toBeDisabled()`.
     await expect(page.getByLabel(/^Employee Code/i)).toBeDisabled();
-    await expect(page.getByLabel(/^Username/i)).toBeDisabled();
+    await expect(page.getByLabel(/^Username/i)).toHaveCount(0);
 
     // Mutate name + save; verify via API.
     await page.getByLabel(/^Name/i).fill(`PW Edited ${uniq}`);
@@ -459,28 +518,41 @@ Code and Username are write-once because HRMS doesn't allow mutating either afte
     expect((emp.user as any)?.name).toMatch(/PW Edited/);
   });
 
-  test('4a. edit — add CITIZEN role round-trips without JsonMappingException (CCRS#439)', {
+  test('4a. edit — add GRO role round-trips without JsonMappingException (CCRS#439)', {
     annotation: {
       type: 'description',
-      description: `Catches CCRS#439: adding a CITIZEN role to an existing employee through the RolesEditor used to surface a JsonMappingException because the configurator sent the role array in a shape egov-hrms couldn't deserialize. Post-fix the round-trip succeeds and HRMS reflects the new role within 5s.
+      description: `Catches CCRS#439: adding a role to an existing employee through the RolesEditor used to surface a JsonMappingException because the configurator sent the role array in a shape egov-hrms couldn't deserialize. Post-fix the round-trip succeeds and HRMS reflects the new role within 5s.
+
+Uses GRO (a PGR employee role — EMP001 already carries it) rather than the
+original repro's CITIZEN: this deployment's egov-hrms now enforces
+ERR_HRMS_INVALID_ROLE for CITIZEN on a type=EMPLOYEE user (probe-verified
+directly against /egov-hrms/employees/_create — same 400 regardless of client
+payload shape), which is a legitimate role/type compatibility rule, not the
+JsonMappingException deserialization bug #439 targets. GRO exercises the same
+"add a not-yet-present role via RolesEditor, Save, no crash, HRMS reflects it"
+path without tripping that unrelated validation.
 
 Steps:
-1. Generate a unique code + Kenya mobile; track for cleanup.
+1. Generate a unique code + tenant-valid mobile; track for cleanup.
 2. Seed a fresh employee via API with ONLY [EMPLOYEE] role.
-3. Confirm the seed has no CITIZEN role yet (assert preRoles.some code === CITIZEN === false).
+3. Confirm the seed has no GRO role yet (assert preRoles.some code === GRO === false).
 4. Open Edit via list-row click.
-5. Locate the Roles combobox by role + name; click; type "CITIZEN"; click the matching option.
+5. Locate the Roles combobox by role + name; click; type "GRO"; click the matching option.
 6. Click Save.
 7. Assert no role=status toast OR body text contains 'JsonMappingException' (count === 0 for both).
-8. expect.poll on HRMS: within 5s, the user.roles array should contain CITIZEN.
+8. expect.poll on HRMS: within 5s, the user.roles array should contain GRO.
 
 Hermetic: doesn't rely on tenant content — seeds and verifies its own employee. Cleanup is via afterAll's softDeleteEmployee; role removal is a known TODO since the helper soft-deactivates the whole employee.`,
     },
     tag: ['@area:configurator-manage', '@area:hrms', '@ccrs:439', '@kind:regression', '@layer:ui', '@persona:admin'] }, async ({
     page,
   }, testInfo) => {
+    test.skip(
+      !seedFksResolved && !process.env.SEED_DEPT,
+      'no existing employee to derive live HRMS FKs from — set SEED_* env vars',
+    );
     // Create a fresh employee via API so we own it + know it has only EMPLOYEE
-    // role (no CITIZEN yet). This keeps the test hermetic instead of relying
+    // role (no GRO yet). This keeps the test hermetic instead of relying
     // on fishing a suitable victim out of the shared tenant.
     const code = testCode(testInfo, 'EMP_ROLE');
     const uniq = code.split('_').pop() || '44444';
@@ -505,7 +577,7 @@ Hermetic: doesn't rely on tenant content — seeds and verifies its own employee
       }],
     });
 
-    // Confirm the seed employee has no CITIZEN role yet — if it somehow does
+    // Confirm the seed employee has no GRO role yet — if it somehow does
     // (roles seeded server-side?), skip rather than produce a misleading pass.
     const preSearch = await postJson(auth,
       `${HRMS_SEARCH}?tenantId=${TENANT_CODE}&codes=${encodeURIComponent(code)}&limit=1&offset=0`,
@@ -513,7 +585,7 @@ Hermetic: doesn't rely on tenant content — seeds and verifies its own employee
     const preEmp = ((preSearch.Employees as HrmsEmployee[]) || [])[0];
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const preRoles = ((preEmp?.user as any)?.roles || []) as Array<{ code?: string }>;
-    expect(preRoles.some((r) => r.code === 'CITIZEN')).toBe(false);
+    expect(preRoles.some((r) => r.code === 'GRO')).toBe(false);
 
     // Open Edit via list-row click (same entry-point as test 4).
     await page.goto(LIST_PATH);
@@ -522,15 +594,18 @@ Hermetic: doesn't rely on tenant content — seeds and verifies its own employee
     await page.getByRole('row').filter({ hasText: code }).click();
     await page.getByRole('button', { name: /^Edit$/i }).click();
 
-    // Roles section — RolesEditor is a combobox. Typing "CITIZEN" should
+    // Roles section — RolesEditor is a combobox. Typing "GRO" should
     // surface a match; click the first option. We key on `combobox` role
     // rather than label text because the label copy varies ("Roles" vs
-    // "Assign roles") across tenants.
+    // "Assign roles") across tenants. The option's accessible name
+    // concatenates code+name with no separator, and the query substring-
+    // matches on role name too (e.g. "DGRO" also contains "gro"), so anchor
+    // at `^` to pick only the row whose code itself starts with GRO.
     const roleCombobox = page.getByRole('combobox', { name: /^Roles?$/i }).first();
     await expect(roleCombobox).toBeVisible({ timeout: 10_000 });
     await roleCombobox.click();
-    await roleCombobox.fill('CITIZEN');
-    await page.getByRole('option', { name: /CITIZEN/i }).first().click();
+    await roleCombobox.fill('GRO');
+    await page.getByRole('option', { name: /^GRO/i }).first().click();
 
     await page.getByRole('button', { name: /^Save$/i }).click();
 
@@ -541,7 +616,7 @@ Hermetic: doesn't rely on tenant content — seeds and verifies its own employee
     const errorBanner = page.getByText(/JsonMappingException/i);
     await expect(errorBanner).toHaveCount(0);
 
-    // Within 5s, the mutation is visible server-side — CITIZEN is now in the
+    // Within 5s, the mutation is visible server-side — GRO is now in the
     // user's roles array. We poll HRMS rather than DOM because the list may
     // re-render without showing roles inline.
     await expect.poll(async () => {
@@ -551,7 +626,7 @@ Hermetic: doesn't rely on tenant content — seeds and verifies its own employee
       const emp = ((res.Employees as HrmsEmployee[]) || [])[0];
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const roles = ((emp?.user as any)?.roles || []) as Array<{ code?: string }>;
-      return roles.some((r) => r.code === 'CITIZEN');
+      return roles.some((r) => r.code === 'GRO');
     }, { timeout: 5_000 }).toBeTruthy();
 
     // TODO: role-removal cleanup — afterAll soft-deactivates the employee,
@@ -581,6 +656,10 @@ The MDMS reason source is asserted indirectly — if the dropdown has no options
     tag: ['@area:configurator-manage', '@area:hrms', '@kind:regression', '@layer:ui', '@persona:admin'] }, async ({
     page,
   }, testInfo) => {
+    test.skip(
+      !seedFksResolved && !process.env.SEED_DEPT,
+      'no existing employee to derive live HRMS FKs from — set SEED_* env vars',
+    );
     const code = testCode(testInfo, 'EMP_DEACT');
     const uniq = code.split('_').pop() || '22222';
     const mobile = generateValidMobile(mobileRule);
@@ -675,6 +754,10 @@ Affirms the safety contract — admins must explicitly opt-in to password rotati
     tag: ['@area:configurator-manage', '@area:hrms', '@kind:regression', '@layer:ui', '@persona:admin'] }, async ({
     page,
   }, testInfo) => {
+    test.skip(
+      !seedFksResolved && !process.env.SEED_DEPT,
+      'no existing employee to derive live HRMS FKs from — set SEED_* env vars',
+    );
     const code = testCode(testInfo, 'EMP_PWD');
     const uniq = code.split('_').pop() || '33333';
     const mobile = generateValidMobile(mobileRule);
@@ -725,7 +808,7 @@ Affirms the safety contract — admins must explicitly opt-in to password rotati
   test('7. bulk import — 3 valid + 2 invalid rows, create 3 lands', {
     annotation: {
       type: 'description',
-      description: `Bulk-import end-to-end with mixed validity: 3 well-formed rows + 2 deliberately broken rows (short mobile + bad date; unknown department + unknown role). Confirms the preview marks 2 errors, the Create button shows "3" (not 5), and HRMS lands all 3 valid employees. Optionally exercises the credentials CSV download.
+      description: `Bulk-import end-to-end with mixed validity: 3 well-formed rows + 2 deliberately broken rows (short mobile; unknown department + unknown role). Confirms the preview marks 2 errors, the Create button shows "3" (not 5), and HRMS lands all 3 valid employees. Optionally exercises the credentials CSV download.
 
 Steps:
 1. Generate 3 valid + 2 invalid codes; track only valid for cleanup.
@@ -739,7 +822,25 @@ Steps:
 9. For each valid code, POST HRMS _search; assert exactly 1 result, isActive !== false.
 10. If "credentials CSV" download button is visible, click it and confirm the download path is non-empty.
 
-The xlsx sheet name is 'Employee' to match excelParser.ts's allow-list (Employee/Employees/EmployeeMaster/HRMS/employee).`,
+The xlsx sheet name is 'Employee' to match excelParser.ts's allow-list (Employee/Employees/EmployeeMaster/HRMS/employee).
+
+No \`jurisdictions\` column is populated: EmployeeBulkImport.tsx treats it as
+fully optional (parse-time: a warning, not a blocking error; validateRow:
+skipped entirely when falsy) — and on this deployment the ROOT tenant (where
+this spec manages employees) has zero boundary-hierarchy nodes at all
+(same fact employee-create-tenant-459 documents), so ANY jurisdiction code
+would fail the row-level "Boundary not found" check regardless of which
+code was chosen. Omitting the column sidesteps a tenant-shape dependency
+this test was never actually about.
+
+Invalid row 1 uses a syntactically well-formed DOB (only the mobile is
+short) rather than mobile+DOB both broken: excelParser.ts's parseEmployeeExcel
+treats a malformed DOB as a parse-time failure and drops the row from the
+returned data array entirely (never reaches the preview table at all), which
+would silently shrink "Total" from 5 to 4 and defeat this test's own "preview
+marks 2 errors" contract. A bad mobile alone still fails validateRow's
+per-tenant MDMS length/pattern check and shows as an Error row, which is what
+the test is actually asserting.`,
     },
     tag: ['@area:configurator-manage', '@area:hrms', '@kind:edge-case', '@layer:ui', '@persona:admin'] }, async ({
     page,
@@ -758,7 +859,9 @@ The xlsx sheet name is 'Employee' to match excelParser.ts's allow-list (Employee
     ).toBeVisible({ timeout: 30_000 });
 
     const rows = [
-      // Valid trio — PW_ codes, 10-digit 07-prefix mobiles, real dept/desig/boundary.
+      // Valid trio — PW_ codes, tenant-valid mobiles, real dept/desig. No
+      // jurisdictions column (see annotation — optional, and unusable at
+      // this spec's ROOT tenant which has no boundary hierarchy at all).
       ...validCodes.map((c, i) => ({
         employeeCode: c,
         name: `PW Bulk ${i + 1}`,
@@ -771,10 +874,13 @@ The xlsx sheet name is 'Employee' to match excelParser.ts's allow-list (Employee
         department: SEED_DEPT,
         designation: SEED_DESIG,
         roles: 'EMPLOYEE',
-        jurisdictions: SEED_BOUNDARY,
+        jurisdictions: '',
         dateOfAppointment: '2026-02-01',
       })),
-      // Invalid row 1 — mobile too short, DOB malformed.
+      // Invalid row 1 — mobile too short. DOB is well-formed on purpose: a
+      // malformed DOB makes excelParser.ts drop the row at PARSE time (never
+      // reaches the preview table), which would silently shrink this test's
+      // "5 rows, 2 errors" contract to 4 rows — see annotation.
       {
         employeeCode: invalidCodes[0],
         name: 'PW Bulk Bad1',
@@ -782,11 +888,11 @@ The xlsx sheet name is 'Employee' to match excelParser.ts's allow-list (Employee
         mobileNumber: '99999',
         emailId: '',
         gender: 'MALE',
-        dob: 'not-a-date',
+        dob: '1988-04-10',
         department: SEED_DEPT,
         designation: SEED_DESIG,
         roles: 'EMPLOYEE',
-        jurisdictions: SEED_BOUNDARY,
+        jurisdictions: '',
         dateOfAppointment: '',
       },
       // Invalid row 2 — unknown department + unknown role code.
@@ -802,7 +908,7 @@ The xlsx sheet name is 'Employee' to match excelParser.ts's allow-list (Employee
         department: 'NO_SUCH_DEPT',
         designation: SEED_DESIG,
         roles: 'NO_SUCH_ROLE',
-        jurisdictions: SEED_BOUNDARY,
+        jurisdictions: '',
         dateOfAppointment: '',
       },
     ];
@@ -828,7 +934,11 @@ The xlsx sheet name is 'Employee' to match excelParser.ts's allow-list (Employee
     await createBtn.click();
 
     // Completion page — 3 landed, download-credentials CTA surfaces.
-    await expect(page.getByText(/3\s*(created|success)/i).first()).toBeVisible({
+    // RC8: completion copy is "Created 3 employees" (number AFTER the word),
+    // not "3 created" — accept either order.
+    await expect(
+      page.getByText(/(?:created\s+3|3\s+(?:created|success))/i).first(),
+    ).toBeVisible({
       timeout: 90_000,
     });
 

--- a/tests/integration-tests/tests/admin/employees.spec.ts
+++ b/tests/integration-tests/tests/admin/employees.spec.ts
@@ -18,7 +18,7 @@
  *  - /access-control/v1/actions/mdms/_get returns 404 at `ke` (pre-existing;
  *    see DEV-LOG §13). Not on the critical create/edit path.
  */
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import ExcelJS from 'exceljs';
 import { loadAuth, employeeSearch, type AuthInfo } from '../utils/manage/api';
 import { testCode, testCodeIndexed } from '../utils/manage/codes';
@@ -209,24 +209,55 @@ test.afterAll(async () => {
 });
 
 test.describe('manage/employees', () => {
-  test('1. list renders, search narrows, status filter applies', {
+  test('1. list renders; search narrows to the matching row; Status filter partitions the list', {
     annotation: {
       type: 'description',
-      description: `Smoke check for /manage/employees: the list renders with the four expected columns (Employee Code, Name, Mobile, Status), search narrows the row count, and the Status filter switches between Active and Inactive without crashing.
+      description: `Smoke check for /manage/employees that actually proves the two filters NARROW.
+
+The previous version could not fail. It asserted \`filtered <= initial\` — a
+narrowing filter can never *increase* a row count, and the grid's debounce
+(DigitList.tsx handleSearchChange -> setFilters(..., undefined, true), ~750ms
+measured) made the two reads identical anyway — and \`inactiveCount >= 0\`,
+a pure tautology. Worse, the Status branch was guarded by
+\`getByLabel(/^Status$/i)\`, which matches NOTHING: the filter is a Radix
+SelectTrigger with no <label>, so the tautology never even ran. This rewrite
+asserts the expected *rows*, and every read goes through an auto-retrying
+poll so the debounce cannot fake a pass.
 
 Steps:
-1. Navigate to /configurator/manage/employees.
-2. Assert role=table is visible.
-3. For each header in ['Employee Code','Name','Mobile','Status'], assert the matching role=columnheader is visible.
-4. Read initial row count; assert > 1.
-5. Type 'zzz_no_such_employee' in the search input; wait networkidle.
-6. Read filtered count; assert filtered <= initial.
-7. Clear search; wait networkidle.
-8. If Status filter visible, click it, pick Inactive, wait networkidle, assert count >= 0.
+1. Pick a needle from live HRMS: the alphabetically-first employee code that
+   occurs in exactly ONE record. Derived, not hardcoded — and uniqueness is
+   checked because the grid's quick-search matches the whole record, so a code
+   like ADMIN also matches every employee whose jurisdiction hierarchy is
+   MAPUTO_ADMIN (measured: 65 of 65 rows on the local stack).
+2. Navigate to the list; assert role=table + the four expected columnheaders.
+3. Read the grid's own "Showing a-b of N" footer for the unfiltered total N;
+   assert N > 1 (otherwise nothing can be narrowed and the test skips).
+4. Type the needle; poll the footer until the total is exactly 1, and assert
+   the single rendered row's Employee Code cell IS the needle.
+5. Type a nonsense term; poll the total to 0 and assert the "No records found"
+   empty state renders (the footer is not rendered at total=0).
+6. Clear the search; poll the total back to N — the filter is reversible.
+7. Status filter (located as the filter bar's only combobox, since Radix gives
+   it no accessible name): select Inactive, then Employed. For each, assert
+   EVERY rendered Status cell carries that status, and record the total.
+8. Assert totalInactive + totalEmployed === N. A filter that is silently
+   ignored returns the full list under both, so the sum would be 2N; a filter
+   that over-narrows makes the sum fall short. Employed/Inactive are the only
+   choices the UI offers, so they must partition the list.
 
-Multi-purpose smoke that exercises the major surface in one pass.`,
+Mutation-tested: deleting the \`search.fill(needle)\` line turns step 4 red
+("expected 1, received 65").`,
     },
     tag: ['@area:configurator-manage', '@area:hrms', '@kind:regression', '@layer:ui', '@persona:admin'] }, async ({ page }) => {
+    // Derived from the deployment, never hardcoded: the first code (in a
+    // deterministic order) that identifies exactly one employee.
+    const needle = await pickUniqueEmployeeCode();
+    test.skip(
+      !needle,
+      'no employee code on this deployment identifies exactly one record — nothing unambiguous to search for',
+    );
+
     await page.goto(LIST_PATH);
 
     const table = page.getByRole('table');
@@ -239,28 +270,76 @@ Multi-purpose smoke that exercises the major surface in one pass.`,
       ).toBeVisible();
     }
 
-    const dataRows = page.getByRole('row');
-    const initialCount = await dataRows.count();
-    expect(initialCount).toBeGreaterThan(1);
+    // Data rows only — getByRole('row') also counts the header row, which is
+    // how "11 rows" used to stand in for "10 employees".
+    const dataRows = table.locator('tbody tr');
+    const baselineTotal = await settledTotal(page);
+    test.skip(
+      baselineTotal < 2,
+      `only ${baselineTotal} employee(s) on this deployment — a narrowing filter cannot be observed`,
+    );
 
-    // Narrow via search — expect row count to drop or empty state to appear.
+    // ── search narrows to exactly the matching row ──────────────────────────
     const search = page.getByPlaceholder(/search/i).first();
     await expect(search).toBeVisible();
-    await search.fill('zzz_no_such_employee');
-    await page.waitForLoadState('networkidle').catch(() => {});
-    const filteredCount = await dataRows.count();
-    expect(filteredCount).toBeLessThanOrEqual(initialCount);
+    await search.fill(needle!);
+    // expect.poll, not a bare read: the grid debounces the filter, so an
+    // immediate count still shows the UNFILTERED page.
+    await expect
+      .poll(() => readTotal(page), {
+        timeout: 20_000,
+        message: `search for '${needle}' must narrow the grid to that one employee`,
+      })
+      .toBe(1);
+    await expect(dataRows).toHaveCount(1);
+    await expect(dataRows.first().locator('td').first()).toHaveText(needle!);
 
-    // Reset and flip Status → Inactive.
+    // ── a term that matches nothing empties the grid ────────────────────────
+    await search.fill('zzz_no_such_employee');
+    await expect
+      .poll(() => readTotal(page), { timeout: 20_000, message: 'a non-matching search must empty the grid' })
+      .toBe(0);
+    await expect(dataRows).toHaveCount(0);
+    await expect(page.getByText(/No records found/i)).toBeVisible();
+
+    // ── clearing restores the full list ─────────────────────────────────────
     await search.fill('');
-    await page.waitForLoadState('networkidle').catch(() => {});
-    const statusFilter = page.getByLabel(/^Status$/i);
-    if (await statusFilter.isVisible().catch(() => false)) {
+    await expect
+      .poll(() => readTotal(page), { timeout: 20_000, message: 'clearing the search must restore every row' })
+      .toBe(baselineTotal);
+
+    // ── Status filter ───────────────────────────────────────────────────────
+    // The filter bar's Status control is a Radix SelectTrigger with no <label>
+    // and no aria-label, so getByLabel(/^Status$/) matches nothing — that is
+    // exactly how the old assertion went unexecuted. It is the only combobox
+    // inside FilterBar's <form>, and it keeps that identity after selection
+    // (its rendered text becomes the chosen value).
+    const statusFilter = page.locator('form').getByRole('combobox').first();
+    await expect(statusFilter, 'the filter bar combobox must be the Status filter').toHaveText(/^Status$/i);
+
+    const statusCells = dataRows.locator('td:nth-child(4)');
+    const totals: Record<string, number> = {};
+    for (const [option, cellText] of [['Inactive', 'INACTIVE'], ['Employed', 'EMPLOYED']] as const) {
       await statusFilter.click();
-      await page.getByRole('option', { name: /Inactive/i }).click();
-      await page.waitForLoadState('networkidle').catch(() => {});
-      expect(await dataRows.count()).toBeGreaterThanOrEqual(0);
+      await page.getByRole('option', { name: new RegExp(`^${option}$`, 'i') }).click();
+      await expect(statusFilter).toHaveText(new RegExp(`^${option}$`, 'i'));
+      // Auto-retrying, so it also absorbs the debounce: no rendered row may
+      // carry a status other than the one selected.
+      await expect(
+        statusCells.filter({ hasNotText: cellText }),
+        `every row under Status='${option}' must show ${cellText}`,
+      ).toHaveCount(0);
+      totals[option] = await settledTotal(page);
     }
+
+    // The two choices the UI offers are the whole vocabulary, so they must
+    // partition the list. A filter that is silently ignored yields the full
+    // list under both (sum = 2N); one that over-narrows falls short.
+    expect(
+      totals.Inactive + totals.Employed,
+      `Status filter must partition the ${baselineTotal} employees — got ` +
+        `${totals.Inactive} Inactive + ${totals.Employed} Employed`,
+    ).toBe(baselineTotal);
   });
 
   test('2. single create — happy path derives code + username, employee lands', {
@@ -965,6 +1044,80 @@ the test is actually asserting.`,
 });
 
 // --- Helpers local to this spec ---
+
+/**
+ * The grid's own record count, read from its "Showing 1-10 of 65" footer.
+ *
+ * The footer is the only honest total on the page: the visible row count is
+ * capped by the page size (10), so a filter that narrows 65 -> 40 changes no
+ * row count at all. DigitDatagrid renders the footer only when total > 0, so an
+ * absent footer plus the empty state means a real zero; an absent footer with
+ * no empty state means the grid is mid-refetch (react-query unmounts the table
+ * while a new filter's query is pending) and the caller must retry.
+ */
+async function readTotal(page: Page): Promise<number | null> {
+  const footer = page.getByText(/Showing\s+\d+\s*[-–]\s*\d+\s+of\s+\d+/i).first();
+  if ((await footer.count()) > 0) {
+    const text = await footer.textContent({ timeout: 2_000 }).catch(() => null);
+    const m = text?.match(/of\s+(\d+)/i);
+    if (m) return Number(m[1]);
+  }
+  if ((await page.getByText(/No records found/i).count()) > 0) return 0;
+  return null;
+}
+
+/**
+ * readTotal() once the grid has stopped moving.
+ *
+ * For a total we can predict, prefer `expect.poll(() => readTotal(page))` —
+ * it retries a stale read away. This exists for the reads whose expected value
+ * is exactly what we are measuring (the per-status totals), where a stale read
+ * would otherwise be indistinguishable from a settled one. The grid debounces
+ * filter changes (~750ms measured), so we wait past that before sampling and
+ * then require two consecutive identical readings.
+ */
+async function settledTotal(page: Page, opts?: { settleMs?: number; timeoutMs?: number }): Promise<number> {
+  const settleMs = opts?.settleMs ?? 2_000;
+  const deadline = Date.now() + (opts?.timeoutMs ?? 20_000);
+  await page.waitForTimeout(settleMs);
+  let previous: number | null = null;
+  while (Date.now() < deadline) {
+    const current = await readTotal(page);
+    if (current !== null && current === previous) return current;
+    previous = current;
+    await page.waitForTimeout(400);
+  }
+  throw new Error(
+    `the employee grid never settled on a record count (last read: ${previous ?? 'none — no footer and no empty state'})`,
+  );
+}
+
+/**
+ * An employee code that identifies exactly ONE record on this deployment.
+ *
+ * The quick-search filter matches the whole serialized record
+ * (dataProvider clientFilter: `JSON.stringify(record).includes(q)`), not just
+ * the code column, so plenty of real codes are useless as a narrowing probe:
+ * searching `ADMIN` on the local stack returns all 65 rows, because every
+ * employee's jurisdiction hierarchy is `MAPUTO_ADMIN`. Uniqueness is checked
+ * against the same record set the grid itself lists (HRMS at TENANT_CODE,
+ * limit 500 — the page size hrmsGetList uses), and candidates are walked in
+ * sorted order so the choice is deterministic across runs.
+ */
+async function pickUniqueEmployeeCode(): Promise<string | null> {
+  const auth = loadAuth();
+  const employees = await employeeSearch(auth, TENANT_CODE, { limit: 500 });
+  const serialized = employees.map((e) => JSON.stringify(e).toLowerCase());
+  const codes = employees
+    .map((e) => String(e.code ?? ''))
+    .filter(Boolean)
+    .sort((a, b) => a.localeCompare(b));
+  for (const code of codes) {
+    const needle = code.toLowerCase();
+    if (serialized.filter((s) => s.includes(needle)).length === 1) return code;
+  }
+  return null;
+}
 
 interface BulkRow {
   employeeCode: string;

--- a/tests/integration-tests/tests/admin/localization.spec.ts
+++ b/tests/integration-tests/tests/admin/localization.spec.ts
@@ -48,15 +48,16 @@ test.afterAll(async () => {
 });
 
 test.describe('manage/localization', () => {
-  test('1. tenant parity — both ke and ke.nairobi return the same rainmaker-common en_IN count', {
+  test('1. tenant parity — root and city tenants serve a coherent rainmaker-common en_IN bundle', {
     annotation: {
       type: 'description',
-      description: `Tenant-parity guard: localization counts at root tenant (ke) and city tenant (ke.nairobi) for rainmaker-common / en_IN must match within ±2 rows. Probed 2026-04-23 at 4,259 rows on each. Tiny skew is tolerated to absorb seed/inline-edit churn.
+      description: `Tenant-parity guard: localization counts at root tenant and city tenant for rainmaker-common / en_IN must be coherent. On a FLAT deployment (root tenant IS the city tenant — the same tenant queried twice) the two counts must match EXACTLY. On a TWO-LEVEL deployment (root != city, e.g. mz / mz.maputo) the localization service resolves the city bundle as root rows PLUS city-specific additions (measured on mz/mz.maputo: 5,789 root rows vs 6,224 city rows — the city adds 435 city-specific rows), so a strict ±2 parity assert is a flat-deployment (Kenya-seed) convention, not a portable service contract. The portable contract this test enforces instead: the city bundle must be AT LEAST as complete as the root's — a city count BELOW root means city-level lookups lost inherited rows, which is the actual regression this test guards against.
 
 Steps:
 1. In parallel, locSearch(TENANT_CODE, 'en_IN', 'rainmaker-common') and locSearch(CITY_TENANT, 'en_IN', 'rainmaker-common').
 2. Assert keRows.length > 100.
-3. Assert |keRows.length - cityRows.length| <= 2.
+3. If TENANT_CODE === CITY_TENANT (flat deployment): assert cityRows.length === keRows.length exactly.
+   Else (two-level deployment): assert cityRows.length >= keRows.length.
 
 Catches a regression where city-level localization stops inheriting from root, or where one tenant gets a partial seed.`,
     },
@@ -75,8 +76,17 @@ Catches a regression where city-level localization stops inheriting from root, o
       'rainmaker-common en_IN not seeded on this deployment (localization bundle not loaded)',
     );
     expect(keRows.length).toBeGreaterThan(100);
-    // ±2 slack — seed / inline-edit churn can create tiny skew.
-    expect(Math.abs(keRows.length - cityRows.length)).toBeLessThanOrEqual(2);
+    if (TENANT_CODE === CITY_TENANT) {
+      // Flat deployment: same tenant queried twice must agree exactly.
+      expect(cityRows.length).toBe(keRows.length);
+    } else {
+      // Two-level deployment: the localization service resolves city = root
+      // rows + city-specific additions (measured on mz/mz.maputo: 5,789 vs
+      // 6,224), so the city bundle must be at least as complete as the
+      // root's. A city count BELOW root means city-level lookups lost
+      // inherited rows — the actual regression this test guards.
+      expect(cityRows.length).toBeGreaterThanOrEqual(keRows.length);
+    }
   });
 
   test('2. upsert + cache-bust round-trip — value lands after bust, not before', {

--- a/tests/integration-tests/tests/admin/localization.spec.ts
+++ b/tests/integration-tests/tests/admin/localization.spec.ts
@@ -85,7 +85,18 @@ Catches a regression where city-level localization stops inheriting from root, o
       // 6,224), so the city bundle must be at least as complete as the
       // root's. A city count BELOW root means city-level lookups lost
       // inherited rows — the actual regression this test guards.
-      expect(cityRows.length).toBeGreaterThanOrEqual(keRows.length);
+      // Exclude rows this SUITE generated. Tenant-onboarding specs upsert
+      // TENANT_TENANTS_<ROOT>_PWT… labels at the ROOT only, so a full run leaves
+      // root ahead of city by exactly those transient artifacts and the parity
+      // check fails for a reason that has nothing to do with inheritance.
+      // Compare the real deployment bundle instead.
+      const isSuiteArtifact = (code: string) => /(^|_)PW[T_]/i.test(code);
+      const rootReal = keRows.filter((r) => !isSuiteArtifact(String(r.code ?? '')));
+      const cityReal = cityRows.filter((r) => !isSuiteArtifact(String(r.code ?? '')));
+      expect(
+        cityReal.length,
+        `city bundle lost inherited rows (root ${rootReal.length} vs city ${cityReal.length})`,
+      ).toBeGreaterThanOrEqual(rootReal.length);
     }
   });
 

--- a/tests/integration-tests/tests/admin/localization.spec.ts
+++ b/tests/integration-tests/tests/admin/localization.spec.ts
@@ -243,17 +243,17 @@ Loose label-match tolerates minor copy tweaks. The 10-row threshold avoids britt
 Steps:
 1. Generate a unique code; track for cleanup.
 2. locUpsert with 'seeded-english'; locCacheBust.
-3. Navigate to /manage/localization; wait for networkidle.
-4. If a search input exists, type the code; wait networkidle.
-5. test.skip if the seeded row isn't visible (virtualization edge case).
+3. Navigate to /manage/localization.
+4. Type the code into the search input.
+5. Wait (auto-retrying) for the seeded row — the grid debounces its refetch.
 6. Set up a waitForRequest promise for the /_upsert POST.
-7. Click the cell containing 'seeded-english'; test.skip if not reachable.
-8. Locate the focused input/textarea; test.skip if not focused.
+7. DOUBLE-click the <td> holding 'seeded-english' — DigitDatagrid arms editing from the cell's onDoubleClick, and the value span is pointer-events-none.
+8. Assert the autofocused input is visible.
 9. Fill 'edited-english'; press Enter.
 10. Assert the upsert XHR resolved truthy.
 11. locCacheBust then locSearch; assert updated.message === 'edited-english'.
 
-Skips gracefully when UI layout shifts make the click target unreachable — better than failing on cosmetic refactors.`,
+Every step is a hard assertion: the previous version had three test.skip guards here (row not surfaced / cell not reachable / no focused input) which turned a real interaction contract into an unconditional self-skip.`,
     },
     tag: ['@area:configurator-manage', '@area:localization', '@kind:regression', '@layer:ui', '@persona:admin'] }, async ({
     page,
@@ -274,20 +274,22 @@ Skips gracefully when UI layout shifts make the click target unreachable — bet
     await page.goto(LIST_PATH);
     await page.waitForLoadState('networkidle').catch(() => {});
 
-    // Search for our seeded code — UI has a text filter on code.
+    // Search for our seeded code — the list's `q` filter is a full-record
+    // substring match (dataProvider.clientFilter), so the code finds the row.
     const search = page.getByPlaceholder(/search/i).first();
-    if (await search.isVisible().catch(() => false)) {
-      await search.fill(code);
-      await page.waitForLoadState('networkidle').catch(() => {});
-    }
+    await expect(search).toBeVisible();
+    await search.fill(code);
 
+    // DigitList.handleSearchChange calls setFilters(..., undefined, true) — a
+    // DEBOUNCED refetch — and typing in an SPA triggers no navigation, so the
+    // page's load state is already 'networkidle' and waitForLoadState() returns
+    // in ~0.2 ms. The old one-shot `isVisible()` guard therefore read the grid
+    // mid-debounce (rows were measured going 11 -> 2 across a 4 s window) and
+    // self-skipped on a row that does surface. Auto-retrying expect instead.
+    // The localization list refetches EVERY locale bundle on each filter change
+    // (~7 s cold), hence the generous budget.
     const row = page.getByRole('row').filter({ hasText: code }).first();
-    // If the pivot view hides non-matching rows via virtualization, we may
-    // need to click the row to reach the edit cell; otherwise inline
-    // edit is the standard react-admin EditableCell.
-    if (!(await row.isVisible().catch(() => false))) {
-      test.skip(true, 'Seeded row not surfaced in the list within networkidle — skipping inline edit');
-    }
+    await expect(row).toBeVisible({ timeout: 45_000 });
 
     // Capture the upsert XHR. The inline-edit path upserts but does NOT
     // fire a cache-bust (that's only done by the API-level save helper), so
@@ -297,18 +299,20 @@ Skips gracefully when UI layout shifts make the click target unreachable — bet
       { timeout: 15_000 },
     ).catch(() => null);
 
-    // Click the en_IN cell for our row and edit.
-    // Style: click the row's English column cell to enter edit mode.
-    const editCell = row.getByText('seeded-english').first();
-    if (!(await editCell.isVisible().catch(() => false))) {
-      test.skip(true, 'Editable cell not reachable via text match — UI layout changed');
-    }
-    await editCell.click();
+    // Arm inline editing on the en_IN cell for our row. Two things matter here
+    // (both learned the hard way once the row above actually started
+    // surfacing): DigitDatagrid arms editing from the CELL's onDoubleClick —
+    // a single click falls through to the row handler and navigates to the
+    // show page — and the rendered value <span> carries `pointer-events-none`
+    // when the column is editable, so the event must be dispatched on the
+    // <td>, not on the text node inside it.
+    const editCell = row.getByRole('cell').filter({ hasText: 'seeded-english' }).first();
+    await expect(editCell).toBeVisible();
+    await editCell.dblclick();
 
+    // EditableCell autofocuses its <input> as soon as editing opens.
     const input = page.locator('input:focus, textarea:focus').first();
-    if (!(await input.isVisible().catch(() => false))) {
-      test.skip(true, 'No editable input focused after cell click — layout changed');
-    }
+    await expect(input).toBeVisible({ timeout: 10_000 });
     await input.fill('edited-english');
     await input.press('Enter');
 
@@ -331,13 +335,13 @@ Skips gracefully when UI layout shifts make the click target unreachable — bet
 Steps:
 1. Generate a unique code; track for cleanup.
 2. locUpsert english-only at TENANT_CODE / en_IN; locCacheBust. NO other-locale counterpart.
-3. Navigate to /manage/localization; wait for networkidle.
-4. If a search input exists, type the code; wait networkidle.
-5. test.skip if the row isn't visible.
+3. Navigate to /manage/localization.
+4. Type the code into the search input.
+5. Wait (auto-retrying) for the seeded row — the grid debounces its refetch.
 6. Read row textContent.
 7. Assert it matches /[—–]|---/ (em-dash, en-dash, or triple-hyphen).
 
-Skips gracefully if virtualization hides the row — UI behavior here is best-effort.`,
+Step 5 used to be a one-shot isVisible() check that self-skipped the assertion; it is now a hard wait, so a missing placeholder is reported rather than skipped over.`,
     },
     tag: ['@area:configurator-manage', '@area:localization', '@kind:edge-case', '@layer:ui', '@persona:admin'] }, async ({ page }, testInfo) => {
     // Seed an en_IN row but NO counterpart in the other locales. The pivoted
@@ -357,15 +361,15 @@ Skips gracefully if virtualization hides the row — UI behavior here is best-ef
     await page.waitForLoadState('networkidle').catch(() => {});
 
     const search = page.getByPlaceholder(/search/i).first();
-    if (await search.isVisible().catch(() => false)) {
-      await search.fill(code);
-      await page.waitForLoadState('networkidle').catch(() => {});
-    }
+    await expect(search).toBeVisible();
+    await search.fill(code);
 
+    // Same debounce race as test 5: setFilters(..., undefined, true) refetches
+    // asynchronously and waitForLoadState('networkidle') is a no-op after an
+    // SPA keystroke, so a one-shot isVisible() check self-skipped on a row that
+    // does eventually render. Let expect auto-retry through the debounce.
     const row = page.getByRole('row').filter({ hasText: code }).first();
-    if (!(await row.isVisible().catch(() => false))) {
-      test.skip(true, 'Seeded row not surfaced in list — skipping dash assertion');
-    }
+    await expect(row).toBeVisible({ timeout: 45_000 });
 
     const rowText = (await row.textContent()) || '';
     // em-dash (U+2014) OR en-dash (U+2013) OR triple-hyphen — accept any
@@ -373,38 +377,83 @@ Skips gracefully if virtualization hides the row — UI behavior here is best-ef
     expect(rowText).toMatch(/[—–]|---/);
   });
 
-  test('7. module filter narrows rows', {
+  test('7. module filter narrows rows to the selected module', {
     annotation: {
       type: 'description',
-      description: `Validates the Module filter on the localization comparator: picking a module option must produce at most as many rows as the unfiltered view (could be equal if the tenant only has rows in one module).
+      description: `Validates the Module filter on the localization comparator: picking a module must leave the grid rendering ONLY that module's rows.
 
 Steps:
-1. Navigate to /manage/localization; wait for networkidle.
-2. Locate getByLabel(/^Module/i); test.skip if not visible.
-3. Read initialRows count.
-4. Click the filter; click the first option; wait for networkidle.
-5. Read filteredRows count.
-6. Assert filteredRows <= initialRows.
+1. Navigate to /manage/localization; wait for the grid to render data rows.
+2. Read the distinct values of the \`module\` column currently on screen.
+3. Locate the Module trigger via getByRole('combobox').filter({ hasText: /module/i }) and open it.
+4. Read the option labels; keep those that are a bare module code (drop the "All modules" sentinel — selecting it is a no-op — and the "Pretty Name (code)" labels) and that differ from what is already on screen.
+5. Over the localization API, pick the first such module that actually has messages on this deployment, so the UI assertion below cannot pass by rendering an empty grid.
+6. Select it; poll (the grid debounces) until the module column holds exactly that one value.
+7. Assert the filtered grid still renders at least one row.
 
-Tolerates the single-module edge case (filter doesn't narrow anything) — only fails if the count actually grows after filter, which would indicate filter logic is broken.`,
+Previously this used getByLabel(/^Module/i), which matched NOTHING — LocalizationList's ModuleSelector renders the caption as a bare <span>Module:</span> next to a Radix SelectTrigger with no <label for> — so the test self-skipped on every deployment. It also clicked getByRole('option').first(), i.e. the "All modules" sentinel, which filters nothing.`,
     },
     tag: ['@area:configurator-manage', '@area:localization', '@kind:regression', '@layer:ui', '@persona:admin'] }, async ({ page }) => {
     await page.goto(LIST_PATH);
-    await page.waitForLoadState('networkidle').catch(() => {});
+    // Cold load refetches every locale bundle (~7 s).
+    await expect(page.getByRole('table').first()).toBeVisible({ timeout: 60_000 });
 
-    const moduleFilter = page.getByLabel(/^Module/i).first();
-    if (!(await moduleFilter.isVisible().catch(() => false))) {
-      test.skip(true, 'Module filter not present on this build');
-    }
+    // Header rows carry role=columnheader; data rows carry role=cell.
+    const dataRows = page.getByRole('row').filter({ has: page.getByRole('cell') });
+    await expect.poll(() => dataRows.count(), { timeout: 45_000 }).toBeGreaterThan(0);
 
-    const initialRows = await page.getByRole('row').count();
+    // Distinct values of the `module` column (2nd column per MultiLocaleDatagrid).
+    const modulesOnPage = async (): Promise<string[]> => {
+      const cells = await dataRows.evaluateAll((rows) =>
+        rows.map((r) => (r.querySelectorAll('td')[1]?.textContent ?? '').trim()),
+      );
+      return Array.from(new Set(cells.filter(Boolean)));
+    };
+
+    const before = await modulesOnPage();
+    expect(before.length, 'unfiltered grid should render module values').toBeGreaterThan(0);
+
+    // ModuleSelector's caption is a bare <span>Module:</span>, NOT a <label for>,
+    // so getByLabel(/^Module/i) matched nothing and this test used to self-skip.
+    // The Radix SelectTrigger is exposed as role=combobox and renders its current
+    // value ("All modules" while unfiltered) — match on that.
+    const moduleFilter = page.getByRole('combobox').filter({ hasText: /module/i }).first();
+    await expect(moduleFilter).toBeVisible();
     await moduleFilter.click();
-    await page.getByRole('option').first().click();
-    await page.waitForLoadState('networkidle').catch(() => {});
 
-    const filteredRows = await page.getByRole('row').count();
-    // The filter either narrows rows or leaves them equal (single module).
-    expect(filteredRows).toBeLessThanOrEqual(initialRows);
+    // MODULE_OPTIONS mixes bare codes ("rainmaker-pgr") with decorated labels
+    // ("Configurator UI (configurator-ui)") and an "All modules" sentinel.
+    // Keep only bare codes we aren't already looking at — picking the sentinel
+    // filters nothing and would make this test vacuous.
+    const candidates = (await page.getByRole('option').allTextContents())
+      .map((t) => t.trim())
+      .filter((t) => /^[a-z0-9][a-z0-9-]*$/i.test(t) && !before.includes(t));
+
+    const auth = loadAuth();
+    let target = '';
+    for (const candidate of candidates) {
+      if ((await locSearch(auth, TENANT_CODE, 'en_IN', candidate)).length > 0) {
+        target = candidate;
+        break;
+      }
+    }
+    // Data gap, not an app bug: a deployment seeded with a single module has no
+    // second module to switch to.
+    test.skip(
+      !target,
+      `no second populated module on this deployment (grid already showing ${JSON.stringify(before)})`,
+    );
+
+    await page.getByRole('option', { name: target, exact: true }).click();
+
+    // setFilters(..., undefined, true) debounces, and selecting an option in an
+    // SPA fires no navigation — waitForLoadState('networkidle') would return in
+    // ~0.2 ms, before React had dispatched the refetch. Poll the rendered column.
+    await expect.poll(modulesOnPage, { timeout: 60_000 }).toEqual([target]);
+    expect(
+      await dataRows.count(),
+      'filtered grid should still render rows',
+    ).toBeGreaterThan(0);
   });
 });
 

--- a/tests/integration-tests/tests/admin/recently-shipped-fixes.spec.ts
+++ b/tests/integration-tests/tests/admin/recently-shipped-fixes.spec.ts
@@ -21,7 +21,7 @@
  */
 import { test, expect } from '@playwright/test';
 import { getDigitToken, loginViaApi } from '../utils/auth';
-import { BASE_URL, TENANT, ROOT_TENANT, ADMIN_USER, ADMIN_PASS } from '../utils/env';
+import { BASE_URL, TENANT, ROOT_TENANT, ADMIN_USER, ADMIN_PASS, LOCALES } from '../utils/env';
 
 const HRMS_SEARCH = `${BASE_URL}/egov-hrms/employees/_search`;
 const PGR_SEARCH = `${BASE_URL}/pgr-services/v2/request/_search`;
@@ -59,6 +59,55 @@ async function swKeSeeded(): Promise<boolean> {
     return (json.messages ?? []).length > 0;
   } catch {
     return false;
+  }
+}
+
+/**
+ * The `COMPLAINT_HIERARCHY.<code>` localization keys this deployment should carry
+ * — derived from its own hierarchy rather than pinned to one rollout's codes.
+ *
+ * RAINMAKER-PGR.ComplaintHierarchy is a single adjacency list holding both the
+ * interior CATEGORY nodes and the leaf complaint types. A leaf carries
+ * `department`/`slaHours`; an interior node carries neither. It's the interior
+ * nodes that render as the dropdown's group headings, which is exactly what
+ * CCRS#42 saw come out blank.
+ */
+async function categoryCodes(): Promise<string[]> {
+  try {
+    const token = await adminToken();
+    const r = await fetch(
+      `${BASE_URL}/mdms-v2/v2/_search?tenantId=${ROOT_TENANT}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          RequestInfo: { authToken: token },
+          MdmsCriteria: {
+            tenantId: ROOT_TENANT,
+            schemaCode: 'RAINMAKER-PGR.ComplaintHierarchy',
+            limit: 500,
+            isActive: true,
+          },
+        }),
+      },
+    );
+    const json = await r.json();
+    const rows: Array<{ data?: Record<string, unknown> }> = json.mdms ?? [];
+    const interior = rows
+      .map((row) => row.data ?? {})
+      .filter((d) => d.department === undefined && d.slaHours === undefined)
+      .map((d) => String(d.code ?? ''))
+      // Exclude the suite's OWN leftovers. complaint-types.spec.ts creates
+      // `PWAUTHORITYTYPE…` / `PWMAINCATEGORY…` / `PWSECTOR…` nodes and they are
+      // never torn down, so on a long-lived box they outnumber the real tree by
+      // 150:1. They have no localization and never will — asserting on them would
+      // fail this test forever, and the sheer count also blew the localization
+      // query past nginx's URL limit (10 kB of codes → a 414 HTML page).
+      .filter((c) => c && !/(^|_)PW[A-Z_]/i.test(c));
+    // Codes are seeded upper-cased into the localization key namespace.
+    return Array.from(new Set(interior.map((c) => `COMPLAINT_HIERARCHY.${c.toUpperCase()}`)));
+  } catch {
+    return [];
   }
 }
 
@@ -302,41 +351,60 @@ If this row goes missing or its copy changes, several PGR UI tests in this suite
 // /localization/messages with module=rainmaker-common,locale=sw_KE and
 // short-circuit if rows === 0) instead of asserting unconditionally.
 test.describe('CCRS#42 — Complaint Type category labels', () => {
-  test('API: 19 SERVICEDEFS.<categoryCode> rows exist in en_IN AND sw_KE', {
+  test('API: every COMPLAINT_HIERARCHY.<categoryCode> row is labelled in every advertised locale', {
     annotation: {
       type: 'description',
-      description: `Catches CCRS#42 (Complaint Type dropdown blank rows). The 19 SERVICEDEFS.<CATEGORYCODE> localization rows must exist in BOTH en_IN and sw_KE locales. These category codes are the parentCode values of the leaf complaint types (interior category nodes of RAINMAKER-PGR.ComplaintHierarchy) — they replaced the legacy menuPath grouping key, but the localization key form SERVICEDEFS.<code> is unchanged. Pre-fix the configurator's complaint type seed didn't push these keys, so the citizen dropdown rendered 19 blank group options.
+      description: `Catches CCRS#42 (Complaint Type dropdown blank rows). Every category node of RAINMAKER-PGR.ComplaintHierarchy must have a COMPLAINT_HIERARCHY.<CODE> localization row in every locale the deployment advertises. These category codes are the parentCode values of the leaf complaint types — they replaced the legacy menuPath grouping key (and the legacy SERVICEDEFS.<code> namespace). Pre-fix the configurator's complaint type seed didn't push these keys, so the citizen dropdown rendered blank group options.
 
 Steps:
-1. For each locale in [en_IN, sw_KE]:
-   - POST /localization/messages/v1/_search with codes for ADMINISTRATION, WATERRELATED, LANDRATES, MOBILITYANDWORKS, FINANCEANDREVENUE.
-   - For each requested code, find the matching message in response.
-   - Assert message exists with non-empty text.
+1. Read RAINMAKER-PGR.ComplaintHierarchy from MDMS and keep the INTERIOR nodes — those carrying neither department nor slaHours. Leaves are complaint types, not categories.
+2. Drop the suite's own PW* leftovers (complaint-types.spec.ts creates and never removes them).
+3. Skip if the deployment has no category nodes at all.
+4. For each locale in LOCALES, POST /localization/messages/v1/_search in chunks of 40 codes and assert each code resolves to a non-empty message.
 
-Tests 5 representative codes across the 19 category (parentCode) values — fewer assertions but covers the full breadth via locale × multiple codes.`,
+Deployment-agnostic by construction: it asserts on whatever hierarchy the tenant
+actually has, in whatever locales it actually advertises. The previous version
+pinned Kenya's five rollout codes (ADMINISTRATION, WATERRELATED, LANDRATES,
+MOBILITYANDWORKS, FINANCEANDREVENUE) and the sw_KE locale, so it failed on the
+first locale of any non-Kenya tenant — and its skip-guard probed sw_KE row counts,
+which is unrelated to whether those codes exist.`,
     },
     tag: ['@area:configurator-manage', '@ccrs:42', '@kind:regression', '@layer:api', '@persona:admin'] }, async () => {
-    test.skip(!(await swKeSeeded()), 'sw_KE (CCRS Kenya rollout) locale not seeded on this deployment');
     // Complaint-type labels moved off the legacy SERVICEDEFS.* namespace to
     // key-based COMPLAINT_HIERARCHY.<categoryCode> (seeded for every node).
-    const codes = [
-      'COMPLAINT_HIERARCHY.ADMINISTRATION',
-      'COMPLAINT_HIERARCHY.WATERRELATED',
-      'COMPLAINT_HIERARCHY.LANDRATES',
-      'COMPLAINT_HIERARCHY.MOBILITYANDWORKS',
-      'COMPLAINT_HIERARCHY.FINANCEANDREVENUE',
-    ];
-    for (const locale of ['en_IN', 'sw_KE']) {
-      const r = await fetch(
-        `${LOC_SEARCH}?codes=${codes.join(',')}&tenantId=${ROOT_TENANT}&locale=${locale}`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ RequestInfo: { authToken: '' } }),
-        },
-      );
-      const json = await r.json();
-      const messages: Array<{ code: string; message: string }> = json.messages ?? [];
+    //
+    // The category codes are read from THIS deployment's own hierarchy, not
+    // pinned to Kenya's rollout. The previous list (ADMINISTRATION, WATERRELATED,
+    // LANDRATES, MOBILITYANDWORKS, FINANCEANDREVENUE) exists only on ke, so on any
+    // other tenant this failed on the very first locale — and the old
+    // `swKeSeeded()` guard could not save it, because it probes whether the sw_KE
+    // LOCALE has rows, which is unrelated to whether the Kenya HIERARCHY exists.
+    const codes = await categoryCodes();
+    test.skip(
+      codes.length === 0,
+      'deployment has no interior ComplaintHierarchy nodes to label',
+    );
+    // Only assert locales this deployment actually advertises — asserting sw_KE
+    // on a non-Kenya tenant is the same pinning mistake in a different field.
+    for (const locale of LOCALES) {
+      // Codes go in the query string, so request them in chunks — a deployment
+      // with a broad hierarchy would otherwise exceed nginx's request-line limit
+      // and get back an HTML 414 that fails as an opaque JSON parse error.
+      const messages: Array<{ code: string; message: string }> = [];
+      for (let i = 0; i < codes.length; i += 40) {
+        const chunk = codes.slice(i, i + 40);
+        const r = await fetch(
+          `${LOC_SEARCH}?codes=${chunk.join(',')}&tenantId=${ROOT_TENANT}&locale=${locale}`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ RequestInfo: { authToken: '' } }),
+          },
+        );
+        expect(r.ok, `localization _search failed for ${locale} (HTTP ${r.status})`).toBeTruthy();
+        const json = await r.json();
+        messages.push(...((json.messages ?? []) as Array<{ code: string; message: string }>));
+      }
       for (const code of codes) {
         const row = messages.find((m) => m.code === code);
         expect(row, `${code} missing in ${locale}`).toBeTruthy();

--- a/tests/integration-tests/tests/admin/tenants.spec.ts
+++ b/tests/integration-tests/tests/admin/tenants.spec.ts
@@ -93,36 +93,67 @@ Catches a regression where TenantList.tsx loses a column or the data provider re
   test('2. search filter narrows to a known tenant code', {
     annotation: {
       type: 'description',
-      description: `End-to-end search-filter test on the tenants list: typing the configured CITY_TENANT code must narrow the grid to a row containing that code; typing a nonsense code must drop the grid to zero data rows. Drives the actual placeholder-matching search input the operator uses.
+      description: `End-to-end search-filter test on the tenants list: typing a REAL tenant code (discovered live over MDMS) must drop every non-matching row from the grid while keeping the matching one; typing a nonsense code must drop the grid to zero data rows.
 
 Steps:
-1. Navigate to /configurator/manage/tenants.
-2. Locate getByPlaceholder(/search/i); assert visible.
-3. Fill CITY_TENANT; wait for networkidle.
-4. Assert at least one row matching CITY_TENANT is visible.
-5. Clear and type "zzz_no_such_tenant_xyz"; wait for networkidle.
-6. Assert getByRole('row').filter({ hasText: 'zzz_no_such_tenant_xyz' }) has count === 0.
+1. mdmsSearch tenant.tenants; pick an active, non-suite-artifact code (prefer CITY_TENANT).
+2. Navigate to /configurator/manage/tenants; wait for the grid to render data rows.
+3. Record how many rendered rows do NOT contain the target code (the narrowing we are about to observe). Skip only if the deployment has a single tenant, where narrowing is unobservable.
+4. Fill the search input with the target code.
+5. Poll (the grid debounces) until zero rendered rows lack the target code.
+6. Assert at least one row containing the target code is still rendered — so an empty grid can't pass step 5.
+7. Clear and type a nonsense code; poll until the grid holds zero data rows.
 
-Confirms the search input feeds into the data provider's filter and the grid re-renders accordingly.`,
+Previously this asserted \`rows.filter({hasText:'zzz_no_such_tenant_xyz'}).count() === 0\` — a literal no tenant row could ever contain, so the assertion held whether or not the search input did anything at all (deleting the fill left it green). Both halves are now mutation-sensitive.`,
     },
     tag: ['@area:configurator-manage', '@kind:regression', '@layer:ui', '@persona:admin'] }, async ({ page }) => {
+    // Discover a real code live rather than pinning a deployment literal.
+    // Prefer the configured CITY_TENANT; otherwise any active city-level code.
+    // The ROOT code is deliberately excluded as a target: it is a prefix of
+    // every city code, so searching for it matches every row and could never
+    // demonstrate narrowing.
+    const auth = loadAuth();
+    const active = (await mdmsSearch(auth, TENANT_CODE, SCHEMA, { limit: 200 }))
+      .filter((r) => r.isActive !== false)
+      .map((r) => r.uniqueIdentifier)
+      .filter((c) => c !== TENANT_CODE);
+    const target = active.includes(CITY_TENANT) ? CITY_TENANT : active[0];
+    expect(target, 'deployment must expose at least one active city tenant').toBeTruthy();
+
     await page.goto(LIST_PATH);
+
+    // Header rows carry role=columnheader, data rows carry role=cell.
+    const dataRows = page.getByRole('row').filter({ has: page.getByRole('cell') });
+    await expect.poll(() => dataRows.count(), { timeout: 30_000 }).toBeGreaterThan(0);
+
+    const nonMatching = dataRows.filter({ hasNotText: target });
+    const nonMatchingBefore = await nonMatching.count();
+    test.skip(
+      nonMatchingBefore === 0,
+      `every rendered tenant row already matches ${target} — narrowing is unobservable on a single-tenant deployment`,
+    );
 
     const search = page.getByPlaceholder(/search/i).first();
     await expect(search).toBeVisible();
-    await search.fill(CITY_TENANT);
-    await page.waitForLoadState('networkidle').catch(() => {});
+    await search.fill(target);
 
-    await expect(
-      page.getByRole('row').filter({ hasText: CITY_TENANT }).first(),
-    ).toBeVisible();
+    // DigitList.handleSearchChange calls setFilters(..., undefined, true) —
+    // a DEBOUNCED refetch. Typing fires no navigation either, so the page's
+    // load state is already 'networkidle' and waitForLoadState() returns in
+    // ~0.2 ms, long before React has dispatched the new query. Poll instead.
+    await expect
+      .poll(() => nonMatching.count(), { timeout: 30_000 })
+      .toBe(0);
+    // ...and the grid must not have simply emptied itself.
+    expect(
+      await dataRows.filter({ hasText: target }).count(),
+      `searching for ${target} should keep its own row`,
+    ).toBeGreaterThan(0);
 
     // A nonsense code should drop us to empty-state (zero data rows).
     await search.fill('');
     await search.fill('zzz_no_such_tenant_xyz');
-    await page.waitForLoadState('networkidle').catch(() => {});
-    const rows = page.getByRole('row').filter({ hasText: 'zzz_no_such_tenant_xyz' });
-    expect(await rows.count()).toBe(0);
+    await expect.poll(() => dataRows.count(), { timeout: 30_000 }).toBe(0);
   });
 
   test('3. show page renders Code / Name / City / District for a known tenant', {
@@ -273,12 +304,10 @@ Teardown is API-only — no UI delete for tenants. Soft-delete via cleanupMdms w
     tag: ['@area:configurator-manage', '@kind:regression', '@layer:ui', '@persona:admin'] }, async ({
     page,
   }, testInfo) => {
-    // Onboarding-data gap: tenant.tenants _create now requires emailId + imageId
-    // (city-setup enriches these). This minimal MDMS payload omits them, so the
-    // create is rejected on a stock deployment. Left skipped rather than faked —
-    // re-enable once the create helper seeds emailId/imageId (or drive the
-    // city-setup wizard) so the row lands.
-    test.skip(true, 'tenant.tenants create requires emailId/imageId not provided by this minimal payload');
+    // (Previously skipped with "tenant.tenants create requires emailId/imageId".
+    // That was wrong: the live schema declares required: ['code','name'] and
+    // emailId / imageId as optional nullable strings, and a minimal _create
+    // returns "status":"successful". Re-enabled 2026-07-27.)
     const auth = loadAuth();
     const code = `${TENANT_CODE}.${testCode(testInfo, 'TNT').toLowerCase().replace(/^pw_/, 'pw')}`;
     createdCodes.add(code);

--- a/tests/integration-tests/tests/admin/theme-applied.spec.ts
+++ b/tests/integration-tests/tests/admin/theme-applied.spec.ts
@@ -1,54 +1,124 @@
 import { test, expect } from '@playwright/test';
 import { BASE_URL } from '../utils/env';
 
+/** The stock DIGIT orange shipped in `digit-ui-esbuild/src/theme/default.json`.
+ *  `src/index.js` calls `applyTheme(defaultTheme)` SYNCHRONOUSLY at bundle load,
+ *  so this is what `--color-primary-main` holds until the MDMS override lands. */
+const STOCK_DIGIT_ORANGE = '#c84c0e';
+
+/** Shape of the `common-masters.ThemeConfig` MDMS record we care about. */
+interface ThemeConfigRecord {
+  colors?: {
+    primary?: { main?: string; dark?: string };
+    digitv2?: Record<string, string>;
+    text?: { primary?: string };
+    border?: string;
+  };
+}
+
 test('MDMS ThemeConfig is fetched and applied as CSS variables', {
   annotation: {
     type: 'description',
-    description: `End-to-end check that the MDMS ThemeConfig actually reaches the browser as CSS custom properties on :root. The citizen login page is the simplest place to test — it triggers theme fetch on load. Reads --color-primary-main, --color-primary-dark, --color-digitv2-header-sidenav, etc. and asserts they are non-empty AND not the default DIGIT orange (#c84c0e — that would mean the MDMS override never landed).
+    description: `End-to-end check that the MDMS ThemeConfig actually reaches the browser as CSS custom properties on :root. The citizen login page is the simplest place to test — StoreService.digitInitData() fetches MDMS on load and calls window.Digit.applyTheme(themeConfig).
+
+Two independent halves, so a green means both "fetched" and "applied":
+1. FETCHED — capture the /egov-mdms-service/v1/_search response the app itself makes and pull common-masters.ThemeConfig[0] out of it. That record IS the expectation; nothing is hardcoded.
+2. APPLIED — poll getComputedStyle(:root) until the five CSS custom properties EQUAL the colours in that record.
 
 Steps:
-1. setTimeout 60s; navigate to /digit-ui/citizen/login, wait 8s for theme apply.
-2. evaluate getComputedStyle on :root; grab five CSS custom properties.
-3. Log the captured theme vars.
-4. Assert primaryMain, primaryDark, and headerSidenav are all truthy.
-5. Assert primaryMain and headerSidenav lowercased are NOT '#c84c0e' (default orange must be overridden).
-6. Assert all three colors match /^#[0-9a-f]{6}$/i.
+1. Attach a response listener for any /v1/_search that captures a body carrying MdmsRes['common-masters'].ThemeConfig[0]. (The MDMS context path is a globalConfig — egov-mdms-service on some deployments, mdms-v2 on others — so the body shape, not the path, identifies the call.)
+2. Navigate to /digit-ui/citizen/login.
+3. expect.poll until the ThemeConfig has been captured (proves it was fetched).
+4. Assert the captured record actually overrides the stock DIGIT orange — otherwise step 5 would be tautological.
+5. expect.poll getComputedStyle(:root) until --color-primary-main / --color-primary-dark / --color-digitv2-header-sidenav / --color-text-primary / --color-border all equal the captured values.
 
-Catches the most common theme regression — MDMS fetch fails or the applyTheme() call is gated wrong, and the default orange leaks through to a Kenya deployment.`,
+Why polling and not a fixed sleep: applyTheme() runs TWICE. src/index.js applies the bundled default synchronously at load; StoreService.digitInitData() overwrites it only after the MDMS round-trip resolves. Reading at a fixed offset races that round-trip — the previous version slept 8s and flipped between pass and fail on the same commit. expect.poll re-reads until the override lands (or fails honestly at the timeout).
+
+Catches the most common theme regression — MDMS fetch fails or the applyTheme() call is gated wrong, and the default orange leaks through to a non-DIGIT-branded deployment.`,
   },
   tag: ['@area:configurator-manage', '@area:theme', '@kind:regression', '@layer:ui', '@persona:admin'] }, async ({ page }) => {
-  test.setTimeout(60_000);
+  test.setTimeout(90_000);
 
-  await page.goto(`${BASE_URL}/digit-ui/citizen/login`, { waitUntil: 'domcontentloaded' });
-  await page.waitForTimeout(8000);
-
-  // Read the CSS custom properties set on :root by applyTheme()
-  const themeVars = await page.evaluate(() => {
-    const root = document.documentElement;
-    const style = getComputedStyle(root);
-    return {
-      primaryMain: style.getPropertyValue('--color-primary-main').trim(),
-      primaryDark: style.getPropertyValue('--color-primary-dark').trim(),
-      headerSidenav: style.getPropertyValue('--color-digitv2-header-sidenav').trim(),
-      textPrimary: style.getPropertyValue('--color-text-primary').trim(),
-      border: style.getPropertyValue('--color-border').trim(),
-    };
+  // --- half 1: the app must FETCH a ThemeConfig ---
+  // Pushed into an array rather than a `let` so TypeScript doesn't narrow the
+  // capture to `null` (assignment happens inside the listener closure).
+  const captured: ThemeConfigRecord[] = [];
+  page.on('response', async (res) => {
+    // The MDMS context path is a globalConfig (MDMS_V1_CONTEXT_PATH), so it is
+    // `egov-mdms-service` on some deployments and `mdms-v2` on others — pinning
+    // either literal is a deployment pin. Match the versioned search path and
+    // let the MdmsRes body shape below do the actual identification.
+    if (!/\/v1\/_search(\?|$)/.test(res.url())) return;
+    try {
+      const body = (await res.json()) as {
+        MdmsRes?: { 'common-masters'?: { ThemeConfig?: ThemeConfigRecord[] } };
+      };
+      const cfg = body?.MdmsRes?.['common-masters']?.ThemeConfig?.[0];
+      if (cfg) captured.push(cfg);
+    } catch {
+      // Non-JSON / aborted response — not the init call we're after.
+    }
   });
 
-  console.log('Theme CSS variables:', themeVars);
+  await page.goto(`${BASE_URL}/digit-ui/citizen/login`, { waitUntil: 'domcontentloaded' });
 
-  // Verify theme was applied (not empty)
-  expect(themeVars.primaryMain).toBeTruthy();
-  expect(themeVars.primaryDark).toBeTruthy();
-  expect(themeVars.headerSidenav).toBeTruthy();
+  await expect
+    .poll(() => captured.length, {
+      timeout: 45_000,
+      message:
+        'the citizen shell must fetch common-masters.ThemeConfig from the MDMS v1 _search on load',
+    })
+    .toBeGreaterThan(0);
 
-  // Verify the default orange (#c84c0e) is NOT present — proves MDMS override worked
-  expect(themeVars.primaryMain.toLowerCase()).not.toBe('#c84c0e');
-  expect(themeVars.headerSidenav.toLowerCase()).not.toBe('#c84c0e');
+  const colors = captured[0].colors ?? {};
+  const expected = {
+    primaryMain: colors.primary?.main ?? '',
+    primaryDark: colors.primary?.dark ?? '',
+    headerSidenav: colors.digitv2?.['header-sidenav'] ?? '',
+    textPrimary: colors.text?.primary ?? '',
+    border: colors.border ?? '',
+  };
+  console.log('MDMS ThemeConfig colours:', expected);
 
-  // All color values must be valid hex
+  // The MDMS record itself must be a real, complete override. Without this
+  // guard the comparison below could "pass" against a half-empty record.
   const hexPattern = /^#[0-9a-f]{6}$/i;
-  expect(themeVars.primaryMain).toMatch(hexPattern);
-  expect(themeVars.primaryDark).toMatch(hexPattern);
-  expect(themeVars.headerSidenav).toMatch(hexPattern);
+  for (const [key, value] of Object.entries(expected)) {
+    expect(value, `MDMS ThemeConfig must define a hex colour for ${key}`).toMatch(hexPattern);
+  }
+  expect(
+    expected.primaryMain.toLowerCase(),
+    'MDMS ThemeConfig still carries the stock DIGIT orange — this deployment has no branding override, so this test could not distinguish "applied" from "never applied"',
+  ).not.toBe(STOCK_DIGIT_ORANGE);
+
+  // --- half 2: the browser must APPLY it to :root ---
+  // Polled, not slept on: index.js paints the bundled default synchronously and
+  // digitInitData() overwrites it only once the MDMS promise resolves.
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const style = getComputedStyle(document.documentElement);
+          const read = (name: string) => style.getPropertyValue(name).trim().toLowerCase();
+          return {
+            primaryMain: read('--color-primary-main'),
+            primaryDark: read('--color-primary-dark'),
+            headerSidenav: read('--color-digitv2-header-sidenav'),
+            textPrimary: read('--color-text-primary'),
+            border: read('--color-border'),
+          };
+        }),
+      {
+        timeout: 45_000,
+        message:
+          'applyTheme() must overwrite the bundled default theme on :root with the MDMS ThemeConfig colours',
+      },
+    )
+    .toEqual({
+      primaryMain: expected.primaryMain.toLowerCase(),
+      primaryDark: expected.primaryDark.toLowerCase(),
+      headerSidenav: expected.headerSidenav.toLowerCase(),
+      textPrimary: expected.textPrimary.toLowerCase(),
+      border: expected.border.toLowerCase(),
+    });
 });

--- a/tests/integration-tests/tests/admin/theme-editor.spec.ts
+++ b/tests/integration-tests/tests/admin/theme-editor.spec.ts
@@ -160,16 +160,16 @@ Uses the auth.setup.ts storageState — admin token already in localStorage.`,
 test('editing a brand token updates the preview live', {
   annotation: {
     type: 'description',
-    description: `Round-trip test for the editor's live preview: changing a color token in the form must mutate the matching preview element's computed backgroundColor on the next render. We drive the "Primary button / bg default" token (colors.button-primary-bg-default) — ThemePreview fans it into the v1 primary.main path that the Primary preview button renders, and it is the last writer to primary.main in ThemePreview's V2_TO_V1_FALLBACK map, so the change is deterministic regardless of the seed record's other tokens. Uses #FF1493 (hot pink) so it can't collide with any kenya-green default. Reverts before exiting so the test is idempotent and never leaves MDMS dirty.
+    description: `Round-trip test for the editor's live preview: changing a color token in the form must mutate the matching preview element's computed backgroundColor on the next render. We drive the "Chart 1" token (colors.chart-1) — in ThemePreview's V2_TO_V1_FALLBACK map, 'chart-1' -> ['digitv2.chart-1'] is the ONLY writer of that v1 path (unlike 'primary.main', which 'sidebar-selected-text' also writes later in Object.entries order, making that assertion record-dependent — green on some theme records, red on others, e.g. bomet's). Chart tokens fan into their own digitv2.chart-N slot with no other writer, so the assertion is deterministic for any theme record. Uses #FF1493 (hot pink) so it can't collide with any seed default. Reverts before exiting so the test is idempotent and never leaves MDMS dirty.
 
 Steps:
 1. setTimeout 90s; navigate to the edit URL.
-2. Click the "Buttons" tab.
-3. Locate the "Primary button / bg default" row, find its <input type="text"> (the form-bound hex input); wait for visibility.
-4. Capture the originalHex (default '#006B3F' fallback).
+2. Click the "Charts" tab.
+3. Locate the "Chart 1" row, find its <input type="text"> (the form-bound hex input); wait for visibility.
+4. Capture the originalHex.
 5. Fill TEST_HEX = '#FF1493' and blur.
-6. Locate the preview button [data-token~="colors.primary.main"] filtered by text "Primary"; assert visible.
-7. Use expect.poll on getComputedStyle(button).backgroundColor; assert it becomes 'rgb(255, 20, 147)' within 5s.
+6. Locate the preview element [data-token~="colors.digitv2.chart-1"] (the first chart bar); assert visible.
+7. Use expect.poll on getComputedStyle(el).backgroundColor; assert it becomes 'rgb(255, 20, 147)' within 5s.
 8. Fill the input back to originalHex and blur.
 
 Doesn't actually click Save — the revert keeps MDMS clean even if a stray click hits the save button.`,
@@ -182,42 +182,40 @@ Doesn't actually click Save — the revert keeps MDMS clean even if a stray clic
     timeout: 45_000,
   });
 
-  // Switch to the Buttons tab so the input is visible.
-  await page.getByRole('tab', { name: 'Buttons' }).first().click({ timeout: 30_000 });
+  // Switch to the Charts tab so the input is visible.
+  await page.getByRole('tab', { name: 'Charts' }).first().click({ timeout: 30_000 });
 
   // ColorInput renders a native <input type=color> + a text box. Target the
   // text box since that binds directly to the form value. The label text
-  // comes from the theme-config descriptor (colors.button-primary-bg-default).
-  const primaryMainRow = page
-    .locator('label', { hasText: /Primary button \/ bg default/i })
+  // comes from the theme-config descriptor (colors.chart-1, label "Chart 1").
+  const chart1Row = page
+    .locator('label', { hasText: /^Chart 1$/i })
     .first()
     .locator('..');
-  const hexInput = primaryMainRow.locator('input[type="text"]').first();
+  const hexInput = chart1Row.locator('input[type="text"]').first();
   await expect(hexInput).toBeVisible({ timeout: 15_000 });
 
   const originalHex = (await hexInput.inputValue()) || '#006B3F';
 
   // A clearly-distinct test color — hot pink, won't collide with any
-  // kenya-green default.
+  // seed default.
   const TEST_HEX = '#FF1493';
   await hexInput.fill(TEST_HEX);
   await hexInput.blur();
 
-  // Read the computed bg color off the primary button in the preview.
-  // Several elements carry data-token~="colors.primary.main" (sidebar
-  // active item, button) but only the button's background is driven by
-  // primary.main — the sidebar active item uses selected-bg. Target the
-  // button by its visible label.
-  const previewButton = page
-    .locator('[data-token~="colors.primary.main"]')
-    .filter({ hasText: /^Primary$/ })
+  // Read the computed bg color off the first chart bar in the preview.
+  // colors.digitv2.chart-1 is written ONLY by the chart-1 form field
+  // (ThemePreview.tsx V2_TO_V1_FALLBACK) — no other token maps into it,
+  // so this is deterministic regardless of the seed record's other tokens.
+  const previewBar = page
+    .locator('[data-token~="colors.digitv2.chart-1"]')
     .first();
-  await expect(previewButton).toBeVisible();
+  await expect(previewBar).toBeVisible();
 
   await expect
     .poll(
       async () =>
-        previewButton.evaluate((el) => getComputedStyle(el as HTMLElement).backgroundColor),
+        previewBar.evaluate((el) => getComputedStyle(el as HTMLElement).backgroundColor),
       { timeout: 5_000 },
     )
     .toBe('rgb(255, 20, 147)');

--- a/tests/integration-tests/tests/admin/users.spec.ts
+++ b/tests/integration-tests/tests/admin/users.spec.ts
@@ -316,6 +316,14 @@ Tolerant of show-vs-edit routing differences — works whether /:id lands on Sho
     // Update Name and Save.
     const nameInput = page.getByLabel(/^Name/i);
     await nameInput.fill(`PW Edited ${uniq}`);
+    // B5 diagnostic guard: if the form is invalid (e.g. a stale bundle's
+    // mobile validator rejecting a live-rule-valid number), Save clicks
+    // silently no-op and the waitForResponse below times out at 30s with a
+    // confusing message. Fail loudly here instead.
+    await expect(
+      page.locator('[aria-invalid="true"]'),
+      'form must be valid before Save',
+    ).toHaveCount(0);
     // Wait for the update to ACTUALLY complete (react-admin's submit is async)
     // rather than a fixed sleep, so the API probe below can't race ahead of it.
     await Promise.all([

--- a/tests/integration-tests/tests/admin/workflow-action-select-521.spec.ts
+++ b/tests/integration-tests/tests/admin/workflow-action-select-521.spec.ts
@@ -43,29 +43,17 @@ test.describe('admin Workflow Action — Escalate visible #521', () => {
     }).catch(() => []);
     test.skip(workable.length === 0, 'no PENDINGATLME complaint seeded to exercise the Escalate action');
 
-    await page.goto(`${BASE_URL}${COMPLAINTS_LIST_URL}?cb=${Date.now()}`);
+    // RC7: the list is sorted most-recent-first, so clicking the FIRST row
+    // used to drive whatever complaint happened to be newest — often a
+    // terminal (CLOSEDAFTERRESOLUTION) one with no workflow action select at
+    // all, not the PENDINGATLME complaint `pgrSearch` above just found.
+    // Navigate straight to that complaint's edit page instead.
+    const workableId = (workable[0]?.service as any)?.serviceRequestId as string;
+    test.skip(!workableId, 'PENDINGATLME complaint had no serviceRequestId');
+
+    await page.goto(`${BASE_URL}${COMPLAINTS_LIST_URL}/${encodeURIComponent(workableId)}/edit?cb=${Date.now()}`);
     await page.waitForLoadState('domcontentloaded');
     await page.waitForTimeout(3_500);
-
-    const firstRow = page.locator('tbody tr').first();
-    if (!(await firstRow.isVisible().catch(() => false))) {
-      // No data — fall back to "complaints page mounted without crash".
-      const bodyText = (await page.textContent('body')) ?? '';
-      expect(bodyText).not.toMatch(/Cannot read properties|TypeError|Error boundary/i);
-      return;
-    }
-
-    await firstRow.click();
-    await page.waitForLoadState('domcontentloaded');
-    await page.waitForTimeout(3_500);
-
-    // Click Edit to surface the Workflow section.
-    const editBtn = page.getByRole('button', { name: /^Edit$/ }).first();
-    if (await editBtn.isVisible({ timeout: 5_000 }).catch(() => false)) {
-      await editBtn.click();
-      await page.waitForLoadState('domcontentloaded');
-      await page.waitForTimeout(3_000);
-    }
 
     await expect(page.getByText(/^Workflow$/i).first()).toBeVisible({ timeout: 10_000 });
 

--- a/tests/integration-tests/tests/api/filestore-fixes-2026-04-29.spec.ts
+++ b/tests/integration-tests/tests/api/filestore-fixes-2026-04-29.spec.ts
@@ -3,7 +3,22 @@ import { test, expect } from '@playwright/test';
 import { loginEmployee, uploadFile } from '../utils/launch-fixes/api.js';
 import { ROOT_TENANT } from '../utils/env';
 
-// 517-byte synthetic JPEG that triggers EG_FILESTORE_INPUT_ERROR.
+// A genuinely VALID 287-byte 1x1 JPEG (baseline, quality 30) — the actual #474
+// case: an image small enough that thumbnail generation used to blow up.
+//
+// Kept distinct from TINY_JPEG_HEX below, which despite its name is NOT a decodable
+// image (see the corrupt-input test). Conflating "tiny" with "corrupt" is what let
+// this file report a fixed bug as broken.
+const VALID_TINY_JPEG_B64 =
+  '/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDABsSFBcUERsXFhceHBsgKEIrKCUlKFE6PTBCYFVlZF9VXVtqeJmBanGQc1tdhbWGkJ6jq62rZ4C8ybqmx5moq6T/2wBDARweHigjKE4rK06kbl1upKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKT/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAT/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAABAb/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCAANSP/9k=';
+
+function validTinyJpegBuffer(): Buffer {
+  return Buffer.from(VALID_TINY_JPEG_B64, 'base64');
+}
+
+// 517-byte CORRUPT JPEG — has the SOI/EOI markers but a broken entropy-coded
+// stream, so no decoder can read it (verified: Python PIL reports "broken data
+// stream", and Java's ImageIO.read() returns null).
 const TINY_JPEG_HEX =
   'ffd8ffe000104a46494600010100000100010000ffdb004300080606070605080707070909080a0c140d0c0b0b0c1912130f141d1a1f1e1d1a1c1c20242e2720222c231c1c2837292c30313434341f27393d38323c2e333432ffdb0043010909090c0b0c180d0d1832211c213232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232' +
   'ffc0001108000100010301220002110103110' +
@@ -15,32 +30,64 @@ function tinyJpegBuffer(): Buffer {
 }
 
 test.describe('05-filestore (#474)', () => {
-  test('REPRO: tiny synthetic JPEG triggers EG_FILESTORE_INPUT_ERROR (pre-fix)', {
+  test('a valid 1x1 JPEG uploads successfully — CCRS#474', {
     annotation: {
       type: 'description',
-      description: `Deterministic reproduction of CCRS#474 — the filestore service used to throw EG_FILESTORE_INPUT_ERROR when the uploaded JPEG was tiny enough that the thumbnail generator failed. The test sends a 517-byte synthetic JPEG (built from a fixed hex literal so it's reproducible) and switches assertion direction based on whether the bug is fixed: pre-fix expects the error code, post-fix expects a fileStoreId. Either outcome is recorded in test annotations so reports show the current state.
+      description: `Regression test for CCRS#474 — filestore threw EG_FILESTORE_INPUT_ERROR when an uploaded JPEG was small enough that thumbnail generation failed. Sends a genuinely valid 287-byte 1x1 JPEG (fixed base64 literal, byte-reproducible) and asserts it yields a fileStoreId.
 
 Steps:
 1. Log in as the test employee.
-2. Build a 517-byte synthetic JPEG buffer from the hardcoded hex.
-3. uploadFile(auth, ROOT_TENANT, 'tiny.jpg', buf, 'image/jpeg', 'PGR').
-4. If response.body.Errors is present, assert Errors[0].code === 'EG_FILESTORE_INPUT_ERROR' and annotate "pre-fix: bug confirmed".
-5. Otherwise assert response.body.files[0].fileStoreId is truthy and annotate "post-fix: upload succeeds".
+2. Build the 287-byte VALID 1x1 JPEG buffer from the embedded base64.
+3. uploadFile(auth, ROOT_TENANT, 'tiny-valid.jpg', buf, 'image/jpeg', 'PGR').
+4. Assert no Errors are returned and files[0].fileStoreId is truthy.
 
-Self-flipping by design: the same spec lives across the fix landing without needing to be rewritten.`,
+TWO DEFECTS WERE FIXED HERE, AND THE SECOND MATTERS MORE.
+
+(a) It was self-flipping — "if Errors, assert the error code; else assert success" —
+so the bug being present and the bug being fixed BOTH counted as a pass. Nothing
+distinguished them in the pass/fail column, only in an annotation nobody gates on.
+
+(b) It fed the *corrupt* TINY_JPEG_HEX payload, which no decoder can read, and called
+that "a tiny JPEG". So it could never have demonstrated #474 either way: a corrupt
+file SHOULD be rejected. #474 is about VALID small images, and this deployment
+handles those correctly — verified by uploading 1x1 and 8x8 JPEGs, both accepted.
+
+The corrupt payload now has its own test below, asserting the behaviour that is
+actually correct for it.`,
     },
     tag: ['@area:pgr', '@ccrs:474', '@kind:lifecycle', '@layer:ui', '@persona:cross'] }, async () => {
     const auth = await loginEmployee();
-    const r = await uploadFile(auth, ROOT_TENANT, 'tiny.jpg', tinyJpegBuffer(), 'image/jpeg', 'PGR');
-    // After the fix, this assertion will flip — the same payload should
-    // succeed and yield a fileStoreId.
-    if (r.body?.Errors) {
-      expect(r.body.Errors[0].code).toBe('EG_FILESTORE_INPUT_ERROR');
-      test.info().annotations.push({ type: 'state', description: 'pre-fix: bug confirmed' });
-    } else {
-      expect(r.body.files?.[0]?.fileStoreId).toBeTruthy();
-      test.info().annotations.push({ type: 'state', description: 'post-fix: upload succeeds' });
-    }
+    const r = await uploadFile(auth, ROOT_TENANT, 'tiny-valid.jpg', validTinyJpegBuffer(), 'image/jpeg', 'PGR');
+    const errCode = r.body?.Errors?.[0]?.code;
+    expect(
+      errCode,
+      `filestore rejected a valid 1x1 JPEG with ${errCode} — CCRS#474 has regressed`,
+    ).toBeUndefined();
+    expect(r.body.files?.[0]?.fileStoreId).toBeTruthy();
+  });
+
+  test('a corrupt JPEG is rejected with a clean error, not a crash', {
+    annotation: {
+      type: 'description',
+      description: `Companion to the #474 test, using the 517-byte CORRUPT payload this file has carried since 2026-04. That payload has valid SOI/EOI markers but a broken entropy-coded stream, so no decoder can read it (Python PIL: "broken data stream"; Java ImageIO.read() returns null).
+
+Rejecting it is CORRECT behaviour — the previous version of this file treated the rejection as proof that CCRS#474 was unfixed, which conflated "tiny" with "corrupt".
+
+What this asserts is that the rejection is a well-formed application error rather than a transport-level crash. Internally filestore does NOT null-check ImageIO's result — CloudFileMgrUtils.createVersionsOfImage:86 throws NullPointerException on largeImage.flush() (visible in egov-filestore logs) — but StorageService catches it and maps it to EG_FILESTORE_INPUT_ERROR, so the API contract holds. That null-check is worth adding upstream; until then this test pins the contract clients depend on.
+
+Steps:
+1. Log in as the test employee.
+2. Build the 517-byte corrupt buffer from TINY_JPEG_HEX.
+3. Upload it.
+4. Assert an Errors array comes back carrying EG_FILESTORE_INPUT_ERROR, and that no fileStoreId was minted for an unreadable file.`,
+    },
+    tag: ['@area:pgr', '@ccrs:474', '@kind:edge-case', '@layer:api', '@persona:cross'] }, async () => {
+    const auth = await loginEmployee();
+    const r = await uploadFile(auth, ROOT_TENANT, 'corrupt.jpg', tinyJpegBuffer(), 'image/jpeg', 'PGR');
+    expect(r.body?.Errors?.[0]?.code, 'a corrupt image should be rejected, not stored').toBe(
+      'EG_FILESTORE_INPUT_ERROR',
+    );
+    expect(r.body?.files?.[0]?.fileStoreId).toBeFalsy();
   });
 
   test('Larger valid JPEG should succeed regardless of fix state (control)', {

--- a/tests/integration-tests/tests/api/pgr-escalation.spec.ts
+++ b/tests/integration-tests/tests/api/pgr-escalation.spec.ts
@@ -130,6 +130,14 @@ test.describe.serial('PGR escalation — API only', () => {
   let allEmployees: any[] = [];
   /** Set to true when prerequisites (workflow + hierarchy) are confirmed. */
   let prerequisitesMet = false;
+  /**
+   * The state ESCALATE@PENDINGATLME actually lands in on THIS deployment.
+   * Kenya wires ESCALATE as a self-loop (stays PENDINGATLME); a supervisor-tier
+   * deployment (maputo) wires it as a forward transition to PENDINGATSUPERVISOR.
+   * Resolved from the live workflow in test 2 so the escalate assertions stay
+   * deployment-agnostic instead of hardcoding the self-loop target.
+   */
+  let escalateNextStateFromLme = 'PENDINGATLME';
 
   test('1 — acquire admin token', {
     annotation: {
@@ -234,6 +242,14 @@ Self-healing: safe to run many times. If the workflow seed gets re-applied betwe
         console.log('+ GRO role on RESOLVEBYSUPERVISOR');
       }
     }
+
+    // Resolve where ESCALATE@PENDINGATLME actually lands on this deployment
+    // (self-loop vs forward-to-supervisor) from the patched config — used by
+    // the escalate assertions below instead of a hardcoded PENDINGATLME.
+    const escAtLme = (pendingAtLme.actions || []).find((a: any) => a.action === 'ESCALATE');
+    const escTargetState = escAtLme && biz.states.find((s: any) => s.uuid === escAtLme.nextState);
+    escalateNextStateFromLme = escTargetState?.applicationStatus || 'PENDINGATLME';
+    console.log(`ESCALATE@PENDINGATLME lands in ${escalateNextStateFromLme}`);
 
     if (!dirty) {
       console.log('PGR workflow config already correct — no update needed');
@@ -482,8 +498,9 @@ Catches Jackson silently-dropped-key bugs and confirms the self-loop preserves s
     });
 
     const data = await assertOk(resp, 'PGR ESCALATE (level 0→1)');
-    // ESCALATE is a self-loop on PENDINGATLME — status stays the same
-    expect(data.ServiceWrappers[0].service.applicationStatus).toBe('PENDINGATLME');
+    // ESCALATE lands in this deployment's configured target — the self-loop
+    // PENDINGATLME (Kenya) or the forward PENDINGATSUPERVISOR (supervisor-tier).
+    expect(data.ServiceWrappers[0].service.applicationStatus).toBe(escalateNextStateFromLme);
     // Verify escalation metadata persisted (singular `additionalDetail` field)
     const updatedDetail = data.ServiceWrappers[0].service.additionalDetail || {};
     expect(updatedDetail.escalationLevel).toBe(1);
@@ -562,6 +579,7 @@ The skip cases are first-class outcomes — the suite is designed to pass on a 2
     },
     tag: ['@area:pgr', '@kind:lifecycle', '@layer:api', '@persona:cross'] }, async () => {
     test.skip(!prerequisitesMet, 'Prerequisites not met');
+    test.skip(escalateNextStateFromLme !== 'PENDINGATLME', 'ESCALATE is a forward transition (PENDINGATLME→PENDINGATSUPERVISOR) on this deployment, not a self-loop; multi-level / PENDINGFORASSIGNMENT self-loop escalation is a different (Kenya) workflow shape. Single-level escalation is covered by tests 6-7.');
 
     // Look up the supervisor's reportingTo
     const supervisorEmp = allEmployees.find((e: any) => e.uuid === supervisorUuid);
@@ -630,6 +648,7 @@ Catches a regression where a transition implementation overwrites or strips addi
     },
     tag: ['@area:pgr', '@kind:lifecycle', '@layer:api', '@persona:cross'] }, async () => {
     test.skip(!prerequisitesMet, 'Prerequisites not met');
+    test.skip(escalateNextStateFromLme !== 'PENDINGATLME', 'ESCALATE is a forward transition (PENDINGATLME→PENDINGATSUPERVISOR) on this deployment, not a self-loop; multi-level / PENDINGFORASSIGNMENT self-loop escalation is a different (Kenya) workflow shape. Single-level escalation is covered by tests 6-7.');
     const fullService = await fetchComplaint(adminToken, adminUserInfo, serviceRequestId);
 
     const resp = await fetch(`${BASE_URL}/pgr-services/v2/request/_update?tenantId=${TENANT}`, {
@@ -683,6 +702,7 @@ Stashes pfaComplaintId for the PFA-escalate + cleanup steps (11 and 12).`,
     },
     tag: ['@area:pgr', '@kind:lifecycle', '@layer:api', '@persona:cross'] }, async () => {
     test.skip(!prerequisitesMet, 'Prerequisites not met');
+    test.skip(escalateNextStateFromLme !== 'PENDINGATLME', 'ESCALATE is a forward transition (PENDINGATLME→PENDINGATSUPERVISOR) on this deployment, not a self-loop; multi-level / PENDINGFORASSIGNMENT self-loop escalation is a different (Kenya) workflow shape. Single-level escalation is covered by tests 6-7.');
     const created = await seedComplaintAsCitizen({ description: `E2E PFA-escalate — ${new Date().toISOString()}` });
     pfaComplaintId = created.srid;
     expect(created.status).toBe('PENDINGFORASSIGNMENT');
@@ -705,6 +725,7 @@ Documents the v2 design: there is no FORWARD → PENDINGATSUPERVISOR detour anym
     },
     tag: ['@area:pgr', '@kind:lifecycle', '@layer:api', '@persona:cross'] }, async () => {
     test.skip(!prerequisitesMet, 'Prerequisites not met');
+    test.skip(escalateNextStateFromLme !== 'PENDINGATLME', 'ESCALATE is a forward transition (PENDINGATLME→PENDINGATSUPERVISOR) on this deployment, not a self-loop; multi-level / PENDINGFORASSIGNMENT self-loop escalation is a different (Kenya) workflow shape. Single-level escalation is covered by tests 6-7.');
     const fullService = await fetchComplaint(adminToken, adminUserInfo, pfaComplaintId);
     const existingDetail = fullService.additionalDetail || {};
     fullService.additionalDetail = {
@@ -750,6 +771,7 @@ Teardown is API-only because PGR has no UI delete affordance — the cleanup is 
     },
     tag: ['@area:pgr', '@kind:lifecycle', '@layer:api', '@persona:cross'] }, async () => {
     test.skip(!prerequisitesMet, 'Prerequisites not met');
+    test.skip(escalateNextStateFromLme !== 'PENDINGATLME', 'ESCALATE is a forward transition (PENDINGATLME→PENDINGATSUPERVISOR) on this deployment, not a self-loop; multi-level / PENDINGFORASSIGNMENT self-loop escalation is a different (Kenya) workflow shape. Single-level escalation is covered by tests 6-7.');
     // Assign
     let fullService = await fetchComplaint(adminToken, adminUserInfo, pfaComplaintId);
     let resp = await fetch(`${BASE_URL}/pgr-services/v2/request/_update?tenantId=${TENANT}`, {

--- a/tests/integration-tests/tests/api/pgr-escalation.spec.ts
+++ b/tests/integration-tests/tests/api/pgr-escalation.spec.ts
@@ -579,7 +579,6 @@ The skip cases are first-class outcomes — the suite is designed to pass on a 2
     },
     tag: ['@area:pgr', '@kind:lifecycle', '@layer:api', '@persona:cross'] }, async () => {
     test.skip(!prerequisitesMet, 'Prerequisites not met');
-    test.skip(escalateNextStateFromLme !== 'PENDINGATLME', 'ESCALATE is a forward transition (PENDINGATLME→PENDINGATSUPERVISOR) on this deployment, not a self-loop; multi-level / PENDINGFORASSIGNMENT self-loop escalation is a different (Kenya) workflow shape. Single-level escalation is covered by tests 6-7.');
 
     // Look up the supervisor's reportingTo
     const supervisorEmp = allEmployees.find((e: any) => e.uuid === supervisorUuid);
@@ -648,7 +647,6 @@ Catches a regression where a transition implementation overwrites or strips addi
     },
     tag: ['@area:pgr', '@kind:lifecycle', '@layer:api', '@persona:cross'] }, async () => {
     test.skip(!prerequisitesMet, 'Prerequisites not met');
-    test.skip(escalateNextStateFromLme !== 'PENDINGATLME', 'ESCALATE is a forward transition (PENDINGATLME→PENDINGATSUPERVISOR) on this deployment, not a self-loop; multi-level / PENDINGFORASSIGNMENT self-loop escalation is a different (Kenya) workflow shape. Single-level escalation is covered by tests 6-7.');
     const fullService = await fetchComplaint(adminToken, adminUserInfo, serviceRequestId);
 
     const resp = await fetch(`${BASE_URL}/pgr-services/v2/request/_update?tenantId=${TENANT}`, {
@@ -702,7 +700,6 @@ Stashes pfaComplaintId for the PFA-escalate + cleanup steps (11 and 12).`,
     },
     tag: ['@area:pgr', '@kind:lifecycle', '@layer:api', '@persona:cross'] }, async () => {
     test.skip(!prerequisitesMet, 'Prerequisites not met');
-    test.skip(escalateNextStateFromLme !== 'PENDINGATLME', 'ESCALATE is a forward transition (PENDINGATLME→PENDINGATSUPERVISOR) on this deployment, not a self-loop; multi-level / PENDINGFORASSIGNMENT self-loop escalation is a different (Kenya) workflow shape. Single-level escalation is covered by tests 6-7.');
     const created = await seedComplaintAsCitizen({ description: `E2E PFA-escalate — ${new Date().toISOString()}` });
     pfaComplaintId = created.srid;
     expect(created.status).toBe('PENDINGFORASSIGNMENT');
@@ -725,7 +722,6 @@ Documents the v2 design: there is no FORWARD → PENDINGATSUPERVISOR detour anym
     },
     tag: ['@area:pgr', '@kind:lifecycle', '@layer:api', '@persona:cross'] }, async () => {
     test.skip(!prerequisitesMet, 'Prerequisites not met');
-    test.skip(escalateNextStateFromLme !== 'PENDINGATLME', 'ESCALATE is a forward transition (PENDINGATLME→PENDINGATSUPERVISOR) on this deployment, not a self-loop; multi-level / PENDINGFORASSIGNMENT self-loop escalation is a different (Kenya) workflow shape. Single-level escalation is covered by tests 6-7.');
     const fullService = await fetchComplaint(adminToken, adminUserInfo, pfaComplaintId);
     const existingDetail = fullService.additionalDetail || {};
     fullService.additionalDetail = {
@@ -771,7 +767,6 @@ Teardown is API-only because PGR has no UI delete affordance — the cleanup is 
     },
     tag: ['@area:pgr', '@kind:lifecycle', '@layer:api', '@persona:cross'] }, async () => {
     test.skip(!prerequisitesMet, 'Prerequisites not met');
-    test.skip(escalateNextStateFromLme !== 'PENDINGATLME', 'ESCALATE is a forward transition (PENDINGATLME→PENDINGATSUPERVISOR) on this deployment, not a self-loop; multi-level / PENDINGFORASSIGNMENT self-loop escalation is a different (Kenya) workflow shape. Single-level escalation is covered by tests 6-7.');
     // Assign
     let fullService = await fetchComplaint(adminToken, adminUserInfo, pfaComplaintId);
     let resp = await fetch(`${BASE_URL}/pgr-services/v2/request/_update?tenantId=${TENANT}`, {

--- a/tests/integration-tests/tests/api/pgr-escalation.spec.ts
+++ b/tests/integration-tests/tests/api/pgr-escalation.spec.ts
@@ -194,17 +194,31 @@ Self-healing: safe to run many times. If the workflow seed gets re-applied betwe
     expect(resolved).toBeTruthy();
 
     let dirty = false;
+    const allStateUuids = new Set<string>(biz.states.map((s: any) => s.uuid));
 
-    // (a) ESCALATE self-loop on PENDINGATLME
-    if (!(pendingAtLme.actions || []).some((a: any) => a.action === 'ESCALATE')) {
+    // (a) ESCALATE on PENDINGATLME → PENDINGATSUPERVISOR
+    //
+    // This block used to push `nextState: pendingAtLme.uuid` — a SELF-LOOP — and that
+    // is where mz.maputo's drift came from: the suite wrote it, then every escalate
+    // assertion re-derived its expectation from the config the suite itself had
+    // written, so nothing ever disagreed. The shipped seed
+    // (utilities/default-data-handler/src/main/resources/PgrWorkflowConfig.json,
+    // commit 8a5d6d9d / CCRS#521) wires PENDINGATLME --ESCALATE--> PENDINGATSUPERVISOR.
+    // Self-healing towards the seed rather than away from it is the whole point.
+    const escAtLme = (pendingAtLme.actions || []).find((a: any) => a.action === 'ESCALATE');
+    if (!escAtLme) {
       pendingAtLme.actions.push({
         tenantId: TENANT, currentState: pendingAtLme.uuid, action: 'ESCALATE',
-        nextState: pendingAtLme.uuid,
+        nextState: pendingAtSup.uuid,
         roles: ['GRO', 'PGR_LME', 'AUTO_ESCALATE', 'PGR_VIEWER'],
         active: true,
       });
       dirty = true;
-      console.log('+ ESCALATE on PENDINGATLME');
+      console.log('+ ESCALATE on PENDINGATLME -> PENDINGATSUPERVISOR');
+    } else if (escAtLme.nextState !== pendingAtSup.uuid) {
+      escAtLme.nextState = pendingAtSup.uuid;
+      dirty = true;
+      console.log('~ ESCALATE on PENDINGATLME retargeted -> PENDINGATSUPERVISOR (was drifted)');
     }
 
     // (b) ESCALATE self-loop on PENDINGFORASSIGNMENT
@@ -226,6 +240,17 @@ Self-healing: safe to run many times. If the workflow seed gets re-applied betwe
       dirty = true;
       console.log('+ GRO role on FORWARD');
     }
+    // (c2) FORWARD's target must be a state that exists.
+    //
+    // The seed hardcoded a state UUID here instead of a state NAME, and UUIDs are
+    // per-tenant — so on any tenant other than the one the seed was captured from,
+    // FORWARD pointed at nothing at all. (The seed has since been corrected to use
+    // "PENDINGATSUPERVISOR"; this repairs deployments already carrying the bad uuid.)
+    if (forwardAction && !allStateUuids.has(forwardAction.nextState)) {
+      console.log(`~ FORWARD nextState ${forwardAction.nextState} matches no state — retargeting`);
+      forwardAction.nextState = pendingAtSup.uuid;
+      dirty = true;
+    }
 
     // (d) RESOLVEBYSUPERVISOR on PENDINGATSUPERVISOR should target RESOLVED (not orphaned RESOLVEDBYSUPERVISOR)
     //     and allow GRO so admin can test supervisor-resolve path
@@ -246,29 +271,36 @@ Self-healing: safe to run many times. If the workflow seed gets re-applied betwe
     // Resolve where ESCALATE@PENDINGATLME actually lands on this deployment
     // (self-loop vs forward-to-supervisor) from the patched config — used by
     // the escalate assertions below instead of a hardcoded PENDINGATLME.
-    const escAtLme = (pendingAtLme.actions || []).find((a: any) => a.action === 'ESCALATE');
-    const escTargetState = escAtLme && biz.states.find((s: any) => s.uuid === escAtLme.nextState);
+    const escAtLmeNow = (pendingAtLme.actions || []).find((a: any) => a.action === 'ESCALATE');
+    const escTargetState = escAtLmeNow && biz.states.find((s: any) => s.uuid === escAtLmeNow.nextState);
     escalateNextStateFromLme = escTargetState?.applicationStatus || 'PENDINGATLME';
     console.log(`ESCALATE@PENDINGATLME lands in ${escalateNextStateFromLme}`);
 
+    // Push the update ONLY when something needed patching — but fall through to the
+    // verification block either way.
+    //
+    // This used to `return` early when `!dirty`, which meant that on every run after
+    // the first (i.e. always, in steady state) the test skipped its own seven
+    // verification assertions and its entire assertion surface collapsed to the four
+    // `findState(...)` truthiness checks above. A test named "ensure PGR workflow
+    // config is correct" that stops checking as soon as the config looks unchanged
+    // cannot detect the config being wrong.
     if (!dirty) {
       console.log('PGR workflow config already correct — no update needed');
-      return;
+    } else {
+      const resp = await fetch(
+        `${BASE_URL}/egov-workflow-v2/egov-wf/businessservice/_update?tenantId=${TENANT}`,
+        {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${adminToken}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            RequestInfo: { apiId: 'Rainmaker', authToken: adminToken, userInfo: adminUserInfo },
+            BusinessServices: [biz],
+          }),
+        },
+      );
+      await assertOk(resp, 'Workflow _update');
     }
-
-    // Push the update
-    const resp = await fetch(
-      `${BASE_URL}/egov-workflow-v2/egov-wf/businessservice/_update?tenantId=${TENANT}`,
-      {
-        method: 'POST',
-        headers: { Authorization: `Bearer ${adminToken}`, 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          RequestInfo: { apiId: 'Rainmaker', authToken: adminToken, userInfo: adminUserInfo },
-          BusinessServices: [biz],
-        }),
-      },
-    );
-    await assertOk(resp, 'Workflow _update');
 
     // Re-fetch and verify everything we changed
     const verifyBiz = await fetchPgrWorkflow(adminToken);
@@ -569,16 +601,33 @@ Loose-but-correct assertions because ESCALATE self-loops emit assignes inconsist
 
 Steps:
 1. test.skip if !prerequisitesMet.
-2. Look up the supervisor in allEmployees; read their current assignment's reportingTo into secondSupervisorUuid.
-3. test.skip if reportingTo is null or the UUID is not in the employee list.
-4. fetchComplaint() and merge { escalationLevel: 2, lastEscalatedAt, escalatedFrom: [...prev, supervisorUuid] } into additionalDetail.
-5. POST _update with workflow { action: 'ESCALATE', assignees: [secondSupervisorUuid], comments }.
-6. Assert applicationStatus stays PENDINGATLME (self-loop) and additionalDetail.escalationLevel === 2.
+2. test.skip unless ESCALATE@PENDINGATLME is a SELF-LOOP — see below.
+3. Look up the supervisor in allEmployees; read their current assignment's reportingTo into secondSupervisorUuid.
+4. test.skip if reportingTo is null or the UUID is not in the employee list.
+5. fetchComplaint() and merge { escalationLevel: 2, lastEscalatedAt, escalatedFrom: [...prev, supervisorUuid] } into additionalDetail.
+6. POST _update with workflow { action: 'ESCALATE', assignees: [secondSupervisorUuid], comments }.
+7. Assert the landing state matches the configured ESCALATE target, and additionalDetail.escalationLevel === 2.
+
+DEPLOYMENT-MODEL GATED. A second consecutive ESCALATE is only reachable when
+ESCALATE is configured as a self-loop on PENDINGATLME (the Kenya model), because the
+complaint is still in PENDINGATLME after the first hop. On the supervisor-tier model
+that the shipped seed configures — PENDINGATLME --ESCALATE--> PENDINGATSUPERVISOR —
+test 6 leaves the complaint in PENDINGATSUPERVISOR, a state on which ESCALATE is not
+defined at all, so the second call correctly 400s with "INVALID ACTION". That is the
+workflow behaving properly, not a defect, so this test self-skips there. This mirrors
+the contract in docs/TEST-PREREQUISITES.md §3: multi-level self-loop assertions
+self-skip on the forward model. Escalating further from PENDINGATSUPERVISOR is what
+FORWARD/RESOLVEBYSUPERVISOR cover.
 
 The skip cases are first-class outcomes — the suite is designed to pass on a 2-level OR 3+ level hierarchy.`,
     },
     tag: ['@area:pgr', '@kind:lifecycle', '@layer:api', '@persona:cross'] }, async () => {
     test.skip(!prerequisitesMet, 'Prerequisites not met');
+    test.skip(
+      escalateNextStateFromLme !== 'PENDINGATLME',
+      `ESCALATE forwards to ${escalateNextStateFromLme} on this deployment, so a second ` +
+        'consecutive ESCALATE is not reachable — multi-level chaining is the self-loop model only',
+    );
 
     // Look up the supervisor's reportingTo
     const supervisorEmp = allEmployees.find((e: any) => e.uuid === supervisorUuid);
@@ -624,7 +673,13 @@ The skip cases are first-class outcomes — the suite is designed to pass on a 2
     });
 
     const data = await assertOk(resp, 'PGR ESCALATE (level 1→2)');
-    expect(data.ServiceWrappers[0].service.applicationStatus).toBe('PENDINGATLME');
+    // Read the target from the deployment's own config, as test 6 does.
+    //
+    // This was hardcoded to 'PENDINGATLME', which PINNED the self-loop drift: the
+    // shipped seed (PgrWorkflowConfig.json) wires PENDINGATLME --ESCALATE-->
+    // PENDINGATSUPERVISOR, so repairing the deployment to match the seed would have
+    // turned THIS test red and looked like the repair broke something.
+    expect(data.ServiceWrappers[0].service.applicationStatus).toBe(escalateNextStateFromLme);
     // Verify escalation metadata persisted through _update (singular field)
     const updatedDetail = data.ServiceWrappers[0].service.additionalDetail || {};
     expect(updatedDetail.escalationLevel).toBe(2);
@@ -649,13 +704,24 @@ Catches a regression where a transition implementation overwrites or strips addi
     test.skip(!prerequisitesMet, 'Prerequisites not met');
     const fullService = await fetchComplaint(adminToken, adminUserInfo, serviceRequestId);
 
+    // Which action closes an escalated complaint depends on where ESCALATE left it.
+    //
+    // Self-loop model: still PENDINGATLME, so RESOLVE applies. Forward model (the
+    // shipped seed): the complaint is in PENDINGATSUPERVISOR, where RESOLVE is not
+    // configured at all and the supervisor's action is RESOLVEBYSUPERVISOR — a plain
+    // RESOLVE there 400s with "INVALID ACTION", which is the workflow being correct.
+    // Resolve the action from the live state rather than assuming one model.
+    const currentState = fullService.applicationStatus as string;
+    const closeAction = currentState === 'PENDINGATSUPERVISOR' ? 'RESOLVEBYSUPERVISOR' : 'RESOLVE';
+    console.log(`closing from ${currentState} via ${closeAction}`);
+
     const resp = await fetch(`${BASE_URL}/pgr-services/v2/request/_update?tenantId=${TENANT}`, {
       method: 'POST',
       headers: { Authorization: `Bearer ${adminToken}`, 'Content-Type': 'application/json' },
       body: JSON.stringify({
         RequestInfo: { apiId: 'Rainmaker', authToken: adminToken, userInfo: adminUserInfo },
         service: fullService,
-        workflow: { action: 'RESOLVE', comments: 'Resolved after escalation — E2E test' },
+        workflow: { action: closeAction, comments: 'Resolved after escalation — E2E test' },
       }),
     });
 
@@ -904,5 +970,45 @@ Long-running (240s) because it depends on a real scheduler tick + real SLA breac
     const final = await fetchComplaint(adminToken, adminUserInfo, autoSrid);
     expect(final.additionalDetail?.escalationLevel).toBeGreaterThanOrEqual(1);
     console.log(`Final additionalDetail.escalationLevel=${final.additionalDetail?.escalationLevel}`);
+  });
+
+  test('14 — audit: PGR workflow config matches the shipped seed', {
+    annotation: {
+      type: 'description',
+      description: `Audits the deployed PGR businessService against the shipped seed (utilities/default-data-handler/src/main/resources/PgrWorkflowConfig.json). Two checks nothing in this suite previously made:
+
+1. Every action's nextState resolves to a state that actually exists. The seed hardcodes state UUIDs for FORWARD and RESOLVEBYSUPERVISOR rather than state NAMES, and those UUIDs do not survive being re-seeded into a new tenant — leaving transitions pointing at nothing.
+2. ESCALATE on PENDINGATLME forwards to PENDINGATSUPERVISOR, per the seed (commit 8a5d6d9d, CCRS#521).
+
+Deliberately LAST in this serial block, and deliberately separate from test 2. These are audits of the deployment's configuration, not preconditions for the escalation chain — gating tests 3-13 on them would trade 11 tests' worth of real coverage for a finding that blocks nothing.
+
+Why #2 needs its own assertion: pgr-services never decides the state (EscalationService only builds the Workflow; the transition is 100% businessService config). Every other escalate assertion in this file reads its expected landing state out of the SAME live config the engine executes, so the suite agrees with itself by construction and cannot see drift. This test is the only place the config is compared against the product's intent.`,
+    },
+    tag: ['@area:pgr', '@kind:regression', '@layer:api', '@persona:cross'] }, async () => {
+    const biz = await fetchPgrWorkflow(adminToken);
+
+    const stateUuids = new Set(biz.states.map((s: any) => s.uuid));
+    const dangling: string[] = [];
+    for (const st of biz.states) {
+      for (const act of st.actions || []) {
+        if (act.nextState && !stateUuids.has(act.nextState)) {
+          dangling.push(`${st.applicationStatus} --${act.action}--> ${act.nextState}`);
+        }
+      }
+    }
+    expect(
+      dangling,
+      `PGR workflow has transitions pointing at non-existent states:\n  ${dangling.join('\n  ')}`,
+    ).toEqual([]);
+
+    const atLme = biz.states.find((s: any) => s.applicationStatus === 'PENDINGATLME');
+    const escAtLme = (atLme?.actions || []).find((a: any) => a.action === 'ESCALATE');
+    const escTarget = biz.states.find((s: any) => s.uuid === escAtLme?.nextState);
+    expect(
+      escTarget?.applicationStatus,
+      'ESCALATE on PENDINGATLME should forward to PENDINGATSUPERVISOR per the shipped ' +
+        'PgrWorkflowConfig.json seed. A self-loop here means the deployment has drifted — ' +
+        "historically written by test 2's own 'add ESCALATE if missing' self-heal.",
+    ).toBe('PENDINGATSUPERVISOR');
   });
 });

--- a/tests/integration-tests/tests/api/proxy-coverage.spec.ts
+++ b/tests/integration-tests/tests/api/proxy-coverage.spec.ts
@@ -12,6 +12,7 @@
  */
 import { test, expect } from '@playwright/test';
 import { BASE_URL, TENANT, ROOT_TENANT, KC_BASE, KC_REALM, KC_CLIENT_ID, ADMIN_USER, ADMIN_PASS } from '../utils/env';
+import { tryGetProfile } from '../utils/profile';
 import { getDigitToken, loginViaApi } from '../utils/auth';
 
 /**
@@ -228,7 +229,7 @@ test.describe('API Proxy Coverage', () => {
       },
       {
         name: 'Boundary search',
-        url: `${BASE_URL}/boundary-service/boundary-relationships/_search?tenantId=${TENANT}&hierarchyType=ADMIN`,
+        url: `${BASE_URL}/boundary-service/boundary-relationships/_search?tenantId=${TENANT}&hierarchyType=${tryGetProfile()?.boundary.hierarchyType || 'ADMIN'}`,
         body: {
           RequestInfo: { apiId: 'Rainmaker' },
         },

--- a/tests/integration-tests/tests/api/proxy-coverage.spec.ts
+++ b/tests/integration-tests/tests/api/proxy-coverage.spec.ts
@@ -11,7 +11,7 @@
  * 3. No API calls are blocked or dropped by the proxy
  */
 import { test, expect } from '@playwright/test';
-import { BASE_URL, TENANT, ROOT_TENANT, KC_BASE, KC_REALM, KC_CLIENT_ID, ADMIN_USER, ADMIN_PASS } from '../utils/env';
+import { BASE_URL, TENANT, ROOT_TENANT, KC_BASE, KC_REALM, KC_CLIENT_ID, ADMIN_USER, ADMIN_PASS, LOCALES } from '../utils/env';
 import { tryGetProfile } from '../utils/profile';
 import { getDigitToken, loginViaApi } from '../utils/auth';
 
@@ -141,6 +141,7 @@ test.describe('API Proxy Coverage', () => {
     tag: ['@area:proxy', '@kind:regression', '@layer:api', '@persona:cross'],
   }, async ({ page }) => {
     const unauthorizedCalls: string[] = [];
+    const authedApiCalls: string[] = [];
 
     page.on('response', (resp) => {
       const url = resp.url();
@@ -151,8 +152,9 @@ test.describe('API Proxy Coverage', () => {
       if (url.includes('/realms/') && url.includes('iframe')) return;
       if (url.includes('/3p-cookies/')) return;
 
+      const path = url.replace(BASE_URL, '').split('?')[0];
+      authedApiCalls.push(`${resp.request().method()} ${path}`);
       if (resp.status() === 401) {
-        const path = url.replace(BASE_URL, '').split('?')[0];
         unauthorizedCalls.push(`${resp.request().method()} ${path}`);
       }
     });
@@ -167,6 +169,16 @@ test.describe('API Proxy Coverage', () => {
       timeout: 30_000,
     });
     await page.waitForTimeout(3000);
+
+    // Presence guard FIRST — without it this test is an absence assertion over a
+    // possibly-empty set. If loginViaApi injected a token the SPA never used, or the
+    // page failed to boot, zero calls would be recorded and `[] === []` would pass
+    // while nothing was exercised. Its sibling above already asserts
+    // `mdmsCalls.length >= 1`; this one did not.
+    expect(
+      authedApiCalls.length,
+      'no authenticated API calls were observed — the 401 check would be vacuous',
+    ).toBeGreaterThan(0);
 
     // No API call after login should return 401
     expect(unauthorizedCalls).toEqual([]);
@@ -188,13 +200,35 @@ test.describe('API Proxy Coverage', () => {
     expect(loginResp.access_token).toBeTruthy();
     const token = loginResp.access_token;
 
+    // A real RequestInfo, not a bare `{apiId}`. Several DIGIT services dereference
+    // these without a null check and answer an unhandled NullPointerException as a
+    // 400 — pgr-services needs `userInfo` (`RequestInfo.getUserInfo().getType()`)
+    // and egov-accesscontrol needs `ts` (`RequestInfo.getTs().longValue()`). With a
+    // stub RequestInfo four of the seven endpoints below 400, which the old
+    // `toBeLessThan(500)` assertion happily called "work with JWT auth".
+    expect(
+      loginResp.UserRequest,
+      'token response should carry UserRequest to build a real RequestInfo',
+    ).toBeTruthy();
+    const requestInfo = {
+      apiId: 'Rainmaker',
+      ver: '.01',
+      ts: 0,
+      action: '_search',
+      did: '1',
+      key: '',
+      msgId: 'proxy-coverage|en_IN',
+      authToken: token,
+      userInfo: loginResp.UserRequest,
+    };
+
     // Test each critical API endpoint
     const endpoints = [
       {
         name: 'MDMS search',
         url: `${BASE_URL}/mdms-v2/v1/_search`,
         body: {
-          RequestInfo: { apiId: 'Rainmaker' },
+          RequestInfo: requestInfo,
           MdmsCriteria: {
             tenantId: ROOT_TENANT,
             moduleDetails: [{ moduleName: 'tenant', masterDetails: [{ name: 'tenants' }] }],
@@ -202,52 +236,46 @@ test.describe('API Proxy Coverage', () => {
         },
       },
       {
+        // locale/tenantId/module are QUERY params on this service — sent in the
+        // body they are simply absent and it 400s "Required request parameter
+        // 'locale' ... is not present". Locale comes from the profile, not a literal.
         name: 'Localization search',
-        url: `${BASE_URL}/localization/messages/v1/_search`,
-        body: {
-          RequestInfo: { apiId: 'Rainmaker' },
-          tenantId: ROOT_TENANT,
-          locale: 'en_IN',
-          module: 'rainmaker-common',
-        },
+        url: `${BASE_URL}/localization/messages/v1/_search?tenantId=${ROOT_TENANT}&locale=${LOCALES[0]}&module=rainmaker-common`,
+        body: { RequestInfo: requestInfo },
       },
       {
+        // Needs tenantId + roleCodes (not `rolesCodes`, and not objects) — the old
+        // shape 400d with "Tenant Id is required" + "Atleast One Role is Required".
         name: 'Access control',
         url: `${BASE_URL}/access/v1/actions/mdms/_get`,
         body: {
-          RequestInfo: { apiId: 'Rainmaker' },
-          rolesCodes: [{ code: 'EMPLOYEE' }],
+          RequestInfo: requestInfo,
+          tenantId: ROOT_TENANT,
+          roleCodes: ['EMPLOYEE'],
+          actionMaster: 'actions-test',
+          enabled: true,
         },
       },
       {
         name: 'PGR search',
         url: `${BASE_URL}/pgr-services/v2/request/_search?tenantId=${TENANT}`,
-        body: {
-          RequestInfo: { apiId: 'Rainmaker' },
-          tenantId: TENANT,
-        },
+        body: { RequestInfo: requestInfo },
       },
       {
         name: 'Boundary search',
         url: `${BASE_URL}/boundary-service/boundary-relationships/_search?tenantId=${TENANT}&hierarchyType=${tryGetProfile()?.boundary.hierarchyType || 'ADMIN'}`,
-        body: {
-          RequestInfo: { apiId: 'Rainmaker' },
-        },
+        body: { RequestInfo: requestInfo },
       },
       {
+        // tenantId is a QUERY param here too — in `criteria` it never arrives.
         name: 'HRMS employee count',
-        url: `${BASE_URL}/egov-hrms/employees/_count`,
-        body: {
-          RequestInfo: { apiId: 'Rainmaker' },
-          criteria: { tenantId: TENANT },
-        },
+        url: `${BASE_URL}/egov-hrms/employees/_count?tenantId=${TENANT}`,
+        body: { RequestInfo: requestInfo },
       },
       {
         name: 'Workflow business service',
         url: `${BASE_URL}/egov-workflow-v2/egov-wf/businessservice/_search?tenantId=${TENANT}&businessServices=PGR`,
-        body: {
-          RequestInfo: { apiId: 'Rainmaker' },
-        },
+        body: { RequestInfo: requestInfo },
       },
     ];
 
@@ -262,16 +290,23 @@ test.describe('API Proxy Coverage', () => {
             },
             body: JSON.stringify(body),
           });
-          return { status: resp.status, ok: resp.ok };
+          return { status: resp.status, ok: resp.ok, body: (await resp.text()).slice(0, 300) };
         },
         { url: endpoint.url, body: endpoint.body, token },
       );
 
-      // API should not return 500/502 (proxy error)
+      // The endpoint must actually WORK, which is what this test's name claims.
+      //
+      // The previous assertion was `toBeLessThan(500)`, which cannot fail for any
+      // reachable endpoint: a 400, a 401, even a 404 from a service that does not
+      // exist all satisfy it. Four of the seven endpoints here were 400ing — one
+      // with a server-side NullPointerException — under a green test. Verified:
+      // pointing a URL at `/pgr-servicesXXX/...` returns 404, and 404 < 500, so the
+      // old form stayed green even against a service that isn't there.
       expect(
-        result.status,
-        `${endpoint.name} returned ${result.status}`,
-      ).toBeLessThan(500);
+        result.ok,
+        `${endpoint.name} returned ${result.status}: ${result.body}`,
+      ).toBe(true);
     }
   });
 

--- a/tests/integration-tests/tests/citizen/citizen-home-page.spec.ts
+++ b/tests/integration-tests/tests/citizen/citizen-home-page.spec.ts
@@ -79,9 +79,15 @@ Catalog test — if a label gets renamed legitimately, update this spec and Stor
     await expect(body).toContainText('File a Complaint');
     await expect(body).toContainText('My Complaints');
 
-    // Sidebar inventory — Story 2.x note
-    for (const item of ['Home', 'Edit Profile', 'Logout', 'HELPLINE']) {
-      await expect(body, `sidebar item "${item}" missing`).toContainText(item);
+    // Sidebar inventory — Story 2.x note.
+    // Matched case-insensitively: these render from localization, so the label
+    // is the translated value ("Helpline"), not the raw key ("HELPLINE"). Pinning
+    // the upper-case form only passed while the bundle was unseeded and the UI
+    // was echoing raw keys back.
+    for (const item of ['Home', 'Edit Profile', 'Logout', 'Helpline']) {
+      await expect(body, `sidebar item "${item}" missing`).toContainText(
+        new RegExp(item.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'),
+      );
     }
   });
 

--- a/tests/integration-tests/tests/citizen/citizen-landing-dispatch.spec.ts
+++ b/tests/integration-tests/tests/citizen/citizen-landing-dispatch.spec.ts
@@ -1,18 +1,34 @@
 /**
  * Citizen landing-page dispatch — ported from local-setup/tests/e2e/specs/citizen/citizen-flow.spec.ts
  *
- * Tests the dispatch logic that drives the citizen landing page:
- *   - language-selection: shown when tenant is not pre-resolved and >1 language configured
- *   - auto-skip-home:     shown when tenantId is pre-resolved by globalConfigs
- *   - auto-skip-login:    shown when stateInfo.languages.length === 1
+ * The citizen entry point has exactly TWO outcomes on load
+ * (digit-ui-esbuild/packages/modules/core/src/pages/citizen/Home/index.js:48-55):
  *
- * Each test self-skips when the current deployment renders a different surface
- * than the one under test — making this spec safe to run on any DIGIT deployment.
+ *   if (!tenantId)        -> push /citizen/select-language   (language-selection)
+ *   else if (redirectURL) -> push /citizen/{redirectURL}     (home)
+ *
+ * `tenantId` is ULBService.getCitizenCurrentTenant(), which with no session
+ * city falls through to getStateId() — globalConfigs' STATE_LEVEL_TENANT_ID.
+ * Discovery records that value as `profile.globalConfigs.stateTenantId`, so
+ * the branch is a pure function of the deployment profile. This spec computes
+ * the expected branch and ASSERTS it, rather than skipping whichever branch it
+ * did not happen to get: a deployment that lost its STATE_LEVEL_TENANT_ID
+ * would silently drop every citizen onto select-language, and a self-skipping
+ * spec would stay green through it.
+ *
+ * There is deliberately no third "auto-skip-login" branch. The
+ * `stateInfo.languages.length === 1` short-circuit that would produce one is
+ * EMPLOYEE-only (core/src/pages/employee/LanguageSelection/index.js:32,47);
+ * the citizen LanguageSelection (core/src/pages/citizen/Home/LanguageSelection.js)
+ * has no length check, always renders the radio list, and only reaches
+ * /citizen/login from its own Continue button. A test for that branch could
+ * not run on any deployment, so it is not written.
  *
  * No @local-only tag — this logic is environment-agnostic.
  */
 import { test, expect, type Page, type Locator } from '@playwright/test';
 import { BASE_URL } from '../utils/env';
+import { getProfile } from '../utils/profile';
 
 // ── Inline page object ────────────────────────────────────────────────────────
 // The legacy suite keeps this in local-setup/tests/e2e/pages/citizen-landing.page.ts.
@@ -26,6 +42,7 @@ class CitizenLandingPage {
   readonly chooseLanguageHeading: Locator;
   readonly allServicesMarker: Locator;
   readonly loginMobileInput: Locator;
+  readonly languageOptions: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -39,6 +56,9 @@ class CitizenLandingPage {
       .getByText(/All Services|ACTION_TEST_ALL_SERVICES_HEADER/i)
       .first();
     this.loginMobileInput = page.locator('input[name="mobileNumber"]').first();
+    // RadioButtons renders one `input.radio-btn[type=radio]` per configured
+    // language (react-components/src/atoms/RadioButtons.js).
+    this.languageOptions = page.locator('input[type="radio"]');
   }
 
   async goto() {
@@ -70,25 +90,44 @@ class CitizenLandingPage {
   }
 }
 
+/**
+ * The branch THIS deployment's own boot config selects.
+ *
+ * Read lazily (not at module scope) so a `--list` / lint pass with no
+ * deployment-profile.json on disk still collects the file.
+ */
+function expectedLanding(): { branch: 'home' | 'language-selection'; why: string } {
+  const stateTenantId = getProfile().globalConfigs.stateTenantId;
+  return stateTenantId
+    ? {
+        branch: 'home',
+        why: `globalConfigs.stateTenantId='${stateTenantId}' resolves a citizen tenant on load, so Home/index.js takes the redirectURL branch`,
+      }
+    : {
+        branch: 'language-selection',
+        why: 'globalConfigs carries no STATE_LEVEL_TENANT_ID, so Home/index.js resolves no tenant and pushes /citizen/select-language',
+      };
+}
+
 // ── Spec ─────────────────────────────────────────────────────────────────────
 
 test.describe('Citizen landing dispatch', () => {
   // Start each test from a clean storage state so per-deployment defaults
-  // (tenant from globalConfigs, single-language auto-skip) drive the
-  // landing — not session leftovers from earlier tests.
+  // (tenant from globalConfigs) drive the landing — not session leftovers
+  // from earlier tests.
   test.use({ storageState: { cookies: [], origins: [] } });
 
   test('smoke: lands on a usable citizen page', {
     annotation: {
       type: 'description',
-      description: `Smoke check that the citizen landing page loads without fatal errors, regardless of deployment mode (language-selection, home, or login). Catches crashes in the dispatch logic.
+      description: `Smoke check that the citizen landing page loads without fatal errors, regardless of dispatch branch (language-selection or home). Catches crashes in the dispatch logic itself, independent of which branch this deployment is configured for.
 
 Steps:
 1. Navigate to /digit-ui/citizen with clean storage.
 2. Wait up to 15s for one of: language-selection page, home page, or login page.
 3. Assert that mode is not 'unknown' (i.e., the page loaded).
 
-Pairs with language-selection, auto-skip-home, and auto-skip-login tests that validate specific dispatch branches.`,
+Pairs with the dispatch-correctness test below, which asserts WHICH branch fired.`,
     },
     tag: ['@area:pgr', '@kind:smoke', '@layer:ui', '@persona:citizen'] }, async ({ page }) => {
     const landing = new CitizenLandingPage(page);
@@ -98,91 +137,55 @@ Pairs with language-selection, auto-skip-home, and auto-skip-login tests that va
     expect(mode).not.toBe('unknown');
   });
 
-  test('language-selection: shows Choose Language and Continue navigates onward', {
+  test('dispatch: lands on the branch globalConfigs selects, and that branch works', {
     annotation: {
       type: 'description',
-      description: `Validates the language-selection dispatch branch — shown when tenant is not pre-resolved by globalConfigs AND stateInfo.languages.length > 1. Asserts the heading + button render and language selection advances to the next step (login, city select, or home).
+      description: `Asserts the citizen landing dispatch took the branch this deployment's own boot config selects, then exercises that branch. The expectation is derived from deployment-profile.json (globalConfigs.stateTenantId) rather than from whatever rendered, so a deployment that lost its STATE_LEVEL_TENANT_ID fails here instead of quietly serving select-language to every citizen.
 
 Steps:
-1. Navigate to /digit-ui/citizen with clean storage.
-2. Detect dispatch mode; skip if not 'language-selection'.
-3. Assert 'Choose Language' heading or Continue button is visible.
-4. Assert body contains 'ENGLISH' (the default language).
-5. Click Continue; assert URL changes to /citizen/login, /citizen/select-city, /citizen/home, or /user/login.
+1. Compute expected branch: stateTenantId present -> 'home', absent -> 'language-selection' (Home/index.js:48-55).
+2. Navigate to /digit-ui/citizen with clean storage; detect the landing surface.
+3. Assert detected === expected. No skip: both branches are testable.
+4a. 'home': assert the All Services marker and the File-a-Complaint entry are visible.
+4b. 'language-selection': assert the Choose Language heading / Continue button renders, assert at least one language radio option is rendered (count comes from stateInfo.languages — no language name is pinned), then click Continue and assert it routes onward to login / city-select / home.
 
-Skips on deployments with single language or pre-resolved tenant — safe to run anywhere.`,
+Never skips — the branch is a function of the profile, and both branches have assertions.`,
     },
     tag: ['@area:pgr', '@kind:regression', '@layer:ui', '@persona:citizen'] }, async ({ page }) => {
+    const { branch, why } = expectedLanding();
+    test.info().annotations.push({ type: 'expected-landing', description: `${branch} — ${why}` });
+
     const landing = new CitizenLandingPage(page);
     await landing.goto();
     const mode = await landing.detectLanding();
-    test.skip(
-      mode !== 'language-selection',
-      `LanguageSelection page not rendered on this deployment (mode=${mode}). Auto-skip happens when tenantId is pre-resolved by globalConfigs OR stateInfo.languages.length === 1.`,
-    );
+
+    expect(
+      mode,
+      `citizen landing dispatched to '${mode}' but this deployment is configured for '${branch}': ${why}`,
+    ).toBe(branch);
+
+    if (branch === 'home') {
+      await expect(landing.allServicesMarker).toBeVisible();
+      await expect(page.getByText(/File a Complaint|HOME_FILE_COMPLAINT|RAINMAKER-PGR/i).first()).toBeVisible();
+      return;
+    }
 
     await expect(landing.chooseLanguageHeading.or(landing.continueButton)).toBeVisible();
-    const body = await page.locator('body').innerText();
-    expect(body.toUpperCase()).toContain('ENGLISH');
+    // The radio list is built from stateInfo.languages. Assert it is non-empty
+    // rather than pinning a language name — 'ENGLISH' is one deployment's data,
+    // not the contract.
+    expect(
+      await landing.languageOptions.count(),
+      'select-language rendered no language options — stateInfo.languages is empty',
+    ).toBeGreaterThan(0);
 
     await landing.continueButton.click();
-    // After choosing a language the SPA may route to login, city-select,
-    // all-services (single-language tenants), or stay on select-language
-    // while loading the next surface.  Accept any citizen sub-path except
-    // the bare language-selection page itself.
+    // Citizen LanguageSelection.onSubmit pushes /citizen/login. Older/compact
+    // builds may land on city-select or all-services instead; accept any
+    // citizen sub-path except the bare language-selection page itself.
     await page.waitForURL(
       /\/(citizen\/(login|select-city|home|all-services)|user\/login)/,
       { timeout: 15_000 },
     );
-  });
-
-  test('auto-skip-home: All Services menu renders', {
-    annotation: {
-      type: 'description',
-      description: `Validates the auto-skip-home dispatch branch — shown when tenantId is pre-resolved by globalConfigs. Asserts the All Services page renders with the File a Complaint action available.
-
-Steps:
-1. Navigate to /digit-ui/citizen with clean storage.
-2. Detect dispatch mode; skip if not 'home'.
-3. Assert 'All Services' marker is visible.
-4. Assert 'File a Complaint' (or localized equivalent) is visible.
-
-Skips on deployments without a pre-configured tenant default — safe to run anywhere.`,
-    },
-    tag: ['@area:pgr', '@kind:regression', '@layer:ui', '@persona:citizen'] }, async ({ page }) => {
-    const landing = new CitizenLandingPage(page);
-    await landing.goto();
-    const mode = await landing.detectLanding();
-    test.skip(
-      mode !== 'home',
-      `Home auto-skip not active on this deployment (mode=${mode}). Tenant default not pre-resolved by globalConfigs.`,
-    );
-
-    await expect(landing.allServicesMarker).toBeVisible();
-    await expect(page.getByText(/File a Complaint|HOME_FILE_COMPLAINT|RAINMAKER-PGR/i).first()).toBeVisible();
-  });
-
-  test('auto-skip-login: single-language tenant lands on login', {
-    annotation: {
-      type: 'description',
-      description: `Validates the auto-skip-login dispatch branch — shown when stateInfo.languages.length === 1 AND no home tenant is pre-resolved by globalConfigs. Asserts the login page renders with the mobile number input visible.
-
-Steps:
-1. Navigate to /digit-ui/citizen with clean storage.
-2. Detect dispatch mode; skip if not 'login'.
-3. Assert mobile number input is visible.
-
-Skips on deployments with multiple languages or a pre-configured tenant default — safe to run anywhere.`,
-    },
-    tag: ['@area:pgr', '@kind:regression', '@layer:ui', '@persona:citizen'] }, async ({ page }) => {
-    const landing = new CitizenLandingPage(page);
-    await landing.goto();
-    const mode = await landing.detectLanding();
-    test.skip(
-      mode !== 'login',
-      `Login auto-skip not active on this deployment (mode=${mode}). Happens when stateInfo.languages.length === 1 AND no home tenant is pre-resolved.`,
-    );
-
-    await expect(landing.loginMobileInput).toBeVisible();
   });
 });

--- a/tests/integration-tests/tests/citizen/full-complaint-lifecycle-ui.spec.ts
+++ b/tests/integration-tests/tests/citizen/full-complaint-lifecycle-ui.spec.ts
@@ -18,7 +18,7 @@ import { getPersona } from '../utils/personas';
 import {
   BASE_URL, TENANT, ROOT_TENANT,
   ADMIN_USER, ADMIN_PASS, FIXED_OTP,
-  DEFAULT_PASSWORD,
+  DEFAULT_PASSWORD, PGR_ID_PREFIX,
   generateCitizenPhone,
 } from '../utils/env';
 
@@ -406,7 +406,10 @@ Long timeout (180s) because of multiple boundary lookups and DOM settles. Catche
       serviceRequestId = capturedId;
     } else {
       const bodyText = await page.locator('body').innerText();
-      const match = bodyText.match(/PG-PGR-\d{4}-\d{2}-\d{2}-\d{6}/);
+      // Build the SRID regex from the deployment's own idgen prefix (PG on
+      // maputo, NCCG on nairobi, …) — a hardcoded `PG-PGR` matched nothing on
+      // any other deployment, leaving serviceRequestId undefined.
+      const match = bodyText.match(new RegExp(`${PGR_ID_PREFIX}-PGR-\\d{4}-\\d{2}-\\d{2}-\\d{6}`));
       if (match) serviceRequestId = match[0];
     }
 

--- a/tests/integration-tests/tests/citizen/pgr-home-layout-and-scroll.spec.ts
+++ b/tests/integration-tests/tests/citizen/pgr-home-layout-and-scroll.spec.ts
@@ -7,13 +7,14 @@
  *          scrolled to the middle of the page (the old `history.listen`
  *          handler leaked across renders and fired before mount).
  * - #441 — rating submit without any "What was good?" checkbox must not
- *          crash the UI. Requires a complaint in RESOLVED state to exercise
- *          the form, which isn't deterministic in a shared deployment —
- *          currently asserted via bundle-level grep until we wire a full
- *          lifecycle fixture.
+ *          crash the UI. Exercised end-to-end: the seed-plan helpers
+ *          (tests/utils/seed.ts) file a complaint as the provisioned citizen
+ *          and drive it to RESOLVED, so the throwaway complaint this test
+ *          submits a rating for is created per run and owned by us.
  */
 import { test, expect } from '@playwright/test';
 import { citizenOtpLogin } from '../utils/citizen-login';
+import { seedComplaintAsCitizen, driveToPendingAtLme, driveToResolved } from '../utils/seed';
 import { BASE_URL } from '../utils/env';
 
 test.describe('citizen PGR regression — shipped fixes', () => {
@@ -121,28 +122,101 @@ Verified 2026-06-29: on compact/v2 builds (Ethiopia), the layout uses an inner-s
     expect(after).toBe(0);
   });
 
-  test.fixme(
+  test(
     '#441 — submit rating without "What was good?" boxes does not crash', {
       annotation: {
         type: 'description',
-        description: `TODO: needs a complaint in RESOLVED state belonging to a citizen we control before this can be exercised end-to-end. Either chain off pgr-lifecycle-ui.spec.ts (which already resolves one) or bootstrap via the PGR API before the browser step. Until then, the code-level guard is verified offline with grep on build/index.js for an isArray check around CS_FEEDBACK_WHAT_WAS_GOOD.
+        description: `Catches CCRS#441: submitting the complaint rating with ZERO "What was good?" checkboxes ticked used to throw ("Cannot read properties of undefined (reading 'join')") inside SelectRating's submit handler, tripping the error boundary and leaving the citizen on a blank page. Fixed in both builds that ship this page — the Array.isArray guard at packages/modules/pgr/src/pages/citizen/Rating/SelectRating.js:26, and the v2 product overlay (products/pgr/.../SelectRating.js) which builds the selections array from local state so it can never be undefined. This test drives the real form with no checkbox touched and asserts nothing throws and the SPA advances; it is build-agnostic by design, since a rewrite of this page is exactly where the bug could come back.
 
-Steps (target):
-1. Seed a RESOLVED complaint owned by the test citizen.
-2. citizenOtpLogin and navigate to /pgr/rate/{srid}.
-3. Submit the rating without checking any "What was good?" feedback boxes.
-4. Assert the page does NOT crash and either advances to the next step or shows a recoverable error.
+Steps:
+1. setTimeout 180s; attach a pageerror listener BEFORE anything navigates.
+2. Seed a throwaway complaint via seedComplaintAsCitizen -> driveToPendingAtLme -> driveToResolved (tests/utils/seed.ts; RESOLVE is PGR_LME-role-gated, not assignee-gated).
+3. citizenOtpLogin as the provisioned citizen (the same identity seed.ts filed as — RATE is only open to the filer) and navigate to /digit-ui/citizen/pgr/rate/{srid}.
+4. Wait for the 5-star row (legacy svg.rating-star or the v2 overlay's role=radio StarRow); click the 4th star so rating > 0 — the submit handler no-ops below that.
+5. Submit WITHOUT ticking any of the four "What was good?" checkboxes; assert none is checked first, so a build that pre-ticks one cannot make this pass vacuously.
+6. Assert the SPA advanced to the PGR /response route (SelectRating pushes \`\${parentRoute}/response\` only after the previously-crashing line).
+7. Assert no uncaught pageerror matching /Cannot read properties of undefined|of undefined \\(reading|is not a function/ and that the error boundary ("Something went wrong") did not render.
 
-Marked test.fixme — runs only when manually un-fixed and the seed step is wired in.`,
+Unlike rate-resolved-complaint.spec.ts this test DOES submit — the complaint is seeded per run and going to CLOSEDAFTERRESOLUTION is harmless.`,
       },
       tag: ['@area:pgr', '@ccrs:441', '@kind:regression', '@layer:ui', '@persona:citizen'] }, async ({ page }) => {
-      // TODO: needs a complaint in RESOLVED state belonging to a citizen
-      // we control. Either chain off pgr-lifecycle-ui.spec.ts (which
-      // already resolves one) or bootstrap via the PGR API before the
-      // browser step. Until then, the code-level guard is verified
-      // offline with `grep isArray(.*CS_FEEDBACK_WHAT_WAS_GOOD)` on
-      // `build/index.js`.
-      void page; // placeholder so the fixme block type-checks
+      test.setTimeout(180_000);
+
+      // Attached before any navigation so a crash during mount is captured too.
+      const pageErrors: string[] = [];
+      page.on('pageerror', (err) => pageErrors.push(err.message));
+
+      const { srid } = await seedComplaintAsCitizen({
+        description: 'PW #441 — rating submitted with no feedback boxes',
+      });
+      await driveToPendingAtLme(srid);
+      await driveToResolved(srid);
+
+      await citizenOtpLogin(page);
+      await page.goto(`${BASE_URL}/digit-ui/citizen/pgr/rate/${srid}`, {
+        waitUntil: 'domcontentloaded',
+        timeout: 30_000,
+      });
+
+      // Two builds ship the 5-star row: the legacy digit-ui-react-components <Rating>
+      // (svg.rating-star) and the v2 product overlay's <StarRow>
+      // (button.v2-rating-star, role=radio in an aria-label="rating"
+      // radiogroup). Match either — the union dedupes, so the count stays 5.
+      const stars = page.locator(
+        '.rating-star, .v2-rating-star, [role="radiogroup"][aria-label="rating"] [role="radio"]',
+      );
+      await expect(stars.first()).toBeVisible({ timeout: 60_000 });
+      await expect(stars).toHaveCount(5);
+
+      // Rating must be > 0 or submit takes the error branch and never reaches
+      // the line under test. Star N is index N-1.
+      await stars.nth(3).click();
+
+      // The whole point of #441: not one checkbox is touched. Assert that is
+      // actually the state we are submitting in — a build that pre-ticked one
+      // would otherwise make this test pass without exercising the bug.
+      const feedbackBoxes = page.locator('input[type="checkbox"]');
+      const checkedCount = await feedbackBoxes.evaluateAll(
+        (els) => els.filter((el) => (el as HTMLInputElement).checked).length,
+      );
+      expect(checkedCount, 'no "What was good?" checkbox may be ticked — that is the regression under test').toBe(0);
+
+      // Legacy build labels the button CS_COMMONS_NEXT ("Next") and gives it
+      // type=submit; the v2 overlay labels it CS_COMMON_SUBMIT ("Submit") with
+      // type=button and an onClick. Match by accessible name so both work —
+      // the sidebar's only other buttons are Logout and HELPLINE.
+      const submit = page
+        .getByRole('button', { name: /submit|next|CS_COMMON_SUBMIT|CS_COMMONS_NEXT/i })
+        .first();
+
+      // The form is interactive before its data is: useComplaintDetails()
+      // chains MDMS getServiceDefs -> PGR search -> boundary ancestors, and
+      // until it lands `complaintDetails?.service` is undefined and the submit
+      // handler no-ops into the "pick a rating" alert. Retry rather than sleep
+      // a magic number — a submit that took has already changed the URL, so
+      // the loop stops on the first one that works.
+      const RESPONSE_ROUTE = /\/citizen\/pgr\/response/;
+      let advanced = RESPONSE_ROUTE.test(page.url());
+      for (let attempt = 0; attempt < 10 && !advanced; attempt++) {
+        await submit.click({ timeout: 10_000 }).catch(() => {});
+        advanced = await page
+          .waitForURL(RESPONSE_ROUTE, { timeout: 8_000 })
+          .then(() => true)
+          .catch(() => false);
+      }
+
+      // Asserted BEFORE the navigation assertion: when #441 regresses, the
+      // throw is the diagnosis and "never navigated" is only its symptom.
+      const fatal = pageErrors.filter((m) =>
+        /Cannot read properties of undefined|of undefined \(reading|is not a function/i.test(m),
+      );
+      expect(fatal, `uncaught error(s) on rating submit:\n${fatal.join('\n')}`).toEqual([]);
+
+      await expect(page.locator('body')).not.toContainText('Something went wrong');
+
+      // SelectRating pushes `${parentRoute}/response` on the line AFTER the
+      // one that used to throw, so reaching it is the crash assertion.
+      expect(advanced, 'rating submit never advanced to the PGR response page').toBe(true);
     },
   );
 });

--- a/tests/integration-tests/tests/employee/digit-ui-shell-2026-05-31.spec.ts
+++ b/tests/integration-tests/tests/employee/digit-ui-shell-2026-05-31.spec.ts
@@ -4,8 +4,9 @@
  * Covers in one run:
  *   #592       /digit-ui/globalConfigs.js served + parseable
  *   #505 sub-1 login background brand-dark, not white
- *   #505 sub-2 header surfaces user initial (post-fix circle removal)
- *   #505 sub-3 banner/header logos sized correctly (96x96)
+ *   #505 sub-2 header surfaces the logged-in user's initial (post-fix
+ *              circle removal)
+ *   #505 sub-3 banner/header logo actually loads and lays out
  *   #505 sub-4 dropdown icons render with dark fill (not white-on-white)
  *   #344       PGR SecurityPolicy lets PGR roles read decrypted
  *              name/mobile (not hex blobs) on complaint detail page
@@ -22,6 +23,7 @@ import {
   TENANT_LABEL,
 } from '../utils/env';
 import { readLifecycleFixtures } from '../utils/lifecycle-fixtures';
+import { getPrincipal } from '../utils/employee-ui';
 
 const LOGIN_URL = '/digit-ui/employee/user/login';
 const INBOX_URL = '/digit-ui/employee/pgr/inbox-v2';
@@ -49,27 +51,24 @@ test.describe('employee digit-ui shell bundle', () => {
   test.use({ storageState: { cookies: [], origins: [] } });
 
   test('login + chrome + visible decrypt + inbox honest drives', { tag: ['@persona:employee'] }, async ({ page }) => {
-    // Onboarding-data gap (#505 brand chrome): the login banner brand color
-    // (#505 sub-1) and the 96x96 banner/header logo (#505 sub-3) only render
-    // once the tenant's branding (logo asset + theme color) is onboarded via
-    // the configurator. This test also drives the #344 decrypt assertion
-    // against ASSIGNED_COMPLAINT_ID, a complaint that must already exist and
-    // sit in the logged-in employee's inbox on the target deployment — not
-    // guaranteed on a fresh bootstrap. Both are seed/onboarding gaps, not code
-    // regressions, so we mark the test fixme with a clear reason rather than
-    // faking a pass. Re-enable once branding is onboarded and a known assigned
-    // complaint (ASSIGNED_COMPLAINT_ID) is seeded on the deployment.
-    test.fixme(
-      true,
-      'onboarding-data gap: #505 brand chrome (banner color + 96x96 logo) requires tenant branding onboarded, and #344 needs a seeded ASSIGNED_COMPLAINT_ID in the employee inbox. Both are configurator-seed gaps, not code regressions.',
-    );
-    // Dead code while the fixme above stands, kept correct for when it's lifted:
-    // an empty resolution (no env override, no lifecycle fixture) must skip
-    // with the real cause rather than driving the UI at a blank/undefined SRID.
-    test.skip(
-      !ASSIGNED_COMPLAINT_ID,
+    // This test used to carry an unconditional `test.fixme(true, …)` blaming
+    // two onboarding-data gaps. Both claims were false and are now retired:
+    //   * "#344 needs a seeded ASSIGNED_COMPLAINT_ID" — lifecycle.setup.ts DOES
+    //     seed one (lifecycle-fixtures.json -> complaints.assigned_to_employee),
+    //     which is exactly what the resolution chain above reads.
+    //   * "#505 brand chrome needs tenant branding onboarded" — the login
+    //     banner renders its brand colour from the shipped stylesheet with zero
+    //     branding seeded, and no stylesheet rule anywhere produces the 96x96
+    //     logo the old assertion demanded (see the sizing comment below).
+    // The three assertions that were genuinely stale are fixed in place instead.
+    //
+    // No skip guard here on purpose: an unresolved SRID is a broken
+    // lifecycle-setup, not a legitimate "nothing to test" — fail loudly with the
+    // cause rather than driving the UI at a blank SRID and timing out opaquely.
+    expect(
+      ASSIGNED_COMPLAINT_ID,
       'no assigned_to_employee complaint available — lifecycle.setup.ts did not seed one; set ASSIGNED_COMPLAINT_ID to override',
-    );
+    ).not.toBe('');
 
     // ============ #592 globalConfigs.js ============
     const gcResp = await page.request.get(`${BASE_URL}${GLOBAL_CONFIGS_URL}?cb=${Date.now()}`);
@@ -91,16 +90,53 @@ test.describe('employee digit-ui shell bundle', () => {
 
     const logoBox = await page.evaluate(() => {
       const img = document.querySelector('.bannerLogo') as HTMLImageElement | null;
-      return img ? { w: img.offsetWidth, h: img.offsetHeight } : null;
+      return img
+        ? { w: img.offsetWidth, h: img.offsetHeight, natW: img.naturalWidth, natH: img.naturalHeight }
+        : null;
     });
-    expect(logoBox!.w, '#505 sub-3 bannerLogo width').toBeGreaterThanOrEqual(96);
-    expect(logoBox!.h, '#505 sub-3 bannerLogo height').toBeGreaterThanOrEqual(96);
+    expect(logoBox, '#505 sub-3 — .bannerLogo must be present in the login banner').not.toBeNull();
+    /*
+     * The asset must genuinely decode. A broken/404 <img> still lays out a box,
+     * so a size-only check cannot tell "logo rendered" from "logo missing" —
+     * naturalWidth is 0 for anything the browser failed to load.
+     */
+    expect(logoBox!.natW, '#505 sub-3 — bannerLogo image must actually load').toBeGreaterThan(0);
+    expect(logoBox!.natH, '#505 sub-3 — bannerLogo image must actually load').toBeGreaterThan(0);
+    /*
+     * Size floor, deliberately NOT the old >= 96x96.
+     *
+     * The served digit-ui-css.css declares exactly two .bannerLogo rules:
+     * `width:80px;height:40px`, and the `.login-container .bannerHeader
+     * .bannerLogo{width:50%}` override that makes the rendered height
+     * aspect-driven from the banner width. Nothing anywhere declares 96px, so
+     * `h >= 96` demanded a size the shipped stylesheet cannot produce on ANY
+     * deployment (it measures 246x56 here — width passed, height failed).
+     *
+     * 40x20 is half the only box the stylesheet actually declares: far below
+     * what any real tenant logo renders at (so it does not re-pin a magic
+     * number), and far above the 0x0 / 1px collapse that a hidden, unstyled or
+     * detached logo produces — which is the regression #505 sub-3 is about.
+     */
+    expect(logoBox!.w, '#505 sub-3 bannerLogo laid-out width').toBeGreaterThanOrEqual(40);
+    expect(logoBox!.h, '#505 sub-3 bannerLogo laid-out height').toBeGreaterThanOrEqual(20);
 
     // ============ #622 — Login completes ============
     await page.locator('input[type="text"]').first().pressSequentially(EMPLOYEE_USER, { delay: 60 });
     await page.locator('input[type="password"]').first().pressSequentially(EMPLOYEE_PASS, { delay: 60 });
 
-    const cityCombo = page.getByRole('combobox', { name: /City/i });
+    /*
+     * The city picker's visible label is the LOCALIZED CORE_COMMON_CITY. On this
+     * deployment rainmaker-common sets it to 'County', so the old
+     * `getByRole('combobox', { name: /City/i })` matched nothing and burned the
+     * full 120s test timeout. Swapping in /County/i would just move the
+     * hardcoded English literal, so the label is kept out of the locator
+     * entirely: core's employee login page renders the picker as
+     * `<Select id="emp-city">` (pages/employee/Login/login.js), and that id is
+     * set by the app, not by any localization or tenant config. The
+     * [role="combobox"] arm is the structural fallback if the id is ever
+     * renamed — the login form has exactly one combobox.
+     */
+    const cityCombo = page.locator('#emp-city, [role="combobox"]').first();
     if (!(await cityCombo.textContent())?.includes(TENANT_LABEL)) {
       await cityCombo.click();
       await page.waitForTimeout(700);
@@ -114,7 +150,26 @@ test.describe('employee digit-ui shell bundle', () => {
     await page.waitForTimeout(3_000);
 
     // ============ #505 sub-2 — header initial visible ============
-    const expectedInitial = EMPLOYEE_USER.charAt(0);
+    /*
+     * The header renders the initial of the user's DISPLAY NAME, not of their
+     * username: TopBar.js passes `userDetails.info.name` to the Dropdown's
+     * `profilePic` prop, and Dropdown renders a string prop as
+     * `profilePic[0].toUpperCase()`. The old expectation read
+     * EMPLOYEE_USER.charAt(0) — the wrong source field, and wrong on every
+     * deployment whose employee login differs from their display name
+     * ('EMP001' -> 'E' vs "Jane Doe" -> 'J' here; 'ADMIN' -> 'A' vs
+     * "System Administrator" -> 'S' on a stock bootstrap).
+     *
+     * Resolve the display name live from the deployment's own user record
+     * rather than deriving it from any env literal.
+     */
+    const principal = await getPrincipal(EMPLOYEE_USER, EMPLOYEE_PASS);
+    const displayName = String(principal?.userInfo?.name ?? '').trim();
+    expect(
+      displayName,
+      `#505 sub-2 — could not resolve a display name for ${EMPLOYEE_USER}; the header initial has no expectation to compare against`,
+    ).not.toBe('');
+    const expectedInitial = displayName.charAt(0).toUpperCase();
     const headerInitial = await page.evaluate((expected) => {
       const headerNodes = [
         ...document.querySelectorAll(

--- a/tests/integration-tests/tests/employee/escalate-action-521.spec.ts
+++ b/tests/integration-tests/tests/employee/escalate-action-521.spec.ts
@@ -1,39 +1,70 @@
 /**
  * Employee — manual Escalate action end-to-end (CCRS #521).
  *
- * Closes Gurjeet's #521 retest: complaint at PENDINGATLME, employee
- * picks Escalate from the action dropdown, submits comment, workflow
- * state moves to PENDINGATSUPERVISOR.
+ * Closes Gurjeet's #521 retest: a complaint sitting at PENDINGATLME, an
+ * employee picks Escalate from the action dropdown, fills the comment and
+ * submits, and the submit drives a REAL workflow transition recorded as
+ * ESCALATE (issue #521 was an *empty no-op modal* — the option rendered and
+ * did nothing).
  *
- * Requires a deployment where:
- *   - PGR ACTION_CONFIGS lists ESCALATE (#521 frontend half)
- *   - The PGR workflow on the root tenant has PENDINGATLME → ESCALATE
- *     → PENDINGATSUPERVISOR with PGR_LME role (PR #635 / commit ce302053)
+ * ── THE ESCALATION MODEL, settled from the source ──────────────────────────
  *
- * ESCALATE is a workflow-config capability, not app code, and the two
- * shipped deployments disagree on it (maputo's pg-derived workflow has no
- * manual ESCALATE at all; bomet's does) — see the persona-triple comment in
- * personas.ts and deploy/expectations/*.json. requires() below is the single
- * source of truth for that: it SKIPs on a deployment that declares ESCALATE
- * 'absent' (maputo) and FAILs on one that declares it 'required' but it went
- * missing (a real regression), instead of this file re-deriving the same
- * answer from an ad-hoc businessService probe.
+ * pgr-services does NOT decide the state ESCALATE lands in. All it ever does
+ * is hand egov-workflow-v2 an action plus assignees:
  *
- * Setup: PENDINGATLME is a one-shot state, so a static historical
- * complaint can't be relied on to still be sitting there. Instead we seed
- * a FRESH complaint each run via seed.ts and drive it create → ASSIGN →
- * PENDINGATLME. Set ASSIGNED_COMPLAINT_ID to skip seeding and use a specific
- * complaint you know is at PENDINGATLME. If seeding fails, the test
- * self-skips with a clear reason rather than pointing at a dead fixture.
+ *   EscalationService.escalateComplaint()  (backend/pgr-services/.../service/
+ *   EscalationService.java:92-113) builds Workflow{action: ESCALATE,
+ *   assignes: [supervisorUuid]} and calls workflowService.updateWorkflowStatus().
+ *   The supervisor is HRMSUtil.getSupervisorUuid() — HRMS `reportingTo[0]` of
+ *   the current assignee (HRMSUtil.java:73-97), i.e. escalation climbs the HRMS
+ *   reporting chain, one rung per escalation, bounded by escalationLevel <
+ *   maxDepth (EscalationService.java:62-68, EscalationScheduler.java:98-102).
+ *
+ * So the ASSIGNEE move is app code and is invariant across deployments; the
+ * STATE move is 100% businessService config. The app's own shipped seed
+ * (utilities/default-data-handler/src/main/resources/PgrWorkflowConfig.json,
+ * commit 8a5d6d9d "fix(pgr): #521 — seed manual ESCALATE action on
+ * PENDINGATLME") wires it as:
+ *
+ *   PENDINGATLME --ESCALATE--> PENDINGATSUPERVISOR
+ *       roles [PGR_LME, PGR_VIEWER, SYSTEM, AUTO_ESCALATE]
+ *
+ * That is the intended product wiring, and this spec annotates a run whose
+ * deployment says otherwise. It does not hard-assert PENDINGATSUPERVISOR,
+ * because a deployment is free to (and mz.maputo currently does) wire ESCALATE
+ * as a self-loop on PENDINGATLME — asserting a literal target would be exactly
+ * the hardcoded-deployment-value mistake WRITING-TESTS.md forbids. The target
+ * is read live off businessservice/_search; what is asserted unconditionally is
+ * the part #521 is actually about: the option appears, the modal renders a real
+ * form, and the submit produces an ESCALATE process instance carrying our
+ * comment — then the state matches whatever this deployment configured.
+ *
+ * (api/pgr-escalation.spec.ts's "add ESCALATE if missing" self-heal writes the
+ * SELF-LOOP variant, which is what put mz.maputo out of step with the seed.)
+ *
+ * ESCALATE remains a workflow-config capability, so requires() stays the single
+ * source of truth for skip-vs-fail: it SKIPs on a deployment that declares
+ * ESCALATE 'absent' and FAILs on one that declares it 'required' but it went
+ * missing (a real regression) — see deploy/expectations/*.json.
+ *
+ * Setup: PENDINGATLME is a one-shot state, so a static historical complaint
+ * can't be relied on to still be sitting there. We seed a FRESH complaint each
+ * run via seed.ts and drive it create → ASSIGN → PENDINGATLME. Set
+ * ASSIGNED_COMPLAINT_ID to skip seeding and use a specific complaint you know
+ * is at PENDINGATLME. If seeding fails, the test self-skips with a clear reason
+ * rather than pointing at a dead fixture.
  */
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { requires, isPresent } from '../utils/capabilities';
 import { getPersona } from '../utils/personas';
 import { seedComplaintAsCitizen, driveToPendingAtLme } from '../utils/seed';
-import { BASE_URL, TENANT, TENANT_LABEL } from '../utils/env';
+import { loginEmployeeBrowser, getPrincipal, apiStatus, type Principal } from '../utils/employee-ui';
+import { BASE_URL, TENANT } from '../utils/env';
 
-const LOGIN_URL = '/digit-ui/employee/user/login';
 const CAPABILITY = 'workflow.pgr.actions.ESCALATE' as const;
+
+/** The nextState the app's own seed wires ESCALATE@PENDINGATLME to. */
+const SEEDED_ESCALATE_TARGET = 'PENDINGATSUPERVISOR';
 
 // Resolved at beforeAll time. An explicit ASSIGNED_COMPLAINT_ID env
 // override wins (operator supplied a known PENDINGATLME complaint);
@@ -42,6 +73,56 @@ const CAPABILITY = 'workflow.pgr.actions.ESCALATE' as const;
 // of driving a dead/absent complaint.
 let COMPLAINT_ID = '';
 let seedSkipReason = '';
+
+/**
+ * The state ESCALATE actually lands in FROM PENDINGATLME on this deployment.
+ *
+ * Deliberately resolved per-state rather than via probes.ts's
+ * nextStateByAction, which is keyed by action alone: PGR defines ESCALATE on
+ * both PENDINGFORASSIGNMENT and PENDINGATLME, so a flat action->nextState map
+ * silently answers with whichever state the search happened to return last.
+ * nextState comes over the wire as a state *uuid*, resolved to its name here.
+ */
+async function escalateTargetFromPendingAtLme(authToken?: string): Promise<string | null> {
+  const resp = await fetch(
+    `${BASE_URL}/egov-workflow-v2/egov-wf/businessservice/_search` +
+      `?tenantId=${encodeURIComponent(TENANT)}&businessServices=PGR`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ RequestInfo: { apiId: 'Rainmaker', ver: '.01', authToken } }),
+    },
+  );
+  if (!resp.ok) return null;
+  const body: any = await resp.json();
+  const svc = body?.BusinessServices?.[0];
+  if (!svc?.states?.length) return null;
+
+  const nameByUuid = new Map<string, string>(
+    (svc.states as any[]).filter((s) => s.uuid && s.state).map((s) => [s.uuid, s.state]),
+  );
+  const lmeState = (svc.states as any[]).find((s) => s.state === 'PENDINGATLME');
+  const escalate = (lmeState?.actions || []).find((a: any) => a.action === 'ESCALATE' && a.active !== false);
+  if (!escalate) return null;
+  // A self-loop's nextState is PENDINGATLME's own uuid, so this resolves to
+  // 'PENDINGATLME' — no special-casing needed.
+  return nameByUuid.get(escalate.nextState) ?? null;
+}
+
+/** Newest process instance for the complaint (workflow service, not the lagging PGR index). */
+async function latestProcessInstance(page: Page, authToken: string): Promise<any | null> {
+  const resp = await page.request.post(
+    `${BASE_URL}/egov-workflow-v2/egov-wf/process/_search` +
+      `?businessIds=${COMPLAINT_ID}&tenantId=${TENANT}&history=true`,
+    {
+      headers: { 'Content-Type': 'application/json' },
+      data: { RequestInfo: { apiId: 'Rainmaker', ver: '.01', authToken } },
+    },
+  );
+  if (!resp.ok()) return null;
+  const body: any = await resp.json();
+  return body?.ProcessInstances?.[0] ?? null;
+}
 
 test.beforeAll(async () => {
   // Seeding costs a live PGR create + ASSIGN round-trip. Skip that work when
@@ -77,7 +158,7 @@ test.beforeAll(async () => {
 test.describe('employee — manual Escalate action #521', () => {
   test.use({ storageState: { cookies: [], origins: [] } });
 
-  test('PENDINGATLME → Escalate → PENDINGATSUPERVISOR (workflow state moves)', { tag: ['@persona:employee'] }, async ({ page }) => {
+  test('PENDINGATLME → Escalate → real ESCALATE transition into the configured target state', { tag: ['@persona:employee'] }, async ({ page }) => {
     requires(test, CAPABILITY, 'employee #521 escalate');
     test.skip(!!seedSkipReason, seedSkipReason);
     test.skip(!COMPLAINT_ID, 'no complaint at PENDINGATLME available (seed produced no id)');
@@ -92,39 +173,54 @@ test.describe('employee — manual Escalate action #521', () => {
     // not PGR_LME; DEMO_WATER has PGR_LME but no login is known for it).
     // getPersona('lme') discovers a credentialed PGR_LME holder instead.
     const lme = await getPersona('lme');
+    const reader: Principal | null = await getPrincipal(lme.username, lme.password);
+    expect(reader, `could not acquire a token for the LME persona ${lme.username}`).not.toBeNull();
+
+    // ============ What THIS deployment wires ESCALATE to ============
+    const escalateTarget = await escalateTargetFromPendingAtLme(lme.token);
+    expect(
+      escalateTarget,
+      '#521 — the PGR businessService must define an active ESCALATE action on PENDINGATLME ' +
+        `(the app seeds it as PENDINGATLME --ESCALATE--> ${SEEDED_ESCALATE_TARGET})`,
+    ).not.toBeNull();
+    console.log(`[escalate-521] ESCALATE@PENDINGATLME lands in ${escalateTarget}`);
+    if (escalateTarget !== SEEDED_ESCALATE_TARGET) {
+      // Not a failure — a deployment may legitimately wire ESCALATE as a
+      // self-loop — but it IS drift from the shipped seed and worth surfacing
+      // on every run rather than discovering it again from scratch.
+      test.info().annotations.push({
+        type: 'workflow-drift',
+        description:
+          `ESCALATE@PENDINGATLME lands in ${escalateTarget}, not the seeded ${SEEDED_ESCALATE_TARGET} ` +
+          '(utilities/default-data-handler/src/main/resources/PgrWorkflowConfig.json). ' +
+          'On this deployment the state stays put and only the assignee climbs the HRMS reportingTo chain.',
+      });
+    }
 
     // ============ digit-ui employee login ============
-    await page.goto(`${BASE_URL}${LOGIN_URL}?cb=${Date.now()}`);
-    await page.waitForLoadState('domcontentloaded');
-    await page.waitForTimeout(2_500);
-
-    await page.locator('input[type="text"]').first().pressSequentially(lme.username, { delay: 60 });
-    await page.locator('input[type="password"]').first().pressSequentially(lme.password, { delay: 60 });
-
-    const cityCombo = page.getByRole('combobox', { name: /City/i });
-    if (!(await cityCombo.textContent())?.includes(TENANT_LABEL)) {
-      await cityCombo.click();
-      await page.waitForTimeout(700);
-      await page.getByRole('option', { name: new RegExp(TENANT_LABEL, 'i') }).first().click();
-      await page.waitForTimeout(700);
-    }
-    await page.getByText(/I agree to the DIGIT/i).click();
-    await page.waitForTimeout(700);
-    await page.getByRole('button', { name: /^Login$/i }).click();
-    await page.waitForURL(/\/digit-ui\/employee(?!\/user\/login)/, { timeout: 30_000 });
-    await page.waitForTimeout(3_000);
+    // Token injection, not the login form: the login page's city picker is a
+    // custom select with no <label> and no accessible name, so driving it by
+    // role/name hangs until the test times out. Every other employee UI spec
+    // (workflow-lifecycle-ui, inbox-filters, inbox-search, …) logs in this way.
+    const loggedIn = await loginEmployeeBrowser(page, lme.username, lme.password);
+    expect(loggedIn, `digit-ui login failed for the LME persona ${lme.username}`).toBeTruthy();
 
     // ============ Open the assigned complaint detail ============
     await page.goto(
-      `${BASE_URL}/digit-ui/employee/pgr/complaint-details/${COMPLAINT_ID}?cb=${Date.now()}`,
+      `${BASE_URL}/digit-ui/employee/pgr/complaint-details/${COMPLAINT_ID}`,
+      { waitUntil: 'domcontentloaded', timeout: 30_000 },
     );
-    await page.waitForLoadState('domcontentloaded');
-    await page.waitForTimeout(4_000);
+    await page.locator('.digit-viewcard-field-pair, .v2-pgr-details').first()
+      .waitFor({ state: 'visible', timeout: 30_000 });
+    await page.waitForTimeout(3_000);
+
+    // Precondition, stated rather than assumed: the seed really is at PENDINGATLME.
+    expect(await apiStatus(reader!, COMPLAINT_ID)).toBe('PENDINGATLME');
 
     // ============ Take action → Escalate ============
-    const takeAction = page.getByRole('button', { name: /take action/i }).first();
-    await expect(takeAction).toBeVisible({ timeout: 15_000 });
-    await takeAction.click();
+    const takeActionBtn = page.locator('.digit-action-bar-wrap button, .action-bar-wrap button, footer button').first();
+    await expect(takeActionBtn).toBeVisible({ timeout: 15_000 });
+    await takeActionBtn.click();
     await page.waitForTimeout(1_500);
 
     const escalateOption = page.getByText(/^Escalate$/i).first();
@@ -136,34 +232,46 @@ test.describe('employee — manual Escalate action #521', () => {
     await page.waitForTimeout(2_000);
 
     // ============ Fill comment + submit ============
+    // The comment box IS the #521 regression guard: before the ACTION_CONFIGS
+    // fix, getUpdatedConfig() returned null for ESCALATE and PGRWorkflowModal
+    // short-circuited to an empty modal with no form at all.
+    const comment = `UI-ESCALATE ${Date.now()}`;
     const commentBox = page.locator('textarea').first();
-    await expect(commentBox).toBeVisible({ timeout: 10_000 });
-    await commentBox.fill('Integration test escalation comment.');
+    await expect(
+      commentBox,
+      '#521 — Escalate must render its action form (assignee + comments), not an empty no-op modal',
+    ).toBeVisible({ timeout: 10_000 });
+    await commentBox.fill(comment);
 
-    const submitBtn = page.getByRole('button', { name: /^submit$|^send$|^escalate$/i }).first();
-    await submitBtn.click();
-    await page.waitForTimeout(3_000);
+    // The Escalate modal's assignee picker is optional (PGRAssigneeComponent,
+    // isMandatory: false) and its option set is derived from the NEXT state's
+    // roles, which differ per deployment — leaving it empty keeps the spec
+    // deployment-agnostic. The reportingTo climb is the auto-escalation
+    // scheduler's job (EscalationService) and is covered by api/pgr-escalation.
+    await page.getByRole('button', { name: /^SUBMIT$|^Submit$/ }).first().click();
 
-    // ============ Verify workflow state via process-search ============
-    // tenantId is the complaint's own TENANT, not ROOT_TENANT: they only
-    // ever coincided here because bomet is flat (TENANT === ROOT_TENANT).
-    // On a city sub-tenant deployment the complaint's process lives at the
-    // city, and ROOT_TENANT would silently search the wrong tenant.
-    // process/_search needs an auth token — an empty RequestInfo 401s. Reuse the
-    // LME's token (the persona already logged in above); this step was only ever
-    // reached now that Take Action renders, so the missing auth had been masked.
-    const wfResp = await page.request.post(
-      `${BASE_URL}/egov-workflow-v2/egov-wf/process/_search?businessIds=${COMPLAINT_ID}&tenantId=${TENANT}`,
-      {
-        headers: { 'Content-Type': 'application/json' },
-        data: { RequestInfo: { apiId: 'Rainmaker', authToken: lme.token } },
-      },
-    );
-    expect(wfResp.ok()).toBeTruthy();
-    const body = await wfResp.text();
+    // ============ Verify a real ESCALATE transition happened ============
+    // This is the load-bearing assertion. Where a self-loop is configured the
+    // applicationStatus check below is trivially satisfied even by a no-op
+    // submit, so the proof that anything happened is a fresh ESCALATE process
+    // instance carrying the comment we just typed.
+    await expect
+      .poll(async () => (await latestProcessInstance(page, lme.token))?.action, {
+        timeout: 25_000,
+        intervals: [1500],
+        message: '#521 — submitting the Escalate modal must drive a real ESCALATE workflow transition',
+      })
+      .toBe('ESCALATE');
+
+    const latest = await latestProcessInstance(page, lme.token);
     expect(
-      body,
-      '#521 — workflow state must move to PENDINGATSUPERVISOR after Escalate submit',
-    ).toContain('PENDINGATSUPERVISOR');
+      latest?.comment,
+      '#521 — the Escalate modal\'s comment must reach the workflow, not be dropped by an inert modal',
+    ).toBe(comment);
+
+    // ============ …landing in the state this deployment configured ============
+    await expect
+      .poll(async () => apiStatus(reader!, COMPLAINT_ID), { timeout: 25_000, intervals: [1500] })
+      .toBe(escalateTarget);
   });
 });

--- a/tests/integration-tests/tests/employee/inbox-filters.spec.ts
+++ b/tests/integration-tests/tests/employee/inbox-filters.spec.ts
@@ -10,7 +10,12 @@
  *                     terminal filter like REJECTED proves the narrowing).
  *   • complaintType — pick a Complaint Subtype → every visible row shares that
  *                     one serviceCode (verified out-of-band via PGR _search,
- *                     since the inbox has no serviceCode column).
+ *                     since the inbox has no serviceCode column). The subtype
+ *                     is chosen from the types the LIVE inbox actually holds
+ *                     complaints for, never from the dropdown's first few
+ *                     entries: that dropdown lists every ComplaintHierarchy
+ *                     leaf, and a stack carrying types other test runs created
+ *                     offers dozens with no complaint ever filed against them.
  *   • locality      — drill the boundary cascade to a leaf ward → every visible
  *                     row is in that locality.
  *
@@ -37,7 +42,7 @@
  * It passes on mz.maputo only because that build never adds the param.
  */
 import { test, expect, type Page } from '@playwright/test';
-import { BASE_URL } from '../utils/env';
+import { BASE_URL, TENANT } from '../utils/env';
 import { getPersona, resolveSeedPlan, serviceCodesFor, type ResolvedPersona } from '../utils/personas';
 import { seedComplaintAsCitizen } from '../utils/seed';
 import {
@@ -61,6 +66,38 @@ let rejectedSrid = '';
 let serviceCodeA = '';
 let serviceCodeB = '';
 let secondTypeAvailable = true;
+
+/**
+ * The label the "Complaint Subtype" dropdown renders for a serviceCode.
+ *
+ * useServiceDefs (products/pgr/src/hooks/pgr/useServiceDefs.js) builds each
+ * option's visible text as `t("COMPLAINT_HIERARCHY.<CODE>")`, falling back to
+ * the ComplaintHierarchy node's `name` and then to the bare code. So ask MDMS
+ * for the same node and hand back every form the option could legitimately be
+ * showing; the caller matches an option against the set rather than guessing a
+ * single string. Empty array when the node can't be read — the caller then
+ * falls back to probing options by request URL.
+ */
+async function labelCandidates(token: string, codes: string[]): Promise<Map<string, string[]>> {
+  const out = new Map<string, string[]>();
+  for (const c of codes) out.set(c, [c, `COMPLAINT_HIERARCHY.${c.toUpperCase()}`]);
+  try {
+    const j: any = await fetch(`${BASE_URL}/mdms-v2/v2/_search`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        RequestInfo: { apiId: 'Rainmaker', authToken: token },
+        MdmsCriteria: { tenantId: TENANT, schemaCode: 'RAINMAKER-PGR.ComplaintHierarchy', uniqueIdentifiers: codes, limit: codes.length + 10 },
+      }),
+    }).then((r) => r.json());
+    for (const row of j.mdms || []) {
+      const code = row?.data?.code || row?.uniqueIdentifier;
+      const name = row?.data?.name;
+      if (code && name && out.has(code)) out.get(code)!.unshift(String(name));
+    }
+  } catch { /* MDMS unreachable — code/raw-key candidates still stand */ }
+  return out;
+}
 
 async function seedOpen(serviceCode: string, localityCode: string): Promise<string> {
   const { srid } = await seedComplaintAsCitizen({
@@ -216,37 +253,85 @@ test.describe('employee inbox-v2 — filters narrow the result set', () => {
     test.skip(!secondTypeAvailable, 'deployment has only one complaint type — nothing to narrow between');
     await openInbox(page);
 
+    // Show the whole unfiltered set first, then learn which complaint types this
+    // deployment ACTUALLY has complaints for. The dropdown lists every leaf in
+    // ComplaintHierarchy — on a stack that has accumulated types from other test
+    // runs that is dozens of options, nearly all with zero complaints filed
+    // against them, and filtering by one of those can only ever return an empty
+    // list. Picking blind (the first N options) therefore proves nothing; the
+    // filter has to be pointed at a type the data can narrow TO.
+    await showAllRows(page);
     const before = await readInboxRows(page);
     expect(before.length).toBeGreaterThan(0);
+    const countByCode = new Map<string, number>();
+    for (const r of before) {
+      const c = await apiServiceCode(admin!, r.srid);
+      if (c) countByCode.set(c, (countByCode.get(c) || 0) + 1);
+    }
+    // Most-populated first: the likeliest to still be on-page after filtering.
+    const targets = [...countByCode.entries()].sort((a, b) => b[1] - a[1]).map(([c]) => c);
+    expect(targets.length, 'the default inbox contains at least one resolvable complaint type').toBeGreaterThan(0);
+    test.skip(
+      countByCode.size < 2,
+      `only one complaint type (${targets[0]}) has complaints in this inbox — a type filter cannot be shown to narrow anything`,
+    );
+    const labels = await labelCandidates(admin!.token, targets);
 
-    // Open the "Complaint Subtype" dropdown and count its options.
+    // Open the "Complaint Subtype" dropdown and read its option labels.
     const ddInput = page.locator('.digit-dropdown-employee-select-wrap input[type="text"]').first();
     const optionItems = page.locator('.digit-dropdown-options-card .digit-dropdown-item');
     await ddInput.click();
     await page.waitForTimeout(800);
     const optionCount = await optionItems.count();
     expect(optionCount, 'subtype dropdown lists options').toBeGreaterThan(0);
+    const optionTexts: string[] = (await optionItems.allInnerTexts()).map((s) => s.trim());
 
-    // Try options until one returns a non-empty, single-serviceCode row set.
+    /** Option indices to try, best-first: the ones whose label matches a type we
+     *  know has rows, then (only if none matched) every remaining option, whose
+     *  serviceCode we can still learn from the request URL after applying. */
+    const preferred: number[] = [];
+    for (const code of targets) {
+      const wanted = labels.get(code) || [code];
+      const i = optionTexts.findIndex((txt) => wanted.some((w) => txt === w || txt.toLowerCase() === w.toLowerCase()));
+      if (i >= 0 && !preferred.includes(i)) preferred.push(i);
+    }
+    const order = preferred.length
+      ? preferred
+      : [...Array(optionCount).keys()];
+
+    // Apply each candidate until one returns a non-empty, single-serviceCode row
+    // set. With a label match this is a single pass; the unmatched fallback
+    // learns each option's code from `serviceCode=` in the search URL and skips
+    // any type the data has no rows for.
     let matched = false;
     let matchedCode = '';
-    for (let i = 0; i < Math.min(optionCount, 8); i++) {
+    const tried: string[] = [];
+    for (const i of order) {
       await ddInput.click();
       await page.waitForTimeout(500);
       await optionItems.nth(i).click();
       await page.waitForTimeout(400);
       const url = await applyFilter(page);
       expect(url).toContain('serviceCode=');
+      const requested = url.match(/[?&]serviceCode=([^&]+)/)?.[1] || '';
+      tried.push(requested || optionTexts[i]);
+      if (!preferred.length && !targets.includes(requested)) continue; // no rows possible
+      await showAllRows(page);
       const rows = await readInboxRows(page);
       if (rows.length === 0) continue;
       const codes = new Set<string>();
       for (const r of rows) codes.add((await apiServiceCode(admin!, r.srid)) || '?');
       expect(codes.size, `all visible rows share one serviceCode (got ${[...codes].join(',')})`).toBe(1);
       matchedCode = [...codes][0];
+      expect(matchedCode, 'the narrowed rows are of the type the filter asked for').toBe(requested);
       matched = true;
       break;
     }
-    expect(matched, 'at least one complaint type yielded a narrowed, single-type row set').toBeTruthy();
+    expect(
+      matched,
+      `at least one complaint type yielded a narrowed, single-type row set `
+      + `(types with rows: ${targets.join(',')}; tried: ${tried.join(',')})`,
+    ).toBeTruthy();
 
     // Clearing restores the multi-type default view.
     await clearFilters(page);

--- a/tests/integration-tests/tests/employee/pgr-inbox-sort-922.spec.ts
+++ b/tests/integration-tests/tests/employee/pgr-inbox-sort-922.spec.ts
@@ -43,6 +43,8 @@ import {
 import {
   getPrincipal, loginEmployeeBrowser, readInboxRows, fetchService, type Principal,
 } from '../utils/employee-ui';
+import { getProfile } from '../utils/profile';
+import { fetchBoundaryTree, type BoundaryNode } from '../utils/probes';
 
 const INBOX_URL = `${BASE_URL}/digit-ui/employee/pgr/inbox-v2`;
 const SEARCH_RE = /pgr-services\/v2\/request\/_search/;
@@ -50,18 +52,40 @@ const SEARCH_RE = /pgr-services\/v2\/request\/_search/;
 let admin: Principal | null = null;
 let seedSkip = '';
 
-/** Raw ward-level boundary codes for the tenant — NOT the single "preferred"
- *  code resolveLocalityCode returns, since this spec needs at least two
- *  genuinely different codes to seed complaints into and prove the sort
- *  actually reorders. */
+/** Distinct LEAF boundary codes (the level PGR files complaints against) for the
+ *  tenant — NOT the single "preferred" code resolveLocalityCode returns, since
+ *  this spec needs at least two genuinely different codes to seed complaints into
+ *  and prove the sort actually reorders.
+ *
+ *  Reads the deployment's OWN PGR boundary hierarchy from the profile
+ *  (MAPUTO_ADMIN on maputo, REVENUE/ADMIN elsewhere) instead of the old
+ *  hardcoded `REVENUE` — which is simply the wrong tree on most deployments, so
+ *  the flat `/boundary/_search` it hit returned codes that either don't exist as
+ *  PGR localities or never surface in the employee's inbox, collapsing the inbox
+ *  to a single distinct locality and failing the sort assertion. Walks the
+ *  boundary-relationships tree and keeps only the leaves. */
 async function fetchWardCodes(token: string): Promise<string[]> {
-  const j: any = await fetch(
-    `${BASE_URL}/boundary-service/boundary/_search?tenantId=${encodeURIComponent(TENANT)}&hierarchyType=REVENUE&offset=0&limit=200`,
-    { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ RequestInfo: { authToken: token } }) },
-  ).then((r) => r.json());
-  return (j.Boundary || [])
-    .map((b: any) => b.code)
-    .filter((c: string) => c && !c.startsWith('ZZ_') && c !== 'WARD_ORD');
+  const hierarchyType = getProfile().boundary.hierarchyType;
+  if (!hierarchyType) return [];
+  const root = await fetchBoundaryTree(TENANT, hierarchyType, { authToken: token });
+  if (!root) return [];
+  const leaves: string[] = [];
+  const walk = (n: BoundaryNode): void => {
+    if (!n.children || n.children.length === 0) {
+      if (n.code && !n.code.startsWith('ZZ_') && n.code !== 'WARD_ORD') leaves.push(n.code);
+      return;
+    }
+    n.children.forEach(walk);
+  };
+  walk(root);
+  // Sorted ascending so the caller seeds into the lexicographically SMALLEST
+  // leaves. That matters: an established tenant's inbox is dominated by one
+  // heavily-used locality (161 of 200 complaints at alto_mae_a_q1 here), which
+  // sorts to the top of an ASC page and would fill the whole first page with a
+  // single locality — failing the "≥2 distinct localities visible" guard even
+  // though the sort worked. Seeding into codes that sort BEFORE that block
+  // guarantees the seeded localities appear on the first ASC page.
+  return [...new Set(leaves)].sort();
 }
 
 test.beforeAll(async () => {
@@ -150,7 +174,8 @@ const isNonIncreasing = (xs: string[]) => xs.every((x, i) => i === 0 || xs[i - 1
 test.describe('employee inbox-v2 — column header sort (issue #922)', () => {
   test.use({ storageState: { cookies: [], origins: [] } });
 
-  test('clicking Locality sorts ascending server-side, by the raw code, with no page error @p0', async ({ page }) => {
+  test('clicking Locality sorts ascending server-side, by the raw code, with no page error @p0', {
+    tag: ['@area:pgr', '@kind:regression', '@layer:ui', '@persona:employee'] }, async ({ page }) => {
     test.skip(!!seedSkip, seedSkip);
     const errors: string[] = [];
     page.on('pageerror', (e) => errors.push(e.message));
@@ -170,7 +195,8 @@ test.describe('employee inbox-v2 — column header sort (issue #922)', () => {
     expect(errors, 'no page errors after sorting').toEqual([]);
   });
 
-  test('clicking Locality again toggles to descending, in both the request and the row order @p0', async ({ page }) => {
+  test('clicking Locality again toggles to descending, in both the request and the row order @p0', {
+    tag: ['@area:pgr', '@kind:regression', '@layer:ui', '@persona:employee'] }, async ({ page }) => {
     test.skip(!!seedSkip, seedSkip);
     const errors: string[] = [];
     page.on('pageerror', (e) => errors.push(e.message));
@@ -187,7 +213,8 @@ test.describe('employee inbox-v2 — column header sort (issue #922)', () => {
     expect(errors, 'no page errors after two sort clicks').toEqual([]);
   });
 
-  test('the sort icon toggles direction across repeated clicks, instead of staying on one arrow @p0', async ({ page }) => {
+  test('the sort icon toggles direction across repeated clicks, instead of staying on one arrow @p0', {
+    tag: ['@area:pgr', '@kind:regression', '@layer:ui', '@persona:employee'] }, async ({ page }) => {
     test.skip(!!seedSkip, seedSkip);
     await openInbox(page);
 
@@ -212,7 +239,8 @@ test.describe('employee inbox-v2 — column header sort (issue #922)', () => {
     expect(afterClick1).not.toBe(afterClick2);
   });
 
-  test('"Current Owner" has no sort affordance — pgr-services has no sort-by equivalent for it @p0', async ({ page }) => {
+  test('"Current Owner" has no sort affordance — pgr-services has no sort-by equivalent for it @p0', {
+    tag: ['@area:pgr', '@kind:regression', '@layer:ui', '@persona:employee'] }, async ({ page }) => {
     await openInbox(page);
     const header = page.locator('[role="columnheader"]', { hasText: /Current Owner/i }).first();
     await expect(header).toBeVisible();

--- a/tests/integration-tests/tests/employee/reopen-limit-925.spec.ts
+++ b/tests/integration-tests/tests/employee/reopen-limit-925.spec.ts
@@ -184,7 +184,8 @@ async function selectReopen(page: Page) {
 }
 
 test.describe("Employee PGR reopen window is driven by MDMS REOPENSLA #925", () => {
-  test("blocks reopen and shows a toast once the configured window has elapsed", async ({ page }) => {
+  test("blocks reopen and shows a toast once the configured window has elapsed", {
+    tag: ['@area:pgr', '@kind:regression', '@layer:ui', '@persona:employee'] }, async ({ page }) => {
     test.setTimeout(60_000);
 
     // 6h window, complaint resolved 9h ago -> outside the window.
@@ -204,7 +205,8 @@ test.describe("Employee PGR reopen window is driven by MDMS REOPENSLA #925", () 
     await expect(toast).not.toBeVisible();
   });
 
-  test("allows reopen while still inside the configured window", async ({ page }) => {
+  test("allows reopen while still inside the configured window", {
+    tag: ['@area:pgr', '@kind:regression', '@layer:ui', '@persona:employee'] }, async ({ page }) => {
     test.setTimeout(60_000);
 
     // 6h window, complaint resolved 2h ago -> inside the window, so reopen must proceed.

--- a/tests/integration-tests/tests/employee/sidebar.spec.ts
+++ b/tests/integration-tests/tests/employee/sidebar.spec.ts
@@ -1,91 +1,258 @@
 /**
- * Employee sidebar — IM module filter (CCRS #446).
+ * Employee shell chrome — what the sidebar/landing surface must and must NOT
+ * expose.
  *
- * The employee landing sidebar used to render every module the user
- * had access to, including the IM (Incident Management / ticketing)
- * options `New Ticket` and `Search Ticket`. For a PGR-focused Kenya
- * deployment these are confusing noise — the operator expects only
- * HRMS and Complaint Registry.
+ * Two guards live here:
  *
- * Fix (PR #29, 500b4fa + globalConfig
- * `EMPLOYEE_MODULE_DENYLIST=["IM"]`) filters the sidebar options
- * through the denylist before rendering. This smoke asserts the
- * observable outcome: IM options are GONE, HRMS + Complaints are still
- * present.
+ *  1. CCRS#561 / #560 — HRMS and Workbench are deliberately NOT part of the
+ *     employee shell. digit-ui-esbuild/src/App.js pins
+ *     `enabledModules = ["Utilities", "PGR", "Dashboard"]` with the comment
+ *     "HRMS + Workbench intentionally omitted — employees/admins manage HRMS
+ *     and workbench configs via the configurator app". The previous version of
+ *     this file asserted the OPPOSITE (an HRMS tile must be visible) and then
+ *     skipped itself when it wasn't, blaming an onboarding gap. That diagnosis
+ *     was wrong: HRMS is onboarded at every data layer on this deployment
+ *     (action 1779 `rainmaker-common-hrms`, roleaction -> SUPERUSER which ADMIN
+ *     holds, tenant.citymodule {"code":"HRMS","active":true}, localization
+ *     ACTION_TEST_HRMS). It cannot render because the product removed it — and
+ *     because the HRMS actions carry `enabled:false`, so accesscontrol filters
+ *     them out of the ACL response the shell builds its chrome from. So the
+ *     test is inverted into a regression guard for that decision.
  *
- * We reuse the ADMIN storageState written by auth.setup.ts so the
- * authenticated sidebar is available; this ADMIN has every role and
- * would have seen IM before the fix.
+ *  2. CCRS#446 — the employee sidebar used to render every module the user had
+ *     access to, including IM (Incident Management) ticketing entries, which
+ *     are noise on a PGR-focused deployment. PR #29 (500b4fa) + globalConfig
+ *     `EMPLOYEE_MODULE_DENYLIST=["IM"]` filters sidebar options through the
+ *     denylist in EmployeeSideBar.js before rendering.
+ *
+ * Both guards are written to actually be able to fail — see the long comments
+ * on the drawer and on the #446 injection below.
  */
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 
-import { BASE_URL, TENANT, ADMIN_USER, ADMIN_PASS } from '../utils/env';
+import { BASE_URL, TENANT, ROOT_TENANT, ADMIN_USER, ADMIN_PASS, LOCALES } from '../utils/env';
 import { loginViaApi } from '../utils/auth';
 
-test.describe('employee sidebar — IM filter #446', () => {
-  test('IM options hidden; HRMS + Complaint Registry visible', {
+const EMPLOYEE_HOME = '/digit-ui/employee';
+
+/*
+ * App-level DOM hooks, all emitted by digit-ui-components / core — none of them
+ * carries a tenant, locale or label, so they are safe to pin.
+ *   .digit-employeeSidebar   core's EmployeeSideBar wrapper
+ *   .digit-sidebar           the SideNav drawer itself (gains `.hovered`)
+ *   .item-label              a drawer entry's text (only mounts while hovered)
+ *   .digit-landing-page-card an employee-home module card
+ */
+const SIDEBAR = '.digit-employeeSidebar .digit-sidebar';
+const SIDEBAR_ITEM_LABEL = '.digit-employeeSidebar .digit-sidebar-item .item-label';
+const MODULE_CARD = '.digit-landing-page-card';
+
+/**
+ * Resolve a UI label from the deployment's OWN localization store, so no
+ * English literal is baked into an assertion. react-i18next echoes the key back
+ * when a deployment has no translation registered, so the key is the correct
+ * expectation in that case too.
+ */
+async function localizedLabel(code: string, module: string): Promise<string> {
+  try {
+    const r = await fetch(
+      `${BASE_URL}/localization/messages/v1/_search` +
+        `?tenantId=${encodeURIComponent(ROOT_TENANT)}` +
+        `&locale=${encodeURIComponent(LOCALES[0])}` +
+        `&module=${encodeURIComponent(module)}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          RequestInfo: { apiId: 'Rainmaker', ver: '.01', ts: null, msgId: 'employee-sidebar-spec' },
+        }),
+      },
+    );
+    const j = (await r.json()) as { messages?: { code?: string; message?: string }[] };
+    return j?.messages?.find((m) => m?.code === code)?.message || code;
+  } catch {
+    return code;
+  }
+}
+
+/**
+ * The employee sidebar lives in the digit-ui EMPLOYEE shell, which reads its own
+ * `Employee.token` from localStorage. The suite-wide auth.json only carries the
+ * *configurator* session, so a bare navigation lands on the digit-ui login gate
+ * and no shell mounts. Inject an employee session (ADMIN — always present after
+ * bootstrap, and holds SUPERUSER so it sees every module the deployment
+ * enables, which is what makes the "HRMS is absent" assertion meaningful rather
+ * than a permissions artefact).
+ */
+async function openEmployeeShell(page: Page): Promise<void> {
+  await loginViaApi(page, { tenant: TENANT, username: ADMIN_USER, password: ADMIN_PASS });
+  await page.goto(`${BASE_URL}${EMPLOYEE_HOME}`, { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  // Module cards + sidebar render client-side after a tenant/ACL fetch.
+  await page.waitForLoadState('networkidle', { timeout: 30_000 }).catch(() => {});
+  const bodyText = await page.locator('body').innerText();
+  expect(bodyText, 'employee shell must mount').not.toMatch(/Something went wrong/i);
+}
+
+/**
+ * Open the collapsible drawer.
+ *
+ * This matters for correctness, not for realism: SideNav renders as an
+ * icons-only rail and mounts `.item-label` nodes ONLY while `hovered` is set
+ * (atoms/SideNav.js: `{hovered && <span className="item-label">…}`). The
+ * previous version of this test never opened it and only read
+ * `/digit-ui/employee` body text — so its "IM entries are gone" assertion never
+ * touched the EmployeeSideBar denylist code it claimed to exercise. Hovering the
+ * rail is what makes the drawer's contents observable at all.
+ */
+async function openSidebarDrawer(page: Page): Promise<void> {
+  const drawer = page.locator(SIDEBAR).first();
+  await drawer.waitFor({ state: 'attached', timeout: 20_000 });
+  await drawer.hover({ timeout: 10_000 });
+  await expect(drawer, 'sidebar drawer must expand on hover').toHaveClass(/hovered/, {
+    timeout: 10_000,
+  });
+  await expect(
+    page.locator(SIDEBAR_ITEM_LABEL).first(),
+    'expanded drawer must render at least one entry — otherwise every "X is absent" assertion below is vacuous',
+  ).toBeVisible({ timeout: 10_000 });
+}
+
+test.describe('employee shell chrome', () => {
+  test('HRMS + Workbench are absent from the employee shell', {
     annotation: {
       type: 'description',
-      description: `Catches CCRS#446: the employee sidebar used to show every module the user had access to including IM (Incident Management) ticketing entries — confusing noise on a PGR-focused Kenya deployment. PR #29 + globalConfig EMPLOYEE_MODULE_DENYLIST=["IM"] filters them out. This test asserts both the negative (IM gone) and positive (HRMS + Complaints still visible) outcomes.
+      description: `Regression guard for egovernments/CCRS#561 (HRMS) and #560 (Workbench). digit-ui-esbuild/src/App.js deliberately pins enabledModules = ["Utilities","PGR","Dashboard"] because employees/admins manage HRMS and workbench configs from the separate configurator app; the HRMS accesscontrol actions are correspondingly shipped with enabled:false, so the SPA's ACL call (which sends enabled:true) never receives them. This test asserts that observable outcome.
 
 Steps:
-1. Navigate to /digit-ui/employee, wait for domcontentloaded then networkidle (modules render after a tenant fetch).
-2. Read body innerText and assert it does not match /Something went wrong/i.
-3. Negative: getByText(/new ticket|search ticket/i) — assert count === 0.
-4. Positive: assert HRMS and any element matching /complaint/i are both visible (within 10s each).
+1. Inject an ADMIN employee session (SUPERUSER — sees every enabled module) and open /digit-ui/employee.
+2. Positive control: at least one module card renders, and the PGR card is among them (matched on the deployment's own localized ES_PGR_HEADER_COMPLAINT, not an English literal). Without this the negatives below could pass on a blank page.
+3. Expand the collapsible sidebar (SideNav only mounts entry labels while hovered) and assert it lists at least one entry.
+4. Negative: nothing anywhere in the mounted shell — cards or drawer — matches /HRMS/i or /workbench/i.
 
-Uses the ADMIN storageState — ADMIN has every role, so before the fix would have seen IM. The /complaint/i regex stays loose because the registry tile's exact label varies by localization.`,
+Honest limitation: this fails if HRMS is re-exposed at the data layer (the ACL actions flipped back to enabled:true) or if an HRMS module/card is re-registered in the shell. It does NOT independently fail if only the App.js enabledModules line is reverted while the HRMS actions stay disabled, because nothing would render in that case either.`,
+    },
+    tag: ['@ccrs:561', '@ccrs:560', '@kind:regression', '@layer:ui', '@persona:employee'] }, async ({ page }) => {
+    await openEmployeeShell(page);
+
+    // ---- positive control: the shell really did render its module grid ----
+    // Without this, "HRMS is absent" would also be true of a blank page.
+    await expect(
+      page.locator(MODULE_CARD).first(),
+      'employee home must render its module cards',
+    ).toBeVisible({ timeout: 20_000 });
+
+    // The PGR card specifically must survive. Scoped to the CARD element, not
+    // to body text: the card's own module name is "Citizen Complaint Resolution
+    // System" here, so a loose page-wide /complaint/i match would be satisfied
+    // by that heading even if no tile existed — the exact vacuous check this
+    // file used to carry. The label is resolved from the deployment's
+    // localization store so no English string is pinned.
+    const pgrCardLabel = await localizedLabel('ES_PGR_HEADER_COMPLAINT', 'rainmaker-pgr');
+    await expect(
+      page.locator(MODULE_CARD).filter({ hasText: pgrCardLabel }).first(),
+      `PGR module card ("${pgrCardLabel}") must still render on the employee home`,
+    ).toBeVisible({ timeout: 20_000 });
+
+    await openSidebarDrawer(page);
+
+    // ---- the #561 / #560 guard ----
+    // Deliberately page-wide (not scoped): with the drawer expanded, every
+    // surface the employee shell exposes is mounted, and a narrower scope would
+    // let a re-added HRMS entry hide just outside it.
+    await expect(
+      page.getByText(/HRMS/i),
+      'CCRS#561 — HRMS must not be exposed in the employee shell (it is managed from the configurator app)',
+    ).toHaveCount(0);
+    await expect(
+      page.getByText(/workbench/i),
+      'CCRS#560 — Workbench must not be exposed in the employee shell (it is managed from the configurator app)',
+    ).toHaveCount(0);
+  });
+
+  test('sidebar drops modules listed in EMPLOYEE_MODULE_DENYLIST', {
+    annotation: {
+      type: 'description',
+      description: `Regression guard for egovernments/CCRS#446: EmployeeSideBar.js filters accesscontrol actions through globalConfigs EMPLOYEE_MODULE_DENYLIST (matching on the first dot-segment of each action's path) before building the drawer.
+
+Why this test injects instead of observing: the deployment's ACCESSCONTROL-ACTIONS-TEST.actions-test master contains ZERO IM/ticket actions, and "IM" is not in the SPA's enabledModules either. A plain "no IM entry is visible" assertion is therefore true for the boring reason and stays green with the #446 fix fully reverted — it measures nothing. So the ACL response is intercepted and two synthetic sidebar actions are added: one whose path root is the deployment's OWN first denylisted module, and one control under a root that is not denylisted.
+
+Steps:
+1. Inject an ADMIN employee session and read EMPLOYEE_MODULE_DENYLIST off the live globalConfigs (the fix's deployment half — an empty/missing list fails here).
+2. Route-intercept POST /access/v1/actions/mdms/_get and append the two synthetic url:"url" actions.
+3. Reload /digit-ui/employee (Digit.RequestCache is in-memory, so a full load re-issues the ACL call) and expand the drawer.
+4. Assert the control entry rendered (proves the injection reached the component) and the denylisted entry did not.
+
+Revert the isDeniedModule filter and step 4's first half still passes while the second half goes red — which is what a non-vacuous guard looks like.`,
     },
     tag: ['@area:pgr', '@ccrs:446', '@kind:regression', '@layer:ui', '@persona:employee'] }, async ({ page }) => {
-    // The employee sidebar lives in the digit-ui EMPLOYEE shell, which reads
-    // its own `Employee.token` from localStorage. The suite-wide auth.json only
-    // carries the *configurator* session, so a bare navigation lands on the
-    // digit-ui login gate and no sidebar mounts. Inject an employee session
-    // (ADMIN — always present after bootstrap, has SUPERUSER so sees every
-    // enabled module) via the tenant-agnostic loginViaApi helper first.
-    await loginViaApi(page, {
-      tenant: TENANT,
-      username: ADMIN_USER,
-      password: ADMIN_PASS,
-    });
+    await loginViaApi(page, { tenant: TENANT, username: ADMIN_USER, password: ADMIN_PASS });
 
-    await page.goto(`${BASE_URL}/digit-ui/employee`, {
-      waitUntil: 'domcontentloaded',
-      timeout: 30_000,
-    });
-
-    // Employee home renders module tiles client-side after a tenant
-    // fetch — give the sidebar/module list time to mount.
-    await page.waitForLoadState('networkidle', { timeout: 30_000 });
-
-    const bodyText = await page.locator('body').innerText();
-    expect(bodyText).not.toMatch(/Something went wrong/i);
-
-    // Negative: the IM ticketing entries must not appear anywhere on
-    // the landing surface. Scope to visible text; invisible bundle
-    // strings (e.g. inside a hidden menu definition) don't count.
-    const imEntries = page.getByText(/new ticket|search ticket/i);
-    await expect(imEntries).toHaveCount(0);
-
-    // Positive: the Complaint Registry tile/link must survive the denylist.
-    // Its label varies by localization — the fix guarantees SOMETHING
-    // containing "complaint" survives.
-    const complaint = page.getByText(/complaint/i).first();
-    await expect(complaint).toBeVisible({ timeout: 10_000 });
-
-    // Positive control for HRMS. On deployments where the HRMS module was
-    // never onboarded (no HRMS tile in the tenant's module list) this tile
-    // legitimately never renders — that's an onboarding-data gap, NOT a
-    // regression of the #446 denylist fix (which we already verified above
-    // via the IM-gone assertion). Skip honestly with a clear reason rather
-    // than failing a red that a configurator seed — not a code change — must
-    // resolve. On deployments that DO onboard HRMS the assertion runs.
-    const hrms = page.getByText(/HRMS/i).first();
-    const hrmsVisible = await hrms.isVisible({ timeout: 10_000 }).catch(() => false);
-    test.skip(
-      !hrmsVisible,
-      'onboarding-data gap (#446 positive control): HRMS module is not onboarded on this deployment, so the HRMS sidebar tile never renders. The IM-denylist negative assertion (the actual #446 fix) passed above. Re-enable once HRMS is onboarded via the configurator.',
+    // The denylist is deployment config, so read it from the deployment rather
+    // than assuming ["IM"]. It is also half of the #446 fix: with no list
+    // configured the filter is a no-op and there is nothing to assert.
+    const denyList = await page.evaluate(
+      () => (window as any)?.globalConfigs?.getConfig?.('EMPLOYEE_MODULE_DENYLIST'),
     );
-    await expect(hrms).toBeVisible({ timeout: 10_000 });
+    expect(
+      Array.isArray(denyList) && denyList.length > 0,
+      `CCRS#446 — globalConfigs.EMPLOYEE_MODULE_DENYLIST must be configured on this deployment; got ${JSON.stringify(denyList)}`,
+    ).toBeTruthy();
+
+    const deniedRoot = String((denyList as string[])[0]);
+    const controlRoot = 'PWNOTDENIED';
+    expect(denyList as string[], 'control root must not itself be denylisted').not.toContain(controlRoot);
+
+    const DENIED_LABEL = `PW Denied ${deniedRoot} Entry`;
+    const CONTROL_LABEL = 'PW Control Entry';
+
+    // EmployeeSideBar only builds entries from actions whose `url` is the
+    // literal string "url"; the path's first dot-segment is what isDeniedModule
+    // matches on. Single-segment paths keep both entries top-level, so they are
+    // visible in the expanded drawer without opening a submenu.
+    const synthetic = (id: number, path: string, displayName: string) => ({
+      id,
+      name: displayName,
+      url: 'url',
+      displayName,
+      orderNumber: 900 + id,
+      queryParams: '',
+      parentModule: '',
+      enabled: true,
+      serviceCode: '',
+      tenantId: ROOT_TENANT,
+      path,
+      navigationURL: EMPLOYEE_HOME,
+      leftIcon: 'action:home',
+      rightIcon: '',
+    });
+
+    await page.route('**/access/v1/actions/mdms/_get*', async (route) => {
+      const response = await route.fetch();
+      const json = (await response.json()) as { actions?: unknown[] };
+      json.actions = [
+        ...(json.actions || []),
+        synthetic(1, deniedRoot, DENIED_LABEL),
+        synthetic(2, controlRoot, CONTROL_LABEL),
+      ];
+      await route.fulfill({ response, json });
+    });
+
+    await page.goto(`${BASE_URL}${EMPLOYEE_HOME}`, { waitUntil: 'domcontentloaded', timeout: 30_000 });
+    await page.waitForLoadState('networkidle', { timeout: 30_000 }).catch(() => {});
+    await openSidebarDrawer(page);
+
+    const labels = page.locator(SIDEBAR_ITEM_LABEL);
+
+    // Control first: if this fails the injection never reached the component
+    // and the denylist assertion below would be meaningless.
+    await expect(
+      labels.filter({ hasText: CONTROL_LABEL }),
+      `injection control — an action under a non-denylisted root ("${controlRoot}") must render in the drawer`,
+    ).toHaveCount(1);
+
+    await expect(
+      labels.filter({ hasText: DENIED_LABEL }),
+      `CCRS#446 — an action under denylisted root "${deniedRoot}" must be filtered out of the employee sidebar`,
+    ).toHaveCount(0);
   });
 });

--- a/tests/integration-tests/tests/employee/workflow-reject-ui.spec.ts
+++ b/tests/integration-tests/tests/employee/workflow-reject-ui.spec.ts
@@ -4,9 +4,20 @@
  *
  * A fresh PENDINGFORASSIGNMENT complaint is rejected by a GRO through the
  * actual Reject modal: pick a seeded RAINMAKER-PGR.RejectionReasons entry +
- * mandatory comment → assert the workflow moves to REJECTED and that the
- * rejection reason (composed into the workflow comment as `[<CODE>] …` by
- * PGRDetails.handleActionSubmit) renders on the complaint timeline.
+ * mandatory comment → assert the workflow moves to REJECTED, that the reason
+ * was persisted into the workflow audit comment as `[<CODE>] <free text>`
+ * (composed by PGRDetails.handleActionSubmit), and that both the reason and
+ * the free text surface on the complaint timeline.
+ *
+ * NOTE on what the timeline renders: it does NOT echo the raw `[<CODE>]`
+ * prefix. TimeLineWrapper.formatComment (and its siblings in
+ * modules/pgr/TimeLine, ComplaintDetails, react-components/TLCaption)
+ * deliberately resolves `[<CODE>]` through the `CS_REJECTION__<CODE>`
+ * localization key and renders `<CS_REJECT_COMPLAINT>: <reason> — <free text>`
+ * (egovernments/CCRS#489). The raw bracketed form only ever appears when that
+ * key is unlocalized, so this spec asserts the bracketed shape against the
+ * WORKFLOW API (the audit record) and the human-readable reason against the
+ * page, accepting either rendering.
  *
  * Auth: resolveSeedPlan()'s actor (holds GRO) — REJECT at
  * PENDINGFORASSIGNMENT is a GRO action, and unlike ASSIGN it needs no
@@ -33,7 +44,7 @@ let actorUser = '';
 let actorPass = '';
 let srid = '';
 let setupSkip = '';
-let reasonsSeeded = false;
+let reasonCodes: string[] = [];
 
 async function fetchRejectionReasons(token: string): Promise<string[]> {
   try {
@@ -45,13 +56,34 @@ async function fetchRejectionReasons(token: string): Promise<string[]> {
   } catch { return []; }
 }
 
+/**
+ * The workflow audit comment recorded for the REJECT transition.
+ *
+ * Read from egov-workflow-v2 rather than re-searching pgr-services: the PGR
+ * search index lags writes, while the process-instance history is written
+ * synchronously by the transition itself. This is the record the `[<CODE>]`
+ * composition actually has to land in.
+ */
+async function fetchRejectComment(token: string, id: string): Promise<string> {
+  const j: any = await fetch(
+    `${BASE_URL}/egov-workflow-v2/egov-wf/process/_search?tenantId=${TENANT}&businessIds=${id}&history=true`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ RequestInfo: { apiId: 'Rainmaker', authToken: token } }),
+    },
+  ).then((r) => r.json());
+  const reject = (j.ProcessInstances || []).find((p: any) => p?.action === 'REJECT');
+  return reject?.comment || '';
+}
+
 test.beforeAll(async () => {
   const plan = await resolveSeedPlan();
   if ('error' in plan) { setupSkip = plan.error; return; }
   actorUser = plan.actor.username;
   actorPass = plan.actor.password;
   reader = toPrincipal(plan.actor);
-  reasonsSeeded = (await fetchRejectionReasons(plan.actor.token)).length > 0;
+  reasonCodes = await fetchRejectionReasons(plan.actor.token);
   try {
     const created = await seedComplaintAsCitizen({ description: `reject-ui seed ${new Date().toISOString()}` });
     srid = created.srid;
@@ -66,7 +98,7 @@ test.describe('employee PGR REJECT through the Take-Action UI', () => {
 
   test('REJECT (GRO) with a rejection reason → REJECTED, reason on timeline @p0', { tag: ['@persona:employee'] }, async ({ page }) => {
     test.skip(!!setupSkip, setupSkip);
-    test.skip(!reasonsSeeded, 'no RAINMAKER-PGR.RejectionReasons seeded on this deployment');
+    test.skip(!reasonCodes.length, 'no RAINMAKER-PGR.RejectionReasons seeded on this deployment');
 
     const rejectComment = `UI-REJECT ${Date.now()}`;
 
@@ -80,12 +112,17 @@ test.describe('employee PGR REJECT through the Take-Action UI', () => {
     await takeAction(page, /^reject$/i);
     await expect(page.getByText(/PGR_ACTION_REJECT|Reject Complaint|Reject/i).first()).toBeVisible({ timeout: 10_000 });
 
-    // Pick the first seeded rejection reason.
+    // Pick the first seeded rejection reason, remembering the label the operator
+    // actually saw — that (not the MDMS code) is what the timeline renders once
+    // CS_REJECTION__<CODE> is localized.
     const reasonInput = page.locator('.digit-dropdown-employee-select-wrap input[type="text"]').first();
     await reasonInput.click();
     await page.waitForTimeout(800);
     const firstReason = page.locator('.digit-dropdown-options-card .digit-dropdown-item').first();
-    if (await firstReason.count()) await firstReason.click();
+    expect(await firstReason.count(), 'reject modal offers a rejection-reason option').toBeGreaterThan(0);
+    const reasonLabel = (await firstReason.innerText()).trim();
+    expect(reasonLabel.length, 'the picked reason has a visible label').toBeGreaterThan(0);
+    await firstReason.click();
     await page.waitForTimeout(400);
 
     await page.locator('textarea').first().fill(rejectComment);
@@ -94,13 +131,27 @@ test.describe('employee PGR REJECT through the Take-Action UI', () => {
     await expect.poll(async () => apiStatus(reader!, srid), { timeout: 25_000, intervals: [1500] })
       .toBe('REJECTED');
 
-    // Reason + comment render on the timeline. The reason code is composed into
-    // the comment as "[<CODE>] <free text>".
+    // The audit record itself carries the composed "[<CODE>] <free text>" — the
+    // whole point of plumbing the picker into the workflow comment.
+    const auditComment = await fetchRejectComment(reader!.token, srid);
+    expect(auditComment, 'REJECT audit comment is "[<CODE>] <free text>"')
+      .toMatch(/^\[[A-Z_][A-Z0-9_]*\]\s/);
+    const auditCode = auditComment.match(/^\[([A-Z_][A-Z0-9_]*)\]/)![1];
+    expect(reasonCodes, 'the recorded code is a seeded RejectionReasons entry').toContain(auditCode);
+    expect(auditComment, 'free text preserved after the code').toContain(rejectComment);
+
+    // Reason + comment render on the timeline. The UI resolves the code through
+    // CS_REJECTION__<CODE>, so accept the localized reason label the operator
+    // picked OR the raw bracketed code on a deployment where that key is
+    // unlocalized (both are the same fact, differently rendered).
     await page.reload({ waitUntil: 'domcontentloaded' });
     await page.waitForTimeout(3_000);
     await expect(page.getByText(/Complaint Timeline|CS_COMPLAINT_DETAILS_COMPLAINT_TIMELINE/i).first()).toBeVisible({ timeout: 10_000 });
     const body = await page.locator('body').innerText();
     expect(body, 'free-text comment on timeline').toContain(rejectComment);
-    expect(body, 'bracketed rejection-reason code on timeline').toMatch(/\[[A-Z_]+\]/);
+    expect(
+      body.includes(reasonLabel) || body.includes(`[${auditCode}]`),
+      `rejection reason on timeline (expected "${reasonLabel}" or "[${auditCode}]")`,
+    ).toBeTruthy();
   });
 });

--- a/tests/integration-tests/tests/specs/pgr-postal-code.spec.ts
+++ b/tests/integration-tests/tests/specs/pgr-postal-code.spec.ts
@@ -11,7 +11,7 @@
 import { test, expect } from '@playwright/test';
 import { loginEmployeeBrowser } from '../utils/employee-ui';
 import {
-  BASE_URL, ADMIN_USER, ADMIN_PASS, POSTAL_CODE_VALID,
+  BASE_URL, ADMIN_USER, ADMIN_PASS, POSTAL_CODE_VALID, POSTAL_CODE_PATTERN,
 } from '../utils/env';
 
 // Default to the deployment ADMIN. The previous default
@@ -30,6 +30,29 @@ const CITY_ADMIN_PASS = process.env.CITY_ADMIN_PASS || ADMIN_PASS;
 // samples may no longer hold — override or gate the tests there.
 
 const CREATE_URL = `${BASE_URL}/digit-ui/employee/pgr/create-complaint`;
+
+/**
+ * Derive postal samples the DEPLOYMENT's own pattern rejects, so the negative
+ * cases stay honest cross-deployment instead of assuming the Kenya 5-digit rule.
+ * `110001`/`123` were only "invalid" against that one shape — on a 6-digit-postal
+ * deployment `110001` is valid and the rejection expectation is simply wrong.
+ *  - tooLong: a valid code with digits appended until the pattern no longer matches.
+ *  - tooShort: the shortest all-`1` prefix the pattern rejects.
+ */
+function postalRejectedSamples(pattern: string, validBase: string): { tooLong: string; tooShort: string } {
+  let re: RegExp;
+  try { re = new RegExp(pattern); } catch { return { tooLong: '1234567', tooShort: '1' }; }
+  let tooLong = validBase || '1';
+  for (let i = 0; i < 12 && re.test(tooLong); i++) tooLong += '9';
+  let tooShort = '1';
+  for (let n = 1; n <= (validBase.length || 5) + 6; n++) {
+    const cand = '1'.repeat(n);
+    if (!re.test(cand)) { tooShort = cand; break; }
+  }
+  return { tooLong, tooShort };
+}
+const { tooLong: INVALID_POSTAL_LONG, tooShort: INVALID_POSTAL_SHORT } =
+  postalRejectedSamples(POSTAL_CODE_PATTERN, POSTAL_CODE_VALID.split('-')[0]);
 
 test.describe('PGR Postal Code Validation (#478)', () => {
   test.beforeEach(async ({ page }) => {
@@ -111,8 +134,6 @@ Catches a regression where the validator over-restricts and rejects valid codes.
     await page.waitForTimeout(1_000);
 
     // No error should appear for the postal code field
-    // The error element is typically a sibling or nearby element with the error key
-    const cardSection = postalInput.locator('xpath=ancestor::div[contains(@class,"field")]');
     const errorNearby = page.locator('text=CS_COMPLAINT_POSTALCODE_INVALID_ERROR');
     await expect(errorNearby).toHaveCount(0);
   });
@@ -140,9 +161,9 @@ Catches a regression where the regex reverts to the legacy 6-digit Indian PIN co
     const postalInput = page.locator('input[name="postalCode"]');
     await expect(postalInput).toBeVisible({ timeout: 15_000 });
 
-    // Enter an over-long postal code (6 digits) — invalid under both the Kenya
-    // 5-digit and Mozambique 4-digit(+suffix) patterns.
-    await postalInput.fill('110001');
+    // Enter an over-long postal code the deployment's own pattern rejects
+    // (valid code + appended digits), not a Kenya-shaped literal.
+    await postalInput.fill(INVALID_POSTAL_LONG);
 
     // Need to trigger form submission for react-hook-form to validate
     // Find the Submit button.
@@ -162,11 +183,12 @@ Catches a regression where the regex reverts to the legacy 6-digit Indian PIN co
     await submitBtn.click();
     await page.waitForTimeout(2_000);
 
-    // The form should show a validation error — either:
-    // 1. The localized error string for CS_COMPLAINT_POSTALCODE_INVALID_ERROR
-    // 2. Or the form stays on the create page (does not navigate away)
-    // We check that we're still on the create-complaint page
+    // Navigation must be blocked AND the postal validation error must surface.
+    // The URL check alone is vacuous (submit could no-op for any reason); pairing
+    // it with the explicit error element proves the postal validator is what
+    // fired — symmetric to the valid case, which asserts count 0 of this locator.
     expect(page.url()).toContain('create-complaint');
+    await expect(page.locator('text=CS_COMPLAINT_POSTALCODE_INVALID_ERROR')).toBeVisible();
   });
 
   test('invalid postal code (short / 3 digits) is rejected', {
@@ -192,9 +214,9 @@ Pairs with the 6-digit edge case to bracket the accepted length range from both 
     const postalInput = page.locator('input[name="postalCode"]');
     await expect(postalInput).toBeVisible({ timeout: 15_000 });
 
-    // Enter a too-short postal code (3 digits) — invalid under every supported
-    // pattern.
-    await postalInput.fill('123');
+    // Enter a too-short postal code the deployment's own pattern rejects,
+    // derived from that pattern rather than assuming a sub-4-digit literal.
+    await postalInput.fill(INVALID_POSTAL_SHORT);
 
     // Submit to trigger validation.
     const submitBtn = page.locator('button[type="button"], button[type="submit"]')
@@ -209,7 +231,8 @@ Pairs with the 6-digit edge case to bracket the accepted length range from both 
     await submitBtn.click();
     await page.waitForTimeout(2_000);
 
-    // Should still be on create-complaint page (validation blocked submission)
+    // Navigation blocked AND the postal error surfaced (see the 6-digit case).
     expect(page.url()).toContain('create-complaint');
+    await expect(page.locator('text=CS_COMPLAINT_POSTALCODE_INVALID_ERROR')).toBeVisible();
   });
 });

--- a/tests/integration-tests/tests/specs/pgr-postal-code.spec.ts
+++ b/tests/integration-tests/tests/specs/pgr-postal-code.spec.ts
@@ -8,10 +8,11 @@
  * Tests the employee-side complaint creation form at
  *   /digit-ui/employee/pgr/create-complaint
  */
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { loginEmployeeBrowser } from '../utils/employee-ui';
 import {
   BASE_URL, ADMIN_USER, ADMIN_PASS, POSTAL_CODE_VALID, POSTAL_CODE_PATTERN,
+  ROOT_TENANT, TENANT, LOCALES,
 } from '../utils/env';
 
 // Default to the deployment ADMIN. The previous default
@@ -22,12 +23,13 @@ import {
 const CITY_ADMIN_USER = process.env.CITY_ADMIN_USER || ADMIN_USER;
 const CITY_ADMIN_PASS = process.env.CITY_ADMIN_PASS || ADMIN_PASS;
 
-// NOTE: postal-code validation is now driven by the CORE_POSTAL_CONFIGS
-// global config (per-tenant regex). The hardcoded 00100 (valid) / 110001
-// (invalid Indian 6-digit) / 123 (too short) samples below only hold on a
-// config-LESS tenant, where the UI falls back to the Kenya 5-digit rule.
-// On a tenant that ships an explicit CORE_POSTAL_CONFIGS regex these
-// samples may no longer hold — override or gate the tests there.
+// NOTE: postal-code validation is driven by the CORE_POSTAL_CONFIGS global
+// config (per-tenant regex), which CreateComplaintConfig.js compiles straight
+// into the field's rules. Nothing below hardcodes a country's postal shape: the
+// accepted sample comes from POSTAL_CODE_VALID and the rejected ones are derived
+// from POSTAL_CODE_PATTERN — both resolved env var -> deployment-profile.json ->
+// legacy default by utils/env.ts, and the profile reads the pattern out of the
+// SPA's own globalConfigs. So these specs compare the form to its own config.
 
 const CREATE_URL = `${BASE_URL}/digit-ui/employee/pgr/create-complaint`;
 
@@ -54,6 +56,127 @@ function postalRejectedSamples(pattern: string, validBase: string): { tooLong: s
 const { tooLong: INVALID_POSTAL_LONG, tooShort: INVALID_POSTAL_SHORT } =
   postalRejectedSamples(POSTAL_CODE_PATTERN, POSTAL_CODE_VALID.split('-')[0]);
 
+/**
+ * The base (hyphen-free) segment of the deployment's valid sample. The
+ * create-complaint postalCode input is `type=number` on the redesigned build and
+ * cannot hold a hyphen, while the base 4/5-digit code is valid on its own (the
+ * '-NN' sector suffix is optional in every pattern we ship). For Kenya '00100'
+ * this is a no-op; for mz.maputo '0101-03' it yields '0101'.
+ */
+const VALID_POSTAL = POSTAL_CODE_VALID.split('-')[0];
+
+/** The localization code the postal validator raises (CreateComplaintConfig populators.error). */
+const POSTAL_ERROR_KEY = 'CS_COMPLAINT_POSTALCODE_INVALID_ERROR';
+
+/**
+ * Resolve what the postal error actually RENDERS AS on this deployment.
+ *
+ * Both the inline CardLabelError and the submit toast render `t(POSTAL_ERROR_KEY)`,
+ * so on any deployment that seeds rainmaker-pgr the raw key NEVER appears in the
+ * DOM — it is replaced by e.g. "Please enter a valid 5-digit postal code". The
+ * previous `text=CS_COMPLAINT_POSTALCODE_INVALID_ERROR` locator therefore matched
+ * nothing, which made the rejection cases unassertable and the acceptance case
+ * (count 0) vacuous: it would have passed with the validator deleted outright.
+ *
+ * Ask the localization service instead, in the locale the SPA is actually running
+ * in, and fall back to the raw key when the deployment has NOT seeded it (i18next
+ * echoes the key back in that case, so the fallback is the truthful expectation —
+ * not a hardcoded English string).
+ */
+async function resolvePostalErrorText(page: Page): Promise<string> {
+  // The locale the employee SPA booted with — the same one t() reads. LOCALES[0]
+  // (profile-discovered) is the floor for the case where the key is absent.
+  const locale =
+    (await page.evaluate(() => localStorage.getItem('Employee.locale')).catch(() => null)) ||
+    LOCALES[0];
+
+  // Search the root tenant first (localization is seeded state-wide), then the
+  // city tenant for deployments that scope messages per city.
+  for (const tenantId of Array.from(new Set([ROOT_TENANT, TENANT]))) {
+    try {
+      const url =
+        `${BASE_URL}/localization/messages/v1/_search` +
+        `?locale=${encodeURIComponent(locale)}&tenantId=${encodeURIComponent(tenantId)}` +
+        `&module=rainmaker-pgr`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ RequestInfo: { apiId: 'Rainmaker' } }),
+      });
+      if (!res.ok) continue;
+      const body = (await res.json()) as { messages?: { code?: string; message?: string }[] };
+      const hit = (body.messages || []).find(
+        (m) => m.code === POSTAL_ERROR_KEY && (m.message || '').trim(),
+      );
+      if (hit) return (hit.message as string).trim();
+    } catch {
+      // Try the next tenant; an unreachable localization service falls through
+      // to the raw key, which is what an unseeded deployment renders anyway.
+    }
+  }
+  return POSTAL_ERROR_KEY;
+}
+
+/**
+ * The postal field's OWN container — the nearest `*-label-field-pair` ancestor of
+ * the input (`digit-label-field-pair` on the redesigned build, `label-field-pair`
+ * on the legacy react-components build).
+ *
+ * Every assertion below is scoped to this so it cannot be satisfied by
+ * absence-everywhere: a create-complaint form that renders no errors at all would
+ * still fail the rejection cases, and the acceptance case measures THIS field
+ * rather than the page.
+ */
+function postalFieldContainer(page: Page) {
+  return page.locator('xpath=//input[@name="postalCode"]/ancestor::*[contains(@class,"label-field-pair")][1]');
+}
+
+/**
+ * The postal validation error, scoped to the postal field.
+ *
+ * Two shapes, because the two UI builds place it differently:
+ *  - redesigned (digit-ui-components): `div.digit-error-message` INSIDE the pair.
+ *  - legacy (react-components FormComposerV2): `h2.card-label-error` rendered as
+ *    the pair's immediate next sibling.
+ */
+function postalErrorLocator(page: Page, message: string) {
+  const inside = postalFieldContainer(page).getByText(message, { exact: false });
+  const sibling = page
+    .locator(
+      'xpath=//input[@name="postalCode"]/ancestor::*[contains(@class,"label-field-pair")][1]' +
+        '/following-sibling::*[1][contains(@class,"card-label-error")]',
+    )
+    .filter({ hasText: message });
+  return inside.or(sibling);
+}
+
+/**
+ * Run the form's validation pass.
+ *
+ * The redesigned create-complaint form keeps Submit `disabled` until EVERY
+ * `isMandatory` populator has a value (createComplaintForm.js submitDisabled →
+ * FormComposerV2 isDisabled → SubmitBar `<button disabled>`), so clicking it is
+ * impossible from a postal-only test — that is why these cases used to skip.
+ * The button is not what validates, though: react-hook-form 6 defaults to
+ * `mode: "onSubmit"` and validates on the form's SUBMIT EVENT. `requestSubmit()`
+ * fires exactly that event and exercises the identical validation pass, with no
+ * dependence on the button's enabled state.
+ */
+async function submitForm(page: Page): Promise<void> {
+  await page.locator('form').first().evaluate((f: HTMLFormElement) => f.requestSubmit());
+}
+
+/** Log in, open the create-complaint form, and return its postal input. */
+async function openCreateComplaint(page: Page) {
+  await page.goto(CREATE_URL, { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  const postalInput = page.locator('input[name="postalCode"]');
+  await expect(postalInput).toBeVisible({ timeout: 30_000 });
+  // The field's container must resolve, or every scoped assertion below would be
+  // vacuously satisfied by a dead locator.
+  await expect(postalFieldContainer(page)).toHaveCount(1);
+  return postalInput;
+}
+
 test.describe('PGR Postal Code Validation (#478)', () => {
   test.beforeEach(async ({ page }) => {
     // loginEmployeeBrowser probes CITY→ROOT for whichever tenant accepts the
@@ -78,15 +201,7 @@ Steps:
 Catches a regression where the field is incorrectly marked required, blocking complaints with no postal code.`,
     },
     tag: ['@area:pgr', '@ccrs:478', '@kind:regression', '@layer:ui', '@persona:cross'] }, async ({ page }) => {
-    await page.goto(CREATE_URL, {
-      waitUntil: 'domcontentloaded',
-      timeout: 30_000,
-    });
-    await page.waitForTimeout(5_000);
-
-    // Wait for the form to render — look for the postal code input
-    const postalInput = page.locator('input[name="postalCode"]');
-    await expect(postalInput).toBeVisible({ timeout: 15_000 });
+    const postalInput = await openCreateComplaint(page);
 
     // Leave postal code empty — it should be optional
     // Fill only the postal code section and check no required-error appears
@@ -104,135 +219,111 @@ Catches a regression where the field is incorrectly marked required, blocking co
       type: 'description',
       description: `Positive case for CCRS#478: a well-formed postal code for this deployment (POSTAL_CODE_VALID — e.g. Kenya "00100" or Mozambique "0101-03") must NOT trigger a validation error. Pairs with the rejection cases to ensure the regex is correct in both directions.
 
+This case used to be VACUOUS twice over: it asserted count 0 of a raw localization key that is never in the DOM (the UI renders t(key)), and it only blurred the field — react-hook-form validates on the SUBMIT event, so nothing had validated when the count was taken. Both defects are removed by (a) asserting on the localization-resolved message, scoped to the postal field's own container, and (b) proving the locator is live before trusting its absence: submit an invalid code first, watch the error appear, then correct the value and watch it clear.
+
 Steps:
 1. Log in via API as the city admin.
 2. Navigate to /digit-ui/employee/pgr/create-complaint and wait for hydration.
-3. Fill input[name="postalCode"] with POSTAL_CODE_VALID and blur.
-4. Assert no element with text "CS_COMPLAINT_POSTALCODE_INVALID_ERROR" is present (count = 0).
+3. Resolve the expected error text from /localization/messages/v1/_search (module rainmaker-pgr, the SPA's own locale), falling back to the raw key when unseeded.
+4. Fill an invalid code, dispatch form.requestSubmit(), assert the scoped postal error IS visible — this proves the assertion locator can match.
+5. Fill POSTAL_CODE_VALID's base segment, dispatch form.requestSubmit(), assert the scoped postal error clears (count = 0).
 
 Catches a regression where the validator over-restricts and rejects valid codes.`,
     },
     tag: ['@area:pgr', '@ccrs:478', '@kind:regression', '@layer:ui', '@persona:cross'] }, async ({ page }) => {
-    await page.goto(CREATE_URL, {
-      waitUntil: 'domcontentloaded',
-      timeout: 30_000,
-    });
-    await page.waitForTimeout(5_000);
+    const postalInput = await openCreateComplaint(page);
+    const expectedError = await resolvePostalErrorText(page);
+    const postalError = postalErrorLocator(page, expectedError);
 
-    const postalInput = page.locator('input[name="postalCode"]');
-    await expect(postalInput).toBeVisible({ timeout: 15_000 });
+    // Arm the assertion: drive the field into the rejected state first, so the
+    // count-0 below is a MEASURED transition rather than an absence that would
+    // hold even with the postal validator ripped out.
+    await postalInput.fill(INVALID_POSTAL_LONG);
+    await submitForm(page);
+    await expect(
+      postalError.first(),
+      `postal error "${expectedError}" must render for the rejected sample ${INVALID_POSTAL_LONG} — ` +
+        'without it the count-0 assertion below would be vacuous',
+    ).toBeVisible({ timeout: 15_000 });
 
-    // Enter a valid postal code for this deployment's format. Use the base
-    // numeric segment (before any '-sector' suffix): the create-complaint
-    // postalCode input is type=number on the redesigned build and can't hold
-    // a hyphen, while the base 4/5-digit code is valid on its own (the suffix
-    // is optional in the pattern). For Kenya "00100" this is a no-op.
-    const validSample = POSTAL_CODE_VALID.split('-')[0];
-    await postalInput.fill(validSample);
-    // Blur to trigger validation
-    await postalInput.blur();
-    await page.waitForTimeout(1_000);
-
-    // No error should appear for the postal code field
-    const errorNearby = page.locator('text=CS_COMPLAINT_POSTALCODE_INVALID_ERROR');
-    await expect(errorNearby).toHaveCount(0);
+    // Now the deployment's own valid sample must clear it. react-hook-form
+    // re-validates on change after the first submit, and the second submit
+    // forces the full pass regardless.
+    await postalInput.fill(VALID_POSTAL);
+    await submitForm(page);
+    await expect(
+      postalError,
+      `valid postal code ${VALID_POSTAL} (pattern ${POSTAL_CODE_PATTERN}) must not raise a postal error`,
+    ).toHaveCount(0);
   });
 
   test('invalid postal code (6 digits / Indian format) is rejected', {
     annotation: {
       type: 'description',
-      description: `Edge case for CCRS#478: a 6-digit Indian-format postal code ("110001") must be rejected. The fix replaced the legacy 6-digit regex with a 5-digit Kenya regex; this test guards against any accidental fallback to the Indian format.
+      description: `Edge case for CCRS#478: a postal code that is too LONG for the deployment's own pattern (POSTAL_CODE_VALID with digits appended until the regex stops matching — e.g. the legacy 6-digit Indian PIN shape on a 5-digit deployment) must be rejected. Guards against an accidental fallback to a looser/longer format.
+
+Previously skipped: it tried to click Submit, which the redesigned form keeps disabled until every mandatory populator is filled. The button is not the validator — react-hook-form 6 validates on the form's submit EVENT — so this dispatches form.requestSubmit() instead and exercises the identical validation pass.
 
 Steps:
 1. Log in via API as the city admin.
 2. Navigate to /digit-ui/employee/pgr/create-complaint.
-3. Fill input[name="postalCode"] with "110001" and click the Submit button.
-4. Assert the URL still contains "create-complaint" (validation blocked navigation away).
+3. Resolve the expected error text from /localization/messages/v1/_search (module rainmaker-pgr), falling back to the raw key when unseeded.
+4. Fill input[name="postalCode"] with the over-long sample and dispatch form.requestSubmit().
+5. Assert the error renders inside the postal field's own container, and that the URL still contains "create-complaint".
 
-Catches a regression where the regex reverts to the legacy 6-digit Indian PIN code format.`,
+Catches a regression where the regex reverts to a longer format (e.g. the legacy 6-digit Indian PIN code).`,
     },
     tag: ['@area:pgr', '@ccrs:478', '@kind:edge-case', '@layer:ui', '@persona:cross'] }, async ({ page }) => {
-    await page.goto(CREATE_URL, {
-      waitUntil: 'domcontentloaded',
-      timeout: 30_000,
-    });
-    await page.waitForTimeout(5_000);
-
-    const postalInput = page.locator('input[name="postalCode"]');
-    await expect(postalInput).toBeVisible({ timeout: 15_000 });
+    const postalInput = await openCreateComplaint(page);
+    const expectedError = await resolvePostalErrorText(page);
 
     // Enter an over-long postal code the deployment's own pattern rejects
     // (valid code + appended digits), not a Kenya-shaped literal.
     await postalInput.fill(INVALID_POSTAL_LONG);
+    await submitForm(page);
 
-    // Need to trigger form submission for react-hook-form to validate
-    // Find the Submit button.
-    const submitBtn = page.locator('button[type="button"], button[type="submit"]')
-      .filter({ hasText: /submit/i }).first();
-    await submitBtn.scrollIntoViewIfNeeded();
-    // The redesigned create-complaint form disables Submit until the *entire*
-    // form is valid, so a postal-only negative test can't drive submit here.
-    // (On that build the postalCode field is also type=number, which silently
-    // ignores its pattern attribute — postal format is only enforced on full
-    // form submit.) Skip cleanly rather than hang on a disabled button; on the
-    // legacy build where Submit is always clickable, the assertion runs.
-    test.skip(
-      !(await submitBtn.isEnabled().catch(() => false)),
-      'Submit is gated behind full-form validity on this build; postal-only negative case not exercisable.',
-    );
-    await submitBtn.click();
-    await page.waitForTimeout(2_000);
-
-    // Navigation must be blocked AND the postal validation error must surface.
-    // The URL check alone is vacuous (submit could no-op for any reason); pairing
-    // it with the explicit error element proves the postal validator is what
-    // fired — symmetric to the valid case, which asserts count 0 of this locator.
+    // The postal validation error must surface ON THE POSTAL FIELD, and
+    // navigation must be blocked. The URL check alone is vacuous (submit could
+    // no-op for any reason); the scoped error element proves the postal
+    // validator is what fired — symmetric to the acceptance case, which asserts
+    // count 0 of this same locator.
+    await expect(
+      postalErrorLocator(page, expectedError).first(),
+      `${INVALID_POSTAL_LONG} must be rejected by pattern ${POSTAL_CODE_PATTERN} with "${expectedError}"`,
+    ).toBeVisible({ timeout: 15_000 });
     expect(page.url()).toContain('create-complaint');
-    await expect(page.locator('text=CS_COMPLAINT_POSTALCODE_INVALID_ERROR')).toBeVisible();
   });
 
   test('invalid postal code (short / 3 digits) is rejected', {
     annotation: {
       type: 'description',
-      description: `Edge case for CCRS#478: a too-short postal code ("123") must be rejected. Confirms the validator enforces minimum length, not just the prefix or character set.
+      description: `Edge case for CCRS#478: a too-SHORT postal code (the shortest all-'1' prefix the deployment's own pattern rejects) must be rejected. Confirms the validator enforces minimum length, not just the prefix or character set.
+
+Previously skipped for the same reason as the over-long case — it clicked a Submit button the redesigned form keeps disabled until every mandatory populator is filled. Uses form.requestSubmit() instead, which is what react-hook-form actually validates on.
 
 Steps:
 1. Log in via API as the city admin.
 2. Navigate to /digit-ui/employee/pgr/create-complaint.
-3. Fill input[name="postalCode"] with "123" and click Submit.
-4. Assert the URL still contains "create-complaint" (validation blocked navigation away).
+3. Resolve the expected error text from /localization/messages/v1/_search (module rainmaker-pgr), falling back to the raw key when unseeded.
+4. Fill input[name="postalCode"] with the too-short sample and dispatch form.requestSubmit().
+5. Assert the error renders inside the postal field's own container, and that the URL still contains "create-complaint".
 
-Pairs with the 6-digit edge case to bracket the accepted length range from both sides.`,
+Pairs with the over-long edge case to bracket the accepted length range from both sides.`,
     },
     tag: ['@area:pgr', '@ccrs:478', '@kind:edge-case', '@layer:ui', '@persona:cross'] }, async ({ page }) => {
-    await page.goto(CREATE_URL, {
-      waitUntil: 'domcontentloaded',
-      timeout: 30_000,
-    });
-    await page.waitForTimeout(5_000);
-
-    const postalInput = page.locator('input[name="postalCode"]');
-    await expect(postalInput).toBeVisible({ timeout: 15_000 });
+    const postalInput = await openCreateComplaint(page);
+    const expectedError = await resolvePostalErrorText(page);
 
     // Enter a too-short postal code the deployment's own pattern rejects,
     // derived from that pattern rather than assuming a sub-4-digit literal.
     await postalInput.fill(INVALID_POSTAL_SHORT);
+    await submitForm(page);
 
-    // Submit to trigger validation.
-    const submitBtn = page.locator('button[type="button"], button[type="submit"]')
-      .filter({ hasText: /submit/i }).first();
-    await submitBtn.scrollIntoViewIfNeeded();
-    // See the 6-digit case: the redesigned form gates Submit behind full-form
-    // validity, so skip rather than hang when it's disabled.
-    test.skip(
-      !(await submitBtn.isEnabled().catch(() => false)),
-      'Submit is gated behind full-form validity on this build; postal-only negative case not exercisable.',
-    );
-    await submitBtn.click();
-    await page.waitForTimeout(2_000);
-
-    // Navigation blocked AND the postal error surfaced (see the 6-digit case).
+    // Scoped error + blocked navigation (see the over-long case).
+    await expect(
+      postalErrorLocator(page, expectedError).first(),
+      `${INVALID_POSTAL_SHORT} must be rejected by pattern ${POSTAL_CODE_PATTERN} with "${expectedError}"`,
+    ).toBeVisible({ timeout: 15_000 });
     expect(page.url()).toContain('create-complaint');
-    await expect(page.locator('text=CS_COMPLAINT_POSTALCODE_INVALID_ERROR')).toBeVisible();
   });
 });

--- a/tests/integration-tests/tests/utils/manage/api.ts
+++ b/tests/integration-tests/tests/utils/manage/api.ts
@@ -197,7 +197,12 @@ export async function mdmsSearch(
   auth: AuthInfo,
   tenantId: string,
   schemaCode: string,
-  options?: { limit?: number; offset?: number; uniqueIdentifiers?: string[] },
+  options?: {
+    limit?: number;
+    offset?: number;
+    uniqueIdentifiers?: string[];
+    isActive?: boolean;
+  },
 ): Promise<MdmsRecord[]> {
   const criteria: Record<string, unknown> = {
     tenantId,
@@ -207,6 +212,16 @@ export async function mdmsSearch(
   };
   if (options?.uniqueIdentifiers?.length) {
     criteria.uniqueIdentifiers = options.uniqueIdentifiers;
+  }
+  // Push isActive to the SERVER so limit/offset paginate over the FILTERED set
+  // — same contract the configurator's DigitApiClient.mdmsSearch uses. Without
+  // it, a tenant polluted with soft-deleted rows (e.g. thousands of PW_ test
+  // leftovers) spends the whole page on inactive records and a caller doing
+  // `.find(r => r.isActive !== false)` over the page gets nothing, even though
+  // the active rows exist. Optional — omitting it preserves the legacy
+  // unfiltered behaviour for existing call sites.
+  if (options?.isActive !== undefined) {
+    criteria.isActive = options.isActive;
   }
   const data = await postJson<{ mdms?: MdmsRecord[] }>(
     auth,

--- a/tests/integration-tests/tests/utils/manage/api.ts
+++ b/tests/integration-tests/tests/utils/manage/api.ts
@@ -125,7 +125,7 @@ export async function apiAuth(): Promise<AuthInfo> {
   return { token: j.access_token, user: j.UserRequest || null, tenant: rootTenant, baseUrl };
 }
 
-function buildRequestInfo(auth: AuthInfo, action?: string): Record<string, unknown> {
+export function buildRequestInfo(auth: AuthInfo, action?: string): Record<string, unknown> {
   return {
     apiId: 'Rainmaker',
     ver: '1.0',


### PR DESCRIPTION
## Deployment-agnostic test changes

Makes the integration suite pass on any deployment (not just bomet/Kenya) and stops
one early failure from hiding the rest.

- **De-serialise** the admin `complaints` + `departments` suites (`mode: 'serial'` →
  `'default'`) so a single failure no longer cascade-skips everything after it.
- **Complaints/departments robustness:** pick an assignable seed-serviceCode complaint;
  assert edits via the `_update` response (search index lags the write); wait for the
  update before asserting; role-based filter selectors; reopen the record before the
  deactivate step.
- **Deployment-agnostic** admin + cross/system specs: resolve tenant/service/locality/
  postal/id-prefix/labels from the profile+env instead of hardcoded Kenya literals;
  read boundary hierarchy and workflow shape live; honest capability/seed skips.

Pairs with the app-fix PR (the two-level-tenant bug fixes those tests exercise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide for writing, running, and interpreting end-to-end integration tests.

* **Tests**
  * Improved coverage for complaints, departments, employees, users, localization, boundaries, workflows, themes, and postal-code validation.
  * Increased test resilience across different deployments, languages, tenant structures, and configuration profiles.
  * Added reliable test data seeding and cleanup for required configuration and localization content.
  * Improved handling of UI timing, validation messages, workflow states, and bulk-import results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->