### PR TITLE
fix(ansible): write pinned NOVU_API_KEY into .env before compose-up (#1551) [develop]

### DIFF
--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -1227,6 +1227,27 @@
         - enable_keycloak | default(false)
         - kcprep_secrets.json.data.data.keycloak_db_password | default('') | length > 0
 
+    # Same ordering trap as the KEYCLOAK SECRETS block above, for Novu (CCRS#1551).
+    # .env is regenerated earlier in this play WITHOUT a NOVU_API_KEY line, and the
+    # novu-bootstrap block that writes one lives AFTER the stack is up — because
+    # MINTING a key requires a healthy novu-api. But a deployment that PINS
+    # novu_api_key in host_vars (Bomet/Nairobi) needs nothing running: the value is
+    # already known here. Without this task the compose-up below resolves
+    # ${NOVU_API_KEY:-changeme} and novu-bridge comes up unauthenticated — and any
+    # play that aborts at "Start DIGIT stack" (the user-preferences healthcheck is
+    # flaky) never reaches the late block, so notifications stay broken silently.
+    - name: "novu prep — write pinned NOVU_API_KEY into .env BEFORE compose-up"
+      ansible.builtin.lineinfile:
+        path: "{{ digit_dir }}/.env"
+        regexp: '^NOVU_API_KEY='
+        line: "NOVU_API_KEY={{ novu_api_key }}"
+        create: true
+        mode: '0600'
+      no_log: true
+      when:
+        - enable_novu | default(false)
+        - (novu_api_key | default('')) | length > 0
+
     # The next two steps are the deploy's long, silent stretch — the image
     # pull (tens of GB on a first run) and the ~40-container up (~10 min on
     # a cold box). Ansible buffers a task's output until it finishes, so


### PR DESCRIPTION
Fixes #1551.

## Root cause

`Manage → Notification Providers` is a `type: 'custom'` react-admin resource whose entire list **and search** is one call — `GET /novu-bridge/novu-adapter/v1/integrations` (`resourceRegistry.ts`). There is no server-side query; the grid is fetched whole and filtered client-side. So when that call fails, the grid is empty and every search returns nothing — which is what the issue reports.

The call was failing because novu-bridge was running with `NOVU_API_KEY=changeme`, so Novu answered 401 `API Key not found` and the bridge returned `NB_NOVU_INTEGRATIONS_FAILED`.

## Why the key was wrong — an ordering bug

| in `playbook-deploy.yml` | effect |
|---|---|
| `.env` regenerated, then `Start DIGIT stack` | `.env` has no `NOVU_API_KEY` line yet, so compose resolves `${NOVU_API_KEY:-changeme}` and novu-bridge starts unauthenticated |
| `novu-bootstrap — wire NOVU_API_KEY into compose .env` (much later) | the only place the key is written |

The late placement is correct *for minting* — `novu-mint-key.sh` POSTs to a healthy novu-api, which only exists after the stack is up. But a deployment that **pins** `novu_api_key` in host_vars (Bomet, Nairobi) needs nothing running: the value is already known before compose-up.

It fails **silently**: `Start DIGIT stack` aborts intermittently (`dependency failed to start: container digit-user-preferences-service is unhealthy` — a known-flaky healthcheck), and an Ansible failure stops the play, so the late block is never reached. The stack still heals and smoke still passes, because smoke does not test notifications.

Consequence worth calling out: **pinning `novu_api_key` in host_vars does not currently protect a box**, because it is only consumed past the abort point.

## The change

One task, placed immediately before the image pull / `Start DIGIT stack`, gated on a pinned key. It mirrors the existing `Keycloak prep — write KEYCLOAK SECRETS into .env BEFORE compose-up` task, which fixed exactly this class of bug. The mint path is untouched.

## Verification (on bomet, real deployment)

Reproduced first: a converge left `NOVU_API_KEY=changeme` and 401s on the integrations endpoint. After this change, re-running the play:

- `TASK [novu prep — write pinned NOVU_API_KEY into .env BEFORE compose-up]` → `changed`, and it runs **before** `Start DIGIT stack`
- `PLAY RECAP: ok=105 changed=34 failed=1` (the remaining failure is an unrelated systemd `BadUnitSetting` on the integration-tests runner unit)
- novu-bridge comes up with the real key; 57 containers, 0 unhealthy
- `GET /novu-bridge/novu-adapter/v1/integrations` → **200**, 4 integrations (2 Twilio SMS, 2 in-app)
- `/configurator/`, `/digit-ui/`, `/citizen/login` all 200

## Follow-ups not in this PR (kept one-concern)

1. Bump the `digit-user-preferences-service` healthcheck `start_period` so `Start DIGIT stack` stops aborting — the Linux task has no converge loop, unlike the macOS one.
2. Add a notifications probe to the bomet wrapper's `smoke()`; this passed green while broken twice.
3. Separately, bomet currently has **no email provider** in Novu (SMS + in-app only), so email notifications are not deliverable there. Unrelated to this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically configures the Novu API key during local setup when Novu is enabled.
  * Ensures the key is securely added before the application stack starts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->