### PR TITLE
fix(dashboard): add a breadcrumb trail and restore the page gutter when embedded

### DIFF
--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardBreadcrumb.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardBreadcrumb.jsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import useDashboardT from "../i18n/useDashboardT";
+
+/**
+ * Breadcrumb trail for the EMBEDDED dashboard (mounted inside the DigitUI
+ * employee chrome by products/dashboard/Module.js).
+ *
+ * Why this exists: the embedded dashboard is a leaf route with no in-page way
+ * back — the only exit was the left rail's Home item, which is easy to miss on
+ * the collapsed 3rem rail and disappears entirely for roles whose access-control
+ * grants don't include it. Every other employee screen (see the PGR module's
+ * BreadCrumbs usage in products/pgr/src/pages/employee/index.js) carries a
+ * "Home / <page>" trail, so this restores the platform convention rather than
+ * inventing a bespoke back button.
+ *
+ * Standalone mode is unaffected: DashboardLayout only renders this when
+ * `embedded`, so <Link> is never mounted outside the host's Router.
+ *
+ * Labels resolve through the dashboard's own t(), which deliberately echoes the
+ * KEY when a message is unseeded so gaps surface in QA. A breadcrumb showing
+ * "DASHBOARD_BREADCRUMB_CURRENT" would be worse than useless on a live env, so
+ * every label goes through `label()`, which falls back to English until the
+ * key is seeded — the same exists()-guarded pattern DashboardHeader uses for
+ * DASHBOARD_HEADER_TITLE.
+ */
+const DashboardBreadcrumb = () => {
+  // Calling the hook (rather than importing translate directly) subscribes this
+  // component to locale changes and late bundle arrivals, so the crumbs
+  // re-render when the user switches language.
+  const { t, exists } = useDashboardT();
+
+  // First seeded key wins; English is the last resort so the trail is always
+  // readable. ACTION_TEST_HOME is the platform's existing "Home" label — the
+  // one the PGR breadcrumbs and the sidebar Home item already use — so a tenant
+  // that has localized its nav gets a consistent word for free.
+  const label = (keys, english) => {
+    const key = keys.find((k) => exists(k));
+    return key ? t(key, english) : english;
+  };
+
+  // contextPath is the deploy-time mount point ("digit-ui"); mirror the
+  // defensive read used elsewhere in the app rather than hardcoding it.
+  const homePath = `/${window?.contextPath}/employee`;
+
+  return (
+    <nav
+      className="dashboard-breadcrumb"
+      aria-label={label(["DASHBOARD_BREADCRUMB_ARIA_LABEL"], "Breadcrumb")}
+    >
+      <ol className="dashboard-breadcrumb-list">
+        <li className="dashboard-breadcrumb-item">
+          <Link to={homePath} className="dashboard-breadcrumb-link">
+            {label(["DASHBOARD_BREADCRUMB_HOME", "ACTION_TEST_HOME"], "Home")}
+          </Link>
+          <span className="dashboard-breadcrumb-separator" aria-hidden="true">
+            /
+          </span>
+        </li>
+        <li className="dashboard-breadcrumb-item">
+          <span className="dashboard-breadcrumb-current" aria-current="page">
+            {label(["DASHBOARD_BREADCRUMB_CURRENT"], "Dashboard")}
+          </span>
+        </li>
+      </ol>
+    </nav>
+  );
+};
+
+export default DashboardBreadcrumb;

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardLayout.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardLayout.jsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from "react";
 import { getBrandTheme } from "../config/dashboardConfig";
+import DashboardBreadcrumb from "./DashboardBreadcrumb";
 import DashboardHeader from "./DashboardHeader";
 import DashboardFilters from "./DashboardFilters";
 import Sidebar from "./Sidebar";
@@ -51,6 +52,9 @@ const DashboardLayout = ({
     >
       {!embedded && <Sidebar onSignOut={onSignOut} />}
       <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col tw-overflow-hidden">
+        {/* Embedded only: standalone renders its own dark Sidebar, which
+            already carries the navigation this trail substitutes for. */}
+        {embedded && <DashboardBreadcrumb />}
         <DashboardHeader
           visibleLayoutIds={visibleLayoutIds}
           catalogItems={catalogItems}

--- a/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
@@ -3894,7 +3894,22 @@
   overflow-x: clip;
   box-sizing: border-box;
   --digit-sidebar-width: 3rem;
-  --dashboard-embedded-inset: 12px;
+  /* Gutter between the host chrome and the dashboard content. 12px read as a
+     missing gutter — cards sat almost flush against the 3rem left rail and the
+     KPI row against the topbar. These match the standalone shell's own
+     tw-p-4 / lg:tw-p-6 (16px, 24px from 1024px up), so embedded and standalone
+     now breathe the same and the page lines up with every other employee
+     screen. Vertical is tracked separately: the grid needs a floor gap that the
+     horizontal inset shouldn't drag around at wide viewports. */
+  --dashboard-embedded-inset: 16px;
+  --dashboard-embedded-inset-y: 16px;
+}
+
+@media (min-width: 1024px) {
+  .dashboard-root.dashboard-embedded {
+    --dashboard-embedded-inset: 24px;
+    --dashboard-embedded-inset-y: 20px;
+  }
 }
 
 .dashboard-root.dashboard-embedded > div {
@@ -3921,6 +3936,9 @@
   box-sizing: border-box;
   padding-left: var(--dashboard-embedded-inset);
   padding-right: var(--dashboard-embedded-inset);
+  /* The grid was the last thing in the scroll container, so the bottom row of
+     cards ended flush against the viewport edge with nothing under it. */
+  padding-bottom: var(--dashboard-embedded-inset-y);
 }
 
 .dashboard-root.dashboard-embedded .dashboard-grid-wrap .react-grid-layout {
@@ -3940,7 +3958,64 @@
 .dashboard-root.dashboard-embedded .dashboard-filters-bar {
   padding-left: var(--dashboard-embedded-inset);
   padding-right: var(--dashboard-embedded-inset);
-  margin-bottom: 12px;
+  /* The filter row sat directly on the header's bottom border and the KPI row
+     sat directly on the filters; give both edges the same rhythm as the
+     horizontal gutter. */
+  padding-top: var(--dashboard-embedded-inset-y);
+  margin-bottom: var(--dashboard-embedded-inset-y);
+}
+
+/* ── Embedded breadcrumb ───────────────────────────────────────────────
+   Rendered only in embedded mode (DashboardLayout). Styled with the
+   dashboard's own tokens rather than the platform's .digit-bread-crumb CSS:
+   that stylesheet ships from the published components package and is not
+   guaranteed to be loaded on the dashboard route, and the dashboard's type
+   scale is smaller than the platform default, so borrowed styles read
+   oversized here. */
+.dashboard-root.dashboard-embedded .dashboard-breadcrumb {
+  flex-shrink: 0;
+  background: var(--surface, #ffffff);
+  padding: 10px var(--dashboard-embedded-inset) 0;
+  box-sizing: border-box;
+}
+
+.dashboard-root.dashboard-embedded .dashboard-breadcrumb-list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.dashboard-root.dashboard-embedded .dashboard-breadcrumb-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.dashboard-root.dashboard-embedded .dashboard-breadcrumb-link {
+  color: var(--muted-foreground, #505a5f);
+  text-decoration: none;
+}
+
+.dashboard-root.dashboard-embedded .dashboard-breadcrumb-link:hover,
+.dashboard-root.dashboard-embedded .dashboard-breadcrumb-link:focus-visible {
+  color: var(--primary, #0b4b3f);
+  text-decoration: underline;
+}
+
+.dashboard-root.dashboard-embedded .dashboard-breadcrumb-separator {
+  color: var(--muted-foreground, #505a5f);
+  opacity: 0.6;
+}
+
+.dashboard-root.dashboard-embedded .dashboard-breadcrumb-current {
+  color: var(--foreground, #0b0c0c);
+  font-weight: 600;
 }
 
 .dashboard-root.dashboard-embedded .dashboard-grid-layout {

--- a/digit-ui-esbuild/products/dashboard/src/styles/input.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/input.css
@@ -2467,7 +2467,22 @@
   overflow-x: clip;
   box-sizing: border-box;
   --digit-sidebar-width: 3rem;
-  --dashboard-embedded-inset: 12px;
+  /* Gutter between the host chrome and the dashboard content. 12px read as a
+     missing gutter — cards sat almost flush against the 3rem left rail and the
+     KPI row against the topbar. These match the standalone shell's own
+     tw-p-4 / lg:tw-p-6 (16px, 24px from 1024px up), so embedded and standalone
+     now breathe the same and the page lines up with every other employee
+     screen. Vertical is tracked separately: the grid needs a floor gap that the
+     horizontal inset shouldn't drag around at wide viewports. */
+  --dashboard-embedded-inset: 16px;
+  --dashboard-embedded-inset-y: 16px;
+}
+
+@media (min-width: 1024px) {
+  .dashboard-root.dashboard-embedded {
+    --dashboard-embedded-inset: 24px;
+    --dashboard-embedded-inset-y: 20px;
+  }
 }
 .dashboard-root.dashboard-embedded > div {
   width: 100%;
@@ -2492,6 +2507,9 @@
   box-sizing: border-box;
   padding-left: var(--dashboard-embedded-inset);
   padding-right: var(--dashboard-embedded-inset);
+  /* The grid was the last thing in the scroll container, so the bottom row of
+     cards ended flush against the viewport edge with nothing under it. */
+  padding-bottom: var(--dashboard-embedded-inset-y);
 }
 
 .dashboard-root.dashboard-embedded .dashboard-grid-wrap .react-grid-layout {
@@ -2511,7 +2529,64 @@
 .dashboard-root.dashboard-embedded .dashboard-filters-bar {
   padding-left: var(--dashboard-embedded-inset);
   padding-right: var(--dashboard-embedded-inset);
-  margin-bottom: 12px;
+  /* The filter row sat directly on the header's bottom border and the KPI row
+     sat directly on the filters; give both edges the same rhythm as the
+     horizontal gutter. */
+  padding-top: var(--dashboard-embedded-inset-y);
+  margin-bottom: var(--dashboard-embedded-inset-y);
+}
+
+/* ── Embedded breadcrumb ───────────────────────────────────────────────
+   Rendered only in embedded mode (DashboardLayout). Styled with the
+   dashboard's own tokens rather than the platform's .digit-bread-crumb CSS:
+   that stylesheet ships from the published components package and is not
+   guaranteed to be loaded on the dashboard route, and the dashboard's type
+   scale is smaller than the platform default, so borrowed styles read
+   oversized here. */
+.dashboard-root.dashboard-embedded .dashboard-breadcrumb {
+  flex-shrink: 0;
+  background: var(--surface, #ffffff);
+  padding: 10px var(--dashboard-embedded-inset) 0;
+  box-sizing: border-box;
+}
+
+.dashboard-root.dashboard-embedded .dashboard-breadcrumb-list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.dashboard-root.dashboard-embedded .dashboard-breadcrumb-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.dashboard-root.dashboard-embedded .dashboard-breadcrumb-link {
+  color: var(--muted-foreground, #505a5f);
+  text-decoration: none;
+}
+
+.dashboard-root.dashboard-embedded .dashboard-breadcrumb-link:hover,
+.dashboard-root.dashboard-embedded .dashboard-breadcrumb-link:focus-visible {
+  color: var(--primary, #0b4b3f);
+  text-decoration: underline;
+}
+
+.dashboard-root.dashboard-embedded .dashboard-breadcrumb-separator {
+  color: var(--muted-foreground, #505a5f);
+  opacity: 0.6;
+}
+
+.dashboard-root.dashboard-embedded .dashboard-breadcrumb-current {
+  color: var(--foreground, #0b0c0c);
+  font-weight: 600;
 }
 
 .dashboard-root.dashboard-embedded .dashboard-grid-layout {


### PR DESCRIPTION
## Problem

Two issues on `/digit-ui/employee/dashboard`, both reported from **cms-pilot**.

**1. No way back.** The embedded dashboard is a leaf route with no in-page navigation. The only exit is the left rail's Home item, which is easy to miss on the collapsed 3rem rail — and does not render for every user who reaches the page. Users get stuck.

**2. Missing gutter.** `DashboardLayout` gives `<main>` `tw-p-4 lg:tw-p-6` in the **standalone** branch but nothing in the **embedded** branch, substituting a flat `--dashboard-embedded-inset: 12px`. Cards sat almost flush against the left rail, the filter row against the header's bottom border, and the bottom card row against the viewport edge.

## Changes

**Breadcrumb** — new `DashboardBreadcrumb.jsx`, rendered by `DashboardLayout` **only when `embedded`**:
- Standalone is untouched — it already has its own dark `Sidebar` carrying this navigation, and gating on `embedded` also guarantees `<Link>` never mounts outside the host's Router.
- Restores the platform convention (`Home / <page>`) that every other employee screen has, rather than inventing a bespoke back button.
- Labels are `exists()`-guarded with English fallbacks. The dashboard's `t()` deliberately echoes the KEY when unseeded so gaps surface in QA — a breadcrumb reading `DASHBOARD_BREADCRUMB_CURRENT` on a live env would be worse than useless. Same pattern `DashboardHeader` already uses for `DASHBOARD_HEADER_TITLE`.
- `DASHBOARD_BREADCRUMB_HOME` falls back to the platform's existing `ACTION_TEST_HOME`, so a tenant that already localized its nav gets a consistent word for free.

**Padding** — inset now matches the standalone shell: **16px, 24px from 1024px up**. Vertical rhythm moves to its own `--dashboard-embedded-inset-y` so the grid's floor gap isn't dragged around by the horizontal value at wide viewports. Adds `padding-bottom` on the grid wrap and `padding-top` on the filters bar.

## Verification

Built this branch (`node esbuild.build.js`, node 20) and measured the **compiled** CSS in a browser at both breakpoints. Breadcrumb, title, filter row and KPI cards all land on the same gutter with no straggler:

| viewport | inset | breadcrumb | title | filters | cards | grid pad-bottom |
|---|---|---|---|---|---|---|
| 900px | 16px | 16 | 16 | 16 | 16 | 16px |
| 1440px+ | 24px | 24 | 24 | 24 | 24 | 20px |

Breadcrumb renders `Home / Dashboard`, current crumb at weight 600, Home links to `/${contextPath}/employee`.

## Notes

- Cherry-picked from the same fix on `master` (#1587, closed in favour of this one). All four touched files differ between `master` and `release-v2.12-moz`, so this was cut fresh off moz rather than retargeted — retargeting would have dragged in the 132 `master` commits moz is behind. Verified after the pick that moz's `searchQuery` / `onSearchQueryChange` props on `DashboardLayout` are **preserved** (the search-box removal is master-only) and that the embedded CSS block is otherwise identical between the two branches.
- Both stylesheets are edited identically — `dashboard.css` is the generated artifact, and this block sits outside the tailwind layers, so regeneration passes it through verbatim.
- **Localization follow-up:** `DASHBOARD_BREADCRUMB_HOME` / `DASHBOARD_BREADCRUMB_CURRENT` / `DASHBOARD_BREADCRUMB_ARIA_LABEL` need seeding in `en_IN` + `pt_PT` on local / cms-pilot / mctd. Until then the English fallbacks render, so this is safe to ship first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)