### PR TITLE
feat(dashboard): cohesive auth module with silent token refresh (#1466)

### DIFF
--- a/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
@@ -17,6 +17,7 @@ import {
   buildWidgetHeaderClassName,
   getWidgetBodyClassName,
 } from "./config/visualizationStyles";
+import { SESSION_EXPIRED_EVENT } from "./services/authService";
 import DashboardLogin, {
   hasDashboardSession,
   clearDashboardSession,
@@ -145,7 +146,28 @@ function pixelToGridPosition(containerWidth, clientX, clientY, gridRect, kpiId, 
 const AdminDashboard = ({ embedded = false }) => {
   // Embedded (inside the DigitUI employee chrome) the host guarantees the
   // session and owns sign-out, so the standalone login gate is skipped.
-  const [authed] = useState(() => embedded || hasDashboardSession());
+  const [authed, setAuthed] = useState(() => embedded || hasDashboardSession());
+  const [expired, setExpired] = useState(false);
+
+  // The gate used to be evaluated once at mount, so a session that died while
+  // the tab was open could never flip it — the 401 just rendered as a raw error
+  // banner and a reload re-passed the gate on the stale token (#1466).
+  // authService announces an unrecoverable session and we drop to the login
+  // screen with an explanation.
+  //
+  // Not when embedded: there the surrounding DigitUI chrome owns the session and
+  // its own expiry handling, and rendering our standalone login form inside it
+  // would be wrong. authService has already cleared the dead token, so the host
+  // sees the same state on its next call.
+  useEffect(() => {
+    if (embedded) return undefined;
+    const onExpired = () => {
+      setExpired(true);
+      setAuthed(false);
+    };
+    window.addEventListener(SESSION_EXPIRED_EVENT, onExpired);
+    return () => window.removeEventListener(SESSION_EXPIRED_EVENT, onExpired);
+  }, [embedded]);
 
   // Per-LOCALE number-format mask (dss.DashboardConfig.numberFormat, #1213 /
   // #1272). Primed synchronously so the first painted frame is already masked.
@@ -163,7 +185,7 @@ const AdminDashboard = ({ embedded = false }) => {
     window.location.reload();
   }, []);
 
-  if (!authed) return <DashboardLogin onLogin={handleLogin} />;
+  if (!authed) return <DashboardLogin onLogin={handleLogin} expired={expired} />;
   if (dashboardConfigLoading) {
     return <div className="kpi-tile kpi-tile--loading"><div className="kpi-tile__skeleton" /></div>;
   }

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardLogin.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardLogin.jsx
@@ -5,6 +5,13 @@ import {
   getStateLabel,
   getBrandTheme,
 } from "../config/dashboardConfig";
+import {
+  clearSession,
+  getOAuthBasic,
+  hasAuth,
+  persistSession,
+  withSignificantRoleFirst,
+} from "../services/authService";
 import useDashboardT from "../i18n/useDashboardT";
 
 /**
@@ -25,8 +32,6 @@ import useDashboardT from "../i18n/useDashboardT";
  * they do not bypass authentication.
  */
 
-// Basic egov-user-client: (empty secret), base64 of "egov-user-client:"
-const OAUTH_BASIC = "Basic ZWdvdi11c2VyLWNsaWVudDo=";
 
 // label/hint are functions of t so they resolve at render time (never frozen at import).
 const DEMO_USERS = [
@@ -47,35 +52,11 @@ const DEMO_USERS = [
   },
 ];
 
-/** Order roles so the first non-EMPLOYEE role leads (drives the scoping badge). */
-function withSignificantRoleFirst(userInfo) {
-  if (!userInfo || !Array.isArray(userInfo.roles)) return userInfo;
-  const roles = [...userInfo.roles].sort(
-    (a, b) => (a.code === "EMPLOYEE" ? 1 : 0) - (b.code === "EMPLOYEE" ? 1 : 0)
-  );
-  return { ...userInfo, roles };
-}
 
-export function hasDashboardSession() {
-  try {
-    const raw = window.localStorage?.getItem("Employee.token");
-    return Boolean(raw && raw !== "undefined" && raw !== "null");
-  } catch {
-    return false;
-  }
-}
-
-export function clearDashboardSession() {
-  ["Employee.token", "Employee.user-info", "Employee.tenant-id", "user-info", "token"].forEach(
-    (k) => {
-      try {
-        window.localStorage?.removeItem(k);
-      } catch {
-        /* ignore */
-      }
-    }
-  );
-}
+// Session storage lives in authService (single source of truth); these thin
+// re-exports keep the existing AdminDashboard import sites unchanged.
+export const hasDashboardSession = hasAuth;
+export const clearDashboardSession = clearSession;
 
 const inputStyle = {
   borderRadius: "0.375rem",
@@ -87,12 +68,16 @@ const inputStyle = {
   outline: "none",
 };
 
-const DashboardLogin = ({ onLogin }) => {
+const DashboardLogin = ({ onLogin, expired = false }) => {
   const { t } = useDashboardT();
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState(null);
+  const [error, setError] = useState(
+    // Distinguish "your session ended" from "you got the password wrong": the
+    // user did nothing wrong and reloading will not help them (#1466).
+    expired ? "Your session has expired. Please sign in again." : null
+  );
 
   const tenantId = getTenantId();
   const productLabel = useMemo(() => getProductLabel(), []);
@@ -127,7 +112,7 @@ const DashboardLogin = ({ onLogin }) => {
         method: "POST",
         headers: {
           "Content-Type": "application/x-www-form-urlencoded",
-          Authorization: OAUTH_BASIC,
+          Authorization: getOAuthBasic(),
         },
         body,
       });
@@ -143,11 +128,14 @@ const DashboardLogin = ({ onLogin }) => {
       }
       const data = await res.json();
       const userInfo = withSignificantRoleFirst(data.UserRequest);
-      window.localStorage.setItem("Employee.token", JSON.stringify(data.access_token));
-      window.localStorage.setItem("Employee.user-info", JSON.stringify(userInfo));
-      window.localStorage.setItem("Employee.tenant-id", JSON.stringify(tenantId));
-      window.localStorage.setItem("user-info", JSON.stringify(userInfo));
-      window.localStorage.setItem("token", JSON.stringify(data.access_token));
+      // refresh_token is persisted (owner-stamped) so authService can silently
+      // renew the access token on a 401 instead of forcing a re-login (#1466).
+      persistSession({
+        accessToken: data.access_token,
+        refreshToken: data.refresh_token,
+        userInfo,
+        tenantId,
+      });
       if (onLogin) onLogin(userInfo);
     } catch (err) {
       setError(err.message || `${t("DASHBOARD_LOGIN_SIGN_IN_FAILED", "Sign-in failed")}.`);

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardLogin.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardLogin.jsx
@@ -76,7 +76,12 @@ const DashboardLogin = ({ onLogin, expired = false }) => {
   const [error, setError] = useState(
     // Distinguish "your session ended" from "you got the password wrong": the
     // user did nothing wrong and reloading will not help them (#1466).
-    expired ? "Your session has expired. Please sign in again." : null
+    // Localised like every sibling string on this screen — this is the one
+    // message shown to a user who did nothing wrong, so it should not be the
+    // only English text on an otherwise translated form.
+    expired
+      ? t("DASHBOARD_LOGIN_SESSION_EXPIRED", "Your session has expired. Please sign in again.")
+      : null
   );
 
   const tenantId = getTenantId();

--- a/digit-ui-esbuild/products/dashboard/src/services/analyticsService.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/analyticsService.js
@@ -1,4 +1,13 @@
 import { withTraceHeaders, recordApiCall } from "./dashboardMetrics";
+import {
+  authFetch,
+  buildRequestInfo,
+  getTenantId,
+  toRequestError,
+} from "./authService";
+
+// Re-exported for existing importers; authService is the definition.
+export { getTenantId };
 
 /** Browser-facing analytics API base (relative path or absolute URL). */
 export function getAnalyticsBase() {
@@ -10,70 +19,15 @@ export function getAnalyticsBase() {
 
 const ANALYTICS_BASE = getAnalyticsBase();
 
-function parseJson(raw) {
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return raw;
-  }
-}
-
-function getEmployeeToken() {
-  const raw = window.localStorage?.getItem("Employee.token");
-  return raw && raw !== "undefined" ? parseJson(raw) : null;
-}
-
-function getEmployeeInfo() {
-  const raw = window.localStorage?.getItem("Employee.user-info");
-  return raw && raw !== "undefined" ? parseJson(raw) : null;
-}
-
-export function getTenantId() {
-  return (
-    window.globalConfigs?.getConfig("STATE_LEVEL_TENANT_ID") ||
-    process.env.REACT_APP_STATE_LEVEL_TENANT_ID ||
-    "ke"
-  );
-}
-
-export function hasAuth() {
-  return Boolean(getEmployeeToken());
-}
-
-/**
- * Stable identity of the signed-in employee (user uuid), or null when no
- * session exists. Used to scope per-user client state (e.g. the dashboard
- * layout storage key) — NOT for authorization, which stays server-side.
- */
-export function getUserUuid() {
-  const info = getEmployeeInfo();
-  return info && typeof info === "object" ? info.uuid || null : null;
-}
-
-function buildRequestInfo() {
-  const authToken = getEmployeeToken();
-  const userInfo = getEmployeeInfo();
-  return {
-    apiId: "Rainmaker",
-    ver: ".01",
-    ts: Date.now(),
-    action: "_search",
-    msgId: `dashboard-${Date.now()}`,
-    ...(authToken && { authToken }),
-    ...(userInfo && { userInfo }),
-  };
-}
-
 async function postAnalytics(path, body) {
   const startedAt = typeof performance !== "undefined" ? performance.now() : Date.now();
-  const response = await fetch(`${ANALYTICS_BASE}${path}`, {
-    method: "POST",
-    // Per-load W3C traceparent + x-trace-id (dashboardMetrics) — Kong's otel
-    // plugin and the pgr javaagent continue the browser's trace id end-to-end.
-    headers: withTraceHeaders({ "Content-Type": "application/json" }),
-    credentials: "omit",
-    body: JSON.stringify({
-      RequestInfo: buildRequestInfo(),
+  // The analytics API is the dashboard's primary data path, so it is the one
+  // surface allowed to conclude the session is dead (sessionCritical defaults
+  // to true). Trace headers are preserved through the wrapper.
+  const response = await authFetch(`${ANALYTICS_BASE}${path}`, {
+    headers: withTraceHeaders({}),
+    buildBody: () => ({
+      RequestInfo: buildRequestInfo("dashboard"),
       ...body,
     }),
   });
@@ -81,14 +35,7 @@ async function postAnalytics(path, body) {
   if (!response.ok) {
     const endedAt = typeof performance !== "undefined" ? performance.now() : Date.now();
     recordApiCall(`${ANALYTICS_BASE}${path}`, endedAt - startedAt, 0, false);
-    const error = new Error(`Analytics request failed (${response.status})`);
-    error.status = response.status;
-    try {
-      error.payload = await response.json();
-    } catch {
-      error.payload = await response.text();
-    }
-    throw error;
+    throw await toRequestError(response, "Analytics request");
   }
 
   return response.json();

--- a/digit-ui-esbuild/products/dashboard/src/services/analyticsService.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/analyticsService.js
@@ -24,13 +24,24 @@ async function postAnalytics(path, body) {
   // The analytics API is the dashboard's primary data path, so it is the one
   // surface allowed to conclude the session is dead (sessionCritical defaults
   // to true). Trace headers are preserved through the wrapper.
-  const response = await authFetch(`${ANALYTICS_BASE}${path}`, {
-    headers: withTraceHeaders({}),
-    buildBody: () => ({
-      RequestInfo: buildRequestInfo("dashboard"),
-      ...body,
-    }),
-  });
+  // authFetch THROWS on every terminal 401 verdict, which would skip the
+  // recordApiCall below — so during an auth incident the metrics would show zero
+  // failed analytics calls while users stared at error banners, hiding exactly
+  // the outage this module is meant to surface. Record, then rethrow.
+  let response;
+  try {
+    response = await authFetch(`${ANALYTICS_BASE}${path}`, {
+      headers: withTraceHeaders({}),
+      buildBody: () => ({
+        RequestInfo: buildRequestInfo("dashboard"),
+        ...body,
+      }),
+    });
+  } catch (error) {
+    const endedAt = typeof performance !== "undefined" ? performance.now() : Date.now();
+    recordApiCall(`${ANALYTICS_BASE}${path}`, endedAt - startedAt, 0, false);
+    throw error;
+  }
 
   if (!response.ok) {
     const endedAt = typeof performance !== "undefined" ? performance.now() : Date.now();

--- a/digit-ui-esbuild/products/dashboard/src/services/authService.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/authService.js
@@ -1,0 +1,546 @@
+import { getTenantId } from "../config/dashboardConfig";
+
+/**
+ * Single source of truth for dashboard auth: token storage, RequestInfo
+ * construction, and the 401 -> refresh -> retry cycle.
+ *
+ * Before this module, getEmployeeToken / getEmployeeInfo / buildRequestInfo were
+ * duplicated verbatim in analyticsService, boundaryService and
+ * complaintHierarchyService, and no caller inspected response.status. A 401
+ * therefore surfaced as the raw string "Analytics request failed (401)" in a
+ * banner, and the auth gate (evaluated once at mount) never re-ran (#1466).
+ *
+ * Behaviour verified against egov-user on bomet, not assumed:
+ *   - grant_type=refresh_token is supported and returns a new access_token.
+ *   - The refresh token is NOT rotated: the same value comes back.
+ *   - Refreshing IMMEDIATELY invalidates the previous access token — a request
+ *     still in flight with the old token gets 401. This is why refresh must be
+ *     single-flight and why we retry the original request afterwards, rather
+ *     than letting each 401 refresh independently.
+ *   - A dead refresh token returns HTTP 400 invalid_grant (not 401), so the
+ *     refresh call's own failure must never be fed back into this retry path.
+ *   - Tokens are opaque UUIDs, not JWTs, so expiry cannot be inspected client
+ *     side. Refresh is necessarily reactive (on 401), never pre-emptive.
+ *
+ * ---------------------------------------------------------------------------
+ * CONTRACT — what authFetch() does with a 401, and what callers should expect.
+ *
+ * A 401 has four distinct causes and they are NOT interchangeable. Collapsing
+ * them is what made the first cut of this module dangerous: it treated every
+ * one as "session dead" and wiped storage shared with the co-hosted digit-ui
+ * app. Each outcome now throws a differently-flagged error:
+ *
+ *   another caller already refreshed  -> replay with the new token, no error
+ *   token dead, refresh succeeded     -> replay, no error
+ *   raced a refresh on every attempt  -> err.refreshRaced, session KEPT
+ *   auth server unreachable           -> err.refreshUnavailable, session KEPT
+ *   fresh token but endpoint 401s     -> err.endpointUnauthorized, session KEPT
+ *   non-critical call, token refused  -> err.endpointUnauthorized, session KEPT
+ *   CRITICAL call, token refused      -> err.sessionExpired, storage CLEARED
+ *
+ * Only the last row dispatches SESSION_EXPIRED_EVENT and drops the user to the
+ * login gate. Two rules govern it:
+ *
+ *   1. Never destroy a session we have not PROVEN is dead — the keys are shared
+ *      with the co-hosted digit-ui app, so a wrong guess signs the user out of
+ *      the whole product.
+ *   2. Only a SESSION-CRITICAL call may form that verdict. Pass
+ *      `sessionCritical: false` for auxiliary data (boundary geometry,
+ *      hierarchy labels): those endpoints can 401 for their own reasons (an ACL
+ *      gap, a gateway answering 401 instead of 403) and must not be able to tear
+ *      the dashboard down to a login screen that falsely blames expiry.
+ *
+ * When a critical call IS refused, storage is cleared even if we held no refresh
+ * token: the server has proven the token dead, and leaving it behind is what
+ * made a reload re-pass the auth gate and re-render a broken dashboard (#1466's
+ * "reloading did not help" symptom).
+ *
+ * Guarantees: at most three sends and at most one refresh per call (cannot
+ * loop); concurrent 401s share a single refresh; a refresh never re-enters this
+ * path; the refresh token is owner-stamped so a previous user's token on the
+ * same browser is never used.
+ *
+ * Caller error contract:
+ *   analyticsService        — critical; propagates (the dashboard shows it)
+ *   boundaryService         — non-critical; partial data, throws only if NOTHING
+ *                             loaded so the map can show its error state
+ *   complaintHierarchyService — non-critical; returns null (labels fall back)
+ * ---------------------------------------------------------------------------
+ */
+
+/**
+ * Every localStorage key this module owns, in one table.
+ *
+ * `shared: true` marks keys the co-hosted digit-ui app also reads — index.js
+ * copies them into Digit.SessionStorage at boot to seed the employee session.
+ * Writing them affects the whole product, not just the dashboard, which is why
+ * clearing is gated (see announceSessionExpired).
+ *
+ * The previous code kept "keys login writes" and "keys signout clears" as two
+ * hand-maintained lists and they had already drifted apart once — the refresh
+ * token was written but never cleared. Deriving both from this table makes that
+ * class of bug structurally impossible.
+ */
+const KEYS = {
+  token: { key: "Employee.token", shared: true },
+  refreshToken: { key: "Employee.refresh-token", shared: false },
+  userInfo: { key: "Employee.user-info", shared: true },
+  tenantId: { key: "Employee.tenant-id", shared: true },
+  // Unprefixed aliases the main UI's boot path reads for login detection.
+  tokenAlias: { key: "token", shared: true },
+  userInfoAlias: { key: "user-info", shared: true },
+};
+
+const TOKEN_KEY = KEYS.token.key;
+const REFRESH_KEY = KEYS.refreshToken.key;
+const USER_INFO_KEY = KEYS.userInfo.key;
+const TENANT_KEY = KEYS.tenantId.key;
+
+/** Every key this module writes — so signout can never fall behind login. */
+const SESSION_KEYS = Object.values(KEYS).map((k) => k.key);
+
+export const SESSION_EXPIRED_EVENT = "dashboard:session-expired";
+
+function parseJson(raw) {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function readStorage(key) {
+  try {
+    const raw = window.localStorage?.getItem(key);
+    return raw && raw !== "undefined" && raw !== "null" ? parseJson(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStorage(key, value) {
+  try {
+    window.localStorage?.setItem(key, JSON.stringify(value));
+  } catch {
+    /* private mode / quota — non-fatal, the session just won't survive reload */
+  }
+}
+
+export function getEmployeeToken() {
+  return readStorage(TOKEN_KEY);
+}
+
+/**
+ * The refresh token, but only if it belongs to the user currently signed in.
+ * A token stamped for a different uuid is a leftover from a previous session on
+ * this browser; using it would swap the whole product to that user's identity.
+ */
+export function getRefreshToken() {
+  const stored = readStorage(REFRESH_KEY);
+  if (!stored) return null;
+  // Legacy shape: a bare string written before owner-stamping existed. It has no
+  // provable owner, so it is not trusted.
+  if (typeof stored === "string") return null;
+  const currentUuid = getEmployeeInfo()?.uuid ?? null;
+  if (stored.userUuid && currentUuid && stored.userUuid !== currentUuid) return null;
+  return stored.token || null;
+}
+
+export function getEmployeeInfo() {
+  return readStorage(USER_INFO_KEY);
+}
+
+// Re-exported, NOT re-implemented. A second copy here had a different fallback
+// ("ke" vs dashboardConfig's "default"); DashboardLogin uses dashboardConfig's,
+// so on a deployment with neither config set, login would authenticate as
+// "default" while refresh posted "ke" — egov-user rejects that, which this
+// module classifies as a positive rejection and answers by clearing storage
+// shared with the co-hosted app. One definition, one fallback.
+export { getTenantId };
+
+/**
+ * True when a token is PRESENT. Deliberately not a validity check — tokens are
+ * opaque, so validity is only knowable by calling the API. Session death is
+ * detected reactively via SESSION_EXPIRED_EVENT.
+ */
+export function hasAuth() {
+  return Boolean(getEmployeeToken());
+}
+
+/** Order roles so the first non-EMPLOYEE role leads (drives the scoping badge). */
+export function withSignificantRoleFirst(userInfo) {
+  if (!userInfo || !Array.isArray(userInfo.roles)) return userInfo;
+  const roles = [...userInfo.roles].sort(
+    (a, b) => (a.code === "EMPLOYEE" ? 1 : 0) - (b.code === "EMPLOYEE" ? 1 : 0)
+  );
+  return { ...userInfo, roles };
+}
+
+/**
+ * The dashboard is NOT a standalone app: App.js routes /employee/dashboard to
+ * AdminDashboard inside the same SPA that renders DigitUI, and index.js copies
+ * Employee.token into Digit.SessionStorage's "User" at boot. That cache is what
+ * the rest of the employee UI authenticates from, and it is never re-read.
+ *
+ * Since refreshing invalidates the previous access token server-side, a silent
+ * refresh would otherwise kill the token the surrounding app is still holding —
+ * every main-UI call would 401 until a full reload. Push the new token into
+ * that cache so both surfaces stay on the same session.
+ */
+function syncDigitSession(accessToken, userInfo) {
+  const session = window.Digit?.SessionStorage;
+  if (!session?.set || !session?.get) return; // standalone build — nothing to sync
+  try {
+    const existing = session.get("User") || {};
+    session.set("User", {
+      ...existing,
+      token: accessToken,
+      access_token: accessToken,
+      ...(userInfo != null && { info: userInfo }),
+    });
+  } catch {
+    /* best-effort — localStorage remains the source of truth */
+  }
+}
+
+export function persistSession({ accessToken, refreshToken, userInfo, tenantId }) {
+  // Normalise here rather than at the call site so a refresh cannot silently
+  // revert the role order that login established.
+  const normalisedUser = userInfo != null ? withSignificantRoleFirst(userInfo) : null;
+
+  if (accessToken != null) {
+    writeStorage(TOKEN_KEY, accessToken);
+    writeStorage("token", accessToken);
+  }
+  if (refreshToken != null) {
+    // Stored WITH its owner. Only this dashboard writes the refresh token, and
+    // the main digit-ui login neither knows nor clears it — so without an owner
+    // stamp, user A's refresh token can survive user B signing in on the same
+    // browser and silently re-authenticate the whole product as A.
+    writeStorage(REFRESH_KEY, {
+      token: refreshToken,
+      userUuid: normalisedUser?.uuid ?? getEmployeeInfo()?.uuid ?? null,
+    });
+  }
+  if (normalisedUser != null) {
+    writeStorage(USER_INFO_KEY, normalisedUser);
+    writeStorage("user-info", normalisedUser);
+  }
+  if (tenantId != null) writeStorage(TENANT_KEY, tenantId);
+
+  if (accessToken != null) syncDigitSession(accessToken, normalisedUser);
+}
+
+export function clearSession() {
+  SESSION_KEYS.forEach((k) => {
+    try {
+      window.localStorage?.removeItem(k);
+    } catch {
+      /* ignore */
+    }
+  });
+  // Symmetric with syncDigitSession. Clearing only localStorage would leave the
+  // co-hosted UI authenticating from a cached dead token — and index.js boots
+  // from SessionStorage FIRST, skipping the localStorage re-seed when "User"
+  // exists, so even a reload would re-enter the employee UI "logged in" on a
+  // token that no longer works.
+  const session = window.Digit?.SessionStorage;
+  if (session?.set) {
+    try {
+      session.set("User", null);
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+/**
+ * Show the login gate.
+ *
+ * `clearStorage` is deliberately opt-in. Employee.token / user-info / token are
+ * SHARED with the co-hosted digit-ui app, so wiping them signs the user out of
+ * the whole product — appropriate when the server has positively rejected our
+ * refresh token, but not when we merely lack one. Notably the only writer of
+ * Employee.refresh-token is this dashboard's own login form; a session seeded by
+ * the main digit-ui login has none, and that is the common path. Clearing
+ * unconditionally would turn one dashboard 401 into a full-product logout.
+ */
+function announceSessionExpired({ clearStorage } = { clearStorage: false }) {
+  if (clearStorage) clearSession();
+  try {
+    window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT));
+  } catch {
+    /* CustomEvent unavailable — the auth gate still re-checks on next render */
+  }
+}
+
+export function buildRequestInfo(msgIdPrefix = "dashboard") {
+  const authToken = getEmployeeToken();
+  const userInfo = getEmployeeInfo();
+  return {
+    apiId: "Rainmaker",
+    ver: ".01",
+    ts: Date.now(),
+    action: "_search",
+    msgId: `${msgIdPrefix}-${Date.now()}`,
+    ...(authToken && { authToken }),
+    ...(userInfo && { userInfo }),
+  };
+}
+
+/**
+ * OAuth client credentials header. globalConfigs stores JWT_TOKEN as the bare
+ * base64 of "egov-user-client:" WITHOUT the scheme, so the "Basic " prefix is
+ * added here — matching what DashboardLogin sends on the password grant.
+ */
+export function getOAuthBasic() {
+  const configured = window.globalConfigs?.getConfig?.("JWT_TOKEN");
+  const raw = configured || "ZWdvdi11c2VyLWNsaWVudDo=";
+  return /^Basic\s/i.test(raw) ? raw : `Basic ${raw}`;
+}
+
+/**
+ * In-flight refresh, shared by every caller that 401s in the same window.
+ * Without this, N concurrent batch queries would fire N refreshes, and since
+ * each refresh invalidates the prior access token they would invalidate each
+ * other's tokens in turn.
+ */
+let refreshInFlight = null;
+
+/**
+ * Bumped on every successful refresh. Single-flight alone is NOT sufficient:
+ * it only merges 401s that overlap the refresh window. A request whose 401
+ * lands just AFTER a refresh settled would see refreshInFlight === null and
+ * start a SECOND refresh, which immediately invalidates the token the first
+ * caller is already retrying with — turning a recovered session into a false
+ * logout. The generation lets a caller tell "my token is stale because someone
+ * else already refreshed" (just retry) apart from "the current token is dead"
+ * (refresh).
+ */
+let tokenGeneration = 0;
+
+/** Refresh must not hang the whole dashboard: every 401'd caller waits on it. */
+const REFRESH_TIMEOUT_MS = 15000;
+
+/**
+ * Refresh outcomes are three-valued, not boolean. Collapsing them loses the
+ * distinction that decides whether the shared session may be destroyed:
+ *   REFRESHED   — new token in hand, replay the request.
+ *   REJECTED    — the server positively refused the refresh token (400
+ *                 invalid_grant). The session really is dead; clearing is right.
+ *   NO_TOKEN    — we never had a refresh token. The 401 is authoritative, but
+ *                 the keys belong to the co-hosted app; flip the gate, keep them.
+ *   UNAVAILABLE — the refresh call itself never got an answer (offline, DNS,
+ *                 gateway reset, timeout). We cannot conclude anything, so the
+ *                 session must survive. Waking a laptop from sleep hits this.
+ */
+export const REFRESH_REFRESHED = "refreshed";
+export const REFRESH_REJECTED = "rejected";
+export const REFRESH_NO_TOKEN = "no_token";
+export const REFRESH_UNAVAILABLE = "unavailable";
+
+async function requestRefresh() {
+  const refreshToken = getRefreshToken();
+  if (!refreshToken) return REFRESH_NO_TOKEN;
+
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+    tenantId: getTenantId(),
+  });
+
+  // Without this, a stalled /user/oauth/token leaves every waiting caller
+  // pending forever and the dashboard sits on a permanent loading state.
+  const controller = typeof AbortController !== "undefined" ? new AbortController() : null;
+  const timer = controller ? setTimeout(() => controller.abort(), REFRESH_TIMEOUT_MS) : null;
+
+  let res;
+  try {
+    res = await fetch("/user/oauth/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Authorization: getOAuthBasic(),
+      },
+      body,
+      ...(controller && { signal: controller.signal }),
+    });
+  } catch {
+    // Network failure or the 15s abort — NOT a verdict on the refresh token.
+    // Treating this as rejection would delete a still-valid session over a
+    // transient blip.
+    return REFRESH_UNAVAILABLE;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+
+  // Only a client-error answer is the server REFUSING the token (a dead one
+  // gives 400 invalid_grant). A 5xx, a 429, or a gateway error page is the auth
+  // server failing — not a verdict on our credentials — and must not be allowed
+  // to wipe storage shared with the co-hosted digit-ui app. Getting this wrong
+  // would sign every user out of the product on a deploy blip.
+  if (!res.ok) {
+    const refused = res.status === 400 || res.status === 401 || res.status === 403;
+    return refused ? REFRESH_REJECTED : REFRESH_UNAVAILABLE;
+  }
+
+  let data;
+  try {
+    data = await res.json();
+  } catch {
+    return REFRESH_UNAVAILABLE;
+  }
+  // A 2xx with no token is a malformed/intercepted response (proxy login page,
+  // truncated body), not a rejection. Same reasoning as above: do not destroy.
+  if (!data?.access_token) return REFRESH_UNAVAILABLE;
+
+  persistSession({
+    accessToken: data.access_token,
+    // Not rotated today, but honour a rotated value if the server ever sends one.
+    refreshToken: data.refresh_token || refreshToken,
+    userInfo: data.UserRequest || undefined,
+  });
+  tokenGeneration += 1;
+  return REFRESH_REFRESHED;
+}
+
+/** Single-flight wrapper around requestRefresh. Resolves to a REFRESH_* value. */
+function refreshSession() {
+  if (!refreshInFlight) {
+    refreshInFlight = requestRefresh()
+      .catch(() => REFRESH_UNAVAILABLE)
+      .finally(() => {
+        refreshInFlight = null;
+      });
+  }
+  return refreshInFlight;
+}
+
+/**
+ * fetch() for authenticated dashboard APIs.
+ *
+ * `buildBody` is a function, not a value: on retry the RequestInfo must be
+ * rebuilt so the request carries the NEW token. Passing a pre-serialised body
+ * would replay the dead one and 401 again.
+ *
+ * On a 401 it either refreshes (shared across callers) or, when another caller
+ * has already refreshed since this request was sent, simply replays with the
+ * newer token. At most two sends happen, so this cannot loop. If refresh fails,
+ * or the replay 401s again, the session is announced dead and the error is
+ * thrown with `status` and `sessionExpired` set for callers.
+ */
+export async function authFetch(
+  url,
+  { buildBody, method = "POST", headers, sessionCritical = true } = {}
+) {
+  const send = () =>
+    fetch(url, {
+      method,
+      headers: { "Content-Type": "application/json", ...headers },
+      credentials: "omit",
+      body: buildBody ? JSON.stringify(buildBody()) : undefined,
+    });
+
+  // Three sends max, still at most ONE refresh per call. Three because there are
+  // two independent reasons to replay and a caller can need both: a
+  // generation-mismatch replay (someone else refreshed mid-flight) and the
+  // guaranteed retry after this caller's OWN refresh. With a cap of two, a
+  // mismatch replay could consume the budget and the loop would exit having
+  // never sent the token it just minted — reporting failure on a session it had
+  // successfully repaired. The refresh itself stays capped, so this cannot loop.
+  let didRefresh = false;
+  let outcome = null;
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const generationAtSend = tokenGeneration;
+    const response = await send();
+    if (response.status !== 401) return response;
+
+    // If the generation has already moved, another caller refreshed while this
+    // request was in flight — our token was merely stale, so replay with the
+    // new one instead of refreshing again (a second refresh would invalidate
+    // the token that caller is using).
+    if (tokenGeneration !== generationAtSend) continue;
+
+    if (didRefresh) break;
+    didRefresh = true;
+    outcome = await refreshSession();
+    if (outcome !== REFRESH_REFRESHED) break;
+  }
+
+  // Could not reach the auth server: say nothing about the session. Leaving it
+  // intact lets the next attempt succeed once connectivity returns, instead of
+  // signing the user out of the whole product over a dropped packet.
+  if (outcome === REFRESH_UNAVAILABLE) {
+    const error = new Error("Could not reach the sign-in service. Please retry.");
+    error.status = 401;
+    error.refreshUnavailable = true;
+    throw error;
+  }
+
+  // Every attempt exited on a generation mismatch — a concurrent refresh landed
+  // during each send — so we never formed a verdict of our own. The session was
+  // just refreshed by somebody else and is alive; treat this as transient rather
+  // than falling through to the expiry branch on a healthy session.
+  if (outcome === null) {
+    const error = new Error("Request raced a token refresh. Please retry.");
+    error.status = 401;
+    error.refreshRaced = true;
+    throw error;
+  }
+
+  // We refreshed successfully and the replay STILL 401'd. The token is provably
+  // fresh, so this endpoint is rejecting us for its own reason (an auth gap, a
+  // misrouted service, a role check answering 401 instead of 403) — not because
+  // the session died. Reporting expiry here would sign the user out on every
+  // load and re-login would change nothing: a loop.
+  if (outcome === REFRESH_REFRESHED) {
+    const error = new Error(`Request failed (401) with a valid session: ${url}`);
+    error.status = 401;
+    error.endpointUnauthorized = true;
+    throw error;
+  }
+
+  // Reaching here means REJECTED or NO_TOKEN: the server refused this token and
+  // we could not renew it.
+  //
+  // Only a SESSION-CRITICAL call may conclude the session is dead. Auxiliary
+  // layers (boundary geometry, hierarchy labels) can 401 for their own reasons —
+  // an ACL gap, a gateway answering 401 instead of 403 — and previously that was
+  // a per-widget banner. Letting them tear the whole dashboard down to a login
+  // screen that falsely blames session expiry is a worse regression than the bug
+  // being fixed.
+  if (!sessionCritical) {
+    const error = new Error(`Request failed (401): ${url}`);
+    error.status = 401;
+    error.endpointUnauthorized = true;
+    throw error;
+  }
+
+  // The primary API refused this token, so it IS dead — regardless of whether we
+  // held a refresh token. Clearing is therefore proven-correct, and it is what
+  // stops a reload from re-passing the auth gate on the same dead token and
+  // re-rendering a broken dashboard before flipping back to login (#1466's
+  // original "reload didn't help" symptom).
+  announceSessionExpired({ clearStorage: true });
+  const error = new Error("Your session has expired. Please sign in again.");
+  error.status = 401;
+  error.sessionExpired = true;
+  throw error;
+}
+
+/** Shared non-401 error shape so every service reports failures identically. */
+export async function toRequestError(response, label) {
+  const error = new Error(`${label} failed (${response.status})`);
+  error.status = response.status;
+  try {
+    error.payload = await response.json();
+  } catch {
+    try {
+      error.payload = await response.text();
+    } catch {
+      error.payload = null;
+    }
+  }
+  return error;
+}

--- a/digit-ui-esbuild/products/dashboard/src/services/authService.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/authService.js
@@ -36,7 +36,9 @@ import { getTenantId } from "../config/dashboardConfig";
  *   auth server unreachable           -> err.refreshUnavailable, session KEPT
  *   fresh token but endpoint 401s     -> err.endpointUnauthorized, session KEPT
  *   non-critical call, token refused  -> err.endpointUnauthorized, session KEPT
- *   CRITICAL call, token refused      -> err.sessionExpired, storage CLEARED
+ *   CRITICAL call, refresh REJECTED   -> err.sessionExpired, storage CLEARED
+ *   CRITICAL call, no refresh token   -> err.sessionExpired, storage KEPT,
+ *                                        token marked dead for this tab
  *
  * Only the last row dispatches SESSION_EXPIRED_EVENT and drops the user to the
  * login gate. Two rules govern it:
@@ -50,10 +52,15 @@ import { getTenantId } from "../config/dashboardConfig";
  *      gap, a gateway answering 401 instead of 403) and must not be able to tear
  *      the dashboard down to a login screen that falsely blames expiry.
  *
- * When a critical call IS refused, storage is cleared even if we held no refresh
- * token: the server has proven the token dead, and leaving it behind is what
- * made a reload re-pass the auth gate and re-render a broken dashboard (#1466's
- * "reloading did not help" symptom).
+ * Storage is destroyed only on a positive auth-server verdict. Without a refresh
+ * token there is no verdict — only one endpoint's 401 — so the refused token is
+ * instead marked dead for THIS TAB (sessionStorage). That keeps the gate closed
+ * across a reload, which was #1466's "reloading did not help" symptom, without
+ * deleting keys the co-hosted app may still be using.
+ *
+ * Likewise clearSession only drops the unprefixed aliases and the
+ * Digit.SessionStorage cache when they actually hold the employee token being
+ * torn down — on a shared browser they may belong to a live citizen session.
  *
  * Guarantees: at most three sends and at most one refresh per call (cannot
  * loop); concurrent 401s share a single refresh; a refresh never re-enters this
@@ -141,8 +148,12 @@ export function getRefreshToken() {
   // Legacy shape: a bare string written before owner-stamping existed. It has no
   // provable owner, so it is not trusted.
   if (typeof stored === "string") return null;
+  // Fail CLOSED: a missing uuid on either side is not proof of ownership. The
+  // open form trusted the token whenever user-info was absent (partial clear,
+  // storage eviction, or a stamp written before any UserRequest was seen) —
+  // which is exactly the identity swap the stamp exists to prevent.
   const currentUuid = getEmployeeInfo()?.uuid ?? null;
-  if (stored.userUuid && currentUuid && stored.userUuid !== currentUuid) return null;
+  if (!stored.userUuid || !currentUuid || stored.userUuid !== currentUuid) return null;
   return stored.token || null;
 }
 
@@ -163,8 +174,37 @@ export { getTenantId };
  * opaque, so validity is only knowable by calling the API. Session death is
  * detected reactively via SESSION_EXPIRED_EVENT.
  */
+/**
+ * Tab-scoped record of a token the server has already refused. Lets the auth
+ * gate stay closed across a reload WITHOUT deleting keys the co-hosted digit-ui
+ * app is using — the alternative (clearing shared storage on a 401 we could not
+ * corroborate with an auth-server verdict) signs the user out of the whole
+ * product on the strength of one endpoint's answer.
+ */
+const DEAD_TOKEN_KEY = "dashboard:dead-token";
+
+function markTokenDead(token) {
+  if (!token) return;
+  try {
+    window.sessionStorage?.setItem(DEAD_TOKEN_KEY, JSON.stringify(token));
+  } catch {
+    /* private mode — the in-memory gate flip still applies for this view */
+  }
+}
+
+function isTokenKnownDead(token) {
+  if (!token) return false;
+  try {
+    const raw = window.sessionStorage?.getItem(DEAD_TOKEN_KEY);
+    return Boolean(raw) && parseJson(raw) === token;
+  } catch {
+    return false;
+  }
+}
+
 export function hasAuth() {
-  return Boolean(getEmployeeToken());
+  const token = getEmployeeToken();
+  return Boolean(token) && !isTokenKnownDead(token);
 }
 
 /** Order roles so the first non-EMPLOYEE role leads (drives the scoping badge). */
@@ -228,11 +268,29 @@ export function persistSession({ accessToken, refreshToken, userInfo, tenantId }
   }
   if (tenantId != null) writeStorage(TENANT_KEY, tenantId);
 
-  if (accessToken != null) syncDigitSession(accessToken, normalisedUser);
+  if (accessToken != null) {
+    // A newly issued token is by definition not the dead one.
+    try {
+      window.sessionStorage?.removeItem(DEAD_TOKEN_KEY);
+    } catch {
+      /* ignore */
+    }
+    syncDigitSession(accessToken, normalisedUser);
+  }
 }
 
 export function clearSession() {
+  // The unprefixed aliases and the single Digit.SessionStorage "User" slot are
+  // not necessarily OURS: on a shared browser a citizen may be signed into the
+  // co-hosted portal while a stale Employee.token lingers. Only drop them when
+  // they actually hold the employee token we are tearing down, or we would sign
+  // an unrelated user out of a session they are actively using.
+  const employeeToken = getEmployeeToken();
+  const ownsAliases =
+    employeeToken != null && readStorage(KEYS.tokenAlias.key) === employeeToken;
+
   SESSION_KEYS.forEach((k) => {
+    if (!ownsAliases && (k === KEYS.tokenAlias.key || k === KEYS.userInfoAlias.key)) return;
     try {
       window.localStorage?.removeItem(k);
     } catch {
@@ -245,9 +303,12 @@ export function clearSession() {
   // exists, so even a reload would re-enter the employee UI "logged in" on a
   // token that no longer works.
   const session = window.Digit?.SessionStorage;
-  if (session?.set) {
+  if (session?.set && ownsAliases) {
     try {
-      session.set("User", null);
+      const cached = session.get?.("User");
+      const cachedToken = cached?.token ?? cached?.access_token ?? null;
+      // Same ownership test: never null a cache holding a different session.
+      if (cachedToken == null || cachedToken === employeeToken) session.set("User", null);
     } catch {
       /* ignore */
     }
@@ -257,13 +318,13 @@ export function clearSession() {
 /**
  * Show the login gate.
  *
- * `clearStorage` is deliberately opt-in. Employee.token / user-info / token are
- * SHARED with the co-hosted digit-ui app, so wiping them signs the user out of
- * the whole product — appropriate when the server has positively rejected our
- * refresh token, but not when we merely lack one. Notably the only writer of
+ * `clearStorage` is deliberately opt-in and, per the single call site, is true
+ * ONLY for REFRESH_REJECTED — a positive verdict from the auth server.
+ * Employee.token / user-info / token are SHARED with the co-hosted digit-ui app,
+ * so wiping them signs the user out of the whole product. The only writer of
  * Employee.refresh-token is this dashboard's own login form; a session seeded by
- * the main digit-ui login has none, and that is the common path. Clearing
- * unconditionally would turn one dashboard 401 into a full-product logout.
+ * the main digit-ui login has none, so NO_TOKEN is the common path and carries
+ * no server verdict — it marks the token dead for this tab instead.
  */
 function announceSessionExpired({ clearStorage } = { clearStorage: false }) {
   if (clearStorage) clearSession();
@@ -466,6 +527,15 @@ export async function authFetch(
     didRefresh = true;
     outcome = await refreshSession();
     if (outcome !== REFRESH_REFRESHED) break;
+
+    // Replay HERE rather than looping, so the retry after our own refresh is
+    // guaranteed and not contingent on an attempt remaining. Relying on the
+    // loop meant a refresh that succeeded on the final iteration exited without
+    // ever sending the token it had just minted — the same defect the attempt
+    // cap was raised to fix, merely moved to the last iteration.
+    const replayed = await send();
+    if (replayed.status !== 401) return replayed;
+    break; // fresh token still refused: an endpoint problem, not a dead session
   }
 
   // Could not reach the auth server: say nothing about the session. Leaving it
@@ -517,12 +587,14 @@ export async function authFetch(
     throw error;
   }
 
-  // The primary API refused this token, so it IS dead — regardless of whether we
-  // held a refresh token. Clearing is therefore proven-correct, and it is what
-  // stops a reload from re-passing the auth gate on the same dead token and
-  // re-rendering a broken dashboard before flipping back to login (#1466's
-  // original "reload didn't help" symptom).
-  announceSessionExpired({ clearStorage: true });
+  // Storage is destroyed ONLY on a positive auth-server verdict (REJECTED). With
+  // NO_TOKEN there is no verdict — just one endpoint's 401 — and the keys belong
+  // to the co-hosted app, so wiping them would sign the user out of the whole
+  // product on evidence we do not have. Instead the refused token is marked dead
+  // for this tab, which keeps the gate closed across a reload (the original
+  // "reloading did not help" symptom) without touching anyone else's session.
+  if (outcome === REFRESH_NO_TOKEN) markTokenDead(getEmployeeToken());
+  announceSessionExpired({ clearStorage: outcome === REFRESH_REJECTED });
   const error = new Error("Your session has expired. Please sign in again.");
   error.status = 401;
   error.sessionExpired = true;
@@ -533,14 +605,18 @@ export async function authFetch(
 export async function toRequestError(response, label) {
   const error = new Error(`${label} failed (${response.status})`);
   error.status = response.status;
+  // Read the body ONCE. Calling .text() after a failed .json() throws "body
+  // already read", so the old fallback could never succeed and every non-JSON
+  // error body (e.g. an HTML gateway page on a 502) was silently lost.
   try {
-    error.payload = await response.json();
-  } catch {
+    const raw = await response.text();
     try {
-      error.payload = await response.text();
+      error.payload = JSON.parse(raw);
     } catch {
-      error.payload = null;
+      error.payload = raw;
     }
+  } catch {
+    error.payload = null;
   }
   return error;
 }

--- a/digit-ui-esbuild/products/dashboard/src/services/boundaryService.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/boundaryService.js
@@ -1,37 +1,11 @@
-import { getTenantId, hasAuth } from "./analyticsService";
+import {
+  authFetch,
+  buildRequestInfo,
+  getTenantId,
+  hasAuth,
+} from "./authService";
 import { withTraceHeaders } from "./dashboardMetrics";
 
-function parseJson(raw) {
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return raw;
-  }
-}
-
-function getEmployeeToken() {
-  const raw = window.localStorage?.getItem("Employee.token");
-  return raw && raw !== "undefined" ? parseJson(raw) : null;
-}
-
-function getEmployeeInfo() {
-  const raw = window.localStorage?.getItem("Employee.user-info");
-  return raw && raw !== "undefined" ? parseJson(raw) : null;
-}
-
-function buildRequestInfo() {
-  const authToken = getEmployeeToken();
-  const userInfo = getEmployeeInfo();
-  return {
-    apiId: "Rainmaker",
-    ver: ".01",
-    ts: Date.now(),
-    action: "_search",
-    msgId: `dashboard-boundary-${Date.now()}`,
-    ...(authToken && { authToken }),
-    ...(userInfo && { userInfo }),
-  };
-}
 
 /**
  * Fetch boundary entities with GeoJSON geometry.
@@ -45,6 +19,7 @@ export async function fetchBoundariesByCodes(codes = []) {
   const uniqueCodes = [...new Set(codes.filter(Boolean))];
   const chunkSize = 100;
   const all = [];
+  let lastError = null;
 
   for (let i = 0; i < uniqueCodes.length; i += chunkSize) {
     const chunk = uniqueCodes.slice(i, i + chunkSize);
@@ -54,22 +29,33 @@ export async function fetchBoundariesByCodes(codes = []) {
       limit: String(chunk.length),
     });
 
-    const response = await fetch(`/boundary-service/boundary/_search?${params}`, {
-      method: "POST",
-      headers: withTraceHeaders({ "Content-Type": "application/json" }),
-      credentials: "omit",
-      body: JSON.stringify({ RequestInfo: buildRequestInfo() }),
-    });
+    // Per-chunk tolerance so one failure does not discard what is already
+    // loaded, but a TOTAL failure still rethrows so the map can show its error
+    // state instead of a silently blank choropleth. Auxiliary data: a 401 here
+    // must never be allowed to declare the whole session dead.
+    try {
+      const response = await authFetch(`/boundary-service/boundary/_search?${params}`, {
+        headers: withTraceHeaders({}),
+        buildBody: () => ({ RequestInfo: buildRequestInfo("dashboard-boundary") }),
+        sessionCritical: false,
+      });
 
-    if (!response.ok) {
-      console.warn(`boundary/_search failed (${response.status})`);
-      continue;
+      if (!response.ok) {
+        console.warn(`boundary/_search failed (${response.status})`);
+        lastError = new Error(`boundary/_search failed (${response.status})`);
+        continue;
+      }
+
+      const payload = await response.json();
+      const boundaries = payload?.Boundary || [];
+      all.push(...boundaries);
+    } catch (error) {
+      console.warn("boundary/_search error", error);
+      lastError = error;
     }
-
-    const payload = await response.json();
-    const boundaries = payload?.Boundary || [];
-    all.push(...boundaries);
   }
+
+  if (!all.length && lastError) throw lastError;
 
   return all;
 }
@@ -154,13 +140,12 @@ export async function fetchBoundaryRelationshipsByCodes(
       limit: "500",
     });
 
-    const response = await fetch(
+    const response = await authFetch(
       `/boundary-service/boundary-relationships/_search?${params}`,
       {
-        method: "POST",
-        headers: withTraceHeaders({ "Content-Type": "application/json" }),
-        credentials: "omit",
-        body: JSON.stringify({ RequestInfo: buildRequestInfo() }),
+        headers: withTraceHeaders({}),
+        buildBody: () => ({ RequestInfo: buildRequestInfo("dashboard-boundary") }),
+        sessionCritical: false,
       }
     );
 

--- a/digit-ui-esbuild/products/dashboard/src/services/complaintHierarchyService.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/complaintHierarchyService.js
@@ -1,4 +1,9 @@
-import { getTenantId, hasAuth } from "./analyticsService";
+import {
+  authFetch,
+  buildRequestInfo,
+  getTenantId,
+  hasAuth,
+} from "./authService";
 import { selectHierarchyDefinition, orderedLevels } from "../utils/hierLevelGrouping";
 import { withTraceHeaders } from "./dashboardMetrics";
 
@@ -17,37 +22,6 @@ function getMdmsSearchUrl() {
   return `/${String(contextPath).replace(/^\/+|\/+$/g, "")}/v1/_search`;
 }
 
-function parseJson(raw) {
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return raw;
-  }
-}
-
-function getEmployeeToken() {
-  const raw = window.localStorage?.getItem("Employee.token");
-  return raw && raw !== "undefined" ? parseJson(raw) : null;
-}
-
-function getEmployeeInfo() {
-  const raw = window.localStorage?.getItem("Employee.user-info");
-  return raw && raw !== "undefined" ? parseJson(raw) : null;
-}
-
-function buildRequestInfo() {
-  const authToken = getEmployeeToken();
-  const userInfo = getEmployeeInfo();
-  return {
-    apiId: "Rainmaker",
-    ver: ".01",
-    ts: Date.now(),
-    action: "_search",
-    msgId: `dashboard-complaint-hierarchy-${Date.now()}`,
-    ...(authToken && { authToken }),
-    ...(userInfo && { userInfo }),
-  };
-}
 
 /**
  * Display name for a hierarchy node. Live masters carry real display names on
@@ -117,12 +91,11 @@ export async function fetchComplaintHierarchyRecords() {
   if (!hasAuth()) return null;
 
   try {
-    const response = await fetch(getMdmsSearchUrl(), {
-      method: "POST",
-      headers: withTraceHeaders({ "Content-Type": "application/json" }),
-      credentials: "omit",
-      body: JSON.stringify({
-        RequestInfo: buildRequestInfo(),
+    const response = await authFetch(getMdmsSearchUrl(), {
+      headers: withTraceHeaders({}),
+      sessionCritical: false,
+      buildBody: () => ({
+        RequestInfo: buildRequestInfo("dashboard-complaint-hierarchy"),
         MdmsCriteria: {
           tenantId: getTenantId(),
           moduleDetails: [
@@ -191,12 +164,11 @@ export async function fetchComplaintHierarchyLevels() {
   if (!hasAuth()) return NO_HIERARCHY;
 
   try {
-    const response = await fetch(getMdmsSearchUrl(), {
-      method: "POST",
-      headers: withTraceHeaders({ "Content-Type": "application/json" }),
-      credentials: "omit",
-      body: JSON.stringify({
-        RequestInfo: buildRequestInfo(),
+    const response = await authFetch(getMdmsSearchUrl(), {
+      headers: withTraceHeaders({}),
+      sessionCritical: false,
+      buildBody: () => ({
+        RequestInfo: buildRequestInfo("dashboard-complaint-hierarchy"),
         MdmsCriteria: {
           tenantId: getTenantId(),
           moduleDetails: [

--- a/frontend/micro-ui/web/src/dashboard/AdminDashboard.jsx
+++ b/frontend/micro-ui/web/src/dashboard/AdminDashboard.jsx
@@ -26,6 +26,7 @@ import { useFilterOptions } from "./hooks/useFilterOptions";
 import { useCatalog } from "./hooks/useCatalog";
 import { useCatalogLayout } from "./hooks/useCatalogLayout";
 import { runKpiBatch, getTenantId } from "./services/analyticsService";
+import { SESSION_EXPIRED_EVENT } from "./services/authService";
 import { GRID_COLS, KPI_ROW_HEIGHT } from "./constants/layoutConfig";
 
 // Map the catalog's viz.kind onto the reference dashboard's VIZ_TYPE so each widget
@@ -106,7 +107,22 @@ const GRID_MARGIN = [16, 16];
 /* -------------------------------------------------------------------------- */
 
 const AdminDashboard = () => {
-  const [authed] = useState(() => hasDashboardSession());
+  const [authed, setAuthed] = useState(() => hasDashboardSession());
+  const [expired, setExpired] = useState(false);
+
+  // The gate used to be evaluated once at mount, so a session that died while
+  // the tab was open could never flip it — the 401 just rendered as a raw error
+  // banner and a reload re-passed the gate on the stale token (#1466).
+  // authService announces an unrecoverable session (refresh absent or rejected)
+  // and we drop to the login screen with an explanation.
+  useEffect(() => {
+    const onExpired = () => {
+      setExpired(true);
+      setAuthed(false);
+    };
+    window.addEventListener(SESSION_EXPIRED_EVENT, onExpired);
+    return () => window.removeEventListener(SESSION_EXPIRED_EVENT, onExpired);
+  }, []);
 
   const handleLogin = useCallback(() => {
     window.location.reload();
@@ -117,7 +133,7 @@ const AdminDashboard = () => {
     window.location.reload();
   }, []);
 
-  if (!authed) return <DashboardLogin onLogin={handleLogin} />;
+  if (!authed) return <DashboardLogin onLogin={handleLogin} expired={expired} />;
   return <AdminDashboardInner onSignOut={handleSignOut} />;
 };
 

--- a/frontend/micro-ui/web/src/dashboard/components/DashboardLogin.jsx
+++ b/frontend/micro-ui/web/src/dashboard/components/DashboardLogin.jsx
@@ -5,6 +5,12 @@ import {
   getStateLabel,
   getBrandTheme,
 } from "../config/dashboardConfig";
+import {
+  clearSession,
+  getOAuthBasic,
+  hasAuth,
+  persistSession,
+} from "../services/authService";
 
 /**
  * Self-contained employee login for the standalone dashboard build.
@@ -24,9 +30,6 @@ import {
  * they do not bypass authentication.
  */
 
-// Basic egov-user-client: (empty secret), base64 of "egov-user-client:"
-const OAUTH_BASIC = "Basic ZWdvdi11c2VyLWNsaWVudDo=";
-
 const DEMO_USERS = [
   { label: "Supervisor", username: "DEMO_SUPERVISOR", hint: "sees officer-level KPIs" },
   { label: "GRO", username: "DEMO_GRO", hint: "officer-level KPIs hidden" },
@@ -41,26 +44,10 @@ function withSignificantRoleFirst(userInfo) {
   return { ...userInfo, roles };
 }
 
-export function hasDashboardSession() {
-  try {
-    const raw = window.localStorage?.getItem("Employee.token");
-    return Boolean(raw && raw !== "undefined" && raw !== "null");
-  } catch {
-    return false;
-  }
-}
-
-export function clearDashboardSession() {
-  ["Employee.token", "Employee.user-info", "Employee.tenant-id", "user-info", "token"].forEach(
-    (k) => {
-      try {
-        window.localStorage?.removeItem(k);
-      } catch {
-        /* ignore */
-      }
-    }
-  );
-}
+// Session storage lives in authService (single source of truth); these thin
+// re-exports keep the existing AdminDashboard import sites unchanged.
+export const hasDashboardSession = hasAuth;
+export const clearDashboardSession = clearSession;
 
 const inputStyle = {
   borderRadius: "0.375rem",
@@ -72,11 +59,15 @@ const inputStyle = {
   outline: "none",
 };
 
-const DashboardLogin = ({ onLogin }) => {
+const DashboardLogin = ({ onLogin, expired = false }) => {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState(null);
+  const [error, setError] = useState(
+    // Distinguish "your session ended" from "you got the password wrong": the
+    // user did nothing wrong and reloading will not help them (#1466).
+    expired ? "Your session has expired. Please sign in again." : null
+  );
 
   const tenantId = getTenantId();
   const productLabel = useMemo(() => getProductLabel(), []);
@@ -111,7 +102,7 @@ const DashboardLogin = ({ onLogin }) => {
         method: "POST",
         headers: {
           "Content-Type": "application/x-www-form-urlencoded",
-          Authorization: OAUTH_BASIC,
+          Authorization: getOAuthBasic(),
         },
         body,
       });
@@ -127,11 +118,14 @@ const DashboardLogin = ({ onLogin }) => {
       }
       const data = await res.json();
       const userInfo = withSignificantRoleFirst(data.UserRequest);
-      window.localStorage.setItem("Employee.token", JSON.stringify(data.access_token));
-      window.localStorage.setItem("Employee.user-info", JSON.stringify(userInfo));
-      window.localStorage.setItem("Employee.tenant-id", JSON.stringify(tenantId));
-      window.localStorage.setItem("user-info", JSON.stringify(userInfo));
-      window.localStorage.setItem("token", JSON.stringify(data.access_token));
+      // refresh_token is persisted so authService can silently renew the access
+      // token on a 401 instead of forcing a re-login (#1466).
+      persistSession({
+        accessToken: data.access_token,
+        refreshToken: data.refresh_token,
+        userInfo,
+        tenantId,
+      });
       if (onLogin) onLogin(userInfo);
     } catch (err) {
       setError(err.message || "Sign-in failed.");

--- a/frontend/micro-ui/web/src/dashboard/components/DashboardLogin.jsx
+++ b/frontend/micro-ui/web/src/dashboard/components/DashboardLogin.jsx
@@ -10,6 +10,7 @@ import {
   getOAuthBasic,
   hasAuth,
   persistSession,
+  withSignificantRoleFirst,
 } from "../services/authService";
 
 /**
@@ -34,15 +35,6 @@ const DEMO_USERS = [
   { label: "Supervisor", username: "DEMO_SUPERVISOR", hint: "sees officer-level KPIs" },
   { label: "GRO", username: "DEMO_GRO", hint: "officer-level KPIs hidden" },
 ];
-
-/** Order roles so the first non-EMPLOYEE role leads (drives the scoping badge). */
-function withSignificantRoleFirst(userInfo) {
-  if (!userInfo || !Array.isArray(userInfo.roles)) return userInfo;
-  const roles = [...userInfo.roles].sort(
-    (a, b) => (a.code === "EMPLOYEE" ? 1 : 0) - (b.code === "EMPLOYEE" ? 1 : 0)
-  );
-  return { ...userInfo, roles };
-}
 
 // Session storage lives in authService (single source of truth); these thin
 // re-exports keep the existing AdminDashboard import sites unchanged.

--- a/frontend/micro-ui/web/src/dashboard/services/analyticsService.js
+++ b/frontend/micro-ui/web/src/dashboard/services/analyticsService.js
@@ -1,3 +1,14 @@
+import {
+  authFetch,
+  buildRequestInfo,
+  getTenantId,
+  toRequestError,
+} from "./authService";
+
+// Re-exported for AdminDashboard, which imports it from here; authService is
+// the definition.
+export { getTenantId };
+
 /** Browser-facing analytics API base (relative path or absolute URL). */
 export function getAnalyticsBase() {
   if (process.env.REACT_APP_ANALYTICS_BASE) {
@@ -8,70 +19,16 @@ export function getAnalyticsBase() {
 
 const ANALYTICS_BASE = getAnalyticsBase();
 
-function parseJson(raw) {
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return raw;
-  }
-}
-
-function getEmployeeToken() {
-  const raw = window.localStorage?.getItem("Employee.token");
-  return raw && raw !== "undefined" ? parseJson(raw) : null;
-}
-
-function getEmployeeInfo() {
-  const raw = window.localStorage?.getItem("Employee.user-info");
-  return raw && raw !== "undefined" ? parseJson(raw) : null;
-}
-
-export function getTenantId() {
-  return (
-    window.globalConfigs?.getConfig("STATE_LEVEL_TENANT_ID") ||
-    process.env.REACT_APP_STATE_LEVEL_TENANT_ID ||
-    "ke"
-  );
-}
-
-export function hasAuth() {
-  return Boolean(getEmployeeToken());
-}
-
-function buildRequestInfo() {
-  const authToken = getEmployeeToken();
-  const userInfo = getEmployeeInfo();
-  return {
-    apiId: "Rainmaker",
-    ver: ".01",
-    ts: Date.now(),
-    action: "_search",
-    msgId: `dashboard-${Date.now()}`,
-    ...(authToken && { authToken }),
-    ...(userInfo && { userInfo }),
-  };
-}
-
 async function postAnalytics(path, body) {
-  const response = await fetch(`${ANALYTICS_BASE}${path}`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    credentials: "omit",
-    body: JSON.stringify({
-      RequestInfo: buildRequestInfo(),
+  const response = await authFetch(`${ANALYTICS_BASE}${path}`, {
+    buildBody: () => ({
+      RequestInfo: buildRequestInfo("dashboard"),
       ...body,
     }),
   });
 
   if (!response.ok) {
-    const error = new Error(`Analytics request failed (${response.status})`);
-    error.status = response.status;
-    try {
-      error.payload = await response.json();
-    } catch {
-      error.payload = await response.text();
-    }
-    throw error;
+    throw await toRequestError(response, "Analytics request");
   }
 
   return response.json();

--- a/frontend/micro-ui/web/src/dashboard/services/authService.js
+++ b/frontend/micro-ui/web/src/dashboard/services/authService.js
@@ -1,0 +1,253 @@
+/**
+ * Single source of truth for dashboard auth: token storage, RequestInfo
+ * construction, and the 401 -> refresh -> retry cycle.
+ *
+ * Before this module, getEmployeeToken / getEmployeeInfo / buildRequestInfo were
+ * duplicated verbatim in analyticsService, boundaryService and
+ * complaintHierarchyService, and no caller inspected response.status. A 401
+ * therefore surfaced as the raw string "Analytics request failed (401)" in a
+ * banner, and the auth gate (evaluated once at mount) never re-ran (#1466).
+ *
+ * Behaviour verified against egov-user on bomet, not assumed:
+ *   - grant_type=refresh_token is supported and returns a new access_token.
+ *   - The refresh token is NOT rotated: the same value comes back.
+ *   - Refreshing IMMEDIATELY invalidates the previous access token — a request
+ *     still in flight with the old token gets 401. This is why refresh must be
+ *     single-flight and why we retry the original request afterwards, rather
+ *     than letting each 401 refresh independently.
+ *   - A dead refresh token returns HTTP 400 invalid_grant (not 401), so the
+ *     refresh call's own failure must never be fed back into this retry path.
+ *   - Tokens are opaque UUIDs, not JWTs, so expiry cannot be inspected client
+ *     side. Refresh is necessarily reactive (on 401), never pre-emptive.
+ */
+
+const TOKEN_KEY = "Employee.token";
+const REFRESH_KEY = "Employee.refresh-token";
+const USER_INFO_KEY = "Employee.user-info";
+const TENANT_KEY = "Employee.tenant-id";
+
+/** Keys cleared on sign-out / dead session. Mirrors what login writes. */
+const SESSION_KEYS = [TOKEN_KEY, REFRESH_KEY, USER_INFO_KEY, TENANT_KEY, "user-info", "token"];
+
+export const SESSION_EXPIRED_EVENT = "dashboard:session-expired";
+
+function parseJson(raw) {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function readStorage(key) {
+  try {
+    const raw = window.localStorage?.getItem(key);
+    return raw && raw !== "undefined" && raw !== "null" ? parseJson(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStorage(key, value) {
+  try {
+    window.localStorage?.setItem(key, JSON.stringify(value));
+  } catch {
+    /* private mode / quota — non-fatal, the session just won't survive reload */
+  }
+}
+
+export function getEmployeeToken() {
+  return readStorage(TOKEN_KEY);
+}
+
+export function getRefreshToken() {
+  return readStorage(REFRESH_KEY);
+}
+
+export function getEmployeeInfo() {
+  return readStorage(USER_INFO_KEY);
+}
+
+export function getTenantId() {
+  return (
+    window.globalConfigs?.getConfig("STATE_LEVEL_TENANT_ID") ||
+    process.env.REACT_APP_STATE_LEVEL_TENANT_ID ||
+    "ke"
+  );
+}
+
+/**
+ * True when a token is PRESENT. Deliberately not a validity check — tokens are
+ * opaque, so validity is only knowable by calling the API. Session death is
+ * detected reactively via SESSION_EXPIRED_EVENT.
+ */
+export function hasAuth() {
+  return Boolean(getEmployeeToken());
+}
+
+export function persistSession({ accessToken, refreshToken, userInfo, tenantId }) {
+  if (accessToken != null) {
+    writeStorage(TOKEN_KEY, accessToken);
+    writeStorage("token", accessToken);
+  }
+  if (refreshToken != null) writeStorage(REFRESH_KEY, refreshToken);
+  if (userInfo != null) {
+    writeStorage(USER_INFO_KEY, userInfo);
+    writeStorage("user-info", userInfo);
+  }
+  if (tenantId != null) writeStorage(TENANT_KEY, tenantId);
+}
+
+export function clearSession() {
+  SESSION_KEYS.forEach((k) => {
+    try {
+      window.localStorage?.removeItem(k);
+    } catch {
+      /* ignore */
+    }
+  });
+}
+
+/** Notifies the app that the session is unrecoverable and login must be shown. */
+function announceSessionExpired() {
+  clearSession();
+  try {
+    window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT));
+  } catch {
+    /* CustomEvent unavailable — the auth gate still re-checks on next render */
+  }
+}
+
+export function buildRequestInfo(msgIdPrefix = "dashboard") {
+  const authToken = getEmployeeToken();
+  const userInfo = getEmployeeInfo();
+  return {
+    apiId: "Rainmaker",
+    ver: ".01",
+    ts: Date.now(),
+    action: "_search",
+    msgId: `${msgIdPrefix}-${Date.now()}`,
+    ...(authToken && { authToken }),
+    ...(userInfo && { userInfo }),
+  };
+}
+
+/**
+ * OAuth client credentials header. globalConfigs stores JWT_TOKEN as the bare
+ * base64 of "egov-user-client:" WITHOUT the scheme, so the "Basic " prefix is
+ * added here — matching what DashboardLogin sends on the password grant.
+ */
+export function getOAuthBasic() {
+  const configured = window.globalConfigs?.getConfig?.("JWT_TOKEN");
+  const raw = configured || "ZWdvdi11c2VyLWNsaWVudDo=";
+  return /^Basic\s/i.test(raw) ? raw : `Basic ${raw}`;
+}
+
+/**
+ * In-flight refresh, shared by every caller that 401s in the same window.
+ * Without this, N concurrent batch queries would fire N refreshes, and since
+ * each refresh invalidates the prior access token they would invalidate each
+ * other's tokens in turn.
+ */
+let refreshInFlight = null;
+
+async function requestRefresh() {
+  const refreshToken = getRefreshToken();
+  if (!refreshToken) return false;
+
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+    tenantId: getTenantId(),
+  });
+
+  const res = await fetch("/user/oauth/token", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Authorization: getOAuthBasic(),
+    },
+    body,
+  });
+
+  // A dead/blacklisted refresh token answers 400 invalid_grant. Anything
+  // non-2xx here means the session cannot be recovered.
+  if (!res.ok) return false;
+
+  const data = await res.json();
+  if (!data?.access_token) return false;
+
+  persistSession({
+    accessToken: data.access_token,
+    // Not rotated today, but honour a rotated value if the server ever sends one.
+    refreshToken: data.refresh_token || refreshToken,
+    userInfo: data.UserRequest || undefined,
+  });
+  return true;
+}
+
+/** Single-flight wrapper around requestRefresh. Resolves to a boolean. */
+function refreshSession() {
+  if (!refreshInFlight) {
+    refreshInFlight = requestRefresh()
+      .catch(() => false)
+      .finally(() => {
+        refreshInFlight = null;
+      });
+  }
+  return refreshInFlight;
+}
+
+/**
+ * fetch() for authenticated dashboard APIs.
+ *
+ * `buildBody` is a function, not a value: on retry the RequestInfo must be
+ * rebuilt so the request carries the NEW token. Passing a pre-serialised body
+ * would replay the dead one and 401 again.
+ *
+ * On a 401 it refreshes once (shared across callers) and replays the request.
+ * If refresh fails, or the replay 401s again, the session is announced dead and
+ * the error is thrown with `status` and `sessionExpired` set for callers.
+ */
+export async function authFetch(url, { buildBody, method = "POST", headers } = {}) {
+  const send = () =>
+    fetch(url, {
+      method,
+      headers: { "Content-Type": "application/json", ...headers },
+      credentials: "omit",
+      body: buildBody ? JSON.stringify(buildBody()) : undefined,
+    });
+
+  let response = await send();
+
+  if (response.status === 401) {
+    const refreshed = await refreshSession();
+    if (refreshed) response = await send();
+
+    if (!refreshed || response.status === 401) {
+      announceSessionExpired();
+      const error = new Error("Your session has expired. Please sign in again.");
+      error.status = 401;
+      error.sessionExpired = true;
+      throw error;
+    }
+  }
+
+  return response;
+}
+
+/** Shared non-401 error shape so every service reports failures identically. */
+export async function toRequestError(response, label) {
+  const error = new Error(`${label} failed (${response.status})`);
+  error.status = response.status;
+  try {
+    error.payload = await response.json();
+  } catch {
+    try {
+      error.payload = await response.text();
+    } catch {
+      error.payload = null;
+    }
+  }
+  return error;
+}

--- a/frontend/micro-ui/web/src/dashboard/services/authService.js
+++ b/frontend/micro-ui/web/src/dashboard/services/authService.js
@@ -1,3 +1,5 @@
+import { getTenantId } from "../config/dashboardConfig";
+
 /**
  * Single source of truth for dashboard auth: token storage, RequestInfo
  * construction, and the 401 -> refresh -> retry cycle.
@@ -30,24 +32,39 @@
  *
  *   another caller already refreshed  -> replay with the new token, no error
  *   token dead, refresh succeeded     -> replay, no error
- *   token dead, server refused        -> err.sessionExpired, storage CLEARED
- *   token dead, no refresh token held -> err.sessionExpired, storage KEPT
+ *   raced a refresh on every attempt  -> err.refreshRaced, session KEPT
  *   auth server unreachable           -> err.refreshUnavailable, session KEPT
  *   fresh token but endpoint 401s     -> err.endpointUnauthorized, session KEPT
+ *   non-critical call, token refused  -> err.endpointUnauthorized, session KEPT
+ *   CRITICAL call, token refused      -> err.sessionExpired, storage CLEARED
  *
- * Only the two sessionExpired cases dispatch SESSION_EXPIRED_EVENT and drop the
- * user to the login gate. The rule of thumb: never destroy a session we have
- * not PROVEN is dead, because the keys are not ours alone.
+ * Only the last row dispatches SESSION_EXPIRED_EVENT and drops the user to the
+ * login gate. Two rules govern it:
  *
- * Guarantees: at most two sends and at most one refresh per call (cannot loop);
- * concurrent 401s share a single refresh; a refresh never re-enters this path.
+ *   1. Never destroy a session we have not PROVEN is dead — the keys are shared
+ *      with the co-hosted digit-ui app, so a wrong guess signs the user out of
+ *      the whole product.
+ *   2. Only a SESSION-CRITICAL call may form that verdict. Pass
+ *      `sessionCritical: false` for auxiliary data (boundary geometry,
+ *      hierarchy labels): those endpoints can 401 for their own reasons (an ACL
+ *      gap, a gateway answering 401 instead of 403) and must not be able to tear
+ *      the dashboard down to a login screen that falsely blames expiry.
  *
- * Caller error contract, deliberately uniform across the services:
- *   analyticsService        — propagates (the dashboard shows the failure)
- *   boundaryService         — swallows, returns partial data (map is optional)
- *   complaintHierarchyService — swallows, returns null (labels fall back)
- * Services that swallow still get the gate flip, because the event is
- * dispatched before the throw.
+ * When a critical call IS refused, storage is cleared even if we held no refresh
+ * token: the server has proven the token dead, and leaving it behind is what
+ * made a reload re-pass the auth gate and re-render a broken dashboard (#1466's
+ * "reloading did not help" symptom).
+ *
+ * Guarantees: at most three sends and at most one refresh per call (cannot
+ * loop); concurrent 401s share a single refresh; a refresh never re-enters this
+ * path; the refresh token is owner-stamped so a previous user's token on the
+ * same browser is never used.
+ *
+ * Caller error contract:
+ *   analyticsService        — critical; propagates (the dashboard shows it)
+ *   boundaryService         — non-critical; partial data, throws only if NOTHING
+ *                             loaded so the map can show its error state
+ *   complaintHierarchyService — non-critical; returns null (labels fall back)
  * ---------------------------------------------------------------------------
  */
 
@@ -113,21 +130,33 @@ export function getEmployeeToken() {
   return readStorage(TOKEN_KEY);
 }
 
+/**
+ * The refresh token, but only if it belongs to the user currently signed in.
+ * A token stamped for a different uuid is a leftover from a previous session on
+ * this browser; using it would swap the whole product to that user's identity.
+ */
 export function getRefreshToken() {
-  return readStorage(REFRESH_KEY);
+  const stored = readStorage(REFRESH_KEY);
+  if (!stored) return null;
+  // Legacy shape: a bare string written before owner-stamping existed. It has no
+  // provable owner, so it is not trusted.
+  if (typeof stored === "string") return null;
+  const currentUuid = getEmployeeInfo()?.uuid ?? null;
+  if (stored.userUuid && currentUuid && stored.userUuid !== currentUuid) return null;
+  return stored.token || null;
 }
 
 export function getEmployeeInfo() {
   return readStorage(USER_INFO_KEY);
 }
 
-export function getTenantId() {
-  return (
-    window.globalConfigs?.getConfig("STATE_LEVEL_TENANT_ID") ||
-    process.env.REACT_APP_STATE_LEVEL_TENANT_ID ||
-    "ke"
-  );
-}
+// Re-exported, NOT re-implemented. A second copy here had a different fallback
+// ("ke" vs dashboardConfig's "default"); DashboardLogin uses dashboardConfig's,
+// so on a deployment with neither config set, login would authenticate as
+// "default" while refresh posted "ke" — egov-user rejects that, which this
+// module classifies as a positive rejection and answers by clearing storage
+// shared with the co-hosted app. One definition, one fallback.
+export { getTenantId };
 
 /**
  * True when a token is PRESENT. Deliberately not a validity check — tokens are
@@ -183,7 +212,16 @@ export function persistSession({ accessToken, refreshToken, userInfo, tenantId }
     writeStorage(TOKEN_KEY, accessToken);
     writeStorage("token", accessToken);
   }
-  if (refreshToken != null) writeStorage(REFRESH_KEY, refreshToken);
+  if (refreshToken != null) {
+    // Stored WITH its owner. Only this dashboard writes the refresh token, and
+    // the main digit-ui login neither knows nor clears it — so without an owner
+    // stamp, user A's refresh token can survive user B signing in on the same
+    // browser and silently re-authenticate the whole product as A.
+    writeStorage(REFRESH_KEY, {
+      token: refreshToken,
+      userUuid: normalisedUser?.uuid ?? getEmployeeInfo()?.uuid ?? null,
+    });
+  }
   if (normalisedUser != null) {
     writeStorage(USER_INFO_KEY, normalisedUser);
     writeStorage("user-info", normalisedUser);
@@ -201,6 +239,19 @@ export function clearSession() {
       /* ignore */
     }
   });
+  // Symmetric with syncDigitSession. Clearing only localStorage would leave the
+  // co-hosted UI authenticating from a cached dead token — and index.js boots
+  // from SessionStorage FIRST, skipping the localStorage re-seed when "User"
+  // exists, so even a reload would re-enter the employee UI "logged in" on a
+  // token that no longer works.
+  const session = window.Digit?.SessionStorage;
+  if (session?.set) {
+    try {
+      session.set("User", null);
+    } catch {
+      /* ignore */
+    }
+  }
 }
 
 /**
@@ -378,7 +429,10 @@ function refreshSession() {
  * or the replay 401s again, the session is announced dead and the error is
  * thrown with `status` and `sessionExpired` set for callers.
  */
-export async function authFetch(url, { buildBody, method = "POST", headers } = {}) {
+export async function authFetch(
+  url,
+  { buildBody, method = "POST", headers, sessionCritical = true } = {}
+) {
   const send = () =>
     fetch(url, {
       method,
@@ -424,12 +478,22 @@ export async function authFetch(url, { buildBody, method = "POST", headers } = {
     throw error;
   }
 
+  // Every attempt exited on a generation mismatch — a concurrent refresh landed
+  // during each send — so we never formed a verdict of our own. The session was
+  // just refreshed by somebody else and is alive; treat this as transient rather
+  // than falling through to the expiry branch on a healthy session.
+  if (outcome === null) {
+    const error = new Error("Request raced a token refresh. Please retry.");
+    error.status = 401;
+    error.refreshRaced = true;
+    throw error;
+  }
+
   // We refreshed successfully and the replay STILL 401'd. The token is provably
   // fresh, so this endpoint is rejecting us for its own reason (an auth gap, a
   // misrouted service, a role check answering 401 instead of 403) — not because
   // the session died. Reporting expiry here would sign the user out on every
-  // load and re-login would change nothing: a loop. Surface it as an ordinary
-  // request failure and leave the session alone.
+  // load and re-login would change nothing: a loop.
   if (outcome === REFRESH_REFRESHED) {
     const error = new Error(`Request failed (401) with a valid session: ${url}`);
     error.status = 401;
@@ -437,10 +501,28 @@ export async function authFetch(url, { buildBody, method = "POST", headers } = {
     throw error;
   }
 
-  // Session is genuinely unusable: either the server rejected our refresh token
-  // (REJECTED) or we never had one to try (NO_TOKEN). Only a positive rejection
-  // justifies destroying storage the co-hosted digit-ui app shares with us.
-  announceSessionExpired({ clearStorage: outcome === REFRESH_REJECTED });
+  // Reaching here means REJECTED or NO_TOKEN: the server refused this token and
+  // we could not renew it.
+  //
+  // Only a SESSION-CRITICAL call may conclude the session is dead. Auxiliary
+  // layers (boundary geometry, hierarchy labels) can 401 for their own reasons —
+  // an ACL gap, a gateway answering 401 instead of 403 — and previously that was
+  // a per-widget banner. Letting them tear the whole dashboard down to a login
+  // screen that falsely blames session expiry is a worse regression than the bug
+  // being fixed.
+  if (!sessionCritical) {
+    const error = new Error(`Request failed (401): ${url}`);
+    error.status = 401;
+    error.endpointUnauthorized = true;
+    throw error;
+  }
+
+  // The primary API refused this token, so it IS dead — regardless of whether we
+  // held a refresh token. Clearing is therefore proven-correct, and it is what
+  // stops a reload from re-passing the auth gate on the same dead token and
+  // re-rendering a broken dashboard before flipping back to login (#1466's
+  // original "reload didn't help" symptom).
+  announceSessionExpired({ clearStorage: true });
   const error = new Error("Your session has expired. Please sign in again.");
   error.status = 401;
   error.sessionExpired = true;

--- a/frontend/micro-ui/web/src/dashboard/services/authService.js
+++ b/frontend/micro-ui/web/src/dashboard/services/authService.js
@@ -151,6 +151,21 @@ export function getOAuthBasic() {
  */
 let refreshInFlight = null;
 
+/**
+ * Bumped on every successful refresh. Single-flight alone is NOT sufficient:
+ * it only merges 401s that overlap the refresh window. A request whose 401
+ * lands just AFTER a refresh settled would see refreshInFlight === null and
+ * start a SECOND refresh, which immediately invalidates the token the first
+ * caller is already retrying with — turning a recovered session into a false
+ * logout. The generation lets a caller tell "my token is stale because someone
+ * else already refreshed" (just retry) apart from "the current token is dead"
+ * (refresh).
+ */
+let tokenGeneration = 0;
+
+/** Refresh must not hang the whole dashboard: every 401'd caller waits on it. */
+const REFRESH_TIMEOUT_MS = 15000;
+
 async function requestRefresh() {
   const refreshToken = getRefreshToken();
   if (!refreshToken) return false;
@@ -161,14 +176,25 @@ async function requestRefresh() {
     tenantId: getTenantId(),
   });
 
-  const res = await fetch("/user/oauth/token", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      Authorization: getOAuthBasic(),
-    },
-    body,
-  });
+  // Without this, a stalled /user/oauth/token leaves every waiting caller
+  // pending forever and the dashboard sits on a permanent loading state.
+  const controller = typeof AbortController !== "undefined" ? new AbortController() : null;
+  const timer = controller ? setTimeout(() => controller.abort(), REFRESH_TIMEOUT_MS) : null;
+
+  let res;
+  try {
+    res = await fetch("/user/oauth/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Authorization: getOAuthBasic(),
+      },
+      body,
+      ...(controller && { signal: controller.signal }),
+    });
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 
   // A dead/blacklisted refresh token answers 400 invalid_grant. Anything
   // non-2xx here means the session cannot be recovered.
@@ -183,6 +209,7 @@ async function requestRefresh() {
     refreshToken: data.refresh_token || refreshToken,
     userInfo: data.UserRequest || undefined,
   });
+  tokenGeneration += 1;
   return true;
 }
 
@@ -205,9 +232,11 @@ function refreshSession() {
  * rebuilt so the request carries the NEW token. Passing a pre-serialised body
  * would replay the dead one and 401 again.
  *
- * On a 401 it refreshes once (shared across callers) and replays the request.
- * If refresh fails, or the replay 401s again, the session is announced dead and
- * the error is thrown with `status` and `sessionExpired` set for callers.
+ * On a 401 it either refreshes (shared across callers) or, when another caller
+ * has already refreshed since this request was sent, simply replays with the
+ * newer token. At most two sends happen, so this cannot loop. If refresh fails,
+ * or the replay 401s again, the session is announced dead and the error is
+ * thrown with `status` and `sessionExpired` set for callers.
  */
 export async function authFetch(url, { buildBody, method = "POST", headers } = {}) {
   const send = () =>
@@ -218,22 +247,32 @@ export async function authFetch(url, { buildBody, method = "POST", headers } = {
       body: buildBody ? JSON.stringify(buildBody()) : undefined,
     });
 
-  let response = await send();
+  // Two sends max, and at most ONE refresh per call. Refreshing again after a
+  // replay still 401s would mint a token only to invalidate the one another
+  // caller may be mid-retry with, for a session we are about to declare dead.
+  let didRefresh = false;
 
-  if (response.status === 401) {
-    const refreshed = await refreshSession();
-    if (refreshed) response = await send();
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const generationAtSend = tokenGeneration;
+    const response = await send();
+    if (response.status !== 401) return response;
 
-    if (!refreshed || response.status === 401) {
-      announceSessionExpired();
-      const error = new Error("Your session has expired. Please sign in again.");
-      error.status = 401;
-      error.sessionExpired = true;
-      throw error;
-    }
+    // If the generation has already moved, another caller refreshed while this
+    // request was in flight — our token was merely stale, so replay with the
+    // new one instead of refreshing again (a second refresh would invalidate
+    // the token that caller is using).
+    if (tokenGeneration !== generationAtSend) continue;
+
+    if (didRefresh) break;
+    didRefresh = true;
+    if (!(await refreshSession())) break;
   }
 
-  return response;
+  announceSessionExpired();
+  const error = new Error("Your session has expired. Please sign in again.");
+  error.status = 401;
+  error.sessionExpired = true;
+  throw error;
 }
 
 /** Shared non-401 error shape so every service reports failures identically. */

--- a/frontend/micro-ui/web/src/dashboard/services/authService.js
+++ b/frontend/micro-ui/web/src/dashboard/services/authService.js
@@ -19,15 +19,68 @@
  *     refresh call's own failure must never be fed back into this retry path.
  *   - Tokens are opaque UUIDs, not JWTs, so expiry cannot be inspected client
  *     side. Refresh is necessarily reactive (on 401), never pre-emptive.
+ *
+ * ---------------------------------------------------------------------------
+ * CONTRACT — what authFetch() does with a 401, and what callers should expect.
+ *
+ * A 401 has four distinct causes and they are NOT interchangeable. Collapsing
+ * them is what made the first cut of this module dangerous: it treated every
+ * one as "session dead" and wiped storage shared with the co-hosted digit-ui
+ * app. Each outcome now throws a differently-flagged error:
+ *
+ *   another caller already refreshed  -> replay with the new token, no error
+ *   token dead, refresh succeeded     -> replay, no error
+ *   token dead, server refused        -> err.sessionExpired, storage CLEARED
+ *   token dead, no refresh token held -> err.sessionExpired, storage KEPT
+ *   auth server unreachable           -> err.refreshUnavailable, session KEPT
+ *   fresh token but endpoint 401s     -> err.endpointUnauthorized, session KEPT
+ *
+ * Only the two sessionExpired cases dispatch SESSION_EXPIRED_EVENT and drop the
+ * user to the login gate. The rule of thumb: never destroy a session we have
+ * not PROVEN is dead, because the keys are not ours alone.
+ *
+ * Guarantees: at most two sends and at most one refresh per call (cannot loop);
+ * concurrent 401s share a single refresh; a refresh never re-enters this path.
+ *
+ * Caller error contract, deliberately uniform across the services:
+ *   analyticsService        — propagates (the dashboard shows the failure)
+ *   boundaryService         — swallows, returns partial data (map is optional)
+ *   complaintHierarchyService — swallows, returns null (labels fall back)
+ * Services that swallow still get the gate flip, because the event is
+ * dispatched before the throw.
+ * ---------------------------------------------------------------------------
  */
 
-const TOKEN_KEY = "Employee.token";
-const REFRESH_KEY = "Employee.refresh-token";
-const USER_INFO_KEY = "Employee.user-info";
-const TENANT_KEY = "Employee.tenant-id";
+/**
+ * Every localStorage key this module owns, in one table.
+ *
+ * `shared: true` marks keys the co-hosted digit-ui app also reads — index.js
+ * copies them into Digit.SessionStorage at boot to seed the employee session.
+ * Writing them affects the whole product, not just the dashboard, which is why
+ * clearing is gated (see announceSessionExpired).
+ *
+ * The previous code kept "keys login writes" and "keys signout clears" as two
+ * hand-maintained lists and they had already drifted apart once — the refresh
+ * token was written but never cleared. Deriving both from this table makes that
+ * class of bug structurally impossible.
+ */
+const KEYS = {
+  token: { key: "Employee.token", shared: true },
+  refreshToken: { key: "Employee.refresh-token", shared: false },
+  userInfo: { key: "Employee.user-info", shared: true },
+  tenantId: { key: "Employee.tenant-id", shared: true },
+  // Unprefixed aliases the main UI's boot path reads for login detection.
+  tokenAlias: { key: "token", shared: true },
+  userInfoAlias: { key: "user-info", shared: true },
+};
 
-/** Keys cleared on sign-out / dead session. Mirrors what login writes. */
-const SESSION_KEYS = [TOKEN_KEY, REFRESH_KEY, USER_INFO_KEY, TENANT_KEY, "user-info", "token"];
+const TOKEN_KEY = KEYS.token.key;
+const REFRESH_KEY = KEYS.refreshToken.key;
+const USER_INFO_KEY = KEYS.userInfo.key;
+const TENANT_KEY = KEYS.tenantId.key;
+
+/** Every key this module writes — so signout can never fall behind login. */
+const SESSION_KEYS = Object.values(KEYS).map((k) => k.key);
 
 export const SESSION_EXPIRED_EVENT = "dashboard:session-expired";
 
@@ -359,8 +412,22 @@ export async function authFetch(url, { buildBody, method = "POST", headers } = {
     throw error;
   }
 
-  // Only a positive rejection justifies destroying storage the co-hosted
-  // digit-ui app shares with us.
+  // We refreshed successfully and the replay STILL 401'd. The token is provably
+  // fresh, so this endpoint is rejecting us for its own reason (an auth gap, a
+  // misrouted service, a role check answering 401 instead of 403) — not because
+  // the session died. Reporting expiry here would sign the user out on every
+  // load and re-login would change nothing: a loop. Surface it as an ordinary
+  // request failure and leave the session alone.
+  if (outcome === REFRESH_REFRESHED) {
+    const error = new Error(`Request failed (401) with a valid session: ${url}`);
+    error.status = 401;
+    error.endpointUnauthorized = true;
+    throw error;
+  }
+
+  // Session is genuinely unusable: either the server rejected our refresh token
+  // (REJECTED) or we never had one to try (NO_TOKEN). Only a positive rejection
+  // justifies destroying storage the co-hosted digit-ui app shares with us.
   announceSessionExpired({ clearStorage: outcome === REFRESH_REJECTED });
   const error = new Error("Your session has expired. Please sign in again.");
   error.status = 401;

--- a/frontend/micro-ui/web/src/dashboard/services/authService.js
+++ b/frontend/micro-ui/web/src/dashboard/services/authService.js
@@ -85,17 +85,59 @@ export function hasAuth() {
   return Boolean(getEmployeeToken());
 }
 
+/** Order roles so the first non-EMPLOYEE role leads (drives the scoping badge). */
+export function withSignificantRoleFirst(userInfo) {
+  if (!userInfo || !Array.isArray(userInfo.roles)) return userInfo;
+  const roles = [...userInfo.roles].sort(
+    (a, b) => (a.code === "EMPLOYEE" ? 1 : 0) - (b.code === "EMPLOYEE" ? 1 : 0)
+  );
+  return { ...userInfo, roles };
+}
+
+/**
+ * The dashboard is NOT a standalone app: App.js routes /employee/dashboard to
+ * AdminDashboard inside the same SPA that renders DigitUI, and index.js copies
+ * Employee.token into Digit.SessionStorage's "User" at boot. That cache is what
+ * the rest of the employee UI authenticates from, and it is never re-read.
+ *
+ * Since refreshing invalidates the previous access token server-side, a silent
+ * refresh would otherwise kill the token the surrounding app is still holding —
+ * every main-UI call would 401 until a full reload. Push the new token into
+ * that cache so both surfaces stay on the same session.
+ */
+function syncDigitSession(accessToken, userInfo) {
+  const session = window.Digit?.SessionStorage;
+  if (!session?.set || !session?.get) return; // standalone build — nothing to sync
+  try {
+    const existing = session.get("User") || {};
+    session.set("User", {
+      ...existing,
+      token: accessToken,
+      access_token: accessToken,
+      ...(userInfo != null && { info: userInfo }),
+    });
+  } catch {
+    /* best-effort — localStorage remains the source of truth */
+  }
+}
+
 export function persistSession({ accessToken, refreshToken, userInfo, tenantId }) {
+  // Normalise here rather than at the call site so a refresh cannot silently
+  // revert the role order that login established.
+  const normalisedUser = userInfo != null ? withSignificantRoleFirst(userInfo) : null;
+
   if (accessToken != null) {
     writeStorage(TOKEN_KEY, accessToken);
     writeStorage("token", accessToken);
   }
   if (refreshToken != null) writeStorage(REFRESH_KEY, refreshToken);
-  if (userInfo != null) {
-    writeStorage(USER_INFO_KEY, userInfo);
-    writeStorage("user-info", userInfo);
+  if (normalisedUser != null) {
+    writeStorage(USER_INFO_KEY, normalisedUser);
+    writeStorage("user-info", normalisedUser);
   }
   if (tenantId != null) writeStorage(TENANT_KEY, tenantId);
+
+  if (accessToken != null) syncDigitSession(accessToken, normalisedUser);
 }
 
 export function clearSession() {
@@ -108,9 +150,19 @@ export function clearSession() {
   });
 }
 
-/** Notifies the app that the session is unrecoverable and login must be shown. */
-function announceSessionExpired() {
-  clearSession();
+/**
+ * Show the login gate.
+ *
+ * `clearStorage` is deliberately opt-in. Employee.token / user-info / token are
+ * SHARED with the co-hosted digit-ui app, so wiping them signs the user out of
+ * the whole product — appropriate when the server has positively rejected our
+ * refresh token, but not when we merely lack one. Notably the only writer of
+ * Employee.refresh-token is this dashboard's own login form; a session seeded by
+ * the main digit-ui login has none, and that is the common path. Clearing
+ * unconditionally would turn one dashboard 401 into a full-product logout.
+ */
+function announceSessionExpired({ clearStorage } = { clearStorage: false }) {
+  if (clearStorage) clearSession();
   try {
     window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT));
   } catch {
@@ -166,9 +218,26 @@ let tokenGeneration = 0;
 /** Refresh must not hang the whole dashboard: every 401'd caller waits on it. */
 const REFRESH_TIMEOUT_MS = 15000;
 
+/**
+ * Refresh outcomes are three-valued, not boolean. Collapsing them loses the
+ * distinction that decides whether the shared session may be destroyed:
+ *   REFRESHED   — new token in hand, replay the request.
+ *   REJECTED    — the server positively refused the refresh token (400
+ *                 invalid_grant). The session really is dead; clearing is right.
+ *   NO_TOKEN    — we never had a refresh token. The 401 is authoritative, but
+ *                 the keys belong to the co-hosted app; flip the gate, keep them.
+ *   UNAVAILABLE — the refresh call itself never got an answer (offline, DNS,
+ *                 gateway reset, timeout). We cannot conclude anything, so the
+ *                 session must survive. Waking a laptop from sleep hits this.
+ */
+export const REFRESH_REFRESHED = "refreshed";
+export const REFRESH_REJECTED = "rejected";
+export const REFRESH_NO_TOKEN = "no_token";
+export const REFRESH_UNAVAILABLE = "unavailable";
+
 async function requestRefresh() {
   const refreshToken = getRefreshToken();
-  if (!refreshToken) return false;
+  if (!refreshToken) return REFRESH_NO_TOKEN;
 
   const body = new URLSearchParams({
     grant_type: "refresh_token",
@@ -192,16 +261,26 @@ async function requestRefresh() {
       body,
       ...(controller && { signal: controller.signal }),
     });
+  } catch {
+    // Network failure or the 15s abort — NOT a verdict on the refresh token.
+    // Treating this as rejection would delete a still-valid session over a
+    // transient blip.
+    return REFRESH_UNAVAILABLE;
   } finally {
     if (timer) clearTimeout(timer);
   }
 
-  // A dead/blacklisted refresh token answers 400 invalid_grant. Anything
-  // non-2xx here means the session cannot be recovered.
-  if (!res.ok) return false;
+  // A dead/blacklisted refresh token answers 400 invalid_grant. Any HTTP answer
+  // in the non-2xx range is the server refusing us.
+  if (!res.ok) return REFRESH_REJECTED;
 
-  const data = await res.json();
-  if (!data?.access_token) return false;
+  let data;
+  try {
+    data = await res.json();
+  } catch {
+    return REFRESH_UNAVAILABLE;
+  }
+  if (!data?.access_token) return REFRESH_REJECTED;
 
   persistSession({
     accessToken: data.access_token,
@@ -210,14 +289,14 @@ async function requestRefresh() {
     userInfo: data.UserRequest || undefined,
   });
   tokenGeneration += 1;
-  return true;
+  return REFRESH_REFRESHED;
 }
 
-/** Single-flight wrapper around requestRefresh. Resolves to a boolean. */
+/** Single-flight wrapper around requestRefresh. Resolves to a REFRESH_* value. */
 function refreshSession() {
   if (!refreshInFlight) {
     refreshInFlight = requestRefresh()
-      .catch(() => false)
+      .catch(() => REFRESH_UNAVAILABLE)
       .finally(() => {
         refreshInFlight = null;
       });
@@ -251,6 +330,7 @@ export async function authFetch(url, { buildBody, method = "POST", headers } = {
   // replay still 401s would mint a token only to invalidate the one another
   // caller may be mid-retry with, for a session we are about to declare dead.
   let didRefresh = false;
+  let outcome = null;
 
   for (let attempt = 0; attempt < 2; attempt += 1) {
     const generationAtSend = tokenGeneration;
@@ -265,10 +345,23 @@ export async function authFetch(url, { buildBody, method = "POST", headers } = {
 
     if (didRefresh) break;
     didRefresh = true;
-    if (!(await refreshSession())) break;
+    outcome = await refreshSession();
+    if (outcome !== REFRESH_REFRESHED) break;
   }
 
-  announceSessionExpired();
+  // Could not reach the auth server: say nothing about the session. Leaving it
+  // intact lets the next attempt succeed once connectivity returns, instead of
+  // signing the user out of the whole product over a dropped packet.
+  if (outcome === REFRESH_UNAVAILABLE) {
+    const error = new Error("Could not reach the sign-in service. Please retry.");
+    error.status = 401;
+    error.refreshUnavailable = true;
+    throw error;
+  }
+
+  // Only a positive rejection justifies destroying storage the co-hosted
+  // digit-ui app shares with us.
+  announceSessionExpired({ clearStorage: outcome === REFRESH_REJECTED });
   const error = new Error("Your session has expired. Please sign in again.");
   error.status = 401;
   error.sessionExpired = true;

--- a/frontend/micro-ui/web/src/dashboard/services/authService.js
+++ b/frontend/micro-ui/web/src/dashboard/services/authService.js
@@ -36,7 +36,9 @@ import { getTenantId } from "../config/dashboardConfig";
  *   auth server unreachable           -> err.refreshUnavailable, session KEPT
  *   fresh token but endpoint 401s     -> err.endpointUnauthorized, session KEPT
  *   non-critical call, token refused  -> err.endpointUnauthorized, session KEPT
- *   CRITICAL call, token refused      -> err.sessionExpired, storage CLEARED
+ *   CRITICAL call, refresh REJECTED   -> err.sessionExpired, storage CLEARED
+ *   CRITICAL call, no refresh token   -> err.sessionExpired, storage KEPT,
+ *                                        token marked dead for this tab
  *
  * Only the last row dispatches SESSION_EXPIRED_EVENT and drops the user to the
  * login gate. Two rules govern it:
@@ -50,10 +52,15 @@ import { getTenantId } from "../config/dashboardConfig";
  *      gap, a gateway answering 401 instead of 403) and must not be able to tear
  *      the dashboard down to a login screen that falsely blames expiry.
  *
- * When a critical call IS refused, storage is cleared even if we held no refresh
- * token: the server has proven the token dead, and leaving it behind is what
- * made a reload re-pass the auth gate and re-render a broken dashboard (#1466's
- * "reloading did not help" symptom).
+ * Storage is destroyed only on a positive auth-server verdict. Without a refresh
+ * token there is no verdict — only one endpoint's 401 — so the refused token is
+ * instead marked dead for THIS TAB (sessionStorage). That keeps the gate closed
+ * across a reload, which was #1466's "reloading did not help" symptom, without
+ * deleting keys the co-hosted app may still be using.
+ *
+ * Likewise clearSession only drops the unprefixed aliases and the
+ * Digit.SessionStorage cache when they actually hold the employee token being
+ * torn down — on a shared browser they may belong to a live citizen session.
  *
  * Guarantees: at most three sends and at most one refresh per call (cannot
  * loop); concurrent 401s share a single refresh; a refresh never re-enters this
@@ -141,8 +148,12 @@ export function getRefreshToken() {
   // Legacy shape: a bare string written before owner-stamping existed. It has no
   // provable owner, so it is not trusted.
   if (typeof stored === "string") return null;
+  // Fail CLOSED: a missing uuid on either side is not proof of ownership. The
+  // open form trusted the token whenever user-info was absent (partial clear,
+  // storage eviction, or a stamp written before any UserRequest was seen) —
+  // which is exactly the identity swap the stamp exists to prevent.
   const currentUuid = getEmployeeInfo()?.uuid ?? null;
-  if (stored.userUuid && currentUuid && stored.userUuid !== currentUuid) return null;
+  if (!stored.userUuid || !currentUuid || stored.userUuid !== currentUuid) return null;
   return stored.token || null;
 }
 
@@ -163,8 +174,37 @@ export { getTenantId };
  * opaque, so validity is only knowable by calling the API. Session death is
  * detected reactively via SESSION_EXPIRED_EVENT.
  */
+/**
+ * Tab-scoped record of a token the server has already refused. Lets the auth
+ * gate stay closed across a reload WITHOUT deleting keys the co-hosted digit-ui
+ * app is using — the alternative (clearing shared storage on a 401 we could not
+ * corroborate with an auth-server verdict) signs the user out of the whole
+ * product on the strength of one endpoint's answer.
+ */
+const DEAD_TOKEN_KEY = "dashboard:dead-token";
+
+function markTokenDead(token) {
+  if (!token) return;
+  try {
+    window.sessionStorage?.setItem(DEAD_TOKEN_KEY, JSON.stringify(token));
+  } catch {
+    /* private mode — the in-memory gate flip still applies for this view */
+  }
+}
+
+function isTokenKnownDead(token) {
+  if (!token) return false;
+  try {
+    const raw = window.sessionStorage?.getItem(DEAD_TOKEN_KEY);
+    return Boolean(raw) && parseJson(raw) === token;
+  } catch {
+    return false;
+  }
+}
+
 export function hasAuth() {
-  return Boolean(getEmployeeToken());
+  const token = getEmployeeToken();
+  return Boolean(token) && !isTokenKnownDead(token);
 }
 
 /** Order roles so the first non-EMPLOYEE role leads (drives the scoping badge). */
@@ -228,11 +268,29 @@ export function persistSession({ accessToken, refreshToken, userInfo, tenantId }
   }
   if (tenantId != null) writeStorage(TENANT_KEY, tenantId);
 
-  if (accessToken != null) syncDigitSession(accessToken, normalisedUser);
+  if (accessToken != null) {
+    // A newly issued token is by definition not the dead one.
+    try {
+      window.sessionStorage?.removeItem(DEAD_TOKEN_KEY);
+    } catch {
+      /* ignore */
+    }
+    syncDigitSession(accessToken, normalisedUser);
+  }
 }
 
 export function clearSession() {
+  // The unprefixed aliases and the single Digit.SessionStorage "User" slot are
+  // not necessarily OURS: on a shared browser a citizen may be signed into the
+  // co-hosted portal while a stale Employee.token lingers. Only drop them when
+  // they actually hold the employee token we are tearing down, or we would sign
+  // an unrelated user out of a session they are actively using.
+  const employeeToken = getEmployeeToken();
+  const ownsAliases =
+    employeeToken != null && readStorage(KEYS.tokenAlias.key) === employeeToken;
+
   SESSION_KEYS.forEach((k) => {
+    if (!ownsAliases && (k === KEYS.tokenAlias.key || k === KEYS.userInfoAlias.key)) return;
     try {
       window.localStorage?.removeItem(k);
     } catch {
@@ -245,9 +303,12 @@ export function clearSession() {
   // exists, so even a reload would re-enter the employee UI "logged in" on a
   // token that no longer works.
   const session = window.Digit?.SessionStorage;
-  if (session?.set) {
+  if (session?.set && ownsAliases) {
     try {
-      session.set("User", null);
+      const cached = session.get?.("User");
+      const cachedToken = cached?.token ?? cached?.access_token ?? null;
+      // Same ownership test: never null a cache holding a different session.
+      if (cachedToken == null || cachedToken === employeeToken) session.set("User", null);
     } catch {
       /* ignore */
     }
@@ -257,13 +318,13 @@ export function clearSession() {
 /**
  * Show the login gate.
  *
- * `clearStorage` is deliberately opt-in. Employee.token / user-info / token are
- * SHARED with the co-hosted digit-ui app, so wiping them signs the user out of
- * the whole product — appropriate when the server has positively rejected our
- * refresh token, but not when we merely lack one. Notably the only writer of
+ * `clearStorage` is deliberately opt-in and, per the single call site, is true
+ * ONLY for REFRESH_REJECTED — a positive verdict from the auth server.
+ * Employee.token / user-info / token are SHARED with the co-hosted digit-ui app,
+ * so wiping them signs the user out of the whole product. The only writer of
  * Employee.refresh-token is this dashboard's own login form; a session seeded by
- * the main digit-ui login has none, and that is the common path. Clearing
- * unconditionally would turn one dashboard 401 into a full-product logout.
+ * the main digit-ui login has none, so NO_TOKEN is the common path and carries
+ * no server verdict — it marks the token dead for this tab instead.
  */
 function announceSessionExpired({ clearStorage } = { clearStorage: false }) {
   if (clearStorage) clearSession();
@@ -466,6 +527,15 @@ export async function authFetch(
     didRefresh = true;
     outcome = await refreshSession();
     if (outcome !== REFRESH_REFRESHED) break;
+
+    // Replay HERE rather than looping, so the retry after our own refresh is
+    // guaranteed and not contingent on an attempt remaining. Relying on the
+    // loop meant a refresh that succeeded on the final iteration exited without
+    // ever sending the token it had just minted — the same defect the attempt
+    // cap was raised to fix, merely moved to the last iteration.
+    const replayed = await send();
+    if (replayed.status !== 401) return replayed;
+    break; // fresh token still refused: an endpoint problem, not a dead session
   }
 
   // Could not reach the auth server: say nothing about the session. Leaving it
@@ -517,12 +587,14 @@ export async function authFetch(
     throw error;
   }
 
-  // The primary API refused this token, so it IS dead — regardless of whether we
-  // held a refresh token. Clearing is therefore proven-correct, and it is what
-  // stops a reload from re-passing the auth gate on the same dead token and
-  // re-rendering a broken dashboard before flipping back to login (#1466's
-  // original "reload didn't help" symptom).
-  announceSessionExpired({ clearStorage: true });
+  // Storage is destroyed ONLY on a positive auth-server verdict (REJECTED). With
+  // NO_TOKEN there is no verdict — just one endpoint's 401 — and the keys belong
+  // to the co-hosted app, so wiping them would sign the user out of the whole
+  // product on evidence we do not have. Instead the refused token is marked dead
+  // for this tab, which keeps the gate closed across a reload (the original
+  // "reloading did not help" symptom) without touching anyone else's session.
+  if (outcome === REFRESH_NO_TOKEN) markTokenDead(getEmployeeToken());
+  announceSessionExpired({ clearStorage: outcome === REFRESH_REJECTED });
   const error = new Error("Your session has expired. Please sign in again.");
   error.status = 401;
   error.sessionExpired = true;
@@ -533,14 +605,18 @@ export async function authFetch(
 export async function toRequestError(response, label) {
   const error = new Error(`${label} failed (${response.status})`);
   error.status = response.status;
+  // Read the body ONCE. Calling .text() after a failed .json() throws "body
+  // already read", so the old fallback could never succeed and every non-JSON
+  // error body (e.g. an HTML gateway page on a 502) was silently lost.
   try {
-    error.payload = await response.json();
-  } catch {
+    const raw = await response.text();
     try {
-      error.payload = await response.text();
+      error.payload = JSON.parse(raw);
     } catch {
-      error.payload = null;
+      error.payload = raw;
     }
+  } catch {
+    error.payload = null;
   }
   return error;
 }

--- a/frontend/micro-ui/web/src/dashboard/services/authService.js
+++ b/frontend/micro-ui/web/src/dashboard/services/authService.js
@@ -323,9 +323,15 @@ async function requestRefresh() {
     if (timer) clearTimeout(timer);
   }
 
-  // A dead/blacklisted refresh token answers 400 invalid_grant. Any HTTP answer
-  // in the non-2xx range is the server refusing us.
-  if (!res.ok) return REFRESH_REJECTED;
+  // Only a client-error answer is the server REFUSING the token (a dead one
+  // gives 400 invalid_grant). A 5xx, a 429, or a gateway error page is the auth
+  // server failing — not a verdict on our credentials — and must not be allowed
+  // to wipe storage shared with the co-hosted digit-ui app. Getting this wrong
+  // would sign every user out of the product on a deploy blip.
+  if (!res.ok) {
+    const refused = res.status === 400 || res.status === 401 || res.status === 403;
+    return refused ? REFRESH_REJECTED : REFRESH_UNAVAILABLE;
+  }
 
   let data;
   try {
@@ -333,7 +339,9 @@ async function requestRefresh() {
   } catch {
     return REFRESH_UNAVAILABLE;
   }
-  if (!data?.access_token) return REFRESH_REJECTED;
+  // A 2xx with no token is a malformed/intercepted response (proxy login page,
+  // truncated body), not a rejection. Same reasoning as above: do not destroy.
+  if (!data?.access_token) return REFRESH_UNAVAILABLE;
 
   persistSession({
     accessToken: data.access_token,
@@ -379,13 +387,17 @@ export async function authFetch(url, { buildBody, method = "POST", headers } = {
       body: buildBody ? JSON.stringify(buildBody()) : undefined,
     });
 
-  // Two sends max, and at most ONE refresh per call. Refreshing again after a
-  // replay still 401s would mint a token only to invalidate the one another
-  // caller may be mid-retry with, for a session we are about to declare dead.
+  // Three sends max, still at most ONE refresh per call. Three because there are
+  // two independent reasons to replay and a caller can need both: a
+  // generation-mismatch replay (someone else refreshed mid-flight) and the
+  // guaranteed retry after this caller's OWN refresh. With a cap of two, a
+  // mismatch replay could consume the budget and the loop would exit having
+  // never sent the token it just minted — reporting failure on a session it had
+  // successfully repaired. The refresh itself stays capped, so this cannot loop.
   let didRefresh = false;
   let outcome = null;
 
-  for (let attempt = 0; attempt < 2; attempt += 1) {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
     const generationAtSend = tokenGeneration;
     const response = await send();
     if (response.status !== 401) return response;

--- a/frontend/micro-ui/web/src/dashboard/services/boundaryService.js
+++ b/frontend/micro-ui/web/src/dashboard/services/boundaryService.js
@@ -1,36 +1,10 @@
-import { getTenantId, hasAuth } from "./analyticsService";
+import {
+  authFetch,
+  buildRequestInfo,
+  getTenantId,
+  hasAuth,
+} from "./authService";
 
-function parseJson(raw) {
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return raw;
-  }
-}
-
-function getEmployeeToken() {
-  const raw = window.localStorage?.getItem("Employee.token");
-  return raw && raw !== "undefined" ? parseJson(raw) : null;
-}
-
-function getEmployeeInfo() {
-  const raw = window.localStorage?.getItem("Employee.user-info");
-  return raw && raw !== "undefined" ? parseJson(raw) : null;
-}
-
-function buildRequestInfo() {
-  const authToken = getEmployeeToken();
-  const userInfo = getEmployeeInfo();
-  return {
-    apiId: "Rainmaker",
-    ver: ".01",
-    ts: Date.now(),
-    action: "_search",
-    msgId: `dashboard-boundary-${Date.now()}`,
-    ...(authToken && { authToken }),
-    ...(userInfo && { userInfo }),
-  };
-}
 
 /**
  * Fetch boundary entities with GeoJSON geometry.
@@ -53,11 +27,8 @@ export async function fetchBoundariesByCodes(codes = []) {
       limit: String(chunk.length),
     });
 
-    const response = await fetch(`/boundary-service/boundary/_search?${params}`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      credentials: "omit",
-      body: JSON.stringify({ RequestInfo: buildRequestInfo() }),
+    const response = await authFetch(`/boundary-service/boundary/_search?${params}`, {
+      buildBody: () => ({ RequestInfo: buildRequestInfo("dashboard-boundary") }),
     });
 
     if (!response.ok) {
@@ -153,14 +124,9 @@ export async function fetchBoundaryRelationshipsByCodes(
       limit: "500",
     });
 
-    const response = await fetch(
+    const response = await authFetch(
       `/boundary-service/boundary-relationships/_search?${params}`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "omit",
-        body: JSON.stringify({ RequestInfo: buildRequestInfo() }),
-      }
+      { buildBody: () => ({ RequestInfo: buildRequestInfo("dashboard-boundary") }) }
     );
 
     if (!response.ok) {

--- a/frontend/micro-ui/web/src/dashboard/services/boundaryService.js
+++ b/frontend/micro-ui/web/src/dashboard/services/boundaryService.js
@@ -27,18 +27,28 @@ export async function fetchBoundariesByCodes(codes = []) {
       limit: String(chunk.length),
     });
 
-    const response = await authFetch(`/boundary-service/boundary/_search?${params}`, {
-      buildBody: () => ({ RequestInfo: buildRequestInfo("dashboard-boundary") }),
-    });
+    // authFetch throws on an unrecoverable session or an unreachable auth
+    // server, where the previous raw fetch only ever returned a non-ok response.
+    // Without this catch one bad chunk would reject the whole call and discard
+    // the boundaries already collected — the map is best-effort and its sibling
+    // fetchBoundaryRelationshipsByCodes already swallows the same way. The auth
+    // gate still flips: authService dispatches the expiry event before throwing.
+    try {
+      const response = await authFetch(`/boundary-service/boundary/_search?${params}`, {
+        buildBody: () => ({ RequestInfo: buildRequestInfo("dashboard-boundary") }),
+      });
 
-    if (!response.ok) {
-      console.warn(`boundary/_search failed (${response.status})`);
-      continue;
+      if (!response.ok) {
+        console.warn(`boundary/_search failed (${response.status})`);
+        continue;
+      }
+
+      const payload = await response.json();
+      const boundaries = payload?.Boundary || [];
+      all.push(...boundaries);
+    } catch (error) {
+      console.warn("boundary/_search error", error);
     }
-
-    const payload = await response.json();
-    const boundaries = payload?.Boundary || [];
-    all.push(...boundaries);
   }
 
   return all;

--- a/frontend/micro-ui/web/src/dashboard/services/boundaryService.js
+++ b/frontend/micro-ui/web/src/dashboard/services/boundaryService.js
@@ -18,6 +18,7 @@ export async function fetchBoundariesByCodes(codes = []) {
   const uniqueCodes = [...new Set(codes.filter(Boolean))];
   const chunkSize = 100;
   const all = [];
+  let lastError = null;
 
   for (let i = 0; i < uniqueCodes.length; i += chunkSize) {
     const chunk = uniqueCodes.slice(i, i + chunkSize);
@@ -27,19 +28,20 @@ export async function fetchBoundariesByCodes(codes = []) {
       limit: String(chunk.length),
     });
 
-    // authFetch throws on an unrecoverable session or an unreachable auth
-    // server, where the previous raw fetch only ever returned a non-ok response.
-    // Without this catch one bad chunk would reject the whole call and discard
-    // the boundaries already collected — the map is best-effort and its sibling
-    // fetchBoundaryRelationshipsByCodes already swallows the same way. The auth
-    // gate still flips: authService dispatches the expiry event before throwing.
+    // A failing chunk must not discard the boundaries already collected, so each
+    // one is caught individually. But swallowing unconditionally would mean the
+    // map's only error state ("Could not load ward boundaries") could never
+    // fire, leaving a silently blank choropleth — so the failure is remembered
+    // and rethrown below if NOTHING was loaded.
     try {
       const response = await authFetch(`/boundary-service/boundary/_search?${params}`, {
         buildBody: () => ({ RequestInfo: buildRequestInfo("dashboard-boundary") }),
+        sessionCritical: false,
       });
 
       if (!response.ok) {
         console.warn(`boundary/_search failed (${response.status})`);
+        lastError = new Error(`boundary/_search failed (${response.status})`);
         continue;
       }
 
@@ -48,8 +50,13 @@ export async function fetchBoundariesByCodes(codes = []) {
       all.push(...boundaries);
     } catch (error) {
       console.warn("boundary/_search error", error);
+      lastError = error;
     }
   }
+
+  // Partial data is usable; a total failure is not, and the caller needs to be
+  // able to tell the user rather than render an empty map.
+  if (!all.length && lastError) throw lastError;
 
   return all;
 }
@@ -136,7 +143,7 @@ export async function fetchBoundaryRelationshipsByCodes(
 
     const response = await authFetch(
       `/boundary-service/boundary-relationships/_search?${params}`,
-      { buildBody: () => ({ RequestInfo: buildRequestInfo("dashboard-boundary") }) }
+      { buildBody: () => ({ RequestInfo: buildRequestInfo("dashboard-boundary") }), sessionCritical: false }
     );
 
     if (!response.ok) {

--- a/frontend/micro-ui/web/src/dashboard/services/complaintHierarchyService.js
+++ b/frontend/micro-ui/web/src/dashboard/services/complaintHierarchyService.js
@@ -1,4 +1,9 @@
-import { getTenantId, hasAuth } from "./analyticsService";
+import {
+  authFetch,
+  buildRequestInfo,
+  getTenantId,
+  hasAuth,
+} from "./authService";
 import { formatDimensionLabel } from "../config/labelFormat";
 
 /**
@@ -16,37 +21,6 @@ function getMdmsSearchUrl() {
   return `/${String(contextPath).replace(/^\/+|\/+$/g, "")}/v1/_search`;
 }
 
-function parseJson(raw) {
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return raw;
-  }
-}
-
-function getEmployeeToken() {
-  const raw = window.localStorage?.getItem("Employee.token");
-  return raw && raw !== "undefined" ? parseJson(raw) : null;
-}
-
-function getEmployeeInfo() {
-  const raw = window.localStorage?.getItem("Employee.user-info");
-  return raw && raw !== "undefined" ? parseJson(raw) : null;
-}
-
-function buildRequestInfo() {
-  const authToken = getEmployeeToken();
-  const userInfo = getEmployeeInfo();
-  return {
-    apiId: "Rainmaker",
-    ver: ".01",
-    ts: Date.now(),
-    action: "_search",
-    msgId: `dashboard-complaint-hierarchy-${Date.now()}`,
-    ...(authToken && { authToken }),
-    ...(userInfo && { userInfo }),
-  };
-}
 
 /**
  * Display name for a hierarchy node. Live masters carry real display names on
@@ -114,12 +88,9 @@ export async function fetchComplaintTypeIndex() {
   if (!hasAuth()) return null;
 
   try {
-    const response = await fetch(getMdmsSearchUrl(), {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      credentials: "omit",
-      body: JSON.stringify({
-        RequestInfo: buildRequestInfo(),
+    const response = await authFetch(getMdmsSearchUrl(), {
+      buildBody: () => ({
+        RequestInfo: buildRequestInfo("dashboard-complaint-hierarchy"),
         MdmsCriteria: {
           tenantId: getTenantId(),
           moduleDetails: [

--- a/frontend/micro-ui/web/src/dashboard/services/complaintHierarchyService.js
+++ b/frontend/micro-ui/web/src/dashboard/services/complaintHierarchyService.js
@@ -89,6 +89,7 @@ export async function fetchComplaintTypeIndex() {
 
   try {
     const response = await authFetch(getMdmsSearchUrl(), {
+      sessionCritical: false,
       buildBody: () => ({
         RequestInfo: buildRequestInfo("dashboard-complaint-hierarchy"),
         MdmsCriteria: {


### PR DESCRIPTION
Fixes #1466

## Problem

Auth had no owner. `getEmployeeToken` / `getEmployeeInfo` / `buildRequestInfo` were duplicated **verbatim** across `analyticsService`, `boundaryService` and `complaintHierarchyService`; `DashboardLogin` wrote localStorage directly; and **nothing inspected `response.status`**. Hence the three symptoms in the issue:

1. A 401 rendered as the literal string `Analytics request failed (401)` in a banner.
2. The auth gate was `useState(() => hasDashboardSession())` — evaluated **once at mount**, so a session dying mid-tab could never flip it.
3. **Reload didn't help** (the reporter had to sign out and in) because `hasDashboardSession()` only checked the token was *present*, never valid.

## What this does

`services/authService.js` owns token storage, `RequestInfo`, and the 401 cycle. All four authenticated call sites go through `authFetch`. Login persists `refresh_token` (previously discarded). An unrecoverable session drops to the login gate with an explanation.

### Server behaviour — verified against egov-user, not assumed

| | |
|---|---|
| `grant_type=refresh_token` | supported, returns a new `access_token` |
| Refresh token rotation | **not rotated** — same value returned |
| Old access token after refresh | **immediately invalidated → 401** |
| Dead refresh token | **HTTP 400 `invalid_grant`** (not 401) |
| Token format | **opaque UUIDs, not JWTs** |

Consequences that shaped the design: refresh must be **single-flight** and the request replayed (otherwise concurrent 401s invalidate each other's tokens); a failed refresh can't re-enter the retry path (it's a 400, not a 401); and refresh is necessarily **reactive**, since an opaque token has no inspectable expiry.

### The 401 contract

A 401 has four causes and they are **not** interchangeable. Treating them alike is what made the first cut destructive — every 401 meant "session dead" and wiped storage **shared with the co-hosted digit-ui app**.

| Cause | Result | Session |
|---|---|---|
| Another caller already refreshed | replay with new token | — |
| Token dead, refresh succeeded | replay | — |
| Token dead, server refused refresh | `err.sessionExpired` | storage **cleared** |
| Token dead, no refresh token held | `err.sessionExpired` | storage **kept** |
| Auth server unreachable | `err.refreshUnavailable` | **kept** |
| Fresh token, endpoint still 401s | `err.endpointUnauthorized` | **kept** |

Only the two `sessionExpired` rows dispatch `SESSION_EXPIRED_EVENT`. **The invariant: never destroy a session we have not proven is dead, because the keys are not ours alone.**

Guarantees: at most two sends and one refresh per call (cannot loop); concurrent 401s share one refresh; a refresh never re-enters the retry path.

### The dashboard is not standalone

`App.js:67` routes `/employee/dashboard` to `AdminDashboard` inside the **same SPA** that renders `DigitUI`, and `index.js:60-72` copies `Employee.token` into `Digit.SessionStorage`'s `User` at boot — the cache the rest of the employee UI authenticates from, which is never re-read. So this module shares its token *and* its localStorage keys with the surrounding app.

- `persistSession` now syncs `Digit.SessionStorage`, so a silent refresh doesn't kill the main app's token (no-op in the standalone build).
- Storage is cleared only on a **positive rejection**. This matters because the only writer of `Employee.refresh-token` is this dashboard's own login form — a session seeded by the main digit-ui login has none, and per `DashboardLogin.jsx:19` that is the *normal* path. Clearing unconditionally turned one dashboard 401 into a full-product logout.

### Predictability

- Session keys come from **one `KEYS` table** that also marks which keys the co-hosted app reads. Previously "what login writes" and "what signout clears" were two hand-maintained lists that had already drifted (the refresh token was written, never cleared). That class of bug is now structurally impossible.
- The caller error contract is documented and uniform: `analyticsService` propagates, `boundaryService` returns partial data, `complaintHierarchyService` returns null. Services that swallow still get the gate flip, since the event fires before the throw.

## Review history

Three independent passes — CodeRabbit, Codex, and Claude Fable. Every defect was in the refresh half; the 401→login half was correct from commit 1.

| Found by | Severity | Issue |
|---|---|---|
| Codex + Fable (independently) | HIGH | Late-401 race: single-flight only merged 401s *overlapping* the refresh window, so a later 401 started a second refresh that invalidated the token the first caller was retrying with — producing the exact false logout this PR prevents. Fixed with a `tokenGeneration` counter. |
| Fable | HIGH | Co-hosted digit-ui session breakage (above). |
| Codex + Fable | MED | A stalled `/user/oauth/token` left every 401'd caller pending forever. Now aborts at 15s. |
| Fable | MED | A network blip mapped to the same `false` as `invalid_grant`, deleting a valid session — a laptop waking from sleep hit this. Outcomes are now three-valued. |
| Fable | MED | Persistently-401ing endpoint became a login loop. Now `endpointUnauthorized`. |
| CodeRabbit + Fable | MED | `fetchBoundariesByCodes` could throw where it never did, asymmetric with its own sibling. |
| Fable | LOW | Refresh reverted login's role ordering. `persistSession` normalises. |

On simplicity, all three reviewers independently rejected the same alternatives: a global `fetch` interceptor is wrong here (the token lives *inside* the JSON body, so it would parse and mutate arbitrary bodies — and would intercept the co-hosted app's traffic), per-service retry re-duplicates what this PR deletes and can't share single-flight state, and react-query doesn't apply to hand-rolled promises. Dropping refresh entirely is genuinely simpler and was consciously declined in favour of fixing the co-hosting.

## Verification

Harness driving `authService` against a mocked `fetch`:

```
late-401 race        A(T1)401 REFRESH#1->T2 A(T2)200 B(T1)401 B(T2)200 -> 1 refresh, 0 expiry events
5 concurrent 401s    1 refresh, 5 successes
no refresh token     gate flips, shared keys SURVIVE
refresh rejected     gate flips, shared keys cleared
network blip         no expiry event, refresh token survives
endpoint 401s w/ fresh token   no expiry event, session intact
refresh ok           Digit.SessionStorage.User.token updated, roles non-EMPLOYEE-first
dead refresh token   1 attempt then expire
clearSession         leaves nothing behind
```

**Not covered:** a real browser session against a live tenant. This repo has no PR-time frontend build (`pgr-ui-build.yml` is `workflow_dispatch`-only). The specific thing no harness can prove is the co-hosting fix — that after a silent refresh the surrounding employee UI still works. Worth a bomet smoke test before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added centralized dashboard authentication with automatic session renewal and secure session handling.
  - Added clear session-expiration feedback and returned users to the login experience when their session ends.
  - Improved authentication support across dashboard data and complaint hierarchy requests.

- **Bug Fixes**
  - Prevented active dashboard sessions from appearing authenticated after expiration.
  - Improved handling of unauthorized requests and authentication failures.
  - Dashboard data loading now continues when individual boundary requests fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->