### PR TITLE
fix(pgr): auto-refresh citizen status after reopen (CCSD-2119)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ReopenComplaint/AddtionalDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ReopenComplaint/AddtionalDetails.js
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
+import { useQueryClient } from "react-query";
 import { useParams, useHistory, Redirect } from "react-router-dom";
 
 import { BackButton, Card, CardHeader, CardText, CardLabelError, TextArea, SubmitBar } from "@egovernments/digit-ui-react-components";
@@ -17,6 +18,7 @@ const AddtionalDetails = (props) => {
   let { t } = useTranslation();
 
   const { complaintDetails } = props;
+  const queryClient = useQueryClient();
 
   // CCSD-2082 Issue 3: reason details are now MANDATORY (reverses CCSD-1955,
   // which had made them optional). Track the value locally so we can block the
@@ -36,9 +38,17 @@ const AddtionalDetails = (props) => {
   const updateComplaint = useCallback(
     async (complaintDetails) => {
       await dispatch(updateComplaints(complaintDetails));
+      // CCSD-2119: the reopen goes through the redux updateComplaints path, which
+      // does NOT touch react-query. The citizen status pill (useComplaintDetails
+      // -> ["complaintDetails", tenantId, id]) and My Complaints list
+      // (useComplaintsListByMobile -> ["complaintsList", …]) therefore kept
+      // serving the pre-reopen status until a manual browser refresh. Invalidate
+      // both so they refetch — active views update live, others on next mount.
+      queryClient.invalidateQueries(["complaintDetails"]);
+      queryClient.invalidateQueries(["complaintsList"]);
       history.push(`${props.match.path}/response/${id}`);
     },
-    [dispatch]
+    [dispatch, queryClient]
   );
 
   const getUpdatedWorkflow = (reopenDetails, type) => {


### PR DESCRIPTION
## CCSD-2119 — Reopen does not auto-update the citizen UI status (manual refresh required)

### Problem
When a citizen reopens a **REJECTED**/**RESOLVED** complaint, the UI keeps showing the old status (e.g. *Rejected*) on both the **Complaint Summary** detail and the **My Complaints** list until the browser is manually refreshed.

### Root cause
The reopen submits through the redux `updateComplaints` action → `Digit.PGRService.update`, which **does not touch react-query**. But the two views that show the status are react-query cached:
- detail pill → `useComplaintDetails` → `["complaintDetails", tenantId, id]`
- My Complaints → `useComplaintList` → `["complaintsList", filters]`

Neither cache is invalidated on reopen, so the stale (pre-reopen) status is served until a hard refetch (manual refresh).

### Fix
Invalidate both query families in the reopen success path (`ReopenComplaint/AddtionalDetails.js`, right after the `updateComplaints` dispatch resolves). Active observers refetch immediately; inactive ones refetch on next mount. One-file, additive change — the create/rate/other flows are untouched.

### Verification (local, `mz`, citizen `888888888`)
Reopened **PRD-2026-000022** (REJECTED → REFERRED backend-confirmed) and navigated **in-app (no browser reload)**:
- **Detail** "Complaint Summary" pill: `REJECTED` → **`REFERRED`**, timeline head = *Reopened*.
- **My Complaints** chip for PRD-2026-000022: `REJECTED` → **`REFERRED`** (list went 2 REJECTED/2 REFERRED → 1 REJECTED/3 REFERRED).

Both updated automatically with **no manual refresh** — matching the ticket's acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)