### PR TITLE
feat(configurator): logo-goes-home + open-portal link (CCSD-2125)

### DIFF
--- a/configurator/src/admin/DigitLayout.tsx
+++ b/configurator/src/admin/DigitLayout.tsx
@@ -5,6 +5,7 @@ import { useApp } from '../App';
 import {
   HelpCircle,
   LogOut,
+  ExternalLink,
   User,
   Building2,
   MapPin,
@@ -184,17 +185,26 @@ export function DigitLayout({ children }: { children?: ReactNode }) {
           sidebarCollapsed ? 'w-16' : 'w-64'
         } bg-card border-r border-border flex flex-col transition-all duration-200 h-full`}
       >
-        {/* Sidebar Header — DIGIT Admin Console branding */}
+        {/* Sidebar Header — DIGIT Admin Console branding.
+            CCSD-2125: the brand is a BUTTON back to the admin home — QA
+            reported "no way back to the home page"; a logo-click-goes-home is
+            the affordance they asked for (and the convention everywhere else). */}
         <div className="h-16 border-b border-border flex items-center px-4 gap-2">
-          <div className="w-1 h-8 bg-primary" />
-          {!sidebarCollapsed && (
-            <div>
-              <span className="font-condensed font-bold text-foreground">DIGIT</span>
-              <span className="font-condensed font-medium text-muted-foreground ml-1">
-                {translate('app.header.brand', { _: 'Complaints Management' })}
-              </span>
-            </div>
-          )}
+          <button
+            onClick={() => navigate('/manage')}
+            className="flex items-center gap-2 text-left rounded-md hover:opacity-80 transition-opacity"
+            title={translate('app.nav.dashboard')}
+          >
+            <div className="w-1 h-8 bg-primary" />
+            {!sidebarCollapsed && (
+              <div>
+                <span className="font-condensed font-bold text-foreground">DIGIT</span>
+                <span className="font-condensed font-medium text-muted-foreground ml-1">
+                  {translate('app.header.brand', { _: 'Complaints Management' })}
+                </span>
+              </div>
+            )}
+          </button>
           <Button
             variant="ghost"
             size="icon"
@@ -381,6 +391,20 @@ export function DigitLayout({ children }: { children?: ReactNode }) {
                   </p>
                   <p className="text-xs text-muted-foreground truncate">{state.tenant}</p>
                 </div>
+                {/* CCSD-2125: the configurator had NO link to the portal at
+                    all — leaving it meant hand-editing the URL. Same-origin
+                    /digit-ui/ is how every CCRS box serves the portal next to
+                    /configurator (host nginx), so a relative link needs no new
+                    config. Opens a new tab: admins keep their editing session. */}
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => window.open('/digit-ui/', '_blank', 'noopener')}
+                  title={translate('app.nav.open_portal', { _: 'Open citizen portal' })}
+                  className="text-muted-foreground hover:text-foreground h-8 w-8 flex-shrink-0"
+                >
+                  <ExternalLink className="w-4 h-4" />
+                </Button>
                 <Button
                   variant="ghost"
                   size="icon"

--- a/configurator/src/components/layout/Layout.tsx
+++ b/configurator/src/components/layout/Layout.tsx
@@ -58,15 +58,20 @@ export default function Layout() {
         <div className="h-1 bg-primary" />
         <div className="max-w-7xl mx-auto px-3 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-14 sm:h-16">
-            {/* Logo with orange accent */}
+            {/* Logo with orange accent.
+                CCSD-2125: brand is a button back to the onboarding home
+                (phase 1) — same logo-goes-home affordance as the admin shell. */}
             <div className="flex items-center gap-2 sm:gap-3">
-              <div className="flex items-center">
+              <button
+                onClick={() => navigate('/')}
+                className="flex items-center text-left rounded-md hover:opacity-80 transition-opacity"
+              >
                 <div className="w-1 h-8 sm:h-10 bg-primary mr-2 sm:mr-3" />
                 <div>
                   <span className="font-condensed font-bold text-foreground text-base sm:text-lg">DIGIT</span>
                   <span className="font-condensed font-medium text-muted-foreground text-base sm:text-lg ml-1">Admin Console</span>
                 </div>
-              </div>
+              </button>
             </div>
 
             {/* Right side */}

--- a/configurator/src/providers/i18nProvider.ts
+++ b/configurator/src/providers/i18nProvider.ts
@@ -40,6 +40,7 @@ const customEnglishMessages: TranslationMessages = {
   app: {
     nav: {
       dashboard: 'Dashboard',
+      open_portal: 'Open citizen portal',
       notifications: 'Notifications',
       notification_configure: 'Configure',
       notification_routing: 'Notification Routing',


### PR DESCRIPTION
## CCSD-2125 — Admin has no button/navigation to return to the home page

### What the audit found
A "Dashboard" sidebar button **did** already exist on every `/manage` screen — but the ticket is still right in two ways: the **logo wasn't a link** (explicitly requested; also the universal convention), and there was **no route from the configurator to the portal at all** — if "home" meant the citizen/employee site, hand-editing the URL was the only way. The Landing Builder's collapsed icons-only sidebar made all of this worse.

### Changes
1. **Brand → home** in both shells: admin (`DigitLayout`) → `/manage`, onboarding (`Layout`) → `/`. The brand stays clickable in the Builder's collapsed sidebar (the orange accent bar remains the target).
2. **Open-portal button** (ExternalLink icon, next to Logout): opens same-origin `/digit-ui/` in a new tab. Same-origin is how every CCRS box serves the portal beside `/configurator` (host nginx), so no new config/env value is needed; new tab keeps the admin's editing session intact.
3. i18n key `app.nav.open_portal` (en) — the `translate()` call carries an inline default for other locales.

### Verified locally
`tsc` clean · `vite build` clean · deployed to local nginx · logged in → from `/manage/tenants` the brand click lands on `/manage` · portal button renders with the "Open citizen portal" tooltip.

### Note for the ticket
The reporter's clarifying questions (which "home"? where were they stuck?) are still unanswered — this ships the superset: configurator-home via logo (convention) + portal via explicit link. If they meant something narrower, both affordances remain correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)