### PR TITLE
fix(ansible): fix deploy.sh first-run failures on stricter ansible-core

### DIFF
--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -210,7 +210,7 @@
           See inventory/host_vars/_example.yml for a worked example.
       when:
         - core_mobile_configs is defined
-        - core_mobile_configs
+        - core_mobile_configs | length > 0
         - _mobile_missing_keys | length > 0
 
     # ==================== Docker host install + config ====================
@@ -450,6 +450,16 @@
     # contexts under docker/ (the existing build-context convention) and repoint
     # them with an Ansible-only overlay. docker-compose.migrations.yml itself
     # stays valid for anyone running compose straight from the repo.
+    # rsync only creates the final path component of `dest`, not
+    # intermediate ones — on a first-time deploy {{ digit_dir }}/docker/
+    # doesn't exist yet (it's only synced wholesale further down, by
+    # "Synchronize docker build context dirs"), so create it explicitly here
+    # rather than relying on task order or a prior run having left it behind.
+    - name: "Ensure docker/ build-context directory exists"
+      ansible.builtin.file:
+        path: "{{ digit_dir }}/docker"
+        state: directory
+
     - name: Synchronize in-repo migrator build contexts
       synchronize:
         src: "../../backend/{{ item }}/src/main/resources/db/"

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -936,6 +936,21 @@
     # 404'ing globalConfigs.js. tar over the baked SPA, leaving those two file
     # mounts intact, sidesteps that. No registry/pinned-image dependency.
     # Default off → no Linux behaviour change.
+    #
+    # digit-ui-build.sh runs `npm run build` on the target host directly (no
+    # Docker), same as the configurator build below — unlike the MCP build,
+    # which builds inside a container and needs no host Node. Unlike the
+    # digit-ui mode=static / digit-ui-v2 / integration-tests build paths,
+    # this one had no ensure-node20 include, so a target with no Node
+    # pre-installed failed with "ERROR: node not on PATH".
+    - name: "Build digit-ui from source — ensure Node 20 + npm (NodeSource)"
+      ansible.builtin.include_tasks: "{{ playbook_dir }}/tasks/ensure-node20.yml"
+      vars:
+        node_ensure_label: "digit-ui build_digit_ui"
+      when:
+        - build_digit_ui | default(false)
+        - ansible_system != "Darwin"
+
     - name: "Build digit-ui from source (when build_digit_ui)"
       ansible.builtin.command: >-
         bash {{ playbook_dir }}/files/digit-ui-build.sh
@@ -1752,6 +1767,18 @@
     # script prints the dist path on its last line; captured into the
     # `configurator_build` var the sync task below consumes. (A real
     # configurator_repo_url still clones, for transitional/standalone use.)
+    #
+    # configurator-build.sh runs `npm`/vite on the target host directly, same
+    # requirement as the digit-ui build above — ensure Node 20 first instead
+    # of assuming it's already on PATH.
+    - name: "Configurator SPA — ensure Node 20 + npm (NodeSource)"
+      ansible.builtin.include_tasks: "{{ playbook_dir }}/tasks/ensure-node20.yml"
+      vars:
+        node_ensure_label: "configurator build_configurator"
+      when:
+        - build_configurator | default(false)
+        - ansible_system != "Darwin"
+
     - name: "Configurator SPA — build dist (when build_configurator)"
       ansible.builtin.command: >-
         bash {{ playbook_dir }}/files/configurator-build.sh

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -1558,6 +1558,22 @@ services:
       SPRING_FLYWAY_USER: egov
       SPRING_FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
       JAVA_OPTS: '-Xmx96m -Xms96m'
+      # Unlike the javaagent-instrumented services above, this app is left
+      # without the OTEL javaagent mounted, so without disabling the
+      # exporters below the OTEL Java SDK bundled with the OpenTelemetryDriver
+      # (see the jdbc:otel: note above) defaults to trying an OTLP export and
+      # the container never reports healthy. docker-compose.yml /
+      # docker-compose.deploy.yaml already carry this; this file didn't.
+      OTEL_TRACES_EXPORTER: none
+      OTEL_METRICS_EXPORTER: none
+      OTEL_LOGS_EXPORTER: none
+      OTEL_INSTRUMENTATION_JDBC_ENABLED: 'false'
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8080/egov-url-shortening/actuator/health >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
     networks:
       - egov-network
 

--- a/local-setup/docker-compose.registry.yml
+++ b/local-setup/docker-compose.registry.yml
@@ -1565,6 +1565,22 @@ services:
       SPRING_FLYWAY_USER: egov
       SPRING_FLYWAY_PASSWORD: egov123
       JAVA_OPTS: '-Xmx96m -Xms96m'
+      # Unlike the javaagent-instrumented services above, this app is left
+      # without the OTEL javaagent mounted, so without disabling the
+      # exporters below the OTEL Java SDK bundled with the OpenTelemetryDriver
+      # (see the jdbc:otel: note above) defaults to trying an OTLP export and
+      # the container never reports healthy. docker-compose.yml /
+      # docker-compose.deploy.yaml already carry this; this file didn't.
+      OTEL_TRACES_EXPORTER: none
+      OTEL_METRICS_EXPORTER: none
+      OTEL_LOGS_EXPORTER: none
+      OTEL_INSTRUMENTATION_JDBC_ENABLED: 'false'
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8080/egov-url-shortening/actuator/health >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
     networks:
       - egov-network
 


### PR DESCRIPTION
## Summary
- The `core_mobile_configs` preflight check used a bare dict in a `when:` list. Older ansible-core silently coerced a non-empty dict to `True`; ansible-core 2.21 (resolved on some controllers, e.g. via a newer pip3/python3.14 install) hard-fails on that implicit coercion instead. Made the check explicit with `| length > 0`.
- "Synchronize in-repo migrator build contexts" rsyncs into `{{ digit_dir }}/docker/<item>-db/` before `{{ digit_dir }}/docker/` itself is created (that only happens ~100 lines later, in "Synchronize docker build context dirs"). rsync only creates the final path component of `dest`, so on a genuinely first-time deploy target (no leftover `docker/` dir from a prior run) this failed with `mkdir ... No such file or directory`. Added an explicit directory-creation task ahead of the migrator sync.

Both were discovered deploying tenant `assam` from a fresh WSL box where neither the newer ansible-core nor the missing prior-run state had been masking the bugs.

## Test plan
- [ ] Re-run `./deploy.sh <tenant>` against a genuinely fresh target (no prior `/opt/digit` state) and confirm both the preflight and the migrator-context sync succeed
- [ ] Re-run against an existing target to confirm no regression (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local deployment reliability when configuration is empty or when build directories do not yet exist.
  * Ensured UI and configurator builds have the required Node.js tooling available automatically.
  * Improved URL-shortening service startup and readiness detection.

* **Chores**
  * Disabled incompatible telemetry and database instrumentation for the URL-shortening service to prevent health-reporting failures.
  * Added more reliable service health checks with appropriate startup timing and retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->