### PR TITLE
feat(deploy): /testing-ui entrance — templated nginx gate + idempotent tenant seeder (default OFF)

### DIFF
--- a/local-setup/ansible/inventory/group_vars/digit.yml
+++ b/local-setup/ansible/inventory/group_vars/digit.yml
@@ -188,3 +188,11 @@ digit_ui_esbuild_branch: main
 # single tenant, set digit_ui_bundle_image in that host_vars file (as pg.test
 # does). Set to "" in host_vars to force an on-host build even if this is on.
 # digit_ui_bundle_image: "ghcr.io/subhashini-egov/digit-ui-esbuild:nightly-develop"
+
+# ── TESTING ENTRANCE (/testing-ui) — default OFF everywhere. ──
+# Opt in per box via host_vars:
+#   testing_ui_enabled: true
+#   testing_tenant: mz.igetesting          # hidden QA tenant
+#   testing_ui_htpasswd: "tester:$apr1$…"  # pre-hashed; keep in vault
+# Optional: testing_seed_source_tenant, testing_ui_banner, testing_emp_password.
+testing_ui_enabled: false

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -648,6 +648,46 @@
         dest: "{{ digit_dir }}/nginx/globalConfigs.js"
         mode: '0644'
 
+    # ==================== TESTING ENTRANCE (/testing-ui) ====================
+    # Everything below renders ONLY when host_vars sets testing_ui_enabled —
+    # default-off boxes produce byte-identical output to before this feature.
+    - name: Render digit-ui globalConfigs.testing.js (testing entrance)
+      when: testing_ui_enabled | default(false)
+      template:
+        src: templates/globalConfigs.js.j2
+        dest: "{{ digit_dir }}/nginx/globalConfigs.testing.js"
+        mode: '0644'
+      vars:
+        context_path: "testing-ui"
+        gc_testing_mode: true
+        login_tenant_allowlist: ["{{ testing_tenant }}"]
+        city_tenant: "{{ testing_tenant }}"
+
+    - name: Write testing-entrance htpasswd
+      when: testing_ui_enabled | default(false)
+      copy:
+        # Pre-hashed htpasswd line(s), e.g. output of:
+        #   printf "tester:%s" "$(openssl passwd -apr1 '<password>')"
+        # Keep the value in vault — it gates the entire testing entrance.
+        content: "{{ testing_ui_htpasswd }}\n"
+        dest: "{{ digit_dir }}/nginx/.htpasswd-testing"
+        mode: '0640'
+
+    - name: Seed the testing tenant (idempotent; additive only)
+      when: testing_ui_enabled | default(false)
+      command: python3 {{ playbook_dir }}/../scripts/seed-testing-tenant.py
+      environment:
+        DIGIT_BASE: "http://localhost"
+        TESTING_TENANT: "{{ testing_tenant }}"
+        SOURCE_TENANT: "{{ testing_seed_source_tenant | default(city_tenant) }}"
+        STATE_TENANT: "{{ state_tenant_id }}"
+        HIERARCHY_TYPE: "{{ hierarchy_type | default('divisao_administrativa') }}"
+        ADMIN_USER: "{{ testing_seed_admin_user | default('ADMIN') }}"
+        ADMIN_PASS: "{{ testing_seed_admin_pass | default('eGov@123') }}"
+        TEST_EMP_PASS: "{{ testing_emp_password | default('eGov@123') }}"
+      register: testing_seed
+      changed_when: "'CREATED' in testing_seed.stdout or 'UPDATED' in testing_seed.stdout"
+
     - name: Add API proxy to digit-ui nginx config
       copy:
         content: |
@@ -705,6 +745,29 @@
               default_type text/html;
             }
 
+            {% if testing_ui_enabled | default(false) %}
+            # ── TESTING ENTRANCE — same bundle, testing config, password at
+            #    the door. Rendered only when testing_ui_enabled. ──
+            location /testing-ui {
+              auth_basic           "Testing";
+              auth_basic_user_file /host-nginx/.htpasswd-testing;
+              alias /var/web/digit-ui;
+              index index.html;
+              try_files $uri $uri/ /testing-ui/index.html;
+              sub_filter '</head>' '<script src="/testing-ui/globalConfigs.js"></script></head>';
+              sub_filter '<div id="root">' '<div style="position:fixed;bottom:0;left:0;right:0;z-index:99999;background:#B32D2D;color:#fff;text-align:center;font:600 12px/1.6 Roboto,sans-serif;padding:3px 8px">{{ testing_ui_banner | default('TESTING ENVIRONMENT &#8212; data created here is not real') }}</div><div id="root">';
+              add_header Cache-Control "no-cache" always;
+            }
+
+            location = /testing-ui/globalConfigs.js {
+              auth_basic           "Testing";
+              auth_basic_user_file /host-nginx/.htpasswd-testing;
+              alias /host-nginx/globalConfigs.testing.js;
+              default_type application/javascript;
+              add_header Cache-Control "no-cache, must-revalidate" always;
+            }
+
+            {% endif %}
             # Proxy API calls to Kong gateway
             location / {
               set $kong http://kong-gateway:8000;

--- a/local-setup/ansible/templates/globalConfigs.js.j2
+++ b/local-setup/ansible/templates/globalConfigs.js.j2
@@ -85,7 +85,18 @@ var globalConfigs = (function () {
   var tokenExchangeUrl = {{ (token_exchange_url | default('')) | to_json }};
   if (!tokenExchangeUrl) { tokenExchangeUrl = "/kc"; }
 
+{% if testing_ui_enabled | default(false) %}
+  // Testing entrance (see nginx /testing-ui). TESTING_TENANT_ID renders on
+  // BOTH entrances (the prod entrance uses it to EXCLUDE testing rows);
+  // TESTING_MODE is true only in the testing render.
+  var testingTenantId = {{ testing_tenant | to_json }};
+  var testingMode = {{ (gc_testing_mode | default(false)) | to_json }};
+{% endif %}
   var getConfig = function (key) {
+{% if testing_ui_enabled | default(false) %}
+    if (key === "TESTING_MODE") return testingMode;
+    if (key === "TESTING_TENANT_ID") return testingTenantId;
+{% endif %}
     if (key === "EMPLOYEE_MODULE_DENYLIST") return employeeModuleDenylist;
     if (key === "LOGIN_TENANT_ALLOWLIST") return loginTenantAllowlist;
     if (key === "STATE_LEVEL_TENANT_ID") {

--- a/local-setup/ansible/templates/nginx-site.conf.j2
+++ b/local-setup/ansible/templates/nginx-site.conf.j2
@@ -400,6 +400,31 @@ server {
 
 {% endif %}
 {% if digit_ui_mode == "static" %}
+{% if testing_ui_enabled | default(false) %}
+  # ── TESTING ENTRANCE (static mode) — same build, testing config, password
+  #    at the door. Rendered ONLY when host_vars sets testing_ui_enabled. ──
+  location = /testing-ui {
+    return 302 /testing-ui/;
+  }
+  location /testing-ui/ {
+    auth_basic           "Testing";
+    auth_basic_user_file {{ digit_dir }}/nginx/.htpasswd-testing;
+    alias /opt/digit-ui-esbuild/build/;
+    try_files $uri $uri/ /testing-ui/index.html;
+    add_header Cache-Control "no-cache" always;
+    sub_filter_once on;
+    sub_filter_types text/html;
+    sub_filter '</head>' '<script src="/testing-ui/globalConfigs.js"></script></head>';
+    sub_filter '<div id="root">' '<div style="position:fixed;bottom:0;left:0;right:0;z-index:99999;background:#B32D2D;color:#fff;text-align:center;font:600 12px/1.6 Roboto,sans-serif;padding:3px 8px">{{ testing_ui_banner | default('TESTING ENVIRONMENT &#8212; data created here is not real') }}</div><div id="root">';
+  }
+  location = /testing-ui/globalConfigs.js {
+    auth_basic           "Testing";
+    auth_basic_user_file {{ digit_dir }}/nginx/.htpasswd-testing;
+    alias {{ digit_dir }}/nginx/globalConfigs.testing.js;
+    default_type application/javascript;
+    add_header Cache-Control "no-cache, must-revalidate" always;
+  }
+{% endif %}
   # digit-ui in static mode: host nginx serves the build artifact from
   # /opt/digit-ui-esbuild/build/ directly. Built by the playbook
   # (`node esbuild.build.js`) — no inner Docker container, no esbuild
@@ -508,6 +533,23 @@ server {
   # Kong. The pre-fix template had NO `container` branch, so this fell
   # into the HMR `else` and sent /user/oauth/token to
   # :{{ upstream_esbuild_port }} (no API there) → 504 on every login.
+{% if testing_ui_enabled | default(false) %}
+  # ── TESTING ENTRANCE (container mode) — host routes; auth + config live in
+  #    the container's digit-ui.conf (rendered by the playbook). ──
+  location = /testing-ui {
+    return 302 /testing-ui/;
+  }
+  location /testing-ui/ {
+    proxy_set_header Accept-Encoding "";
+    proxy_pass http://{{ nginx_upstream_host | default('127.0.0.1') }}:{{ upstream_esbuild_port }};
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_read_timeout 120s;
+    proxy_buffering off;
+  }
+{% endif %}
   location = /digit-ui {
     return 302 /digit-ui/;
   }

--- a/local-setup/scripts/seed-testing-tenant.py
+++ b/local-setup/scripts/seed-testing-tenant.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Seed the hidden TESTING tenant for the /testing-ui entrance.
+
+Run by the deploy playbook when `testing_ui_enabled: true` (idempotent —
+every create treats an already-exists/duplicate response as success), or by
+hand:
+
+    DIGIT_BASE=http://localhost TESTING_TENANT=mz.igetesting \
+    SOURCE_TENANT=mz.ige STATE_TENANT=mz \
+    ADMIN_USER=ADMIN ADMIN_PASS='eGov@123' \
+    python3 seed-testing-tenant.py
+
+What it seeds (all ADDITIVE — no prod record is modified):
+  MDMS  : tenant.tenants row, tenant.citymodule membership (PGR+HRMS),
+          RAINMAKER-PGR.ComplaintRelatedToMap row (code <TESTING_CODE>),
+          RAINMAKER-PGR.ComplaintTemplateType clone (extendedAttributes
+          validation reads it at create), RAINMAKER-PGR.MapConfig
+          (boundaryTenantId = the testing tenant), common-masters.IdFormat
+          (TST- complaint prefix), common-masters.Department +
+          Designation clones (HRMS validates them per tenant).
+  BOUNDARY: hierarchy definition + full relationship tree + geometry
+          copied from SOURCE_TENANT.
+  LOC   : boundary-label module copied to the testing tenant (labels load
+          at the TREE's tenant); entrance labels at the state tenant.
+  HRMS  : 4 test employees (reception/screening/supervisor/case manager),
+          password eGov@123 — CHANGE ON REAL DEPLOYMENTS via TEST_EMP_PASS.
+
+Deliberately NOT seeded: NotificationRouting/Template (no SMS/email ever
+fires from the testing tenant) and any DSS/dashboard config.
+"""
+import json
+import os
+import sys
+import time
+import urllib.parse
+import urllib.request
+
+BASE = os.environ.get("DIGIT_BASE", "http://localhost")
+T = os.environ.get("TESTING_TENANT", "mz.igetesting")
+SRC = os.environ.get("SOURCE_TENANT", "mz.ige")
+STATE = os.environ.get("STATE_TENANT", "mz")
+CODE = os.environ.get("TESTING_CODE", "IGETESTING")
+HIER = os.environ.get("HIERARCHY_TYPE", "divisao_administrativa")
+ADMIN_USER = os.environ.get("ADMIN_USER", "ADMIN")
+ADMIN_PASS = os.environ.get("ADMIN_PASS", "eGov@123")
+EMP_PASS = os.environ.get("TEST_EMP_PASS", "eGov@123")
+
+CHANGED = False
+
+
+def call(path, body):
+    req = urllib.request.Request(BASE + path, data=json.dumps(body).encode(),
+                                 headers={"Content-Type": "application/json"})
+    try:
+        return json.load(urllib.request.urlopen(req))
+    except urllib.error.HTTPError as e:
+        return {"HTTPError": e.code, "body": e.read().decode()[:400]}
+
+
+def ok_or_dup(r, label):
+    """Create responses: success OR already-exists both count as seeded."""
+    global CHANGED
+    status = r.get("ResponseInfo", {}).get("status")
+    if status == "successful":
+        CHANGED = True
+        print(f"CREATED {label}")
+        return True
+    body = r.get("body", "")
+    if r.get("HTTPError") and ("DUPLICATE" in body or "already exist" in body.lower() or "unique" in body.lower()):
+        print(f"exists  {label}")
+        return True
+    print(f"FAILED  {label}: {r}", file=sys.stderr)
+    return False
+
+
+def auth():
+    data = urllib.parse.urlencode({
+        "username": ADMIN_USER, "password": ADMIN_PASS, "grant_type": "password",
+        "scope": "read", "tenantId": STATE, "userType": "EMPLOYEE"}).encode()
+    req = urllib.request.Request(BASE + "/user/oauth/token", data=data, headers={
+        "Authorization": "Basic ZWdvdi11c2VyLWNsaWVudDo=",
+        "Content-Type": "application/x-www-form-urlencoded"})
+    d = json.load(urllib.request.urlopen(req))
+    return {"authToken": d["access_token"], "userInfo": d["UserRequest"]}
+
+
+RI = auth()
+
+
+def mdms_rows(schema, tenant, limit=200):
+    return call("/mdms-v2/v2/_search", {"RequestInfo": RI, "MdmsCriteria": {
+        "tenantId": tenant, "schemaCode": schema, "limit": limit}}).get("mdms", [])
+
+
+def mdms_create(schema, tenant, uid, data):
+    return ok_or_dup(call(f"/mdms-v2/v2/_create/{schema}", {"RequestInfo": RI, "Mdms": {
+        "tenantId": tenant, "schemaCode": schema, "uniqueIdentifier": uid,
+        "isActive": True, "data": data}}), f"{schema}@{tenant}/{uid}")
+
+
+def mdms_update(row):
+    r = call(f"/mdms-v2/v2/_update/{row['schemaCode']}", {"RequestInfo": RI, "Mdms": row})
+    return r.get("ResponseInfo", {}).get("status") == "successful"
+
+
+# ── 1. tenants row ───────────────────────────────────────────────────────────
+existing = {r["data"].get("code") for r in mdms_rows("tenant.tenants", STATE)}
+if T not in existing:
+    src = [r for r in mdms_rows("tenant.tenants", STATE) if r["data"].get("code") == SRC][0]
+    d = dict(src["data"])
+    d.update({"code": T, "name": f"{CODE.title()} (Testing)", "tenantId": T,
+              "description": "TESTING tenant - QA only, not for production users"})
+    d["city"] = {**d.get("city", {}), "code": T.upper(), "name": f"{CODE.title()} (Testing)",
+                 "districtTenantCode": T}
+    mdms_create("tenant.tenants", STATE, T, d)
+else:
+    print(f"exists  tenant.tenants/{T}")
+
+# ── 2. citymodule membership ─────────────────────────────────────────────────
+for row in mdms_rows("tenant.citymodule", STATE):
+    if row["data"].get("code") in ("PGR", "HRMS"):
+        codes = [x["code"] for x in row["data"].get("tenants", [])]
+        if T not in codes:
+            row["data"]["tenants"].append({"code": T})
+            if mdms_update(row):
+                CHANGED = True
+                print(f"UPDATED citymodule/{row['data']['code']} += {T}")
+        else:
+            print(f"exists  citymodule/{row['data']['code']}")
+
+# ── 3. dispatcher row + template clone ───────────────────────────────────────
+crtm = mdms_rows("RAINMAKER-PGR.ComplaintRelatedToMap", STATE)
+if not any(r["data"].get("code") == CODE for r in crtm):
+    mdms_create("RAINMAKER-PGR.ComplaintRelatedToMap", STATE, CODE, {
+        "code": CODE, "name": f"PGR_RELATEDTO_NAME_{CODE}", "active": True,
+        "tenantId": STATE, "shortName": CODE, "tenantCode": T, "displayOrder": 99})
+else:
+    print(f"exists  ComplaintRelatedToMap/{CODE}")
+
+tpls = mdms_rows("RAINMAKER-PGR.ComplaintTemplateType", STATE)
+if not any(r["data"].get("caseRelatedTo") == CODE for r in tpls):
+    src_tpl = [r for r in tpls if r["data"].get("caseRelatedTo") != CODE][0]
+    d = dict(src_tpl["data"]); d["caseRelatedTo"] = CODE
+    mdms_create("RAINMAKER-PGR.ComplaintTemplateType", STATE, CODE, d)
+else:
+    print(f"exists  ComplaintTemplateType/{CODE}")
+
+# ── 4. MapConfig + IdFormat at the testing tenant ────────────────────────────
+if not mdms_rows("RAINMAKER-PGR.MapConfig", T):
+    base = mdms_rows("RAINMAKER-PGR.MapConfig", STATE)
+    d = dict(base[0]["data"]) if base else {"code": "DEFAULT"}
+    d["boundaryTenantId"] = T
+    mdms_create("RAINMAKER-PGR.MapConfig", T, "DEFAULT", d)
+else:
+    print("exists  MapConfig")
+
+seq = "SEQ_EG_PGR" + T.replace(".", "").upper()
+if not any(r["data"].get("idname") == "pgr.servicerequestid" for r in mdms_rows("common-masters.IdFormat", T)):
+    mdms_create("common-masters.IdFormat", T, "pgr.servicerequestid",
+                {"format": f"TST-[cy:yyyy]-[{seq}]", "idname": "pgr.servicerequestid"})
+else:
+    print("exists  IdFormat")
+
+# ── 5. Department + Designation clones (HRMS validates per tenant) ───────────
+have_depts = {r["data"].get("code") for r in mdms_rows("common-masters.Department", T)}
+src_depts = mdms_rows("common-masters.Department", SRC)
+central = [r for r in src_depts if r["data"].get("code") == "central"] or src_depts[:1]
+for r in central:
+    if r["data"]["code"] not in have_depts:
+        mdms_create("common-masters.Department", T, r["uniqueIdentifier"], dict(r["data"]))
+have_desig = {r["data"].get("code") for r in mdms_rows("common-masters.Designation", T)}
+for r in mdms_rows("common-masters.Designation", SRC):
+    if r["data"]["code"] not in have_desig:
+        mdms_create("common-masters.Designation", T, r["uniqueIdentifier"], dict(r["data"]))
+
+# ── 6. boundary: definition + tree + geometry copy ───────────────────────────
+d = call("/boundary-service/boundary-hierarchy-definition/_search", {"RequestInfo": RI,
+        "BoundaryTypeHierarchySearchCriteria": {"tenantId": T, "hierarchyType": HIER, "limit": 1, "offset": 0}})
+if not (d.get("BoundaryHierarchy") or []):
+    s = call("/boundary-service/boundary-hierarchy-definition/_search", {"RequestInfo": RI,
+            "BoundaryTypeHierarchySearchCriteria": {"tenantId": SRC, "hierarchyType": HIER, "limit": 1, "offset": 0}})
+    bh = [{"boundaryType": b["boundaryType"], "parentBoundaryType": b.get("parentBoundaryType"), "active": True}
+          for b in s["BoundaryHierarchy"][0]["boundaryHierarchy"]]
+    call("/boundary-service/boundary-hierarchy-definition/_create", {"RequestInfo": RI,
+         "BoundaryHierarchy": {"tenantId": T, "hierarchyType": HIER, "boundaryHierarchy": bh}})
+    CHANGED = True
+    print("CREATED boundary hierarchy definition")
+else:
+    print("exists  boundary hierarchy definition")
+
+tree = call(f"/boundary-service/boundary-relationships/_search?tenantId={T}&hierarchyType={HIER}&includeChildren=true",
+            {"RequestInfo": RI})
+have_nodes = set()
+def _walk(n):
+    have_nodes.add(n["code"])
+    for c in n.get("children") or []:
+        _walk(c)
+for tb in tree.get("TenantBoundary", []):
+    b = tb.get("boundary"); b = b if isinstance(b, list) else ([b] if b else [])
+    for root in b:
+        _walk(root)
+
+src_tree = call(f"/boundary-service/boundary-relationships/_search?tenantId={SRC}&hierarchyType={HIER}&includeChildren=true",
+                {"RequestInfo": RI})
+nodes = []
+def _collect(n, parent):
+    nodes.append({"code": n["code"], "boundaryType": n.get("boundaryType"), "parent": parent})
+    for c in n.get("children") or []:
+        _collect(c, n["code"])
+for tb in src_tree.get("TenantBoundary", []):
+    b = tb.get("boundary"); b = b if isinstance(b, list) else ([b] if b else [])
+    for root in b:
+        _collect(root, None)
+
+missing = [n for n in nodes if n["code"] not in have_nodes]
+if missing:
+    codes = [n["code"] for n in nodes]
+    geo = {}
+    for i in range(0, len(codes), 40):
+        g = call(f"/boundary-service/boundary/_search?tenantId={SRC}&codes={','.join(codes[i:i+40])}&limit=100",
+                 {"RequestInfo": RI})
+        for row in g.get("Boundary", []):
+            geo[row["code"]] = row.get("geometry")
+    ents = [{"tenantId": T, "code": n["code"], "geometry": geo.get(n["code"])} for n in missing]
+    for i in range(0, len(ents), 40):
+        call("/boundary-service/boundary/_create", {"RequestInfo": RI, "Boundary": ents[i:i+40]})
+    made = 0
+    for n in missing:  # BFS order — parents before children
+        r = call("/boundary-service/boundary-relationships/_create", {"RequestInfo": RI,
+                 "BoundaryRelationship": {"tenantId": T, "code": n["code"], "hierarchyType": HIER,
+                                          "boundaryType": n["boundaryType"], "parent": n["parent"]}})
+        if r.get("TenantBoundary") is not None or (r.get("ResponseInfo") and not r.get("HTTPError")):
+            made += 1
+    CHANGED = True
+    print(f"CREATED boundary tree: {made}/{len(missing)} nodes copied")
+else:
+    print(f"exists  boundary tree ({len(have_nodes)} nodes)")
+
+# ── 7. localization: boundary labels + entrance labels ───────────────────────
+MOD = f"rainmaker-boundary-{HIER}"
+for loc in ("pt_PT", "en_IN"):
+    msgs = []
+    for src_t in (SRC, STATE):
+        r = call(f"/localization/messages/v1/_search?tenantId={src_t}&locale={loc}&module={MOD}", {"RequestInfo": RI})
+        msgs = r.get("messages", [])
+        if msgs:
+            break
+    if msgs:
+        up = [{"code": m["code"], "message": m["message"], "module": MOD, "locale": loc} for m in msgs]
+        call("/localization/messages/v1/_upsert", {"RequestInfo": RI, "tenantId": T, "messages": up})
+        print(f"seeded  boundary labels {loc}: {len(up)}")
+labels = {
+    "pt_PT": [(f"TENANT_TENANTS_{T.replace('.', '_').upper()}", f"{CODE.title()} (Ambiente de Teste)"),
+              (f"PGR_RELATEDTO_NAME_{CODE}", f"{CODE.title()} (Ambiente de Teste)")],
+    "en_IN": [(f"TENANT_TENANTS_{T.replace('.', '_').upper()}", f"{CODE.title()} (Testing)"),
+              (f"PGR_RELATEDTO_NAME_{CODE}", f"{CODE.title()} (Testing)")],
+}
+for loc, pairs in labels.items():
+    up = [{"code": c, "message": m, "module": "rainmaker-common", "locale": loc} for c, m in pairs]
+    call("/localization/messages/v1/_upsert", {"RequestInfo": RI, "tenantId": STATE, "messages": up})
+print("seeded  entrance labels")
+
+# ── 8. HRMS test employees (full CMS chain) ──────────────────────────────────
+ROLES = {"TSTREC": ("CMS_RECEPTION_OFFICER", "reception_officer", "Tester Recepcao"),
+         "TSTSCR": ("CMS_SCREENING_OFFICER", "screening_officer", "Tester Triagem"),
+         "TSTSUP": ("CMS_SUPERVISOR", "supervisor", "Tester Supervisor"),
+         "TSTCM": ("CMS_CASE_MANAGER", "case_manager", "Tester Gestor de Caso")}
+prov = next((n["code"] for n in nodes if n["parent"] is None), None)
+now = int(time.time() * 1000)
+i = 0
+for code, (role, desig, name) in ROLES.items():
+    i += 1
+    r = call(f"/egov-hrms/employees/_search?tenantId={T}&codes={code}&limit=2&offset=0", {"RequestInfo": RI})
+    if r.get("Employees"):
+        print(f"exists  employee {code}")
+        continue
+    emp = {"tenantId": T, "code": code, "employeeStatus": "EMPLOYED", "employeeType": "PERMANENT",
+           "dateOfAppointment": now - 86400000,
+           "user": {"name": name, "userName": code, "password": EMP_PASS, "mobileNumber": f"8477000{i:02d}",
+                    "gender": "MALE", "dob": 631152000000, "type": "EMPLOYEE", "tenantId": T,
+                    "roles": [{"code": "EMPLOYEE", "name": "EMPLOYEE", "tenantId": T},
+                              {"code": role, "name": role, "tenantId": T}]},
+           "assignments": [{"fromDate": now - 86400000, "toDate": None, "isCurrentAssignment": True,
+                            "department": "central", "designation": desig}],
+           "jurisdictions": [{"hierarchy": HIER, "boundaryType": "Provincia", "boundary": prov, "tenantId": T}],
+           "serviceHistory": [], "education": [], "tests": [], "documents": [],
+           "deactivationDetails": [], "reactivationDetails": []}
+    r = call("/egov-hrms/employees/_create", {"RequestInfo": RI, "Employees": [emp]})
+    if (r.get("Employees") or [{}])[0].get("code"):
+        CHANGED = True
+        print(f"CREATED employee {code}")
+    else:
+        print(f"FAILED  employee {code}: {r}", file=sys.stderr)
+
+print("DONE", "CHANGED" if CHANGED else "no-op")


### PR DESCRIPTION
Part 2 of the testing-entrance goal (deployment half; FE half is #1431).

## What one deploy gives an opted-in box
With host_vars `testing_ui_enabled: true` (+ `testing_tenant`, vaulted `testing_ui_htpasswd`), a single `./deploy.sh <tenant>` run stands up the parallel testing entrance:
- **nginx gate** rendered by `nginx-site.conf.j2` in BOTH digit-ui modes (static: gated alias of the same build; container: gated passthrough + gated locations in the container conf) — basic-auth at the door, "TESTING ENVIRONMENT" banner injected via sub_filter
- **`globalConfigs.testing.js`** rendered from the SAME template as prod's config (second render with `context_path=testing-ui`, `gc_testing_mode=true`, allowlist = the testing tenant) — stays in sync with every future config change automatically; the prod render gains only `TESTING_TENANT_ID` (the FE exclude-guard key)
- **`scripts/seed-testing-tenant.py`** — idempotent, additive-only seeder: tenants row, citymodule membership, dispatcher row, ComplaintTemplateType, MapConfig, `TST-` IdFormat, department/designation clones, full boundary tree + labels copy, 4 CMS-chain test employees. NotificationRouting deliberately NOT seeded → the testing tenant can never send SMS/email.

## Default OFF = provably zero impact
Flag unset → `globalConfigs.js.j2` and `nginx-site.conf.j2` render **byte-identically** to before (verified by direct jinja renders in both static and container modes — assertions in the PR's validation run) and none of the new tasks execute. Every existing box (pilot, mctd, future IGE/IGSAE) deploys unchanged.

## Proven end-to-end on local before templating
The exact artifacts these templates render were hand-applied on the local box and verified: gate 401/200, banner, dispatcher auto-selects the testing authority, complaint **TST-2026-000015** filed end-to-end with the TST- prefix, test employee sees it, prod entrance shows none of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)