### PR TITLE
fix(ansible): floor the max-file divisor so lint (and 0m) can't divide by zero

### DIFF
--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -320,10 +320,35 @@
                      * _u[(docker_log_max_size | regex_search('([kmgKMG])[bB]?$', '\\1') | first | lower)] }}"
             _tt: "{{ (docker_log_total_size | regex_search('^([0-9.]+)', '\\1') | first | float)
                      * _u[(docker_log_total_size | regex_search('([kmgKMG])[bB]?$', '\\1') | first | lower)] }}"
+          # The divisor below is floored at 1 byte — `[1, (_sz | float)] | max`
+          # — so the division can never raise. Two reasons that is not paranoia:
+          #
+          # 1. ansible-lint renders a task's Jinja using that task's `vars`
+          #    only. It never loads inventory group_vars, and this playbook has
+          #    no committed inventory (deploy.sh generates hosts.yml, and
+          #    group_vars live under inventory/). So at lint time
+          #    docker_log_max_size is undefined, `| float` yields 0.0, and an
+          #    unfloored division aborts the whole run with "jinja[invalid]:
+          #    Error rendering template: float division by zero" — a CI failure
+          #    with no runtime counterpart.
+          #
+          # 2. `default()` evaluates its argument eagerly, so this division runs
+          #    even when docker_log_max_file IS set. The guard task above is
+          #    skipped in exactly that case, so a host combining the escape
+          #    hatch with docker_log_max_size: "0m" would hit a real
+          #    ZeroDivisionError at runtime.
+          #
+          # Keep the floor INLINE. Hoisting it into a helper var does not work:
+          # ansible-lint resolves a task var only when it is self-contained, so
+          # a var defined in terms of _sz reads back as undefined, collapses to
+          # 0.0, and reintroduces the very error this avoids.
+          #
+          # A zero max-size reaching this point is still caught downstream —
+          # dockerd rejects a "max-size": "0m" log-opt itself.
           ansible.builtin.set_fact:
             docker_log_max_file_effective: >-
               {{ docker_log_max_file
-                 | default([1, ((_tt | float) / (_sz | float)) | int] | max, true) }}
+                 | default([1, ((_tt | float) / ([1, (_sz | float)] | max)) | int] | max, true) }}
 
         # daemon.json is written unconditionally now. It used to be gated on
         # insecure_registries being non-empty, which meant hosts on a TLS


### PR DESCRIPTION
## Problem

`ansible-lint playbook-deploy.yml` fails on **every** PR since the log-rotation work landed, so the `Ansible static validation` check is permanently red on `develop` and on the release PR (#1378):

```
jinja[invalid]: Error rendering template: float division by zero
playbook-deploy.yml:324:44  Task: Docker logging — derive max-file from the total cap
```

## Root cause

**ansible-lint renders a task's Jinja using that task's `vars` only — it never loads inventory group_vars.**

This playbook ships no committed inventory (`deploy.sh` generates `inventory/hosts.yml`, and `group_vars/` lives under `inventory/`). So at lint time `docker_log_max_size` is undefined, `| float` collapses to `0.0`, and the derivation divides by it.

Things I verified rather than assumed:

- Task vars **are** resolved by the linter when self-contained — so "vars aren't in scope" is not the explanation.
- Pointing the linter at an inventory (`ANSIBLE_INVENTORY=inventory/hosts.yml.example`) does **not** help. The rule renders templates in isolation, so there is no structural fix — it has to be the expression.
- The floor **must stay inline**. Hoisting it into a helper var (`_szf`) does not work: ansible-lint resolves a task var only when it is self-contained, so a var defined in terms of `_sz` reads back as undefined, collapses to `0.0`, and reintroduces the exact same error. That was a real failed attempt, hence the comment warning against it.
- The neighbouring guard task never tripped this because it only *compares* (`0.0 > 0.0` → `False`); only the division raises.

## This also fixes a real runtime bug

`default()` evaluates its argument **eagerly**, so the division runs even when `docker_log_max_file` IS set — and the guard task above is skipped in exactly that case (`when: not (docker_log_max_file | default('', true))`).

A host combining the escape hatch with `docker_log_max_size: "0m"` therefore hit a genuine `ZeroDivisionError`. Demonstrated before/after:

| form | result |
|---|---|
| old | `ZeroDivisionError: float division by zero` |
| new | `5` (honours the escape hatch) |

## Verification

- `ansible-lint playbook-deploy.yml` → **Passed**, 0 failures (`Profile 'basic' was required, but 'production' profile passed`)
- `yamllint -c .yamllint playbook-deploy.yml` → exit 0
- `yamllint -c .yamllint inventory/group_vars/ inventory/host_vars/` → exit 0
- Old and new expressions produce **identical** output across every case tried, so the derived `max-file` is unchanged:

| max-size / total | escape hatch | old | new |
|---|---|---|---|
| `100m` / `1g` (shipped default) | — | 10 | 10 |
| `10m` / `1g` | — | 102 | 102 |
| `500m` / `1g` | — | 2 | 2 |
| `1g` / `1g` (slice == cap) | — | 1 | 1 |
| `64k` / `10m` | — | 160 | 160 |
| `1g` / `10g` | — | 10 | 10 |
| `100m` / `1g` | `3` | 3 | 3 |

## Note on sequencing

This targets `develop`. Merging it before #1378 (`develop` → `master`) lets the fix ride along and clears `Ansible static validation` on the release PR itself; otherwise `master` keeps the broken lint until the next release.

The other two red checks on #1378 (`test` → `Localization module check`, `tilt-test` → telemetry verification) are separate pre-existing failures and are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)