### PR TITLE
fix(dashboard): remove the non-functional search box from the esbuild dashboard (#1474)

### DIFF
--- a/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
@@ -427,8 +427,6 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
     findDragHoverTarget,
   } = useCatalogLayout(kpis, pack?.layout);
 
-  const [searchQuery, setSearchQuery] = useState("");
-
   const [draggingWidgetId, setDraggingWidgetId] = useState(null);
   const draggingWidgetIdRef = useRef(null);
   const gridWrapRef = useRef(null);
@@ -645,19 +643,6 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
     [layout]
   );
 
-  // Title-based tile search: dim tiles whose title doesn't match the query.
-  // Matches against the LOCALIZED title (what the user sees on the tile).
-  const matchesSearch = useCallback(
-    (kpiId) => {
-      const q = searchQuery.trim().toLowerCase();
-      if (!q) return true;
-      const title = (resolveTitle(kpis[kpiId]) || kpiId).toLowerCase();
-      return title.includes(q);
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- i18nTick re-resolves titles on late bundle arrival
-    [searchQuery, kpis, i18nTick]
-  );
-
   // Add-KPI picker source: every role-visible catalog tile (already filtered
   // server-side), shaped to the picker's { id, metric, type, itemType } contract.
   // `language` re-localizes the resolved names on a language switch; `i18nTick`
@@ -846,8 +831,6 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
       onResetLayout={resetLayout}
       onDragWidgetStart={handleDragWidgetStart}
       onDragWidgetEnd={handleDragWidgetEnd}
-      searchQuery={searchQuery}
-      onSearchQueryChange={setSearchQuery}
       onExport={handleExport}
       filters={filters}
       onFilterChange={handleFilterChange}
@@ -918,7 +901,6 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
         >
           {layout.map((item) => {
             const isKpi = isCardKind(kpis[item.i]?.viz?.kind);
-            const dimClass = matchesSearch(item.i) ? "" : " dashboard-search-dimmed";
             const ignoredNote = typeFilterIgnored(batch.results?.[item.i]) ? (
               <TypeFilterIgnoredNote />
             ) : null;
@@ -936,7 +918,7 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
               return (
                 <div
                   key={item.i}
-                  className={`dashboard-kpi-widget dashboard-widget-surface tw-group tw-relative tw-flex tw-h-full tw-flex-col${dimClass}`}
+                  className="dashboard-kpi-widget dashboard-widget-surface tw-group tw-relative tw-flex tw-h-full tw-flex-col"
                 >
                   {removeBtn}
                   {renderTile(item.i)}
@@ -968,7 +950,7 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
             return (
               <section
                 key={item.i}
-                className={`dashboard-widget-surface tw-group tw-relative tw-flex tw-h-full tw-min-h-0 tw-flex-col tw-overflow-hidden tw-rounded tw-border tw-border-border tw-bg-surface${dimClass}`}
+                className="dashboard-widget-surface tw-group tw-relative tw-flex tw-h-full tw-min-h-0 tw-flex-col tw-overflow-hidden tw-rounded tw-border tw-border-border tw-bg-surface"
               >
                 {removeBtn}
                 {!selfHeaders && (

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardHeader.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardHeader.jsx
@@ -77,13 +77,6 @@ function buildSubtitle(filters, filterOptions, t, language) {
   return `${geo} · ${period}`;
 }
 
-const SearchIcon = () => (
-  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
-    <circle cx="11" cy="11" r="8" />
-    <line x1="21" y1="21" x2="16.65" y2="16.65" />
-  </svg>
-);
-
 const ExportIcon = () => (
   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
     <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
@@ -99,8 +92,6 @@ const DashboardHeader = ({
   onResetLayout,
   onDragWidgetStart,
   onDragWidgetEnd,
-  searchQuery,
-  onSearchQueryChange,
   onExport,
   filters,
   filterOptions,
@@ -213,22 +204,6 @@ const DashboardHeader = ({
         </div>
 
         <div className="dashboard-header-controls">
-          <label className="dashboard-header-search tw-hidden sm:tw-inline-flex">
-            <span className="dashboard-header-search-icon" aria-hidden>
-              <SearchIcon />
-            </span>
-            <input
-              type="search"
-              value={searchQuery}
-              onChange={(e) => onSearchQueryChange(e.target.value)}
-              placeholder={t(
-                "DASHBOARD_HEADER_SEARCH_PLACEHOLDER",
-                "Search complaints, wards, citizens."
-              )}
-              className="dashboard-header-search-input"
-            />
-          </label>
-
           <div className="dashboard-header-kpi-anchor">
             <button
               ref={addKpiRef}

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardLayout.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardLayout.jsx
@@ -12,8 +12,6 @@ const DashboardLayout = ({
   onResetLayout,
   onDragWidgetStart,
   onDragWidgetEnd,
-  searchQuery,
-  onSearchQueryChange,
   onExport,
   filters,
   onFilterChange,
@@ -58,8 +56,6 @@ const DashboardLayout = ({
           onResetLayout={onResetLayout}
           onDragWidgetStart={onDragWidgetStart}
           onDragWidgetEnd={onDragWidgetEnd}
-          searchQuery={searchQuery}
-          onSearchQueryChange={onSearchQueryChange}
           onExport={onExport}
           filters={filters}
           filterOptions={filterOptions}

--- a/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
@@ -529,89 +529,6 @@
   align-items: center;
   gap: 0.5rem;
 }
-
-.dashboard-header-search{
-  position: relative;
-  margin: 0px;
-  display: inline-flex;
-  height: 2rem;
-  flex-shrink: 0;
-  align-items: center;
-}
-
-.dashboard-header-search-icon {
-  position: absolute;
-  left: 10px;
-  top: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 16px;
-  height: 16px;
-  color: var(--dashboard-muted-foreground, #6b6860);
-  pointer-events: none;
-  transform: translateY(-50%);
-}
-
-.dashboard-header-search-input{
-  margin: 0px;
-  box-sizing: border-box;
-  display: block;
-  height: 2rem;
-  width: 14rem;
-  -webkit-appearance: none;
-     -moz-appearance: none;
-          appearance: none;
-  border-radius: 4px;
-  border-width: 1px;
-  border-color: var(--border);
-  background-color: var(--surface);
-  padding-top: 0px;
-  padding-bottom: 0px;
-  padding-left: 2rem;
-  padding-right: 0.75rem;
-  font-size: 12px;
-  line-height: 1;
-  color: var(--foreground);
-}
-
-.dashboard-header-search-input::-moz-placeholder{
-  color: var(--muted-foreground);
-}
-
-.dashboard-header-search-input::placeholder{
-  color: var(--muted-foreground);
-}
-
-.dashboard-header-search-input:focus{
-  border-color: var(--foreground);
-  outline: 2px solid transparent;
-  outline-offset: 2px;
-}
-
-.dashboard-header-search-input {
-  -webkit-appearance: none;
-}
-
-/* A global digit-ui input[type=...]:not(.a):not(.b)… rule is !important and its
-     long :not(.class) chain outranks this class, forcing the left padding to
-     ~12px so text slides under the search icon. A no-op :not(#…) lifts this into
-     the ID-specificity column and, with !important, wins. */
-
-.dashboard-header-search-input:not(#dashboard-search-noop) {
-  padding-left: 2rem !important;
-}
-
-.dashboard-header-search-input::-webkit-search-decoration,
-  .dashboard-header-search-input::-webkit-search-cancel-button {
-  -webkit-appearance: none;
-  appearance: none;
-}
-
-.dashboard-header-search-input:focus {
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 15%, transparent);
-}
-
 .dashboard-header-controls .dashboard-header-btn{
   margin: 0px;
   box-sizing: border-box;
@@ -1644,26 +1561,7 @@
   .dashboard-header-controls .dashboard-header-btn{
     padding-left: 0.5rem;
     padding-right: 0.5rem;
-  }
-
-  .dashboard-header-mobile-search {
-    display: block;
-    border-bottom: 1px solid var(--border);
-    background-color: var(--surface);
-    padding: 0.5rem 0.75rem;
-  }
-
-  .dashboard-header-search--mobile {
-    display: flex !important;
-    width: 100%;
-  }
-
-  .dashboard-header-search--mobile .dashboard-header-search-input {
-    width: 100%;
-    min-width: 0;
-  }
-
-  .dashboard-filters-card {
+  }  .dashboard-filters-card {
     align-items: stretch;
     padding-left: 0.5rem;
     padding-right: 0.5rem;
@@ -1716,11 +1614,6 @@
 }
 
 @media (min-width: 640px) and (max-width: 1023px) {
-  .dashboard-header-search-input{
-    width: 11rem;
-    max-width: 100%;
-  }
-
   .dashboard-filters-row {
     row-gap: 0.5rem;
   }
@@ -3144,12 +3037,6 @@
   color: var(--status-breach);
   font-weight: 500;
 }
-
-.dashboard-search-dimmed {
-  opacity: 0.12;
-  pointer-events: none;
-}
-
 .tw-pointer-events-none{
   pointer-events: none;
 }
@@ -3249,11 +3136,6 @@
 .tw-inline-flex{
   display: inline-flex;
 }
-
-.tw-hidden{
-  display: none;
-}
-
 .tw-h-1\.5{
   height: 0.375rem;
 }
@@ -4089,26 +3971,6 @@
   padding-top: 0.5rem !important;
   padding-bottom: 0.5rem !important;
 }
-
-/* Header search — same height as Add KPI / Reset / Export (vendor forces 44px). */
-
-.dashboard-root .dashboard-header-search,
-.dashboard-root .dashboard-header-search-input:not(#dashboard-search-noop) {
-  height: 2rem !important;
-  min-height: 2rem !important;
-  max-height: 2rem !important;
-}
-
-.dashboard-root .dashboard-header-search-input:not(#dashboard-search-noop) {
-  font-size: 12px !important;
-  line-height: 1.25 !important;
-  padding-top: 0 !important;
-  padding-bottom: 0 !important;
-  padding-left: 2rem !important;
-  border-radius: 4px !important;
-  box-sizing: border-box !important;
-}
-
 .dashboard-root .dashboard-header-controls .dashboard-header-btn {
   height: 2rem !important;
   min-height: 2rem !important;
@@ -4142,12 +4004,6 @@
 
 .hover\:tw-text-foreground:hover{
   color: var(--foreground);
-}
-
-@media (min-width: 640px){
-  .sm\:tw-inline-flex{
-    display: inline-flex;
-  }
 }
 
 @media (min-width: 1024px){

--- a/digit-ui-esbuild/products/dashboard/src/styles/input.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/input.css
@@ -381,48 +381,6 @@
   .dashboard-header-controls {
     @apply tw-flex tw-min-w-0 tw-flex-wrap tw-items-center tw-gap-2;
   }
-
-  .dashboard-header-search {
-    @apply tw-relative tw-m-0 tw-inline-flex tw-h-8 tw-shrink-0 tw-items-center;
-  }
-
-  .dashboard-header-search-icon {
-    position: absolute;
-    left: 10px;
-    top: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 16px;
-    height: 16px;
-    color: var(--dashboard-muted-foreground, #6b6860);
-    pointer-events: none;
-    transform: translateY(-50%);
-  }
-
-  .dashboard-header-search-input {
-    @apply tw-box-border tw-m-0 tw-block tw-h-8 tw-w-56 tw-appearance-none tw-rounded-sm tw-border tw-border-border tw-bg-surface tw-py-0 tw-pl-8 tw-pr-3 tw-text-[12px] tw-leading-none tw-text-foreground placeholder:tw-text-muted-foreground focus:tw-border-foreground focus:tw-outline-none;
-    -webkit-appearance: none;
-  }
-
-  /* A global digit-ui input[type=...]:not(.a):not(.b)… rule is !important and its
-     long :not(.class) chain outranks this class, forcing the left padding to
-     ~12px so text slides under the search icon. A no-op :not(#…) lifts this into
-     the ID-specificity column and, with !important, wins. */
-  .dashboard-header-search-input:not(#dashboard-search-noop) {
-    padding-left: 2rem !important;
-  }
-
-  .dashboard-header-search-input::-webkit-search-decoration,
-  .dashboard-header-search-input::-webkit-search-cancel-button {
-    -webkit-appearance: none;
-    appearance: none;
-  }
-
-  .dashboard-header-search-input:focus {
-    box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 15%, transparent);
-  }
-
   .dashboard-header-controls .dashboard-header-btn {
     @apply tw-box-border tw-m-0 tw-inline-flex tw-h-8 tw-min-h-8 tw-max-h-8 tw-shrink-0 tw-items-center tw-justify-center tw-gap-1.5 tw-rounded-sm tw-border tw-border-solid tw-border-border tw-bg-surface tw-px-2.5 tw-py-0 tw-text-[12px] tw-font-medium tw-leading-none tw-text-foreground;
     font-family: inherit;
@@ -954,11 +912,6 @@
     width: 100% !important;
     min-width: 0;
   }
-
-  .dashboard-header-mobile-search {
-    display: none;
-  }
-
   .dashboard-sidebar-backdrop {
     display: none;
   }
@@ -1094,26 +1047,7 @@
 
     .dashboard-header-controls .dashboard-header-btn {
       @apply tw-px-2;
-    }
-
-    .dashboard-header-mobile-search {
-      display: block;
-      border-bottom: 1px solid var(--border);
-      background-color: var(--surface);
-      padding: 0.5rem 0.75rem;
-    }
-
-    .dashboard-header-search--mobile {
-      display: flex !important;
-      width: 100%;
-    }
-
-    .dashboard-header-search--mobile .dashboard-header-search-input {
-      width: 100%;
-      min-width: 0;
-    }
-
-    .dashboard-filters-card {
+    }    .dashboard-filters-card {
       align-items: stretch;
       @apply tw-px-2 tw-py-1.5;
     }
@@ -1163,11 +1097,6 @@
   }
 
   @media (min-width: 640px) and (max-width: 1023px) {
-    .dashboard-header-search-input {
-      @apply tw-w-44;
-      max-width: 100%;
-    }
-
     .dashboard-filters-row {
       row-gap: 0.5rem;
     }
@@ -2336,12 +2265,6 @@
     color: var(--status-breach);
     font-weight: 500;
   }
-
-  .dashboard-search-dimmed {
-    opacity: 0.12;
-    pointer-events: none;
-  }
-
   .dashboard-sla-status-select {
     appearance: none;
     -webkit-appearance: none;
@@ -2655,25 +2578,6 @@
   padding-top: 0.5rem !important;
   padding-bottom: 0.5rem !important;
 }
-
-/* Header search — same height as Add KPI / Reset / Export (vendor forces 44px). */
-.dashboard-root .dashboard-header-search,
-.dashboard-root .dashboard-header-search-input:not(#dashboard-search-noop) {
-  height: 2rem !important;
-  min-height: 2rem !important;
-  max-height: 2rem !important;
-}
-
-.dashboard-root .dashboard-header-search-input:not(#dashboard-search-noop) {
-  font-size: 12px !important;
-  line-height: 1.25 !important;
-  padding-top: 0 !important;
-  padding-bottom: 0 !important;
-  padding-left: 2rem !important;
-  border-radius: 4px !important;
-  box-sizing: border-box !important;
-}
-
 .dashboard-root .dashboard-header-controls .dashboard-header-btn {
   height: 2rem !important;
   min-height: 2rem !important;


### PR DESCRIPTION
Follow-up to #1511.

#1511 removed the dead search box from `frontend/micro-ui/web/src/dashboard/`, but the dashboard is **duplicated** — `digit-ui-esbuild/products/dashboard/` is a parallel copy, and *that* is the one served at `/digit-ui/employee/dashboard`. The mirror was never updated, so the placeholder search input is still live on bomet today.

### Changes
Ports the #1511 removal into the esbuild copy:

- `AdminDashboard.jsx` — drop `searchQuery` state, `matchesSearch`, and the `dashboard-search-dimmed` class application on both widget branches
- `components/DashboardHeader.jsx` — drop `SearchIcon`, the `searchQuery`/`onSearchQueryChange` props, and the search `<label>`
- `components/DashboardLayout.jsx` — drop the prop pass-through
- `styles/dashboard.css`, `styles/input.css` — drop `.dashboard-header-search*`, `.dashboard-search-dimmed`, `.dashboard-header-mobile-search`, and the `.tw-hidden` / `.sm\:tw-inline-flex` utilities that only the search markup used

No behaviour change beyond removing the box — the mirror had no `utils/dashboardSearch.js` (that dead util existed only on the micro-ui side).

### Verification
- `npm run build` in `digit-ui-esbuild/` completes clean
- built bundle contains **0** occurrences of `Search complaints` and **0** `dashboard-header-search` CSS rules (both non-zero before)
- brace balance checked on both stylesheets after the rule deletions; the one `@media (min-width: 640px)` block left empty by the utility removal is pruned

### Note on the duplication
This is the second time a dashboard fix has had to be applied twice. Every change to `frontend/micro-ui/web/src/dashboard/` needs a matching change in `digit-ui-esbuild/products/dashboard/` or it never reaches users. Worth tracking separately — the micro-ui copy is no longer the served one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed dashboard tile search functionality, including search input, icon, filtering, and tile dimming.
  * Simplified the dashboard header by retaining KPI controls, layout reset, and export actions.
  * Removed obsolete responsive and search-related styling while preserving existing tile, drag-and-drop, and layout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->