### PR TITLE
fix(pgr): scope the citizen boundary cascade to the filing tenant

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/BoundaryComponent.js
+++ b/digit-ui-esbuild/products/pgr/src/components/BoundaryComponent.js
@@ -16,7 +16,15 @@ const humanizeBoundaryType = (raw) =>
 
 const BoundaryComponent = ({ t, config, onSelect, userType, formData, readOnly }) => {
 
-  const tenantId = Digit.ULBService.getCurrentTenantId();
+  // Callers that know which tenant the record belongs to pass it explicitly.
+  // The fallback is only a default, and a poor one for citizens:
+  // ULBService.getCurrentTenantId() returns the user's own tenant for EMPLOYEE
+  // but STATE_LEVEL_TENANT_ID for everyone else, so a citizen always lands on
+  // the state root regardless of the city they are filing in. A state root
+  // commonly carries no boundary tree of its own, which renders the cascade
+  // empty; worse, where it does, the citizen picks boundaries from one tenant
+  // and the complaint is created in another.
+  const tenantId = config?.tenantId || Digit.ULBService.getCurrentTenantId();
 
   // Employee jurisdiction gate (egovernments/CCRS#496).
   //

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
@@ -349,6 +349,9 @@ interface StepBodyProps {
   hierarchyDef?: ComplaintHierarchyDef | null;
   nodes?: ClassificationNode[];
   t: (key: string) => string;
+  /** Tenant the complaint will be created under. Steps that read tenant-scoped
+   *  masters must use THIS, not a tenant re-derived from the session. */
+  tenantId?: string;
 }
 
 /**
@@ -658,7 +661,7 @@ function Step1Map({ data, patch, t }: StepBodyProps) {
  * pincode missing from Nominatim) the affected control becomes
  * interactive so the user can fill the gap manually.
  */
-function Step2Location({ data, patch, t }: StepBodyProps) {
+function Step2Location({ data, patch, t, tenantId }: StepBodyProps) {
   const PGRBoundaryComponent = Digit?.ComponentRegistryService?.getComponent("PGRBoundaryComponent");
 
   // The map's resolveWard writes ward.{code, name} into
@@ -694,7 +697,13 @@ function Step2Location({ data, patch, t }: StepBodyProps) {
           <PGRBoundaryComponent
             t={t}
             userType="citizen"
-            config={{ key: "SelectedBoundary", populators: { name: "SelectedBoundary" }, label: "" }}
+            // Scope the cascade to the tenant the complaint FILES under, which is
+            // the same tenant the map resolves against. Without it the cascade
+            // falls back to ULBService.getCurrentTenantId(), which returns
+            // STATE_LEVEL_TENANT_ID for every citizen — so a citizen whose home
+            // city is set would pick boundaries out of the state root's tree and
+            // attach them to a complaint filed in their city.
+            config={{ key: "SelectedBoundary", populators: { name: "SelectedBoundary" }, label: "", tenantId }}
             formData={data}
             // Ask the cascade to render its dropdowns as disabled
             // wherever it has an auto-filled value. Levels left empty
@@ -1023,6 +1032,7 @@ const CreatePGRFlowV2: React.FC = () => {
     hierarchyDef: hierData?.def ?? null,
     nodes: hierData?.nodes ?? [],
     t,
+    tenantId,
   };
 
   return (


### PR DESCRIPTION
Follow-up to #1392 (merged). This commit was pushed moments after that PR merged, so it missed the merge — re-raised unchanged on top of current `master`.

Fixes the **citizen sees no boundaries while employee does** half of #1380.

## Problem

`BoundaryComponent` resolved its tree from `ULBService.getCurrentTenantId()`:

```js
const tenantId =
  user?.info?.type === "EMPLOYEE" && user?.info?.tenantId
    ? user?.info?.tenantId
    : window?.globalConfigs.getConfig("STATE_LEVEL_TENANT_ID");
```

That returns the user's own tenant **only for `EMPLOYEE`**. Every citizen falls through to `STATE_LEVEL_TENANT_ID` — the state root — regardless of the city being filed in.

The citizen create flow already computes the filing tenant:

```js
const tenantId =
  Digit.SessionStorage.get("CITIZEN.COMMON.HOME.CITY")?.code ||
  Digit.ULBService.getCurrentTenantId();
```

and uses it for `useCreateComplaint(tenantId)` and the create payload. `useMapConfig` resolves the map from that **same expression**. Of the three consumers, the boundary cascade was the only one not using it.

`CITIZEN.COMMON.HOME.CITY` is set on Keycloak citizen SSO login and by the location picker, so this is reachable, not theoretical.

Consequences:

- A state root carrying no boundary tree of its own renders an **empty cascade**, while an employee — whose session tenant *is* the city — sees boundaries fine. That is the citizen/employee asymmetry reported in #1380.
- Where the root *does* carry a tree, the citizen picks a boundary from one tenant's tree while the complaint is created in another.

## Change

Pass the filing tenant explicitly instead of re-deriving it from session identity: `StepBodyProps` carries `tenantId`, and `Step2Location` hands it to the cascade via the `config.tenantId` prop the component now honours.

## Blast radius

- **Fallback unchanged** — `config?.tenantId || Digit.ULBService.getCurrentTenantId()`. Employees and every caller not passing the prop behave exactly as today.
- **Filing tenant not changed.** Which tenant a complaint is created under is untouched, and `ComplaintsList` retrieves using the same expression the create path uses, so a filer's existing and future complaints stay visible exactly as before.
- **Data note for reviewers:** where a state root and its city tree use *different* boundary codes, complaints filed before this change carry root-tree codes while new ones carry city-tree codes. Anything keyed on boundary code (inbox filters, ward dashboards, escalation routing) would see both vintages. This PR deliberately does not migrate that — flagging it so it is a decision rather than a surprise.

Both files parse+bundle clean under the repo's esbuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)