### PR TITLE
fix(configurator): make UI Homepage / Security Policy / Encryption Policy editable (CCSD-2002/2000/1998)

### DIFF
--- a/configurator/packages/data-provider/src/providers/resourceRegistry.ts
+++ b/configurator/packages/data-provider/src/providers/resourceRegistry.ts
@@ -22,6 +22,10 @@ export interface ResourceConfig {
     update?: string;
   };
   dedicated?: boolean;
+  /** When set, the generic UI hides/blocks Edit + Create unless the logged-in
+   *  user has one of these role codes. UX gate only — server authority is the
+   *  role-action mapping (e.g. action 2627 → MDMS_ADMIN for the enc policy). */
+  writeRoles?: string[];
   /** For `type: 'custom'` resources only: the origin-relative path of the
    *  read-only GET endpoint on the out-of-band service (e.g.
    *  `/novu-bridge/novu-adapter/v1/logs`). The data provider prefixes it with
@@ -150,7 +154,7 @@ export const REGISTRY: Record<string, ResourceConfig> = {
   'role-actions': { type: 'mdms', label: 'Role Actions', schema: 'ACCESSCONTROL-ROLEACTIONS.roleactions', idField: 'id', nameField: 'rolecode', descriptionField: 'actionid' },
   roles: { type: 'mdms', label: 'Roles', schema: MDMS_SCHEMAS.ROLES, idField: 'code', nameField: 'name', descriptionField: 'description' },
   'action-mappings': { type: 'mdms', label: 'Action Mappings', schema: 'ACCESSCONTROL-ACTIONS-TEST.actions-test', idField: 'id', nameField: 'displayName', descriptionField: 'url' },
-  'encryption-policy': { type: 'mdms', label: 'Encryption Policy', schema: 'DataSecurity.EncryptionPolicy', idField: 'key', nameField: 'key' },
+  'encryption-policy': { type: 'mdms', label: 'Encryption Policy', schema: 'DataSecurity.EncryptionPolicy', idField: 'key', nameField: 'key', writeRoles: ['MDMS_ADMIN', 'SUPERUSER'] }, // CCSD-1998
   'decryption-abac': { type: 'mdms', label: 'Decryption ABAC', schema: 'DataSecurity.DecryptionABAC', idField: 'key', nameField: 'key' }, // CCSD-1999: schema id is 'key', not 'model'
   'masking-patterns': { type: 'mdms', label: 'Masking Patterns', schema: 'DataSecurity.MaskingPatterns', idField: 'patternId', nameField: 'patternId' },
   'security-policy': { type: 'mdms', label: 'Security Policy', schema: 'DataSecurity.SecurityPolicy', idField: 'model', nameField: 'model' },

--- a/configurator/src/admin/MdmsResourceCreate.tsx
+++ b/configurator/src/admin/MdmsResourceCreate.tsx
@@ -6,6 +6,7 @@ import { useResourceContext, useInput, required } from 'ra-core';
 import { getResourceConfig } from '@/providers/bridge';
 import { useResourceLabel } from '@/providers/useResourceLabel';
 import { useSchemaDefinition } from '@/hooks/useSchemaDefinition';
+import { useCanWriteResource } from '@/hooks/useCanWriteResource';
 import { orderFields, formatFieldLabel } from './schemaUtils';
 import { Label } from '@/components/ui/label';
 import { getDescriptor } from './schemaDescriptors';
@@ -106,11 +107,24 @@ export function MdmsResourceCreate() {
   const label = useResourceLabel()(resource);
   const { definition } = useSchemaDefinition(config?.schema);
   const descriptor = getDescriptor(config?.schema);
+  // Role gate (CCSD-1998): called before any early return to keep hook order
+  // stable. Also blocks deep links straight to /manage/<resource>/create.
+  const canWrite = useCanWriteResource(resource);
 
   const defaults = useMemo(() => {
     if (!definition) return undefined;
     return buildDefaults(definition);
   }, [definition]);
+
+  if (!canWrite) {
+    return (
+      <div className="p-6">
+        <div className="rounded-md border bg-muted/30 p-4 text-sm text-muted-foreground">
+          Creating {label} is restricted to: {(config?.writeRoles ?? []).join(', ')}.
+        </div>
+      </div>
+    );
+  }
 
   if (!definition) {
     return (

--- a/configurator/src/admin/MdmsResourceEdit.tsx
+++ b/configurator/src/admin/MdmsResourceEdit.tsx
@@ -6,6 +6,7 @@ import { useEditContext, useResourceContext } from 'ra-core';
 import { getResourceConfig, getResourceLabel } from '@/providers/bridge';
 import { getDescriptor } from './schemaDescriptors';
 import { customEditors } from './themeEditor';
+import { useCanWriteResource } from '@/hooks/useCanWriteResource';
 
 function MdmsEditFields() {
   const resource = useResourceContext() ?? '';
@@ -71,6 +72,19 @@ export function MdmsResourceEdit() {
   const config = getResourceConfig(resource);
   const descriptor = getDescriptor(config?.schema);
   const label = getResourceLabel(resource);
+  // Role gate (CCSD-1998): called before any early return to keep hook order
+  // stable. Also blocks deep links straight to /manage/<resource>/:id/edit.
+  const canWrite = useCanWriteResource(resource);
+
+  if (!canWrite) {
+    return (
+      <div className="p-6">
+        <div className="rounded-md border bg-muted/30 p-4 text-sm text-muted-foreground">
+          Editing {label} is restricted to: {(config?.writeRoles ?? []).join(', ')}.
+        </div>
+      </div>
+    );
+  }
 
   // Escape hatch: if the descriptor names a custom editor, mount that instead.
   if (descriptor?.customEditor) {

--- a/configurator/src/admin/MdmsResourcePage.tsx
+++ b/configurator/src/admin/MdmsResourcePage.tsx
@@ -5,6 +5,7 @@ import { useListContext, useResourceContext } from 'ra-core';
 import { getResourceConfig, getResourceBySchema } from '@/providers/bridge';
 import { useResourceLabel } from '@/providers/useResourceLabel';
 import { useSchemaDefinition } from '@/hooks/useSchemaDefinition';
+import { useCanWriteResource } from '@/hooks/useCanWriteResource';
 import { generateColumns, getRefMap, generateFilterElements } from './schemaUtils';
 
 export function MdmsResourcePage() {
@@ -12,6 +13,8 @@ export function MdmsResourcePage() {
   const config = getResourceConfig(resource);
   const label = useResourceLabel()(resource);
   const { definition } = useSchemaDefinition(config?.schema);
+  // Role gate (CCSD-1998): hide Create on write-restricted resources.
+  const canWrite = useCanWriteResource(resource);
 
   // Compute refMap once, reused by columns and filters
   const refMap = useMemo(() => {
@@ -33,7 +36,7 @@ export function MdmsResourcePage() {
   const subtitle = config?.schema ? `Schema: ${config.schema}` : undefined;
 
   return (
-    <DigitList title={label} subtitle={subtitle} filters={filterElements} hasCreate>
+    <DigitList title={label} subtitle={subtitle} filters={filterElements} hasCreate={canWrite}>
       {schemaColumns ? (
         <DigitDatagrid columns={schemaColumns} rowClick="show" />
       ) : (

--- a/configurator/src/admin/MdmsResourceShow.tsx
+++ b/configurator/src/admin/MdmsResourceShow.tsx
@@ -7,6 +7,7 @@ import { getResourceConfig, getResourceBySchema } from '@/providers/bridge';
 import { useResourceLabel } from '@/providers/useResourceLabel';
 import { useSchemaDefinition } from '@/hooks/useSchemaDefinition';
 import { useReverseRefs } from '@/hooks/useReverseRefs';
+import { useCanWriteResource } from '@/hooks/useCanWriteResource';
 import { groupShowFields, getRefMap, formatFieldLabel } from './schemaUtils';
 import type { SchemaDefinition, RefMapEntry } from './schemaUtils';
 import type { ReverseRef } from '@/hooks/useReverseRefs';
@@ -16,13 +17,15 @@ export function MdmsResourceShow() {
   const config = getResourceConfig(resource);
   const label = useResourceLabel()(resource);
   const { record } = useShowController();
+  // Role gate (CCSD-1998): hide the Edit button on write-restricted resources.
+  const canWrite = useCanWriteResource(resource);
 
   // Fetch schema definition and reverse refs
   const { definition } = useSchemaDefinition(config?.schema);
   const { refs: reverseRefs } = useReverseRefs(config?.schema);
 
   return (
-    <DigitShow title={record ? `${label}: ${record[config?.idField ?? 'id'] ?? record.id}` : label} hasEdit>
+    <DigitShow title={record ? `${label}: ${record[config?.idField ?? 'id'] ?? record.id}` : label} hasEdit={canWrite}>
       {(rec: Record<string, unknown>) => {
         if (definition) {
           return <SchemaShowContent rec={rec} definition={definition} reverseRefs={reverseRefs} />;

--- a/configurator/src/admin/schemaDescriptors/data-security.ts
+++ b/configurator/src/admin/schemaDescriptors/data-security.ts
@@ -1,0 +1,37 @@
+import type { SchemaDescriptor } from './types';
+
+/**
+ * CCSD-2000: the generic MDMS edit form skips object/array fields with no
+ * descriptor; SecurityPolicy's only editable content IS object/array (`model`
+ * is the immutable id), so the Edit page rendered nothing editable.
+ *
+ * `model` is deliberately not listed: descriptor-rendered fields bypass the
+ * idField-disable logic in MdmsResourceEdit, so leaving it to the generic
+ * fallback loop keeps the record key rendered but immutable.
+ */
+export const securityPolicyDescriptor: SchemaDescriptor = {
+  schema: 'DataSecurity.SecurityPolicy',
+  fields: [
+    {
+      path: 'uniqueIdentifier',
+      label: 'Unique Identifier (JSON)',
+      widget: 'json',
+      required: true,
+      help: 'Object {name, jsonPath} locating the record id inside the model, e.g. {"name":"uuid","jsonPath":"/uuid"}',
+    },
+    {
+      path: 'attributes',
+      label: 'Attributes (JSON)',
+      widget: 'json',
+      required: true,
+      help: 'Array of {name, jsonPath, patternId, defaultVisibility} — the model fields this policy masks',
+    },
+    {
+      path: 'roleBasedDecryptionPolicy',
+      label: 'Role-Based Decryption Policy (JSON)',
+      widget: 'json',
+      required: true,
+      help: 'Array of {roles[], attributeAccessList[{attribute, firstLevelVisibility, secondLevelVisibility}]}',
+    },
+  ],
+};

--- a/configurator/src/admin/schemaDescriptors/encryption-policy.ts
+++ b/configurator/src/admin/schemaDescriptors/encryption-policy.ts
@@ -1,0 +1,24 @@
+import type { SchemaDescriptor } from './types';
+
+/**
+ * CCSD-1998: an EncryptionPolicy record is `{key, attributeList:[{jsonPath,
+ * type}]}` — `key` is the idField (rendered disabled) and `attributeList` was
+ * skipped as an undescribed object, so the Edit page had zero editable inputs.
+ * The object-table widget gives the attribute list a proper row editor.
+ */
+export const encryptionPolicyDescriptor: SchemaDescriptor = {
+  schema: 'DataSecurity.EncryptionPolicy',
+  fields: [
+    {
+      path: 'attributeList',
+      label: 'Encrypted attributes',
+      widget: 'object-table',
+      required: true,
+      columns: [
+        { key: 'jsonPath', label: 'JSON Path' },
+        { key: 'type', label: 'Type' },
+      ],
+      help: 'Attributes encrypted for this key; type selects the encryption technique (e.g. Normal).',
+    },
+  ],
+};

--- a/configurator/src/admin/schemaDescriptors/index.ts
+++ b/configurator/src/admin/schemaDescriptors/index.ts
@@ -12,6 +12,9 @@ import { mapConfigDescriptor } from './map-config';
 import { landingSectionDescriptor } from './landing-section';
 import { landingPageConfigDescriptor } from './landing-page-config';
 import { cityModuleDescriptor } from './city-module';
+import { uiHomePageDescriptor } from './ui-homepage';
+import { securityPolicyDescriptor } from './data-security';
+import { encryptionPolicyDescriptor } from './encryption-policy';
 
 /** Map of schema code -> descriptor. Add new entries as we cover more schemas. */
 const DESCRIPTORS: Record<string, SchemaDescriptor> = {
@@ -28,6 +31,9 @@ const DESCRIPTORS: Record<string, SchemaDescriptor> = {
   [landingSectionDescriptor.schema]: landingSectionDescriptor,
   [landingPageConfigDescriptor.schema]: landingPageConfigDescriptor,
   [cityModuleDescriptor.schema]: cityModuleDescriptor,
+  [uiHomePageDescriptor.schema]: uiHomePageDescriptor,
+  [securityPolicyDescriptor.schema]: securityPolicyDescriptor,
+  [encryptionPolicyDescriptor.schema]: encryptionPolicyDescriptor,
 };
 
 export function getDescriptor(schemaCode?: string): SchemaDescriptor | undefined {

--- a/configurator/src/admin/schemaDescriptors/types.ts
+++ b/configurator/src/admin/schemaDescriptors/types.ts
@@ -18,7 +18,9 @@ export type WidgetKind =
   | 'regex'      // pattern field + live sample tester
   | 'chip-array' // string[] editor (add on Enter, remove on x)
   | 'duration-ms' // number input alongside d/h/m/s display
-  | 'locale-list'; // table editor for {label, value}[] arrays (e.g. StateInfo.languages)
+  | 'locale-list' // table editor for {label, value}[] arrays (e.g. StateInfo.languages)
+  | 'json'        // raw-JSON textarea for object/array fields (parse-validated; blocks save while invalid)
+  | 'object-table'; // table editor for arrays of flat objects with configurable columns
 
 /** A single field override. `path` is dot-notation into the record (e.g. "rules.pattern"). */
 export interface FieldSpec {
@@ -34,6 +36,8 @@ export interface FieldSpec {
   max?: number;
   /** For text/regex widgets — a static pattern to also enforce client-side. */
   pattern?: string;
+  /** For 'object-table': column definitions; each row is an object keyed by these. */
+  columns?: { key: string; label: string }[];
 }
 
 /** A grouping of fields shown as a titled section in the form. */

--- a/configurator/src/admin/schemaDescriptors/ui-homepage.ts
+++ b/configurator/src/admin/schemaDescriptors/ui-homepage.ts
@@ -1,0 +1,105 @@
+import type { SchemaDescriptor } from './types';
+
+/**
+ * Descriptor for `common-masters.uiHomePage` — the citizen homepage layout
+ * master (banners, services card, info card, what's-new) (CCSD-2002).
+ *
+ * Needed because every field except `redirectURL` is a nested object and the
+ * generic Edit form skips objects it has no descriptor for; `redirectURL`
+ * itself is the row id (x-unique) and renders disabled on the generic loop.
+ * Net effect before this descriptor: the Edit screen had zero editable inputs.
+ *
+ * `redirectURL` is intentionally not listed (stays on the generic loop,
+ * rendered disabled — it is the MDMS unique identifier). The per-service
+ * `props` arrays inside citizenServicesCard / informationAndUpdatesCard have
+ * no matching widget yet; unrendered fields stay in the form defaultValues
+ * and the data provider merges onto the existing record, so they round-trip
+ * unchanged on save.
+ */
+export const uiHomePageDescriptor: SchemaDescriptor = {
+  schema: 'common-masters.uiHomePage',
+  groups: [
+    {
+      title: 'App banners',
+      fields: [
+        'appBannerMobile.enabled',
+        'appBannerMobile.bannerUrl',
+        'appBannerDesktop.enabled',
+        'appBannerDesktop.bannerUrl',
+      ],
+    },
+    {
+      title: 'WhatsApp banners',
+      fields: [
+        'whatsAppBannerMobile.enabled',
+        'whatsAppBannerMobile.bannerUrl',
+        'whatsAppBannerMobile.navigationUrl',
+        'whatsAppBannerDesktop.enabled',
+        'whatsAppBannerDesktop.bannerUrl',
+        'whatsAppBannerDesktop.navigationUrl',
+      ],
+    },
+    {
+      title: 'Citizen services card',
+      fields: [
+        'citizenServicesCard.enabled',
+        'citizenServicesCard.headerLabel',
+        'citizenServicesCard.sideOption.enabled',
+        'citizenServicesCard.sideOption.name',
+        'citizenServicesCard.sideOption.navigationUrl',
+      ],
+    },
+    {
+      title: 'Information & updates card',
+      fields: [
+        'informationAndUpdatesCard.enabled',
+        'informationAndUpdatesCard.headerLabel',
+        'informationAndUpdatesCard.sideOption.enabled',
+        'informationAndUpdatesCard.sideOption.name',
+        'informationAndUpdatesCard.sideOption.navigationUrl',
+      ],
+    },
+    {
+      title: "What's new section",
+      fields: [
+        'whatsNewSection.enabled',
+        'whatsNewSection.headerLabel',
+        'whatsNewSection.sideOption.enabled',
+        'whatsNewSection.sideOption.name',
+        'whatsNewSection.sideOption.navigationUrl',
+      ],
+    },
+  ],
+  fields: [
+    { path: 'appBannerMobile.enabled', widget: 'boolean', label: 'App banner (mobile) — enabled' },
+    { path: 'appBannerMobile.bannerUrl', widget: 'text', label: 'App banner (mobile) — image URL' },
+    { path: 'appBannerDesktop.enabled', widget: 'boolean', label: 'App banner (desktop) — enabled' },
+    { path: 'appBannerDesktop.bannerUrl', widget: 'text', label: 'App banner (desktop) — image URL' },
+    { path: 'whatsAppBannerMobile.enabled', widget: 'boolean', label: 'WhatsApp banner (mobile) — enabled' },
+    { path: 'whatsAppBannerMobile.bannerUrl', widget: 'text', label: 'WhatsApp banner (mobile) — image URL' },
+    { path: 'whatsAppBannerMobile.navigationUrl', widget: 'text', label: 'WhatsApp banner (mobile) — link URL' },
+    { path: 'whatsAppBannerDesktop.enabled', widget: 'boolean', label: 'WhatsApp banner (desktop) — enabled' },
+    { path: 'whatsAppBannerDesktop.bannerUrl', widget: 'text', label: 'WhatsApp banner (desktop) — image URL' },
+    { path: 'whatsAppBannerDesktop.navigationUrl', widget: 'text', label: 'WhatsApp banner (desktop) — link URL' },
+    { path: 'citizenServicesCard.enabled', widget: 'boolean', label: 'Citizen services card — enabled' },
+    {
+      path: 'citizenServicesCard.headerLabel',
+      widget: 'text',
+      label: 'Citizen services card — header label',
+      help: 'Localization key or plain text shown as the card title.',
+    },
+    { path: 'citizenServicesCard.sideOption.enabled', widget: 'boolean', label: 'Citizen services card — side link enabled' },
+    { path: 'citizenServicesCard.sideOption.name', widget: 'text', label: 'Citizen services card — side link label' },
+    { path: 'citizenServicesCard.sideOption.navigationUrl', widget: 'text', label: 'Citizen services card — side link URL' },
+    { path: 'informationAndUpdatesCard.enabled', widget: 'boolean', label: 'Info & updates card — enabled' },
+    { path: 'informationAndUpdatesCard.headerLabel', widget: 'text', label: 'Info & updates card — header label' },
+    { path: 'informationAndUpdatesCard.sideOption.enabled', widget: 'boolean', label: 'Info & updates card — side link enabled' },
+    { path: 'informationAndUpdatesCard.sideOption.name', widget: 'text', label: 'Info & updates card — side link label' },
+    { path: 'informationAndUpdatesCard.sideOption.navigationUrl', widget: 'text', label: 'Info & updates card — side link URL' },
+    { path: 'whatsNewSection.enabled', widget: 'boolean', label: "What's new — enabled" },
+    { path: 'whatsNewSection.headerLabel', widget: 'text', label: "What's new — header label" },
+    { path: 'whatsNewSection.sideOption.enabled', widget: 'boolean', label: "What's new — side link enabled" },
+    { path: 'whatsNewSection.sideOption.name', widget: 'text', label: "What's new — side link label" },
+    { path: 'whatsNewSection.sideOption.navigationUrl', widget: 'text', label: "What's new — side link URL" },
+  ],
+};

--- a/configurator/src/admin/widgets/JsonInput.tsx
+++ b/configurator/src/admin/widgets/JsonInput.tsx
@@ -1,0 +1,84 @@
+import { useRef, useState } from 'react';
+import { useInput, type InputProps } from 'ra-core';
+import { Label } from '@/components/ui/label';
+
+interface JsonInputProps extends InputProps {
+  label?: string;
+  help?: string;
+  rows?: number;
+}
+
+/** Raw-JSON textarea for object/array fields the form has no richer widget for
+ *  (CCSD-2000: DataSecurity.SecurityPolicy is all objects/arrays, so the
+ *  generic Edit form rendered nothing editable).
+ *
+ *  - Holds the raw text locally; the FORM value is always the parsed object.
+ *  - While the text doesn't parse, an inline error shows and save is blocked
+ *    (the validator reads a ref so it always sees the latest parse state).
+ *  - Empty text clears the field (form value becomes undefined). */
+export function JsonInput({ label, help, rows = 8, ...inputProps }: JsonInputProps) {
+  // Parse-state ref: the useInput validate closure must always see the latest
+  // error without re-registering the validator (identity has to stay stable).
+  const errRef = useRef<string | null>(null);
+  const validateRef = useRef(() => (errRef.current ? 'Invalid JSON' : undefined));
+  const { id, field, isRequired } = useInput({ ...inputProps, validate: validateRef.current });
+
+  const [text, setText] = useState(() =>
+    field.value === undefined || field.value === null ? '' : JSON.stringify(field.value, null, 2)
+  );
+  const [parseError, setParseError] = useState<string | null>(null);
+
+  const onTextChange = (t: string) => {
+    setText(t);
+    if (t.trim() === '') {
+      errRef.current = null;
+      setParseError(null);
+      field.onChange(undefined);
+      return;
+    }
+    try {
+      const parsed = JSON.parse(t);
+      errRef.current = null;
+      setParseError(null);
+      field.onChange(parsed);
+    } catch {
+      errRef.current = 'invalid';
+      setParseError('Invalid JSON — fix the syntax to enable save.');
+    }
+  };
+
+  return (
+    <div>
+      {label && (
+        <Label htmlFor={id} className="mb-1.5 block text-sm font-medium text-foreground">
+          {label}
+          {isRequired && (
+            <span className="text-destructive ml-0.5" aria-label="required">
+              *
+            </span>
+          )}
+        </Label>
+      )}
+      <textarea
+        id={id}
+        rows={rows}
+        spellCheck={false}
+        value={text}
+        onChange={(e) => onTextChange(e.target.value)}
+        onBlur={field.onBlur}
+        aria-invalid={!!parseError || undefined}
+        aria-describedby={parseError ? `${id}-error` : undefined}
+        className={
+          'w-full rounded-md border bg-background p-2 font-mono text-xs ' +
+          (parseError ? 'border-destructive focus-visible:ring-destructive' : 'border-input')
+        }
+      />
+      {parseError && (
+        <p id={`${id}-error`} className="mt-1 text-xs text-destructive" role="alert">
+          {parseError}
+        </p>
+      )}
+      {!parseError && help && <p className="mt-1 text-xs text-muted-foreground">{help}</p>}
+    </div>
+  );
+}

--- a/configurator/src/admin/widgets/ObjectTableInput.tsx
+++ b/configurator/src/admin/widgets/ObjectTableInput.tsx
@@ -1,0 +1,113 @@
+import { useInput, type InputProps } from 'ra-core';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { X, Plus } from 'lucide-react';
+
+type Row = Record<string, unknown>;
+
+interface ObjectTableInputProps extends InputProps {
+  label?: string;
+  help?: string;
+  /** Column definitions; each row is a flat object keyed by these. */
+  columns: { key: string; label: string }[];
+}
+
+/** Table editor for arrays of flat objects with configurable columns —
+ *  generalization of LocaleListInput's {label, value} table (CCSD-1998:
+ *  DataSecurity.EncryptionPolicy.attributeList is [{jsonPath, type}], which no
+ *  existing widget could edit).
+ *
+ *  - One table row per array entry; every column editable inline.
+ *  - "Add row" appends an entry with all columns blank; × removes a row.
+ *  - Form value is always an array of flat objects (never undefined). */
+export function ObjectTableInput({ label, help, columns, ...inputProps }: ObjectTableInputProps) {
+  const { id, field, isRequired } = useInput(inputProps);
+  const value: Row[] = Array.isArray(field.value) ? field.value : [];
+
+  const updateRow = (idx: number, patch: Row) => {
+    field.onChange(value.map((r, i) => (i === idx ? { ...r, ...patch } : r)));
+  };
+
+  const addRow = () => {
+    const blank: Row = {};
+    columns.forEach((c) => {
+      blank[c.key] = '';
+    });
+    field.onChange([...value, blank]);
+  };
+
+  const removeRow = (idx: number) => {
+    field.onChange(value.filter((_, i) => i !== idx));
+  };
+
+  return (
+    <div>
+      {label && (
+        <Label htmlFor={id} className="mb-1.5 block text-sm font-medium text-foreground">
+          {label}
+          {isRequired && <span className="text-destructive ml-0.5">*</span>}
+        </Label>
+      )}
+
+      <div className="rounded-md border">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/50 text-xs font-medium text-muted-foreground">
+            <tr>
+              {columns.map((c) => (
+                <th key={c.key} className="text-left px-3 py-2">
+                  {c.label}
+                </th>
+              ))}
+              <th className="px-2 w-10"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {value.length === 0 && (
+              <tr>
+                <td
+                  colSpan={columns.length + 1}
+                  className="px-3 py-4 text-center text-xs text-muted-foreground italic"
+                >
+                  No rows yet — add one below.
+                </td>
+              </tr>
+            )}
+            {value.map((row, idx) => (
+              <tr key={idx} className="border-t">
+                {columns.map((c) => (
+                  <td key={c.key} className="px-3 py-1.5">
+                    <Input
+                      type="text"
+                      value={String(row[c.key] ?? '')}
+                      onChange={(e) => updateRow(idx, { [c.key]: e.target.value })}
+                      className="h-8 text-sm font-mono"
+                    />
+                  </td>
+                ))}
+                <td className="px-2 py-1.5 text-right">
+                  <button
+                    type="button"
+                    onClick={() => removeRow(idx)}
+                    aria-label={`Remove row ${idx + 1}`}
+                    className="p-1 rounded hover:bg-destructive/10 hover:text-destructive transition"
+                  >
+                    <X className="w-4 h-4" />
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-2 flex items-center gap-2">
+        <Button type="button" variant="outline" size="sm" onClick={addRow} className="gap-1.5">
+          <Plus className="w-3.5 h-3.5" />
+          Add row
+        </Button>
+        {help && <span className="text-xs text-muted-foreground">{help}</span>}
+      </div>
+    </div>
+  );
+}

--- a/configurator/src/admin/widgets/index.tsx
+++ b/configurator/src/admin/widgets/index.tsx
@@ -5,6 +5,8 @@ import { ChipArrayInput } from './ChipArrayInput';
 import { DurationMsInput } from './DurationMsInput';
 import { BooleanInput } from './BooleanInput';
 import { LocaleListInput } from './LocaleListInput';
+import { JsonInput } from './JsonInput';
+import { ObjectTableInput } from './ObjectTableInput';
 import type { FieldSpec } from '../schemaDescriptors/types';
 
 interface WidgetDispatchProps {
@@ -31,6 +33,10 @@ export function WidgetForFieldSpec({ spec, source }: WidgetDispatchProps) {
       return <DurationMsInput {...shared} help={spec.help} min={spec.min} max={spec.max} />;
     case 'locale-list':
       return <LocaleListInput {...shared} help={spec.help} />;
+    case 'json':
+      return <JsonInput {...shared} help={spec.help} />;
+    case 'object-table':
+      return <ObjectTableInput {...shared} columns={spec.columns ?? []} help={spec.help} />;
     case 'boolean':
       return <BooleanInput {...shared} help={spec.help} />;
     case 'integer':
@@ -45,4 +51,4 @@ export function WidgetForFieldSpec({ spec, source }: WidgetDispatchProps) {
   }
 }
 
-export { ColorInput, RegexInput, ChipArrayInput, DurationMsInput, BooleanInput, LocaleListInput };
+export { ColorInput, RegexInput, ChipArrayInput, DurationMsInput, BooleanInput, LocaleListInput, JsonInput, ObjectTableInput };

--- a/configurator/src/hooks/useCanWriteResource.ts
+++ b/configurator/src/hooks/useCanWriteResource.ts
@@ -1,0 +1,20 @@
+import { usePermissions } from 'ra-core';
+import { getResourceConfig } from '@/providers/bridge';
+
+/** Can the logged-in user write (create/edit) this resource?
+ *
+ *  Reads the registry's optional `writeRoles` (CCSD-1998 — e.g. the
+ *  Encryption Policy master is restricted to MDMS_ADMIN/SUPERUSER).
+ *  Resources without `writeRoles` are writable by anyone who can log in,
+ *  exactly as before. UX gate only — the server-side authority is the
+ *  ACCESSCONTROL role-action mapping.
+ *
+ *  While permissions are still resolving, gated resources report `false`
+ *  (buttons appear once roles load) — fail-closed, never fail-open. */
+export function useCanWriteResource(resource: string): boolean {
+  const { permissions } = usePermissions();
+  const writeRoles = getResourceConfig(resource)?.writeRoles;
+  if (!writeRoles?.length) return true;
+  const roles: string[] = Array.isArray(permissions) ? permissions : [];
+  return writeRoles.some((r) => roles.includes(r));
+}


### PR DESCRIPTION
Single PR covering the **Moz configurator-edit cluster**. Three masters could not be edited because the generic MDMS Edit form skips top-level object/array fields with no schema descriptor — and these masters have *only* object/array content besides their immutable id, so the Edit page rendered one disabled field and nothing else.

## Fixed (code) — verified locally in Playwright
| Ticket | Master | Fix |
|---|---|---|
| **CCSD-2002** | `common-masters.uiHomePage` | descriptor with ~25 grouped text/boolean fields (app + WhatsApp banners, citizen-services / info-updates / what's-new cards); `redirectURL` stays the disabled id; unrendered per-service `props` round-trip untouched |
| **CCSD-2000** | `DataSecurity.SecurityPolicy` | descriptor + **new `json` widget** — a parse-validated JSON textarea (blocks save while invalid) for `uniqueIdentifier` / `attributes` / `roleBasedDecryptionPolicy` |
| **CCSD-1998** | `DataSecurity.EncryptionPolicy` | descriptor + **new `object-table` widget** (configurable columns, generalized from `LocaleListInput`) for `attributeList`; **plus** an optional registry `writeRoles` + `useCanWriteResource` gate limiting Create/Edit to `MDMS_ADMIN`/`SUPERUSER` |

### New/changed files
- New widgets: `widgets/JsonInput.tsx`, `widgets/ObjectTableInput.tsx` (+ `WidgetKind` `json` / `object-table`)
- New descriptors: `schemaDescriptors/{ui-homepage,data-security,encryption-policy}.ts`
- Role gate: `hooks/useCanWriteResource.ts`, registry `writeRoles`, wired into `MdmsResource{Edit,Create,Show,Page}.tsx` (also blocks deep-links to `…/edit` / `…/create`)

### Local verification (Playwright, tenant `mz`, ADMIN/SUPERUSER)
- All three Edit pages render their fields **populated** (previously: one disabled field).
- Encryption Policy: edited a row → **Save → `POST /mdms-v2/v2/_update` 202 → round-tripped with no data loss** (then restored). StateInfo's known "silent-submit-swallow" does **not** affect these.
- Encryption Policy list shows the **Create** button for SUPERUSER (positive gate); the negative case is fail-closed by construction.

Additive only — every other master falls through the unchanged generic loop; `tsc` clean on all touched files (pre-existing landingBuilder errors unrelated).

## Also triaged in the same sweep (no code needed here)
Verified **already fixed** on `release-v2.12-moz` (cited commit), so no change in this PR:
- **CCSD-2117** back-to-create draft leak → cleared on success+failure (`37850e84`, PR #1278)
- **CCSD-1985** yellow-vs-orange button → token unified (`11c372d8`)
- **CCSD-1983** stretched brand logo → navbar img `object-fit` (`3b21d9a4`)
- **CCSD-1979** hide DATA_PROCESSING/TRUTHFULNESS on create → product decision reversed; hidden only on detail views (`60f60aac`)
- **CCSD-1976** timeline mask actor name → merged (`428f3894`)
- **CCSD-1986** citizen default Portuguese → already the shared default-locale path

**Out of this PR (per direction):** CCSD-2064 (env/ops — pilot pgr-services needs the `ALLOWED_SOURCE` override, not a repo change) and CCSD-2003 (product decision on which masters to hide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)