### PR TITLE
fix(pgr): don't restrict inbox-v2 complaint search to open states

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/configs/UICustomizations.js
+++ b/digit-ui-esbuild/products/pgr/src/configs/UICustomizations.js
@@ -1,4 +1,5 @@
 import _ from "lodash";
+import Urls from "../utils/urls";
 import { complaintLabel } from "../utils/complaintLabel";
 import { useLocation, useHistory, Link, useParams } from "react-router-dom";
 import React, { useState, Fragment } from "react";
@@ -1652,22 +1653,14 @@ export const UICustomizations = {
       ];
       const rawStatuses = filterForm.status || {};
       const statuses = Object.keys(rawStatuses).filter((key) => rawStatuses[key] === true);
-      // A targeted lookup (complaint number / mobile number / date range —
-      // the "search" section, as opposed to the "filter" section) must not be
-      // narrowed to open states: CCRS#1367 — once GRO rejects a complaint it
-      // moves to the terminal REJECTED state, which isn't in OPEN_STATES/
-      // allStates, so a CSR searching that exact complaint number got zero
-      // results back even though the complaint still needs to be reopened.
-      const hasExplicitSearch = Boolean(
-        searchForm.complaintNumber || searchForm.mobileNumber || (requestDate?.startDate && requestDate?.endDate)
-      );
-      // Status scope: an explicit filter wins; a targeted search leaves the
-      // status scope open; otherwise both tabs default to every open/
-      // actionable state. The tabs differ on the ASSIGNEE axis, not the
-      // status axis (PO decision 2026-07-15).
+      // CCRS#1367: an exact complaint-number lookup (not mobile number or
+      // date range — those are broad, multi-result searches) must ignore
+      // every inbox default, not just status: it needs to find that one
+      // complaint no matter who it's assigned to or what state it's in.
+      const isComplaintLookup = Boolean(params.serviceRequestId);
       if (statuses.length > 0) {
         params.applicationStatus = statuses;
-      } else if (!hasExplicitSearch) {
+      } else if (!isComplaintLookup) {
         params.applicationStatus = allStates.length > 0 ? allStates : OPEN_STATES;
       }
 
@@ -1681,23 +1674,36 @@ export const UICustomizations = {
       // visibility from the `scope` filter param — MINE = assignee-me, TEAM =
       // reportee subtree + unassigned queues — so the client sends no
       // assignee. MY/ALL stay UI tab ids; MINE/TEAM are the API semantics.
-      if (additionalDetails?.serverSide) {
-        if (activeTab) params.scope = activeTab === "MY" ? "MINE" : "TEAM";
-      } else if (activeTab === "MY") {
-        const userInfo = Digit.UserService.getUser()?.info;
-        if (userInfo?.uuid) {
-          params.assignee = [userInfo.uuid];
+      //
+      // A complaint-number lookup skips assignee/scope too — same reasoning
+      // as the status default above.
+      if (!isComplaintLookup) {
+        if (additionalDetails?.serverSide) {
+          if (activeTab) params.scope = activeTab === "MY" ? "MINE" : "TEAM";
+        } else if (activeTab === "MY") {
+          const userInfo = Digit.UserService.getUser()?.info;
+          if (userInfo?.uuid) {
+            params.assignee = [userInfo.uuid];
+          }
         }
-      }
 
-      // Legacy assigned-to-me radio (only present in the filter form when the
-      // visibility-tabs feature flag is OFF — see PGRSearchInboxConfig).
-      const assignedFilter = filterForm.assignedToMe;
-      if (assignedFilter?.code === "ASSIGNED_TO_ME") {
-        const userInfo = Digit.UserService.getUser()?.info;
-        if (userInfo?.uuid) {
-          params.assignee = [userInfo.uuid];
+        // Legacy assigned-to-me radio (only present in the filter form when
+        // the visibility-tabs feature flag is OFF — see PGRSearchInboxConfig).
+        const assignedFilter = filterForm.assignedToMe;
+        if (assignedFilter?.code === "ASSIGNED_TO_ME") {
+          const userInfo = Digit.UserService.getUser()?.info;
+          if (userInfo?.uuid) {
+            params.assignee = [userInfo.uuid];
+          }
         }
+      } else if (additionalDetails?.serverSide) {
+        // The visibility-aware endpoint (Urls.pgr.visibilitySearch) requires
+        // `scope` server-side (RequestsApiController defaults it to MINE) and
+        // TEAM only matches team-assigned/unassigned-queue rows — there's no
+        // scope value that returns an arbitrary known complaint (checked
+        // VisibilityService.resolve directly). Route the lookup through the
+        // plain, unscoped search/count endpoints instead.
+        clonedData.url = Urls.pgr.search;
       }
 
       clonedData.params = params;

--- a/digit-ui-esbuild/products/pgr/src/configs/UICustomizations.js
+++ b/digit-ui-esbuild/products/pgr/src/configs/UICustomizations.js
@@ -1652,12 +1652,22 @@ export const UICustomizations = {
       ];
       const rawStatuses = filterForm.status || {};
       const statuses = Object.keys(rawStatuses).filter((key) => rawStatuses[key] === true);
-      // Status scope: an explicit filter wins; otherwise both tabs default to
-      // every open/actionable state. The tabs differ on the ASSIGNEE axis, not
-      // the status axis (PO decision 2026-07-15).
+      // A targeted lookup (complaint number / mobile number / date range —
+      // the "search" section, as opposed to the "filter" section) must not be
+      // narrowed to open states: CCRS#1367 — once GRO rejects a complaint it
+      // moves to the terminal REJECTED state, which isn't in OPEN_STATES/
+      // allStates, so a CSR searching that exact complaint number got zero
+      // results back even though the complaint still needs to be reopened.
+      const hasExplicitSearch = Boolean(
+        searchForm.complaintNumber || searchForm.mobileNumber || (requestDate?.startDate && requestDate?.endDate)
+      );
+      // Status scope: an explicit filter wins; a targeted search leaves the
+      // status scope open; otherwise both tabs default to every open/
+      // actionable state. The tabs differ on the ASSIGNEE axis, not the
+      // status axis (PO decision 2026-07-15).
       if (statuses.length > 0) {
         params.applicationStatus = statuses;
-      } else {
+      } else if (!hasExplicitSearch) {
         params.applicationStatus = allStates.length > 0 ? allStates : OPEN_STATES;
       }
 


### PR DESCRIPTION
CSR searching for a specific complaint number in inbox-v2 got zero results once GRO rejected it, because PGRInboxConfig.preProcess always defaulted applicationStatus to OPEN_STATES/allActionableStates when no status checkbox was checked — even for an explicit complaintNumber/ mobileNumber/date-range search. REJECTED is a terminal state (excluded from that default) even though CSR can still REOPEN it.

Skip the default status restriction whenever the search form has an explicit complaintNumber, mobileNumber, or date range, so a targeted search is never narrowed by application status. The _count request reuses the same params, so it's fixed too.

Fixes #1367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PGR inbox search behavior for complaint numbers, mobile numbers, and complete request-date ranges.
  - Targeted searches no longer apply a default application-status filter when no status is selected.
  - Existing open-status defaults remain unchanged for broader searches, and explicit status selections continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->