### PR TITLE
CCSD-2067 + login/OTP pt_PT localisations (subtitle, phone screen, mobile validation, OTP)

### DIFF
--- a/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-common.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-common.json
@@ -6,6 +6,78 @@
         "locale": "pt_PT"
     },
     {
+        "code": "CS_LOGIN_PROVIDE_MOBILE_NUMBER",
+        "message": "Introduza o seu número de telemóvel",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CORE_COMMON_MOBILE_NUMBER",
+        "message": "Número de Telemóvel",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "ERR_INVALID_MOBILE_NUMBER",
+        "message": "Por favor, introduza um número de telemóvel válido",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "MOBILE_VALIDATION_DIGITS",
+        "message": "dígitos",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "MOBILE_VALIDATION_STARTING_WITH",
+        "message": "começando por",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "MOBILE_VALIDATION_AT_LEAST",
+        "message": "pelo menos",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "MOBILE_VALIDATION_OR",
+        "message": "ou",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_COMMONS_NEXT",
+        "message": "Seguinte",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_LOGIN_OTP",
+        "message": "Verificação do OTP",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_LOGIN_OTP_TEXT",
+        "message": "Introduza o OTP enviado para",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_RESEND_OTP",
+        "message": "Reenviar OTP",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_RESEND_ANOTHER_OTP",
+        "message": "Reenviar OTP em",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
         "code": "EVENTS_DATERANGE_LABEL",
         "message": "Intervalo de Datas",
         "module": "rainmaker-common",

--- a/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-common.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-common.json
@@ -1,5 +1,11 @@
 [
     {
+        "code": "CS_LOGIN_TEXT",
+        "message": "Todas as comunicações referentes à reclamação/queixa serão enviadas para este número de telemóvel.",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
         "code": "EVENTS_DATERANGE_LABEL",
         "message": "Intervalo de Datas",
         "module": "rainmaker-common",


### PR DESCRIPTION
## What & why
Adds missing **pt_PT** localisations for the citizen **login/OTP** flow (module `rainmaker-common`). These strings had no pt_PT rows, so the page fell back to English. Includes the CCSD-2067 subtitle fix plus the rest of the login + OTP screens.

## Strings added (pt_PT)
**Phone-number screen**
- `CS_LOGIN_TEXT` — *Todas as comunicações referentes à reclamação/queixa serão enviadas para este número de telemóvel.* (**CCSD-2067** — was 'candidatura'/English)
- `CS_LOGIN_PROVIDE_MOBILE_NUMBER` — *Introduza o seu número de telemóvel*
- `CORE_COMMON_MOBILE_NUMBER` — *Número de Telemóvel*
- `CS_COMMONS_NEXT` — *Seguinte*
- Mobile-validation error (composed by `buildMobileErrorMessage` from the tenant regex): `ERR_INVALID_MOBILE_NUMBER`, `MOBILE_VALIDATION_DIGITS`, `MOBILE_VALIDATION_STARTING_WITH`, `MOBILE_VALIDATION_AT_LEAST`, `MOBILE_VALIDATION_OR` → e.g. *Por favor, introduza um número de telemóvel válido (9 dígitos, começando por 8)*

**OTP screen**
- `CS_LOGIN_OTP` — *Verificação do OTP*
- `CS_LOGIN_OTP_TEXT` — *Introduza o OTP enviado para* (number appended by the app)
- `CS_RESEND_OTP` — *Reenviar OTP*
- `CS_RESEND_ANOTHER_OTP` — *Reenviar OTP em* (countdown)

## Notes
- File: `utilities/default-data-handler/.../localisations/pt_PT/rainmaker-common.json`. Base is `release-v2.12-moz`.
- Applied to the running localisation (state tenant `mz`, inherited by `mz.ige`) and verified on the live login/OTP screens before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)