### PR TITLE
fix(citizen-ui-v2): drive mobile country code from globalConfigs, not hardcoded +254

### DIFF
--- a/digit-ui-v2/src/components/layout/CitizenLayout.tsx
+++ b/digit-ui-v2/src/components/layout/CitizenLayout.tsx
@@ -22,6 +22,12 @@ const NAV: { to: string; label: string; icon: React.ComponentType<{ className?: 
 export default function CitizenLayout() {
   const { state, logout } = useApp();
   const navigate = useNavigate();
+  // Country dial prefix from globalConfigs (injected by nginx/Ansible) — same
+  // source the login page uses. Falls back to +254 only if unconfigured, so the
+  // logged-in header matches the tenant's countryCode instead of hardcoding it.
+  const countryCode =
+    (window as unknown as { globalConfigs?: { getConfig?: (k: string) => { countryCode?: string } | undefined } })
+      .globalConfigs?.getConfig?.('CORE_MOBILE_CONFIGS')?.countryCode ?? '+254';
 
   return (
     <div className="min-h-screen flex flex-col bg-muted/20">
@@ -35,7 +41,7 @@ export default function CitizenLayout() {
           </div>
           <div className="flex items-center gap-3 text-sm">
             <span className="text-primary-foreground/80">
-              {state.user?.name || (state.user?.mobile ? `+254 ${state.user.mobile}` : '')}
+              {state.user?.name || (state.user?.mobile ? `${countryCode} ${state.user.mobile}` : '')}
             </span>
             <Button
               size="sm"

--- a/local-setup/ansible/templates/nginx-site.conf.j2
+++ b/local-setup/ansible/templates/nginx-site.conf.j2
@@ -59,10 +59,22 @@ server {
     add_header Cache-Control "public, max-age=31536000, immutable" always;
     try_files $uri =404;
   }
+  # digit-ui-v2 reads window.globalConfigs.getConfig('CORE_MOBILE_CONFIGS')
+  # (countryCode + mobileNumberRegex) at runtime, but its Vite index.html ships
+  # no <script> to define window.globalConfigs — so without this it falls back to
+  # a hardcoded +254/Kenya default. Inject the SAME globalConfigs.js the legacy
+  # /digit-ui/ uses (rendered from core_mobile_configs, carrying the tenant's
+  # +91), exactly as the /digit-ui/ block does below. Served via the exact-match
+  # location so it wins over the /citizen prefix.
+  location = /citizen/globalConfigs.js {
+    alias {{ digit_dir }}/nginx/globalConfigs.js;
+  }
   location /citizen {
     alias /var/www/citizen/;
     try_files $uri $uri/ /citizen/index.html;
     add_header Cache-Control "no-cache, must-revalidate" always;
+    sub_filter '</head>' '<script src="/citizen/globalConfigs.js"></script></head>';
+    sub_filter_once on;
   }
 
 {% endif %}

--- a/local-setup/ansible/templates/nginx-site.conf.j2
+++ b/local-setup/ansible/templates/nginx-site.conf.j2
@@ -65,9 +65,14 @@ server {
   # a hardcoded +254/Kenya default. Inject the SAME globalConfigs.js the legacy
   # /digit-ui/ uses (rendered from core_mobile_configs, carrying the tenant's
   # +91), exactly as the /digit-ui/ block does below. Served via the exact-match
-  # location so it wins over the /citizen prefix.
+  # location so it wins over the /citizen prefix. add_header does NOT inherit
+  # from the sibling /citizen block, so the no-cache header has to be repeated
+  # here (same as /digit-ui/globalConfigs.js) — otherwise the browser applies
+  # heuristic freshness and keeps serving a stale tenant config after a
+  # redeploy or a core_mobile_configs change.
   location = /citizen/globalConfigs.js {
     alias {{ digit_dir }}/nginx/globalConfigs.js;
+    add_header Cache-Control "no-cache, must-revalidate" always;
   }
   location /citizen {
     alias /var/www/citizen/;


### PR DESCRIPTION
## Problem

On an India (`pg`) deployment, the digit-ui-v2 citizen SPA at `/citizen/` shows **`+254` / "Kenyan"** on the login page and header, even though `core_mobile_configs` is `+91` and the legacy `/digit-ui/` citizen UI correctly shows `+91`.

Two independent causes:

**1. nginx never injects globalConfigs for `/citizen/`.** digit-ui-v2 reads `window.globalConfigs.getConfig('CORE_MOBILE_CONFIGS')` at runtime, but its Vite `index.html` ships no `<script>` to define `window.globalConfigs`. So the config read returns `undefined` and it falls back to a hardcoded `+254`. The legacy `/digit-ui/` block already injects `globalConfigs.js` via `sub_filter` — `/citizen/` just never got the same treatment.

**2. `CitizenLayout.tsx` hardcodes `+254 ${mobile}`** in the logged-in header, ignoring config entirely.

## Fix

- **nginx (`nginx-site.conf.j2`)**: for the `/citizen` block, inject the same rendered `globalConfigs.js` the legacy UI uses (`sub_filter '</head>' '<script src="/citizen/globalConfigs.js">…'` + an exact-match `alias` location). Same file, carrying the tenant's `core_mobile_configs`.
- **`CitizenLayout.tsx`**: read the prefix from `globalConfigs CORE_MOBILE_CONFIGS.countryCode`, fallback `+254` only if unconfigured — matching the login page (which already renders `{mobileCfg.prefix}`).

## Verification (live pg deploy)

Rendered `/citizen/` in a real headless Chromium before/after:

- **Before**: `+254` badge, placeholder `712345678`, copy "Enter your **Kenyan** mobile number."
- **After**: `+91` badge, placeholder `7000000000`, copy "Enter your mobile number."

`/citizen/globalConfigs.js` serves 200 with `countryCode: "+91"`, and the `sub_filter` injects the `<script>` into `index.html`. The built bundle's only remaining `+254` are `?? '+254'` fallbacks (the hardcoded `+254 ${mobile}` display literal is gone).

## Build-source note

develop's in-repo `digit-ui-v2/` is config-driven for the login prefix already (`{mobileCfg.prefix}`) and builds clean (`tsc -b` passes). The deploy's pinned source (`ChakshuGautam` fork `@feat/digit-ui-v2-keycloak`) still hardcodes it — so operators should point `digit_ui_v2_repo` at this repo's `digit-ui-v2/` to get the config-driven build. Flagging for review: confirm the in-repo `digit-ui-v2/` is the intended deploy source vs the fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Citizen-facing pages now use tenant-configured country codes for logged-in identifiers.
  * Runtime configuration is automatically loaded for the Citizen application, enabling environment-specific settings.

* **Bug Fixes**
  * Corrected mobile header display to avoid relying on a fixed country code.
  * Ensured runtime configuration is loaded without browser caching, so updated settings are applied reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->