### PR TITLE
fix(pgr): landing — "Fala Cidadão" rebrand, Portuguese-only, in-app privacy policy

### DIFF
--- a/digit-ui-esbuild/packages/modules/core/src/App.js
+++ b/digit-ui-esbuild/packages/modules/core/src/App.js
@@ -75,6 +75,8 @@ export const DigitApp = ({ stateCode, modules, appTenants, logoUrl, logoUrlWhite
   // Public PGR landing page — mounted shell-free (no topbar/sidebar) below.
   // Registered by the PGR module; absent when PGR isn't an enabled module.
   const PGRLandingPage = Digit?.ComponentRegistryService?.getComponent?.("PGRLandingPage");
+  // Public privacy-policy page — also shell-free; linked from the landing.
+  const PGRPrivacyPolicy = Digit?.ComponentRegistryService?.getComponent?.("PGRPrivacyPolicy");
   let sourceUrl = `${window.location.origin}/citizen`;
   const commonProps = {
     stateInfo,
@@ -98,6 +100,11 @@ export const DigitApp = ({ stateCode, modules, appTenants, logoUrl, logoUrlWhite
       {PGRLandingPage && (
         <Route exact path={`/${window?.contextPath}/landing`}>
           <PGRLandingPage />
+        </Route>
+      )}
+      {PGRPrivacyPolicy && (
+        <Route exact path={`/${window?.contextPath}/privacy-policy`}>
+          <PGRPrivacyPolicy />
         </Route>
       )}
      {allowedUserTypes?.some(userType=>userType=="employee")&& <Route path={`/${window?.contextPath}/employee`}>

--- a/digit-ui-esbuild/products/pgr/src/Module.js
+++ b/digit-ui-esbuild/products/pgr/src/Module.js
@@ -33,6 +33,8 @@ import SelectImages from "../../pgr/src/pages/citizen/Create/Steps/SelectImages"
 import CreatePGRFlow from "./pages/citizen/Create/CreatePGRFlowV2";
 // Public landing page (shell-free), mounted by core at /<contextPath>/landing.
 import PGRLandingEntry from "./pages/citizen/Landing/AppEntry";
+// Public privacy-policy page (shell-free), mounted by core at /<contextPath>/privacy-policy.
+import PGRPrivacyPolicyPage from "./pages/citizen/Landing/PrivacyPolicyPage";
 
 
 export const PGRReducers = getRootReducer;
@@ -134,6 +136,7 @@ const componentsToRegister = {
   SelectImages,
   CreatePGRFlow: CreatePGRFlow,
   PGRLandingPage: PGRLandingEntry,
+  PGRPrivacyPolicy: PGRPrivacyPolicyPage,
 };
 
 export const initPGRComponents = () => {

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/AppEntry.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/AppEntry.tsx
@@ -22,6 +22,7 @@ export function PGRLandingEntry() {
       TRACK_COMPLAINT: `/${ctx}/citizen/pgr/complaints`,
       CITIZEN_LOGIN: `/${ctx}/citizen/login`,
       EMPLOYEE_LOGIN: `/${ctx}/employee`,
+      PRIVACY: `/${ctx}/privacy-policy`,
     }),
     [ctx]
   );

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/PrivacyPolicyPage.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/PrivacyPolicyPage.tsx
@@ -1,0 +1,71 @@
+// Standalone, shell-free in-app Privacy Policy page. Mounted by core App.js at
+// /${contextPath}/privacy-policy and linked from the landing's PRIVACY route +
+// footer. Text resolves via useLandingCopy (built-in deck in content.ts,
+// overridable by PGR_LANDING_* localisation keys).
+import * as React from "react";
+import { ArrowLeft } from "lucide-react";
+import { buildTokenStyle, CONTAINER } from "./tokens";
+import { useLandingCopy } from "./useLandingCopy";
+import { LandingLink } from "./components/LandingLink";
+
+const BODY_KEYS = [
+  "PRIVACY_PAGE_P1",
+  "PRIVACY_PAGE_P2",
+  "PRIVACY_PAGE_P3",
+  "PRIVACY_PAGE_P4",
+  "PRIVACY_PAGE_P5",
+];
+
+export function PGRPrivacyPolicyPage() {
+  const { c, i18n } = useLandingCopy();
+  const ctx = (typeof window !== "undefined" && (window as any)?.contextPath) || "digit-ui";
+
+  // Portuguese-first public page: if the app's active locale isn't PT, switch
+  // to pt_PT once on mount. Prefer the platform LocalizationService (fetches
+  // the locale bundle + records the choice) and fall back to a bare i18n switch
+  // (the copy deck's pt strings still resolve). Runs once.
+  React.useEffect(() => {
+    const active = String(i18n?.language || "").toLowerCase();
+    if (active.startsWith("pt")) return;
+    try {
+      const D = (typeof window !== "undefined" ? (window as any).Digit : undefined) as any;
+      const stateCode = D?.ULBService?.getStateId?.();
+      if (D?.LocalizationService?.changeLanguage) {
+        D.LocalizationService.changeLanguage("pt_PT", stateCode);
+        return;
+      }
+    } catch {
+      /* fall through */
+    }
+    i18n?.changeLanguage?.("pt_PT");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div className="v2-scope pgr-landing min-h-screen bg-[hsl(var(--pgrl-page))]" style={buildTokenStyle()}>
+      <header className="bg-[hsl(var(--pgrl-deep))] text-[hsl(var(--pgrl-on-primary))]">
+        <div className={`${CONTAINER} flex min-h-[56px] items-center justify-between gap-3 py-2`}>
+          <span className="font-semibold uppercase tracking-wide">{c("PORTAL_NAME")}</span>
+          <LandingLink
+            to={`/${ctx}/landing`}
+            className="inline-flex items-center gap-1.5 text-sm font-semibold no-underline !text-[hsl(var(--pgrl-on-primary))]"
+          >
+            <ArrowLeft aria-hidden className="h-4 w-4" /> {c("NAV_HOME")}
+          </LandingLink>
+        </div>
+      </header>
+      <main className={`${CONTAINER} py-10`}>
+        <h1 className="mb-6 text-2xl font-bold text-[hsl(var(--pgrl-ink))]">{c("PRIVACY_PAGE_TITLE")}</h1>
+        <div className="flex max-w-3xl flex-col gap-4">
+          {BODY_KEYS.map((k) => (
+            <p key={k} className="m-0 text-base leading-relaxed text-[hsl(var(--pgrl-ink-soft))]">
+              {c(k)}
+            </p>
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+}
+
+export default PGRPrivacyPolicyPage;

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/components/HeroSection.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/components/HeroSection.tsx
@@ -12,7 +12,7 @@
 //     above the fold; secondary channels shrink to compact chips.
 
 import * as React from "react";
-import { Send, Search, Lock, Hash, Bell, Smartphone, MessageCircle, Phone } from "lucide-react";
+import { Send, Search, Lock, Hash, Bell, Smartphone, MessageCircle, Phone, Info } from "lucide-react";
 import { cn } from "@egovernments/digit-ui-components-v2";
 import { CtaLink } from "./CtaLink";
 import { useLandingCopy } from "../useLandingCopy";
@@ -91,6 +91,16 @@ export function HeroSection({ routes, imageUrl, section }: HeroSectionProps) {
           <p className="mb-0 mt-4 max-w-2xl text-base leading-relaxed text-[hsl(var(--pgrl-on-primary))] sm:text-lg">
             {c(section?.subtitleKey, "HERO_LEDE")}
           </p>
+
+          {/* Pilot-phase notice: government yellow with dark on-accent text (the
+              approved high-contrast pairing for accent surfaces). */}
+          <div
+            role="note"
+            className="mt-4 flex items-start gap-2 rounded-lg bg-[hsl(var(--pgrl-accent))] px-4 py-3 text-sm font-medium text-[hsl(var(--pgrl-on-accent))] shadow-sm sm:text-base"
+          >
+            <Info aria-hidden className="mt-0.5 h-5 w-5 shrink-0" />
+            <span>{c("HERO_PILOT_NOTICE")}</span>
+          </div>
 
           <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
             <CtaLink

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/components/LandingFooter.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/components/LandingFooter.tsx
@@ -36,11 +36,7 @@ const GROUPS: FooterGroup[] = [
     titleKey: "FOOTER_LINKS",
     links: [
       { labelKey: "NAV_SUBMIT", route: "REGISTER_COMPLAINT" },
-      { labelKey: "NAV_TRACK", route: "TRACK_COMPLAINT" },
-      { labelKey: "NAV_TRAINING", route: "TRAINING" },
-      { labelKey: "FOOTER_FAQ", route: "FAQ" },
-      { labelKey: "NAV_CONTACTS", route: "CONTACTS" },
-      { labelKey: "NAV_ABOUT", route: "ABOUT" },
+      { labelKey: "NAV_TRACK", route: "TRACK_COMPLAINT" }
     ],
   },
   {

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/components/UtilityBar.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/components/UtilityBar.tsx
@@ -19,8 +19,7 @@ export interface LanguageOption {
 }
 
 export const DEFAULT_LANGUAGES: LanguageOption[] = [
-  { code: "pt_PT", label: "PT" },
-  { code: "en_IN", label: "EN" },
+  { code: "pt_PT", label: "PT" }
 ];
 
 export interface UtilityBarProps {
@@ -68,7 +67,7 @@ export function UtilityBar({ routes, languages, onLanguageChange }: UtilityBarPr
             {c("UTILITY_PHONE_LABEL")}
           </a>
 
-          <div role="group" aria-label={c("ARIA_LANGUAGE")} className="flex items-center gap-1">
+          {languages.length > 1 && <div role="group" aria-label={c("ARIA_LANGUAGE")} className="flex items-center gap-1">
             {languages.map((lng, i) => (
               <React.Fragment key={lng.code}>
                 {i > 0 && (
@@ -93,7 +92,7 @@ export function UtilityBar({ routes, languages, onLanguageChange }: UtilityBarPr
                 </button>
               </React.Fragment>
             ))}
-          </div>
+          </div>}
 
           <LandingLink to={routes.CITIZEN_LOGIN} className={cn(UTIL_LINK, "font-semibold")}>
             <LogIn aria-hidden className="h-3.5 w-3.5" />

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/content.ts
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/content.ts
@@ -38,7 +38,7 @@ export type IconComponent = React.ComponentType<{ className?: string; "aria-hidd
 export const LANDING_COPY = {
   // Chrome ------------------------------------------------------------------
   GOV_NAME: { pt: "República de Moçambique", en: "Republic of Mozambique" },
-  PORTAL_NAME: { pt: "Portal de Reclamações e Denúncias", en: "Complaints and Reports Portal" },
+  PORTAL_NAME: { pt: "Fala Cidadão", en: "Complaints and Reports Portal" },
   ORG_NAMES: { pt: "IGE e IGSAE", en: "IGE and IGSAE" },
   TAGLINE: { pt: "O cidadão fala. O Estado responde.", en: "The citizen speaks. The State responds." },
   MOTTO_VALUES: { pt: "Transparência · Integridade", en: "Transparency · Integrity" },
@@ -63,7 +63,7 @@ export const LANDING_COPY = {
 
   // Hero -----------------------------------------------------------------—--
   HERO_EYEBROW: { pt: "República de Moçambique · IGE · IGSAE", en: "Republic of Mozambique · IGE · IGSAE" },
-  HERO_TITLE: { pt: "Portal de Reclamações e Denúncias", en: "Complaints and Reports Portal" },
+  HERO_TITLE: { pt: "Fala Cidadão", en: "Complaints and Reports Portal" },
   HERO_LEDE: {
     pt: "Canal nacional para reclamações, queixas, petições e denúncias sobre serviços públicos, administração pública e actividades económicas — com acompanhamento simples, seguro e transparente.",
     en: "The national channel for complaints, grievances, petitions and reports about public services, public administration and economic activities — with simple, secure and transparent tracking.",
@@ -93,11 +93,6 @@ export const LANDING_COPY = {
   TYPE_GRIEVANCE_DESC: {
     pt: "Comunicação de má conduta, negligência, abuso de poder ou incumprimento de deveres por funcionários, agentes ou instituições públicas.",
     en: "Reporting misconduct, negligence, abuse of power or failure to perform duties by public officials, agents or institutions.",
-  },
-  TYPE_PETITION_TITLE: { pt: "Petições", en: "Petitions" },
-  TYPE_PETITION_DESC: {
-    pt: "Pedidos formais dirigidos ao Estado para apreciação, intervenção, revisão de decisões ou adopção de medidas de interesse público.",
-    en: "Formal requests addressed to the State for consideration, intervention, review of decisions or adoption of public-interest measures.",
   },
   TYPE_REPORT_TITLE: { pt: "Denúncias", en: "Reports" },
   TYPE_REPORT_DESC: {
@@ -204,7 +199,7 @@ export const LANDING_COPY = {
   FOOTER_TERMS: { pt: "Termos de Utilização", en: "Terms of Use" },
   FOOTER_ACCESSIBILITY: { pt: "Acessibilidade", en: "Accessibility" },
   FOOTER_COPYRIGHT: {
-    pt: "Portal de Reclamações e Denúncias · República de Moçambique. Todos os direitos reservados.",
+    pt: "Fala Cidadão · República de Moçambique. Todos os direitos reservados.",
     en: "Complaints and Reports Portal · Republic of Mozambique. All rights reserved.",
   },
 
@@ -247,7 +242,6 @@ export interface ManifestationType {
 export const MANIFESTATION_TYPES: ManifestationType[] = [
   { id: "reclamacao", icon: FileText, titleKey: "TYPE_COMPLAINT_TITLE", descKey: "TYPE_COMPLAINT_DESC", accentVar: "--pgrl-type-complaint", route: "REGISTER_COMPLAINT" },
   { id: "queixa", icon: Megaphone, titleKey: "TYPE_GRIEVANCE_TITLE", descKey: "TYPE_GRIEVANCE_DESC", accentVar: "--pgrl-type-grievance", route: "REGISTER_COMPLAINT" },
-  { id: "peticao", icon: Scale, titleKey: "TYPE_PETITION_TITLE", descKey: "TYPE_PETITION_DESC", accentVar: "--pgrl-type-petition", route: "REGISTER_COMPLAINT" },
   { id: "denuncia", icon: ShieldAlert, titleKey: "TYPE_REPORT_TITLE", descKey: "TYPE_REPORT_DESC", accentVar: "--pgrl-type-report", route: "REGISTER_COMPLAINT" },
 ];
 
@@ -315,10 +309,10 @@ export const DEFAULT_NEWS: NewsItem[] = [
     dateLabel: "07 Jul 2026",
     dateTime: "2026-07-07",
     tag: "Portal",
-    title: "Portal de Reclamações e Denúncias inicia fase piloto em três províncias do norte do país",
+    title: "Fala Cidadão inicia fase piloto em três províncias do norte do país",
     excerpt:
       "O Governo de Moçambique lançou oficialmente a fase piloto do Portal nas províncias de Nampula, Cabo Delgado e Niassa, com expansão gradual prevista para os próximos três meses.",
-    source: "Portal de Reclamações e Denúncias",
+    source: "Fala Cidadão",
     href: "#",
   },
   {
@@ -340,7 +334,7 @@ export const DEFAULT_NEWS: NewsItem[] = [
     title: "Mil formadores comunitários capacitados para promover a utilização do portal em todo o país",
     excerpt:
       "Formadores de todas as províncias actuarão como embaixadores da plataforma, apoiando a sensibilização dos cidadãos e o uso dos canais digitais junto das suas comunidades.",
-    source: "Portal de Reclamações e Denúncias",
+    source: "Fala Cidadão",
     href: "#",
   },
   {

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/content.ts
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/content.ts
@@ -156,6 +156,29 @@ export const LANDING_COPY = {
   },
   PRIVACY_LINK: { pt: "Ler a Política de Privacidade", en: "Read the Privacy Policy" },
 
+  // Privacy policy (full page) ---------------------------------------------
+  PRIVACY_PAGE_TITLE: { pt: "Política de Privacidade", en: "Privacy Policy" },
+  PRIVACY_PAGE_P1: {
+    pt: "A Plataforma Fala Cidadão está empenhada em proteger a sua privacidade e em assegurar que as suas informações pessoais são tratadas de forma segura, transparente e em conformidade com a legislação aplicável.",
+    en: "The Fala Cidadão Platform is committed to protecting your privacy and ensuring your personal information is handled securely, transparently and in compliance with applicable law.",
+  },
+  PRIVACY_PAGE_P2: {
+    pt: "Ao utilizar esta Plataforma, o utilizador consente na recolha e no tratamento das informações que fornece para efeitos de registo, investigação, gestão e resolução da sua reclamação, petições, queixas e denúncia. As informações recolhidas podem incluir o seu nome, dados de contacto, elementos de identificação quando aplicável, detalhes da reclamação, documentos de suporte, fotografias e outras provas que decida apresentar.",
+    en: "By using this Platform you consent to the collection and processing of the information you provide to register, investigate, manage and resolve your complaint, petitions, grievances and reports. This may include your name, contact details, identifying details where applicable, complaint details, supporting documents, photographs and other evidence you submit.",
+  },
+  PRIVACY_PAGE_P3: {
+    pt: "As suas informações pessoais apenas serão acedidas por funcionários e instituições do Governo devidamente autorizados e responsáveis pelo tratamento da sua reclamação. Não serão partilhadas com terceiros não autorizados nem utilizadas para fins comerciais ou de marketing. Nos casos previstos pela Plataforma, as reclamações submetidas como confidenciais terão a identidade do autor protegida, sendo esta divulgada apenas para um grupo restrito e senior de funcionarios ou quando exigido por lei.",
+    en: "Your personal information will only be accessed by duly authorised government officials and institutions responsible for handling your complaint. It will not be shared with unauthorised third parties or used for commercial or marketing purposes. Where the Platform allows, complaints submitted as confidential will have the author's identity protected, disclosed only to a restricted, senior group of officials or when required by law.",
+  },
+  PRIVACY_PAGE_P4: {
+    pt: "A Plataforma implementa medidas técnicas e organizativas adequadas para salvaguardar as suas informações contra o acesso, alteração, divulgação ou perda não autorizados. Podem igualmente ser recolhidas informações técnicas, tais como dados do dispositivo, endereço IP e utilização do sistema, com o objetivo de melhorar a segurança, o desempenho do sistema e a qualidade do serviço.",
+    en: "The Platform implements appropriate technical and organisational measures to safeguard your information against unauthorised access, alteration, disclosure or loss. Technical information may also be collected, such as device data, IP address and system usage, to improve security, system performance and service quality.",
+  },
+  PRIVACY_PAGE_P5: {
+    pt: "As suas informações serão conservadas apenas durante o período necessário para processar a sua reclamação, cumprir obrigações legais e manter os registos oficiais do Governo. O utilizador pode solicitar o acesso às suas informações pessoais ou a respetiva correção, sujeito à legislação aplicável e a quaisquer restrições necessárias para proteger investigações em curso.",
+    en: "Your information will be retained only for the period necessary to process your complaint, comply with legal obligations and maintain official government records. You may request access to or correction of your personal information, subject to applicable law and any restrictions necessary to protect ongoing investigations.",
+  },
+
   // News ---------------------------------------------------------------—---
   NEWS_TITLE: { pt: "Últimas Actualizações", en: "Latest Updates" },
   NEWS_READ_MORE: { pt: "Ler mais", en: "Read more" },

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/content.ts
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/content.ts
@@ -223,10 +223,7 @@ export interface NavItem {
 export const NAV_ITEMS: NavItem[] = [
   { labelKey: "NAV_HOME", route: "HOME" },
   { labelKey: "NAV_SUBMIT", route: "REGISTER_COMPLAINT" },
-  { labelKey: "NAV_TRACK", route: "TRACK_COMPLAINT" },
-  { labelKey: "NAV_TRAINING", route: "TRAINING" },
-  { labelKey: "NAV_ABOUT", route: "ABOUT" },
-  { labelKey: "NAV_CONTACTS", route: "CONTACTS" },
+  { labelKey: "NAV_TRACK", route: "TRACK_COMPLAINT" }
 ];
 
 export interface ManifestationType {

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/content.ts
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/content.ts
@@ -64,6 +64,10 @@ export const LANDING_COPY = {
   // Hero -----------------------------------------------------------------—--
   HERO_EYEBROW: { pt: "República de Moçambique · IGE · IGSAE", en: "Republic of Mozambique · IGE · IGSAE" },
   HERO_TITLE: { pt: "Fala Cidadão", en: "Complaints and Reports Portal" },
+  HERO_PILOT_NOTICE: {
+    pt: "Esta plataforma está em fase piloto e, de momento, está disponível apenas para a Cidade de Maputo.",
+    en: "This platform is in a pilot phase and, for now, is available only for the City of Maputo.",
+  },
   HERO_LEDE: {
     pt: "Canal nacional para reclamações, queixas, petições e denúncias sobre serviços públicos, administração pública e actividades económicas — com acompanhamento simples, seguro e transparente.",
     en: "The national channel for complaints, grievances, petitions and reports about public services, public administration and economic activities — with simple, secure and transparent tracking.",

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/index.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Landing/index.tsx
@@ -105,6 +105,16 @@ function ConfiguredLanding(props: PGRLandingPageProps) {
     [i18n]
   );
 
+  // Portuguese-first public page: if the app's active locale isn't PT, switch
+  // to pt_PT once on mount (through the same handler the switcher uses, so the
+  // locale bundle loads). Keeps the landing in Portuguese even when the app
+  // default is English.
+  React.useEffect(() => {
+    const active = String(i18n?.language || "").toLowerCase();
+    if (!active.startsWith("pt")) (props.onLanguageChange ?? defaultLanguageChange)("pt_PT");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <LandingRenderer
       config={config}

--- a/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
@@ -7518,6 +7518,12 @@
         "locale": "en_IN"
     },
     {
+        "code": "PGR_LANDING_HERO_PILOT_NOTICE",
+        "message": "This platform is in a pilot phase and, for now, is available only for the City of Maputo.",
+        "module": "rainmaker-pgr",
+        "locale": "en_IN"
+    },
+    {
         "code": "PGR_LANDING_HERO_LEDE",
         "message": "The national channel for complaints, grievances, petitions and reports about public services, public administration and economic activities — with simple, secure and transparent tracking.",
         "module": "rainmaker-pgr",

--- a/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
@@ -8110,5 +8110,41 @@
         "message": "The window for reopening this complaint has closed",
         "module": "rainmaker-pgr",
         "locale": "en_IN"
+    },
+    {
+        "code": "PGR_LANDING_PRIVACY_PAGE_TITLE",
+        "message": "Privacy Policy",
+        "module": "rainmaker-pgr",
+        "locale": "en_IN"
+    },
+    {
+        "code": "PGR_LANDING_PRIVACY_PAGE_P1",
+        "message": "The Fala Cidadão Platform is committed to protecting your privacy and ensuring your personal information is handled securely, transparently and in compliance with applicable law.",
+        "module": "rainmaker-pgr",
+        "locale": "en_IN"
+    },
+    {
+        "code": "PGR_LANDING_PRIVACY_PAGE_P2",
+        "message": "By using this Platform you consent to the collection and processing of the information you provide to register, investigate, manage and resolve your complaint, petitions, grievances and reports. This may include your name, contact details, identifying details where applicable, complaint details, supporting documents, photographs and other evidence you submit.",
+        "module": "rainmaker-pgr",
+        "locale": "en_IN"
+    },
+    {
+        "code": "PGR_LANDING_PRIVACY_PAGE_P3",
+        "message": "Your personal information will only be accessed by duly authorised government officials and institutions responsible for handling your complaint. It will not be shared with unauthorised third parties or used for commercial or marketing purposes. Where the Platform allows, complaints submitted as confidential will have the author's identity protected, disclosed only to a restricted, senior group of officials or when required by law.",
+        "module": "rainmaker-pgr",
+        "locale": "en_IN"
+    },
+    {
+        "code": "PGR_LANDING_PRIVACY_PAGE_P4",
+        "message": "The Platform implements appropriate technical and organisational measures to safeguard your information against unauthorised access, alteration, disclosure or loss. Technical information may also be collected, such as device data, IP address and system usage, to improve security, system performance and service quality.",
+        "module": "rainmaker-pgr",
+        "locale": "en_IN"
+    },
+    {
+        "code": "PGR_LANDING_PRIVACY_PAGE_P5",
+        "message": "Your information will be retained only for the period necessary to process your complaint, comply with legal obligations and maintain official government records. You may request access to or correction of your personal information, subject to applicable law and any restrictions necessary to protect ongoing investigations.",
+        "module": "rainmaker-pgr",
+        "locale": "en_IN"
     }
 ]

--- a/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
@@ -1450,5 +1450,41 @@
         "message": "Tipo de Reclamação",
         "module": "rainmaker-pgr",
         "locale": "pt_PT"
+    },
+    {
+        "code": "PGR_LANDING_PRIVACY_PAGE_TITLE",
+        "message": "Política de Privacidade",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "PGR_LANDING_PRIVACY_PAGE_P1",
+        "message": "A Plataforma Fala Cidadão está empenhada em proteger a sua privacidade e em assegurar que as suas informações pessoais são tratadas de forma segura, transparente e em conformidade com a legislação aplicável.",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "PGR_LANDING_PRIVACY_PAGE_P2",
+        "message": "Ao utilizar esta Plataforma, o utilizador consente na recolha e no tratamento das informações que fornece para efeitos de registo, investigação, gestão e resolução da sua reclamação, petições, queixas e denúncia. As informações recolhidas podem incluir o seu nome, dados de contacto, elementos de identificação quando aplicável, detalhes da reclamação, documentos de suporte, fotografias e outras provas que decida apresentar.",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "PGR_LANDING_PRIVACY_PAGE_P3",
+        "message": "As suas informações pessoais apenas serão acedidas por funcionários e instituições do Governo devidamente autorizados e responsáveis pelo tratamento da sua reclamação. Não serão partilhadas com terceiros não autorizados nem utilizadas para fins comerciais ou de marketing. Nos casos previstos pela Plataforma, as reclamações submetidas como confidenciais terão a identidade do autor protegida, sendo esta divulgada apenas para um grupo restrito e senior de funcionarios ou quando exigido por lei.",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "PGR_LANDING_PRIVACY_PAGE_P4",
+        "message": "A Plataforma implementa medidas técnicas e organizativas adequadas para salvaguardar as suas informações contra o acesso, alteração, divulgação ou perda não autorizados. Podem igualmente ser recolhidas informações técnicas, tais como dados do dispositivo, endereço IP e utilização do sistema, com o objetivo de melhorar a segurança, o desempenho do sistema e a qualidade do serviço.",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "PGR_LANDING_PRIVACY_PAGE_P5",
+        "message": "As suas informações serão conservadas apenas durante o período necessário para processar a sua reclamação, cumprir obrigações legais e manter os registos oficiais do Governo. O utilizador pode solicitar o acesso às suas informações pessoais ou a respetiva correção, sujeito à legislação aplicável e a quaisquer restrições necessárias para proteger investigações em curso.",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
     }
 ]

--- a/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
@@ -601,7 +601,7 @@
     },
     {
         "code": "PGR_LANDING_PORTAL_NAME",
-        "message": "Portal de Reclamações e Denúncias",
+        "message": "Fala Cidadão",
         "module": "rainmaker-pgr",
         "locale": "pt_PT"
     },

--- a/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
@@ -732,6 +732,12 @@
         "locale": "pt_PT"
     },
     {
+        "code": "PGR_LANDING_HERO_PILOT_NOTICE",
+        "message": "Esta plataforma está em fase piloto e, de momento, está disponível apenas para a Cidade de Maputo.",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
         "code": "PGR_LANDING_HERO_LEDE",
         "message": "Canal nacional para reclamações, queixas, petições e denúncias sobre serviços públicos, administração pública e actividades económicas — com acompanhamento simples, seguro e transparente.",
         "module": "rainmaker-pgr",


### PR DESCRIPTION
## What & why

Adapts the public PGR landing page for the Mozambique (**Fala Cidadão**) deployment: rebrand, a slimmer/Portuguese-only public surface, and an in-app privacy policy so citizens see a compliant, localized entry point.

## Changes

- **Rebrand** — portal renamed to **"Fala Cidadão"**; removed the **Petition** manifestation type from the landing (kept Reclamação / Queixa / Denúncia).
- **Portuguese-only public surface** — dropped English from the language switcher (`DEFAULT_LANGUAGES` → PT only; selector hidden when ≤1 language) and force `pt_PT` on mount for both the landing and privacy pages, routed through the platform `LocalizationService` so the locale bundle actually loads.
- **Trimmed navigation & footer** links to the set relevant for this deployment.
- **New in-app Privacy Policy page** — shell-free `PrivacyPolicyPage.tsx` mounted at `/${contextPath}/privacy-policy`, linked from the landing footer and the `PRIVACY` route. Registered as `PGRPrivacyPolicy` in the PGR `Module.js` and wired into core `App.js` alongside the landing route. Content is 5 paragraphs resolved via the copy deck / `PGR_LANDING_*` localization.
- **Localization seeds** — added the 6 `PGR_LANDING_PRIVACY_PAGE_*` keys (title + P1–P5) to the default-data-handler `pt_PT` and `en_IN` `rainmaker-pgr.json` bundles.

Files: `core/App.js`, `products/pgr/src/Module.js`, and under `products/pgr/src/pages/citizen/Landing/` (`AppEntry.tsx`, `PrivacyPolicyPage.tsx` [new], `index.tsx`, `content.ts`, `components/UtilityBar.tsx`, `components/LandingFooter.tsx`), plus the two `default-data-handler` localisation files.

## Reviewer notes

- **Base is `release-v2.12-moz`** (the Mozambique line), not `master`. The 4 commits were rebased cleanly onto the current moz tip; the only conflict was a tail-append in `en_IN/rainmaker-pgr.json`, resolved by keeping **both** moz's new keys and the new privacy keys.
- **FE build verified green** locally — `npm run build` (esbuild) completes with **0 errors** (only pre-existing `direct-eval` warnings in `InboxSearchComposerV2.js`). A static integration pass confirmed every import/export/symbol the touched files rely on still resolves against the moz base.
- Runtime precedence: MDMS `PGR_LANDING_*` localization overrides the built-in `content.ts` deck, so the seed files must be deployed for the new strings to appear.
- **Non-blocking follow-ups** (cosmetic, out of scope here): `content.ts` `FINAL_TITLE`/a comment still reference "Petição"/"four cards" (now 3), and `tokens.ts` `typePetition` is now an orphaned token — safe to tidy later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
