### PR TITLE
feat(pgr): read isTestingTenant flag to scope tenants to /digit-ui-test entrance

### DIFF
--- a/digit-ui-esbuild/packages/libraries/src/services/molecules/Store/service.js
+++ b/digit-ui-esbuild/packages/libraries/src/services/molecules/Store/service.js
@@ -188,6 +188,17 @@ export const StoreService = {
     // .filter((item) => !!moduleTenants.find((mt) => mt.code === item.code))
     // .map((tenant) => ({ i18nKey: `TENANT_TENANTS_${tenant.code.replace(".", "_").toUpperCase()}`, ...tenant }));
 
+    // Testing-tenant codes — derived from the AUTHORITATIVE tenant.tenants
+    // master (GetCitiesWithi18nKeys drops arbitrary fields on the multi-root
+    // path, so initData.tenants can't be trusted to carry the flag). The
+    // configurator's "Make this a testing tenant" checkbox writes
+    // `isTestingTenant: true` onto the tenant record; the citizen/employee UIs
+    // read these codes to route the tenant to the /digit-ui-test entrance and
+    // hide it from production. Cached as a plain array for a synchronous read.
+    initData.testingTenantCodes = (MdmsRes?.tenant?.tenants || [])
+      .filter((t) => t?.isTestingTenant === true)
+      .map((t) => t.code);
+
     await LocalizationService.getLocale({
       modules: [`${modulePrefix}-common`, `digit-ui`, `digit-tenants`, `${modulePrefix}-${stateCode.toLowerCase()}`],
       locale: initData.selectedLanguage,

--- a/digit-ui-esbuild/packages/modules/core/src/pages/employee/Login/config.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/employee/Login/config.js
@@ -58,8 +58,11 @@ export const loginConfig = [
             // the dropdown is filtered to those codes; when absent,
             // the historical "all tenants" behaviour is preserved
             // (CCRS#443 sub-1).
+            // Also drops testing tenants on the production entrance (and keeps
+            // only them on /digit-ui-test) — mirrors login.js isTenantVisibleOnEntrance
+            // and products/pgr testingTenant.js, so a flagged tenant never leaks here.
             select:
-              "(data)=>{ const all=Array.isArray(data['tenant'].tenants)?Digit.Utils.getUnique(data['tenant'].tenants):[]; const allow=window?.globalConfigs?.getConfig?.('LOGIN_TENANT_ALLOWLIST'); const filtered=Array.isArray(allow)&&allow.length>0?all.filter(t=>allow.includes(t.code)):all; return filtered.map(ele=>({code:ele.code,name:Digit.Utils.locale.getTransformedLocale('TENANT_TENANTS_'+ele.code)}))}",
+              "(data)=>{ const all=Array.isArray(data['tenant'].tenants)?Digit.Utils.getUnique(data['tenant'].tenants):[]; const allow=window?.globalConfigs?.getConfig?.('LOGIN_TENANT_ALLOWLIST'); const allowed=Array.isArray(allow)&&allow.length>0?all.filter(t=>allow.includes(t.code)):all; let codes=[]; try{const c=window?.Digit?.SessionStorage?.get?.('initData')?.testingTenantCodes; if(Array.isArray(c))codes=c.filter(Boolean);}catch(e){} const cfg=window?.globalConfigs?.getConfig?.('TESTING_TENANT_ID'); if(cfg&&codes.indexOf(cfg)<0)codes.push(cfg); const testing=new Set(codes); const onTest=!!window?.globalConfigs?.getConfig?.('TESTING_MODE'); const filtered=allowed.filter(t=>testing.size===0?!onTest:(onTest?testing.has(t.code):!testing.has(t.code))); return filtered.map(ele=>({code:ele.code,name:Digit.Utils.locale.getTransformedLocale('TENANT_TENANTS_'+ele.code)}))}",
           },
         },
       },

--- a/digit-ui-esbuild/packages/modules/core/src/pages/employee/Login/login.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/employee/Login/login.js
@@ -35,6 +35,33 @@ import Header from "../../../components/Header";
 import Carousel from "./Carousel/Carousel";
 import ImageComponent from "../../../components/ImageComponent";
 
+// Testing-tenant visibility for the employee login city/institution dropdown.
+// Mirrors products/pgr/src/utils/testingTenant.js (can't import it — core must
+// not depend on a product). A tenant is "testing" when the configurator's
+// "Make this a testing tenant" checkbox set isTestingTenant on its record
+// (StoreService caches the codes as initData.testingTenantCodes), UNIONED with
+// the legacy deploy-time TESTING_TENANT_ID for boxes not yet migrated. On a
+// production entrance the dropdown must hide testing tenants; on the gated
+// /digit-ui-test entrance (TESTING_MODE) it shows only them.
+const getTestingTenantCodes = () => {
+  let codes = [];
+  try {
+    const cached = window?.Digit?.SessionStorage?.get?.("initData")?.testingTenantCodes;
+    if (Array.isArray(cached)) codes = cached.filter(Boolean);
+  } catch (e) {
+    /* initData not ready — legacy config below still applies */
+  }
+  const cfg = window?.globalConfigs?.getConfig?.("TESTING_TENANT_ID");
+  if (cfg && !codes.includes(cfg)) codes.push(cfg);
+  return new Set(codes);
+};
+const isTenantVisibleOnEntrance = (tenantCode) => {
+  const testing = getTestingTenantCodes();
+  const onTestingEntrance = !!window?.globalConfigs?.getConfig?.("TESTING_MODE");
+  if (testing.size === 0) return !onTestingEntrance;
+  return onTestingEntrance ? testing.has(tenantCode) : !testing.has(tenantCode);
+};
+
 const setEmployeeDetail = (userObject, token) => {
   if (Digit.Utils.getMultiRootTenant() && process.env.NODE_ENV !== "development") return;
   let locale = JSON.parse(sessionStorage.getItem("Digit.locale"))?.value || Digit.Utils.getDefaultLanguage();
@@ -207,9 +234,12 @@ const Login = ({ config: propsConfig, t, isDisabled, loginOTPBased, appTenants }
   const cityOptions = useMemo(() => {
     const all = Array.isArray(cities) ? cities : [];
     const allow = window?.globalConfigs?.getConfig?.("LOGIN_TENANT_ALLOWLIST");
-    const filtered = Array.isArray(allow) && allow.length > 0
+    const allowed = Array.isArray(allow) && allow.length > 0
       ? all.filter((tnt) => allow.includes(tnt.code))
       : all;
+    // Keep testing tenants off the production entrance (and non-testing
+    // tenants off /digit-ui-test) — matches the citizen dispatcher/list.
+    const filtered = allowed.filter((tnt) => isTenantVisibleOnEntrance(tnt.code));
     return filtered.map((tnt) => ({
       value: tnt.code,
       label: tr(`TENANT_TENANTS_${Digit?.Utils?.locale?.getTransformedLocale?.(tnt.code) ?? tnt.code}`, tnt.name || tnt.code),

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintsList.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintsList.js
@@ -19,6 +19,7 @@
 
 import React, { useEffect } from "react";
 import { complaintLabel } from "../../utils/complaintLabel";
+import { isVisibleOnEntrance } from "../../utils/testingTenant";
 import { useTranslation } from "react-i18next";
 import { useHistory, useRouteMatch } from "react-router-dom";
 
@@ -295,16 +296,12 @@ export const ComplaintsList = () => {
   // search runs at the STATE tenant, which spans every child tenant — so a
   // tester who used a personal mobile on the testing entrance would otherwise
   // see TST- rows mixed into their real list here. The prod entrance drops
-  // testing-tenant rows; the testing entrance (TESTING_MODE) lists ONLY them.
-  // Deployments without a testing setup (no TESTING_TENANT_ID) are untouched.
+  // testing-tenant rows; the testing entrance lists ONLY them. Which tenants
+  // are "testing" comes from the isTestingTenant flag (config fallback) —
+  // see utils/testingTenant. Deployments without a testing setup are untouched.
   const visibleWrappers = React.useMemo(() => {
     const all = data?.ServiceWrappers || [];
-    const testingTenant = window?.globalConfigs?.getConfig?.("TESTING_TENANT_ID");
-    if (!testingTenant) return all;
-    const isTestingEntrance = !!window?.globalConfigs?.getConfig?.("TESTING_MODE");
-    return all.filter(({ service }) =>
-      isTestingEntrance ? service?.tenantId === testingTenant : service?.tenantId !== testingTenant
-    );
+    return all.filter(({ service }) => isVisibleOnEntrance(service?.tenantId));
   }, [data]);
 
   return (

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
@@ -21,6 +21,7 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { complaintLabel } from "../../../utils/complaintLabel";
+import { isVisibleOnEntrance } from "../../../utils/testingTenant";
 import PGRDatePicker from "../../../components/PGRDatePicker";
 import PgrFileUpload from "../../../components/PgrFileUpload";
 import { useDispatch } from "react-redux";
@@ -1649,16 +1650,12 @@ const CreatePGRFlowV2: React.FC = () => {
       select: (raw: any) =>
         ((raw?.["RAINMAKER-PGR"]?.ComplaintRelatedToMap || []) as RelatedToOption[])
           .filter((o) => o?.active !== false && !!o?.code && !!o?.name && !!o?.tenantCode)
-          // Entrance scoping: the TESTING entrance (globalConfigs TESTING_MODE
-          // + TESTING_TENANT_ID, served only at the gated /testing-ui path)
-          // sees ONLY the testing authority; every other entrance never sees
-          // it. Same MDMS rows, no schema change — the tenantCode is the flag.
-          .filter((o) => {
-            const testingTenant = window?.globalConfigs?.getConfig?.("TESTING_TENANT_ID");
-            if (!testingTenant) return true; // deployment without a testing setup
-            const isTestingEntrance = !!window?.globalConfigs?.getConfig?.("TESTING_MODE");
-            return isTestingEntrance ? o.tenantCode === testingTenant : o.tenantCode !== testingTenant;
-          })
+          // Entrance scoping: the gated /digit-ui-test entrance sees ONLY
+          // testing-tenant authorities; production entrances never see them.
+          // Which tenants are "testing" comes from the isTestingTenant flag
+          // (set via the configurator checkbox) with the legacy
+          // TESTING_TENANT_ID config as fallback — see utils/testingTenant.
+          .filter((o: RelatedToOption) => isVisibleOnEntrance(o.tenantCode))
           .sort((a, b) => (a.displayOrder ?? 0) - (b.displayOrder ?? 0)),
     },
     { schemaCode: "PGR_COMPLAINT_RELATED_TO_MAP", tenantId: stateTenant }

--- a/digit-ui-esbuild/products/pgr/src/utils/testingTenant.js
+++ b/digit-ui-esbuild/products/pgr/src/utils/testingTenant.js
@@ -1,0 +1,43 @@
+// Testing-tenant scoping — shared by the citizen create dispatcher and the
+// complaints list so the same rule decides tenant visibility everywhere.
+//
+// A tenant is "testing" when the configurator's "Make this a testing tenant"
+// checkbox set `isTestingTenant: true` on its record. StoreService reads the
+// authoritative tenant.tenants master and caches the codes as
+// initData.testingTenantCodes, so this resolves synchronously (usable inside a
+// react-query `select`, no hook needed).
+//
+// FLAG ∪ LEGACY CONFIG: flagged codes are UNIONED with the legacy deploy-time
+// globalConfigs TESTING_TENANT_ID (not flag-else-config) — on a box mid-
+// migration where one tenant is flagged but another is still known only via
+// the config, both must stay hidden from production.
+//
+// TESTING_MODE (per-entrance boolean, still from globalConfigs) identifies
+// whether THIS entrance is the testing one; the flag identifies WHICH tenants
+// are testing. The two are orthogonal and both required.
+
+export const getTestingTenantCodes = () => {
+  let codes = [];
+  try {
+    const cached = window?.Digit?.SessionStorage?.get?.("initData")?.testingTenantCodes;
+    if (Array.isArray(cached)) codes = cached.filter(Boolean);
+  } catch (e) {
+    /* initData not ready — the legacy config below still applies */
+  }
+  const cfg = window?.globalConfigs?.getConfig?.("TESTING_TENANT_ID");
+  if (cfg && !codes.includes(cfg)) codes.push(cfg);
+  return new Set(codes);
+};
+
+export const isTestingEntrance = () => !!window?.globalConfigs?.getConfig?.("TESTING_MODE");
+
+// Should a row belonging to `tenantCode` be shown on THIS entrance?
+//   - no testing setup at all (empty set)  -> prod shows everything, testing shows nothing
+//   - testing entrance                     -> only testing-tenant rows
+//   - production entrance                  -> everything EXCEPT testing-tenant rows
+export const isVisibleOnEntrance = (tenantCode) => {
+  const testing = getTestingTenantCodes();
+  const onTestingEntrance = isTestingEntrance();
+  if (testing.size === 0) return !onTestingEntrance;
+  return onTestingEntrance ? testing.has(tenantCode) : !testing.has(tenantCode);
+};


### PR DESCRIPTION
## What
Replaces the deploy-time-only `TESTING_TENANT_ID` pin with a **data-driven** model: the configurator's "Make this a testing tenant" checkbox (companion PR) writes `isTestingTenant` onto the tenant record, and the UIs read it to decide which tenants belong on the gated `/digit-ui-test` entrance vs. production.

## Changes
- **StoreService** computes `initData.testingTenantCodes` from the **authoritative** `tenant.tenants` master. (`GetCitiesWithi18nKeys` drops arbitrary fields on the multi-root path, so `initData.tenants` can't be trusted to carry the flag.)
- **New shared util** `products/pgr/src/utils/testingTenant.js`:
  - resolves the testing set as the **UNION** of flagged codes and the legacy `TESTING_TENANT_ID` config, so a box **mid-migration** keeps a config-only testing tenant hidden;
  - `isVisibleOnEntrance(code)` decides per-entrance visibility (`TESTING_MODE` marks the entrance).
- **Citizen** create dispatcher + complaints list filter by `isVisibleOnEntrance`.
- **Employee login** city/institution dropdown (`login.js` + `config.js` select) now also drops testing tenants on the production entrance — matches the configurator dialog's promise. Core inlines the semantics (it must not import a product util).

## Backward compatible
With **no** flag and **no** `TESTING_TENANT_ID`, production shows all tenants exactly as today. On a box still using `TESTING_TENANT_ID`, behaviour is unchanged (union folds it in).

## Testing
- Bundle rebuilt + deployed locally.
- Verified against the live bundle on the **production** entrance: with `mz.igetesting` flagged, `testingTenantCodes = ["mz.igetesting"]`, the union with the legacy config resolves it to **hidden**, and `mz.ige` / `mz.igsae` / `mz` stay visible — in the citizen dispatcher/list **and** the employee login dropdown.
- Addresses an adversarial review pass (union fallback, login-dropdown scope).

## Notes
Part of a 3-PR set (configurator flag / this / seeder removal). Independent — merges in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)