### PR TITLE
fix(configurator): mint the enc-service key on the duplicate-tenant path too

### DIFF
--- a/configurator/src/pages/Phase1Page.tsx
+++ b/configurator/src/pages/Phase1Page.tsx
@@ -221,16 +221,14 @@ export default function Phase1Page() {
       // definitely has the tenant.tenants schema, either pre-existing or just
       // registered by bootstrap). This replaces the previous `state.tenant`
       // target — that was a localStorage value, not a deliberate write target.
-      let tenantAlreadyExisted = false;
       try {
         await mdmsService.createTenant(parentState, tenant);
       } catch (err) {
         const msg = err instanceof ApiClientError ? err.firstError : (err instanceof Error ? err.message : '');
         if (!/duplicate|already exists|unique|NON_UNIQUE/i.test(msg)) throw err;
-        tenantAlreadyExisted = true;
       }
 
-      // Give the brand-new tenant its egov-enc-service symmetric key.
+      // Make sure the tenant has its egov-enc-service symmetric key.
       //
       // Every write that carries PII — Phase 4's employees (mobile/email), and
       // any citizen user later — is encrypted per tenant. A tenant with no key
@@ -241,31 +239,34 @@ export default function Phase1Page() {
       // "pre-bootstrap — generate enc-service key"); the wizard has to do it for
       // the tenants IT creates.
       //
-      // Deliberately narrow, so this can never rotate a live tenant's key:
-      //   - only here, on the tenant-CREATION path;
-      //   - skipped entirely when the tenant already existed (duplicate above),
-      //     and skipped for a fresh state root because bootstrapStateRoot()
-      //     already registered the key for it;
-      //   - the endpoint itself is create-if-missing (returns created:false and
-      //     the same keyId when a key exists) — see ensureEncKey();
-      //   - and there is no standalone "regenerate key" control anywhere in the UI.
+      // Called unconditionally, including when createTenant above reported a
+      // duplicate. An existing tenant.tenants record is not evidence of an
+      // existing key — the two live in different services, and every tenant the
+      // wizard created before ensureEncKey existed has the record but no key.
+      // Re-running Phase 1 is the one repair an operator would reach for, so
+      // that path is exactly the one that must mint the key.
+      //
+      // Safe to call on a tenant that already has a key: /crypto/v1/_generatekey
+      // is create-if-missing, never a rotation. Verified against a live tenant
+      // (ke.bomet's sibling pu.chandigarh): first call {created:true,keyId:184},
+      // second {created:false,keyId:184}, one row throughout with an unchanged
+      // key_id. Rotation would strand already-encrypted data (#622) and remains
+      // a deliberate ops action — the UI exposes no "regenerate key" control.
       //
       // Non-fatal: the tenant itself is created and usable for Phases 2-3, so
       // don't roll the operator back to the upload step. Warn instead — Phase 4
       // surfaces the underlying encryption error if this really didn't take.
-      if (!tenantAlreadyExisted) {
-        try {
-          await ensureEncKey(tenant.code);
-        } catch (encErr) {
-          const msg = encErr instanceof ApiClientError
-            ? encErr.firstError
-            : (encErr instanceof Error ? encErr.message : String(encErr));
-          console.warn(`[phase1] enc-service key generation for ${tenant.code} failed: ${msg}`);
-          setWarning(
-            `Tenant created, but registering it with the encryption service failed (${msg}). ` +
-            `Employee creation in Phase 4 will fail until this is resolved.`
-          );
-        }
+      try {
+        await ensureEncKey(tenant.code);
+      } catch (encErr) {
+        const msg = encErr instanceof ApiClientError
+          ? encErr.firstError
+          : (encErr instanceof Error ? encErr.message : String(encErr));
+        console.warn(`[phase1] enc-service key generation for ${tenant.code} failed: ${msg}`);
+        setWarning(
+          `Tenant created, but registering it with the encryption service failed (${msg}). ` +
+          `Employee creation in Phase 4 will fail until this is resolved.`
+        );
       }
 
       // Create localization for tenant name, also at the parent state.


### PR DESCRIPTION
Follow-up to #1375, which fixed #1370 for tenants created from now on but left every tenant created before it permanently broken. Closes the repair path.

## The guard

`Phase1Page` calls `ensureEncKey()` only when `createTenant()` succeeded:

```ts
if (!tenantAlreadyExisted) {
  await ensureEncKey(tenant.code);
}
```

An existing `tenant.tenants` record is not evidence of an existing egov-enc-service key — the two live in different services. Every tenant the wizard created before `ensureEncKey()` existed has the record and no key, and re-running Phase 1 for it is the one repair an operator would naturally reach for. That is exactly the path the guard turns into a no-op. CodeRabbit raised this on #1375; it merged as-is.

This PR drops the guard so the call runs on both paths.

## Why calling it unconditionally is safe

`POST /crypto/v1/_generatekey` is create-if-missing, never a rotation — the same property #1375 relied on to justify calling it at all. Re-verified on bomet against `pu.chandigarh`, the actual tenant from #1370:

| call | response | `eg_enc_symmetric_keys` |
| --- | --- | --- |
| 1st | `{"tenantId":"pu.chandigarh","created":true,"keyId":184}` | one row, `key_id=441120` |
| 2nd | `{"tenantId":"pu.chandigarh","created":false,"keyId":184}` | same one row, `key_id` unchanged |

Rotation would strand already-encrypted data (#622) and stays a deliberate ops action; the UI still exposes no "regenerate key" control.

## Verification of the underlying bug

`pu.chandigarh` was created through the wizard by the same operator whose request is pasted in #1370 — MDMS `createdby` is `fd328e56-…`, the `userInfo.uuid` in that cURL, stamped ~1h40m before the failing call. Its parent `pu` had a key; it did not.

- Before minting: `_encrypt` for `pu.chandigarh` → 500, enc-service log `CustomException: pu.chandigarh : Tenant Id not found`. `pu` and `ke.bomet` encrypt fine. HRMS wraps that into the ticket's `UNKNOWN_ERROR "Unknown error occurred in encryption process"`.
- After minting: `_encrypt` → `["441120|sEjGMMho…"]`, and replaying #1370's employee payload against `/egov-hrms/employees/_create` returns **200**. The missing key was the only thing wrong with that Phase 4 run.

18 tenants on bomet currently have an active `tenant.tenants` record and no active key row; `pu.chandigarh` has been repaired by hand.

## Checks

No new `tsc` or `eslint` findings — zero tsc errors in `Phase1Page.tsx`, and the file's single lint error (`set-state-in-effect` at line 130, untouched here) reproduces identically on unmodified `master`. Both were already red on `master` for unrelated reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tenant creation handling when a tenant already exists.
  * Encryption key registration is now attempted consistently during tenant setup.
  * Added non-blocking warnings when encryption key registration fails, clarifying the potential impact on employee creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->