### PR TITLE
fix(ops): deploy-pilot-fe.sh — auto-select node 20 (server default moved to v22)

### DIFF
--- a/local-setup/scripts/deploy-pilot-fe.sh
+++ b/local-setup/scripts/deploy-pilot-fe.sh
@@ -58,15 +58,37 @@ if [ "$DO_PULL" = 1 ]; then
   git -C "$REPO" pull --ff-only
   log "HEAD is now:"
   git -C "$REPO" log --oneline -3
+
+  # the executed copy usually lives in ~ (outside the repo); warn when the
+  # freshly-pulled repo version differs so the operator refreshes it
+  if ! cmp -s "$0" "$REPO/local-setup/scripts/deploy-pilot-fe.sh"; then
+    log "NOTE: the repo has a newer deploy-pilot-fe.sh than the copy you are running."
+    log "      refresh it after this run: cp $REPO/local-setup/scripts/deploy-pilot-fe.sh ~/"
+  fi
 fi
 
 # ---------- A. digit-ui (esbuild) ----------
 deploy_ui() {
   log "=== digit-ui (esbuild) ==="
 
-  # node 20 gate — esbuild build breaks on older node
-  local NODEV; NODEV="$(node -v)"
-  case "$NODEV" in v20.*) ;; *) echo "ERROR: node is $NODEV, need v20.x" >&2; exit 1 ;; esac
+  # node 20 gate — the esbuild build needs v20.x. If the default node isn't
+  # v20, auto-pick one: $NODE20_BIN (a .../bin dir) first, then the newest
+  # nvm-installed v20.
+  case "$(node -v 2>/dev/null || true)" in
+    v20.*) ;;
+    *)
+      local N20="${NODE20_BIN:-}"
+      [ -n "$N20" ] || N20="$(ls -d "$HOME"/.nvm/versions/node/v20.*/bin 2>/dev/null | sort -V | tail -1 || true)"
+      if [ -n "$N20" ] && [ -x "$N20/node" ]; then
+        export PATH="$N20:$PATH"
+        log "default node is not v20 → using $N20 ($(node -v))"
+      fi
+      case "$(node -v 2>/dev/null || true)" in v20.*) ;; *)
+        echo "ERROR: node is $(node -v 2>/dev/null || echo missing), need v20.x." >&2
+        echo "       Install one ('nvm install 20') or point NODE20_BIN at a v20 bin dir." >&2
+        exit 1 ;;
+      esac ;;
+  esac
 
   [ -f "$GLOBAL_CONFIGS" ] || { echo "ERROR: $GLOBAL_CONFIGS not found" >&2; exit 1; }
   docker ps --format '{{.Names}}' | grep -qx digit-ui \


### PR DESCRIPTION
## Summary
First real run of `deploy-pilot-fe.sh` on the pilot hit the node gate: server default node is now **v22.22.2** while the esbuild build needs v20. Instead of hard-failing:

- auto-select a v20: `$NODE20_BIN` (explicit override, a `.../bin` dir) first, else the newest `~/.nvm/versions/node/v20.*/bin`; prepend to `PATH`
- error only when no v20 is found, with an actionable hint (`nvm install 20` / `NODE20_BIN`)
- new: warn when the executed `~/deploy-pilot-fe.sh` copy differs from the freshly-pulled repo copy, so operators know to refresh it

## Test plan
- `bash -n` syntax check
- gate logic: v20 default → untouched; non-v20 with nvm v20 present → PATH prepend + version log; nothing found → clear error
- Follow-up to #1486, observed live on cms-ansible-pilot

🤖 Generated with [Claude Code](https://claude.com/claude-code)