### PR TITLE
fix(dashboard): scale the map's Created legend to the data (#1461)

### DIFF
--- a/digit-mcp/src/tools/dashboard-l10n-seed.ts
+++ b/digit-mcp/src/tools/dashboard-l10n-seed.ts
@@ -820,36 +820,6 @@ export const DASHBOARD_L10N_MESSAGES: { code: string; message: string; module: s
     "module": "rainmaker-dashboard"
   },
   {
-    "code": "DASHBOARD_MAP_LEGEND_COUNT_1_3",
-    "message": "1–3",
-    "module": "rainmaker-dashboard"
-  },
-  {
-    "code": "DASHBOARD_MAP_LEGEND_COUNT_11_13",
-    "message": "11–13",
-    "module": "rainmaker-dashboard"
-  },
-  {
-    "code": "DASHBOARD_MAP_LEGEND_COUNT_14_15",
-    "message": "14–15",
-    "module": "rainmaker-dashboard"
-  },
-  {
-    "code": "DASHBOARD_MAP_LEGEND_COUNT_4_5",
-    "message": "4–5",
-    "module": "rainmaker-dashboard"
-  },
-  {
-    "code": "DASHBOARD_MAP_LEGEND_COUNT_6_8",
-    "message": "6–8",
-    "module": "rainmaker-dashboard"
-  },
-  {
-    "code": "DASHBOARD_MAP_LEGEND_COUNT_9_10",
-    "message": "9–10",
-    "module": "rainmaker-dashboard"
-  },
-  {
     "code": "DASHBOARD_MAP_LEGEND_EXPAND",
     "message": "Expand legend",
     "module": "rainmaker-dashboard"
@@ -2401,36 +2371,6 @@ export const DASHBOARD_L10N_MESSAGES_PT_PT: { code: string; message: string; mod
   {
     "code": "DASHBOARD_MAP_LEGEND_COLLAPSE",
     "message": "Recolher legenda",
-    "module": "rainmaker-dashboard"
-  },
-  {
-    "code": "DASHBOARD_MAP_LEGEND_COUNT_1_3",
-    "message": "1–3",
-    "module": "rainmaker-dashboard"
-  },
-  {
-    "code": "DASHBOARD_MAP_LEGEND_COUNT_11_13",
-    "message": "11–13",
-    "module": "rainmaker-dashboard"
-  },
-  {
-    "code": "DASHBOARD_MAP_LEGEND_COUNT_14_15",
-    "message": "14–15",
-    "module": "rainmaker-dashboard"
-  },
-  {
-    "code": "DASHBOARD_MAP_LEGEND_COUNT_4_5",
-    "message": "4–5",
-    "module": "rainmaker-dashboard"
-  },
-  {
-    "code": "DASHBOARD_MAP_LEGEND_COUNT_6_8",
-    "message": "6–8",
-    "module": "rainmaker-dashboard"
-  },
-  {
-    "code": "DASHBOARD_MAP_LEGEND_COUNT_9_10",
-    "message": "9–10",
     "module": "rainmaker-dashboard"
   },
   {

--- a/digit-ui-esbuild/products/dashboard/src/components/GeographyChoroplethMap.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/GeographyChoroplethMap.jsx
@@ -6,10 +6,12 @@ import {
   getGeographyMapLegendFooter,
   getGeographyMapLegendTitle,
   getCreatedCountFillStyle,
+  buildCreatedCountScale,
   getOpenShareFillStyle,
   getResolvedShareFillStyle,
 } from "../config/geographyMapPresentation";
 import { buildMapHoverTooltipHtml, buildComplaintPinTooltipHtml } from "../config/mapHoverPresentation";
+import { getNumberFormatStamp } from "../utils/numberFormat";
 import useDashboardT from "../i18n/useDashboardT";
 import { dimensionLabel } from "../i18n/dimensionLabel";
 import { fetchBoundariesByCodes, fetchBoundaryRelationshipsByCodes } from "../services/boundaryService";
@@ -90,7 +92,7 @@ function createComplaintPinPopup(pin, radius) {
 const MAP_COUNTY_MAX_ZOOM = 10; // below -> county outline only
 const MAP_SUBCOUNTY_MAX_ZOOM = 12; // below -> sub-counties; at/above -> wards
 
-function resolveFeatureStyle(feature, layerMode, focusedCode, zoom = 11) {
+function resolveFeatureStyle(feature, layerMode, focusedCode, zoom = 11, createdBuckets) {
   const props = feature?.properties ?? {};
   const isFocused = focusedCode && props.code === focusedCode;
   const base =
@@ -98,7 +100,10 @@ function resolveFeatureStyle(feature, layerMode, focusedCode, zoom = 11) {
       ? getOpenShareFillStyle(props.openPct)
       : layerMode === "resolved"
         ? getResolvedShareFillStyle(props.resolvedPct)
-        : getCreatedCountFillStyle(Number(props.count) || Number(props.created) || 0);
+        : getCreatedCountFillStyle(
+            Number(props.count) || Number(props.created) || 0,
+            createdBuckets
+          );
 
   const weight = isFocused ? 2.5 : zoom < 11 ? 0.75 : zoom < 14 ? 1.1 : 1.5;
 
@@ -321,7 +326,26 @@ const GeographyChoroplethMap = ({
 
   const visibleComplaintPins = displayLayers.complaintPins ?? [];
 
-  const legendItems = useMemo(() => getGeographyMapLegend(layerMode), [layerMode, language]);
+  // Scale the Created layer to the data actually on the map (#1461). Derived from
+  // the WARD series, never from the rendered features: zoom rolls counts up by
+  // summing children, so a per-level scale would rewrite the legend on every
+  // scroll step. Not keyed on layerMode either — toggling layers must not move it.
+  const createdBuckets = useMemo(
+    () => buildCreatedCountScale((wardCounts || []).map((w) => w?.count)).buckets,
+    [wardCounts]
+  );
+  // wardCounts is rebuilt by identity on every layer toggle, so depend on the
+  // EDGES rather than the array — an identical scale must not force Leaflet to
+  // tear down and rebuild every polygon.
+  const createdScaleKey = useMemo(
+    () => createdBuckets.map((b) => `${b.min ?? 0}:${b.max ?? 0}`).join("|"),
+    [createdBuckets]
+  );
+  const legendItems = useMemo(
+    () => getGeographyMapLegend(layerMode, createdBuckets),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [layerMode, language, createdScaleKey, getNumberFormatStamp()]
+  );
   const legendTitle = getGeographyMapLegendTitle(layerMode);
   const legendFooter = getGeographyMapLegendFooter(drillTrail.length);
 
@@ -530,7 +554,7 @@ const GeographyChoroplethMap = ({
 
     L.geoJSON(geoFeatures, {
       style: (feature) =>
-        resolveFeatureStyle(feature, layerMode, focusedCode, zoomLevelRef.current),
+        resolveFeatureStyle(feature, layerMode, focusedCode, zoomLevelRef.current, createdBuckets),
       onEachFeature: (feature, layer) => {
         layer.feature = feature;
         const code = feature?.properties?.code;
@@ -548,7 +572,8 @@ const GeographyChoroplethMap = ({
             feature,
             layerMode,
             focusedCode,
-            zoomLevelRef.current
+            zoomLevelRef.current,
+            createdBuckets
           );
           layer.setStyle({ ...s, weight: 2.5, fillOpacity: Math.min(s.fillOpacity + 0.1, 0.75) });
           layer.bringToFront?.();
@@ -556,7 +581,7 @@ const GeographyChoroplethMap = ({
 
         layer.on("mouseout", () => {
           layer.setStyle(
-            resolveFeatureStyle(feature, layerMode, focusedCode, zoomLevelRef.current)
+            resolveFeatureStyle(feature, layerMode, focusedCode, zoomLevelRef.current, createdBuckets)
           );
         });
 
@@ -615,6 +640,7 @@ const GeographyChoroplethMap = ({
     // (#882 ward-tooltip precedent) so bound tooltip text picks up the new locale.
     language,
     layerMode,
+    createdScaleKey,
   ]);
 
   // ── update choropleth border weights when zoom / focus / mode changes ─────
@@ -623,10 +649,13 @@ const GeographyChoroplethMap = ({
       const feature = layer.feature;
       if (!feature) return;
       layer.setStyle(
-        resolveFeatureStyle(feature, layerMode, focusedCode, zoomLevel)
+        resolveFeatureStyle(feature, layerMode, focusedCode, zoomLevel, createdBuckets)
       );
     });
-  }, [focusedCode, layerMode, zoomLevel]);
+    // createdScaleKey, not createdBuckets: the array is rebuilt on every layer
+    // toggle but the scale itself rarely changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [focusedCode, layerMode, zoomLevel, createdScaleKey]);
 
   // ── draw complaint pins — redraw on data change; resize on zoom without closing popup
   useEffect(() => {

--- a/digit-ui-esbuild/products/dashboard/src/config/geographyMapPresentation.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/geographyMapPresentation.js
@@ -1,6 +1,7 @@
 // Not a component — translate lazily inside render-time functions only (never
 // at module level), so language switches pick up fresh strings.
 import { translate as t } from "../i18n/localeRuntime";
+import { formatNumber } from "../utils/numberFormat";
 
 /** @typedef {'created' | 'open' | 'resolved'} GeographyMapLayerId */
 
@@ -30,16 +31,136 @@ export function getGeographyMapLayerMeta(layerId) {
   return GEOGRAPHY_MAP_LAYERS.find((layer) => layer.id === layerId);
 }
 
-/** Created — complaint count buckets (blue scale). */
-export const CREATED_COUNT_LEGEND = [
-  { id: "none", label: "No complaints", fill: "#ffffff", stroke: "#d1d5db", fillOpacity: 0.95 },
-  { id: "b1", label: "1–3", fill: "#dbeafe", stroke: "#bfdbfe", fillOpacity: 0.78 },
-  { id: "b2", label: "4–5", fill: "#93c5fd", stroke: "#60a5fa", fillOpacity: 0.76 },
-  { id: "b3", label: "6–8", fill: "#60a5fa", stroke: "#3b82f6", fillOpacity: 0.74 },
-  { id: "b4", label: "9–10", fill: "#3b82f6", stroke: "#2563eb", fillOpacity: 0.74 },
-  { id: "b5", label: "11–13", fill: "#2563eb", stroke: "#1d4ed8", fillOpacity: 0.76 },
-  { id: "b6", label: "14–15", fill: "#1e40af", stroke: "#1e3a8a", fillOpacity: 0.78 },
+/** The white "nothing here" swatch, shared by all three legends. */
+export const CREATED_COUNT_NONE = {
+  id: "none",
+  label: "No complaints",
+  fill: "#ffffff",
+  stroke: "#d1d5db",
+  fillOpacity: 0.95,
+};
+
+/** Created — the blue ramp, darkest last. Bucket EDGES are computed per tenant. */
+export const CREATED_COUNT_RAMP = [
+  { fill: "#dbeafe", stroke: "#bfdbfe", fillOpacity: 0.78 },
+  { fill: "#93c5fd", stroke: "#60a5fa", fillOpacity: 0.76 },
+  { fill: "#60a5fa", stroke: "#3b82f6", fillOpacity: 0.74 },
+  { fill: "#3b82f6", stroke: "#2563eb", fillOpacity: 0.74 },
+  { fill: "#2563eb", stroke: "#1d4ed8", fillOpacity: 0.76 },
+  { fill: "#1e40af", stroke: "#1e3a8a", fillOpacity: 0.78 },
 ];
+
+export const MAX_CREATED_COUNT_BUCKETS = CREATED_COUNT_RAMP.length;
+
+/**
+ * Fallback scale, used only when no data has been seen yet (and by the legacy
+ * getWowChangeFillStyle path). Real scales come from buildCreatedCountScale.
+ */
+export const CREATED_COUNT_LEGEND = [
+  CREATED_COUNT_NONE,
+  { id: "b1", label: "1–3", min: 1, max: 3, ...CREATED_COUNT_RAMP[0] },
+  { id: "b2", label: "4–5", min: 4, max: 5, ...CREATED_COUNT_RAMP[1] },
+  { id: "b3", label: "6–8", min: 6, max: 8, ...CREATED_COUNT_RAMP[2] },
+  { id: "b4", label: "9–10", min: 9, max: 10, ...CREATED_COUNT_RAMP[3] },
+  { id: "b5", label: "11–13", min: 11, max: 13, ...CREATED_COUNT_RAMP[4] },
+  { id: "b6", label: "14+", min: 14, max: Infinity, ...CREATED_COUNT_RAMP[5] },
+];
+
+/** Round up to the next 1–2–5 ladder rung (1,2,5,10,20,50,100,…). */
+function niceCeil(value) {
+  if (!(value > 1)) return 1;
+  const decade = 10 ** Math.floor(Math.log10(value));
+  const mantissa = value / decade;
+  const rung = mantissa <= 1 ? 1 : mantissa <= 2 ? 2 : mantissa <= 5 ? 5 : 10;
+  return rung * decade;
+}
+
+/**
+ * Build the Created-layer scale from the values actually on the map (#1461).
+ *
+ * The old scale was a constant topping out at 15, so on a tenant like bomet —
+ * where one ward holds 1250 complaints and the next holds 55 — every ward
+ * saturated the darkest bucket and the choropleth carried no information at all.
+ *
+ * Complaint volume is skewed MULTIPLICATIVELY (1250 / 55 / 3), so the breaks are
+ * geometric rather than linear: an equal-interval scale over [0, max] would put
+ * all 22 of bomet's smaller wards in bucket 1 and merely invert the bug. Breaks
+ * are then snapped up to the 1–2–5 ladder, which is itself near-logarithmic, so
+ * "log spacing" and "round human numbers" cost nothing against each other — and
+ * quantization gives free hysteresis: the legend only moves when the max crosses
+ * a rung, not on every refresh.
+ *
+ * Quantile/Jenks breaks were rejected: with 6–23 wards they degenerate into a
+ * rank map, produce arbitrary labels like "3–1250", and reshuffle on every
+ * filter change.
+ *
+ * The domain must be the WARD-level series. Zoom rolls counts up by summing
+ * children, so scaling to the rendered features would rewrite the legend on
+ * every scroll step; the open-ended top bucket absorbs rolled-up values instead.
+ *
+ * Pure and total — safe to call with anything.
+ *
+ * @param {Array<number>} values raw per-ward counts
+ * @returns {{ max: number, breaks: number[], buckets: object[] }}
+ */
+export function buildCreatedCountScale(values = []) {
+  let max = 0;
+  for (const raw of Array.isArray(values) ? values : []) {
+    const n = Math.trunc(Number(raw));
+    if (Number.isFinite(n) && n > max) max = n;
+  }
+  if (max <= 0) return { max: 0, breaks: [], buckets: [CREATED_COUNT_NONE] };
+
+  let breaks;
+  if (max <= MAX_CREATED_COUNT_BUCKETS) {
+    // Tiny tenants (mz peaks at 32; a fresh install at 1): give each count its
+    // own shade rather than rounding a max of 8 up to a 50-wide bucket.
+    breaks = Array.from({ length: max - 1 }, (_, i) => i + 1);
+  } else {
+    // Geometric interior breaks, snapped up to the ladder. The top bucket is
+    // open-ended, so only MAX-1 edges are needed.
+    breaks = Array.from({ length: MAX_CREATED_COUNT_BUCKETS - 1 }, (_, i) =>
+      niceCeil(max ** ((i + 1) / MAX_CREATED_COUNT_BUCKETS))
+    );
+  }
+  // Snapping collapses duplicates; that is how the scale degrades gracefully to
+  // fewer buckets on small domains instead of emitting empty ranges.
+  breaks = [...new Set(breaks)].filter((b) => b >= 1 && b < max).sort((a, b) => a - b);
+
+  const edges = [...breaks, Infinity];
+  const last = edges.length - 1;
+  return {
+    max,
+    breaks,
+    buckets: [
+      CREATED_COUNT_NONE,
+      ...edges.map((upper, i) => {
+        const lower = i === 0 ? 1 : edges[i - 1] + 1;
+        // Always anchor the darkest stop to the top bucket, however few there are.
+        const ramp =
+          CREATED_COUNT_RAMP[
+            last === 0 ? CREATED_COUNT_RAMP.length - 1 : Math.round((i * (CREATED_COUNT_RAMP.length - 1)) / last)
+          ];
+        return { id: `b${i + 1}`, label: formatBucketLabel(lower, upper), min: lower, max: upper, ...ramp };
+      }),
+    ],
+  };
+}
+
+/**
+ * "1–5" / "501+" / "7". Numerals only: legend labels used to be seeded l10n
+ * messages, but a computed range has no fixed key and translate() renders the
+ * RAW KEY when a message is missing — so a minted key would paint
+ * "DASHBOARD_MAP_LEGEND_COUNT_124_248" on screen. The seeded count messages were
+ * byte-identical across en_IN and pt_PT anyway (they were pure numerals), so
+ * nothing translatable is lost. Digit grouping still honours the tenant mask.
+ */
+function formatBucketLabel(lower, upper) {
+  const n = (value) => formatNumber(value, { decimals: 0 }) ?? String(value);
+  if (upper === Infinity) return `${n(lower)}+`;
+  if (lower === upper) return n(lower);
+  return `${n(lower)}–${n(upper)}`;
+}
 
 /** % Open — share of filed complaints still open (red scale). */
 export const OPEN_SHARE_LEGEND = [
@@ -68,18 +189,6 @@ function localizeLegendBucketLabel(label) {
   switch (label) {
     case "No complaints":
       return t("DASHBOARD_MAP_LEGEND_NO_COMPLAINTS", "No complaints");
-    case "1–3":
-      return t("DASHBOARD_MAP_LEGEND_COUNT_1_3", "1–3");
-    case "4–5":
-      return t("DASHBOARD_MAP_LEGEND_COUNT_4_5", "4–5");
-    case "6–8":
-      return t("DASHBOARD_MAP_LEGEND_COUNT_6_8", "6–8");
-    case "9–10":
-      return t("DASHBOARD_MAP_LEGEND_COUNT_9_10", "9–10");
-    case "11–13":
-      return t("DASHBOARD_MAP_LEGEND_COUNT_11_13", "11–13");
-    case "14–15":
-      return t("DASHBOARD_MAP_LEGEND_COUNT_14_15", "14–15");
     case "0%":
       return t("DASHBOARD_MAP_LEGEND_PCT_0", "0%");
     case "≤ 20%":
@@ -97,13 +206,15 @@ function localizeLegendBucketLabel(label) {
   }
 }
 
-export function getGeographyMapLegend(layerId) {
+export function getGeographyMapLegend(layerId, createdBuckets = CREATED_COUNT_LEGEND) {
   const legend =
     layerId === "open"
       ? OPEN_SHARE_LEGEND
       : layerId === "resolved"
         ? RESOLVED_SHARE_LEGEND
-        : CREATED_COUNT_LEGEND;
+        : createdBuckets;
+  // The share legends keep their seeded messages; computed count labels are
+  // already numerals and fall through localizeLegendBucketLabel's default.
   return legend.map((bucket) => ({ ...bucket, label: localizeLegendBucketLabel(bucket.label) }));
 }
 
@@ -141,15 +252,17 @@ function bucketToFillStyle(bucket) {
   };
 }
 
-export function getCreatedCountBucket(count) {
+/** Range scan, so it classifies against ANY generated scale, not fixed edges. */
+export function getCreatedCountBucket(count, buckets = CREATED_COUNT_LEGEND) {
+  const scale = Array.isArray(buckets) && buckets.length ? buckets : CREATED_COUNT_LEGEND;
   const n = Number(count) || 0;
-  if (n <= 0) return CREATED_COUNT_LEGEND[0];
-  if (n <= 3) return CREATED_COUNT_LEGEND[1];
-  if (n <= 5) return CREATED_COUNT_LEGEND[2];
-  if (n <= 8) return CREATED_COUNT_LEGEND[3];
-  if (n <= 10) return CREATED_COUNT_LEGEND[4];
-  if (n <= 13) return CREATED_COUNT_LEGEND[5];
-  return CREATED_COUNT_LEGEND[6];
+  if (n <= 0) return scale[0];
+  for (let i = 1; i < scale.length; i += 1) {
+    if (n <= scale[i].max) return scale[i];
+  }
+  // Above every edge — only reachable when the top bucket is not open-ended
+  // (rolled-up county values against a stale scale).
+  return scale[scale.length - 1];
 }
 
 export function getSharePctBucket(pct, legend) {
@@ -163,8 +276,8 @@ export function getSharePctBucket(pct, legend) {
   return legend[6];
 }
 
-export function getCreatedCountFillStyle(count) {
-  return bucketToFillStyle(getCreatedCountBucket(count));
+export function getCreatedCountFillStyle(count, buckets = CREATED_COUNT_LEGEND) {
+  return bucketToFillStyle(getCreatedCountBucket(count, buckets));
 }
 
 export function getOpenShareFillStyle(openPct) {

--- a/digit-ui-esbuild/products/dashboard/src/config/geographyMapPresentation.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/geographyMapPresentation.test.js
@@ -1,0 +1,174 @@
+// Data-driven Created-layer scale (#1461).
+// Run from digit-ui-esbuild/:  node --test products/dashboard/src/config/geographyMapPresentation.test.js
+//
+// The module is ESM and imports the i18n runtime, so it is bundled to CJS with
+// the repo's own esbuild — same idiom as services/dashboardMetrics.test.js.
+// buildCreatedCountScale is pure, so the whole edge-case table is testable with
+// no DOM and no Leaflet.
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const esbuild = require("esbuild");
+
+const ENTRY = path.join(__dirname, "geographyMapPresentation.js");
+const OUT = path.join(os.tmpdir(), `geographyMapPresentation.cjs.${process.pid}.js`);
+
+esbuild.buildSync({
+  entryPoints: [ENTRY],
+  bundle: true,
+  format: "cjs",
+  platform: "neutral",
+  outfile: OUT,
+  define: { "process.env.NODE_ENV": '"production"' },
+});
+process.on("exit", () => {
+  try {
+    fs.unlinkSync(OUT);
+  } catch (e) {
+    /* already gone */
+  }
+});
+
+const {
+  buildCreatedCountScale,
+  getCreatedCountBucket,
+  getGeographyMapLegend,
+  CREATED_COUNT_RAMP,
+  MAX_CREATED_COUNT_BUCKETS,
+} = require(OUT);
+
+/** Bucket labels minus the leading "No complaints" swatch. */
+const ranges = (values) =>
+  buildCreatedCountScale(values)
+    .buckets.slice(1)
+    .map((b) => b.label);
+
+/* ------------------------------------------------------------------ */
+/* The bug: real tenant distributions                                  */
+/* ------------------------------------------------------------------ */
+
+test("bomet's 23 wards spread across the ramp instead of saturating", () => {
+  // Measured on bomet 2026-08-03: one ward holds 1250, the next 55.
+  const bomet = [1250, 55, 40, 29, 26, 24, 23, 13, 6, 4, 3, 3, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+  assert.deepEqual(ranges(bomet), ["1–5", "6–20", "21–50", "51–200", "201–500", "501+"]);
+
+  // The old scale put ALL of these in the top bucket. Now they separate.
+  const bucketOf = (n) => getCreatedCountBucket(n, buildCreatedCountScale(bomet).buckets).label;
+  assert.equal(bucketOf(1250), "501+");
+  assert.equal(bucketOf(55), "51–200");
+  assert.equal(bucketOf(40), "21–50");
+  assert.equal(bucketOf(13), "6–20");
+  assert.equal(bucketOf(3), "1–5");
+
+  const distinct = new Set(bomet.map(bucketOf));
+  assert.ok(distinct.size >= 4, `expected real discrimination, got ${distinct.size} shades`);
+});
+
+test("mz's small domain gets per-count shades, not 50-wide buckets", () => {
+  // Measured on mz 2026-08-03.
+  assert.deepEqual(ranges([32, 21, 15, 1, 1, 1, 1]), ["1–2", "3–5", "6–10", "11–20", "21+"]);
+});
+
+/* ------------------------------------------------------------------ */
+/* Edge cases                                                          */
+/* ------------------------------------------------------------------ */
+
+test("empty / all-zero domains yield only the none bucket", () => {
+  for (const input of [[], [0, 0, 0], undefined, null, "nonsense"]) {
+    const { max, buckets } = buildCreatedCountScale(input);
+    assert.equal(max, 0);
+    assert.deepEqual(
+      buckets.map((b) => b.id),
+      ["none"]
+    );
+  }
+});
+
+test("max below the bucket count gives every count its own shade", () => {
+  assert.deepEqual(ranges([6, 2, 1]), ["1", "2", "3", "4", "5", "6+"]);
+  assert.deepEqual(ranges([3, 1]), ["1", "2", "3+"]);
+});
+
+test("a single ward, and all-equal wards, do not crash or produce empty ranges", () => {
+  assert.deepEqual(ranges([1]), ["1+"]);
+  assert.deepEqual(ranges([7, 7, 7]), ["1–2", "3–5", "6+"]);
+});
+
+test("garbage values are coerced, never thrown on", () => {
+  const { max, buckets } = buildCreatedCountScale([null, undefined, NaN, -5, "12", 4.9]);
+  assert.equal(max, 12, "strings parse, negatives floor at 0, floats truncate");
+  assert.ok(buckets.length > 1);
+});
+
+test("counts at or below zero classify as the none bucket", () => {
+  const { buckets } = buildCreatedCountScale([100]);
+  for (const n of [0, -1, NaN, null, undefined]) {
+    assert.equal(getCreatedCountBucket(n, buckets).id, "none");
+  }
+});
+
+/* ------------------------------------------------------------------ */
+/* Invariants that must hold for EVERY domain                          */
+/* ------------------------------------------------------------------ */
+
+test("buckets are contiguous, ascending, open-ended, and never exceed the ramp", () => {
+  for (const max of [1, 2, 5, 6, 7, 8, 15, 32, 55, 99, 100, 1250, 99999]) {
+    const { buckets } = buildCreatedCountScale([max]);
+    const data = buckets.slice(1);
+    assert.ok(data.length >= 1 && data.length <= MAX_CREATED_COUNT_BUCKETS, `count for max=${max}`);
+    assert.equal(data[0].min, 1, `starts at 1 for max=${max}`);
+    assert.equal(data[data.length - 1].max, Infinity, `open-ended for max=${max}`);
+    for (let i = 1; i < data.length; i += 1) {
+      assert.equal(data[i].min, data[i - 1].max + 1, `no gap/overlap at ${i} for max=${max}`);
+    }
+    // The darkest stop must always mark the top bucket, however few there are.
+    assert.equal(
+      data[data.length - 1].fill,
+      CREATED_COUNT_RAMP[CREATED_COUNT_RAMP.length - 1].fill,
+      `darkest stop anchored for max=${max}`
+    );
+  }
+});
+
+test("every value in the domain lands in exactly one bucket", () => {
+  const domain = [1250, 55, 40, 13, 6, 1];
+  const { buckets } = buildCreatedCountScale(domain);
+  for (const value of domain) {
+    const hits = buckets.slice(1).filter((b) => value >= b.min && value <= b.max);
+    assert.equal(hits.length, 1, `value ${value} matched ${hits.length} buckets`);
+  }
+});
+
+test("the scale is stable while the max stays on the same ladder rung", () => {
+  // Hysteresis is the point of snapping to 1-2-5: a refresh that nudges the max
+  // must not redraw the legend under the reader.
+  const base = ranges([1250]);
+  for (const max of [1180, 1245, 1260, 1400]) {
+    assert.deepEqual(ranges([max]), base, `legend moved at max=${max}`);
+  }
+});
+
+/* ------------------------------------------------------------------ */
+/* The share legends must be untouched by all of this                  */
+/* ------------------------------------------------------------------ */
+
+test("percent legends keep their fixed buckets and seeded labels", () => {
+  for (const layer of ["open", "resolved"]) {
+    const legend = getGeographyMapLegend(layer, buildCreatedCountScale([1250]).buckets);
+    assert.equal(legend.length, 7);
+    assert.deepEqual(
+      legend.map((b) => b.id),
+      ["none", "p0", "p20", "p40", "p60", "p80", "p100"]
+    );
+  }
+});
+
+test("the created legend reflects the computed scale", () => {
+  const { buckets } = buildCreatedCountScale([1250]);
+  const legend = getGeographyMapLegend("created", buckets);
+  assert.equal(legend.length, buckets.length);
+  assert.equal(legend[legend.length - 1].label, "501+");
+});

--- a/docs/dashboard-configuration/90-localization.md
+++ b/docs/dashboard-configuration/90-localization.md
@@ -37,7 +37,7 @@ Two resolution seams in `products/dashboard/src/i18n/`:
 ## 2. Dashboard-owned keys (module `rainmaker-dashboard`)
 
 Seed all of these per locale. The authoritative en_IN set is the generated pack
-`digit-mcp/src/tools/dashboard-l10n-seed.ts` (277 messages) — grep it rather than trusting this
+`digit-mcp/src/tools/dashboard-l10n-seed.ts` (309 messages) — grep it rather than trusting this
 table to stay exhaustive.
 
 | family | pattern | examples | source of the key |

--- a/frontend/micro-ui/web/src/dashboard/components/GeographyChoroplethMap.jsx
+++ b/frontend/micro-ui/web/src/dashboard/components/GeographyChoroplethMap.jsx
@@ -6,6 +6,7 @@ import {
   getGeographyMapLegendFooter,
   getGeographyMapLegendTitle,
   getCreatedCountFillStyle,
+  buildCreatedCountScale,
   getOpenShareFillStyle,
   getResolvedShareFillStyle,
 } from "../config/geographyMapPresentation";
@@ -89,7 +90,7 @@ function createComplaintPinPopup(pin, radius) {
 const MAP_COUNTY_MAX_ZOOM = 10; // below -> county outline only
 const MAP_SUBCOUNTY_MAX_ZOOM = 12; // below -> sub-counties; at/above -> wards
 
-function resolveFeatureStyle(feature, layerMode, focusedCode, zoom = 11) {
+function resolveFeatureStyle(feature, layerMode, focusedCode, zoom = 11, createdBuckets) {
   const props = feature?.properties ?? {};
   const isFocused = focusedCode && props.code === focusedCode;
   const base =
@@ -97,7 +98,10 @@ function resolveFeatureStyle(feature, layerMode, focusedCode, zoom = 11) {
       ? getOpenShareFillStyle(props.openPct)
       : layerMode === "resolved"
         ? getResolvedShareFillStyle(props.resolvedPct)
-        : getCreatedCountFillStyle(Number(props.count) || Number(props.created) || 0);
+        : getCreatedCountFillStyle(
+            Number(props.count) || Number(props.created) || 0,
+            createdBuckets
+          );
 
   const weight = isFocused ? 2.5 : zoom < 11 ? 0.75 : zoom < 14 ? 1.1 : 1.5;
 
@@ -319,7 +323,21 @@ const GeographyChoroplethMap = ({
 
   const visibleComplaintPins = displayLayers.complaintPins ?? [];
 
-  const legendItems = useMemo(() => getGeographyMapLegend(layerMode), [layerMode]);
+  // Scale the Created layer to the data on the map (#1461) — see the esbuild
+  // copy for why the domain is the ward series and not the rendered features.
+  const createdBuckets = useMemo(
+    () => buildCreatedCountScale((wardCounts || []).map((w) => w?.count)).buckets,
+    [wardCounts]
+  );
+  const createdScaleKey = useMemo(
+    () => createdBuckets.map((b) => `${b.min ?? 0}:${b.max ?? 0}`).join("|"),
+    [createdBuckets]
+  );
+  const legendItems = useMemo(
+    () => getGeographyMapLegend(layerMode, createdBuckets),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [layerMode, createdScaleKey]
+  );
   const legendTitle = getGeographyMapLegendTitle(layerMode);
   const legendFooter = getGeographyMapLegendFooter(drillTrail.length);
 
@@ -528,7 +546,7 @@ const GeographyChoroplethMap = ({
 
     L.geoJSON(geoFeatures, {
       style: (feature) =>
-        resolveFeatureStyle(feature, layerMode, focusedCode, zoomLevelRef.current),
+        resolveFeatureStyle(feature, layerMode, focusedCode, zoomLevelRef.current, createdBuckets),
       onEachFeature: (feature, layer) => {
         layer.feature = feature;
         const code = feature?.properties?.code;
@@ -554,7 +572,7 @@ const GeographyChoroplethMap = ({
 
         layer.on("mouseout", () => {
           layer.setStyle(
-            resolveFeatureStyle(feature, layerMode, focusedCode, zoomLevelRef.current)
+            resolveFeatureStyle(feature, layerMode, focusedCode, zoomLevelRef.current, createdBuckets)
           );
         });
 
@@ -610,6 +628,7 @@ const GeographyChoroplethMap = ({
     drillTrail,
     joined.geoFeatures?.features,
     layerMode,
+    createdScaleKey,
   ]);
 
   // ── update choropleth border weights when zoom / focus / mode changes ─────
@@ -618,10 +637,11 @@ const GeographyChoroplethMap = ({
       const feature = layer.feature;
       if (!feature) return;
       layer.setStyle(
-        resolveFeatureStyle(feature, layerMode, focusedCode, zoomLevel)
+        resolveFeatureStyle(feature, layerMode, focusedCode, zoomLevel, createdBuckets)
       );
     });
-  }, [focusedCode, layerMode, zoomLevel]);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [focusedCode, layerMode, zoomLevel, createdScaleKey]);
 
   // ── draw complaint pins — redraw on data change; resize on zoom without closing popup
   useEffect(() => {

--- a/frontend/micro-ui/web/src/dashboard/config/geographyMapPresentation.js
+++ b/frontend/micro-ui/web/src/dashboard/config/geographyMapPresentation.js
@@ -26,16 +26,137 @@ export function getGeographyMapLayerMeta(layerId) {
   return GEOGRAPHY_MAP_LAYERS.find((layer) => layer.id === layerId);
 }
 
-/** Created — complaint count buckets (blue scale). */
-export const CREATED_COUNT_LEGEND = [
-  { id: "none", label: "No complaints", fill: "#ffffff", stroke: "#d1d5db", fillOpacity: 0.95 },
-  { id: "b1", label: "1–3", fill: "#dbeafe", stroke: "#bfdbfe", fillOpacity: 0.78 },
-  { id: "b2", label: "4–5", fill: "#93c5fd", stroke: "#60a5fa", fillOpacity: 0.76 },
-  { id: "b3", label: "6–8", fill: "#60a5fa", stroke: "#3b82f6", fillOpacity: 0.74 },
-  { id: "b4", label: "9–10", fill: "#3b82f6", stroke: "#2563eb", fillOpacity: 0.74 },
-  { id: "b5", label: "11–13", fill: "#2563eb", stroke: "#1d4ed8", fillOpacity: 0.76 },
-  { id: "b6", label: "14–15", fill: "#1e40af", stroke: "#1e3a8a", fillOpacity: 0.78 },
+/** The white "nothing here" swatch, shared by all three legends. */
+export const CREATED_COUNT_NONE = {
+  id: "none",
+  label: "No complaints",
+  fill: "#ffffff",
+  stroke: "#d1d5db",
+  fillOpacity: 0.95,
+};
+
+/** Created — the blue ramp, darkest last. Bucket EDGES are computed per tenant. */
+export const CREATED_COUNT_RAMP = [
+  { fill: "#dbeafe", stroke: "#bfdbfe", fillOpacity: 0.78 },
+  { fill: "#93c5fd", stroke: "#60a5fa", fillOpacity: 0.76 },
+  { fill: "#60a5fa", stroke: "#3b82f6", fillOpacity: 0.74 },
+  { fill: "#3b82f6", stroke: "#2563eb", fillOpacity: 0.74 },
+  { fill: "#2563eb", stroke: "#1d4ed8", fillOpacity: 0.76 },
+  { fill: "#1e40af", stroke: "#1e3a8a", fillOpacity: 0.78 },
 ];
+
+export const MAX_CREATED_COUNT_BUCKETS = CREATED_COUNT_RAMP.length;
+
+/**
+ * Fallback scale, used only when no data has been seen yet (and by the legacy
+ * getWowChangeFillStyle path). Real scales come from buildCreatedCountScale.
+ */
+export const CREATED_COUNT_LEGEND = [
+  CREATED_COUNT_NONE,
+  { id: "b1", label: "1–3", min: 1, max: 3, ...CREATED_COUNT_RAMP[0] },
+  { id: "b2", label: "4–5", min: 4, max: 5, ...CREATED_COUNT_RAMP[1] },
+  { id: "b3", label: "6–8", min: 6, max: 8, ...CREATED_COUNT_RAMP[2] },
+  { id: "b4", label: "9–10", min: 9, max: 10, ...CREATED_COUNT_RAMP[3] },
+  { id: "b5", label: "11–13", min: 11, max: 13, ...CREATED_COUNT_RAMP[4] },
+  { id: "b6", label: "14+", min: 14, max: Infinity, ...CREATED_COUNT_RAMP[5] },
+];
+
+/** Round up to the next 1–2–5 ladder rung (1,2,5,10,20,50,100,…). */
+function niceCeil(value) {
+  if (!(value > 1)) return 1;
+  const decade = 10 ** Math.floor(Math.log10(value));
+  const mantissa = value / decade;
+  const rung = mantissa <= 1 ? 1 : mantissa <= 2 ? 2 : mantissa <= 5 ? 5 : 10;
+  return rung * decade;
+}
+
+/**
+ * Build the Created-layer scale from the values actually on the map (#1461).
+ *
+ * The old scale was a constant topping out at 15, so on a tenant like bomet —
+ * where one ward holds 1250 complaints and the next holds 55 — every ward
+ * saturated the darkest bucket and the choropleth carried no information at all.
+ *
+ * Complaint volume is skewed MULTIPLICATIVELY (1250 / 55 / 3), so the breaks are
+ * geometric rather than linear: an equal-interval scale over [0, max] would put
+ * all 22 of bomet's smaller wards in bucket 1 and merely invert the bug. Breaks
+ * are then snapped up to the 1–2–5 ladder, which is itself near-logarithmic, so
+ * "log spacing" and "round human numbers" cost nothing against each other — and
+ * quantization gives free hysteresis: the legend only moves when the max crosses
+ * a rung, not on every refresh.
+ *
+ * Quantile/Jenks breaks were rejected: with 6–23 wards they degenerate into a
+ * rank map, produce arbitrary labels like "3–1250", and reshuffle on every
+ * filter change.
+ *
+ * The domain must be the WARD-level series. Zoom rolls counts up by summing
+ * children, so scaling to the rendered features would rewrite the legend on
+ * every scroll step; the open-ended top bucket absorbs rolled-up values instead.
+ *
+ * Pure and total — safe to call with anything.
+ *
+ * @param {Array<number>} values raw per-ward counts
+ * @returns {{ max: number, breaks: number[], buckets: object[] }}
+ */
+export function buildCreatedCountScale(values = []) {
+  let max = 0;
+  for (const raw of Array.isArray(values) ? values : []) {
+    const n = Math.trunc(Number(raw));
+    if (Number.isFinite(n) && n > max) max = n;
+  }
+  if (max <= 0) return { max: 0, breaks: [], buckets: [CREATED_COUNT_NONE] };
+
+  let breaks;
+  if (max <= MAX_CREATED_COUNT_BUCKETS) {
+    // Tiny tenants (mz peaks at 32; a fresh install at 1): give each count its
+    // own shade rather than rounding a max of 8 up to a 50-wide bucket.
+    breaks = Array.from({ length: max - 1 }, (_, i) => i + 1);
+  } else {
+    // Geometric interior breaks, snapped up to the ladder. The top bucket is
+    // open-ended, so only MAX-1 edges are needed.
+    breaks = Array.from({ length: MAX_CREATED_COUNT_BUCKETS - 1 }, (_, i) =>
+      niceCeil(max ** ((i + 1) / MAX_CREATED_COUNT_BUCKETS))
+    );
+  }
+  // Snapping collapses duplicates; that is how the scale degrades gracefully to
+  // fewer buckets on small domains instead of emitting empty ranges.
+  breaks = [...new Set(breaks)].filter((b) => b >= 1 && b < max).sort((a, b) => a - b);
+
+  const edges = [...breaks, Infinity];
+  const last = edges.length - 1;
+  return {
+    max,
+    breaks,
+    buckets: [
+      CREATED_COUNT_NONE,
+      ...edges.map((upper, i) => {
+        const lower = i === 0 ? 1 : edges[i - 1] + 1;
+        // Always anchor the darkest stop to the top bucket, however few there are.
+        const ramp =
+          CREATED_COUNT_RAMP[
+            last === 0 ? CREATED_COUNT_RAMP.length - 1 : Math.round((i * (CREATED_COUNT_RAMP.length - 1)) / last)
+          ];
+        return { id: `b${i + 1}`, label: formatBucketLabel(lower, upper), min: lower, max: upper, ...ramp };
+      }),
+    ],
+  };
+}
+
+/**
+ * "1–5" / "501+" / "7". Numerals only: legend labels used to be seeded l10n
+ * messages, but a computed range has no fixed key and translate() renders the
+ * RAW KEY when a message is missing — so a minted key would paint
+ * "DASHBOARD_MAP_LEGEND_COUNT_124_248" on screen. The seeded count messages were
+ * byte-identical across en_IN and pt_PT anyway (they were pure numerals), so
+ * nothing translatable is lost. The esbuild copy additionally applies the tenant digit mask.
+ */
+function formatBucketLabel(lower, upper) {
+  // No numberFormat module in this tree — raw numerals (see the esbuild copy).
+  const n = (value) => String(value);
+  if (upper === Infinity) return `${n(lower)}+`;
+  if (lower === upper) return n(lower);
+  return `${n(lower)}–${n(upper)}`;
+}
 
 /** % Open — share of filed complaints still open (red scale). */
 export const OPEN_SHARE_LEGEND = [
@@ -59,10 +180,10 @@ export const RESOLVED_SHARE_LEGEND = [
   { id: "p100", label: "> 80%", fill: "#14532d", stroke: "#052e16", fillOpacity: 0.8 },
 ];
 
-export function getGeographyMapLegend(layerId) {
+export function getGeographyMapLegend(layerId, createdBuckets = CREATED_COUNT_LEGEND) {
   if (layerId === "open") return OPEN_SHARE_LEGEND;
   if (layerId === "resolved") return RESOLVED_SHARE_LEGEND;
-  return CREATED_COUNT_LEGEND;
+  return createdBuckets;
 }
 
 export function getGeographyMapLegendTitle(layerId) {
@@ -84,15 +205,14 @@ function bucketToFillStyle(bucket) {
   };
 }
 
-export function getCreatedCountBucket(count) {
+export function getCreatedCountBucket(count, buckets = CREATED_COUNT_LEGEND) {
+  const scale = Array.isArray(buckets) && buckets.length ? buckets : CREATED_COUNT_LEGEND;
   const n = Number(count) || 0;
-  if (n <= 0) return CREATED_COUNT_LEGEND[0];
-  if (n <= 3) return CREATED_COUNT_LEGEND[1];
-  if (n <= 5) return CREATED_COUNT_LEGEND[2];
-  if (n <= 8) return CREATED_COUNT_LEGEND[3];
-  if (n <= 10) return CREATED_COUNT_LEGEND[4];
-  if (n <= 13) return CREATED_COUNT_LEGEND[5];
-  return CREATED_COUNT_LEGEND[6];
+  if (n <= 0) return scale[0];
+  for (let i = 1; i < scale.length; i += 1) {
+    if (n <= scale[i].max) return scale[i];
+  }
+  return scale[scale.length - 1];
 }
 
 export function getSharePctBucket(pct, legend) {
@@ -106,8 +226,8 @@ export function getSharePctBucket(pct, legend) {
   return legend[6];
 }
 
-export function getCreatedCountFillStyle(count) {
-  return bucketToFillStyle(getCreatedCountBucket(count));
+export function getCreatedCountFillStyle(count, buckets = CREATED_COUNT_LEGEND) {
+  return bucketToFillStyle(getCreatedCountBucket(count, buckets));
 }
 
 export function getOpenShareFillStyle(openPct) {

--- a/local-setup/db/dss-mdms-seed/l10n/en_IN.json
+++ b/local-setup/db/dss-mdms-seed/l10n/en_IN.json
@@ -805,36 +805,6 @@
     "module": "rainmaker-dashboard"
   },
   {
-    "code": "DASHBOARD_MAP_LEGEND_COUNT_1_3",
-    "message": "1–3",
-    "module": "rainmaker-dashboard"
-  },
-  {
-    "code": "DASHBOARD_MAP_LEGEND_COUNT_11_13",
-    "message": "11–13",
-    "module": "rainmaker-dashboard"
-  },
-  {
-    "code": "DASHBOARD_MAP_LEGEND_COUNT_14_15",
-    "message": "14–15",
-    "module": "rainmaker-dashboard"
-  },
-  {
-    "code": "DASHBOARD_MAP_LEGEND_COUNT_4_5",
-    "message": "4–5",
-    "module": "rainmaker-dashboard"
-  },
-  {
-    "code": "DASHBOARD_MAP_LEGEND_COUNT_6_8",
-    "message": "6–8",
-    "module": "rainmaker-dashboard"
-  },
-  {
-    "code": "DASHBOARD_MAP_LEGEND_COUNT_9_10",
-    "message": "9–10",
-    "module": "rainmaker-dashboard"
-  },
-  {
     "code": "DASHBOARD_MAP_LEGEND_EXPAND",
     "message": "Expand legend",
     "module": "rainmaker-dashboard"

--- a/local-setup/db/dss-mdms-seed/l10n/pt_PT.json
+++ b/local-setup/db/dss-mdms-seed/l10n/pt_PT.json
@@ -805,36 +805,6 @@
     "module": "rainmaker-dashboard"
   },
   {
-    "code": "DASHBOARD_MAP_LEGEND_COUNT_1_3",
-    "message": "1–3",
-    "module": "rainmaker-dashboard"
-  },
-  {
-    "code": "DASHBOARD_MAP_LEGEND_COUNT_11_13",
-    "message": "11–13",
-    "module": "rainmaker-dashboard"
-  },
-  {
-    "code": "DASHBOARD_MAP_LEGEND_COUNT_14_15",
-    "message": "14–15",
-    "module": "rainmaker-dashboard"
-  },
-  {
-    "code": "DASHBOARD_MAP_LEGEND_COUNT_4_5",
-    "message": "4–5",
-    "module": "rainmaker-dashboard"
-  },
-  {
-    "code": "DASHBOARD_MAP_LEGEND_COUNT_6_8",
-    "message": "6–8",
-    "module": "rainmaker-dashboard"
-  },
-  {
-    "code": "DASHBOARD_MAP_LEGEND_COUNT_9_10",
-    "message": "9–10",
-    "module": "rainmaker-dashboard"
-  },
-  {
     "code": "DASHBOARD_MAP_LEGEND_EXPAND",
     "message": "Expandir legenda",
     "module": "rainmaker-dashboard"


### PR DESCRIPTION
Fixes #1461.

## What was wrong

The Created layer's legend was a hardcoded constant — `CREATED_COUNT_LEGEND` plus matching thresholds in `getCreatedCountBucket` — bucketing at 1–3 / 4–5 / 6–8 / 9–10 / 11–13 / 14–15.

Measured on bomet (2026-08-03), the 23 wards hold:

```
1250, 55, 40, 29, 26, 24, 23, 13, 6, 4, 3, 3, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1
```

Every one of them exceeded or saturated the top bucket, so the entire choropleth rendered a single flat colour and carried no information. Meanwhile the hover tooltip never goes through bucketing at all (`config/mapHoverPresentation.js:37-67` reads the raw value), which is why the report shows a legend capping at 15 next to a tooltip reading 970. The legend was wrong on its own; the tooltip was right.

The two percent layers were never affected — `getSharePctBucket` is bounded 0–100 by construction — and are untouched here.

## The scale

Bucket edges are computed from the ward series. The distribution is skewed **multiplicatively** (1250 / 55 / 3), so breaks are geometric rather than linear: an equal-interval scale over `[0, max]` gives ~208-wide buckets and puts all 22 smaller wards in bucket 1 — the same flat map, just inverted. Breaks then snap up to the 1‑2‑5 ladder (1, 2, 5, 10, 20, 50, …), which is itself near-logarithmic, so "log spacing" and "round human numbers" cost nothing against each other.

| tenant | max | legend |
|---|---|---|
| bomet | 1250 | `1–5 / 6–20 / 21–50 / 51–200 / 201–500 / 501+` |
| mz | 32 | `1–2 / 3–5 / 6–10 / 11–20 / 21+` |
| small | 8 | `1–2 / 3–5 / 6+` |
| tiny | 6 | one shade per count |

On bomet that occupies 5 of 6 buckets: `1–5` holds the 14 smallest wards, `6–20` holds 2, `21–50` holds 5, `51–200` holds Chemaner, `501+` holds Chesoen.

**Stability.** Ladder quantization is free hysteresis — the legend only moves when the max crosses a rung, so 1180 / 1245 / 1260 / 1400 all render identically (there is a test for this). Quantile and Jenks breaks were rejected: at 6–23 wards they degenerate into a rank map where a one-complaint difference shifts a ward two shades, produce arbitrary labels like "3–1250", and reshuffle on every filter change.

**Domain is the ward series, not the rendered features.** Zoom changes `activeLevel` and `aggregateWardCountsToLevel` sums children into rollups, so scaling to what is on screen would rewrite the legend on every scroll step. The open-ended top bucket absorbs rolled-up county values instead.

## Labels and l10n

Labels become plain numerals, which required removing six seeded messages. The reasoning matters: a computed range has no fixed key, and `translate()` returns the **raw key** when a message is missing (`i18n/localeRuntime.js:80`) — so minting `DASHBOARD_MAP_LEGEND_COUNT_124_248` would paint that literal string on screen in every locale, including en_IN. `localizeLegendBucketLabel`'s existing `default:` passthrough renders computed numerals verbatim, which is exactly what we want.

The six `DASHBOARD_MAP_LEGEND_COUNT_*` messages were **byte-identical between en_IN and pt_PT** (they were pure numerals), so no translation is lost. They are removed from both packs symmetrically and `local-setup/db/dss-mdms-seed/export-l10n.mjs` re-run; its 1:1 and `--check` assertions both pass. The percent legends keep their seeded messages untouched.

`geographyMapPresentation.js` now imports `formatNumber`, so hundreds-scale numerals honour the tenant digit mask from #1213/#1272 (with the established `?? raw` fallback). Stale DB rows for the removed codes are harmless.

## Tests

New `config/geographyMapPresentation.test.js`, 12 cases, following the existing `dashboardMetrics.test.js` idiom (esbuild-to-CJS; the factory is pure so no DOM or Leaflet needed):

```
node --test products/dashboard/src/config/geographyMapPresentation.test.js   # 12/12
```

Covers both real tenant distributions, the edge-case table (empty / all-zero / single ward / all-equal / max < bucket count / max = 1 / garbage input), and invariants that must hold for **every** domain: buckets contiguous and ascending with no gaps, top bucket open-ended, darkest ramp stop always anchored to the top bucket however few buckets there are, every value in exactly one bucket, and legend stability across a ladder rung.

`node esbuild.build.js` succeeds (the 20 warnings are pre-existing `eval` warnings in unrelated PGR code).

## Notes for review

- Both copies are updated. `frontend/micro-ui/web/src/dashboard/` is behind the esbuild tree (no i18n seam, no `numberFormat` module), so it gets the same scale with raw numerals rather than a straight copy. It is still imported by `frontend/micro-ui/web/src/App.js`, so it is not dead code.
- `resolveFeatureStyle` takes one extra parameter (5 call sites). The effect deps use a derived `createdScaleKey` string rather than the bucket array, because `wardCounts` is rebuilt by identity on every layer toggle and would otherwise force a full Leaflet rebuild for an identical scale.
- `CREATED_COUNT_LEGEND` is retained as the default/fallback so the legacy `getWowChangeFillStyle` path in `mapGeoUtils.js` is unaffected.
- Not addressed here: bomet's 20 complaints with no resolvable ward are filtered out upstream (`KpiTile.jsx:882-885`) and still vanish from the map with no "unmapped" bucket. Separate issue.
