### PR TITLE
fix(db-normalize): handle postgres restart window during container st…

### DIFF
--- a/docker-compose.egov-digit.yaml
+++ b/docker-compose.egov-digit.yaml
@@ -114,12 +114,18 @@ services:
     ports:
     - 15432:5432
     healthcheck:
+      # -h forces the TCP path every consumer actually connects over. Without it,
+      # pg_isready defaults to the Unix socket, which the docker-entrypoint temp
+      # server (listen_addresses='') answers on during initdb, well before the
+      # real server starts listening on 5432 - so depends_on: service_healthy
+      # trips "healthy" before the restart into the real server completes.
       test:
       - CMD-SHELL
-      - pg_isready -U egov
+      - pg_isready -h 127.0.0.1 -U egov
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 60s
     networks:
     - egov-network
 

--- a/local-setup/db/normalize/normalize.py
+++ b/local-setup/db/normalize/normalize.py
@@ -92,6 +92,7 @@ def decide(
 import os
 import subprocess
 import sys
+import time
 from typing import Iterable, List
 
 MAP_PATH = os.environ.get("MAP_PATH", "/map.yml")
@@ -124,6 +125,14 @@ LOCK_TIMEOUT = "30s"        # abort a blocked LOCK TABLE
 STATEMENT_TIMEOUT = "300s"  # cap any single statement server-side
 SUBPROCESS_TIMEOUT = 600    # hard client-side backstop on the psql process (seconds)
 
+# postgres-db's healthcheck is plain `pg_isready`, which reports ready against the
+# docker-entrypoint-initdb.d temp server too (that's how a fresh fast-path volume
+# loads full-dump.sql). Postgres then restarts into its real server, and depends_on:
+# service_healthy does not cover that restart — connections during it get refused.
+# Retry through that window instead of treating it as the deliberate abort below.
+CONNECT_RETRY_SECONDS = 60
+CONNECT_RETRY_INTERVAL = 2
+
 
 def psql(sql: str, *, capture: bool = True) -> str:
     """Run SQL. ON_ERROR_STOP=1 so a failure is a non-zero exit, not a warning.
@@ -151,6 +160,18 @@ def psql(sql: str, *, capture: bool = True) -> str:
         sys.stderr.write(proc.stderr or "")
         raise subprocess.CalledProcessError(proc.returncode, "psql", proc.stdout, proc.stderr)
     return (proc.stdout or "").strip()
+
+
+def wait_for_connection() -> None:
+    deadline = time.monotonic() + CONNECT_RETRY_SECONDS
+    while True:
+        try:
+            psql("SELECT 1;")
+            return
+        except subprocess.CalledProcessError:
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(CONNECT_RETRY_INTERVAL)
 
 
 def list_tables() -> Set[str]:
@@ -209,6 +230,7 @@ COMMIT;
 
 def main() -> int:
     services = load_map(MAP_PATH)
+    wait_for_connection()
     present = list_tables()
 
     # Decide everything first, so an abort happens BEFORE anything is modified.

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -114,12 +114,18 @@ services:
     ports:
     - 15432:5432
     healthcheck:
+      # -h forces the TCP path every consumer actually connects over. Without it,
+      # pg_isready defaults to the Unix socket, which the docker-entrypoint temp
+      # server (listen_addresses='') answers on during initdb, well before the
+      # real server starts listening on 5432 - so depends_on: service_healthy
+      # trips "healthy" before the restart into the real server completes.
       test:
       - CMD-SHELL
-      - pg_isready -U egov
+      - pg_isready -h 127.0.0.1 -U egov
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 60s
     networks:
     - egov-network
 


### PR DESCRIPTION
## Fix `db-history-normalize` false-positive failure on fresh fast-path deploys

### Error

`./deploy.sh` reliably failed at the "Start DIGIT stack" task — reproduced even after a full `docker stop/rm` + `docker volume rm` wipe, so it wasn't stale-volume state:

```
fatal: [ige]: FAILED! => {"changed": false, "cmd": "COMPOSE_PROFILES=mcp,notifications docker compose -f docker-compose.egov-digit.yaml -f docker-compose.fast-path.yml -f docker-compose.migrations.yml -f docker-compose.migrations.ansible.yml -f docker-compose.monitoring.yml up -d", "msg": "non-zero return code", "rc": 1, ...
...
Container db-history-normalize Error service "db-history-normalize" didn't complete successfully: exit 1
Container docker-postgres Error dependency postgres-db failed to start
Container db-history-normalize Error service "db-history-normalize" didn't complete successfully: exit 1
...
service "db-history-normalize" didn't complete successfully: exit 1
```

`docker logs db-history-normalize`:

```
psql: error: connection to server at "postgres-db" (172.18.0.14), port 5432 failed: Connection refused
	Is the server running on that host and accepting TCP/IP connections?
Traceback (most recent call last):
  File "/usr/local/bin/normalize.py", line 251, in <module>
    sys.exit(main())
             ~~~~^^
  File "/usr/local/bin/normalize.py", line 212, in main
    present = list_tables()
  File "/usr/local/bin/normalize.py", line 157, in list_tables
    out = psql("SELECT tablename FROM pg_tables WHERE schemaname = 'public';")
  File "/usr/local/bin/normalize.py", line 152, in psql
    raise subprocess.CalledProcessError(proc.returncode, "psql", proc.stdout, proc.stderr)
subprocess.CalledProcessError: Command 'psql' returned non-zero exit status 2.
```

### Root cause

`postgres-db`'s healthcheck is bare `pg_isready -U egov` (`docker-compose.egov-digit.yaml`), with no `start_period`. On a fresh volume with `db_fast_path: true`, Postgres:

1. runs `docker-entrypoint-initdb.d/01-full-dump.sql` (loads 54 tables) against a **temporary** internal instance,
2. shuts that instance down,
3. starts the **real** server other containers actually connect to.

`pg_isready` succeeds against the temporary instance in step 1, so Compose marks `postgres-db` healthy too early. `depends_on: condition: service_healthy` is satisfied, `db-history-normalize` starts, and it can land in the gap between steps 2 and 3, getting `Connection refused` over the network hostname. This is a known Docker Postgres image race, not a data problem — `db-history-normalize`'s own decision logic (`decide()`) never even ran; the traceback happened before any real/abort logic was reached.

`db-history-normalize` gates every other migrator, and it was the only piece in the startup chain with zero connection retry — despite already having a deliberate timeout/retry philosophy for lock/statement handling (`LOCK_TIMEOUT`, `STATEMENT_TIMEOUT`, `SUBPROCESS_TIMEOUT`).

### Fix

`local-setup/db/normalize/normalize.py`:

- Added `wait_for_connection()`: retries a trivial `SELECT 1;` every 2s for up to 60s, re-raising only if the whole window elapses.
- Called it as the first thing in `main()`, before `list_tables()`.

This only absorbs the one-time startup race. It does not touch `decide()` or the deliberate-`ABORT` path — a genuine "data present, no matching Flyway history" abort still fails immediately, exactly as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local database setup reliability by waiting for PostgreSQL to become ready before running Flyway history normalization.
  * Added automatic connection retries for up to one minute, reducing failures caused by startup timing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->