### PR TITLE
fix(dashboard): make map pins follow the layer toggle and the time window (#1461)

### DIFF
--- a/ansible/nairobi-mdms/mdms/dss/KpiDefinition.json
+++ b/ansible/nairobi-mdms/mdms/dss/KpiDefinition.json
@@ -2232,6 +2232,79 @@
   {
     "tenantId": "ke",
     "data": {
+      "id": "cl_map_complaint_pins_all",
+      "version": "1.0.0",
+      "status": "published",
+      "query": {
+        "grain": "facts",
+        "filters": {
+          "has_geo_pin": true
+        },
+        "dimensions": [
+          "service_request_id",
+          "latitude",
+          "longitude",
+          "ward_code",
+          "service_code",
+          "application_status",
+          "created_date",
+          "source",
+          "sla_status_bucket",
+          "is_open",
+          "is_resolved"
+        ],
+        "measures": [
+          {
+            "name": "total",
+            "agg": "count"
+          }
+        ],
+        "sort": [
+          {
+            "by": "created_date",
+            "dir": "desc"
+          }
+        ],
+        "limit": 1000
+      },
+      "supportsSeries": false,
+      "viz": {
+        "kind": "table",
+        "format": "integer",
+        "valueKey": "total",
+        "accent": "slate",
+        "group": "complaint-landscape",
+        "titleKey": "CMS-DASHBOARD.DASHBOARD_KPI_CL_MAP_COMPLAINT_PINS",
+        "dimensionKey": "service_request_id",
+        "measureKeys": [
+          "total"
+        ],
+        "compose": null,
+        "pii": false,
+        "title": "Complaint locations",
+        "internal": true
+      },
+      "params": [
+        {
+          "name": "window",
+          "default": "last_7d",
+          "allowed": [
+            "last_1d",
+            "last_7d",
+            "last_30d",
+            "wtd",
+            "mtd"
+          ]
+        }
+      ],
+      "rbac": {
+        "visibleTo": []
+      }
+    }
+  },
+  {
+    "tenantId": "ke",
+    "data": {
       "id": "cl_chart_department_flow_ratio",
       "version": "1.0.0",
       "status": "published",

--- a/digit-mcp/src/tools/dashboard-catalog-seed.ts
+++ b/digit-mcp/src/tools/dashboard-catalog-seed.ts
@@ -2527,6 +2527,76 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
     }
   },
   {
+    "id": "cl_map_complaint_pins_all",
+    "version": "1.0.0",
+    "status": "published",
+    "query": {
+      "grain": "facts",
+      "filters": {
+        "has_geo_pin": true
+      },
+      "dimensions": [
+        "service_request_id",
+        "latitude",
+        "longitude",
+        "ward_code",
+        "service_code",
+        "application_status",
+        "created_date",
+        "source",
+        "sla_status_bucket",
+        "is_open",
+        "is_resolved"
+      ],
+      "measures": [
+        {
+          "name": "total",
+          "agg": "count"
+        }
+      ],
+      "sort": [
+        {
+          "by": "created_date",
+          "dir": "desc"
+        }
+      ],
+      "limit": 1000
+    },
+    "supportsSeries": false,
+    "viz": {
+      "kind": "table",
+      "format": "integer",
+      "valueKey": "total",
+      "accent": "slate",
+      "group": "complaint-landscape",
+      "titleKey": "CMS-DASHBOARD.DASHBOARD_KPI_CL_MAP_COMPLAINT_PINS",
+      "dimensionKey": "service_request_id",
+      "measureKeys": [
+        "total"
+      ],
+      "compose": null,
+      "pii": false,
+      "title": "Complaint locations",
+      "internal": true
+    },
+    "params": [
+      {
+        "name": "window",
+        "default": "last_7d",
+        "allowed": [
+          "last_1d",
+          "last_7d",
+          "last_30d",
+          "wtd",
+          "mtd"
+        ]
+      }
+    ],
+    "rbac": {
+      "visibleTo": []
+    }
+  },
+  {
     "id": "cl_chart_department_flow_ratio",
     "version": "1.0.0",
     "status": "published",

--- a/digit-mcp/src/tools/dashboard-l10n-seed.ts
+++ b/digit-mcp/src/tools/dashboard-l10n-seed.ts
@@ -870,6 +870,46 @@ export const DASHBOARD_L10N_MESSAGES: { code: string; message: string; module: s
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_COVERAGE_OF",
+    "message": " of ",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_COVERAGE_SUFFIX",
+    "message": " shown on the map (rest have no location)",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_CREATED",
+    "message": "Pins: complaints filed",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_OPEN",
+    "message": "Pins: complaints still open",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_OPEN_ONLY",
+    "message": "Pins: complaints still open — pins do not follow this layer",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_RESOLVED",
+    "message": "Pins: complaints resolved",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_TRUNCATED",
+    "message": "Showing the most recent 1,000 only",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_UNMAPPED",
+    "message": " complaints have no ward and are not mapped",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "DASHBOARD_MAP_LEGEND_TITLE",
     "message": "Map legend",
     "module": "rainmaker-dashboard"
@@ -2421,6 +2461,46 @@ export const DASHBOARD_L10N_MESSAGES_PT_PT: { code: string; message: string; mod
   {
     "code": "DASHBOARD_MAP_LEGEND_PCT_LTE_20",
     "message": "≤ 20%",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_COVERAGE_OF",
+    "message": " de ",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_COVERAGE_SUFFIX",
+    "message": " apresentados no mapa (os restantes não têm localização)",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_CREATED",
+    "message": "Marcadores: reclamações registadas",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_OPEN",
+    "message": "Marcadores: reclamações ainda em aberto",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_OPEN_ONLY",
+    "message": "Marcadores: reclamações ainda em aberto — os marcadores não acompanham esta camada",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_RESOLVED",
+    "message": "Marcadores: reclamações resolvidas",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_TRUNCATED",
+    "message": "A mostrar apenas as 1000 mais recentes",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_UNMAPPED",
+    "message": " reclamações não têm bairro e não são mapeadas",
     "module": "rainmaker-dashboard"
   },
   {

--- a/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
@@ -41,6 +41,7 @@ import {
   isMapKind,
   buildRefs,
   buildRefsKey,
+  PIN_ROW_CAP,
 } from "./utils/queryPlan";
 import {
   hierLevelParam,
@@ -297,10 +298,23 @@ function assembleResult(kpiId, def, results) {
   if (isMapKind(viz.kind)) {
     const pinRes = results?.[`${kpiId}__pins`];
     if (pinRes?.rows?.length) {
+      // Whether the pin source projects the open/resolved state at all. The
+      // legacy def (cl_map_complaint_pins) does not — its rows are open-only —
+      // so the UI must fall back to "pins do not follow this layer" rather than
+      // silently classing every pin as neither open nor resolved.
+      assembled.pinsStatusKnown = (pinRes.columns || []).some(
+        (c) => (typeof c === "string" ? c : c?.name) === "is_open"
+      );
+      // The server clamps every query at AnalyticsPlanner.MAX_LIMIT, so a
+      // result exactly at the cap is indistinguishable from a truncated one.
+      assembled.pinsTruncated = pinRes.rows.length >= PIN_ROW_CAP;
       assembled.pins = pinRes.rows
         .map((r) => ({
           id: r.service_request_id,
           serviceRequestId: r.service_request_id,
+          // Booleans arrive as true/"true" depending on the JDBC/JSON path.
+          isOpen: r.is_open === true || r.is_open === "true",
+          isResolved: r.is_resolved === true || r.is_resolved === "true",
           // Kajal's resolveComplaintPinPositions needs wardCode to place a pin
           // (snaps/jitters around the ward centroid when the geo-pin is unusable).
           wardCode: String(r.ward_code ?? ""),

--- a/digit-ui-esbuild/products/dashboard/src/components/GeographyChoroplethMap.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/GeographyChoroplethMap.jsx
@@ -5,6 +5,8 @@ import {
   getGeographyMapLegend,
   getGeographyMapLegendFooter,
   getGeographyMapLegendTitle,
+  getGeographyMapPinLegendEntry,
+  getGeographyMapPinStyle,
   getCreatedCountFillStyle,
   buildCreatedCountScale,
   getOpenShareFillStyle,
@@ -95,15 +97,16 @@ const MAP_SUBCOUNTY_MAX_ZOOM = 12; // below -> sub-counties; at/above -> wards
 function resolveFeatureStyle(feature, layerMode, focusedCode, zoom = 11, createdBuckets) {
   const props = feature?.properties ?? {};
   const isFocused = focusedCode && props.code === focusedCode;
+  // `filed` gates the share layers on the white "No complaints" swatch: a ward
+  // with nothing filed has a 0% share, which would otherwise paint like a ward
+  // that has complaints but none open/resolved.
+  const filed = Number(props.count) || Number(props.created) || 0;
   const base =
     layerMode === "open"
-      ? getOpenShareFillStyle(props.openPct)
+      ? getOpenShareFillStyle(props.openPct, filed)
       : layerMode === "resolved"
-        ? getResolvedShareFillStyle(props.resolvedPct)
-        : getCreatedCountFillStyle(
-            Number(props.count) || Number(props.created) || 0,
-            createdBuckets
-          );
+        ? getResolvedShareFillStyle(props.resolvedPct, filed)
+        : getCreatedCountFillStyle(filed, createdBuckets);
 
   const weight = isFocused ? 2.5 : zoom < 11 ? 0.75 : zoom < 14 ? 1.1 : 1.5;
 
@@ -164,6 +167,12 @@ const GeographyChoroplethMap = ({
   onLayerModeChange,
   layerOptions = [],
   cityLabel = getMapCityLabel(),
+  // Pin provenance for the legend row: 'per-layer' when the pin source projects
+  // is_open/is_resolved, 'open-only' on a tenant still serving the legacy def.
+  pinSemantics = "open-only",
+  pinsTruncated = false,
+  layerTotal = 0,
+  unmappedTotal = 0,
 }) => {
   const { t, language } = useDashboardT();
   const shellRef = useRef(null);
@@ -345,6 +354,29 @@ const GeographyChoroplethMap = ({
     () => getGeographyMapLegend(layerMode, createdBuckets),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [layerMode, language, createdScaleKey, getNumberFormatStamp()]
+  );
+  // Kept OUT of legendItems on purpose: that array is a colour scale scanned by
+  // range (getCreatedCountBucket), so the pin row renders as its own <li> below.
+  const pinLegendEntry = useMemo(
+    () =>
+      getGeographyMapPinLegendEntry(layerMode, {
+        shown: complaintPins.length,
+        total: layerTotal,
+        semantics: pinSemantics,
+        truncated: pinsTruncated,
+        unmapped: unmappedTotal,
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      layerMode,
+      complaintPins.length,
+      layerTotal,
+      pinSemantics,
+      pinsTruncated,
+      unmappedTotal,
+      language,
+      getNumberFormatStamp(),
+    ]
   );
   const legendTitle = getGeographyMapLegendTitle(layerMode);
   const legendFooter = getGeographyMapLegendFooter(drillTrail.length);
@@ -675,6 +707,9 @@ const GeographyChoroplethMap = ({
     }
 
     const currentZoom = zoomLevelRef.current;
+    // Pins carry the LAYER's colour (slate filed / amber open / green resolved),
+    // so a pin can never read as "open" while sitting on the Resolved layer.
+    const pinStyle = getGeographyMapPinStyle(layerMode);
 
     visibleComplaintPins.forEach((pin) => {
       if (pin.lat == null || pin.lng == null) return;
@@ -687,9 +722,9 @@ const GeographyChoroplethMap = ({
         renderer: pinRendererRef.current ?? undefined,
         pane: "complaintPins",
         radius: baseRadius,
-        color: "#b45309",
+        color: pinStyle.stroke,
         weight: 1.5,
-        fillColor: "#f59e0b",
+        fillColor: pinStyle.fill,
         fillOpacity: 0.92,
       });
 
@@ -750,7 +785,9 @@ const GeographyChoroplethMap = ({
     }
     // `language` dep: popup content is baked at bind time — rebuild pins on
     // language switch so pin tooltips re-render localized (#882 precedent).
-  }, [visibleComplaintPins, language]);
+    // `layerMode`: pin colour follows the layer. (The pin ARRAY also changes per
+    // layer, but not on an 'open-only' catalog where all three are identical.)
+  }, [visibleComplaintPins, language, layerMode]);
 
   // ── initial fit ───────────────────────────────────────────────────────────
   useEffect(() => {
@@ -962,6 +999,26 @@ const GeographyChoroplethMap = ({
                     </span>
                   </li>
                 ))}
+                <li className="dashboard-map-legend-pin-row tw-flex tw-items-start tw-gap-2 tw-border-t tw-border-border tw-pt-1.5">
+                  <span
+                    className="dashboard-map-legend-swatch dashboard-map-legend-swatch--pin"
+                    style={{
+                      backgroundColor: pinLegendEntry.swatch.fill,
+                      borderColor: pinLegendEntry.swatch.stroke,
+                      borderRadius: "9999px",
+                    }}
+                  />
+                  <span className="tw-flex tw-flex-col tw-gap-0.5">
+                    <span className="tw-text-[10px] tw-leading-tight tw-text-foreground">
+                      {pinLegendEntry.label}
+                    </span>
+                    {pinLegendEntry.note ? (
+                      <span className="tw-text-[9px] tw-leading-tight tw-text-muted-foreground">
+                        {pinLegendEntry.note}
+                      </span>
+                    ) : null}
+                  </span>
+                </li>
               </ul>
               <p className="tw-border-t tw-border-border tw-px-2.5 tw-py-2 tw-text-[9px] tw-leading-snug tw-text-muted-foreground">
                 {legendFooter}

--- a/digit-ui-esbuild/products/dashboard/src/components/KpiTile.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/KpiTile.jsx
@@ -12,6 +12,11 @@ import OpenComplaintsByGeographyWidget from './OpenComplaintsByGeographyWidget';
 import { evaluateCompose } from '../utils/composeKpi';
 import { applyGroupByToColumns } from '../utils/hierLevelGrouping';
 import { formatNumber } from '../utils/numberFormat';
+import {
+  GEO_MAP_LAYER_KEYS,
+  partitionPinsByLayer,
+  summarizeWardRows,
+} from '../utils/complaintPins';
 import { getNumberTileDeltaClass, formatOfficerLabel, dimensionKindForName } from '../config/kpiDisplay';
 import {
   resolveSlaRiskPresentation,
@@ -867,12 +872,11 @@ function renderSlaRiskTable(ctx) {
 // Her widget fetches its own ward geometry and toggles created/open/resolved
 // layers; it reads layers[layerKey] (ward series), layers.wardDetails, and
 // layers.complaintPinsByLayer[layerKey]. We shape the tile's ward aggregate +
-// the companion pin source into that contract. (Per-layer distinct counts —
-// created vs open vs resolved — is a refinement; today every layer shows the
-// tile's aggregate so the toggle always renders data.)
+// the companion pin source into that contract. The ward series carries all
+// three counts so any layer renders; the PINS are now partitioned per layer
+// (previously the same open-only array was pinned to all three, so the Resolved
+// layer shaded "0 resolved" underneath still-open complaints).
 // ---------------------------------------------------------------------------
-
-const GEO_MAP_LAYER_KEYS = ['created', 'open', 'resolved'];
 
 function adaptMapLayers(ctx) {
   const { viz, result } = ctx;
@@ -904,17 +908,42 @@ function adaptMapLayers(ctx) {
       };
     });
   const pins = result.pins || [];
-  const layers = { wardDetails: {}, complaintPinsByLayer: {}, complaintPinsError: null };
+  const statusKnown = result.pinsStatusKnown === true;
+  const { layerTotals, unmapped } = summarizeWardRows(result.rows || [], dimKey);
+  const layers = {
+    wardDetails: {},
+    complaintPinsByLayer: partitionPinsByLayer(pins, statusKnown),
+    complaintPinsError: null,
+    // 'open-only' = the tenant's catalog still has the legacy pin def, so pins
+    // cannot follow the layer; the legend says so instead of lying by omission.
+    pinSemantics: statusKnown ? 'per-layer' : 'open-only',
+    pinsTruncated: result.pinsTruncated === true,
+    layerTotals,
+    unmapped,
+  };
   for (const key of GEO_MAP_LAYER_KEYS) {
     layers[key] = wards;
-    layers.complaintPinsByLayer[key] = pins;
   }
   return layers;
 }
 
+/**
+ * The map branch is memoized on its own inputs: adaptMapLayers re-derives fresh
+ * ward/pin ARRAYS on every parent render, and the Leaflet pin effect keys off
+ * that identity — so an unmemoized call tore down and rebuilt up to 1,000
+ * circle markers (closing any open popup) on every unrelated re-render.
+ */
+function MapTile({ ctx, loading }) {
+  const layers = React.useMemo(
+    () => adaptMapLayers(ctx),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [ctx.result, ctx.viz, ctx.locale]
+  );
+  return <OpenComplaintsByGeographyWidget layers={layers} loading={loading} />;
+}
+
 function renderChoroplethMap(ctx) {
-  const { loading } = ctx;
-  return <OpenComplaintsByGeographyWidget layers={adaptMapLayers(ctx)} loading={loading} />;
+  return <MapTile ctx={ctx} loading={ctx.loading} />;
 }
 
 // ---------------------------------------------------------------------------

--- a/digit-ui-esbuild/products/dashboard/src/components/OpenComplaintsByGeographyWidget.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/OpenComplaintsByGeographyWidget.jsx
@@ -43,6 +43,16 @@ const OpenComplaintsByGeographyWidget = ({ layers, loading = false }) => {
     }));
   }, [layers, resolvedLayer]);
 
+  const pinSemantics = layers?.pinSemantics ?? "open-only";
+  const pinLayerKey = pinSemantics === "open-only" ? "open" : resolvedLayer;
+  const totals = layers?.layerTotals ?? {};
+  const pinLayerTotal =
+    (pinLayerKey === "open"
+      ? totals.open
+      : pinLayerKey === "resolved"
+        ? totals.resolved
+        : totals.filed) ?? 0;
+
   if (loading && !wardCounts.length) {
     return (
       <div className="tw-flex tw-h-full tw-min-h-[220px] tw-items-center tw-justify-center tw-p-4 tw-text-[12px] tw-text-muted-foreground">
@@ -64,6 +74,15 @@ const OpenComplaintsByGeographyWidget = ({ layers, loading = false }) => {
         wardCounts={wardCounts}
         complaintPins={layers?.complaintPinsByLayer?.[resolvedLayer] ?? []}
         complaintPinsError={layers?.complaintPinsError ?? null}
+        pinSemantics={pinSemantics}
+        pinsTruncated={layers?.pinsTruncated ?? false}
+        // The layer's own denominator: how many complaints the pins on THIS
+        // layer are drawn from, so the legend can state pin coverage honestly.
+        // In 'open-only' mode the pins mean "open" on every layer, so the
+        // denominator must stay the open count or the coverage line would
+        // compare open pins against filed complaints.
+        layerTotal={pinLayerTotal}
+        unmappedTotal={layers?.unmapped?.filed ?? 0}
         layerMode={resolvedLayer}
         onLayerModeChange={setActiveLayer}
         layerOptions={layerOptions}

--- a/digit-ui-esbuild/products/dashboard/src/config/geographyMapPresentation.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/geographyMapPresentation.js
@@ -218,6 +218,88 @@ export function getGeographyMapLegend(layerId, createdBuckets = CREATED_COUNT_LE
   return legend.map((bucket) => ({ ...bucket, label: localizeLegendBucketLabel(bucket.label) }));
 }
 
+/**
+ * Pin colours, one per layer. DELIBERATELY not part of any legend array:
+ * getGeographyMapLegend returns a colour SCALE that getCreatedCountBucket scans
+ * by range, so an extra entry in there would corrupt bucket classification.
+ * The pin row is rendered as a separate <li> below the scale.
+ */
+export const GEOGRAPHY_MAP_PIN_STYLES = {
+  created: { fill: "#475569", stroke: "#334155" },
+  open: { fill: "#f59e0b", stroke: "#b45309" },
+  resolved: { fill: "#16a34a", stroke: "#15803d" },
+};
+
+export function getGeographyMapPinStyle(layerId) {
+  return GEOGRAPHY_MAP_PIN_STYLES[layerId] || GEOGRAPHY_MAP_PIN_STYLES.created;
+}
+
+const pinNum = (value) => {
+  const n = Number(value) || 0;
+  return formatNumber(n, { decimals: 0 }) ?? String(n);
+};
+
+/**
+ * The pin legend row: what the pins on the CURRENT layer mean, plus the honesty
+ * notes (how many of the layer's complaints actually carry a location, whether
+ * the row cap truncated them, and how many complaints have no ward at all and
+ * are therefore not on the map anywhere).
+ *
+ * @param {GeographyMapLayerId} layerId
+ * @param {{shown?: number, total?: number, semantics?: 'per-layer'|'open-only',
+ *          truncated?: boolean, unmapped?: number}} pins
+ * @returns {{swatch: {fill: string, stroke: string}, label: string, note: string}}
+ */
+export function getGeographyMapPinLegendEntry(layerId, pins = {}) {
+  const semantics = pins.semantics === "open-only" ? "open-only" : "per-layer";
+  // Old catalog + new UI: pins are still hard-filtered to open complaints, so
+  // they cannot follow the toggle. Say that on EVERY layer rather than
+  // mislabelling open complaints as "filed" or "resolved".
+  const label =
+    semantics === "open-only"
+      ? t(
+          "DASHBOARD_MAP_LEGEND_PINS_OPEN_ONLY",
+          "Pins: complaints still open — pins do not follow this layer"
+        )
+      : layerId === "open"
+        ? t("DASHBOARD_MAP_LEGEND_PINS_OPEN", "Pins: complaints still open")
+        : layerId === "resolved"
+          ? t("DASHBOARD_MAP_LEGEND_PINS_RESOLVED", "Pins: complaints resolved")
+          : t("DASHBOARD_MAP_LEGEND_PINS_CREATED", "Pins: complaints filed");
+
+  // No interpolation in the message store — compose by concatenation, the same
+  // pattern as getGeographyMapLegendFooter.
+  const notes = [];
+  const total = Number(pins.total) || 0;
+  if (total > 0) {
+    notes.push(
+      pinNum(pins.shown) +
+        t("DASHBOARD_MAP_LEGEND_PINS_COVERAGE_OF", " of ") +
+        pinNum(total) +
+        t(
+          "DASHBOARD_MAP_LEGEND_PINS_COVERAGE_SUFFIX",
+          " shown on the map (rest have no location)"
+        )
+    );
+  }
+  if (pins.truncated) {
+    notes.push(
+      t("DASHBOARD_MAP_LEGEND_PINS_TRUNCATED", "Showing the most recent 1,000 only")
+    );
+  }
+  if (Number(pins.unmapped) > 0) {
+    notes.push(
+      pinNum(pins.unmapped) +
+        t(
+          "DASHBOARD_MAP_LEGEND_PINS_UNMAPPED",
+          " complaints have no ward and are not mapped"
+        )
+    );
+  }
+
+  return { swatch: getGeographyMapPinStyle(layerId), label, note: notes.join(" · ") };
+}
+
 export function getGeographyMapLegendTitle(layerId) {
   if (layerId === "open") return t("DASHBOARD_MAP_LEGEND_TITLE_OPEN", "% Open");
   if (layerId === "resolved") return t("DASHBOARD_MAP_LEGEND_TITLE_RESOLVED", "% Resolved");
@@ -265,7 +347,14 @@ export function getCreatedCountBucket(count, buckets = CREATED_COUNT_LEGEND) {
   return scale[scale.length - 1];
 }
 
-export function getSharePctBucket(pct, legend) {
+/**
+ * `filed` is passed so a ward with NO complaints gets the white "No complaints"
+ * swatch. Both share layers compute pct as 0 when filed is 0, and pct 0 maps to
+ * legend[1] ("0%") — so the white swatch was unreachable and an empty ward
+ * painted identically to one with complaints but none resolved.
+ */
+export function getSharePctBucket(pct, legend, filed) {
+  if (filed !== undefined && !(Number(filed) > 0)) return legend[0];
   const value = Number(pct);
   if (!Number.isFinite(value) || value < 0) return legend[0];
   if (value === 0) return legend[1];
@@ -280,12 +369,12 @@ export function getCreatedCountFillStyle(count, buckets = CREATED_COUNT_LEGEND) 
   return bucketToFillStyle(getCreatedCountBucket(count, buckets));
 }
 
-export function getOpenShareFillStyle(openPct) {
-  return bucketToFillStyle(getSharePctBucket(openPct, OPEN_SHARE_LEGEND));
+export function getOpenShareFillStyle(openPct, filed) {
+  return bucketToFillStyle(getSharePctBucket(openPct, OPEN_SHARE_LEGEND, filed));
 }
 
-export function getResolvedShareFillStyle(resolvedPct) {
-  return bucketToFillStyle(getSharePctBucket(resolvedPct, RESOLVED_SHARE_LEGEND));
+export function getResolvedShareFillStyle(resolvedPct, filed) {
+  return bucketToFillStyle(getSharePctBucket(resolvedPct, RESOLVED_SHARE_LEGEND, filed));
 }
 
 /** @deprecated Legacy WoW styling — map uses created/open/resolved layers only. */

--- a/digit-ui-esbuild/products/dashboard/src/config/geographyMapPresentation.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/geographyMapPresentation.test.js
@@ -36,6 +36,13 @@ const {
   buildCreatedCountScale,
   getCreatedCountBucket,
   getGeographyMapLegend,
+  getGeographyMapPinLegendEntry,
+  getSharePctBucket,
+  getOpenShareFillStyle,
+  getResolvedShareFillStyle,
+  OPEN_SHARE_LEGEND,
+  RESOLVED_SHARE_LEGEND,
+  GEOGRAPHY_MAP_PIN_STYLES,
   CREATED_COUNT_RAMP,
   MAX_CREATED_COUNT_BUCKETS,
 } = require(OUT);
@@ -171,4 +178,106 @@ test("the created legend reflects the computed scale", () => {
   const legend = getGeographyMapLegend("created", buckets);
   assert.equal(legend.length, buckets.length);
   assert.equal(legend[legend.length - 1].label, "501+");
+});
+
+/* ------------------------------------------------------------------ */
+/* A ward with nothing filed must reach the white swatch               */
+/* ------------------------------------------------------------------ */
+
+test("zero filed complaints paints the white 'No complaints' swatch, not 0%", () => {
+  // Both share layers compute pct = 0 when filed is 0, and pct 0 used to map to
+  // legend[1] ("0%") — so an empty ward looked like a ward with complaints and
+  // none open/resolved, and the white swatch was unreachable.
+  for (const legend of [OPEN_SHARE_LEGEND, RESOLVED_SHARE_LEGEND]) {
+    assert.equal(getSharePctBucket(0, legend, 0).id, "none");
+    assert.equal(getSharePctBucket(0, legend, undefined).id, "p0", "legacy call site unchanged");
+    assert.equal(getSharePctBucket(0, legend, 4).id, "p0", "filed>0 with 0% stays 0%");
+    assert.equal(getSharePctBucket(35, legend, 20).id, "p40");
+  }
+  assert.equal(getOpenShareFillStyle(0, 0).fillColor, OPEN_SHARE_LEGEND[0].fill);
+  assert.notEqual(getOpenShareFillStyle(0, 3).fillColor, OPEN_SHARE_LEGEND[0].fill);
+  assert.equal(getResolvedShareFillStyle(0, 0).fillColor, RESOLVED_SHARE_LEGEND[0].fill);
+});
+
+/* ------------------------------------------------------------------ */
+/* The pin legend row (separate from the colour scale on purpose)      */
+/* ------------------------------------------------------------------ */
+
+test("the pin entry is NOT part of the colour scale", () => {
+  // getCreatedCountBucket range-scans getGeographyMapLegend's array; a pin entry
+  // inside it would corrupt bucket classification.
+  const { buckets } = buildCreatedCountScale([1250]);
+  for (const layer of ["created", "open", "resolved"]) {
+    for (const item of getGeographyMapLegend(layer, buckets)) {
+      assert.ok(!/pin/i.test(item.id), `legend scale leaked a pin entry: ${item.id}`);
+    }
+  }
+});
+
+// NOTE ON EXPECTED STRINGS: translate() renders the RAW KEY when no message
+// store is primed (localeRuntime has no test seam), so these assert the CODE
+// each branch selects — the English literals in the source are the seeded
+// fallbacks, verified by the l10n pack, not by this file.
+
+test("pin label and swatch follow the layer under per-layer semantics", () => {
+  const of = (layer) => getGeographyMapPinLegendEntry(layer, { semantics: "per-layer" });
+  assert.equal(of("created").label, "DASHBOARD_MAP_LEGEND_PINS_CREATED");
+  assert.equal(of("open").label, "DASHBOARD_MAP_LEGEND_PINS_OPEN");
+  assert.equal(of("resolved").label, "DASHBOARD_MAP_LEGEND_PINS_RESOLVED");
+  assert.deepEqual(of("created").swatch, GEOGRAPHY_MAP_PIN_STYLES.created);
+  assert.deepEqual(of("open").swatch, GEOGRAPHY_MAP_PIN_STYLES.open);
+  assert.deepEqual(of("resolved").swatch, GEOGRAPHY_MAP_PIN_STYLES.resolved);
+  // Every layer must be visually distinguishable.
+  assert.equal(new Set(["created", "open", "resolved"].map((l) => of(l).swatch.fill)).size, 3);
+  // Unknown / missing layer degrades to the Created styling rather than throwing.
+  assert.deepEqual(
+    getGeographyMapPinLegendEntry(undefined, {}).swatch,
+    GEOGRAPHY_MAP_PIN_STYLES.created
+  );
+});
+
+test("open-only semantics says so on EVERY layer", () => {
+  for (const layer of ["created", "open", "resolved"]) {
+    const entry = getGeographyMapPinLegendEntry(layer, { semantics: "open-only" });
+    assert.equal(entry.label, "DASHBOARD_MAP_LEGEND_PINS_OPEN_ONLY");
+  }
+  // Anything that is not exactly 'open-only' is treated as per-layer.
+  assert.equal(
+    getGeographyMapPinLegendEntry("open", { semantics: "nonsense" }).label,
+    "DASHBOARD_MAP_LEGEND_PINS_OPEN"
+  );
+});
+
+test("the coverage note is composed by concatenation, never interpolation", () => {
+  const entry = getGeographyMapPinLegendEntry("created", {
+    semantics: "per-layer",
+    shown: 42,
+    total: 137,
+  });
+  assert.equal(
+    entry.note,
+    "42DASHBOARD_MAP_LEGEND_PINS_COVERAGE_OF137DASHBOARD_MAP_LEGEND_PINS_COVERAGE_SUFFIX"
+  );
+  assert.ok(!/\{|\}|%s/.test(entry.note), "no interpolation placeholders");
+  // Nothing to compare against -> no note at all rather than "0 of 0".
+  assert.equal(getGeographyMapPinLegendEntry("created", { shown: 0, total: 0 }).note, "");
+});
+
+test("truncation and unmapped complaints are surfaced, not swallowed", () => {
+  const entry = getGeographyMapPinLegendEntry("open", {
+    semantics: "per-layer",
+    shown: 1000,
+    total: 4200,
+    truncated: true,
+    unmapped: 17,
+  });
+  assert.deepEqual(entry.note.split(" \u00b7 "), [
+    "1000DASHBOARD_MAP_LEGEND_PINS_COVERAGE_OF4200DASHBOARD_MAP_LEGEND_PINS_COVERAGE_SUFFIX",
+    "DASHBOARD_MAP_LEGEND_PINS_TRUNCATED",
+    "17DASHBOARD_MAP_LEGEND_PINS_UNMAPPED",
+  ]);
+  // No cap hit, nothing unmapped -> just the coverage line.
+  const clean = getGeographyMapPinLegendEntry("open", { shown: 3, total: 4, unmapped: 0 });
+  assert.equal(clean.note.includes("TRUNCATED"), false);
+  assert.equal(clean.note.includes("UNMAPPED"), false);
 });

--- a/digit-ui-esbuild/products/dashboard/src/utils/complaintPins.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/complaintPins.js
@@ -1,0 +1,64 @@
+/**
+ * Per-layer partitioning of the map's complaint pins.
+ *
+ * The choropleth toggles between Created / Open / Resolved, but the pin overlay
+ * used to show ONE set of pins on all three layers — and that set was hard
+ * filtered to `is_open` by the pin KPI itself, so the Resolved layer shaded
+ * "0 resolved" underneath a scatter of still-open complaints.
+ *
+ * Lives in its own module (rather than inside KpiTile.jsx) so it is pure and
+ * unit-testable without bundling a React tree, matching the other utils/ here.
+ */
+
+export const GEO_MAP_LAYER_KEYS = ["created", "open", "resolved"];
+
+/**
+ * Split pins into the three map layers.
+ *
+ *   created  — every pin in the window (a complaint filed IS a pin)
+ *   open     — pins whose complaint is still open
+ *   resolved — pins whose complaint is resolved
+ *
+ * `statusKnown === false` means the pin source does not project is_open /
+ * is_resolved (the legacy cl_map_complaint_pins def, which is open-only). There
+ * is no honest way to partition those, so we keep the legacy behaviour — the
+ * same array on all three layers — and the caller labels it 'open-only' in the
+ * legend so the reader is not misled.
+ *
+ * @param {Array<object>} pins
+ * @param {boolean} statusKnown
+ * @returns {{created: object[], open: object[], resolved: object[]}}
+ */
+export function partitionPinsByLayer(pins, statusKnown) {
+  const all = Array.isArray(pins) ? pins : [];
+  if (!statusKnown) return { created: all, open: all, resolved: all };
+  return {
+    created: all,
+    open: all.filter((pin) => pin?.isOpen === true),
+    resolved: all.filter((pin) => pin?.isResolved === true),
+  };
+}
+
+/**
+ * Totals over the ward series, plus the counts that the ward mapper DROPS
+ * (rows with a null/blank ward code). Those complaints are real and counted by
+ * every card on the dashboard; silently discarding them made the map's numbers
+ * disagree with the cards with no explanation on screen.
+ *
+ * @param {Array<object>} rows raw result rows
+ * @param {string} dimKey the ward dimension column
+ * @returns {{layerTotals: {filed:number,open:number,resolved:number},
+ *            unmapped: {filed:number,open:number,resolved:number}}}
+ */
+export function summarizeWardRows(rows, dimKey) {
+  const layerTotals = { filed: 0, open: 0, resolved: 0 };
+  const unmapped = { filed: 0, open: 0, resolved: 0 };
+  for (const row of Array.isArray(rows) ? rows : []) {
+    const code = String(row?.[dimKey] ?? "").trim();
+    const bucket = code && code !== "null" ? layerTotals : unmapped;
+    bucket.filed += Number(row?.filed) || 0;
+    bucket.open += Number(row?.open) || 0;
+    bucket.resolved += Number(row?.resolved) || 0;
+  }
+  return { layerTotals, unmapped };
+}

--- a/digit-ui-esbuild/products/dashboard/src/utils/complaintPins.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/complaintPins.test.js
@@ -1,0 +1,145 @@
+// Per-layer map pins: partitioning + the ward totals the map used to discard.
+// Run from digit-ui-esbuild/:  node --test products/dashboard/src/utils/complaintPins.test.js
+//
+// Same idiom as hierLevelGrouping.test.js / dashboardMetrics.test.js: the module
+// under test is ESM, so it is bundled to CJS with the repo's own esbuild.
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const esbuild = require("esbuild");
+
+function bundle(entry) {
+  const out = path.join(os.tmpdir(), `${path.basename(entry, ".js")}.cjs.${process.pid}.js`);
+  esbuild.buildSync({
+    entryPoints: [path.join(__dirname, entry)],
+    bundle: true,
+    format: "cjs",
+    platform: "neutral",
+    outfile: out,
+  });
+  process.on("exit", () => {
+    try {
+      fs.unlinkSync(out);
+    } catch (e) {
+      /* already gone */
+    }
+  });
+  return require(out);
+}
+
+const { partitionPinsByLayer, summarizeWardRows, GEO_MAP_LAYER_KEYS } =
+  bundle("complaintPins.js");
+const { resolvePinKpiId, buildRefs, buildRefsKey, PIN_KPI_ID, PIN_KPI_ID_ALL, PIN_ROW_CAP } =
+  bundle("queryPlan.js");
+
+const PINS = [
+  { id: "a", isOpen: true, isResolved: false },
+  { id: "b", isOpen: false, isResolved: true },
+  { id: "c", isOpen: false, isResolved: false }, // e.g. rejected/withdrawn
+  { id: "d", isOpen: true, isResolved: false },
+];
+
+/* ------------------------------------------------------------------ */
+/* partitionPinsByLayer — the QA ticket                                */
+/* ------------------------------------------------------------------ */
+
+test("per-layer semantics: each layer gets its own pins", () => {
+  const byLayer = partitionPinsByLayer(PINS, true);
+  assert.deepEqual(byLayer.created.map((p) => p.id), ["a", "b", "c", "d"]);
+  assert.deepEqual(byLayer.open.map((p) => p.id), ["a", "d"]);
+  // The bug: the Resolved layer shaded "0 resolved" underneath OPEN pins.
+  assert.deepEqual(byLayer.resolved.map((p) => p.id), ["b"]);
+});
+
+test("a complaint that is neither open nor resolved appears only under Created", () => {
+  const byLayer = partitionPinsByLayer([{ id: "c", isOpen: false, isResolved: false }], true);
+  assert.equal(byLayer.created.length, 1);
+  assert.equal(byLayer.open.length, 0);
+  assert.equal(byLayer.resolved.length, 0);
+});
+
+test("open-only semantics: legacy behaviour — the same array on all three layers", () => {
+  // The legacy pin def projects no is_open/is_resolved, so nothing can be
+  // partitioned; the UI labels this mode instead of guessing.
+  const byLayer = partitionPinsByLayer(PINS, false);
+  for (const key of GEO_MAP_LAYER_KEYS) {
+    assert.equal(byLayer[key], PINS, `layer ${key} must reuse the source array`);
+  }
+});
+
+test("partitioning is total: junk in, empty layers out", () => {
+  for (const input of [null, undefined, "nope", 7]) {
+    const byLayer = partitionPinsByLayer(input, true);
+    for (const key of GEO_MAP_LAYER_KEYS) assert.deepEqual(byLayer[key], []);
+  }
+  // Missing flags never count as open/resolved.
+  const byLayer = partitionPinsByLayer([{ id: "x" }, null], true);
+  assert.equal(byLayer.created.length, 2);
+  assert.equal(byLayer.open.length, 0);
+  assert.equal(byLayer.resolved.length, 0);
+});
+
+/* ------------------------------------------------------------------ */
+/* summarizeWardRows — the counts the map silently dropped             */
+/* ------------------------------------------------------------------ */
+
+test("ward totals split mapped wards from the ward-less rows the map drops", () => {
+  const rows = [
+    { ward_code: "W1", filed: 10, open: 4, resolved: 5 },
+    { ward_code: "W2", filed: 5, open: 1, resolved: 4 },
+    { ward_code: null, filed: 3, open: 2, resolved: 1 },
+    { ward_code: "null", filed: 2, open: 2, resolved: 0 },
+    { ward_code: "  ", filed: 1, open: 0, resolved: 1 },
+  ];
+  const { layerTotals, unmapped } = summarizeWardRows(rows, "ward_code");
+  assert.deepEqual(layerTotals, { filed: 15, open: 5, resolved: 9 });
+  assert.deepEqual(unmapped, { filed: 6, open: 4, resolved: 2 });
+});
+
+test("ward totals are total over garbage input", () => {
+  assert.deepEqual(summarizeWardRows(null, "ward_code").layerTotals, {
+    filed: 0,
+    open: 0,
+    resolved: 0,
+  });
+  const { layerTotals } = summarizeWardRows([{ ward_code: "W1", filed: "12" }], "ward_code");
+  assert.equal(layerTotals.filed, 12, "numeric strings coerce");
+});
+
+/* ------------------------------------------------------------------ */
+/* resolvePinKpiId — the catalog fallback                              */
+/* ------------------------------------------------------------------ */
+
+test("the per-layer pin def wins when the catalog has it, legacy otherwise", () => {
+  assert.equal(resolvePinKpiId({ [PIN_KPI_ID_ALL]: {}, [PIN_KPI_ID]: {} }), PIN_KPI_ID_ALL);
+  // A tenant bootstrapped before the new record keeps its pin layer.
+  assert.equal(resolvePinKpiId({ [PIN_KPI_ID]: {} }), PIN_KPI_ID);
+  assert.equal(resolvePinKpiId({}), PIN_KPI_ID);
+  assert.equal(resolvePinKpiId(null), PIN_KPI_ID);
+  assert.equal(PIN_ROW_CAP, 1000, "must match AnalyticsPlanner.MAX_LIMIT");
+});
+
+test("buildRefs points __pins at the resolved source, keeping the ref key stable", () => {
+  const mapDef = { kpiId: "map", viz: { kind: "map" }, params: [] };
+  const tiles = [{ kpiId: "map" }];
+
+  const legacy = buildRefs(tiles, { map: mapDef, [PIN_KPI_ID]: {} }, {}, {});
+  assert.equal(legacy.map__pins.kpiId, PIN_KPI_ID);
+
+  const upgraded = buildRefs(tiles, { map: mapDef, [PIN_KPI_ID_ALL]: {} }, {}, {});
+  assert.equal(upgraded.map__pins.kpiId, PIN_KPI_ID_ALL, "same key, new source");
+  assert.deepEqual(Object.keys(upgraded), Object.keys(legacy));
+});
+
+test("buildRefsKey changes when a tenant's catalog gains the per-layer def", () => {
+  const mapDef = { kpiId: "map", viz: { kind: "map" }, params: [] };
+  const tiles = [{ kpiId: "map" }];
+  assert.notEqual(
+    buildRefsKey(tiles, { map: mapDef }, {}, {}),
+    buildRefsKey(tiles, { map: mapDef, [PIN_KPI_ID_ALL]: {} }, {}, {}),
+    "the batch effect must refire — the ref key alone never changes"
+  );
+});

--- a/digit-ui-esbuild/products/dashboard/src/utils/queryPlan.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/queryPlan.js
@@ -26,6 +26,37 @@ export const MAP_KINDS = new Set(["map", "choropleth-map"]);
 // to overlay per-complaint pins (the FE map widget has the pin layer; this feeds it).
 export const PIN_KPI_ID = "cl_map_complaint_pins";
 
+/**
+ * The per-layer pin source. The legacy def hard-filters `is_open`, so its pins
+ * can only ever mean "still open" — the Resolved layer shaded "0 resolved"
+ * underneath open-complaint pins. Worse, `filters.is_open` with no
+ * `window.timeRole` trips the backend's live-open-snapshot exemption
+ * (KpiQueryComposer.isLiveOpenSnapshot), which skips BOTH the base window and
+ * the global dateFrom/dateTo — so the legacy pins were "all open complaints,
+ * all time" against a last_7d choropleth, wrong on every layer.
+ *
+ * The replacement def drops `is_open` from filters (no exemption -> pins obey
+ * the same window/range as the wards) and projects is_open/is_resolved as
+ * dimensions so the FE can partition pins per layer.
+ */
+export const PIN_KPI_ID_ALL = "cl_map_complaint_pins_all";
+
+/**
+ * Server-side row cap. AnalyticsPlanner clamps every query at MAX_LIMIT = 1000
+ * regardless of the def's `limit`, so a full result set is indistinguishable
+ * from a truncated one at exactly this size — the UI says "most recent 1,000".
+ */
+export const PIN_ROW_CAP = 1000;
+
+/**
+ * Prefer the per-layer pin def, fall back to the legacy one. A tenant whose
+ * catalog predates the new record keeps working (pins stay open-only, and the
+ * UI says so) instead of losing its pin layer entirely.
+ */
+export function resolvePinKpiId(kpis) {
+  return kpis && kpis[PIN_KPI_ID_ALL] ? PIN_KPI_ID_ALL : PIN_KPI_ID;
+}
+
 export function isCardKind(kind) {
   return CARD_KINDS.has(kind);
 }
@@ -91,6 +122,7 @@ export function tileParams(def, filters, hierOverrides) {
  */
 export function buildRefs(tiles, kpis, filters, hierOverrides) {
   const refs = {};
+  const pinKpiId = resolvePinKpiId(kpis);
   for (const tile of tiles) {
     const kpiId = tile.kpiId;
     const def = kpis[kpiId];
@@ -108,7 +140,9 @@ export function buildRefs(tiles, kpis, filters, hierOverrides) {
     }
     if (isMapKind(kind)) {
       // Per-complaint pins (same filters/scope) overlaid on the ward choropleth.
-      refs[`${kpiId}__pins`] = { kpiId: PIN_KPI_ID, params: { ...base } };
+      // The ref KEY stays `${kpiId}__pins` whichever source resolves, so nothing
+      // downstream (assembleResult, countErrorWidgets) has to know.
+      refs[`${kpiId}__pins`] = { kpiId: pinKpiId, params: { ...base } };
     }
   }
   return refs;
@@ -127,5 +161,9 @@ export function buildRefsKey(tiles, kpis, filters, hierOverrides) {
     kinds: tiles.map((t) => kpis[t.kpiId]?.viz?.kind),
     gp: globalParams(filters),
     hier: tiles.map((t) => appliedHierLevel(kpis[t.kpiId], hierOverrides)),
+    // A tenant whose catalog gains the per-layer pin def must refire the batch:
+    // the ref key is unchanged, so this is the only signal that the __pins ref
+    // now points at a different source.
+    pin: resolvePinKpiId(kpis),
   });
 }

--- a/docs/dashboard-configuration/70-esbuild-embedding.md
+++ b/docs/dashboard-configuration/70-esbuild-embedding.md
@@ -228,8 +228,10 @@ Key files and behaviours:
   Persistence is debounced (300 ms) on drag/resize.
 - **`AdminDashboard.buildRefs`** — one `{kpiId, params}` ref per tile, plus companion refs keyed
   by `viz.kind`: `__prior` (delta cards, `compare:"prior"`), `__series` (sparkline cards,
-  `series:"daily"`), `__pins` (map tiles, the internal `cl_map_complaint_pins` source). Only card
-  and map kinds emit companions, so a plain chart issues a single query.
+  `series:"daily"`), `__pins` (map tiles, the internal pin source — `cl_map_complaint_pins_all`
+  when the tenant's catalog has it, else the legacy open-only `cl_map_complaint_pins`; see
+  `utils/queryPlan.resolvePinKpiId`). Only card and map kinds emit companions, so a plain chart
+  issues a single query.
 - **`AdminDashboard.globalParams`** — the filter-bar → param mapping: `geography!="all"` → `ward`,
   `complaintType!="all"` → `serviceCode`, an active date range → `dateFrom`/`dateTo` (`yyyy-MM-dd`).
   **No global `window` is emitted**, so each def keeps its baked window when no date range is

--- a/docs/dashboard-demo/README.md
+++ b/docs/dashboard-demo/README.md
@@ -121,8 +121,10 @@ The admin (executive) pack seeds **12 tiles** (15 available). Walk the tile grou
 - **Ward performance table** (`cl_table_ward_performance`) and *Recurring
   ward×subtype* (`cl_table_recurring_ward_subtype`) — where and what keeps breaking.
 - **The Leaflet choropleth map + pins.** *Ward WoW current* (`cl_map_ward_wow_current`)
-  shades each ward by open-complaint volume; *complaint pins* (`cl_map_complaint_pins`)
-  drops individual pins. Hover a ward for a tooltip (count + WoW delta). Ward highlight
+  shades each ward by open-complaint volume; *complaint pins*
+  (`cl_map_complaint_pins_all`, falling back to the legacy open-only
+  `cl_map_complaint_pins`) drops individual pins, partitioned to follow the
+  Created / Open / Resolved layer toggle. Hover a ward for a tooltip (count + WoW delta). Ward highlight
   colour and basemap are MDMS-driven (`RAINMAKER-PGR.MapConfig`), defaulting to
   orange on the light CARTO voyager basemap.
 

--- a/frontend/micro-ui/web/src/dashboard/AdminDashboard.jsx
+++ b/frontend/micro-ui/web/src/dashboard/AdminDashboard.jsx
@@ -155,6 +155,26 @@ const MAP_KINDS = new Set(["map", "choropleth-map"]);
 // to overlay per-complaint pins (the FE map widget has the pin layer; this feeds it).
 const PIN_KPI_ID = "cl_map_complaint_pins";
 
+// The per-layer pin source. The legacy def hard-filters `is_open`, so its pins
+// can only ever mean "still open" — the Resolved layer shaded "0 resolved"
+// underneath open-complaint pins. Worse, `filters.is_open` with no
+// `window.timeRole` trips the backend's live-open-snapshot exemption
+// (KpiQueryComposer.isLiveOpenSnapshot), which skips BOTH the base window and
+// the global dateFrom/dateTo — so the legacy pins were "all open complaints,
+// all time" against a last_7d choropleth. The replacement def drops that filter
+// and projects is_open/is_resolved so the FE can partition pins per layer.
+const PIN_KPI_ID_ALL = "cl_map_complaint_pins_all";
+
+// AnalyticsPlanner clamps every query at MAX_LIMIT = 1000, so a result at
+// exactly this size is indistinguishable from a truncated one.
+const PIN_ROW_CAP = 1000;
+
+// Prefer the per-layer def; a tenant whose catalog predates it keeps working
+// (pins stay open-only, and the map legend says so).
+function resolvePinKpiId(kpis) {
+  return kpis && kpis[PIN_KPI_ID_ALL] ? PIN_KPI_ID_ALL : PIN_KPI_ID;
+}
+
 function isCardKind(kind) {
   return CARD_KINDS.has(kind);
 }
@@ -202,6 +222,7 @@ function globalParams(filters) {
 function buildRefs(tiles, kpis, filters) {
   const gp = globalParams(filters);
   const refs = {};
+  const pinKpiId = resolvePinKpiId(kpis);
   for (const tile of tiles) {
     const kpiId = tile.kpiId;
     const def = kpis[kpiId];
@@ -218,7 +239,8 @@ function buildRefs(tiles, kpis, filters) {
     }
     if (isMapKind(kind)) {
       // Per-complaint pins (same filters/scope) overlaid on the ward choropleth.
-      refs[`${kpiId}__pins`] = { kpiId: PIN_KPI_ID, params: { ...gp } };
+      // The ref KEY stays `${kpiId}__pins` whichever source resolves.
+      refs[`${kpiId}__pins`] = { kpiId: pinKpiId, params: { ...gp } };
     }
   }
   return refs;
@@ -280,10 +302,21 @@ function assembleResult(kpiId, def, results) {
   if (isMapKind(viz.kind)) {
     const pinRes = results?.[`${kpiId}__pins`];
     if (pinRes?.rows?.length) {
+      // Whether the pin source projects the open/resolved state at all. The
+      // legacy def does not — its rows are open-only — so the UI falls back to
+      // "pins do not follow this layer" rather than classing every pin as
+      // neither open nor resolved.
+      assembled.pinsStatusKnown = (pinRes.columns || []).some(
+        (c) => (typeof c === "string" ? c : c?.name) === "is_open"
+      );
+      assembled.pinsTruncated = pinRes.rows.length >= PIN_ROW_CAP;
       assembled.pins = pinRes.rows
         .map((r) => ({
           id: r.service_request_id,
           serviceRequestId: r.service_request_id,
+          // Booleans arrive as true/"true" depending on the JDBC/JSON path.
+          isOpen: r.is_open === true || r.is_open === "true",
+          isResolved: r.is_resolved === true || r.is_resolved === "true",
           // Kajal's resolveComplaintPinPositions needs wardCode to place a pin
           // (snaps/jitters around the ward centroid when the geo-pin is unusable).
           wardCode: String(r.ward_code ?? ""),
@@ -405,6 +438,9 @@ const AdminDashboardInner = ({ onSignOut }) => {
         ids: tiles.map((t) => t.kpiId),
         kinds: tiles.map((t) => kpis[t.kpiId]?.viz?.kind),
         gp: globalParams(filters),
+        // A tenant gaining the per-layer pin def must refire the batch: the ref
+        // key is unchanged, so this is the only signal the source moved.
+        pin: resolvePinKpiId(kpis),
       }),
     [tiles, filters, kpis]
   );

--- a/frontend/micro-ui/web/src/dashboard/components/GeographyChoroplethMap.jsx
+++ b/frontend/micro-ui/web/src/dashboard/components/GeographyChoroplethMap.jsx
@@ -5,6 +5,8 @@ import {
   getGeographyMapLegend,
   getGeographyMapLegendFooter,
   getGeographyMapLegendTitle,
+  getGeographyMapPinLegendEntry,
+  getGeographyMapPinStyle,
   getCreatedCountFillStyle,
   buildCreatedCountScale,
   getOpenShareFillStyle,
@@ -93,15 +95,16 @@ const MAP_SUBCOUNTY_MAX_ZOOM = 12; // below -> sub-counties; at/above -> wards
 function resolveFeatureStyle(feature, layerMode, focusedCode, zoom = 11, createdBuckets) {
   const props = feature?.properties ?? {};
   const isFocused = focusedCode && props.code === focusedCode;
+  // `filed` gates the share layers on the white "No complaints" swatch: a ward
+  // with nothing filed has a 0% share, which would otherwise paint like a ward
+  // that has complaints but none open/resolved.
+  const filed = Number(props.count) || Number(props.created) || 0;
   const base =
     layerMode === "open"
-      ? getOpenShareFillStyle(props.openPct)
+      ? getOpenShareFillStyle(props.openPct, filed)
       : layerMode === "resolved"
-        ? getResolvedShareFillStyle(props.resolvedPct)
-        : getCreatedCountFillStyle(
-            Number(props.count) || Number(props.created) || 0,
-            createdBuckets
-          );
+        ? getResolvedShareFillStyle(props.resolvedPct, filed)
+        : getCreatedCountFillStyle(filed, createdBuckets);
 
   const weight = isFocused ? 2.5 : zoom < 11 ? 0.75 : zoom < 14 ? 1.1 : 1.5;
 
@@ -162,6 +165,12 @@ const GeographyChoroplethMap = ({
   onLayerModeChange,
   layerOptions = [],
   cityLabel = getMapCityLabel(),
+  // Pin provenance for the legend row: 'per-layer' when the pin source projects
+  // is_open/is_resolved, 'open-only' on a tenant still serving the legacy def.
+  pinSemantics = "open-only",
+  pinsTruncated = false,
+  layerTotal = 0,
+  unmappedTotal = 0,
 }) => {
   const shellRef = useRef(null);
   const frameRef = useRef(null);
@@ -337,6 +346,19 @@ const GeographyChoroplethMap = ({
     () => getGeographyMapLegend(layerMode, createdBuckets),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [layerMode, createdScaleKey]
+  );
+  // Kept OUT of legendItems on purpose: that array is a colour scale scanned by
+  // range (getCreatedCountBucket), so the pin row renders as its own <li> below.
+  const pinLegendEntry = useMemo(
+    () =>
+      getGeographyMapPinLegendEntry(layerMode, {
+        shown: complaintPins.length,
+        total: layerTotal,
+        semantics: pinSemantics,
+        truncated: pinsTruncated,
+        unmapped: unmappedTotal,
+      }),
+    [layerMode, complaintPins.length, layerTotal, pinSemantics, pinsTruncated, unmappedTotal]
   );
   const legendTitle = getGeographyMapLegendTitle(layerMode);
   const legendFooter = getGeographyMapLegendFooter(drillTrail.length);
@@ -661,6 +683,9 @@ const GeographyChoroplethMap = ({
     }
 
     const currentZoom = zoomLevelRef.current;
+    // Pins carry the LAYER's colour (slate filed / amber open / green resolved),
+    // so a pin can never read as "open" while sitting on the Resolved layer.
+    const pinStyle = getGeographyMapPinStyle(layerMode);
 
     visibleComplaintPins.forEach((pin) => {
       if (pin.lat == null || pin.lng == null) return;
@@ -673,9 +698,9 @@ const GeographyChoroplethMap = ({
         renderer: pinRendererRef.current ?? undefined,
         pane: "complaintPins",
         radius: baseRadius,
-        color: "#b45309",
+        color: pinStyle.stroke,
         weight: 1.5,
-        fillColor: "#f59e0b",
+        fillColor: pinStyle.fill,
         fillOpacity: 0.92,
       });
 
@@ -734,7 +759,9 @@ const GeographyChoroplethMap = ({
     } else {
       selectedPinKeyRef.current = null;
     }
-  }, [visibleComplaintPins]);
+    // `layerMode`: pin colour follows the layer. (The pin ARRAY also changes per
+    // layer, but not on an 'open-only' catalog where all three are identical.)
+  }, [visibleComplaintPins, layerMode]);
 
   // ── initial fit ───────────────────────────────────────────────────────────
   useEffect(() => {
@@ -931,6 +958,26 @@ const GeographyChoroplethMap = ({
                     </span>
                   </li>
                 ))}
+                <li className="dashboard-map-legend-pin-row tw-flex tw-items-start tw-gap-2 tw-border-t tw-border-border tw-pt-1.5">
+                  <span
+                    className="dashboard-map-legend-swatch dashboard-map-legend-swatch--pin"
+                    style={{
+                      backgroundColor: pinLegendEntry.swatch.fill,
+                      borderColor: pinLegendEntry.swatch.stroke,
+                      borderRadius: "9999px",
+                    }}
+                  />
+                  <span className="tw-flex tw-flex-col tw-gap-0.5">
+                    <span className="tw-text-[10px] tw-leading-tight tw-text-foreground">
+                      {pinLegendEntry.label}
+                    </span>
+                    {pinLegendEntry.note ? (
+                      <span className="tw-text-[9px] tw-leading-tight tw-text-muted-foreground">
+                        {pinLegendEntry.note}
+                      </span>
+                    ) : null}
+                  </span>
+                </li>
               </ul>
               <p className="tw-border-t tw-border-border tw-px-2.5 tw-py-2 tw-text-[9px] tw-leading-snug tw-text-muted-foreground">
                 {legendFooter}

--- a/frontend/micro-ui/web/src/dashboard/components/KpiTile.jsx
+++ b/frontend/micro-ui/web/src/dashboard/components/KpiTile.jsx
@@ -822,12 +822,51 @@ function renderSlaRiskTable(ctx) {
 // Her widget fetches its own ward geometry and toggles created/open/resolved
 // layers; it reads layers[layerKey] (ward series), layers.wardDetails, and
 // layers.complaintPinsByLayer[layerKey]. We shape the tile's ward aggregate +
-// the companion pin source into that contract. (Per-layer distinct counts —
-// created vs open vs resolved — is a refinement; today every layer shows the
-// tile's aggregate so the toggle always renders data.)
+// the companion pin source into that contract. The ward series carries all
+// three counts so any layer renders; the PINS are now partitioned per layer
+// (previously the same open-only array was pinned to all three, so the Resolved
+// layer shaded "0 resolved" underneath still-open complaints).
 // ---------------------------------------------------------------------------
 
 const GEO_MAP_LAYER_KEYS = ['created', 'open', 'resolved'];
+
+/**
+ * Split pins into the three map layers: created = every pin in the window,
+ * open/resolved = the pins whose complaint is in that state.
+ *
+ * `statusKnown === false` means the pin source does not project is_open /
+ * is_resolved (the legacy cl_map_complaint_pins def, which is open-only), so
+ * nothing can honestly be partitioned — keep the legacy behaviour and let the
+ * legend say the pins do not follow the layer.
+ */
+function partitionPinsByLayer(pins, statusKnown) {
+  const all = Array.isArray(pins) ? pins : [];
+  if (!statusKnown) return { created: all, open: all, resolved: all };
+  return {
+    created: all,
+    open: all.filter((pin) => pin?.isOpen === true),
+    resolved: all.filter((pin) => pin?.isResolved === true),
+  };
+}
+
+/**
+ * Totals over the ward series, plus the counts the ward mapper DROPS (rows with
+ * a null/blank ward code). Those complaints are real and counted by every card
+ * on the dashboard; discarding them silently made the map disagree with the
+ * cards with no explanation on screen.
+ */
+function summarizeWardRows(rows, dimKey) {
+  const layerTotals = { filed: 0, open: 0, resolved: 0 };
+  const unmapped = { filed: 0, open: 0, resolved: 0 };
+  for (const row of Array.isArray(rows) ? rows : []) {
+    const code = String(row?.[dimKey] ?? '').trim();
+    const bucket = code && code !== 'null' ? layerTotals : unmapped;
+    bucket.filed += Number(row?.filed) || 0;
+    bucket.open += Number(row?.open) || 0;
+    bucket.resolved += Number(row?.resolved) || 0;
+  }
+  return { layerTotals, unmapped };
+}
 
 function adaptMapLayers(ctx) {
   const { viz, result } = ctx;
@@ -859,17 +898,39 @@ function adaptMapLayers(ctx) {
       };
     });
   const pins = result.pins || [];
-  const layers = { wardDetails: {}, complaintPinsByLayer: {}, complaintPinsError: null };
+  const statusKnown = result.pinsStatusKnown === true;
+  const { layerTotals, unmapped } = summarizeWardRows(result.rows || [], dimKey);
+  const layers = {
+    wardDetails: {},
+    complaintPinsByLayer: partitionPinsByLayer(pins, statusKnown),
+    complaintPinsError: null,
+    // 'open-only' = the tenant's catalog still has the legacy pin def, so pins
+    // cannot follow the layer; the legend says so instead of lying by omission.
+    pinSemantics: statusKnown ? 'per-layer' : 'open-only',
+    pinsTruncated: result.pinsTruncated === true,
+    layerTotals,
+    unmapped,
+  };
   for (const key of GEO_MAP_LAYER_KEYS) {
     layers[key] = wards;
-    layers.complaintPinsByLayer[key] = pins;
   }
   return layers;
 }
 
+/**
+ * The map branch is memoized on its own inputs: adaptMapLayers re-derives fresh
+ * ward/pin ARRAYS on every parent render, and the Leaflet pin effect keys off
+ * that identity — so an unmemoized call tore down and rebuilt up to 1000 circle
+ * markers (closing any open popup) on every unrelated re-render.
+ */
+function MapTile({ ctx, loading }) {
+  // (this tree's ctx carries no locale — labels here are not localized)
+  const layers = React.useMemo(() => adaptMapLayers(ctx), [ctx.result, ctx.viz]);
+  return <OpenComplaintsByGeographyWidget layers={layers} loading={loading} />;
+}
+
 function renderChoroplethMap(ctx) {
-  const { loading } = ctx;
-  return <OpenComplaintsByGeographyWidget layers={adaptMapLayers(ctx)} loading={loading} />;
+  return <MapTile ctx={ctx} loading={ctx.loading} />;
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/micro-ui/web/src/dashboard/components/OpenComplaintsByGeographyWidget.jsx
+++ b/frontend/micro-ui/web/src/dashboard/components/OpenComplaintsByGeographyWidget.jsx
@@ -25,6 +25,19 @@ const OpenComplaintsByGeographyWidget = ({ layers, loading = false }) => {
     }));
   }, [layers, resolvedLayer]);
 
+  const pinSemantics = layers?.pinSemantics ?? "open-only";
+  // In 'open-only' mode the pins mean "open" on every layer, so the denominator
+  // must stay the open count or the coverage line would compare open pins
+  // against filed complaints.
+  const pinLayerKey = pinSemantics === "open-only" ? "open" : resolvedLayer;
+  const totals = layers?.layerTotals ?? {};
+  const pinLayerTotal =
+    (pinLayerKey === "open"
+      ? totals.open
+      : pinLayerKey === "resolved"
+        ? totals.resolved
+        : totals.filed) ?? 0;
+
   if (loading && !wardCounts.length) {
     return (
       <div className="tw-flex tw-h-full tw-min-h-[220px] tw-items-center tw-justify-center tw-p-4 tw-text-[12px] tw-text-muted-foreground">
@@ -44,6 +57,10 @@ const OpenComplaintsByGeographyWidget = ({ layers, loading = false }) => {
         wardCounts={wardCounts}
         complaintPins={layers?.complaintPinsByLayer?.[resolvedLayer] ?? []}
         complaintPinsError={layers?.complaintPinsError ?? null}
+        pinSemantics={pinSemantics}
+        pinsTruncated={layers?.pinsTruncated ?? false}
+        layerTotal={pinLayerTotal}
+        unmappedTotal={layers?.unmapped?.filed ?? 0}
         layerMode={resolvedLayer}
         onLayerModeChange={setActiveLayer}
         layerOptions={GEOGRAPHY_MAP_LAYERS}

--- a/frontend/micro-ui/web/src/dashboard/config/geographyMapPresentation.js
+++ b/frontend/micro-ui/web/src/dashboard/config/geographyMapPresentation.js
@@ -186,6 +186,54 @@ export function getGeographyMapLegend(layerId, createdBuckets = CREATED_COUNT_LE
   return createdBuckets;
 }
 
+/**
+ * Pin colours, one per layer. DELIBERATELY not part of any legend array:
+ * getGeographyMapLegend returns a colour SCALE that getCreatedCountBucket scans
+ * by range, so an extra entry there would corrupt bucket classification. The pin
+ * row renders as a separate <li> below the scale.
+ */
+export const GEOGRAPHY_MAP_PIN_STYLES = {
+  created: { fill: "#475569", stroke: "#334155" },
+  open: { fill: "#f59e0b", stroke: "#b45309" },
+  resolved: { fill: "#16a34a", stroke: "#15803d" },
+};
+
+export function getGeographyMapPinStyle(layerId) {
+  return GEOGRAPHY_MAP_PIN_STYLES[layerId] || GEOGRAPHY_MAP_PIN_STYLES.created;
+}
+
+/**
+ * The pin legend row: what the pins on the CURRENT layer mean, plus the honesty
+ * notes (pin coverage for this layer, whether the row cap truncated them, and
+ * how many complaints have no ward and are therefore not on the map at all).
+ *
+ * `semantics: 'open-only'` means the tenant still serves the legacy pin def,
+ * whose rows are open complaints regardless of the selected layer.
+ */
+export function getGeographyMapPinLegendEntry(layerId, pins = {}) {
+  const semantics = pins.semantics === "open-only" ? "open-only" : "per-layer";
+  const label =
+    semantics === "open-only"
+      ? "Pins: complaints still open — pins do not follow this layer"
+      : layerId === "open"
+        ? "Pins: complaints still open"
+        : layerId === "resolved"
+          ? "Pins: complaints resolved"
+          : "Pins: complaints filed";
+
+  const notes = [];
+  const total = Number(pins.total) || 0;
+  if (total > 0) {
+    notes.push(`${Number(pins.shown) || 0} of ${total} shown on the map (rest have no location)`);
+  }
+  if (pins.truncated) notes.push("Showing the most recent 1000 only");
+  if (Number(pins.unmapped) > 0) {
+    notes.push(`${Number(pins.unmapped)} complaints have no ward and are not mapped`);
+  }
+
+  return { swatch: getGeographyMapPinStyle(layerId), label, note: notes.join(" · ") };
+}
+
 export function getGeographyMapLegendTitle(layerId) {
   return getGeographyMapLayerMeta(layerId)?.legendTitle ?? "Map legend";
 }
@@ -215,7 +263,14 @@ export function getCreatedCountBucket(count, buckets = CREATED_COUNT_LEGEND) {
   return scale[scale.length - 1];
 }
 
-export function getSharePctBucket(pct, legend) {
+/**
+ * `filed` is passed so a ward with NO complaints gets the white "No complaints"
+ * swatch. Both share layers compute pct as 0 when filed is 0, and pct 0 maps to
+ * legend[1] ("0%") — so the white swatch was unreachable and an empty ward
+ * painted identically to one with complaints but none resolved.
+ */
+export function getSharePctBucket(pct, legend, filed) {
+  if (filed !== undefined && !(Number(filed) > 0)) return legend[0];
   const value = Number(pct);
   if (!Number.isFinite(value) || value < 0) return legend[0];
   if (value === 0) return legend[1];
@@ -230,12 +285,12 @@ export function getCreatedCountFillStyle(count, buckets = CREATED_COUNT_LEGEND) 
   return bucketToFillStyle(getCreatedCountBucket(count, buckets));
 }
 
-export function getOpenShareFillStyle(openPct) {
-  return bucketToFillStyle(getSharePctBucket(openPct, OPEN_SHARE_LEGEND));
+export function getOpenShareFillStyle(openPct, filed) {
+  return bucketToFillStyle(getSharePctBucket(openPct, OPEN_SHARE_LEGEND, filed));
 }
 
-export function getResolvedShareFillStyle(resolvedPct) {
-  return bucketToFillStyle(getSharePctBucket(resolvedPct, RESOLVED_SHARE_LEGEND));
+export function getResolvedShareFillStyle(resolvedPct, filed) {
+  return bucketToFillStyle(getSharePctBucket(resolvedPct, RESOLVED_SHARE_LEGEND, filed));
 }
 
 /** @deprecated Legacy WoW styling — map uses created/open/resolved layers only. */

--- a/local-setup/db/dss-mdms-seed/l10n/en_IN.json
+++ b/local-setup/db/dss-mdms-seed/l10n/en_IN.json
@@ -855,6 +855,46 @@
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_COVERAGE_OF",
+    "message": " of ",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_COVERAGE_SUFFIX",
+    "message": " shown on the map (rest have no location)",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_CREATED",
+    "message": "Pins: complaints filed",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_OPEN",
+    "message": "Pins: complaints still open",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_OPEN_ONLY",
+    "message": "Pins: complaints still open — pins do not follow this layer",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_RESOLVED",
+    "message": "Pins: complaints resolved",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_TRUNCATED",
+    "message": "Showing the most recent 1,000 only",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_UNMAPPED",
+    "message": " complaints have no ward and are not mapped",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "DASHBOARD_MAP_LEGEND_TITLE",
     "message": "Map legend",
     "module": "rainmaker-dashboard"

--- a/local-setup/db/dss-mdms-seed/l10n/pt_PT.json
+++ b/local-setup/db/dss-mdms-seed/l10n/pt_PT.json
@@ -855,6 +855,46 @@
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_COVERAGE_OF",
+    "message": " de ",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_COVERAGE_SUFFIX",
+    "message": " apresentados no mapa (os restantes não têm localização)",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_CREATED",
+    "message": "Marcadores: reclamações registadas",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_OPEN",
+    "message": "Marcadores: reclamações ainda em aberto",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_OPEN_ONLY",
+    "message": "Marcadores: reclamações ainda em aberto — os marcadores não acompanham esta camada",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_RESOLVED",
+    "message": "Marcadores: reclamações resolvidas",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_TRUNCATED",
+    "message": "A mostrar apenas as 1000 mais recentes",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_MAP_LEGEND_PINS_UNMAPPED",
+    "message": " reclamações não têm bairro e não são mapeadas",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "DASHBOARD_MAP_LEGEND_TITLE",
     "message": "Legenda do mapa",
     "module": "rainmaker-dashboard"


### PR DESCRIPTION
Fixes the map-pin half of #1461's family: QA reported "Resolved count is 0 still points are displayed on map".

## Two defects, one cause

The choropleth tile toggles Created / Open / Resolved, but the pin overlay came from `cl_map_complaint_pins`, whose query is `filters: {is_open: true, has_geo_pin: true}` with **no window**.

1. **Pins ignore the layer toggle.** The same open-complaint array was painted on all three layers (`complaintPinsByLayer` was stubbed with one array three times), so the Resolved layer shaded "0 resolved" beneath a scatter of still-open complaints.
2. **Pins ignore time, too — and this is the bigger one.** `filters.is_open` + no `window.timeRole` is exactly the shape `KpiQueryComposer.isLiveOpenSnapshot()` treats as a timeless live snapshot, so the composer skips **both** the window and `dateFrom`/`dateTo`. The pins were *all open complaints, all time* floating over a `last_7d` choropleth — wrong on **all three** layers, not just Resolved.

## Why a NEW KPI id rather than editing the existing record

`tenant_bootstrap` seeds the catalog as a create-if-absent floor (`digit-mcp/src/tools/mdms-tenant.ts:1770-1773`). An **edit** to `cl_map_complaint_pins` would pass review, pass local-setup, and change nothing on any already-bootstrapped tenant — the same trap that has bitten three dashboard fixes this week. A **new id** is the one thing the floor does propagate.

So this adds `cl_map_complaint_pins_all`: no `is_open` filter (which removes the live-snapshot exemption so pins finally obey the window and date range), `is_open`/`is_resolved` projected so the client can partition, `sort` by `created_date desc`, and `limit: 1000` — the honest number, since `AnalyticsPlanner.MAX_LIMIT` clamps there regardless of what the def says. Sorting makes truncation deterministic ("most recent N") instead of arbitrary.

The seed diff is purely additive: 39 → 40 records, **zero deletions**, every existing record untouched.

## Behaviour

| Layer | Pins | Colour |
|---|---|---|
| Created | every complaint filed in the window | slate `#475569` |
| Open | still open | amber `#f59e0b` (unchanged) |
| Resolved | resolved | green `#16a34a` |

An amber "alert" dot on a green good-news choropleth was itself a contradiction, hence the per-layer colour.

**Graceful degradation.** `resolvePinKpiId()` prefers the new id and falls back to the legacy one. On a tenant that hasn't received the new record, rows carry no status, `pinSemantics` is `'open-only'`, pins behave exactly as today, and the legend says so explicitly — *"Pins: complaints still open — pins do not follow this layer"* — on every layer. No blank map, no crash, and the new def is safe to seed ahead of any UI release.

**Disclosure instead of silence.** The pin legend row now carries coverage ("N of M shown on the map (rest have no location)"), a truncation note when the 1000 cap bites, and a count of complaints with no ward. Those ward-less complaints were previously discarded silently in `adaptMapLayers`, which is why the map's numbers disagreed with the cards with nothing on screen explaining it.

## Also fixed

`getSharePctBucket(0)` returned the "0%" bucket, so the white "No complaints" swatch was unreachable — a ward with **zero** complaints painted the same pale colour as a ward with complaints but none resolved. Now gated on `filed === 0`. That accounts for a good part of the "0 with pins over it" impression. The `filed` argument is optional, so no existing call site changes behaviour.

## Performance

`adaptMapLayers` runs on every render and now returns freshly-partitioned arrays into a Leaflet effect that rebuilds up to 1000 `circleMarker`s. The map branch is wrapped in a memoized `MapTile` component — without it this would turn a latent per-render rebuild into a visible one.

## Not touched, deliberately

`getGeographyMapLegend`'s array, `getCreatedCountBucket`, `createdBuckets` / `createdScaleKey` and the polygon-restyle effect deps — all part of PR #1556's contract, which relies on the scale staying stable across layer toggles. The pin legend is a separate `getGeographyMapPinLegendEntry()` rendered as its own `<li>` below the colour scale.

## Verification

```
node --test <all suites>                                   169 pass / 0 fail
  config/geographyMapPresentation.test.js   18/18  (11 pre-existing from #1556 + 7 new)
  utils/complaintPins.test.js                9/9   (new)
  utils/hierLevelGrouping.test.js            unchanged, passing
node esbuild.build.js                                      Build complete
node digit-mcp/scripts/gen-dashboard-catalog.mjs --check    OK
node local-setup/db/dss-mdms-seed/export-l10n.mjs --check   OK
```

8 new l10n codes added symmetrically to en_IN and pt_PT (317 messages each, 1:1 assertion passes).

## Notes for review

- Both dashboard copies are updated. `frontend/micro-ui/web/src/dashboard/` (still imported by `App.js`) has no i18n seam or `numberFormat`, so it gets the same behaviour with raw numerals; the partition helper is inlined there rather than adding a util module to a tree with no test harness.
- **Release note worth leading with:** after this lands, applying a date filter will visibly move the pins. Today they never move. Expect "the pins broke" reports.
- Existing tenants need the new record — merging alone will not deliver it, per the floor behaviour above.
