### PR TITLE
fix(pgr): Complainant Name first + schema x-order on Additional Details (CCSD-2123)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/PgrExtendedAttributesView.js
+++ b/digit-ui-esbuild/products/pgr/src/components/PgrExtendedAttributesView.js
@@ -7,7 +7,9 @@
 // value -> row mapper: NO schema fetch, NO masking logic, NO translation of the
 // values themselves.
 
-import { prettifyKey } from "../utils/extendedAttributes";
+import React from "react";
+
+import { prettifyKey, fieldsFromSchema } from "../utils/extendedAttributes";
 
 // Internal / control keys that are not user-facing data rows: the discriminator,
 // the confidentiality flag, the schema version, the hierarchy breadcrumbs (which
@@ -59,10 +61,60 @@ const labelKeyOf = (k) => `PGR_EXT_${k.replace(/([a-z0-9])([A-Z])/g, "$1_$2").to
 // nothing (graceful gating — safe before the backend read side ships).
 // Pass t to localize the labels; the prettified English key remains the
 // fallback whenever a PGR_EXT_* key is not in the loaded bundle.
-export function buildExtendedAttributeRows(extendedAttributes, t) {
+// CCSD-2123: the backend returns extendedAttributes in Postgres jsonb key
+// order — key LENGTH, then bytewise — so witnessName (11 chars) always came
+// out ahead of complainantName (15) and the witness led the card.
+//
+// Display order:
+//   1. complainantName is ALWAYS first (primary subject of the record). This
+//      one is pinned in code because it is not a schema field — the citizen
+//      wizard writes it as a free key under additionalProperties, so no
+//      x-order can ever cover it.
+//   2. Schema fields follow the SAME x-order the create form renders with
+//      (pass orderedKeys from useExtendedAttributeOrder below).
+//   3. Anything else keeps its incoming relative order (sort is stable).
+const rankOf = (k, orderedKeys) => {
+  if (k === "complainantName") return -1;
+  const i = orderedKeys ? orderedKeys.indexOf(k) : -1;
+  return i === -1 ? 999 : i;
+};
+
+// Resolve the display order for a complaint's extendedAttributes from the
+// SAME masters the create forms use: ComplaintTemplateType (caseRelatedTo →
+// schemaRef) + ComplaintExtendedAttributeSchema (schemaRef → schema with
+// x-order). Returns the ordered fieldKey list, or null while loading / when
+// the category has no schema — callers just get jsonb order until then.
+// Mirrors createComplaintForm.js: state-tenant fetch, cached forever.
+export function useExtendedAttributeOrder(extendedAttributes) {
+  const caseRelatedTo = extendedAttributes && extendedAttributes.caseRelatedTo;
+  const stateTenant = (Digit?.ULBService?.getCurrentTenantId?.() || "").split(".")[0];
+  const { data: templates } = Digit.Hooks.useCustomMDMS(stateTenant, "RAINMAKER-PGR", [{ name: "ComplaintTemplateType" }], {
+    cacheTime: Infinity,
+    select: (raw) => raw?.["RAINMAKER-PGR"]?.ComplaintTemplateType || [],
+  });
+  const { data: schemasByRef } = Digit.Hooks.useCustomMDMS(stateTenant, "RAINMAKER-PGR", [{ name: "ComplaintExtendedAttributeSchema" }], {
+    cacheTime: Infinity,
+    select: (raw) => {
+      const rows = raw?.["RAINMAKER-PGR"]?.ComplaintExtendedAttributeSchema || [];
+      return rows.reduce((acc, r) => {
+        if (r && r.schemaRef) acc[r.schemaRef] = r.schema;
+        return acc;
+      }, {});
+    },
+  });
+  return React.useMemo(() => {
+    if (!caseRelatedTo || !templates || !schemasByRef) return null;
+    const tpl = templates.find((x) => x && x.caseRelatedTo === caseRelatedTo);
+    const fields = fieldsFromSchema(tpl && schemasByRef[tpl.schemaRef]);
+    return fields.length ? fields.map((f) => f.fieldKey) : null;
+  }, [caseRelatedTo, templates, schemasByRef]);
+}
+
+export function buildExtendedAttributeRows(extendedAttributes, t, orderedKeys) {
   if (!extendedAttributes || typeof extendedAttributes !== "object") return [];
   return Object.keys(extendedAttributes)
     .filter((k) => !SKIP_KEYS.has(k))
+    .sort((a, b) => rankOf(a, orderedKeys) - rankOf(b, orderedKeys))
     .map((k) => {
       const lk = labelKeyOf(k);
       const translated = typeof t === "function" ? t(lk) : lk;

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintDetails.js
@@ -22,7 +22,7 @@ import { buildComplaintPath } from "../../utils/complaintHierarchyPath";
 import TimelineWrapper from "../../components/TimeLineWrapper";
 import ComplaintPhotos from "../../components/ComplaintPhotos";
 import ComplaintLocationMap from "../../components/ComplaintLocationMap";
-import { buildExtendedAttributeRows } from "../../components/PgrExtendedAttributesView";
+import { buildExtendedAttributeRows, useExtendedAttributeOrder } from "../../components/PgrExtendedAttributesView";
 import StarRated from "../../components/timelineInstances/StarRated";
 
 // Terminal (non-active) states across standard PGR *and* the mz.igsae CMS workflow.
@@ -234,6 +234,9 @@ const ComplaintDetailsPage = () => {
     tenantId,
     id,
   });
+  // CCSD-2123: schema x-order for the Additional Details card (complainantName
+  // is pinned first inside buildExtendedAttributeRows regardless).
+  const extAttrOrder = useExtendedAttributeOrder(complaintDetails?.service?.extendedAttributes);
 
   // Complaint classification hierarchy (configurable N levels). Absent on
   // un-migrated tenants -> buildComplaintPath returns null and the legacy flat
@@ -456,7 +459,7 @@ const ComplaintDetailsPage = () => {
             {(() => {
               // Read-only "Additional Details" — just fetch service.extendedAttributes
               // and show it; the backend already returns masked ("****") values.
-              const extAttrRows = buildExtendedAttributeRows(complaintDetails?.service?.extendedAttributes, t);
+              const extAttrRows = buildExtendedAttributeRows(complaintDetails?.service?.extendedAttributes, t, extAttrOrder);
               return extAttrRows.length > 0 ? (
                 <Card style={{ padding: "20px 24px", display: "flex", flexDirection: "column", gap: "12px" }}>
                   <SectionTitle>{tr("CS_COMPLAINT_DETAILS_ADDITIONAL_DETAILS", "Additional Details")}</SectionTitle>

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
@@ -10,7 +10,7 @@ import PGRWorkflowModal from "../../components/PGRWorkflowModal";
 import ComplaintLocationMap from "../../components/ComplaintLocationMap";
 import Urls from "../../utils/urls";
 import ComplaintPhotos from "../../components/ComplaintPhotos";
-import { buildExtendedAttributeRows } from "../../components/PgrExtendedAttributesView";
+import { buildExtendedAttributeRows, useExtendedAttributeOrder } from "../../components/PgrExtendedAttributesView";
 import { buildComplaintPath } from "../../utils/complaintHierarchyPath";
 import { selectServiceDefsFromComplaintHierarchy } from "../../utils";
 import useReopenWindow from "../../hooks/pgr/useReopenWindow";
@@ -181,6 +181,9 @@ const PGRDetails = () => {
 
   // Fetch complaint details
   const { isLoading, isError, error, data: pgrData, revalidate: pgrSearchRevalidate } = Digit.Hooks.pgr.usePGRSearch({ serviceRequestId: id }, tenantId);
+  // CCSD-2123: schema x-order for the Additional Details rows (complainantName
+  // pinned first inside buildExtendedAttributeRows regardless).
+  const extAttrOrder = useExtendedAttributeOrder(pgrData?.ServiceWrappers?.[0]?.service?.extendedAttributes);
 
   // Use the complaint's tenantId for workflow queries (complaints live at city level,
   // but getCurrentTenantId() may return root tenant for root-level ADMIN users)
@@ -622,11 +625,11 @@ const PGRDetails = () => {
               // Read-only "Additional Details" — fetch service.extendedAttributes
               // and show it as label:value rows; backend returns masked ("****")
               // values. Renders nothing when there are no extended attributes.
-              ...(buildExtendedAttributeRows(pgrData?.ServiceWrappers?.[0]?.service?.extendedAttributes, t).length > 0
+              ...(buildExtendedAttributeRows(pgrData?.ServiceWrappers?.[0]?.service?.extendedAttributes, t, extAttrOrder).length > 0
                 ? [{
                   cardType: "primary",
                   header: t("CS_COMPLAINT_DETAILS_ADDITIONAL_DETAILS"),
-                  fieldPairs: buildExtendedAttributeRows(pgrData?.ServiceWrappers?.[0]?.service?.extendedAttributes, t).map((r) => ({
+                  fieldPairs: buildExtendedAttributeRows(pgrData?.ServiceWrappers?.[0]?.service?.extendedAttributes, t, extAttrOrder).map((r) => ({
                     inline: true,
                     label: r.label,
                     type: "text",


### PR DESCRIPTION
## CCSD-2123 — Complainant Name shown after Witness Name

### Root cause
The details pages render `service.extendedAttributes` in raw `Object.keys()` order = **Postgres jsonb key order** (key length, then bytewise). `witnessName` (11 chars) always sorted ahead of `complainantName` (15), and the card ignored the `x-order` the create forms use (`instituteName` x-order 1 rendered third). Editing MDMS alone could not fix it — the view never read the schema, and `complainantName` isn't a schema field at all (free key via `additionalProperties`).

### Fix (per review discussion: reuse the order that's already in the schema JSON, don't hardcode a layout)
1. **`complainantName` pinned first in code** — the primary subject of the record; pinned in code because no `x-order` can ever cover a non-schema key.
2. **Schema fields follow the existing `x-order`** — resolved through the same masters the create form uses (`ComplaintTemplateType` → `schemaRef` → `ComplaintExtendedAttributeSchema`), via the existing `fieldsFromSchema` helper. **Zero MDMS changes on any environment.** Product reorders the card by editing the schema it already owns.
3. Unknown keys keep incoming order (stable sort); while masters load, the card gracefully shows jsonb order.

New `useExtendedAttributeOrder` hook next to `buildExtendedAttributeRows`; both details pages wired.

### Verified locally (fixture PRD-2026-000023; stored jsonb order was witness-first)
| page | rendered order |
|---|---|
| Citizen details | Complainant Name → Institute Name → Witness Name → Witness Address → Witness Note |
| Employee details | identical |

🤖 Generated with [Claude Code](https://claude.com/claude-code)