### PR TITLE
CCSD-2070: Update confidentiality toggle description for clarity

### DIFF
--- a/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
@@ -1339,7 +1339,7 @@
     },
     {
         "code": "PGR_EXT_IS_CONFIDENTIAL_HINT",
-        "message": "A visibilidade é garantida assim que o processamento seguro é ativado; por enquanto, isso sinaliza a reclamação para que a equipe esteja ciente.",
+        "message": "A sua identidade será protegida através do mascaramento dos dados pessoais, sendo acessível apenas a oficiais seniores autorizados.",
         "module": "rainmaker-pgr",
         "locale": "pt_PT"
     },


### PR DESCRIPTION
## What & why
The confidentiality toggle on the complaint-registration page had a confusing disclaimer. This replaces it with a clear explanation of how identity protection works (data masking, senior-officer-only access).

## Change (pt_PT, `rainmaker-pgr`)
`PGR_EXT_IS_CONFIDENTIAL_HINT`:
- **before:** *A visibilidade é garantida assim que o processamento seguro é ativado; por enquanto, isso sinaliza a reclamação para que a equipe esteja ciente.*
- **after:** *A sua identidade será protegida através do mascaramento dos dados pessoais, sendo acessível apenas a oficiais seniores autorizados.*

Label `PGR_EXT_IS_CONFIDENTIAL_LABEL` (*Mantenha os detalhes confidenciais.*) unchanged, so the full toggle text reads as the ticket's expected text.

## Notes
- Base `release-v2.12-moz`. File: `.../localisations/pt_PT/rainmaker-pgr.json`.
- Applied to the running localisation (state tenant `mz`, inherited by `mz.ige`) and verified on the live registration page before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)