### PR TITLE
fix(theme): CCSD-2060 — remove orange !important pins; theme vars drive all brand colors

### DIFF
--- a/digit-ui-esbuild/packages/modules/core/src/pages/common/Login/index.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/common/Login/index.js
@@ -203,7 +203,9 @@ const UnifiedLogin = ({ stateCode }) => {
             style={{
               width: "100%",
               padding: "0.625rem 1rem",
-              backgroundColor: isSubmitDisabled ? "#B1B4B6" : "#F47738",
+              backgroundColor: isSubmitDisabled
+                ? "#B1B4B6"
+                : "var(--color-button-primary-bg-default, var(--color-primary-main, #F47738))",
               color: "#fff",
               border: "none",
               borderRadius: "4px",

--- a/digit-ui-esbuild/packages/modules/core/src/pages/employee/Otp/index.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/employee/Otp/index.js
@@ -152,8 +152,8 @@ const Otp = ({ isLogin = false }) => {
         buttonStyle={{ 
           width: "100%", 
           maxWidth: "408px",
-          backgroundColor: "#F47738",
-          borderColor: "#F47738",
+          backgroundColor: "var(--color-button-primary-bg-default, var(--color-primary-main, #F47738))",
+          borderColor: "var(--color-button-primary-bg-default, var(--color-primary-main, #F47738))",
           color: "#fff",
           fontWeight: "500",
           padding: "12px 24px",

--- a/digit-ui-esbuild/packages/react-components/src/atoms/EmployeeModuleCard.js
+++ b/digit-ui-esbuild/packages/react-components/src/atoms/EmployeeModuleCard.js
@@ -96,7 +96,7 @@ const ModuleCardFullWidth = ({ moduleName,  links = [], isCitizen = false, class
           <span className="text removeHeight">{moduleName}</span>
           <span className="link">
             <a href={subHeaderLink}>
-              <span className={"inbox-total"} style={{ display: "flex", alignItems: "center", color: "#F47738", fontWeight: "bold" }} onClick={()=>history.push(`${link}`)}>
+              <span className={"inbox-total"} style={{ display: "flex", alignItems: "center", color: "var(--color-primary-main, #F47738)", fontWeight: "bold" }} onClick={()=>history.push(`${link}`)}>
                 {subHeader || "-"}
                 <span style={{ marginLeft: "10px" }}>
                   {" "}

--- a/digit-ui-esbuild/packages/react-components/src/atoms/contants.js
+++ b/digit-ui-esbuild/packages/react-components/src/atoms/contants.js
@@ -1,1 +1,4 @@
-export const COLOR_FILL = "#c84c0e";
+// Theme-var indirection (CCSD-2060): resolves to the tenant's MDMS theme at
+// paint time; the hex is only the themeless fallback. var() resolves in both
+// CSS style props and SVG presentation attributes (verified on Chromium).
+export const COLOR_FILL = "var(--color-primary-main, #c84c0e)";

--- a/digit-ui-esbuild/packages/react-components/src/atoms/svgindex.js
+++ b/digit-ui-esbuild/packages/react-components/src/atoms/svgindex.js
@@ -1,5 +1,8 @@
 import React from "react";
-const COLOR_FILL = "#c84c0e";
+// Theme-var indirection (CCSD-2060): icon default fills follow the tenant's
+// MDMS theme; the hex is only the themeless fallback. var() resolves in SVG
+// presentation attributes (verified on Chromium).
+const COLOR_FILL = "var(--color-primary-main, #c84c0e)";
 
 const CreateEstimateIcon = ({ className, style = {}, fill = COLOR_FILL }) => (
   <svg width="18" height="18" viewBox="0 0 18 18" fill="none" className={className} style={style} xmlns="http://www.w3.org/2000/svg">
@@ -680,7 +683,7 @@ const ReceiptIcon = () => (
 const ReceiptInboxIcon = () => (
   <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 22" width="24">
     <path d="M0 0h24v24H0z" fill="none"></path>
-    <path d="M20 2H4c-1.1 0-1.99.9-1.99 2L2 22l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-7 9h-2V5h2v6zm0 4h-2v-2h2v2z" fill="#c84c0e"></path>
+    <path d="M20 2H4c-1.1 0-1.99.9-1.99 2L2 22l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-7 9h-2V5h2v6zm0 4h-2v-2h2v2z" fill={COLOR_FILL}></path>
   </svg>
 );
 

--- a/digit-ui-esbuild/packages/react-components/src/hoc/Tutorial/Tutorial.js
+++ b/digit-ui-esbuild/packages/react-components/src/hoc/Tutorial/Tutorial.js
@@ -6,7 +6,7 @@ let theme = {
   // primaryColor: '#ad7bff',
   // arrowColor: '#000',
   // textColor: '#fff',
-  primaryColor: '#c84c0e',
+  primaryColor: 'var(--color-primary-main, #c84c0e)',
   arrowColor: '#FFFFFF',
   textColor: '#505A5F',
   zIndex:9999

--- a/digit-ui-esbuild/packages/react-components/src/molecules/DetailsCard.js
+++ b/digit-ui-esbuild/packages/react-components/src/molecules/DetailsCard.js
@@ -60,7 +60,7 @@ const DetailsCard = ({ data, serviceRequestIdKey, linkPrefix, handleSelect, sele
             key={itemIndex}
             style={{
               border: selectedItems?.includes(object[keyForSelected])
-                ? '2px solid #c84c0e'
+                ? '2px solid var(--color-primary-main, #c84c0e)'
                 : '2px solid #fff',
             }}
             className="details-container"

--- a/digit-ui-esbuild/public/vendor/overrides.css
+++ b/digit-ui-esbuild/public/vendor/overrides.css
@@ -6264,22 +6264,15 @@ header.digit-header .digit-dropdown-master {
 }
 
 /* ============================================================================
-   CCSD-1985 — unify all primary buttons to the Moz brand ORANGE (#c84c0e).
-   The v2 buttons paint inline from var(--color-button-primary-bg-default, …),
-   which the tenant theme had set to yellow (#FEC931), while orange leaked
-   through the legacy paths — two shades on one screen. Force the brand button
-   vars to orange with !important so every path (v2 inline-var buttons, legacy
-   --color-primary-main buttons, submit bars) resolves to one shade. !important
-   on these custom properties beats applyTheme's runtime (non-important) :root
-   values. Text stays dark via --color-text-primary.
+   CCSD-2060 — the CCSD-1985 orange !important pins that used to live here
+   are REMOVED. They force-locked --color-button-primary-bg-default/hover/
+   pressed, --color-primary-2 and --color-primary-main to DIGIT orange, which
+   beat the MDMS ThemeConfig's runtime :root values — so buttons, module
+   icons and logout stayed orange on a green/yellow-themed tenant (QA #29).
+   The two-shades-on-one-screen problem CCSD-1985 pinned against is now
+   solved where it belongs: applyTheme's v3 expansion fans primary-2 onto
+   --color-primary-main, so the tenant record keeps every path on ONE shade.
    ========================================================================= */
-:root {
-  --color-button-primary-bg-default: #c84c0e !important;
-  --color-button-primary-bg-hover: #a83d0b !important;
-  --color-button-primary-bg-pressed: #8f340a !important;
-  --color-primary-2: #c84c0e !important;
-  --color-primary-main: #c84c0e !important;
-}
 
 /* CCSD-1995 — pre-login background: lighten the .banner overlay (0.8 -> 0.55,
    same teal family) so the StateInfo bannerUrl image (Maputo hero) reads


### PR DESCRIPTION
## Jira
[CCSD-2060](https://digit-discuss.atlassian.net/browse/CCSD-2060) — [Moz QA #29] Some buttons/icons are orange, off-palette (ticket is in **To Review** with the root-cause analysis).

## Problem
On the green/yellow-themed Moz tenants, the CMS module icon (citizen + employee), citizen & employee logout, the citizen login button and several workflow action buttons rendered DIGIT default orange `#c84c0e`.

## Root cause (two layers)
1. **`public/vendor/overrides.css` (CCSD-1985 block)** pinned `--color-button-primary-bg-default/hover/pressed`, `--color-primary-2` and `--color-primary-main` to orange with `!important`. A stylesheet `!important` on a custom property beats the runtime `:root` values `applyTheme` writes from `common-masters.ThemeConfig` — those five vars could never be themed, on any tenant.
2. **Hardcoded orange** in: employee Login submit (`#F47738`), employee OTP resend, react-components `COLOR_FILL` icon constants (`svgindex.js`, `contants.js`), `DetailsCard` selected border, `EmployeeModuleCard` inbox count, `Tutorial` (joyride) primaryColor.

## Fix
- Removed the pin block (explanatory comment left in place). The one-shade consistency CCSD-1985 wanted is preserved by `applyTheme`'s v3 expansion (`primary-2` fans onto `--color-primary-main`), so the ThemeConfig record keeps every paint path on one shade.
- Converted every hardcode to `var(--color-…, <old hex>)` — the old hex stays as the themeless fallback, so tenants without a ThemeConfig record are pixel-identical to today. `var()` resolves in SVG presentation attributes (verified on Chromium), so `fill={COLOR_FILL}` keeps working.

## Verification (local, rebuilt bundle + css)
- Citizen login button: `#F9CE1E` (was orange) — inline `var(--color-button-primary-bg-default, …)` now resolves to the record value.
- Employee login button: `#F9CE1E` (was hardcoded `#F47738`).
- Module icons (citizen sidebar + employee module card): `#FEC931`.
- `.submit-bar` / action buttons: `#FEC931`.
- Sidebar selected pill: `#f9cb24` (after syncing the local ThemeConfig record with the 6 keys the pilot record already has).

## Rollout notes
- cms-pilot: deploy rebuilt bundle **and** `vendor/overrides.css`; its ThemeConfig record is already complete — no data change needed.
- ⚠️ **mctd**: with the pins gone, mctd follows *its* ThemeConfig record — confirm that record's palette before deploying this branch there (CCSD-1985 originally pinned orange for mctd-era consistency).
- No test harness exists for the FE (QA-owned per team policy); verification was manual on local as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CCSD-2060]: https://digit-discuss.atlassian.net/browse/CCSD-2060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ