### PR TITLE
feat(moz-loc): seed CCSD-1930 complaint-channel labels (were rendering raw keys)

### DIFF
--- a/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
@@ -8182,5 +8182,35 @@
         "message": "OPTIONAL",
         "module": "rainmaker-pgr",
         "locale": "en_IN"
+    },
+    {
+        "code": "ES_CREATECOMPLAINT_RECEIVED_CHANNEL",
+        "message": "Received Channel",
+        "module": "rainmaker-pgr",
+        "locale": "en_IN"
+    },
+    {
+        "code": "PGR_CHANNEL_IN_PERSON",
+        "message": "In Person",
+        "module": "rainmaker-pgr",
+        "locale": "en_IN"
+    },
+    {
+        "code": "PGR_CHANNEL_EMAIL",
+        "message": "Email",
+        "module": "rainmaker-pgr",
+        "locale": "en_IN"
+    },
+    {
+        "code": "PGR_CHANNEL_LETTER",
+        "message": "Letter",
+        "module": "rainmaker-pgr",
+        "locale": "en_IN"
+    },
+    {
+        "code": "PGR_CHANNEL_LINHA_VERDE",
+        "message": "Green Line",
+        "module": "rainmaker-pgr",
+        "locale": "en_IN"
     }
 ]

--- a/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
@@ -1606,5 +1606,35 @@
         "message": "OPCIONAL",
         "module": "rainmaker-pgr",
         "locale": "pt_PT"
+    },
+    {
+        "code": "ES_CREATECOMPLAINT_RECEIVED_CHANNEL",
+        "message": "Canal de Recepção",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "PGR_CHANNEL_IN_PERSON",
+        "message": "Presencial",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "PGR_CHANNEL_EMAIL",
+        "message": "E-mail",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "PGR_CHANNEL_LETTER",
+        "message": "Carta",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "PGR_CHANNEL_LINHA_VERDE",
+        "message": "Linha Verde",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
     }
 ]


### PR DESCRIPTION
The reception-channel chips + section label on the employee create-complaint form rendered as **raw keys** on cms-pilot (`PGR_CHANNEL_IN_PERSON`, `PGR_CHANNEL_EMAIL`, `PGR_CHANNEL_LETTER`, `PGR_CHANNEL_LINHA_VERDE`, `ES_CREATECOMPLAINT_RECEIVED_CHANNEL`) because they were only referenced in `ChannelChipsComponent.js`/`CreateComplaintConfig.js` and never committed to the localization seed.

Adds them to `pt_PT` + `en_IN` `rainmaker-pgr.json` so fresh deploys / `ccrs-migrate` carry them.

| key | pt | en |
|---|---|---|
| ES_CREATECOMPLAINT_RECEIVED_CHANNEL | Canal de Recepção | Received Channel |
| PGR_CHANNEL_IN_PERSON | Presencial | In Person |
| PGR_CHANNEL_EMAIL | E-mail | Email |
| PGR_CHANNEL_LETTER | Carta | Letter |
| PGR_CHANNEL_LINHA_VERDE | Linha Verde | Green Line |

Already **upserted live to cms-pilot** this session (verified). Other envs need the same upsert since default-data-handler does not overwrite existing rows. Part of CCSD-1930.

🤖 Generated with [Claude Code](https://claude.com/claude-code)