### PR TITLE
feat(configurator): 'Make this a testing tenant' checkbox (isTestingTenant flag)

### DIFF
--- a/configurator/packages/data-provider/src/providers/dataProvider.test.ts
+++ b/configurator/packages/data-provider/src/providers/dataProvider.test.ts
@@ -134,6 +134,52 @@ describe('createDigitDataProvider', () => {
     assert.equal((captured as { active: boolean }).active, false);
   });
 
+  it('preserves the additive isTestingTenant flag through a tenant update and getOne round-trip', async () => {
+    // The "Make this a testing tenant" checkbox writes an additive
+    // `isTestingTenant` field onto the tenant.tenants record. MDMS accepts it
+    // dynamically (no schema migration), but update()'s sanitize strips `id`
+    // and `_`-prefixed metadata — this locks in that a plain additive field is
+    // NOT stripped on the way out and is returned on the way back in.
+    const tenantRecord = {
+      id: 'ten-id',
+      tenantId: 'mz',
+      schemaCode: 'tenant.tenants',
+      uniqueIdentifier: 'mz.igetesting',
+      data: { code: 'mz.igetesting', name: 'IGE Testing', isTestingTenant: false },
+      isActive: true,
+      auditDetails: { createdBy: 'x', lastModifiedBy: 'x', createdTime: 1, lastModifiedTime: 1 },
+    };
+    mock.method(client, 'mdmsSearch', async () => [tenantRecord]);
+    let captured: Record<string, unknown> | null = null;
+    mock.method(client, 'mdmsUpdate', async (rec: { data: Record<string, unknown> }) => {
+      captured = rec.data;
+      return { ...tenantRecord, data: rec.data };
+    });
+
+    const dp = createDigitDataProvider(client, 'mz');
+    const result = await dp.update('tenants', {
+      id: 'mz.igetesting',
+      data: {
+        id: 'mz.igetesting',
+        code: 'mz.igetesting',
+        name: 'IGE Testing',
+        isTestingTenant: true, // the flag the checkbox sets
+        _isActive: true,
+        _uniqueIdentifier: 'mz.igetesting',
+        _schemaCode: 'tenant.tenants',
+        _mdmsId: 'ten-id',
+      },
+      previousData: {} as never,
+    });
+
+    // Write side: the flag survives the id/_-prefixed strip.
+    assert.ok(captured, 'mdmsUpdate should have been called');
+    assert.equal((captured as { isTestingTenant: unknown }).isTestingTenant, true);
+    assert.equal((captured as { code: string }).code, 'mz.igetesting');
+    // Read side: the returned record carries the flag back for the UI.
+    assert.equal((result.data as { isTestingTenant: unknown }).isTestingTenant, true);
+  });
+
   it('does not let a stale reActivateEmployee in the form payload override the fresh fetch (closes #813)', async () => {
     // EmployeeEdit.tsx has no input bound to reActivateEmployee, so any value
     // present in the submitted form data is a stale leftover from whatever

--- a/configurator/src/resources/tenants/TenantEdit.tsx
+++ b/configurator/src/resources/tenants/TenantEdit.tsx
@@ -1,4 +1,5 @@
 import { DigitEdit, DigitFormInput, v } from '@/admin';
+import { TestingTenantToggle } from './TestingTenantToggle';
 
 export function TenantEdit() {
   return (
@@ -27,6 +28,7 @@ export function TenantEdit() {
         label="Address"
         help="Office address shown in the citizen footer / contact pages."
       />
+      <TestingTenantToggle />
     </DigitEdit>
   );
 }

--- a/configurator/src/resources/tenants/TenantShow.tsx
+++ b/configurator/src/resources/tenants/TenantShow.tsx
@@ -22,7 +22,14 @@ function TenantDetail() {
       </LabelFieldPair>
       <LabelFieldPair>
         <CardLabel>Name</CardLabel>
-        <Field>{String(record.name ?? '')}</Field>
+        <Field>
+          {String(record.name ?? '')}
+          {record.isTestingTenant ? (
+            <span className="ml-2 inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800">
+              Testing tenant
+            </span>
+          ) : null}
+        </Field>
       </LabelFieldPair>
       <LabelFieldPair>
         <CardLabel>Description</CardLabel>

--- a/configurator/src/resources/tenants/TestingTenantToggle.tsx
+++ b/configurator/src/resources/tenants/TestingTenantToggle.tsx
@@ -1,0 +1,176 @@
+import { useState } from 'react';
+import { useInput } from 'ra-core';
+import { useWatch } from 'react-hook-form';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Label } from '@/components/ui/label';
+import { AlertTriangle, FlaskConical } from 'lucide-react';
+
+// "Make this a testing tenant" — writes the `isTestingTenant` flag onto the
+// tenant record (MDMS accepts it as an additive field). The flag is what the
+// citizen/employee UIs read to route a tenant to the gated /digit-ui-test
+// entrance and hide it from production surfaces — replacing the old
+// deploy-time globalConfigs TESTING_TENANT_ID pin with per-tenant data an
+// ADMIN can toggle here.
+//
+// Guard rails against mistakenly flagging production:
+//   1. The tenant NAME must contain "Testing" (case-insensitive).
+//   2. Root/state tenants (code without a ".") cannot be flagged — only
+//      sub-tenants. This blocks marking e.g. `mz` itself.
+//   3. Enabling shows a confirmation dialog spelling out the consequences.
+// Whole-word match — "IGE Testing" / "Testing Tenant" pass, but "Contesting"
+// and "Testington" (which merely contain the substring) do not.
+const NAME_MUST_CONTAIN = /\btesting\b/i;
+const isSubTenant = (code?: string) => !!code && code.includes('.');
+
+// Enforced at SAVE time too, not just at toggle time: if an operator flags a
+// tenant and later renames it to a production name (dropping "Testing"), the
+// form must refuse to save while the flag is still true — otherwise a
+// production tenant silently persists isTestingTenant:true and is hidden from
+// production. Returns an error string (react-admin surfaces it) or undefined.
+const validateTestingFlag = (value: unknown, allValues: Record<string, unknown>) => {
+  if (value !== true) return undefined;
+  const nm = (allValues?.name as string | undefined) ?? '';
+  const cd = (allValues?.code as string | undefined) ?? '';
+  if (!NAME_MUST_CONTAIN.test(nm) || !isSubTenant(cd)) {
+    return 'A testing tenant’s Name must contain the word "Testing" and it must be a sub-tenant. Rename it, or uncheck "Make this a testing tenant".';
+  }
+  return undefined;
+};
+
+export function TestingTenantToggle() {
+  const { id, field, fieldState } = useInput({
+    source: 'isTestingTenant',
+    parse: (v: boolean) => v,
+    validate: validateTestingFlag,
+  });
+  const name = (useWatch({ name: 'name' }) as string | undefined) ?? '';
+  const code = (useWatch({ name: 'code' }) as string | undefined) ?? '';
+
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [blockOpen, setBlockOpen] = useState(false);
+  const [blockReason, setBlockReason] = useState<string[]>([]);
+
+  const checked = !!field.value;
+
+  const attemptEnable = () => {
+    const reasons: string[] = [];
+    if (!NAME_MUST_CONTAIN.test(name)) {
+      reasons.push('The tenant Name must contain the word "Testing" (e.g. "IGE Testing").');
+    }
+    if (!isSubTenant(code)) {
+      reasons.push('Only a sub-tenant can be a testing tenant — a root/state tenant cannot be flagged.');
+    }
+    if (reasons.length) {
+      setBlockReason(reasons);
+      setBlockOpen(true); // checkbox stays unchecked (value not set)
+      return;
+    }
+    setConfirmOpen(true); // wait for explicit confirmation before enabling
+  };
+
+  const onToggle = (next: boolean) => {
+    if (!next) {
+      field.onChange(false); // disabling is immediate
+      return;
+    }
+    attemptEnable();
+  };
+
+  return (
+    <div className="rounded-md border border-amber-300 bg-amber-50/50 p-3">
+      <div className="flex items-center gap-2">
+        <input
+          id={id}
+          type="checkbox"
+          checked={checked}
+          onChange={(e) => onToggle(e.target.checked)}
+          onBlur={field.onBlur}
+          className="h-4 w-4 rounded border-gray-300"
+        />
+        <Label htmlFor={id} className="flex items-center gap-1.5 text-sm font-medium text-foreground">
+          <FlaskConical className="h-4 w-4 text-amber-600" />
+          Make this a testing tenant
+        </Label>
+      </div>
+      <p className="mt-1 pl-6 text-xs text-muted-foreground">
+        Routes this tenant to the gated <code>/digit-ui-test</code> entrance and hides it from
+        production. Name must contain "Testing".
+      </p>
+      {fieldState.error ? (
+        <p className="mt-1 pl-6 text-xs font-medium text-red-600">
+          {(fieldState.error as { message?: string })?.message ?? String(fieldState.error)}
+        </p>
+      ) : null}
+
+      {/* Confirmation before enabling */}
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2">
+              <FlaskConical className="h-5 w-5 text-amber-600" />
+              Make “{name || code}” a testing tenant?
+            </AlertDialogTitle>
+            <AlertDialogDescription asChild>
+              <div className="space-y-2 text-sm">
+                <p>Flagging this tenant as a testing tenant will:</p>
+                <ul className="list-disc space-y-1 pl-5">
+                  <li>Show it <strong>only</strong> on the password-gated <code>/digit-ui-test</code> entrance.</li>
+                  <li><strong>Hide</strong> it from the production citizen and employee UIs (dispatcher, complaints list, login institutions).</li>
+                  <li>Keep its complaints out of production reports (complaints filed here are test data).</li>
+                </ul>
+                <p className="flex items-start gap-1.5 rounded bg-amber-100 p-2 text-amber-800">
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                  <span>Only do this for a genuine QA/testing tenant. Real citizens and employees will lose access to it on the production entrance.</span>
+                </p>
+              </div>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-amber-600 hover:bg-amber-700"
+              onClick={() => {
+                field.onChange(true);
+                setConfirmOpen(false);
+              }}
+            >
+              Yes, make it a testing tenant
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Blocked (validation failed) */}
+      <AlertDialog open={blockOpen} onOpenChange={setBlockOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5 text-red-600" />
+              Can’t flag this tenant as testing
+            </AlertDialogTitle>
+            <AlertDialogDescription asChild>
+              <div className="space-y-2 text-sm">
+                <p>This safeguard prevents marking a production tenant by mistake:</p>
+                <ul className="list-disc space-y-1 pl-5">
+                  {blockReason.map((r) => <li key={r}>{r}</li>)}
+                </ul>
+              </div>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogAction onClick={() => setBlockOpen(false)}>OK</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}


### PR DESCRIPTION
## What
Adds a guarded **"Make this a testing tenant"** checkbox to the Tenant edit page in the configurator. It writes an additive `isTestingTenant: true` flag onto the `tenant.tenants` MDMS record — replacing the deploy-time-only `globalConfigs.TESTING_TENANT_ID` pin with per-tenant data an ADMIN can manage in the UI. The citizen/employee UIs read this flag to route a tenant to the gated `/digit-ui-test` entrance and hide it from production (see companion FE PR).

## Guard rails (avoid mistakenly flagging a production tenant)
- **Name must contain the whole word "Testing"** — word-boundary match, so `Contesting` / `Testington` do **not** qualify.
- **Only sub-tenants** (code with a `.`) can be flagged — never a root/state tenant like `mz`.
- **Enable requires confirming a consequence dialog**; a block dialog explains why when the guards fail.
- **Enforced again at save time** via a field validator — renaming a flagged tenant to a production name fails the save instead of silently persisting a hidden production tenant.

## Also
- Tenant **Show** page shows an amber "Testing tenant" badge.
- MDMS accepts the field additively — **no schema migration**.
- New **round-trip unit test** in `dataProvider.test.ts` locks in that the flag survives `update()` sanitize and comes back on `getOne`.

## Testing
- `data-provider` unit tests pass (8/8, incl. the new round-trip test).
- Configurator `tsc --noEmit` clean.
- Verified live locally: flagging `mz.igetesting` persists `isTestingTenant: true`; `mz` / `mz.ige` / `mz.igsae` stay unflagged.

## Notes
Part of a 3-PR set (configurator flag / esbuild FE flag-read / local-setup seeder removal). Independent — merges in any order. Supersedes the config-driven testing-tenant approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)