### PR TITLE
fix(ui): QA batch 2 additions — receipt channel, Endereço label (#26/#31/#30) (moz)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
+++ b/digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
@@ -277,6 +277,29 @@ export const CreateComplaintConfig = {
                 error: "CS_DESC_MIN_CHARS",
               },
             },
+            {
+              // QA #26: how the complaint reached the Reception Officer
+              // (email / in-person / letter / linha verde). Optional; travels
+              // as extendedAttributes.receivedChannel and shows on the details
+              // pages via the generic extended-attributes card. The stored
+              // value is the human-readable option code — the viewer renders
+              // values verbatim by design.
+              isMandatory: false,
+              key: "ReceivedChannel",
+              type: "dropdown",
+              label: "ES_CREATECOMPLAINT_RECEIVED_CHANNEL",
+              disable: false,
+              populators: {
+                name: "ReceivedChannel",
+                optionsKey: "name",
+                options: [
+                  { code: "E-mail", name: "PGR_CHANNEL_EMAIL" },
+                  { code: "Presencial", name: "PGR_CHANNEL_IN_PERSON" },
+                  { code: "Carta", name: "PGR_CHANNEL_LETTER" },
+                  { code: "Linha Verde", name: "PGR_CHANNEL_LINHA_VERDE" },
+                ],
+              },
+            },
           ],
         },
 

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintDetails.js
@@ -302,11 +302,26 @@ const ComplaintDetailsPage = () => {
 
   const geoLocation = complaintDetails?.service?.address?.geoLocation;
   const address = complaintDetails?.service?.address;
+  // QA #31: complaints store only the lowercase boundary CODE (name is null),
+  // so the Endereço line rendered raw codes like "zumbo". Resolve through the
+  // boundary localization (module rainmaker-boundary-*) when loaded; otherwise
+  // title-case the code — always readable, never a raw identifier.
+  const localityLabel = (() => {
+    const loc = address?.locality;
+    if (!loc) return null;
+    if (loc.name) return loc.name;
+    if (!loc.code) return null;
+    const viaT = t(loc.code);
+    if (viaT && viaT !== loc.code) return viaT;
+    return String(loc.code)
+      .replace(/[_-]+/g, " ")
+      .replace(/\b\w/g, (c) => c.toUpperCase());
+  })();
   const displayAddress = [
     address?.buildingName,
     address?.street,
     address?.landmark,
-    address?.locality?.name || address?.locality?.code,
+    localityLabel,
     address?.pincode,
   ]
     .filter(Boolean)

--- a/digit-ui-esbuild/products/pgr/src/utils/index.js
+++ b/digit-ui-esbuild/products/pgr/src/utils/index.js
@@ -260,6 +260,17 @@ export const formPayloadToCreateComplaint = (formData, tenantId, user, extOpts) 
     };
   }
 
+  // QA #26: receipt channel picked by the Reception Officer. Attached like
+  // complainantAddress — even without a category mapping — so the value never
+  // silently drops; absent when the officer didn't pick one.
+  const receivedChannel = formData?.ReceivedChannel?.code;
+  if (receivedChannel) {
+    complaint.service.extendedAttributes = {
+      ...(complaint.service.extendedAttributes || {}),
+      receivedChannel,
+    };
+  }
+
   return complaint;
 };
 


### PR DESCRIPTION
## What

Delta PR: #1364 was merged minutes before this commit landed on its branch, stranding it (same merge-race as before). This carries exactly that one commit onto the current moz tip.

- **#26**: Reception Officer create form gains an optional **"Canal de Recepção"** dropdown (E-mail / Presencial / Carta / Linha Verde). Travels as `extendedAttributes.receivedChannel` and renders on both details pages through the generic extended-attributes card. Verified live on the local stack (field renders localized under Detalhes Adicionais).
- **#31**: citizen details "Endereço" rendered the raw lowercase boundary CODE (complaints store `locality.code` only, `name` is null — e.g. "zumbo"). New `localityLabel` resolver: boundary localization first, title-cased code as the always-readable fallback.
- **#30** (no code change, for the record): the "r/" Complaint SubType label came from corrupted pt_PT localization rows (`COMPLAINT_HIERARCHY.COMPLAINT_PUBLICSERVICE` + two more mangled labels in the same family) — fixed by upsert on local, 20.40.49.209 and mctd.

Option/field localization keys (en+pt) already upserted to all three environments.

Twin commits are already on the #1363 (master-2.12-fixes, incl. the #27 min-20 port) and #1366 (release-v2.12) PR branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)