### PR TITLE
fix(pgr): employee create form's map pin was discarded — no map for supervisors (CCSD-2131)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/utils/index.js
+++ b/digit-ui-esbuild/products/pgr/src/utils/index.js
@@ -203,7 +203,17 @@ export const formPayloadToCreateComplaint = (formData, tenantId, user, extOpts) 
         "locality": {
           "code": formData?.SelectedBoundary?.code || formData?.SelectLocality?.code,
         },
-        "geoLocation": {}
+        // CCSD-2131: the employee form's map pin (GeoLocationsPoint, added with
+        // the PGRComplaintLocationMap field) was silently DISCARDED here — this
+        // was hardcoded {} — so every technician-created complaint persisted
+        // with no coordinates and the details pages hid the location map.
+        // Citizen-parity semantics: send {latitude, longitude} when a pin
+        // exists, else keep the EMPTY OBJECT — the persister needs the object
+        // to be present even when the coords are not (see CCSD-1949/#1094).
+        "geoLocation":
+          typeof formData?.GeoLocationsPoint?.lat === "number" && typeof formData?.GeoLocationsPoint?.lng === "number"
+            ? { "latitude": formData.GeoLocationsPoint.lat, "longitude": formData.GeoLocationsPoint.lng }
+            : {}
       },
       "additionalDetail": JSON.stringify(additionalDetail),
       "auditDetails": {


### PR DESCRIPTION
## CCSD-2131 — Supervisor cannot see the location map for Reception-created complaints

### Root cause
The employee create form **does** capture a location (the `PGRComplaintLocationMap` pin, added in #447, writes `formData.GeoLocationsPoint`) — but `formPayloadToCreateComplaint` hardcoded `"geoLocation": {}`, so the pin was **silently discarded on submit**. #447 wired the field into the form but never into the payload builder. Complaints then persisted without coordinates, and both details pages mount the location card only when `latitude && longitude` are present → no map for the supervisor. (The map component itself is fine: an API-created complaint with coords renders the map on the employee details page.)

### Fix — 1 expression, citizen parity
```js
"geoLocation": (typeof GeoLocationsPoint?.lat === "number" && typeof GeoLocationsPoint?.lng === "number")
  ? { latitude: lat, longitude: lng } : {}
```
The `{}` fallback is deliberate: the persister requires the `geoLocation` **object** to exist even when there are no coords (the CCSD-1949/#1094 contract) — never omit it.

### Verification
Standalone unit run of the transform: pin → `{latitude:-25.91, longitude:32.57}` · no pin → `{}` · non-numeric pin → `{}`. Render path proven independently (E-2026-000022, API-created with coords, shows the map to a supervisor). Full bundle builds clean and is deployed on local.

### Flagged on the ticket (product to confirm)
- The pin stays **optional** — a technician who doesn't place it still creates a complaint with no map. If every complaint must have one, that's a follow-up (make the field mandatory or add a boundary-centroid fallback).
- The picker auto-seeds the tenant's default centre on mount (citizen parity), so untouched maps will now stamp the configured city centre — make sure `RAINMAKER-PGR.MapConfig` is seeded on each env or the built-in fallback centre is wrong.
- Forward-only: pre-fix complaints permanently have `{}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)