### PR TITLE
Ansible docker data root rhel support

### DIFF
--- a/local-setup/ansible/README.md
+++ b/local-setup/ansible/README.md
@@ -520,6 +520,41 @@ flags. Setting back to `false` sweeps the running search containers.
 ./deploy.sh <tenant> --check --diff --tags compose-config
 ```
 
+### Relocating Docker's storage to another partition — `docker_data_root`
+
+`docker_data_root` (see `inventory/group_vars/all.yml`) only takes effect on
+a box where Docker/containerd have never been started — the playbook fails
+the deploy instead of relocating a `/var/lib/docker` or `/var/lib/containerd`
+that already holds data, since pointing daemon.json/containerd's config at
+an empty directory would orphan every existing image and named volume
+(including the Postgres complaint database).
+
+To move an **already-populated** box's storage by hand first, then let the
+playbook take over:
+
+```bash
+# On the target host, as root:
+systemctl stop docker containerd
+
+mkdir -p /opt/docker /opt/containerd
+rsync -aHAX --info=progress2 /var/lib/docker/  /opt/docker/
+rsync -aHAX --info=progress2 /var/lib/containerd/ /opt/containerd/
+
+# RHEL family only (SELinux enforcing) — match the fcontext the playbook
+# would otherwise register, then relabel:
+semanage fcontext -a -e /var/lib/docker /opt/docker
+semanage fcontext -a -e /var/lib/containerd /opt/containerd
+restorecon -RF /opt/docker /opt/containerd
+
+# Once you've verified the copies (diff -rq old vs new, or just trust rsync),
+# reclaim the space:
+rm -rf /var/lib/docker/* /var/lib/containerd/*
+```
+
+Then set `docker_data_root: "/opt/docker"` in the tenant's host_vars and
+run `./deploy.sh <tenant>` as usual — the playbook finds both directories
+already relocated (and now empty at their original path) and proceeds.
+
 ## Troubleshooting
 
 ### `http: server gave HTTP response to HTTPS client` on docker pull

--- a/local-setup/ansible/README.md
+++ b/local-setup/ansible/README.md
@@ -534,7 +534,11 @@ playbook take over:
 
 ```bash
 # On the target host, as root:
-systemctl stop docker containerd
+# Stop docker.socket too — leaving it active means any client that touches
+# /var/run/docker.sock during the copy (a stray `docker ps`, a monitoring
+# agent, a cron job) socket-activates dockerd again, which then writes into
+# /var/lib/docker while rsync is still reading it.
+systemctl stop docker.socket docker.service containerd
 
 mkdir -p /opt/docker /opt/containerd
 rsync -aHAX --info=progress2 /var/lib/docker/  /opt/docker/
@@ -547,8 +551,11 @@ semanage fcontext -a -e /var/lib/containerd /opt/containerd
 restorecon -RF /opt/docker /opt/containerd
 
 # Once you've verified the copies (diff -rq old vs new, or just trust rsync),
-# reclaim the space:
-rm -rf /var/lib/docker/* /var/lib/containerd/*
+# reclaim the space. Remove the directories themselves rather than `rm -rf
+# .../*` — a bare `*` glob skips dotfiles (e.g. dockerd's own
+# .buildNodeID), which would otherwise survive and make the playbook's
+# emptiness guard see the "cleaned" path as still populated on the next run:
+rm -rf /var/lib/docker /var/lib/containerd
 ```
 
 Then set `docker_data_root: "/opt/docker"` in the tenant's host_vars and

--- a/local-setup/ansible/inventory/group_vars/all.yml
+++ b/local-setup/ansible/inventory/group_vars/all.yml
@@ -19,3 +19,16 @@ configurator_www_dir: "{{ '/var/www/configurator' if (ansible_system | default('
 # Host port the macOS nginx container publishes (maps to its :80). Linux is
 # unaffected (host nginx binds 80/443 directly).
 nginx_host_port: 80
+
+# Optional: move Docker's data-root (images + named volumes — the bulk of
+# disk usage) off the root filesystem onto a dedicated partition, e.g.
+# "/opt/docker". Empty = Docker's default (/var/lib/docker). Set this on any
+# box where `/` is small and a larger partition (commonly /opt) is available
+# — a fresh RHEL box pulling the ~30 images in this stack onto a small `/`
+# reliably fills it mid-deploy. Setting this ALSO relocates containerd's own
+# root (a separate config file Docker's data-root does not control — the
+# image layers actually live there) to a sibling "containerd" directory, e.g.
+# "/opt/containerd". Only takes effect on a box where Docker/containerd have
+# never been started before — see local-setup/ansible/README.md for the
+# migration steps if they're already populated on the root filesystem.
+docker_data_root: ""

--- a/local-setup/ansible/inventory/host_vars/_example.yml
+++ b/local-setup/ansible/inventory/host_vars/_example.yml
@@ -36,6 +36,19 @@ domain: digit.example.com
 # 127.0.0.1 with `Host:` header.
 tls_enabled: true
 
+# Optional. Default empty (Docker's own default: /var/lib/docker, on the
+# root filesystem). Set to a path on a larger/dedicated partition, e.g.
+# "/opt/docker", when `/` is small — a fresh box pulling the ~30 images in
+# this stack onto a small `/` reliably fills it mid-deploy with "no space
+# left on device". Setting this ALSO relocates containerd's own image-layer
+# store (a separate config that Docker's data-root does not control) to a
+# sibling directory, e.g. "/opt/containerd" — both are relabeled for SELinux
+# automatically on RHEL-family targets. Only takes effect on a box where
+# Docker/containerd have never been started before; an already-populated
+# /var/lib/docker needs a manual stop+rsync+relabel migration first (see
+# local-setup/ansible/README.md).
+docker_data_root: ""
+
 # ────────── DIGIT tenancy ──────────
 
 # REQUIRED. Four-tier tenant slug:

--- a/local-setup/ansible/inventory/host_vars/bomet.yml.example
+++ b/local-setup/ansible/inventory/host_vars/bomet.yml.example
@@ -41,6 +41,12 @@ docker_default_platform: ''
 domain: localhost
 tls_enabled: false
 insecure_registries: []
+# Empty = Docker's default (/var/lib/docker on the root filesystem) — fine
+# here since this is a single-partition local box. Set to e.g. "/opt/docker"
+# on a target where `/` is small and a larger partition (commonly /opt) is
+# available; see the docker_data_root comment in inventory/host_vars/_example.yml
+# for what it does (also relocates containerd's root, relabels for SELinux).
+docker_data_root: ""
 
 # ── identity / tenancy ──
 # Kit shape was bare `ke` everywhere, but the configurator wizard created the
@@ -55,6 +61,11 @@ tenant_id: ke
 ui_state_tenant_id: ke.bomet
 nginx_preserve_vhost: false        # kit: true — local box has no hand-managed vhost to preserve
 login_tenant_allowlist: []
+
+# Hide these modules in the employee UI. IM (inbox-v2) needs the search
+# stack, which is off on this box (enable_search_stack: false below).
+employee_module_denylist:
+  - IM
 
 # ── geography / boundary model (Bomet County) ──
 map_center: { lat: -0.7817, lng: 35.3428 }
@@ -74,6 +85,20 @@ core_mobile_configs:
   countryCode: '+254'
   mobileNumberRegex: ^[17][0-9]{8}$
 
+# Postal-code validation (SPA globalConfigs CORE_POSTAL_CONFIGS). Kenya: 5
+# digits. Empty/absent falls back to this same pattern anyway, but set it
+# explicitly so it's not relying on the hardcoded legacy default.
+core_postal_configs:
+  postalCodePattern: "^[0-9]{5}$"
+  postalCodeLength: 5
+  postalCodeErrorMessage: "CS_COMPLAINT_POSTALCODE_INVALID_ERROR"
+
+# ── Branding ──
+# Footer logos shown in citizen + employee UI. Use absolute URLs; copied to
+# /var/www/brand/ when nginx_features.brand_assets: true (off below).
+footer_logo_url: ""
+footer_bw_logo_url: ""
+
 # ── feature toggles (exact Bomet shape, except MCP — see header) ──
 asset_s3_bucket: pg-egov-assets
 digit_ui_mode: container
@@ -82,11 +107,26 @@ enable_mcp: true                   # kit: false — needed locally to bootstrap 
 build_mcp: true                    # kit: false — build digit-mcp:local like the mz bring-up did
 enable_novu: true                  # config-driven notifications target: Novu
 db_fast_path: true                 # REQUIRED — see kit NON-PERSISTED-STATE.md / DB section
+# New in _example.yml: scripts/preflight.py refuses db_fast_path: true without this
+# explicit ack (deploy.sh would fail preflight otherwise). Set only after confirming
+# this box has no anonymous-volume postgres data worth keeping.
+db_fast_path_ack_data_wipe: true
 build_otp_publisher: true          # not in kit: real Bomet box already has otp-publisher:local;
                                    # the notifications profile needs it, so build it here
 build_digit_ui: true
 build_configurator: true
 tolerate_bootstrap_failures: true  # bootstrap is partial-success tolerant (see kit GAPS)
+
+# Build the pass-through novu-bridge / config-driven pgr-services from source
+# on the box instead of pulling a published/preview image. Off by default,
+# same as _example.yml — this tenant currently uses the published images
+# (pgr_services_image / novu_bridge_image below).
+build_novu_bridge: false
+build_pgr_services: false
+
+# Init the nairobi-mdms git submodule on the controller. Only needed if this
+# tenant's onboarding uses those JSONs — not the case here.
+requires_nairobi_mdms: false
 
 # ── Config-driven notifications (design D1/D4/D6/D7/D8) ──
 # Bomet is the FIRST tenant cut over. PGR reads PGR.NotificationRouting +
@@ -95,6 +135,11 @@ tolerate_bootstrap_failures: true  # bootstrap is partial-success tolerant (see 
 # docker-compose.bomet.yml ALSO hard-sets PGR_NOTIFICATION_CONFIG_DRIVEN=true.
 pgr_notification_config_driven: true
 novu_bridge_channel: "sms"         # SMS-first; add WHATSAPP/EMAIL as config-only routing edits
+
+# Build a subpath-rebased Novu dashboard image so the SPA serves cleanly
+# under /novu. Not required here (enable_keycloak is false below, so no
+# domain-sharing conflict yet) — matches _example.yml's off-by-default.
+build_novu_dashboard: false
 
 # Custom image pins (built+pushed to the VPC registry by CI). Replace <sha>
 # with the actual CI tags once the Phase 1/2 images are built. Until then the
@@ -109,6 +154,27 @@ twilio_account_sid: ""
 twilio_auth_token: ""
 twilio_whatsapp_from: "whatsapp:+14155238886"
 
+# ── Optional services (opt-in via flags; all off, matching _example.yml) ──
+# Real OTP stack (egov-otp/user-otp/egov-notification-sms). Off keeps the
+# local kong.yml mock (fixed OTP 123456) — fine for this local box.
+enable_otp_services: false
+# Turbopass (OSM location autocomplete) — standalone on-box container.
+enable_turbopass: false
+# Self-hosted Overpass (boundary-polygon fetch) — falls back to public
+# overpass-api.de when off.
+enable_overpass: false
+
+# ── digit-integration-tests dashboards (off — not used on this box) ──
+enable_integration_tests: false
+integration_tests_dashboard_base: "/tests-v2/"
+integration_tests_basic_auth_user: "digit-tests"
+enable_integration_tests_runner: false
+
+# ── CI / lifecycle ──
+run_ci_tests: false                # post-deploy XLSX dataloader + Playwright suite
+force_clean: false                 # tear down + redeploy from scratch (NEVER on live data)
+install_claude_code: false         # installs Claude Code CLI on the target
+
 nginx_features:
   brand_assets: false
   configurator: true
@@ -118,6 +184,8 @@ nginx_features:
   mcp: true                        # kit: false — paired with enable_mcp above
   keycloak: true
   digit_ui_v2: true
+  integration_tests: false         # pair with enable_integration_tests above
+  integration_tests_runner: false  # pair with enable_integration_tests_runner above
 
 # ── auth (Keycloak) ──
 enable_keycloak: false
@@ -129,6 +197,7 @@ auth_provider: ""
 keycloak_client_id: digit-ui
 enable_digit_ui_v2: true
 digit_ui_esbuild_branch: feat/keycloak-auth-adapter
+digit_ui_v2_repo: "https://github.com/ChakshuGautam/Citizen-Complaint-Resolution-System.git"
 digit_ui_v2_branch: feat/digit-ui-v2-keycloak
 keycloak_google_client_id: ''      # kit: CHANGE_ME — blank skips Google IdP wiring
 

--- a/local-setup/ansible/inventory/host_vars/bomet.yml.example
+++ b/local-setup/ansible/inventory/host_vars/bomet.yml.example
@@ -86,12 +86,13 @@ core_mobile_configs:
   mobileNumberRegex: ^[17][0-9]{8}$
 
 # Postal-code validation (SPA globalConfigs CORE_POSTAL_CONFIGS). Kenya: 5
-# digits. Empty/absent falls back to this same pattern anyway, but set it
-# explicitly so it's not relying on the hardcoded legacy default.
+# digits. The pattern is the single knob — length and the localized error
+# message are derived from it (postalCodeLength / postalCodeErrorMessage
+# were removed in v2.12). Empty/absent falls back to this same pattern
+# anyway, but set it explicitly so it's not relying on the hardcoded
+# legacy default.
 core_postal_configs:
   postalCodePattern: "^[0-9]{5}$"
-  postalCodeLength: 5
-  postalCodeErrorMessage: "CS_COMPLAINT_POSTALCODE_INVALID_ERROR"
 
 # ── Branding ──
 # Footer logos shown in citizen + employee UI. Use absolute URLs; copied to

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -665,7 +665,21 @@
                 - ansible_facts['os_family'] == 'RedHat'
                 - _selinux_enforced
 
-            - name: "SELinux — restorecon the relocated storage dirs (RHEL family)"
+            # Expensive: walks every file individually (read + possibly
+            # rewrite its security.selinux xattr). Only needed the FIRST time
+            # the relocation happens — the semanage equivalence above makes
+            # new files Docker/containerd create afterward inherit the
+            # correct label automatically (default SELinux file-creation
+            # behavior: a new file/dir inherits its parent's context absent
+            # an explicit type-transition rule, and the parent here is
+            # already correctly labeled after this one pass). Re-running
+            # restorecon on every subsequent deploy against an
+            # already-relocated, already-populated data-root just re-walks
+            # a now-large Docker/containerd tree for nothing — on a
+            # multi-GB overlay2 store this has been observed to take
+            # 15-20+ minutes on IOPS-limited cloud block storage, blocking
+            # every redeploy for no benefit.
+            - name: "SELinux — restorecon the relocated storage dirs (RHEL family, first relocation only)"
               ansible.builtin.command: "restorecon -RF {{ item }}"
               loop:
                 - "{{ _docker_data_root }}"
@@ -674,6 +688,7 @@
               when:
                 - ansible_facts['os_family'] == 'RedHat'
                 - _selinux_enforced
+                - not (_relocation_already_applied | bool)
 
             - name: "Restart containerd if its config changed"
               ansible.builtin.service:

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -185,25 +185,23 @@
 
   tasks:
     # ==================== Preflight: target OS ====================
-    # The playbook installs Docker + nginx + node + python via apt and
-    # manages docker.service via systemd. Both assume an Ubuntu-family
-    # target. Fail fast on Mac/RHEL/etc with a clear message rather than
-    # halfway through with `apt: command not found` or systemd errors.
+    # The playbook installs Docker + nginx + node + python and manages
+    # docker.service via systemd. Every apt/dnf-package task below is
+    # branched on ansible_facts['os_family'] — Debian (apt) or RedHat
+    # (dnf: Rocky/Alma/CentOS Stream/RHEL). Fail fast on anything else
+    # (Alpine, etc) with a clear message rather than halfway through with
+    # a "module not found" or systemd error.
     #
-    # Mac operators: spin up an Ubuntu 24.04 VM (UTM, OrbStack, Multipass,
-    # Lima, or a remote VPS) and point `ansible_host` in your host_vars
-    # at that VM. The Mac itself runs only ansible-playbook + ssh.
-    # Supported targets: Debian-family (Ubuntu) for full host provisioning,
-    # and macOS (Darwin) via the thin Mac path — Docker Desktop/OrbStack
+    # Mac operators: see the thin Mac path below — Docker Desktop/OrbStack
     # already provides Docker, nginx runs as a container, and the
-    # apt/systemd/host-nginx tasks are skipped (when: ansible_system != 'Darwin').
-    # Anything else (RHEL, Alpine, …) is genuinely unsupported.
-    - name: "preflight — target OS must be Debian-family or macOS"
+    # apt/dnf/systemd/host-nginx tasks are skipped (when: ansible_system != 'Darwin').
+    - name: "preflight — target OS must be Debian-family, RHEL-family, or macOS"
       ansible.builtin.fail:
         msg: |
           Target host {{ inventory_hostname }} is {{ ansible_facts['os_family'] }}
           ({{ ansible_facts['distribution'] | default('?') }} {{ ansible_facts['distribution_version'] | default('?') }}).
-          This playbook supports Ubuntu/Debian (full host provisioning) and
+          This playbook supports Ubuntu/Debian (apt), RHEL-family (dnf: Rocky
+          Linux/AlmaLinux/CentOS Stream/RHEL) for full host provisioning, and
           macOS (thin Mac path — containerized nginx, Docker Desktop/OrbStack).
 
           On macOS, in inventory/host_vars/<tenant>.yml set:
@@ -212,7 +210,7 @@
           and ensure Docker Desktop or OrbStack is running, then run
           `./deploy.sh <tenant>` from the Mac terminal.
       when:
-        - ansible_facts['os_family'] != 'Debian'
+        - ansible_facts['os_family'] not in ['Debian', 'RedHat']
         - ansible_system != 'Darwin'
 
     # common-masters.MobileNumberValidation (utilities/default-data-handler)
@@ -335,39 +333,43 @@
           when: (ansible_memtotal_mb | int) < (wsl_memory_gb | int) * 1024 * 0.85
 
     # ==================== Docker host install + config ====================
-    # Linux/Debian targets only. On macOS the operator already runs Docker
-    # Desktop / OrbStack, so apt + docker.service + /etc/docker/daemon.json
-    # don't apply — this whole block is skipped on Darwin.
-    - name: "Docker host install + config (Linux/Debian targets only)"
+    # Linux targets only (Debian or RHEL family). On macOS the operator
+    # already runs Docker Desktop / OrbStack, so apt/dnf + docker.service +
+    # /etc/docker/daemon.json don't apply — this whole block is skipped on
+    # Darwin.
+    - name: "Docker host install + config (Linux targets only)"
       when: ansible_system != "Darwin"
       block:
-        # ==================== Docker Installation ====================
-        - name: Install Docker prerequisites
+        # ==================== Docker Installation (Debian/Ubuntu) ====================
+        - name: Install Docker prerequisites (Debian/Ubuntu)
           apt:
             name: [ca-certificates, curl, gnupg]
             state: present
             update_cache: yes
+          when: ansible_facts['os_family'] == 'Debian'
 
-        - name: Add Docker GPG key
+        - name: Add Docker GPG key (Debian/Ubuntu)
           shell: |
             install -m 0755 -d /etc/apt/keyrings
             curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
             chmod a+r /etc/apt/keyrings/docker.asc
           args:
             creates: /etc/apt/keyrings/docker.asc
+          when: ansible_facts['os_family'] == 'Debian'
 
-        - name: Add Docker repository
+        - name: Add Docker repository (Debian/Ubuntu)
           shell: |
             echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo $VERSION_CODENAME) stable" > /etc/apt/sources.list.d/docker.list
           args:
             creates: /etc/apt/sources.list.d/docker.list
+          when: ansible_facts['os_family'] == 'Debian'
 
         # Ubuntu 24.04 ships `docker.io` + `docker-compose-v2` from the
         # archive. Both conflict with Docker's upstream packages — they own
         # the same `/usr/libexec/docker/cli-plugins/docker-compose` file —
         # so dpkg refuses to install the upstream packages until the archive
         # ones are removed. Idempotent: no-op if they're not installed.
-        - name: Remove conflicting Ubuntu-archive Docker packages
+        - name: Remove conflicting Ubuntu-archive Docker packages (Debian/Ubuntu)
           apt:
             name:
               - docker.io
@@ -379,8 +381,9 @@
               - runc
             state: absent
             purge: yes
+          when: ansible_facts['os_family'] == 'Debian'
 
-        - name: Install Docker Engine
+        - name: Install Docker Engine (Debian/Ubuntu)
           apt:
             name:
               - docker-ce
@@ -390,14 +393,218 @@
               - docker-compose-plugin
             state: present
             update_cache: yes
+          when: ansible_facts['os_family'] == 'Debian'
 
-        # apt installs docker.service `disabled` on Ubuntu 24.04 — enable +
+        # ==================== Docker Installation (RHEL family) ====================
+        # Rocky Linux / AlmaLinux / CentOS Stream / RHEL. Docker publishes no
+        # separate "rocky"/"alma" repo — the upstream linux/rhel repo is the
+        # documented path for every RHEL rebuild, BUT the stock
+        # docker-ce.repo uses $releasever, which resolves to the host's
+        # actual major version — and Docker has never published EL10
+        # packages (download.docker.com/linux/rhel/10/.../repodata/repomd.xml
+        # 404s; confirmed on Rocky Linux 10 as of 2026, see
+        # github.com/docker/roadmap#847 and the Rocky Linux forum thread on
+        # this exact failure). The documented workaround is pinning to the
+        # EL9 package set, which installs and runs fine on EL10 (same glibc
+        # ABI family). We write the repo file ourselves with releasever
+        # hardcoded instead of using the get_url'd stock file, so this
+        # self-heals if/when Docker ships real EL10 packages (bump
+        # docker_rhel_releasever_override in group_vars once they do).
+        - name: "Docker repo (RHEL family) — resolve releasever to use"
+          ansible.builtin.set_fact:
+            _docker_rhel_releasever: >-
+              {{ docker_rhel_releasever_override
+                 | default('9' if (ansible_distribution_major_version | int) >= 10
+                            else ansible_distribution_major_version, true) }}
+          when: ansible_facts['os_family'] == 'RedHat'
+
+        - name: "Docker repo (RHEL family) — write docker-ce.repo pinned to a published releasever"
+          ansible.builtin.copy:
+            dest: /etc/yum.repos.d/docker-ce.repo
+            mode: '0644'
+            content: |
+              [docker-ce-stable]
+              name=Docker CE Stable - $basearch
+              baseurl=https://download.docker.com/linux/rhel/{{ _docker_rhel_releasever }}/$basearch/stable
+              enabled=1
+              gpgcheck=1
+              gpgkey=https://download.docker.com/linux/rhel/gpg
+          when: ansible_facts['os_family'] == 'RedHat'
+
+        # podman/podman-docker ship on RHEL-family cloud images and own the
+        # same `docker` CLI shim path as Docker CE's packages — same
+        # conflict as Ubuntu's docker.io above. Idempotent: no-op if absent.
+        - name: Remove conflicting RHEL-family container packages
+          dnf:
+            name: [podman, podman-docker, runc]
+            state: absent
+          when: ansible_facts['os_family'] == 'RedHat'
+
+        - name: Install Docker Engine (RHEL family)
+          dnf:
+            name:
+              - docker-ce
+              - docker-ce-cli
+              - containerd.io
+              - docker-buildx-plugin
+              - docker-compose-plugin
+            state: present
+            update_cache: yes
+          when: ansible_facts['os_family'] == 'RedHat'
+
+        # ==================== Relocate Docker + containerd storage (optional) ====================
+        # Set docker_data_root in host_vars (e.g. "/opt/docker") to move BOTH
+        # Docker's data-root (images/volumes metadata) AND containerd's own
+        # root (the actual image-layer store — a separate config file that
+        # Docker's data-root does NOT control) off a small root filesystem.
+        # Without this, a fresh box with a small `/` and a larger `/opt`
+        # fills `/` mid-deploy pulling the ~30 images in this stack and dies
+        # with "no space left on device". Must run before containerd/docker
+        # are ever started — relocating an already-populated /var/lib/docker
+        # or /var/lib/containerd needs a stop+rsync+relabel migration instead
+        # (not handled here; do that by hand first if Docker's already run).
+        - name: "Docker/containerd storage relocation (when docker_data_root is set)"
+          when: (docker_data_root | default('') | length) > 0
+          vars:
+            _containerd_root: "{{ docker_data_root | dirname }}/containerd"
+          block:
+            - name: "Ensure Docker data-root directory exists"
+              ansible.builtin.file:
+                path: "{{ docker_data_root }}"
+                state: directory
+                mode: '0711'
+
+            - name: "Ensure containerd root directory exists"
+              ansible.builtin.file:
+                path: "{{ _containerd_root }}"
+                state: directory
+                mode: '0711'
+
+            - name: "containerd — ensure a default config.toml exists"
+              ansible.builtin.shell: containerd config default > /etc/containerd/config.toml
+              args:
+                creates: /etc/containerd/config.toml
+
+            - name: "containerd — point root at the relocated directory"
+              ansible.builtin.lineinfile:
+                path: /etc/containerd/config.toml
+                regexp: '^\s*root\s*='
+                line: 'root = "{{ _containerd_root }}"'
+              register: containerd_root_config
+
+            # semanage errors if the exact equivalence already exists (e.g. a
+            # re-run) — that's not a real failure, just already-done.
+            - name: "SELinux — label the relocated storage dirs like the originals (RHEL family)"
+              ansible.builtin.command: "semanage fcontext -a -e {{ item.orig }} {{ item.new }}"
+              loop:
+                - { orig: /var/lib/docker, new: "{{ docker_data_root }}" }
+                - { orig: /var/lib/containerd, new: "{{ _containerd_root }}" }
+              register: _semanage_fcontext
+              failed_when: >-
+                _semanage_fcontext.rc != 0
+                and 'already defined' not in (_semanage_fcontext.stderr | default(''))
+              changed_when: _semanage_fcontext.rc == 0
+              when:
+                - ansible_facts['os_family'] == 'RedHat'
+                - ansible_facts['selinux']['status'] | default('disabled') == 'enabled'
+
+            - name: "SELinux — restorecon the relocated storage dirs (RHEL family)"
+              ansible.builtin.command: "restorecon -RF {{ item }}"
+              loop:
+                - "{{ docker_data_root }}"
+                - "{{ _containerd_root }}"
+              changed_when: false
+              when:
+                - ansible_facts['os_family'] == 'RedHat'
+                - ansible_facts['selinux']['status'] | default('disabled') == 'enabled'
+
+            - name: "Restart containerd if its config changed"
+              ansible.builtin.service:
+                name: containerd
+                state: restarted
+                enabled: true
+              when: containerd_root_config.changed | default(false)
+
+            - name: "Ensure containerd is enabled + running"
+              ansible.builtin.service:
+                name: containerd
+                state: started
+                enabled: true
+
+        # apt/dnf both install docker.service disabled by default — enable +
         # start it explicitly so subsequent tasks can talk to the daemon.
         - name: Ensure docker daemon is enabled + running
           service:
             name: docker
             state: started
             enabled: yes
+
+        # ==================== firewalld (RHEL family only) ====================
+        # Ubuntu's ufw ships inactive by default on cloud images, so this
+        # playbook never needed firewall tasks. Rocky/RHEL-family images
+        # ship firewalld ACTIVE with only ssh/dhcpv6-client open in the
+        # default zone — without this, host nginx comes up fine but every
+        # external request just times out. Docker's own iptables/nftables
+        # rules for published container ports are unaffected by firewalld
+        # zones, so only the host-nginx-facing ports need opening here.
+        - name: "firewalld — ensure installed + running (RHEL family)"
+          block:
+            - name: Install firewalld
+              dnf:
+                name: firewalld
+                state: present
+
+            - name: Ensure firewalld is enabled + running
+              service:
+                name: firewalld
+                state: started
+                enabled: yes
+
+            - name: Open http/https in the default zone
+              ansible.posix.firewalld:
+                service: "{{ item }}"
+                permanent: true
+                immediate: true
+                state: enabled
+              loop: [http, https]
+
+            # Only relevant when nginx is configured to listen on a
+            # non-standard port (host_vars `nginx_host_port`); http/https
+            # above cover the default 80/443.
+            - name: "Open nginx_host_port if it isn't 80/443"
+              ansible.posix.firewalld:
+                port: "{{ nginx_host_port }}/tcp"
+                permanent: true
+                immediate: true
+                state: enabled
+              when:
+                - nginx_host_port is defined
+                - nginx_host_port | int not in [80, 443]
+          when: ansible_facts['os_family'] == 'RedHat'
+
+        # ==================== SELinux (RHEL family only) ====================
+        # Rocky/RHEL-family images ship SELinux Enforcing by default. Host
+        # nginx reverse-proxying to the Dockerized backend (Kong, esbuild,
+        # MCP, Grafana, Gatus, Novu, …) needs httpd_can_network_connect —
+        # without it every proxy_pass 502s with an AVC denial
+        # (avc: denied { name_connect } for ... scontext=...httpd_t). This
+        # is the single most common "deploy finished green but the site
+        # 502s" gap on a fresh RHEL-family box.
+        - name: "SELinux — allow nginx to proxy to backend services (RHEL family)"
+          block:
+            - name: Ensure libselinux-python bindings + policy tools are present
+              dnf:
+                name: [policycoreutils-python-utils]
+                state: present
+
+            - name: "setsebool httpd_can_network_connect=on (persistent)"
+              ansible.posix.seboolean:
+                name: httpd_can_network_connect
+                state: true
+                persistent: true
+          when:
+            - ansible_facts['os_family'] == 'RedHat'
+            - ansible_facts['selinux']['status'] | default('disabled') == 'enabled'
 
         # ==================== Root mount propagation (WSL2 only) ====================
         # The monitoring overlay's node-exporter binds /:/rootfs:ro,rslave
@@ -567,7 +774,9 @@
                   {{ {'log-driver': 'json-file',
                       'log-opts': {'max-size': docker_log_max_size,
                                    'max-file': docker_log_max_file_effective | string},
-                      'insecure-registries': insecure_registries | default([])} }}
+                      'insecure-registries': insecure_registries | default([])}
+                     | combine({'data-root': docker_data_root}
+                               if (docker_data_root | default('') | length > 0) else {}) }}
               ansible.builtin.copy:
                 dest: /etc/docker/daemon.json
                 content: "{{ _existing | combine(_ours, recursive=True) | to_nice_json }}\n"
@@ -2259,14 +2468,23 @@
         - enable_integration_tests | default(false)
         - integration_tests_dir is defined
 
-    - name: "integration-tests — ensure htpasswd tooling for basic-auth"
+    - name: "integration-tests — ensure htpasswd tooling for basic-auth (Debian/Ubuntu)"
       ansible.builtin.apt:
         name: apache2-utils
         state: present
       when:
         - enable_integration_tests | default(false)
         - integration_tests_basic_auth_password is defined
-        - ansible_system != "Darwin"
+        - ansible_facts['os_family'] == 'Debian'
+
+    - name: "integration-tests — ensure htpasswd tooling for basic-auth (RHEL family)"
+      ansible.builtin.dnf:
+        name: httpd-tools
+        state: present
+      when:
+        - enable_integration_tests | default(false)
+        - integration_tests_basic_auth_password is defined
+        - ansible_facts['os_family'] == 'RedHat'
 
     # Idempotent via `creates`: rotate the password by deleting the file and
     # re-running. Password comes from vault/host_vars; the task skips entirely
@@ -2335,12 +2553,23 @@
         - integration_tests_dir is defined
         - ansible_system != "Darwin"
 
-    # Host nginx (Linux/Debian) — apt nginx + /etc/nginx site. Skipped on
+    # Host nginx (Linux) — package install + /etc/nginx site. Skipped on
     # macOS, where nginx runs as a container instead (next block).
-    - name: "Host nginx — Linux/Debian only"
-      when: ansible_system != "Darwin"
+    #
+    # Debian's nginx package auto-includes /etc/nginx/sites-enabled/* from
+    # nginx.conf, so the site lives in sites-available + a sites-enabled
+    # symlink. RHEL-family's nginx RPM has NO sites-available/sites-enabled
+    # convention at all — its stock nginx.conf only includes
+    # /etc/nginx/conf.d/*.conf. Writing to sites-available on Rocky/RHEL
+    # would render a file nginx never reads. So on RedHat the site is
+    # rendered straight into conf.d, replacing the RPM's own
+    # conf.d/default.conf (the RHEL equivalent of Debian's sites-enabled/default).
+    - name: "Host nginx — Linux, Debian/Ubuntu"
+      when:
+        - ansible_system != "Darwin"
+        - ansible_facts['os_family'] == 'Debian'
       block:
-        - name: "Host nginx — install if missing"
+        - name: "Host nginx — install if missing (Debian/Ubuntu)"
           ansible.builtin.apt:
             name: nginx
             state: present
@@ -2353,7 +2582,7 @@
       # install task above still runs (idempotent), so the package is
       # always present; only the site file is left alone.
 
-        - name: "Host nginx — render site config from template"
+        - name: "Host nginx — render site config from template (Debian/Ubuntu)"
           ansible.builtin.template:
             src: templates/nginx-site.conf.j2
             dest: "/etc/nginx/sites-available/{{ domain }}"
@@ -2361,7 +2590,7 @@
           notify: Reload nginx
           when: not (nginx_preserve_vhost | default(false))
 
-        - name: "Host nginx — enable site"
+        - name: "Host nginx — enable site (Debian/Ubuntu)"
           ansible.builtin.file:
             src: "/etc/nginx/sites-available/{{ domain }}"
             dest: "/etc/nginx/sites-enabled/{{ domain }}"
@@ -2370,15 +2599,43 @@
           notify: Reload nginx
           when: not (nginx_preserve_vhost | default(false))
 
-        - name: "Host nginx — remove default site"
+        - name: "Host nginx — remove default site (Debian/Ubuntu)"
           ansible.builtin.file:
             path: /etc/nginx/sites-enabled/default
             state: absent
           notify: Reload nginx
           when: not (nginx_preserve_vhost | default(false))
 
-        - name: "Host nginx — flush handlers so reload happens before validation"
-          ansible.builtin.meta: flush_handlers
+    - name: "Host nginx — Linux, RHEL family"
+      when:
+        - ansible_system != "Darwin"
+        - ansible_facts['os_family'] == 'RedHat'
+      block:
+        - name: "Host nginx — install if missing (RHEL family)"
+          ansible.builtin.dnf:
+            name: nginx
+            state: present
+
+        - name: "Host nginx — render site config from template (RHEL family, conf.d)"
+          ansible.builtin.template:
+            src: templates/nginx-site.conf.j2
+            dest: "/etc/nginx/conf.d/{{ domain }}.conf"
+            mode: '0644'
+          notify: Reload nginx
+          when: not (nginx_preserve_vhost | default(false))
+
+        - name: "Host nginx — remove RPM's stock default site (RHEL family)"
+          ansible.builtin.file:
+            path: /etc/nginx/conf.d/default.conf
+            state: absent
+          notify: Reload nginx
+          when: not (nginx_preserve_vhost | default(false))
+
+    # meta tasks don't reliably honor `when:`, but flush_handlers is a no-op
+    # if nothing notified above (e.g. on Darwin, where neither nginx block
+    # ran) so it's safe to leave unconditional.
+    - name: "Host nginx — flush handlers so reload happens before validation"
+      ansible.builtin.meta: flush_handlers
 
     # macOS thin path: run nginx as a container instead of host nginx.
     # Renders the same template (upstream host -> host.docker.internal so
@@ -2411,6 +2668,26 @@
               nginx:1.27-alpine
           register: mac_nginx
           changed_when: true
+
+    # ==================== SELinux content labeling (RHEL family only) ====================
+    # Files copied/synced into /var/www/* (configurator, citizen SPA,
+    # integration-tests dashboards, brand assets, …) by the copy/synchronize
+    # tasks above don't automatically get the httpd_sys_content_t SELinux
+    # label — copy/synchronize aren't SELinux-aware the way package-managed
+    # files are, so new files can land with the wrong context (or none) even
+    # though /var/www itself has a correct default fcontext mapping. Result:
+    # nginx (confined to the httpd_t domain) gets an AVC denial reading them
+    # and every static path 403s even though Unix permissions are fine — this
+    # is exactly what "validate — configurator returns 200" catches. Re-apply
+    # the default context recursively; idempotent and cheap.
+    - name: "SELinux — restore httpd_sys_content_t on /var/www (RHEL family)"
+      ansible.builtin.command: restorecon -Rv /var/www
+      register: _restorecon_varwww
+      changed_when: "'Relabeled' in (_restorecon_varwww.stdout | default(''))"
+      failed_when: false
+      when:
+        - ansible_facts['os_family'] == 'RedHat'
+        - ansible_facts['selinux']['status'] | default('disabled') == 'enabled'
 
     # ============================================================
     # Infrastructure validation — runs before the heavy CI tests
@@ -3578,7 +3855,7 @@
         msg: "Claude Code install disabled. Set install_claude_code: true in host_vars to enable."
       when: not (install_claude_code | default(false))
 
-    - name: Install Node.js 20 LTS (needed for CC and tests)
+    - name: Install Node.js 20 LTS (needed for CC and tests, Debian/Ubuntu)
       shell: |
         set -o pipefail
         if ! node --version 2>/dev/null | grep -qE "^v2[02]"; then
@@ -3591,7 +3868,22 @@
       changed_when: "'nodejs is already' not in nodejs_install.stdout"
       when:
         - install_claude_code | default(false)
-        - ansible_system != "Darwin"
+        - ansible_facts['os_family'] == 'Debian'
+
+    - name: Install Node.js 20 LTS (needed for CC and tests, RHEL family)
+      shell: |
+        set -o pipefail
+        if ! node --version 2>/dev/null | grep -qE "^v2[02]"; then
+          curl -fsSL https://rpm.nodesource.com/setup_20.x | bash -
+          dnf install -y nodejs
+        fi
+      args:
+        executable: /bin/bash
+      register: nodejs_install_rhel
+      changed_when: "'nodejs is already' not in nodejs_install_rhel.stdout"
+      when:
+        - install_claude_code | default(false)
+        - ansible_facts['os_family'] == 'RedHat'
 
     - name: Install Claude Code CLI
       shell: npm install -g @anthropic-ai/claude-code
@@ -3882,13 +4174,21 @@
     # ==================================================================
     # CI TESTS — Stage A: XLSX-Driven DataLoader E2E
     # ==================================================================
-    - name: Install Python3 and pip
+    - name: Install Python3 and pip (Debian/Ubuntu)
       apt:
         name: [python3, python3-pip]
         state: present
       when:
         - run_ci_tests | default(false)
-        - ansible_system != "Darwin"
+        - ansible_facts['os_family'] == 'Debian'
+
+    - name: Install Python3 and pip (RHEL family)
+      dnf:
+        name: [python3, python3-pip]
+        state: present
+      when:
+        - run_ci_tests | default(false)
+        - ansible_facts['os_family'] == 'RedHat'
 
     - name: Install Python dependencies for DataLoader
       pip:
@@ -4014,8 +4314,40 @@
       changed_when: false
 
       when: run_ci_tests | default(false) and (run_playwright_tests | default(false))
+    # Playwright's `--with-deps` OS-dependency installer only knows how to
+    # drive apt (Ubuntu/Debian) — on RHEL family it no-ops with a warning
+    # and leaves Chromium's shared libs missing, so the browser fails to
+    # launch later with a cryptic "error while loading shared libraries".
+    # Install the equivalent RPM packages ourselves first, then run
+    # `playwright install chromium` WITHOUT --with-deps on that family.
+    - name: "Install Chromium runtime dependencies (RHEL family, Playwright has no dnf support)"
+      dnf:
+        name:
+          - nss
+          - atk
+          - at-spi2-atk
+          - cups-libs
+          - libdrm
+          - libxkbcommon
+          - libXcomposite
+          - libXdamage
+          - libXfixes
+          - libXrandr
+          - mesa-libgbm
+          - alsa-lib
+          - pango
+          - cairo
+        state: present
+      when:
+        - run_ci_tests | default(false)
+        - run_playwright_tests | default(false)
+        - ansible_facts['os_family'] == 'RedHat'
+
     - name: Install Playwright Chromium with system dependencies
-      shell: 'npx playwright install{{ " --with-deps" if ansible_system != "Darwin" else "" }} chromium'
+      shell: >-
+        npx playwright install
+        {{ " --with-deps" if (ansible_system != "Darwin" and ansible_facts['os_family'] != 'RedHat') else "" }}
+        chromium
       args:
         chdir: "{{ digit_dir }}/e2e-tests"
       changed_when: false

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -431,334 +431,380 @@
         # enabled + running"). force: false → an operator-managed
         # policy-rc.d is left alone (and never removed by us either: the
         # release task below only fires when this one created the file).
-        - name: "Docker install — hold package auto-start until data-root is configured (Debian/Ubuntu)"
-          ansible.builtin.copy:
-            dest: /usr/sbin/policy-rc.d
-            mode: '0755'
-            force: false
-            content: |
-              #!/bin/sh
-              # Temporary: installed by the DIGIT ansible deploy while
-              # docker-ce is installed with a relocated data-root; removed
-              # again in the same run.
-              exit 101
-          register: _docker_autostart_hold
-          when:
-            - ansible_facts['os_family'] == 'Debian'
-            - (docker_data_root | default('') | length) > 0
-
-        - name: Install Docker Engine (Debian/Ubuntu)
-          apt:
-            name:
-              - docker-ce
-              - docker-ce-cli
-              - containerd.io
-              - docker-buildx-plugin
-              - docker-compose-plugin
-            state: present
-            update_cache: yes
-          when: ansible_facts['os_family'] == 'Debian'
-
-        # ==================== Docker Installation (RHEL family) ====================
-        # Rocky Linux / AlmaLinux / CentOS Stream / RHEL. Docker publishes no
-        # separate "rocky"/"alma" repo — the upstream linux/rhel repo is the
-        # documented path for every RHEL rebuild, BUT the stock
-        # docker-ce.repo uses $releasever, which resolves to the host's
-        # actual major version — and Docker has never published EL10
-        # packages (download.docker.com/linux/rhel/10/.../repodata/repomd.xml
-        # 404s; confirmed on Rocky Linux 10 as of 2026, see
-        # github.com/docker/roadmap#847 and the Rocky Linux forum thread on
-        # this exact failure). The documented workaround is pinning to the
-        # EL9 package set, which installs and runs fine on EL10 (same glibc
-        # ABI family). We write the repo file ourselves with releasever
-        # hardcoded instead of using the get_url'd stock file, so this
-        # self-heals if/when Docker ships real EL10 packages (bump
-        # docker_rhel_releasever_override in group_vars once they do).
-        - name: "Docker repo (RHEL family) — resolve releasever to use"
-          ansible.builtin.set_fact:
-            _docker_rhel_releasever: >-
-              {{ docker_rhel_releasever_override
-                 | default('9' if (ansible_distribution_major_version | int) >= 10
-                            else ansible_distribution_major_version, true) }}
-          when: ansible_facts['os_family'] == 'RedHat'
-
-        - name: "Docker repo (RHEL family) — write docker-ce.repo pinned to a published releasever"
-          ansible.builtin.copy:
-            dest: /etc/yum.repos.d/docker-ce.repo
-            mode: '0644'
-            content: |
-              [docker-ce-stable]
-              name=Docker CE Stable - $basearch
-              baseurl=https://download.docker.com/linux/rhel/{{ _docker_rhel_releasever }}/$basearch/stable
-              enabled=1
-              gpgcheck=1
-              gpgkey=https://download.docker.com/linux/rhel/gpg
-          when: ansible_facts['os_family'] == 'RedHat'
-
-        # podman/podman-docker ship on RHEL-family cloud images and own the
-        # same `docker` CLI shim path as Docker CE's packages — same
-        # conflict as Ubuntu's docker.io above. Idempotent: no-op if absent.
-        - name: Remove conflicting RHEL-family container packages
-          dnf:
-            name: [podman, podman-docker, runc]
-            state: absent
-          when: ansible_facts['os_family'] == 'RedHat'
-
-        - name: Install Docker Engine (RHEL family)
-          dnf:
-            name:
-              - docker-ce
-              - docker-ce-cli
-              - containerd.io
-              - docker-buildx-plugin
-              - docker-compose-plugin
-            state: present
-            update_cache: yes
-          when: ansible_facts['os_family'] == 'RedHat'
-
-        # semanage (and the libselinux python bindings the seboolean module
-        # needs) live in policycoreutils-python-utils, which minimal
-        # RHEL-family cloud images do not preinstall. One early install
-        # serves both the storage-relocation labeling below and the nginx
-        # SELinux block further down.
-        - name: "SELinux — ensure policy tooling is present (RHEL family)"
-          dnf:
-            name: policycoreutils-python-utils
-            state: present
-          when:
-            - ansible_facts['os_family'] == 'RedHat'
-            - _selinux_enforced
-
-        # ==================== Relocate Docker + containerd storage (optional) ====================
-        # Set docker_data_root in host_vars (e.g. "/opt/docker") to move BOTH
-        # Docker's data-root (images/volumes metadata) AND containerd's own
-        # root (the actual image-layer store — a separate config file that
-        # Docker's data-root does NOT control) off a small root filesystem.
-        # Without this, a fresh box with a small `/` and a larger `/opt`
-        # fills `/` mid-deploy pulling the ~30 images in this stack and dies
-        # with "no space left on device". Must run before containerd/docker
-        # are ever started — relocating an already-populated /var/lib/docker
-        # or /var/lib/containerd needs a stop+rsync+relabel migration instead
-        # (not handled here; do that by hand first if Docker's already run).
-        - name: "Docker/containerd storage relocation (when docker_data_root is set)"
-          when: (docker_data_root | default('') | length) > 0
-          vars:
-            # Strip any trailing slash before deriving the sibling containerd
-            # dir — dirname('/opt/docker/') is '/opt/docker' (nests containerd
-            # INSIDE Docker's own data-root instead of beside it). A top-level
-            # value like '/docker' has dirname '/', which would yield the
-            # bogus '//containerd' — collapse that to '/containerd'.
-            _docker_data_root: "{{ docker_data_root | regex_replace('/+$', '') }}"
-            _containerd_root: "{{ (_docker_data_root | dirname | regex_replace('^/$', '')) ~ '/containerd' }}"
+        - name: "Docker install — configure data-root before first start (Debian/Ubuntu), always releasing the auto-start hold"
           block:
-            # If daemon.json already points at the relocated data-root, the
-            # relocation was applied by an earlier run and anything left in
-            # /var/lib/docker (or /var/lib/containerd) is a harmless
-            # first-start skeleton, not live data — skip the populated-guard
-            # so routine re-deploys don't hard-fail. String-match rather than
-            # from_json so an unparseable daemon.json can't blow up the guard
-            # itself (the daemon.json merge task later fails with a clear
-            # message in that case).
-            - name: "Guard — read daemon.json to detect an already-applied relocation"
-              ansible.builtin.slurp:
-                src: /etc/docker/daemon.json
-              register: _daemon_json_pre
-              failed_when: false
+          - name: "Docker install — hold package auto-start until data-root is configured (Debian/Ubuntu)"
+            ansible.builtin.copy:
+              dest: /usr/sbin/policy-rc.d
+              mode: '0755'
+              force: false
+              content: |
+                #!/bin/sh
+                # Temporary: installed by the DIGIT ansible deploy while
+                # docker-ce is installed with a relocated data-root; removed
+                # again in the same run.
+                exit 101
+            register: _docker_autostart_hold
+            when:
+              - ansible_facts['os_family'] == 'Debian'
+              - (docker_data_root | default('') | length) > 0
 
-            - name: "Guard — note whether the relocation is already in effect"
-              ansible.builtin.set_fact:
-                _relocation_already_applied: >-
-                  {{ _daemon_json_pre.content is defined
-                     and (_daemon_json_pre.content | b64decode)
-                         is search('"data-root"\s*:\s*"' ~ (_docker_data_root | regex_escape) ~ '/?"') }}
+          - name: Install Docker Engine (Debian/Ubuntu)
+            apt:
+              name:
+                - docker-ce
+                - docker-ce-cli
+                - containerd.io
+                - docker-buildx-plugin
+                - docker-compose-plugin
+              state: present
+              update_cache: yes
+            when: ansible_facts['os_family'] == 'Debian'
 
-            # Relocating a data-root that Docker/containerd have already
-            # written to would point daemon.json/config.toml at an empty
-            # directory: every existing image and named volume (including the
-            # Postgres complaint database) becomes invisible and the stack
-            # silently re-initializes from scratch. Only a fresh/never-started
-            # box may set docker_data_root; an already-populated /var/lib/docker
-            # or /var/lib/containerd needs a stop+rsync+relabel migration done
-            # by hand first.
-            - name: "Guard — check /var/lib/docker and /var/lib/containerd are still empty"
-              ansible.builtin.command: "find {{ item }} -mindepth 1 -maxdepth 1"
-              loop:
-                - /var/lib/docker
-                - /var/lib/containerd
-              register: _live_dataroot_check
-              changed_when: false
-              failed_when: false
-              when: not (_relocation_already_applied | bool)
+          # ==================== Docker Installation (RHEL family) ====================
+          # Rocky Linux / AlmaLinux / CentOS Stream / RHEL. Docker publishes no
+          # separate "rocky"/"alma" repo — the upstream linux/rhel repo is the
+          # documented path for every RHEL rebuild, BUT the stock
+          # docker-ce.repo uses $releasever, which resolves to the host's
+          # actual major version — and Docker briefly had no EL10 packages
+          # (download.docker.com/linux/rhel/10/ 404'd earlier in 2026;
+          # github.com/docker/roadmap#847). Docker now publishes a
+          # linux/rhel/10/ tree for x86_64 and aarch64, so the host's real
+          # major version is used by default. docker_rhel_releasever_override
+          # remains as an escape hatch for a future major version that again
+          # ships without packages (pin it to the last published releasever
+          # until Docker catches up).
+          - name: "Docker repo (RHEL family) — resolve releasever to use"
+            ansible.builtin.set_fact:
+              _docker_rhel_releasever: >-
+                {{ docker_rhel_releasever_override | default(ansible_distribution_major_version, true) }}
+            when: ansible_facts['os_family'] == 'RedHat'
 
-            - name: "Guard — refuse to relocate an already-populated data-root"
-              ansible.builtin.fail:
-                msg: >-
-                  docker_data_root is set to "{{ _docker_data_root }}" but
-                  {{ item.item }} already contains data, meaning Docker/containerd
-                  have already run against the default location on this box.
-                  Relocating now would orphan every existing image and named
-                  volume (including the Postgres complaint database) — stop
-                  docker/containerd, rsync {{ item.item }} to its new home by
-                  hand (relabeling under SELinux if applicable), then re-run.
-              loop: "{{ _live_dataroot_check.results | default([]) }}"
-              loop_control:
-                label: "{{ item.item | default('') }}"
-              when:
-                - not (_relocation_already_applied | bool)
-                - (item.stdout_lines | default([]) | length) > 0
+          - name: "Docker repo (RHEL family) — write docker-ce.repo pinned to a published releasever"
+            ansible.builtin.copy:
+              dest: /etc/yum.repos.d/docker-ce.repo
+              mode: '0644'
+              content: |
+                [docker-ce-stable]
+                name=Docker CE Stable - $basearch
+                baseurl=https://download.docker.com/linux/rhel/{{ _docker_rhel_releasever }}/$basearch/stable
+                enabled=1
+                gpgcheck=1
+                gpgkey=https://download.docker.com/linux/rhel/gpg
+            when: ansible_facts['os_family'] == 'RedHat'
 
-            - name: "Ensure Docker data-root directory exists"
-              ansible.builtin.file:
-                path: "{{ _docker_data_root }}"
-                state: directory
-                mode: '0711'
+          # podman/podman-docker ship on RHEL-family cloud images and own the
+          # same `docker` CLI shim path as Docker CE's packages — same
+          # conflict as Ubuntu's docker.io above. Idempotent: no-op if absent.
+          - name: Remove conflicting RHEL-family container packages
+            dnf:
+              name: [podman, podman-docker, runc]
+              state: absent
+            when: ansible_facts['os_family'] == 'RedHat'
 
-            - name: "Ensure containerd root directory exists"
-              ansible.builtin.file:
-                path: "{{ _containerd_root }}"
-                state: directory
-                mode: '0711'
+          - name: Install Docker Engine (RHEL family)
+            dnf:
+              name:
+                - docker-ce
+                - docker-ce-cli
+                - containerd.io
+                - docker-buildx-plugin
+                - docker-compose-plugin
+              state: present
+              update_cache: yes
+            when: ansible_facts['os_family'] == 'RedHat'
 
-            - name: "containerd — ensure a default config.toml exists"
-              ansible.builtin.shell: |
-                set -eo pipefail
-                mkdir -p /etc/containerd
-                containerd config default > /etc/containerd/config.toml
-              args:
-                executable: /bin/bash
-                creates: /etc/containerd/config.toml
+          # semanage (and the libselinux python bindings the seboolean module
+          # needs) live in policycoreutils-python-utils, which minimal
+          # RHEL-family cloud images do not preinstall. One early install
+          # serves both the storage-relocation labeling below and the nginx
+          # SELinux block further down.
+          - name: "SELinux — ensure policy tooling is present (RHEL family)"
+            dnf:
+              name: policycoreutils-python-utils
+              state: present
+            when:
+              - ansible_facts['os_family'] == 'RedHat'
+              - _selinux_enforced
 
-            # The containerd.io package's shipped config.toml stub has no
-            # top-level `root =` key, so the regexp below matches nothing and
-            # lineinfile appends the line at EOF — landing it inside whatever
-            # `[table]` last preceded it in TOML instead of at the document
-            # root, where containerd silently ignores it. insertbefore: BOF
-            # guarantees the key lands above any table header when absent.
-            - name: "containerd — point root at the relocated directory"
-              ansible.builtin.lineinfile:
-                path: /etc/containerd/config.toml
-                regexp: '^\s*root\s*='
-                line: 'root = "{{ _containerd_root }}"'
-                insertbefore: BOF
-              register: containerd_root_config
+          # ==================== Relocate Docker + containerd storage (optional) ====================
+          # Set docker_data_root in host_vars (e.g. "/opt/docker") to move BOTH
+          # Docker's data-root (images/volumes metadata) AND containerd's own
+          # root (the actual image-layer store — a separate config file that
+          # Docker's data-root does NOT control) off a small root filesystem.
+          # Without this, a fresh box with a small `/` and a larger `/opt`
+          # fills `/` mid-deploy pulling the ~30 images in this stack and dies
+          # with "no space left on device". Must run before containerd/docker
+          # are ever started — relocating an already-populated /var/lib/docker
+          # or /var/lib/containerd needs a stop+rsync+relabel migration instead
+          # (not handled here; do that by hand first if Docker's already run).
+          - name: "Docker/containerd storage relocation (when docker_data_root is set)"
+            when: (docker_data_root | default('') | length) > 0
+            vars:
+              # Strip any trailing slash before deriving the sibling containerd
+              # dir — dirname('/opt/docker/') is '/opt/docker' (nests containerd
+              # INSIDE Docker's own data-root instead of beside it). A top-level
+              # value like '/docker' has dirname '/', which would yield the
+              # bogus '//containerd' — collapse that to '/containerd'.
+              _docker_data_root: "{{ docker_data_root | regex_replace('/+$', '') }}"
+              _containerd_root: "{{ (_docker_data_root | dirname | regex_replace('^/$', '')) ~ '/containerd' }}"
+            block:
+              # If daemon.json already points at the relocated data-root, the
+              # relocation was applied by an earlier run and anything left in
+              # /var/lib/docker (or /var/lib/containerd) is a harmless
+              # first-start skeleton, not live data — skip the populated-guard
+              # so routine re-deploys don't hard-fail. String-match rather than
+              # from_json so an unparseable daemon.json can't blow up the guard
+              # itself (the daemon.json merge task later fails with a clear
+              # message in that case).
+              - name: "Guard — read daemon.json to detect an already-applied relocation"
+                ansible.builtin.slurp:
+                  src: /etc/docker/daemon.json
+                register: _daemon_json_pre
+                failed_when: false
 
-            # semanage is provided by the "SELinux — ensure policy tooling is
-            # present" task above (before this relocation block).
-            #
-            # semanage errors if the exact equivalence already exists (e.g. a
-            # re-run) — that's not a real failure, just already-done. Fresh
-            # adds say "already defined"; re-adding after equivalences already
-            # exist for both paths says "already exists" instead — tolerate
-            # both.
-            - name: "SELinux — label the relocated storage dirs like the originals (RHEL family)"
-              ansible.builtin.command: "semanage fcontext -a -e {{ item.orig }} {{ item.new }}"
-              loop:
-                - { orig: /var/lib/docker, new: "{{ _docker_data_root }}" }
-                - { orig: /var/lib/containerd, new: "{{ _containerd_root }}" }
-              register: _semanage_fcontext
-              failed_when: >-
-                _semanage_fcontext.rc != 0
-                and 'already defined' not in (_semanage_fcontext.stderr | default(''))
-                and 'already exists' not in (_semanage_fcontext.stderr | default(''))
-              changed_when: _semanage_fcontext.rc == 0
-              when:
-                - ansible_facts['os_family'] == 'RedHat'
-                - _selinux_enforced
+              - name: "Guard — read containerd config.toml to detect its currently-configured root"
+                ansible.builtin.slurp:
+                  src: /etc/containerd/config.toml
+                register: _containerd_config_pre
+                failed_when: false
 
-            # Expensive: walks every file individually (read + possibly
-            # rewrite its security.selinux xattr). Only needed the FIRST time
-            # the relocation happens — the semanage equivalence above makes
-            # new files Docker/containerd create afterward inherit the
-            # correct label automatically (default SELinux file-creation
-            # behavior: a new file/dir inherits its parent's context absent
-            # an explicit type-transition rule, and the parent here is
-            # already correctly labeled after this one pass). Re-running
-            # restorecon on every subsequent deploy against an
-            # already-relocated, already-populated data-root just re-walks
-            # a now-large Docker/containerd tree for nothing — on a
-            # multi-GB overlay2 store this has been observed to take
-            # 15-20+ minutes on IOPS-limited cloud block storage, blocking
-            # every redeploy for no benefit.
-            - name: "SELinux — restorecon the relocated storage dirs (RHEL family, first relocation only)"
-              ansible.builtin.command: "restorecon -RF {{ item }}"
-              loop:
-                - "{{ _docker_data_root }}"
-                - "{{ _containerd_root }}"
-              changed_when: false
-              when:
-                - ansible_facts['os_family'] == 'RedHat'
-                - _selinux_enforced
-                - not (_relocation_already_applied | bool)
+              - name: "Guard — note whether the relocation is already in effect"
+                ansible.builtin.set_fact:
+                  _relocation_already_applied: >-
+                    {{ _daemon_json_pre.content is defined
+                       and (_daemon_json_pre.content | b64decode)
+                           is search('"data-root"\s*:\s*"' ~ (_docker_data_root | regex_escape) ~ '/?"') }}
 
-            - name: "Restart containerd if its config changed"
-              ansible.builtin.service:
-                name: containerd
-                state: restarted
-                enabled: true
-              when: containerd_root_config.changed | default(false)
+              # Extract whatever data-root/root Docker/containerd are
+              # CURRENTLY configured to use, if anything — not just whether
+              # /var/lib/* happens to be empty. A box already relocated to one
+              # custom path (e.g. /opt/docker) has nothing under
+              # /var/lib/docker, so checking only the compiled-in default
+              # would let a SECOND relocation (e.g. to /data/docker) sail
+              # through the emptiness check and silently orphan the data
+              # actually live at /opt/docker.
+              - name: "Guard — extract the currently-configured data-root/containerd-root (if any)"
+                ansible.builtin.set_fact:
+                  _current_docker_root: >-
+                    {{ (((_daemon_json_pre.content | default('') | b64decode)
+                         | regex_search('"data-root"\s*:\s*"[^"]*"')) | default(''))
+                       | regex_replace('^.*"([^"]*)"$', '\1') }}
+                  _current_containerd_root: >-
+                    {{ (((_containerd_config_pre.content | default('') | b64decode)
+                         | regex_search('(?m)^\s*root\s*=\s*"[^"]*"')) | default(''))
+                       | regex_replace('^.*"([^"]*)"$', '\1') }}
 
-            - name: "Ensure containerd is enabled + running"
-              ansible.builtin.service:
-                name: containerd
-                state: started
-                enabled: true
+              # Resolve which directory each store actually needs checking:
+              # its current custom location if it's already been relocated
+              # once before (even to a DIFFERENT path than this run's
+              # target), otherwise the compiled-in default.
+              - name: "Guard — resolve which directory to check for each store"
+                ansible.builtin.set_fact:
+                  _dataroot_guard_targets:
+                    - label: docker
+                      current: "{{ _current_docker_root }}"
+                      check_path: "{{ _current_docker_root if (_current_docker_root | length) > 0 else '/var/lib/docker' }}"
+                      matches_target: "{{ _current_docker_root == _docker_data_root }}"
+                    - label: containerd
+                      current: "{{ _current_containerd_root }}"
+                      check_path: "{{ _current_containerd_root if (_current_containerd_root | length) > 0 else '/var/lib/containerd' }}"
+                      matches_target: "{{ _current_containerd_root == _containerd_root }}"
 
-            # Seed the data-root into daemon.json BEFORE dockerd's first
-            # start. The full merged daemon.json (log rotation, insecure
-            # registries) is written much later in this play — but "Ensure
-            # docker daemon is enabled + running" below starts dockerd first,
-            # and without the seed that first start populates the default
-            # /var/lib/docker, tripping the relocation guard above on every
-            # subsequent re-deploy. Merge, don't overwrite: operator-set keys
-            # in an existing daemon.json survive (the later merge task keeps
-            # them too).
-            - name: "Docker — seed data-root into daemon.json before first start"
-              block:
-                - name: "Docker — write daemon.json with the relocated data-root"
-                  vars:
-                    _existing: >-
-                      {{ (_daemon_json_pre.content | default('') | b64decode | from_json)
-                         if (_daemon_json_pre.content is defined
-                             and (_daemon_json_pre.content | b64decode | trim | length) > 0)
-                         else {} }}
-                  ansible.builtin.copy:
-                    dest: /etc/docker/daemon.json
-                    content: "{{ _existing | combine({'data-root': _docker_data_root}) | to_nice_json }}\n"
-                    mode: '0644'
-                  register: _daemon_json_seed
-              rescue:
-                - name: "Docker — existing daemon.json is unreadable"
-                  ansible.builtin.fail:
-                    msg: >-
-                      /etc/docker/daemon.json exists but could not be parsed
-                      as JSON, so the relocated data-root could not be seeded
-                      into it. Fix or remove that file and re-run — it has
-                      been left untouched rather than overwritten.
+              # Relocating a data-root that Docker/containerd have already
+              # written to — whether that's the compiled-in default
+              # (/var/lib/docker, /var/lib/containerd) or a PREVIOUSLY
+              # relocated custom path — would point daemon.json/config.toml at
+              # an empty directory: every existing image and named volume
+              # (including the Postgres complaint database) becomes invisible
+              # and the stack silently re-initializes from scratch. Only a
+              # fresh/never-relocated box, or one already relocated to this
+              # EXACT target, may proceed.
+              - name: "Guard — check the resolved store directories are still empty"
+                ansible.builtin.command: "find {{ item.check_path }} -mindepth 1 -maxdepth 1"
+                loop: "{{ _dataroot_guard_targets }}"
+                loop_control:
+                  label: "{{ item.label }}: {{ item.check_path }}"
+                register: _live_dataroot_check
+                changed_when: false
+                failed_when: false
+                when: not (item.matches_target | bool)
 
-            - name: "Docker — check whether dockerd is already running"
-              ansible.builtin.command: systemctl is-active docker
-              register: _dockerd_active
-              changed_when: false
-              failed_when: false
+              - name: "Guard — refuse to relocate an already-populated data-root"
+                ansible.builtin.fail:
+                  msg: >-
+                    docker_data_root is set to "{{ _docker_data_root }}" but
+                    {{ item.item.check_path }} already contains data
+                    {{ '(a previously relocated ' ~ item.item.label ~ ' root)'
+                       if (item.item.current | length) > 0
+                       else '(the compiled-in default ' ~ item.item.label ~ ' root)' }},
+                    meaning Docker/containerd have already run against it.
+                    Relocating now would orphan every existing image and named
+                    volume (including the Postgres complaint database) — stop
+                    docker/containerd, rsync {{ item.item.check_path }} to its
+                    new home by hand (relabeling under SELinux if applicable),
+                    then re-run.
+                loop: "{{ _live_dataroot_check.results | default([]) }}"
+                loop_control:
+                  label: "{{ item.item.label | default('') }}"
+                when:
+                  - item.item is defined
+                  - not (item.item.matches_target | bool)
+                  - (item.stdout_lines | default([]) | length) > 0
 
-            - name: "Docker — restart a running dockerd to apply the relocated data-root"
-              ansible.builtin.service:
-                name: docker
-                state: restarted
-              when:
-                - _daemon_json_seed.changed | default(false)
-                - (_dockerd_active.stdout | default('')) == 'active'
+              - name: "Ensure Docker data-root directory exists"
+                ansible.builtin.file:
+                  path: "{{ _docker_data_root }}"
+                  state: directory
+                  mode: '0711'
 
-        # Release the Debian package auto-start hold now that the data-root
-        # is configured — only if this run created it (an operator-managed
-        # policy-rc.d is never touched).
-        - name: "Docker install — release the package auto-start hold (Debian/Ubuntu)"
-          ansible.builtin.file:
-            path: /usr/sbin/policy-rc.d
-            state: absent
-          when:
-            - ansible_facts['os_family'] == 'Debian'
-            - _docker_autostart_hold.changed | default(false)
+              - name: "Ensure containerd root directory exists"
+                ansible.builtin.file:
+                  path: "{{ _containerd_root }}"
+                  state: directory
+                  mode: '0711'
+
+              - name: "containerd — ensure a default config.toml exists"
+                ansible.builtin.shell: |
+                  set -eo pipefail
+                  mkdir -p /etc/containerd
+                  containerd config default > /etc/containerd/config.toml
+                args:
+                  executable: /bin/bash
+                  creates: /etc/containerd/config.toml
+
+              # The containerd.io package's shipped config.toml stub has no
+              # top-level `root =` key, so the regexp below matches nothing and
+              # lineinfile appends the line at EOF — landing it inside whatever
+              # `[table]` last preceded it in TOML instead of at the document
+              # root, where containerd silently ignores it. insertbefore: BOF
+              # guarantees the key lands above any table header when absent.
+              - name: "containerd — point root at the relocated directory"
+                ansible.builtin.lineinfile:
+                  path: /etc/containerd/config.toml
+                  regexp: '^\s*root\s*='
+                  line: 'root = "{{ _containerd_root }}"'
+                  insertbefore: BOF
+                register: containerd_root_config
+
+              # semanage is provided by the "SELinux — ensure policy tooling is
+              # present" task above (before this relocation block).
+              #
+              # semanage errors if the exact equivalence already exists (e.g. a
+              # re-run) — that's not a real failure, just already-done. Fresh
+              # adds say "already defined"; re-adding after equivalences already
+              # exist for both paths says "already exists" instead — tolerate
+              # both.
+              - name: "SELinux — label the relocated storage dirs like the originals (RHEL family)"
+                ansible.builtin.command: "semanage fcontext -a -e {{ item.orig }} {{ item.new }}"
+                loop:
+                  - { orig: /var/lib/docker, new: "{{ _docker_data_root }}" }
+                  - { orig: /var/lib/containerd, new: "{{ _containerd_root }}" }
+                register: _semanage_fcontext
+                failed_when: >-
+                  _semanage_fcontext.rc != 0
+                  and 'already defined' not in (_semanage_fcontext.stderr | default(''))
+                  and 'already exists' not in (_semanage_fcontext.stderr | default(''))
+                changed_when: _semanage_fcontext.rc == 0
+                when:
+                  - ansible_facts['os_family'] == 'RedHat'
+                  - _selinux_enforced
+
+              # Expensive: walks every file individually (read + possibly
+              # rewrite its security.selinux xattr). Only needed the FIRST time
+              # the relocation happens — the semanage equivalence above makes
+              # new files Docker/containerd create afterward inherit the
+              # correct label automatically (default SELinux file-creation
+              # behavior: a new file/dir inherits its parent's context absent
+              # an explicit type-transition rule, and the parent here is
+              # already correctly labeled after this one pass). Re-running
+              # restorecon on every subsequent deploy against an
+              # already-relocated, already-populated data-root just re-walks
+              # a now-large Docker/containerd tree for nothing — on a
+              # multi-GB overlay2 store this has been observed to take
+              # 15-20+ minutes on IOPS-limited cloud block storage, blocking
+              # every redeploy for no benefit.
+              - name: "SELinux — restorecon the relocated storage dirs (RHEL family, first relocation only)"
+                ansible.builtin.command: "restorecon -RF {{ item }}"
+                loop:
+                  - "{{ _docker_data_root }}"
+                  - "{{ _containerd_root }}"
+                changed_when: false
+                when:
+                  - ansible_facts['os_family'] == 'RedHat'
+                  - _selinux_enforced
+                  - not (_relocation_already_applied | bool)
+
+              - name: "Restart containerd if its config changed"
+                ansible.builtin.service:
+                  name: containerd
+                  state: restarted
+                  enabled: true
+                when: containerd_root_config.changed | default(false)
+
+              - name: "Ensure containerd is enabled + running"
+                ansible.builtin.service:
+                  name: containerd
+                  state: started
+                  enabled: true
+
+              # Seed the data-root into daemon.json BEFORE dockerd's first
+              # start. The full merged daemon.json (log rotation, insecure
+              # registries) is written much later in this play — but "Ensure
+              # docker daemon is enabled + running" below starts dockerd first,
+              # and without the seed that first start populates the default
+              # /var/lib/docker, tripping the relocation guard above on every
+              # subsequent re-deploy. Merge, don't overwrite: operator-set keys
+              # in an existing daemon.json survive (the later merge task keeps
+              # them too).
+              - name: "Docker — seed data-root into daemon.json before first start"
+                block:
+                  - name: "Docker — write daemon.json with the relocated data-root"
+                    vars:
+                      _existing: >-
+                        {{ (_daemon_json_pre.content | default('') | b64decode | from_json)
+                           if (_daemon_json_pre.content is defined
+                               and (_daemon_json_pre.content | b64decode | trim | length) > 0)
+                           else {} }}
+                    ansible.builtin.copy:
+                      dest: /etc/docker/daemon.json
+                      content: "{{ _existing | combine({'data-root': _docker_data_root}) | to_nice_json }}\n"
+                      mode: '0644'
+                    register: _daemon_json_seed
+                rescue:
+                  - name: "Docker — existing daemon.json is unreadable"
+                    ansible.builtin.fail:
+                      msg: >-
+                        /etc/docker/daemon.json exists but could not be parsed
+                        as JSON, so the relocated data-root could not be seeded
+                        into it. Fix or remove that file and re-run — it has
+                        been left untouched rather than overwritten.
+
+              - name: "Docker — check whether dockerd is already running"
+                ansible.builtin.command: systemctl is-active docker
+                register: _dockerd_active
+                changed_when: false
+                failed_when: false
+
+              - name: "Docker — restart a running dockerd to apply the relocated data-root"
+                ansible.builtin.service:
+                  name: docker
+                  state: restarted
+                when:
+                  - _daemon_json_seed.changed | default(false)
+                  - (_dockerd_active.stdout | default('')) == 'active'
+
+          always:
+          # Release the Debian package auto-start hold now that the data-root
+          # is configured — only if this run created it (an operator-managed
+          # policy-rc.d is never touched).
+          - name: "Docker install — release the package auto-start hold (Debian/Ubuntu)"
+            ansible.builtin.file:
+              path: /usr/sbin/policy-rc.d
+              state: absent
+            when:
+              - ansible_facts['os_family'] == 'Debian'
+              - _docker_autostart_hold.changed | default(false)
 
         # apt/dnf both install docker.service disabled by default — enable +
         # start it explicitly so subsequent tasks can talk to the daemon.
@@ -777,6 +823,7 @@
         # rules for published container ports are unaffected by firewalld
         # zones, so only the host-nginx-facing ports need opening here.
         - name: "firewalld — ensure installed + running (RHEL family)"
+          when: ansible_facts['os_family'] == 'RedHat'
           block:
             - name: Install firewalld
               dnf:
@@ -801,7 +848,6 @@
                 immediate: true
                 state: enabled
               loop: [http, https]
-          when: ansible_facts['os_family'] == 'RedHat'
 
         # ==================== SELinux (RHEL family only) ====================
         # Rocky/RHEL-family images ship SELinux Enforcing by default. Host
@@ -812,6 +858,9 @@
         # is the single most common "deploy finished green but the site
         # 502s" gap on a fresh RHEL-family box.
         - name: "SELinux — allow nginx to proxy to backend services (RHEL family)"
+          when:
+            - ansible_facts['os_family'] == 'RedHat'
+            - _selinux_enforced
           block:
             # policycoreutils-python-utils (semanage + the libselinux python
             # bindings seboolean needs) is installed once, early, by the
@@ -821,9 +870,6 @@
                 name: httpd_can_network_connect
                 state: true
                 persistent: true
-          when:
-            - ansible_facts['os_family'] == 'RedHat'
-            - _selinux_enforced
 
         # ==================== Root mount propagation (WSL2 only) ====================
         # The monitoring overlay's node-exporter binds /:/rootfs:ro,rslave

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -158,6 +158,18 @@
       changed_when: stop_digit_ui.stdout == "stopped"
       when: digit_ui_mode == "hmr"
 
+    # Ubuntu cloud images ship rsync/git/tmux; Rocky/Alma *minimal* cloud
+    # images do not. The always-on config sync (ansible.posix.synchronize →
+    # rsync on the target), the /opt/digit-ui-esbuild git clone below, and
+    # hmr's tmux session all hard-require them — install up front so a fresh
+    # minimal box doesn't die halfway through provisioning, after Docker/
+    # firewalld/SELinux have already mutated it.
+    - name: "Baseline CLI tooling (RHEL family: rsync, git, tmux)"
+      ansible.builtin.dnf:
+        name: [rsync, git, tmux]
+        state: present
+      when: ansible_facts['os_family'] == 'RedHat'
+
     # `static` and `hmr` modes need the digit-ui-esbuild source on disk —
     # HMR runs `node esbuild.dev.js` from it, static builds via
     # `node esbuild.build.js`. `container` mode skips this entirely:
@@ -212,6 +224,18 @@
       when:
         - ansible_facts['os_family'] not in ['Debian', 'RedHat']
         - ansible_system != 'Darwin'
+
+    # Playwright's `--with-deps` only knows apt: it must be dropped on the
+    # RHEL family (RPM equivalents come from tasks/ensure-chromium-deps.yml)
+    # and on Darwin (no apt). One fact, referenced by every
+    # `playwright install` call site, keeps that policy in a single place —
+    # a third OS family only ever needs this one expression updated.
+    - name: "Playwright — resolve the --with-deps flag once for all call sites"
+      ansible.builtin.set_fact:
+        _playwright_with_deps_flag: >-
+          {{ '--with-deps' if (ansible_system != 'Darwin'
+                               and ansible_facts['os_family'] != 'RedHat')
+             else '' }}
 
     # ansible_facts['selinux'] is the boolean `false` (not a dict) when the
     # libselinux Python bindings are absent, and a dict like {"status": "..."}
@@ -396,6 +420,33 @@
             purge: yes
           when: ansible_facts['os_family'] == 'Debian'
 
+        # The docker-ce/containerd.io deb postinst auto-starts docker.service
+        # and containerd.service DURING package install — before the storage
+        # relocation below can run — which populates /var/lib/docker and
+        # /var/lib/containerd on the default root and trips the relocation
+        # guard on a genuinely fresh box. policy-rc.d exit 101 is the
+        # Debian-documented switch deb-systemd-invoke consults: it holds the
+        # postinst auto-start until the relocated data-root is configured,
+        # and is removed again below (before "Ensure docker daemon is
+        # enabled + running"). force: false → an operator-managed
+        # policy-rc.d is left alone (and never removed by us either: the
+        # release task below only fires when this one created the file).
+        - name: "Docker install — hold package auto-start until data-root is configured (Debian/Ubuntu)"
+          ansible.builtin.copy:
+            dest: /usr/sbin/policy-rc.d
+            mode: '0755'
+            force: false
+            content: |
+              #!/bin/sh
+              # Temporary: installed by the DIGIT ansible deploy while
+              # docker-ce is installed with a relocated data-root; removed
+              # again in the same run.
+              exit 101
+          register: _docker_autostart_hold
+          when:
+            - ansible_facts['os_family'] == 'Debian'
+            - (docker_data_root | default('') | length) > 0
+
         - name: Install Docker Engine (Debian/Ubuntu)
           apt:
             name:
@@ -465,6 +516,19 @@
             update_cache: yes
           when: ansible_facts['os_family'] == 'RedHat'
 
+        # semanage (and the libselinux python bindings the seboolean module
+        # needs) live in policycoreutils-python-utils, which minimal
+        # RHEL-family cloud images do not preinstall. One early install
+        # serves both the storage-relocation labeling below and the nginx
+        # SELinux block further down.
+        - name: "SELinux — ensure policy tooling is present (RHEL family)"
+          dnf:
+            name: policycoreutils-python-utils
+            state: present
+          when:
+            - ansible_facts['os_family'] == 'RedHat'
+            - _selinux_enforced
+
         # ==================== Relocate Docker + containerd storage (optional) ====================
         # Set docker_data_root in host_vars (e.g. "/opt/docker") to move BOTH
         # Docker's data-root (images/volumes metadata) AND containerd's own
@@ -481,11 +545,33 @@
           vars:
             # Strip any trailing slash before deriving the sibling containerd
             # dir — dirname('/opt/docker/') is '/opt/docker' (nests containerd
-            # INSIDE Docker's own data-root instead of beside it), and
-            # dirname('/docker') is '/' (yields the bogus '//containerd').
+            # INSIDE Docker's own data-root instead of beside it). A top-level
+            # value like '/docker' has dirname '/', which would yield the
+            # bogus '//containerd' — collapse that to '/containerd'.
             _docker_data_root: "{{ docker_data_root | regex_replace('/+$', '') }}"
-            _containerd_root: "{{ _docker_data_root | dirname }}/containerd"
+            _containerd_root: "{{ (_docker_data_root | dirname | regex_replace('^/$', '')) ~ '/containerd' }}"
           block:
+            # If daemon.json already points at the relocated data-root, the
+            # relocation was applied by an earlier run and anything left in
+            # /var/lib/docker (or /var/lib/containerd) is a harmless
+            # first-start skeleton, not live data — skip the populated-guard
+            # so routine re-deploys don't hard-fail. String-match rather than
+            # from_json so an unparseable daemon.json can't blow up the guard
+            # itself (the daemon.json merge task later fails with a clear
+            # message in that case).
+            - name: "Guard — read daemon.json to detect an already-applied relocation"
+              ansible.builtin.slurp:
+                src: /etc/docker/daemon.json
+              register: _daemon_json_pre
+              failed_when: false
+
+            - name: "Guard — note whether the relocation is already in effect"
+              ansible.builtin.set_fact:
+                _relocation_already_applied: >-
+                  {{ _daemon_json_pre.content is defined
+                     and (_daemon_json_pre.content | b64decode)
+                         is search('"data-root"\s*:\s*"' ~ (_docker_data_root | regex_escape) ~ '/?"') }}
+
             # Relocating a data-root that Docker/containerd have already
             # written to would point daemon.json/config.toml at an empty
             # directory: every existing image and named volume (including the
@@ -502,6 +588,7 @@
               register: _live_dataroot_check
               changed_when: false
               failed_when: false
+              when: not (_relocation_already_applied | bool)
 
             - name: "Guard — refuse to relocate an already-populated data-root"
               ansible.builtin.fail:
@@ -513,10 +600,12 @@
                   volume (including the Postgres complaint database) — stop
                   docker/containerd, rsync {{ item.item }} to its new home by
                   hand (relabeling under SELinux if applicable), then re-run.
-              loop: "{{ _live_dataroot_check.results }}"
+              loop: "{{ _live_dataroot_check.results | default([]) }}"
               loop_control:
-                label: "{{ item.item }}"
-              when: (item.stdout_lines | default([]) | length) > 0
+                label: "{{ item.item | default('') }}"
+              when:
+                - not (_relocation_already_applied | bool)
+                - (item.stdout_lines | default([]) | length) > 0
 
             - name: "Ensure Docker data-root directory exists"
               ansible.builtin.file:
@@ -553,19 +642,9 @@
                 insertbefore: BOF
               register: containerd_root_config
 
-            # semanage lives in policycoreutils-python-utils, which is not
-            # preinstalled on minimal RHEL-family cloud images and is
-            # otherwise only installed later by the nginx SELinux block below
-            # — install it here first so labeling doesn't rc=127 before that
-            # block ever runs.
-            - name: "SELinux — ensure semanage is available (RHEL family)"
-              dnf:
-                name: policycoreutils-python-utils
-                state: present
-              when:
-                - ansible_facts['os_family'] == 'RedHat'
-                - _selinux_enforced
-
+            # semanage is provided by the "SELinux — ensure policy tooling is
+            # present" task above (before this relocation block).
+            #
             # semanage errors if the exact equivalence already exists (e.g. a
             # re-run) — that's not a real failure, just already-done. Fresh
             # adds say "already defined"; re-adding after equivalences already
@@ -609,6 +688,63 @@
                 state: started
                 enabled: true
 
+            # Seed the data-root into daemon.json BEFORE dockerd's first
+            # start. The full merged daemon.json (log rotation, insecure
+            # registries) is written much later in this play — but "Ensure
+            # docker daemon is enabled + running" below starts dockerd first,
+            # and without the seed that first start populates the default
+            # /var/lib/docker, tripping the relocation guard above on every
+            # subsequent re-deploy. Merge, don't overwrite: operator-set keys
+            # in an existing daemon.json survive (the later merge task keeps
+            # them too).
+            - name: "Docker — seed data-root into daemon.json before first start"
+              block:
+                - name: "Docker — write daemon.json with the relocated data-root"
+                  vars:
+                    _existing: >-
+                      {{ (_daemon_json_pre.content | default('') | b64decode | from_json)
+                         if (_daemon_json_pre.content is defined
+                             and (_daemon_json_pre.content | b64decode | trim | length) > 0)
+                         else {} }}
+                  ansible.builtin.copy:
+                    dest: /etc/docker/daemon.json
+                    content: "{{ _existing | combine({'data-root': _docker_data_root}) | to_nice_json }}\n"
+                    mode: '0644'
+                  register: _daemon_json_seed
+              rescue:
+                - name: "Docker — existing daemon.json is unreadable"
+                  ansible.builtin.fail:
+                    msg: >-
+                      /etc/docker/daemon.json exists but could not be parsed
+                      as JSON, so the relocated data-root could not be seeded
+                      into it. Fix or remove that file and re-run — it has
+                      been left untouched rather than overwritten.
+
+            - name: "Docker — check whether dockerd is already running"
+              ansible.builtin.command: systemctl is-active docker
+              register: _dockerd_active
+              changed_when: false
+              failed_when: false
+
+            - name: "Docker — restart a running dockerd to apply the relocated data-root"
+              ansible.builtin.service:
+                name: docker
+                state: restarted
+              when:
+                - _daemon_json_seed.changed | default(false)
+                - (_dockerd_active.stdout | default('')) == 'active'
+
+        # Release the Debian package auto-start hold now that the data-root
+        # is configured — only if this run created it (an operator-managed
+        # policy-rc.d is never touched).
+        - name: "Docker install — release the package auto-start hold (Debian/Ubuntu)"
+          ansible.builtin.file:
+            path: /usr/sbin/policy-rc.d
+            state: absent
+          when:
+            - ansible_facts['os_family'] == 'Debian'
+            - _docker_autostart_hold.changed | default(false)
+
         # apt/dnf both install docker.service disabled by default — enable +
         # start it explicitly so subsequent tasks can talk to the daemon.
         - name: Ensure docker daemon is enabled + running
@@ -638,6 +774,11 @@
                 state: started
                 enabled: yes
 
+            # http/https cover everything host nginx binds on Linux
+            # (nginx-site.conf.j2 listens only on 80/443). nginx_host_port is
+            # a macOS-container-only knob and is deliberately NOT opened here
+            # — doing so would punch a permanent hole for a port nothing
+            # listens on when host_vars are copied from a Mac tenant.
             - name: Open http/https in the default zone
               ansible.posix.firewalld:
                 service: "{{ item }}"
@@ -645,19 +786,6 @@
                 immediate: true
                 state: enabled
               loop: [http, https]
-
-            # Only relevant when nginx is configured to listen on a
-            # non-standard port (host_vars `nginx_host_port`); http/https
-            # above cover the default 80/443.
-            - name: "Open nginx_host_port if it isn't 80/443"
-              ansible.posix.firewalld:
-                port: "{{ nginx_host_port }}/tcp"
-                permanent: true
-                immediate: true
-                state: enabled
-              when:
-                - nginx_host_port is defined
-                - nginx_host_port | int not in [80, 443]
           when: ansible_facts['os_family'] == 'RedHat'
 
         # ==================== SELinux (RHEL family only) ====================
@@ -670,11 +798,9 @@
         # 502s" gap on a fresh RHEL-family box.
         - name: "SELinux — allow nginx to proxy to backend services (RHEL family)"
           block:
-            - name: Ensure libselinux-python bindings + policy tools are present
-              dnf:
-                name: [policycoreutils-python-utils]
-                state: present
-
+            # policycoreutils-python-utils (semanage + the libselinux python
+            # bindings seboolean needs) is installed once, early, by the
+            # "SELinux — ensure policy tooling is present" task above.
             - name: "setsebool httpd_can_network_connect=on (persistent)"
               ansible.posix.seboolean:
                 name: httpd_can_network_connect
@@ -2612,7 +2738,7 @@
     - name: "integration-tests runner — install Playwright browsers (repo-local binary, matched version)"
       ansible.builtin.command: >-
         node_modules/.bin/playwright install
-        {{ "" if ansible_facts['os_family'] == 'RedHat' else "--with-deps" }}
+        {{ _playwright_with_deps_flag }}
         chromium
       args:
         chdir: "{{ integration_tests_dir }}"
@@ -4417,11 +4543,12 @@
       when:
         - run_ci_tests | default(false)
         - run_playwright_tests | default(false)
+        - ansible_system != "Darwin"
 
     - name: Install Playwright Chromium with system dependencies
       shell: >-
         npx playwright install
-        {{ " --with-deps" if (ansible_system != "Darwin" and ansible_facts['os_family'] != 'RedHat') else "" }}
+        {{ _playwright_with_deps_flag }}
         chromium
       args:
         chdir: "{{ digit_dir }}/e2e-tests"

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -213,6 +213,19 @@
         - ansible_facts['os_family'] not in ['Debian', 'RedHat']
         - ansible_system != 'Darwin'
 
+    # ansible_facts['selinux'] is the boolean `false` (not a dict) when the
+    # libselinux Python bindings are absent, and a dict like {"status": "..."}
+    # when they are present. Subscripting `['status']` straight into a bare
+    # `false` raises a type error — `| default(...)` only catches Undefined,
+    # not a valid-but-wrong-shape value — so every RHEL-only SELinux gate
+    # below reads this single fact instead of re-deriving the unsafe
+    # subscript.
+    - name: "Resolve whether SELinux is enforcing (RHEL family)"
+      ansible.builtin.set_fact:
+        _selinux_enforced: >-
+          {{ (ansible_facts['selinux'] is mapping)
+             and (ansible_facts['selinux'].get('status', 'disabled') == 'enabled') }}
+
     # common-masters.MobileNumberValidation (utilities/default-data-handler)
     # only accepts countryCode + mobileNumberRegex — the old UserValidation-era
     # fields (mobilePrefix, mobileNumberPattern, mobileNumberLength,
@@ -466,11 +479,48 @@
         - name: "Docker/containerd storage relocation (when docker_data_root is set)"
           when: (docker_data_root | default('') | length) > 0
           vars:
-            _containerd_root: "{{ docker_data_root | dirname }}/containerd"
+            # Strip any trailing slash before deriving the sibling containerd
+            # dir — dirname('/opt/docker/') is '/opt/docker' (nests containerd
+            # INSIDE Docker's own data-root instead of beside it), and
+            # dirname('/docker') is '/' (yields the bogus '//containerd').
+            _docker_data_root: "{{ docker_data_root | regex_replace('/+$', '') }}"
+            _containerd_root: "{{ _docker_data_root | dirname }}/containerd"
           block:
+            # Relocating a data-root that Docker/containerd have already
+            # written to would point daemon.json/config.toml at an empty
+            # directory: every existing image and named volume (including the
+            # Postgres complaint database) becomes invisible and the stack
+            # silently re-initializes from scratch. Only a fresh/never-started
+            # box may set docker_data_root; an already-populated /var/lib/docker
+            # or /var/lib/containerd needs a stop+rsync+relabel migration done
+            # by hand first.
+            - name: "Guard — check /var/lib/docker and /var/lib/containerd are still empty"
+              ansible.builtin.command: "find {{ item }} -mindepth 1 -maxdepth 1"
+              loop:
+                - /var/lib/docker
+                - /var/lib/containerd
+              register: _live_dataroot_check
+              changed_when: false
+              failed_when: false
+
+            - name: "Guard — refuse to relocate an already-populated data-root"
+              ansible.builtin.fail:
+                msg: >-
+                  docker_data_root is set to "{{ _docker_data_root }}" but
+                  {{ item.item }} already contains data, meaning Docker/containerd
+                  have already run against the default location on this box.
+                  Relocating now would orphan every existing image and named
+                  volume (including the Postgres complaint database) — stop
+                  docker/containerd, rsync {{ item.item }} to its new home by
+                  hand (relabeling under SELinux if applicable), then re-run.
+              loop: "{{ _live_dataroot_check.results }}"
+              loop_control:
+                label: "{{ item.item }}"
+              when: (item.stdout_lines | default([]) | length) > 0
+
             - name: "Ensure Docker data-root directory exists"
               ansible.builtin.file:
-                path: "{{ docker_data_root }}"
+                path: "{{ _docker_data_root }}"
                 state: directory
                 mode: '0711'
 
@@ -481,42 +531,70 @@
                 mode: '0711'
 
             - name: "containerd — ensure a default config.toml exists"
-              ansible.builtin.shell: containerd config default > /etc/containerd/config.toml
+              ansible.builtin.shell: |
+                set -eo pipefail
+                mkdir -p /etc/containerd
+                containerd config default > /etc/containerd/config.toml
               args:
+                executable: /bin/bash
                 creates: /etc/containerd/config.toml
 
+            # The containerd.io package's shipped config.toml stub has no
+            # top-level `root =` key, so the regexp below matches nothing and
+            # lineinfile appends the line at EOF — landing it inside whatever
+            # `[table]` last preceded it in TOML instead of at the document
+            # root, where containerd silently ignores it. insertbefore: BOF
+            # guarantees the key lands above any table header when absent.
             - name: "containerd — point root at the relocated directory"
               ansible.builtin.lineinfile:
                 path: /etc/containerd/config.toml
                 regexp: '^\s*root\s*='
                 line: 'root = "{{ _containerd_root }}"'
+                insertbefore: BOF
               register: containerd_root_config
 
+            # semanage lives in policycoreutils-python-utils, which is not
+            # preinstalled on minimal RHEL-family cloud images and is
+            # otherwise only installed later by the nginx SELinux block below
+            # — install it here first so labeling doesn't rc=127 before that
+            # block ever runs.
+            - name: "SELinux — ensure semanage is available (RHEL family)"
+              dnf:
+                name: policycoreutils-python-utils
+                state: present
+              when:
+                - ansible_facts['os_family'] == 'RedHat'
+                - _selinux_enforced
+
             # semanage errors if the exact equivalence already exists (e.g. a
-            # re-run) — that's not a real failure, just already-done.
+            # re-run) — that's not a real failure, just already-done. Fresh
+            # adds say "already defined"; re-adding after equivalences already
+            # exist for both paths says "already exists" instead — tolerate
+            # both.
             - name: "SELinux — label the relocated storage dirs like the originals (RHEL family)"
               ansible.builtin.command: "semanage fcontext -a -e {{ item.orig }} {{ item.new }}"
               loop:
-                - { orig: /var/lib/docker, new: "{{ docker_data_root }}" }
+                - { orig: /var/lib/docker, new: "{{ _docker_data_root }}" }
                 - { orig: /var/lib/containerd, new: "{{ _containerd_root }}" }
               register: _semanage_fcontext
               failed_when: >-
                 _semanage_fcontext.rc != 0
                 and 'already defined' not in (_semanage_fcontext.stderr | default(''))
+                and 'already exists' not in (_semanage_fcontext.stderr | default(''))
               changed_when: _semanage_fcontext.rc == 0
               when:
                 - ansible_facts['os_family'] == 'RedHat'
-                - ansible_facts['selinux']['status'] | default('disabled') == 'enabled'
+                - _selinux_enforced
 
             - name: "SELinux — restorecon the relocated storage dirs (RHEL family)"
               ansible.builtin.command: "restorecon -RF {{ item }}"
               loop:
-                - "{{ docker_data_root }}"
+                - "{{ _docker_data_root }}"
                 - "{{ _containerd_root }}"
               changed_when: false
               when:
                 - ansible_facts['os_family'] == 'RedHat'
-                - ansible_facts['selinux']['status'] | default('disabled') == 'enabled'
+                - _selinux_enforced
 
             - name: "Restart containerd if its config changed"
               ansible.builtin.service:
@@ -604,7 +682,7 @@
                 persistent: true
           when:
             - ansible_facts['os_family'] == 'RedHat'
-            - ansible_facts['selinux']['status'] | default('disabled') == 'enabled'
+            - _selinux_enforced
 
         # ==================== Root mount propagation (WSL2 only) ====================
         # The monitoring overlay's node-exporter binds /:/rootfs:ro,rslave
@@ -775,7 +853,7 @@
                       'log-opts': {'max-size': docker_log_max_size,
                                    'max-file': docker_log_max_file_effective | string},
                       'insecure-registries': insecure_registries | default([])}
-                     | combine({'data-root': docker_data_root}
+                     | combine({'data-root': docker_data_root | regex_replace('/+$', '')}
                                if (docker_data_root | default('') | length > 0) else {}) }}
               ansible.builtin.copy:
                 dest: /etc/docker/daemon.json
@@ -2521,9 +2599,21 @@
         - integration_tests_dir is defined
         - ansible_system != "Darwin"
 
+    # `--with-deps` only knows apt (Ubuntu/Debian); on RHEL family it no-ops
+    # and leaves Chromium's shared libs missing, so install the RPM
+    # equivalents first and drop --with-deps on that family below.
+    - name: "integration-tests runner — install Chromium runtime dependencies (RHEL family)"
+      ansible.builtin.include_tasks: "{{ playbook_dir }}/tasks/ensure-chromium-deps.yml"
+      when:
+        - enable_integration_tests_runner | default(false)
+        - integration_tests_dir is defined
+        - ansible_system != "Darwin"
+
     - name: "integration-tests runner — install Playwright browsers (repo-local binary, matched version)"
       ansible.builtin.command: >-
-        node_modules/.bin/playwright install --with-deps chromium
+        node_modules/.bin/playwright install
+        {{ "" if ansible_facts['os_family'] == 'RedHat' else "--with-deps" }}
+        chromium
       args:
         chdir: "{{ integration_tests_dir }}"
       changed_when: true
@@ -2616,6 +2706,18 @@
             name: nginx
             state: present
 
+        # Debian's nginx package starts the service via its maintainer
+        # scripts; the RHEL RPM leaves the unit stopped and disabled after
+        # install. The "Reload nginx" handler (flushed a few tasks below)
+        # runs `systemctl reload nginx`, which fails against an inactive unit
+        # on a first Rocky/Alma/RHEL deploy — and even if that were ignored,
+        # nginx would never come back after a reboot.
+        - name: "Host nginx — ensure enabled + running (RHEL family)"
+          ansible.builtin.service:
+            name: nginx
+            state: started
+            enabled: true
+
         - name: "Host nginx — render site config from template (RHEL family, conf.d)"
           ansible.builtin.template:
             src: templates/nginx-site.conf.j2
@@ -2628,6 +2730,21 @@
           ansible.builtin.file:
             path: /etc/nginx/conf.d/default.conf
             state: absent
+          notify: Reload nginx
+          when: not (nginx_preserve_vhost | default(false))
+
+        # The AppStream package's catch-all default_server block is not in
+        # conf.d/default.conf — it's embedded directly in /etc/nginx/nginx.conf
+        # itself, so removing default.conf above doesn't touch it; bare/
+        # non-matching Host headers would still land there instead of our
+        # vhost. Stock nginx.conf's `include /etc/nginx/conf.d/*.conf;` is
+        # parsed before that embedded block, so stripping its default_server
+        # flag lets our conf.d vhost win as the implicit default instead.
+        - name: "Host nginx — disable RPM's built-in default_server block (RHEL family)"
+          ansible.builtin.replace:
+            path: /etc/nginx/nginx.conf
+            regexp: '(listen\s+(?:\[::\]:)?\d+\s+)default_server;'
+            replace: '\1;'
           notify: Reload nginx
           when: not (nginx_preserve_vhost | default(false))
 
@@ -2687,7 +2804,7 @@
       failed_when: false
       when:
         - ansible_facts['os_family'] == 'RedHat'
-        - ansible_facts['selinux']['status'] | default('disabled') == 'enabled'
+        - _selinux_enforced
 
     # ============================================================
     # Infrastructure validation — runs before the heavy CI tests
@@ -3855,35 +3972,16 @@
         msg: "Claude Code install disabled. Set install_claude_code: true in host_vars to enable."
       when: not (install_claude_code | default(false))
 
-    - name: Install Node.js 20 LTS (needed for CC and tests, Debian/Ubuntu)
-      shell: |
-        set -o pipefail
-        if ! node --version 2>/dev/null | grep -qE "^v2[02]"; then
-          curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
-          apt-get install -y nodejs
-        fi
-      args:
-        executable: /bin/bash
-      register: nodejs_install
-      changed_when: "'nodejs is already' not in nodejs_install.stdout"
+    # Needed for CC and tests. Was two inline apt/dnf NodeSource shells here
+    # (duplicating tasks/ensure-node20.yml with an already-divergent version
+    # regexp) — reuse the shared helper like every other call site instead.
+    - name: "Claude Code — ensure Node 20 + npm (NodeSource)"
+      ansible.builtin.include_tasks: "{{ playbook_dir }}/tasks/ensure-node20.yml"
+      vars:
+        node_ensure_label: "Claude Code"
       when:
         - install_claude_code | default(false)
-        - ansible_facts['os_family'] == 'Debian'
-
-    - name: Install Node.js 20 LTS (needed for CC and tests, RHEL family)
-      shell: |
-        set -o pipefail
-        if ! node --version 2>/dev/null | grep -qE "^v2[02]"; then
-          curl -fsSL https://rpm.nodesource.com/setup_20.x | bash -
-          dnf install -y nodejs
-        fi
-      args:
-        executable: /bin/bash
-      register: nodejs_install_rhel
-      changed_when: "'nodejs is already' not in nodejs_install_rhel.stdout"
-      when:
-        - install_claude_code | default(false)
-        - ansible_facts['os_family'] == 'RedHat'
+        - ansible_system != "Darwin"
 
     - name: Install Claude Code CLI
       shell: npm install -g @anthropic-ai/claude-code
@@ -4314,34 +4412,11 @@
       changed_when: false
 
       when: run_ci_tests | default(false) and (run_playwright_tests | default(false))
-    # Playwright's `--with-deps` OS-dependency installer only knows how to
-    # drive apt (Ubuntu/Debian) — on RHEL family it no-ops with a warning
-    # and leaves Chromium's shared libs missing, so the browser fails to
-    # launch later with a cryptic "error while loading shared libraries".
-    # Install the equivalent RPM packages ourselves first, then run
-    # `playwright install chromium` WITHOUT --with-deps on that family.
     - name: "Install Chromium runtime dependencies (RHEL family, Playwright has no dnf support)"
-      dnf:
-        name:
-          - nss
-          - atk
-          - at-spi2-atk
-          - cups-libs
-          - libdrm
-          - libxkbcommon
-          - libXcomposite
-          - libXdamage
-          - libXfixes
-          - libXrandr
-          - mesa-libgbm
-          - alsa-lib
-          - pango
-          - cairo
-        state: present
+      ansible.builtin.include_tasks: "{{ playbook_dir }}/tasks/ensure-chromium-deps.yml"
       when:
         - run_ci_tests | default(false)
         - run_playwright_tests | default(false)
-        - ansible_facts['os_family'] == 'RedHat'
 
     - name: Install Playwright Chromium with system dependencies
       shell: >-

--- a/local-setup/ansible/tasks/ensure-chromium-deps.yml
+++ b/local-setup/ansible/tasks/ensure-chromium-deps.yml
@@ -1,0 +1,32 @@
+# Playwright's `--with-deps` OS-dependency installer only knows how to
+# drive apt (Ubuntu/Debian) — on RHEL family it no-ops with a warning and
+# leaves Chromium's shared libs (and fonts) missing, so the browser fails
+# to launch later with a cryptic "error while loading shared libraries",
+# or launches with every page rendering blank/tofu glyphs. Install the
+# equivalent RPM packages ourselves, then have callers run
+# `playwright install chromium` WITHOUT --with-deps on this family.
+#
+# Shared by both Playwright call sites (e2e-tests CI stage and the
+# integration-tests runner) so a future dependency bump only needs to
+# happen once.
+- name: "Install Chromium runtime dependencies (RHEL family, Playwright has no dnf support)"
+  ansible.builtin.dnf:
+    name:
+      - nss
+      - atk
+      - at-spi2-atk
+      - cups-libs
+      - libdrm
+      - libxkbcommon
+      - libXcomposite
+      - libXdamage
+      - libXfixes
+      - libXrandr
+      - mesa-libgbm
+      - alsa-lib
+      - pango
+      - cairo
+      - liberation-fonts
+      - google-noto-emoji-color-fonts
+    state: present
+  when: ansible_facts['os_family'] == 'RedHat'

--- a/local-setup/ansible/tasks/ensure-chromium-deps.yml
+++ b/local-setup/ansible/tasks/ensure-chromium-deps.yml
@@ -6,6 +6,12 @@
 # equivalent RPM packages ourselves, then have callers run
 # `playwright install chromium` WITHOUT --with-deps on this family.
 #
+# The list mirrors Playwright's published Chromium dependency set for the
+# RPM family — every runtime lib is named explicitly rather than relying
+# on transitive RPM pulls (e.g. cairo→libX11), which differ between
+# minimal cloud images. Revisit on Playwright version bumps: only apt
+# targets get Playwright's auto-resolved list.
+#
 # Shared by both Playwright call sites (e2e-tests CI stage and the
 # integration-tests runner) so a future dependency bump only needs to
 # happen once.
@@ -15,18 +21,30 @@
       - nss
       - atk
       - at-spi2-atk
+      - at-spi2-core
       - cups-libs
+      - dbus-libs
       - libdrm
       - libxkbcommon
+      - libX11
       - libXcomposite
       - libXdamage
+      - libXext
       - libXfixes
       - libXrandr
+      - libXrender
+      - libXtst
+      - libxshmfence
       - mesa-libgbm
       - alsa-lib
       - pango
       - cairo
       - liberation-fonts
-      - google-noto-emoji-color-fonts
+      # EL9 ships the color-emoji font as google-noto-emoji-color-fonts;
+      # EL10 renamed it google-noto-color-emoji-fonts (the old name has no
+      # match on Rocky/Alma 10 AppStream and would hard-fail the task).
+      - "{{ 'google-noto-color-emoji-fonts'
+            if (ansible_distribution_major_version | int) >= 10
+            else 'google-noto-emoji-color-fonts' }}"
     state: present
   when: ansible_facts['os_family'] == 'RedHat'

--- a/local-setup/ansible/tasks/ensure-node20.yml
+++ b/local-setup/ansible/tasks/ensure-node20.yml
@@ -1,24 +1,25 @@
 # Ensure Node 20 + a matching npm from NodeSource.
 #
-# Why not just `apt install nodejs`? On Ubuntu that ships Node 18 AND NO npm
-# (npm is a separate archive package), so apt alone leaves node present but
-# npm missing — downstream `npm install` silently no-op'd and builds failed
-# later with a confusing "Cannot find module 'esbuild'". NodeSource bundles a
-# matching npm. The install is gated on a version probe so re-deploys are a
+# Why not just `apt install nodejs` / `dnf install nodejs`? On Ubuntu the
+# archive ships Node 18 AND NO npm (npm is a separate archive package), so
+# apt alone leaves node present but npm missing — downstream `npm install`
+# silently no-op'd and builds failed later with a confusing "Cannot find
+# module 'esbuild'". NodeSource bundles a matching npm on both package
+# families. The install is gated on a version probe so re-deploys are a
 # no-op once Node >=20 is already present.
 #
 # Contract for callers:
 #   - Set `node_ensure_label` (a string) for readable task names.
 #   - Apply the enabling `when:` (e.g. feature flags) on the `include_tasks`
 #     statement — it propagates to every task in this file. Always exclude
-#     Darwin at the call site (NodeSource + apt-get is Debian/Ubuntu only).
+#     Darwin at the call site (NodeSource is Linux-only).
 - name: "{{ node_ensure_label }} — probe installed node version"
   ansible.builtin.command: node --version
   register: _ensure_node_ver
   changed_when: false
   failed_when: false
 
-- name: "{{ node_ensure_label }} — install NodeSource Node 20 (node <20 or npm absent)"
+- name: "{{ node_ensure_label }} — install NodeSource Node 20 (Debian/Ubuntu; node <20 or npm absent)"
   ansible.builtin.shell: |
     set -euo pipefail
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
@@ -26,5 +27,18 @@
   args:
     executable: /bin/bash
   when: >-
-    _ensure_node_ver.rc != 0
-    or (_ensure_node_ver.stdout | default('') is not match('^v(2[0-9]|[3-9][0-9])\.'))
+    ansible_facts['os_family'] == 'Debian'
+    and (_ensure_node_ver.rc != 0
+    or (_ensure_node_ver.stdout | default('') is not match('^v(2[0-9]|[3-9][0-9])\.')))
+
+- name: "{{ node_ensure_label }} — install NodeSource Node 20 (RHEL family; node <20 or npm absent)"
+  ansible.builtin.shell: |
+    set -euo pipefail
+    curl -fsSL https://rpm.nodesource.com/setup_20.x | bash -
+    dnf install -y nodejs
+  args:
+    executable: /bin/bash
+  when: >-
+    ansible_facts['os_family'] == 'RedHat'
+    and (_ensure_node_ver.rc != 0
+    or (_ensure_node_ver.stdout | default('') is not match('^v(2[0-9]|[3-9][0-9])\.')))

--- a/local-setup/ansible/tasks/ensure-node20.yml
+++ b/local-setup/ansible/tasks/ensure-node20.yml
@@ -19,6 +19,12 @@
   changed_when: false
   failed_when: false
 
+- name: "{{ node_ensure_label }} — probe installed npm version"
+  ansible.builtin.command: npm --version
+  register: _ensure_npm_ver
+  changed_when: false
+  failed_when: false
+
 - name: "{{ node_ensure_label }} — install NodeSource Node 20 (Debian/Ubuntu; node <20 or npm absent)"
   ansible.builtin.shell: |
     set -euo pipefail
@@ -29,6 +35,7 @@
   when: >-
     ansible_facts['os_family'] == 'Debian'
     and (_ensure_node_ver.rc != 0
+    or _ensure_npm_ver.rc != 0
     or (_ensure_node_ver.stdout | default('') is not match('^v(2[0-9]|[3-9][0-9])\.')))
 
 - name: "{{ node_ensure_label }} — install NodeSource Node 20 (RHEL family; node <20 or npm absent)"
@@ -41,4 +48,5 @@
   when: >-
     ansible_facts['os_family'] == 'RedHat'
     and (_ensure_node_ver.rc != 0
+    or _ensure_npm_ver.rc != 0
     or (_ensure_node_ver.stdout | default('') is not match('^v(2[0-9]|[3-9][0-9])\.')))

--- a/local-setup/ansible/tasks/ensure-node20.yml
+++ b/local-setup/ansible/tasks/ensure-node20.yml
@@ -25,28 +25,23 @@
   changed_when: false
   failed_when: false
 
-- name: "{{ node_ensure_label }} — install NodeSource Node 20 (Debian/Ubuntu; node <20 or npm absent)"
-  ansible.builtin.shell: |
-    set -euo pipefail
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
-    apt-get install -y nodejs
-  args:
-    executable: /bin/bash
-  when: >-
-    ansible_facts['os_family'] == 'Debian'
-    and (_ensure_node_ver.rc != 0
-    or _ensure_npm_ver.rc != 0
-    or (_ensure_node_ver.stdout | default('') is not match('^v(2[0-9]|[3-9][0-9])\.')))
+# One decision, one install task. The version floor/probe logic lives only
+# here — the Debian and RHEL paths differ solely in the NodeSource repo host
+# and the package manager, so those two strings are templated rather than
+# duplicating the whole task per OS family (which previously let the version
+# regexps drift apart).
+- name: "{{ node_ensure_label }} — decide whether NodeSource Node 20 is needed"
+  ansible.builtin.set_fact:
+    _node_needs_install: >-
+      {{ _ensure_node_ver.rc != 0
+         or _ensure_npm_ver.rc != 0
+         or (_ensure_node_ver.stdout | default('') is not match('^v(2[0-9]|[3-9][0-9])\.')) }}
 
-- name: "{{ node_ensure_label }} — install NodeSource Node 20 (RHEL family; node <20 or npm absent)"
+- name: "{{ node_ensure_label }} — install NodeSource Node 20 (node <20 or npm absent)"
   ansible.builtin.shell: |
     set -euo pipefail
-    curl -fsSL https://rpm.nodesource.com/setup_20.x | bash -
-    dnf install -y nodejs
+    curl -fsSL https://{{ 'deb' if ansible_facts['os_family'] == 'Debian' else 'rpm' }}.nodesource.com/setup_20.x | bash -
+    {{ 'apt-get' if ansible_facts['os_family'] == 'Debian' else 'dnf' }} install -y nodejs
   args:
     executable: /bin/bash
-  when: >-
-    ansible_facts['os_family'] == 'RedHat'
-    and (_ensure_node_ver.rc != 0
-    or _ensure_npm_ver.rc != 0
-    or (_ensure_node_ver.stdout | default('') is not match('^v(2[0-9]|[3-9][0-9])\.')))
+  when: _node_needs_install | bool


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local deployment setup now supports Red Hat-based Linux systems in addition to Debian and macOS.
  * Docker and containerd data can be relocated to a dedicated storage partition.
  * Deployment configuration now supports optional integration tests, service toggles, UI module visibility, branding, and regional validation settings.
  * Nginx, Chromium, Playwright, and Node.js setup is now handled across supported operating systems.

* **Documentation**
  * Added guidance for relocating existing container storage and configuring the new deployment options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->