### PR TITLE
[CCSD-2076] Translate Feedback/Rating section to Portuguese

### DIFF
--- a/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
@@ -1243,7 +1243,7 @@
     },
     {
         "code": "CS_FEEDBACK_EASY_SUBMIT",
-        "message": "É fácil apresentar a reclamação.",
+        "message": "Fácil submeter a reclamação",
         "module": "rainmaker-pgr",
         "locale": "pt_PT"
     },
@@ -1255,19 +1255,49 @@
     },
     {
         "code": "CS_FEEDBACK_COMMUNICATION",
-        "message": "Comunicação e atualizações",
+        "message": "Comunicação e actualizações",
         "module": "rainmaker-pgr",
         "locale": "pt_PT"
     },
     {
         "code": "CS_RATING_COMMENTS_PLACEHOLDER",
-        "message": "Compartilhe qualquer outra informação que você gostaria que a equipe soubesse…",
+        "message": "Partilhe qualquer outro feedback ou sugestão para a equipa...",
         "module": "rainmaker-pgr",
         "locale": "pt_PT"
     },
     {
         "code": "CS_COMPLAINT_RATE_SUBTEXT",
-        "message": "Sua avaliação nos ajuda a melhorar. Leva apenas um instante.",
+        "message": "A sua avaliação ajuda-nos a melhorar. Leva apenas um momento.",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_COMPLAINT_RATE_HELP_TEXT",
+        "message": "Deixe a sua avaliação",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_COMPLAINT_RATE_TEXT",
+        "message": "De forma geral, quão satisfeito está com o tratamento da sua reclamação?",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_FEEDBACK_WHAT_WAS_GOOD",
+        "message": "O que fizemos bem? (Seleccione todas as opções aplicáveis) (opcional)",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_FEEDBACK_OTHERS",
+        "message": "Outro",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_FEEDBACK_ENTER_RATING_ERROR",
+        "message": "Por favor, seleccione uma avaliação antes de submeter.",
         "module": "rainmaker-pgr",
         "locale": "pt_PT"
     },
@@ -1490,6 +1520,24 @@
     {
         "code": "PGR_LANDING_PRIVACY_PAGE_P5",
         "message": "As suas informações serão conservadas apenas durante o período necessário para processar a sua reclamação, cumprir obrigações legais e manter os registos oficiais do Governo. O utilizador pode solicitar o acesso às suas informações pessoais ou a respetiva correção, sujeito à legislação aplicável e a quaisquer restrições necessárias para proteger investigações em curso.",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_FEEDBACK_RATE_TEXT",
+        "message": "Como avalia a sua experiência connosco?",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_COMMON_COMMENTS",
+        "message": "Comentários",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_COMMON_SUBMIT",
+        "message": "Submeter",
         "module": "rainmaker-pgr",
         "locale": "pt_PT"
     }


### PR DESCRIPTION
## [CCSD-2076] Translate Feedback/Rating Section

Localizes the feedback/rating section on the complaint tracking page to European/Mozambican Portuguese, and changes the section heading from "Opinião" to **"Deixe a sua avaliação"**.

### Changes
All in `utilities/default-data-handler/.../pt_PT/rainmaker-pgr.json` (localization-only; the component already renders via keys):

| Element | Key | Portuguese |
|---|---|---|
| Section heading | `CS_COMPLAINT_RATE_HELP_TEXT` | Deixe a sua avaliação |
| Intro text | `CS_COMPLAINT_RATE_SUBTEXT` | A sua avaliação ajuda-nos a melhorar. Leva apenas um momento. |
| Rate question | `CS_FEEDBACK_RATE_TEXT` / `CS_COMPLAINT_RATE_TEXT` | Como avalia a sua experiência connosco? / De forma geral, quão satisfeito está… |
| "What was good?" | `CS_FEEDBACK_WHAT_WAS_GOOD` | O que fizemos bem? (Seleccione todas as opções aplicáveis) (opcional) |
| Rating options | `CS_FEEDBACK_EASY_SUBMIT`, `CS_FEEDBACK_COMMUNICATION`, `CS_FEEDBACK_RESOLUTION_TIME`, `CS_FEEDBACK_OTHERS` | Fácil submeter a reclamação · Comunicação e actualizações · Tempo de resolução · Outro |
| Validation error | `CS_FEEDBACK_ENTER_RATING_ERROR` | Por favor, seleccione uma avaliação antes de submeter. |
| Comments label | `CS_COMMON_COMMENTS` | Comentários |
| Placeholder | `CS_RATING_COMMENTS_PLACEHOLDER` | Partilhe qualquer outro feedback ou sugestão para a equipa... |
| Submit button | `CS_COMMON_SUBMIT` | Submeter |

### Notes
- Replaces earlier **Brazilian**-PT values (`atualizações`, `Compartilhe…você…equipe`, `Sua avaliação nos ajuda…instante`) with Moz orthography, and fixes the ticket's `anyhing` → `anything` typo.
- Includes `CS_FEEDBACK_RATE_TEXT` (the star-field key the deployed build uses) in addition to the source's `CS_COMPLAINT_RATE_TEXT`, so both build versions render correctly.
- `CS_COMMON_COMMENTS` / `CS_COMMON_SUBMIT` are shared keys that were untranslated app-wide; they now render Portuguese platform-wide.
- Verified live against `mz.ige` / `pt_PT` on the rating screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CCSD-2076]: https://digit-discuss.atlassian.net/browse/CCSD-2076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ