### PR TITLE
fix(dashboard): ownership-check alias writes; make sign-out unconditional (#1535, #1536)

### DIFF
--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardLogin.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardLogin.jsx
@@ -56,7 +56,14 @@ const DEMO_USERS = [
 // Session storage lives in authService (single source of truth); these thin
 // re-exports keep the existing AdminDashboard import sites unchanged.
 export const hasDashboardSession = hasAuth;
-export const clearDashboardSession = clearSession;
+// Sign-out must ALWAYS leave this browser with no employee session. Aliasing
+// the ownership-gated clearSession directly (as this did) meant that when the
+// unprefixed `token` alias had been rewritten by the co-hosted UI or stored in
+// a different encoding, Sign out + reload left the aliases and the
+// Digit.SessionStorage "User" cache holding a live employee token — the next
+// person on a shared kiosk landed in the employee UI still authenticated as
+// the employee who had just signed out (#1536).
+export const clearDashboardSession = () => clearSession({ force: true });
 
 const inputStyle = {
   borderRadius: "0.375rem",
@@ -140,6 +147,9 @@ const DashboardLogin = ({ onLogin, expired = false }) => {
         refreshToken: data.refresh_token,
         userInfo,
         tenantId,
+        // Explicit sign-in: taking over the shared aliases IS the intent here.
+        // Every other caller (the silent refresh) leaves this false (#1535).
+        claimAliases: true,
       });
       if (onLogin) onLogin(userInfo);
     } catch (err) {

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardLogin.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardLogin.jsx
@@ -58,11 +58,13 @@ const DEMO_USERS = [
 export const hasDashboardSession = hasAuth;
 // Sign-out must ALWAYS leave this browser with no employee session. Aliasing
 // the ownership-gated clearSession directly (as this did) meant that when the
-// unprefixed `token` alias had been rewritten by the co-hosted UI or stored in
-// a different encoding, Sign out + reload left the aliases and the
-// Digit.SessionStorage "User" cache holding a live employee token — the next
-// person on a shared kiosk landed in the employee UI still authenticated as
-// the employee who had just signed out (#1536).
+// unprefixed `token` alias held a value other than Employee.token — rewritten
+// by the co-hosted UI, or a leftover from an earlier session — Sign out +
+// reload left the aliases and the Digit.SessionStorage "User" cache holding a
+// live employee token, and the next person on a shared kiosk landed in the
+// employee UI still authenticated as the employee who had just signed out
+// (#1536). The force flag still refuses to delete aliases that are provably a
+// DIFFERENT live user's — see clearSession.
 export const clearDashboardSession = () => clearSession({ force: true });
 
 const inputStyle = {

--- a/digit-ui-esbuild/products/dashboard/src/services/authService.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/authService.js
@@ -60,7 +60,12 @@ import { getTenantId } from "../config/dashboardConfig";
  *
  * Likewise clearSession only drops the unprefixed aliases and the
  * Digit.SessionStorage cache when they actually hold the employee token being
- * torn down — on a shared browser they may belong to a live citizen session.
+ * torn down — on a shared browser they may belong to a live citizen session. An
+ * explicit sign-out overrides that (it must leave no employee session behind on
+ * a kiosk) with one exception: aliases carrying a DIFFERENT identity are proven
+ * to be someone else's and are still spared. The mirror-image rule governs
+ * writes: persistSession seizes the aliases only on a deliberate sign-in, never
+ * on a silent background refresh (#1535, #1536).
  *
  * Guarantees: at most three sends and at most one refresh per call (cannot
  * loop); concurrent 401s share a single refresh; a refresh never re-enters this
@@ -135,6 +140,38 @@ function writeStorage(key, value) {
 
 export function getEmployeeToken() {
   return readStorage(TOKEN_KEY);
+}
+
+/**
+ * The ownership predicates, defined ONCE.
+ *
+ * These rules were hand-copied into persistSession and clearSession, and the
+ * copies drifting apart is precisely what produced #1535 (the write side never
+ * got the clear side's ownership check) and #1536. Two mirrored files times two
+ * functions gave eight sites that had to change in lockstep; now there is one
+ * definition per rule.
+ */
+function readAliasToken() {
+  return readStorage(KEYS.tokenAlias.key);
+}
+
+/**
+ * True when the shared unprefixed aliases still hold `token`.
+ *
+ * Encoding is NOT a hazard here despite the two writers disagreeing about it:
+ * the main digit-ui login stores the token raw while this module JSON-stringifies
+ * it, but readStorage -> parseJson falls back to the raw string when JSON.parse
+ * throws, and an opaque UUID is never valid JSON. So the comparison holds across
+ * both encodings, and a mismatch always means a DIFFERENT VALUE — someone else's
+ * token, or a leftover.
+ */
+function ownsSharedAliases(token, aliasToken = readAliasToken()) {
+  return token != null && aliasToken === token;
+}
+
+/** The token a Digit.SessionStorage "User" entry authenticates with, if any. */
+function getCachedSessionToken(cached) {
+  return cached?.token ?? cached?.access_token ?? null;
 }
 
 /**
@@ -236,9 +273,24 @@ function syncDigitSession(accessToken, userInfo, { claim = false, previousToken 
     // authenticates from it too. Overwriting it on a background refresh would
     // swap an actively-signed-in citizen to the employee identity without any
     // user action (#1535). Only write when this is a deliberate sign-in, or
-    // when the cache is empty / already holds the token we are replacing.
-    const cachedToken = existing?.token ?? existing?.access_token ?? null;
-    if (!claim && cachedToken != null && cachedToken !== previousToken) return;
+    // when the cache is provably ours.
+    //
+    // Token equality alone does NOT prove that: the cache is sessionStorage
+    // (per-tab) while previousToken comes from localStorage (shared), so a
+    // sibling tab that refreshed first leaves THIS tab's cache one vintage
+    // behind — indistinguishable, by token, from a stranger's. Refusing to
+    // write there strands the tab on a token the earlier refresh already
+    // invalidated, and a reload does not heal it because index.js boots from
+    // this cache and skips the localStorage re-seed while it looks populated.
+    // Identity is the tab-independent proof; a citizen's cache still fails it.
+    const cachedToken = getCachedSessionToken(existing);
+    const cachedUuid = existing?.info?.uuid ?? null;
+    // A refresh usually carries no UserRequest, so fall back to stored identity.
+    const ourUuid = userInfo?.uuid ?? getEmployeeInfo()?.uuid ?? null;
+    const ownsCache =
+      cachedToken === previousToken ||
+      (cachedUuid != null && ourUuid != null && cachedUuid === ourUuid);
+    if (!claim && !ownsCache) return;
     session.set("User", {
       ...existing,
       token: accessToken,
@@ -267,9 +319,12 @@ export function persistSession({ accessToken, refreshToken, userInfo, tenantId, 
   // refreshes clobbers a citizen's live session on the co-hosted portal with
   // the employee identity, an identity swap with no user action (#1535).
   const previousToken = getEmployeeToken();
-  const ownsAliases =
-    previousToken != null && readStorage(KEYS.tokenAlias.key) === previousToken;
-  const mayWriteAliases = claimAliases || ownsAliases || readStorage(KEYS.tokenAlias.key) == null;
+  // Read the alias ONCE: two reads of a value that cannot change between them
+  // are a wasted parse, and they let a later edit make the two expressions
+  // disagree — silently splitting one ownership decision into two.
+  const aliasToken = readAliasToken();
+  const mayWriteAliases =
+    claimAliases || ownsSharedAliases(previousToken, aliasToken) || aliasToken == null;
 
   if (accessToken != null) {
     writeStorage(TOKEN_KEY, accessToken);
@@ -300,7 +355,13 @@ export function persistSession({ accessToken, refreshToken, userInfo, tenantId, 
     } catch {
       /* ignore */
     }
-    syncDigitSession(accessToken, normalisedUser, { claim: claimAliases, previousToken });
+    // Pass mayWriteAliases, not claimAliases: an EMPTY "User" cache is not ours
+    // to take while the aliases belong to someone else. Digit's storage expires
+    // entries after 24h, so a kiosk left overnight nulls a citizen's cache while
+    // their aliases stay live — and writing the employee identity into it would
+    // re-enter #1535 through the cache door, since index.js boots from the cache
+    // first and would then serve the employee session under the citizen's aliases.
+    syncDigitSession(accessToken, normalisedUser, { claim: mayWriteAliases, previousToken });
   }
 }
 
@@ -319,11 +380,24 @@ export function clearSession({ force = false } = {}) {
   // tearing down, or we would sign an unrelated user out of a session they are
   // actively using.
   const employeeToken = getEmployeeToken();
-  const ownsAliases =
-    employeeToken != null && readStorage(KEYS.tokenAlias.key) === employeeToken;
+  const ownsAliases = ownsSharedAliases(employeeToken);
+
+  // A forced sign-out must leave no employee session behind, so it drops the
+  // aliases even when they no longer match our token — that mismatch is usually
+  // a leftover, and leaving it stranded is what #1536 was about. But "not
+  // provably ours" is not "provably someone else's": when the `user-info` alias
+  // carries a DIFFERENT uuid, the aliases are positively identified as another
+  // live session, and deleting them would sign a citizen out of the co-hosted
+  // portal mid-flow — breaking rule 1 above to fix a leftover. A missing uuid on
+  // either side proves nothing, so those still clear.
+  const employeeUuid = getEmployeeInfo()?.uuid ?? null;
+  const aliasUuid = readStorage(KEYS.userInfoAlias.key)?.uuid ?? null;
+  const aliasesAreForeign =
+    !ownsAliases && aliasUuid != null && employeeUuid != null && aliasUuid !== employeeUuid;
+  const mayDropAliases = ownsAliases || (force && !aliasesAreForeign);
 
   SESSION_KEYS.forEach((k) => {
-    if (!force && !ownsAliases && (k === KEYS.tokenAlias.key || k === KEYS.userInfoAlias.key)) return;
+    if (!mayDropAliases && (k === KEYS.tokenAlias.key || k === KEYS.userInfoAlias.key)) return;
     try {
       window.localStorage?.removeItem(k);
     } catch {
@@ -344,10 +418,13 @@ export function clearSession({ force = false } = {}) {
   if (session?.set) {
     try {
       const cached = session.get?.("User");
-      const cachedToken = cached?.token ?? cached?.access_token ?? null;
+      const cachedToken = getCachedSessionToken(cached);
       // Never null a cache holding a DIFFERENT live session — but on an
-      // explicit sign-out an empty cache is the required end state.
-      if (force || cachedToken == null || cachedToken === employeeToken) session.set("User", null);
+      // explicit sign-out an empty cache is the required end state. A cache with
+      // no token authenticates nobody, so it is safe to drop UNLESS it still
+      // carries a foreign identity payload the co-hosted UI is rendering from.
+      if (force || cachedToken === employeeToken || (cachedToken == null && !cached?.info))
+        session.set("User", null);
     } catch {
       /* ignore */
     }
@@ -493,6 +570,16 @@ async function requestRefresh() {
   // A 2xx with no token is a malformed/intercepted response (proxy login page,
   // truncated body), not a rejection. Same reasoning as above: do not destroy.
   if (!data?.access_token) return REFRESH_UNAVAILABLE;
+
+  // The refresh token was read up to 15s ago. A sign-out — in this tab or, since
+  // localStorage is shared and nothing broadcasts the event, in another one —
+  // may have wiped the session in the meantime. Persisting now would write a
+  // freshly issued employee token back into keys the user just cleared, and
+  // because the wipe leaves the aliases vacant, mayWriteAliases would let it
+  // take those too: the next person at a shared kiosk boots straight into the
+  // signed-out employee's session. clearSession always drops REFRESH_KEY, so its
+  // absence is the marker. Nothing to clean up — we wrote nothing.
+  if (readStorage(REFRESH_KEY) == null) return REFRESH_UNAVAILABLE;
 
   persistSession({
     accessToken: data.access_token,

--- a/digit-ui-esbuild/products/dashboard/src/services/authService.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/authService.js
@@ -227,11 +227,18 @@ export function withSignificantRoleFirst(userInfo) {
  * every main-UI call would 401 until a full reload. Push the new token into
  * that cache so both surfaces stay on the same session.
  */
-function syncDigitSession(accessToken, userInfo) {
+function syncDigitSession(accessToken, userInfo, { claim = false, previousToken = null } = {}) {
   const session = window.Digit?.SessionStorage;
   if (!session?.set || !session?.get) return; // standalone build — nothing to sync
   try {
     const existing = session.get("User") || {};
+    // The "User" slot is a SINGLE shared cache — the co-hosted citizen portal
+    // authenticates from it too. Overwriting it on a background refresh would
+    // swap an actively-signed-in citizen to the employee identity without any
+    // user action (#1535). Only write when this is a deliberate sign-in, or
+    // when the cache is empty / already holds the token we are replacing.
+    const cachedToken = existing?.token ?? existing?.access_token ?? null;
+    if (!claim && cachedToken != null && cachedToken !== previousToken) return;
     session.set("User", {
       ...existing,
       token: accessToken,
@@ -243,14 +250,30 @@ function syncDigitSession(accessToken, userInfo) {
   }
 }
 
-export function persistSession({ accessToken, refreshToken, userInfo, tenantId }) {
+/**
+ * @param claimAliases  true only for an explicit sign-in through the dashboard
+ *   login form, where taking ownership of the shared unprefixed aliases IS the
+ *   intent. A silent background refresh passes false: it may refresh OUR
+ *   session, but it must never seize aliases that now belong to someone else.
+ */
+export function persistSession({ accessToken, refreshToken, userInfo, tenantId, claimAliases = false }) {
   // Normalise here rather than at the call site so a refresh cannot silently
   // revert the role order that login established.
   const normalisedUser = userInfo != null ? withSignificantRoleFirst(userInfo) : null;
 
+  // Read BEFORE writing: the token the aliases must currently hold for us to
+  // still own them. This is the write-side counterpart of clearSession's
+  // ownsAliases check — without it, a stale tab that 401s and silently
+  // refreshes clobbers a citizen's live session on the co-hosted portal with
+  // the employee identity, an identity swap with no user action (#1535).
+  const previousToken = getEmployeeToken();
+  const ownsAliases =
+    previousToken != null && readStorage(KEYS.tokenAlias.key) === previousToken;
+  const mayWriteAliases = claimAliases || ownsAliases || readStorage(KEYS.tokenAlias.key) == null;
+
   if (accessToken != null) {
     writeStorage(TOKEN_KEY, accessToken);
-    writeStorage("token", accessToken);
+    if (mayWriteAliases) writeStorage("token", accessToken);
   }
   if (refreshToken != null) {
     // Stored WITH its owner. Only this dashboard writes the refresh token, and
@@ -264,7 +287,9 @@ export function persistSession({ accessToken, refreshToken, userInfo, tenantId }
   }
   if (normalisedUser != null) {
     writeStorage(USER_INFO_KEY, normalisedUser);
-    writeStorage("user-info", normalisedUser);
+    // The two aliases move as a pair — a `token` from one identity beside a
+    // `user-info` from another is worse than either alone.
+    if (mayWriteAliases) writeStorage("user-info", normalisedUser);
   }
   if (tenantId != null) writeStorage(TENANT_KEY, tenantId);
 
@@ -275,22 +300,30 @@ export function persistSession({ accessToken, refreshToken, userInfo, tenantId }
     } catch {
       /* ignore */
     }
-    syncDigitSession(accessToken, normalisedUser);
+    syncDigitSession(accessToken, normalisedUser, { claim: claimAliases, previousToken });
   }
 }
 
-export function clearSession() {
+/**
+ * @param force  true for an explicit user-initiated sign-out, which must ALWAYS
+ *   leave this browser with no employee session — see clearDashboardSession.
+ *   Left false for an automatic teardown (a server-rejected refresh), where the
+ *   aliases may since have been taken over by a citizen on the co-hosted portal
+ *   and silently signing them out would be the greater harm.
+ */
+export function clearSession({ force = false } = {}) {
   // The unprefixed aliases and the single Digit.SessionStorage "User" slot are
   // not necessarily OURS: on a shared browser a citizen may be signed into the
-  // co-hosted portal while a stale Employee.token lingers. Only drop them when
-  // they actually hold the employee token we are tearing down, or we would sign
-  // an unrelated user out of a session they are actively using.
+  // co-hosted portal while a stale Employee.token lingers. Outside an explicit
+  // sign-out, only drop them when they actually hold the employee token we are
+  // tearing down, or we would sign an unrelated user out of a session they are
+  // actively using.
   const employeeToken = getEmployeeToken();
   const ownsAliases =
     employeeToken != null && readStorage(KEYS.tokenAlias.key) === employeeToken;
 
   SESSION_KEYS.forEach((k) => {
-    if (!ownsAliases && (k === KEYS.tokenAlias.key || k === KEYS.userInfoAlias.key)) return;
+    if (!force && !ownsAliases && (k === KEYS.tokenAlias.key || k === KEYS.userInfoAlias.key)) return;
     try {
       window.localStorage?.removeItem(k);
     } catch {
@@ -302,13 +335,19 @@ export function clearSession() {
   // from SessionStorage FIRST, skipping the localStorage re-seed when "User"
   // exists, so even a reload would re-enter the employee UI "logged in" on a
   // token that no longer works.
+  //
+  // Gated on what the cache actually HOLDS, not on alias ownership (#1536): if
+  // a citizen rewrote the unprefixed alias, ownsAliases is false while the
+  // cache still holds the employee's dead token, and keying off ownership would
+  // strand exactly the token this teardown exists to remove.
   const session = window.Digit?.SessionStorage;
-  if (session?.set && ownsAliases) {
+  if (session?.set) {
     try {
       const cached = session.get?.("User");
       const cachedToken = cached?.token ?? cached?.access_token ?? null;
-      // Same ownership test: never null a cache holding a different session.
-      if (cachedToken == null || cachedToken === employeeToken) session.set("User", null);
+      // Never null a cache holding a DIFFERENT live session — but on an
+      // explicit sign-out an empty cache is the required end state.
+      if (force || cachedToken == null || cachedToken === employeeToken) session.set("User", null);
     } catch {
       /* ignore */
     }

--- a/digit-ui-esbuild/products/dashboard/src/services/authSessionOwnership.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/authSessionOwnership.test.js
@@ -134,6 +134,46 @@ test("aliases are claimed when absent", () => {
   assert.equal(JSON.parse(localStorage._dump().token), "employee-new");
 });
 
+test("a refresh re-syncs our OWN cache even when it is a vintage behind", () => {
+  // Two tabs, one employee. Tab A refreshed first (Employee.token is already
+  // T1) while this tab's per-tab "User" cache still holds T0. Token equality
+  // cannot tell that apart from a stranger's cache; identity can. Refusing to
+  // write here strands the surrounding employee UI on T0, which tab A's refresh
+  // already invalidated server-side — and a reload does not heal it, because
+  // index.js boots from this cache and skips the localStorage re-seed.
+  const { mod, readUser } = load({
+    local: {
+      "Employee.token": enc("employee-t1"),
+      "Employee.user-info": enc({ uuid: "employee" }),
+      token: enc("employee-t1"),
+    },
+    user: { token: "employee-t0", info: { uuid: "employee" } },
+  });
+
+  mod.persistSession({ accessToken: "employee-t2" });
+
+  assert.equal(readUser().token, "employee-t2", "our own stale cache is repaired");
+});
+
+test("a silent refresh does not claim an EXPIRED cache while aliases are foreign", () => {
+  // Digit's storage expires "User" after 24h, so a kiosk left overnight has a
+  // null cache beside a citizen's still-live aliases. Emptiness alone must not
+  // license the write, or #1535's identity swap returns through the cache.
+  const { mod, readUser } = load({
+    local: {
+      "Employee.token": enc("employee-old"),
+      "Employee.user-info": enc({ uuid: "employee" }),
+      token: enc("citizen-token"),
+      "user-info": enc({ uuid: "citizen" }),
+    },
+    user: undefined,
+  });
+
+  mod.persistSession({ accessToken: "employee-new", userInfo: { uuid: "employee", roles: [] } });
+
+  assert.equal(readUser(), undefined, "the shared cache is left for the citizen");
+});
+
 /* ------------------------------------------------------------------ */
 /* #1536 — sign-out is unconditional; teardown keys off the cache      */
 /* ------------------------------------------------------------------ */
@@ -159,6 +199,29 @@ test("forced sign-out clears aliases even when the alias was rewritten", () => {
   assert.equal(readUser(), null, "Digit session cache emptied");
 });
 
+test("forced sign-out spares aliases that are provably a DIFFERENT user's", () => {
+  // The kiosk rule ("always leave no employee session behind") must not reach
+  // as far as deleting a session we can positively identify as someone else's:
+  // the user-info alias carries a different uuid, so a citizen is signed into
+  // the co-hosted portal right now and would lose their half-filed complaint.
+  const { mod, localStorage } = load({
+    local: {
+      "Employee.token": enc("employee-live"),
+      "Employee.user-info": enc({ uuid: "employee" }),
+      token: enc("citizen-token"),
+      "user-info": enc({ uuid: "citizen" }),
+    },
+    user: { token: "citizen-token", info: { uuid: "citizen" } },
+  });
+
+  mod.clearSession({ force: true });
+
+  const dump = localStorage._dump();
+  assert.equal(JSON.parse(dump.token), "citizen-token", "the citizen stays signed in");
+  assert.deepEqual(JSON.parse(dump["user-info"]), { uuid: "citizen" }, "their identity survives");
+  assert.equal(dump["Employee.token"], undefined, "our own session is gone regardless");
+});
+
 test("automatic teardown still spares a citizen's live aliases", () => {
   const { mod, localStorage } = load({
     local: { "Employee.token": enc("employee-dead"), token: enc("citizen-token") },
@@ -170,6 +233,42 @@ test("automatic teardown still spares a citizen's live aliases", () => {
   const dump = localStorage._dump();
   assert.equal(JSON.parse(dump.token), "citizen-token", "citizen stays signed in");
   assert.equal(dump["Employee.token"], undefined, "the dead employee token is dropped");
+});
+
+test("a refresh in flight when the user signs out does not resurrect the session", async () => {
+  // Nothing broadcasts a sign-out, and localStorage is shared across tabs, so a
+  // refresh started before the wipe can land after it. Writing the freshly
+  // issued token then would restore Employee.* AND — the aliases now being
+  // vacant, hence "claimable" — the shared aliases too, handing the next person
+  // at the kiosk the session the employee just signed out of (#1536).
+  const { mod, localStorage } = load({
+    local: {
+      "Employee.token": enc("employee-live"),
+      "Employee.user-info": enc({ uuid: "employee" }),
+      "Employee.refresh-token": enc({ token: "refresh-1", userUuid: "employee" }),
+      token: enc("employee-live"),
+    },
+    user: { token: "employee-live", info: { uuid: "employee" } },
+  });
+
+  const realFetch = global.fetch;
+  global.fetch = async (url) => {
+    if (String(url).includes("/user/oauth/token")) {
+      mod.clearSession({ force: true }); // the employee clicks Sign out mid-flight
+      return { ok: true, status: 200, json: async () => ({ access_token: "employee-new" }) };
+    }
+    return { ok: false, status: 401, json: async () => ({}) };
+  };
+
+  try {
+    await assert.rejects(() => mod.authFetch("/analytics", { buildBody: () => ({}) }));
+  } finally {
+    global.fetch = realFetch;
+  }
+
+  const dump = localStorage._dump();
+  assert.equal(dump["Employee.token"], undefined, "the signed-out session stays gone");
+  assert.equal(dump.token, undefined, "and it does not re-claim the shared aliases");
 });
 
 test("automatic teardown drops a dead token cached under a foreign alias", () => {

--- a/digit-ui-esbuild/products/dashboard/src/services/authSessionOwnership.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/authSessionOwnership.test.js
@@ -1,0 +1,187 @@
+// Shared-alias ownership tests for authService (#1535, #1536).
+// Run from digit-ui-esbuild/:  node --test products/dashboard/src/services/authSessionOwnership.test.js
+//
+// authService.js is ESM (like the rest of products/), so the test bundles it to
+// CJS with the repo's own esbuild and reloads it per test for fresh module
+// state — same idiom as dashboardMetrics.test.js.
+//
+// The scenario under test throughout: the dashboard and the citizen-facing
+// digit-ui portal are CO-HOSTED and share the unprefixed `token` / `user-info`
+// localStorage aliases plus the single Digit.SessionStorage "User" slot.
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const esbuild = require("esbuild");
+
+const ENTRY = path.join(__dirname, "authService.js");
+const OUT = path.join(os.tmpdir(), `authService.cjs.${process.pid}.js`);
+
+esbuild.buildSync({
+  entryPoints: [ENTRY],
+  bundle: true,
+  format: "cjs",
+  platform: "neutral",
+  outfile: OUT,
+  define: {
+    "process.env.NODE_ENV": '"production"',
+    "process.env.REACT_APP_STATE_LEVEL_TENANT_ID": '""',
+  },
+});
+process.on("exit", () => {
+  try {
+    fs.unlinkSync(OUT);
+  } catch (e) {
+    /* already gone */
+  }
+});
+
+function makeStorage(seed = {}) {
+  const map = new Map(Object.entries(seed));
+  return {
+    getItem: (k) => (map.has(k) ? map.get(k) : null),
+    setItem: (k, v) => map.set(k, v),
+    removeItem: (k) => map.delete(k),
+    _dump: () => Object.fromEntries(map),
+  };
+}
+
+/** Values land in localStorage JSON-encoded — mirror that when seeding. */
+const enc = (v) => JSON.stringify(v);
+
+function load({ local = {}, user = undefined } = {}) {
+  const localStorage = makeStorage(local);
+  let userSlot = user;
+  global.window = {
+    localStorage,
+    sessionStorage: makeStorage(),
+    Digit: {
+      SessionStorage: {
+        get: (k) => (k === "User" ? userSlot : undefined),
+        set: (k, v) => {
+          if (k === "User") userSlot = v;
+        },
+      },
+    },
+    dispatchEvent: () => {},
+  };
+  delete require.cache[require.resolve(OUT)];
+  const mod = require(OUT);
+  return { mod, localStorage, readUser: () => userSlot };
+}
+
+/* ------------------------------------------------------------------ */
+/* #1535 — persistSession must not seize aliases it does not own       */
+/* ------------------------------------------------------------------ */
+
+test("silent refresh does not clobber a citizen's aliases", () => {
+  // A citizen is signed into the co-hosted portal; the aliases are THEIRS.
+  // A stale dashboard tab 401s and silently refreshes in the background.
+  const { mod, localStorage, readUser } = load({
+    local: {
+      "Employee.token": enc("employee-old"),
+      token: enc("citizen-token"),
+      "user-info": enc({ uuid: "citizen" }),
+    },
+    user: { token: "citizen-token", info: { uuid: "citizen" } },
+  });
+
+  mod.persistSession({ accessToken: "employee-new", userInfo: { uuid: "employee", roles: [] } });
+
+  const dump = localStorage._dump();
+  assert.equal(JSON.parse(dump.token), "citizen-token", "citizen's token alias survives");
+  assert.deepEqual(JSON.parse(dump["user-info"]), { uuid: "citizen" }, "citizen's user-info survives");
+  assert.equal(JSON.parse(dump["Employee.token"]), "employee-new", "our own key still refreshes");
+  assert.equal(readUser().token, "citizen-token", "citizen's Digit session cache untouched");
+});
+
+test("silent refresh DOES update aliases it still owns", () => {
+  const { mod, localStorage, readUser } = load({
+    local: {
+      "Employee.token": enc("employee-old"),
+      token: enc("employee-old"),
+      "user-info": enc({ uuid: "employee" }),
+    },
+    user: { token: "employee-old" },
+  });
+
+  mod.persistSession({ accessToken: "employee-new", userInfo: { uuid: "employee", roles: [] } });
+
+  const dump = localStorage._dump();
+  assert.equal(JSON.parse(dump.token), "employee-new", "our own alias follows the refresh");
+  assert.equal(readUser().token, "employee-new", "co-hosted UI stays on the live token");
+});
+
+test("explicit sign-in claims the aliases", () => {
+  const { mod, localStorage } = load({
+    local: { token: enc("citizen-token"), "user-info": enc({ uuid: "citizen" }) },
+  });
+
+  mod.persistSession({
+    accessToken: "employee-new",
+    userInfo: { uuid: "employee", roles: [] },
+    claimAliases: true,
+  });
+
+  assert.equal(JSON.parse(localStorage._dump().token), "employee-new");
+});
+
+test("aliases are claimed when absent", () => {
+  const { mod, localStorage } = load({ local: {} });
+  mod.persistSession({ accessToken: "employee-new", userInfo: { uuid: "employee", roles: [] } });
+  assert.equal(JSON.parse(localStorage._dump().token), "employee-new");
+});
+
+/* ------------------------------------------------------------------ */
+/* #1536 — sign-out is unconditional; teardown keys off the cache      */
+/* ------------------------------------------------------------------ */
+
+test("forced sign-out clears aliases even when the alias was rewritten", () => {
+  // The kiosk case: alias no longer byte-matches Employee.token, so the
+  // ownership gate would have skipped it and left a live token behind.
+  const { mod, localStorage, readUser } = load({
+    local: {
+      "Employee.token": enc("employee-live"),
+      token: enc("something-else"),
+      "user-info": enc({ uuid: "employee" }),
+    },
+    user: { token: "employee-live" },
+  });
+
+  mod.clearSession({ force: true });
+
+  const dump = localStorage._dump();
+  assert.equal(dump.token, undefined, "token alias is gone");
+  assert.equal(dump["user-info"], undefined, "user-info alias is gone");
+  assert.equal(dump["Employee.token"], undefined, "our own key is gone");
+  assert.equal(readUser(), null, "Digit session cache emptied");
+});
+
+test("automatic teardown still spares a citizen's live aliases", () => {
+  const { mod, localStorage } = load({
+    local: { "Employee.token": enc("employee-dead"), token: enc("citizen-token") },
+    user: { token: "citizen-token" },
+  });
+
+  mod.clearSession();
+
+  const dump = localStorage._dump();
+  assert.equal(JSON.parse(dump.token), "citizen-token", "citizen stays signed in");
+  assert.equal(dump["Employee.token"], undefined, "the dead employee token is dropped");
+});
+
+test("automatic teardown drops a dead token cached under a foreign alias", () => {
+  // ownsAliases is false (the alias was rewritten), but the "User" cache still
+  // holds the employee's dead token — gating the cache clear on alias
+  // ownership stranded exactly the token this teardown exists to remove.
+  const { mod, readUser } = load({
+    local: { "Employee.token": enc("employee-dead"), token: enc("rewritten-by-someone") },
+    user: { token: "employee-dead" },
+  });
+
+  mod.clearSession();
+
+  assert.equal(readUser(), null, "dead token no longer cached for the co-hosted UI");
+});

--- a/frontend/micro-ui/web/src/dashboard/components/DashboardLogin.jsx
+++ b/frontend/micro-ui/web/src/dashboard/components/DashboardLogin.jsx
@@ -41,11 +41,13 @@ const DEMO_USERS = [
 export const hasDashboardSession = hasAuth;
 // Sign-out must ALWAYS leave this browser with no employee session. Aliasing
 // the ownership-gated clearSession directly (as this did) meant that when the
-// unprefixed `token` alias had been rewritten by the co-hosted UI or stored in
-// a different encoding, Sign out + reload left the aliases and the
-// Digit.SessionStorage "User" cache holding a live employee token — the next
-// person on a shared kiosk landed in the employee UI still authenticated as
-// the employee who had just signed out (#1536).
+// unprefixed `token` alias held a value other than Employee.token — rewritten
+// by the co-hosted UI, or a leftover from an earlier session — Sign out +
+// reload left the aliases and the Digit.SessionStorage "User" cache holding a
+// live employee token, and the next person on a shared kiosk landed in the
+// employee UI still authenticated as the employee who had just signed out
+// (#1536). The force flag still refuses to delete aliases that are provably a
+// DIFFERENT live user's — see clearSession.
 export const clearDashboardSession = () => clearSession({ force: true });
 
 const inputStyle = {

--- a/frontend/micro-ui/web/src/dashboard/components/DashboardLogin.jsx
+++ b/frontend/micro-ui/web/src/dashboard/components/DashboardLogin.jsx
@@ -39,7 +39,14 @@ const DEMO_USERS = [
 // Session storage lives in authService (single source of truth); these thin
 // re-exports keep the existing AdminDashboard import sites unchanged.
 export const hasDashboardSession = hasAuth;
-export const clearDashboardSession = clearSession;
+// Sign-out must ALWAYS leave this browser with no employee session. Aliasing
+// the ownership-gated clearSession directly (as this did) meant that when the
+// unprefixed `token` alias had been rewritten by the co-hosted UI or stored in
+// a different encoding, Sign out + reload left the aliases and the
+// Digit.SessionStorage "User" cache holding a live employee token — the next
+// person on a shared kiosk landed in the employee UI still authenticated as
+// the employee who had just signed out (#1536).
+export const clearDashboardSession = () => clearSession({ force: true });
 
 const inputStyle = {
   borderRadius: "0.375rem",
@@ -117,6 +124,9 @@ const DashboardLogin = ({ onLogin, expired = false }) => {
         refreshToken: data.refresh_token,
         userInfo,
         tenantId,
+        // Explicit sign-in: taking over the shared aliases IS the intent here.
+        // Every other caller (the silent refresh) leaves this false (#1535).
+        claimAliases: true,
       });
       if (onLogin) onLogin(userInfo);
     } catch (err) {

--- a/frontend/micro-ui/web/src/dashboard/services/authService.js
+++ b/frontend/micro-ui/web/src/dashboard/services/authService.js
@@ -60,7 +60,12 @@ import { getTenantId } from "../config/dashboardConfig";
  *
  * Likewise clearSession only drops the unprefixed aliases and the
  * Digit.SessionStorage cache when they actually hold the employee token being
- * torn down — on a shared browser they may belong to a live citizen session.
+ * torn down — on a shared browser they may belong to a live citizen session. An
+ * explicit sign-out overrides that (it must leave no employee session behind on
+ * a kiosk) with one exception: aliases carrying a DIFFERENT identity are proven
+ * to be someone else's and are still spared. The mirror-image rule governs
+ * writes: persistSession seizes the aliases only on a deliberate sign-in, never
+ * on a silent background refresh (#1535, #1536).
  *
  * Guarantees: at most three sends and at most one refresh per call (cannot
  * loop); concurrent 401s share a single refresh; a refresh never re-enters this
@@ -135,6 +140,38 @@ function writeStorage(key, value) {
 
 export function getEmployeeToken() {
   return readStorage(TOKEN_KEY);
+}
+
+/**
+ * The ownership predicates, defined ONCE.
+ *
+ * These rules were hand-copied into persistSession and clearSession, and the
+ * copies drifting apart is precisely what produced #1535 (the write side never
+ * got the clear side's ownership check) and #1536. Two mirrored files times two
+ * functions gave eight sites that had to change in lockstep; now there is one
+ * definition per rule.
+ */
+function readAliasToken() {
+  return readStorage(KEYS.tokenAlias.key);
+}
+
+/**
+ * True when the shared unprefixed aliases still hold `token`.
+ *
+ * Encoding is NOT a hazard here despite the two writers disagreeing about it:
+ * the main digit-ui login stores the token raw while this module JSON-stringifies
+ * it, but readStorage -> parseJson falls back to the raw string when JSON.parse
+ * throws, and an opaque UUID is never valid JSON. So the comparison holds across
+ * both encodings, and a mismatch always means a DIFFERENT VALUE — someone else's
+ * token, or a leftover.
+ */
+function ownsSharedAliases(token, aliasToken = readAliasToken()) {
+  return token != null && aliasToken === token;
+}
+
+/** The token a Digit.SessionStorage "User" entry authenticates with, if any. */
+function getCachedSessionToken(cached) {
+  return cached?.token ?? cached?.access_token ?? null;
 }
 
 /**
@@ -236,9 +273,24 @@ function syncDigitSession(accessToken, userInfo, { claim = false, previousToken 
     // authenticates from it too. Overwriting it on a background refresh would
     // swap an actively-signed-in citizen to the employee identity without any
     // user action (#1535). Only write when this is a deliberate sign-in, or
-    // when the cache is empty / already holds the token we are replacing.
-    const cachedToken = existing?.token ?? existing?.access_token ?? null;
-    if (!claim && cachedToken != null && cachedToken !== previousToken) return;
+    // when the cache is provably ours.
+    //
+    // Token equality alone does NOT prove that: the cache is sessionStorage
+    // (per-tab) while previousToken comes from localStorage (shared), so a
+    // sibling tab that refreshed first leaves THIS tab's cache one vintage
+    // behind — indistinguishable, by token, from a stranger's. Refusing to
+    // write there strands the tab on a token the earlier refresh already
+    // invalidated, and a reload does not heal it because index.js boots from
+    // this cache and skips the localStorage re-seed while it looks populated.
+    // Identity is the tab-independent proof; a citizen's cache still fails it.
+    const cachedToken = getCachedSessionToken(existing);
+    const cachedUuid = existing?.info?.uuid ?? null;
+    // A refresh usually carries no UserRequest, so fall back to stored identity.
+    const ourUuid = userInfo?.uuid ?? getEmployeeInfo()?.uuid ?? null;
+    const ownsCache =
+      cachedToken === previousToken ||
+      (cachedUuid != null && ourUuid != null && cachedUuid === ourUuid);
+    if (!claim && !ownsCache) return;
     session.set("User", {
       ...existing,
       token: accessToken,
@@ -267,9 +319,12 @@ export function persistSession({ accessToken, refreshToken, userInfo, tenantId, 
   // refreshes clobbers a citizen's live session on the co-hosted portal with
   // the employee identity, an identity swap with no user action (#1535).
   const previousToken = getEmployeeToken();
-  const ownsAliases =
-    previousToken != null && readStorage(KEYS.tokenAlias.key) === previousToken;
-  const mayWriteAliases = claimAliases || ownsAliases || readStorage(KEYS.tokenAlias.key) == null;
+  // Read the alias ONCE: two reads of a value that cannot change between them
+  // are a wasted parse, and they let a later edit make the two expressions
+  // disagree — silently splitting one ownership decision into two.
+  const aliasToken = readAliasToken();
+  const mayWriteAliases =
+    claimAliases || ownsSharedAliases(previousToken, aliasToken) || aliasToken == null;
 
   if (accessToken != null) {
     writeStorage(TOKEN_KEY, accessToken);
@@ -300,7 +355,13 @@ export function persistSession({ accessToken, refreshToken, userInfo, tenantId, 
     } catch {
       /* ignore */
     }
-    syncDigitSession(accessToken, normalisedUser, { claim: claimAliases, previousToken });
+    // Pass mayWriteAliases, not claimAliases: an EMPTY "User" cache is not ours
+    // to take while the aliases belong to someone else. Digit's storage expires
+    // entries after 24h, so a kiosk left overnight nulls a citizen's cache while
+    // their aliases stay live — and writing the employee identity into it would
+    // re-enter #1535 through the cache door, since index.js boots from the cache
+    // first and would then serve the employee session under the citizen's aliases.
+    syncDigitSession(accessToken, normalisedUser, { claim: mayWriteAliases, previousToken });
   }
 }
 
@@ -319,11 +380,24 @@ export function clearSession({ force = false } = {}) {
   // tearing down, or we would sign an unrelated user out of a session they are
   // actively using.
   const employeeToken = getEmployeeToken();
-  const ownsAliases =
-    employeeToken != null && readStorage(KEYS.tokenAlias.key) === employeeToken;
+  const ownsAliases = ownsSharedAliases(employeeToken);
+
+  // A forced sign-out must leave no employee session behind, so it drops the
+  // aliases even when they no longer match our token — that mismatch is usually
+  // a leftover, and leaving it stranded is what #1536 was about. But "not
+  // provably ours" is not "provably someone else's": when the `user-info` alias
+  // carries a DIFFERENT uuid, the aliases are positively identified as another
+  // live session, and deleting them would sign a citizen out of the co-hosted
+  // portal mid-flow — breaking rule 1 above to fix a leftover. A missing uuid on
+  // either side proves nothing, so those still clear.
+  const employeeUuid = getEmployeeInfo()?.uuid ?? null;
+  const aliasUuid = readStorage(KEYS.userInfoAlias.key)?.uuid ?? null;
+  const aliasesAreForeign =
+    !ownsAliases && aliasUuid != null && employeeUuid != null && aliasUuid !== employeeUuid;
+  const mayDropAliases = ownsAliases || (force && !aliasesAreForeign);
 
   SESSION_KEYS.forEach((k) => {
-    if (!force && !ownsAliases && (k === KEYS.tokenAlias.key || k === KEYS.userInfoAlias.key)) return;
+    if (!mayDropAliases && (k === KEYS.tokenAlias.key || k === KEYS.userInfoAlias.key)) return;
     try {
       window.localStorage?.removeItem(k);
     } catch {
@@ -344,10 +418,13 @@ export function clearSession({ force = false } = {}) {
   if (session?.set) {
     try {
       const cached = session.get?.("User");
-      const cachedToken = cached?.token ?? cached?.access_token ?? null;
+      const cachedToken = getCachedSessionToken(cached);
       // Never null a cache holding a DIFFERENT live session — but on an
-      // explicit sign-out an empty cache is the required end state.
-      if (force || cachedToken == null || cachedToken === employeeToken) session.set("User", null);
+      // explicit sign-out an empty cache is the required end state. A cache with
+      // no token authenticates nobody, so it is safe to drop UNLESS it still
+      // carries a foreign identity payload the co-hosted UI is rendering from.
+      if (force || cachedToken === employeeToken || (cachedToken == null && !cached?.info))
+        session.set("User", null);
     } catch {
       /* ignore */
     }
@@ -493,6 +570,16 @@ async function requestRefresh() {
   // A 2xx with no token is a malformed/intercepted response (proxy login page,
   // truncated body), not a rejection. Same reasoning as above: do not destroy.
   if (!data?.access_token) return REFRESH_UNAVAILABLE;
+
+  // The refresh token was read up to 15s ago. A sign-out — in this tab or, since
+  // localStorage is shared and nothing broadcasts the event, in another one —
+  // may have wiped the session in the meantime. Persisting now would write a
+  // freshly issued employee token back into keys the user just cleared, and
+  // because the wipe leaves the aliases vacant, mayWriteAliases would let it
+  // take those too: the next person at a shared kiosk boots straight into the
+  // signed-out employee's session. clearSession always drops REFRESH_KEY, so its
+  // absence is the marker. Nothing to clean up — we wrote nothing.
+  if (readStorage(REFRESH_KEY) == null) return REFRESH_UNAVAILABLE;
 
   persistSession({
     accessToken: data.access_token,

--- a/frontend/micro-ui/web/src/dashboard/services/authService.js
+++ b/frontend/micro-ui/web/src/dashboard/services/authService.js
@@ -227,11 +227,18 @@ export function withSignificantRoleFirst(userInfo) {
  * every main-UI call would 401 until a full reload. Push the new token into
  * that cache so both surfaces stay on the same session.
  */
-function syncDigitSession(accessToken, userInfo) {
+function syncDigitSession(accessToken, userInfo, { claim = false, previousToken = null } = {}) {
   const session = window.Digit?.SessionStorage;
   if (!session?.set || !session?.get) return; // standalone build — nothing to sync
   try {
     const existing = session.get("User") || {};
+    // The "User" slot is a SINGLE shared cache — the co-hosted citizen portal
+    // authenticates from it too. Overwriting it on a background refresh would
+    // swap an actively-signed-in citizen to the employee identity without any
+    // user action (#1535). Only write when this is a deliberate sign-in, or
+    // when the cache is empty / already holds the token we are replacing.
+    const cachedToken = existing?.token ?? existing?.access_token ?? null;
+    if (!claim && cachedToken != null && cachedToken !== previousToken) return;
     session.set("User", {
       ...existing,
       token: accessToken,
@@ -243,14 +250,30 @@ function syncDigitSession(accessToken, userInfo) {
   }
 }
 
-export function persistSession({ accessToken, refreshToken, userInfo, tenantId }) {
+/**
+ * @param claimAliases  true only for an explicit sign-in through the dashboard
+ *   login form, where taking ownership of the shared unprefixed aliases IS the
+ *   intent. A silent background refresh passes false: it may refresh OUR
+ *   session, but it must never seize aliases that now belong to someone else.
+ */
+export function persistSession({ accessToken, refreshToken, userInfo, tenantId, claimAliases = false }) {
   // Normalise here rather than at the call site so a refresh cannot silently
   // revert the role order that login established.
   const normalisedUser = userInfo != null ? withSignificantRoleFirst(userInfo) : null;
 
+  // Read BEFORE writing: the token the aliases must currently hold for us to
+  // still own them. This is the write-side counterpart of clearSession's
+  // ownsAliases check — without it, a stale tab that 401s and silently
+  // refreshes clobbers a citizen's live session on the co-hosted portal with
+  // the employee identity, an identity swap with no user action (#1535).
+  const previousToken = getEmployeeToken();
+  const ownsAliases =
+    previousToken != null && readStorage(KEYS.tokenAlias.key) === previousToken;
+  const mayWriteAliases = claimAliases || ownsAliases || readStorage(KEYS.tokenAlias.key) == null;
+
   if (accessToken != null) {
     writeStorage(TOKEN_KEY, accessToken);
-    writeStorage("token", accessToken);
+    if (mayWriteAliases) writeStorage("token", accessToken);
   }
   if (refreshToken != null) {
     // Stored WITH its owner. Only this dashboard writes the refresh token, and
@@ -264,7 +287,9 @@ export function persistSession({ accessToken, refreshToken, userInfo, tenantId }
   }
   if (normalisedUser != null) {
     writeStorage(USER_INFO_KEY, normalisedUser);
-    writeStorage("user-info", normalisedUser);
+    // The two aliases move as a pair — a `token` from one identity beside a
+    // `user-info` from another is worse than either alone.
+    if (mayWriteAliases) writeStorage("user-info", normalisedUser);
   }
   if (tenantId != null) writeStorage(TENANT_KEY, tenantId);
 
@@ -275,22 +300,30 @@ export function persistSession({ accessToken, refreshToken, userInfo, tenantId }
     } catch {
       /* ignore */
     }
-    syncDigitSession(accessToken, normalisedUser);
+    syncDigitSession(accessToken, normalisedUser, { claim: claimAliases, previousToken });
   }
 }
 
-export function clearSession() {
+/**
+ * @param force  true for an explicit user-initiated sign-out, which must ALWAYS
+ *   leave this browser with no employee session — see clearDashboardSession.
+ *   Left false for an automatic teardown (a server-rejected refresh), where the
+ *   aliases may since have been taken over by a citizen on the co-hosted portal
+ *   and silently signing them out would be the greater harm.
+ */
+export function clearSession({ force = false } = {}) {
   // The unprefixed aliases and the single Digit.SessionStorage "User" slot are
   // not necessarily OURS: on a shared browser a citizen may be signed into the
-  // co-hosted portal while a stale Employee.token lingers. Only drop them when
-  // they actually hold the employee token we are tearing down, or we would sign
-  // an unrelated user out of a session they are actively using.
+  // co-hosted portal while a stale Employee.token lingers. Outside an explicit
+  // sign-out, only drop them when they actually hold the employee token we are
+  // tearing down, or we would sign an unrelated user out of a session they are
+  // actively using.
   const employeeToken = getEmployeeToken();
   const ownsAliases =
     employeeToken != null && readStorage(KEYS.tokenAlias.key) === employeeToken;
 
   SESSION_KEYS.forEach((k) => {
-    if (!ownsAliases && (k === KEYS.tokenAlias.key || k === KEYS.userInfoAlias.key)) return;
+    if (!force && !ownsAliases && (k === KEYS.tokenAlias.key || k === KEYS.userInfoAlias.key)) return;
     try {
       window.localStorage?.removeItem(k);
     } catch {
@@ -302,13 +335,19 @@ export function clearSession() {
   // from SessionStorage FIRST, skipping the localStorage re-seed when "User"
   // exists, so even a reload would re-enter the employee UI "logged in" on a
   // token that no longer works.
+  //
+  // Gated on what the cache actually HOLDS, not on alias ownership (#1536): if
+  // a citizen rewrote the unprefixed alias, ownsAliases is false while the
+  // cache still holds the employee's dead token, and keying off ownership would
+  // strand exactly the token this teardown exists to remove.
   const session = window.Digit?.SessionStorage;
-  if (session?.set && ownsAliases) {
+  if (session?.set) {
     try {
       const cached = session.get?.("User");
       const cachedToken = cached?.token ?? cached?.access_token ?? null;
-      // Same ownership test: never null a cache holding a different session.
-      if (cachedToken == null || cachedToken === employeeToken) session.set("User", null);
+      // Never null a cache holding a DIFFERENT live session — but on an
+      // explicit sign-out an empty cache is the required end state.
+      if (force || cachedToken == null || cachedToken === employeeToken) session.set("User", null);
     } catch {
       /* ignore */
     }


### PR DESCRIPTION
Fixes #1535. Fixes #1536. The two review comments raised on #1515 that were merged past. Same root cause, one file (×2 copies), so they land together.

## Context

The dashboard and the citizen portal are co-hosted: they share the unprefixed `token` / `user-info` localStorage aliases and the single `Digit.SessionStorage` "User" slot. #1515 correctly recognised this on the **clear** side (`ownsAliases`) and stamped an owner onto the refresh token. The **write** side never got the same treatment, and the new gate had two side effects on sign-out.

## #1535 — persistSession seized aliases it did not own

`persistSession` wrote `token` and `user-info` with the employee identity on *every* silent refresh, unconditionally.

**Failure:** a citizen is signed into the portal. A stale dashboard tab in the background 401s, silently refreshes, and overwrites the citizen's aliases with the employee token and user-info. The main UI's boot path reads those aliases for login detection, so on next reload the citizen is silently switched to the employee identity — no user action anywhere.

**Fix:** alias writes are gated three ways —
- an explicit sign-in **claims** them (`claimAliases: true`, set only at the login call site — that is the one place where taking them over is the intent);
- a background refresh writes them only if they still hold the token being replaced;
- an absent alias is free to take.

`syncDigitSession` was overwriting the shared "User" cache unconditionally for the same reason and is now gated the same way. The two aliases move as a pair — a `token` from one identity beside a `user-info` from another is worse than either alone.

## #1536 — two consequences of the ownsAliases gate

**1. Sign-out lost its unconditional-clear guarantee.** `clearDashboardSession` was aliased straight to the gated `clearSession`, so "Sign out always removes the aliases" only held while the alias byte-matched `Employee.token`. On a shared kiosk, if the alias held a value other than `Employee.token` — rewritten by the co-hosted UI, or a leftover from an earlier session — Sign out + reload left `token`, `user-info` and the "User" cache holding a live employee token — the next person landed in the employee UI authenticated as the employee who had just signed out.

(An earlier draft of this description blamed an encoding mismatch. That was wrong and is corrected here: `readStorage` → `parseJson` falls back to the raw string when `JSON.parse` throws, and an opaque UUID is never valid JSON, so the comparison holds across both writers' encodings. A mismatch always means a *different value*.)

`clearSession` now takes `{ force }`. Set for user-initiated sign-out only; the automatic teardown (server-rejected refresh) keeps the ownership gate, where silently signing a citizen out would be the greater harm.

**2. The SessionStorage teardown was gated on the wrong condition** — alias ownership rather than what the cache holds. If a citizen later overwrote the alias, `ownsAliases` is false while the cache still holds the employee's dead token, so the gate stranded exactly the token the teardown exists to remove. It now keys off the cached token directly.

## Tests

New `authSessionOwnership.test.js`, **11 cases**, following the existing `dashboardMetrics.test.js` idiom (esbuild-to-CJS + mocked storage). Run from `digit-ui-esbuild/`:

```
node --test products/dashboard/src/services/authSessionOwnership.test.js
```

Every defect case was verified against the module *without* its fix, so the suite guards behaviour rather than asserting the new API. 7 cases cover #1535/#1536 (3 fail pre-fix); 4 more were added in the review round below (all 4 fail against the first commit of this PR, while the original 7 keep passing).

## Review round 2 — `bcec0b92e`

Six findings from the review of the first commit. Each is a case where token equality was standing in for ownership and cannot carry that weight.

1. **`syncDigitSession` stranded our own stale cache.** The "User" slot is `sessionStorage` (per-tab) while `previousToken` is `localStorage` (shared), so a sibling tab that refreshed first leaves this tab's cache one vintage behind — by token alone, indistinguishable from a stranger's. Skipping the write left the surrounding employee UI authenticating with a token the earlier refresh had already invalidated, and a reload did not heal it because `index.js` boots from that cache and skips the localStorage re-seed. Ownership now also accepts a matching `info.uuid` (falling back to stored identity, since a refresh usually returns no `UserRequest`).
2. **The cache write was gated on emptiness, not ownership.** Digit storage expires entries after 24h, so a kiosk left overnight has a null cache beside a citizen's still-live aliases — and the employee identity was being written into it. `syncDigitSession` now receives `mayWriteAliases`, not `claimAliases`.
3. **A refresh in flight across a sign-out resurrected the session.** Nothing broadcasts sign-out and localStorage is shared, so a refresh started before the wipe could land after it, rewriting `Employee.*` and — the aliases now being vacant, hence "claimable" — the shared aliases too. `requestRefresh` re-checks that the refresh token still exists before persisting; `clearSession` always drops it, so its absence is the marker.
4. **Forced sign-out could delete a citizen's live aliases.** It now spares aliases whose `user-info` carries a *different* uuid — those are positively identified as someone else's session, and deleting them signs a citizen out mid-flow, breaking the module's rule 1 to fix a leftover. A missing uuid on either side proves nothing and still clears, so the kiosk case of #1536 is unchanged.
5. **Token-less cache** is dropped on a non-force teardown only when it carries no identity payload either.
6. **The ownership predicates were hand-copied** across two functions × two mirrored files — the same drift that produced #1535. Extracted as `readAliasToken` / `ownsSharedAliases` / `getCachedSessionToken`; the alias is now read once in `persistSession` rather than twice.

One finding was **not** actioned: nulling the `Digit.SessionStorage` "User" cache on a forced sign-out cannot sign out a citizen in another tab, because `Digit.SessionStorage` is backed by `window.sessionStorage` (`packages/libraries/src/services/atoms/Utils/Storage.js:64`) and is therefore per-tab. The only cache reachable from that line is the one in the tab where Sign out was clicked, where an empty cache is the intended end state.

## Notes for review

- Both copies (`digit-ui-esbuild/products/dashboard/` and `frontend/micro-ui/web/src/dashboard/`) are updated; `authService.js` stays byte-identical between them.
- All four call sites audited: sign-out → forced clear; login → claims aliases; `announceSessionExpired(clearStorage)` → unforced clear (unchanged semantics); `requestRefresh` → unclaimed persist.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard sign-out to reliably clear stale session data.
  * Prevented background session refreshes from overwriting another active user’s session.
  * Improved handling of shared authentication data across dashboard and citizen portal sessions.
  * Prevented in-progress refresh requests from restoring sessions after sign-out.
  * Ensured explicit sign-ins correctly establish session ownership.

* **Tests**
  * Added coverage for session ownership, refresh behavior, sign-out, cache expiry, and shared browser storage scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->