### PR TITLE
feat(pgr): Complainant Details card on employee complaint details (CCSD-2130)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
@@ -618,6 +618,36 @@ const PGRDetails = () => {
                   },
                 ],
               },
+              // CCSD-2130: "Complainant Details" — service.citizen was captured
+              // (mandatory on the Reception form), persisted to the user
+              // service, and returned on every search, but NEVER rendered: the
+              // timeline deliberately masks the citizen actor for everyone,
+              // assuming a complainant card that had not been built. This is
+              // that card. Values arrive from the backend post-policy (it
+              // returns "****" when masking applies), so this stays a dumb
+              // value→row mapper like Additional Details.
+              ...((pgrData?.ServiceWrappers?.[0]?.service?.citizen?.name ||
+                   pgrData?.ServiceWrappers?.[0]?.service?.citizen?.mobileNumber)
+                ? [{
+                  cardType: "primary",
+                  header: t("CS_COMPLAINT_DETAILS_COMPLAINANT_DETAILS"),
+                  fieldPairs: [
+                    {
+                      inline: true,
+                      label: t("COMPLAINTS_COMPLAINANT_NAME"),
+                      type: "text",
+                      value: pgrData?.ServiceWrappers[0].service?.citizen?.name || "NA",
+                    },
+                    {
+                      inline: true,
+                      label: t("COMPLAINTS_COMPLAINANT_CONTACT_NUMBER"),
+                      type: "text",
+                      value: pgrData?.ServiceWrappers[0].service?.citizen?.mobileNumber || "NA",
+                    },
+                  ],
+                }]
+                : []
+              ),
               // Read-only "Additional Details" — fetch service.extendedAttributes
               // and show it as label:value rows; backend returns masked ("****")
               // values. Renders nothing when there are no extended attributes.

--- a/utilities/default-data-handler/src/main/resources/localisations/default/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/default/rainmaker-pgr.json
@@ -7474,5 +7474,11 @@
         "message": "No eligible employee found for this department. An employee with the required role must be onboarded before this complaint can be assigned.",
         "module": "rainmaker-pgr",
         "locale": "default"
+    },
+    {
+        "code": "CS_COMPLAINT_DETAILS_COMPLAINANT_DETAILS",
+        "message": "Complainant Details",
+        "module": "rainmaker-pgr",
+        "locale": "default"
     }
 ]

--- a/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
@@ -8242,5 +8242,11 @@
         "message": "No eligible employee found for this department. An employee with the required role must be onboarded before this complaint can be assigned.",
         "module": "rainmaker-pgr",
         "locale": "en_IN"
+    },
+    {
+        "code": "CS_COMPLAINT_DETAILS_COMPLAINANT_DETAILS",
+        "message": "Complainant Details",
+        "module": "rainmaker-pgr",
+        "locale": "en_IN"
     }
 ]

--- a/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
@@ -1690,5 +1690,11 @@
         "message": "Nenhum funcionário elegível encontrado para este departamento. É necessário cadastrar um funcionário com a função adequada antes de atribuir esta reclamação.",
         "module": "rainmaker-pgr",
         "locale": "pt_PT"
+    },
+    {
+        "code": "CS_COMPLAINT_DETAILS_COMPLAINANT_DETAILS",
+        "message": "Dados do Reclamante",
+        "module": "rainmaker-pgr",
+        "locale": "pt_PT"
     }
 ]


### PR DESCRIPTION
## CCSD-2130 — Complaints submitted by Reception Technicians have no complainant details

### The real diagnosis (differs from the ticket)
The details are **not** lost. Name + mobile are mandatory on the Reception form, the backend rejects creates without them, they persist to the user service, and every search returns them on `service.citizen`. They were just never **displayed**: no complainant row has ever existed on the employee details page, and the timeline deliberately masks the citizen actor for everyone — its code comment refers to "the complainant card" as the one place identity should show in clear… a card that was never built. Citizen-filed complaints only *appeared* to work because that flow also writes the name into `extendedAttributes`.

### Change
A **Complainant Details** card (name + contact number from `service.citizen`) above Additional Details, rendered whenever either value exists.
- **Retroactive for free**: existing complaints already carry `accountId`, and search enrichment returns the citizen — historical complaints get the card with no migration.
- **No client-side privacy logic**: values arrive post-security-policy from the backend (it returns `****` where masking applies), keeping this a dumb value→row mapper like the Additional Details card. If product later restricts who sees identity in clear, that's a policy/master change, not a UI change.
- Labels reuse the create form's existing keys (already live in en+pt on all envs); the new header key is seeded in the repo and upserted + cache-busted on local, cms-pilot, mctd.

### Verified locally (supervisor EMP471, Reception-created complaint)
```
Dados do Reclamante
  Nome do reclamante:                Teste Cidadao
  Número de telefone do reclamante.: 847700123
```

### Open per the ticket comments
Which roles may see identity in clear on confidential complaints (currently governed entirely by the backend security policy, which is all-PLAIN on these envs), and whether the inbox/list should also show the complainant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)