### PR TITLE
fix(css): brand emblem shrank on citizen Edit-Profile page (CCSD-1983)

### DIFF
--- a/digit-ui-esbuild/public/vendor/overrides.css
+++ b/digit-ui-esbuild/public/vendor/overrides.css
@@ -6283,3 +6283,21 @@ header.digit-header .digit-dropdown-master {
     linear-gradient(rgba(11, 75, 102, 0.55), rgba(11, 75, 102, 0.55)),
     var(--banner-url) no-repeat center center / cover !important;
 }
+
+/* CCSD-1983 follow-up — the brand emblem shrank (24px) on the citizen
+   Edit-Profile page. That page renders the same citizen-style topbar
+   (.navbar > .hambuger-back-wrapper > img.city) but wrapped in the
+   `.employee`-classed shell, so every `.citizen`-scoped 32px rule missed it
+   and the emblem fell to the vendor `.navbar img { height:24px }`.
+   Target img.city directly (it is the brand-emblem class, used only in this
+   topbar) so the emblem is a consistent 32px on every page regardless of the
+   shell wrapper; object-fit:contain keeps the original anti-stretch fix. */
+.navbar img.city,
+.hambuger-back-wrapper img.city {
+  height: 32px !important;
+  min-height: 32px !important;
+  width: auto !important;
+  min-width: 0 !important;
+  max-width: 160px !important;
+  object-fit: contain !important;
+}


### PR DESCRIPTION
## CCSD-1983 (QA re-test follow-up)
Gurjeet's re-test: after the original anti-stretch fix, the top-left brand emblem **shrinks** on the citizen Edit-Profile page (`/citizen/user/profile`) — 24px there vs 32px everywhere else.

## Root cause
The Edit-Profile page renders the same citizen-style topbar (`.navbar > .hambuger-back-wrapper > img.city`) but wrapped in the **`.employee`-classed shell** (shared TopBarSideBar), so the `.citizen`-scoped 32px rule missed it and the emblem fell through to the vendor `.navbar img { height: 24px }`.

Ancestor chain on the profile page (inspected live):
`img.city ← .hambuger-back-wrapper ← .navbar ← … ← div.employee ← .body-container`

## Fix
Target `img.city` directly — it's the brand-emblem class and is used only in this topbar — so the emblem is a consistent **32px on every page regardless of the shell wrapper**. `object-fit: contain` + `width: auto` keep the original anti-stretch behaviour.

## Verified live on local (Playwright, logged-in citizen session)
- `/citizen/user/profile`: emblem **24px → 32px** (30×32, contain) ✅
- `/citizen/all-services`: unchanged 32px ✅
- employee login topbar: no `.navbar img` present — no regression surface ✅

CSS-only (`public/vendor/overrides.css`), hot-deployed + verified on the local box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)