### PR TITLE
fix(pgr): make attachment optional for AWAITINGINFORMATION action (CCSD-2081)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
@@ -70,9 +70,16 @@ const buildActionFormConfig = ({ action, assigneeRoles = [], isTerminal = false,
   // docUploadRequired on the BusinessService (previously that flag also gated
   // visibility, so most actions had no way to attach evidence). The backend
   // persists workflow.verificationDocuments per transition unconditionally.
+  //
+  // CCSD-2081: AWAITINGINFORMATION ("Aguardar informação") targets the
+  // INFOFROMCITIZEN state, which is docUploadRequired — meant for the CITIZEN's
+  // later response, not the officer REQUESTING info. Requiring the officer to
+  // attach a file just to ask a question is wrong, so the attachment is
+  // optional for this action regardless of the target state's flag.
+  const ATTACHMENT_OPTIONAL_ACTIONS = ["AWAITINGINFORMATION"];
   body.push({
     type: "component",
-    isMandatory: !!docUploadRequired,
+    isMandatory: !!docUploadRequired && !ATTACHMENT_OPTIONAL_ACTIONS.includes(action),
     component: "PGRActionUploadComponent",
     key: "SelectedDocuments",
     label: "CS_COMMON_ATTACHMENTS",


### PR DESCRIPTION
## CCSD-2081
Changing a complaint status to **"Aguardar informação"** (AWAITINGINFORMATION) required an attachment; it should be optional.

## Root cause
The employee action modal ([PGRDetails.js `buildActionFormConfig`](digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js)) sets the attachment field's `isMandatory` from the action's **target-state** `docUploadRequired` flag. `AWAITINGINFORMATION` targets **INFOFROMCITIZEN**, which is `docUploadRequired: true` — but that flag is meant for the *citizen's* later response, not for the officer *requesting* information. So the officer was forced to attach a file just to ask a question.

## Fix (one line)
```js
const ATTACHMENT_OPTIONAL_ACTIONS = ["AWAITINGINFORMATION"];
// …
isMandatory: !!docUploadRequired && !ATTACHMENT_OPTIONAL_ACTIONS.includes(action),
```
The uploader still renders (officer *may* attach), it's just not required. Other actions whose target state is `docUploadRequired` are unchanged. Backend still persists `workflow.verificationDocuments` unconditionally.

## Verification
- Source + built bundle both carry the guard (`["AWAITINGINFORMATION"]`).
- Boolean is trivially correct: AWAITINGINFORMATION → `true && !true` = **false** (optional); other docUploadRequired actions → `true && !false` = **true** (still mandatory).
- ⚠️ Full case-manager UI pass (INVESTIGATION → "Aguardar informação" with no file) is best done on **pilot after deploy**, where the CMS_CASE_MANAGER flow + INVESTIGATION-state complaints exist (local `mz` root has no CMS case-manager users to drive that modal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)