### PR TITLE
fix(pgr): timeline always masks the complainant's name and number

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/TimeLineWrapper.js
+++ b/digit-ui-esbuild/products/pgr/src/components/TimeLineWrapper.js
@@ -183,11 +183,15 @@ const TimelineWrapper = ({ businessId, isWorkFlowLoading, workflowData, labelPre
             const steps = workflowData.ProcessInstances.map((instance, index) => {
                 const assignee = instance?.assignes?.[0];
                 const personRecord = isAssigningAction(instance?.action) ? assignee : instance?.assigner;
-                // Confidential complaints: mask the CITIZEN actor's identity
-                // (employees stay visible — accountability is intact).
+                // Product call (2026-07-23, follow-up on QA #19): the timeline
+                // ALWAYS masks the CITIZEN actor's name and number — even on
+                // non-confidential complaints. The complainant card is the one
+                // place that shows clear identity, per the viewer's privilege.
+                // (maskConfidential is kept as a prop for compatibility but the
+                // citizen actor no longer depends on it.)
                 const isEmployeeActor = personRecord && !isCitizenActor(personRecord);
                 const maskThis =
-                  (maskConfidential && isCitizenActor(personRecord)) ||
+                  isCitizenActor(personRecord) ||
                   (maskEmployeeContacts && isEmployeeActor);
                 // QA #19 part 1: citizen view drops employee identity lines
                 // entirely (hide, not mask).


### PR DESCRIPTION
## Requirement (product call, 2026-07-23 — follow-up on QA #19 / CCSD-2050)
The complaint timeline must never show the complainant's identity in clear — on **all** complaints, not only confidential ones (verified on pilot PB-PGR-2026-07-23-003536 / 003539, whose Applied entries showed `João António / 888844441`).

## Change
One condition in `TimelineWrapper`: the CITIZEN actor's entry is now masked unconditionally (name initial + `******`+last-4 number). Previously it masked only when `maskConfidential` was set (confidential complaints).
- Employee actors unchanged: masked on the employee page (`maskEmployeeContacts`), hidden on the citizen page (`hideEmployeeContacts`).
- The complainant card stays the single place with clear identity, per the viewer's backend privilege.
- `maskConfidential` prop kept for compatibility (now redundant for the citizen actor).

One file, one condition + comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)