### PR TITLE
feat(pgr): single-authority auto-select + testing-entrance scoping (citizen flow)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintsList.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintsList.js
@@ -291,6 +291,22 @@ export const ComplaintsList = () => {
     return v === key ? fallback : v;
   };
 
+  // Entrance scoping for the testing tenant: the citizen "my complaints"
+  // search runs at the STATE tenant, which spans every child tenant — so a
+  // tester who used a personal mobile on the testing entrance would otherwise
+  // see TST- rows mixed into their real list here. The prod entrance drops
+  // testing-tenant rows; the testing entrance (TESTING_MODE) lists ONLY them.
+  // Deployments without a testing setup (no TESTING_TENANT_ID) are untouched.
+  const visibleWrappers = React.useMemo(() => {
+    const all = data?.ServiceWrappers || [];
+    const testingTenant = window?.globalConfigs?.getConfig?.("TESTING_TENANT_ID");
+    if (!testingTenant) return all;
+    const isTestingEntrance = !!window?.globalConfigs?.getConfig?.("TESTING_MODE");
+    return all.filter(({ service }) =>
+      isTestingEntrance ? service?.tenantId === testingTenant : service?.tenantId !== testingTenant
+    );
+  }, [data]);
+
   return (
     <div
       className="v2-scope"
@@ -351,7 +367,7 @@ export const ComplaintsList = () => {
               </Button>
             }
           />
-        ) : !data?.ServiceWrappers?.length ? (
+        ) : !visibleWrappers.length ? (
           <EmptyState
             icon={<Inbox style={{ height: "1.5rem", width: "1.5rem" }} />}
             title={tr("CS_NO_COMPLAINTS_TITLE", "No complaints yet")}
@@ -370,7 +386,7 @@ export const ComplaintsList = () => {
               gap: "12px",
             }}
           >
-            {data.ServiceWrappers.map(({ service }) => (
+            {visibleWrappers.map(({ service }) => (
               <ComplaintRow
                 key={service.serviceRequestId}
                 data={service}

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
@@ -1455,7 +1455,8 @@ function StepComplaint(props: StepBodyProps) {
           ? tr(t, "CS_HINT_TYPE_SUB", "This helps us route your complaint to the right team.")
           : tr(t, "CS_HINT_RELATED_SUB", "Based on your selection, relevant options will appear automatically.")}
       />
-      {hasDispatcher ? <RelatedToStepBody {...props} /> : null}
+      {/* Single-authority: the one option is auto-selected upstream — no picker. */}
+      {hasDispatcher && (relatedToOptions?.length ?? 0) > 1 ? <RelatedToStepBody {...props} /> : null}
       <ReporterDetailsCard {...props} />
       {showType ? (
         catalogueLoading ? <InlineSpinner /> : <Step0Type {...props} />
@@ -1648,11 +1649,38 @@ const CreatePGRFlowV2: React.FC = () => {
       select: (raw: any) =>
         ((raw?.["RAINMAKER-PGR"]?.ComplaintRelatedToMap || []) as RelatedToOption[])
           .filter((o) => o?.active !== false && !!o?.code && !!o?.name && !!o?.tenantCode)
+          // Entrance scoping: the TESTING entrance (globalConfigs TESTING_MODE
+          // + TESTING_TENANT_ID, served only at the gated /testing-ui path)
+          // sees ONLY the testing authority; every other entrance never sees
+          // it. Same MDMS rows, no schema change — the tenantCode is the flag.
+          .filter((o) => {
+            const testingTenant = window?.globalConfigs?.getConfig?.("TESTING_TENANT_ID");
+            if (!testingTenant) return true; // deployment without a testing setup
+            const isTestingEntrance = !!window?.globalConfigs?.getConfig?.("TESTING_MODE");
+            return isTestingEntrance ? o.tenantCode === testingTenant : o.tenantCode !== testingTenant;
+          })
           .sort((a, b) => (a.displayOrder ?? 0) - (b.displayOrder ?? 0)),
     },
     { schemaCode: "PGR_COMPLAINT_RELATED_TO_MAP", tenantId: stateTenant }
   );
   const hasDispatcher = Array.isArray(relatedToOptions) && relatedToOptions.length > 0;
+
+  // Single-authority deployments (one active row — e.g. IGE-only after the
+  // split, or the testing entrance): the authority is a foregone conclusion,
+  // so pick it automatically and never render the dropdown. Multi-authority
+  // keeps the picker exactly as before. The auto-pick mirrors the manual
+  // handler's patch (resolvedTenantId drives catalogue/boundary/map fetches).
+  React.useEffect(() => {
+    if (!Array.isArray(relatedToOptions) || relatedToOptions.length !== 1) return;
+    const o = relatedToOptions[0];
+    if (formData.caseRelatedTo === o.code && formData.resolvedTenantId === o.tenantCode) return;
+    patch({
+      caseRelatedTo: o.code,
+      caseRelatedToName: o.name,
+      resolvedTenantId: o.tenantCode,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [relatedToOptions, formData.caseRelatedTo, formData.resolvedTenantId]);
 
   // Catalogue tenant: the authority-resolved sub-tenant once picked, else the
   // base tenant (legacy). Changing it re-fetches the hierarchy at that tenant.


### PR DESCRIPTION
Part 1 of the testing-entrance goal (FE half; ansible half follows separately).

## 1. Single-authority dispatcher (Req 1)
ComplaintRelatedToMap with exactly ONE active row → authority auto-selected (caseRelatedTo + resolvedTenantId) and the dropdown never renders. Multi-row unchanged; zero-row legacy unchanged. With the IGSAE row deactivated (active:false — reversible data change), the citizen goes straight to the complaint-type step. Same build serves current combined env + future IGE-only and IGSAE-only servers via MDMS alone.

## 2. Testing-entrance scoping (Req 2, FE half)
Driven by globalConfigs `TESTING_MODE` + `TESTING_TENANT_ID` (served only at the nginx-gated `/testing-ui` path):
- dispatcher options filtered per entrance (testing sees only the testing authority; prod never sees it) — tenantCode is the flag, no schema change
- citizen complaints list scoped per entrance — the state-tenant search spans child tenants (verified empirically), so prod drops TST rows and testing lists only them

Deployments without `TESTING_TENANT_ID` are byte-identical to today.

## Verified live (local)
- prod `/digit-ui`: dispatcher hidden, IGE auto-selected, draft bleed from the other entrance self-heals, complaints list empty for a testing-only citizen, no banner
- `/testing-ui` (basic-auth gate): IGETESTING auto-selected, complaint **TST-2026-000015** filed end-to-end (TST- idgen prefix), listed with the AMBIENTE DE TESTE banner; TSTREC test employee sees it in search

🤖 Generated with [Claude Code](https://claude.com/claude-code)