### PR TITLE
fix(moz): QA batch — PT loc (2085/2083/2084/2071) + consent group labels (2072) + repair #1443 pt_PT JSON

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
@@ -1170,7 +1170,15 @@ function Step3Description({ data, patch, templateFields, t }: StepBodyProps) {
         {extended ? (
           <div className="space-y-2">
             {/* Consents are EXPLICIT at create (CCSD-1979 revisited: show at
-                create; hidden only on the details/view screens — CCSD-1988). */}
+                create; hidden only on the details/view screens — CCSD-1988).
+                CCSD-2072: group the mandatory consents under an OBRIGATÓRIO
+                header and the confidential opt-in under OPCIONAL. */}
+            <div className="text-xs font-semibold uppercase tracking-wide" style={{ color: PRIMARY }}>
+              {tr(t, "PGR_CONSENT_SECTION_MANDATORY", "Mandatory")}
+              <span className="ml-0.5" style={{ color: "var(--color-error, #d4351c)" }} aria-hidden>
+                *
+              </span>
+            </div>
             {REQUIRED_CONSENTS.map((c) => (
               <label key={c.code} className="flex items-start gap-2 text-sm">
                 <input
@@ -1188,7 +1196,10 @@ function Step3Description({ data, patch, templateFields, t }: StepBodyProps) {
                 </span>
               </label>
             ))}
-            <label className="flex items-start gap-2 text-sm pt-2 border-t border-border">
+            <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground pt-3 mt-1 border-t border-border">
+              {tr(t, "PGR_CONSENT_SECTION_OPTIONAL", "Optional")}
+            </div>
+            <label className="flex items-start gap-2 text-sm">
               <input
                 type="checkbox"
                 style={CHECKBOX_STYLE}

--- a/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-common.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-common.json
@@ -9832,5 +9832,23 @@
         "message": "By selecting “I agree to the Privacy Policy”, you confirm that the information provided is accurate and that you understand and accept the collection, use, storage and processing of your personal data for the purposes described above.",
         "module": "rainmaker-common",
         "locale": "en_IN"
+    },
+    {
+        "code": "USERNAME",
+        "message": "Username",
+        "module": "rainmaker-common",
+        "locale": "en_IN"
+    },
+    {
+        "code": "CORE_FORGOT_USERNAME_PLACEHOLDER",
+        "message": "Your work username",
+        "module": "rainmaker-common",
+        "locale": "en_IN"
+    },
+    {
+        "code": "CORE_COMMON_BACK_TO_LOGIN",
+        "message": "Back to login",
+        "module": "rainmaker-common",
+        "locale": "en_IN"
     }
 ]

--- a/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
@@ -751,7 +751,7 @@
     },
     {
         "code": "CS_ADDCOMPLAINT_UPLOAD_PHOTO",
-        "message": "Upload complaint photos",
+        "message": "Upload complaint photos or documents",
         "module": "rainmaker-pgr",
         "locale": "en_IN"
     },
@@ -8168,6 +8168,18 @@
     {
         "code": "PGR_LANDING_PRIVACY_PAGE_P5",
         "message": "Your information will be retained only for the period necessary to process your complaint, comply with legal obligations and maintain official government records. You may request access to or correction of your personal information, subject to applicable law and any restrictions necessary to protect ongoing investigations.",
+        "module": "rainmaker-pgr",
+        "locale": "en_IN"
+    },
+    {
+        "code": "PGR_CONSENT_SECTION_MANDATORY",
+        "message": "MANDATORY",
+        "module": "rainmaker-pgr",
+        "locale": "en_IN"
+    },
+    {
+        "code": "PGR_CONSENT_SECTION_OPTIONAL",
+        "message": "OPTIONAL",
         "module": "rainmaker-pgr",
         "locale": "en_IN"
     }

--- a/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-common.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-common.json
@@ -2,6 +2,10 @@
     {
         "code": "CS_HOME_HEADER",
         "message": "Todos os Serviços",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
         "code": "CS_LOGIN_TEXT",
         "message": "Todas as comunicações referentes à reclamação/queixa serão enviadas para este número de telemóvel.",
         "module": "rainmaker-common",
@@ -10,6 +14,10 @@
     {
         "code": "ACTION_TEST_PGR",
         "message": "Fala Cidadão",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
         "code": "CS_LOGIN_PROVIDE_MOBILE_NUMBER",
         "message": "Introduza o seu número de telemóvel",
         "module": "rainmaker-common",
@@ -18,6 +26,10 @@
     {
         "code": "CS_COMMON_HOME_COMPLAINTS",
         "message": "Fala Cidadão",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
         "code": "CORE_COMMON_MOBILE_NUMBER",
         "message": "Número de Telemóvel",
         "module": "rainmaker-common",
@@ -248,6 +260,60 @@
     {
         "code": "MODULE_PGR",
         "message": "Fala Cidadão",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CORE_COMMON_LOGIN",
+        "message": "Entrar",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CORE_COMMON_FORGOT_PASSWORD",
+        "message": "Esqueceu a senha?",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CORE_COMMON_FORGOT_PASSWORD_LABEL",
+        "message": "Esqueceu a senha?",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "ES_FORGOT_PASSWORD_DESC",
+        "message": "Introduza o seu nome de usuário e instituição. Enviaremos um código único para repor a sua senha.",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "USERNAME",
+        "message": "Nome de usuário",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CORE_FORGOT_USERNAME_PLACEHOLDER",
+        "message": "O seu nome de usuário de trabalho",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CORE_COMMON_CONTINUE",
+        "message": "Continuar",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CORE_COMMON_BACK_TO_LOGIN",
+        "message": "Voltar ao início de sessão",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "ACTION_TEST_SEARCH_COMPLAINT",
+        "message": "Pesquisar Reclamação",
         "module": "rainmaker-common",
         "locale": "pt_PT"
     }

--- a/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
@@ -1582,5 +1582,29 @@
         "message": "Submeter",
         "module": "rainmaker-pgr",
         "locale": "pt_PT"
+    },
+    {
+        "code": "CS_ADDCOMPLAINT_UPLOAD_PHOTO",
+        "message": "Enviar fotos ou documentos da reclamação",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_UPLOAD_HINT",
+        "message": "Formatos permitidos: JPG, PNG, PDF, DOC, DOCX, XLS, XLSX. Até 5 MB por ficheiro.",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "PGR_CONSENT_SECTION_MANDATORY",
+        "message": "OBRIGATÓRIO",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "PGR_CONSENT_SECTION_OPTIONAL",
+        "message": "OPCIONAL",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
     }
 ]

--- a/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
@@ -475,7 +475,7 @@
     },
     {
         "code": "WF_INBOX_HEADER_LOCALITY",
-        "message": "Localidade",
+        "message": "Distrito",
         "module": "rainmaker-pgr",
         "locale": "pt_PT"
     },
@@ -1559,6 +1559,7 @@
         "module": "rainmaker-pgr",
         "locale": "pt_PT"
     },
+    {
         "code": "CS_FEEDBACK_RATE_TEXT",
         "message": "Como avalia a sua experiência connosco?",
         "module": "rainmaker-pgr",
@@ -1570,6 +1571,7 @@
         "module": "rainmaker-pgr",
         "locale": "pt_PT"
     },
+    {
         "code": "CS_COMMON_COMMENTS",
         "message": "Comentários",
         "module": "rainmaker-pgr",


### PR DESCRIPTION
Consolidated Mozambique QA batch (localization + small UI), plus a necessary repair of pre-existing JSON corruption in the same pt_PT files.

## CCSD-2085 — complaints table header
`WF_INBOX_HEADER_LOCALITY` pt: **"Localidade" → "Distrito"** (column shows a district).

## CCSD-2083 — employee sidebar
Added pt `ACTION_TEST_SEARCH_COMPLAINT` = **"Pesquisar Reclamação"** ("Home"/`ACTION_TEST_HOME` was already "Início").

## CCSD-2084 — employee login + forgot-password
Added pt (`rainmaker-common`): `CORE_COMMON_LOGIN` "Entrar", `CORE_COMMON_FORGOT_PASSWORD(_LABEL)` "Esqueceu a senha?", `ES_FORGOT_PASSWORD_DESC`, `USERNAME`, `CORE_FORGOT_USERNAME_PLACEHOLDER`, `CORE_COMMON_CONTINUE` "Continuar", `CORE_COMMON_BACK_TO_LOGIN`. Added en_IN for the 3 keys with no English entry.
> Branding "Presidência" → "Inspecção Geral do Estado (IGE)" is **not** here — that's `TENANT_TENANTS_MZ`, a live-seeded global tenant-name key (data change + scope decision).

## CCSD-2071 — citizen create upload section
- `CS_ADDCOMPLAINT_UPLOAD_PHOTO`: pt **"Enviar fotos ou documentos da reclamação"** (added "ou documentos"); en "Upload complaint photos" → "…or documents".
- `CS_UPLOAD_HINT`: the live pt value rendered a **literal `{formats}`** (single-brace token i18next never interpolates). Replaced with a static list: **"Formatos permitidos: JPG, PNG, PDF, DOC, DOCX, XLS, XLSX. Até 5 MB por ficheiro."**

## CCSD-2072 — citizen create consent checkboxes
`CreatePGRFlowV2.tsx` Step3Description: group the two mandatory consents under an **OBRIGATÓRIO \*** header and the optional confidential opt-in under **OPCIONAL**. New keys `PGR_CONSENT_SECTION_MANDATORY`/`PGR_CONSENT_SECTION_OPTIONAL`. Each checkbox stays individually selectable; mandatory validation untouched; confidential body text unchanged.

## Data-integrity repair (pre-existing #1443 "Fala Cidadão" / CCSD-2077)
- `pt_PT/rainmaker-pgr.json` **was invalid JSON** — `CS_FEEDBACK_RATE_TEXT` and `CS_COMMON_COMMENTS` missing their opening `{`, so the whole pt_PT PGR loc failed to seed. Restored the braces.
- `pt_PT/rainmaker-common.json` had 3 merged objects dropping `CS_HOME_HEADER`, `ACTION_TEST_PGR`, `CS_COMMON_HOME_COMPLAINTS`. Split back into separate objects.

## Testing
All touched JSON parses (raw `"code"` count == parsed entries); modified TSX passes esbuild syntax check.
**Existing envs (cms-pilot, mctd):** `WF_INBOX_HEADER_LOCALITY`, `CS_ADDCOMPLAINT_UPLOAD_PHOTO`, `CS_UPLOAD_HINT` need a live loc upsert (default-data-handler does not overwrite existing rows); new `PGR_CONSENT_SECTION_*` / `ACTION_TEST_SEARCH_COMPLAINT` are additive.

Closes CCSD-2085, CCSD-2083, CCSD-2071, CCSD-2072. Partially addresses CCSD-2084 (login/forgot done; branding pending a data change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)