### PR TITLE
feat(spa): CI-built configurator + digit-ui-esbuild images as the default serving path

### DIFF
--- a/.github/workflows/spa-build.yml
+++ b/.github/workflows/spa-build.yml
@@ -1,0 +1,185 @@
+name: SPA Build Pipeline
+run-name: Build ${{ github.event.inputs.pipeline_name }}
+
+# Builds + publishes the Vite/esbuild SPA images (self-contained Dockerfiles)
+# to the egovio Docker Hub org as multi-arch (amd64 + arm64) manifests.
+#
+# Differs from pgr-ui-build.yml in exactly one way: the docker build CONTEXT
+# is the app's work-dir from build/build-config.yml, not the repo root.
+# configurator/Dockerfile and digit-ui-esbuild/docker/Dockerfile COPY
+# package.json etc. relative to their own directory and take no WORK_DIR
+# build-arg (unlike the legacy micro-ui Dockerfile).
+on:
+  workflow_dispatch:
+    inputs:
+      pipeline_name:
+        description: 'App to build and publish'
+        required: true
+        type: choice
+        options:
+          - configurator
+          - digit-ui-esbuild
+
+env:
+  DOCKER_USERNAME: ${{ vars.DOCKER_USERNAME }}
+  DOCKER_PASSWORD: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+jobs:
+  resolve-config:
+    name: Resolve ${{ github.event.inputs.pipeline_name }} config
+    runs-on: ubuntu-latest
+    outputs:
+      work_dir:   ${{ steps.setenv.outputs.work_dir }}
+      image_name: ${{ steps.setenv.outputs.image_name }}
+      dockerfile: ${{ steps.setenv.outputs.dockerfile }}
+      tag:        ${{ steps.tag.outputs.tag }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Install yq
+        run: |
+          VERSION="4.30.8"
+          URL="https://github.com/mikefarah/yq/releases/download/v${VERSION}/yq_linux_amd64"
+          sudo curl -sSL "$URL" -o /usr/local/bin/yq
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Resolve env from build-config.yml
+        id: setenv
+        run: |
+          PIPELINE_NAME="${{ github.event.inputs.pipeline_name }}"
+          DEFAULT_DOCKERFILE="Dockerfile"
+          echo "### Pipeline Name - $PIPELINE_NAME" >> $GITHUB_STEP_SUMMARY
+
+          # Find exactly one matching config block
+          MATCHING_CONFIGS=$(yq eval -o=json '.config[] | select(.name | test("/'"$PIPELINE_NAME"'$"))' build/build-config.yml)
+          MATCH_COUNT=$(echo "$MATCHING_CONFIGS" | jq -s 'length')
+          if [ "$MATCH_COUNT" -ne 1 ]; then
+            echo "ERROR: Expected exactly 1 matching pipeline config, but found $MATCH_COUNT"
+            exit 1
+          fi
+
+          SERVICE_BUILD_CONFIG=$(echo "$MATCHING_CONFIGS" | jq -c '.build[] | select(.["image-name"])')
+          SERVICE_WORK_DIR=$(echo "$SERVICE_BUILD_CONFIG" | yq eval -r '.["work-dir"] // ""' -)
+          SERVICE_IMAGE_NAME=$(echo "$SERVICE_BUILD_CONFIG" | yq eval -r '.["image-name"] // ""' -)
+          SERVICE_DOCKERFILE=$(echo "$SERVICE_BUILD_CONFIG" | yq eval -r '.dockerfile // ""' -)
+
+          if [ -z "$SERVICE_DOCKERFILE" ]; then
+            SERVICE_DOCKERFILE="$SERVICE_WORK_DIR/$DEFAULT_DOCKERFILE"
+          fi
+
+          echo "work_dir=$SERVICE_WORK_DIR" >> $GITHUB_OUTPUT
+          echo "image_name=$SERVICE_IMAGE_NAME" >> $GITHUB_OUTPUT
+          echo "dockerfile=$SERVICE_DOCKERFILE" >> $GITHUB_OUTPUT
+
+          echo "#### Application Config Summary" >> $GITHUB_STEP_SUMMARY
+          echo "Application Work Directory - $SERVICE_WORK_DIR" >> $GITHUB_STEP_SUMMARY
+          echo "Image Name - $SERVICE_IMAGE_NAME" >> $GITHUB_STEP_SUMMARY
+          echo "Dockerfile Path - $SERVICE_DOCKERFILE" >> $GITHUB_STEP_SUMMARY
+
+      # Deterministic <branch>-<shortsha> tag. Re-running for the same commit
+      # re-pushes the same tag (idempotent) — no Docker Hub tag lookup needed.
+      - name: Generate the Tag
+        id: tag
+        run: |
+          set -euo pipefail
+          BRANCH="${GITHUB_REF_NAME//\//-}"
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+          NEXT_TAG="${BRANCH}-${COMMIT_HASH}"
+          echo "tag=$NEXT_TAG" >> "$GITHUB_OUTPUT"
+          echo "tag - $NEXT_TAG" >> $GITHUB_STEP_SUMMARY
+
+  build-matrix:
+    name: Build application ${{ matrix.arch }}
+    needs: [resolve-config]
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    outputs:
+      amd64_digest: ${{ steps.digest_amd64.outputs.digest }}
+      arm64_digest: ${{ steps.digest_arm64.outputs.digest }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker Layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-${{ matrix.arch }}-buildx-${{ github.event.inputs.pipeline_name }}-${{ github.ref_name }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.arch }}-buildx-${{ github.event.inputs.pipeline_name }}-
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_PASSWORD }}
+
+      # Context is the app's work-dir: these Dockerfiles COPY relative to
+      # their own directory. --file stays cwd-relative (repo root).
+      - name: Build image for ${{ matrix.arch }}
+        run: |
+          docker buildx build \
+            --platform ${{ matrix.platform }} \
+            --file ${{ needs.resolve-config.outputs.dockerfile }} \
+            --tag egovio/${{ needs.resolve-config.outputs.image_name }}:${{ needs.resolve-config.outputs.tag }}-${{ matrix.arch }} \
+            --cache-from=type=local,src=/tmp/.buildx-cache \
+            --cache-to=type=local,dest=/tmp/.buildx-cache,mode=max \
+            --push \
+            ${{ needs.resolve-config.outputs.work_dir }}
+
+      - name: Inspect Manifest
+        run: |
+          docker buildx imagetools inspect egovio/${{ needs.resolve-config.outputs.image_name }}:${{ needs.resolve-config.outputs.tag }}-${{ matrix.arch }}
+
+      - name: Export Digest (amd64)
+        if: matrix.arch == 'amd64'
+        id: digest_amd64
+        run: |
+          digest=$(docker buildx imagetools inspect \
+            egovio/${{ needs.resolve-config.outputs.image_name }}:${{ needs.resolve-config.outputs.tag }}-${{ matrix.arch }} \
+            --format '{{json .}}' | jq -r '.manifest.manifests[] | select(.platform.architecture=="amd64" and .platform.os=="linux") | .digest')
+          echo "digest=$digest" >> $GITHUB_OUTPUT
+
+      - name: Export Digest (arm64)
+        if: matrix.arch == 'arm64'
+        id: digest_arm64
+        run: |
+          digest=$(docker buildx imagetools inspect \
+            egovio/${{ needs.resolve-config.outputs.image_name }}:${{ needs.resolve-config.outputs.tag }}-${{ matrix.arch }} \
+            --format '{{json .}}' | jq -r '.manifest.manifests[] | select(.platform.architecture=="arm64" and .platform.os=="linux") | .digest')
+          echo "digest=$digest" >> $GITHUB_OUTPUT
+
+  create-manifest:
+    name: Create and Push Manifest
+    needs: [build-matrix, resolve-config]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_PASSWORD }}
+
+      - name: Create and push manifest
+        run: |
+          docker manifest create egovio/${{ needs.resolve-config.outputs.image_name }}:${{ needs.resolve-config.outputs.tag }} \
+            --amend egovio/${{ needs.resolve-config.outputs.image_name }}@${{ needs.build-matrix.outputs.amd64_digest }} \
+            --amend egovio/${{ needs.resolve-config.outputs.image_name }}@${{ needs.build-matrix.outputs.arm64_digest }}
+          docker manifest push egovio/${{ needs.resolve-config.outputs.image_name }}:${{ needs.resolve-config.outputs.tag }}
+
+      - name: Add summary to GitHub Actions
+        run: |
+          echo "- Image: egovio/${{ needs.resolve-config.outputs.image_name }}:${{ needs.resolve-config.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Platform: amd64, arm64" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/spa-build.yml
+++ b/.github/workflows/spa-build.yml
@@ -35,7 +35,7 @@ jobs:
       tag:        ${{ steps.tag.outputs.tag }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install yq
         run: |
@@ -102,18 +102,15 @@ jobs:
             platform: linux/arm64
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
-    outputs:
-      amd64_digest: ${{ steps.digest_amd64.outputs.digest }}
-      arm64_digest: ${{ steps.digest_arm64.outputs.digest }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Cache Docker Layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-${{ matrix.arch }}-buildx-${{ github.event.inputs.pipeline_name }}-${{ github.ref_name }}
@@ -121,7 +118,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.arch }}-buildx-${{ github.event.inputs.pipeline_name }}-
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_PASSWORD }}
@@ -143,41 +140,29 @@ jobs:
         run: |
           docker buildx imagetools inspect egovio/${{ needs.resolve-config.outputs.image_name }}:${{ needs.resolve-config.outputs.tag }}-${{ matrix.arch }}
 
-      - name: Export Digest (amd64)
-        if: matrix.arch == 'amd64'
-        id: digest_amd64
-        run: |
-          digest=$(docker buildx imagetools inspect \
-            egovio/${{ needs.resolve-config.outputs.image_name }}:${{ needs.resolve-config.outputs.tag }}-${{ matrix.arch }} \
-            --format '{{json .}}' | jq -r '.manifest.manifests[] | select(.platform.architecture=="amd64" and .platform.os=="linux") | .digest')
-          echo "digest=$digest" >> $GITHUB_OUTPUT
-
-      - name: Export Digest (arm64)
-        if: matrix.arch == 'arm64'
-        id: digest_arm64
-        run: |
-          digest=$(docker buildx imagetools inspect \
-            egovio/${{ needs.resolve-config.outputs.image_name }}:${{ needs.resolve-config.outputs.tag }}-${{ matrix.arch }} \
-            --format '{{json .}}' | jq -r '.manifest.manifests[] | select(.platform.architecture=="arm64" and .platform.os=="linux") | .digest')
-          echo "digest=$digest" >> $GITHUB_OUTPUT
-
   create-manifest:
     name: Create and Push Manifest
     needs: [build-matrix, resolve-config]
     runs-on: ubuntu-latest
     steps:
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_PASSWORD }}
 
+      # Stitch the multi-arch manifest from the per-arch TAGS the build
+      # matrix pushed. No digest plumbing through matrix job outputs —
+      # matrix children share one output namespace, so the last finisher
+      # would overwrite the other's digest (and conditional steps leave
+      # one of them empty).
       - name: Create and push manifest
         run: |
-          docker manifest create egovio/${{ needs.resolve-config.outputs.image_name }}:${{ needs.resolve-config.outputs.tag }} \
-            --amend egovio/${{ needs.resolve-config.outputs.image_name }}@${{ needs.build-matrix.outputs.amd64_digest }} \
-            --amend egovio/${{ needs.resolve-config.outputs.image_name }}@${{ needs.build-matrix.outputs.arm64_digest }}
-          docker manifest push egovio/${{ needs.resolve-config.outputs.image_name }}:${{ needs.resolve-config.outputs.tag }}
+          docker buildx imagetools create \
+            --tag egovio/${{ needs.resolve-config.outputs.image_name }}:${{ needs.resolve-config.outputs.tag }} \
+            egovio/${{ needs.resolve-config.outputs.image_name }}:${{ needs.resolve-config.outputs.tag }}-amd64 \
+            egovio/${{ needs.resolve-config.outputs.image_name }}:${{ needs.resolve-config.outputs.tag }}-arm64
+          docker buildx imagetools inspect egovio/${{ needs.resolve-config.outputs.image_name }}:${{ needs.resolve-config.outputs.tag }}
 
       - name: Add summary to GitHub Actions
         run: |

--- a/docker-compose.egov-digit.yaml
+++ b/docker-compose.egov-digit.yaml
@@ -1444,7 +1444,7 @@ services:
   # docker build -t digit-ui-dev -f ../Citizen-Complaint-Resolution-System/frontend/micro-ui/web/docker/Dockerfile ../Citizen-Complaint-Resolution-System/frontend/micro-ui
   # ===========================================================================
   digit-ui:
-    image: egovio/digit-ui-esbuild:master-c96345c
+    image: ${DIGIT_UI_IMAGE:-egovio/digit-ui-esbuild:master-c96345c}
     container_name: digit-ui
     ports:
       - "18080:80"

--- a/docker-compose.egov-digit.yaml
+++ b/docker-compose.egov-digit.yaml
@@ -1444,7 +1444,7 @@ services:
   # docker build -t digit-ui-dev -f ../Citizen-Complaint-Resolution-System/frontend/micro-ui/web/docker/Dockerfile ../Citizen-Complaint-Resolution-System/frontend/micro-ui
   # ===========================================================================
   digit-ui:
-    image: egovio/digit-ui:pgr-fixes
+    image: egovio/digit-ui-esbuild:master-c96345c
     container_name: digit-ui
     ports:
       - "18080:80"

--- a/docker-compose.egov-digit.yaml
+++ b/docker-compose.egov-digit.yaml
@@ -1444,7 +1444,7 @@ services:
   # docker build -t digit-ui-dev -f ../Citizen-Complaint-Resolution-System/frontend/micro-ui/web/docker/Dockerfile ../Citizen-Complaint-Resolution-System/frontend/micro-ui
   # ===========================================================================
   digit-ui:
-    image: ${DIGIT_UI_IMAGE:-egovio/digit-ui-esbuild:master-c96345c}
+    image: ${DIGIT_UI_IMAGE:-egovio/digit-ui-esbuild:master-cae07a3}
     container_name: digit-ui
     ports:
       - "18080:80"

--- a/local-setup/ansible/inventory/host_vars/localhost-full.yml.example
+++ b/local-setup/ansible/inventory/host_vars/localhost-full.yml.example
@@ -69,8 +69,8 @@ enable_otp_services: false
 enable_search_stack: false
 enable_mcp: true
 build_mcp: true
-build_digit_ui: true
-build_otp_publisher: true
+build_digit_ui: false
+build_otp_publisher: false
 digit_ui_esbuild_branch: "feat/keycloak-auth-adapter"
 tolerate_bootstrap_failures: true
 enable_turbopass: false
@@ -98,7 +98,7 @@ db_fast_path_ack_data_wipe: true
 run_ci_tests: false
 force_clean: false
 install_claude_code: false
-build_configurator: true
+build_configurator: false
 
 nginx_features:
   brand_assets: false

--- a/local-setup/ansible/inventory/host_vars/localhost-slim.yml.example
+++ b/local-setup/ansible/inventory/host_vars/localhost-slim.yml.example
@@ -74,7 +74,7 @@ enable_otp_services: false
 enable_search_stack: false
 enable_mcp: true
 build_mcp: true
-build_digit_ui: true
+build_digit_ui: false
 build_otp_publisher: false         # slim: notifications path is off
 digit_ui_esbuild_branch: "feat/keycloak-auth-adapter"
 tolerate_bootstrap_failures: true
@@ -106,7 +106,7 @@ install_claude_code: false
 # Configurator is back in even on slim: runtime cost is nil (static SPA
 # served by host nginx, no container) — only the one-time vite build at
 # deploy costs RAM, and swap absorbs it.
-build_configurator: true
+build_configurator: false
 
 nginx_features:
   brand_assets: false

--- a/local-setup/ansible/inventory/host_vars/localhost-slim.yml.example
+++ b/local-setup/ansible/inventory/host_vars/localhost-slim.yml.example
@@ -103,9 +103,11 @@ db_fast_path_ack_data_wipe: true
 run_ci_tests: false
 force_clean: false
 install_claude_code: false
-# Configurator is back in even on slim: runtime cost is nil (static SPA
-# served by host nginx, no container) — only the one-time vite build at
-# deploy costs RAM, and swap absorbs it.
+# Configurator stays in even on slim: with build_configurator false the
+# deploy pulls the CI-built egovio/configurator image and host nginx
+# proxies /configurator/ to that container (a tiny static-file nginx,
+# negligible RAM) — no on-box vite build. Set true to build the dist on
+# the host and serve it from host nginx instead (costs RAM at deploy).
 build_configurator: false
 
 nginx_features:

--- a/local-setup/ansible/templates/digit.env.j2
+++ b/local-setup/ansible/templates/digit.env.j2
@@ -39,13 +39,13 @@ NOVU_BRIDGE_IMAGE={{ novu_bridge_image | default('egovio/novu-bridge:master-8116
 # fallback. Pin via `digit_ui_image:` in host_vars (e.g. the legacy
 # micro-ui egovio/digit-ui:pgr-fixes, or a nightly) and set
 # build_digit_ui:false so the deploy PULLS it instead of rebuilding.
-DIGIT_UI_IMAGE={{ digit_ui_image | default('egovio/digit-ui-esbuild:master-c96345c') }}
+DIGIT_UI_IMAGE={{ digit_ui_image | default('egovio/digit-ui-esbuild:master-cae07a3') }}
 
 # configurator image. CI-built by the SPA Build Pipeline (multi-arch),
 # served by the `configurator` compose service and proxied at
 # /configurator/ by host nginx when build_configurator is false. Pin via
 # `configurator_image:` in host_vars; default matches the compose fallback.
-CONFIGURATOR_IMAGE={{ configurator_image | default('egovio/configurator:master-c96345c') }}
+CONFIGURATOR_IMAGE={{ configurator_image | default('egovio/configurator:master-cae07a3') }}
 
 # JVM flags appended to every service's JAVA_TOOL_OPTIONS, gated on target OS.
 # Darwin (Apple-Silicon Mac under Rosetta amd64): the C2 JIT compiler SIGBUSes

--- a/local-setup/ansible/templates/digit.env.j2
+++ b/local-setup/ansible/templates/digit.env.j2
@@ -41,6 +41,12 @@ NOVU_BRIDGE_IMAGE={{ novu_bridge_image | default('egovio/novu-bridge:master-8116
 # build_digit_ui:false so the deploy PULLS it instead of rebuilding.
 DIGIT_UI_IMAGE={{ digit_ui_image | default('egovio/digit-ui-esbuild:master-c96345c') }}
 
+# configurator image. CI-built by the SPA Build Pipeline (multi-arch),
+# served by the `configurator` compose service and proxied at
+# /configurator/ by host nginx when build_configurator is false. Pin via
+# `configurator_image:` in host_vars; default matches the compose fallback.
+CONFIGURATOR_IMAGE={{ configurator_image | default('egovio/configurator:master-c96345c') }}
+
 # JVM flags appended to every service's JAVA_TOOL_OPTIONS, gated on target OS.
 # Darwin (Apple-Silicon Mac under Rosetta amd64): the C2 JIT compiler SIGBUSes
 # (CompileBroker::collect_statistics) and CDS mmap'd archives also SIGBUS — so

--- a/local-setup/ansible/templates/digit.env.j2
+++ b/local-setup/ansible/templates/digit.env.j2
@@ -34,12 +34,12 @@ OTP_PUBLISHER_IMAGE={{ otp_publisher_image | default('otp-publisher:local') }}
 # egovio Docker Hub build (matches the compose fallback).
 NOVU_BRIDGE_IMAGE={{ novu_bridge_image | default('egovio/novu-bridge:master-8116812') }}
 
-# digit-ui (legacy micro-ui) image. Canonical nightly form is
-# <registry>/digit-ui:nightly-develop — pin via `digit_ui_image:` in host_vars
-# and set build_digit_ui:false so the deploy PULLS it instead of rebuilding.
-# Default is the pinned egovio Docker Hub tag (amd64-only for now, see #1552).
-# The modern esbuild UI is a separate path.
-DIGIT_UI_IMAGE={{ digit_ui_image | default('egovio/digit-ui:pgr-fixes') }}
+# digit-ui image. Default is the modern esbuild bundle image, CI-built by
+# the SPA Build Pipeline (multi-arch amd64+arm64) and matching the compose
+# fallback. Pin via `digit_ui_image:` in host_vars (e.g. the legacy
+# micro-ui egovio/digit-ui:pgr-fixes, or a nightly) and set
+# build_digit_ui:false so the deploy PULLS it instead of rebuilding.
+DIGIT_UI_IMAGE={{ digit_ui_image | default('egovio/digit-ui-esbuild:master-c96345c') }}
 
 # JVM flags appended to every service's JAVA_TOOL_OPTIONS, gated on target OS.
 # Darwin (Apple-Silicon Mac under Rosetta amd64): the C2 JIT compiler SIGBUSes

--- a/local-setup/ansible/templates/nginx-site.conf.j2
+++ b/local-setup/ansible/templates/nginx-site.conf.j2
@@ -25,8 +25,10 @@ server {
   # do it explicitly.
   location = /configurator { return 302 /configurator/; }
 
+{% if build_configurator | default(false) %}
 {% if nginx_features.configurator_caching %}
-  # Configurator SPA — long-cache the hashed assets/, no-cache index.
+  # Configurator SPA — host-built dist (build_configurator: true).
+  # Long-cache the hashed assets/, no-cache index.
   location /configurator/assets/ {
     alias /var/www/configurator/assets/;
     add_header Cache-Control "public, max-age=31536000, immutable" always;
@@ -39,10 +41,25 @@ server {
     add_header Cache-Control "no-cache, must-revalidate" always;
   }
 {% else %}
-  # Configurator SPA (no asset-level caching).
+  # Configurator SPA — host-built dist (build_configurator: true), no
+  # asset-level caching.
   location /configurator/ {
     alias /var/www/configurator/;
     try_files $uri $uri/ /configurator/index.html;
+  }
+{% endif %}
+{% else %}
+  # Configurator SPA — proxied to the CI-built container image
+  # (egovio/configurator, `configurator` service in the compose stack).
+  # This is the default path when build_configurator is false: no on-box
+  # vite build, the SPA and the platform APIs share this origin so login
+  # works on any host/domain this server answers for.
+  location /configurator/ {
+    proxy_pass http://{{ nginx_upstream_host | default('127.0.0.1') }}:{{ upstream_configurator_port | default(18890) }}/configurator/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
   }
 {% endif %}
 

--- a/local-setup/docker-compose.db-migrations.yml
+++ b/local-setup/docker-compose.db-migrations.yml
@@ -1214,7 +1214,7 @@ services:
   # a local build instead.
   # ===========================================================================
   digit-ui:
-    image: ${DIGIT_UI_IMAGE:-egovio/digit-ui-esbuild:master-c96345c}
+    image: ${DIGIT_UI_IMAGE:-egovio/digit-ui-esbuild:master-cae07a3}
     container_name: digit-ui
     ports:
       - "18080:80"

--- a/local-setup/docker-compose.db-migrations.yml
+++ b/local-setup/docker-compose.db-migrations.yml
@@ -1214,7 +1214,7 @@ services:
   # a local build instead.
   # ===========================================================================
   digit-ui:
-    image: ${DIGIT_UI_IMAGE:-egovio/digit-ui:pgr-fixes}
+    image: ${DIGIT_UI_IMAGE:-egovio/digit-ui-esbuild:master-c96345c}
     container_name: digit-ui
     ports:
       - "18080:80"

--- a/local-setup/docker-compose.deploy.yaml
+++ b/local-setup/docker-compose.deploy.yaml
@@ -830,7 +830,7 @@ services:
       - egov-network
 
   digit-ui:
-    image: ${DIGIT_UI_IMAGE:-egovio/digit-ui:pgr-fixes}
+    image: ${DIGIT_UI_IMAGE:-egovio/digit-ui-esbuild:master-c96345c}
     container_name: digit-ui
     ports:
       - "18080:80"

--- a/local-setup/docker-compose.deploy.yaml
+++ b/local-setup/docker-compose.deploy.yaml
@@ -830,7 +830,7 @@ services:
       - egov-network
 
   digit-ui:
-    image: ${DIGIT_UI_IMAGE:-egovio/digit-ui-esbuild:master-c96345c}
+    image: ${DIGIT_UI_IMAGE:-egovio/digit-ui-esbuild:master-cae07a3}
     container_name: digit-ui
     ports:
       - "18080:80"

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -1576,10 +1576,10 @@ services:
   # ===========================================================================
   digit-ui:
     # Parameterized so deploys can pin a nightly-develop (or other) build via
-    # DIGIT_UI_IMAGE; default keeps the prior pinned tag. NOTE: this is the
-    # legacy micro-ui container — the modern esbuild bundle is laid in via
-    # build_digit_ui or served by host nginx (see build/NIGHTLY-BUILDS.md).
-    image: ${DIGIT_UI_IMAGE:-egovio/digit-ui:pgr-fixes}
+    # DIGIT_UI_IMAGE. Default is the modern esbuild bundle image (CI-built by
+    # the SPA Build Pipeline, multi-arch); the bundle lives at
+    # /var/web/digit-ui, matching the mounted digit-ui.conf root.
+    image: ${DIGIT_UI_IMAGE:-egovio/digit-ui-esbuild:master-c96345c}
     container_name: digit-ui
     ports:
       - "18080:80"
@@ -1598,6 +1598,27 @@ services:
       timeout: 10s
       retries: 5
       start_period: 60s
+    networks:
+      - egov-network
+
+  # ===========================================================================
+  # Configurator (DIGIT Studio) — tenant onboarding admin console
+  # Static Vite SPA served by the image's nginx under /configurator/.
+  # Tenant-neutral (no VITE_* baked); CI-built by the SPA Build Pipeline.
+  # Ansible deploys may instead serve a host-built dist via host nginx
+  # (build_configurator: true) — this container is the pull-based default.
+  # ===========================================================================
+  configurator:
+    image: ${CONFIGURATOR_IMAGE:-egovio/configurator:master-c96345c}
+    container_name: configurator
+    ports:
+      - "18890:80"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:80/configurator/ >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
     networks:
       - egov-network
 

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -1579,7 +1579,7 @@ services:
     # DIGIT_UI_IMAGE. Default is the modern esbuild bundle image (CI-built by
     # the SPA Build Pipeline, multi-arch); the bundle lives at
     # /var/web/digit-ui, matching the mounted digit-ui.conf root.
-    image: ${DIGIT_UI_IMAGE:-egovio/digit-ui-esbuild:master-c96345c}
+    image: ${DIGIT_UI_IMAGE:-egovio/digit-ui-esbuild:master-cae07a3}
     container_name: digit-ui
     ports:
       - "18080:80"
@@ -1609,7 +1609,7 @@ services:
   # (build_configurator: true) — this container is the pull-based default.
   # ===========================================================================
   configurator:
-    image: ${CONFIGURATOR_IMAGE:-egovio/configurator:master-c96345c}
+    image: ${CONFIGURATOR_IMAGE:-egovio/configurator:master-cae07a3}
     container_name: configurator
     ports:
       - "18890:80"

--- a/local-setup/docker-compose.registry.yml
+++ b/local-setup/docker-compose.registry.yml
@@ -1529,7 +1529,7 @@ services:
   # a local build instead.
   # ===========================================================================
   digit-ui:
-    image: ${DIGIT_UI_IMAGE:-egovio/digit-ui:pgr-fixes}
+    image: ${DIGIT_UI_IMAGE:-egovio/digit-ui-esbuild:master-c96345c}
     container_name: digit-ui
     ports:
       - "18080:80"

--- a/local-setup/docker-compose.registry.yml
+++ b/local-setup/docker-compose.registry.yml
@@ -1529,7 +1529,7 @@ services:
   # a local build instead.
   # ===========================================================================
   digit-ui:
-    image: ${DIGIT_UI_IMAGE:-egovio/digit-ui-esbuild:master-c96345c}
+    image: ${DIGIT_UI_IMAGE:-egovio/digit-ui-esbuild:master-cae07a3}
     container_name: digit-ui
     ports:
       - "18080:80"

--- a/local-setup/docker-compose.yml
+++ b/local-setup/docker-compose.yml
@@ -1019,7 +1019,7 @@ services:
       - egov-network
 
   digit-ui:
-    image: ${DIGIT_UI_IMAGE:-egovio/digit-ui:pgr-fixes}
+    image: ${DIGIT_UI_IMAGE:-egovio/digit-ui-esbuild:master-c96345c}
     container_name: digit-ui
     restart: on-failure
     ports:

--- a/local-setup/docker-compose.yml
+++ b/local-setup/docker-compose.yml
@@ -1019,7 +1019,7 @@ services:
       - egov-network
 
   digit-ui:
-    image: ${DIGIT_UI_IMAGE:-egovio/digit-ui-esbuild:master-c96345c}
+    image: ${DIGIT_UI_IMAGE:-egovio/digit-ui-esbuild:master-cae07a3}
     container_name: digit-ui
     restart: on-failure
     ports:


### PR DESCRIPTION
# Summary

Ships the SPA container pipeline end to end: a GitHub Actions workflow that builds + publishes multi-arch images for **configurator** and **digit-ui-esbuild** to the egovio Docker Hub org, and the compose/ansible changes that make those images the default serving path — no on-box `npm`/`vite`/`esbuild` builds on fresh deployments.

## Commits

1. **`ci: SPA build pipeline`** — dispatch-driven workflow (`Actions → SPA Build Pipeline`) resolving work-dir/dockerfile/image from `build/build-config.yml` like `pgr-ui-build.yml`, with two deltas: the build context is the app's own directory (these Dockerfiles COPY relative to themselves, no `WORK_DIR` arg), and a deterministic `<branch>-<shortsha>` tag (drops the Docker Hub tag-lookup that hard-fails rebuilds via the `grep || true |` precedence bug). Builds amd64 on `ubuntu-latest` + arm64 on `ubuntu-24.04-arm` (native, no QEMU), stitches the manifest.
2. **`feat(spa): serve from CI-built images`** —
   - `DIGIT_UI_IMAGE` default → `egovio/digit-ui-esbuild:master-cae07a3` in every compose variant (drop-in: the bundle lives at `/var/web/digit-ui`, matching the mounted `digit-ui.conf`; the service keeps its `digit-ui` name, and the legacy micro-ui image remains one `digit_ui_image:` pin away)
   - new `configurator` service (`egovio/configurator:master-cae07a3`, port 18890, `CONFIGURATOR_IMAGE` override)
   - `nginx-site.conf.j2`: with `build_configurator: false` (now the default), `/configurator/` **proxies the container** instead of aliasing the on-disk dist, so the SPA and platform APIs share one origin and login works on any host/domain (`Host $host` passthrough); `build_configurator: true` keeps the host-built dist path unchanged
   - `digit.env.j2`: `DIGIT_UI_IMAGE` default matches the compose fallback (the old `pgr-fixes` default silently reverted digit-ui on every re-deploy)
   - host_vars examples: `build_digit_ui` / `build_otp_publisher` / `build_configurator` default `false` — SPA/UI deploys pull images instead of building on the box

## Testing

- Both Dockerfiles built locally with the workflow's exact invocation; images smoke-tested (SPA deep links, `globalConfigs.js` runtime injection)
- Published `master-cae07a3` images pulled and verified multi-arch
- Full `./deploy.sh` converge on a live tenant: `PLAY RECAP failed=0`, INFRA VALIDATION all green, nginx config generated purely from the updated template
- Verified via `localhost` **and** a mapped test domain (`testtenant.local`): `/digit-ui/`, `/configurator/`, `/configurator/login`, `/citizen/`, oauth login — all 200 on both origins; configurator-via-nginx ETag equals the container's (image confirmed as responder)

## Notes for reviewers

- Fresh-box behavior change: `/configurator/` is served by the container by default; setting `build_configurator: true` restores the on-box vite build + dist serving.
- Deploy-time capacity: the parallel flyway migrator burst needs headroom on 16 GB hosts (validation box needed a second 4G swapfile). Pre-existing, unrelated to this change, but worth knowing when re-deploying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

