### PR TITLE
docs(local-setup): fix outdated Ansible steps + document tenant onboarding via configurator (#1355)

### DIFF
--- a/local-setup/README.md
+++ b/local-setup/README.md
@@ -10,10 +10,10 @@ There are **two independent ways** to run this stack. Pick one:
 |------|----------|---------------|
 | **[Option A: Docker Compose](#option-a-docker-compose)** | Quick setup, no extra tools | Docker only |
 | **[Option B: Tilt](#option-b-tilt)** | Dashboard, grouped services, dev buttons | Docker + Tilt |
+| **[Option C: Ansible (Remote Server)](#option-c-ansible-remote-server)** | Deploy to a remote Ubuntu machine | Ansible + SSH |
 
-| **[Option C: Ansible (Remote Server)](#option-c-ansible-remote-server)** | Deploy to a remote Ubuntu machine | Docker + Ansible |
-
-Options A and B run locally. Option C deploys to a remote server, pulling pre-built images from a public registry. **Pick one.**
+Options A and B run locally. Option C deploys a full per-tenant stack to a
+remote Ubuntu machine with `./deploy.sh <tenant>`. **Pick one.**
 
 ---
 
@@ -209,7 +209,16 @@ tilt up    # uses the default Tiltfile with hot reload
 
 ## Option C: Ansible (Remote Server)
 
-Deploy the full DIGIT stack to any fresh Ubuntu 24.04 machine using Ansible. Images are pulled from the public registry at `registry.preview.egov.theflywheel.in` — no VPC access or local builds needed.
+Deploy the full DIGIT stack to a remote Ubuntu machine with a single,
+config-driven Ansible playbook. Each tenant is an independent stack (~35
+containers) driven by its own `host_vars/<tenant>.yml`; one command —
+`./deploy.sh <tenant>` — installs Docker, syncs configs, seeds secrets,
+pulls/builds images, starts the stack, and runs smoke + lifecycle tests.
+
+> **This is the quick-start.** The authoritative Ansible reference is
+> [`ansible/README.md`](ansible/README.md) — it covers `host_vars`, OpenBao
+> secrets, TLS/domain setup, per-tenant compose overlays, subset deploys, and
+> the configurator/MCP build options.
 
 ### Prerequisites
 
@@ -217,83 +226,75 @@ On your **control machine** (laptop/CI server):
 
 | Tool | Install |
 |------|---------|
-| [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/) | `pip install ansible` |
-| SSH access to the target machine | Key-based auth recommended |
+| [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/) | `pip3 install --user ansible`, then `ansible-galaxy install -r ansible/requirements.yml` |
+| Node.js 20 | Required on the controller — the digit-ui and configurator builds run here |
+| SSH access to the target | Key-based `root` login (no password) |
 
 The **target machine** needs:
-- Ubuntu 24.04 (fresh install)
-- At least 8 vCPU, 16 GB RAM, 50 GB disk
-- Root or sudo access
-- Internet access (to pull images from the public registry)
+- Ubuntu (fresh install), 8 vCPU / 16 GB RAM / 50 GB disk
+- Reachable over SSH as `root`
 
-### Step 1: Configure inventory
+### Step 1: Create the tenant's host_vars
+
+The only tracked host_vars file is `_example.yml`. Copy it into a file named
+after your tenant (real tenant files are gitignored — they hold secrets):
 
 ```bash
 cd local-setup/ansible
-cp inventory.ini.example inventory.ini
+cp inventory/host_vars/_example.yml inventory/host_vars/<tenant>.yml
 ```
 
-Edit `inventory.ini` and replace the placeholder IP with your target machine:
+Edit `<tenant>.yml` — every field is commented. The non-negotiable ones:
+- `ansible_host` — IP/hostname Ansible SSHes into
+- `domain` — public hostname (nginx `server_name` + Grafana root URL)
+- `state_tenant_id` / `boot_tenant` / `tenant_id` — DIGIT tenancy slugs
+- `secrets_path` + `bootstrap_secrets.*` — OpenBao path + initial secrets
+- keep `db_fast_path: true` (a fresh install needs it — no SQL slow path exists)
 
-```ini
-[targets]
-203.0.113.10 ansible_user=root
+No inventory edit is needed: `deploy.sh` regenerates `inventory/hosts.yml` from
+`host_vars/*.yml` on every run. To enable the browser onboarding wizard, also set:
+
+```yaml
+nginx_features: { configurator: true }
+build_configurator: true
 ```
 
-### Step 2: Run the playbook
+### Step 2: Deploy
 
 ```bash
-ansible-playbook -i inventory.ini playbook-deploy.yml
+./deploy.sh <tenant>                 # full deploy
+./deploy.sh <tenant> --check --diff  # dry-run: no changes, show every diff
 ```
 
-The playbook will:
-1. Install Docker Engine and Docker Compose on the target
-2. Copy all config files (Kong, nginx, OTEL, DB seeds, etc.)
-3. Download the OpenTelemetry Java Agent (~21 MB)
-4. Pull ~30 container images from the public registry
-5. Start the DIGIT stack
-6. Wait for health checks (Kong, persister, HRMS, UI — up to 10 min)
-7. Run CI tests: XLSX-driven DataLoader (Bomet County) + Playwright E2E
+`deploy.sh` is tenant-agnostic — it forwards any extra flags to
+`ansible-playbook` (`--tags`, `--limit`, `--start-at-task`, `-vvv`, …).
+
+The first deploy installs Docker + Compose, creates `/opt/digit/`, syncs
+configs, initialises + unseals OpenBao and seeds secrets, pulls/builds images,
+starts the stack, waits on health gates, and (unless `run_ci_tests: false`)
+runs the Postman + Playwright suites. Subsequent deploys are idempotent — only
+changed configs trigger restarts.
 
 ### Step 3: Access the application
 
-After the playbook completes, the stack is available on the target machine:
+The host nginx serves everything on ports 80/443:
 
 | What | URL |
 |------|-----|
-| DIGIT UI (Employee login) | `http://<target-ip>:18000/digit-ui/employee` |
-| Kong Gateway (API base) | `http://<target-ip>:18000` |
-| Gatus Health Dashboard | `http://<target-ip>:18889` |
-| Grafana (Tracing) | `http://<target-ip>:13000` |
+| DIGIT UI (employee) | `https://<domain>/digit-ui/employee` |
+| DIGIT UI (citizen) | `https://<domain>/digit-ui/citizen` |
+| Configurator wizard | `https://<domain>/configurator/` (if enabled) |
+| Grafana (tracing) | `https://<domain>/grafana/` |
+| Gatus health dashboard | `https://<domain>/status/` |
 
-### Customizing the deployment
+For a local/sandbox deploy (`domain: localhost`, `tls_enabled: false`), use
+`http://localhost/...`.
 
-Override playbook variables to deploy with different tenant data:
+### Next: onboard a tenant
 
-```bash
-ansible-playbook -i inventory.ini playbook-deploy.yml \
-  -e boot_tenant=mz.lilongwe \
-  -e county_xlsx=/path/to/your-county-data.xlsx
-```
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `boot_tenant` | `ke.bomet` | City tenant ID for E2E tests |
-| `county_xlsx` | Bomet county XLSX (bundled) | Path to county data Excel file |
-
-### Public Docker Registry
-
-All images are hosted at `registry.preview.egov.theflywheel.in` — a read-only HTTPS proxy to the internal build registry. No authentication required for pulls.
-
-```bash
-# Browse available images
-curl -s https://registry.preview.egov.theflywheel.in/v2/_catalog | jq .
-
-# Pull an image directly
-docker pull registry.preview.egov.theflywheel.in/egovio/pgr-services:latest
-```
-
-The registry is read-only — push operations return `405 Method Not Allowed`.
+Once the stack is up, create your city and load its master data — via the
+browser **configurator wizard** or the Jupyter DataLoader. See the
+[Tenant Onboarding guide](docs/TENANT-ONBOARDING.md).
 
 ### What the Ansible playbook deploys
 
@@ -321,116 +322,84 @@ Between them these include:
 | **Tools** | Jupyter Lab (DataLoader), Gatus (health monitoring) |
 | **Seeds** | Tenant data, security config, workflow config, localization, user accounts |
 
-### Files involved
+### Files & configuration
+
+The Ansible tree, `host_vars` layout, templates, and runbooks are documented in
+[`ansible/README.md`](ansible/README.md). At a glance:
 
 ```
-local-setup/
-├── ansible/
-│   ├── playbook-deploy.yml         # Main deployment playbook
-│   └── inventory.ini.example       # Template inventory
-├── docker-compose.egov-digit.yaml  # What the playbook actually deploys
-├── docker-compose.fast-path.yml    # Overlay: db_fast_path
-├── docker-compose.migrations.yml   # Overlay: schema migrations
-├── docker-compose.migrations.ansible.yml # Overlay: ansible-specific migrators
-├── kong/
-│   └── kong.yml                    # API gateway routes + auth enrichment + RBAC (pre-function)
-├── nginx/
-│   ├── digit-ui.conf               # UI + API proxy config
-│   ├── globalConfigs.js            # Runtime UI configuration
-│   ├── mdms-proxy.conf             # MDMS backward-compat proxy
-│   ├── user-proxy.conf             # User service load balancer
-│   ├── workflow-proxy.conf         # Workflow service load balancer
-├── otel/
-│   ├── download-agent.sh           # Downloads OTEL Java Agent (~21MB)
-│   ├── otel-collector-config.yaml  # Collector → Tempo pipeline
-│   ├── tempo-config.yaml           # Trace storage config
-│   └── grafana/provisioning/       # Grafana datasource for Tempo
-├── seeds/
-│   └── user-seed.sh                # Creates ADMIN + GRO users via API
-├── data/
-│   └── Bomet county...xlsx         # Sample county data for E2E tests
-├── configs/egov-persister/         # Kafka consumer configs (9 YAML files)
-├── db/                             # Full DB dump + flyway history map
-├── gatus/                          # Health monitoring config
-├── jupyter/                        # DataLoader library + notebook
-├── scripts/                        # CI dataloader scripts
-└── tests/                          # Playwright E2E + smoke tests
+local-setup/ansible/
+├── deploy.sh                  # Single entrypoint — ./deploy.sh <tenant> [flags]
+├── playbook-deploy.yml        # The playbook
+├── requirements.yml           # Ansible collections to install
+├── inventory/
+│   ├── group_vars/            # Defaults inherited by every tenant
+│   └── host_vars/             # Per-tenant config (_example.yml is the template)
+├── templates/                 # Jinja2 — globalConfigs.js, nginx-site.conf, digit.env, …
+├── files/                     # Build scripts — configurator, digit-ui, mcp, …
+└── runbooks/                  # OpenBao, tenant-onboarding status, Bomet walkthrough
 ```
-
-### Relationship to PR #318
-
-This deployment setup builds on the work from [PR #318](https://github.com/egovernments/Citizen-Complaint-Resolution-System/pull/318) (Local setup enhancements and fixes), which added:
-
-- **DataLoader v2** (`jupyter/dataloader/crs_loader.py`) — rewritten loader with XLSX-driven tenant setup, boundary management, and rollback support
-- **Native auth config** (`nginx/globalConfigs.js`) — switched from Keycloak to DIGIT native auth provider
-- **PGR inbox components** — DesktopInbox, MobileInbox, Filter, ComplaintCard, search components
-- **Inbox data hooks** (`useInboxData`, `useComplaintStatus`, `useComplaintStatusCount`) — new React hooks for inbox queries
-- **Employee PGR inbox rewrite** — simplified PGRInbox page using the new components
-- **Playwright E2E tests** — tenant setup smoke tests (`pgr-tenant.test.ts`)
-
-This PR (#319) takes those local-setup enhancements and makes them deployable to any remote machine via Ansible, with:
-- A public Docker registry (no VPC access needed)
-- Full OTEL distributed tracing (Collector + Tempo + Grafana)
-- Kong auth enrichment (authToken → userInfo resolution)
-- Nginx reverse proxies for scaled services (user, workflow)
-- Automated CI test pipeline (XLSX DataLoader + Playwright)
 
 ---
 
-## Setting Up a New Tenant (Jupyter DataLoader)
+## Setting Up a New Tenant & Loading Master Data
 
-After the stack is running, you can create a new city/tenant with all the master data needed for PGR complaints. The DataLoader notebook guides you through this step by step.
+Once the stack is running, create a new city/tenant and load everything a PGR
+complaint needs — the tenant record + branding, the boundary hierarchy, common
+masters (departments, designations, complaint types), and employees.
 
-> **Full documentation**: See the [DIGIT CRS Deployment Guide](https://docs.digit.org/complaints-resolution/deploy/setup/production-setup/deploy-crs/unified-approach/1.-login-and-add-tenant) for detailed instructions on the tenant setup flow.
+**Full step-by-step instructions live in the
+[Tenant Onboarding guide](docs/TENANT-ONBOARDING.md).** There are three paths,
+all creating the same data:
 
-### Step 1: Open Jupyter Lab
+| Path | Interface | Available on |
+|------|-----------|--------------|
+| **Configurator wizard** | Browser — upload one XLSX per phase | Ansible deploys with `nginx_features.configurator: true` |
+| **Jupyter DataLoader** | `DataLoader_v2.ipynb` (Python) | Any stack (Docker Compose, Tilt, Ansible) |
+| **MCP `city_setup_from_xlsx`** | REST / automation | Deploys with `enable_mcp: true` |
 
-Open http://localhost:18000/jupyter/lab?token=digit-crs-local
+> **Order always matters:** Tenant → Boundaries → Masters → Employees. Each
+> phase validates codes created by the previous one.
 
-The default token is `digit-crs-local` (configurable via the `JUPYTER_TOKEN` env var in `docker-compose.yml`).
+### Quick path — Jupyter DataLoader
 
-### Step 2: Open the DataLoader notebook
-
-In the Jupyter file browser on the left, click **DataLoader_v2.ipynb** to open it.
-
-### Step 3: Configure variables
-
-The first code cell contains configuration. Edit these values:
+For a local Docker Compose / Tilt stack, open Jupyter Lab at
+http://localhost:18000/jupyter/lab?token=digit-crs-local (token configurable via
+`JUPYTER_TOKEN`) and open **DataLoader_v2.ipynb**. The first configuration cell
+both logs in **and** creates the tenant — edit and run it:
 
 ```python
-URL = "http://kong:8000"          # Kong gateway (inside Docker network) - don't change
-USERNAME = "ADMIN"                 # Superuser username - don't change
-PASSWORD = "eGov@123"             # Superuser password - don't change
-TENANT_ID = "pg"                   # Root tenant for login - don't change
-TARGET_TENANT = "pg.myorg"         # <-- Change this to your new tenant name
+URL          = "http://kong:8000"   # Kong gateway inside the Docker network — leave as-is
+USERNAME     = "ADMIN"
+PASSWORD     = "eGov@123"
+TENANT_ID    = "pg"                  # root tenant you log in against
+TARGET_TENANT = "pg.myorg"           # <-- your new tenant (pattern: <state>.<city>)
+
+loader = CRSLoader(URL)
+loader.login(username=USERNAME, password=PASSWORD, tenant_id=TENANT_ID)
+loader.create_tenant(TARGET_TENANT, "My Org", users=[
+    {"username": "ADMIN", "password": "eGov@123", "name": "Admin",
+     "roles": ["SUPERUSER", "EMPLOYEE", "CSR", "GRO", "DGRO", "PGR_LME", "PGR_VIEWER", "CITIZEN"]}
+])
+loader.login(username="ADMIN", password="eGov@123", tenant_id=TARGET_TENANT)
 ```
 
-> **Naming convention**: Tenant IDs follow the pattern `<state>.<city>`. For example: `pg.mumbai`, `pg.bangalore`, `pg.citya`.
-
-### Step 4: Run each phase
-
-Run the notebook cells in order. Each phase has a header cell explaining what it does, followed by one or more code cells to execute.
-
-| Phase | What to do | What happens | Expected output |
-|-------|-----------|-------------|-----------------|
-| **Phase 1: Tenant & Branding** | Run the cell | Creates your new tenant in MDMS with UI branding config | `Tenant 'pg.myorg' created successfully!` |
-| **Phase 2a: Boundary Template** | Run the cell | Downloads an Excel template for defining your admin hierarchy | An `.xlsx` file appears in the file browser |
-| **Phase 2b: Load Boundaries** | Fill in the Excel template, then run the cell | Uploads your boundary hierarchy (State > District > Block > Ward) | `Boundaries loaded: X records` |
-| **Phase 3: Common Masters** | Run the cell | Loads departments, designations, complaint types from the Excel template | Summary showing created/existing/failed counts |
-| **Phase 4: Employees** | Run the cell | Creates employee accounts via HRMS with roles and department assignments | `Created: N employees` |
-| **Phase 5: Localizations** | Run the cell (optional) | Loads translations for Hindi, Tamil, etc. | `Uploaded N messages` |
-| **Phase 6: Workflow** | Run the cell | Configures the 11-state PGR complaint workflow | `Workflow already configured` or `Workflow updated` |
-
-**After all phases complete**, your new tenant is ready. You can log into the UI, select your city, and create complaints.
+Then run the remaining cells top to bottom: **2a** boundary template → **2b**
+load boundaries → **3** common masters → **4** employees → **5** localizations
+(optional) → **6** workflow. See the
+[Tenant Onboarding guide](docs/TENANT-ONBOARDING.md#b-jupyter-dataloader-scripted)
+for the per-phase details and template shapes.
 
 ### Rollback
 
-If something goes wrong, each phase has a rollback function:
+Each phase has an inverse. Note `full_reset` takes the boundary **hierarchy
+type first**, then the tenant:
 
 ```python
-loader.full_reset(TARGET_TENANT)              # Reset everything for this tenant
-loader.rollback_common_masters(TARGET_TENANT)  # Just reset masters
-loader.delete_boundaries(TARGET_TENANT)        # Just reset boundaries
+loader.delete_boundaries(TARGET_TENANT)          # Phase 2
+loader.rollback_common_masters(TARGET_TENANT)    # Phase 3
+loader.rollback_tenant(TARGET_TENANT)            # Phase 1 (tenant + branding)
+loader.full_reset("REVENUE", TARGET_TENANT)      # everything (pass the hierarchy you used)
 ```
 
 ---
@@ -711,9 +680,13 @@ local-setup/
 ├── docker-compose.tilt.yml         # Overlay: points pgr-services/digit-ui at Tilt's locally built images
 ├── Tiltfile                        # Tilt with hot reload (requires Maven/Yarn)
 ├── Tiltfile.db-dump                # Tilt with pre-built images (recommended)
-├── ansible/
-│   ├── playbook-deploy.yml         # Ansible: install Docker, deploy stack, run CI tests
-│   └── inventory.ini.example       # Template inventory with placeholder IP
+├── ansible/                        # Config-driven remote deploy — see ansible/README.md
+│   ├── deploy.sh                   # Entrypoint: ./deploy.sh <tenant> [flags]
+│   ├── playbook-deploy.yml         # The playbook
+│   ├── inventory/host_vars/        # Per-tenant config (_example.yml is the template)
+│   ├── templates/                  # globalConfigs.js, nginx-site.conf, digit.env, …
+│   ├── files/                      # Build scripts (configurator, digit-ui, mcp, …)
+│   └── runbooks/                   # OpenBao, tenant-onboarding, Bomet walkthrough
 ├── kong/
 │   └── kong.yml                    # API gateway routes + OTEL + auth enrichment + RBAC (pre-function)
 ├── nginx/
@@ -758,7 +731,9 @@ local-setup/
 │   └── smoke/                      # Smoke tests (pgr-workflow, pgr-tenant)
 ├── postman/                        # Newman/Postman collections
 ├── gatus/                          # Health monitoring dashboard config
-└── docs/                           # Additional documentation
+└── docs/
+    ├── TENANT-ONBOARDING.md        # Enable a tenant + load master data (configurator / DataLoader)
+    └── …                           # Local/hybrid/remote setup guides
 
 ../backend/pgr-services/            # PGR Java source (hot reload target)
 ../frontend/micro-ui/               # DIGIT UI React source (hot reload target)

--- a/local-setup/README.md
+++ b/local-setup/README.md
@@ -294,7 +294,8 @@ changed configs trigger restarts.
 
 ### Step 3: Access the application
 
-The host nginx serves everything on ports 80/443:
+The host nginx serves everything on ports 80/443. `tls_enabled` defaults to
+`true`, so the HTTPS forms below are the normal case:
 
 | What | URL |
 |------|-----|
@@ -319,7 +320,7 @@ The playbook deploys `docker-compose.egov-digit.yaml` plus overlays — **not**
 `docker-compose.registry.yml`, which it never references. The exact stack is built in
 `ansible/playbook-deploy.yml` ("Compute compose -f flags"):
 
-```
+```text
 -f docker-compose.egov-digit.yaml
 [-f docker-compose.fast-path.yml]          # when db_fast_path is set
 -f docker-compose.migrations.yml
@@ -344,7 +345,7 @@ Between them these include:
 The Ansible tree, `host_vars` layout, templates, and runbooks are documented in
 [`ansible/README.md`](ansible/README.md). At a glance:
 
-```
+```text
 local-setup/ansible/
 ├── deploy.sh                  # Single entrypoint — ./deploy.sh <tenant> [flags]
 ├── playbook-deploy.yml        # The playbook
@@ -489,7 +490,7 @@ python3 scripts/ci-dataloader.py
 ```
 
 **Expected output**:
-```
+```text
 [1/6] Login
   Authentication successful!
 [2/6] Create tenant
@@ -687,7 +688,7 @@ docker compose up -d                       # Fresh start
 
 ## Project Structure
 
-```
+```text
 local-setup/
 ├── docker-compose.yml              # Main service definitions (~3.8GB RAM, registry images)
 ├── docker-compose.registry.yml     # All images from public registry (NOT the Ansible

--- a/local-setup/README.md
+++ b/local-setup/README.md
@@ -275,6 +275,19 @@ starts the stack, waits on health gates, and (unless `run_ci_tests: false`)
 runs the Postman + Playwright suites. Subsequent deploys are idempotent — only
 changed configs trigger restarts.
 
+**Two first-deploy stops and their fixes:**
+
+- **Preflight fails** with `db_fast_path: true requires db_fast_path_ack_data_wipe: true`
+  → set `db_fast_path_ack_data_wipe: true` in `host_vars` (it acknowledges that
+  the fast-path overlay recreates the Postgres container and wipes anonymous-volume
+  data) and re-run.
+- **`rsync … mkdir "/opt/digit/docker/…" failed: No such file or directory`** —
+  only on a freshly-wiped `/opt/digit` (the playbook creates `/opt/digit` but not
+  the `docker/` subdir before the migrator rsync). Create it once and re-run:
+  ```bash
+  sudo install -d -o "$USER" -g "$USER" /opt/digit/docker && ./deploy.sh <tenant>
+  ```
+
 ### Step 3: Access the application
 
 The host nginx serves everything on ports 80/443:

--- a/local-setup/README.md
+++ b/local-setup/README.md
@@ -249,7 +249,9 @@ Edit `<tenant>.yml` — every field is commented. The non-negotiable ones:
 - `domain` — public hostname (nginx `server_name` + Grafana root URL)
 - `state_tenant_id` / `boot_tenant` / `tenant_id` — DIGIT tenancy slugs
 - `secrets_path` + `bootstrap_secrets.*` — OpenBao path + initial secrets
-- keep `db_fast_path: true` (a fresh install needs it — no SQL slow path exists)
+- keep `db_fast_path: true` (a fresh install needs it — no SQL slow path exists),
+  and set `db_fast_path_ack_data_wipe: true` alongside it — preflight refuses to
+  run without that explicit acknowledgement
 
 No inventory edit is needed: `deploy.sh` regenerates `inventory/hosts.yml` from
 `host_vars/*.yml` on every run. To enable the browser onboarding wizard, also set:
@@ -283,9 +285,11 @@ changed configs trigger restarts.
   data) and re-run.
 - **`rsync … mkdir "/opt/digit/docker/…" failed: No such file or directory`** —
   only on a freshly-wiped `/opt/digit` (the playbook creates `/opt/digit` but not
-  the `docker/` subdir before the migrator rsync). Create it once and re-run:
+  the `docker/` subdir before the migrator rsync). Create it once **on the target
+  machine**, then re-run the deploy from the controller:
   ```bash
-  sudo install -d -o "$USER" -g "$USER" /opt/digit/docker && ./deploy.sh <tenant>
+  ssh <target> 'sudo install -d -o $(id -un) -g $(id -gn) /opt/digit/docker'
+  ./deploy.sh <tenant>
   ```
 
 ### Step 3: Access the application

--- a/local-setup/docs/TENANT-ONBOARDING.md
+++ b/local-setup/docs/TENANT-ONBOARDING.md
@@ -1,0 +1,256 @@
+# Enable a New Tenant & Load Master Data
+
+Operator how-to for standing up a new city (tenant) on a running DIGIT CRS
+stack and loading everything a PGR complaint needs: the tenant record and
+branding, the boundary hierarchy, common masters (departments, designations,
+complaint types), and employees.
+
+There are three ways to do this. They all create the same data — pick the one
+that matches how your stack is deployed:
+
+| Path | Interface | Best for | Where it's available |
+|------|-----------|----------|----------------------|
+| **[Configurator wizard](#a-configurator-wizard-browser)** | Browser (upload XLSX) | Non-technical operators onboarding a real city | Ansible deploys with `nginx_features.configurator: true` |
+| **[Jupyter DataLoader](#b-jupyter-dataloader-scripted)** | Jupyter notebook (Python) | Developers, scripted/local setups | Any stack (Docker Compose, Tilt, Ansible) |
+| **[MCP `city_setup_from_xlsx`](#c-mcp-automation)** | REST / MCP tool | CI, fully-automated onboarding | Deploys with `enable_mcp: true` |
+
+> **Order always matters:** Tenant → Boundaries → Masters → Employees. Each
+> phase validates codes created by the previous one (an employee's jurisdiction
+> must reference a boundary that already exists; a complaint type's department
+> must already be in the Department master).
+
+---
+
+## A. Configurator wizard (browser)
+
+The configurator (a.k.a. DIGIT Studio) is a browser SPA served at
+`/configurator/`. An operator uploads four XLSX templates — one per phase — and
+the wizard creates the tenant and loads all master data through the onboarding
+API.
+
+### Prerequisites
+
+The configurator ships **only with the Ansible deploy**, and only when enabled
+in the tenant's `host_vars`:
+
+```yaml
+# local-setup/ansible/inventory/host_vars/<tenant>.yml
+nginx_features:
+  configurator: true         # renders the /configurator/ nginx location
+build_configurator: true     # clone + `vite build` the SPA at deploy time
+```
+
+Re-run `./deploy.sh <tenant>` after flipping these. See
+[`../ansible/README.md`](../ansible/README.md) for the full deploy flow.
+
+### Open it
+
+```
+http://<domain>/configurator/
+```
+
+Log in as `ADMIN` / `eGov@123` against the **root** tenant (e.g. `ke`). The
+wizard walks the four phases in order.
+
+### Phase 1 — Tenant
+
+The wizard creates the **city** tenant (e.g. `ke.bomet`). Everything you upload
+in later phases lands on this city tenant, *not* on the root.
+
+### Phase 2 — Boundaries
+
+**Download Template** gives one sample row per hierarchy level. Fill it in and
+re-upload. Rules:
+
+- One row per place; **parents before children**.
+- `boundaryType` = the hierarchy level name, spelled exactly.
+- `code` unique (e.g. `WARD_001`); `parentCode` = the parent's `code`; the
+  root row's `parentCode` is empty.
+- Delete the `Sample_*` rows before uploading.
+
+> Example shape (Bomet): 1 Country + 1 County + 5 Subcounties + 25 Wards = 32 rows.
+
+> **Known issue — empty boundary dropdowns after upload.** On some versions the
+> wizard leaves `boundary_relationship.ancestralmaterializedpath` empty, so
+> boundary dropdowns render only the root. If you hit this, apply the SQL
+> backfill + `docker restart boundary-service` documented in
+> [`../ansible/runbooks/03-bomet-onboarding.md`](../ansible/runbooks/03-bomet-onboarding.md)
+> (§2.2).
+
+### Phase 3 — Departments, Designations & Complaint Types
+
+Three sheets in one workbook.
+
+- **Department** — each row has a `code` (e.g. `HealthServices`,
+  `WaterandSewage`) plus a display name.
+- **Designation** — designation codes + names.
+- **ComplaintType** — authored in plain, human-readable terms; the codes are
+  derived for you:
+
+  | Complaint Type* | Complaint sub type* | department | slaHours | keywords | active |
+  |---|---|---|---|---|---|
+  | Water Pipes | Pipe leakage or damage | WaterandSewage | 48 | leak, damage | true |
+  | Water Pipes | Low pressure | WaterandSewage | 48 | low pressure | true |
+
+  - `menuPath` = PascalCase(Complaint Type*) → `WaterPipes`
+  - `serviceCode` = PascalCase(Type + sub type) → `WaterPipesLowPressure`
+  - Rows sharing a **Complaint Type** collapse into one citizen-menu entry.
+  - Punctuation (`& / ' ( ) . ,`) is stripped from generated codes.
+  - `department` **must match** a `code` in the Department sheet.
+
+### Phase 4 — Employees
+
+Template columns:
+
+```
+employeeCode | name | userName | mobileNumber | emailId | gender | dob |
+department | designation | roles | jurisdictions | dateOfAppointment
+```
+
+- `mobileNumber` — must satisfy the tenant's mobile regex (Kenya:
+  `^[17][0-9]{8}$`, i.e. exactly 9 digits).
+- `roles` — validated against `ACCESSCONTROL-ROLES`. Use `EMPLOYEE` plus a
+  workflow role: **GRO** (receives/assigns), **DGRO** (department/subcounty
+  assigner), **PGR_LME** (resolver).
+- `jurisdictions` — boundary codes created in Phase 2 (`WARD_001`,
+  `SUBCOUNTY_001`, …).
+- `department` accepts a **comma-separated list** (`HealthServices,WaterandSewage`).
+  The first is the current HRMS assignment; the rest are historical assignments.
+  PGR lets a person be assigned a complaint when **any** of their departments
+  matches the complaint's department.
+- Dates (`dob`, `dateOfAppointment`) accept text `YYYY-MM-DD` or spreadsheet
+  date cells.
+
+### Point the UI at the new tenant
+
+Because the wizard puts all data on the city tenant, the SPA must land there.
+In `host_vars/<tenant>.yml`:
+
+```yaml
+ui_state_tenant_id: ke.bomet     # SPA boots on the wizard-created city
+boot_tenant: ke.bomet
+hierarchy_type: BOMET-Hierarchy  # MUST match the Phase 2 hierarchy name
+```
+
+Leave `state_root` / `state_tenant_id` / `tenant_id` at the **root** (`ke`) —
+those drive the JVM `STATE_LEVEL_TENANT_ID` pins. Re-run `./deploy.sh <tenant>`.
+
+---
+
+## B. Jupyter DataLoader (scripted)
+
+Available on every stack (Docker Compose, Tilt, Ansible). The `DataLoader_v2`
+notebook runs the same phases in Python, driven by the XLSX templates bundled
+under `jupyter/dataloader/templates/`.
+
+### 1. Open Jupyter Lab
+
+```
+http://localhost:18000/jupyter/lab?token=digit-crs-local
+```
+
+The default token is `digit-crs-local` (override via `JUPYTER_TOKEN` in
+`docker-compose.yml`). In the file browser, open **DataLoader_v2.ipynb**.
+
+### 2. Configure + create the tenant (Phase 1)
+
+The first configuration cell logs in **and** creates the tenant — there is no
+separate "run Phase 1" cell. Edit the values, then run it:
+
+```python
+URL          = "http://kong:8000"   # Kong gateway inside the Docker network — leave as-is
+USERNAME     = "ADMIN"
+PASSWORD     = "eGov@123"
+TENANT_ID    = "pg"                  # root tenant you log in against
+TARGET_TENANT = "pg.myorg"           # <-- your new tenant (pattern: <state>.<city>)
+
+loader = CRSLoader(URL)
+loader.login(username=USERNAME, password=PASSWORD, tenant_id=TENANT_ID)
+
+# Creates the tenant (also enables PGR & HRMS) and its ADMIN user:
+loader.create_tenant(TARGET_TENANT, "My Org", users=[
+    {"username": "ADMIN", "password": "eGov@123", "name": "Admin",
+     "roles": ["SUPERUSER", "EMPLOYEE", "CSR", "GRO", "DGRO", "PGR_LME", "PGR_VIEWER", "CITIZEN"]}
+])
+loader.login(username="ADMIN", password="eGov@123", tenant_id=TARGET_TENANT)
+```
+
+Creating a tenant under a brand-new root (e.g. `ethiopia.addis`) auto-bootstraps
+that root — schemas and essential MDMS data are copied from `pg` first.
+
+### 3. Run the remaining phases in order
+
+| Cell | Call | What it does |
+|------|------|--------------|
+| Phase 2a | `loader.load_hierarchy(name, levels, target_tenant, output_dir="upload")` | Defines the boundary hierarchy and writes an Excel template to `upload/` |
+| Phase 2b | `loader.load_boundaries(<file>, target_tenant, hierarchy_type)` | Uploads the filled boundary sheet; creates entities + parent/child relationships |
+| Phase 3  | `loader.load_common_masters(<file>, target_tenant)` | Departments, designations, complaint types |
+| Phase 4  | `loader.load_employees(<file>, target_tenant)` | HRMS employees with roles, departments, jurisdictions |
+| Phase 5  | `loader.load_localizations(<file>, target_tenant)` | *Optional* — bulk translation messages (and, optionally, a new UI language) |
+| Phase 6  | `loader.load_workflow("templates/PgrWorkflowConfig.json", target_tenant)` | The PGR complaint-workflow state machine |
+
+The bundled templates live in `jupyter/dataloader/templates/`
+(`Boundary_Master.xlsx`, `Common and Complaint Master.xlsx`, the employee
+master, `localization.xlsx`, `PgrWorkflowConfig.json`). Copy and edit them for
+your city.
+
+### Rollback
+
+Each phase has an inverse. **Note the argument order** — `full_reset` takes the
+boundary hierarchy type *first*, then the tenant:
+
+```python
+loader.delete_boundaries(TARGET_TENANT)          # Phase 2
+loader.rollback_common_masters(TARGET_TENANT)    # Phase 3
+loader.rollback_tenant(TARGET_TENANT)            # Phase 1 (tenant + branding)
+loader.full_reset("REVENUE", TARGET_TENANT)      # everything (pass the hierarchy you used)
+```
+
+Employees (Phase 4) cannot be deleted via API — HRMS records are deactivated,
+not removed.
+
+---
+
+## C. MCP automation
+
+For CI or hands-off onboarding, the DIGIT-MCP server drives the same steps
+through its tools — `tenant_bootstrap` (once per new root), then `city_setup`
+and the masters/employees/localization tools, or the `city_setup_from_xlsx`
+orchestrator that sequences the four phases from a folder of XLSX files.
+Requires a deploy with `enable_mcp: true`. See the step-by-step
+[City Setup Guide](../../digit-mcp/docs/guides/city-setup.md) in the digit-mcp
+package.
+
+---
+
+## After onboarding — verify
+
+A successful onboarding should leave you able to:
+
+1. Open the employee login page and see the new tenant in the **City** dropdown.
+2. Log in as `ADMIN` / `eGov@123` against the new tenant.
+3. See the tenant in the HRMS / PGR / Workbench module switchers after login.
+4. See departments, designations, and complaint types populated for the tenant.
+5. See boundaries populate the location dropdowns in the complaint form.
+
+Quick API check that the tenant record landed:
+
+```bash
+curl -s -X POST "http://localhost:18000/mdms-v2/v1/_search" \
+  -H "Content-Type: application/json" \
+  -d '{"RequestInfo":{"apiId":"Rainmaker"},"MdmsCriteria":{"tenantId":"<root>","moduleDetails":[{"moduleName":"tenant","masterDetails":[{"name":"tenants"}]}]}}' \
+  | grep -o '"code":"[^"]*"'
+```
+
+Then run the PGR lifecycle Postman collection against the tenant to confirm the
+full create → assign → resolve → close flow works — see the *Testing the deploy*
+section of [`../ansible/README.md`](../ansible/README.md).
+
+## Troubleshooting & known issues
+
+Onboarding edge cases (empty boundary dropdowns, first-cold-deploy bootstrap
+ordering, employee date/department parsing) and their workarounds are tracked in
+the Ansible runbooks:
+
+- [`../ansible/runbooks/02-tenant-onboarding-status.md`](../ansible/runbooks/02-tenant-onboarding-status.md) — what a correct onboarding must achieve, and resolved vs. open bugs.
+- [`../ansible/runbooks/03-bomet-onboarding.md`](../ansible/runbooks/03-bomet-onboarding.md) — the end-to-end deploy + wizard walkthrough, per-phase template rules, and SQL workarounds.

--- a/local-setup/docs/TENANT-ONBOARDING.md
+++ b/local-setup/docs/TENANT-ONBOARDING.md
@@ -221,7 +221,103 @@ Requires a deploy with `enable_mcp: true`. See the step-by-step
 [City Setup Guide](../../digit-mcp/docs/guides/city-setup.md) in the digit-mcp
 package.
 
+### Worked headless run (`city_setup_from_xlsx` over the REST shim)
+
+The orchestrator is exposed on the shim at `POST /v1/tools/city_setup_from_xlsx`.
+Files are read **inside** the MCP container, so stage them there first. Run the
+steps in this order — each avoids a failure seen in practice.
+
+**1. Pre-create the boundary hierarchy at the tenant.** The loader auto-names a
+fresh hierarchy per city (`<CITY>_ADMIN`), but the UI reads a **single global
+`HIERARCHY_TYPE`** for every tenant. Create the hierarchy under that shared name
+(`ADMIN`) with your exact levels first, so the loader reuses it:
+
+```bash
+curl -s "$BASE/boundary-service/boundary-hierarchy-definition/_create" \
+  -H 'Content-Type: application/json' -d '{
+    "RequestInfo":{"authToken":"<TOKEN>","userInfo":{"userName":"ADMIN","tenantId":"<root>","type":"EMPLOYEE"}},
+    "BoundaryHierarchy":{"tenantId":"<tenant>","hierarchyType":"ADMIN","boundaryHierarchy":[
+      {"boundaryType":"<L1>","parentBoundaryType":null,"active":true},
+      {"boundaryType":"<L2>","parentBoundaryType":"<L1>","active":true}]}}'
+```
+
+**2. Wait until the backend is healthy for ≥ 5 min.** After a fresh deploy the
+JVM tier keeps warming/restarting; onboarding into that window causes transient
+5xx that corrupt the load (and can make the loader auto-create the wrong-named
+hierarchy from a swallowed error). Confirm `boundary-service` shows `healthy`.
+
+**3. Run it:**
+
+```bash
+docker cp <files-dir> digit-mcp:/tmp/onboard
+curl -s -m 900 "$BASE/v1/tools/city_setup_from_xlsx" -H 'Content-Type: application/json' -d '{
+  "tenant_id":"<tenant>",
+  "tenant_file":"/tmp/onboard/01-Tenant-And-Branding-Master.xlsx",
+  "boundary_file":"/tmp/onboard/02-Boundaries.xlsx",
+  "boundary_geojson_file":"/tmp/onboard/02-Boundaries-Polygons.geojson",
+  "masters_file":"/tmp/onboard/03-Common-and-Complaint-Master.xlsx",
+  "employee_file":"/tmp/onboard/04-Employees.xlsx",
+  "auth":{"username":"ADMIN","password":"eGov@123","tenant_id":"<root>"}
+}'
+```
+
+The optional GeoJSON sidecar attaches Polygon/MultiPolygon geometry to boundary
+rows by `properties.code`; include only real geometry (a boundary with no polygon
+still works in the dropdown, it just won't resolve map pins).
+
+**Known phase failures on the headless path & recovery:**
+
+- **Tenant phase** fails with a schema error on null `city.latitude/longitude` →
+  register the tenant directly: clone a known-good `tenant.tenants` row (patching
+  `code`/`name`/`tenantId`/`city.code`) and append the new code to the
+  `tenant.citymodule` rows (PGR / HRMS / Workbench). Re-run the remaining phases.
+- **Employee phase** fails with "encryption process" / "Tenant Id not found" →
+  `egov-enc-service` has no key for a tenant that wasn't registered yet. After the
+  tenant exists: `docker restart egov-enc-service`, then re-run with only
+  `employee_file`.
+- **Employee jurisdiction** lands on the wrong root (the loader scopes to the
+  first boundary root) → fix directly:
+  ```sql
+  UPDATE eg_hrms_jurisdiction j SET boundary='<intended-root-code>'
+  FROM eg_hrms_employee e WHERE e.uuid = j.employeeid AND e.tenantid = '<tenant>';
+  ```
+- **MapConfig not written.** Unlike the configurator wizard's Phase 2, the
+  headless path does **not** write `RAINMAKER-PGR.MapConfig`, so the citizen map
+  has no boundary source. Seed it (see the [map post-config](#after-onboarding-enable-the-map--boundaries) below).
+
 ---
+
+## After onboarding — enable the map & boundaries
+
+Two settings decide whether the map pin and boundary cascade actually work for
+citizens (easy to miss, and not created by the headless path):
+
+- **`RAINMAKER-PGR.MapConfig` per tenant.** The configurator wizard's Phase 2
+  writes this; the headless path does not. Without it the citizen map has no
+  boundary source. Seed one record per tenant (its `boundaryTenantId` = the
+  tenant itself):
+
+  ```bash
+  curl -s "$BASE/mdms-v2/v2/_create/RAINMAKER-PGR.MapConfig" -H 'Content-Type: application/json' -d '{
+    "RequestInfo":{"authToken":"<TOKEN>","userInfo":{"userName":"ADMIN","tenantId":"<root>","type":"EMPLOYEE"}},
+    "Mdms":{"tenantId":"<tenant>","schemaCode":"RAINMAKER-PGR.MapConfig","uniqueIdentifier":"DEFAULT",
+      "data":{"code":"DEFAULT","boundaryTenantId":"<tenant>","center":{"lat":<lat>,"lng":<lng>},
+              "defaultZoom":11,"baseMapTheme":"voyager","geocodeCountryCodes":"<cc>"},"isActive":true}}'
+  ```
+
+- **`pgr_boundary_lowest_level`** (host_vars → globalConfigs `PGR_BOUNDARY_LOWEST_LEVEL`)
+  — set to the level that tiles your territory **with real geometry** (e.g.
+  `Ward`), not a deeper level only some regions have. It caps *both* the map's
+  pin-resolution level and the dropdown cascade so they agree; if the name isn't
+  a level of the tree the map silently falls back to the deepest level (a
+  `console.warn` names the levels it does have).
+
+- **Citizen home city.** The citizen map and cascade resolve against
+  `CITIZEN.COMMON.HOME.CITY`; ensure it's set on citizen login (SSO mapper /
+  location picker), else citizens fall back to the state root (no city tree →
+  blank map/cascade). As a deployment-wide fallback for citizens without a home
+  city, globalConfigs `MAP_TENANT` (from `city_tenant`) can point at a tenant
+  that has geometry.
 
 ## After onboarding — verify
 

--- a/local-setup/docs/TENANT-ONBOARDING.md
+++ b/local-setup/docs/TENANT-ONBOARDING.md
@@ -12,7 +12,7 @@ that matches how your stack is deployed:
 |------|-----------|----------|----------------------|
 | **[Configurator wizard](#a-configurator-wizard-browser)** | Browser (upload XLSX) | Non-technical operators onboarding a real city | Ansible deploys with `nginx_features.configurator: true` |
 | **[Jupyter DataLoader](#b-jupyter-dataloader-scripted)** | Jupyter notebook (Python) | Developers, scripted/local setups | Any stack (Docker Compose, Tilt, Ansible) |
-| **[MCP `city_setup_from_xlsx`](#c-mcp-automation)** | REST / MCP tool | CI, fully-automated onboarding | Deploys with `enable_mcp: true` |
+| **[MCP `city_setup_from_xlsx`](#c-mcp-automation)** | REST / MCP tool | CI, fully-automated onboarding | Deploys with `enable_mcp: true` + `nginx_features.mcp: true` |
 
 > **Order always matters:** Tenant → Boundaries → Masters → Employees. Each
 > phase validates codes created by the previous one (an employee's jurisdiction
@@ -111,7 +111,11 @@ department | designation | roles | jurisdictions | dateOfAppointment
   `^[17][0-9]{8}$`, i.e. exactly 9 digits).
 - `roles` — validated against `ACCESSCONTROL-ROLES`. Use `EMPLOYEE` plus a
   workflow role: **GRO** (receives/assigns), **DGRO** (department/subcounty
-  assigner), **PGR_LME** (resolver).
+  assigner), **PGR_LME** (resolver). Add **CSR** for anyone who must *file* a
+  complaint from the employee portal — the employee create-complaint screen is
+  gated on that role, so a GRO/DGRO/PGR_LME-only employee can process complaints
+  but cannot raise one. Give at least one employee `EMPLOYEE,CSR` if you want to
+  test the create flow end to end.
 - `jurisdictions` — boundary codes created in Phase 2 (`WARD_001`,
   `SUBCOUNTY_001`, …).
 - `department` accepts a **comma-separated list** (`HealthServices,WaterandSewage`).
@@ -134,6 +138,14 @@ hierarchy_type: BOMET-Hierarchy  # MUST match the Phase 2 hierarchy name
 
 Leave `state_root` / `state_tenant_id` / `tenant_id` at the **root** (`ke`) —
 those drive the JVM `STATE_LEVEL_TENANT_ID` pins. Re-run `./deploy.sh <tenant>`.
+
+> **`hierarchy_type` is a single global value, not per-tenant.** The UI sends it
+> on every boundary lookup regardless of which tenant is active, so **all tenants
+> on one deployment must use the same hierarchy name**. Onboarding a second city
+> under a differently-named hierarchy will silently blank the boundary dropdowns
+> for one of them. If you plan to host more than one city, standardise on one
+> name (`ADMIN` is the UI default) and create each tenant's hierarchy under it —
+> see [§C step 1](#worked-headless-run-city_setup_from_xlsx-over-the-rest-shim).
 
 ---
 
@@ -227,6 +239,34 @@ The orchestrator is exposed on the shim at `POST /v1/tools/city_setup_from_xlsx`
 Files are read **inside** the MCP container, so stage them there first. Run the
 steps in this order — each avoids a failure seen in practice.
 
+**Prerequisites.** The REST shim needs **both** flags in `host_vars` — the
+service *and* its nginx location:
+
+```yaml
+enable_mcp: true
+nginx_features: { mcp: true }     # exposes /mcp + /v1/*
+```
+
+Confirm it's reachable: `curl -s $BASE/v1/healthz` → `{"status":"ok",…}`.
+
+**Where to run these commands.** `curl` can run anywhere that can reach the
+host; `docker …` and `psql` commands run **on the deployment target** (SSH in
+first for a remote Option C deploy).
+
+**Shell setup** — every snippet below assumes these two variables:
+
+```bash
+# Ansible deploy: the host nginx (add https:// + your domain if TLS is on).
+# Docker Compose / Tilt stacks: http://localhost:18000 (Kong).
+BASE=http://localhost
+
+TOKEN=$(curl -s "$BASE/user/oauth/token" \
+  -H 'Authorization: Basic ZWdvdi11c2VyLWNsaWVudDo=' \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d 'grant_type=password&scope=read&username=ADMIN&password=eGov@123&tenantId=<root>&userType=EMPLOYEE' \
+  | jq -r .access_token)
+```
+
 **1. Pre-create the boundary hierarchy at the tenant.** The loader auto-names a
 fresh hierarchy per city (`<CITY>_ADMIN`), but the UI reads a **single global
 `HIERARCHY_TYPE`** for every tenant. Create the hierarchy under that shared name
@@ -235,7 +275,7 @@ fresh hierarchy per city (`<CITY>_ADMIN`), but the UI reads a **single global
 ```bash
 curl -s "$BASE/boundary-service/boundary-hierarchy-definition/_create" \
   -H 'Content-Type: application/json' -d '{
-    "RequestInfo":{"authToken":"<TOKEN>","userInfo":{"userName":"ADMIN","tenantId":"<root>","type":"EMPLOYEE"}},
+    "RequestInfo":{"authToken":"'"$TOKEN"'","userInfo":{"userName":"ADMIN","tenantId":"<root>","type":"EMPLOYEE"}},
     "BoundaryHierarchy":{"tenantId":"<tenant>","hierarchyType":"ADMIN","boundaryHierarchy":[
       {"boundaryType":"<L1>","parentBoundaryType":null,"active":true},
       {"boundaryType":"<L2>","parentBoundaryType":"<L1>","active":true}]}}'
@@ -267,23 +307,47 @@ still works in the dropdown, it just won't resolve map pins).
 
 **Known phase failures on the headless path & recovery:**
 
-- **Tenant phase** fails with a schema error on null `city.latitude/longitude` →
-  register the tenant directly: clone a known-good `tenant.tenants` row (patching
-  `code`/`name`/`tenantId`/`city.code`) and append the new code to the
-  `tenant.citymodule` rows (PGR / HRMS / Workbench). Re-run the remaining phases.
+- **Tenant phase** fails with a schema error on null `city.latitude/longitude`
+  (surfaces as `ValidationException.getKeyword() is null` — mdms-v2's error
+  formatter NPEs on the underlying schema violation) → register the tenant
+  directly by cloning a known-good row, then re-run the remaining phases:
+  ```bash
+  docker exec -i docker-postgres psql -U egov -d egov <<'SQL'
+  -- clone an existing city's tenant.tenants row, patching identity fields
+  INSERT INTO eg_mdms_data (id, tenantid, uniqueidentifier, schemacode, data, isactive,
+                            createdby, lastmodifiedby, createdtime, lastmodifiedtime)
+  SELECT md5(random()::text || clock_timestamp()::text), '<root>', '<tenant>', 'tenant.tenants',
+         jsonb_set(jsonb_set(jsonb_set(jsonb_set(src.data::jsonb,
+           '{code}', '"<tenant>"'), '{name}', '"<City Name>"'),
+           '{tenantId}', '"<tenant>"'), '{city,code}', '"<TENANT-UPPER>"'),
+         true, src.createdby, src.lastmodifiedby,
+         (extract(epoch from now())*1000)::bigint, (extract(epoch from now())*1000)::bigint
+  FROM (SELECT data, createdby, lastmodifiedby FROM eg_mdms_data
+        WHERE schemacode='tenant.tenants' AND uniqueidentifier='<existing-city>') src;
+
+  -- make the tenant visible to the modules (PGR / HRMS / Workbench)
+  UPDATE eg_mdms_data SET data = jsonb_set(data::jsonb, '{tenants}',
+           (data::jsonb->'tenants') || '[{"code":"<tenant>"}]'::jsonb)
+  WHERE schemacode='tenant.citymodule' AND tenantid='<root>'
+    AND NOT (data::jsonb->'tenants') @> '[{"code":"<tenant>"}]'::jsonb;
+  SQL
+  ```
 - **Employee phase** fails with "encryption process" / "Tenant Id not found" →
   `egov-enc-service` has no key for a tenant that wasn't registered yet. After the
   tenant exists: `docker restart egov-enc-service`, then re-run with only
   `employee_file`.
 - **Employee jurisdiction** lands on the wrong root (the loader scopes to the
-  first boundary root) → fix directly:
-  ```sql
+  first boundary root) → fix directly (SQL runs on the target host; the DB
+  container is `docker-postgres`, user/db `egov`):
+  ```bash
+  docker exec -i docker-postgres psql -U egov -d egov <<'SQL'
   UPDATE eg_hrms_jurisdiction j SET boundary='<intended-root-code>'
   FROM eg_hrms_employee e WHERE e.uuid = j.employeeid AND e.tenantid = '<tenant>';
+  SQL
   ```
 - **MapConfig not written.** Unlike the configurator wizard's Phase 2, the
   headless path does **not** write `RAINMAKER-PGR.MapConfig`, so the citizen map
-  has no boundary source. Seed it (see the [map post-config](#after-onboarding-enable-the-map--boundaries) below).
+  has no boundary source. Seed it (see the [map post-config](#after-onboarding--enable-the-map--boundaries) below).
 
 ---
 
@@ -299,7 +363,7 @@ citizens (easy to miss, and not created by the headless path):
 
   ```bash
   curl -s "$BASE/mdms-v2/v2/_create/RAINMAKER-PGR.MapConfig" -H 'Content-Type: application/json' -d '{
-    "RequestInfo":{"authToken":"<TOKEN>","userInfo":{"userName":"ADMIN","tenantId":"<root>","type":"EMPLOYEE"}},
+    "RequestInfo":{"authToken":"'"$TOKEN"'","userInfo":{"userName":"ADMIN","tenantId":"<root>","type":"EMPLOYEE"}},
     "Mdms":{"tenantId":"<tenant>","schemaCode":"RAINMAKER-PGR.MapConfig","uniqueIdentifier":"DEFAULT",
       "data":{"code":"DEFAULT","boundaryTenantId":"<tenant>","center":{"lat":<lat>,"lng":<lng>},
               "defaultZoom":11,"baseMapTheme":"voyager","geocodeCountryCodes":"<cc>"},"isActive":true}}'
@@ -332,10 +396,20 @@ A successful onboarding should leave you able to:
 Quick API check that the tenant record landed:
 
 ```bash
-curl -s -X POST "http://localhost:18000/mdms-v2/v1/_search" \
+# $BASE = http://<domain> on an Ansible deploy; http://localhost:18000 (Kong)
+# on a Docker Compose / Tilt stack.
+curl -s -X POST "$BASE/mdms-v2/v1/_search" \
   -H "Content-Type: application/json" \
   -d '{"RequestInfo":{"apiId":"Rainmaker"},"MdmsCriteria":{"tenantId":"<root>","moduleDetails":[{"moduleName":"tenant","masterDetails":[{"name":"tenants"}]}]}}' \
   | grep -o '"code":"[^"]*"'
+```
+
+Boundary sanity-check (counts per level, and that geometry actually landed):
+
+```bash
+curl -s -X POST "$BASE/boundary-service/boundary-relationships/_search?tenantId=<tenant>&hierarchyType=<hierarchy>&includeChildren=true" \
+  -H 'Content-Type: application/json' -d '{"RequestInfo":{"authToken":"'"$TOKEN"'"}}' \
+  | jq '[.TenantBoundary[0].boundary | .. | objects | select(has("boundaryType")).boundaryType] | group_by(.) | map({(.[0]): length}) | add'
 ```
 
 Then run the PGR lifecycle Postman collection against the tenant to confirm the

--- a/local-setup/docs/TENANT-ONBOARDING.md
+++ b/local-setup/docs/TENANT-ONBOARDING.md
@@ -45,9 +45,13 @@ Re-run `./deploy.sh <tenant>` after flipping these. See
 
 ### Open it
 
+```text
+https://<domain>/configurator/
 ```
-http://<domain>/configurator/
-```
+
+`tls_enabled` defaults to `true`, so HTTPS is the normal case; use
+`http://<domain>/configurator/` only on a sandbox deploy with
+`tls_enabled: false` (e.g. `domain: localhost`).
 
 Log in as `ADMIN` / `eGov@123` against the **root** tenant (e.g. `ke`). The
 wizard walks the four phases in order.
@@ -102,7 +106,7 @@ Three sheets in one workbook.
 
 Template columns:
 
-```
+```text
 employeeCode | name | userName | mobileNumber | emailId | gender | dob |
 department | designation | roles | jurisdictions | dateOfAppointment
 ```
@@ -131,13 +135,14 @@ Because the wizard puts all data on the city tenant, the SPA must land there.
 In `host_vars/<tenant>.yml`:
 
 ```yaml
-ui_state_tenant_id: ke.bomet     # SPA boots on the wizard-created city
-boot_tenant: ke.bomet
-hierarchy_type: BOMET-Hierarchy  # MUST match the Phase 2 hierarchy name
+ui_state_tenant_id: <root>.<city>   # SPA boots on the wizard-created city
+boot_tenant: <root>.<city>          #   e.g. ke.bomet
+hierarchy_type: <hierarchy-name>    # MUST match the Phase 2 hierarchy name
 ```
 
-Leave `state_root` / `state_tenant_id` / `tenant_id` at the **root** (`ke`) —
-those drive the JVM `STATE_LEVEL_TENANT_ID` pins. Re-run `./deploy.sh <tenant>`.
+Leave `state_root` / `state_tenant_id` / `tenant_id` at the **root** (`<root>`,
+e.g. `ke`) — those drive the JVM `STATE_LEVEL_TENANT_ID` pins. Re-run
+`./deploy.sh <tenant>`.
 
 > **`hierarchy_type` is a single global value, not per-tenant.** The UI sends it
 > on every boundary lookup regardless of which tenant is active, so **all tenants
@@ -157,12 +162,26 @@ under `jupyter/dataloader/templates/`.
 
 ### 1. Open Jupyter Lab
 
-```
+**Docker Compose / Tilt (local):** reachable through Kong —
+
+```text
 http://localhost:18000/jupyter/lab?token=digit-crs-local
 ```
 
 The default token is `digit-crs-local` (override via `JUPYTER_TOKEN` in
-`docker-compose.yml`). In the file browser, open **DataLoader_v2.ipynb**.
+`docker-compose.yml`).
+
+**Ansible (remote target):** the host nginx does **not** publish a `/jupyter`
+location, so there is no public URL — tunnel to the container's host-bound port
+instead. This stack also starts Jupyter with an empty token, so no `?token=` is
+needed:
+
+```bash
+ssh -L 18888:127.0.0.1:18888 <target>
+# then open http://localhost:18888/jupyter/lab
+```
+
+In the file browser, open **DataLoader_v2.ipynb**.
 
 ### 2. Configure + create the tenant (Phase 1)
 
@@ -246,6 +265,18 @@ service *and* its nginx location:
 enable_mcp: true
 nginx_features: { mcp: true }     # exposes /mcp + /v1/*
 ```
+
+The target must also be able to **pull or build the MCP image**. Compose
+validates every image before starting any service, so an unreachable registry
+fails the whole `docker compose up`, not just MCP. Either:
+
+- `build_mcp: true` — build from the vendored in-tree source (no registry
+  needed); or
+- leave it off and use the playbook's pinned public image default.
+
+If your `host_vars` overrides `mcp_image` / `docker_registry` to the Hetzner VPC
+registry (`10.0.0.4:5000`), the target must be VPC-internal — see the
+`enable_mcp` notes in `_example.yml`.
 
 Confirm it's reachable: `curl -s $BASE/v1/healthz` → `{"status":"ok",…}`.
 


### PR DESCRIPTION
Closes #1355.

The Ansible deployment instructions in `local-setup` were outdated, and there was no documentation for enabling a new tenant / loading master data via the **configurator**. This PR fixes both.

## Why
- **Option C (Ansible)** in `local-setup/README.md` still described a superseded flow: `cp inventory.ini.example inventory.ini` → `ansible-playbook -i inventory.ini playbook-deploy.yml`, images from a public preview registry, and a "This PR (#319)…" narrative. The real deploy is config-driven: `./deploy.sh <tenant>` reading `inventory/host_vars/<tenant>.yml` (see `local-setup/ansible/README.md`).
- The **"Setting Up a New Tenant"** section was factually wrong — it described a "Phase 1" cell that doesn't exist in `DataLoader_v2.ipynb` (tenant creation happens in the config cell via `create_tenant(...)`), and a rollback `full_reset(TARGET_TENANT)` that actually passes the tenant as the *hierarchy* argument (signature is `full_reset(hierarchy_type, target_tenant)`).
- **"Configurator"** = `digit-configurator`, the browser onboarding wizard served at `/configurator/` (enabled per-tenant via `nginx_features.configurator: true`). It had no operator-facing documentation.

## Changes
- **`local-setup/README.md`**
  - Rewrote **Option C** to the current `./deploy.sh <tenant>` + host_vars flow, host-nginx access URLs (`/digit-ui/`, `/configurator/`, `/grafana/`, `/status/`), and a pointer to the authoritative `ansible/README.md`.
  - Removed the stale **PR #318/#319** framing and the outdated "Files involved" tree.
  - Corrected the tenant/DataLoader section (real `create_tenant` config-cell flow; correct `full_reset("REVENUE", TARGET_TENANT)` rollback).
- **`local-setup/docs/TENANT-ONBOARDING.md`** (new) — operator how-to for enabling a tenant + loading master data three ways: the **configurator wizard** (per-phase XLSX rules: boundaries, complaint types, employees), the **Jupyter DataLoader** (corrected 6-phase flow), and **MCP** automation — plus a post-onboarding verification checklist.

## Notes
- Based on `develop` (not `master`): the current Ansible + configurator tooling this documents lives on `develop`, not yet on `master`.
- Docs-only; every referenced file/path and code fact (Kong port, Jupyter token, `create_tenant`/`full_reset` signatures, template filenames) was verified against `develop`.
- Iterative — happy to expand the configurator XLSX template details or fold in the runbook known-issues as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated local setup guidance with an Ansible/SSH, per-tenant deployment workflow (config-driven deploy and dry-run options), including tenant-specific configuration, access URLs, and rollback/reset instructions.
  * Expanded tenant onboarding documentation with three equivalent onboarding paths (Configurator, Jupyter DataLoader, and MCP automation), enforcing the required phase order and adding end-to-end run/verification details.
  * Added new “after onboarding” instructions for enabling map and boundaries, plus troubleshooting and status/runbook references.
  * Refreshed project structure and references to match the current Ansible-based deployment layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->