### PR TITLE
Revert "fix(l10n): Linha Verde stays Linha Verde in English (seed)"

### DIFF
--- a/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
@@ -7423,7 +7423,7 @@
     },
     {
         "code": "PGR_LANDING_UTILITY_GREEN_LINE",
-        "message": "Linha Verde 1490",
+        "message": "Green Line 1490",
         "module": "rainmaker-pgr",
         "locale": "en_IN"
     },
@@ -7579,7 +7579,7 @@
     },
     {
         "code": "PGR_LANDING_HERO_CHANNEL_LINE",
-        "message": "Linha Verde 1490",
+        "message": "Green Line 1490",
         "module": "rainmaker-pgr",
         "locale": "en_IN"
     },
@@ -7795,7 +7795,7 @@
     },
     {
         "code": "PGR_LANDING_CHANNEL_LINE_TITLE",
-        "message": "Linha Verde 1490",
+        "message": "Green Line 1490",
         "module": "rainmaker-pgr",
         "locale": "en_IN"
     },
@@ -7945,7 +7945,7 @@
     },
     {
         "code": "PGR_LANDING_FOOTER_GREEN_LINE",
-        "message": "Linha Verde 1490",
+        "message": "Green Line 1490",
         "module": "rainmaker-pgr",
         "locale": "en_IN"
     },


### PR DESCRIPTION
Reverts #1403 — product call confirmed: English keeps **"Green Line 1490"** for the landing hotline keys (and "Green Line" for the channel chip). Live localization rows on local/cms-pilot/mctd are being restored to the same values in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)