### PR TITLE
fix(pgr): sheet-v4 round 2 — all remaining QA fixes for moz (15 commits)

### DIFF
--- a/backend/pgr-services/src/main/resources/application.properties
+++ b/backend/pgr-services/src/main/resources/application.properties
@@ -135,7 +135,9 @@ employee.allowed.search.params=serviceRequestId,ids,mobileNumber,serviceCode,app
 pgr.department.scope.roles=
 
 #Sources
-allowed.source=whatsapp,web,mobile,RB Bot
+# QA #26: Reception Officer channel-of-receipt codes (email/inperson/letter/
+# linhaverde) ride service.source — the employee create form sends them.
+allowed.source=whatsapp,web,mobile,RB Bot,email,inperson,letter,linhaverde
 
 #Migration
 persister.save.transition.wf.topic=save-wf-transitions

--- a/digit-ui-esbuild/packages/libraries/src/hooks/pgr/useComplaintDetails.js
+++ b/digit-ui-esbuild/packages/libraries/src/hooks/pgr/useComplaintDetails.js
@@ -53,10 +53,16 @@ const getDetailsRow = ({ id, service, complaintType }) => ({
   CS_ADDCOMPLAINT_COMPLAINT_SUB_TYPE: `COMPLAINT_HIERARCHY.${service.serviceCode.toUpperCase()}`,
   CS_COMPLAINT_ADDTIONAL_DETAILS: service.description,
   CS_COMPLAINT_FILED_DATE: Digit.DateUtils.ConvertTimestampToDate(service.auditDetails.createdTime),
+  // QA #31/#25: the Endereço row shows ONLY what the complainant typed —
+  // the boundary key (ADMIN_<code>) and the tenant name (TENANT_TENANTS_*)
+  // were concatenated here and rendered as raw codes / authority names
+  // ("MZ_IGE_ADMIN_hungaro", "…, Matola, IGSAE"). Both removed per product
+  // call; buildingName/street included so employee-created complaints (which
+  // store the address there) still show their address.
   ES_CREATECOMPLAINT_ADDRESS: [
+    service.address.buildingName,
+    service.address.street,
     service.address.landmark,
-    Digit.Utils.getMultiRootTenant() ? `ADMIN_${service.address.locality.code}` : Digit.Utils.locale.getLocalityCode(service.address.locality, service.tenantId),
-    `TENANT_TENANTS_${service?.tenantId?.toUpperCase?.()?.replace(".", "_")}`,
     service.address.pincode,
   ],
 });

--- a/digit-ui-esbuild/packages/libraries/src/hooks/pgr/useComplaintDetails.js
+++ b/digit-ui-esbuild/packages/libraries/src/hooks/pgr/useComplaintDetails.js
@@ -43,7 +43,19 @@ const fetchBoundaryAncestors = async (tenantId, localityCode) => {
   }
 };
 
-const getDetailsRow = ({ id, service, complaintType }) => ({
+// Boundary codes arrive as raw identifiers, sometimes prefixed with the
+// tenant/hierarchy chain ("MZ_IGE_ADMIN_hungaro"). Render them readable
+// without depending on the boundary localization module being loaded:
+// strip the ALL-CAPS prefix, then title-case ("Hungaro", "Vila De Sena").
+const readableBoundary = (code) => {
+  if (!code) return null;
+  const bare = String(code).replace(/^(?:[A-Z0-9]+_)+(?=[^A-Z])/, "");
+  return bare
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+};
+
+const getDetailsRow = ({ id, service, complaintType, boundaryAncestors }) => ({
   CS_COMPLAINT_DETAILS_COMPLAINT_NO: id,
   CS_COMPLAINT_DETAILS_APPLICATION_STATUS: `CS_COMMON_${service.applicationStatus}`,
   // Key-based (COMPLAINT_HIERARCHY.<code>) — the display t()s these values, so
@@ -53,16 +65,17 @@ const getDetailsRow = ({ id, service, complaintType }) => ({
   CS_ADDCOMPLAINT_COMPLAINT_SUB_TYPE: `COMPLAINT_HIERARCHY.${service.serviceCode.toUpperCase()}`,
   CS_COMPLAINT_ADDTIONAL_DETAILS: service.description,
   CS_COMPLAINT_FILED_DATE: Digit.DateUtils.ConvertTimestampToDate(service.auditDetails.createdTime),
-  // QA #31/#25: the Endereço row shows ONLY what the complainant typed —
-  // the boundary key (ADMIN_<code>) and the tenant name (TENANT_TENANTS_*)
-  // were concatenated here and rendered as raw codes / authority names
-  // ("MZ_IGE_ADMIN_hungaro", "…, Matola, IGSAE"). Both removed per product
-  // call; buildingName/street included so employee-created complaints (which
-  // store the address there) still show their address.
+  // QA #31/#25: Endereço = what the complainant typed + the READABLE
+  // administrative chain, leaf upward ("Landmark, locality, district,
+  // province"). The old raw boundary key (ADMIN_<code>) and the tenant /
+  // authority name (TENANT_TENANTS_* → "…, IGSAE") are gone. Boundary names
+  // are derived readable (see readableBoundary) so nothing renders as a raw
+  // identifier even when boundary localization isn't loaded.
   ES_CREATECOMPLAINT_ADDRESS: [
     service.address.buildingName,
     service.address.street,
     service.address.landmark,
+    ...[...(boundaryAncestors || [])].reverse().map((b) => readableBoundary(b?.code)),
     service.address.pincode,
   ],
 });

--- a/digit-ui-esbuild/packages/libraries/src/hooks/pgr/useComplaintDetails.js
+++ b/digit-ui-esbuild/packages/libraries/src/hooks/pgr/useComplaintDetails.js
@@ -65,19 +65,24 @@ const getDetailsRow = ({ id, service, complaintType, boundaryAncestors }) => ({
   CS_ADDCOMPLAINT_COMPLAINT_SUB_TYPE: `COMPLAINT_HIERARCHY.${service.serviceCode.toUpperCase()}`,
   CS_COMPLAINT_ADDTIONAL_DETAILS: service.description,
   CS_COMPLAINT_FILED_DATE: Digit.DateUtils.ConvertTimestampToDate(service.auditDetails.createdTime),
-  // QA #31/#25: Endereço = what the complainant typed + the READABLE
-  // administrative chain, leaf upward ("Landmark, locality, district,
-  // province"). The old raw boundary key (ADMIN_<code>) and the tenant /
-  // authority name (TENANT_TENANTS_* → "…, IGSAE") are gone. Boundary names
-  // are derived readable (see readableBoundary) so nothing renders as a raw
-  // identifier even when boundary localization isn't loaded.
-  ES_CREATECOMPLAINT_ADDRESS: [
-    service.address.buildingName,
-    service.address.street,
-    service.address.landmark,
-    ...[...(boundaryAncestors || [])].reverse().map((b) => readableBoundary(b?.code)),
-    service.address.pincode,
-  ],
+  // QA #31/#25 (product call): Endereço shows the TYPED address when one
+  // exists — the complainant-entered address (extendedAttributes, arrives
+  // masked "****" on confidential complaints) plus any typed location parts.
+  // Only when nothing was typed does it fall back to the READABLE
+  // administrative chain, leaf upward ("Municipio Namaacha, Namaacha,
+  // Maputo Provincia"). The raw boundary key and tenant/authority name of
+  // the original composition stay gone.
+  ES_CREATECOMPLAINT_ADDRESS: (() => {
+    const typed = [
+      (service.extendedAttributes || {}).complainantAddress,
+      service.address.buildingName,
+      service.address.street,
+      service.address.landmark,
+      service.address.pincode,
+    ].filter((v) => v && String(v).trim());
+    if (typed.length) return typed;
+    return [...(boundaryAncestors || [])].reverse().map((b) => readableBoundary(b?.code));
+  })(),
 });
 
 const isEmptyOrNull = (obj) => obj === undefined || obj === null || Object.keys(obj).length === 0;

--- a/digit-ui-esbuild/packages/libraries/src/hooks/pgr/useComplaintDetails.js
+++ b/digit-ui-esbuild/packages/libraries/src/hooks/pgr/useComplaintDetails.js
@@ -66,14 +66,17 @@ const getDetailsRow = ({ id, service, complaintType, boundaryAncestors }) => ({
   CS_COMPLAINT_ADDTIONAL_DETAILS: service.description,
   CS_COMPLAINT_FILED_DATE: Digit.DateUtils.ConvertTimestampToDate(service.auditDetails.createdTime),
   // QA #31/#25 (product call): Endereço shows the TYPED address when one
-  // exists — the complainant-entered address (extendedAttributes, arrives
-  // masked "****" on confidential complaints) plus any typed location parts.
-  // Only when nothing was typed does it fall back to the READABLE
-  // administrative chain, leaf upward ("Municipio Namaacha, Namaacha,
-  // Maputo Provincia"). The raw boundary key and tenant/authority name of
-  // the original composition stay gone.
+  // exists. The typed complainant address is persisted by the BACKEND into
+  // the User Service and returned as service.citizen.correspondenceAddress
+  // (the extendedAttributes copy is stripped on write) — masking there is
+  // backend policy. Typed location parts follow; only when nothing was
+  // typed does the row fall back to the READABLE administrative chain,
+  // leaf upward ("Municipio Namaacha, Namaacha, Maputo Provincia"). The
+  // raw boundary key and tenant/authority name of the original composition
+  // stay gone.
   ES_CREATECOMPLAINT_ADDRESS: (() => {
     const typed = [
+      service.citizen?.correspondenceAddress,
       (service.extendedAttributes || {}).complainantAddress,
       service.address.buildingName,
       service.address.street,

--- a/digit-ui-esbuild/products/pgr/src/Module.js
+++ b/digit-ui-esbuild/products/pgr/src/Module.js
@@ -14,6 +14,7 @@ import TimelineWrapper from "./components/TimeLineWrapper";
 import AssigneeComponent from "./components/AssigneeComponent";
 import VerificationDocsComponent from "./components/VerificationDocsComponent";
 import ActionUploadComponent from "./components/ActionUploadComponent";
+import ChannelChipsComponent from "./components/ChannelChipsComponent";
 import PGRSearchInbox from "./pages/employee/PGRInbox";
 import CreateComplaint from "./pages/employee/CreateComplaint";
 import Response from "./components/Response";
@@ -114,6 +115,7 @@ const componentsToRegister = {
   PGRAssigneeComponent: AssigneeComponent,
   PGRVerificationDocsComponent: VerificationDocsComponent,
   PGRActionUploadComponent: ActionUploadComponent,
+  PGRChannelChipsComponent: ChannelChipsComponent,
   PGRSearchInbox,
   PGRAdminSearch,
   PGRCreateComplaint: CreateComplaint,

--- a/digit-ui-esbuild/products/pgr/src/components/ChannelChipsComponent.js
+++ b/digit-ui-esbuild/products/pgr/src/components/ChannelChipsComponent.js
@@ -59,8 +59,10 @@ const ChannelChipsComponent = ({ config, onSelect, formData }) => {
   const pick = (opt) => onSelect(key, { code: opt.code, name: opt.name });
 
   return (
-    <div style={{ width: "100%" }}>
-      <div role="radiogroup" aria-label={t("ES_CREATECOMPLAINT_RECEIVED_CHANNEL")} style={{ display: "flex", flexWrap: "wrap", gap: "10px" }}>
+    // Same width cap as the inputs below (the platform caps field controls at
+    // ~600px) so the chip row's right edge lines up with the mobile number.
+    <div style={{ width: "100%", maxWidth: "600px" }}>
+      <div role="radiogroup" aria-label={t("ES_CREATECOMPLAINT_RECEIVED_CHANNEL")} style={{ display: "flex", flexWrap: "wrap", gap: "8px" }}>
         {OPTIONS.map((opt) => {
           const isSelected = selected === opt.code;
           return (
@@ -79,14 +81,22 @@ const ChannelChipsComponent = ({ config, onSelect, formData }) => {
               style={{
                 display: "inline-flex",
                 alignItems: "center",
+                // Fill the control column: 140px basis + grow → all 4 chips
+                // share one row on desktop (4×140 + gaps < 600px cap) and the
+                // row's right edge lines up with the inputs below; on phones
+                // they wrap into a tidy 2×2 grid instead of overflowing.
+                flex: "1 1 140px",
+                minWidth: "140px",
+                whiteSpace: "nowrap",
+                justifyContent: "space-between",
                 gap: "8px",
-                padding: "8px 14px",
+                padding: "8px 10px",
                 borderRadius: "8px",
                 border: `1px solid ${isSelected ? ACCENT : "#E0E0E0"}`,
                 backgroundColor: isSelected ? ACCENT_BG : "#F7F7F7",
                 color: isSelected ? ACCENT : "#363636",
                 fontWeight: 600,
-                fontSize: "0.875rem",
+                fontSize: "0.8125rem",
                 lineHeight: 1,
                 cursor: "pointer",
                 userSelect: "none",
@@ -94,8 +104,10 @@ const ChannelChipsComponent = ({ config, onSelect, formData }) => {
                 transition: "background-color 0.12s ease-out, border-color 0.12s ease-out",
               }}
             >
-              {ICONS[opt.icon]}
-              <span>{t(opt.name)}</span>
+              <span style={{ display: "inline-flex", alignItems: "center", gap: "8px" }}>
+                {ICONS[opt.icon]}
+                <span>{t(opt.name)}</span>
+              </span>
               {isSelected ? (
                 <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden>
                   <circle cx="12" cy="12" r="10" style={{ fill: ACCENT }} />

--- a/digit-ui-esbuild/products/pgr/src/components/ChannelChipsComponent.js
+++ b/digit-ui-esbuild/products/pgr/src/components/ChannelChipsComponent.js
@@ -10,7 +10,7 @@ const OPTIONS = [
   { code: "email", name: "PGR_CHANNEL_EMAIL", icon: "mail" },
   { code: "inperson", name: "PGR_CHANNEL_IN_PERSON", icon: "person" },
   { code: "letter", name: "PGR_CHANNEL_LETTER", icon: "letter" },
-  { code: "linhaverde", name: "PGR_CHANNEL_LINHA_VERDE", icon: "headset" },
+  { code: "linhaverde", name: "PGR_CHANNEL_LINHA_VERDE", icon: "phone" },
 ];
 
 const ICONS = {
@@ -33,11 +33,9 @@ const ICONS = {
       <path d="M9 12h6M9 16h6" />
     </svg>
   ),
-  headset: (
+  phone: (
     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
-      <path d="M4 13a8 8 0 0 1 16 0" />
-      <rect x="3" y="13" width="4" height="6" rx="2" />
-      <rect x="17" y="13" width="4" height="6" rx="2" />
+      <path d="M5 4h4l2 5-2.5 1.5a11 11 0 0 0 5 5L15 13l5 2v4a2 2 0 0 1-2 2A16 16 0 0 1 3 6a2 2 0 0 1 2-2Z" />
     </svg>
   ),
 };

--- a/digit-ui-esbuild/products/pgr/src/components/ChannelChipsComponent.js
+++ b/digit-ui-esbuild/products/pgr/src/components/ChannelChipsComponent.js
@@ -1,93 +1,109 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 
-// QA #26 — Canal de Recepção as a CHIP selector (radio-style pills with an
-// icon + label + check circle), rendered at the top of the employee create
-// form. The selected option's CODE rides service.source at submit
-// (email / inperson / letter / linhaverde — kept in pgr-services'
+// QA #26 — Canal de Recepção as a CHIP selector (card-style pills with an
+// icon + label + radio circle), rendered just above the mobile number on the
+// employee create form. The selected option's CODE rides service.source at
+// submit (email / inperson / letter / linhaverde — kept in pgr-services'
 // allowed.source list).
+//
+// Rendered as SPANs, not <button>: the platform stylesheet resets buttons
+// with !important rules that beat inline styles (same lesson as the admin
+// search chips), which flattened the pills into bare text.
 const OPTIONS = [
-  { code: "email", name: "PGR_CHANNEL_EMAIL", icon: "mail" },
+  // In Person first (product call) — it is also the pre-selected default.
   { code: "inperson", name: "PGR_CHANNEL_IN_PERSON", icon: "person" },
+  { code: "email", name: "PGR_CHANNEL_EMAIL", icon: "mail" },
   { code: "letter", name: "PGR_CHANNEL_LETTER", icon: "letter" },
   { code: "linhaverde", name: "PGR_CHANNEL_LINHA_VERDE", icon: "phone" },
 ];
 
 const ICONS = {
   mail: (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
       <rect x="3" y="5" width="18" height="14" rx="2" />
       <path d="m3 7 9 6 9-6" />
     </svg>
   ),
   person: (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
       <circle cx="12" cy="8" r="4" />
       <path d="M4 21c0-4 4-6 8-6s8 2 8 6" />
     </svg>
   ),
   letter: (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
       <path d="M6 3h9l4 4v14a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1Z" />
       <path d="M15 3v4h4" />
       <path d="M9 12h6M9 16h6" />
     </svg>
   ),
   phone: (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
       <path d="M5 4h4l2 5-2.5 1.5a11 11 0 0 0 5 5L15 13l5 2v4a2 2 0 0 1-2 2A16 16 0 0 1 3 6a2 2 0 0 1 2-2Z" />
     </svg>
   ),
 };
 
-const ACCENT = "var(--color-success, #00703C)";
-const ACCENT_BG = "var(--color-success-bg, #E8F3EE)";
+const ACCENT = "#00703C";
+const ACCENT_BG = "#E8F3EE";
 
 const ChannelChipsComponent = ({ config, onSelect, formData }) => {
   const { t } = useTranslation();
   const key = config?.key || "ReceivedChannel";
   const selected = formData?.[key]?.code;
 
+  const pick = (opt) => onSelect(key, { code: opt.code, name: opt.name });
+
   return (
-    <div style={{ marginBottom: "16px" }}>
-      <div role="radiogroup" aria-label={t("ES_CREATECOMPLAINT_RECEIVED_CHANNEL")} style={{ display: "flex", flexWrap: "wrap", gap: "12px" }}>
+    <div style={{ width: "100%" }}>
+      <div role="radiogroup" aria-label={t("ES_CREATECOMPLAINT_RECEIVED_CHANNEL")} style={{ display: "flex", flexWrap: "wrap", gap: "14px" }}>
         {OPTIONS.map((opt) => {
           const isSelected = selected === opt.code;
           return (
-            <button
+            <span
               key={opt.code}
-              type="button"
               role="radio"
               aria-checked={isSelected}
-              onClick={() => onSelect(key, { code: opt.code, name: opt.name })}
+              tabIndex={0}
+              onClick={() => pick(opt)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  pick(opt);
+                }
+              }}
               style={{
                 display: "inline-flex",
                 alignItems: "center",
-                gap: "8px",
-                padding: "8px 14px",
-                borderRadius: "10px",
-                border: `1px solid ${isSelected ? ACCENT : "var(--color-border, #E0E0E0)"}`,
-                backgroundColor: isSelected ? ACCENT_BG : "var(--color-background-secondary, #F6F6F6)",
-                color: isSelected ? ACCENT : "var(--color-text-heading, #363636)",
+                gap: "12px",
+                padding: "14px 20px",
+                borderRadius: "12px",
+                border: `1px solid ${isSelected ? ACCENT : "#E0E0E0"}`,
+                backgroundColor: isSelected ? ACCENT_BG : "#F7F7F7",
+                color: isSelected ? ACCENT : "#363636",
                 fontWeight: 600,
-                fontSize: "0.875rem",
+                fontSize: "1rem",
+                lineHeight: 1,
                 cursor: "pointer",
+                userSelect: "none",
+                boxShadow: "0 1px 3px rgba(0,0,0,0.08)",
                 transition: "background-color 0.12s ease-out, border-color 0.12s ease-out",
               }}
             >
               {ICONS[opt.icon]}
               <span>{t(opt.name)}</span>
               {isSelected ? (
-                <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden>
-                  <circle cx="12" cy="12" r="10" fill={ACCENT.startsWith("var") ? "#00703C" : ACCENT} />
+                <svg width="22" height="22" viewBox="0 0 24 24" aria-hidden>
+                  <circle cx="12" cy="12" r="10" fill={ACCENT} />
                   <path d="m8 12 3 3 5-6" fill="none" stroke="#fff" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
                 </svg>
               ) : (
-                <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden>
-                  <circle cx="12" cy="12" r="9" fill="none" stroke="var(--color-border, #C5C5C5)" strokeWidth="2" />
+                <svg width="22" height="22" viewBox="0 0 24 24" aria-hidden>
+                  <circle cx="12" cy="12" r="9" fill="#fff" stroke="#C5C5C5" strokeWidth="2" />
                 </svg>
               )}
-            </button>
+            </span>
           );
         })}
       </div>

--- a/digit-ui-esbuild/products/pgr/src/components/ChannelChipsComponent.js
+++ b/digit-ui-esbuild/products/pgr/src/components/ChannelChipsComponent.js
@@ -20,33 +20,36 @@ const OPTIONS = [
 
 const ICONS = {
   mail: (
-    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
       <rect x="3" y="5" width="18" height="14" rx="2" />
       <path d="m3 7 9 6 9-6" />
     </svg>
   ),
   person: (
-    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
       <circle cx="12" cy="8" r="4" />
       <path d="M4 21c0-4 4-6 8-6s8 2 8 6" />
     </svg>
   ),
   letter: (
-    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
       <path d="M6 3h9l4 4v14a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1Z" />
       <path d="M15 3v4h4" />
       <path d="M9 12h6M9 16h6" />
     </svg>
   ),
   phone: (
-    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
       <path d="M5 4h4l2 5-2.5 1.5a11 11 0 0 0 5 5L15 13l5 2v4a2 2 0 0 1-2 2A16 16 0 0 1 3 6a2 2 0 0 1 2-2Z" />
     </svg>
   ),
 };
 
-const ACCENT = "#00703C";
-const ACCENT_BG = "#E8F3EE";
+// Same theme tokens the rest of the PGR UI uses (StatusPill, links):
+// primary accent with the platform fallback chain; selected bg = the
+// theme's selected-pill tint.
+const ACCENT = "var(--color-primary-1, var(--color-primary-main, #c84c0e))";
+const ACCENT_BG = "var(--color-primary-selected-bg, #FFF4D7)";
 
 const ChannelChipsComponent = ({ config, onSelect, formData }) => {
   const { t } = useTranslation();
@@ -57,7 +60,7 @@ const ChannelChipsComponent = ({ config, onSelect, formData }) => {
 
   return (
     <div style={{ width: "100%" }}>
-      <div role="radiogroup" aria-label={t("ES_CREATECOMPLAINT_RECEIVED_CHANNEL")} style={{ display: "flex", flexWrap: "wrap", gap: "14px" }}>
+      <div role="radiogroup" aria-label={t("ES_CREATECOMPLAINT_RECEIVED_CHANNEL")} style={{ display: "flex", flexWrap: "wrap", gap: "10px" }}>
         {OPTIONS.map((opt) => {
           const isSelected = selected === opt.code;
           return (
@@ -76,30 +79,30 @@ const ChannelChipsComponent = ({ config, onSelect, formData }) => {
               style={{
                 display: "inline-flex",
                 alignItems: "center",
-                gap: "12px",
-                padding: "14px 20px",
-                borderRadius: "12px",
+                gap: "8px",
+                padding: "8px 14px",
+                borderRadius: "8px",
                 border: `1px solid ${isSelected ? ACCENT : "#E0E0E0"}`,
                 backgroundColor: isSelected ? ACCENT_BG : "#F7F7F7",
                 color: isSelected ? ACCENT : "#363636",
                 fontWeight: 600,
-                fontSize: "1rem",
+                fontSize: "0.875rem",
                 lineHeight: 1,
                 cursor: "pointer",
                 userSelect: "none",
-                boxShadow: "0 1px 3px rgba(0,0,0,0.08)",
+                boxShadow: "0 1px 2px rgba(0,0,0,0.05)",
                 transition: "background-color 0.12s ease-out, border-color 0.12s ease-out",
               }}
             >
               {ICONS[opt.icon]}
               <span>{t(opt.name)}</span>
               {isSelected ? (
-                <svg width="22" height="22" viewBox="0 0 24 24" aria-hidden>
-                  <circle cx="12" cy="12" r="10" fill={ACCENT} />
+                <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden>
+                  <circle cx="12" cy="12" r="10" style={{ fill: ACCENT }} />
                   <path d="m8 12 3 3 5-6" fill="none" stroke="#fff" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
                 </svg>
               ) : (
-                <svg width="22" height="22" viewBox="0 0 24 24" aria-hidden>
+                <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden>
                   <circle cx="12" cy="12" r="9" fill="#fff" stroke="#C5C5C5" strokeWidth="2" />
                 </svg>
               )}

--- a/digit-ui-esbuild/products/pgr/src/components/ChannelChipsComponent.js
+++ b/digit-ui-esbuild/products/pgr/src/components/ChannelChipsComponent.js
@@ -1,0 +1,100 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+// QA #26 — Canal de Recepção as a CHIP selector (radio-style pills with an
+// icon + label + check circle), rendered at the top of the employee create
+// form. The selected option's CODE rides service.source at submit
+// (email / inperson / letter / linhaverde — kept in pgr-services'
+// allowed.source list).
+const OPTIONS = [
+  { code: "email", name: "PGR_CHANNEL_EMAIL", icon: "mail" },
+  { code: "inperson", name: "PGR_CHANNEL_IN_PERSON", icon: "person" },
+  { code: "letter", name: "PGR_CHANNEL_LETTER", icon: "letter" },
+  { code: "linhaverde", name: "PGR_CHANNEL_LINHA_VERDE", icon: "headset" },
+];
+
+const ICONS = {
+  mail: (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+      <rect x="3" y="5" width="18" height="14" rx="2" />
+      <path d="m3 7 9 6 9-6" />
+    </svg>
+  ),
+  person: (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+      <circle cx="12" cy="8" r="4" />
+      <path d="M4 21c0-4 4-6 8-6s8 2 8 6" />
+    </svg>
+  ),
+  letter: (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+      <path d="M6 3h9l4 4v14a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1Z" />
+      <path d="M15 3v4h4" />
+      <path d="M9 12h6M9 16h6" />
+    </svg>
+  ),
+  headset: (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+      <path d="M4 13a8 8 0 0 1 16 0" />
+      <rect x="3" y="13" width="4" height="6" rx="2" />
+      <rect x="17" y="13" width="4" height="6" rx="2" />
+    </svg>
+  ),
+};
+
+const ACCENT = "var(--color-success, #00703C)";
+const ACCENT_BG = "var(--color-success-bg, #E8F3EE)";
+
+const ChannelChipsComponent = ({ config, onSelect, formData }) => {
+  const { t } = useTranslation();
+  const key = config?.key || "ReceivedChannel";
+  const selected = formData?.[key]?.code;
+
+  return (
+    <div style={{ marginBottom: "16px" }}>
+      <div role="radiogroup" aria-label={t("ES_CREATECOMPLAINT_RECEIVED_CHANNEL")} style={{ display: "flex", flexWrap: "wrap", gap: "12px" }}>
+        {OPTIONS.map((opt) => {
+          const isSelected = selected === opt.code;
+          return (
+            <button
+              key={opt.code}
+              type="button"
+              role="radio"
+              aria-checked={isSelected}
+              onClick={() => onSelect(key, { code: opt.code, name: opt.name })}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: "8px",
+                padding: "8px 14px",
+                borderRadius: "10px",
+                border: `1px solid ${isSelected ? ACCENT : "var(--color-border, #E0E0E0)"}`,
+                backgroundColor: isSelected ? ACCENT_BG : "var(--color-background-secondary, #F6F6F6)",
+                color: isSelected ? ACCENT : "var(--color-text-heading, #363636)",
+                fontWeight: 600,
+                fontSize: "0.875rem",
+                cursor: "pointer",
+                transition: "background-color 0.12s ease-out, border-color 0.12s ease-out",
+              }}
+            >
+              {ICONS[opt.icon]}
+              <span>{t(opt.name)}</span>
+              {isSelected ? (
+                <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden>
+                  <circle cx="12" cy="12" r="10" fill={ACCENT.startsWith("var") ? "#00703C" : ACCENT} />
+                  <path d="m8 12 3 3 5-6" fill="none" stroke="#fff" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              ) : (
+                <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden>
+                  <circle cx="12" cy="12" r="9" fill="none" stroke="var(--color-border, #C5C5C5)" strokeWidth="2" />
+                </svg>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default ChannelChipsComponent;

--- a/digit-ui-esbuild/products/pgr/src/components/PgrExtendedAttributesView.js
+++ b/digit-ui-esbuild/products/pgr/src/components/PgrExtendedAttributesView.js
@@ -23,6 +23,10 @@ const SKIP_KEYS = new Set([
   // details pages (product call, sheet-v4 review) — skipping it here avoids
   // a duplicate row in the Additional Details card.
   "complainantAddress",
+  // receivedChannel now travels as service.source (product call) and is not
+  // a display row; skipping also hides it on complaints created while it
+  // briefly lived in extendedAttributes.
+  "receivedChannel",
   "email",
   // Moz QA (CCSD-1988): consents are an internal acceptance record, not a
   // user-facing data row — never show them on the view screens.

--- a/digit-ui-esbuild/products/pgr/src/components/PgrExtendedAttributesView.js
+++ b/digit-ui-esbuild/products/pgr/src/components/PgrExtendedAttributesView.js
@@ -19,7 +19,9 @@ const SKIP_KEYS = new Set([
   "schemaVersion",
   "hierarchyLevel1",
   "hierarchyLevel2",
-  "complainantAddress",
+  // complainantAddress is SHOWN (product call, sheet-v4 review): it renders
+  // as its own "Endereço do Reclamante" row via PGR_EXT_COMPLAINANT_ADDRESS_LABEL.
+  // The backend still masks it ("****") on confidential complaints.
   "email",
   // Moz QA (CCSD-1988): consents are an internal acceptance record, not a
   // user-facing data row — never show them on the view screens.

--- a/digit-ui-esbuild/products/pgr/src/components/PgrExtendedAttributesView.js
+++ b/digit-ui-esbuild/products/pgr/src/components/PgrExtendedAttributesView.js
@@ -19,9 +19,10 @@ const SKIP_KEYS = new Set([
   "schemaVersion",
   "hierarchyLevel1",
   "hierarchyLevel2",
-  // complainantAddress is SHOWN (product call, sheet-v4 review): it renders
-  // as its own "Endereço do Reclamante" row via PGR_EXT_COMPLAINANT_ADDRESS_LABEL.
-  // The backend still masks it ("****") on confidential complaints.
+  // complainantAddress renders as the VALUE of the main Address row on both
+  // details pages (product call, sheet-v4 review) — skipping it here avoids
+  // a duplicate row in the Additional Details card.
+  "complainantAddress",
   "email",
   // Moz QA (CCSD-1988): consents are an internal acceptance record, not a
   // user-facing data row — never show them on the view screens.

--- a/digit-ui-esbuild/products/pgr/src/components/TimeLineWrapper.js
+++ b/digit-ui-esbuild/products/pgr/src/components/TimeLineWrapper.js
@@ -27,11 +27,13 @@ const maskPhone = (phone) => {
 const isCitizenActor = (person) =>
   Array.isArray(person?.roles) && person.roles.some((r) => (r?.code || r) === "CITIZEN");
 
-// QA #19: maskEmployeeContacts — set by the EMPLOYEE details page only —
+// QA #19: maskEmployeeContacts — set by the EMPLOYEE details page —
 // masks every non-citizen actor's name and mobile in the timeline (the
-// requirement is mask, not remove). The citizen page never passes it, so
-// citizen-side behaviour is driven by maskConfidential/backend masking alone.
-const TimelineWrapper = ({ businessId, isWorkFlowLoading, workflowData, labelPrefix = "", currentStateChildren = null, maskConfidential = false, maskEmployeeContacts = false }) => {
+// requirement is mask, not remove).
+// QA #19 part 1 (sheet v4): hideEmployeeContacts — set by the CITIZEN details
+// page — OMITS employee name and contact lines entirely (the citizen must not
+// see who handled the complaint). Citizen actors' own entries stay visible.
+const TimelineWrapper = ({ businessId, isWorkFlowLoading, workflowData, labelPrefix = "", currentStateChildren = null, maskConfidential = false, maskEmployeeContacts = false, hideEmployeeContacts = false }) => {
     const { t } = useTranslation();
 
     const tenantId = Digit.ULBService.getCurrentTenantId();
@@ -183,18 +185,23 @@ const TimelineWrapper = ({ businessId, isWorkFlowLoading, workflowData, labelPre
                 const personRecord = isAssigningAction(instance?.action) ? assignee : instance?.assigner;
                 // Confidential complaints: mask the CITIZEN actor's identity
                 // (employees stay visible — accountability is intact).
+                const isEmployeeActor = personRecord && !isCitizenActor(personRecord);
                 const maskThis =
                   (maskConfidential && isCitizenActor(personRecord)) ||
-                  (maskEmployeeContacts && personRecord && !isCitizenActor(personRecord));
+                  (maskEmployeeContacts && isEmployeeActor);
+                // QA #19 part 1: citizen view drops employee identity lines
+                // entirely (hide, not mask).
+                const hideThis = hideEmployeeContacts && isEmployeeActor;
                 const mobile = isAssigningAction(instance?.action) ? assignee?.mobileNumber : instance?.assigner?.mobileNumber;
                 // The backend already masks the mobile per viewer privilege
                 // ("Contact Details: *****0104"). Mirror that decision onto the
                 // NAME: a viewer the backend won't show the number to shouldn't
                 // see the person's identity either.
                 const backendMasked = typeof mobile === "string" && mobile.includes("*");
-                const personLine =
-                  maskThis || backendMasked ? maskName(formatPerson(personRecord)) : formatPerson(personRecord);
-                const shownMobile = maskThis ? maskPhone(mobile) : mobile;
+                const personLine = hideThis
+                  ? null
+                  : maskThis || backendMasked ? maskName(formatPerson(personRecord)) : formatPerson(personRecord);
+                const shownMobile = hideThis ? null : maskThis ? maskPhone(mobile) : mobile;
                 const contactLine = shownMobile ? `${t("ES_COMMON_CONTACT_DETAILS")}: ${shownMobile}` : null;
 
                 // Workflow-driven label: try the localized key, else fall back to the

--- a/digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
+++ b/digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
@@ -8,16 +8,18 @@ export const CreateComplaintConfig = {
           head: "ES_CREATECOMPLAINT_PROVIDE_COMPLAINANT_DETAILS",
           body: [
             {
-              // QA #26 (product call): channel-of-receipt CHIP selector at the
-              // top of the form (above the mobile number). The selected CODE
-              // becomes service.source at submit (email / inperson / letter /
-              // linhaverde — kept in pgr-services' allowed.source list).
-              // Defaults to "inperson" via the mount-time draft seed.
+              // QA #26 (product call): channel-of-receipt CHIP selector just
+              // above the mobile number — label in the LEFT column, chips in
+              // the control column (inline row, same as the fields below).
+              // The selected CODE becomes service.source at submit (email /
+              // inperson / letter / linhaverde — kept in pgr-services'
+              // allowed.source list). "In Person" is first and pre-selected.
+              inline: true,
               isMandatory: false,
               type: "component",
               component: "PGRChannelChipsComponent",
               key: "ReceivedChannel",
-              withoutLabel: true,
+              label: "ES_CREATECOMPLAINT_RECEIVED_CHANNEL",
               populators: { name: "ReceivedChannel" },
             },
             {

--- a/digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
+++ b/digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
@@ -16,6 +16,9 @@ export const CreateComplaintConfig = {
               // allowed.source list). "In Person" is first and pre-selected.
               inline: true,
               isMandatory: false,
+              // Always carries a value (defaults to inperson) — suppress the
+              // generic "(Optional)" label suffix.
+              noOptionalSuffix: true,
               type: "component",
               component: "PGRChannelChipsComponent",
               key: "ReceivedChannel",

--- a/digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
+++ b/digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
@@ -287,12 +287,11 @@ export const CreateComplaintConfig = {
               },
             },
             {
-              // QA #26: how the complaint reached the Reception Officer
-              // (email / in-person / letter / linha verde). Optional; travels
-              // as extendedAttributes.receivedChannel and shows on the details
-              // pages via the generic extended-attributes card. The stored
-              // value is the human-readable option code — the viewer renders
-              // values verbatim by design.
+              // QA #26 (product call): how the complaint reached the Reception
+              // Officer. The selected CODE becomes the complaint's
+              // service.source (replacing the hardcoded "web") — codes must
+              // stay in pgr-services' allowed.source list. Not displayed on
+              // the details pages.
               isMandatory: false,
               key: "ReceivedChannel",
               type: "dropdown",
@@ -302,10 +301,10 @@ export const CreateComplaintConfig = {
                 name: "ReceivedChannel",
                 optionsKey: "name",
                 options: [
-                  { code: "E-mail", name: "PGR_CHANNEL_EMAIL" },
-                  { code: "Presencial", name: "PGR_CHANNEL_IN_PERSON" },
-                  { code: "Carta", name: "PGR_CHANNEL_LETTER" },
-                  { code: "Linha Verde", name: "PGR_CHANNEL_LINHA_VERDE" },
+                  { code: "email", name: "PGR_CHANNEL_EMAIL" },
+                  { code: "inperson", name: "PGR_CHANNEL_IN_PERSON" },
+                  { code: "letter", name: "PGR_CHANNEL_LETTER" },
+                  { code: "linhaverde", name: "PGR_CHANNEL_LINHA_VERDE" },
                 ],
               },
             },

--- a/digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
+++ b/digit-ui-esbuild/products/pgr/src/configs/CreateComplaintConfig.js
@@ -8,6 +8,19 @@ export const CreateComplaintConfig = {
           head: "ES_CREATECOMPLAINT_PROVIDE_COMPLAINANT_DETAILS",
           body: [
             {
+              // QA #26 (product call): channel-of-receipt CHIP selector at the
+              // top of the form (above the mobile number). The selected CODE
+              // becomes service.source at submit (email / inperson / letter /
+              // linhaverde — kept in pgr-services' allowed.source list).
+              // Defaults to "inperson" via the mount-time draft seed.
+              isMandatory: false,
+              type: "component",
+              component: "PGRChannelChipsComponent",
+              key: "ReceivedChannel",
+              withoutLabel: true,
+              populators: { name: "ReceivedChannel" },
+            },
+            {
               inline: true,
               label: "COMPLAINTS_COMPLAINANT_CONTACT_NUMBER",
               isMandatory: true,
@@ -284,28 +297,6 @@ export const CreateComplaintConfig = {
                   pattern: /^(?=[\s\S]{20,1000}$)(?=(?:[\s\S]*?\p{L}){3})[\s\S]*$/u,
                 },
                 error: "CS_DESC_MIN_CHARS",
-              },
-            },
-            {
-              // QA #26 (product call): how the complaint reached the Reception
-              // Officer. The selected CODE becomes the complaint's
-              // service.source (replacing the hardcoded "web") — codes must
-              // stay in pgr-services' allowed.source list. Not displayed on
-              // the details pages.
-              isMandatory: false,
-              key: "ReceivedChannel",
-              type: "dropdown",
-              label: "ES_CREATECOMPLAINT_RECEIVED_CHANNEL",
-              disable: false,
-              populators: {
-                name: "ReceivedChannel",
-                optionsKey: "name",
-                options: [
-                  { code: "email", name: "PGR_CHANNEL_EMAIL" },
-                  { code: "inperson", name: "PGR_CHANNEL_IN_PERSON" },
-                  { code: "letter", name: "PGR_CHANNEL_LETTER" },
-                  { code: "linhaverde", name: "PGR_CHANNEL_LINHA_VERDE" },
-                ],
               },
             },
           ],

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintDetails.js
@@ -305,31 +305,13 @@ const ComplaintDetailsPage = () => {
 
   const geoLocation = complaintDetails?.service?.address?.geoLocation;
   const address = complaintDetails?.service?.address;
-  // QA #31: complaints store only the lowercase boundary CODE (name is null),
-  // so the Endereço line rendered raw codes like "zumbo". Resolve through the
-  // boundary localization (module rainmaker-boundary-*) when loaded; otherwise
-  // title-case the code — always readable, never a raw identifier.
-  const localityLabel = (() => {
-    const loc = address?.locality;
-    if (!loc) return null;
-    if (loc.name) return loc.name;
-    if (!loc.code) return null;
-    const viaT = t(loc.code);
-    if (viaT && viaT !== loc.code) return viaT;
-    // QA #25/#31 (sheet v4): some environments prefix boundary codes with the
-    // tenant/hierarchy chain (e.g. "MZ_IGE_ADMIN_hungaro") — strip the leading
-    // ALL-CAPS segments so the citizen sees "Hungaro", not the raw chain.
-    // Bare codes ("zumbo", "vila_de_sena") pass through untouched.
-    const bare = String(loc.code).replace(/^(?:[A-Z0-9]+_)+(?=[^A-Z])/, "");
-    return bare
-      .replace(/[_-]+/g, " ")
-      .replace(/\b\w/g, (c) => c.toUpperCase());
-  })();
+  // QA #31/#25: show ONLY what the complainant typed — no boundary code, no
+  // tenant/authority name (those rendered as raw identifiers like
+  // "MZ_IGE_ADMIN_hungaro" or appended "…, IGSAE").
   const displayAddress = [
     address?.buildingName,
     address?.street,
     address?.landmark,
-    localityLabel,
     address?.pincode,
   ]
     .filter(Boolean)

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintDetails.js
@@ -217,6 +217,9 @@ function WorkflowComponent({ complaintDetails, id }) {
       workflowData={workflowData}
       labelPrefix="WF_PGR_"
       currentStateChildren={currentStateChildren}
+      // QA #19 part 1 (sheet v4): the citizen must not see which employee
+      // handled the complaint — employee name + contact lines are omitted.
+      hideEmployeeContacts
     />
   );
 }
@@ -313,7 +316,12 @@ const ComplaintDetailsPage = () => {
     if (!loc.code) return null;
     const viaT = t(loc.code);
     if (viaT && viaT !== loc.code) return viaT;
-    return String(loc.code)
+    // QA #25/#31 (sheet v4): some environments prefix boundary codes with the
+    // tenant/hierarchy chain (e.g. "MZ_IGE_ADMIN_hungaro") — strip the leading
+    // ALL-CAPS segments so the citizen sees "Hungaro", not the raw chain.
+    // Bare codes ("zumbo", "vila_de_sena") pass through untouched.
+    const bare = String(loc.code).replace(/^(?:[A-Z0-9]+_)+(?=[^A-Z])/, "");
+    return bare
       .replace(/[_-]+/g, " ")
       .replace(/\b\w/g, (c) => c.toUpperCase());
   })();

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
@@ -430,7 +430,13 @@ function mapFormDataToRequest(formData: FormData, tenantId: string, user: any, d
       rowVersion: 1,
       address: {
         landmark: validateString(formData?.landmark),
-        buildingName: "",
+        // Product call (sheet-v4 review): the typed complainant address ALSO
+        // travels as the complaint's plain address so the details Address row
+        // can show it (the extendedAttributes copy is withheld by the backend
+        // DataSecurity pipeline on read). Skipped on CONFIDENTIAL complaints —
+        // there the complainant's address must stay hidden, and the details
+        // row falls back to the administrative chain.
+        buildingName: formData?.isConfidential ? "" : validateString(formData?.complainantAddress) || "",
         street: "",
         pincode: validateString(formData?.postalCode),
         locality: {

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
@@ -430,13 +430,7 @@ function mapFormDataToRequest(formData: FormData, tenantId: string, user: any, d
       rowVersion: 1,
       address: {
         landmark: validateString(formData?.landmark),
-        // Product call (sheet-v4 review): the typed complainant address ALSO
-        // travels as the complaint's plain address so the details Address row
-        // can show it (the extendedAttributes copy is withheld by the backend
-        // DataSecurity pipeline on read). Skipped on CONFIDENTIAL complaints —
-        // there the complainant's address must stay hidden, and the details
-        // row falls back to the administrative chain.
-        buildingName: formData?.isConfidential ? "" : validateString(formData?.complainantAddress) || "",
+        buildingName: "",
         street: "",
         pincode: validateString(formData?.postalCode),
         locality: {

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/CreateComplaint/createComplaintForm.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/CreateComplaint/createComplaintForm.js
@@ -55,7 +55,15 @@ const CreateComplaintForm = ({
     const draftValid = __draftMeta
       ? __draftMeta.tenant === tenantId && __draftMeta.user === draftUserUuid
       : Object.keys(draftValues).length === 0; // legacy/unstamped non-empty drafts are stale — drop
-    initialDraftRef.current = draftValid ? draftValues : {};
+    const seeded = draftValid ? draftValues : {};
+    // QA #26: channel-of-receipt defaults to "Presencial" (in person) — the
+    // Reception Officer's most common case — unless the draft carries a
+    // choice already. The user can still change it; the code rides
+    // service.source at submit.
+    if (!seeded.ReceivedChannel) {
+      seeded.ReceivedChannel = { code: "inperson", name: "PGR_CHANNEL_IN_PERSON" };
+    }
+    initialDraftRef.current = seeded;
   }
   // JSON snapshot of the last persisted draft — cheap change detection so the
   // sessionStorage write (and the re-render it causes) happens only on real

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/CreateComplaint/createComplaintForm.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/CreateComplaint/createComplaintForm.js
@@ -417,7 +417,9 @@ const CreateComplaintForm = ({
     const withOptional = withExt.map((section) => ({
       ...section,
       body: (section.body || []).map((field) =>
-        field?.label && field.isMandatory !== true
+        // noOptionalSuffix: per-field opt-out (e.g. the channel chips — it
+        // always has a value via its default, so "(Optional)" is noise).
+        field?.label && field.isMandatory !== true && !field.noOptionalSuffix
           ? { ...field, label: `${t(field.label)} ${optionalSuffix}` }
           : field
       ),

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
@@ -41,21 +41,11 @@ const parseAdditionalDetail = (ad) => {
 
 const buildActionFormConfig = ({ action, assigneeRoles = [], isTerminal = false, docUploadRequired = false, assigneeMandatory }) => {
   const body = [];
-  if (action === "REJECT") {
-    body.push({
-      isMandatory: false,
-      key: "SelectedReason",
-      type: "dropdown",
-      label: "CS_REJECT_COMPLAINT",
-      disable: false,
-      populators: {
-        name: "SelectedReason",
-        optionsKey: "name",
-        error: "Required",
-        mdmsConfig: { masterName: "RejectionReasons", moduleName: "RAINMAKER-PGR", localePrefix: "CS_REJECTION_" },
-      },
-    });
-  }
+  // QA #23 (sheet v4 follow-up): the REJECT modal carries NO dropdowns at all —
+  // no assignee (below) and no rejection-reason picker (removed per product
+  // call; the officer's justification goes in the mandatory comments).
+  // handleActionSubmit still parses legacy "[CODE] …" comments for complaints
+  // rejected while the picker existed, so old timelines render unchanged.
   // QA #23: rejecting a complaint must not offer an assignee — REJECT is a
   // verdict, not a hand-off (the CMS workflow's REJECT target state is not
   // terminal and has assignable roles, which is why the dropdown appeared).

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
@@ -59,7 +59,11 @@ const buildActionFormConfig = ({ action, assigneeRoles = [], isTerminal = false,
   // QA #23: rejecting a complaint must not offer an assignee — REJECT is a
   // verdict, not a hand-off (the CMS workflow's REJECT target state is not
   // terminal and has assignable roles, which is why the dropdown appeared).
-  if (action !== "REJECT" && !isTerminal && (assigneeRoles?.length || 0) > 0) {
+  // QA #22 (sheet v4 decision): AWAITINGINFORMATION is a state update — the
+  // complaint waits on the CITIZEN, so picking a "next level user" makes no
+  // sense and mis-assigned it to another case manager. No assignee here either.
+  const NO_ASSIGNEE_ACTIONS = ["REJECT", "AWAITINGINFORMATION"];
+  if (!NO_ASSIGNEE_ACTIONS.includes(action) && !isTerminal && (assigneeRoles?.length || 0) > 0) {
     body.push({
       type: "component",
       // Callers pass assigneeMandatory (dept-mapping + actor aware); default

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
@@ -578,6 +578,18 @@ const PGRDetails = () => {
                     label: t("CS_COMPLAINT_LANDMARK__DETAILS"),
                     value: pgrData?.ServiceWrappers[0].service?.address?.landmark || "NA",
                   },
+                  // Typed address (product call, sheet-v4 review): the
+                  // complainant-entered address shows as its own row —
+                  // arrives masked ("****") on confidential complaints.
+                  ...(pgrData?.ServiceWrappers?.[0]?.service?.extendedAttributes?.complainantAddress
+                    ? [
+                        {
+                          inline: true,
+                          label: t("ES_CREATECOMPLAINT_ADDRESS"),
+                          value: pgrData.ServiceWrappers[0].service.extendedAttributes.complainantAddress,
+                        },
+                      ]
+                    : []),
                   // Pincode is optional in this deployment; only show it when set.
                   ...(pgrData?.ServiceWrappers[0].service?.address?.pincode
                     ? [

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
@@ -578,15 +578,19 @@ const PGRDetails = () => {
                     label: t("CS_COMPLAINT_LANDMARK__DETAILS"),
                     value: pgrData?.ServiceWrappers[0].service?.address?.landmark || "NA",
                   },
-                  // Typed address (product call, sheet-v4 review): the
-                  // complainant-entered address shows as its own row —
-                  // arrives masked ("****") on confidential complaints.
-                  ...(pgrData?.ServiceWrappers?.[0]?.service?.extendedAttributes?.complainantAddress
+                  // Typed address (product call, sheet-v4 review): the backend
+                  // persists the complainant-entered address into the User
+                  // Service and returns it as citizen.correspondenceAddress —
+                  // masked/absent per backend policy on confidential complaints.
+                  ...((pgrData?.ServiceWrappers?.[0]?.service?.citizen?.correspondenceAddress ||
+                      pgrData?.ServiceWrappers?.[0]?.service?.extendedAttributes?.complainantAddress)
                     ? [
                         {
                           inline: true,
                           label: t("ES_CREATECOMPLAINT_ADDRESS"),
-                          value: pgrData.ServiceWrappers[0].service.extendedAttributes.complainantAddress,
+                          value:
+                            pgrData.ServiceWrappers[0].service.citizen?.correspondenceAddress ||
+                            pgrData.ServiceWrappers[0].service.extendedAttributes?.complainantAddress,
                         },
                       ]
                     : []),

--- a/digit-ui-esbuild/products/pgr/src/utils/index.js
+++ b/digit-ui-esbuild/products/pgr/src/utils/index.js
@@ -189,12 +189,7 @@ export const formPayloadToCreateComplaint = (formData, tenantId, user, extOpts) 
       "rowVersion": 1,
       "address": {
         "landmark": formData?.landmark,
-        // Product call (sheet-v4 review): the typed complainant address ALSO
-        // travels as the complaint's plain address (the extendedAttributes
-        // copy is withheld by the backend on read). Confidential complaints
-        // skip the copy so the complainant's address stays hidden. AddressOne
-        // (legacy building field) wins when a caller ever supplies it.
-        "buildingName": formData?.AddressOne || (!formData?.isConfidential && formData?.ComplainantAddress?.trim()) || "",
+        "buildingName": formData?.AddressOne,
         "street": formData?.AddressTwo,
         "pincode": formData?.postalCode,
         // `SelectedBoundary` is the deepest node the operator picked

--- a/digit-ui-esbuild/products/pgr/src/utils/index.js
+++ b/digit-ui-esbuild/products/pgr/src/utils/index.js
@@ -189,7 +189,12 @@ export const formPayloadToCreateComplaint = (formData, tenantId, user, extOpts) 
       "rowVersion": 1,
       "address": {
         "landmark": formData?.landmark,
-        "buildingName": formData?.AddressOne,
+        // Product call (sheet-v4 review): the typed complainant address ALSO
+        // travels as the complaint's plain address (the extendedAttributes
+        // copy is withheld by the backend on read). Confidential complaints
+        // skip the copy so the complainant's address stays hidden. AddressOne
+        // (legacy building field) wins when a caller ever supplies it.
+        "buildingName": formData?.AddressOne || (!formData?.isConfidential && formData?.ComplainantAddress?.trim()) || "",
         "street": formData?.AddressTwo,
         "pincode": formData?.postalCode,
         // `SelectedBoundary` is the deepest node the operator picked

--- a/digit-ui-esbuild/products/pgr/src/utils/index.js
+++ b/digit-ui-esbuild/products/pgr/src/utils/index.js
@@ -183,7 +183,11 @@ export const formPayloadToCreateComplaint = (formData, tenantId, user, extOpts) 
       "serviceCode": getEffectiveServiceCode(formData?.SelectComplaintType,formData?.SelectSubComplaintType),
       "description": formData?.description,
       "applicationStatus": "CREATED",
-      "source": "web",
+      // QA #26 (product call): the Reception Officer's channel-of-receipt IS
+      // the complaint's source (was hardcoded "web"). Codes must exist in
+      // pgr-services' allowed.source list (email/inperson/letter/linhaverde
+      // added there). Employee flow only — the citizen wizard stays "web".
+      "source": formData?.ReceivedChannel?.code || "web",
       "citizen": userInfo,
       "isDeleted": false,
       "rowVersion": 1,
@@ -257,17 +261,6 @@ export const formPayloadToCreateComplaint = (formData, tenantId, user, extOpts) 
     complaint.service.extendedAttributes = {
       ...(complaint.service.extendedAttributes || {}),
       complainantAddress,
-    };
-  }
-
-  // QA #26: receipt channel picked by the Reception Officer. Attached like
-  // complainantAddress — even without a category mapping — so the value never
-  // silently drops; absent when the officer didn't pick one.
-  const receivedChannel = formData?.ReceivedChannel?.code;
-  if (receivedChannel) {
-    complaint.service.extendedAttributes = {
-      ...(complaint.service.extendedAttributes || {}),
-      receivedChannel,
     };
   }
 


### PR DESCRIPTION
## What

The remaining sheet-v4 work for moz. The merged #1377 carried only the FIRST additions commit (its head branch diverged from where later work landed); this PR delivers everything since, rebased cleanly onto the current moz tip (post #1377/#1349/#1399 merges — zero conflicts, final tree verified identical to the locally-tested build).

**Release-v2.12 already has all of this via #1366 — this PR restores moz↔release parity.**

| Sheet item | Fix |
|---|---|
| **#19 part 1** | Citizen timeline hides employee name + contact lines entirely (employee-side masking unchanged) |
| **#22** | AWAITINGINFORMATION offers no assignee (state update, not hand-off); boundary-prefix strip |
| **#23 follow-up** | REJECT modal drops the rejection-reason picker — no dropdowns at all (justification goes in comments); legacy "[CODE] …" comments still render |
| **#25/#31** | Address rework: typed address (backend's `citizen.correspondenceAddress`) drives the Address row on BOTH views, readable administrative chain as fallback ("Municipio Namaacha, Namaacha, Maputo Provincia"), boundary/tenant tokens gone |
| **#26** | Channel-of-receipt final design: chip selector (icon + label + radio circle) above the mobile number, In Person first + pre-selected, platform theme tokens, input-width aligned on desktop, responsive on mobile, no "(Optional)" suffix, phone icon for Linha Verde. Selected CODE rides `service.source` (email/inperson/letter/linhaverde) |

## ⚠️ Deploy note

pgr-services needs `ALLOWED_SOURCE=whatsapp,web,mobile,RB Bot,email,inperson,letter,linhaverde` (env override or image rebuild — the repo default in `backend/pgr-services` is updated here) before channel submits will pass validation. Applied on local via compose override; cms-pilot/mctd need the same at deploy time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)