### PR TITLE
chore: port WSL2/localhost deploy (#1518) + ansible-2.19 conditional fix to master

### DIFF
--- a/WINDOWS-QUICKSTART.md
+++ b/WINDOWS-QUICKSTART.md
@@ -1,0 +1,167 @@
+# Windows Quickstart — DIGIT via WSL2 in one session
+
+Validated 2026-07-29 on a 16 GB Windows machine / WSL2 Ubuntu 24.04. Brings up
+the full DIGIT stack with `./deploy.sh <name>` — the playbook self-heals every
+WSL-specific quirk (memory caps, mount propagation, Node toolchain), so the
+happy path is short. The same steps work on any Linux machine or VM; only the
+WSL2 sections are Windows-specific.
+
+## What you get
+
+~40 containers: all DIGIT core services, PGR, the employee UI, citizen SPA,
+configurator (DIGIT Studio), Kong, host nginx on port 80, Gatus health board,
+Grafana/Prometheus/Loki/Tempo observability, Jupyter DataLoader, OpenBao —
+on the dump-seeded `pg` / `pg.citya` tenants. Login works immediately.
+
+Two sizing profiles (see step 4):
+
+| Template | Fits | Difference |
+|----------|------|------------|
+| `localhost-slim.yml.example` | **16 GB machine** (12 GB WSL VM) | No Novu notifications stack (~2 GB). Everything else identical. |
+| `localhost-full.yml.example` | 32 GB machine | Adds Novu (SMS/WhatsApp delivery pipeline). |
+
+## Prerequisites
+
+- Windows 10/11 with hardware virtualization enabled (Intel VT-x / AMD SVM —
+  usually on by default; enable in BIOS if step 1 errors with `0x80370102`).
+- ≥ 16 GB RAM and ~60 GB free disk.
+- **Do NOT install Docker Desktop** (or disable its WSL integration for this
+  distro). The playbook installs Docker Engine natively inside WSL and manages
+  its daemon; Docker Desktop's injected `docker` conflicts with it.
+
+## 1. Install WSL2 + Ubuntu (PowerShell as Administrator)
+
+```powershell
+wsl --update
+wsl --install -d Ubuntu-24.04
+```
+
+Reboot if Windows asks, run the install command again if the distro isn't
+there yet, then create your Linux user on first launch. Confirm you're in:
+
+```bash
+uname -a          # must contain "microsoft ... WSL2"
+systemctl is-system-running   # "running" or "degraded" (Ubuntu 24.04 default)
+```
+
+If systemd reports `offline`, add to `/etc/wsl.conf`:
+
+```ini
+[boot]
+systemd=true
+```
+
+then `wsl --shutdown` in PowerShell and relaunch Ubuntu.
+
+## 2. Install the deploy tooling (inside WSL)
+
+```bash
+sudo apt update && sudo apt install -y git ansible python3 python3-pip rsync curl
+ansible --version    # ansible-core must be < 2.19 — Ubuntu 24.04's apt (2.16.x) is correct
+```
+
+> **Version matters.** The playbook breaks on ansible-core ≥ 2.19. Use the apt
+> package; don't pip-install a newer one.
+
+## 3. Clone INSIDE the WSL filesystem
+
+```bash
+git clone https://github.com/egovernments/Citizen-Complaint-Resolution-System.git
+cd Citizen-Complaint-Resolution-System
+```
+
+> **Never run the stack from a Windows-side clone** (`/mnt/c/...`). Windows
+> git checks out CRLF line endings, which break every shell script with
+> errors like `cannot execute: required file not found` or
+> `$'\r': command not found`, and `/mnt/c` bind mounts are slow. Clone under
+> your Linux home.
+
+## 4. Create your host_vars from a template
+
+```bash
+cd local-setup/ansible
+cp inventory/host_vars/localhost-slim.yml.example inventory/host_vars/mybox.yml
+# 32 GB machine? use localhost-full.yml.example instead
+```
+
+The defaults are validated — nothing needs editing for a local bring-up. The
+filename (`mybox`) is just your tenant handle for `deploy.sh`.
+
+## 5. Deploy (as root)
+
+```bash
+sudo -i
+cd /home/<you>/Citizen-Complaint-Resolution-System/local-setup/ansible
+./deploy.sh mybox
+```
+
+Root is required: the play installs Docker, writes system config, and
+regenerates `inventory/hosts.yml`.
+
+**Expect the first run to stop early, once, on purpose.** The play writes the
+WSL memory caps into your Windows-side `.wslconfig` (12 GB VM / 16 GB swap /
+6 CPUs by default) and then fails fast telling you to apply them — Ansible
+cannot restart the VM it runs inside:
+
+```powershell
+wsl --shutdown        # from PowerShell
+```
+
+Reopen Ubuntu, re-run the same `./deploy.sh mybox`. From here it runs through:
+Docker Engine install, WSL mount-propagation fix (automatic), image pull
+(tens of GB — the long pole on a first run), Node 20 install, UI builds,
+~40-container stack up, health waits, and end-to-end validation probes.
+
+**Watch it live** from a second WSL terminal (the deploy banner prints this):
+
+```bash
+tail -f /opt/digit/digit-stack-up.mybox.progress
+```
+
+First run from a blank machine: expect 30–60 min depending on bandwidth.
+Re-runs into a healthy stack are idempotent and take ~1–2 min.
+
+## 6. Verify + log in (from your Windows browser)
+
+| What | URL |
+|------|-----|
+| Employee UI | http://localhost/digit-ui/ — `ADMIN` / `eGov@123`, select **City A** |
+| Citizen SPA | http://localhost/citizen/ |
+| Configurator (DIGIT Studio) | http://localhost/configurator/ |
+| Health dashboard (Gatus) | http://localhost/status/ |
+| Grafana | http://localhost:13000 |
+| Jupyter DataLoader | http://localhost:18000/jupyter/lab?token=digit-crs-local |
+
+The play's final `INFRA VALIDATION RESULTS` summary should show every row
+green before you ever open a browser.
+
+## Day-to-day
+
+```bash
+sudo -i && cd .../local-setup/ansible
+./deploy.sh mybox        # idempotent — also the "bring it back" command after
+                         # a reboot or wsl --shutdown
+```
+
+Container data persists in Docker volumes; the stack directory is
+`/opt/digit`. Keep `/opt/digit/.openbao/init.json` safe — it holds the
+OpenBao unseal key for re-deploys.
+
+## If something breaks
+
+| Symptom | Cause / fix |
+|---------|-------------|
+| `x509: certificate has expired` on image pull | `registry.preview.egov.theflywheel.in`'s cert lapsed. The templates ship an `insecure_registries` workaround already; if you removed it, put it back or get the cert renewed. |
+| `cannot execute: required file not found` / `$'\r'` errors | You're in a Windows-side clone. Re-clone inside WSL (step 3). |
+| `Permission denied: inventory/hosts.yml` | Run `deploy.sh` as root (step 5). |
+| Deploy frozen AND new WSL windows won't open | VM memory starvation — the `.wslconfig` caps aren't applied. `wsl --shutdown` from PowerShell, reopen, re-run the deploy (it verifies the caps before doing anything heavy). |
+| `path / is mounted on / but it is not a shared or slave mount` | Handled automatically (`make-rshared-root.service`) — seeing it means you're on a branch without the fix. |
+| Containers OOM-killed / restart-looping | `free -h` inside WSL; check `dmesg \| grep -i oom`. On 16 GB machines use the **slim** template and close heavy Windows apps. |
+| Port 80 already in use | Something on Windows (IIS?) owns it: `netstat -ano \| findstr :80` in PowerShell. |
+| `Conditional result was ...` errors at play start | ansible-core ≥ 2.19 — install the apt version (step 2). |
+
+## Not included in the slim profile
+
+Novu notifications (SMS/WhatsApp delivery). Everything else — including the
+configurator's tenant-onboarding wizard (MCP) — is in. To add Novu you need
+~2 GB more headroom: use `localhost-full.yml.example` on a bigger machine.

--- a/local-setup/README.md
+++ b/local-setup/README.md
@@ -15,6 +15,11 @@ There are **three independent ways** to run this stack. Pick one:
 Options A and B run locally. Option C deploys a full per-tenant stack to a
 remote Ubuntu machine with `./deploy.sh <tenant>`. **Pick one.**
 
+> **On Windows?** The full Ansible stack also runs locally via WSL2 — see
+> [WINDOWS-QUICKSTART.md](../WINDOWS-QUICKSTART.md) (validated end-to-end on a
+> 16 GB machine; the playbook self-heals the WSL-specific quirks). The macOS
+> equivalent is [MAC-QUICKSTART.md](../MAC-QUICKSTART.md).
+
 ---
 
 ## Prerequisites

--- a/local-setup/ansible/deploy.sh
+++ b/local-setup/ansible/deploy.sh
@@ -77,10 +77,14 @@ if [[ "${SKIP_LINT:-0}" != "1" ]]; then
   run_static_validation
 fi
 
-# ansible buffers a task's stdout until the task ENDS, so the macOS Rosetta
-# converge (10-40min) looks like a dead hang with zero feedback. Tell the
-# operator the live escape hatches UP FRONT, before ansible swallows output.
-cat >&2 <<'BANNER'
+# ansible buffers a task's stdout until the task ENDS, so the long compose
+# steps (macOS Rosetta converge 10-40min; Linux pull + up ~10min cold) look
+# like a dead hang with zero feedback. Tell the operator the live escape
+# hatches UP FRONT, before ansible swallows output. The progress file
+# differs per platform: mac-stack-up.sh owns its own sink; the Linux path
+# tees to a per-tenant file (compose_progress_file in group_vars).
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  cat >&2 <<'BANNER'
 ────────────────────────────────────────────────────────────────────────
  DIGIT deploy starting. The macOS converge step is long and ansible shows
  NO output until it finishes. For LIVE progress, in another terminal run:
@@ -92,6 +96,20 @@ cat >&2 <<'BANNER'
  NETWORK ENDPOINT' = stop, restart the engine, re-run PLAIN (no SKIP_DOWN).
 ────────────────────────────────────────────────────────────────────────
 BANNER
+else
+  cat >&2 <<BANNER
+────────────────────────────────────────────────────────────────────────
+ DIGIT deploy starting. The image pull + stack-up steps are long and
+ ansible shows NO output until each finishes. For LIVE progress, in
+ another terminal run:
+
+     tail -f /opt/digit/digit-stack-up.${1:-<tenant>}.progress
+     watch -n5 "docker ps --format '{{.Names}}\t{{.Status}}' | grep -E 'healthy|Exited|Restart'"
+
+ (The tail target is announced again by the 'Progress sink' task.)
+────────────────────────────────────────────────────────────────────────
+BANNER
+fi
 
 # Regenerate inventory/hosts.yml from whatever host_vars exist on disk.
 # Every file (except _example.yml) becomes a host under `digit:`.

--- a/local-setup/ansible/inventory/group_vars/digit.yml
+++ b/local-setup/ansible/inventory/group_vars/digit.yml
@@ -164,6 +164,33 @@ docker_log_total_size: "1g"
 # is treated as unset, so the derivation still applies.
 # docker_log_max_file: 10
 
+# Live progress sink for the deploy's two long compose steps (image pull +
+# stack up). Their output streams here as they run, so the operator can
+# `tail -f` it from another terminal instead of waiting for the task to end.
+# Same idea as the Mac path's /tmp/mac-stack-up.progress.
+# Per-tenant filename: concurrent deploys of two tenants on one box must
+# not interleave into one file.
+# Lives under digit_dir, NOT /tmp: the deploy writes here with tee as
+# root, and a predictable root-written path in world-writable /tmp is a
+# symlink-attack target (a local user pre-creates a symlink, root's tee
+# follows it and overwrites the target). digit_dir is root-owned on
+# Linux, so only root can place anything at this path; the file itself
+# is created 0644 so a non-root operator can still tail it.
+compose_progress_file: "{{ digit_dir }}/digit-stack-up.{{ inventory_hostname }}.progress"
+
+# WSL2-only (ignored everywhere else): the [wsl2] resource caps the deploy
+# writes into the Windows-side .wslconfig. WSL defaults to ~50% of host
+# RAM, which starves the JVM stack and freezes the whole VM; these are
+# sized for a 16 GB host (12 GB VM + big swap for JVM startup spikes).
+# Hosts with 32 GB should override wsl_memory_gb: 20 in host_vars.
+# NOTE: ansible can WRITE the config but cannot APPLY it — that takes
+# `wsl --shutdown` from Windows, which would kill the VM ansible runs in.
+# The deploy fails fast with instructions when the running VM doesn't
+# match these values yet.
+wsl_memory_gb: 12
+wsl_swap_gb: 16
+wsl_processors: 6
+
 # On-target directory for digit-mcp when build_mcp is true. Vendored deploys
 # rsync CCRS digit-mcp/ here; a git mcp_repo_url clones/updates here instead.
 mcp_repo: "{{ digit_dir }}/digit-mcp"

--- a/local-setup/ansible/inventory/host_vars/localhost-full.yml.example
+++ b/local-setup/ansible/inventory/host_vars/localhost-full.yml.example
@@ -1,0 +1,130 @@
+# Self-targeting local deploy (localhost, no TLS) on the dump-seeded
+# pg / pg.citya tenants — the FULL stack (Novu + MCP + both SPAs).
+# Derived from the pg.citya config validated on the eGov dev box
+# 2026-07-27; domain generalized to localhost so it works on any box.
+# Needs ~16 GB for the containers alone — on a 16 GB host use
+# localhost-slim.yml.example instead.
+#
+# Usage:
+#   cp inventory/host_vars/localhost-full.yml.example \
+#      inventory/host_vars/mybox.yml
+#   ./deploy.sh mybox
+# Login: http://localhost/digit-ui/  ADMIN / eGov@123
+
+ansible_host: localhost
+ansible_connection: local
+
+# WORKAROUND, remove once the registry cert is renewed: the Let's Encrypt
+# wildcard for *.preview.egov.theflywheel.in expired 2026-07-25 and image
+# pulls fail with "x509: certificate has expired". Fresh box, so no
+# existing entries to preserve (on shared boxes, ALWAYS carry the box's
+# existing entries forward — this list REPLACES, it does not merge).
+insecure_registries: ["registry.preview.egov.theflywheel.in"]
+
+domain: localhost
+tls_enabled: false
+
+state_root: pg
+state_tenant_id: pg
+boot_tenant: pg.citya
+tenant_id: pg
+ui_state_tenant_id: pg.citya
+
+map_center:
+  lat: 30.7333
+  lng: 76.7794
+
+login_tenant_allowlist: []
+employee_module_denylist: []
+
+pgr_boundary_highest_level: "State"
+pgr_boundary_lowest_level: "Locality"
+boundary_type: "Locality"
+hierarchy_type: "ADMIN"
+
+core_mobile_configs:
+  countryCode: "+91"
+  mobileNumberRegex: "^[6-9][0-9]{9}$"
+
+core_postal_configs:
+  postalCodePattern: "^[0-9]{6}$"
+  postalCodeLength: 6
+  postalCodeErrorMessage: "CS_COMPLAINT_POSTALCODE_INVALID_ERROR"
+
+asset_s3_bucket: "pg-egov-assets"
+footer_logo_url: ""
+footer_bw_logo_url: ""
+
+digit_ui_mode: container
+enable_digit_ui_v2: true
+digit_ui_v2_repo: "https://github.com/egovernments/Citizen-Complaint-Resolution-System.git"
+digit_ui_v2_branch: "fix/citizen-ui-v2-mobile-config"
+
+enable_integration_tests: false
+integration_tests_dashboard_base: "/tests-v2/"
+integration_tests_basic_auth_user: "digit-tests"
+enable_integration_tests_runner: false
+
+enable_otp_services: false
+enable_search_stack: false
+enable_mcp: true
+build_mcp: true
+build_digit_ui: true
+build_otp_publisher: true
+digit_ui_esbuild_branch: "feat/keycloak-auth-adapter"
+tolerate_bootstrap_failures: true
+enable_turbopass: false
+enable_overpass: false
+
+enable_novu: true
+build_novu_dashboard: false
+novu_api_key: ""
+twilio_account_sid: ""
+twilio_auth_token: ""
+twilio_whatsapp_from: "whatsapp:+14155238886"
+pgr_notification_config_driven: true
+build_novu_bridge: false
+build_pgr_services: false
+novu_bridge_channel: "sms"
+
+enable_keycloak: false
+auth_provider: ""
+keycloak_client_id: "digit-ui"
+keycloak_google_client_id: ""
+
+requires_nairobi_mdms: false
+db_fast_path: true
+db_fast_path_ack_data_wipe: true
+run_ci_tests: false
+force_clean: false
+install_claude_code: false
+build_configurator: true
+
+nginx_features:
+  brand_assets: false
+  configurator: true
+  configurator_caching: false
+  status: true
+  api_pgr: false
+  mcp: true
+  keycloak: true
+  digit_ui_v2: true
+  integration_tests: false
+  integration_tests_runner: false
+nginx_preserve_vhost: false
+
+secrets_path: kv/digit/pg.citya
+
+# Local-only bootstrap values, pinned by the db_fast_path dump — do not
+# "harden" them; the dump's data must match.
+bootstrap_secrets:
+  postgres_password: egov123
+  mcp_db_password: egov123
+  minio_root_user: minioadmin
+  minio_root_password: minioadmin
+  elasticsearch_master_password: "asd@#$@$!132123"
+  egov_hrms_default_password: "eGov@123"
+  keycloak_admin_password: "eGov@123"
+  keycloak_db_password: "eGov@123"
+  keycloak_google_client_secret: ""
+  token_exchange_system_password: "eGov@123"

--- a/local-setup/ansible/inventory/host_vars/localhost-slim.yml.example
+++ b/local-setup/ansible/inventory/host_vars/localhost-slim.yml.example
@@ -1,0 +1,138 @@
+# localhost-full minus Novu — self-targeting deploy for a 16 GB host
+# (e.g. Windows/WSL2 with ~12 GB for the VM). Validated end-to-end on
+# WSL2 Ubuntu 24.04, 2026-07-29.
+#
+# The ONLY functional delta from localhost-full.yml.example is the Novu
+# notifications stack (novu-mongo/api/worker/ws/dashboard/bridge +
+# otp-publisher, ~1.5-2 GB resident): that is the one piece that risks
+# freezing a 12 GB VM. Everything else matches: core services, PGR,
+# employee UI (same esbuild branch), citizen SPA (/citizen/),
+# configurator (/configurator/), MCP (wizard tenant bootstrap works),
+# Kong, Gatus, Jupyter, seeded pg / pg.citya tenants.
+#
+# Usage:
+#   cp inventory/host_vars/localhost-slim.yml.example \
+#      inventory/host_vars/mybox.yml
+#   ./deploy.sh mybox
+# Login: http://localhost/digit-ui/  ADMIN / eGov@123
+
+ansible_host: localhost
+ansible_connection: local
+
+# WORKAROUND, remove once the registry cert is renewed: the Let's Encrypt
+# wildcard for *.preview.egov.theflywheel.in expired 2026-07-25 and image
+# pulls fail with "x509: certificate has expired". Fresh box, so no
+# existing entries to preserve (on shared boxes, ALWAYS carry the box's
+# existing entries forward — this list REPLACES, it does not merge).
+insecure_registries: ["registry.preview.egov.theflywheel.in"]
+
+domain: localhost
+tls_enabled: false
+
+state_root: pg
+state_tenant_id: pg
+boot_tenant: pg.citya
+tenant_id: pg
+ui_state_tenant_id: pg.citya
+
+map_center:
+  lat: 30.7333
+  lng: 76.7794
+
+login_tenant_allowlist: []
+employee_module_denylist: []
+
+pgr_boundary_highest_level: "State"
+pgr_boundary_lowest_level: "Locality"
+boundary_type: "Locality"
+hierarchy_type: "ADMIN"
+
+core_mobile_configs:
+  countryCode: "+91"
+  mobileNumberRegex: "^[6-9][0-9]{9}$"
+
+core_postal_configs:
+  postalCodePattern: "^[0-9]{6}$"
+  postalCodeLength: 6
+  postalCodeErrorMessage: "CS_COMPLAINT_POSTALCODE_INVALID_ERROR"
+
+asset_s3_bucket: "pg-egov-assets"
+footer_logo_url: ""
+footer_bw_logo_url: ""
+
+digit_ui_mode: container
+enable_digit_ui_v2: true
+digit_ui_v2_repo: "https://github.com/egovernments/Citizen-Complaint-Resolution-System.git"
+digit_ui_v2_branch: "fix/citizen-ui-v2-mobile-config"
+
+enable_integration_tests: false
+integration_tests_dashboard_base: "/tests-v2/"
+integration_tests_basic_auth_user: "digit-tests"
+enable_integration_tests_runner: false
+
+enable_otp_services: false
+enable_search_stack: false
+enable_mcp: true
+build_mcp: true
+build_digit_ui: true
+build_otp_publisher: false         # slim: notifications path is off
+digit_ui_esbuild_branch: "feat/keycloak-auth-adapter"
+tolerate_bootstrap_failures: true
+enable_turbopass: false
+enable_overpass: false
+
+enable_novu: false                 # slim: drops the whole notifications profile
+build_novu_dashboard: false
+novu_api_key: ""
+twilio_account_sid: ""
+twilio_auth_token: ""
+twilio_whatsapp_from: "whatsapp:+14155238886"
+pgr_notification_config_driven: false
+build_novu_bridge: false
+build_pgr_services: false
+novu_bridge_channel: "sms"
+
+enable_keycloak: false
+auth_provider: ""
+keycloak_client_id: "digit-ui"
+keycloak_google_client_id: ""
+
+requires_nairobi_mdms: false
+db_fast_path: true
+db_fast_path_ack_data_wipe: true
+run_ci_tests: false
+force_clean: false
+install_claude_code: false
+# Configurator is back in even on slim: runtime cost is nil (static SPA
+# served by host nginx, no container) — only the one-time vite build at
+# deploy costs RAM, and swap absorbs it.
+build_configurator: true
+
+nginx_features:
+  brand_assets: false
+  configurator: true
+  configurator_caching: false
+  status: true
+  api_pgr: false
+  mcp: true
+  keycloak: true
+  digit_ui_v2: true
+  integration_tests: false
+  integration_tests_runner: false
+nginx_preserve_vhost: false
+
+secrets_path: kv/digit/pg.citya
+
+# Local-only bootstrap values, pinned by the db_fast_path dump — do not
+# "harden" them; the dump's data must match.
+bootstrap_secrets:
+  postgres_password: egov123
+  mcp_db_password: egov123
+  minio_root_user: minioadmin
+  minio_root_password: minioadmin
+  elasticsearch_master_password: "asd@#$@$!132123"
+  egov_hrms_default_password: "eGov@123"
+  keycloak_admin_password: "eGov@123"
+  keycloak_db_password: "eGov@123"
+  keycloak_google_client_secret: ""
+  token_exchange_system_password: "eGov@123"

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -259,6 +259,76 @@
         - core_mobile_configs
         - _mobile_missing_keys | length > 0
 
+    # ==================== WSL2 resource config (.wslconfig) ====================
+    # WSL2 defaults to ~50% of host RAM for the VM; the JVM stack then
+    # thrashes the VM into a freeze (deploy hangs, new WSL sessions won't
+    # even open). The Windows-side %UserProfile%\.wslconfig governs the
+    # caps, and it's reachable from inside WSL via /mnt/c — so the deploy
+    # manages the [wsl2] keys itself (ini_file edits just our keys; any
+    # other settings in the file are preserved).
+    #
+    # What ansible CANNOT do is apply the file: that takes `wsl --shutdown`
+    # from Windows, which would kill the VM this play runs inside. So after
+    # writing, compare the running VM's memory to the target and fail fast
+    # with instructions instead of deploying into a doomed memory budget.
+    # Skipped entirely on non-WSL hosts.
+    - name: "WSL — manage Windows-side .wslconfig + verify it is applied"
+      when:
+        - ansible_system != "Darwin"
+        - "'microsoft' in (ansible_kernel | lower)"
+      block:
+        # Windows interop gives us %UserProfile% without guessing the
+        # username; chdir avoids cmd.exe's UNC-working-dir warning noise.
+        - name: "WSL — locate the Windows user profile"
+          ansible.builtin.command: /mnt/c/Windows/System32/cmd.exe /c "echo %UserProfile%"
+          args:
+            chdir: /mnt/c
+          register: wsl_userprofile
+          changed_when: false
+          failed_when: false
+
+        - name: "WSL — interop unavailable, cannot manage .wslconfig"
+          ansible.builtin.debug:
+            msg: >-
+              WARNING: Windows interop is disabled in this WSL distro, so
+              the deploy cannot write .wslconfig. Set [wsl2] memory={{ wsl_memory_gb }}GB
+              swap={{ wsl_swap_gb }}GB processors={{ wsl_processors }} in
+              %UserProfile%\.wslconfig yourself.
+          when: wsl_userprofile.rc != 0 or (wsl_userprofile.stdout | trim | length == 0)
+
+        - name: "WSL — translate the profile path to a WSL path"
+          ansible.builtin.command: wslpath "{{ wsl_userprofile.stdout | trim }}"
+          register: wsl_userprofile_linux
+          changed_when: false
+          when: wsl_userprofile.rc == 0 and (wsl_userprofile.stdout | trim | length > 0)
+
+        - name: "WSL — write [wsl2] caps into .wslconfig"
+          community.general.ini_file:
+            path: "{{ wsl_userprofile_linux.stdout | trim }}/.wslconfig"
+            section: wsl2
+            option: "{{ item.option }}"
+            value: "{{ item.value }}"
+            no_extra_spaces: true
+          loop:
+            - { option: memory, value: "{{ wsl_memory_gb }}GB" }
+            - { option: swap, value: "{{ wsl_swap_gb }}GB" }
+            - { option: processors, value: "{{ wsl_processors }}" }
+          when: wsl_userprofile_linux is not skipped
+
+        # 85% tolerance: the VM reports slightly less than the configured
+        # cap (kernel reservations), and we only care about catching the
+        # ~50%-default / stale-cap case, not rounding.
+        - name: "WSL — fail fast until the new caps are actually applied"
+          ansible.builtin.fail:
+            msg: >-
+              This WSL VM is running with
+              {{ (ansible_memtotal_mb / 1024) | round(1) }} GB but .wslconfig
+              now requests {{ wsl_memory_gb }} GB. Ansible cannot restart the
+              VM it is running inside. From Windows PowerShell run:
+              `wsl --shutdown`, reopen this distro, and re-run
+              ./deploy.sh — the deploy will then proceed.
+          when: (ansible_memtotal_mb | int) < (wsl_memory_gb | int) * 1024 * 0.85
+
     # ==================== Docker host install + config ====================
     # Linux/Debian targets only. On macOS the operator already runs Docker
     # Desktop / OrbStack, so apt + docker.service + /etc/docker/daemon.json
@@ -323,6 +393,54 @@
             name: docker
             state: started
             enabled: yes
+
+        # ==================== Root mount propagation (WSL2 only) ====================
+        # The monitoring overlay's node-exporter binds /:/rootfs:ro,rslave
+        # (docker-compose.monitoring.yml). rslave requires the host's / to be
+        # a shared mount. systemd makes it so on standard Ubuntu, but WSL2's
+        # init leaves / private, and `docker compose up` then dies with
+        # "path / is mounted on / but it is not a shared or slave mount".
+        # On WSL install a boot-time oneshot that re-shares / before
+        # docker.service, and apply it now.
+        #
+        # Deliberately gated on the WSL kernel string ONLY — not on the
+        # current propagation of /. A non-WSL host with a private / (LXC,
+        # hardened MountFlags) made that choice on purpose; a deploy must
+        # not override it. Matching the kernel (not the live state) also
+        # means a WSL box where the operator ran `mount --make-rshared /`
+        # by hand still gets the boot persistence.
+        - name: "Root mount — persist make-rshared for WSL2's private /"
+          when: "'microsoft' in (ansible_kernel | lower)"
+          block:
+            - name: "Root mount — install make-rshared oneshot unit"
+              ansible.builtin.copy:
+                dest: /etc/systemd/system/make-rshared-root.service
+                mode: "0644"
+                content: |
+                  # Installed by the DIGIT ansible deploy: hosts whose init
+                  # leaves / private (WSL2) break container rslave bind
+                  # mounts (node-exporter's /:/rootfs:ro,rslave) unless /
+                  # is re-shared before docker starts.
+                  [Unit]
+                  Description=Make / a shared mount for container rslave binds
+                  DefaultDependencies=no
+                  After=local-fs.target
+                  Before=docker.service
+
+                  [Service]
+                  Type=oneshot
+                  ExecStart=/usr/bin/mount --make-rshared /
+                  RemainAfterExit=yes
+
+                  [Install]
+                  WantedBy=multi-user.target
+
+            - name: "Root mount — enable unit + make / rshared now"
+              ansible.builtin.systemd:
+                name: make-rshared-root.service
+                enabled: true
+                state: started
+                daemon_reload: true
 
         # ==================== Docker Configuration ====================
         # Log rotation. Docker's json-file driver keeps growing a container's
@@ -1008,6 +1126,19 @@
     # 404'ing globalConfigs.js. tar over the baked SPA, leaving those two file
     # mounts intact, sidesteps that. No registry/pinned-image dependency.
     # Default off → no Linux behaviour change.
+    #
+    # files/digit-ui-build.sh hard-fails without node on PATH — the same
+    # Ubuntu gap the static/v2 paths already guard (apt nodejs = Node 18,
+    # no npm; see tasks/ensure-node20.yml). Darwin excluded per the helper
+    # contract (node comes from brew there).
+    - name: "digit-ui build — ensure Node 20 + npm (NodeSource) for on-host build"
+      ansible.builtin.include_tasks: "{{ playbook_dir }}/tasks/ensure-node20.yml"
+      vars:
+        node_ensure_label: "digit-ui build"
+      when:
+        - build_digit_ui | default(false)
+        - ansible_system != "Darwin"
+
     - name: "Build digit-ui from source (when build_digit_ui)"
       ansible.builtin.command: >-
         bash {{ playbook_dir }}/files/digit-ui-build.sh
@@ -1122,16 +1253,52 @@
         - enable_keycloak | default(false)
         - kcprep_secrets.json.data.data.keycloak_db_password | default('') | length > 0
 
+    # The next two steps are the deploy's long, silent stretch — the image
+    # pull (tens of GB on a first run) and the ~40-container up (~10 min on
+    # a cold box). Ansible buffers a task's output until it finishes, so
+    # without a side channel the operator stares at nothing. Stream the
+    # live compose output (docker compose emits per-container Created/
+    # Started/Healthy transitions on the fly) to compose_progress_file via
+    # tee; ansible still captures the full output for the task result, and
+    # pipefail keeps the compose exit code authoritative.
+    - name: "Progress sink — where to watch the long compose steps"
+      ansible.builtin.debug:
+        msg: >-
+          LONG STEPS AHEAD (image pull, then stack up). Follow live progress
+          from another terminal with:  tail -f {{ compose_progress_file }}
+
+    # Defense-in-depth against symlink attacks: tee below runs as root,
+    # and if an operator overrides compose_progress_file back into a
+    # world-writable dir (/tmp), a local user could pre-plant a symlink
+    # there for root's tee to follow. Recreate the path as a fresh
+    # regular file first, 0644 so a non-root operator can still tail it.
+    - name: "Progress sink — drop any pre-existing file/symlink at the path"
+      ansible.builtin.file:
+        path: "{{ compose_progress_file }}"
+        state: absent
+
+    - name: "Progress sink — create the progress file fresh (regular file, 0644)"
+      ansible.builtin.file:
+        path: "{{ compose_progress_file }}"
+        state: touch
+        mode: "0644"
+
     - name: Pull all images from VPC registry
-      shell: COMPOSE_PROFILES={{ compose_profiles }} docker compose {{ compose_files }} pull --ignore-pull-failures
+      shell: |
+        set -o pipefail
+        COMPOSE_PROFILES={{ compose_profiles }} docker compose {{ compose_files }} pull --ignore-pull-failures 2>&1 | tee {{ compose_progress_file }}
       args:
         chdir: "{{ digit_dir }}"
+        executable: /bin/bash
       changed_when: false
 
     - name: Start DIGIT stack (Linux/Debian)
-      shell: COMPOSE_PROFILES={{ compose_profiles }} docker compose {{ compose_files }} up -d
+      shell: |
+        set -o pipefail
+        COMPOSE_PROFILES={{ compose_profiles }} docker compose {{ compose_files }} up -d 2>&1 | tee -a {{ compose_progress_file }}
       args:
         chdir: "{{ digit_dir }}"
+        executable: /bin/bash
       changed_when: false
       when: ansible_system != "Darwin"
 
@@ -1843,6 +2010,19 @@
     # script prints the dist path on its last line; captured into the
     # `configurator_build` var the sync task below consumes. (A real
     # configurator_repo_url still clones, for transitional/standalone use.)
+    #
+    # files/configurator-build.sh hard-fails without node >= 20.19 on PATH —
+    # same Ubuntu gap as the digit-ui build (see tasks/ensure-node20.yml).
+    # Darwin excluded per the helper contract (node comes from brew there).
+    - name: "Configurator SPA — ensure Node 20 + npm (NodeSource) for dist build"
+      ansible.builtin.include_tasks: "{{ playbook_dir }}/tasks/ensure-node20.yml"
+      vars:
+        node_ensure_label: "configurator build"
+      when:
+        - nginx_features.configurator | default(false)
+        - build_configurator | default(false)
+        - ansible_system != "Darwin"
+
     - name: "Configurator SPA — build dist (when build_configurator)"
       ansible.builtin.command: >-
         bash {{ playbook_dir }}/files/configurator-build.sh

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -256,7 +256,12 @@
           See inventory/host_vars/_example.yml for a worked example.
       when:
         - core_mobile_configs is defined
-        - core_mobile_configs
+        # Boolean-safe truthiness: ansible-core >= 2.19 rejects a bare dict
+        # as a conditional ("conditional statements must be boolean"), which
+        # aborted every deploy at this task. `default({}, true)` also maps an
+        # explicit null (`core_mobile_configs:` with no value) to {} so the
+        # skip short-circuits before _mobile_missing_keys would dict2items it.
+        - core_mobile_configs | default({}, true) | length > 0
         - _mobile_missing_keys | length > 0
 
     # ==================== WSL2 resource config (.wslconfig) ====================

--- a/local-setup/ansible/requirements.yml
+++ b/local-setup/ansible/requirements.yml
@@ -1,3 +1,4 @@
 ---
 collections:
   - name: ansible.posix   # provides: synchronize, mount, sysctl, etc.
+  - name: community.general   # provides: ini_file (WSL .wslconfig management)

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -1304,6 +1304,12 @@ services:
         condition: service_healthy
       egov-enc-service:
         condition: service_healthy
+      # The script talks to egov-user-proxy (EGOV_USER_HOST below), and a
+      # container's DNS name only registers once the container exists — on
+      # a cold start the seed could burn its whole retry budget on curl
+      # exit 6 (couldn't resolve host) because the proxy hadn't started yet.
+      egov-user-proxy:
+        condition: service_started
     volumes:
       - ./seeds/user-seed.sh:/user-seed.sh:ro
     entrypoint: ["sh", "/user-seed.sh"]


### PR DESCRIPTION
Ports two develop-side changes to master so both branches deploy on modern controllers and Windows/WSL2 hosts:

## 1. Cherry-pick of #1518 (merged to develop) — WSL2/localhost end-to-end deploy

`WINDOWS-QUICKSTART.md`, `localhost-full.yml.example` / `localhost-slim.yml.example` host_vars templates, and the fresh-box playbook fixes that came with them (Node20 ensure-guard for on-host `build_digit_ui`/`build_configurator`, `make-rshared-root.service` self-heal for WSL2's private `/`, `user-seed` `depends_on` egov-user-proxy cold-start ordering, per-tenant `compose_progress_file`, platform-aware `deploy.sh` banner). Applied via `cherry-pick -m 1` of merge `c86189b9`; no conflicts against master.

The slim template was validated end-to-end on a 16 GB WSL2 box (`ok=98 failed=0`, all infra validation green); the full template mirrors the config validated on the eGov dev box.

## 2. Cherry-pick of the ansible-core >= 2.19 conditional fix (PR #1544 on develop)

Master's `playbook-deploy.yml` has the same bare-dict `when:` condition (`- core_mobile_configs`) that ansible-core >= 2.19 rejects as non-boolean, aborting **every** deploy on a modern controller — reproduced today on 2.20.3 during a fresh master deploy on the eGov dev box. Same one-line fix as #1544: `core_mobile_configs | default({}, true) | length > 0` (boolean everywhere, old skip-when-empty semantics kept, null-safe before `dict2items`). See #1544 for the four-state verification matrix on 2.20.3.

## Verification

- Combined playbook passes `ansible-playbook --syntax-check` on ansible-core 2.20.3.
- A fresh master deploy with the conditional fix applied completed `failed=0` on the dev box today (the #1519 doc-validation stack), so master's task set is clean on 2.20.3 once this lands.

Merge #1544 first (or together) to keep develop and master textually identical on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)