### PR TITLE
fix(pgr): legacy notification path uses COMPLAINT_HIERARCHY localization key

### DIFF
--- a/backend/pgr-services/src/main/java/org/egov/pgr/service/NotificationService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/service/NotificationService.java
@@ -519,7 +519,7 @@ public class NotificationService {
         }
 
 
-        String localisedComplaint = notificationUtil.getCustomizedMsgForPlaceholder(localizationMessage,"pgr.complaint.category."+request.getService().getServiceCode());
+        String localisedComplaint = notificationUtil.getCustomizedMsgForPlaceholder(localizationMessage,"COMPLAINT_HIERARCHY."+request.getService().getServiceCode());
 
         Long createdTime = serviceWrapper.getService().getAuditDetails().getCreatedTime();
         LocalDate date = Instant.ofEpochMilli(createdTime > 1_000_000_000_000L ? createdTime : createdTime * 1000)

--- a/backend/pgr-services/src/main/java/org/egov/pgr/service/NotificationService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/service/NotificationService.java
@@ -519,8 +519,8 @@ public class NotificationService {
         }
 
 
-        String localisedComplaint = notificationUtil.getCustomizedMsgForPlaceholder(localizationMessage,"COMPLAINT_HIERARCHY."+request.getService().getServiceCode());
-        // A missing COMPLAINT_HIERARCHY.<code> entry must not abort the notification: a null
+        String localisedComplaint = getLocalisedComplaintType(localizationMessage, request.getService().getServiceCode());
+        // An entry missing from both namespaces must not abort the notification: a null
         // replacement makes String.replace throw. Fall back to the raw service code.
         if (!StringUtils.hasText(localisedComplaint))
             localisedComplaint = StringUtils.hasText(request.getService().getServiceCode())
@@ -552,6 +552,24 @@ public class NotificationService {
         message.put(EMPLOYEE, Arrays.asList(messageForEmployee));
 
         return message;
+    }
+
+    /**
+     * Resolves the localized complaint-type label for a service code: the current
+     * COMPLAINT_HIERARCHY.<code> namespace first, then the legacy pgr.complaint.category.<code>
+     * namespace for tenants whose localization predates the hierarchy migration.
+     *
+     * @param localizationMessage - Localization messages blob for the rainmaker-pgr module
+     * @param serviceCode - Service code of the complaint
+     * @return - Returns the localized label, or null when neither namespace has an entry
+     */
+    private String getLocalisedComplaintType(String localizationMessage, String serviceCode) {
+        String localised = notificationUtil.getCustomizedMsgForPlaceholder(localizationMessage,
+                "COMPLAINT_HIERARCHY." + serviceCode);
+        if (!StringUtils.hasText(localised))
+            localised = notificationUtil.getCustomizedMsgForPlaceholder(localizationMessage,
+                    "pgr.complaint.category." + serviceCode);
+        return localised;
     }
 
     /**
@@ -1173,8 +1191,7 @@ public class NotificationService {
         try {
             String loc = notificationUtil.getLocalizationMessages(tenantId, ri, PGR_MODULE);
             if (StringUtils.hasText(service.getServiceCode())) {
-                String ct = notificationUtil.getCustomizedMsgForPlaceholder(loc,
-                        "pgr.complaint.category." + service.getServiceCode());
+                String ct = getLocalisedComplaintType(loc, service.getServiceCode());
                 if (StringUtils.hasText(ct)) put(v, "complaint_type", ct);
             }
             if (StringUtils.hasText(service.getApplicationStatus())) {

--- a/backend/pgr-services/src/main/java/org/egov/pgr/service/NotificationService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/service/NotificationService.java
@@ -520,6 +520,11 @@ public class NotificationService {
 
 
         String localisedComplaint = notificationUtil.getCustomizedMsgForPlaceholder(localizationMessage,"COMPLAINT_HIERARCHY."+request.getService().getServiceCode());
+        // A missing COMPLAINT_HIERARCHY.<code> entry must not abort the notification: a null
+        // replacement makes String.replace throw. Fall back to the raw service code.
+        if (!StringUtils.hasText(localisedComplaint))
+            localisedComplaint = StringUtils.hasText(request.getService().getServiceCode())
+                    ? request.getService().getServiceCode() : "";
 
         Long createdTime = serviceWrapper.getService().getAuditDetails().getCreatedTime();
         LocalDate date = Instant.ofEpochMilli(createdTime > 1_000_000_000_000L ? createdTime : createdTime * 1000)

--- a/backend/pgr-services/src/test/java/org/egov/pgr/service/notification/NotificationConfigDrivenEmissionTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/service/notification/NotificationConfigDrivenEmissionTest.java
@@ -11,6 +11,7 @@ import org.egov.pgr.util.HRMSUtil;
 import org.egov.pgr.util.MDMSUtils;
 import org.egov.pgr.util.NotificationUtil;
 import org.egov.pgr.web.models.AuditDetails;
+import org.egov.pgr.web.models.Notification.SMSRequest;
 import org.egov.pgr.web.models.Service;
 import org.egov.pgr.web.models.ServiceRequest;
 import org.egov.pgr.web.models.User;
@@ -38,6 +39,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -182,6 +184,44 @@ public class NotificationConfigDrivenEmissionTest {
                 .thenReturn("Garbage Not Collected");
         when(notificationUtil.getShortnerURL(anyString())).thenReturn("http://short/x");
 
+        notificationService.process(legacyApplyRequest(), "save-pgr-request");
+
+        // The localization key for complaint type MUST use the COMPLAINT_HIERARCHY prefix.
+        verify(notificationUtil).getCustomizedMsgForPlaceholder(anyString(), eq("COMPLAINT_HIERARCHY.GarbageNeeds"));
+    }
+
+    /**
+     * When the COMPLAINT_HIERARCHY.<serviceCode> entry is missing from localization,
+     * getCustomizedMsgForPlaceholder returns null; the legacy path must fall back to the raw
+     * service code instead of NPE-ing inside String.replace (which the catch-all in process()
+     * would swallow, silently dropping the notification).
+     */
+    @Test
+    void legacyPath_missingComplaintLocalization_fallsBackToServiceCode() {
+        when(config.getNotificationConfigDriven()).thenReturn(false);
+        when(config.getIsSMSEnabled()).thenReturn(true);
+
+        when(notificationUtil.getCustomizedMsg(eq("APPLY"), eq("PENDINGFORASSIGNMENT"), eq("CITIZEN"), anyString()))
+                .thenReturn("Dear Citizen, your complaint {complaint_type} has been filed.");
+        when(notificationUtil.getDefaultMsg(eq("CITIZEN"), anyString())).thenReturn("Default notification.");
+        when(notificationUtil.getCustomizedMsgForPlaceholder(anyString(), startsWith("COMPLAINT_HIERARCHY.")))
+                .thenReturn(null);
+        when(notificationUtil.getShortnerURL(anyString())).thenReturn("http://short/x");
+
+        notificationService.process(legacyApplyRequest(), "save-pgr-request");
+
+        // The citizen SMS must still go out, with the raw service code in place of the label.
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<SMSRequest>> sms = ArgumentCaptor.forClass((Class) List.class);
+        verify(notificationUtil, atLeastOnce()).sendSMS(eq(TENANT), sms.capture());
+        assertTrue(sms.getAllValues().stream().flatMap(List::stream)
+                        .anyMatch(r -> r.getMessage() != null
+                                && r.getMessage().contains("your complaint GarbageNeeds has been filed")),
+                "citizen SMS should contain the raw service code as the complaint-type fallback");
+    }
+
+    /** APPLY -> PENDINGFORASSIGNMENT request for the legacy-path tests. */
+    private ServiceRequest legacyApplyRequest() {
         User citizen = User.builder()
                 .uuid("citizen-uuid").name("Jane Doe")
                 .mobileNumber("712345678").countryCode("+254").emailId("jane@example.com")
@@ -195,13 +235,8 @@ public class NotificationConfigDrivenEmissionTest {
                 .auditDetails(AuditDetails.builder().createdTime(1719600000000L).createdBy("citizen-uuid").build())
                 .build();
         Workflow workflow = Workflow.builder().action("APPLY").assignes(Collections.emptyList()).build();
-        ServiceRequest applyRequest = ServiceRequest.builder()
+        return ServiceRequest.builder()
                 .requestInfo(new RequestInfo()).service(service).workflow(workflow).build();
-
-        notificationService.process(applyRequest, "save-pgr-request");
-
-        // The localization key for complaint type MUST use the COMPLAINT_HIERARCHY prefix.
-        verify(notificationUtil).getCustomizedMsgForPlaceholder(anyString(), eq("COMPLAINT_HIERARCHY.GarbageNeeds"));
     }
 
     /** Stub egov-user _search to return the given (uuid, mobile, email) users for a roleCodes query. */

--- a/backend/pgr-services/src/test/java/org/egov/pgr/service/notification/NotificationConfigDrivenEmissionTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/service/notification/NotificationConfigDrivenEmissionTest.java
@@ -37,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -158,6 +159,49 @@ public class NotificationConfigDrivenEmissionTest {
         notificationService.process(assignRequest(), "save-pgr-request");
         verify(notificationRouter, org.mockito.Mockito.never())
                 .route(anyString(), anyString(), any(), anyString(), anyString());
+    }
+
+    /**
+     * Pins the localization key prefix used in the legacy (config-driven=false) path.
+     * NotificationService.getFinalMessage() must call getCustomizedMsgForPlaceholder with
+     * "COMPLAINT_HIERARCHY.<serviceCode>", NOT the old "pgr.complaint.category.<serviceCode>".
+     *
+     * The test drives the APPLY->PENDINGFORASSIGNMENT transition because "APPLY_PENDINGFORASSIGNMENT"
+     * is in NOTIFICATION_ENABLE_FOR_STATUS and the branch reaches line 522 without any HTTP calls
+     * (no assignee lookup needed).
+     */
+    @Test
+    void legacyPath_complaintLocalizationLookup_usesComplaintHierarchyPrefix() {
+        when(config.getNotificationConfigDriven()).thenReturn(false);
+
+        // Stub the citizen body and default msg so getFinalMessage() does not bail before line 522.
+        when(notificationUtil.getCustomizedMsg(eq("APPLY"), eq("PENDINGFORASSIGNMENT"), eq("CITIZEN"), anyString()))
+                .thenReturn("Dear Citizen, your complaint {complaint_type} has been filed.");
+        when(notificationUtil.getDefaultMsg(eq("CITIZEN"), anyString())).thenReturn("Default notification.");
+        when(notificationUtil.getCustomizedMsgForPlaceholder(anyString(), startsWith("COMPLAINT_HIERARCHY.")))
+                .thenReturn("Garbage Not Collected");
+        when(notificationUtil.getShortnerURL(anyString())).thenReturn("http://short/x");
+
+        User citizen = User.builder()
+                .uuid("citizen-uuid").name("Jane Doe")
+                .mobileNumber("712345678").countryCode("+254").emailId("jane@example.com")
+                .build();
+        Service service = Service.builder()
+                .tenantId(TENANT)
+                .serviceRequestId("PGR-2026-001")
+                .applicationStatus("PENDINGFORASSIGNMENT")
+                .serviceCode("GarbageNeeds")
+                .citizen(citizen)
+                .auditDetails(AuditDetails.builder().createdTime(1719600000000L).createdBy("citizen-uuid").build())
+                .build();
+        Workflow workflow = Workflow.builder().action("APPLY").assignes(Collections.emptyList()).build();
+        ServiceRequest applyRequest = ServiceRequest.builder()
+                .requestInfo(new RequestInfo()).service(service).workflow(workflow).build();
+
+        notificationService.process(applyRequest, "save-pgr-request");
+
+        // The localization key for complaint type MUST use the COMPLAINT_HIERARCHY prefix.
+        verify(notificationUtil).getCustomizedMsgForPlaceholder(anyString(), eq("COMPLAINT_HIERARCHY.GarbageNeeds"));
     }
 
     /** Stub egov-user _search to return the given (uuid, mobile, email) users for a roleCodes query. */

--- a/backend/pgr-services/src/test/java/org/egov/pgr/service/notification/NotificationConfigDrivenEmissionTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/service/notification/NotificationConfigDrivenEmissionTest.java
@@ -220,6 +220,38 @@ public class NotificationConfigDrivenEmissionTest {
                 "citizen SMS should contain the raw service code as the complaint-type fallback");
     }
 
+    /**
+     * Tenants localized before the hierarchy migration only carry pgr.complaint.category.<code>
+     * entries: when COMPLAINT_HIERARCHY.<code> misses, the label must resolve from the legacy
+     * namespace before falling back to the raw code.
+     */
+    @Test
+    void legacyPath_missingHierarchyKey_fallsBackToLegacyCategoryKey() {
+        when(config.getNotificationConfigDriven()).thenReturn(false);
+        when(config.getIsSMSEnabled()).thenReturn(true);
+
+        when(notificationUtil.getCustomizedMsg(eq("APPLY"), eq("PENDINGFORASSIGNMENT"), eq("CITIZEN"), anyString()))
+                .thenReturn("Dear Citizen, your complaint {complaint_type} has been filed.");
+        when(notificationUtil.getDefaultMsg(eq("CITIZEN"), anyString())).thenReturn("Default notification.");
+        when(notificationUtil.getCustomizedMsgForPlaceholder(anyString(), startsWith("COMPLAINT_HIERARCHY.")))
+                .thenReturn(null);
+        when(notificationUtil.getCustomizedMsgForPlaceholder(anyString(), eq("pgr.complaint.category.GarbageNeeds")))
+                .thenReturn("Garbage Not Collected");
+        when(notificationUtil.getShortnerURL(anyString())).thenReturn("http://short/x");
+
+        notificationService.process(legacyApplyRequest(), "save-pgr-request");
+
+        // The hierarchy namespace is tried first; the legacy namespace then supplies the label.
+        verify(notificationUtil).getCustomizedMsgForPlaceholder(anyString(), eq("COMPLAINT_HIERARCHY.GarbageNeeds"));
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<SMSRequest>> sms = ArgumentCaptor.forClass((Class) List.class);
+        verify(notificationUtil, atLeastOnce()).sendSMS(eq(TENANT), sms.capture());
+        assertTrue(sms.getAllValues().stream().flatMap(List::stream)
+                        .anyMatch(r -> r.getMessage() != null
+                                && r.getMessage().contains("your complaint Garbage Not Collected has been filed")),
+                "citizen SMS should carry the label resolved from the legacy pgr.complaint.category namespace");
+    }
+
     /** APPLY -> PENDINGFORASSIGNMENT request for the legacy-path tests. */
     private ServiceRequest legacyApplyRequest() {
         User citizen = User.builder()


### PR DESCRIPTION
## Summary
- The legacy (`pgr.notification.config.driven=false`, the shipped default) notification path in `NotificationService.getFinalMessage()` resolved the `{complaint_type}` label with the retired `pgr.complaint.category.<serviceCode>` localization key. The platform's current tooling — frontend `complaintLabel.js`, xstate-chatbot, `docs/migration/migrate.cjs`, and XLSX onboarding — seeds and reads `COMPLAINT_HIERARCHY.<code>`, so hierarchy-migrated tenants got the raw service code (or a silently dropped message) in citizen/employee SMS.
- Switches the lookup to `COMPLAINT_HIERARCHY.<serviceCode>` and pins the key prefix with a service-layer test driving the APPLY → PENDINGFORASSIGNMENT transition.

## Test plan
- `mvn test` on `backend/pgr-services` (JDK 17): **173 tests, 0 failures, 0 errors, 0 skipped** — including the new `legacyPath_complaintLocalizationLookup_usesComplaintHierarchyPrefix`.

## Review notes / known follow-ups
A pre-push code review of this diff flagged the following for reviewer attention:
1. **Config-driven path still on the old key** — `buildPlaceholderValues()` (NotificationService.java:1171-1172) still looks up `pgr.complaint.category.<code>` for the same `{complaint_type}` placeholder, so the two paths now read different namespaces. Tenants seeded only with `COMPLAINT_HIERARCHY.*` keys will render the raw code when the config-driven flag is on (e2e case C6 asserts name-not-code).
2. **No fallback on a key miss** — `getCustomizedMsgForPlaceholder` returns `null` for a missing key, and `messageForCitizen.replace("{complaint_type}", null)` throws an NPE that `process()`'s catch-all swallows, silently dropping the whole notification. Tenants whose localization only has the old keys (the `default-data-handler` / dataloader seeds ship only `pgr.complaint.category.*`; docs note this gap exists on ke.bomet legacy codes) go from working SMS to none. A `StringUtils.hasText` fallback to the raw serviceCode — as the config-driven path already does — would degrade gracefully instead.
3. **Exact-case lookup** — other consumers (UI, chatbot) query `COMPLAINT_HIERARCHY.<CODE>` uppercased; this lookup uses the exact-case code and relies on seeders emitting both variants.
4. New keys are currently seeded only for `en_IN`; non-en_IN locales that had the old keys (e.g. hi_IN) will miss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated complaint type localization in notification messages to correctly use the complaint hierarchy labels, with safe fallbacks to legacy values and the raw service code when needed.
  * Improved consistency of complaint-related text across notification scenarios.

* **Tests**
  * Added and expanded test coverage for legacy notification flows, including verification of the localization key behavior and fallback handling when localized values are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->