### PR TITLE
fix(pgr): mask complainant identity on confidential complaints (CCSD-2130)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
@@ -519,6 +519,27 @@ const PGRDetails = () => {
   const filedByUuid = complaintService?.auditDetails?.createdBy;
   const filedOnBehalfOfCitizen = Boolean(complainantUuid && filedByUuid && complainantUuid !== filedByUuid);
 
+  // CCSD-2130: confidential complaints must not expose the complainant.
+  //
+  // The backend ALREADY masks service.extendedAttributes on these — verified
+  // against a live confidential complaint: complainantName / witnessName /
+  // witnessAddress / witnessNote all come back "****". What it does NOT mask is
+  // the service.citizen block, which pgr-services enriches from egov-user on
+  // every search and where every attribute is defaultVisibility PLAIN — so
+  // name, mobileNumber and correspondenceAddress arrive in clear.
+  //
+  // This masks exactly those citizen-derived rows, matching the backend's own
+  // "****" convention so the two sources read consistently. It is a DISPLAY
+  // control only: the values are still present in the API response, so the
+  // durable fix is backend masking gated on CONFIDENTIAL_COMPLAINT_VIEWER (the
+  // role ComplaintTemplateType.allowedViewerRoles already names but which does
+  // not yet exist). Tracked separately — do not treat this as enforcement.
+  const isConfidentialComplaint = complaintService?.extendedAttributes?.isConfidential === true;
+  // Same sentinel the backend emits, so masked rows look identical whichever
+  // side did the masking.
+  const CONFIDENTIAL_MASK = "****";
+  const maskIfConfidential = (value) => (isConfidentialComplaint ? CONFIDENTIAL_MASK : value);
+
   return (
     <div className="v2-pgr-details v2-scope">
       {/* Header */}
@@ -601,17 +622,23 @@ const PGRDetails = () => {
                   },
                   // Typed address (product call, sheet-v4 review): the backend
                   // persists the complainant-entered address into the User
-                  // Service and returns it as citizen.correspondenceAddress —
-                  // masked/absent per backend policy on confidential complaints.
+                  // Service and returns it as citizen.correspondenceAddress.
+                  // CCSD-2130: that field is NOT masked server-side on
+                  // confidential complaints (verified live — it came back in
+                  // clear while extendedAttributes were "****"), so mask it here
+                  // alongside the complainant name/mobile. The
+                  // extendedAttributes.complainantAddress fallback already
+                  // arrives masked, so the mask is idempotent for that branch.
                   ...((pgrData?.ServiceWrappers?.[0]?.service?.citizen?.correspondenceAddress ||
                       pgrData?.ServiceWrappers?.[0]?.service?.extendedAttributes?.complainantAddress)
                     ? [
                         {
                           inline: true,
                           label: t("ES_CREATECOMPLAINT_ADDRESS"),
-                          value:
+                          value: maskIfConfidential(
                             pgrData.ServiceWrappers[0].service.citizen?.correspondenceAddress ||
-                            pgrData.ServiceWrappers[0].service.extendedAttributes?.complainantAddress,
+                            pgrData.ServiceWrappers[0].service.extendedAttributes?.complainantAddress
+                          ),
                         },
                       ]
                     : []),
@@ -642,13 +669,13 @@ const PGRDetails = () => {
                         inline: true,
                         label: t("COMPLAINTS_COMPLAINANT_NAME"),
                         type: "text",
-                        value: complaintService?.citizen?.name || "NA",
+                        value: maskIfConfidential(complaintService?.citizen?.name || "NA"),
                       },
                       {
                         inline: true,
                         label: t("COMPLAINTS_COMPLAINANT_CONTACT_NUMBER"),
                         type: "text",
-                        value: complaintService?.citizen?.mobileNumber || "NA",
+                        value: maskIfConfidential(complaintService?.citizen?.mobileNumber || "NA"),
                       },
                     ],
                   }]


### PR DESCRIPTION
## CCSD-2130 (3rd QA point) — Complainant Details must be hidden/masked when confidentiality is selected

### Scope was set by checking what the backend already does
Fetched a **live confidential complaint** (`isConfidential: true`) from the API before writing anything:

| field | returned |
|---|---|
| `extendedAttributes.complainantName` | `"****"` — already masked |
| `extendedAttributes.witnessName / witnessAddress / witnessNote` | `"****"` — already masked |
| **`service.citizen.name`** | `"KAHSDAD"` — **in clear** |
| **`service.citizen.mobileNumber`** | `"888888888"` — **in clear** |
| **`service.citizen.correspondenceAddress`** | `"TEST TEST"` — **in clear** |

The masking service covers `extendedAttributes` but **not** the `service.citizen` block, which `pgr-services` enriches from egov-user on every search and where every User attribute is `defaultVisibility: PLAIN`. So the citizen-filed path (which shows the name via Additional Details) was **already** protected; only the employee-filed path leaked.

### Change
Masks exactly the citizen-derived rows — complainant name, mobile, and the typed address — using the same `"****"` sentinel the backend emits, so both sources render consistently. Also corrects a stale comment that claimed the address was "masked/absent per backend policy on confidential complaints"; it is not.

### ⚠️ This is a display control, not enforcement
The values are still in the API response — visible via devtools, a saved HAR, or a direct API call. **This must not be recorded as "confidentiality implemented."**

The durable fix is backend masking of `service.citizen` gated on `CONFIDENTIAL_COMPLAINT_VIEWER` — a role that `ComplaintTemplateType.allowedViewerRoles` already names on all three template types (IGE, IGSAE, IGETESTING) but which **does not exist in the roles master**. The intended design was clearly role-based backend masking; it was never finished. Raised separately for the backend owner.

### Verified locally on purpose-built fixtures
| fixture | expectation | result |
|---|---|---|
| `PRD-2026-000024` — confidential **+ employee-filed** | masked | name `****`, phone `****`; real values (`Ana Confidencial`, `849001122`) appear **nowhere** in the rendered page ✅ |
| `PRD-2026-000023` — not confidential | unchanged | real values still shown, nothing masked ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)