### PR TITLE
fix(pgr): assignee always mandatory on ASSIGN + explicit no-eligible-employee message (CCSD-2124)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/AssigneeComponent.js
+++ b/digit-ui-esbuild/products/pgr/src/components/AssigneeComponent.js
@@ -98,6 +98,24 @@ const AssigneeComponent = ({ config, onSelect, formState, defaultValues }) => {
   if (error) return <div>{t("CS_COMMON_EMPLOYEE_FETCH_ERROR")}</div>;
   if (isEmployeeDataLoading) return <Loader />;
 
+  // CCSD-2124: the assignee is mandatory on ASSIGN, so an EMPTY list would
+  // leave the operator stuck behind a generic "required field" toast with no
+  // way to see why. Say it plainly: nobody with the required role exists in
+  // the scoped department (or tenant) — a staffing/onboarding gap, not a UI
+  // failure. The submit stays blocked (mandatory + no value).
+  if (!assignees || assignees.length === 0) {
+    const K = "CS_COMMON_NO_ASSIGNABLE_EMPLOYEES";
+    const msg =
+      t(K) === K
+        ? "No eligible employee found for this department. An employee with the required role must be onboarded before this complaint can be assigned."
+        : t(K);
+    return (
+      <div className="assignee-dropdown-container">
+        <div style={{ color: "var(--color-error, #d4351c)", fontSize: "0.875rem", fontWeight: 500 }}>{msg}</div>
+      </div>
+    );
+  }
+
   return (
     <div className="assignee-dropdown-container">
       <Dropdown

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
@@ -263,20 +263,16 @@ const PGRDetails = () => {
     setToast({ show: false, label: "", type: "" });
   };
 
-  // Assignee requirement on ASSIGN:
-  // - complaint type mapped to a department  -> mandatory (scoped routing; a person must be picked)
-  // - unmapped type ("NA"/absent department) -> OPTIONAL — the complaint may move forward
-  //   unassigned (pgr skips department validation and the workflow accepts empty assignes)
-  // - EXCEPT a CMS_SCREENING_OFFICER (incl. multi-role users): routing IS their job,
-  //   so the assignee stays mandatory for them even on unmapped types.
-  const isAssigneeMandatory = (action) => {
-    if (action?.action !== "ASSIGN") return false;
-    const roles = userInfo?.info?.roles?.map((r) => r.code) || [];
-    if (roles.includes("CMS_SCREENING_OFFICER")) return true;
-    const def = serviceDefs?.find((d) => d.serviceCode === pgrData?.ServiceWrappers?.[0]?.service?.serviceCode);
-    const department = def?.department;
-    return !!department && department !== "NA";
-  };
+  // CCSD-2124: the assignee is ALWAYS mandatory on ASSIGN. The previous
+  // carve-out (optional when the complaint type had no department mapping and
+  // the actor wasn't a screening officer) let a supervisor submit with no
+  // Case Manager — the complaint advanced with no responsible owner, and the
+  // backend accepts empty assignes for every action (workflow has no
+  // assignee-required rule), so the FE gate is the only gate.
+  // When the scoped department has no eligible employee, AssigneeComponent now
+  // says so explicitly instead of rendering an empty dropdown — staffing gaps
+  // surface as a clear message, not as an ownerless complaint.
+  const isAssigneeMandatory = (action) => action?.action === "ASSIGN";
 
   // Prepare and submit the update complaint request
   const handleActionSubmit = (_data) => {

--- a/utilities/default-data-handler/src/main/resources/localisations/default/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/default/rainmaker-pgr.json
@@ -7468,5 +7468,11 @@
         "message": "All Complaints",
         "module": "rainmaker-pgr",
         "locale": "default"
+    },
+    {
+        "code": "CS_COMMON_NO_ASSIGNABLE_EMPLOYEES",
+        "message": "No eligible employee found for this department. An employee with the required role must be onboarded before this complaint can be assigned.",
+        "module": "rainmaker-pgr",
+        "locale": "default"
     }
 ]

--- a/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
@@ -8236,5 +8236,11 @@
         "message": "Images, PDF, DOC, audio or video up to 5 MB each. You can upload up to 5 files.",
         "module": "rainmaker-pgr",
         "locale": "en_IN"
+    },
+    {
+        "code": "CS_COMMON_NO_ASSIGNABLE_EMPLOYEES",
+        "message": "No eligible employee found for this department. An employee with the required role must be onboarded before this complaint can be assigned.",
+        "module": "rainmaker-pgr",
+        "locale": "en_IN"
     }
 ]

--- a/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
@@ -1684,5 +1684,11 @@
         "message": "Imagens, PDF, DOC, áudio ou vídeo até 5 MB cada. Pode carregar até 5 ficheiros.",
         "module": "rainmaker-pgr",
         "locale": "pt_PT"
+    },
+    {
+        "code": "CS_COMMON_NO_ASSIGNABLE_EMPLOYEES",
+        "message": "Nenhum funcionário elegível encontrado para este departamento. É necessário cadastrar um funcionário com a função adequada antes de atribuir esta reclamação.",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
     }
 ]


### PR DESCRIPTION
## CCSD-2124 — Supervisor Assignment form allows submission without an assignee

### Root cause
`isAssigneeMandatory` had a deliberate carve-out: mandatory for screening officers, but for everyone else it depended on the complaint type's MDMS department — silently **optional** when the department was `"NA"`/unmapped or the serviceCode didn't resolve. And the FE gate is the **only** gate: egov-workflow-v2 has no assignee-required rule (verified in the running image — `validateAssignes` only role-checks assignees that were supplied), and pgr-services' `validateAssignee()` is an empty stub. Result: complaints advanced with no responsible owner.

### Fix
1. **ASSIGN is unconditionally mandatory** — every actor, every complaint type. One flag drives both the `*` marker and submit validation, so they can't drift.
2. **Empty-list guard**: making the field mandatory would hard-block operators behind a generic "required field" toast when the scoped department has no eligible employee (known staffing gaps). `AssigneeComponent` now renders an explicit localized message (`CS_COMMON_NO_ASSIGNABLE_EMPLOYEES`, en+pt) instead of an empty dropdown. Submission stays blocked — per the ticket, a complaint must not advance ownerless; the message makes the *why* actionable (onboarding gap).

Loc seeded in the repo and already upserted live on local + cms-pilot + mctd (cache-busted), so the message renders translated the moment this deploys.

### Verified locally as a real supervisor (EMP471 @ mz.igsae)
Fresh REFERRED fixture with an **unmapped department** — exactly the previously-optional case:
| step | result |
|---|---|
| Assign modal | renders **Employee Name \*** |
| Submit with comments, no assignee | **blocked** — toast `Required fields missing: Employee Name`, modal stays open, complaint stays REFERRED |
| Select case manager → submit | `Assigned Successfully`, REFERRED → INVESTIGATION |

(The no-eligible-employee message path is code-reviewed but not exercised live — the fixture's unscoped department listed all case managers. Reproducing it needs a dept-scoped complaint in an unstaffed department.)

### Deliberately out of scope (flagged on the ticket)
- REASSIGN keeps its optional picker pending product's answer.
- Server-side enforcement (the `docUploadRequired` analogue) is a backend change — no workflow-config flag exists for assignee-required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)