### PR TITLE
feat(citizen): single-module sidebar — drop All Services row, redirect page, rename entry to Início

### DIFF
--- a/digit-ui-esbuild/packages/digit-ui-components-v2/src/components/layout/citizen-sidebar.tsx
+++ b/digit-ui-esbuild/packages/digit-ui-components-v2/src/components/layout/citizen-sidebar.tsx
@@ -9,7 +9,7 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Link, useLocation, useHistory } from "react-router-dom";
-import { Home, Pencil, LogOut, Phone, AlertOctagon, LogIn } from "lucide-react";
+import { Pencil, LogOut, Phone, AlertOctagon, LogIn } from "lucide-react";
 import { cn } from "../../lib/cn";
 
 declare const Digit: any;
@@ -550,13 +550,24 @@ export function CitizenSidebar({
         // suffix so the row stays highlighted on any /<module>/* route
         // (file a complaint, complaints list, complaint detail, …).
         const prefix = entry.sidebarURL?.replace(/-home$/, "");
+        const moduleKey =
+          Digit?.Utils?.locale?.getTransformedLocale?.(key) ?? key;
+        // Label: prefer a CITIZEN-specific override, fall back to the shared
+        // ACTION_TEST_<MODULE> key. The employee sidebar renders that same
+        // ACTION_TEST_<MODULE> key, so relabelling the citizen row via
+        // localisation alone would also rename the module for staff (e.g.
+        // "Fala Cidadão" → "Início" over the employee's Create/Search
+        // Complaint group). The override keeps the two surfaces independent.
+        const overrideKey = `CS_CITIZEN_SIDEBAR_${moduleKey}`;
+        const overridden = t(overrideKey);
         return [
           {
             kind: isInternal ? ("link" as ItemKind) : ("external" as ItemKind),
             Icon: AlertOctagon,
-            text: t(
-              `ACTION_TEST_${Digit?.Utils?.locale?.getTransformedLocale?.(key) ?? key}`
-            ),
+            text:
+              overridden && overridden !== overrideKey
+                ? overridden
+                : t(`ACTION_TEST_${moduleKey}`),
             link: entry.sidebarURL,
             matchPrefixes: prefix ? [prefix] : undefined,
           },
@@ -569,17 +580,12 @@ export function CitizenSidebar({
   const items: NavItem[] = React.useMemo(() => {
     if (isLoggedInCitizen) {
       return [
-        {
-          kind: "link",
-          Icon: Home,
-          text: t("COMMON_BOTTOM_NAVIGATION_HOME"),
-          link: `/${contextPath}/citizen/all-services`,
-          // Only match the all-services surface itself; using the bare
-          // `/citizen` prefix would steal the active state from every
-          // module surface (e.g. /citizen/pgr-home would light Home up
-          // instead of Citizen Complaint).
-          matchPrefixes: [`/${contextPath}/citizen/all-services`],
-        },
+        // CCSD-2126 follow-up: the dedicated "Home" row (→ /citizen/all-services)
+        // is gone. With a single module the All Services page is just a page
+        // holding one card, so the row duplicated the module link and was the
+        // surface where two entries could appear highlighted at once. The
+        // /citizen/all-services route now redirects to the module home (see
+        // pages/citizen/index.js), so nothing is unreachable.
         ...moduleLinks,
         {
           kind: "link",

--- a/digit-ui-esbuild/packages/modules/core/src/pages/citizen/index.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/citizen/index.js
@@ -259,6 +259,22 @@ const Home = ({
       },
     }
   );
+  // CCSD-2126 follow-up: the sole citizen module's home, when there is exactly
+  // one. Derived from the SAME MDMS rows the sidebar renders (grouped by
+  // parentModule above), so it follows the configured sidebarURL rather than
+  // hardcoding a module path — a tenant that renames or re-points its module
+  // keeps working, and multi-module tenants resolve to null (no redirect).
+  const soleCitizenModuleHome = React.useMemo(() => {
+    const entries = Object.values(linkData || {})
+      .map((rows) => rows?.[0])
+      .filter((entry) => entry?.sidebar === `${window.contextPath}-links` && entry?.sidebarURL);
+    if (entries.length !== 1) return null;
+    const url = entries[0].sidebarURL;
+    // Only ever redirect to an internal path, and never back to this route.
+    if (!url.startsWith("/") || url.includes("/all-services")) return null;
+    return url;
+  }, [linkData]);
+
   const classname = Digit.Hooks.useRouteSubscription(pathname);
   const { t } = useTranslation();
   const { path } = useRouteMatch();
@@ -351,13 +367,24 @@ const Home = ({
             />
           </Route>
           <Route path={`${path}/all-services`}>
-            <AppHome
-              userType="citizen"
-              modules={modules}
-              getCitizenMenu={linkData}
-              fetchedCitizen={isLinkDataFetched}
-              isLoading={islinkDataLoading}
-            />
+            {/* CCSD-2126 follow-up: when the deployment exposes exactly ONE
+                citizen module (the Moz/CCRS case), All Services is a page
+                holding a single card, and the sidebar row that pointed here
+                duplicated the module link. Send the citizen straight to that
+                module's home instead. Multi-module deployments are untouched
+                and still get the picker. Wait for the MDMS link data before
+                deciding, otherwise we'd render the page and then bounce. */}
+            {isLinkDataFetched && soleCitizenModuleHome ? (
+              <Redirect to={soleCitizenModuleHome} />
+            ) : (
+              <AppHome
+                userType="citizen"
+                modules={modules}
+                getCitizenMenu={linkData}
+                fetchedCitizen={isLinkDataFetched}
+                isLoading={islinkDataLoading}
+              />
+            )}
           </Route>
 
           <Route path={`${path}/login`}>

--- a/utilities/default-data-handler/src/main/resources/localisations/default/rainmaker-common.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/default/rainmaker-common.json
@@ -8866,5 +8866,11 @@
         "message": "Fala Cidadão",
         "module": "rainmaker-common",
         "locale": "default"
+    },
+    {
+        "code": "CS_CITIZEN_SIDEBAR_PGR",
+        "message": "Home",
+        "module": "rainmaker-common",
+        "locale": "default"
     }
 ]

--- a/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-common.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-common.json
@@ -9862,5 +9862,11 @@
         "message": "Português",
         "module": "rainmaker-common",
         "locale": "en_IN"
+    },
+    {
+        "code": "CS_CITIZEN_SIDEBAR_PGR",
+        "message": "Home",
+        "module": "rainmaker-common",
+        "locale": "en_IN"
     }
 ]

--- a/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-common.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-common.json
@@ -328,5 +328,11 @@
         "message": "Português",
         "module": "rainmaker-common",
         "locale": "pt_PT"
+    },
+    {
+        "code": "CS_CITIZEN_SIDEBAR_PGR",
+        "message": "Início",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
     }
 ]


### PR DESCRIPTION
## What
On the Moz/CCRS deployment the citizen left sidebar showed **two** entries that went to effectively the same place — a hardcoded **Home** row (→ `/citizen/all-services`) and the **module** row — while All Services itself was just a page holding a single card. That page was also the surface where the CCSD-2126 double-highlight appeared.

After this change, a logged-in citizen sees:

```
EN:  Home  ·  Edit Profile  ·  Logout  ·  HELPLINE
PT:  Início · Actualizar Perfil · Sair · LINHA DE APOIO
```

## Changes
1. **`citizen-sidebar.tsx`** — remove the hardcoded Home row from the logged-in branch (the logged-out branch never had one); drop the now-unused `Home` icon import.
2. **`pages/citizen/index.js`** — `/citizen/all-services` redirects to the sole module's home when exactly one citizen module is configured, so nothing becomes unreachable.
3. **Label override** — the module row prefers `CS_CITIZEN_SIDEBAR_<MODULE>`, falling back to `ACTION_TEST_<MODULE>`; seeded `CS_CITIZEN_SIDEBAR_PGR` = `Início` / `Home`.

## Two deliberate design calls
**The redirect target is derived, not hardcoded.** It reads the same MDMS `sidebarURL` the sidebar renders, so a tenant that renames or re-points its module keeps working. Multi-module deployments resolve to `null` and still get the All Services picker — this is additive for everyone except single-module tenants. It's guarded on `isLinkDataFetched` (otherwise the page renders then bounces) and refuses non-internal targets and all-services itself (no redirect loop).

**The rename needed a code change, not just localisation.** `ACTION_TEST_PGR` is rendered by the **employee** sidebar too — verified live on mctd, where the employee UI shows "Fala Cidadão" from that same key over its Create/Search Complaint group. Renaming the key alone would have relabelled the module for staff. The override keeps the two surfaces independent.

## Verified locally (mz citizen, all caches purged)
| check | result |
|---|---|
| `/citizen/all-services` | redirects → `/citizen/pgr-home` |
| Row pointing at all-services | none |
| Highlighted rows | exactly 1 |
| Sidebar EN | Home / Edit Profile / Logout / HELPLINE |
| Sidebar PT | Início / Actualizar Perfil / Sair / LINHA DE APOIO |

## Rollout note
The label needs `CS_CITIZEN_SIDEBAR_PGR` present on the target env. Seeded in the repo for fresh deployments; for existing envs upsert it and call `POST /localization/messages/cache-bust`, otherwise the row falls back to `ACTION_TEST_PGR` ("Fala Cidadão") — a safe fallback, not a breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)