### PR TITLE
fix(ansible): boolean-safe core_mobile_configs conditional (ansible-core >= 2.19)

### DIFF
--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -256,7 +256,12 @@
           See inventory/host_vars/_example.yml for a worked example.
       when:
         - core_mobile_configs is defined
-        - core_mobile_configs
+        # Boolean-safe truthiness: ansible-core >= 2.19 rejects a bare dict
+        # as a conditional ("conditional statements must be boolean"), which
+        # aborted every deploy at this task. `default({}, true)` also maps an
+        # explicit null (`core_mobile_configs:` with no value) to {} so the
+        # skip short-circuits before _mobile_missing_keys would dict2items it.
+        - core_mobile_configs | default({}, true) | length > 0
         - _mobile_missing_keys | length > 0
 
     # ==================== WSL2 resource config (.wslconfig) ====================


### PR DESCRIPTION
## The problem

The `core_mobile_configs` schema preflight (added with the mobile-validation rework) lists the variable itself as a bare `when:` condition:

```yaml
when:
  - core_mobile_configs is defined
  - core_mobile_configs            # <- a dict, not a boolean
  - _mobile_missing_keys | length > 0
```

ansible-core >= 2.19 enforces boolean conditionals, so on a modern controller **every deploy aborts at this task** with `conditional statements must be boolean`, regardless of what host_vars contains. Reproduced on ansible-core 2.20.3 (eGov dev box); the current workaround in circulation is pinning ansible-core < 2.19, which just delays the break.

## The fix

```yaml
  - core_mobile_configs | default({}, true) | length > 0
```

- Boolean on every ansible-core version — deliberately avoids `is truthy` (new in 2.16) so older controllers keep working.
- Exact old semantics preserved: defined-but-empty dict still skips the preflight.
- The `default({}, true)` also maps an explicit null (`core_mobile_configs:` with no value) to `{}`, so the condition short-circuits before `_mobile_missing_keys` would run `dict2items` over `None` — the one case where simply deleting the bare line would have traded the 2.19 break for a template error.

## Verification

Ran the conditional + vars chain on ansible-core 2.20.3 across the four states:

| host_vars state | result |
|---|---|
| valid (countryCode + mobileNumberRegex) | preflight skipped, deploy proceeds |
| incomplete (`countryCode` only) | fails fast with the schema message |
| `core_mobile_configs: {}` | skipped (unchanged behaviour) |
| `core_mobile_configs:` (null) | skipped, no dict2items error |

`ansible-playbook --syntax-check` passes on the full playbook. A full `./deploy.sh` with this exact one-line semantic (bare line removed) completed `failed=0` on the same 2.20.3 box today — the rest of the playbook contains no other non-boolean conditionals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment preflight handling when mobile configuration settings are missing or empty.
  * Prevented conditional validation errors during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->