### PR TITLE
fix(dashboard): count only currently-resolved complaints in resolved KPIs (#1467)

### DIFF
--- a/ansible/nairobi-mdms/mdms/dss/KpiDefinition.json
+++ b/ansible/nairobi-mdms/mdms/dss/KpiDefinition.json
@@ -113,6 +113,7 @@
             "numerator": {
               "agg": "count",
               "filter": {
+                "is_open": false,
                 "is_resolved": true
               }
             },
@@ -391,6 +392,7 @@
             "numerator": {
               "agg": "count",
               "filter": {
+                "is_open": false,
                 "is_resolved": true,
                 "sla_breached": false
               }
@@ -923,6 +925,7 @@
             "numerator": {
               "agg": "count",
               "filter": {
+                "is_open": false,
                 "is_resolved": true
               }
             },
@@ -1409,6 +1412,7 @@
             "name": "resolved",
             "agg": "count",
             "filter": {
+              "is_open": false,
               "is_resolved": true
             }
           }
@@ -1781,6 +1785,7 @@
             "name": "resolved",
             "agg": "count",
             "filter": {
+              "is_open": false,
               "is_resolved": true
             }
           },
@@ -1788,6 +1793,7 @@
             "name": "on_time",
             "agg": "count",
             "filter": {
+              "is_open": false,
               "is_resolved": true,
               "sla_breached": false
             }
@@ -1902,6 +1908,7 @@
             "name": "resolved",
             "agg": "count",
             "filter": {
+              "is_open": false,
               "is_resolved": true
             }
           },
@@ -2246,6 +2253,7 @@
             "name": "resolved",
             "agg": "count",
             "filter": {
+              "is_open": false,
               "is_resolved": true
             }
           }
@@ -2464,6 +2472,7 @@
             "numerator": {
               "agg": "count",
               "filter": {
+                "is_open": false,
                 "is_resolved": true
               },
               "window": {
@@ -3154,6 +3163,7 @@
             "agg": "count",
             "name": "resolved",
             "filter": {
+              "is_open": false,
               "is_resolved": true
             },
             "window": {

--- a/digit-mcp/src/tools/dashboard-catalog-seed.ts
+++ b/digit-mcp/src/tools/dashboard-catalog-seed.ts
@@ -480,6 +480,7 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
           "numerator": {
             "agg": "count",
             "filter": {
+              "is_open": false,
               "is_resolved": true
             }
           },
@@ -746,6 +747,7 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
           "numerator": {
             "agg": "count",
             "filter": {
+              "is_open": false,
               "is_resolved": true,
               "sla_breached": false
             }
@@ -1254,6 +1256,7 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
           "numerator": {
             "agg": "count",
             "filter": {
+              "is_open": false,
               "is_resolved": true
             }
           },
@@ -1725,6 +1728,7 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
           "name": "resolved",
           "agg": "count",
           "filter": {
+            "is_open": false,
             "is_resolved": true
           }
         }
@@ -2088,6 +2092,7 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
           "name": "resolved",
           "agg": "count",
           "filter": {
+            "is_open": false,
             "is_resolved": true
           }
         },
@@ -2095,6 +2100,7 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
           "name": "on_time",
           "agg": "count",
           "filter": {
+            "is_open": false,
             "is_resolved": true,
             "sla_breached": false
           }
@@ -2206,6 +2212,7 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
           "name": "resolved",
           "agg": "count",
           "filter": {
+            "is_open": false,
             "is_resolved": true
           }
         },
@@ -2541,6 +2548,7 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
           "name": "resolved",
           "agg": "count",
           "filter": {
+            "is_open": false,
             "is_resolved": true
           }
         }
@@ -2750,6 +2758,7 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
           "numerator": {
             "agg": "count",
             "filter": {
+              "is_open": false,
               "is_resolved": true
             },
             "window": {
@@ -3419,6 +3428,7 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
           "agg": "count",
           "name": "resolved",
           "filter": {
+            "is_open": false,
             "is_resolved": true
           },
           "window": {


### PR DESCRIPTION
Fixes the seed side of #1467, point 3.

## The defect

`is_resolved` on the analytics grain is **sticky**: it is `resolved_at IS NOT NULL`, where `resolved_at` is `min(entered_at) FILTER (WHERE status IN ('RESOLVED','CLOSEDAFTERRESOLUTION'))` — [`V20260629000000__grain_scope_columns.sql:142`](../blob/develop/backend/pgr-services/src/main/resources/db/migration/main/V20260629000000__grain_scope_columns.sql#L142). It records that a complaint *has ever been* resolved and never clears on reopen. `is_open` is the live state.

So a reopened complaint is `is_open = true` **and** `is_resolved = true` simultaneously, and every KPI filtering on a bare `is_resolved` counts it as resolved while it is still sitting open in someone's inbox.

This was diagnosed on `mz` for #1467 and fixed there directly on 29 Jul. This PR fixes the seed so the same records are correct for every tenant created from here on.

## Live impact

**bomet** (`ke`, 1,514 complaints) — **14** complaints are open and "resolved" at the same time:

| Measure | Now | After | Delta |
|---|---|---|---|
| Resolution rate numerator | 321 ever-resolved | 307 currently-resolved | 21.2% → 20.3% |
| SLA compliance numerator | 261 | 261 | unchanged — all 14 are already `sla_breached` |
| Map `resolved`, CHESOEN ward | 295 | 281 | filed 1250 / open 871 / resolved 295 → 281 |

The map does not visibly break the 100% bound on bomet the way it did on `mz`: all 14 overlaps sit in CHESOEN, where rejected complaints (neither open nor ever-resolved) absorb the double-count. It is a silent inflation there, not an obvious one.

## What changed

`is_open: false` added to ten measures that mean "resolved right now":

| Record | Measure |
|---|---|
| `cl_resolution_rate_count` | `pct` numerator |
| `cl_sla_compliance_rate_count` | `pct` numerator |
| `cl_chart_department_resolution_rate` | `rate` numerator |
| `cl_flow_ratio_count` | `ratio` numerator |
| `cl_map_ward_wow_current` | `resolved` |
| `cl_chart_over_time_created_daily` | `resolved`, `on_time` |
| `cl_chart_department_flow_ratio` | `resolved` |
| `ep_table_employee_performance` | `resolved` |
| `cl_table_service_quality_by_channel` | `resolved` |

`digit-mcp/src/tools/dashboard-catalog-seed.ts` is regenerated from the seed via `node digit-mcp/scripts/gen-dashboard-catalog.mjs` (the file is generated; `--check` passes).

## Deliberately NOT changed

- **Reopen-rate numerator/denominator pairs** — `cl_reopen_rate_count`, `cl_table_complaint_type_details.reopen_rate`, `ep_table_employee_performance.reopen_rate`, `cl_table_ward_performance.reopen_rate`. "Reopened ÷ resolved" needs the *ever-resolved* denominator; adding `is_open: false` divides by zero for exactly the complaints the tile exists to count.
- **`has_rating` CSAT measures** (4 records) — a citizen rating can only be produced by RATE out of RESOLVED. Dropping those rows because the complaint was later reopened would discard real, already-recorded ratings and bias CSAT.
- **`avg_resolution_ms`** (`cl_table_complaint_type_details`, `cl_table_subtype_performance`) — `resolution_ms` is time-to-*first*-resolution by construction. Adding `is_open: false` changes the population without fixing the semantics; this needs either an upstream `resolved_at` fix or a retitle to "time to first resolution".
- **`ontime_rate` pairs** (`cl_table_complaint_type_details`, `cl_table_ward_performance`) — arguably the same defect: the denominator is historical while `sla_breached` is evaluated against the live clock for reopened rows, so a complaint resolved on time then reopened silently leaves the numerator but stays in the denominator. Left alone because it is a product decision, and both must move together. **Flagging for a call.**

## Important: this does not fix any existing tenant

`tenant_bootstrap` seeds this catalog as a **floor** — create-if-absent, first-writer-wins ([`mdms-tenant.ts:1770-1773`](../blob/develop/digit-mcp/src/tools/mdms-tenant.ts#L1770-L1773)). A tenant that already carries `cl_resolution_rate_count` keeps its existing copy; bootstrap will never update it.

So this PR corrects **new tenants only**. bomet needs a direct mdms-v2 `_update` against its live records, prepared separately. (`mz` was already fixed by hand on 29 Jul.)

## Related, not fixed here

`RESOLVEDBYSUPERVISOR` is a terminal success state in the seeded workflow ([`PgrWorkflowConfig.json:351`](../blob/develop/utilities/crs_dataloader/templates/PgrWorkflowConfig.json#L351)) that the grain does not count as a resolution — such complaints would be `is_open = false` AND `is_resolved = false`, invisible to every resolved KPI both before and after this change. Currently **zero rows** carry that status on bomet or mz, so it is latent rather than live. Worth a separate issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved complaint resolution metrics by ensuring resolved counts include only closed complaints.
  * Updated resolution rates, SLA metrics, department and channel performance, ward maps, time-series reports, and employee metrics for more accurate results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->