### PR TITLE
fix(pgr): timeline fully masks complainant name & number (no last-4 / first-letter)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/TimeLineWrapper.js
+++ b/digit-ui-esbuild/products/pgr/src/components/TimeLineWrapper.js
@@ -6,24 +6,16 @@ import { convertEpochFormateToDate } from '../utils';
 // NOTE: no useMyContext() here — the citizen route tree has no MyContext
 // provider, and this wrapper renders on BOTH citizen and employee details.
 // CCSD-1971 (B4): when a complaint is marked confidential, the CITIZEN's
-// identity must not surface in the employee timeline. Names show first char +
-// asterisks; contact numbers keep the last 4 digits (the backend already
-// masks the mobile, this covers the name and any unmasked residue).
-// Fixed-shape mask, mirroring the number convention (*****0104): first letter
-// of each word + exactly three stars — "CMS Case Manager" → "C*** C*** M***".
-// Fixed star count so the mask doesn't leak the real name's length.
-const maskName = (name) => {
-  if (!name || name.length < 2) return name;
-  return String(name)
-    .split(/\s+/)
-    .filter(Boolean)
-    .map((w) => w.charAt(0) + "***")
-    .join(" ");
-};
-const maskPhone = (phone) => {
-  if (!phone || phone.length < 4) return phone;
-  return "******" + phone.slice(-4);
-};
+// identity must not surface in the employee timeline. The complainant's name
+// and number are FULLY masked — no first letter, no last 4 digits — so nothing
+// (value or length) leaks; the backend's own mobile masking is a second layer.
+// Fully masked — the timeline reveals NO complainant PII: not the name's first
+// letter and not the number's last 4 digits. A single fixed token so neither the
+// value nor its length (nor word count) can leak. Clear identity lives only on
+// the complainant card, shown per the viewer's privilege.
+const MASKED = "******";
+const maskName = (name) => (name ? MASKED : name);
+const maskPhone = (phone) => (phone ? MASKED : phone);
 const isCitizenActor = (person) =>
   Array.isArray(person?.roles) && person.roles.some((r) => (r?.code || r) === "CITIZEN");
 


### PR DESCRIPTION
Follow-up to #1417 (CCSD-1971 B4 — "timeline always masks the complainant's name and number").

## Problem
The mask still leaked a bit of the value:
- **Name** → first letter of each word + stars: `C*** C*** M***` (leaks initials + word count).
- **Number** → `******0104` (leaks the last 4 digits).

## Change
Both `maskName` and `maskPhone` now collapse to a single fixed token `******`, so **nothing leaks** — not the first letter, not the last 4 digits, not the length or word count.

```js
const MASKED = "******";
const maskName  = (name)  => (name  ? MASKED : name);
const maskPhone = (phone) => (phone ? MASKED : phone);
```

Only the **mask output** changed. Every call-site is untouched: the citizen actor is still always masked, `maskEmployeeContacts` (employee view) still masks non-citizen actors, `hideEmployeeContacts` (citizen view) still omits employee lines entirely, and the backend-masked-mobile mirror still masks the name when the backend masked the number. Clear identity remains only on the complainant card (shown per the viewer's privilege).

## Testing
`TimeLineWrapper.js` passes esbuild syntax check. FE-only; needs a digit-ui rebuild to take effect on an env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)