### PR TITLE
fix(pgr): citizen map resolves MapConfig + boundaries at the authority-selected tenant

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/GeoLocations.js
+++ b/digit-ui-esbuild/products/pgr/src/components/GeoLocations.js
@@ -81,7 +81,14 @@ const wardStyleFor = (WARD_COLOR, selectedCode, hoveredCode) => (feature) => {
   return                          { color: WARD_COLOR, weight: 1,   opacity: 0.6, fillColor: WARD_COLOR, fillOpacity: 0    };
 };
 
-const GeoLocations = ({ t, config, onSelect, formData }) => {
+const GeoLocations = ({ t, config, onSelect, formData, tenantId }) => {
+  // Acting tenant for the MAP (MapConfig record + ward-boundary tree). The
+  // citizen wizard passes the authority-resolved sub-tenant (mz.ige/mz.igsae)
+  // once the first dropdown is picked — before this, the MapConfig fetch ran
+  // at the logged-in tenant (state root "mz" for citizens), whose boundary
+  // tree is empty on multi-authority envs, so the ward overlay never drew.
+  // Employee create passes nothing and keeps resolving at the acting city.
+  const mapTenantId = tenantId || config?.tenantId || formData?.resolvedTenantId;
   const { t: trans, i18n } = useTranslation();
   // Nominatim Accept-Language is ISO 639-1 — derive from the active i18n
   // locale (e.g. `sw_KE` → `sw`) so place names come back in the user's
@@ -104,7 +111,7 @@ const GeoLocations = ({ t, config, onSelect, formData }) => {
     maxZoom,
     geocodeCountryCodes,
     searchViewbox,
-  } = useMapConfig();
+  } = useMapConfig(mapTenantId);
 
   const nominatimCountry = useMemo(
     () => (geocodeCountryCodes ? `&countrycodes=${encodeURIComponent(geocodeCountryCodes)}` : ""),
@@ -141,7 +148,7 @@ const GeoLocations = ({ t, config, onSelect, formData }) => {
   const [selectedWard, setSelectedWard] = useState(null);
   // Tenant ward polygons (boundary-service when MAP_TENANT is set, else
   // the bundled static Nairobi wards). Null while the fetch is in flight.
-  const tenantBoundaries = useTenantBoundaries();
+  const tenantBoundaries = useTenantBoundaries(mapTenantId);
   const mapRef = useRef(null);
   const searchInputRef = useRef(null);
   const hasInitialized = useRef(false);

--- a/digit-ui-esbuild/products/pgr/src/hooks/pgr/useMapConfig.js
+++ b/digit-ui-esbuild/products/pgr/src/hooks/pgr/useMapConfig.js
@@ -115,8 +115,12 @@ const asViewbox = (v) => {
 //
 // MDMS errors (master not registered for this tenant) must not break the map —
 // they are swallowed and every field falls through to its next tier.
-const useMapConfig = () => {
+const useMapConfig = (tenantIdOverride) => {
+  // Acting tenant, most specific first: an explicit caller override (the
+  // citizen wizard's authority-resolved sub-tenant), the citizen's chosen
+  // city, then the logged-in tenant.
   const tenantId =
+    (typeof tenantIdOverride === "string" && tenantIdOverride.trim()) ||
     Digit?.SessionStorage?.get?.("CITIZEN.COMMON.HOME.CITY")?.code ||
     Digit?.ULBService?.getCurrentTenantId?.();
 
@@ -130,7 +134,12 @@ const useMapConfig = () => {
       enabled: !!tenantId,
       select: (d) => d?.["RAINMAKER-PGR"]?.MapConfig,
     },
-    { schemaCode: "RAINMAKER-PGR.MapConfig" }
+    // tenantId MUST ride inside the mdmsv2 arg: the hook's mdmsv2 branch
+    // ignores the positional tenant and falls back to the logged-in tenant
+    // (state root "mz" for citizens) — which is how the citizen map read the
+    // state MapConfig record instead of the acting authority's. Also
+    // tenant-scopes the hook's cache key.
+    { schemaCode: "RAINMAKER-PGR.MapConfig", tenantId }
   );
 
   // The MDMS read is async, so on the first render every field still holds its

--- a/digit-ui-esbuild/products/pgr/src/hooks/pgr/useTenantBoundaries.js
+++ b/digit-ui-esbuild/products/pgr/src/hooks/pgr/useTenantBoundaries.js
@@ -68,11 +68,13 @@ const GEOMETRY_CHUNK_SIZE = 40;
 //
 // Returns null while the fetch is in flight; consumers gate the <GeoJSON>
 // layer on features.length and skip pin resolution until it arrives.
-const useTenantBoundaries = () => {
+const useTenantBoundaries = (tenantIdOverride) => {
   const [tenantBoundaries, setTenantBoundaries] = useState(null);
   // Which tenant's tree to draw is resolved from MDMS MapConfig, falling back to
-  // the deploy-time globalConfigs MAP_TENANT key.
-  const { isReady, boundaryTenantId: MAP_TENANT } = useMapConfig();
+  // the deploy-time globalConfigs MAP_TENANT key. Callers with an explicit
+  // acting tenant (citizen wizard's authority-resolved sub-tenant) pass it so
+  // the MapConfig lookup happens there instead of the logged-in tenant.
+  const { isReady, boundaryTenantId: MAP_TENANT } = useMapConfig(tenantIdOverride);
   // The hierarchy is a boundary construct rather than a map one, so it is not
   // part of MapConfig; it stays on globalConfigs until a default-boundary-
   // hierarchy master exists to own it.

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
@@ -936,6 +936,10 @@ function Step1Map({ data, patch, t }: StepBodyProps) {
       {GeoLocations ? (
         <GeoLocations
           t={t}
+          // The map's MapConfig + ward-boundary tree resolve at the tenant the
+          // FIRST dropdown picked (ComplaintRelatedToMap tenantCode), not the
+          // citizen's login tenant (state root) whose tree is empty.
+          tenantId={(data as any)?.resolvedTenantId}
           config={{
             key: "GeoLocationsPoint",
             populators: { name: "GeoLocationsPoint" },


### PR DESCRIPTION
## Problem
On the citizen create wizard's map step, the `/mdms-v2/v1/_search` for `RAINMAKER-PGR.MapConfig` always went out with `tenantId: "mz"` — the citizen's login tenant — regardless of the authority picked in the first dropdown. On multi-authority envs the state record's boundary tree is empty, so ward polygons and boundary click-to-fill never rendered for citizens. (Employees were unaffected: their logged-in tenant is the acting city, which has city-level MapConfig records.)

## Root cause
Two stacked gaps:
1. `useCustomMDMS`'s **mdmsv2 branch ignores the positional tenant argument** (`mdmsv2.tenantId || getCurrentTenantId()`), and `useMapConfig` never set `mdmsv2.tenantId` — so its carefully computed city-aware tenant was silently discarded.
2. Nothing threaded the wizard's **authority-resolved tenant** (`formData.resolvedTenantId`, from ComplaintRelatedToMap `tenantCode`) into the map at all.

## Fix
- `useMapConfig(tenantIdOverride)` — acting tenant = explicit override → `CITIZEN.COMMON.HOME.CITY` → logged-in tenant, **passed inside the mdmsv2 arg** so the fetch actually uses it (and the hook's cache key becomes tenant-scoped).
- `useTenantBoundaries(tenantIdOverride)` — threads through to the MapConfig lookup.
- `GeoLocations` — optional `tenantId` prop (falls back to `config.tenantId` / `formData.resolvedTenantId`).
- `CreatePGRFlowV2` Step1Map — passes `data.resolvedTenantId`.

## Compatibility
Employee create passes nothing → resolves at the acting city exactly as today. Tenants without city MapConfig records inherit the state record via mdms-v2 resolution, unchanged. Complements the pilot data fix (state `mz` record → `boundaryTenantId: mz.ige`): with this PR, an IGSAE citizen gets IGSAE's own tree instead of the state fallback.

No FE test harness (QA-owned per team policy); the edits were compile-verified and the request-tenant change is directly observable in the network tab on the wizard's map step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)