### PR TITLE
fix(ansible): make Novu browser-facing URLs overridable (#1435)

### DIFF
--- a/local-setup/ansible/inventory/host_vars/_example.yml
+++ b/local-setup/ansible/inventory/host_vars/_example.yml
@@ -363,6 +363,26 @@ novu_bridge_channel: "sms"
 # Subscriber-identify TTL cache (ms) — skip redundant POST /v1/subscribers.
 # novu_bridge_identify_cache_ttl_ms: 300000
 
+# Browser-facing origin for the Novu dashboard SPA (scheme + host, no trailing
+# slash). The dashboard runs in the OPERATOR's browser, so these URLs must name
+# a host the browser can reach — not an in-cluster or loopback address.
+#
+# Defaults to this tenant's own `domain` + `tls_enabled` scheme, which is
+# correct whenever the ansible-managed vhost is the one the browser hits.
+# Set this only when TLS terminates on a vhost whose hostname differs from
+# `domain` — e.g. `domain: localhost` for the internal vhost, with a
+# separately-managed public vhost proxying /novu/, /novu-api/ and /novu-ws/.
+# novu_public_base_url: "https://pilot.example.org"
+
+# Escape hatch for the rare case where the API / WS / dashboard live on
+# DIFFERENT hosts. Prefer novu_public_base_url above — it sets all four at
+# once and keeps the paths aligned with the nginx location blocks.
+# novu_api_public_url:  "https://pilot.example.org/novu-api"
+# novu_ws_public_url:   "https://pilot.example.org/novu-ws"
+# novu_api_root_url:    "https://pilot.example.org/novu-api"
+# novu_front_base_url:  "https://pilot.example.org/novu"
+# novu_node_env: "production"
+
 # ────────── Keycloak SSO (opt-in) ──────────
 # Adds 2 containers (keycloak + token-exchange-svc) plus the host
 # nginx /auth/ and /token-exchange/ location blocks. Inert in the

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -27,6 +27,52 @@
     DOCKER_DEFAULT_PLATFORM: "{{ docker_default_platform | default('') }}"
 
   pre_tasks:
+    # ── host_vars naming preflight ─────────────────────────────────────────
+    # Ansible variables are lowercase (every key in inventory/host_vars/ is).
+    # The env-var names on the LEFT of `=` in templates/digit.env.j2 are
+    # UPPERCASE, so it is easy to copy e.g. NOVU_API_ROOT_URL out of a rendered
+    # .env into host_vars — where nothing reads it. Ansible accepts the key
+    # silently and the deploy renders defaults instead, which is only
+    # discoverable by diffing the rendered .env afterwards (issue #1435).
+    # Fail loudly at the start of the run instead.
+    - name: "preflight — locate this host's host_vars file"
+      ansible.builtin.stat:
+        path: "{{ playbook_dir }}/inventory/host_vars/{{ inventory_hostname }}.yml"
+      register: host_vars_file
+      delegate_to: localhost
+      become: false
+      changed_when: false
+
+    - name: "preflight — read this host's host_vars file"
+      ansible.builtin.slurp:
+        src: "{{ host_vars_file.stat.path }}"
+      register: host_vars_raw
+      delegate_to: localhost
+      become: false
+      when: host_vars_file.stat.exists
+
+    - name: "preflight — reject UPPERCASE host_vars keys (nothing reads them)"
+      ansible.builtin.assert:
+        that: uppercase_host_vars_keys | length == 0
+        fail_msg: |
+          host_vars/{{ inventory_hostname }}.yml defines UPPERCASE key(s):
+            {{ uppercase_host_vars_keys | join(', ') }}
+          Ansible variables are lowercase. These keys are read by NOTHING —
+          the deploy will render template defaults instead. Rename them to
+          lowercase, e.g. NOVU_API_ROOT_URL -> novu_api_root_url.
+          To point the Novu dashboard at an origin other than `domain`, set
+          novu_public_base_url once rather than each URL individually.
+        success_msg: "host_vars key naming OK"
+      vars:
+        uppercase_host_vars_keys: >-
+          {{ (host_vars_raw.content | b64decode).splitlines()
+             | select('match', '^[A-Z][A-Za-z0-9_]*:')
+             | map('regex_replace', ':.*$', '')
+             | list }}
+      when: host_vars_file.stat.exists
+      delegate_to: localhost
+      become: false
+
     # ── Force-clean teardown ───────────────────────────────────────────────
     # Opt-in via `force_clean: true` in host_vars. Tears down all running
     # containers and removes orphaned networks before re-deploying, so a

--- a/local-setup/ansible/templates/digit.env.j2
+++ b/local-setup/ansible/templates/digit.env.j2
@@ -55,14 +55,24 @@ MAC_JVM_OPTS={{ '-XX:TieredStopAtLevel=1 -Xshare:off' if ansible_system == 'Darw
 {% if enable_novu | default(false) %}
 # Novu dashboard SPA runs in the operator's browser — it can't reach
 # `localhost:14002` because that would mean the operator's laptop.
-# Use the rendered domain, proxied through the host nginx /novu-api/
-# and /novu-ws/ locations (defined in nginx-site.conf.j2 under the
-# same enable_novu flag). Single-origin keeps cookies / CORS clean.
-NOVU_NODE_ENV=production
-NOVU_API_PUBLIC_URL={{ 'https://' + domain if (tls_enabled | default(true)) else 'http://' + domain }}/novu-api
-NOVU_WS_PUBLIC_URL={{ 'https://' + domain if (tls_enabled | default(true)) else 'http://' + domain }}/novu-ws
-NOVU_API_ROOT_URL={{ 'https://' + domain if (tls_enabled | default(true)) else 'http://' + domain }}/novu-api
-NOVU_FRONT_BASE_URL={{ 'https://' + domain if (tls_enabled | default(true)) else 'http://' + domain }}/novu
+# It must use the origin the BROWSER reaches, proxied through the host
+# nginx /novu-api/ and /novu-ws/ locations (defined in nginx-site.conf.j2
+# under the same enable_novu flag). Single-origin keeps cookies / CORS clean.
+#
+# That origin defaults to this tenant's own `domain`, which is right whenever
+# the ansible-managed vhost is the one the browser hits. Override
+# `novu_public_base_url` (scheme + host, no trailing slash) when TLS
+# terminates on a vhost whose hostname differs from `domain` — e.g. an
+# internal `domain: localhost` fronted by a separately-managed public vhost.
+# The /novu-api, /novu-ws and /novu paths stay owned by this template because
+# they must match the nginx location blocks; the per-URL overrides below are
+# an escape hatch for the rare split-host case, not the normal knob.
+{% set novu_public_origin = novu_public_base_url | default(('https://' if (tls_enabled | default(true)) else 'http://') + domain) %}
+NOVU_NODE_ENV={{ novu_node_env | default('production') }}
+NOVU_API_PUBLIC_URL={{ novu_api_public_url | default(novu_public_origin + '/novu-api') }}
+NOVU_WS_PUBLIC_URL={{ novu_ws_public_url | default(novu_public_origin + '/novu-ws') }}
+NOVU_API_ROOT_URL={{ novu_api_root_url | default(novu_public_origin + '/novu-api') }}
+NOVU_FRONT_BASE_URL={{ novu_front_base_url | default(novu_public_origin + '/novu') }}
 # Dashboard image: locally-built subpath-rebased image when
 # `build_novu_dashboard: true` (tag novu-dashboard:local), else stock registry.
 # Resolved by the "Resolve novu-dashboard image tag" set_fact in the playbook.


### PR DESCRIPTION
Fixes #1435.

## The problem

The Novu dashboard is a browser SPA, so `NOVU_API_PUBLIC_URL` / `WS_PUBLIC_URL` / `API_ROOT_URL` / `FRONT_BASE_URL` must name an origin the **operator's browser** can reach. `digit.env.j2` hardcoded all four from `domain`:

```jinja
NOVU_API_PUBLIC_URL={{ 'https://' + domain if (tls_enabled | default(true)) else 'http://' + domain }}/novu-api
```

There is no variable there, so a tenant whose public origin differs from `domain` cannot express that in inventory at all — no name and no casing works. On the reporting tenant the dashboard was left calling `http://localhost/novu-api`, i.e. the operator's own laptop, and did not load.

## The fix — a three-tier cascade

| tier | variable | when |
|---|---|---|
| 1 | `novu_api_root_url`, `novu_ws_public_url`, … | escape hatch: API / WS / dashboard genuinely on different hosts |
| 2 | **`novu_public_base_url`** | the origin — the normal knob, sets all four at once |
| 3 | `domain` + `tls_enabled` scheme | unchanged current behaviour, the default |

Tier 2 is what operators actually need. A tenant terminating TLS on a vhost whose hostname differs from `domain` — `domain: localhost` for the ansible-managed internal vhost, with a separately managed public vhost proxying `/novu/`, `/novu-api/`, `/novu-ws/` — now sets **one** variable instead of four:

```yaml
novu_public_base_url: "https://pilot.example.org"
```

The `/novu-api`, `/novu-ws` and `/novu` paths stay owned by the template, because they have to match the nginx `location` blocks; hand-retyping them per-tenant is how one of them ends up wrong. `NOVU_NODE_ENV` becomes overridable for symmetry.

## No behaviour change for existing tenants

With no overrides the cascade falls through to the current expression. Verified by rendering this template and master's side by side for a tls tenant, a no-tls tenant, and one with `tls_enabled` unset — all three byte-identical. Also checked that a tier-1 override wins while the other three keep the tier-2 origin.

## Second commit-worth: the failure was silent

The env-var names on the left of `=` in this template are UPPERCASE, so copying one into `host_vars` is a natural mistake. Ansible then accepts `NOVU_API_ROOT_URL:` as a perfectly valid variable that nothing reads, and the deploy renders defaults. The only way to notice is to diff the rendered `.env` afterwards — which is exactly how #1435 was found, after a deploy cycle.

Added a preflight assert that fails at the start of the run and names the offending keys:

```
host_vars/<tenant>.yml defines UPPERCASE key(s):
  NOVU_API_ROOT_URL, NOVU_FRONT_BASE_URL, NOVU_NODE_ENV, NOVU_BRIDGE_WORKFLOW_ID_WHATSAPP
Ansible variables are lowercase. These keys are read by NOTHING —
the deploy will render template defaults instead. ...
```

Tested against a fixture carrying the reporting tenant's real key set (fails, names all four), a corrected lowercase one (passes), and a commented-out `# NOVU_API_ROOT_URL:` (correctly ignored). It reads the host_vars file directly rather than `hostvars`, so injected facts cannot cause false positives, and skips cleanly when a host is defined inline in `hosts.yml`.

## Validation

- `ansible-playbook --syntax-check` clean
- template render diff vs `master` across 3 tenant shapes — identical
- cascade precedence + `novu_node_env` override — tested
- preflight assert — tested both directions

No deploy was run; all inspection of the reporting host was read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)