### PR TITLE
fix(dashboard): repair KPI catalog records authored against a UI that never shipped

### DIFF
--- a/ansible/nairobi-mdms/mdms/dss/KpiDefinition.json
+++ b/ansible/nairobi-mdms/mdms/dss/KpiDefinition.json
@@ -1997,13 +1997,6 @@
             "type": "officer"
           },
           {
-            "id": "role",
-            "label": "Role",
-            "labelKey": "DASHBOARD_COL_ROLE",
-            "align": "left",
-            "type": "text"
-          },
-          {
             "id": "department_code",
             "label": "Dept",
             "labelKey": "DASHBOARD_COL_DEPT",
@@ -3211,39 +3204,39 @@
       "id": "cl_table_subtype_performance",
       "viz": {
         "pii": false,
-        "kind": "rankedList",
+        "kind": "table",
         "group": "complaint-landscape",
         "title": "Complaint sub-type performance",
         "accent": "teal",
         "format": "hoursDays",
         "columns": [
           {
-            "id": "subtypeLabel",
+            "id": "service_code",
             "type": "text",
             "align": "left",
             "label": "Subtype",
-            "width": "30%"
+            "width": "40%"
           },
           {
-            "id": "share_pct",
-            "type": "percent",
-            "align": "left",
-            "label": "% of complaints",
-            "width": "18%"
+            "id": "total",
+            "type": "integer",
+            "align": "right",
+            "label": "Complaints",
+            "width": "20%"
           },
           {
-            "id": "avgResolutionMs",
+            "id": "avg_resolution_ms",
             "type": "hoursDays",
-            "align": "left",
+            "align": "right",
             "label": "Avg resolution",
-            "width": "22%"
+            "width": "20%"
           },
           {
-            "id": "idealSlaMs",
+            "id": "ideal_sla_ms",
             "type": "hoursDays",
-            "align": "left",
+            "align": "right",
             "label": "SLA",
-            "width": "18%"
+            "width": "20%"
           }
         ],
         "compose": null,
@@ -3256,8 +3249,7 @@
           "avg_resolution_ms",
           "ideal_sla_ms"
         ],
-        "dimensionKey": "service_code",
-        "tableProfile": "subtypePerformance"
+        "dimensionKey": "service_code"
       },
       "rbac": {
         "visibleTo": [

--- a/ansible/nairobi-mdms/mdms/dss/KpiDefinition.json
+++ b/ansible/nairobi-mdms/mdms/dss/KpiDefinition.json
@@ -582,6 +582,7 @@
       "query": {
         "grain": "facts",
         "filters": {
+          "is_open": false,
           "is_resolved": true
         },
         "measures": [
@@ -782,7 +783,7 @@
             "dir": "desc"
           }
         ],
-        "limit": 8
+        "limit": 500
       },
       "supportsSeries": false,
       "viz": {
@@ -803,7 +804,7 @@
         "measureKey": "total",
         "seriesLabel": "Filed",
         "seriesLabelKey": "DASHBOARD_SERIES_FILED",
-        "limit": 8,
+        "limit": 500,
         "subtitle": "Complaints filed, by type",
         "subtitleKey": "CMS-DASHBOARD.DASHBOARD_KPI_CL_CHART_COMPLAINTS_BY_TYPE_SUBTITLE",
         "labelFormat": "dimension"
@@ -1035,7 +1036,7 @@
           }
         ],
         "sortBySegment": "breached",
-        "limit": 8,
+        "limit": 120,
         "labelFormat": "officer",
         "compose": null,
         "pii": {
@@ -1135,7 +1136,7 @@
             "color": "var(--chart-4)"
           }
         ],
-        "limit": 8,
+        "limit": 300,
         "subtitle": "Subtypes with the most open complaints, each broken down by which workflow stage they're stuck in.",
         "subtitleKey": "CMS-DASHBOARD.DASHBOARD_KPI_CL_CHART_OPEN_BY_TYPE_STAGE_SUBTITLE",
         "labelFormat": "dimension"
@@ -1490,7 +1491,8 @@
             "numerator": {
               "agg": "count",
               "filter": {
-                "is_reopened": true
+                "is_reopened": true,
+                "is_resolved": true
               }
             },
             "denominator": {
@@ -1717,7 +1719,7 @@
             "column": "sla_target_ms"
           }
         ],
-        "limit": 50
+        "limit": 1000
       },
       "supportsSeries": false,
       "viz": {
@@ -2266,7 +2268,7 @@
           "filed",
           "resolved"
         ],
-        "limit": 12,
+        "limit": 500,
         "labelFormat": "department",
         "compose": null,
         "pii": false,

--- a/digit-mcp/src/tools/dashboard-catalog-seed.ts
+++ b/digit-mcp/src/tools/dashboard-catalog-seed.ts
@@ -2301,13 +2301,6 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
           "type": "officer"
         },
         {
-          "id": "role",
-          "label": "Role",
-          "labelKey": "DASHBOARD_COL_ROLE",
-          "align": "left",
-          "type": "text"
-        },
-        {
           "id": "department_code",
           "label": "Dept",
           "labelKey": "DASHBOARD_COL_DEPT",
@@ -3473,39 +3466,39 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
     "id": "cl_table_subtype_performance",
     "viz": {
       "pii": false,
-      "kind": "rankedList",
+      "kind": "table",
       "group": "complaint-landscape",
       "title": "Complaint sub-type performance",
       "accent": "teal",
       "format": "hoursDays",
       "columns": [
         {
-          "id": "subtypeLabel",
+          "id": "service_code",
           "type": "text",
           "align": "left",
           "label": "Subtype",
-          "width": "30%"
+          "width": "40%"
         },
         {
-          "id": "share_pct",
-          "type": "percent",
-          "align": "left",
-          "label": "% of complaints",
-          "width": "18%"
+          "id": "total",
+          "type": "integer",
+          "align": "right",
+          "label": "Complaints",
+          "width": "20%"
         },
         {
-          "id": "avgResolutionMs",
+          "id": "avg_resolution_ms",
           "type": "hoursDays",
-          "align": "left",
+          "align": "right",
           "label": "Avg resolution",
-          "width": "22%"
+          "width": "20%"
         },
         {
-          "id": "idealSlaMs",
+          "id": "ideal_sla_ms",
           "type": "hoursDays",
-          "align": "left",
+          "align": "right",
           "label": "SLA",
-          "width": "18%"
+          "width": "20%"
         }
       ],
       "compose": null,
@@ -3518,8 +3511,7 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
         "avg_resolution_ms",
         "ideal_sla_ms"
       ],
-      "dimensionKey": "service_code",
-      "tableProfile": "subtypePerformance"
+      "dimensionKey": "service_code"
     },
     "rbac": {
       "visibleTo": [

--- a/digit-mcp/src/tools/dashboard-catalog-seed.ts
+++ b/digit-mcp/src/tools/dashboard-catalog-seed.ts
@@ -928,6 +928,7 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
     "query": {
       "grain": "facts",
       "filters": {
+        "is_open": false,
         "is_resolved": true
       },
       "measures": [
@@ -1119,7 +1120,7 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
           "dir": "desc"
         }
       ],
-      "limit": 8
+      "limit": 500
     },
     "supportsSeries": false,
     "viz": {
@@ -1140,7 +1141,7 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
       "measureKey": "total",
       "seriesLabel": "Filed",
       "seriesLabelKey": "DASHBOARD_SERIES_FILED",
-      "limit": 8,
+      "limit": 500,
       "subtitle": "Complaints filed, by type",
       "subtitleKey": "CMS-DASHBOARD.DASHBOARD_KPI_CL_CHART_COMPLAINTS_BY_TYPE_SUBTITLE",
       "labelFormat": "dimension"
@@ -1363,7 +1364,7 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
         }
       ],
       "sortBySegment": "breached",
-      "limit": 8,
+      "limit": 120,
       "labelFormat": "officer",
       "compose": null,
       "pii": {
@@ -1460,7 +1461,7 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
           "color": "var(--chart-4)"
         }
       ],
-      "limit": 8,
+      "limit": 300,
       "subtitle": "Subtypes with the most open complaints, each broken down by which workflow stage they're stuck in.",
       "subtitleKey": "CMS-DASHBOARD.DASHBOARD_KPI_CL_CHART_OPEN_BY_TYPE_STAGE_SUBTITLE",
       "labelFormat": "dimension"
@@ -1803,7 +1804,8 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
           "numerator": {
             "agg": "count",
             "filter": {
-              "is_reopened": true
+              "is_reopened": true,
+              "is_resolved": true
             }
           },
           "denominator": {
@@ -2027,7 +2029,7 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
           "column": "sla_target_ms"
         }
       ],
-      "limit": 50
+      "limit": 1000
     },
     "supportsSeries": false,
     "viz": {
@@ -2561,7 +2563,7 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
         "filed",
         "resolved"
       ],
-      "limit": 12,
+      "limit": 500,
       "labelFormat": "department",
       "compose": null,
       "pii": false,


### PR DESCRIPTION
**Draft** — a cumulative branch for MDMS/seed repairs to the dashboard catalog. More will be stacked on as they are confirmed on a live tenant; see the checklist at the bottom.

## The class of defect

Four `dss.KpiDefinition` table records declare a `tableProfile` — `subtypePerformance`, `wardPerformance`, `serviceQualityByChannel`, `wardSubtypeRecurring` — that **exists in no frontend code on any branch**. Searching the whole history, those strings appear only ever as MDMS *data*, never as code. The deployed bundle confirms it: `grep subtypePerformance` over `build/index.js` returns 0, while `data-table` returns 4.

With no profile implementation, the tiles fall through to the generic `rankedList` renderer, which ignores `viz.valueKey` and plots the **first** measure using the tile's format:

```js
function primaryMeasure(result, viz) {
  return measureColumns(result, viz)[0] || { name: viz.measureKey || 'total' };
}
```
`KpiTile.jsx:215`

Their column ids are also camelCase (`avgResolutionMs`, `wardLabel`, `avgCsat`) while the query returns snake_case (`avg_resolution_ms`, `ward_code`, `avg_csat`) — so no column could ever bind. Same root cause: written against the UI that was never built.

**Provenance:** these records were created on bomet on 2026-07-02 by the shared `ADMIN` superuser, then copied *into* the repo on 2026-07-10 by `69f015223` ("fold in the 11 second-wave KPIs that were live on bomet but missing from the repo copy"). They were never part of the canonical 27-KPI catalog (`8a28b81aa`, Jun 30) and so were never checked against what the dashboard can actually render.

## Why this belongs in the seed rather than per-tenant repair

The defect is tenant-invariant — verified identical in all three places:

| Record | bomet | mz | master seed |
|---|---|---|---|
| `cl_table_subtype_performance` | repaired 2026-08-04 | broken | **broken** |
| `cl_table_ward_performance` | broken | broken | **broken** |
| `cl_table_service_quality_by_channel` | broken | broken | **broken** |
| `cl_table_recurring_ward_subtype` | broken | broken | **broken** |

Every new tenant inherits all four.

## What is in this commit

**`cl_table_subtype_performance`** — the only one whose *numbers* were wrong. First measure is `total` (a count), tile format is `hoursDays`, so 774 complaints rendered as **"0 hrs"** and every row on the tile read 0. Now `kind: table`, phantom profile removed, column ids bound to what the query produces. This is byte-identical to the repair verified live on bomet on 2026-08-04. `share_pct` is dropped — no measure computes it.

**`ep_table_employee_performance`** — drops the `role` column, which no measure produces and which rendered permanently empty.

`DASHBOARD_COL_ROLE` is deliberately **kept** in the l10n packs: live tenants still carry the `role` column in their own records, and removing the key would make those tiles render a raw key string.

`digit-mcp/src/tools/dashboard-catalog-seed.ts` is regenerated (`gen-dashboard-catalog.mjs --check` passes).

## Not in this commit — needs a product decision

The other three tiles show *correct numbers* (their `format` is `integer` and `valueKey` happens to equal the first measure); they are only degraded to a single-column list. Repairing them fully is not mechanical, because each asks for a column **no measure computes**:

| Record | Uncomputable column(s) |
|---|---|
| `cl_table_ward_performance` | `open`, `resolutionRate` |
| `cl_table_service_quality_by_channel` | `resolutionRate` |
| `cl_table_recurring_ward_subtype` | `trendPct` |

Each needs either a new measure added to the query (backend) or the column dropped (config). That is a call on whether "Ward performance", "Service quality by channel" and "Recurring by ward & sub-type" are wanted as features at all.

## Standing gap this does NOT close

Merging this fixes **new tenants only**. `tenant_bootstrap` seeds the catalog as a create-if-absent floor (`digit-mcp/src/tools/mdms-tenant.ts:1770-1773`), so bomet and mz keep their existing records and must be repaired directly — as bomet already was. Same limitation that applied to #1546.

## Checklist for this branch

- [x] `cl_table_subtype_performance` — wrong numbers, repaired, live-verified on bomet
- [x] `ep_table_employee_performance` — dangling `role` column dropped
- [ ] `cl_table_ward_performance` — pending decision on `open` / `resolutionRate`
- [ ] `cl_table_service_quality_by_channel` — pending decision on `resolutionRate`
- [ ] `cl_table_recurring_ward_subtype` — pending decision on `trendPct`
- [ ] mz: apply the confirmed repairs to its live records


---

## Update — live-verified repairs folded in (2026-08-04)

Seven further records added, each applied to bomet **first** and verified against SQL ground truth before being folded back here. The seed and bomet's 39 live records are now identical on query/columns/kind/limit.

**Truncation** — charts silently hiding rows, with no "other" bucket and no indicator:

| Record | Change | Why |
|---|---|---|
| `cl_chart_complaints_by_type` | limit 8 → 500 | 24 types in a 30d window; top 8 summed to 1,135 of 1,169, so 34 complaints were invisible and the chart could never reconcile with any headline |
| `cl_table_complaints_at_risk` | limit 50 → 1000 | against **1,106** at-risk complaints — it was showing 4.5% |
| `cl_chart_open_by_type_stage` | viz.limit 8 → 300 | hid 110 of 1,149 |
| `cl_chart_officer_sla` | viz.limit 8 → 120 | |
| `cl_chart_department_flow_ratio` | viz.limit 12 → 500 | |

1000 is the honest ceiling for the at-risk table: `AnalyticsPlanner.MAX_LIMIT` clamps every query there regardless of the def, so **106 rows remain hidden** until that cap is raised. That needs a backend change and is out of scope here.

**Correctness**

- `cl_table_complaint_type_details` — `reopen_rate` numerator scoped to ever-resolved. 11 complaints on bomet were reopened out of a **REJECTED** state and so were never resolved; they entered the numerator with no possibility of appearing in the denominator, rendering a **200%** reopen rate. This matches the shape already used by `cl_table_ward_performance` and `ep_table_employee_performance`, both of which were already correct.
- `cl_resolved_date_range_count` — `{is_open:false, is_resolved:true}`. Missed by the sticky-`is_resolved` pass in #1546. It coincides with the strict reading inside a 7-day window (79 = 79) but diverges all-time (330 vs 316), so it would have started disagreeing with the resolution-rate numerator as soon as anyone widened the range.

All were verified live: reopen rates over 100% went to **0 rows**, the stage chart now sums 1,154 across 53 rows, and resolved-in-range returns 79 matching SQL exactly.
