### PR TITLE
fix(pgr): citizen REOPEN/RATE must merge additionalDetail, not replace it (CCSD-2012)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Rating/SelectRating.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Rating/SelectRating.js
@@ -14,6 +14,7 @@ import {
 } from "@egovernments/digit-ui-components-v2";
 
 import { updateComplaints } from "../../../redux/actions/index";
+import { mergeAdditionalDetail } from "../../../utils/additionalDetail";
 
 // i18n fallback — when a translation key is unavailable, surface the
 // English copy instead of leaving a raw constant on screen.
@@ -167,7 +168,18 @@ const SelectRating = ({ parentRoute }) => {
     const selections = FEEDBACK_OPTIONS.filter((o) => picks[o.key]).map((o) => tr(t, o.key, o.fallback));
 
     complaintDetails.service.rating = rating;
-    complaintDetails.service.additionalDetail = selections.join(",");
+    // CCSD-2012 (sibling of the reopen clobber): this used to REPLACE the
+    // whole additionalDetail object with the bare CSV string. The backend
+    // can't read a string there (extractAdditionalDetails → {}), so it (a)
+    // silently discarded the feedback AND (b) re-derived `department` from
+    // the serviceCode — "NA" for unmapped codes — hiding the complaint from
+    // department-scoped supervisors, and poisoning a later REOPEN with the
+    // wrong department. Merge the CSV under its own key instead: routing
+    // data survives and the feedback actually persists for the first time.
+    complaintDetails.service.additionalDetail = mergeAdditionalDetail(
+      complaintDetails.service.additionalDetail,
+      { ratingFeedback: selections.join(",") }
+    );
     complaintDetails.workflow = {
       action: "RATE",
       comments,

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ReopenComplaint/AddtionalDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ReopenComplaint/AddtionalDetails.js
@@ -7,6 +7,7 @@ import { BackButton, Card, CardHeader, CardText, TextArea, SubmitBar } from "@eg
 
 import { updateComplaints } from "../../../redux/actions/index";
 import { LOCALIZATION_KEY } from "../../../constants/Localization";
+import { mergeAdditionalDetail } from "../../../utils/additionalDetail";
 
 const AddtionalDetails = (props) => {
   // const [details, setDetails] = useState(null);
@@ -56,9 +57,20 @@ const AddtionalDetails = (props) => {
         // complaintDetails,
         "REOPEN"
       );
-      complaintDetails.service.additionalDetail = {
-        REOPEN_REASON: reopenDetails.reason,
-      };
+      // CCSD-2012: MERGE the reopen reason into additionalDetail instead of
+      // replacing the object. Replacing dropped the `department` stamped at
+      // create/ASSIGN, so the backend re-derived it from the serviceCode —
+      // "NA" for unmapped codes — and department-scoped supervisors could no
+      // longer see the reopened complaint (inbox empty + details "No Results
+      // Found" while the workflow's Take Action still rendered).
+      // resetEscalation: a reopen starts a fresh lifecycle — carrying the
+      // escalation bookkeeping over would freeze auto-escalation at the old
+      // level (the pre-fix replace reset it by accident; we do it on purpose).
+      complaintDetails.service.additionalDetail = mergeAdditionalDetail(
+        complaintDetails.service.additionalDetail,
+        { REOPEN_REASON: reopenDetails.reason },
+        { resetEscalation: true }
+      );
       updateComplaint({ service: complaintDetails.service, workflow: complaintDetails.workflow });
     }
     return (

--- a/digit-ui-esbuild/products/pgr/src/utils/additionalDetail.js
+++ b/digit-ui-esbuild/products/pgr/src/utils/additionalDetail.js
@@ -1,0 +1,55 @@
+/**
+ * additionalDetail helpers (CCSD-2012).
+ *
+ * `service.additionalDetail` is a grab-bag the backend and employee flows
+ * stamp routing/bookkeeping data into — `department` (create/ASSIGN routing;
+ * dept-scoped supervisors' visibility depends on it), `serviceName`,
+ * `supervisorName`/`supervisorContactNumber`, and the auto-escalation state
+ * (`escalationLevel`, `lastEscalatedAt`, `escalatedFrom`).
+ *
+ * Two citizen flows (REOPEN, RATE) used to REPLACE the whole object with just
+ * their own payload. The backend then re-derived `department` from the
+ * serviceCode — "NA" for unmapped codes — and department-scoped supervisors
+ * lost the complaint entirely (inbox empty, details "No Results Found").
+ * These helpers make "merge, never replace" cheap to do right.
+ */
+
+/**
+ * Normalize a service.additionalDetail value to a plain object.
+ * Live records arrive as an OBJECT on some complaints and a JSON STRING on
+ * others (legacy rows round-trip double-encoded — same shape the employee
+ * details page parses; see PGRDetails.js parseAdditionalDetail). Anything
+ * else (null, arrays, non-JSON strings) yields {}.
+ */
+export const readAdditionalDetailObject = (raw) => {
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) return raw;
+  if (typeof raw === "string" && raw.trim()) {
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return parsed;
+    } catch (e) {
+      /* not JSON — fall through */
+    }
+  }
+  return {};
+};
+
+/**
+ * Auto-escalation bookkeeping written by pgr-services EscalationService.
+ * A REOPEN starts a fresh lifecycle: carrying these over would (a) freeze
+ * escalation forever once a first-life complaint hit maxDepth and (b) apply
+ * the stale level-N SLA to the new cycle. The pre-fix replace reset them by
+ * accident; we reset them on purpose.
+ */
+export const ESCALATION_KEYS = ["escalationLevel", "lastEscalatedAt", "escalatedFrom"];
+
+/**
+ * Merge `patch` into an existing additionalDetail value, preserving routing
+ * data (department etc.). `resetEscalation: true` (REOPEN) drops the
+ * escalation bookkeeping so the new lifecycle escalates from level 0.
+ */
+export const mergeAdditionalDetail = (existingRaw, patch, { resetEscalation = false } = {}) => {
+  const existing = { ...readAdditionalDetailObject(existingRaw) };
+  if (resetEscalation) ESCALATION_KEYS.forEach((k) => delete existing[k]);
+  return { ...existing, ...patch };
+};


### PR DESCRIPTION
## CCSD-2012 — supervisor can't see/assign reopened complaints

### Root cause (frontend — corrected from the earlier backend framing)
Two citizen flows **replace** the whole `service.additionalDetail` with just their own payload:
- **REOPEN** (`ReopenComplaint/AddtionalDetails.js`): `additionalDetail = { REOPEN_REASON }` — wipes the `department` stamped at create/ASSIGN.
- **RATE** (`Rating/SelectRating.js`): `additionalDetail = selections.join(",")` — a plain **string**; the backend can't read it (`extractAdditionalDetails` → `{}`), so it wipes the department **and silently discards the feedback**.

The backend then re-derives `department` from the serviceCode — **"NA"** for unmapped codes — and department-scoped supervisors lose the complaint entirely: **inbox empty + details "No Results Found"** while the (unscoped) workflow **Take Action** still renders. Verified live on cms-pilot: reopened `P-2026-000050` = REFERRED / unassigned / `department:"NA"`; supervisor by-id search → 0, screening officer → 51.

The RATE clobber also **defeats the reopen fix** on the common rate-then-reopen path and reproduces the symptom on RATE alone — hence both in one PR.

### Fix
New shared helper `utils/additionalDetail.js`:
- `readAdditionalDetailObject` — object or legacy JSON-string shape (same shape the employee page already parses), garbage degrades to `{}`
- `mergeAdditionalDetail(existing, patch, {resetEscalation})` — merge, never replace

REOPEN merges `REOPEN_REASON` **with `resetEscalation`** — the old replace was accidentally resetting `escalationLevel/lastEscalatedAt/escalatedFrom`; a blind spread would freeze auto-escalation at the old level and apply stale SLAs to the new lifecycle, so the reset is now deliberate. RATE merges the CSV under `ratingFeedback` (feedback actually persists for the first time; nothing read the old CSV back).

### Verification
- **Unit:** 10 assertions on the helper (merge/strip/JSON-string/garbage shapes/no mutation) — all pass.
- **E2E (local stack, CMS workflow at `mz`):** built bundle deployed; citizen reopened a REJECTED complaint through the real UI → stored record: `REJECTED→REFERRED`, **`department: DEPT_1` preserved**, `serviceName` kept, `REOPEN_REASON` added, seeded `escalationLevel/lastEscalatedAt` **stripped**. 6/6 assertions pass.
- **4-lens adversarial review** (regression / root-cause completeness / sibling sweep / claim accuracy): every raised issue addressed. No reader of `REOPEN_REASON` exists; domain events read `department` via `instanceof Map` and benefit from preservation; no size constraint on the column.

### What this does NOT solve (noted on the ticket)
- Complaints whose department was **already "NA"** at reopen time (unmapped serviceCode, never routed via ASSIGN) stay NA — a data/mapping condition, not this regression.
- Reopen still transitions with **no assignee** (REFERRED / PENDINGFORASSIGNMENT queues); visibility relies on the department axis or the InboxVisibility tabs.
- The screening-REJECT → `CLOSEDAFTERREJECTION` (terminal) vs `REJECTED` (reopenable) debate on the ticket is a separate product decision.

Dead copies of both clobbers remain in the unbundled `packages/modules/pgr` tree (esbuild aliases `products/pgr`; flagged in the ticket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)