### PR TITLE
fix: CCRS#1551 — Novu key lost on every aborted converge (ordering + healthcheck)

### DIFF
--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -1227,6 +1227,27 @@
         - enable_keycloak | default(false)
         - kcprep_secrets.json.data.data.keycloak_db_password | default('') | length > 0
 
+    # Same ordering trap as the KEYCLOAK SECRETS block above, for Novu (CCRS#1551).
+    # .env is regenerated earlier in this play WITHOUT a NOVU_API_KEY line, and the
+    # novu-bootstrap block that writes one lives AFTER the stack is up — because
+    # MINTING a key requires a healthy novu-api. But a deployment that PINS
+    # novu_api_key in host_vars (Bomet/Nairobi) needs nothing running: the value is
+    # already known here. Without this task the compose-up below resolves
+    # ${NOVU_API_KEY:-changeme} and novu-bridge comes up unauthenticated — and any
+    # play that aborts at "Start DIGIT stack" (the user-preferences healthcheck is
+    # flaky) never reaches the late block, so notifications stay broken silently.
+    - name: "novu prep — write pinned NOVU_API_KEY into .env BEFORE compose-up"
+      ansible.builtin.lineinfile:
+        path: "{{ digit_dir }}/.env"
+        regexp: '^NOVU_API_KEY='
+        line: "NOVU_API_KEY={{ novu_api_key }}"
+        create: true
+        mode: '0600'
+      no_log: true
+      when:
+        - enable_novu | default(false)
+        - (novu_api_key | default('')) | length > 0
+
     # The next two steps are the deploy's long, silent stretch — the image
     # pull (tens of GB on a first run) and the ~40-container up (~10 min on
     # a cold box). Ansible buffers a task's output until it finishes, so

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -2180,7 +2180,15 @@ services:
       interval: 30s
       timeout: 5s
       retries: 5
-      start_period: 30s
+      # 30s was never enough for a Spring Boot cold start and is an outlier among
+      # its peers (egov-hrms 150s, egov-user 120s, boundary-service 120s,
+      # digit-config-service 90s — the last added in this very same commit).
+      # novu-bridge is the only service that depends_on this one with
+      # condition: service_healthy, so when it flaps the whole `compose up -d`
+      # exits non-zero, ansible stops the play, and every task after
+      # "Start DIGIT stack" is silently skipped. That is the mechanism behind
+      # CCRS#1551. Align with the other JVM services.
+      start_period: 120s
     networks:
       - egov-network
 


### PR DESCRIPTION
Fixes #1551. Targets **master** — bomet deploys from master (`GIT_BRANCH=master`; `/opt/ccrs` resets to `origin/master` nightly), so the fix only reaches the affected box from this branch.

Two commits: the actual fix, plus the trigger that keeps setting it off.

## What the user sees

`Manage → Notification Providers` is a `type: 'custom'` react-admin resource whose entire list **and search** is one call — `GET /novu-bridge/novu-adapter/v1/integrations` (`resourceRegistry.ts`). There is no server-side query; the grid is fetched whole and filtered client-side. So when that call fails, the grid is empty and every search returns nothing.

The call was failing because novu-bridge ran with `NOVU_API_KEY=changeme`, so Novu answered 401 `API Key not found` and the bridge returned `NB_NOVU_INTEGRATIONS_FAILED`.

## Commit 1 — write a pinned NOVU_API_KEY before compose-up (the fix)

| in `playbook-deploy.yml` | effect |
|---|---|
| `.env` regenerated (~task 807), then `Start DIGIT stack` | `.env` has no `NOVU_API_KEY` line yet, so compose resolves `${NOVU_API_KEY:-changeme}` and novu-bridge starts unauthenticated |
| `novu-bootstrap — wire NOVU_API_KEY into compose .env` (~task 3000) | the only place the key is written |

The late placement is correct *for minting*: `novu-mint-key.sh` POSTs to a healthy novu-api, which only exists once the stack is up. But a deployment that **pins** `novu_api_key` in host_vars (Bomet, Nairobi) needs nothing running — the value is already known. So this splits the two paths: pinned keys are written before compose-up, minting stays where it is.

It matters because an Ansible task failure **stops the play**. `Start DIGIT stack` at line 1269 is followed by **190 of the playbook's 257 tasks** — all skipped on abort, including the novu block. The stack then heals on its own and smoke passes, so it looks green.

Consequence worth calling out: **pinning `novu_api_key` in host_vars does not currently protect a box**, because it is only consumed past the abort point.

Mirrors the existing `Keycloak prep — write KEYCLOAK SECRETS into .env BEFORE compose-up` task, which fixed exactly this class of bug.

## Commit 2 — give digit-user-preferences-service a realistic start_period

| service | start_period |
|---|---|
| egov-hrms | 150s |
| egov-user / boundary-service | 120s |
| digit-config-service | 90s |
| **digit-user-preferences-service** | **30s** |

All Spring Boot, same `wget /health` check. `digit-config-service` was added in the *same commit* (`1af96be98`, 2026-05-15) and got 90s — 30s reads as an oversight.

**`novu-bridge` is the only service in the file that `depends_on` this one with `condition: service_healthy`**, so the one flaky service gates precisely the service whose key then goes missing. When it loses the race the whole `up -d` exits non-zero and the play aborts.

Observed on bomet: `PLAY RECAP: ok=55 failed=1` when it trips, `ok=105 failed=1` when it doesn't. Same box, same playbook — a 50-task swing decided by a healthcheck race.

**This is deliberately not presented as the fix.** It reduces how often the play aborts; it does not make the key survive an abort. Commit 1 does that. Two reasons it can't stand alone: in the very converge that produced this bug, `redpanda` *also* reported `Error dependency ... failed to start`, so user-preferences wasn't the only trigger; and 44 services declare 108 `service_healthy` dependencies in total, any of which can lose the same race.

## Verification (bomet, real deployment)

Reproduced first — a converge left `NOVU_API_KEY=changeme` and 401s. After the change:

- `TASK [novu prep — write pinned NOVU_API_KEY into .env BEFORE compose-up]` → `changed`, running **before** `Start DIGIT stack` (play line 1134 vs 1152)
- `PLAY RECAP: ok=105 changed=34 failed=1` (remaining failure is an unrelated systemd `BadUnitSetting` on the integration-tests runner unit)
- novu-bridge comes up with the real key; 57 containers, 0 unhealthy
- `GET /novu-bridge/novu-adapter/v1/integrations` → **200**, 4 integrations
- `/configurator/`, `/digit-ui/`, `/citizen/login` all 200

Caveat kept honest: that validating run's `Start DIGIT stack` happened to succeed, so it did not re-exercise the abort path. The fix is ordering-based so it holds either way, but the deliberate abort test (stop `digit-user-preferences-service`, force the play to abort, confirm the key survives) has not been run yet.

## Not in this PR

- Robustness: give the Linux `Start DIGIT stack` the converge/retry loop the macOS branch already has, so an intermittent compose-up stops silently skipping 74% of the play.
- 20 credential vars use fail-open `${VAR:-placeholder}` defaults (`KC_ADMIN_PASSWORD:-admin`, `MINIO_ROOT_PASSWORD:-minioadmin`, …). Hard-failing them would break fresh installs, so the answer is probe-based detection, not `${VAR:?err}`.
- bomet's wrapper (not tracked here) gained a post-converge `ensure_novu_key` re-assert and a `novu integrations -> 200` check in `smoke()` — the outage stayed invisible for 15 days because smoke never touched Novu.