### PR TITLE
fix(dashboard): clicking a complaint pin threw, so no popup ever opened (#1576)

### DIFF
--- a/digit-ui-esbuild/products/dashboard/src/components/GeographyChoroplethMap.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/GeographyChoroplethMap.jsx
@@ -69,6 +69,22 @@ function complaintPinPopupOffset(radius) {
   return L.point(0, -Math.max(radius + 10, 12));
 }
 
+/**
+ * Close whichever ward tooltip is currently open.
+ *
+ * NOT `map.closeTooltip()` — Leaflet 1.9's Map.closeTooltip(tooltip) dereferences
+ * its argument (`tooltip.close()`), so calling it bare throws
+ * "Cannot read properties of undefined (reading 'close')". Thrown from the pin
+ * click handler that exception aborted the event before Leaflet's own bindPopup
+ * listener ran, so clicking a pin silently did nothing (#1576). Layer.closeTooltip()
+ * takes no argument and is the correct call.
+ */
+function closeOpenTooltips(map) {
+  map?.eachLayer?.((layer) => {
+    if (layer !== map && typeof layer.closeTooltip === "function") layer.closeTooltip();
+  });
+}
+
 function closeOtherPinPopups(activeCircle, pinLayersByKey = {}) {
   Object.values(pinLayersByKey).forEach((circle) => {
     if (circle !== activeCircle && circle.isPopupOpen?.()) {
@@ -730,7 +746,17 @@ const GeographyChoroplethMap = ({
 
       circle.on("click", () => {
         closeOtherPinPopups(circle, pinLayersByKeyRef.current);
-        map.closeTooltip();
+        closeOpenTooltips(map);
+      });
+
+      // Hover feedback. Without a tooltip of its own a pin showed nothing on
+      // hover while still stealing the pointer from the ward polygon beneath it,
+      // so the ward tooltip vanished and nothing replaced it (#1576).
+      circle.bindTooltip(buildComplaintPinTooltipHtml(pin), {
+        ...HOVER_TOOLTIP_OPTIONS,
+        sticky: false,
+        offset: [0, -(baseRadius + 4)],
+        direction: "top",
       });
 
       circle.on("mouseover", function () {
@@ -746,9 +772,10 @@ const GeographyChoroplethMap = ({
       });
 
       circle.on("popupopen", function () {
+        this.closeTooltip?.();
         closeOtherPinPopups(this, pinLayersByKeyRef.current);
         selectedPinKeyRef.current = key;
-        map.closeTooltip();
+        closeOpenTooltips(map);
         const radius = markerRadiusForZoom(zoomLevelRef.current, false, { complaint: true });
         Object.entries(pinLayersByKeyRef.current).forEach(([, layer]) => {
           const layerRadius = markerRadiusForZoom(zoomLevelRef.current, false, { complaint: true });

--- a/digit-ui-esbuild/products/dashboard/src/components/mapTooltipTeardown.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/components/mapTooltipTeardown.test.js
@@ -1,0 +1,64 @@
+// Guards the pin-click crash from #1576.
+// Run from digit-ui-esbuild/:  node --test products/dashboard/src/components/mapTooltipTeardown.test.js
+//
+// Leaflet 1.9's Map.closeTooltip(tooltip) dereferences its argument:
+//     closeTooltip: function (tooltip) { tooltip.close(); return this; }
+// so `map.closeTooltip()` throws TypeError. Thrown from the pin click handler,
+// that exception aborted the event BEFORE Leaflet's own bindPopup listener ran,
+// so clicking a complaint pin silently did nothing.
+//
+// GeographyChoroplethMap.jsx cannot be bundled here (it pulls in Leaflet, React
+// and CSS), so this asserts the two things that actually matter: the real
+// Leaflet signature still behaves as assumed, and the source carries no bare
+// `map.closeTooltip()` call in either dashboard copy.
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+/** Strip comments so the scan sees code, not the note explaining the bug. */
+function stripComments(src) {
+  return src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+}
+
+const COPIES = [
+  path.join(__dirname, "GeographyChoroplethMap.jsx"),
+  path.join(__dirname, "../../../../../frontend/micro-ui/web/src/dashboard/components/GeographyChoroplethMap.jsx"),
+];
+
+test("Leaflet's Map.closeTooltip still requires an argument", () => {
+  // If a Leaflet upgrade ever makes the bare call safe, this fails and the
+  // workaround can be revisited — rather than being cargo-culted forever.
+  const src = fs.readFileSync(
+    path.join(__dirname, "../../../../node_modules/leaflet/dist/leaflet-src.js"),
+    "utf8"
+  );
+  const match = src.match(/closeTooltip: function \(tooltip\) \{\s*tooltip\.close\(\);/);
+  assert.ok(match, "Map.closeTooltip no longer dereferences its argument — re-check the workaround");
+});
+
+for (const file of COPIES) {
+  const label = file.includes("digit-ui-esbuild") || !file.includes("micro-ui") ? "esbuild" : "legacy";
+  test(`no bare map.closeTooltip() in the ${label} map component`, () => {
+    if (!fs.existsSync(file)) return; // legacy tree may be absent in some checkouts
+    const src = stripComments(fs.readFileSync(file, "utf8"));
+    assert.equal(
+      /\bmap\.closeTooltip\(\s*\)/.test(src),
+      false,
+      "bare map.closeTooltip() throws in Leaflet 1.9 — use closeOpenTooltips(map)"
+    );
+    assert.ok(fs.readFileSync(file, "utf8").includes("function closeOpenTooltips"), "closeOpenTooltips helper missing");
+  });
+
+  test(`complaint pins bind a hover tooltip in the ${label} map component`, () => {
+    if (!fs.existsSync(file)) return;
+    const src = fs.readFileSync(file, "utf8");
+    // Pins previously had bindPopup (click) only, so hovering one showed nothing
+    // while still stealing the pointer from the ward polygon beneath it.
+    assert.ok(
+      /circle\.bindTooltip\(/.test(src),
+      "pins must bind a tooltip or hovering a pin hides the ward tooltip and shows nothing"
+    );
+  });
+}

--- a/frontend/micro-ui/web/src/dashboard/components/GeographyChoroplethMap.jsx
+++ b/frontend/micro-ui/web/src/dashboard/components/GeographyChoroplethMap.jsx
@@ -67,6 +67,17 @@ function complaintPinPopupOffset(radius) {
   return L.point(0, -Math.max(radius + 10, 12));
 }
 
+/**
+ * Close whichever ward tooltip is open. NOT map.closeTooltip() — Leaflet 1.9's
+ * Map.closeTooltip(tooltip) dereferences its argument, so a bare call throws and
+ * (from the pin click handler) aborted the event before the popup could open (#1576).
+ */
+function closeOpenTooltips(map) {
+  map?.eachLayer?.((layer) => {
+    if (layer !== map && typeof layer.closeTooltip === "function") layer.closeTooltip();
+  });
+}
+
 function closeOtherPinPopups(activeCircle, pinLayersByKey = {}) {
   Object.values(pinLayersByKey).forEach((circle) => {
     if (circle !== activeCircle && circle.isPopupOpen?.()) {
@@ -706,7 +717,16 @@ const GeographyChoroplethMap = ({
 
       circle.on("click", () => {
         closeOtherPinPopups(circle, pinLayersByKeyRef.current);
-        map.closeTooltip();
+        closeOpenTooltips(map);
+      });
+
+      // Pins had no tooltip of their own, so hovering one showed nothing while
+      // still stealing the pointer from the ward polygon beneath (#1576).
+      circle.bindTooltip(buildComplaintPinTooltipHtml(pin), {
+        ...HOVER_TOOLTIP_OPTIONS,
+        sticky: false,
+        offset: [0, -(baseRadius + 4)],
+        direction: "top",
       });
 
       circle.on("mouseover", function () {
@@ -722,9 +742,10 @@ const GeographyChoroplethMap = ({
       });
 
       circle.on("popupopen", function () {
+        this.closeTooltip?.();
         closeOtherPinPopups(this, pinLayersByKeyRef.current);
         selectedPinKeyRef.current = key;
-        map.closeTooltip();
+        closeOpenTooltips(map);
         const radius = markerRadiusForZoom(zoomLevelRef.current, false, { complaint: true });
         Object.entries(pinLayersByKeyRef.current).forEach(([, layer]) => {
           const layerRadius = markerRadiusForZoom(zoomLevelRef.current, false, { complaint: true });


### PR DESCRIPTION
Fixes two of the map items on #1576. Both were reported as UI oddities; the first is a hard JS exception.

## 1. Clicking a pin threw, so the popup never opened

Leaflet 1.9's `Map.closeTooltip` dereferences its argument:

```js
closeTooltip: function (tooltip) { tooltip.close(); return this; }
```

We called it bare — `map.closeTooltip()` — at `GeographyChoroplethMap.jsx:733` and `:751`, which throws:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'close')
    at G.closeTooltip (leaflet)
    at G.<anonymous>            <- our pin click handler
    at G.fire / _fireDOMEvent / _handleDOMEvent
```

The critical detail is *where* it throws. The handler is registered **before** `bindPopup`, so Leaflet's own click listener never runs — the exception aborts the event. Clicking a complaint pin did nothing at all, leaving only a console error. Reported as "even clicking is not showing anything on top of pins".

Replaced with `closeOpenTooltips(map)`, which closes via `Layer.closeTooltip()` — the overload that takes no argument.

## 2. Hovering a pin hid the tooltip and showed nothing

Pins bound a **popup** (click) but never a **tooltip**, while living in a pane above the ward polygons. Moving the pointer onto a pin fired the polygon's `mouseout`, Leaflet hid the ward tooltip, and the pin had nothing to display — exactly the reported "hover works elsewhere on the map, but hovering the points makes the tooltip hide away".

Pins now bind a hover tooltip built from the same content builder as the popup, and `popupopen` closes it so the two never double-render.

## Both copies

The legacy `frontend/micro-ui/web/src/dashboard/` tree (still imported by `App.js`) carried the identical bare call and the identical missing tooltip. Both are fixed.

## Regression test

`components/mapTooltipTeardown.test.js` asserts two things:

- **Leaflet's signature still behaves as assumed** — reading the real `leaflet-src.js`. If a future upgrade makes the bare call safe, this fails and the workaround gets revisited rather than cargo-culted forever.
- **Neither copy regains a bare `map.closeTooltip()`**, and pins keep a bound tooltip. The scan strips comments first, so the explanatory note about the bug doesn't match itself.

The component can't be bundled in a unit test (it pulls in Leaflet, React and CSS), so this guards the invariant at source level — which is the level the bug lived at.

```
node --test <all suites>   174 pass / 0 fail   (169 existing + 5 new)
node esbuild.build.js      Build complete
```

## Not in this PR

The remaining #1576 item — the department bar labelled `-` — is a data gap, not a UI bug: `RudeBehavior` resolves to `WATER_ENV` because ServiceDefs has that row, while `SampleSectorExampleSubType1` (182 of the 232 unlabelled complaints) has **zero** rows among the 3,999 ServiceDefs records, so the grain's left join writes NULL. That needs ServiceDefs entries seeded, or the grain made hierarchy-aware after the N-level cutover.

Also unrelated but seen in the same console: `<g> attribute transform: Expected number, "translate(NaN, 0)"`, and `Icon not found` for `action:home` / `dynamic:ContractIcon`. Not investigated here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved map tooltip handling to prevent errors when opening complaint popups.
  - Ensured active ward and complaint-pin tooltips close cleanly during map interactions.
  - Added consistent hover tooltip behavior and positioning for complaint pins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->