### PR TITLE
feat(pgr): reception-officer inbox shows the complaints they created (CCSD-2135)

### DIFF
--- a/backend/pgr-services/src/main/java/org/egov/pgr/repository/rowmapper/PGRQueryBuilder.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/repository/rowmapper/PGRQueryBuilder.java
@@ -114,6 +114,13 @@ public class PGRQueryBuilder {
             preparedStmtList.add(criteria.getDepartment());
         }
 
+        // Audit creator (reception-officer inbox: "complaints I filed").
+        if (StringUtils.hasText(criteria.getCreatedBy())) {
+            addClauseIfRequired(preparedStmtList, builder);
+            builder.append(" ser.createdby = ? ");
+            preparedStmtList.add(criteria.getCreatedBy());
+        }
+
         //When UI tries to fetch "escalated" complaints count.
         if(criteria.getSlaDeltaMaxLimit() != null && criteria.getSlaDeltaMinLimit() == null){
             addClauseIfRequired(preparedStmtList, builder);

--- a/backend/pgr-services/src/main/java/org/egov/pgr/web/models/RequestSearchCriteria.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/web/models/RequestSearchCriteria.java
@@ -114,6 +114,14 @@ public class RequestSearchCriteria {
     @JsonProperty("department")
     private String department;
 
+    // Filters on the complaint's audit creator (eg_pgr_service_v2.createdby).
+    // Drives the reception-officer inbox: a CMS_RECEPTION_OFFICER files
+    // complaints on citizens' behalf and needs to track the ones THEY created
+    // (they are neither the accountId — that's the citizen — nor an assignee).
+    @SafeHtml
+    @JsonProperty("createdBy")
+    private String createdBy;
+
     @JsonIgnore
     private Set<String> serviceRequestIds;
 

--- a/digit-ui-esbuild/products/pgr/src/configs/UICustomizations.js
+++ b/digit-ui-esbuild/products/pgr/src/configs/UICustomizations.js
@@ -1605,6 +1605,22 @@ export const UICustomizations = {
         sortOrder: (clonedData?.state?.tableForm?.sortOrder || "ASC").toUpperCase(),
       };
 
+      // Reception-officer inbox: a CMS_RECEPTION_OFFICER files complaints on
+      // citizens' behalf but is neither the accountId (that's the citizen) nor
+      // ever an assignee — so the inbox showed them nothing of their own work.
+      // Scope their inbox to the complaints THEY created (audit createdby;
+      // pgr-services filters on it server-side, so pagination/count stay
+      // correct). Applied only when reception is the user's SOLE CMS role —
+      // a multi-role user (e.g. reception + supervisor) keeps the wider view
+      // their other role is entitled to.
+      const cmsRoles = (Digit.UserService.getUser()?.info?.roles || [])
+        .map((r) => r?.code)
+        .filter((c) => c && (c.startsWith("CMS_") || c === "SUPERUSER" || c === "ADMIN"));
+      if (cmsRoles.includes("CMS_RECEPTION_OFFICER") && cmsRoles.every((c) => c === "CMS_RECEPTION_OFFICER")) {
+        const ownUuid = Digit.UserService.getUser()?.info?.uuid;
+        if (ownUuid) params.createdBy = ownUuid;
+      }
+
       // Search form fields
       if (searchForm.complaintNumber) {
         params.serviceRequestId = searchForm.complaintNumber;


### PR DESCRIPTION
## CCSD-2135 — Reception Officer inbox: "complaints I filed"

A `CMS_RECEPTION_OFFICER` files complaints on citizens' behalf but is **neither the accountId** (that's the citizen) **nor ever an assignee** — so the inbox showed them nothing of their own work.

### Why this is FE **and** backend
The requested change was to add `createdBy=<uuid>` to the inbox search call — but I verified empirically that the deployed backend **silently ignores** an unknown `createdBy` param (a bogus uuid returned the identical 30-row result set; `RequestSearchCriteria` has no such field). The FE change alone would have been a no-op that *looks* done.

**Backend (pgr-services):** new `createdBy` search criteria — `@SafeHtml @JsonProperty` field beside its `accountId`/`assignee` siblings + one where-clause on `ser.createdby` in the shared query builder (the count query wraps the same builder, so `totalCount`/pagination stay consistent).

**Frontend (inbox-v2):** `PGRInboxConfig.preProcess` adds `createdBy=<own uuid>` when `CMS_RECEPTION_OFFICER` is the user's **sole** CMS/admin role — a multi-role user (reception + supervisor) keeps the wider view their other role is entitled to.

### Verified end-to-end on local (jar built from this branch and swapped into the running container)
| probe | result |
|---|---|
| API, no param | 30 rows (unchanged) |
| API, `createdBy=<EMP431 uuid>` | **1 row — exactly the complaint EMP431 created** |
| API, bogus uuid | 0 rows |
| Inbox as EMP431 (pure reception) | 1 row (E-2026-000022); network call carries `createdBy=<own uuid>` |
| Inbox as EMP471 (supervisor) | full view, **no** `createdBy` in the call |

### Rollout
- FE ships with the normal `deploy-pilot-fe.sh ui` bundle deploy.
- Backend needs a **pgr-services image rebuild + repin** on each env. Until that image lands, the extra param is ignored server-side and the inbox behaves exactly as today — additive, safe to deploy in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)