### PR TITLE
fix(testing-seeder): skip cleanly when source tenant isn't onboarded (fresh-deploy safety)

### DIFF
--- a/local-setup/scripts/seed-testing-tenant.py
+++ b/local-setup/scripts/seed-testing-tenant.py
@@ -85,7 +85,17 @@ def auth():
     return {"authToken": d["access_token"], "userInfo": d["UserRequest"]}
 
 
-RI = auth()
+# Fail-safe: on a from-zero deploy the state tenant isn't bootstrapped yet
+# (ADMIN@<state> doesn't exist), so auth() would throw and fail the whole
+# deploy. Skip cleanly instead — enable the testing entrance after the tenant
+# is onboarded.
+try:
+    RI = auth()
+except Exception as e:
+    print(f"SKIP: cannot authenticate ADMIN@{STATE} yet — state tenant not "
+          f"bootstrapped. Enable the testing entrance after onboarding. "
+          f"[{type(e).__name__}]")
+    sys.exit(0)
 
 
 def mdms_rows(schema, tenant, limit=200):
@@ -103,6 +113,34 @@ def mdms_update(row):
     r = call(f"/mdms-v2/v2/_update/{row['schemaCode']}", {"RequestInfo": RI, "Mdms": row})
     return r.get("ResponseInfo", {}).get("status") == "successful"
 
+
+# ── 0. source-readiness guard ────────────────────────────────────────────────
+# The seeder CLONES tenant-scoped data (boundary tree, departments,
+# ComplaintTemplateType, MapConfig) FROM the source/state tenant, so that
+# tenant must be onboarded FIRST. On a fresh box those are added by
+# ccrs-migrate / the configurator AFTER the base deploy — until then, skip
+# rather than clone an empty/partial tenant (which would produce a broken
+# testing tenant). State-level masters (ComplaintHierarchy, FormValidations,
+# ThemeConfig, workflow, most localization) are INHERITED by mz.igetesting via
+# mdms-v2 tenant-tree resolution, so those are not checked here.
+def source_ready():
+    tree = call(
+        f"/boundary-service/boundary-relationships/_search"
+        f"?tenantId={SRC}&hierarchyType={HIER}&includeChildren=true",
+        {"RequestInfo": RI})
+    has_tree = bool(tree.get("TenantBoundary") or [])
+    has_tpl = len(mdms_rows("RAINMAKER-PGR.ComplaintTemplateType", STATE)) > 0
+    return has_tree, has_tpl
+
+
+_tree_ok, _tpl_ok = source_ready()
+if not (_tree_ok and _tpl_ok):
+    _missing = ([] if _tree_ok else [f"boundary tree @ {SRC}"]) + \
+               ([] if _tpl_ok else [f"ComplaintTemplateType @ {STATE}"])
+    print(f"SKIP: source tenant not onboarded yet — missing: {', '.join(_missing)}. "
+          f"Run ccrs-migrate / configurator onboarding, then re-enable the "
+          f"testing entrance.")
+    sys.exit(0)
 
 # ── 1. tenants row ───────────────────────────────────────────────────────────
 existing = {r["data"].get("code") for r in mdms_rows("tenant.tenants", STATE)}


### PR DESCRIPTION
Follow-up to #1432/#1436. Makes the testing-tenant seeder **fail-safe on a from-zero deployment**.

## Problem
`seed-testing-tenant.py` clones tenant-scoped data (boundary tree, departments/designations, ComplaintTemplateType, MapConfig) FROM the source/state tenant. On an existing box (pilot) that tenant is already populated, so it works. But on a **fresh deploy** the state tenant is bootstrapped *later* in the playbook, and its PGR/Moz data is added by **manual** `ccrs-migrate` / configurator steps the playbook doesn't run — so with `testing_ui_enabled: true` the seed task ran before `mz` existed and **errored, failing the whole deploy**.

## Fix (seeder-only, ~20 lines, no playbook change)
Two guards, both `exit 0` (clean skip — the ansible `command` task succeeds with no change):
1. **auth failure** — `ADMIN@<state>` not created yet → print SKIP, exit 0.
2. **source-readiness preflight** — no boundary tree @ source OR no `ComplaintTemplateType` @ state → print SKIP with the exact missing pieces, exit 0.

## Behavior
| Box | Before | After |
|---|---|---|
| Fresh from-zero + `testing_ui_enabled` | seed task errors → **deploy fails** | prints `SKIP: source tenant not onboarded…` → **deploy succeeds**, entrance dormant |
| After onboarding `mz` (ccrs-migrate/configurator), re-deploy | — | source ready → seeds normally |
| Pilot / already-onboarded | works | works (guards pass, no behavior change) |

State-level masters (ComplaintHierarchy, FormValidations, ThemeConfig, workflow, most localization) are unaffected — they inherit via mdms-v2 tenant-tree resolution, never cloned.

Verified locally: exit-0 SKIP on a missing source tenant and on auth failure; unchanged happy path on a ready source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)