### PR TITLE
fix(db-seed): seed boundary.additionaldetails as '{}' not NULL

### DIFF
--- a/local-setup/db/full-dump.sql
+++ b/local-setup/db/full-dump.sql
@@ -2148,19 +2148,19 @@ COPY public.accesscontrol_schema_version (installed_rank, version, description, 
 --
 
 COPY public.boundary (id, tenantid, code, geometry, additionaldetails, createdtime, createdby, lastmodifiedtime, lastmodifiedby) FROM stdin;
-098443ce-1c97-40d3-aec1-44a2e45d22da	pg	PG_CITYA	{"type": "Polygon", "coordinates": [[[74.8, 31.5], [74.9, 31.5], [74.9, 31.7], [74.8, 31.7], [74.8, 31.5]]]}	\N	1781073055245	system	1781073055245	system
-a1fb63a5-8305-4365-a3f3-e86337b6c809	pg	PG_CITYA_B1	{"type": "Polygon", "coordinates": [[[74.83, 31.57], [74.87, 31.57], [74.87, 31.63], [74.83, 31.63], [74.83, 31.57]]]}	\N	1781073055245	system	1781073055245	system
-215072ee-890f-4140-9451-f3c08929e614	pg	PG_CITYA_Z1	{"type": "Polygon", "coordinates": [[[74.82, 31.55], [74.88, 31.55], [74.88, 31.65], [74.82, 31.65], [74.82, 31.55]]]}	\N	1781073055245	system	1781073055245	system
-f971f0f0-f691-4b3d-bde1-a539daf5029c	pg	PG_STATE	{"type": "Polygon", "coordinates": [[[74.0, 30.0], [78.0, 30.0], [78.0, 33.0], [74.0, 33.0], [74.0, 30.0]]]}	\N	1781073055245	system	1781073055245	system
-8cf59d36-879b-498d-886c-969b799b9ed0	pg	SUN01_LOCALITY	{"type": "Point", "coordinates": [74.87155, 31.63089]}	\N	1781073055245	system	1781073055245	system
-d160ceda-65a5-4d2a-b19d-e69ef9be2c22	pg	SUN02_LOCALITY	{"type": "Point", "coordinates": [74.85, 31.61]}	\N	1781073055245	system	1781073055245	system
-78120481-4402-4284-a81c-c8f2b00e58ad	pg	SUN03_LOCALITY	{"type": "Point", "coordinates": [74.84, 31.60]}	\N	1781073055245	system	1781073055245	system
-88ba1d4c-540f-4351-9289-becd79cfdeae	pg.citya	PG_CITYA_ADMIN_CITY	{"type": "Polygon", "coordinates": [[[77.17, 28.56], [70.11, 22.50], [77.58, 13.05], [86.42, 23.77], [77.17, 28.56]]]}	\N	1781072283555	system	1781072283555	system
-665a5db2-b61f-4730-b769-fee204b70a0a	pg.citya	Z1_ADMIN_ZONE	{"type": "Polygon", "coordinates": [[[77.17, 28.56], [70.11, 22.50], [77.58, 13.05], [86.42, 23.77], [77.17, 28.56]]]}	\N	1781072283555	system	1781072283555	system
-e7675727-dcfa-46b7-aa92-09bacb36f673	pg.citya	Z2_ADMIN_ZONE	{"type": "Polygon", "coordinates": [[[77.20, 28.60], [70.15, 22.55], [77.60, 13.10], [86.45, 23.80], [77.20, 28.60]]]}	\N	1783555200000	system	1783555200000	system
-a04109d4-ace4-4608-9903-e279d4d9c158	pg.citya	W1_ADMIN_WARD	{"type": "Point", "coordinates": [74.871552, 31.63089]}	\N	1783555200000	system	1783555200000	system
-8c1db4e2-50d7-4f1f-b3ed-0620944eafa9	pg.citya	W2_ADMIN_WARD	{"type": "Point", "coordinates": [74.9, 31.6]}	\N	1783555200000	system	1783555200000	system
-d6fa339e-c7b3-4d0e-8ef4-d5f80837c8a0	pg.citya	W3_ADMIN_WARD	{"type": "Point", "coordinates": [74.85, 31.65]}	\N	1783555200000	system	1783555200000	system
+098443ce-1c97-40d3-aec1-44a2e45d22da	pg	PG_CITYA	{"type": "Polygon", "coordinates": [[[74.8, 31.5], [74.9, 31.5], [74.9, 31.7], [74.8, 31.7], [74.8, 31.5]]]}	{}	1781073055245	system	1781073055245	system
+a1fb63a5-8305-4365-a3f3-e86337b6c809	pg	PG_CITYA_B1	{"type": "Polygon", "coordinates": [[[74.83, 31.57], [74.87, 31.57], [74.87, 31.63], [74.83, 31.63], [74.83, 31.57]]]}	{}	1781073055245	system	1781073055245	system
+215072ee-890f-4140-9451-f3c08929e614	pg	PG_CITYA_Z1	{"type": "Polygon", "coordinates": [[[74.82, 31.55], [74.88, 31.55], [74.88, 31.65], [74.82, 31.65], [74.82, 31.55]]]}	{}	1781073055245	system	1781073055245	system
+f971f0f0-f691-4b3d-bde1-a539daf5029c	pg	PG_STATE	{"type": "Polygon", "coordinates": [[[74.0, 30.0], [78.0, 30.0], [78.0, 33.0], [74.0, 33.0], [74.0, 30.0]]]}	{}	1781073055245	system	1781073055245	system
+8cf59d36-879b-498d-886c-969b799b9ed0	pg	SUN01_LOCALITY	{"type": "Point", "coordinates": [74.87155, 31.63089]}	{}	1781073055245	system	1781073055245	system
+d160ceda-65a5-4d2a-b19d-e69ef9be2c22	pg	SUN02_LOCALITY	{"type": "Point", "coordinates": [74.85, 31.61]}	{}	1781073055245	system	1781073055245	system
+78120481-4402-4284-a81c-c8f2b00e58ad	pg	SUN03_LOCALITY	{"type": "Point", "coordinates": [74.84, 31.60]}	{}	1781073055245	system	1781073055245	system
+88ba1d4c-540f-4351-9289-becd79cfdeae	pg.citya	PG_CITYA_ADMIN_CITY	{"type": "Polygon", "coordinates": [[[77.17, 28.56], [70.11, 22.50], [77.58, 13.05], [86.42, 23.77], [77.17, 28.56]]]}	{}	1781072283555	system	1781072283555	system
+665a5db2-b61f-4730-b769-fee204b70a0a	pg.citya	Z1_ADMIN_ZONE	{"type": "Polygon", "coordinates": [[[77.17, 28.56], [70.11, 22.50], [77.58, 13.05], [86.42, 23.77], [77.17, 28.56]]]}	{}	1781072283555	system	1781072283555	system
+e7675727-dcfa-46b7-aa92-09bacb36f673	pg.citya	Z2_ADMIN_ZONE	{"type": "Polygon", "coordinates": [[[77.20, 28.60], [70.15, 22.55], [77.60, 13.10], [86.45, 23.80], [77.20, 28.60]]]}	{}	1783555200000	system	1783555200000	system
+a04109d4-ace4-4608-9903-e279d4d9c158	pg.citya	W1_ADMIN_WARD	{"type": "Point", "coordinates": [74.871552, 31.63089]}	{}	1783555200000	system	1783555200000	system
+8c1db4e2-50d7-4f1f-b3ed-0620944eafa9	pg.citya	W2_ADMIN_WARD	{"type": "Point", "coordinates": [74.9, 31.6]}	{}	1783555200000	system	1783555200000	system
+d6fa339e-c7b3-4d0e-8ef4-d5f80837c8a0	pg.citya	W3_ADMIN_WARD	{"type": "Point", "coordinates": [74.85, 31.65]}	{}	1783555200000	system	1783555200000	system
 \.
 
 


### PR DESCRIPTION
## Problem

On a fresh **db_fast_path** deploy, HRMS employee onboarding fails for every row with:

```
IllegalArgumentException: argument "content" is null   (HTTP 400)
```

The error surfaces in `egov-hrms`, but the origin is **`boundary-service`**. Its entity search `POST /boundary-service/boundary/_search` throws whenever a `boundary` row has `additionaldetails = NULL` — and the dump's `COPY public.boundary` block seeds **all 13 rows** with `\N`.

## Why it hides until employee creation

| Caller | Endpoint | Table | Affected? |
|---|---|---|---|
| Configurator jurisdiction validation | `/boundary-relationships/_search` | `boundary_relationship` | ✅ works |
| **HRMS `employees/_create`** | **`/boundary/_search`** | **`boundary`** | ❌ 400 on NULL additionaldetails |

So the sheet passes the configurator's validation, then every create 400s at the HRMS jurisdiction check. Nothing in the sheet is wrong.

## Fix

Seed `{}` (jsonb empty object) instead of `\N` for all 13 rows in the `COPY public.boundary` block. Scoped strictly to that block — `geometry`, timestamps, and every other column are untouched (13 insertions / 13 deletions, one field each).

## Verification (live pg deploy)

- Reproduced: `/boundary/_search` → 400 `argument "content" is null` for a NULL-additionaldetails boundary.
- `update boundary set additionaldetails = '{}' where additionaldetails is null` → entity search returns **200** for all 6 pg.citya boundaries.
- Full **HRMS `employees/_create` succeeds end to end** (user account + assignment + jurisdiction) once the boundaries are non-NULL.

## Note

This patches the seed so new deploys are correct. The deeper fix — boundary-service tolerating NULL `additionaldetails` on read — belongs in that service and is out of scope here; this unblocks the db_fast_path onboarding path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated boundary records in the local database setup so their additional details are represented as empty objects instead of null values.
  * Preserved existing boundary identifiers, locations, and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->