### PR TITLE
CCSD-2130: Preserve createdBy filter for employee-created complaint details

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/configs/UICustomizations.js
+++ b/digit-ui-esbuild/products/pgr/src/configs/UICustomizations.js
@@ -1716,11 +1716,16 @@ export const UICustomizations = {
           return (
             <div style={{ display: "grid" }}>
               <span className="link" style={{ display: "grid" }}>
-                <Link
-                  to={`/${window.contextPath}/employee/pgr/complaint-details/${value}`}
-                >
-                  {String(value ? (column.translate ? t(column.prefix ? `${column.prefix}${value}` : value) : value) : t("ES_COMMON_NA"))}
-                </Link>
+                {(() => {
+                  const currentUserUuid = Digit.UserService.getUser()?.info?.uuid;
+                  const creatorUuid = row?.businessObject?.service?.auditDetails?.createdBy;
+                  const query = creatorUuid && creatorUuid === currentUserUuid ? `?createdBy=${encodeURIComponent(currentUserUuid)}` : "";
+                  return (
+                    <Link to={`/${window.contextPath}/employee/pgr/complaint-details/${value}${query}`}>
+                      {String(value ? (column.translate ? t(column.prefix ? `${column.prefix}${value}` : value) : value) : t("ES_COMMON_NA"))}
+                    </Link>
+                  );
+                })()}
               </span>
               {(() => {
                 // Complaint Type label = the parent group's NODE NAME, straight
@@ -1771,7 +1776,10 @@ export const UICustomizations = {
     MobileDetailsOnClick: (row, tenantId) => {
       const complaintNo = row?.["CS_COMMON_COMPLAINT_NO"];
       if (!complaintNo) return `/${window.contextPath}/employee/pgr/inbox-v2`;
-      return `/${window.contextPath}/employee/pgr/complaint-details/${complaintNo}`;
+      const currentUserUuid = Digit.UserService.getUser()?.info?.uuid;
+      const creatorUuid = row?.businessObject?.service?.auditDetails?.createdBy || row?.businessObject?.service?.createdBy;
+      const query = creatorUuid && creatorUuid === currentUserUuid ? `?createdBy=${encodeURIComponent(currentUserUuid)}` : "";
+      return `/${window.contextPath}/employee/pgr/complaint-details/${complaintNo}${query}`;
     },
   },
   CampaignsInboxConfig: {

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { complaintLabel } from "../../utils/complaintLabel";
 import { useTranslation } from "react-i18next";
-import { useHistory, useParams } from "react-router-dom/cjs/react-router-dom.min";
+import { useHistory, useLocation, useParams } from "react-router-dom/cjs/react-router-dom.min";
 import { HeaderComponent, Button, Card, Footer, SummaryCard, Tag, Timeline, Toast, NoResultsFound } from "@egovernments/digit-ui-components";
 import { ActionBar, Loader, DisplayPhotos, ImageViewer } from "@egovernments/digit-ui-react-components";
 import { convertEpochFormateToDate } from "../../utils";
@@ -173,7 +173,13 @@ const PGRDetails = () => {
   }
 
   // Fetch complaint details
-  const { isLoading, isError, error, data: pgrData, revalidate: pgrSearchRevalidate } = Digit.Hooks.pgr.usePGRSearch({ serviceRequestId: id }, tenantId);
+  const location = useLocation();
+  const queryParams = new URLSearchParams(location.search);
+  const searchCreatedBy = queryParams.get("createdBy");
+  const { isLoading, isError, error, data: pgrData, revalidate: pgrSearchRevalidate } = Digit.Hooks.pgr.usePGRSearch(
+    { serviceRequestId: id, ...(searchCreatedBy ? { createdBy: searchCreatedBy } : {}) },
+    tenantId
+  );
 
   // Use the complaint's tenantId for workflow queries (complaints live at city level,
   // but getCurrentTenantId() may return root tenant for root-level ADMIN users)
@@ -498,6 +504,15 @@ const PGRDetails = () => {
     t,
   });
 
+  // CCSD-2130: only show the complainant details card when the complaint was
+  // filed on behalf of a citizen by an employee. If the createdBy uuid matches
+  // the citizen/accountId uuid, it means the citizen filed it themself and the
+  // card would otherwise echo the masked actor.
+  const complaintService = pgrData?.ServiceWrappers?.[0]?.service;
+  const complainantUuid = complaintService?.citizen?.uuid || complaintService?.accountId;
+  const filedByUuid = complaintService?.auditDetails?.createdBy;
+  const filedOnBehalfOfCitizen = Boolean(complainantUuid && filedByUuid && complainantUuid !== filedByUuid);
+
   return (
     <div className="v2-pgr-details v2-scope">
       {/* Header */}
@@ -612,6 +627,26 @@ const PGRDetails = () => {
                   },
                 ],
               },
+              ...(filedOnBehalfOfCitizen
+                ? [{
+                    cardType: "primary",
+                    header: t("ES_CREATECOMPLAINT_PROVIDE_COMPLAINANT_DETAILS"),
+                    fieldPairs: [
+                      {
+                        inline: true,
+                        label: t("COMPLAINTS_COMPLAINANT_NAME"),
+                        type: "text",
+                        value: complaintService?.citizen?.name || "NA",
+                      },
+                      {
+                        inline: true,
+                        label: t("COMPLAINTS_COMPLAINANT_CONTACT_NUMBER"),
+                        type: "text",
+                        value: complaintService?.citizen?.mobileNumber || "NA",
+                      },
+                    ],
+                  }]
+                : []),
               // Read-only "Additional Details" — fetch service.extendedAttributes
               // and show it as label:value rows; backend returns masked ("****")
               // values. Renders nothing when there are no extended attributes.


### PR DESCRIPTION
This PR contains only the two intended changes:

- Preserve createdBy query parameter for employee-created complaint details retrieval in `digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js`
- Preserve createdBy on employee inbox complaint links in `digit-ui-esbuild/products/pgr/src/configs/UICustomizations.js`

The branch is based on `release-v2.12-moz` and contains only the targeted files.