### PR TITLE
fix(analytics): repoint grain MVs to ComplaintHierarchy (#1494)

### DIFF
--- a/backend/pgr-services/src/main/resources/db/migration/main/V20260731000000__repoint_grain_mvs_to_complainthierarchy.sql
+++ b/backend/pgr-services/src/main/resources/db/migration/main/V20260731000000__repoint_grain_mvs_to_complainthierarchy.sql
@@ -12,7 +12,7 @@
 -- #917 runbook flagged as missing (operator-runbook.md, gotcha G8).
 --
 -- ONLY the two `mdms` CTEs change (one per MV). Everything else is
--- byte-identical to V20260717000000, which is already applied on live
+-- otherwise identical to V20260717000000, which is already applied on live
 -- deployments, hence this NEW migration (flyway migrations are append-only).
 --
 -- OPERATOR PRECONDITION — this is a query fix, not a data fix. It is correct
@@ -127,20 +127,23 @@ mdms AS (   -- #1494: ComplaintHierarchy LEAF rows (was RAINMAKER-PGR.ServiceDef
             -- department (the configurator writes 'NA' for a blank onboarding cell), and
             -- filtering on department would drop those complaint types out of the grain
             -- entirely rather than merely leaving department_code NULL.
-            -- 'NA' is normalised to NULL so it never reaches a dashboard as a label.
+            -- The "no department" sentinels are normalised to NULL so they never reach a
+            -- dashboard as a label. Match ServiceRequestValidator:185-186, which treats
+            -- NULL, blank/whitespace and any case of 'NA' as "no department constraint".
+            -- The surviving value keeps its ORIGINAL case: department codes are mixed-case
+            -- in practice (e.g. 'zambezia_csrep' alongside 'CENTER') and are compared
+            -- verbatim against the department master and the HRMS codes in RBAC scoping,
+            -- so folding case here would break both.
   SELECT DISTINCT ON (data->>'code')
          data->>'code' AS service_code,
-         NULLIF(coalesce(data->>'department', data->'departments'->>0), 'NA') AS department_code
+         CASE WHEN upper(btrim(coalesce(data->>'department', data->'departments'->>0))) IN ('NA','')
+              THEN NULL
+              ELSE btrim(coalesce(data->>'department', data->'departments'->>0))
+         END AS department_code
   FROM eg_mdms_data
   WHERE schemacode = 'RAINMAKER-PGR.ComplaintHierarchy' AND isactive
-    AND data->>'levelCode' IN (
-          SELECT DISTINCT lvl->>'levelCode'
-          FROM eg_mdms_data d
-          CROSS JOIN LATERAL jsonb_array_elements(d.data->'levels') lvl
-          WHERE d.schemacode = 'RAINMAKER-PGR.ComplaintHierarchyDefinition' AND d.isactive
-            AND (lvl->>'isLeafServiceCode')::boolean
-        )
-  ORDER BY data->>'code', length(tenantid)
+    AND data->>'levelCode' IN (SELECT level_code FROM chlvl)   -- WITH RECURSIVE: forward ref is legal
+  ORDER BY data->>'code', length(tenantid), tenantid
 ),
 chlvl AS (   -- #1079: levelCodes flagged isLeafServiceCode in ComplaintHierarchyDefinition
   SELECT DISTINCT lvl->>'levelCode' AS level_code
@@ -324,17 +327,14 @@ mdms AS (   -- #1494: ComplaintHierarchy LEAF rows (was RAINMAKER-PGR.ServiceDef
          (data->>'slaHours')::int        AS mdms_sla_hours,
          NULL::text                      AS legacy_service_group,   -- #1494: retired with menuPath
          (data->>'order')::smallint      AS service_order,
-         NULLIF(coalesce(data->>'department', data->'departments'->>0), 'NA') AS department_code
+         CASE WHEN upper(btrim(coalesce(data->>'department', data->'departments'->>0))) IN ('NA','')
+              THEN NULL
+              ELSE btrim(coalesce(data->>'department', data->'departments'->>0))
+         END AS department_code
   FROM eg_mdms_data
   WHERE schemacode = 'RAINMAKER-PGR.ComplaintHierarchy' AND isactive
-    AND data->>'levelCode' IN (
-          SELECT DISTINCT lvl->>'levelCode'
-          FROM eg_mdms_data d
-          CROSS JOIN LATERAL jsonb_array_elements(d.data->'levels') lvl
-          WHERE d.schemacode = 'RAINMAKER-PGR.ComplaintHierarchyDefinition' AND d.isactive
-            AND (lvl->>'isLeafServiceCode')::boolean
-        )
-  ORDER BY data->>'code', length(tenantid)
+    AND data->>'levelCode' IN (SELECT level_code FROM chlvl)   -- WITH RECURSIVE: forward ref is legal
+  ORDER BY data->>'code', length(tenantid), tenantid
 ),
 chlvl AS (   -- #1079: levelCodes flagged isLeafServiceCode in ComplaintHierarchyDefinition
   SELECT DISTINCT lvl->>'levelCode' AS level_code
@@ -505,3 +505,7 @@ CREATE INDEX ix_cf_status  ON complaint_facts(application_status);
 CREATE INDEX ix_cf_created ON complaint_facts(created_week_start);
 CREATE INDEX ix_cf_open    ON complaint_facts(is_open) WHERE is_open;
 CREATE INDEX ix_cf_ward    ON complaint_facts(ward_code);
+-- #1494: department is an RBAC scope axis — applyScope adds `department_code IN (...)`
+-- to EVERY facts query for a department-scoped principal, and it is a grouping
+-- dimension for the department tiles. The events grain already has ix_ce_dept.
+CREATE INDEX ix_cf_dept    ON complaint_facts(department_code);

--- a/backend/pgr-services/src/main/resources/db/migration/main/V20260731000000__repoint_grain_mvs_to_complainthierarchy.sql
+++ b/backend/pgr-services/src/main/resources/db/migration/main/V20260731000000__repoint_grain_mvs_to_complainthierarchy.sql
@@ -1,0 +1,507 @@
+-- ============================================================================
+-- #1494: repoint the V2 grain MVs from the retired RAINMAKER-PGR.ServiceDefs
+-- master to RAINMAKER-PGR.ComplaintHierarchy.
+--
+-- #917 moved the complaint taxonomy to ComplaintHierarchy and retired
+-- ServiceDefs, but the grain MVs kept joining the old master for
+-- department_code, slaHours and service_group. A repoint WAS attempted on that
+-- branch — it edited V20260608000000 in place (already applied, so a no-op on
+-- live environments) and, on a fresh 0->1 replay, was immediately overwritten
+-- by V20260609000000, which restated the same CTE from ServiceDefs. Every
+-- later migration copied that shape forward. This is the forward migration the
+-- #917 runbook flagged as missing (operator-runbook.md, gotcha G8).
+--
+-- ONLY the two `mdms` CTEs change (one per MV). Everything else is
+-- byte-identical to V20260717000000, which is already applied on live
+-- deployments, hence this NEW migration (flyway migrations are append-only).
+--
+-- OPERATOR PRECONDITION — this is a query fix, not a data fix. It is correct
+-- only where the #917 data migration has actually run for the tenant AND its
+-- hierarchy leaves carry real departments. A tenant onboarded from a sheet with
+-- a blank Department column has department 'NA' on every leaf and will show no
+-- department breakdown after this lands. Run the preflight in
+-- docs/migration/tenant-department-migration-guide.md BEFORE deploying, and
+-- note that retiring ServiceDefs (#1496) is only safe after this migration.
+--
+-- Original V20260717000000 header follows.
+-- ----------------------------------------------------------------------------
+-- #1111 R5 widening (found in the bomet integration deploy): ALSO NULL
+-- complaint_node_path when the matched hierarchy node's parentCode contains '.'.
+--
+-- V20260716000000 NULLed the path only when the node's OWN code contains '.'
+-- (legacy flat imports whose single-node code IS a dotted 'complaints.
+-- categories.*' string). Bomet data showed a second pollution shape that
+-- heuristic misses: nodes whose code is CLEAN but whose stored parentCode /
+-- path still carries the legacy pollution — e.g. node 'DamagedRoad' with path
+-- 'complaints.categories.DamagedRoad.DamagedRoad' (depth 4). Splitting those
+-- paths on '.' survives R5 and still fabricates a garbage 'complaints' level-1
+-- bucket (30 live fact rows on bomet at authoring time).
+--
+-- Fix: the cnp CTE now emits NULL complaint_node_path when a dotted code OR
+-- parentCode appears ANYWHERE in the matched node's ancestor chain (the chwalk
+-- rows; the node itself is depth 1, so this contains the node+parent check —
+-- a clean leaf under `legacy.dotted -> CleanParent -> CleanLeaf` is caught
+-- too, review finding on #1282); those rows take the
+-- SAME leaf fallback the query-time level expression already has for
+-- flat/legacy tenants (coalesce(nullif(split_part(...)),''), service_code) —
+-- i.e. they roll up as themselves instead of polluting level buckets.
+-- complaint_depth and the path-derived service_group/service_parent_code
+-- follow (service_group is hierarchy-derived only as of #1494; the legacy
+-- ServiceDefs.menuPath fallback is retired).
+-- Everything else is byte-identical to V20260716000000, which is already
+-- applied on live deployments, hence this NEW migration with the widened
+-- predicate (flyway migrations are append-only).
+--
+-- NOTE: this supersedes the events/facts definitions in V20260716000000 (which
+-- superseded V20260708000000, V20260629000000, V20260608000000 in turn).
+-- Recreate BOTH MVs in any future shape change — the originals cannot be
+-- edited without breaking deployed checksums.
+-- ============================================================================
+
+
+-- ---- grain 1: complaint_events ----------------------------------------------
+DROP MATERIALIZED VIEW IF EXISTS complaint_events CASCADE;
+CREATE MATERIALIZED VIEW complaint_events AS
+WITH RECURSIVE svc AS (
+  SELECT s.servicerequestid, s.id AS pgr_id, s.tenantid, s.servicecode, s.accountid,
+         s.source, s.createdtime AS complaint_created_at, s.createdby AS filed_by_uuid,
+         a.locality AS locality_code, a.latitude, a.longitude,
+         (a.latitude IS NOT NULL AND a.longitude IS NOT NULL) AS has_geo_pin
+  FROM eg_pgr_service_v2 s
+  LEFT JOIN eg_pgr_address_v2 a ON a.parentid = s.id
+),
+bnd0 AS (   -- one row per boundary code: full root->leaf path + the node's own (leaf) type,
+            -- tenant and hierarchy; longest ancestral path wins (as before)
+  SELECT DISTINCT ON (code) code, tenantid, hierarchytype,
+         boundarytype AS leaf_type,
+         (ancestralmaterializedpath || '|' || code) AS boundary_path
+  FROM boundary_relationship
+  ORDER BY code, length(ancestralmaterializedpath) DESC
+),
+btype AS (  -- per-node level type (same dedupe rule), to type every path segment
+  SELECT DISTINCT ON (code) code, boundarytype
+  FROM boundary_relationship
+  ORDER BY code, length(ancestralmaterializedpath) DESC
+),
+wardlvl AS (   -- #1079: the tenant's 'Ward' level and the level directly above it,
+               -- from the boundary_hierarchy level registry
+  SELECT DISTINCT ON (h.tenantid, h.hierarchytype) h.tenantid, h.hierarchytype,
+         lvl->>'boundaryType'       AS ward_type,
+         lvl->>'parentBoundaryType' AS zone_type
+  FROM boundary_hierarchy h
+  CROSS JOIN LATERAL jsonb_array_elements(h.boundaryhierarchy) lvl
+  WHERE lower(lvl->>'boundaryType') = 'ward'
+),
+bnd AS (   -- #1079: registry-resolved named levels per boundary code.
+           -- FALLBACK (no Ward level in the tenant's hierarchy): leaf / parent-of-leaf.
+  SELECT b.code, b.boundary_path,
+         b.code      AS boundary_leaf_code,
+         b.leaf_type AS boundary_leaf_type,
+         CASE WHEN w.ward_type IS NOT NULL THEN seg.ward_seg
+              ELSE segs.arr[array_length(segs.arr,1)] END     AS ward_code,
+         CASE WHEN w.ward_type IS NOT NULL THEN seg.zone_seg
+              ELSE segs.arr[array_length(segs.arr,1)-1] END   AS zone_code
+  FROM bnd0 b
+  LEFT JOIN wardlvl w ON w.tenantid = b.tenantid AND w.hierarchytype = b.hierarchytype
+  CROSS JOIN LATERAL (SELECT string_to_array(b.boundary_path,'|') AS arr) segs
+  LEFT JOIN LATERAL (
+    SELECT max(s.seg) FILTER (WHERE lower(bt.boundarytype) = lower(w.ward_type)) AS ward_seg,
+           max(s.seg) FILTER (WHERE lower(bt.boundarytype) = lower(w.zone_type)) AS zone_seg
+    FROM unnest(segs.arr) s(seg)
+    LEFT JOIN btype bt ON bt.code = s.seg
+  ) seg ON true
+),
+bs AS (
+  SELECT DISTINCT ON (tenantid, businessservice) tenantid, businessservice, businessservicesla
+  FROM eg_wf_businessservice_v2
+),
+asg AS (
+  SELECT processinstanceid, count(*) AS assignee_count,
+         (array_agg(assignee ORDER BY assignee))[1] AS assignee_uuid
+  FROM eg_wf_assignee_v2 GROUP BY processinstanceid
+),
+mdms AS (   -- #1494: ComplaintHierarchy LEAF rows (was RAINMAKER-PGR.ServiceDefs).
+            -- Dedupe by code preferring the root (shortest) tenant, as before.
+            -- Leaf detection is by levelCode against the registry's isLeafServiceCode
+            -- level, NOT by "department IS NOT NULL" — a leaf may legitimately carry no
+            -- department (the configurator writes 'NA' for a blank onboarding cell), and
+            -- filtering on department would drop those complaint types out of the grain
+            -- entirely rather than merely leaving department_code NULL.
+            -- 'NA' is normalised to NULL so it never reaches a dashboard as a label.
+  SELECT DISTINCT ON (data->>'code')
+         data->>'code' AS service_code,
+         NULLIF(coalesce(data->>'department', data->'departments'->>0), 'NA') AS department_code
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.ComplaintHierarchy' AND isactive
+    AND data->>'levelCode' IN (
+          SELECT DISTINCT lvl->>'levelCode'
+          FROM eg_mdms_data d
+          CROSS JOIN LATERAL jsonb_array_elements(d.data->'levels') lvl
+          WHERE d.schemacode = 'RAINMAKER-PGR.ComplaintHierarchyDefinition' AND d.isactive
+            AND (lvl->>'isLeafServiceCode')::boolean
+        )
+  ORDER BY data->>'code', length(tenantid)
+),
+chlvl AS (   -- #1079: levelCodes flagged isLeafServiceCode in ComplaintHierarchyDefinition
+  SELECT DISTINCT lvl->>'levelCode' AS level_code
+  FROM eg_mdms_data d
+  CROSS JOIN LATERAL jsonb_array_elements(d.data->'levels') lvl
+  WHERE d.schemacode = 'RAINMAKER-PGR.ComplaintHierarchyDefinition' AND d.isactive
+    AND (lvl->>'isLeafServiceCode')::boolean
+),
+ch AS (   -- ComplaintHierarchy nodes; dedupe by code preferring leaf-level records
+          -- (registry leaf detection), then the root (shortest) tenant
+  SELECT DISTINCT ON (data->>'code')
+         data->>'code'                  AS code,
+         NULLIF(data->>'path','')       AS node_path,
+         NULLIF(data->>'parentCode','') AS parent_code
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.ComplaintHierarchy' AND isactive
+  ORDER BY data->>'code',
+           (data->>'levelCode' IN (SELECT level_code FROM chlvl)) DESC,
+           length(tenantid)
+),
+chwalk AS (   -- recursive parentCode walk (robust fallback when path is absent)
+  SELECT code AS leaf_code, code, parent_code, code::text AS built_path, 1 AS depth
+  FROM ch
+  UNION ALL
+  SELECT w.leaf_code, p.code, p.parent_code, (p.code || '.' || w.built_path), w.depth + 1
+  FROM chwalk w
+  JOIN ch p ON p.code = w.parent_code
+  WHERE w.depth < 12
+),
+cnp AS (   -- #1079: complaint_node_path per code = master path, else recursive build.
+           -- #1111/R5: NULL when the matched node's OWN code contains '.' — legacy flat
+           -- imports carry dots INSIDE one code, so any '.'-split of their path would
+           -- fabricate garbage level buckets; NULL path => the query-time level expr
+           -- falls back to the leaf service_code instead.
+           -- R5 widening: ALSO NULL when a dotted code/parentCode appears ANYWHERE in the
+           -- node's ancestor chain (chwalk carries the node itself at depth 1, so this
+           -- strictly contains the old node+parent predicate) — clean-code nodes anywhere
+           -- under a dotted legacy code inherit a polluted path/built_path and would
+           -- otherwise survive as the same garbage buckets.
+  SELECT ch.code,
+         CASE WHEN EXISTS (
+                SELECT 1 FROM chwalk w
+                WHERE w.leaf_code = ch.code
+                  AND (position('.' IN w.code) > 0
+                       OR position('.' IN coalesce(w.parent_code, '')) > 0)
+              ) THEN NULL
+              ELSE coalesce(ch.node_path, walk.built_path) END AS complaint_node_path
+  FROM ch
+  LEFT JOIN LATERAL (
+    SELECT w.built_path FROM chwalk w WHERE w.leaf_code = ch.code
+    ORDER BY w.depth DESC LIMIT 1
+  ) walk ON true
+),
+tx AS (
+  SELECT pi.id AS event_id, pi.businessid AS service_request_id, pi.tenantid,
+         pi.businessservice, pi.action, pi.assigner AS actor_uuid,
+         pi.escalated, pi.rating AS event_rating, pi.comment,
+         pi.createdtime AS entered_at,
+         st.state AS status, st.seq AS status_seq, st.sla AS state_sla_ms,
+         st.isterminatestate AS status_is_terminal,
+         lead(pi.createdtime) OVER w AS exited_at,
+         lag(st.state)        OVER w AS previous_status,
+         lag(st.seq)          OVER w AS previous_status_seq,
+         row_number()         OVER w AS seq_no,
+         (lead(pi.id) OVER w IS NULL) AS is_current_state
+  FROM eg_wf_processinstance_v2 pi
+  LEFT JOIN eg_wf_state_v2 st ON st.uuid = pi.status
+  WINDOW w AS (PARTITION BY pi.businessid ORDER BY pi.createdtime, pi.id)
+)
+SELECT
+  tx.event_id, tx.service_request_id, tx.tenantid AS tenant_id,
+  tx.businessservice AS business_service, tx.seq_no, tx.is_current_state,
+  tx.action, tx.status, tx.previous_status,
+  coalesce(tx.status_is_terminal,false)        AS status_is_terminal,
+  (NOT coalesce(tx.status_is_terminal,false))  AS status_is_open,
+  tx.actor_uuid, asg.assignee_uuid,
+  (ua.type = 'SYSTEM')                         AS actor_is_system,
+  tx.entered_at, tx.exited_at,
+  (tx.exited_at - tx.entered_at)               AS dwell_ms,
+  tx.status_seq, tx.previous_status_seq,
+  (tx.status_seq - tx.previous_status_seq)     AS seq_delta,
+  (tx.status_seq < tx.previous_status_seq)     AS is_backward_transition,
+  tx.state_sla_ms,
+  CASE WHEN tx.state_sla_ms IS NOT NULL AND tx.exited_at IS NOT NULL
+       THEN (tx.exited_at - tx.entered_at) > tx.state_sla_ms END AS state_sla_breached_on_exit,
+  bs.businessservicesla                        AS business_sla_ms,
+  (tx.action IN ('ASSIGN','REASSIGN'))         AS is_assignment,
+  (tx.action = 'REOPEN')                       AS is_reopen,
+  coalesce(tx.escalated,false)                 AS is_escalation,
+  CASE WHEN coalesce(tx.escalated,false)
+       THEN (CASE WHEN ua.type='SYSTEM' THEN 'auto' ELSE 'manual' END) END AS escalation_source,
+  (tx.comment IS NOT NULL AND tx.comment <> '') AS has_comment,
+  length(tx.comment)                           AS comment_length,
+  tx.event_rating,
+  coalesce(asg.assignee_count,0)               AS assignee_count,
+  (coalesce(asg.assignee_count,0) > 1)         AS has_multiple_assignees,
+  svc.accountid AS account_id, svc.source, svc.servicecode AS service_code,
+  m.department_code,                                                      -- S2: department row-scope axis
+  cnp.complaint_node_path,                                                -- #1079: complaint taxonomy axis
+  array_length(string_to_array(cnp.complaint_node_path,'.'),1)::smallint AS complaint_depth,
+  svc.locality_code, svc.has_geo_pin,
+  svc.complaint_created_at,
+  (tx.entered_at - svc.complaint_created_at)   AS complaint_age_at_event_ms,
+  bnd.boundary_path,
+  bnd.zone_code,                               -- #1079: registry-resolved (was split_part pos 2)
+  bnd.ward_code,                               -- #1079: registry-resolved (was split_part pos 3)
+  bnd.boundary_leaf_code,                      -- #1079: leaf node, depth-agnostic
+  bnd.boundary_leaf_type,
+  (to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3')::date AS occurred_date,
+  date_trunc('week',(to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3'))::date AS occurred_week_start,
+  to_char((to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3'),'YYYY-MM') AS occurred_month,
+  extract(hour   FROM (to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3'))::smallint AS occurred_hour,
+  extract(isodow FROM (to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3'))::smallint AS occurred_dow,
+  (extract(isodow FROM (to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3')) IN (6,7)) AS occurred_is_weekend,
+  (extract(hour  FROM (to_timestamp(tx.entered_at/1000) AT TIME ZONE 'Etc/GMT-3')) BETWEEN 8 AND 17) AS occurred_is_business_hr
+FROM tx
+LEFT JOIN svc ON svc.servicerequestid = tx.service_request_id
+LEFT JOIN bnd ON bnd.code = svc.locality_code
+LEFT JOIN cnp ON cnp.code = svc.servicecode
+LEFT JOIN LATERAL (                          -- #1028 fix 3: exact tenant, else state root
+  SELECT b.businessservicesla
+  FROM bs b
+  WHERE b.businessservice = tx.businessservice
+    AND b.tenantid IN (tx.tenantid, split_part(tx.tenantid,'.',1))
+  ORDER BY length(b.tenantid) DESC
+  LIMIT 1
+) bs ON true
+LEFT JOIN asg ON asg.processinstanceid = tx.event_id
+LEFT JOIN mdms m ON m.service_code = svc.servicecode
+LEFT JOIN eg_user ua ON ua.uuid = tx.actor_uuid;
+
+CREATE UNIQUE INDEX ux_complaint_events ON complaint_events(event_id);
+CREATE INDEX ix_ce_timeline ON complaint_events(service_request_id, seq_no);
+CREATE INDEX ix_ce_status   ON complaint_events(status);
+CREATE INDEX ix_ce_assignee ON complaint_events(assignee_uuid);
+CREATE INDEX ix_ce_week     ON complaint_events(occurred_week_start);
+CREATE INDEX ix_ce_dept     ON complaint_events(department_code);
+
+-- ---- grain 2: complaint_facts (CASCADE dropped by the events recreate) ------
+DROP MATERIALIZED VIEW IF EXISTS complaint_facts CASCADE;
+CREATE MATERIALIZED VIEW complaint_facts AS
+WITH RECURSIVE clock AS (SELECT (extract(epoch FROM now())*1000)::bigint AS now_ms),
+roll AS (
+  SELECT service_request_id,
+         min(entered_at)                                            AS created_at,
+         max(entered_at)                                            AS last_transition_at,
+         count(*)                                                   AS transition_count,
+         count(*) FILTER (WHERE is_assignment)                      AS assignment_count,
+         count(*) FILTER (WHERE is_escalation)                      AS escalation_count,
+         count(*) FILTER (WHERE is_reopen)                          AS reopen_count,
+         count(DISTINCT assignee_uuid)                              AS distinct_assignee_count,
+         count(DISTINCT actor_uuid)                                 AS distinct_actor_count,
+         count(*) FILTER (WHERE actor_is_system)                    AS system_transition_count,
+         count(*) FILTER (WHERE NOT actor_is_system)                AS manual_transition_count,
+         bool_or(status IN ('REJECTED','CLOSEDAFTERREJECTION'))     AS was_rejected,
+         min(entered_at) FILTER (WHERE is_assignment)               AS first_assigned_at,
+         min(entered_at) FILTER (WHERE status IN ('RESOLVED','CLOSEDAFTERRESOLUTION')) AS resolved_at,
+         max(entered_at) FILTER (WHERE is_escalation)               AS last_escalated_at,
+         min(entered_at) FILTER (WHERE is_escalation)               AS first_escalated_at,
+         max(dwell_ms)                                              AS max_dwell_ms,
+         sum(dwell_ms) FILTER (WHERE assignee_uuid IS NOT NULL)     AS assigned_dwell_ms,
+         sum(dwell_ms) FILTER (WHERE assignee_uuid IS NULL)         AS unassigned_dwell_ms
+  FROM complaint_events GROUP BY service_request_id
+),
+cur AS (
+  SELECT service_request_id, status AS application_status, status_seq AS current_state_seq,
+         status_is_open AS is_open, assignee_uuid AS current_assignee_uuid,
+         state_sla_ms AS current_state_sla_ms, business_sla_ms,
+         boundary_path, ward_code, zone_code,
+         boundary_leaf_code, boundary_leaf_type                     -- #1079
+  FROM complaint_events WHERE is_current_state
+),
+mdms AS (   -- #1494: ComplaintHierarchy LEAF rows (was RAINMAKER-PGR.ServiceDefs).
+            -- See the matching CTE in complaint_events above for the leaf-detection and
+            -- 'NA' rationale. legacy_service_group was ServiceDefs.menuPath, which the
+            -- #917 migration consumed and did NOT carry onto the new master — grouping is
+            -- parentCode-driven now, so the fallback is retired to NULL and service_group
+            -- resolves from the hierarchy path alone (see the coalesce below).
+  SELECT DISTINCT ON (data->>'code')
+         data->>'code'                   AS service_code,
+         (data->>'slaHours')::int        AS mdms_sla_hours,
+         NULL::text                      AS legacy_service_group,   -- #1494: retired with menuPath
+         (data->>'order')::smallint      AS service_order,
+         NULLIF(coalesce(data->>'department', data->'departments'->>0), 'NA') AS department_code
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.ComplaintHierarchy' AND isactive
+    AND data->>'levelCode' IN (
+          SELECT DISTINCT lvl->>'levelCode'
+          FROM eg_mdms_data d
+          CROSS JOIN LATERAL jsonb_array_elements(d.data->'levels') lvl
+          WHERE d.schemacode = 'RAINMAKER-PGR.ComplaintHierarchyDefinition' AND d.isactive
+            AND (lvl->>'isLeafServiceCode')::boolean
+        )
+  ORDER BY data->>'code', length(tenantid)
+),
+chlvl AS (   -- #1079: levelCodes flagged isLeafServiceCode in ComplaintHierarchyDefinition
+  SELECT DISTINCT lvl->>'levelCode' AS level_code
+  FROM eg_mdms_data d
+  CROSS JOIN LATERAL jsonb_array_elements(d.data->'levels') lvl
+  WHERE d.schemacode = 'RAINMAKER-PGR.ComplaintHierarchyDefinition' AND d.isactive
+    AND (lvl->>'isLeafServiceCode')::boolean
+),
+ch AS (   -- ComplaintHierarchy nodes; dedupe by code preferring leaf-level records
+          -- (registry leaf detection), then the root (shortest) tenant
+  SELECT DISTINCT ON (data->>'code')
+         data->>'code'                  AS code,
+         NULLIF(data->>'path','')       AS node_path,
+         NULLIF(data->>'parentCode','') AS parent_code
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.ComplaintHierarchy' AND isactive
+  ORDER BY data->>'code',
+           (data->>'levelCode' IN (SELECT level_code FROM chlvl)) DESC,
+           length(tenantid)
+),
+chwalk AS (   -- recursive parentCode walk (robust fallback when path is absent)
+  SELECT code AS leaf_code, code, parent_code, code::text AS built_path, 1 AS depth
+  FROM ch
+  UNION ALL
+  SELECT w.leaf_code, p.code, p.parent_code, (p.code || '.' || w.built_path), w.depth + 1
+  FROM chwalk w
+  JOIN ch p ON p.code = w.parent_code
+  WHERE w.depth < 12
+),
+cnp AS (   -- #1079: complaint_node_path per code = master path, else recursive build.
+           -- #1111/R5: NULL when the matched node's OWN code contains '.' — legacy flat
+           -- imports carry dots INSIDE one code, so any '.'-split of their path would
+           -- fabricate garbage level buckets; NULL path => the query-time level expr
+           -- falls back to the leaf service_code instead.
+           -- R5 widening: ALSO NULL when a dotted code/parentCode appears ANYWHERE in the
+           -- node's ancestor chain (chwalk carries the node itself at depth 1, so this
+           -- strictly contains the old node+parent predicate) — clean-code nodes anywhere
+           -- under a dotted legacy code inherit a polluted path/built_path and would
+           -- otherwise survive as the same garbage buckets.
+  SELECT ch.code,
+         CASE WHEN EXISTS (
+                SELECT 1 FROM chwalk w
+                WHERE w.leaf_code = ch.code
+                  AND (position('.' IN w.code) > 0
+                       OR position('.' IN coalesce(w.parent_code, '')) > 0)
+              ) THEN NULL
+              ELSE coalesce(ch.node_path, walk.built_path) END AS complaint_node_path
+  FROM ch
+  LEFT JOIN LATERAL (
+    SELECT w.built_path FROM chwalk w WHERE w.leaf_code = ch.code
+    ORDER BY w.depth DESC LIMIT 1
+  ) walk ON true
+),
+esc AS (   -- #1028 fix 2: EscalationConfig ladder source (one record per tenant, at state root)
+  SELECT tenantid,
+         data->'overrides'         AS overrides,
+         data->'defaultSlaByLevel' AS default_levels
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.EscalationConfig' AND isactive
+),
+seq AS (
+  SELECT id, row_number() OVER (PARTITION BY accountid ORDER BY createdtime, id) AS complaint_seq_for_citizen
+  FROM eg_pgr_service_v2
+)
+SELECT
+  s.servicerequestid AS service_request_id, s.id AS pgr_id, s.tenantid AS tenant_id,
+  s.accountid AS account_id, 'PGR'::text AS business_service,
+  s.servicecode AS service_code, cur.application_status, s.source, s.rating AS rating_raw, s.active,
+  length(s.description) AS description_length,
+  (s.description IS NOT NULL AND s.description <> '') AS has_description,
+  s.createdby AS filed_by_uuid, (s.createdby <> s.accountid) AS filed_on_behalf,
+  a.locality AS locality_code, a.pincode, a.city, a.latitude, a.longitude,
+  (a.latitude IS NOT NULL AND a.longitude IS NOT NULL) AS has_geo_pin,
+  (a.parentid IS NOT NULL) AS has_address,
+  cur.boundary_path,
+  (length(coalesce(cur.boundary_path,'')) - length(replace(coalesce(cur.boundary_path,''),'|','')) + 1)::smallint AS boundary_depth,
+  cur.ward_code, cur.zone_code,
+  cur.boundary_leaf_code, cur.boundary_leaf_type,                          -- #1079
+  cnp.complaint_node_path,                                                 -- #1079
+  cx.complaint_depth,                                                      -- #1079
+  coalesce(cx.root_code, m.legacy_service_group) AS service_group,         -- #1079: ROOT category
+  cx.service_parent_code,                                                  -- #1079: immediate parent
+  m.service_order, m.mdms_sla_hours, m.department_code,
+  cur.current_state_seq, cur.current_state_sla_ms, tgt.sla_target_ms,      -- #1028: COALESCE'd target
+  (m.mdms_sla_hours IS NOT NULL AND cur.business_sla_ms IS NOT NULL
+    AND m.mdms_sla_hours::bigint*3600000 <> cur.business_sla_ms) AS sla_config_mismatch,
+  roll.created_at, roll.first_assigned_at, roll.first_assigned_at AS first_response_at,
+  roll.resolved_at, roll.last_transition_at, roll.first_escalated_at, roll.last_escalated_at,
+  roll.transition_count, roll.assignment_count, roll.escalation_count, roll.reopen_count,
+  roll.distinct_assignee_count, roll.distinct_actor_count,
+  roll.system_transition_count, roll.manual_transition_count,
+  roll.was_rejected, (roll.reopen_count > 0) AS is_reopened,
+  cur.is_open, (roll.resolved_at IS NOT NULL) AS is_resolved,
+  roll.max_dwell_ms, roll.assigned_dwell_ms, roll.unassigned_dwell_ms,
+  cur.current_assignee_uuid,
+  (roll.resolved_at - roll.created_at)                            AS resolution_ms,
+  (roll.first_assigned_at - roll.created_at)                      AS time_to_assign_ms,
+  CASE WHEN cur.is_open THEN clock.now_ms - roll.created_at END   AS open_age_ms,
+  CASE WHEN cur.is_open THEN clock.now_ms - roll.last_transition_at END AS current_state_age_ms,
+  (roll.first_escalated_at - roll.created_at)                     AS first_escalation_ms,
+  CASE WHEN cur.is_open  THEN (tgt.sla_target_ms IS NOT NULL AND (clock.now_ms - roll.created_at) > tgt.sla_target_ms)
+       WHEN roll.resolved_at IS NOT NULL THEN (tgt.sla_target_ms IS NOT NULL AND (roll.resolved_at - roll.created_at) > tgt.sla_target_ms)
+       ELSE false END                                            AS sla_breached,
+  (cur.is_open AND cur.current_state_sla_ms IS NOT NULL
+    AND (clock.now_ms - roll.last_transition_at) > cur.current_state_sla_ms) AS current_state_sla_breached,
+  CASE WHEN NOT cur.is_open THEN NULL
+       WHEN (clock.now_ms - roll.created_at) < 86400000  THEN '<1d'
+       WHEN (clock.now_ms - roll.created_at) < 259200000 THEN '1-3d'
+       WHEN (clock.now_ms - roll.created_at) < 604800000 THEN '3-7d'
+       ELSE '>7d' END                                            AS aging_bucket,
+  CASE WHEN NOT cur.is_open OR tgt.sla_target_ms IS NULL THEN NULL
+       WHEN (clock.now_ms - roll.created_at) > tgt.sla_target_ms       THEN 'breached'
+       WHEN (clock.now_ms - roll.created_at) > 0.8*tgt.sla_target_ms   THEN 'approaching'
+       ELSE 'within' END                                         AS sla_status_bucket,
+  (s.rating IS NOT NULL) AS has_rating, s.rating, (s.rating IS NOT NULL AND s.rating <= 2) AS is_negative_rating,
+  seq.complaint_seq_for_citizen, (seq.complaint_seq_for_citizen = 1) AS is_first_time_complainant,
+  (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3')::date AS created_date,
+  date_trunc('week',(to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'))::date AS created_week_start,
+  to_char((to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'),'YYYY-MM') AS created_month,
+  extract(year FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'))::smallint AS created_year,
+  to_char((to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'),'YYYY-"Q"Q') AS created_quarter,
+  extract(hour FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'))::smallint AS created_hour,
+  extract(isodow FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3'))::smallint AS created_dow,
+  (extract(isodow FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3')) IN (6,7)) AS created_is_weekend,
+  (extract(hour FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE 'Etc/GMT-3')) BETWEEN 8 AND 17) AS created_is_business_hr,
+  (to_timestamp(roll.resolved_at/1000) AT TIME ZONE 'Etc/GMT-3')::date AS resolved_date,
+  to_char((to_timestamp(roll.resolved_at/1000) AT TIME ZONE 'Etc/GMT-3'),'YYYY-MM') AS resolved_month,
+  clock.now_ms AS facts_built_at
+FROM eg_pgr_service_v2 s
+CROSS JOIN clock
+LEFT JOIN eg_pgr_address_v2 a ON a.parentid = s.id
+LEFT JOIN roll ON roll.service_request_id = s.servicerequestid
+LEFT JOIN cur  ON cur.service_request_id  = s.servicerequestid
+LEFT JOIN mdms m ON m.service_code = s.servicecode
+LEFT JOIN cnp ON cnp.code = s.servicecode
+CROSS JOIN LATERAL (                         -- #1079: path-derived complaint-axis fields
+  SELECT x.arr[1]                            AS root_code,
+         array_length(x.arr,1)::smallint     AS complaint_depth,
+         x.arr[array_length(x.arr,1)-1]      AS service_parent_code
+  FROM (SELECT string_to_array(cnp.complaint_node_path,'.') AS arr) x
+) cx
+LEFT JOIN LATERAL (                          -- #1028 fix 2: ladder total for this complaint's
+  SELECT CASE                                -- service code, from the nearest EscalationConfig
+           WHEN jsonb_typeof(e.overrides -> s.servicecode) = 'array'   -- (exact tenant, else state root)
+             THEN (SELECT sum(v.value::numeric)::bigint
+                   FROM jsonb_array_elements_text(e.overrides -> s.servicecode) v)
+           WHEN jsonb_typeof(e.default_levels) = 'array'
+             THEN (SELECT sum(v.value::numeric)::bigint
+                   FROM jsonb_array_elements_text(e.default_levels) v)
+         END AS ladder_sla_ms
+  FROM esc e
+  WHERE e.tenantid IN (s.tenantid, split_part(s.tenantid,'.',1))
+  ORDER BY length(e.tenantid) DESC
+  LIMIT 1
+) lad ON true
+CROSS JOIN LATERAL (                         -- #1028: the decided SLA-target precedence
+  SELECT coalesce(m.mdms_sla_hours::bigint * 3600000,   -- 1) ComplaintHierarchy leaf slaHours
+                  lad.ladder_sla_ms,                    -- 2) escalation-ladder total
+                  cur.business_sla_ms                   -- 3) workflow SLA (state-root fallback)
+         ) AS sla_target_ms
+) tgt
+LEFT JOIN seq ON seq.id = s.id
+WHERE s.active = true;
+
+CREATE UNIQUE INDEX ux_complaint_facts ON complaint_facts(service_request_id);
+CREATE INDEX ix_cf_service ON complaint_facts(service_code);
+CREATE INDEX ix_cf_status  ON complaint_facts(application_status);
+CREATE INDEX ix_cf_created ON complaint_facts(created_week_start);
+CREATE INDEX ix_cf_open    ON complaint_facts(is_open) WHERE is_open;
+CREATE INDEX ix_cf_ward    ON complaint_facts(ward_code);

--- a/docs/migration/operator-runbook.md
+++ b/docs/migration/operator-runbook.md
@@ -76,6 +76,10 @@ docker exec docker-postgres psql -U egov -d egov -tAc \
 # proven result: ke=249 (76 cat + 173 leaf), ke.ige=138 (45 cat + 93 leaf)
 ```
 
+> **Row count alone is not enough (G10).** A tenant can land the full count with `department: "NA"` on
+> every leaf and show no department breakdown on any dashboard. Also run Check 2 in
+> [tenant-department-migration-guide.md](./tenant-department-migration-guide.md).
+
 ---
 
 ## 3. CUTOVER deploy (lockstep — only after every used tenant is migrated)
@@ -121,9 +125,23 @@ At tenant **ke.ige** (hard-refresh the browser first):
 3. Resolve → RESOLVED.
 4. A pre-migration complaint still opens (serviceCode preserved).
 
-## 5. Retire old masters — LAST, only after step 4 passes
+### 4.5 Verify ANALYTICS — the check steps 1-4 cannot make (#1494)
+Steps 1-4 all exercise the complaint flow, which fails loudly. Analytics fails silently: tiles keep
+rendering with blank departments. This step is what would have caught G8.
+1. Deploy `V20260731000000__repoint_grain_mvs_to_complainthierarchy.sql` (repoints the grain MVs off
+   `ServiceDefs`). Grains rebuild on the scheduler, default 5 min.
+2. Run Checks 1 and 2 in [tenant-department-migration-guide.md](./tenant-department-migration-guide.md)
+   — every in-use complaint type has a hierarchy node, AND leaves carry real departments (not `NA`).
+3. Open a department-grouped dashboard tile ("Complaints by departments") and confirm real department
+   names, not blanks. A tenant whose leaves are all `NA` needs a back-fill — see the guide.
+
+## 5. Retire old masters — LAST, only after steps 4 AND 4.5 pass
 Deactivate/delete `RAINMAKER-PGR.ServiceDefs` / `ClassificationNode` / `ComplaintTypeDepartments`.
 **Keep them until step 4 passes** — together with your snapshot they are the rollback path.
+
+> **Do not retire `ServiceDefs` before the #1494 repoint is deployed.** Until then the grain MVs still
+> join it, and on a properly-migrated tenant it supplies a large share of the working `department_code`
+> values — deleting it first blanks every department tile. Repoint, verify (4.5), then retire.
 
 ## 6. Rollback
 ```bash
@@ -160,9 +178,19 @@ docker exec -i docker-postgres pg_restore -U egov -d egov --clean --if-exists < 
 - **(G6) deploy is data-safe but re-seeds DDH.** No `down -v` (volumes kept; full-dump only loads into an
   empty DB), so data survives — but DDH re-seed can revert the x-ref fix → re-apply (step 3c).
 - **(G7) No fallback.** Migrate every used tenant before the backend cutover, or those tenants hard-fail.
-- **(G8) V2 grain-MV gap.** The analytics materialized-view forward Flyway migration was not authored on the
-  branch (still reads `ServiceDefs`/`menuPath`) — does not block the complaint flow, but dashboards using the
-  grain MV are stale until a `repoint_grain_mvs_to_complainthierarchy` migration is added.
+- **(G8) V2 grain-MV gap — CLOSED by `V20260731000000__repoint_grain_mvs_to_complainthierarchy.sql` (#1494).**
+  The analytics MVs kept reading `ServiceDefs`/`menuPath` after the cutover. A repoint was attempted on the
+  #917 branch but edited an already-applied migration, so it was a no-op live and was overwritten by the next
+  migration on a fresh replay. It does not block the complaint flow, which is why it survived step 4 — see G9.
+  Deploying the repoint is now a **prerequisite for step 5**, not optional cleanup.
+- **(G9) Step 4 only proves the complaint flow.** Every check in step 4 is a create/assign/resolve check, and
+  all of them pass while dashboards are silently wrong. Analytics fails *quietly* — tiles keep rendering, just
+  with blank or missing departments. Verify a department-grouped tile explicitly (step 4.5); do not infer
+  analytics health from a green complaint flow.
+- **(G10) Row counts are not data quality.** "Verify the data landed" counts rows. A tenant onboarded from a
+  sheet with a blank Department column lands the full row count with `department: "NA"` on **every** leaf, and
+  shows no department breakdown anywhere. Run Check 2 in
+  [tenant-department-migration-guide.md](./tenant-department-migration-guide.md).
 
 ## Server differences
 - **Schema install:** your CD deploys the branch `default-data-handler`, which registers the schema — so you

--- a/docs/migration/tenant-department-migration-guide.md
+++ b/docs/migration/tenant-department-migration-guide.md
@@ -81,20 +81,38 @@ old default seed with zero complaints against them — dead configuration, not a
 
 ### Check 2 — leaves carry real departments
 
+This counts the same rows the materialized view counts: LEAF rows only, with the same
+`department` / `departments[0]` fallback and the same blank/`NA` normalisation.
+
 ```sql
+WITH leaf_levels AS (
+  SELECT DISTINCT lvl->>'levelCode' AS level_code
+  FROM eg_mdms_data d
+  CROSS JOIN LATERAL jsonb_array_elements(d.data->'levels') lvl
+  WHERE d.schemacode = 'RAINMAKER-PGR.ComplaintHierarchyDefinition' AND d.isactive
+    AND (lvl->>'isLeafServiceCode')::boolean
+),
+leaves AS (
+  SELECT tenantid,
+         btrim(coalesce(data->>'department', data->'departments'->>0)) AS dept
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.ComplaintHierarchy' AND isactive
+    AND data->>'levelCode' IN (SELECT level_code FROM leaf_levels)
+)
 SELECT tenantid,
-       count(*) FILTER (WHERE data->>'department' IS NOT NULL
-                          AND data->>'department' <> 'NA') AS real_dept,
-       count(*) FILTER (WHERE data->>'department' = 'NA')  AS na_dept,
-       count(*) FILTER (WHERE data->>'department' IS NULL) AS no_dept,
-       count(*) AS total_rows
-FROM eg_mdms_data
-WHERE schemacode = 'RAINMAKER-PGR.ComplaintHierarchy' AND isactive
+       count(*) FILTER (WHERE upper(coalesce(dept,'')) NOT IN ('NA','')) AS real_dept,
+       count(*) FILTER (WHERE upper(coalesce(dept,'')) IN ('NA',''))     AS unusable,
+       count(*) AS leaves
+FROM leaves
 GROUP BY 1 ORDER BY 1;
 ```
 
-`total_rows` includes interior nodes, which correctly have no department — so `no_dept` is never
-expected to be zero. What matters is **`real_dept` relative to the number of leaves**.
+Every row counted is a leaf, so **`real_dept` should equal `leaves`**. `unusable` is the number of
+complaint types that will show no department — whether from `NA`, a blank, or an absent field.
+
+If the tenant has no `ComplaintHierarchyDefinition`, `leaf_levels` is empty and this returns nothing
+— which is itself a finding: the MV's leaf filter would match nothing either, so no complaint type
+would carry a department. Install the definition before going further.
 
 - **`real_dept` covers your leaves** → deploy the repoint; department tiles will populate.
 - **`na_dept` is most or all of your leaves** → the repoint is safe but will show no department
@@ -112,9 +130,19 @@ FROM complaint_facts f
 LEFT JOIN (
   SELECT DISTINCT ON (data->>'code')
          data->>'code' AS code,
-         nullif(coalesce(data->>'department', data->'departments'->>0), 'NA') AS dept
+         CASE WHEN upper(btrim(coalesce(data->>'department', data->'departments'->>0))) IN ('NA','')
+              THEN NULL
+              ELSE btrim(coalesce(data->>'department', data->'departments'->>0))
+         END AS dept
   FROM eg_mdms_data
   WHERE schemacode = 'RAINMAKER-PGR.ComplaintHierarchy' AND isactive
+    AND data->>'levelCode' IN (
+          SELECT DISTINCT lvl->>'levelCode'
+          FROM eg_mdms_data d
+          CROSS JOIN LATERAL jsonb_array_elements(d.data->'levels') lvl
+          WHERE d.schemacode = 'RAINMAKER-PGR.ComplaintHierarchyDefinition' AND d.isactive
+            AND (lvl->>'isLeafServiceCode')::boolean
+        )
   ORDER BY 1, length(tenantid)
 ) ch ON ch.code = f.service_code
 GROUP BY 1, 2 ORDER BY 3 DESC;
@@ -136,7 +164,7 @@ Needed when Check 2 shows `NA` leaves and you want department tiles for that ten
    ```sql
    SELECT data->>'code', data->>'name'
    FROM eg_mdms_data
-   WHERE schemacode LIKE '%Department%' AND isactive AND tenantid = '<tenant>';
+   WHERE schemacode = 'common-masters.Department' AND isactive AND tenantid = '<tenant>';
    ```
 2. Map each `NA` leaf to one of those codes. This is a decision for the city, not a mechanical
    transform — nothing in the data implies the right answer.

--- a/docs/migration/tenant-department-migration-guide.md
+++ b/docs/migration/tenant-department-migration-guide.md
@@ -1,0 +1,174 @@
+# Tenant Guide — Departments on the Complaint Hierarchy
+
+> Companion to [operator-runbook.md](./operator-runbook.md). Read this before deploying
+> `V20260731000000__repoint_grain_mvs_to_complainthierarchy.sql`, and before retiring the
+> `RAINMAKER-PGR.ServiceDefs` master on any tenant.
+
+## Why this guide exists
+
+Analytics dashboards resolve a complaint's department by joining the complaint's `servicecode` to
+an MDMS master. That join used to read `RAINMAKER-PGR.ServiceDefs`, which is retired. It now reads
+`RAINMAKER-PGR.ComplaintHierarchy`.
+
+Switching the query is only half the job. **The new master has to actually carry departments for
+that tenant.** Those are two independent conditions, and a tenant needs both:
+
+| | hierarchy leaves have real departments | leaves have `NA` / no department |
+|---|---|---|
+| **MV repointed** | works | no department breakdown |
+| **MV not repointed** | no department breakdown | no department breakdown |
+
+A tenant can pass every check in the main runbook — correct row counts, working complaint flow —
+and still show nothing on department tiles, because row count is not data quality.
+
+## The three states a leaf can be in
+
+A leaf is a filable complaint type (a `ComplaintHierarchy` row whose `levelCode` is the level flagged
+`isLeafServiceCode`). Interior nodes are categories and never carry a department.
+
+**1. Real department — the working state**
+```json
+{ "code": "StreetLightNotWorking", "levelCode": "SUB_TYPE",
+  "department": "DEPT_1", "slaHours": 336 }
+```
+
+**2. `NA` — the silent failure**
+```json
+{ "code": "SomeComplaintType", "levelCode": "SUB_TYPE",
+  "department": "NA" }
+```
+`NA` is a placeholder, not a department. The configurator writes it when the onboarding sheet's
+Department column is blank. It is **valid data** — `ServiceRequestValidator` treats it as "no
+department constraint", which is a deliberate, supported state for complaint types that any
+department may handle. It is only a problem for analytics, where it means "no breakdown".
+
+**3. Absent — same effect as `NA`**
+```json
+{ "code": "SomeComplaintType", "levelCode": "SUB_TYPE" }
+```
+The `#917` migration omits the key entirely when the source had no department. Backend code treats
+absent and `NA` identically.
+
+The migration normalises `NA` to `NULL` so it never renders as a department label on a dashboard.
+
+## Preflight — run this before deploying the repoint
+
+Two separate checks. **Both must pass.** The first is the one the main runbook already implies;
+the second is the one that catches an `NA`-populated tenant.
+
+### Check 1 — every in-use complaint type has a hierarchy node
+
+```sql
+SELECT s.tenantid, s.servicecode, count(*) AS complaints
+FROM eg_pgr_service_v2 s
+LEFT JOIN (
+  SELECT DISTINCT data->>'code' AS code
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.ComplaintHierarchy' AND isactive
+) ch ON ch.code = s.servicecode
+WHERE ch.code IS NULL
+GROUP BY 1, 2
+ORDER BY 3 DESC;
+```
+
+- **No rows** → every complaint type in use has migrated. Good.
+- **Rows returned** → those types were never migrated. They are *also* broken in the complaint
+  flow (there is no fallback — the picker is built from the hierarchy), so fix them regardless.
+  Re-run `migrate.cjs` for the tenant.
+
+Count only what has complaints. A tenant may carry hundreds of orphaned `ServiceDefs` rows from an
+old default seed with zero complaints against them — dead configuration, not a problem.
+
+### Check 2 — leaves carry real departments
+
+```sql
+SELECT tenantid,
+       count(*) FILTER (WHERE data->>'department' IS NOT NULL
+                          AND data->>'department' <> 'NA') AS real_dept,
+       count(*) FILTER (WHERE data->>'department' = 'NA')  AS na_dept,
+       count(*) FILTER (WHERE data->>'department' IS NULL) AS no_dept,
+       count(*) AS total_rows
+FROM eg_mdms_data
+WHERE schemacode = 'RAINMAKER-PGR.ComplaintHierarchy' AND isactive
+GROUP BY 1 ORDER BY 1;
+```
+
+`total_rows` includes interior nodes, which correctly have no department — so `no_dept` is never
+expected to be zero. What matters is **`real_dept` relative to the number of leaves**.
+
+- **`real_dept` covers your leaves** → deploy the repoint; department tiles will populate.
+- **`na_dept` is most or all of your leaves** → the repoint is safe but will show no department
+  breakdown. Back-fill first (below) if those tiles matter to this tenant.
+
+### Confirm the outcome before committing
+
+This predicts the exact effect of the repoint without changing anything:
+
+```sql
+SELECT coalesce(f.department_code, '(none)') AS before,
+       coalesce(ch.dept, '(none)')           AS after,
+       count(*)
+FROM complaint_facts f
+LEFT JOIN (
+  SELECT DISTINCT ON (data->>'code')
+         data->>'code' AS code,
+         nullif(coalesce(data->>'department', data->'departments'->>0), 'NA') AS dept
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.ComplaintHierarchy' AND isactive
+  ORDER BY 1, length(tenantid)
+) ch ON ch.code = f.service_code
+GROUP BY 1, 2 ORDER BY 3 DESC;
+```
+
+Read the result as:
+
+- `(none) → DEPT_X` — rows the repoint **fixes**.
+- `DEPT_X → DEPT_Y` — rows **remapped**. Expected where the hierarchy adopted a renamed department
+  vocabulary; the new value is the correct one, but dashboard labels will visibly change.
+- `DEPT_X → (none)` — rows that **regress**. Each one is a complaint type whose department exists
+  only in the retired master. Back-fill it before deploying, or accept the loss knowingly.
+
+## Back-filling departments
+
+Needed when Check 2 shows `NA` leaves and you want department tiles for that tenant.
+
+1. List the departments available to the tenant:
+   ```sql
+   SELECT data->>'code', data->>'name'
+   FROM eg_mdms_data
+   WHERE schemacode LIKE '%Department%' AND isactive AND tenantid = '<tenant>';
+   ```
+2. Map each `NA` leaf to one of those codes. This is a decision for the city, not a mechanical
+   transform — nothing in the data implies the right answer.
+3. Apply via the configurator's complaint-hierarchy editor, or by re-running the onboarding sheet
+   with the Department column filled in.
+4. Re-run Check 2, then refresh the grains (they rebuild on the scheduler, default 5 minutes).
+
+Back-filling is safe to do before or after the repoint; the tiles populate once both are true.
+
+## Interaction with department scoping
+
+`dss.DashboardConfig.departmentScoping` controls whether employees are restricted to their own
+department's rows. It is enforced unless explicitly set to `disabled`.
+
+```sql
+SELECT tenantid, data->>'departmentScoping'
+FROM eg_mdms_data WHERE schemacode = 'dss.DashboardConfig' AND isactive;
+```
+
+**Do not enable scoping on a tenant whose leaves are `NA`.** Scoping filters with
+`department_code IN (...)`, and `NULL` never matches — so every employee would see zero rows on
+every tile, including tiles unrelated to department. Back-fill departments first, then enable.
+
+## Ordering with the ServiceDefs retirement
+
+Retiring `ServiceDefs` (#1496) is only safe **after** this repoint is deployed. Until then the grain
+MVs still read that master, and on a properly-migrated tenant it is the source of a large share of
+working `department_code` values — deleting it first blanks them.
+
+Correct order:
+
+1. Deploy the repoint migration.
+2. Run Checks 1 and 2 per tenant; back-fill where needed.
+3. Confirm department tiles render.
+4. Then retire `ServiceDefs` / `ClassificationNode` / `ComplaintTypeDepartments`.


### PR DESCRIPTION
Closes #1494. Unblocks #1496. Partially addresses #1479 — see Scope. Follows up #917, which flagged this gap.

## The issue

Complaint types used to live in the MDMS master `RAINMAKER-PGR.ServiceDefs`. #917 moved them to `RAINMAKER-PGR.ComplaintHierarchy` and retired the old master.

The backend, the frontends and the MDMS schemas all moved. **The analytics SQL did not.** The two grain materialized views still join `ServiceDefs` for department, SLA and service group.

So on a tenant with no `ServiceDefs` rows, the join matches nothing, `department_code` is NULL, and every department-grouped dashboard tile renders blank.

## Why it was missed

#917 (`feat/complaint-hierarchy-2master`) *did* try to fix this — commit `4f49ffc0d` repointed the CTE, but it edited an **already-applied** migration (`V20260608000000`) instead of adding a new one. Two things went wrong:

- Flyway had already run that file and records a checksum, so editing it changed nothing on any existing environment.
- On a fresh install it replays, then `V20260609000000` runs next and rebuilds the same view from `ServiceDefs`, overwriting it.

The fix was written into the one file where it could not take effect, and it looked correct in review. Every later migration that restated the view copied the `ServiceDefs` shape forward.

Nothing caught it: the MV tests assert on generated SQL *column names*, which never changed, and no CI replays migrations against a real database.

**Credit where due — this was spotted at the time.** The #917 runbook (`f96e98f8f`) recorded it the next day as gotcha G8, naming the required fix almost exactly:

> **(G8) V2 grain-MV gap.** The analytics materialized-view forward Flyway migration was not authored on the branch (still reads `ServiceDefs`/`menuPath`) — does not block the complaint flow, but dashboards using the grain MV are stale until a `repoint_grain_mvs_to_complainthierarchy` migration is added.

The judgement call there was correct on its own terms: the gap genuinely doesn't block complaints, so proceeding with the cutover was reasonable. What wasn't visible to anyone was that `4f49ffc0d` couldn't take effect at all — so the remaining gap was wider than G8 implies. The item was recorded once, in the gotcha list, and never carried into the post-cutover notes where follow-ups were tracked.

## The fix

A forward migration, `V20260731000000__repoint_grain_mvs_to_complainthierarchy.sql`. It copies `V20260717000000` and changes **only the two `mdms` CTEs** — everything else is byte-identical, per the existing convention in this migration chain.

Three details worth review:

- **Leaf detection is by `levelCode`**, checked against the level flagged `isLeafServiceCode` in the hierarchy definition — not by `department IS NOT NULL`. A leaf may legitimately have no department, so the convenient filter would have dropped those complaint types out of analytics entirely rather than just leaving the column NULL.
- **`'NA'` is normalised to NULL.** That is the placeholder the configurator writes for a blank Department column during onboarding. It is not a department and must never reach a dashboard as a label.
- **`legacy_service_group` is retired.** It read `ServiceDefs.menuPath`, which the #917 migration consumed and deliberately did not carry onto the new master. `service_group` now resolves from the hierarchy path alone.

Both unique indexes are recreated — refresh runs `CONCURRENTLY` and the scheduler swallows a failure into a `log.warn`, so a missing index would mean silently stale dashboards rather than an error.

## Verification

Executed against a live database inside a transaction that was rolled back: runs clean, both views rebuild, all indexes create, server left untouched.

Simulated the department delta on two installs:

**Install A** — data migration ran properly:
```
(null) → DEPT_1              138 rows
(null) → WATER_ENV            17 rows
(null) → DEPT_2                8 rows
DEPT_4 → ROADS_PUBLIC_WORKS    6 rows
DEPT_1 → MEDICAL_SVC           3 rows
```
~184 rows repaired, **zero regressions**. Note the last two: some departments were renamed in the new master, so a few tile labels change rather than merely filling in. The new value is the correct one.

**Install B** — onboarded from a sheet with a blank Department column. All 47 leaves carry `department: "NA"`, so the repoint yields no department breakdown there. **This is a data problem, not a query problem** — no migration can fix it. That tenant needs a back-fill, which is what the new guide covers.

## Also in this PR

**`docs/migration/tenant-department-migration-guide.md`** — new. Two preflight checks (every in-use complaint type has a hierarchy node; leaves carry real departments rather than `NA`), a query that predicts the exact before/after per tenant, back-fill instructions, and the ordering constraint against #1496.

**`docs/migration/operator-runbook.md`** — G8 closed; two new gotchas.

- **G9**: step 4 is entirely create/assign/resolve checks. All of them pass while dashboards are silently wrong. That is precisely how this survived the cutover, so a new step 4.5 verifies a department tile explicitly.
- **G10**: "verify the data landed" counts rows. A tenant can land the full count with `NA` on every leaf. Row count is not data quality.
- Step 5 now states that retiring `ServiceDefs` before this migration blanks department tiles on properly-migrated tenants, since the old master is currently supplying those values.

## Scope

Not included, deliberately:

- **The department back-fill** for `NA` tenants — operator/config work, not code.
- **Inbox vs dashboard SLA (#1479)** — partially addressed. Inbox already reads `ComplaintHierarchy` (via the `getServiceDefs` adapter); the dashboard read `ServiceDefs`, so the two disagreed on any type whose `slaHours` differed between masters. This migration removes that source of divergence — `sla_target_ms` leg 1 now reads the same master the Inbox does.

  **It does not close #1479.** Two independent contributors remain:
  1. **Different fallbacks.** When a type has no `slaHours`, the Inbox falls back to a hardcoded 5 days (`DEFAULT_SLA_MS = 432000000`, `usePGRInboxSearch.js:152`) while the grain falls through to the escalation-ladder total, then the workflow SLA. Same complaint, two different budgets.
  2. **Not like-for-like by construction.** The dashboard figure is `avg(sla_target_ms)` over a bucket — documented at `docs/dashboard-configuration/10-kpi-catalog.md:203` as averaging heterogeneous per-subtype targets and explicitly *"not 'the SLA' of the category"*. It will not equal a single complaint's Inbox value even once the masters agree.

  So this narrows #1479 to those two, both of which need a product decision on which fallback and which aggregation are correct.
- **Blank vs "Unknown" tile labels** — belongs in the frontend label layer, not the grain.

## One thing to check before release

Any environment that applied `V20260608000000` before it was edited on 2026-06-23 has a stale Flyway checksum and will fail `validate` on its next deploy — the deploy path runs the Flyway CLI with validation on by default and there is no repair step anywhere. At least one live install is in this state. Unrelated to this change, but it will surface on the same deploy.

```sql
SELECT version, checksum FROM pgr_services_schema WHERE version = '20260608000000';
-- 548793456 = current file, fine.  -1108071609 = pre-edit, will fail validate.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Analytics**
  - Complaint analytics now use active complaint hierarchy data for services, departments, SLA values, ordering, and hierarchy paths.
  - Improved handling prevents legacy taxonomy codes from creating invalid hierarchy groupings.
  - Analytics views retain event and fact calculations with updated service-group and parent-code details.

- **Documentation**
  - Added tenant migration guidance, validation steps, cutover requirements, and warnings for safely retiring legacy service data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->