### PR TITLE
fix(pgr): employee create — don't restore just-submitted draft on return (CCSD-2117)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/employee/CreateComplaint/createComplaintForm.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/CreateComplaint/createComplaintForm.js
@@ -482,6 +482,11 @@ const CreateComplaintForm = ({
     if (reset && formResetRef.current !== reset) {
       formResetRef.current = reset;
     }
+    // After a successful create, ignore all further change events for this mount
+    // so the post-submit reset() cannot re-persist the just-submitted draft
+    // (CCSD-2117). The component unmounts on navigation to the response page, so
+    // the next Create Complaint mount starts with submittedRef=false again.
+    if (submittedRef.current) return;
     recomputeSubmitDisabled(formData);
 
     // Real-time mobile validation: show/hide CardLabelError as the user types.
@@ -609,6 +614,13 @@ const CreateComplaintForm = ({
   // sessionStorage cache; resetForm() clears react-hook-form's in-memory
   // values (also closes egovernments/CCRS#478 — form-clear-on-success).
   const formResetRef = useRef(null);
+  // True once a complaint has been created successfully. Suppresses any further
+  // draft persistence for the remaining life of this mount (CCSD-2117): without
+  // it, the reset() we fire on success re-runs onFormValueChange with the still
+  // stale submitted values, which re-writes the draft with a fresh __draftMeta —
+  // so returning to Create Complaint restored the just-submitted data. The ref
+  // resets to false on remount, so the next complaint persists normally.
+  const submittedRef = useRef(false);
 
   const onFormSubmit = (_data) => {
     if (!isBoundaryLeaf(_data?.SelectedBoundary)) {
@@ -677,6 +689,9 @@ const CreateComplaintForm = ({
           // state before navigating, so that if the operator hits Back
           // (or the route is remounted) the form is empty rather than
           // restored to the just-submitted complaint's values.
+          // submittedRef guards onFormValueChange so the reset() below can't
+          // re-persist the stale draft (CCSD-2117); set it before resetting.
+          submittedRef.current = true;
           clearSessionFormData();
           draftJsonRef.current = JSON.stringify({});
           if (typeof formResetRef.current === "function") {


### PR DESCRIPTION
## CCSD-2117
QA repro: reception officer creates a complaint → Home → Create Complaint again → **the previous complaint's data is pre-filled** (should be blank).

## Root cause
On successful create the handler clears the session draft and calls FormComposerV2's `reset()` to blank the form. But `reset()` re-runs `onFormValueChange` with the **still-stale, just-submitted** form values *before* the reset propagates, and the change-persist branch re-writes the draft to `sessionStorage` with a fresh `__draftMeta` stamp. That re-persisted draft then passes the mount-time validity check, so the next Create Complaint mount restores it.

(The earlier PR #1278 correctly cleared on success/failure — but this reset-triggered *re-write* slips in right after the clear, which is why it still reproduced.)

## Fix
A `submittedRef` guard:
- set `submittedRef.current = true` in the success handler, before `clearSessionFormData()` + `reset()`
- `onFormValueChange` returns early while it's set → the post-submit reset can't re-persist

The ref lives only for the current mount; navigating to the response page unmounts Create Complaint, so the next mount starts fresh (`false`) and persists drafts normally. Failure paths unchanged (draft dropped, on-screen values kept for retry).

## Verification
Targeted, additive React-ref change. ⚠️ **Not run locally** — this checkout has no `digit-ui-esbuild/node_modules`, so a local esbuild build/deploy wasn't possible; needs the standard CI/build + a reception-officer create→home→create pass to confirm on a running env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)