### PR TITLE
feat(audit): enable signed audit logging for PGR complaints and workflow transitions

### DIFF
--- a/configs/egov-persister/egov-workflow-v2-persister.yml
+++ b/configs/egov-persister/egov-workflow-v2-persister.yml
@@ -5,10 +5,16 @@ serviceMaps:
     description: Persists workflow processInstanceFromRequest details in eg_workflow_v2  table
     fromTopic: save-wf-transitions
     isTransaction: true
+    isAuditEnabled: true
+    module: Workflow
+    objecIdJsonPath: $.id
+    tenantIdJsonPath: $.tenantId
+    transactionCodeJsonPath: $.businessId
+    auditAttributeBasePath: $.ProcessInstances.*
     queryMaps:
 
     - query: INSERT INTO eg_wf_processinstance_v2( id,tenantid,businessService,businessId,moduleName,action,status,comment, assigner, stateSla,businessServiceSla, previousStatus, createdby, lastmodifiedby, createdtime, lastmodifiedtime, rating, escalated) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
-      basePath: ProcessInstances.*
+      basePath: $.ProcessInstances.*
       jsonMaps:
       - jsonPath: $.ProcessInstances.*.id
 
@@ -48,7 +54,7 @@ serviceMaps:
 
 
     - query: INSERT INTO eg_wf_document_v2( id, tenantid, active, documenttype,documentUid, processinstanceid, filestoreid, createdby, lastmodifiedby, createdtime, lastmodifiedtime) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
-      basePath: ProcessInstances.*.documents.*
+      basePath: $.ProcessInstances.*.documents.*
       jsonMaps:
       - jsonPath: $.ProcessInstances.documents.*.id
 
@@ -74,7 +80,7 @@ serviceMaps:
 
 
     - query: INSERT INTO eg_wf_assignee_v2(processinstanceid, tenantid, assignee, createdby, lastmodifiedby, createdtime, lastmodifiedtime) VALUES (?, ?, ?, ?, ?, ?, ?);
-      basePath: ProcessInstances.*.assignes.*
+      basePath: $.ProcessInstances.*.assignes.*
       jsonMaps:
       - jsonPath: $.ProcessInstances[*][?({uuid} in @.assignes[*].uuid)].id
 
@@ -97,10 +103,16 @@ serviceMaps:
     description: Persists BusinessService in the table
     fromTopic: save-wf-businessservice
     isTransaction: true
+    isAuditEnabled: true
+    module: Workflow
+    objecIdJsonPath: $.uuid
+    tenantIdJsonPath: $.tenantId
+    transactionCodeJsonPath: $.businessService
+    auditAttributeBasePath: $.BusinessServices.*
     queryMaps:
 
     - query: INSERT INTO eg_wf_businessservice_v2(businessServiceSla, businessservice, business, tenantid, uuid, geturi, posturi, createdby, createdtime, lastmodifiedby, lastmodifiedtime) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
-      basePath: BusinessServices.*
+      basePath: $.BusinessServices.*
       jsonMaps:
       - jsonPath: $.BusinessServices.*.businessServiceSla
 
@@ -128,7 +140,7 @@ serviceMaps:
 
 
     - query: INSERT INTO eg_wf_state_v2(seq, uuid, tenantid, businessserviceid, state,applicationStatus,sla,docuploadrequired, isstartstate, isterminatestate,isStateUpdatable, createdby, createdtime, lastmodifiedby, lastmodifiedtime) VALUES (nextval('seq_eg_wf_state_v2'),? , ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
-      basePath: BusinessServices.*.states.*
+      basePath: $.BusinessServices.*.states.*
       jsonMaps:
       - jsonPath: $.BusinessServices.*.states.*.uuid
 
@@ -161,7 +173,7 @@ serviceMaps:
 
 
     - query: INSERT INTO eg_wf_action_v2( uuid,tenantId,active, currentState, action, nextstate, roles, createdby, createdtime, lastmodifiedby, lastmodifiedtime) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
-      basePath: BusinessServices.*.states.*.actions.*
+      basePath: $.BusinessServices.*.states.*.actions.*
       jsonMaps:
       - jsonPath: $.BusinessServices.*.states.*.actions.*.uuid
 
@@ -193,10 +205,16 @@ serviceMaps:
     description: Persists BusinessService in the table
     fromTopic: update-wf-businessservice
     isTransaction: true
+    isAuditEnabled: true
+    module: Workflow
+    objecIdJsonPath: $.uuid
+    tenantIdJsonPath: $.tenantId
+    transactionCodeJsonPath: $.businessService
+    auditAttributeBasePath: $.BusinessServices.*
     queryMaps:
 
     - query: UPDATE eg_wf_businessservice_v2 SET businessservicesla=?,businessservice=?, business=?, geturi=?, posturi=?, lastmodifiedby=?, lastmodifiedtime=? WHERE uuid=?;
-      basePath: BusinessServices.*
+      basePath: $.BusinessServices.*
       jsonMaps:
       - jsonPath: $.BusinessServices.*.businessServiceSla
 
@@ -218,7 +236,7 @@ serviceMaps:
 
 
     - query: INSERT INTO eg_wf_state_v2(seq, uuid, tenantid, businessserviceid, state,applicationStatus,sla,docuploadrequired, isstartstate, isterminatestate,isStateUpdatable, createdby, createdtime, lastmodifiedby, lastmodifiedtime) VALUES (nextval('seq_eg_wf_state_v2'), ?,?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT (uuid) DO UPDATE SET state=EXCLUDED.state,sla=EXCLUDED.sla,docuploadrequired=EXCLUDED.docuploadrequired,isstartstate=EXCLUDED.isstartstate, isterminatestate=EXCLUDED.isterminatestate,isStateUpdatable=EXCLUDED.isStateUpdatable, lastmodifiedby=EXCLUDED.lastmodifiedby, lastmodifiedtime=EXCLUDED.lastmodifiedtime;
-      basePath: BusinessServices.*.states.*
+      basePath: $.BusinessServices.*.states.*
       jsonMaps:
 
       - jsonPath: $.BusinessServices.*.states.*.uuid
@@ -250,7 +268,7 @@ serviceMaps:
       - jsonPath: $.BusinessServices.*.states.*.auditDetails.lastModifiedTime
 
     - query: INSERT INTO eg_wf_action_v2( uuid,tenantId,active, currentState, action, nextstate, roles, createdby, createdtime, lastmodifiedby, lastmodifiedtime) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT (uuid) DO UPDATE SET active=EXCLUDED.active, action=EXCLUDED.action, nextstate=EXCLUDED.nextstate, roles=EXCLUDED.roles, lastmodifiedby=EXCLUDED.lastmodifiedby, lastmodifiedtime=EXCLUDED.lastmodifiedtime;
-      basePath: BusinessServices.*.states.*.actions.*
+      basePath: $.BusinessServices.*.states.*.actions.*
       jsonMaps:
 
       - jsonPath: $.BusinessServices.*.states.*.actions.*.uuid

--- a/configs/egov-persister/pgr-services-persister.yml
+++ b/configs/egov-persister/pgr-services-persister.yml
@@ -5,10 +5,16 @@ serviceMaps:
     description: Persists pgr service request in tables
     fromTopic: save-pgr-request
     isTransaction: true
+    isAuditEnabled: true
+    module: CMS
+    objecIdJsonPath: $.id
+    tenantIdJsonPath: $.tenantId
+    transactionCodeJsonPath: $.serviceRequestId
+    auditAttributeBasePath: $.service
     queryMaps:
 
     - query: INSERT INTO eg_pgr_service_v2(id, tenantid, servicecode, servicerequestid, description, accountid, additionaldetails, extended_attributes, applicationstatus, source, createdby, createdtime, lastmodifiedby, lastmodifiedtime) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
-      basePath: service
+      basePath: $.service
       jsonMaps:
       - jsonPath: $.service.id
 
@@ -43,7 +49,7 @@ serviceMaps:
       - jsonPath: $.service.auditDetails.lastModifiedTime
 
     - query: INSERT INTO eg_pgr_address_v2(id, tenantid, parentid, doorno, plotno, buildingname, street, landmark, city, pincode, locality, district, region, state, country, latitude, longitude, additionaldetails, createdby, createdtime, lastmodifiedby, lastmodifiedtime) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
-      basePath: service.address
+      basePath: $.service.address
       jsonMaps:
       - jsonPath: $.service.address.id
 
@@ -92,7 +98,7 @@ serviceMaps:
       - jsonPath: $.service.auditDetails.lastModifiedTime
 
     - query: INSERT INTO eg_pgr_document_v2(id, document_type, filestore_id, document_uid, service_id, additional_details, created_by, last_modified_by, created_time, last_modified_time) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
-      basePath: service.documents.*
+      basePath: $.service.documents.*
       jsonMaps:
       - jsonPath: $.service.documents.*.id
 
@@ -122,10 +128,16 @@ serviceMaps:
     description: Updates pgr service request in tables
     fromTopic: update-pgr-request
     isTransaction: true
+    isAuditEnabled: true
+    module: CMS
+    objecIdJsonPath: $.id
+    tenantIdJsonPath: $.tenantId
+    transactionCodeJsonPath: $.serviceRequestId
+    auditAttributeBasePath: $.service
     queryMaps:
 
     - query: UPDATE eg_pgr_service_v2 SET servicecode=?, rating = ?,servicerequestid=?, description=?, accountid=?, additionaldetails=?, extended_attributes=?, applicationstatus=?, lastmodifiedby=?, lastmodifiedtime=? WHERE id=?;
-      basePath: service
+      basePath: $.service
       jsonMaps:
       - jsonPath: $.service.serviceCode
 
@@ -155,7 +167,7 @@ serviceMaps:
 
 
     - query: UPDATE eg_pgr_address_v2 SET doorno=?, plotno=?, buildingname=?, street=?, landmark=?, city=?, pincode=?, locality=?, district=?, region=?, state=?, country=?, latitude=?, longitude=?,additionaldetails=?, lastmodifiedby=?, lastmodifiedtime=? WHERE id=?;
-      basePath: service.address
+      basePath: $.service.address
       jsonMaps:
       - jsonPath: $.service.address.doorNo
 

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -615,13 +615,22 @@ services:
       SPRING_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SPRING_KAFKA_CONSUMER_GROUP_ID: audit-service
       PROCESS_AUDIT_LOGS_KAFKA_TOPIC: process-audit-records
-      PERSIST_AUDIT_LOGS_KAFKA_TOPIC: persist-audit-records
+      # signed logs are published where audit-service-persister.yml consumes them
+      # (app property is persister.audit.kafka.topic; PERSIST_AUDIT_LOGS_KAFKA_TOPIC
+      # bound to nothing in this build)
+      PERSISTER_AUDIT_KAFKA_TOPIC: audit-create
+      # audit-service decides WHAT to audit by parsing the same persister configs
+      # (mappings with isAuditEnabled: true). Without this it falls back to the
+      # image's baked-in GitHub URLs and never audits local topics.
+      EGOV_PERSIST_YML_REPO_PATH: /persister-config/
       # integrity-hash signing goes through enc-service (same as K8s EGOV_ENC_SIGN_HOST)
       EGOV_ENC_SIGN_HOST: http://egov-enc-service:1234
       SERVER_PORT: 8080
       SECURITY_BASIC_ENABLED: 'false'
       MANAGEMENT_SECURITY_ENABLED: 'false'
       MANAGEMENT_HEALTH_DB_ENABLED: 'false'
+    volumes:
+      - ./configs/egov-persister:/persister-config:ro
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:8080/audit-service/actuator/health >/dev/null 2>&1 || exit 1"]
       interval: 30s


### PR DESCRIPTION
## Summary

Enables the signed audit-log chain (`egov-persister` → `process-audit-records` → `audit-service` → `audit-create` → `eg_audit_logs`) for complaint creation/update and workflow persistence.

### Persister configs
- **`configs/egov-persister/pgr-services-persister.yml`** — `save-pgr-request` and `update-pgr-request` mappings are now audit-enabled under module **CMS**, keyed on `auditAttributeBasePath: $.service` with `$.serviceRequestId` as the transaction code (chosen over the sample's `$.transactionCode`, which doesn't exist on the PGR service object — a missing JSON path makes audit-service throw).
- **`configs/egov-persister/egov-workflow-v2-persister.yml`** — `save-wf-transitions` (module **Workflow**, keyed on `$.ProcessInstances.*` / `$.businessId`) and both `wf-businessservice` mappings (keyed on `$.BusinessServices.*` / `$.businessService`) are audit-enabled.
- All `basePath` values in audit-enabled mappings are now `$.`-prefixed: audit-service computes child paths relative to `auditAttributeBasePath` via substring math and crashes on unprefixed paths (`basePath: service` vs `$.service`). The persister accepts both forms, so persistence behaviour is unchanged.

Note: the mapping field really is `objecIdJsonPath` (upstream typo) — the docs' `objectIdJsonPath` is silently ignored.

### Compose wiring (`local-setup/docker-compose.egov-digit.yaml`)
- audit-service now mounts `./configs/egov-persister` and sets `EGOV_PERSIST_YML_REPO_PATH=/persister-config/`. audit-service decides **what** to audit by parsing the persister YAMLs itself (`isAuditEnabled: true` mappings); previously it fell back to the image's baked-in GitHub URLs, so no local topic was ever audited despite the persister forwarding every message.
- Replaced the no-op `PERSIST_AUDIT_LOGS_KAFKA_TOPIC` env with `PERSISTER_AUDIT_KAFKA_TOPIC: audit-create` — the property the app actually binds, matching what `audit-service-persister.yml` consumes.

## Test plan

Verified end-to-end on a local stack (services restarted so both persister and audit-service reload configs):

- Filed a complaint via `POST /pgr-services/v2/request/_create` and assigned it via `_update` (ASSIGN).
- `eg_audit_logs` shows 6 signed rows for the complaint, correlated by `transactioncode` = serviceRequestId:
  - module **CMS**: `eg_pgr_service_v2` + `eg_pgr_address_v2`, CREATE and UPDATE
  - module **Workflow**: `eg_wf_processinstance_v2`, one CREATE per transition (APPLY, ASSIGN)
- All rows carry the acting user's UUID, an HMAC `integrityhash`, and the full field snapshot in `keyValueMap`.
- audit-service no longer logs `Failed to fetch auditAttributes` on workflow topics.

⚠️ Reviewer note: during verification we found the stack's running `pgr-services-dev:latest` image predates the `extendedAttributes` field while this repo's persister config maps `$.service.extendedAttributes` — on such a stack every complaint create dead-letters in the persister (pre-existing issue, independent of this PR). Verification was done with a jar built from this repo's `backend/pgr-services`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled audit logging for workflow and service request data persistence.
  * Added audit tracking for workflow transitions, business services, documents, assignees, addresses, and service requests.
  * Configured local audit processing with persister rules and integrity-hash signing support.

* **Bug Fixes**
  * Improved JSONPath handling for workflow and service request persistence mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->