### PR TITLE
fix(workflow): INFOFROMCITIZEN docUploadRequired=false — AWAITINGINFORMATION needs no attachment (CCSD-2081)

### DIFF
--- a/utilities/default-data-handler/src/main/resources/CmsPgrWorkflowConfig.json
+++ b/utilities/default-data-handler/src/main/resources/CmsPgrWorkflowConfig.json
@@ -186,7 +186,7 @@
           "sla": 300000,
           "state": "INFOFROMCITIZEN",
           "applicationStatus": "AWAITINGINFORMATION",
-          "docUploadRequired": true,
+          "docUploadRequired": false,
           "isStartState": false,
           "isTerminateState": false,
           "isStateUpdatable": false,


### PR DESCRIPTION
Completes **CCSD-2081** alongside the FE PR **#1505**.

## Why #1505 alone wasn't enough
#1505 made the attachment field optional in the action modal, but submitting still failed at the backend:
```
400 INVALID DOCUMENT — "Documents cannot be null for status: INFOFROMCITIZEN"
```
egov-workflow-v2 enforces `docUploadRequired` server-side, and `CmsPgrWorkflowConfig.json` had **INFOFROMCITIZEN `docUploadRequired: true`**. `docUploadRequired` gates transitions **into** a state — i.e. the officer's `AWAITINGINFORMATION` action — which is precisely what CCSD-2081 wants optional.

## Fix
Flip **INFOFROMCITIZEN `docUploadRequired` → false**. This is the authoritative control: the FE also derives the attachment's `isMandatory` from it, so it makes both the UI *and* the backend treat the attachment as optional. (The citizen's response *out* of INFOFROMCITIZEN is governed by the destination state, unaffected.)

## Deploy note
Seed change — running envs also need the **workflow businessservice updated** (`egov-workflow-v2 …/businessservice/_update`) to load the new flag; the seed only applies on a fresh workflow load.

Verified on pilot (see CCSD-2081): after the running-workflow update, the case manager submits "Aguardar informação" with **no attachment** and it transitions to AWAITINGINFORMATION.

🤖 Generated with [Claude Code](https://claude.com/claude-code)