### PR TITLE
fix(pgr): reopen workflow — reason options, document uploads, mandatory details (CCSD-2082)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ReopenComplaint/AddtionalDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ReopenComplaint/AddtionalDetails.js
@@ -1,23 +1,29 @@
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams, useHistory, Redirect } from "react-router-dom";
 
-import { BackButton, Card, CardHeader, CardText, TextArea, SubmitBar } from "@egovernments/digit-ui-react-components";
+import { BackButton, Card, CardHeader, CardText, CardLabelError, TextArea, SubmitBar } from "@egovernments/digit-ui-react-components";
 
 import { updateComplaints } from "../../../redux/actions/index";
 import { LOCALIZATION_KEY } from "../../../constants/Localization";
 import { mergeAdditionalDetail } from "../../../utils/additionalDetail";
 
 const AddtionalDetails = (props) => {
-  // const [details, setDetails] = useState(null);
   const history = useHistory();
   let { id } = useParams();
   const dispatch = useDispatch();
   const appState = useSelector((state) => state)["common"];
   let { t } = useTranslation();
-  
-  const {complaintDetails} = props
+
+  const { complaintDetails } = props;
+
+  // CCSD-2082 Issue 3: reason details are now MANDATORY (reverses CCSD-1955,
+  // which had made them optional). Track the value locally so we can block the
+  // reopen and surface an error until the citizen provides an explanation.
+  const [details, setDetails] = useState(() => Digit.SessionStorage.get(`reopen.${id}`)?.addtionalDetail || "");
+  const [error, setError] = useState(false);
+
   useEffect(() => {
     if (appState.complaints) {
       const { response } = appState.complaints;
@@ -50,6 +56,11 @@ const AddtionalDetails = (props) => {
   };
 
   function reopenComplaint() {
+    // CCSD-2082 Issue 3: require a non-empty explanation before reopening.
+    if (!details || !details.trim()) {
+      setError(true);
+      return;
+    }
     let reopenDetails = Digit.SessionStorage.get(`reopen.${id}`);
     if (complaintDetails) {
       complaintDetails.workflow = getUpdatedWorkflow(
@@ -84,24 +95,32 @@ const AddtionalDetails = (props) => {
   }
 
   function textInput(e) {
-    // setDetails(e.target.value);
+    const value = e.target.value;
+    setDetails(value);
+    if (error && value && value.trim()) setError(false);
     let reopenDetails = Digit.SessionStorage.get(`reopen.${id}`);
     Digit.SessionStorage.set(`reopen.${id}`, {
       ...reopenDetails,
-      addtionalDetail: e.target.value,
+      addtionalDetail: value,
     });
   }
+
+  // CCSD-2082 Issue 3: mandatory label. Falls back to the required PT copy when
+  // the localisation key is not yet present, so it reads correctly pre-seed.
+  const detailsLabel =
+    t("CS_REOPEN_DETAILS_LABEL") === "CS_REOPEN_DETAILS_LABEL"
+      ? "Forneça os detalhes do motivo da re-abertura da reclamação"
+      : t("CS_REOPEN_DETAILS_LABEL");
 
   return (
     <React.Fragment>
       <Card>
         <CardHeader>
-          {t(`${LOCALIZATION_KEY.CS_ADDCOMPLAINT}_PROVIDE_ADDITIONAL_DETAILS`) +
-            // Free-text details are not required to reopen (CCSD-1955)
-            " " + (t("CS_OPTIONAL_SUFFIX") === "CS_OPTIONAL_SUFFIX" ? "(Optional)" : t("CS_OPTIONAL_SUFFIX"))}
+          {detailsLabel} <span style={{ color: "#d4351c" }}>*</span>
         </CardHeader>
         <CardText>{t(`${LOCALIZATION_KEY.CS_ADDCOMPLAINT}_ADDITIONAL_DETAILS_TEXT`)}</CardText>
-        <TextArea name={"AdditionalDetails"} onChange={textInput}></TextArea>
+        <TextArea name={"AdditionalDetails"} value={details} onChange={textInput}></TextArea>
+        {error ? <CardLabelError>{t(`${LOCALIZATION_KEY.CS_ADDCOMPLAINT}_ERROR_REOPEN_DETAILS`)}</CardLabelError> : null}
         <div onClick={reopenComplaint}>
           <SubmitBar label={t(`${LOCALIZATION_KEY.CS_HEADER}_REOPEN_COMPLAINT`)} />
         </div>

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ReopenComplaint/UploadPhoto.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ReopenComplaint/UploadPhoto.js
@@ -23,6 +23,11 @@ const toDocument = (fileStoreId) => ({
   additionalDetails: {},
 });
 
+// CCSD-2082 Issue 2 asks for images AND documents only (PDF/DOC/DOCX) — NOT
+// audio/video. PgrFileUpload's default accept includes audio/video (that's for
+// the create wizard / action modals per CCSD-1971), so scope it down here.
+const REOPEN_ACCEPT = "image/*,.pdf,.doc,.docx";
+
 const UploadPhoto = (props) => {
   const { t } = useTranslation();
   const history = useHistory();
@@ -52,12 +57,25 @@ const UploadPhoto = (props) => {
     t("CS_REOPEN_UPLOAD_HEADER") === "CS_REOPEN_UPLOAD_HEADER"
       ? "Attach documents or photos (optional)"
       : t("CS_REOPEN_UPLOAD_HEADER");
+  // Hint mirrors the restricted accept (images + PDF/DOC/DOCX, no audio/video).
+  const uploadHint =
+    t("CS_REOPEN_UPLOAD_HINT") === "CS_REOPEN_UPLOAD_HINT"
+      ? "Images, PDF, DOC or DOCX up to 5 MB each. You can upload up to 5 files."
+      : t("CS_REOPEN_UPLOAD_HINT");
 
   return (
     <React.Fragment>
       <Card>
         <CardHeader>{header}</CardHeader>
-        <PgrFileUpload t={t} tenantId={tenantId} fieldKey="ReopenDocuments" value={value} onSelect={onSelect} />
+        <PgrFileUpload
+          t={t}
+          tenantId={tenantId}
+          fieldKey="ReopenDocuments"
+          value={value}
+          onSelect={onSelect}
+          accept={REOPEN_ACCEPT}
+          hint={uploadHint}
+        />
         <SubmitBar label={t(`${LOCALIZATION_KEY.PT_COMMONS}_NEXT`)} onSubmit={next} />
       </Card>
     </React.Fragment>

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ReopenComplaint/UploadPhoto.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ReopenComplaint/UploadPhoto.js
@@ -23,10 +23,10 @@ const toDocument = (fileStoreId) => ({
   additionalDetails: {},
 });
 
-// CCSD-2082 Issue 2 asks for images AND documents only (PDF/DOC/DOCX) — NOT
-// audio/video. PgrFileUpload's default accept includes audio/video (that's for
-// the create wizard / action modals per CCSD-1971), so scope it down here.
-const REOPEN_ACCEPT = "image/*,.pdf,.doc,.docx";
+// CCSD-2082 Issue 2: accept images AND documents (PDF/DOC/DOCX) — and, per the
+// follow-up, audio/video too (same set as the create wizard / action modals,
+// CCSD-1971). Matches PgrFileUpload's default; kept explicit for clarity.
+const REOPEN_ACCEPT = "image/*,.pdf,.doc,.docx,.mp3,.wav,.m4a,.aac,.mp4,.mov,.avi,.mkv";
 
 const UploadPhoto = (props) => {
   const { t } = useTranslation();
@@ -57,10 +57,10 @@ const UploadPhoto = (props) => {
     t("CS_REOPEN_UPLOAD_HEADER") === "CS_REOPEN_UPLOAD_HEADER"
       ? "Attach documents or photos (optional)"
       : t("CS_REOPEN_UPLOAD_HEADER");
-  // Hint mirrors the restricted accept (images + PDF/DOC/DOCX, no audio/video).
+  // Hint mirrors the accepted types (images, PDF/DOC/DOCX, audio, video).
   const uploadHint =
     t("CS_REOPEN_UPLOAD_HINT") === "CS_REOPEN_UPLOAD_HINT"
-      ? "Images, PDF, DOC or DOCX up to 5 MB each. You can upload up to 5 files."
+      ? "Images, PDF, DOC, audio or video up to 5 MB each. You can upload up to 5 files."
       : t("CS_REOPEN_UPLOAD_HINT");
 
   return (

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ReopenComplaint/UploadPhoto.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ReopenComplaint/UploadPhoto.js
@@ -1,43 +1,45 @@
 import React, { useEffect, useState } from "react";
-import { Link, useHistory, useParams } from "react-router-dom";
+import { useHistory, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
-import { Card, SubmitBar, BackButton, ImageUploadHandler, CardLabelError, LinkButton } from "@egovernments/digit-ui-react-components";
+import { Card, CardHeader, SubmitBar } from "@egovernments/digit-ui-react-components";
 
 import { LOCALIZATION_KEY } from "../../../constants/Localization";
+import PgrFileUpload from "../../../components/PgrFileUpload";
+
+// CCSD-2082:
+//  - Issue 2: the reopen attachment step used ImageUploadHandler (images
+//    only — camera icon). Reuse PgrFileUpload — the same drop-zone the citizen
+//    create wizard and the employee action modals use — which accepts images
+//    AND documents (PDF/DOC/DOCX, audio, video; 5 MB each) with a format hint.
+//  - Issue 3: the "Pular e continuar" (Skip and continue) link is removed.
+//    Attaching stays OPTIONAL (Issue 2 only asks to widen the accepted types,
+//    not to require an attachment), so "Próximo" proceeds with or without a
+//    file. The mandatory step is now the reason-details screen (AddtionalDetails).
+const toDocument = (fileStoreId) => ({
+  documentType: "PHOTO",
+  fileStoreId,
+  documentUid: fileStoreId,
+  additionalDetails: {},
+});
 
 const UploadPhoto = (props) => {
   const { t } = useTranslation();
   const history = useHistory();
-  let { id } = useParams();
+  const { id } = useParams();
   const [verificationDocuments, setVerificationDocuments] = useState(null);
-  const [valid, setValid] = useState(true);
 
-  const handleUpload = (ids) => {
-    setDocState(ids);
+  const tenantId = props?.complaintDetails?.service?.tenantId || Digit.ULBService.getCurrentTenantId();
+
+  // Live value for the uploader's preview cards = the fileStoreIds we hold.
+  const value = Array.isArray(verificationDocuments) ? verificationDocuments.map((d) => d.fileStoreId).filter(Boolean) : [];
+
+  // PgrFileUpload reports (fieldKey, [fileStoreId,...]) on every add/remove.
+  const onSelect = (_key, ids) => {
+    setVerificationDocuments((ids || []).map(toDocument));
   };
 
-  const setDocState = (ids) => {
-    if (ids?.length) {
-      const documents = ids.map((id) => ({
-        documentType: "PHOTO",
-        fileStoreId: id,
-        documentUid: "",
-        additionalDetails: {},
-      }));
-      setVerificationDocuments(documents);
-    }
-  };
-
-  function save() {
-    if (verificationDocuments === null) {
-      setValid(false);
-    } else {
-      history.push(`${props.match.path}/addional-details/${id}`);
-    }
-  }
-
-  function skip() {
+  function next() {
     history.push(`${props.match.path}/addional-details/${id}`);
   }
 
@@ -46,27 +48,17 @@ const UploadPhoto = (props) => {
     Digit.SessionStorage.set(`reopen.${id}`, { ...reopenDetails, verificationDocuments });
   }, [verificationDocuments, id]);
 
+  const header =
+    t("CS_REOPEN_UPLOAD_HEADER") === "CS_REOPEN_UPLOAD_HEADER"
+      ? "Attach documents or photos (optional)"
+      : t("CS_REOPEN_UPLOAD_HEADER");
+
   return (
     <React.Fragment>
       <Card>
-        <ImageUploadHandler
-          header={
-            t(`${LOCALIZATION_KEY.CS_ADDCOMPLAINT}_UPLOAD_PHOTO`) +
-            // Photos are skippable on reopen — label them optional (CCSD-1955)
-            (props.skip ? " " + (t("CS_OPTIONAL_SUFFIX") === "CS_OPTIONAL_SUFFIX" ? "(Optional)" : t("CS_OPTIONAL_SUFFIX")) : "")
-          }
-          tenantId={props?.complaintDetails?.service?.tenantId}
-          cardText=""
-          onPhotoChange={handleUpload}
-          uploadedImages={null}
-        />
-        {/* <Link to={`${props.match.path}/addional-details/${id}`}>
-          <SubmitBar label={t(`${LOCALIZATION_KEY.PT_COMMONS}_NEXT`)} />
-        </Link> */}
-
-        {valid ? null : <CardLabelError>{t(`${LOCALIZATION_KEY.CS_ADDCOMPLAINT}_UPLOAD_ERROR_MESSAGE`)}</CardLabelError>}
-        <SubmitBar label={t(`${LOCALIZATION_KEY.PT_COMMONS}_NEXT`)} onSubmit={save} />
-        {props.skip ? <LinkButton label={t(`${LOCALIZATION_KEY.CORE_COMMON}_SKIP_CONTINUE`)} onClick={skip} /> : null}
+        <CardHeader>{header}</CardHeader>
+        <PgrFileUpload t={t} tenantId={tenantId} fieldKey="ReopenDocuments" value={value} onSelect={onSelect} />
+        <SubmitBar label={t(`${LOCALIZATION_KEY.PT_COMMONS}_NEXT`)} onSubmit={next} />
       </Card>
     </React.Fragment>
   );

--- a/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
@@ -8233,7 +8233,7 @@
     },
     {
         "code": "CS_REOPEN_UPLOAD_HINT",
-        "message": "Images, PDF, DOC or DOCX up to 5 MB each. You can upload up to 5 files.",
+        "message": "Images, PDF, DOC, audio or video up to 5 MB each. You can upload up to 5 files.",
         "module": "rainmaker-pgr",
         "locale": "en_IN"
     }

--- a/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
@@ -2803,25 +2803,25 @@
     },
     {
         "code": "CS_REOPEN_OPTION_FOUR",
-        "message": "No permanent solution",
+        "message": "Other reason. Specify in the window below.",
         "module": "rainmaker-pgr",
         "locale": "en_IN"
     },
     {
         "code": "CS_REOPEN_OPTION_ONE",
-        "message": "No work was done",
+        "message": "I have new facts or evidence that may change the decision made.",
         "module": "rainmaker-pgr",
         "locale": "en_IN"
     },
     {
         "code": "CS_REOPEN_OPTION_THREE",
-        "message": "Employee did not turn up",
+        "message": "The response received does not match the facts or the situation reported.",
         "module": "rainmaker-pgr",
         "locale": "en_IN"
     },
     {
         "code": "CS_REOPEN_OPTION_TWO",
-        "message": "Only partial work was done",
+        "message": "The solution provided did not adequately resolve the complaint.",
         "module": "rainmaker-pgr",
         "locale": "en_IN"
     },
@@ -8210,6 +8210,24 @@
     {
         "code": "PGR_CHANNEL_LINHA_VERDE",
         "message": "Green Line",
+        "module": "rainmaker-pgr",
+        "locale": "en_IN"
+    },
+    {
+        "code": "CS_REOPEN_UPLOAD_HEADER",
+        "message": "Attach documents or photos (optional)",
+        "module": "rainmaker-pgr",
+        "locale": "en_IN"
+    },
+    {
+        "code": "CS_REOPEN_DETAILS_LABEL",
+        "message": "Provide the details of the reason for reopening the complaint",
+        "module": "rainmaker-pgr",
+        "locale": "en_IN"
+    },
+    {
+        "code": "CS_ADDCOMPLAINT_ERROR_REOPEN_DETAILS",
+        "message": "Please provide the reason details for reopening the complaint.",
         "module": "rainmaker-pgr",
         "locale": "en_IN"
     }

--- a/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
@@ -8230,5 +8230,11 @@
         "message": "Please provide the reason details for reopening the complaint.",
         "module": "rainmaker-pgr",
         "locale": "en_IN"
+    },
+    {
+        "code": "CS_REOPEN_UPLOAD_HINT",
+        "message": "Images, PDF, DOC or DOCX up to 5 MB each. You can upload up to 5 files.",
+        "module": "rainmaker-pgr",
+        "locale": "en_IN"
     }
 ]

--- a/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
@@ -1678,5 +1678,11 @@
         "message": "Por favor, forneça os detalhes do motivo da reabertura da reclamação.",
         "module": "rainmaker-pgr",
         "locale": "pt_PT"
+    },
+    {
+        "code": "CS_REOPEN_UPLOAD_HINT",
+        "message": "Imagens, PDF, DOC ou DOCX até 5 MB cada. Pode carregar até 5 ficheiros.",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
     }
 ]

--- a/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
@@ -1681,7 +1681,7 @@
     },
     {
         "code": "CS_REOPEN_UPLOAD_HINT",
-        "message": "Imagens, PDF, DOC ou DOCX até 5 MB cada. Pode carregar até 5 ficheiros.",
+        "message": "Imagens, PDF, DOC, áudio ou vídeo até 5 MB cada. Pode carregar até 5 ficheiros.",
         "module": "rainmaker-pgr",
         "locale": "pt_PT"
     }

--- a/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
@@ -1636,5 +1636,47 @@
         "message": "Linha Verde",
         "module": "rainmaker-pgr",
         "locale": "pt_PT"
+    },
+    {
+        "code": "CS_REOPEN_OPTION_ONE",
+        "message": "Possuo novos factos ou provas que podem alterar a decisão tomada.",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_REOPEN_OPTION_TWO",
+        "message": "A solução apresentada não resolveu adequadamente a reclamação.",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_REOPEN_OPTION_THREE",
+        "message": "A resposta recebida não corresponde aos factos ou à situação reportada.",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_REOPEN_OPTION_FOUR",
+        "message": "Outro motivo. Especifique na janela a seguir.",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_REOPEN_UPLOAD_HEADER",
+        "message": "Anexar documentos ou fotografias (opcional)",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_REOPEN_DETAILS_LABEL",
+        "message": "Forneça os detalhes do motivo da re-abertura da reclamação",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "CS_ADDCOMPLAINT_ERROR_REOPEN_DETAILS",
+        "message": "Por favor, forneça os detalhes do motivo da reabertura da reclamação.",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
     }
 ]


### PR DESCRIPTION
**Stacked on #1502 (CCSD-2012)** — base is that branch so the diff shows only the CCSD-2082 changes; merge #1502 first (or retarget to release-v2.12-moz after it merges).

Three fixes to the citizen complaint-reopening wizard (`products/pgr/src/pages/citizen/ReopenComplaint/`):

### Issue 1 — reopening reason options (loc-only)
Updated `CS_REOPEN_OPTION_ONE…FOUR` (en_IN + pt_PT seed) to the new set:
- Possuo novos factos ou provas que podem alterar a decisão tomada.
- A solução apresentada não resolveu adequadamente a reclamação.
- A resposta recebida não corresponde aos factos ou à situação reportada.
- Outro motivo. Especifique na janela a seguir.

`Reason.js` already renders these keys — no code change.

### Issue 2 — allow document attachments
`UploadPhoto.js` used `ImageUploadHandler` (images only). Swapped for **`PgrFileUpload`** (the shared uploader from the create wizard / action modals) → accepts **images + PDF/DOC/DOCX + audio/video, 5 MB each**, with a localized format hint (`accept="image/*,.pdf,.doc,.docx,.mp3,…"`).

### Issue 3 — mandatory reason details
Reverses **CCSD-1955** (which had made details/photos optional):
- Reason-details field is now **required** — empty submit is blocked with an inline error (`CS_ADDCOMPLAINT_ERROR_REOPEN_DETAILS`).
- Label → **"Forneça os detalhes do motivo da re-abertura da reclamação"** + required asterisk (no "(Optional)").
- Removed the **"Pular e continuar"** skip on the upload step. The attachment itself stays **optional** (Issue 2 only asks to widen accepted types), so Next proceeds with or without a file.

New loc keys (en_IN + pt_PT): `CS_REOPEN_UPLOAD_HEADER`, `CS_REOPEN_DETAILS_LABEL`, `CS_ADDCOMPLAINT_ERROR_REOPEN_DETAILS`.

### Verified end-to-end (local stack, Playwright, citizen, pt_PT)
- New reason options render ✅
- Upload step: `accept` includes `.pdf/.doc/.docx`; **no** "Pular e continuar" ✅
- Empty details → blocked + error "Por favor, forneça os detalhes do motivo da reabertura da reclamação." ✅
- Filled details → reopen succeeds (`REFERRED`); `REOPEN_REASON` + workflow comments captured; **department preserved (DEPT_1)** (i.e. #1502 still holds) ✅

Loc keys upserted to local; **pilot upsert pending deploy**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)