### PR TITLE
fix(pgr): glassmorphism map location tooltip (stop it covering the map)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/ComplaintLocationMap.js
+++ b/digit-ui-esbuild/products/pgr/src/components/ComplaintLocationMap.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo } from "react";
 import { MapContainer, TileLayer, Marker, Tooltip, GeoJSON } from "react-leaflet";
 import "leaflet/dist/leaflet.css";
 import L from "leaflet";
+import { injectGlassTooltipStyle } from "../utils/mapTooltipStyle";
 import { CardLabel } from "@egovernments/digit-ui-react-components";
 import { useTranslation } from "react-i18next";
 import booleanPointInPolygon from "@turf/boolean-point-in-polygon";
@@ -16,6 +17,9 @@ L.Icon.Default.mergeOptions({
   iconUrl: "https://unpkg.com/leaflet@1.6.0/dist/images/marker-icon.png",
   shadowUrl: "https://unpkg.com/leaflet@1.6.0/dist/images/marker-shadow.png",
 });
+
+// Frosted-glass styling for the address tooltip so it no longer covers the map.
+injectGlassTooltipStyle();
 
 const NavigationIcon = () => (
   <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -195,7 +199,7 @@ const ComplaintLocationMap = ({ latitude, longitude, address }) => {
             )}
             <Marker position={[latitude, longitude]}>
               {displayAddress && (
-                <Tooltip permanent direction="top" offset={[0, -30]} opacity={1}>
+                <Tooltip permanent direction="top" offset={[0, -30]} opacity={1} className="pgr-loc-tooltip">
                   <div style={{
                     fontSize: "14px",
                     fontWeight: "600",

--- a/digit-ui-esbuild/products/pgr/src/components/GeoLocations.js
+++ b/digit-ui-esbuild/products/pgr/src/components/GeoLocations.js
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { MapContainer, TileLayer, Marker, Tooltip, Polygon, GeoJSON, useMapEvents, useMap } from "react-leaflet";
 import "leaflet/dist/leaflet.css";
+import { injectGlassTooltipStyle } from "../utils/mapTooltipStyle";
 import L from "leaflet";
 import { CardLabel, Loader } from "@egovernments/digit-ui-react-components";
 import { Toast } from "@egovernments/digit-ui-components";
@@ -18,6 +19,9 @@ L.Icon.Default.mergeOptions({
   iconUrl: "https://unpkg.com/leaflet@1.6.0/dist/images/marker-icon.png",
   shadowUrl: "https://unpkg.com/leaflet@1.6.0/dist/images/marker-shadow.png",
 });
+
+// Frosted-glass styling for the address tooltip so it no longer covers the map.
+injectGlassTooltipStyle();
 
 // Inline-SVG accent fills follow the runtime theme via `--color-primary-accent`.
 // `currentColor` reads the host element's `color`, which we drive from the CSS var.

--- a/digit-ui-esbuild/products/pgr/src/utils/mapTooltipStyle.js
+++ b/digit-ui-esbuild/products/pgr/src/utils/mapTooltipStyle.js
@@ -1,0 +1,58 @@
+// Glassmorphism styling for the PGR map location tooltips — the permanent
+// Leaflet tooltip that shows the reverse-geocoded address on the create-location
+// picker (GeoLocations.js, class `custom-leaflet-tooltip`) and the complaint
+// details view (ComplaintLocationMap.js, class `pgr-loc-tooltip`).
+//
+// Before: the tooltip was a solid box sitting on top of the pin that covered the
+// pin and the map behind it. This turns it into a translucent frosted-glass
+// panel — the map stays visible (blurred) through it and it no longer dominates
+// the view. Injected once (idempotent): Leaflet tooltip internals (the panel
+// background and the ::before arrow) can't be styled inline, so a stylesheet is
+// required. `!important` overrides Leaflet's default `.leaflet-tooltip` box.
+//
+// Colours are theme-aware: the text uses the app's --color-text-primary and the
+// glass tint is a neutral frost that reads on the light CARTO basemap.
+const STYLE_ID = "pgr-glass-tooltip-style";
+
+export function injectGlassTooltipStyle() {
+  if (typeof document === "undefined") return;
+  if (document.getElementById(STYLE_ID)) return;
+  const el = document.createElement("style");
+  el.id = STYLE_ID;
+  el.textContent = `
+    .custom-leaflet-tooltip.leaflet-tooltip,
+    .pgr-loc-tooltip.leaflet-tooltip {
+      background: rgba(255, 255, 255, 0.5) !important;
+      -webkit-backdrop-filter: blur(12px) saturate(150%);
+      backdrop-filter: blur(12px) saturate(150%);
+      border: 1px solid rgba(255, 255, 255, 0.6) !important;
+      border-radius: 12px !important;
+      box-shadow: 0 6px 22px rgba(16, 24, 40, 0.14) !important;
+      color: var(--color-text-primary, #0B0C0C) !important;
+      padding: 2px 6px !important;
+    }
+    /* Keep the inner content legible and inheriting the frosted panel colour */
+    .custom-leaflet-tooltip.leaflet-tooltip > div,
+    .pgr-loc-tooltip.leaflet-tooltip > div {
+      color: var(--color-text-primary, #0B0C0C) !important;
+    }
+    /* Tint the direction arrow to the glass so it isn't a solid wedge */
+    .custom-leaflet-tooltip.leaflet-tooltip-top::before,
+    .pgr-loc-tooltip.leaflet-tooltip-top::before {
+      border-top-color: rgba(255, 255, 255, 0.5) !important;
+    }
+    .custom-leaflet-tooltip.leaflet-tooltip-bottom::before,
+    .pgr-loc-tooltip.leaflet-tooltip-bottom::before {
+      border-bottom-color: rgba(255, 255, 255, 0.5) !important;
+    }
+    .custom-leaflet-tooltip.leaflet-tooltip-left::before,
+    .pgr-loc-tooltip.leaflet-tooltip-left::before {
+      border-left-color: rgba(255, 255, 255, 0.5) !important;
+    }
+    .custom-leaflet-tooltip.leaflet-tooltip-right::before,
+    .pgr-loc-tooltip.leaflet-tooltip-right::before {
+      border-right-color: rgba(255, 255, 255, 0.5) !important;
+    }
+  `;
+  document.head.appendChild(el);
+}


### PR DESCRIPTION
## Problem
The permanent Leaflet tooltip that shows the reverse-geocoded address rendered as a **solid box sitting on top of the pin** — it covered the marker and blocked the map behind it. Happens on both:
- the **create-location picker** (`GeoLocations.js`, citizen + employee create), and
- the **complaint-details** map (`ComplaintLocationMap.js`, citizen + employee view).

## Fix
New shared util `products/pgr/src/utils/mapTooltipStyle.js` injects (once, idempotent) a **frosted-glass** style for the tooltip:
- translucent background `rgba(255,255,255,0.5)` + `backdrop-filter: blur(12px) saturate(150%)` → the map stays visible (blurred) **through** the panel instead of being hidden;
- soft rounded border + shadow, theme-aware text (`--color-text-primary`);
- the `::before` **direction arrow** tinted to the glass so it isn't a solid wedge.

Applied to `.custom-leaflet-tooltip` (picker — already had the class) and a new `.pgr-loc-tooltip` class added to the details-view tooltip. `!important` overrides Leaflet's default `.leaflet-tooltip` box (which can't be styled inline, hence the injected sheet).

## Testing
- Full esbuild build compiles; the glass CSS ships in the bundle (verified); deployed to the local container.
- FE-only, no behaviour change — only the tooltip's appearance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)