### PR TITLE
fix(ansible): create digit_dir/docker before syncing migrator contexts

### DIFF
--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -475,6 +475,20 @@
     # contexts under docker/ (the existing build-context convention) and repoint
     # them with an Ansible-only overlay. docker-compose.migrations.yml itself
     # stays valid for anyone running compose straight from the repo.
+    #
+    # rsync creates only the FINAL component of the destination path, so this
+    # needs {{ digit_dir }}/docker to exist already. On a cold-start box it does
+    # not: the task that creates it ("Synchronize docker build context dirs")
+    # runs ~100 tasks later. Without this the FIRST deploy to a fresh host dies
+    # with rsync rc=11, mkdir "<digit_dir>/docker/pgr-services-db" failed
+    # (ENOENT) — while a re-deploy onto a host that already has the directory
+    # passes, which is why it went unnoticed. Idempotent.
+    - name: Ensure docker build-context dir exists (cold start)
+      file:
+        path: "{{ digit_dir }}/docker"
+        state: directory
+        mode: "0755"
+
     - name: Synchronize in-repo migrator build contexts
       synchronize:
         src: "../../backend/{{ item }}/src/main/resources/db/"


### PR DESCRIPTION
## Problem

`./deploy.sh <tenant>` fails on **any cold-start box**:

```
rsync: [Receiver] mkdir "/opt/digit/docker/pgr-services-db" failed:
No such file or directory (2)
rsync error: error in file IO (code 11) at main.c(800) [Receiver=3.2.7]
```

`Synchronize in-repo migrator build contexts` (playbook-deploy.yml:478) rsyncs into `{{ digit_dir }}/docker/<svc>-db/`, but nothing has created `{{ digit_dir }}/docker` yet:

| Line | Task | Creates |
|---|---|---|
| 442 | Create DIGIT directory | `{{ digit_dir }}` only |
| **478** | **Synchronize in-repo migrator build contexts** | **needs `{{ digit_dir }}/docker` — absent** |
| 585 | Synchronize docker build context dirs | `{{ digit_dir }}/docker` — ~100 tasks too late |

rsync creates only the *final* component of a destination path, hence `ENOENT`.

## Why it went unnoticed

The task has no `when:` gate, so it runs on every deploy — but a **re-deploy** onto a host that already has `docker/` passes. Only a genuinely fresh host hits it. Introduced by bc020cee, which added the migrator sync ahead of the pre-existing `docker/` sync.

## Fix

An idempotent `file: state=directory` task immediately before the sync.

## Verification

Reproduced and fixed on a wiped Ubuntu 24.04 host (no `/opt/digit`):

- **Before:** `failed=1`, three failed loop items (`pgr-services`, `novu-bridge`, `digit-config-service`), deploy aborted at task 17.
- **After:** new task `changed`; sync `changed` for all three items; full deploy `ok=123 changed=40 failed=0`, `INFRA VALIDATION` all green (containers HEALTHY, UI/configurator/status/MCP 200, auth token minted, OpenBao unsealed).
- `ansible-lint`: passes (`production` profile).

Worth noting: `synchronize` *did* honour `become` here despite the usual caveat, so `ENOENT` was the entire failure — no permissions change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment reliability on fresh hosts by ensuring required Docker directories are created before synchronization.
  * Prevented deployment failures caused by missing destination directories during initial setup.
  * Re-deployments remain safe and idempotent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->