### PR TITLE
fix(core): employee login + forgot-password ignored localization (double-resolve)

### DIFF
--- a/digit-ui-esbuild/packages/modules/core/src/pages/employee/ForgotPassword/index.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/employee/ForgotPassword/index.js
@@ -12,9 +12,15 @@ const EmployeeForgotPassword = ({stateCode}) => {
   const params = useMemo(() =>
     loginConfig.map(
       (step) => {
+        // Pass the raw loc KEYS through — forgotPassword.js resolves them via
+        // its own tr(key, fallback) at render. Pre-resolving with t() here and
+        // letting tr() run again double-resolves: tr sees an already-translated
+        // message, trans(message) === message, and returns the English fallback
+        // — so the header/description/submit texts ignored the locale. Keeping
+        // raw keys makes tr() resolve them once.
         const texts = {};
         for (const key in step.texts) {
-          texts[key] = t(step.texts[key]);
+          texts[key] = step.texts[key];
         }
         return { ...step, texts };
       },

--- a/digit-ui-esbuild/packages/modules/core/src/pages/employee/Login/index.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/employee/Login/index.js
@@ -55,9 +55,15 @@ const EmployeeLogin = ({ stateCode, appTenants }) => {
   const loginParams = useMemo(() =>
     loginConfig.map(
       (step) => {
+        // Pass the raw loc KEYS through — the login component resolves them via
+        // its own tr(key, fallback) at render. Pre-resolving here with t() and
+        // then letting tr() run again double-resolves: tr sees an already-
+        // translated message, trans(message) === message, and returns the
+        // English fallback — so the header/submit/forgot texts ignored the
+        // locale entirely. Keeping raw keys makes tr() resolve them once.
         const texts = {};
         for (const key in step.texts) {
-          texts[key] = t(step.texts[key]);
+          texts[key] = step.texts[key];
         }
         return { ...step, texts };
       },
@@ -68,9 +74,15 @@ const EmployeeLogin = ({ stateCode, appTenants }) => {
   const loginOtpParams = useMemo(() =>
     loginOtpConfig.map(
       (step) => {
+        // Pass the raw loc KEYS through — the login component resolves them via
+        // its own tr(key, fallback) at render. Pre-resolving here with t() and
+        // then letting tr() run again double-resolves: tr sees an already-
+        // translated message, trans(message) === message, and returns the
+        // English fallback — so the header/submit/forgot texts ignored the
+        // locale entirely. Keeping raw keys makes tr() resolve them once.
         const texts = {};
         for (const key in step.texts) {
-          texts[key] = t(step.texts[key]);
+          texts[key] = step.texts[key];
         }
         return { ...step, texts };
       },


### PR DESCRIPTION
## Symptom
On the employee **login** and **forgot-password** screens, the header, submit button and forgot/description copy render in **English** even when the pt_PT values are present on the backend — while the field labels next to them (Nome de usuário, Cidade, …) localize correctly. Verified the loc **is** on the backend (`CORE_COMMON_FORGOT_PASSWORD_LABEL` = "Esqueceu sua senha?", `CORE_COMMON_CONTINUE` = "Continuar", `CORE_COMMON_LOGIN` = "Entrar", …), so it was not a data gap.

## Root cause — double resolution
`Login/index.js` and `ForgotPassword/index.js` **pre-resolve** the config `texts`:
```js
for (const key in step.texts) texts[key] = t(step.texts[key]);   // key -> message
```
The component then runs each through its own `tr`:
```js
const tr = (key, fallback) => { const v = trans(key); return v === key ? fallback : v; };
```
Since `texts.header` is **already a translated message**, `trans(message)` returns it unchanged → `v === key` is true → `tr` returns the **English fallback**. So these texts ignored localization entirely. The input labels were never pre-resolved (passed as raw keys), which is why only the `texts` group was broken.

## Fix
Pass the **raw keys** through so `tr()` resolves them once:
```js
for (const key in step.texts) texts[key] = step.texts[key];   // raw key
```

## Proof
Resolution simulation of both paths:
```
BEFORE (double-resolve): "Forgot password?"   <- English fallback (bug)
AFTER  (raw key):        "Esqueceu sua senha?" <- pt resolves
```
Build compiles; deployed to the local container. FE-only; **benefits every deployment** — the login/forgot texts now honour localization instead of always falling back to hardcoded English. Fixes the remaining visible part of CCSD-2084.

🤖 Generated with [Claude Code](https://claude.com/claude-code)