### PR TITLE
fix(pgr): resolve complaint-map pins at the configured boundary level

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/BoundaryComponent.js
+++ b/digit-ui-esbuild/products/pgr/src/components/BoundaryComponent.js
@@ -2,6 +2,7 @@ import { Loader } from "@egovernments/digit-ui-components";
 import { Field as V2Field, Select as V2Select } from "@egovernments/digit-ui-components-v2";
 import React, { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { sameLevelName } from "../utils/boundaryLevels";
 
 // Humanize a boundary-type code for use as a graceful fallback when its
 // localization key isn't seeded: "SUB_COUNTY" -> "Sub County", "bairro" ->
@@ -117,9 +118,10 @@ const BoundaryComponent = ({ t, config, onSelect, userType, formData, readOnly }
   const { effectiveHierarchy, lowestLevelCapped } = useMemo(() => {
     const configuredLowest = window?.globalConfigs?.getConfig?.("PGR_BOUNDARY_LOWEST_LEVEL");
     if (!configuredLowest) return { effectiveHierarchy: boundaryHierarchy, lowestLevelCapped: false };
-    const idx = boundaryHierarchy.findIndex(
-      (k) => String(k).toLowerCase() === String(configuredLowest).toLowerCase()
-    );
+    // Accent-insensitive: operators author this in host_vars with the tenant's
+    // own orthography, which need not match how the loader spelled the level in
+    // the tree. A miss here is silent — the cap just never applies.
+    const idx = boundaryHierarchy.findIndex((k) => sameLevelName(k, configuredLowest));
     return idx >= 0
       ? { effectiveHierarchy: boundaryHierarchy.slice(0, idx + 1), lowestLevelCapped: true }
       : { effectiveHierarchy: boundaryHierarchy, lowestLevelCapped: false };
@@ -192,10 +194,19 @@ useEffect(() => {
     // value directly as a fallback so auto-fill recovers once init
     // lands. Skip only when BOTH are empty; the effect re-runs when
     // childrenData settles.
-    let hierarchy = boundaryHierarchy;
+    // Match the hint at the level the cascade actually files at — the CAPPED
+    // hierarchy. Using the raw tree depth here made the map and the cascade
+    // disagree whenever PGR_BOUNDARY_LOWEST_LEVEL sits above the deepest seeded
+    // level: the map resolved a pin to the deeper level, findWardPath looked for
+    // a node of that deeper type, and on a tenant that seeds it only patchily the
+    // lookup found nothing and auto-fill silently no-opped.
+    let hierarchy = effectiveHierarchy;
     if (hierarchy.length === 0) {
       const order = Digit.SessionStorage.get("boundaryHierarchyOrder");
       hierarchy = Array.isArray(order) ? order.map((item) => item.code) : [];
+      const configuredLowest = window?.globalConfigs?.getConfig?.("PGR_BOUNDARY_LOWEST_LEVEL");
+      const idx = configuredLowest ? hierarchy.findIndex((k) => sameLevelName(k, configuredLowest)) : -1;
+      if (idx >= 0) hierarchy = hierarchy.slice(0, idx + 1);
     }
     if (hierarchy.length === 0) return;
     const targetType = hierarchy[hierarchy.length - 1];

--- a/digit-ui-esbuild/products/pgr/src/hooks/pgr/useTenantBoundaries.js
+++ b/digit-ui-esbuild/products/pgr/src/hooks/pgr/useTenantBoundaries.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import useMapConfig from "./useMapConfig";
+import { sameLevelName } from "../../utils/boundaryLevels";
 
 // No hardcoded boundary data. When a tenant has no usable geometry (or no
 // boundary tenant is configured), the map shows NO ward overlay rather than
@@ -117,11 +118,40 @@ const useTenantBoundaries = () => {
           roots.forEach((root) => walk(root, undefined, 0));
         });
 
-        // Leaf level = the deepest depth present in the tree (Ward in a
-        // County > Sub-County > Ward hierarchy). Only leaves carry the
-        // polygons the map needs.
-        const maxDepth = nodes.reduce((max, n) => (n.depth > max ? n.depth : max), -1);
-        const leaves = nodes.filter((n) => n.depth === maxDepth);
+        // Which level the pin resolves against. PGR_BOUNDARY_LOWEST_LEVEL is the
+        // level the boundary cascade files at, so the map has to resolve at that
+        // same level or the two disagree: the map hands back a node the cascade
+        // is not looking for and auto-fill silently no-ops.
+        //
+        // It also decides coverage. Deeper is not better — a level only the
+        // populated parts of a tenant carry (Mozambique seeds Município for 66
+        // of 158 Distritos) leaves every pin outside them unresolvable, while
+        // the level above tiles the whole territory.
+        //
+        // Falls back to the deepest depth in the tree when nothing is configured
+        // or the configured name is not a level of THIS tree, which is the
+        // pre-existing behaviour.
+        const configuredLevel = window?.globalConfigs?.getConfig?.("PGR_BOUNDARY_LOWEST_LEVEL");
+        const atConfiguredLevel = configuredLevel
+          ? nodes.filter((n) => sameLevelName(n.boundaryType, configuredLevel))
+          : [];
+
+        let leaves;
+        if (atConfiguredLevel.length > 0) {
+          leaves = atConfiguredLevel;
+        } else {
+          if (configuredLevel) {
+            // Silent fallbacks here cost hours to diagnose — the map looks fine
+            // and merely resolves nothing. Say which levels the tree does have.
+            console.warn(
+              `PGR_BOUNDARY_LOWEST_LEVEL "${configuredLevel}" is not a level of the ${MAP_TENANT} boundary tree ` +
+                `(levels present: ${[...new Set(nodes.map((n) => n.boundaryType))].join(", ") || "none"}). ` +
+                "Falling back to the deepest level."
+            );
+          }
+          const maxDepth = nodes.reduce((max, n) => (n.depth > max ? n.depth : max), -1);
+          leaves = nodes.filter((n) => n.depth === maxDepth);
+        }
 
         // Step 2: geometry per leaf code, chunked.
         const geometryByCode = {};

--- a/digit-ui-esbuild/products/pgr/src/utils/boundaryLevels.js
+++ b/digit-ui-esbuild/products/pgr/src/utils/boundaryLevels.js
@@ -1,0 +1,34 @@
+/**
+ * Comparing a configured boundary level name against the tree's own.
+ *
+ * `PGR_BOUNDARY_LOWEST_LEVEL` is authored by an operator in host_vars, so it
+ * carries the tenant's own orthography — Mozambique writes "Municipio" with an
+ * accent. The boundary tree stores whatever the loader wrote, which for the
+ * same deployment is the unaccented form. A plain (even case-insensitive)
+ * comparison therefore misses, and because both sides read correct to a human
+ * the miss is invisible: the level simply never applies and the caller falls
+ * back, with no error anywhere.
+ *
+ * So compare on a folded form — strip diacritics, casefold, trim — rather than
+ * asking operators to guess which spelling the loader happened to use.
+ */
+
+// U+0300-U+036F = combining diacritical marks, what NFD splits accents into.
+// Written as escapes: the literal characters are invisible in a diff.
+const COMBINING_MARKS = /[\u0300-\u036f]/g;
+
+/** "Municipio" with an accent -> "municipio". Leaves ASCII names untouched. */
+export const foldLevelName = (name) =>
+  String(name ?? "")
+    .normalize("NFD")
+    .replace(COMBINING_MARKS, "")
+    .trim()
+    .toLowerCase();
+
+/** True when two boundary level names denote the same level. */
+export const sameLevelName = (a, b) => {
+  const fa = foldLevelName(a);
+  return fa.length > 0 && fa === foldLevelName(b);
+};
+
+export default sameLevelName;


### PR DESCRIPTION
## Problem

The complaint map resolves a dropped pin against the **deepest level present in the boundary tree**, ignoring `PGR_BOUNDARY_LOWEST_LEVEL` — the level the boundary cascade actually files at.

`useTenantBoundaries.js`:
```js
const maxDepth = nodes.reduce((max, n) => (n.depth > max ? n.depth : max), -1);
const leaves = nodes.filter((n) => n.depth === maxDepth);
```

Two consequences:

**1. The map and the cascade can disagree.** The map resolves to the deepest level and writes it to `GeoLocationsPoint.ward`; `BoundaryComponent.findWardPath` then searches for a node of that same deeper type, because `targetType` was computed from the **uncapped** `boundaryHierarchy` rather than `effectiveHierarchy`. On a tenant that seeds the deepest level only patchily, the lookup finds nothing and the boundary dropdowns silently stay empty after dropping a pin.

**2. Deeper is not better for coverage.** Mozambique seeds `Municipio` under only **66 of 158** `Distrito`s, so resolving at `Municipio` leaves every pin outside a municipality unresolvable — while `Distrito` tiles the whole territory. The operator already declares the intended level; the map just wasn't reading it.

Reported as part of egovernments/Citizen-Complaint-Resolution-System#1380 (boundary dropdown not auto-populated from the map).

## Change

- `useTenantBoundaries` selects the resolution level from `PGR_BOUNDARY_LOWEST_LEVEL` when that level exists in the tree.
- `BoundaryComponent` computes `targetType` from `effectiveHierarchy` (the capped one), so map and cascade target the same level.
- New `utils/boundaryLevels.js` — accent-insensitive level-name comparison, shared by both.

## Why accent-insensitive

Operators author `PGR_BOUNDARY_LOWEST_LEVEL` in `host_vars` with the tenant's own orthography, while the loader writes the unaccented form into the tree. On the Mozambique pilot, byte-for-byte:

| source | value | length |
|---|---|---|
| `globalConfigs.js` | `Município` | 10 |
| `boundary_relationship.boundarytype` | `Municipio` (hex `4d756e69636970696f`) | 9 |

The existing `String(k).toLowerCase() === String(configuredLowest).toLowerCase()` misses — and the miss is **invisible**: the cap simply never applies, with no error anywhere. Both sides read correct to a human.

## Backwards compatibility

Unchanged when the key is unset, or when it names a level absent from the tree. Both fall back to the previous deepest-level selection — the second with a `console.warn` naming the levels the tree *does* have, so the fallback is not silent.

## Verification

Parse/bundle-checked all three files with the repo's own esbuild.

Level matcher unit-tested (9 cases, all pass): accented vs plain, case-only, whitespace, genuinely-different levels, and empty/null which must **not** match.

Selection logic replayed against the **live `mz.ige` tree** (235 boundaries, fetched from `boundary-relationships/_search`):

| `PGR_BOUNDARY_LOWEST_LEVEL` | selected | renderable geometry | path |
|---|---|---|---|
| unset | 66 | 56 | fallback: deepest depth (**identical to today**) |
| `Municipio` | 66 | 56 | configured level |
| `Município` | 66 | 56 | configured level (**was a miss before**) |
| `Distrito` | 158 | 157 | configured level |
| `Provincia` | 11 | 0 | configured level |
| `Bairro` (absent) | 66 | 56 | fallback + warning |

## Not in scope

Two related findings from the same investigation, deliberately left out:

- **The Mozambique boundary geometry is largely placeholder** — 99 of 235 boundaries share one identical 1°×1° square at Null Island, and no `Municipio` has geometry of its own (each is a copy of its parent `Distrito`). This PR lets an operator pick a level that *has* data; it cannot create data. Note `hasRealGeometry` does not reject that square (it only rejects spans < ~0.001°), so it renders and participates in point-in-polygon.
- **The citizen map draws no overlay while the employee map does**, because the map reads MapConfig from the *session* tenant (a state root, which carries no boundaries) rather than the tenant the complaint files under. The fix needs the citizen authority-picker flow, which does not exist on `master`.

Both are being raised separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boundary-level matching across differences in capitalization, spacing, and diacritical marks.
  * Fixed map-based location autofill to resolve ward paths using the correct configured hierarchy level.
  * Added fallback behavior when the configured lowest boundary level is unavailable, preventing boundary selection failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->