### PR TITLE
ci: SPA build pipeline for configurator and digit-ui-esbuild

### DIFF
--- a/.github/workflows/spa-build.yml
+++ b/.github/workflows/spa-build.yml
@@ -1,0 +1,185 @@
+name: SPA Build Pipeline
+run-name: Build ${{ github.event.inputs.pipeline_name }}
+
+# Builds + publishes the Vite/esbuild SPA images (self-contained Dockerfiles)
+# to the egovio Docker Hub org as multi-arch (amd64 + arm64) manifests.
+#
+# Differs from pgr-ui-build.yml in exactly one way: the docker build CONTEXT
+# is the app's work-dir from build/build-config.yml, not the repo root.
+# configurator/Dockerfile and digit-ui-esbuild/docker/Dockerfile COPY
+# package.json etc. relative to their own directory and take no WORK_DIR
+# build-arg (unlike the legacy micro-ui Dockerfile).
+on:
+  workflow_dispatch:
+    inputs:
+      pipeline_name:
+        description: 'App to build and publish'
+        required: true
+        type: choice
+        options:
+          - configurator
+          - digit-ui-esbuild
+
+env:
+  DOCKER_USERNAME: ${{ vars.DOCKER_USERNAME }}
+  DOCKER_PASSWORD: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+jobs:
+  resolve-config:
+    name: Resolve ${{ github.event.inputs.pipeline_name }} config
+    runs-on: ubuntu-latest
+    outputs:
+      work_dir:   ${{ steps.setenv.outputs.work_dir }}
+      image_name: ${{ steps.setenv.outputs.image_name }}
+      dockerfile: ${{ steps.setenv.outputs.dockerfile }}
+      tag:        ${{ steps.tag.outputs.tag }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Install yq
+        run: |
+          VERSION="4.30.8"
+          URL="https://github.com/mikefarah/yq/releases/download/v${VERSION}/yq_linux_amd64"
+          sudo curl -sSL "$URL" -o /usr/local/bin/yq
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Resolve env from build-config.yml
+        id: setenv
+        run: |
+          PIPELINE_NAME="${{ github.event.inputs.pipeline_name }}"
+          DEFAULT_DOCKERFILE="Dockerfile"
+          echo "### Pipeline Name - $PIPELINE_NAME" >> $GITHUB_STEP_SUMMARY
+
+          # Find exactly one matching config block
+          MATCHING_CONFIGS=$(yq eval -o=json '.config[] | select(.name | test("/'"$PIPELINE_NAME"'$"))' build/build-config.yml)
+          MATCH_COUNT=$(echo "$MATCHING_CONFIGS" | jq -s 'length')
+          if [ "$MATCH_COUNT" -ne 1 ]; then
+            echo "ERROR: Expected exactly 1 matching pipeline config, but found $MATCH_COUNT"
+            exit 1
+          fi
+
+          SERVICE_BUILD_CONFIG=$(echo "$MATCHING_CONFIGS" | jq -c '.build[] | select(.["image-name"])')
+          SERVICE_WORK_DIR=$(echo "$SERVICE_BUILD_CONFIG" | yq eval -r '.["work-dir"] // ""' -)
+          SERVICE_IMAGE_NAME=$(echo "$SERVICE_BUILD_CONFIG" | yq eval -r '.["image-name"] // ""' -)
+          SERVICE_DOCKERFILE=$(echo "$SERVICE_BUILD_CONFIG" | yq eval -r '.dockerfile // ""' -)
+
+          if [ -z "$SERVICE_DOCKERFILE" ]; then
+            SERVICE_DOCKERFILE="$SERVICE_WORK_DIR/$DEFAULT_DOCKERFILE"
+          fi
+
+          echo "work_dir=$SERVICE_WORK_DIR" >> $GITHUB_OUTPUT
+          echo "image_name=$SERVICE_IMAGE_NAME" >> $GITHUB_OUTPUT
+          echo "dockerfile=$SERVICE_DOCKERFILE" >> $GITHUB_OUTPUT
+
+          echo "#### Application Config Summary" >> $GITHUB_STEP_SUMMARY
+          echo "Application Work Directory - $SERVICE_WORK_DIR" >> $GITHUB_STEP_SUMMARY
+          echo "Image Name - $SERVICE_IMAGE_NAME" >> $GITHUB_STEP_SUMMARY
+          echo "Dockerfile Path - $SERVICE_DOCKERFILE" >> $GITHUB_STEP_SUMMARY
+
+      # Deterministic <branch>-<shortsha> tag. Re-running for the same commit
+      # re-pushes the same tag (idempotent) — no Docker Hub tag lookup needed.
+      - name: Generate the Tag
+        id: tag
+        run: |
+          set -euo pipefail
+          BRANCH="${GITHUB_REF_NAME//\//-}"
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+          NEXT_TAG="${BRANCH}-${COMMIT_HASH}"
+          echo "tag=$NEXT_TAG" >> "$GITHUB_OUTPUT"
+          echo "tag - $NEXT_TAG" >> $GITHUB_STEP_SUMMARY
+
+  build-matrix:
+    name: Build application ${{ matrix.arch }}
+    needs: [resolve-config]
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    outputs:
+      amd64_digest: ${{ steps.digest_amd64.outputs.digest }}
+      arm64_digest: ${{ steps.digest_arm64.outputs.digest }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker Layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-${{ matrix.arch }}-buildx-${{ github.event.inputs.pipeline_name }}-${{ github.ref_name }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.arch }}-buildx-${{ github.event.inputs.pipeline_name }}-
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_PASSWORD }}
+
+      # Context is the app's work-dir: these Dockerfiles COPY relative to
+      # their own directory. --file stays cwd-relative (repo root).
+      - name: Build image for ${{ matrix.arch }}
+        run: |
+          docker buildx build \
+            --platform ${{ matrix.platform }} \
+            --file ${{ needs.resolve-config.outputs.dockerfile }} \
+            --tag egovio/${{ needs.resolve-config.outputs.image_name }}:${{ needs.resolve-config.outputs.tag }}-${{ matrix.arch }} \
+            --cache-from=type=local,src=/tmp/.buildx-cache \
+            --cache-to=type=local,dest=/tmp/.buildx-cache,mode=max \
+            --push \
+            ${{ needs.resolve-config.outputs.work_dir }}
+
+      - name: Inspect Manifest
+        run: |
+          docker buildx imagetools inspect egovio/${{ needs.resolve-config.outputs.image_name }}:${{ needs.resolve-config.outputs.tag }}-${{ matrix.arch }}
+
+      - name: Export Digest (amd64)
+        if: matrix.arch == 'amd64'
+        id: digest_amd64
+        run: |
+          digest=$(docker buildx imagetools inspect \
+            egovio/${{ needs.resolve-config.outputs.image_name }}:${{ needs.resolve-config.outputs.tag }}-${{ matrix.arch }} \
+            --format '{{json .}}' | jq -r '.manifest.manifests[] | select(.platform.architecture=="amd64" and .platform.os=="linux") | .digest')
+          echo "digest=$digest" >> $GITHUB_OUTPUT
+
+      - name: Export Digest (arm64)
+        if: matrix.arch == 'arm64'
+        id: digest_arm64
+        run: |
+          digest=$(docker buildx imagetools inspect \
+            egovio/${{ needs.resolve-config.outputs.image_name }}:${{ needs.resolve-config.outputs.tag }}-${{ matrix.arch }} \
+            --format '{{json .}}' | jq -r '.manifest.manifests[] | select(.platform.architecture=="arm64" and .platform.os=="linux") | .digest')
+          echo "digest=$digest" >> $GITHUB_OUTPUT
+
+  create-manifest:
+    name: Create and Push Manifest
+    needs: [build-matrix, resolve-config]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_PASSWORD }}
+
+      - name: Create and push manifest
+        run: |
+          docker manifest create egovio/${{ needs.resolve-config.outputs.image_name }}:${{ needs.resolve-config.outputs.tag }} \
+            --amend egovio/${{ needs.resolve-config.outputs.image_name }}@${{ needs.build-matrix.outputs.amd64_digest }} \
+            --amend egovio/${{ needs.resolve-config.outputs.image_name }}@${{ needs.build-matrix.outputs.arm64_digest }}
+          docker manifest push egovio/${{ needs.resolve-config.outputs.image_name }}:${{ needs.resolve-config.outputs.tag }}
+
+      - name: Add summary to GitHub Actions
+        run: |
+          echo "- Image: egovio/${{ needs.resolve-config.outputs.image_name }}:${{ needs.resolve-config.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Platform: amd64, arm64" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Dispatch-driven workflow that builds the two self-contained SPA Dockerfiles (configurator/Dockerfile, digit-ui-esbuild/docker/Dockerfile) and publishes multi-arch (amd64 + arm64) manifests to the egovio Docker Hub org, resolving work-dir/dockerfile/image-name from build/build-config.yml like pgr-ui-build.yml.

Two deliberate deltas from pgr-ui-build.yml:
- the docker build CONTEXT is the app's work-dir (these Dockerfiles COPY relative to their own directory and take no WORK_DIR build-arg)
- the tag is a deterministic <branch>-<shortsha> (drops the Docker Hub tag-lookup step, which carries a grep-precedence bug that hard-fails rebuilds of an already-built commit)

Both images verified locally with the workflow's exact invocation: build OK, nginx serves /configurator/ and /digit-ui/ incl. SPA deep links.