### PR TITLE
fix: post-submit bounces to language-selection — RegExp-in-pattern-attr crash + hardcoded /digit-ui/ navigation

### DIFF
--- a/digit-ui-esbuild/packages/react-components/src/atoms/TextInput.js
+++ b/digit-ui-esbuild/packages/react-components/src/atoms/TextInput.js
@@ -2,6 +2,14 @@ import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import { LocateIcon } from "./svgindex";
 
+// The native `pattern` attribute must be a bare regex SOURCE string. Callers
+// (e.g. the FormValidations-driven getters) may hand us a compiled RegExp —
+// stringifying that into the DOM produces "/src/u" (slashes + flags), which
+// old Chrome silently ignored but Chrome 150+ compiles (v-flag) and THROWS on
+// form-submit click, crashing the page (observed as a bounce to the employee
+// language-selection screen on create-complaint ENVIAR).
+const asPatternAttr = (p) => (p instanceof RegExp ? p.source : p);
+
 const TextInput = (props) => {
   const user_type = Digit.SessionStorage.get("userType");
   const [date, setDate] = useState(props?.type==="date"&&props?.value);
@@ -47,7 +55,7 @@ const TextInput = (props) => {
             minLength={props.minlength}
             maxLength={props.maxlength}
             max={props.max}
-            pattern={props?.validation && props.ValidationRequired ? props?.validation?.pattern : props.pattern}
+            pattern={asPatternAttr(props?.validation && props.ValidationRequired ? props?.validation?.pattern : props.pattern)}
             min={props.min}
             readOnly={props.disable}
             title={props?.validation && props.ValidationRequired ? props?.validation?.title :props.title}
@@ -85,7 +93,7 @@ const TextInput = (props) => {
             maxLength={props.maxlength}
             max={props.max}
             required={props?.validation && props.ValidationRequired ? props?.validation?.isRequired :props.isRequired || (props.type === "date" && (props.name === "fromDate" ? data.toDate : data.fromDate))}
-            pattern={props?.validation && props.ValidationRequired ? props?.validation?.pattern : props.pattern}
+            pattern={asPatternAttr(props?.validation && props.ValidationRequired ? props?.validation?.pattern : props.pattern)}
             min={props.min}
             readOnly={props.disable}
             title={props?.validation && props.ValidationRequired ? props?.validation?.title :props.title}

--- a/digit-ui-esbuild/products/pgr/src/components/timelineInstances/rejected.js
+++ b/digit-ui-esbuild/products/pgr/src/components/timelineInstances/rejected.js
@@ -24,7 +24,7 @@ const Rejected = ({ action, nextActions, complaintDetails, ComplainMaxIdleTime, 
       nextActions.map((action, index) => {
         if (action && action !== "COMMENT") {
           return (
-            <Link key={index} to={`/digit-ui/citizen/pgr/${action.toLowerCase()}/${serviceRequestId}`}>
+            <Link key={index} to={`/${window?.contextPath || "digit-ui"}/citizen/pgr/${action.toLowerCase()}/${serviceRequestId}`}>
               <ActionLinks>{t(`CS_COMMON_${action}`)}</ActionLinks>
             </Link>
           );
@@ -65,7 +65,7 @@ const Rejected = ({ action, nextActions, complaintDetails, ComplainMaxIdleTime, 
           // hadn't loaded yet. Use a strict-numeric guard.
           if (action !== "REOPEN" || reopenWindowOpen)
           return (
-            <Link key={index} to={`/digit-ui/citizen/pgr/${action.toLowerCase()}/${serviceRequestId}`}>
+            <Link key={index} to={`/${window?.contextPath || "digit-ui"}/citizen/pgr/${action.toLowerCase()}/${serviceRequestId}`}>
               <ActionLinks>{t(`CS_COMMON_${action}`)}</ActionLinks>
             </Link>
           );

--- a/digit-ui-esbuild/products/pgr/src/components/timelineInstances/resolved.js
+++ b/digit-ui-esbuild/products/pgr/src/components/timelineInstances/resolved.js
@@ -26,7 +26,7 @@ const Resolved = ({ action, nextActions,complaintDetails, ComplainMaxIdleTime, r
       nextActions.map((action, index) => {
         if (action && action !== "COMMENT") {
           return (
-            <Link key={index} to={`/digit-ui/citizen/pgr/${action.toLowerCase()}/${serviceRequestId}`}>
+            <Link key={index} to={`/${window?.contextPath || "digit-ui"}/citizen/pgr/${action.toLowerCase()}/${serviceRequestId}`}>
               <ActionLinks>{t(`CS_COMMON_${action}`)}</ActionLinks>
             </Link>
           );
@@ -63,7 +63,7 @@ const Resolved = ({ action, nextActions,complaintDetails, ComplainMaxIdleTime, r
           // so REOPEN was hidden whenever auditDetails was still loading.
           if (action !== "REOPEN" || reopenWindowOpen)
           return (
-            <Link key={index} to={`/digit-ui/citizen/pgr/${action.toLowerCase()}/${serviceRequestId}`}>
+            <Link key={index} to={`/${window?.contextPath || "digit-ui"}/citizen/pgr/${action.toLowerCase()}/${serviceRequestId}`}>
               <ActionLinks>{t(`CS_COMMON_${action}`)}</ActionLinks>
             </Link>
           );

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintDetails.js
@@ -189,7 +189,7 @@ function WorkflowComponent({ complaintDetails, id }) {
             const key = `CS_COMMON_${action}`;
             const label = t(key) === key ? action : t(key);
             return (
-              <Link key={action} to={`/digit-ui/citizen/pgr/${action.toLowerCase()}/${id}`}>
+              <Link key={action} to={`/${window?.contextPath || "digit-ui"}/citizen/pgr/${action.toLowerCase()}/${id}`}>
                 <button
                   type="button"
                   style={{

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
@@ -1873,7 +1873,7 @@ const CreatePGRFlowV2: React.FC = () => {
         onError: () => {
           dispatch({ type: "CREATE_COMPLAINT", payload: { responseInfo: { status: "failed" } } });
           setSubmitting(false);
-          history.push(`/digit-ui/citizen/pgr/response`);
+          history.push(`/${window?.contextPath || "digit-ui"}/citizen/pgr/response`);
         },
         onSuccess: async (responseData: any) => {
           // Create is done — drop the session draft so the next visit starts fresh.
@@ -1881,7 +1881,7 @@ const CreatePGRFlowV2: React.FC = () => {
           dispatch({ type: "CREATE_COMPLAINT", payload: responseData });
           await client.refetchQueries(["complaintsList"]);
           setSubmitting(false);
-          history.push(`/digit-ui/citizen/pgr/response`);
+          history.push(`/${window?.contextPath || "digit-ui"}/citizen/pgr/response`);
         },
       });
       return;

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/FormExplorer.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/FormExplorer.js
@@ -191,7 +191,7 @@ const FormExplorer = () => {
           type: "CREATE_COMPLAINT",
           payload: { responseInfo: { status: "failed" } },
         });
-        history.push(`/digit-ui/citizen/pgr/response`);
+        history.push(`/${window?.contextPath || "digit-ui"}/citizen/pgr/response`);
       },
       onSuccess: async (responseData) => {
         dispatch({
@@ -202,10 +202,10 @@ const FormExplorer = () => {
           const id = responseData.ServiceWrappers[0].service.serviceRequestId;
 
           await client.refetchQueries(["complaintsList"]);
-          history.push(`/digit-ui/citizen/pgr/response`);
+          history.push(`/${window?.contextPath || "digit-ui"}/citizen/pgr/response`);
 
         } else {
-          history.push(`/digit-ui/citizen/pgr/response`);
+          history.push(`/${window?.contextPath || "digit-ui"}/citizen/pgr/response`);
         }
       },
     });


### PR DESCRIPTION
Two distinct bugs that both end with the user dumped on `/employee/user/language-selection` after submitting a complaint. Found while QA-ing the /testing-ui entrance; **the first one affects production on current Chrome**.

## 1. RegExp serialized into the native `pattern` attribute (prod-affecting)
`TextInput` forwards `validation.pattern` into the DOM. The FormValidations-driven getters supply a **compiled RegExp**, which React stringifies as `/source/u` — slashes and flag included. Legacy Chrome ignored invalid patterns silently; **Chrome 150+ compiles pattern attributes (v-flag) and throws on the submit click**, crashing the employee create page. Fix: normalize `RegExp → .source` at the attribute boundary (2 sites).

## 2. Ten hardcoded `/digit-ui/` citizen navigations (entrance-compat)
Post-create success (`→ /pgr/response`), reopen/rate links from complaint details and timeline — all hardcoded the `/digit-ui/` prefix. Under any other entrance (the gated `/testing-ui` context path from #1431/#1432), the pushed path matches no route and the router falls through to the employee entry screen — reproducing exactly the reported bug (the create itself succeeded; only the redirect was wrong). All ten now interpolate `window.contextPath` with `digit-ui` as default — **prod output is byte-identical**.

Verified on local: citizen create on /testing-ui now lands on the response page; employee ENVIAR no longer throws on Chrome 150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)