### PR TITLE
fix(analytics): pin "complaints created today" to the calendar day (#1462)

### DIFF
--- a/ansible/nairobi-mdms/mdms/dss/KpiDefinition.json
+++ b/ansible/nairobi-mdms/mdms/dss/KpiDefinition.json
@@ -66,7 +66,12 @@
             "name": "total",
             "agg": "count"
           }
-        ]
+        ],
+        "window": {
+          "name": "dtd",
+          "timeRole": "filed_at",
+          "pinned": true
+        }
       },
       "supportsSeries": true,
       "viz": {
@@ -87,19 +92,7 @@
         "dateKey": "created_date",
         "sparklineMeasureKey": "total"
       },
-      "params": [
-        {
-          "name": "window",
-          "default": "last_1d",
-          "allowed": [
-            "last_1d",
-            "last_7d",
-            "last_30d",
-            "wtd",
-            "mtd"
-          ]
-        }
-      ],
+      "params": [],
       "rbac": {
         "visibleTo": []
       }

--- a/backend/pgr-services/ANALYTICS-QUERY-API.md
+++ b/backend/pgr-services/ANALYTICS-QUERY-API.md
@@ -142,15 +142,29 @@ with no range it fell back to a rolling 24h rather than the calendar day.
 
 For a pinned window:
 
-- the `window` param and `dateFrom`/`dateTo` do **not** rewrite the time predicate;
-- if the selected range cannot contain the pinned interval, the entry is **suppressed** — no SQL is
-  run and the result is `{ rows: [], rowCount: 0, suppressed: "filter_excludes_window" }`, so the
-  tile renders "no data for the applied filters" rather than a number for the wrong period;
+- the `window` param and `dateFrom`/`dateTo` do **not** rewrite the time predicate; a supplied
+  `window` param comes back as `paramsIgnored: ["window"]` rather than being silently swallowed;
+- if the selected range does not **cover** the pinned interval, the entry is **suppressed** — no SQL
+  is run and the result is `{ rows: [], rowCount: 0, suppressed: "filter_excludes_window" }`.
+  Coverage, not mere overlap: a partial intersection would report the tile's full pinned total under
+  a filter that excludes part of that period;
 - `compare: "prior"` means the preceding window of equal span (yesterday, for `dtd`) rather than the
   prior-equal-duration of the selected range;
-- `series: "daily"` is unaffected — the sparkline is trend context over the selected range and stays
+- `series: "daily"` gets an axis **wider** than the pin — the selected range, else the `window` param,
+  else a rolling `last_30d` — so the sparkline is a trend rather than a single bucket, and it stays
   answerable even when the headline value is suppressed;
-- `ward` / `serviceCode` / `complaintPath` / `hierLevel` still apply: pinning fixes **time**, not filters.
+- `ward` / `serviceCode` / `complaintPath` / `hierLevel` still apply: pinning fixes **time**, not filters;
+- pinning a boundless window (`all` / `live`) is meaningless — there is no interval to cover and no
+  preceding period — and is ignored: such a def takes the ordinary path.
+
+The pinned window is resolved **once** per request and baked into explicit `gte`/`lt` bounds, so the
+suppression verdict and the executed SQL are always judged against the same instant.
+
+`suppressed` is a machine-readable reason code on the response, not a rendering: the dashboard
+currently falls back to its existing unavailable state for such a tile. Wording the empty state
+("No data available with applied filters") and distinguishing it from an ordinary zero is
+[#1456](https://github.com/egovernments/Citizen-Complaint-Resolution-System/issues/1456), which this
+reason code exists to give the frontend something to key off.
 
 Unpinned defs — every other tile — are completely unchanged.
 

--- a/backend/pgr-services/ANALYTICS-QUERY-API.md
+++ b/backend/pgr-services/ANALYTICS-QUERY-API.md
@@ -119,10 +119,40 @@ distinct-countable but not filterable** — arbitrary UUID probing is rejected.
 "window": { "name": "last_30d", "timeBucket": "month", "timeRole": "filed_at" }
 ```
 
-- `name`: `all` | `live` | `last_<N>d` | `wtd` | `mtd` | `qtd` | `ytd` (computed in EAT/UTC+3).
+- `name`: `all` | `live` | `last_<N>d` | `dtd` | `wtd` | `mtd` | `qtd` | `ytd` (computed in EAT/UTC+3).
+  `dtd` is the **calendar** day ("today"); `last_1d` is a rolling 24h and drifts across midnight.
+- `pinned`: `true` marks the window as the tile's own time axis — the `window` param and
+  `dateFrom`/`dateTo` no longer rewrite it (see **Pinned windows** below). Default `false`,
+  i.e. every existing def keeps letting the dashboard's range govern its time axis.
 - `timeBucket`: `day` | `week` | `month` | `quarter` | `year` — adds a `bucket` group-by column.
 - `timeRole`: a named time column for the grain (e.g. facts: `filed_at`, `resolved_at`;
   events: `event_at`; daily: `snapshot_date`). Defaults per grain.
+
+### Pinned windows
+
+A def that means a fixed period regardless of the dashboard's filters declares it on the window:
+
+```json
+"window": { "name": "dtd", "timeRole": "filed_at", "pinned": true }
+```
+
+"Complaints created today" is the motivating case (#1462): with the range filter applied it was
+counting the **selected range**, so a month filter made it identical to "New complaints created";
+with no range it fell back to a rolling 24h rather than the calendar day.
+
+For a pinned window:
+
+- the `window` param and `dateFrom`/`dateTo` do **not** rewrite the time predicate;
+- if the selected range cannot contain the pinned interval, the entry is **suppressed** — no SQL is
+  run and the result is `{ rows: [], rowCount: 0, suppressed: "filter_excludes_window" }`, so the
+  tile renders "no data for the applied filters" rather than a number for the wrong period;
+- `compare: "prior"` means the preceding window of equal span (yesterday, for `dtd`) rather than the
+  prior-equal-duration of the selected range;
+- `series: "daily"` is unaffected — the sparkline is trend context over the selected range and stays
+  answerable even when the headline value is suppressed;
+- `ward` / `serviceCode` / `complaintPath` / `hierLevel` still apply: pinning fixes **time**, not filters.
+
+Unpinned defs — every other tile — are completely unchanged.
 
 ### `params` — kpiId-by-reference tuning knobs
 
@@ -134,8 +164,8 @@ ignored) and every declared param with an `allowed` list is enforced server-side
 
 | param | effect |
 |---|---|
-| `window` | overrides `query.window.name`, preserving `timeRole`/`timeBucket` |
-| `dateFrom` + `dateTo` | inclusive ISO dates → half-open range on the grain's time column; removes the base window |
+| `window` | overrides `query.window.name`, preserving `timeRole`/`timeBucket` — **ignored on a pinned window** |
+| `dateFrom` + `dateTo` | inclusive ISO dates → half-open range on the grain's time column; removes the base window. **On a pinned window it does not rewrite the predicate** — it only decides whether the tile is answerable |
 | `ward` | narrows `ward_code = ?` iff filterable on the grain |
 | `serviceCode` | narrows `service_code = ?` iff filterable — the param for complaint-type **leaf** selections (exact match; works on every grain incl. daily) |
 | `complaintPath` | narrows to a complaint-hierarchy **interior** node's whole subtree: a delimiter-guarded `subtree` predicate on `complaint_node_path` (`= ? OR LIKE ?\|\|'.%'`) iff the grain carries the path column (facts/events). Value = the node's dot-path (`SANITATION.SEWAGE`); validated against `[A-Za-z0-9._/-]` (max 256 chars) — anything else is `invalid_param`. On the daily grain (no path column) the filter cannot apply and the result envelope reports `paramsIgnored:["complaintPath"]` instead of silently serving unfiltered numbers. Leaf selections keep using `serviceCode`; NULL-path rows (node codes containing `.`, flat tenants) never match a subtree |

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java
@@ -22,6 +22,7 @@ public class AnalyticsPlanner {
     private static final ZoneId EAT = ZoneId.of("Africa/Nairobi");           // UTC+3
     private static final Pattern ALIAS = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]{0,63}$");
     private static final Set<String> BUCKETS = new HashSet<>(Arrays.asList("day","week","month","quarter","year"));
+    private static final Pattern LAST_N_DAYS = Pattern.compile("^last_(\\d+)d$");
     private static final int MAX_LIMIT = 1000;
 
     private final AnalyticsCatalog catalog;
@@ -282,6 +283,35 @@ public class AnalyticsPlanner {
     }
 
     // ---------- window ----------
+
+    /**
+     * Resolve a named window to its inclusive start instant (epoch-ms) in EAT. Every window ends at
+     * {@code now}, so the name alone fixes the interval {@code [start, now)}.
+     *
+     * <p>Returns {@code null} for the boundless names ({@code all}) and for {@code live}, which is a
+     * state predicate rather than a time interval — callers handle those before asking.
+     *
+     * <p>Shared with {@link KpiQueryComposer}, which needs the same start instant to decide whether a
+     * pinned window overlaps the dashboard's selected date range. Keeping one implementation means a
+     * window can never mean one thing when planned and another when range-checked.
+     */
+    static Long windowStartMs(String name, long now){
+        if (name == null || name.equals("all") || name.equals("live")) return null;
+        ZonedDateTime nowEat = Instant.ofEpochMilli(now).atZone(EAT);
+        java.util.regex.Matcher lastN = LAST_N_DAYS.matcher(name);
+        if (lastN.matches()) return now - Long.parseLong(lastN.group(1)) * 86400000L;
+        switch (name) {
+            // dtd — day-to-date: the CALENDAR day in EAT, i.e. "today". Distinct from last_1d, which
+            // is a rolling 24h and drifts across midnight (#1462).
+            case "dtd": return nowEat.toLocalDate().atStartOfDay(EAT).toInstant().toEpochMilli();
+            case "wtd": return nowEat.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)).toLocalDate().atStartOfDay(EAT).toInstant().toEpochMilli();
+            case "mtd": return nowEat.withDayOfMonth(1).toLocalDate().atStartOfDay(EAT).toInstant().toEpochMilli();
+            case "qtd": return nowEat.toLocalDate().with(IsoFields.DAY_OF_QUARTER, 1L).atStartOfDay(EAT).toInstant().toEpochMilli();
+            case "ytd": return nowEat.withDayOfYear(1).toLocalDate().atStartOfDay(EAT).toInstant().toEpochMilli();
+            default: throw new IllegalArgumentException("invalid_param: unknown window '" + name + "'");
+        }
+    }
+
     private void applyWindow(JsonNode window, Grain g, String timeCol, List<String> conj, List<Object> params){
         if (window == null || !window.hasNonNull("name")) return;
         String name = window.get("name").asText();
@@ -291,18 +321,8 @@ public class AnalyticsPlanner {
             params.add(true); return;
         }
         long now = System.currentTimeMillis();
-        ZonedDateTime nowEat = Instant.ofEpochMilli(now).atZone(EAT);
-        Long fromMs;
-        java.util.regex.Matcher lastN = Pattern.compile("^last_(\\d+)d$").matcher(name);
-        if (lastN.matches()) {
-            fromMs = now - Long.parseLong(lastN.group(1)) * 86400000L;
-        } else switch (name) {
-            case "wtd": fromMs = nowEat.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)).toLocalDate().atStartOfDay(EAT).toInstant().toEpochMilli(); break;
-            case "mtd": fromMs = nowEat.withDayOfMonth(1).toLocalDate().atStartOfDay(EAT).toInstant().toEpochMilli(); break;
-            case "qtd": { LocalDate d = nowEat.toLocalDate().with(IsoFields.DAY_OF_QUARTER, 1L); fromMs = d.atStartOfDay(EAT).toInstant().toEpochMilli(); break; }
-            case "ytd": fromMs = nowEat.withDayOfYear(1).toLocalDate().atStartOfDay(EAT).toInstant().toEpochMilli(); break;
-            default: throw new IllegalArgumentException("invalid_param: unknown window '" + name + "'");
-        }
+        Long fromMs = windowStartMs(name, now);
+        if (fromMs == null) return;
         if (g.isEpochMs(timeCol)) {
             conj.add(timeCol + " >= ?"); params.add(fromMs);
             conj.add(timeCol + " < ?");  params.add(now);

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
@@ -486,6 +486,19 @@ public class AnalyticsService {
      */
     private Map<String,Object> runOne(JsonNode q, AnalyticsScope scope, QueryTelemetry tel,
                                       String entryName, String kpiId){
+        // #1462: a pinned-window def whose interval falls outside the selected date range is
+        // unanswerable, not empty-by-filter. Return no rows WITHOUT running SQL, flagged so the tile
+        // renders "no data for the applied filters" rather than a zero the user would read as fact.
+        if (q.path(KpiQueryComposer.SUPPRESSED).asBoolean(false)) {
+            Map<String,Object> r = new LinkedHashMap<>();
+            r.put("grain", q.hasNonNull("grain") ? q.get("grain").asText() : "facts");
+            r.put("columns", Collections.emptyList());
+            r.put("rows", Collections.emptyList());
+            r.put("rowCount", 0);
+            r.put("suppressed", "filter_excludes_window");
+            r.put("tookMs", 0L);
+            return r;
+        }
         AnalyticsPlanner.Planned p = planner.plan(q, scope);
         long t0 = System.currentTimeMillis();
         List<Map<String,Object>> rows = jdbc.queryForList(p.sql, p.params.toArray());
@@ -511,7 +524,7 @@ public class AnalyticsService {
         Map<String,Object> out = new LinkedHashMap<>();
         out.put("aggFns", AnalyticsCatalog.AGG_FNS);
         out.put("filterOps", Arrays.asList("eq","ne","gt","gte","lt","lte","in","isnull","starts_with","subtree"));
-        out.put("windows", Arrays.asList("all","live","last_<N>d","wtd","mtd","qtd","ytd"));
+        out.put("windows", Arrays.asList("all","live","last_<N>d","dtd","wtd","mtd","qtd","ytd"));
         out.put("timeBuckets", Arrays.asList("day","week","month","quarter","year"));
         Map<String,Object> grains = new LinkedHashMap<>();
         for (Grain g : catalog.grains()) {

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
@@ -205,7 +205,11 @@ public class AnalyticsService {
      */
     private JsonNode resolveKpiRef(JsonNode queryNode, String tenantId, Set<String> callerRoles,
                                    List<String> paramsIgnored) {
-        if (!queryNode.has("kpiId")) return queryNode;
+        // Inline path: the suppression marker is composer-internal, so a caller-supplied one is
+        // stripped rather than trusted. Replaying a logged effective query (which legitimately
+        // carries it) must still be planned and validated, not short-circuited into a clean empty
+        // result that masks whatever the planner would have rejected.
+        if (!queryNode.has("kpiId")) return stripSuppressionMarker(queryNode);
 
         String kpiId = queryNode.get("kpiId").asText();
         Optional<KpiDefinition> def = kpiCatalogService.getDef(kpiId, tenantId);
@@ -343,6 +347,20 @@ public class AnalyticsService {
             if (srcQuery == null)
                 throw new IllegalArgumentException("kpi_forbidden: compose source '" + srcId.asText() + "' not authorized");
             Map<String,Object> r = runOne(srcQuery, scope, tel, entryName, srcId.asText());
+            // A suppressed source is UNANSWERABLE, not zero. firstRow() would flatten it to {} and
+            // computeCompose would read a missing measure as 0 — netBacklogDaily would then publish a
+            // confident number derived from a period the filter excludes. Propagate instead.
+            if (r.containsKey("suppressed")) {
+                Map<String,Object> out = new LinkedHashMap<>();
+                out.put("grain", "compose");
+                out.put("columns", Collections.emptyList());
+                out.put("rows", Collections.emptyList());
+                out.put("rowCount", 0);
+                out.put("compose", type);
+                out.put("suppressed", r.get("suppressed"));
+                if (!paramsIgnored.isEmpty()) out.put("paramsIgnored", paramsIgnored);
+                return out;
+            }
             sourceRows.add(firstRow(r));
         }
 
@@ -358,6 +376,20 @@ public class AnalyticsService {
         out.put("compose", type);
         if (!paramsIgnored.isEmpty()) out.put("paramsIgnored", paramsIgnored);
         return out;
+    }
+
+    /**
+     * Remove a caller-supplied {@link KpiQueryComposer#SUPPRESSED} marker. Copy-on-write: the request
+     * body is left untouched unless the marker is actually present.
+     */
+    private JsonNode stripSuppressionMarker(JsonNode queryNode) {
+        if (queryNode == null || !queryNode.isObject() || !queryNode.has(KpiQueryComposer.SUPPRESSED))
+            return queryNode;
+        com.fasterxml.jackson.databind.node.ObjectNode copy =
+                (com.fasterxml.jackson.databind.node.ObjectNode) queryNode.deepCopy();
+        copy.remove(KpiQueryComposer.SUPPRESSED);
+        log.debug("ignoring caller-supplied '{}' on an inline query", KpiQueryComposer.SUPPRESSED);
+        return copy;
     }
 
     /** Build a synthetic {kpiId, params} ref node so a source kpiId resolves through the normal path. */

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiQueryComposer.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiQueryComposer.java
@@ -85,11 +85,16 @@ import java.util.regex.Pattern;
  * <p><b>Pinned windows (#1462).</b> A def may declare {@code window: {name, pinned: true}} to keep
  * its own time axis — "complaints created today" means today whatever range the user picked. For
  * such a def the {@code window} param and {@code dateFrom}/{@code dateTo} do NOT rewrite the time
- * predicate. If the selected range does not overlap the pinned interval the entry is SUPPRESSED
- * (no rows, {@code suppressed:"filter_excludes_window"}) so the tile can render an explicit
- * "no data for the applied filters" instead of a number for the wrong period; {@code compare:"prior"}
- * then means the preceding window of equal span (yesterday, for {@code dtd}). Non-time params
- * (ward / serviceCode / complaintPath / hierLevel) still apply — pinning fixes time, not filters.
+ * predicate — a supplied {@code window} param is reported back as {@code paramsIgnored:["window"]}
+ * rather than silently swallowed. If the selected range does not COVER the pinned interval the entry
+ * is SUPPRESSED (no rows, {@code suppressed:"filter_excludes_window"}) so the tile can render an
+ * empty state instead of a number for a period the filter excludes; {@code compare:"prior"} then
+ * means the preceding window of equal span (yesterday, for {@code dtd}), and {@code series:"daily"}
+ * gets an axis wider than the pin (the range, else the {@code window} param, else a rolling default)
+ * so the sparkline is a trend rather than a single point. Non-time params (ward / serviceCode /
+ * complaintPath / hierLevel) still apply — pinning fixes time, not filters. Pinning a BOUNDLESS
+ * window ({@code all} / {@code live}) is meaningless and ignored: there is no interval to cover and
+ * no preceding period, so such a def takes the ordinary path.
  *
  * <p>{@code compare}/{@code series} compose with {@code window}/{@code dateFrom}/{@code dateTo}/
  * {@code ward}/{@code serviceCode}: the window/range params resolve the <em>current</em> range first,
@@ -109,6 +114,11 @@ public class KpiQueryComposer {
     private static final long MS_PER_DAY = 86_400_000L;
     /** Sparkline daily-series safety cap, matching the FE {@code Math.min(366, ...)}. */
     private static final int MAX_SERIES_DAYS = 366;
+    /**
+     * Trend axis for a pinned def's sparkline when the request carries neither a date range nor a
+     * window param — a pinned window is too narrow to be a trend (dtd would be one point).
+     */
+    private static final String DEFAULT_SERIES_WINDOW = "last_30d";
     /**
      * Marker written onto the merged query when a pinned window cannot be answered under the
      * selected range (#1462). Read and stripped by {@link AnalyticsService} before planning — it is
@@ -185,20 +195,31 @@ public class KpiQueryComposer {
         // A PINNED window owns its own time axis: the def declares what period it means ("today",
         // "this week") and the dashboard's date range must not redefine it (#1462). Unlike a live-open
         // snapshot — which is timeless and simply ignores the range — a pinned window occupies a real
-        // interval, so a range that excludes that interval makes the tile unanswerable rather than
-        // merely unfiltered. That case is SUPPRESSED: no value, so the tile can say "no data for the
-        // applied filters" instead of quietly reporting a number for a different period.
-        if (isPinnedWindow(next)) {
+        // interval, so a range that does not COVER that interval makes the tile unanswerable rather
+        // than merely unfiltered. That case is SUPPRESSED: no value, so the tile can render an empty
+        // state instead of quietly reporting a number for a period the filter excludes.
+        PinnedWindow pinned = pinnedWindow(next);
+        if (pinned != null) {
             if (series && !prior) {
-                // The sparkline is trend CONTEXT for the pinned value, not the value itself: it keeps
-                // its existing range-bucketed behaviour and stays answerable even when the pinned
-                // interval sits outside the range (the tile then shows a trend but no headline number).
+                // The sparkline is trend CONTEXT for the pinned value, not the value itself, and a
+                // trend needs an axis WIDER than the pinned interval — a pinned dtd would otherwise
+                // bucket "today" into a single flat point. So the series follows the selected range,
+                // else an explicit window param, else a rolling default; and it stays answerable even
+                // when the pinned interval sits outside the range (trend shown, headline suppressed).
+                applyPinnedSeriesAxis(next, params, bounds);
                 applyDailySeries(next, g, bounds);
             } else {
-                // Overlap is decided FIRST: applyPinnedPrior consumes the window node.
-                boolean suppress = bounds != null && !pinnedWindowOverlaps(next, bounds);
-                if (prior) applyPinnedPrior(next, g);
+                // Decided BEFORE the window is consumed below, and from the SAME clock reading the
+                // bounds are materialized with, so the suppression verdict and the executed SQL can
+                // never straddle EAT midnight and disagree.
+                boolean suppress = bounds != null && !rangeCoversPinnedWindow(pinned, bounds);
+                if (prior) applyPinnedPrior(next, g, pinned);
+                else       materializePinnedWindow(next, g, pinned);
                 if (suppress) next.put(SUPPRESSED, true);
+                // The window param cannot override a pin — say so, rather than silently ignoring it
+                // (the complaintPath precedent: an unappliable param is reported, never swallowed).
+                if (params.hasNonNull("window") && !params.get("window").asText().isEmpty())
+                    reportIgnored(paramsIgnoredOut, "window");
             }
             applyNarrowingParams(next, g, params, paramsIgnoredOut);
             return next;
@@ -339,33 +360,76 @@ public class KpiQueryComposer {
     // ---- pinned window (#1462) ----
 
     /**
-     * A def PINS its window when it declares {@code window: {name, pinned: true}} — "this tile means
-     * today / this week, whatever the dashboard's date range says". Without the flag the range wins,
-     * which is the historical behaviour for every other tile and stays unchanged.
+     * A pinned window RESOLVED against one clock reading: its start, "now", and the EAT calendar days
+     * either maps to. Every downstream decision — suppression, the materialized SQL bounds, the prior
+     * period — reads this single snapshot, so a request cannot be judged against one calendar day and
+     * executed against the next.
      */
-    private boolean isPinnedWindow(JsonNode query) {
-        JsonNode window = query.get("window");
-        return window != null && window.isObject()
-                && window.hasNonNull("name") && window.path("pinned").asBoolean(false);
+    private static final class PinnedWindow {
+        final long nowMs, startMs;
+        final LocalDate startDate, today;
+        PinnedWindow(long nowMs, long startMs) {
+            this.nowMs = nowMs; this.startMs = startMs;
+            this.startDate = Instant.ofEpochMilli(startMs).atZone(EAT).toLocalDate();
+            this.today = Instant.ofEpochMilli(nowMs).atZone(EAT).toLocalDate();
+        }
+        /** Span in whole EAT days, inclusive of both ends — 1 for {@code dtd}. */
+        long spanDays() { return Math.max(1, java.time.temporal.ChronoUnit.DAYS.between(startDate, today) + 1); }
     }
 
     /**
-     * Does the pinned window's interval intersect the selected range? The window covers
-     * {@code [windowStart, now]}; the range covers {@code [dateFrom, dateTo]}. They miss each other
-     * when the range ends before the window opens, or begins after today.
+     * Resolve the def's pinned window, or {@code null} if it has none.
      *
-     * <p>For the {@code dtd} ("today") case this reduces to the intuitive rule: the range must
-     * contain today. Comparison is on EAT calendar days — the same zone the planner buckets in — so a
-     * range ending "today" counts as containing today regardless of clock time.
+     * <p>A def PINS its window when it declares {@code window: {name, pinned: true}} — "this tile means
+     * today / this week, whatever the dashboard's date range says". Without the flag the range wins,
+     * which is the historical behaviour for every other tile and stays unchanged.
+     *
+     * <p>Pinning is only meaningful for a BOUNDED window. {@code all} / {@code live} have no start
+     * instant, so there is no interval for a range to cover and no preceding period to compare
+     * against — pinning them is ignored and they take the ordinary path rather than silently
+     * degrading into a query whose prior equals its current.
      */
-    private boolean pinnedWindowOverlaps(JsonNode query, Bounds bounds) {
+    private PinnedWindow pinnedWindow(JsonNode query) {
+        JsonNode window = query.get("window");
+        if (window == null || !window.isObject()
+                || !window.hasNonNull("name") || !window.path("pinned").asBoolean(false)) return null;
         long now = System.currentTimeMillis();
-        Long startMs = AnalyticsPlanner.windowStartMs(query.path("window").path("name").asText(), now);
-        if (startMs == null) return true;                       // boundless window: nothing to miss.
-        LocalDate windowStart = Instant.ofEpochMilli(startMs).atZone(EAT).toLocalDate();
-        LocalDate today = Instant.ofEpochMilli(now).atZone(EAT).toLocalDate();
+        Long startMs = AnalyticsPlanner.windowStartMs(window.get("name").asText(), now);
+        if (startMs == null) {
+            log.debug("ignoring pinned:true on boundless window '{}' — nothing to pin", window.get("name").asText());
+            return null;
+        }
+        return new PinnedWindow(now, startMs);
+    }
+
+    /**
+     * Does the selected range COVER the whole pinned interval? The window spans
+     * {@code [startDate, today]}; the range spans {@code [dateFrom, dateTo]}.
+     *
+     * <p>Coverage, not mere overlap: a partial intersection would let the tile report its full pinned
+     * total under a filter that excludes part of that period — a "created this week" tile showing
+     * Monday–Friday under a two-day filter — which is the same wrong-period-number class #1462 exists
+     * to remove. For the {@code dtd} case both rules coincide: the range must contain today.
+     *
+     * <p>Comparison is on EAT calendar days, the zone the planner buckets in, so a range ending
+     * "today" covers today regardless of clock time.
+     */
+    private boolean rangeCoversPinnedWindow(PinnedWindow pinned, Bounds bounds) {
         LocalDate rangeEnd = bounds.toExclusive.minusDays(1);   // back to the inclusive dateTo
-        return !rangeEnd.isBefore(windowStart) && !bounds.fromDate.isAfter(today);
+        return !bounds.fromDate.isAfter(pinned.startDate) && !rangeEnd.isBefore(pinned.today);
+    }
+
+    /**
+     * Bake the pinned window into explicit {@code gte}/{@code lt} bounds and drop the window node, so
+     * the planner does not re-resolve it against a second, later clock reading. The predicate is
+     * identical to what {@link AnalyticsPlanner#applyWindow} would emit — {@code [start, now)} — it is
+     * simply pinned to the instant the request was judged against.
+     */
+    private void materializePinnedWindow(ObjectNode query, Grain g, PinnedWindow pinned) {
+        String col = dateFilterColumn(query, g);
+        if (col == null || !g.filterable.contains(col)) return;   // leave the window for the planner.
+        bindPinnedBounds(query, col, pinned.startDate, pinned.startMs, pinned.today.plusDays(1), pinned.nowMs);
+        query.remove("window");
     }
 
     /**
@@ -373,29 +437,42 @@ public class KpiQueryComposer {
      * span, NOT the FE's prior-equal-duration-of-the-selected-range (which would compare "today"
      * against a month). For {@code dtd} this is yesterday — matching the tile's "vs yesterday" label.
      */
-    private void applyPinnedPrior(ObjectNode query, Grain g) {
+    private void applyPinnedPrior(ObjectNode query, Grain g, PinnedWindow pinned) {
         String col = dateFilterColumn(query, g);
         if (col == null || !g.filterable.contains(col)) {
             log.debug("grain '{}' has no filterable time column for a pinned compare:prior; skipping", g.name);
             return;
         }
-        long now = System.currentTimeMillis();
-        Long startMs = AnalyticsPlanner.windowStartMs(query.path("window").path("name").asText(), now);
-        if (startMs == null) return;
-        LocalDate windowStart = Instant.ofEpochMilli(startMs).atZone(EAT).toLocalDate();
-        LocalDate today = Instant.ofEpochMilli(now).atZone(EAT).toLocalDate();
-        long spanDays = Math.max(1, java.time.temporal.ChronoUnit.DAYS.between(windowStart, today) + 1);
-        LocalDate priorStart = windowStart.minusDays(spanDays);
+        LocalDate priorStart = pinned.startDate.minusDays(pinned.spanDays());
+        bindPinnedBounds(query, col, priorStart, priorStart.atStartOfDay(EAT).toInstant().toEpochMilli(),
+                pinned.startDate, pinned.startMs);
+        query.remove("window");   // the explicit prior bounds now govern the time axis.
+    }
 
+    /** Bind a half-open pinned interval: ISO dates on the daily grain, epoch-ms elsewhere. */
+    private void bindPinnedBounds(ObjectNode query, String col,
+                                  LocalDate fromDate, long fromMs, LocalDate toExclusive, long toMs) {
         ObjectNode bound = mergeableFilterObject(query, col);
         if ("snapshot_date".equals(col)) {
-            bound.put("gte", priorStart.toString());
-            bound.put("lt", windowStart.toString());
+            bound.put("gte", fromDate.toString());
+            bound.put("lt", toExclusive.toString());
         } else {
-            bound.put("gte", priorStart.atStartOfDay(EAT).toInstant().toEpochMilli());
-            bound.put("lt", windowStart.atStartOfDay(EAT).toInstant().toEpochMilli());
+            bound.put("gte", fromMs);
+            bound.put("lt", toMs);
         }
-        query.remove("window");   // the explicit prior bounds now govern the time axis.
+    }
+
+    /**
+     * Give a pinned def's sparkline an axis wider than the pin. With a selected range,
+     * {@link #applyDailySeries} uses it and this is a no-op. Without one, the pinned window would
+     * otherwise survive and bucket the whole trend into a single point, so it is replaced by the
+     * caller's {@code window} param (honoured here, where it is meaningful) or a rolling default.
+     */
+    private void applyPinnedSeriesAxis(ObjectNode query, JsonNode params, Bounds bounds) {
+        if (bounds != null) return;                             // the range already supplies the axis.
+        String windowName = params.hasNonNull("window") ? params.get("window").asText() : "";
+        applyWindowName(query, windowName.isEmpty() ? DEFAULT_SERIES_WINDOW : windowName);
+        ((ObjectNode) query.get("window")).remove("pinned");    // the axis is a trend, not the pin.
     }
 
     // ---- prior period ----
@@ -662,8 +739,7 @@ public class KpiQueryComposer {
                     + " [A-Za-z0-9._/-], at most " + MAX_COMPLAINT_PATH_LENGTH + " chars");
         if (!g.prefixFilterable.contains("complaint_node_path")) {
             log.debug("grain '{}' has no complaint_node_path; ignoring complaintPath param (reported)", g.name);
-            if (paramsIgnoredOut != null && !paramsIgnoredOut.contains("complaintPath"))
-                paramsIgnoredOut.add("complaintPath");
+            reportIgnored(paramsIgnoredOut, "complaintPath");
             return;
         }
         mergeableFilterObject(query, "complaint_node_path").put("subtree", path);
@@ -695,6 +771,15 @@ public class KpiQueryComposer {
         JsonNode existing = filters.get(col);
         if (existing != null && existing.isObject()) return (ObjectNode) existing;
         return filters.putObject(col);
+    }
+
+    /**
+     * Record a supplied param that could NOT be applied, deduped. Surfaced on the result envelope as
+     * {@code paramsIgnored}, so a caller is never left assuming a narrowing (or a window) took effect
+     * when it did not.
+     */
+    private void reportIgnored(List<String> paramsIgnoredOut, String param) {
+        if (paramsIgnoredOut != null && !paramsIgnoredOut.contains(param)) paramsIgnoredOut.add(param);
     }
 
     /** Read a string param, returning null when absent/null (so the switch on it is total). */

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiQueryComposer.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiQueryComposer.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.time.DayOfWeek;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
@@ -81,6 +82,15 @@ import java.util.regex.Pattern;
  *       keys into one def + {@code {series:"daily"}}.</li>
  * </ul>
  *
+ * <p><b>Pinned windows (#1462).</b> A def may declare {@code window: {name, pinned: true}} to keep
+ * its own time axis — "complaints created today" means today whatever range the user picked. For
+ * such a def the {@code window} param and {@code dateFrom}/{@code dateTo} do NOT rewrite the time
+ * predicate. If the selected range does not overlap the pinned interval the entry is SUPPRESSED
+ * (no rows, {@code suppressed:"filter_excludes_window"}) so the tile can render an explicit
+ * "no data for the applied filters" instead of a number for the wrong period; {@code compare:"prior"}
+ * then means the preceding window of equal span (yesterday, for {@code dtd}). Non-time params
+ * (ward / serviceCode / complaintPath / hierLevel) still apply — pinning fixes time, not filters.
+ *
  * <p>{@code compare}/{@code series} compose with {@code window}/{@code dateFrom}/{@code dateTo}/
  * {@code ward}/{@code serviceCode}: the window/range params resolve the <em>current</em> range first,
  * then {@code compare:"prior"} shifts it back one equal period, and {@code series:"daily"} buckets it.
@@ -99,6 +109,12 @@ public class KpiQueryComposer {
     private static final long MS_PER_DAY = 86_400_000L;
     /** Sparkline daily-series safety cap, matching the FE {@code Math.min(366, ...)}. */
     private static final int MAX_SERIES_DAYS = 366;
+    /**
+     * Marker written onto the merged query when a pinned window cannot be answered under the
+     * selected range (#1462). Read and stripped by {@link AnalyticsService} before planning — it is
+     * never a grammar field and never reaches SQL.
+     */
+    static final String SUPPRESSED = "__suppressed";
     /** {@code complaintPath} length cap — live paths are short dot-joined UPPER_SNAKE codes. */
     static final int MAX_COMPLAINT_PATH_LENGTH = 256;
     /**
@@ -166,6 +182,28 @@ public class KpiQueryComposer {
         // delta uses a prior-week comparison and the sparkline a rolling window, per reference.)
         boolean liveOpenSnapshot = isLiveOpenSnapshot(next, g);
 
+        // A PINNED window owns its own time axis: the def declares what period it means ("today",
+        // "this week") and the dashboard's date range must not redefine it (#1462). Unlike a live-open
+        // snapshot — which is timeless and simply ignores the range — a pinned window occupies a real
+        // interval, so a range that excludes that interval makes the tile unanswerable rather than
+        // merely unfiltered. That case is SUPPRESSED: no value, so the tile can say "no data for the
+        // applied filters" instead of quietly reporting a number for a different period.
+        if (isPinnedWindow(next)) {
+            if (series && !prior) {
+                // The sparkline is trend CONTEXT for the pinned value, not the value itself: it keeps
+                // its existing range-bucketed behaviour and stays answerable even when the pinned
+                // interval sits outside the range (the tile then shows a trend but no headline number).
+                applyDailySeries(next, g, bounds);
+            } else {
+                // Overlap is decided FIRST: applyPinnedPrior consumes the window node.
+                boolean suppress = bounds != null && !pinnedWindowOverlaps(next, bounds);
+                if (prior) applyPinnedPrior(next, g);
+                if (suppress) next.put(SUPPRESSED, true);
+            }
+            applyNarrowingParams(next, g, params, paramsIgnoredOut);
+            return next;
+        }
+
         // ---- window override (skipped when an explicit range is supplied; range governs time) ----
         // Also skipped for compare:"prior" with no range, where the prior-WEEK fallback governs time,
         // and for live-open snapshots (point-in-time; no window axis).
@@ -189,6 +227,17 @@ public class KpiQueryComposer {
             applyDailySeries(next, g, bounds);
         }
 
+        applyNarrowingParams(next, g, params, paramsIgnoredOut);
+
+        return next;
+    }
+
+    /**
+     * The non-time narrowing params — ward, service type, complaint subtree, hierarchy rollup.
+     * Applied on every path, pinned windows included: pinning fixes a tile's <em>time</em> axis, it
+     * does not exempt it from the dashboard's ward / type filters.
+     */
+    private void applyNarrowingParams(ObjectNode next, Grain g, JsonNode params, List<String> paramsIgnoredOut) {
         // ---- narrowing dimension filters (only if the grain supports the column) ----
         if (params.hasNonNull("ward")) {
             String ward = params.get("ward").asText();
@@ -208,8 +257,6 @@ public class KpiQueryComposer {
             String hierLevel = params.get("hierLevel").asText();
             if (!hierLevel.isEmpty() && !"leaf".equals(hierLevel)) applyHierLevel(next, g, hierLevel);
         }
-
-        return next;
     }
 
     // ---- window ----
@@ -287,6 +334,68 @@ public class KpiQueryComposer {
             bound.put("gte", fromMs);
             bound.put("lt", toMs);
         }
+    }
+
+    // ---- pinned window (#1462) ----
+
+    /**
+     * A def PINS its window when it declares {@code window: {name, pinned: true}} — "this tile means
+     * today / this week, whatever the dashboard's date range says". Without the flag the range wins,
+     * which is the historical behaviour for every other tile and stays unchanged.
+     */
+    private boolean isPinnedWindow(JsonNode query) {
+        JsonNode window = query.get("window");
+        return window != null && window.isObject()
+                && window.hasNonNull("name") && window.path("pinned").asBoolean(false);
+    }
+
+    /**
+     * Does the pinned window's interval intersect the selected range? The window covers
+     * {@code [windowStart, now]}; the range covers {@code [dateFrom, dateTo]}. They miss each other
+     * when the range ends before the window opens, or begins after today.
+     *
+     * <p>For the {@code dtd} ("today") case this reduces to the intuitive rule: the range must
+     * contain today. Comparison is on EAT calendar days — the same zone the planner buckets in — so a
+     * range ending "today" counts as containing today regardless of clock time.
+     */
+    private boolean pinnedWindowOverlaps(JsonNode query, Bounds bounds) {
+        long now = System.currentTimeMillis();
+        Long startMs = AnalyticsPlanner.windowStartMs(query.path("window").path("name").asText(), now);
+        if (startMs == null) return true;                       // boundless window: nothing to miss.
+        LocalDate windowStart = Instant.ofEpochMilli(startMs).atZone(EAT).toLocalDate();
+        LocalDate today = Instant.ofEpochMilli(now).atZone(EAT).toLocalDate();
+        LocalDate rangeEnd = bounds.toExclusive.minusDays(1);   // back to the inclusive dateTo
+        return !rangeEnd.isBefore(windowStart) && !bounds.fromDate.isAfter(today);
+    }
+
+    /**
+     * {@code compare:"prior"} against a pinned window: the immediately-preceding window of the same
+     * span, NOT the FE's prior-equal-duration-of-the-selected-range (which would compare "today"
+     * against a month). For {@code dtd} this is yesterday — matching the tile's "vs yesterday" label.
+     */
+    private void applyPinnedPrior(ObjectNode query, Grain g) {
+        String col = dateFilterColumn(query, g);
+        if (col == null || !g.filterable.contains(col)) {
+            log.debug("grain '{}' has no filterable time column for a pinned compare:prior; skipping", g.name);
+            return;
+        }
+        long now = System.currentTimeMillis();
+        Long startMs = AnalyticsPlanner.windowStartMs(query.path("window").path("name").asText(), now);
+        if (startMs == null) return;
+        LocalDate windowStart = Instant.ofEpochMilli(startMs).atZone(EAT).toLocalDate();
+        LocalDate today = Instant.ofEpochMilli(now).atZone(EAT).toLocalDate();
+        long spanDays = Math.max(1, java.time.temporal.ChronoUnit.DAYS.between(windowStart, today) + 1);
+        LocalDate priorStart = windowStart.minusDays(spanDays);
+
+        ObjectNode bound = mergeableFilterObject(query, col);
+        if ("snapshot_date".equals(col)) {
+            bound.put("gte", priorStart.toString());
+            bound.put("lt", windowStart.toString());
+        } else {
+            bound.put("gte", priorStart.atStartOfDay(EAT).toInstant().toEpochMilli());
+            bound.put("lt", windowStart.atStartOfDay(EAT).toInstant().toEpochMilli());
+        }
+        query.remove("window");   // the explicit prior bounds now govern the time axis.
     }
 
     // ---- prior period ----

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiQueryComposerPinnedWindowTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiQueryComposerPinnedWindowTest.java
@@ -1,0 +1,232 @@
+package org.egov.pgr.analytics;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Pins the {@code window.pinned} contract (#1462) — the fix for "Complaints created today" reporting
+ * the selected date range instead of today.
+ *
+ * <p>Covers: the new {@code dtd} calendar-day window (vs the rolling {@code last_1d} it replaces),
+ * a pinned window surviving both the {@code window} param and an explicit {@code dateFrom}/
+ * {@code dateTo}, suppression when the selected range cannot contain the pinned interval,
+ * {@code compare:"prior"} meaning yesterday rather than a prior-equal-duration-of-the-range, the
+ * sparkline staying answerable, non-time params still narrowing a pinned query, and — the
+ * regression guard that matters most — that every UNPINNED def behaves exactly as before.
+ */
+public class KpiQueryComposerPinnedWindowTest {
+
+    private static final ZoneId EAT = ZoneId.of("Africa/Nairobi");
+
+    private final ObjectMapper om = new ObjectMapper();
+    private final AnalyticsCatalog catalog = new AnalyticsCatalog();
+    private final KpiQueryComposer composer = new KpiQueryComposer(catalog);
+    private final AnalyticsPlanner planner = new AnalyticsPlanner(catalog);
+    private final AnalyticsScope stateScope = new AnalyticsScope("ke", true, null, null, null);
+
+    private JsonNode json(String s) {
+        try { return om.readTree(s); } catch (Exception e) { throw new RuntimeException(e); }
+    }
+
+    private LocalDate today() { return Instant.now().atZone(EAT).toLocalDate(); }
+
+    /** The seeded "complaints created today" def, post-fix: a pinned calendar-day window. */
+    private JsonNode createdTodayBase() {
+        return json("{\"grain\":\"facts\",\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}],"
+                + "\"window\":{\"name\":\"dtd\",\"timeRole\":\"filed_at\",\"pinned\":true}}");
+    }
+
+    /** Same shape, unpinned — the historical behaviour every other tile relies on. */
+    private JsonNode unpinnedBase() {
+        return json("{\"grain\":\"facts\",\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}],"
+                + "\"window\":{\"name\":\"last_7d\",\"timeRole\":\"filed_at\"}}");
+    }
+
+    private JsonNode merge(JsonNode base, String params) {
+        return composer.mergeParams(base, json(params), new ArrayList<>());
+    }
+
+    private boolean suppressed(JsonNode merged) {
+        return merged.path("__suppressed").asBoolean(false);
+    }
+
+    // ---- the dtd window itself ----
+
+    /** dtd is the calendar day in EAT — NOT last_1d's rolling 24h, which drifts across midnight. */
+    @Test
+    public void dtdIsTheCalendarDayNotARollingDay() {
+        long now = System.currentTimeMillis();
+        long dtd = AnalyticsPlanner.windowStartMs("dtd", now);
+        long rolling = AnalyticsPlanner.windowStartMs("last_1d", now);
+
+        assertEquals(today().atStartOfDay(EAT).toInstant().toEpochMilli(), dtd,
+                "dtd must start at EAT midnight of the current day");
+        assertEquals(now - 86_400_000L, rolling, "last_1d must remain a rolling 24h window");
+        assertTrue(dtd >= rolling, "midnight today is never earlier than 24h ago");
+    }
+
+    /** dtd plans into a real time predicate, so a pinned tile still filters on its own axis. */
+    @Test
+    public void dtdPlansIntoATimePredicate() {
+        AnalyticsPlanner.Planned p = planner.plan(createdTodayBase(), stateScope);
+        assertTrue(p.sql.contains("created_at >= ?") && p.sql.contains("created_at < ?"),
+                "expected a bounded created_at predicate, got: " + p.sql);
+    }
+
+    @Test
+    public void unknownWindowNameStillRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> AnalyticsPlanner.windowStartMs("dtd_", System.currentTimeMillis()));
+    }
+
+    // ---- pinning beats the dashboard globals ----
+
+    /** The whole bug: a selected range must not redefine what "today" means. */
+    @Test
+    public void dateRangeDoesNotRewriteAPinnedWindow() {
+        LocalDate t = today();
+        JsonNode merged = merge(createdTodayBase(),
+                "{\"dateFrom\":\"" + t.minusDays(30) + "\",\"dateTo\":\"" + t + "\"}");
+
+        assertEquals("dtd", merged.path("window").path("name").asText(),
+                "pinned window must survive the global range");
+        assertFalse(merged.has("filters"),
+                "no created_at range filter may be injected over a pinned window");
+        assertFalse(suppressed(merged), "the range contains today, so the tile is answerable");
+    }
+
+    /** The window param (the FE's per-tile default) must not override a pin either. */
+    @Test
+    public void windowParamDoesNotOverrideAPinnedWindow() {
+        JsonNode merged = merge(createdTodayBase(), "{\"window\":\"last_30d\"}");
+        assertEquals("dtd", merged.path("window").path("name").asText());
+    }
+
+    // ---- suppression ----
+
+    /** Range entirely in the past: today cannot be in it, so the tile has no answer. */
+    @Test
+    public void rangeEndingBeforeTodaySuppresses() {
+        LocalDate t = today();
+        JsonNode merged = merge(createdTodayBase(),
+                "{\"dateFrom\":\"" + t.minusDays(30) + "\",\"dateTo\":\"" + t.minusDays(1) + "\"}");
+        assertTrue(suppressed(merged), "a range ending yesterday excludes today");
+    }
+
+    /** Range entirely in the future: same. */
+    @Test
+    public void rangeStartingAfterTodaySuppresses() {
+        LocalDate t = today();
+        JsonNode merged = merge(createdTodayBase(),
+                "{\"dateFrom\":\"" + t.plusDays(1) + "\",\"dateTo\":\"" + t.plusDays(7) + "\"}");
+        assertTrue(suppressed(merged), "a range starting tomorrow excludes today");
+    }
+
+    /** A single-day range on today is the boundary case — inclusive, so answerable. */
+    @Test
+    public void rangeOfExactlyTodayIsNotSuppressed() {
+        LocalDate t = today();
+        JsonNode merged = merge(createdTodayBase(),
+                "{\"dateFrom\":\"" + t + "\",\"dateTo\":\"" + t + "\"}");
+        assertFalse(suppressed(merged));
+    }
+
+    /** No range at all (the dashboard default) — nothing to conflict with. */
+    @Test
+    public void noRangeIsNeverSuppressed() {
+        assertFalse(suppressed(merge(createdTodayBase(), "{\"window\":\"last_7d\"}")));
+    }
+
+    /** Suppression is a marker for the service, never a grammar field: it must not reach SQL. */
+    @Test
+    public void suppressionMarkerIsNotAPlannableField() {
+        LocalDate t = today();
+        JsonNode merged = merge(createdTodayBase(),
+                "{\"dateFrom\":\"" + t.minusDays(9) + "\",\"dateTo\":\"" + t.minusDays(2) + "\"}");
+        assertTrue(suppressed(merged));
+        // The planner ignores it rather than emitting it — the service short-circuits before planning,
+        // but a stray plan() call must still never produce a __suppressed column or predicate.
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope);
+        assertFalse(p.sql.contains("__suppressed"), "marker leaked into SQL: " + p.sql);
+    }
+
+    // ---- prior ----
+
+    /** "vs yesterday" must mean yesterday, not the prior 30 days because a month was selected. */
+    @Test
+    public void priorOnAPinnedDayMeansYesterday() {
+        LocalDate t = today();
+        JsonNode merged = merge(createdTodayBase(),
+                "{\"compare\":\"prior\",\"dateFrom\":\"" + t.minusDays(30) + "\",\"dateTo\":\"" + t + "\"}");
+
+        long expectedFrom = t.minusDays(1).atStartOfDay(EAT).toInstant().toEpochMilli();
+        long expectedTo = t.atStartOfDay(EAT).toInstant().toEpochMilli();
+        assertEquals(expectedFrom, merged.path("filters").path("created_at").path("gte").asLong());
+        assertEquals(expectedTo, merged.path("filters").path("created_at").path("lt").asLong());
+        assertFalse(merged.has("window"), "explicit prior bounds replace the window");
+    }
+
+    // ---- sparkline ----
+
+    /** The trend line is context, not the headline number: it stays answerable and range-bucketed. */
+    @Test
+    public void dailySeriesStaysAnswerableOnAPinnedDef() {
+        LocalDate t = today();
+        JsonNode merged = merge(createdTodayBase(),
+                "{\"series\":\"daily\",\"dateFrom\":\"" + t.minusDays(9) + "\",\"dateTo\":\"" + t.minusDays(2) + "\"}");
+
+        assertFalse(suppressed(merged), "a sparkline over the selected range is well-defined");
+        List<String> dims = new ArrayList<>();
+        merged.path("dimensions").forEach(d -> dims.add(d.asText()));
+        assertTrue(dims.contains("created_date"), "expected the daily date dimension, got " + dims);
+    }
+
+    // ---- pinning fixes time, not filters ----
+
+    @Test
+    public void narrowingParamsStillApplyToAPinnedQuery() {
+        JsonNode merged = merge(createdTodayBase(), "{\"ward\":\"WARD_1\",\"serviceCode\":\"Pothole\"}");
+        assertEquals("WARD_1", merged.path("filters").path("ward_code").path("eq").asText());
+        assertEquals("Pothole", merged.path("filters").path("service_code").path("eq").asText());
+        assertEquals("dtd", merged.path("window").path("name").asText());
+    }
+
+    // ---- regression guard: unpinned defs are untouched ----
+
+    /** Every other tile must keep letting the global range govern its time axis. */
+    @Test
+    public void unpinnedDefsStillHonourTheDateRange() {
+        LocalDate t = today();
+        JsonNode merged = merge(unpinnedBase(),
+                "{\"dateFrom\":\"" + t.minusDays(30) + "\",\"dateTo\":\"" + t + "\"}");
+
+        assertFalse(merged.has("window"), "range must still remove an unpinned window");
+        assertEquals(t.minusDays(30).atStartOfDay(java.time.ZoneOffset.UTC).toInstant().toEpochMilli(),
+                merged.path("filters").path("created_at").path("gte").asLong());
+        assertFalse(suppressed(merged), "unpinned defs are never suppressed");
+    }
+
+    /** Including when the selected range is nowhere near today. */
+    @Test
+    public void unpinnedDefsAreNeverSuppressed() {
+        JsonNode merged = merge(unpinnedBase(), "{\"dateFrom\":\"2020-01-01\",\"dateTo\":\"2020-01-31\"}");
+        assertFalse(suppressed(merged));
+    }
+
+    @Test
+    public void unpinnedWindowParamOverrideStillWorks() {
+        JsonNode merged = merge(unpinnedBase(), "{\"window\":\"mtd\"}");
+        assertEquals("mtd", merged.path("window").path("name").asText());
+        assertEquals("filed_at", merged.path("window").path("timeRole").asText(),
+                "the timeRole must be preserved across a window override");
+    }
+}

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiQueryComposerPinnedWindowTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiQueryComposerPinnedWindowTest.java
@@ -9,8 +9,10 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Pins the {@code window.pinned} contract (#1462) — the fix for "Complaints created today" reporting
@@ -38,6 +40,19 @@ public class KpiQueryComposerPinnedWindowTest {
     }
 
     private LocalDate today() { return Instant.now().atZone(EAT).toLocalDate(); }
+
+    /**
+     * Run a day-sensitive assertion and abandon it (rather than fail) if EAT midnight passed while it
+     * ran. The composer reads its own clock, so a case that computes an expectation from {@code today()}
+     * and then merges is inherently a two-clock comparison — around 21:00 UTC that is a real CI window.
+     * Aborting keeps the suite honest: it never passes on a stale day, and never fails for one either.
+     */
+    private void onAStableDay(Supplier<LocalDate> body) {
+        LocalDate before = today();
+        LocalDate used = body.get();
+        assumeTrue(before.equals(today()), "EAT midnight passed mid-test; day-boundary case abandoned");
+        assertEquals(before, used, "test helper must exercise the day it captured");
+    }
 
     /** The seeded "complaints created today" def, post-fix: a pinned calendar-day window. */
     private JsonNode createdTodayBase() {
@@ -93,22 +108,33 @@ public class KpiQueryComposerPinnedWindowTest {
     /** The whole bug: a selected range must not redefine what "today" means. */
     @Test
     public void dateRangeDoesNotRewriteAPinnedWindow() {
-        LocalDate t = today();
-        JsonNode merged = merge(createdTodayBase(),
-                "{\"dateFrom\":\"" + t.minusDays(30) + "\",\"dateTo\":\"" + t + "\"}");
+        onAStableDay(() -> {
+            LocalDate t = today();
+            JsonNode merged = merge(createdTodayBase(),
+                    "{\"dateFrom\":\"" + t.minusDays(30) + "\",\"dateTo\":\"" + t + "\"}");
 
-        assertEquals("dtd", merged.path("window").path("name").asText(),
-                "pinned window must survive the global range");
-        assertFalse(merged.has("filters"),
-                "no created_at range filter may be injected over a pinned window");
-        assertFalse(suppressed(merged), "the range contains today, so the tile is answerable");
+            // The pin is now materialized into explicit bounds instead of being left as a window node
+            // for the planner to re-resolve, so assert on the bound interval rather than window.name.
+            assertFalse(merged.has("window"), "the pinned window is baked into explicit bounds");
+            assertEquals(t.atStartOfDay(EAT).toInstant().toEpochMilli(),
+                    merged.path("filters").path("created_at").path("gte").asLong(),
+                    "bounds must start at EAT midnight TODAY, not at the range start");
+            assertFalse(suppressed(merged), "the range covers today, so the tile is answerable");
+            return t;
+        });
     }
 
     /** The window param (the FE's per-tile default) must not override a pin either. */
     @Test
-    public void windowParamDoesNotOverrideAPinnedWindow() {
-        JsonNode merged = merge(createdTodayBase(), "{\"window\":\"last_30d\"}");
-        assertEquals("dtd", merged.path("window").path("name").asText());
+    public void windowParamDoesNotOverrideAPinnedWindowAndIsReported() {
+        List<String> ignored = new ArrayList<>();
+        JsonNode merged = composer.mergeParams(createdTodayBase(), json("{\"window\":\"last_30d\"}"), ignored);
+
+        long midnight = today().atStartOfDay(EAT).toInstant().toEpochMilli();
+        assertEquals(midnight, merged.path("filters").path("created_at").path("gte").asLong(),
+                "the pin still governs; last_30d must not widen it");
+        assertEquals(List.of("window"), ignored,
+                "an unappliable window param must be reported, not silently swallowed");
     }
 
     // ---- suppression ----
@@ -116,28 +142,37 @@ public class KpiQueryComposerPinnedWindowTest {
     /** Range entirely in the past: today cannot be in it, so the tile has no answer. */
     @Test
     public void rangeEndingBeforeTodaySuppresses() {
-        LocalDate t = today();
-        JsonNode merged = merge(createdTodayBase(),
-                "{\"dateFrom\":\"" + t.minusDays(30) + "\",\"dateTo\":\"" + t.minusDays(1) + "\"}");
-        assertTrue(suppressed(merged), "a range ending yesterday excludes today");
+        onAStableDay(() -> {
+            LocalDate t = today();
+            JsonNode merged = merge(createdTodayBase(),
+                    "{\"dateFrom\":\"" + t.minusDays(30) + "\",\"dateTo\":\"" + t.minusDays(1) + "\"}");
+            assertTrue(suppressed(merged), "a range ending yesterday excludes today");
+            return t;
+        });
     }
 
     /** Range entirely in the future: same. */
     @Test
     public void rangeStartingAfterTodaySuppresses() {
-        LocalDate t = today();
-        JsonNode merged = merge(createdTodayBase(),
-                "{\"dateFrom\":\"" + t.plusDays(1) + "\",\"dateTo\":\"" + t.plusDays(7) + "\"}");
-        assertTrue(suppressed(merged), "a range starting tomorrow excludes today");
+        onAStableDay(() -> {
+            LocalDate t = today();
+            JsonNode merged = merge(createdTodayBase(),
+                    "{\"dateFrom\":\"" + t.plusDays(1) + "\",\"dateTo\":\"" + t.plusDays(7) + "\"}");
+            assertTrue(suppressed(merged), "a range starting tomorrow excludes today");
+            return t;
+        });
     }
 
     /** A single-day range on today is the boundary case — inclusive, so answerable. */
     @Test
     public void rangeOfExactlyTodayIsNotSuppressed() {
-        LocalDate t = today();
-        JsonNode merged = merge(createdTodayBase(),
-                "{\"dateFrom\":\"" + t + "\",\"dateTo\":\"" + t + "\"}");
-        assertFalse(suppressed(merged));
+        onAStableDay(() -> {
+            LocalDate t = today();
+            JsonNode merged = merge(createdTodayBase(),
+                    "{\"dateFrom\":\"" + t + "\",\"dateTo\":\"" + t + "\"}");
+            assertFalse(suppressed(merged));
+            return t;
+        });
     }
 
     /** No range at all (the dashboard default) — nothing to conflict with. */
@@ -164,15 +199,18 @@ public class KpiQueryComposerPinnedWindowTest {
     /** "vs yesterday" must mean yesterday, not the prior 30 days because a month was selected. */
     @Test
     public void priorOnAPinnedDayMeansYesterday() {
-        LocalDate t = today();
-        JsonNode merged = merge(createdTodayBase(),
-                "{\"compare\":\"prior\",\"dateFrom\":\"" + t.minusDays(30) + "\",\"dateTo\":\"" + t + "\"}");
+        onAStableDay(() -> {
+            LocalDate t = today();
+            JsonNode merged = merge(createdTodayBase(),
+                    "{\"compare\":\"prior\",\"dateFrom\":\"" + t.minusDays(30) + "\",\"dateTo\":\"" + t + "\"}");
 
-        long expectedFrom = t.minusDays(1).atStartOfDay(EAT).toInstant().toEpochMilli();
-        long expectedTo = t.atStartOfDay(EAT).toInstant().toEpochMilli();
-        assertEquals(expectedFrom, merged.path("filters").path("created_at").path("gte").asLong());
-        assertEquals(expectedTo, merged.path("filters").path("created_at").path("lt").asLong());
-        assertFalse(merged.has("window"), "explicit prior bounds replace the window");
+            long expectedFrom = t.minusDays(1).atStartOfDay(EAT).toInstant().toEpochMilli();
+            long expectedTo = t.atStartOfDay(EAT).toInstant().toEpochMilli();
+            assertEquals(expectedFrom, merged.path("filters").path("created_at").path("gte").asLong());
+            assertEquals(expectedTo, merged.path("filters").path("created_at").path("lt").asLong());
+            assertFalse(merged.has("window"), "explicit prior bounds replace the window");
+            return t;
+        });
     }
 
     // ---- sparkline ----
@@ -197,7 +235,81 @@ public class KpiQueryComposerPinnedWindowTest {
         JsonNode merged = merge(createdTodayBase(), "{\"ward\":\"WARD_1\",\"serviceCode\":\"Pothole\"}");
         assertEquals("WARD_1", merged.path("filters").path("ward_code").path("eq").asText());
         assertEquals("Pothole", merged.path("filters").path("service_code").path("eq").asText());
-        assertEquals("dtd", merged.path("window").path("name").asText());
+        assertEquals(today().atStartOfDay(EAT).toInstant().toEpochMilli(),
+                merged.path("filters").path("created_at").path("gte").asLong(),
+                "the pin still governs the time axis alongside the narrowing filters");
+    }
+
+    // ---- review follow-ups (#1483) ----
+
+    /** A pinned WEEK under a two-day filter must not report the whole week: coverage, not overlap. */
+    @Test
+    public void partialOverlapOfAMultiDayPinIsSuppressed() {
+        onAStableDay(() -> {
+            LocalDate t = today();
+            JsonNode weekly = json("{\"grain\":\"facts\",\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}],"
+                    + "\"window\":{\"name\":\"wtd\",\"timeRole\":\"filed_at\",\"pinned\":true}}");
+            JsonNode merged = merge(weekly,
+                    "{\"dateFrom\":\"" + t.minusDays(1) + "\",\"dateTo\":\"" + t + "\"}");
+
+            LocalDate weekStart = t.with(java.time.temporal.TemporalAdjusters.previousOrSame(java.time.DayOfWeek.MONDAY));
+            // Only meaningful from Wednesday on: earlier in the week the 2-day range genuinely covers
+            // the whole week-to-date, so there is nothing partial to assert.
+            assumeTrue(t.minusDays(1).isAfter(weekStart),
+                    "early in the week the range covers the pinned window; nothing partial to test");
+            assertTrue(suppressed(merged),
+                    "a range covering only part of the pinned week must not report the full week");
+            return t;
+        });
+    }
+
+    /** Pinning something boundless has no meaning; it must degrade to the ordinary path, not to a lie. */
+    @Test
+    public void pinningABoundlessWindowIsIgnored() {
+        JsonNode boundless = json("{\"grain\":\"facts\",\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}],"
+                + "\"window\":{\"name\":\"all\",\"timeRole\":\"filed_at\",\"pinned\":true}}");
+        LocalDate t = today();
+        JsonNode merged = merge(boundless,
+                "{\"compare\":\"prior\",\"dateFrom\":\"" + t.minusDays(9) + "\",\"dateTo\":\"" + t + "\"}");
+
+        assertFalse(suppressed(merged), "a boundless window has no interval to miss");
+        assertTrue(merged.path("filters").path("created_at").has("gte"),
+                "prior must still shift the range, not silently re-run the current query");
+        assertNotEquals(t.atStartOfDay(EAT).toInstant().toEpochMilli(),
+                merged.path("filters").path("created_at").path("gte").asLong());
+    }
+
+    /** With no range and no window param, the sparkline must still have a multi-day axis. */
+    @Test
+    public void defaultStateSparklineGetsAWiderAxisThanThePin() {
+        JsonNode merged = merge(createdTodayBase(), "{\"series\":\"daily\"}");
+
+        assertEquals("last_30d", merged.path("window").path("name").asText(),
+                "a pinned dtd axis would bucket the whole trend into one point");
+        assertFalse(merged.path("window").path("pinned").asBoolean(false),
+                "the series axis is a trend, not the pin");
+    }
+
+    /** An explicit window param IS meaningful for the series axis, so it is honoured there. */
+    @Test
+    public void windowParamSetsTheSparklineAxis() {
+        JsonNode merged = merge(createdTodayBase(), "{\"series\":\"daily\",\"window\":\"last_7d\"}");
+        assertEquals("last_7d", merged.path("window").path("name").asText());
+    }
+
+    /** The pin is resolved once and baked in, so the planner cannot re-resolve it on a later clock. */
+    @Test
+    public void pinnedWindowIsMaterializedNotLeftForThePlanner() {
+        // NB: an empty params object returns the base query untouched (pre-existing short-circuit),
+        // in which case the planner resolves the window itself — still a single clock read. The
+        // materialization contract applies once any param triggers a merge.
+        assertEquals(createdTodayBase().toString(), merge(createdTodayBase(), "{}").toString(),
+                "empty params must remain a no-op");
+        JsonNode merged = merge(createdTodayBase(), "{\"serviceCode\":\"Pothole\"}");
+        assertFalse(merged.has("window"), "the window must be consumed into explicit bounds");
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope);
+        assertTrue(p.sql.contains("created_at >= ?") && p.sql.contains("created_at < ?"),
+                "materialized bounds must still produce the same bounded predicate: " + p.sql);
     }
 
     // ---- regression guard: unpinned defs are untouched ----

--- a/digit-mcp/src/tools/dashboard-catalog-seed.ts
+++ b/digit-mcp/src/tools/dashboard-catalog-seed.ts
@@ -436,7 +436,12 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
           "name": "total",
           "agg": "count"
         }
-      ]
+      ],
+      "window": {
+        "name": "dtd",
+        "timeRole": "filed_at",
+        "pinned": true
+      }
     },
     "supportsSeries": true,
     "viz": {
@@ -457,19 +462,7 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
       "dateKey": "created_date",
       "sparklineMeasureKey": "total"
     },
-    "params": [
-      {
-        "name": "window",
-        "default": "last_1d",
-        "allowed": [
-          "last_1d",
-          "last_7d",
-          "last_30d",
-          "wtd",
-          "mtd"
-        ]
-      }
-    ],
+    "params": [],
     "rbac": {
       "visibleTo": []
     }


### PR DESCRIPTION
Fixes #1462. Also removes the mechanism behind the "why do these two tiles disagree" half of #1465.

## The bug

"Complaints created today" reported the **selected date range**, not today. Two independent causes:

1. The def carries no time predicate of its own — it relied on a `window` param. `KpiQueryComposer` deletes the base window whenever `dateFrom`/`dateTo` are present, so with a range applied the tile counted the whole range. With the pilot's 28/06–28/07 filter it read **8**, exactly equal to "New complaints created"; the true figure for that day was 7.
2. Its fallback window `last_1d` is a **rolling 24 hours**, not the calendar day — so even with no range applied it never meant "today", and drifted across midnight.

## The fix

- **`dtd`** ("day-to-date") joins `wtd`/`mtd`/`qtd`/`ytd` in the window vocabulary — the calendar day in EAT.
- **`window.pinned: true`** lets a def own its time axis: the `window` param and `dateFrom`/`dateTo` no longer rewrite the predicate.
- When the selected range **cannot contain** the pinned interval the entry is **suppressed** — no SQL is run, the result is `{ rows: [], rowCount: 0, suppressed: "filter_excludes_window" }` — so the tile renders "no data for the applied filters" rather than a number for the wrong period. This is the behaviour agreed with @subhamegov on the ticket: widget stays, data does not.
- Window-start resolution is now shared between `AnalyticsPlanner` and `KpiQueryComposer`, so a window cannot mean one thing when planned and another when range-checked.

Deliberate scoping:

- **Pinning fixes time, not filters** — `ward` / `serviceCode` / `complaintPath` / `hierLevel` still narrow a pinned query.
- **`compare:"prior"`** on a pinned window means the preceding window of equal span (yesterday, for `dtd`) instead of the prior-equal-duration of the selected range — which is what the tile's "vs yesterday" label always claimed.
- **`series:"daily"` is untouched** — the sparkline is trend context over the selected range, so it stays answerable even when the headline value is suppressed.

## Blast radius

`pinned` defaults to false, so **every other tile is unchanged** — the global range keeps governing their time axis exactly as before. That is asserted explicitly, not assumed: `unpinnedDefsStillHonourTheDateRange`, `unpinnedDefsAreNeverSuppressed`, `unpinnedWindowParamOverrideStillWorks`.

The only def flipped in this PR is `cl_created_today_count` (window pinned to `dtd`; its now-meaningless `window` param dropped).

## Tests

`KpiQueryComposerPinnedWindowTest` — 16 cases: `dtd` vs `last_1d` semantics, pinning beating both the `window` param and an explicit range, suppression on ranges ending before / starting after today, the inclusive single-day boundary, the marker never reaching SQL, prior-means-yesterday, sparkline survival, narrowing params still applying, and the three unpinned regression guards.

```
Tests run: 191, Failures: 0, Errors: 0, Skipped: 0   (full pgr-services suite)
```

## Not in this PR

- The empty-state **copy** ("No data available with applied filters") is #1456 — this PR gives that work a `suppressed` reason to render against; today the tile falls back to the existing unavailable state.
- The wording changes that disambiguate the two "created" tiles are the MDMS half of #1465.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pinned KPI time windows that remain fixed despite dashboard date-range or tile-window settings.
  * Introduced `dtd` calendar-day windows, prior-period comparisons, and daily-series support.
  * Updated the daily complaint-count KPI to use a fixed day-to-date window.
* **Bug Fixes**
  * Suppressed results when selected ranges don’t fully cover pinned windows.
  * Preserved non-time filters for pinned KPIs.
* **Documentation**
  * Documented pinned-window behavior and parameter handling.
* **Tests**
  * Added coverage for pinned-window composition, suppression, comparisons, and filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->