### PR TITLE
fix(configurator): surface Create/Edit buttons on role-actions (completes #1184)

### DIFF
--- a/configurator/src/resources/role-actions/RoleActionList.tsx
+++ b/configurator/src/resources/role-actions/RoleActionList.tsx
@@ -10,7 +10,7 @@ const columns: DigitColumn[] = [
 
 export function RoleActionList() {
   return (
-    <DigitList title="app.resources.role_actions" sort={{ field: 'rolecode', order: 'ASC' }}>
+    <DigitList title="app.resources.role_actions" sort={{ field: 'rolecode', order: 'ASC' }} hasCreate>
       <DigitDatagrid columns={columns} rowClick="show" />
     </DigitList>
   );

--- a/configurator/src/resources/role-actions/RoleActionShow.tsx
+++ b/configurator/src/resources/role-actions/RoleActionShow.tsx
@@ -6,7 +6,7 @@ export function RoleActionShow() {
   const { record } = useShowController();
 
   return (
-    <DigitShow title={record ? `Role Action: ${record.rolecode ?? record.id}` : 'Role Action'}>
+    <DigitShow title={record ? `Role Action: ${record.rolecode ?? record.id}` : 'Role Action'} hasEdit>
       {(rec: Record<string, unknown>) => (
         <div className="space-y-6">
           <FieldSection title="Details">


### PR DESCRIPTION
Follow-up to **#1184 / CCSD-1996**, which enabled schema-driven Create + Edit on the `role-actions` resource.

## Gap
#1184 wired the create/edit **routes** on the `<Resource>`:
```jsx
<Resource name="role-actions" list={RoleActionList} show={RoleActionShow}
          edit={MdmsResourceEdit} create={MdmsResourceCreate} />
```
…but `RoleActionList` (custom, via `DigitList`) and `RoleActionShow` (via `DigitShow`) only render the **Create / Edit buttons** when `hasCreate` / `hasEdit` are passed — and both default to `false`. So the create/edit **pages** worked (reachable only by manually typing `…/manage/role-actions/create`), but **no button** surfaced them at `/configurator/manage/role-actions`. That's why the Create button is missing on the page.

## Fix
- `RoleActionList` → `<DigitList … hasCreate>` — renders the **Create** button (navigates to `…/role-actions/create`).
- `RoleActionShow` → `<DigitShow … hasEdit>` — renders the **Edit** button.

Two-line change; both props are already declared on the components. Needs a **configurator rebuild + deploy** for the buttons to appear on an env.

The remaining enhancement from #1184 (reference-select dropdowns for `rolecode`/`actionid` instead of free-text/number) is still a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)