### PR TITLE
fix(compose): give digit-user-preferences-service a realistic start_period

### DIFF
--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -2180,7 +2180,15 @@ services:
       interval: 30s
       timeout: 5s
       retries: 5
-      start_period: 30s
+      # 30s was never enough for a Spring Boot cold start and is an outlier among
+      # its peers (egov-hrms 150s, egov-user 120s, boundary-service 120s,
+      # digit-config-service 90s — the last added in this very same commit).
+      # novu-bridge is the only service that depends_on this one with
+      # condition: service_healthy, so when it flaps the whole `compose up -d`
+      # exits non-zero, ansible stops the play, and every task after
+      # "Start DIGIT stack" is silently skipped. That is the mechanism behind
+      # CCRS#1551. Align with the other JVM services.
+      start_period: 120s
     networks:
       - egov-network
 


### PR DESCRIPTION
Companion to #1571. That PR fixes the *symptom* of CCRS#1551 (the Novu key being written after the stack comes up); this one removes the *trigger*.

## The outlier

| service | start_period |
|---|---|
| egov-hrms | 150s |
| egov-user | 120s |
| boundary-service | 120s |
| digit-config-service | 90s |
| **digit-user-preferences-service** | **30s** |

All are Spring Boot services with the same `wget /health` check. `digit-config-service` was added in the *same commit* as this one (`1af96be98`, 2026-05-15) and got 90s. 30s reads as an oversight, not a decision.

## Why a slow healthcheck becomes a silent deploy failure

`novu-bridge` is the **only** service in the compose file declaring:

```yaml
depends_on:
  digit-user-preferences-service:
    condition: service_healthy
```

So when this container isn't healthy in time, the whole `docker compose up -d` exits non-zero with `dependency failed to start: container digit-user-preferences-service is unhealthy`. Ansible treats that as a task failure and **stops the play** — every task after `Start DIGIT stack` is skipped: MDMS seeds, the tenant rewrites, and the `novu-bootstrap` block that writes `NOVU_API_KEY` into `.env`.

The containers then go healthy on their own a minute later and the heal loop finishes the job, so the deploy *looks* fine. On bomet this produced a 15-day silent outage of notifications (2026-07-20 → 08-03) during which the nightly logged `OK` and smoke passed, because nothing in smoke touched Novu.

Observed on bomet: with the old value, `PLAY RECAP: ok=55 failed=1` (aborted at `Start DIGIT stack`). On a run where it did not trip, `ok=105`. Same playbook, same box — a 50-task difference decided by a healthcheck race.

## The change

`start_period: 30s` → `120s`, matching egov-user and boundary-service. No other field touched; `interval`/`timeout`/`retries` are unchanged, so a genuinely dead container is still reported unhealthy — it just gets a fair cold-start window first.

## Note

This does not make the play *robust* to the failure, only much less likely to hit it. The deeper issue — that an intermittent compose-up failure silently skips half the playbook — is worth addressing separately, e.g. by giving the Linux `Start DIGIT stack` task the converge/retry loop the macOS branch already has.