### PR TITLE
fix(ops): deploy-pilot-fe.sh container check uses sudo docker (fixes mctd abort)

### DIFF
--- a/local-setup/scripts/deploy-pilot-fe.sh
+++ b/local-setup/scripts/deploy-pilot-fe.sh
@@ -93,7 +93,11 @@ deploy_ui() {
   log "node $(node -v)"
 
   [ -f "$GLOBAL_CONFIGS" ] || { echo "ERROR: $GLOBAL_CONFIGS not found" >&2; exit 1; }
-  docker ps --format '{{.Names}}' | grep -qx digit-ui \
+  # sudo like every other docker call in this script: on boxes where the
+  # operator is NOT in the docker group (mctd), bare `docker ps` fails with
+  # "permission denied ... docker.sock" and this check misread that as
+  # "container is not running".
+  sudo docker ps --format '{{.Names}}' | grep -qx digit-ui \
     || { echo "ERROR: digit-ui container is not running" >&2; exit 1; }
 
   log "syncing source into $UI_BUILD_DIR (no --delete, keeps node_modules)"


### PR DESCRIPTION
## Real failure on mctd (egov@srvigeigsae, 2026-07-31)

```
[deploy-pilot-fe] node v22.22.2
permission denied while trying to connect to the docker API at unix:///var/run/docker.sock
ERROR: digit-ui container is not running
```

The digit-ui pre-check was the **only** docker invocation in the script without `sudo`. On boxes where the operator isn't in the docker group (mctd), bare `docker ps` fails at the socket and the check misreads the permission error as "container not running". Pilot never hit it because its operator is in the docker group.

One-line fix: `sudo docker ps`, consistent with every other docker call in the script. Verified on mctd via the equivalent sed-patched copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)