### PR TITLE
fix(pgr): break the reverse-geocode feedback loop in the complaint map

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/GeoLocations.js
+++ b/digit-ui-esbuild/products/pgr/src/components/GeoLocations.js
@@ -144,6 +144,12 @@ const GeoLocations = ({ t, config, onSelect, formData }) => {
   const mapRef = useRef(null);
   const searchInputRef = useRef(null);
   const hasInitialized = useRef(false);
+  // Coords of the last reverse-geocode ATTEMPT (not success). The formData
+  // sync effect below must never re-request coords that were already tried:
+  // a failed / rate-limited Nominatim call writes {lat, lng} without an
+  // address back into formData via onSelect, and re-fetching on that write
+  // turns one failure into an infinite request loop (CCRS#1380 symptom 4).
+  const lastReverseAttempt = useRef(null);
 
   // Leaflet writes the stroke as an SVG DOM attribute, which doesn't resolve
   // CSS `var()`. Read the runtime accent at mount so the user-drawn polygon
@@ -206,24 +212,46 @@ const GeoLocations = ({ t, config, onSelect, formData }) => {
     }
   }, [isReady, DEFAULT_CENTER.lat, DEFAULT_CENTER.lng]);
 
+  // Sync FROM formData (wizard restore / re-entering the map step).
+  //
+  // Depend on the field's VALUES, not the formData object. The wizard
+  // rebuilds formData on every patch — including the patch our own
+  // fetchAddress issues through onSelect — so keying this effect on object
+  // identity made it re-run after every fetch. When the reverse geocode came
+  // back without an address (Nominatim error, rate limit, or a response with
+  // no display_name), the re-run called fetchAddress again, whose onSelect
+  // patched formData again: an infinite request loop that hammered Nominatim
+  // (guaranteeing further rate-limit failures that sustained it) and kept the
+  // map churning. Reported as CCRS#1380 symptom 4.
+  const savedPoint = formData?.[config.key];
+  const savedLat = savedPoint?.lat;
+  const savedLng = savedPoint?.lng;
+  const savedAddress = savedPoint?.address;
   useEffect(() => {
-    if (formData?.[config.key]) {
-      const { lat, lng, address: savedAddress } = formData[config.key];
-      if (lat && lng) {
-        setCoords({ lat, lng });
-        setMarkerPos([lat, lng]);
-        // Restore saved address if available
-        if (savedAddress) {
-          setAddress(savedAddress);
-          setSearchQuery(savedAddress);
-        } else if (!address) {
-          fetchAddress(lat, lng);
-        }
-      }
+    if (!savedLat || !savedLng) return;
+    setCoords({ lat: savedLat, lng: savedLng });
+    setMarkerPos([savedLat, savedLng]);
+    // Restore saved address if available
+    if (savedAddress) {
+      setAddress(savedAddress);
+      setSearchQuery(savedAddress);
+    } else if (!address && lastReverseAttempt.current !== `${savedLat},${savedLng}`) {
+      // Only reverse-geocode coords that were never attempted (a genuine
+      // restore, e.g. Back into the map step with a pin but no address). A
+      // failed attempt must not re-trigger itself through the formData
+      // round-trip; user actions (pin drop, search, locate-me) always go
+      // through fetchAddress directly and are unaffected by this guard.
+      fetchAddress(savedLat, savedLng);
     }
-  }, [formData, config.key]);
+    // `address` is deliberately not a dep: it only gates the one-shot restore
+    // fetch, and re-running on address changes would undo manual edits.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [savedLat, savedLng, savedAddress]);
 
   const fetchAddress = async (lat, lng) => {
+    // Record the attempt BEFORE the request so even a throwing fetch marks
+    // these coords as tried — the sync effect keys off this to avoid looping.
+    lastReverseAttempt.current = `${lat},${lng}`;
     const ward = resolveWard(lat, lng, tenantBoundaries);
     setSelectedWard(ward?.code || null);
     try {


### PR DESCRIPTION
Fixes the **continuous API invocation / map repeatedly repositioning** half of #1380 (symptom 4). Companion to #1392 (merged) and #1401, which cover the boundary-dropdown symptoms.

## Problem

`GeoLocations.js` syncs map state *from* the form with the **whole `formData` object** as the effect dependency:

```js
useEffect(() => {
  ... fetchAddress(lat, lng); ...
}, [formData, config.key]);
```

Every `onSelect` the component itself issues rebuilds `formData` through the wizard's `patch` (`CreatePGRFlowV2.tsx` Step1Map), so this effect re-runs after every fetch. The cycle:

1. A pin drop (or the mount-time seeding of the default centre) calls `fetchAddress` → Nominatim reverse geocode.
2. If Nominatim **fails, is rate-limited, or returns no `display_name`**, `fetchAddress` writes `{lat, lng, ward}` — **no `address`** — into the form.
3. New `formData` identity → the effect re-runs → saved point has no address → calls `fetchAddress` **again** → goto 2.

The loop is self-sustaining: the rapid-fire requests trip Nominatim's ~1 req/s rate limit, which guarantees the failure path, which keeps the loop alive. Each cycle also resets marker / selected-ward / search-box state, remounting the ward overlay — the visible "map keeps shifting" churn. Because the component seeds the default centre on mount, the loop can start with **no user interaction**, and a shared egress IP (typical hand-run deployment) makes the trigger condition routine.

## Change

Two guards in `GeoLocations.js`, nothing else:

- **Depend on values, not identity.** The sync effect now keys on the saved point's `lat` / `lng` / `address` instead of the `formData` object, so unrelated form writes — including the component's own round-trip — no longer re-run it.
- **Never re-request attempted coords.** A ref records the last reverse-geocode attempt (set *before* the request, so a throwing fetch still counts). The sync effect skips coords already attempted; one failed lookup stays one failed lookup.

## Blast radius

- A genuine restore (re-entering the map step with a pin saved but no address) still reverse-geocodes **once** — the ref only blocks repeats of the same coords.
- User actions (pin drop, suggestion select, search, locate-me) call `fetchAddress` directly and bypass the guard entirely — manual retry at the same spot still works.
- The success path is byte-identical: address, pincode extraction, ward resolution, `PGR_MAP_LOCATION` session save, and the `onSelect` payload are unchanged.

## Verification

Parse/bundle-checked with esbuild. Traced the loop statically: with the guard, the failure path terminates after one request (effect re-run hits the ref match and stops); the success path terminates exactly as before (saved address short-circuits the fetch branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented repeated address lookup attempts when reverse geocoding fails or returns no address.
  - Improved restoration of saved location data, avoiding request loops and reducing unnecessary network activity.
  - Location forms now behave more reliably in rate-limit and service-error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->