### PR TITLE
fix(ci): green the Ansible-lint and Gatus-coverage checks on master

### DIFF
--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -433,381 +433,381 @@
         # release task below only fires when this one created the file).
         - name: "Docker install — configure data-root before first start (Debian/Ubuntu), always releasing the auto-start hold"
           block:
-          - name: "Docker install — hold package auto-start until data-root is configured (Debian/Ubuntu)"
-            ansible.builtin.copy:
-              dest: /usr/sbin/policy-rc.d
-              mode: '0755'
-              force: false
-              content: |
-                #!/bin/sh
-                # Temporary: installed by the DIGIT ansible deploy while
-                # docker-ce is installed with a relocated data-root; removed
-                # again in the same run.
-                exit 101
-            register: _docker_autostart_hold
-            when:
-              - ansible_facts['os_family'] == 'Debian'
-              - (docker_data_root | default('') | length) > 0
+            - name: "Docker install — hold package auto-start until data-root is configured (Debian/Ubuntu)"
+              ansible.builtin.copy:
+                dest: /usr/sbin/policy-rc.d
+                mode: '0755'
+                force: false
+                content: |
+                  #!/bin/sh
+                  # Temporary: installed by the DIGIT ansible deploy while
+                  # docker-ce is installed with a relocated data-root; removed
+                  # again in the same run.
+                  exit 101
+              register: _docker_autostart_hold
+              when:
+                - ansible_facts['os_family'] == 'Debian'
+                - (docker_data_root | default('') | length) > 0
 
-          - name: Install Docker Engine (Debian/Ubuntu)
-            apt:
-              name:
-                - docker-ce
-                - docker-ce-cli
-                - containerd.io
-                - docker-buildx-plugin
-                - docker-compose-plugin
-              state: present
-              update_cache: yes
-            when: ansible_facts['os_family'] == 'Debian'
+            - name: Install Docker Engine (Debian/Ubuntu)
+              apt:
+                name:
+                  - docker-ce
+                  - docker-ce-cli
+                  - containerd.io
+                  - docker-buildx-plugin
+                  - docker-compose-plugin
+                state: present
+                update_cache: yes
+              when: ansible_facts['os_family'] == 'Debian'
 
-          # ==================== Docker Installation (RHEL family) ====================
-          # Rocky Linux / AlmaLinux / CentOS Stream / RHEL. Docker publishes no
-          # separate "rocky"/"alma" repo — the upstream linux/rhel repo is the
-          # documented path for every RHEL rebuild, BUT the stock
-          # docker-ce.repo uses $releasever, which resolves to the host's
-          # actual major version — and Docker briefly had no EL10 packages
-          # (download.docker.com/linux/rhel/10/ 404'd earlier in 2026;
-          # github.com/docker/roadmap#847). Docker now publishes a
-          # linux/rhel/10/ tree for x86_64 and aarch64, so the host's real
-          # major version is used by default. docker_rhel_releasever_override
-          # remains as an escape hatch for a future major version that again
-          # ships without packages (pin it to the last published releasever
-          # until Docker catches up).
-          - name: "Docker repo (RHEL family) — resolve releasever to use"
-            ansible.builtin.set_fact:
-              _docker_rhel_releasever: >-
-                {{ docker_rhel_releasever_override | default(ansible_distribution_major_version, true) }}
-            when: ansible_facts['os_family'] == 'RedHat'
+            # ==================== Docker Installation (RHEL family) ====================
+            # Rocky Linux / AlmaLinux / CentOS Stream / RHEL. Docker publishes no
+            # separate "rocky"/"alma" repo — the upstream linux/rhel repo is the
+            # documented path for every RHEL rebuild, BUT the stock
+            # docker-ce.repo uses $releasever, which resolves to the host's
+            # actual major version — and Docker briefly had no EL10 packages
+            # (download.docker.com/linux/rhel/10/ 404'd earlier in 2026;
+            # github.com/docker/roadmap#847). Docker now publishes a
+            # linux/rhel/10/ tree for x86_64 and aarch64, so the host's real
+            # major version is used by default. docker_rhel_releasever_override
+            # remains as an escape hatch for a future major version that again
+            # ships without packages (pin it to the last published releasever
+            # until Docker catches up).
+            - name: "Docker repo (RHEL family) — resolve releasever to use"
+              ansible.builtin.set_fact:
+                _docker_rhel_releasever: >-
+                  {{ docker_rhel_releasever_override | default(ansible_distribution_major_version, true) }}
+              when: ansible_facts['os_family'] == 'RedHat'
 
-          - name: "Docker repo (RHEL family) — write docker-ce.repo pinned to a published releasever"
-            ansible.builtin.copy:
-              dest: /etc/yum.repos.d/docker-ce.repo
-              mode: '0644'
-              content: |
-                [docker-ce-stable]
-                name=Docker CE Stable - $basearch
-                baseurl=https://download.docker.com/linux/rhel/{{ _docker_rhel_releasever }}/$basearch/stable
-                enabled=1
-                gpgcheck=1
-                gpgkey=https://download.docker.com/linux/rhel/gpg
-            when: ansible_facts['os_family'] == 'RedHat'
+            - name: "Docker repo (RHEL family) — write docker-ce.repo pinned to a published releasever"
+              ansible.builtin.copy:
+                dest: /etc/yum.repos.d/docker-ce.repo
+                mode: '0644'
+                content: |
+                  [docker-ce-stable]
+                  name=Docker CE Stable - $basearch
+                  baseurl=https://download.docker.com/linux/rhel/{{ _docker_rhel_releasever }}/$basearch/stable
+                  enabled=1
+                  gpgcheck=1
+                  gpgkey=https://download.docker.com/linux/rhel/gpg
+              when: ansible_facts['os_family'] == 'RedHat'
 
-          # podman/podman-docker ship on RHEL-family cloud images and own the
-          # same `docker` CLI shim path as Docker CE's packages — same
-          # conflict as Ubuntu's docker.io above. Idempotent: no-op if absent.
-          - name: Remove conflicting RHEL-family container packages
-            dnf:
-              name: [podman, podman-docker, runc]
-              state: absent
-            when: ansible_facts['os_family'] == 'RedHat'
+            # podman/podman-docker ship on RHEL-family cloud images and own the
+            # same `docker` CLI shim path as Docker CE's packages — same
+            # conflict as Ubuntu's docker.io above. Idempotent: no-op if absent.
+            - name: Remove conflicting RHEL-family container packages
+              dnf:
+                name: [podman, podman-docker, runc]
+                state: absent
+              when: ansible_facts['os_family'] == 'RedHat'
 
-          - name: Install Docker Engine (RHEL family)
-            dnf:
-              name:
-                - docker-ce
-                - docker-ce-cli
-                - containerd.io
-                - docker-buildx-plugin
-                - docker-compose-plugin
-              state: present
-              update_cache: yes
-            when: ansible_facts['os_family'] == 'RedHat'
+            - name: Install Docker Engine (RHEL family)
+              dnf:
+                name:
+                  - docker-ce
+                  - docker-ce-cli
+                  - containerd.io
+                  - docker-buildx-plugin
+                  - docker-compose-plugin
+                state: present
+                update_cache: yes
+              when: ansible_facts['os_family'] == 'RedHat'
 
-          # semanage (and the libselinux python bindings the seboolean module
-          # needs) live in policycoreutils-python-utils, which minimal
-          # RHEL-family cloud images do not preinstall. One early install
-          # serves both the storage-relocation labeling below and the nginx
-          # SELinux block further down.
-          - name: "SELinux — ensure policy tooling is present (RHEL family)"
-            dnf:
-              name: policycoreutils-python-utils
-              state: present
-            when:
-              - ansible_facts['os_family'] == 'RedHat'
-              - _selinux_enforced
+            # semanage (and the libselinux python bindings the seboolean module
+            # needs) live in policycoreutils-python-utils, which minimal
+            # RHEL-family cloud images do not preinstall. One early install
+            # serves both the storage-relocation labeling below and the nginx
+            # SELinux block further down.
+            - name: "SELinux — ensure policy tooling is present (RHEL family)"
+              dnf:
+                name: policycoreutils-python-utils
+                state: present
+              when:
+                - ansible_facts['os_family'] == 'RedHat'
+                - _selinux_enforced
 
-          # ==================== Relocate Docker + containerd storage (optional) ====================
-          # Set docker_data_root in host_vars (e.g. "/opt/docker") to move BOTH
-          # Docker's data-root (images/volumes metadata) AND containerd's own
-          # root (the actual image-layer store — a separate config file that
-          # Docker's data-root does NOT control) off a small root filesystem.
-          # Without this, a fresh box with a small `/` and a larger `/opt`
-          # fills `/` mid-deploy pulling the ~30 images in this stack and dies
-          # with "no space left on device". Must run before containerd/docker
-          # are ever started — relocating an already-populated /var/lib/docker
-          # or /var/lib/containerd needs a stop+rsync+relabel migration instead
-          # (not handled here; do that by hand first if Docker's already run).
-          - name: "Docker/containerd storage relocation (when docker_data_root is set)"
-            when: (docker_data_root | default('') | length) > 0
-            vars:
-              # Strip any trailing slash before deriving the sibling containerd
-              # dir — dirname('/opt/docker/') is '/opt/docker' (nests containerd
-              # INSIDE Docker's own data-root instead of beside it). A top-level
-              # value like '/docker' has dirname '/', which would yield the
-              # bogus '//containerd' — collapse that to '/containerd'.
-              _docker_data_root: "{{ docker_data_root | regex_replace('/+$', '') }}"
-              _containerd_root: "{{ (_docker_data_root | dirname | regex_replace('^/$', '')) ~ '/containerd' }}"
-            block:
-              # If daemon.json already points at the relocated data-root, the
-              # relocation was applied by an earlier run and anything left in
-              # /var/lib/docker (or /var/lib/containerd) is a harmless
-              # first-start skeleton, not live data — skip the populated-guard
-              # so routine re-deploys don't hard-fail. String-match rather than
-              # from_json so an unparseable daemon.json can't blow up the guard
-              # itself (the daemon.json merge task later fails with a clear
-              # message in that case).
-              - name: "Guard — read daemon.json to detect an already-applied relocation"
-                ansible.builtin.slurp:
-                  src: /etc/docker/daemon.json
-                register: _daemon_json_pre
-                failed_when: false
+            # ==================== Relocate Docker + containerd storage (optional) ====================
+            # Set docker_data_root in host_vars (e.g. "/opt/docker") to move BOTH
+            # Docker's data-root (images/volumes metadata) AND containerd's own
+            # root (the actual image-layer store — a separate config file that
+            # Docker's data-root does NOT control) off a small root filesystem.
+            # Without this, a fresh box with a small `/` and a larger `/opt`
+            # fills `/` mid-deploy pulling the ~30 images in this stack and dies
+            # with "no space left on device". Must run before containerd/docker
+            # are ever started — relocating an already-populated /var/lib/docker
+            # or /var/lib/containerd needs a stop+rsync+relabel migration instead
+            # (not handled here; do that by hand first if Docker's already run).
+            - name: "Docker/containerd storage relocation (when docker_data_root is set)"
+              when: (docker_data_root | default('') | length) > 0
+              vars:
+                # Strip any trailing slash before deriving the sibling containerd
+                # dir — dirname('/opt/docker/') is '/opt/docker' (nests containerd
+                # INSIDE Docker's own data-root instead of beside it). A top-level
+                # value like '/docker' has dirname '/', which would yield the
+                # bogus '//containerd' — collapse that to '/containerd'.
+                _docker_data_root: "{{ docker_data_root | regex_replace('/+$', '') }}"
+                _containerd_root: "{{ (_docker_data_root | dirname | regex_replace('^/$', '')) ~ '/containerd' }}"
+              block:
+                # If daemon.json already points at the relocated data-root, the
+                # relocation was applied by an earlier run and anything left in
+                # /var/lib/docker (or /var/lib/containerd) is a harmless
+                # first-start skeleton, not live data — skip the populated-guard
+                # so routine re-deploys don't hard-fail. String-match rather than
+                # from_json so an unparseable daemon.json can't blow up the guard
+                # itself (the daemon.json merge task later fails with a clear
+                # message in that case).
+                - name: "Guard — read daemon.json to detect an already-applied relocation"
+                  ansible.builtin.slurp:
+                    src: /etc/docker/daemon.json
+                  register: _daemon_json_pre
+                  failed_when: false
 
-              - name: "Guard — read containerd config.toml to detect its currently-configured root"
-                ansible.builtin.slurp:
-                  src: /etc/containerd/config.toml
-                register: _containerd_config_pre
-                failed_when: false
+                - name: "Guard — read containerd config.toml to detect its currently-configured root"
+                  ansible.builtin.slurp:
+                    src: /etc/containerd/config.toml
+                  register: _containerd_config_pre
+                  failed_when: false
 
-              - name: "Guard — note whether the relocation is already in effect"
-                ansible.builtin.set_fact:
-                  _relocation_already_applied: >-
-                    {{ _daemon_json_pre.content is defined
-                       and (_daemon_json_pre.content | b64decode)
-                           is search('"data-root"\s*:\s*"' ~ (_docker_data_root | regex_escape) ~ '/?"') }}
+                - name: "Guard — note whether the relocation is already in effect"
+                  ansible.builtin.set_fact:
+                    _relocation_already_applied: >-
+                      {{ _daemon_json_pre.content is defined
+                         and (_daemon_json_pre.content | b64decode)
+                             is search('"data-root"\s*:\s*"' ~ (_docker_data_root | regex_escape) ~ '/?"') }}
 
-              # Extract whatever data-root/root Docker/containerd are
-              # CURRENTLY configured to use, if anything — not just whether
-              # /var/lib/* happens to be empty. A box already relocated to one
-              # custom path (e.g. /opt/docker) has nothing under
-              # /var/lib/docker, so checking only the compiled-in default
-              # would let a SECOND relocation (e.g. to /data/docker) sail
-              # through the emptiness check and silently orphan the data
-              # actually live at /opt/docker.
-              - name: "Guard — extract the currently-configured data-root/containerd-root (if any)"
-                ansible.builtin.set_fact:
-                  _current_docker_root: >-
-                    {{ (((_daemon_json_pre.content | default('') | b64decode)
-                         | regex_search('"data-root"\s*:\s*"[^"]*"')) | default(''))
-                       | regex_replace('^.*"([^"]*)"$', '\1') }}
-                  _current_containerd_root: >-
-                    {{ (((_containerd_config_pre.content | default('') | b64decode)
-                         | regex_search('(?m)^\s*root\s*=\s*"[^"]*"')) | default(''))
-                       | regex_replace('^.*"([^"]*)"$', '\1') }}
+                # Extract whatever data-root/root Docker/containerd are
+                # CURRENTLY configured to use, if anything — not just whether
+                # /var/lib/* happens to be empty. A box already relocated to one
+                # custom path (e.g. /opt/docker) has nothing under
+                # /var/lib/docker, so checking only the compiled-in default
+                # would let a SECOND relocation (e.g. to /data/docker) sail
+                # through the emptiness check and silently orphan the data
+                # actually live at /opt/docker.
+                - name: "Guard — extract the currently-configured data-root/containerd-root (if any)"
+                  ansible.builtin.set_fact:
+                    _current_docker_root: >-
+                      {{ (((_daemon_json_pre.content | default('') | b64decode)
+                           | regex_search('"data-root"\s*:\s*"[^"]*"')) | default(''))
+                         | regex_replace('^.*"([^"]*)"$', '\1') }}
+                    _current_containerd_root: >-
+                      {{ (((_containerd_config_pre.content | default('') | b64decode)
+                           | regex_search('(?m)^\s*root\s*=\s*"[^"]*"')) | default(''))
+                         | regex_replace('^.*"([^"]*)"$', '\1') }}
 
-              # Resolve which directory each store actually needs checking:
-              # its current custom location if it's already been relocated
-              # once before (even to a DIFFERENT path than this run's
-              # target), otherwise the compiled-in default.
-              - name: "Guard — resolve which directory to check for each store"
-                ansible.builtin.set_fact:
-                  _dataroot_guard_targets:
-                    - label: docker
-                      current: "{{ _current_docker_root }}"
-                      check_path: "{{ _current_docker_root if (_current_docker_root | length) > 0 else '/var/lib/docker' }}"
-                      matches_target: "{{ _current_docker_root == _docker_data_root }}"
-                    - label: containerd
-                      current: "{{ _current_containerd_root }}"
-                      check_path: "{{ _current_containerd_root if (_current_containerd_root | length) > 0 else '/var/lib/containerd' }}"
-                      matches_target: "{{ _current_containerd_root == _containerd_root }}"
+                # Resolve which directory each store actually needs checking:
+                # its current custom location if it's already been relocated
+                # once before (even to a DIFFERENT path than this run's
+                # target), otherwise the compiled-in default.
+                - name: "Guard — resolve which directory to check for each store"
+                  ansible.builtin.set_fact:
+                    _dataroot_guard_targets:
+                      - label: docker
+                        current: "{{ _current_docker_root }}"
+                        check_path: "{{ _current_docker_root if (_current_docker_root | length) > 0 else '/var/lib/docker' }}"
+                        matches_target: "{{ _current_docker_root == _docker_data_root }}"
+                      - label: containerd
+                        current: "{{ _current_containerd_root }}"
+                        check_path: "{{ _current_containerd_root if (_current_containerd_root | length) > 0 else '/var/lib/containerd' }}"
+                        matches_target: "{{ _current_containerd_root == _containerd_root }}"
 
-              # Relocating a data-root that Docker/containerd have already
-              # written to — whether that's the compiled-in default
-              # (/var/lib/docker, /var/lib/containerd) or a PREVIOUSLY
-              # relocated custom path — would point daemon.json/config.toml at
-              # an empty directory: every existing image and named volume
-              # (including the Postgres complaint database) becomes invisible
-              # and the stack silently re-initializes from scratch. Only a
-              # fresh/never-relocated box, or one already relocated to this
-              # EXACT target, may proceed.
-              - name: "Guard — check the resolved store directories are still empty"
-                ansible.builtin.command: "find {{ item.check_path }} -mindepth 1 -maxdepth 1"
-                loop: "{{ _dataroot_guard_targets }}"
-                loop_control:
-                  label: "{{ item.label }}: {{ item.check_path }}"
-                register: _live_dataroot_check
-                changed_when: false
-                failed_when: false
-                when: not (item.matches_target | bool)
+                # Relocating a data-root that Docker/containerd have already
+                # written to — whether that's the compiled-in default
+                # (/var/lib/docker, /var/lib/containerd) or a PREVIOUSLY
+                # relocated custom path — would point daemon.json/config.toml at
+                # an empty directory: every existing image and named volume
+                # (including the Postgres complaint database) becomes invisible
+                # and the stack silently re-initializes from scratch. Only a
+                # fresh/never-relocated box, or one already relocated to this
+                # EXACT target, may proceed.
+                - name: "Guard — check the resolved store directories are still empty"
+                  ansible.builtin.command: "find {{ item.check_path }} -mindepth 1 -maxdepth 1"
+                  loop: "{{ _dataroot_guard_targets }}"
+                  loop_control:
+                    label: "{{ item.label }}: {{ item.check_path }}"
+                  register: _live_dataroot_check
+                  changed_when: false
+                  failed_when: false
+                  when: not (item.matches_target | bool)
 
-              - name: "Guard — refuse to relocate an already-populated data-root"
-                ansible.builtin.fail:
-                  msg: >-
-                    docker_data_root is set to "{{ _docker_data_root }}" but
-                    {{ item.item.check_path }} already contains data
-                    {{ '(a previously relocated ' ~ item.item.label ~ ' root)'
-                       if (item.item.current | length) > 0
-                       else '(the compiled-in default ' ~ item.item.label ~ ' root)' }},
-                    meaning Docker/containerd have already run against it.
-                    Relocating now would orphan every existing image and named
-                    volume (including the Postgres complaint database) — stop
-                    docker/containerd, rsync {{ item.item.check_path }} to its
-                    new home by hand (relabeling under SELinux if applicable),
-                    then re-run.
-                loop: "{{ _live_dataroot_check.results | default([]) }}"
-                loop_control:
-                  label: "{{ item.item.label | default('') }}"
-                when:
-                  - item.item is defined
-                  - not (item.item.matches_target | bool)
-                  - (item.stdout_lines | default([]) | length) > 0
+                - name: "Guard — refuse to relocate an already-populated data-root"
+                  ansible.builtin.fail:
+                    msg: >-
+                      docker_data_root is set to "{{ _docker_data_root }}" but
+                      {{ item.item.check_path }} already contains data
+                      {{ '(a previously relocated ' ~ item.item.label ~ ' root)'
+                         if (item.item.current | length) > 0
+                         else '(the compiled-in default ' ~ item.item.label ~ ' root)' }},
+                      meaning Docker/containerd have already run against it.
+                      Relocating now would orphan every existing image and named
+                      volume (including the Postgres complaint database) — stop
+                      docker/containerd, rsync {{ item.item.check_path }} to its
+                      new home by hand (relabeling under SELinux if applicable),
+                      then re-run.
+                  loop: "{{ _live_dataroot_check.results | default([]) }}"
+                  loop_control:
+                    label: "{{ item.item.label | default('') }}"
+                  when:
+                    - item.item is defined
+                    - not (item.item.matches_target | bool)
+                    - (item.stdout_lines | default([]) | length) > 0
 
-              - name: "Ensure Docker data-root directory exists"
-                ansible.builtin.file:
-                  path: "{{ _docker_data_root }}"
-                  state: directory
-                  mode: '0711'
+                - name: "Ensure Docker data-root directory exists"
+                  ansible.builtin.file:
+                    path: "{{ _docker_data_root }}"
+                    state: directory
+                    mode: '0711'
 
-              - name: "Ensure containerd root directory exists"
-                ansible.builtin.file:
-                  path: "{{ _containerd_root }}"
-                  state: directory
-                  mode: '0711'
+                - name: "Ensure containerd root directory exists"
+                  ansible.builtin.file:
+                    path: "{{ _containerd_root }}"
+                    state: directory
+                    mode: '0711'
 
-              - name: "containerd — ensure a default config.toml exists"
-                ansible.builtin.shell: |
-                  set -eo pipefail
-                  mkdir -p /etc/containerd
-                  containerd config default > /etc/containerd/config.toml
-                args:
-                  executable: /bin/bash
-                  creates: /etc/containerd/config.toml
+                - name: "containerd — ensure a default config.toml exists"
+                  ansible.builtin.shell: |
+                    set -eo pipefail
+                    mkdir -p /etc/containerd
+                    containerd config default > /etc/containerd/config.toml
+                  args:
+                    executable: /bin/bash
+                    creates: /etc/containerd/config.toml
 
-              # The containerd.io package's shipped config.toml stub has no
-              # top-level `root =` key, so the regexp below matches nothing and
-              # lineinfile appends the line at EOF — landing it inside whatever
-              # `[table]` last preceded it in TOML instead of at the document
-              # root, where containerd silently ignores it. insertbefore: BOF
-              # guarantees the key lands above any table header when absent.
-              - name: "containerd — point root at the relocated directory"
-                ansible.builtin.lineinfile:
-                  path: /etc/containerd/config.toml
-                  regexp: '^\s*root\s*='
-                  line: 'root = "{{ _containerd_root }}"'
-                  insertbefore: BOF
-                register: containerd_root_config
+                # The containerd.io package's shipped config.toml stub has no
+                # top-level `root =` key, so the regexp below matches nothing and
+                # lineinfile appends the line at EOF — landing it inside whatever
+                # `[table]` last preceded it in TOML instead of at the document
+                # root, where containerd silently ignores it. insertbefore: BOF
+                # guarantees the key lands above any table header when absent.
+                - name: "containerd — point root at the relocated directory"
+                  ansible.builtin.lineinfile:
+                    path: /etc/containerd/config.toml
+                    regexp: '^\s*root\s*='
+                    line: 'root = "{{ _containerd_root }}"'
+                    insertbefore: BOF
+                  register: containerd_root_config
 
-              # semanage is provided by the "SELinux — ensure policy tooling is
-              # present" task above (before this relocation block).
-              #
-              # semanage errors if the exact equivalence already exists (e.g. a
-              # re-run) — that's not a real failure, just already-done. Fresh
-              # adds say "already defined"; re-adding after equivalences already
-              # exist for both paths says "already exists" instead — tolerate
-              # both.
-              - name: "SELinux — label the relocated storage dirs like the originals (RHEL family)"
-                ansible.builtin.command: "semanage fcontext -a -e {{ item.orig }} {{ item.new }}"
-                loop:
-                  - { orig: /var/lib/docker, new: "{{ _docker_data_root }}" }
-                  - { orig: /var/lib/containerd, new: "{{ _containerd_root }}" }
-                register: _semanage_fcontext
-                failed_when: >-
-                  _semanage_fcontext.rc != 0
-                  and 'already defined' not in (_semanage_fcontext.stderr | default(''))
-                  and 'already exists' not in (_semanage_fcontext.stderr | default(''))
-                changed_when: _semanage_fcontext.rc == 0
-                when:
-                  - ansible_facts['os_family'] == 'RedHat'
-                  - _selinux_enforced
+                # semanage is provided by the "SELinux — ensure policy tooling is
+                # present" task above (before this relocation block).
+                #
+                # semanage errors if the exact equivalence already exists (e.g. a
+                # re-run) — that's not a real failure, just already-done. Fresh
+                # adds say "already defined"; re-adding after equivalences already
+                # exist for both paths says "already exists" instead — tolerate
+                # both.
+                - name: "SELinux — label the relocated storage dirs like the originals (RHEL family)"
+                  ansible.builtin.command: "semanage fcontext -a -e {{ item.orig }} {{ item.new }}"
+                  loop:
+                    - { orig: /var/lib/docker, new: "{{ _docker_data_root }}" }
+                    - { orig: /var/lib/containerd, new: "{{ _containerd_root }}" }
+                  register: _semanage_fcontext
+                  failed_when: >-
+                    _semanage_fcontext.rc != 0
+                    and 'already defined' not in (_semanage_fcontext.stderr | default(''))
+                    and 'already exists' not in (_semanage_fcontext.stderr | default(''))
+                  changed_when: _semanage_fcontext.rc == 0
+                  when:
+                    - ansible_facts['os_family'] == 'RedHat'
+                    - _selinux_enforced
 
-              # Expensive: walks every file individually (read + possibly
-              # rewrite its security.selinux xattr). Only needed the FIRST time
-              # the relocation happens — the semanage equivalence above makes
-              # new files Docker/containerd create afterward inherit the
-              # correct label automatically (default SELinux file-creation
-              # behavior: a new file/dir inherits its parent's context absent
-              # an explicit type-transition rule, and the parent here is
-              # already correctly labeled after this one pass). Re-running
-              # restorecon on every subsequent deploy against an
-              # already-relocated, already-populated data-root just re-walks
-              # a now-large Docker/containerd tree for nothing — on a
-              # multi-GB overlay2 store this has been observed to take
-              # 15-20+ minutes on IOPS-limited cloud block storage, blocking
-              # every redeploy for no benefit.
-              - name: "SELinux — restorecon the relocated storage dirs (RHEL family, first relocation only)"
-                ansible.builtin.command: "restorecon -RF {{ item }}"
-                loop:
-                  - "{{ _docker_data_root }}"
-                  - "{{ _containerd_root }}"
-                changed_when: false
-                when:
-                  - ansible_facts['os_family'] == 'RedHat'
-                  - _selinux_enforced
-                  - not (_relocation_already_applied | bool)
+                # Expensive: walks every file individually (read + possibly
+                # rewrite its security.selinux xattr). Only needed the FIRST time
+                # the relocation happens — the semanage equivalence above makes
+                # new files Docker/containerd create afterward inherit the
+                # correct label automatically (default SELinux file-creation
+                # behavior: a new file/dir inherits its parent's context absent
+                # an explicit type-transition rule, and the parent here is
+                # already correctly labeled after this one pass). Re-running
+                # restorecon on every subsequent deploy against an
+                # already-relocated, already-populated data-root just re-walks
+                # a now-large Docker/containerd tree for nothing — on a
+                # multi-GB overlay2 store this has been observed to take
+                # 15-20+ minutes on IOPS-limited cloud block storage, blocking
+                # every redeploy for no benefit.
+                - name: "SELinux — restorecon the relocated storage dirs (RHEL family, first relocation only)"
+                  ansible.builtin.command: "restorecon -RF {{ item }}"
+                  loop:
+                    - "{{ _docker_data_root }}"
+                    - "{{ _containerd_root }}"
+                  changed_when: false
+                  when:
+                    - ansible_facts['os_family'] == 'RedHat'
+                    - _selinux_enforced
+                    - not (_relocation_already_applied | bool)
 
-              - name: "Restart containerd if its config changed"
-                ansible.builtin.service:
-                  name: containerd
-                  state: restarted
-                  enabled: true
-                when: containerd_root_config.changed | default(false)
+                - name: "Restart containerd if its config changed"
+                  ansible.builtin.service:
+                    name: containerd
+                    state: restarted
+                    enabled: true
+                  when: containerd_root_config.changed | default(false)
 
-              - name: "Ensure containerd is enabled + running"
-                ansible.builtin.service:
-                  name: containerd
-                  state: started
-                  enabled: true
+                - name: "Ensure containerd is enabled + running"
+                  ansible.builtin.service:
+                    name: containerd
+                    state: started
+                    enabled: true
 
-              # Seed the data-root into daemon.json BEFORE dockerd's first
-              # start. The full merged daemon.json (log rotation, insecure
-              # registries) is written much later in this play — but "Ensure
-              # docker daemon is enabled + running" below starts dockerd first,
-              # and without the seed that first start populates the default
-              # /var/lib/docker, tripping the relocation guard above on every
-              # subsequent re-deploy. Merge, don't overwrite: operator-set keys
-              # in an existing daemon.json survive (the later merge task keeps
-              # them too).
-              - name: "Docker — seed data-root into daemon.json before first start"
-                block:
-                  - name: "Docker — write daemon.json with the relocated data-root"
-                    vars:
-                      _existing: >-
-                        {{ (_daemon_json_pre.content | default('') | b64decode | from_json)
-                           if (_daemon_json_pre.content is defined
-                               and (_daemon_json_pre.content | b64decode | trim | length) > 0)
-                           else {} }}
-                    ansible.builtin.copy:
-                      dest: /etc/docker/daemon.json
-                      content: "{{ _existing | combine({'data-root': _docker_data_root}) | to_nice_json }}\n"
-                      mode: '0644'
-                    register: _daemon_json_seed
-                rescue:
-                  - name: "Docker — existing daemon.json is unreadable"
-                    ansible.builtin.fail:
-                      msg: >-
-                        /etc/docker/daemon.json exists but could not be parsed
-                        as JSON, so the relocated data-root could not be seeded
-                        into it. Fix or remove that file and re-run — it has
-                        been left untouched rather than overwritten.
+                # Seed the data-root into daemon.json BEFORE dockerd's first
+                # start. The full merged daemon.json (log rotation, insecure
+                # registries) is written much later in this play — but "Ensure
+                # docker daemon is enabled + running" below starts dockerd first,
+                # and without the seed that first start populates the default
+                # /var/lib/docker, tripping the relocation guard above on every
+                # subsequent re-deploy. Merge, don't overwrite: operator-set keys
+                # in an existing daemon.json survive (the later merge task keeps
+                # them too).
+                - name: "Docker — seed data-root into daemon.json before first start"
+                  block:
+                    - name: "Docker — write daemon.json with the relocated data-root"
+                      vars:
+                        _existing: >-
+                          {{ (_daemon_json_pre.content | default('') | b64decode | from_json)
+                             if (_daemon_json_pre.content is defined
+                                 and (_daemon_json_pre.content | b64decode | trim | length) > 0)
+                             else {} }}
+                      ansible.builtin.copy:
+                        dest: /etc/docker/daemon.json
+                        content: "{{ _existing | combine({'data-root': _docker_data_root}) | to_nice_json }}\n"
+                        mode: '0644'
+                      register: _daemon_json_seed
+                  rescue:
+                    - name: "Docker — existing daemon.json is unreadable"
+                      ansible.builtin.fail:
+                        msg: >-
+                          /etc/docker/daemon.json exists but could not be parsed
+                          as JSON, so the relocated data-root could not be seeded
+                          into it. Fix or remove that file and re-run — it has
+                          been left untouched rather than overwritten.
 
-              - name: "Docker — check whether dockerd is already running"
-                ansible.builtin.command: systemctl is-active docker
-                register: _dockerd_active
-                changed_when: false
-                failed_when: false
+                - name: "Docker — check whether dockerd is already running"
+                  ansible.builtin.command: systemctl is-active docker
+                  register: _dockerd_active
+                  changed_when: false
+                  failed_when: false
 
-              - name: "Docker — restart a running dockerd to apply the relocated data-root"
-                ansible.builtin.service:
-                  name: docker
-                  state: restarted
-                when:
-                  - _daemon_json_seed.changed | default(false)
-                  - (_dockerd_active.stdout | default('')) == 'active'
+                - name: "Docker — restart a running dockerd to apply the relocated data-root"
+                  ansible.builtin.service:
+                    name: docker
+                    state: restarted
+                  when:
+                    - _daemon_json_seed.changed | default(false)
+                    - (_dockerd_active.stdout | default('')) == 'active'
 
           always:
-          # Release the Debian package auto-start hold now that the data-root
-          # is configured — only if this run created it (an operator-managed
-          # policy-rc.d is never touched).
-          - name: "Docker install — release the package auto-start hold (Debian/Ubuntu)"
-            ansible.builtin.file:
-              path: /usr/sbin/policy-rc.d
-              state: absent
-            when:
-              - ansible_facts['os_family'] == 'Debian'
-              - _docker_autostart_hold.changed | default(false)
+            # Release the Debian package auto-start hold now that the data-root
+            # is configured — only if this run created it (an operator-managed
+            # policy-rc.d is never touched).
+            - name: "Docker install — release the package auto-start hold (Debian/Ubuntu)"
+              ansible.builtin.file:
+                path: /usr/sbin/policy-rc.d
+                state: absent
+              when:
+                - ansible_facts['os_family'] == 'Debian'
+                - _docker_autostart_hold.changed | default(false)
 
-        # apt/dnf both install docker.service disabled by default — enable +
-        # start it explicitly so subsequent tasks can talk to the daemon.
+          # apt/dnf both install docker.service disabled by default — enable +
+          # start it explicitly so subsequent tasks can talk to the daemon.
         - name: Ensure docker daemon is enabled + running
           service:
             name: docker

--- a/local-setup/docker-compose.db-migrations.yml
+++ b/local-setup/docker-compose.db-migrations.yml
@@ -1301,6 +1301,7 @@ services:
       # These services are ungated in this file, so the toggles are fixed:
       # "true" where the service always starts, "false" where it is absent.
       GATUS_PROFILE_OTP: "true"
+      GATUS_CONFIGURATOR: "false"
       GATUS_PROFILE_SEARCH: "false"
       GATUS_PROFILE_MCP: "false"
       GATUS_PROFILE_KEYCLOAK: "false"

--- a/local-setup/docker-compose.deploy.yaml
+++ b/local-setup/docker-compose.deploy.yaml
@@ -914,6 +914,7 @@ services:
       # These services are ungated in this file, so the toggles are fixed:
       # "true" where the service always starts, "false" where it is absent.
       GATUS_PROFILE_OTP: "true"
+      GATUS_CONFIGURATOR: "false"
       GATUS_PROFILE_SEARCH: "false"
       GATUS_PROFILE_MCP: "false"
       GATUS_PROFILE_KEYCLOAK: "false"

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -1685,6 +1685,7 @@ services:
       # Profile-gated stacks: keep these beside COMPOSE_PROFILES in .env.
       # Unset means off -- gatus enables an endpoint when its variable is missing.
       GATUS_PROFILE_OTP: ${GATUS_PROFILE_OTP:-false}
+      GATUS_CONFIGURATOR: ${GATUS_CONFIGURATOR:-true}
       GATUS_PROFILE_SEARCH: ${GATUS_PROFILE_SEARCH:-false}
       GATUS_PROFILE_MCP: ${GATUS_PROFILE_MCP:-false}
       GATUS_PROFILE_KEYCLOAK: ${GATUS_PROFILE_KEYCLOAK:-false}

--- a/local-setup/docker-compose.registry.yml
+++ b/local-setup/docker-compose.registry.yml
@@ -1608,6 +1608,7 @@ services:
       # These services are ungated in this file, so the toggles are fixed:
       # "true" where the service always starts, "false" where it is absent.
       GATUS_PROFILE_OTP: "true"
+      GATUS_CONFIGURATOR: "false"
       GATUS_PROFILE_SEARCH: "true"
       GATUS_PROFILE_MCP: "false"
       GATUS_PROFILE_KEYCLOAK: "false"

--- a/local-setup/docker-compose.yml
+++ b/local-setup/docker-compose.yml
@@ -1135,6 +1135,7 @@ services:
       # These services are ungated in this file, so the toggles are fixed:
       # "true" where the service always starts, "false" where it is absent.
       GATUS_PROFILE_OTP: "true"
+      GATUS_CONFIGURATOR: "false"
       GATUS_PROFILE_SEARCH: "false"
       GATUS_PROFILE_MCP: "false"
       GATUS_PROFILE_KEYCLOAK: "false"

--- a/local-setup/gatus/config.yaml
+++ b/local-setup/gatus/config.yaml
@@ -412,6 +412,18 @@ endpoints:
     conditions:
       - "[STATUS] == 200"
 
+  # Configurator (DIGIT Studio) — tenant onboarding admin console. Serving
+  # dependency: onboarding a new city goes through this SPA. Probes the base
+  # path rather than / because the image serves the bundle under /configurator/
+  # and redirects / to it.
+  - name: Configurator
+    group: Application
+    enabled: ${GATUS_CONFIGURATOR}
+    url: "http://configurator:80/configurator/"
+    interval: 30s
+    conditions:
+      - "[STATUS] == 200"
+
   # ==================== API Functionality Tests ====================
   - name: MDMS API - Tenant Search
     group: API Tests

--- a/local-setup/k8s/tools/gatus.yaml
+++ b/local-setup/k8s/tools/gatus.yaml
@@ -427,6 +427,18 @@ data:
         conditions:
           - "[STATUS] == 200"
 
+      # Configurator (DIGIT Studio) — tenant onboarding admin console. Defined
+      # here for tier parity; no configurator manifest exists under
+      # local-setup/k8s/ yet, so it is switched OFF via GATUS_CONFIGURATOR in
+      # the Deployment env below. Flip that to "true" when the manifest lands.
+      - name: Configurator
+        group: Application
+        enabled: ${GATUS_CONFIGURATOR}
+        url: "http://configurator:80/configurator/"
+        interval: 30s
+        conditions:
+          - "[STATUS] == 200"
+
       # ==================== API Functionality Tests ====================
       - name: MDMS API - Tenant Search
         group: API Tests
@@ -505,6 +517,9 @@ spec:
             # k3s has no manifests for the optional stacks, so every toggle is off.
             # Flip one to "true" only once the matching manifests land under
             # local-setup/k8s/ -- keep it in step with the compose tier.
+            # No configurator Deployment in the k3s tier yet.
+            - name: GATUS_CONFIGURATOR
+              value: "false"
             - name: GATUS_PROFILE_OTP
               value: "false"
             - name: GATUS_PROFILE_SEARCH


### PR DESCRIPTION
## What & why

Two CI checks fail on `master` **today**, independently of any open PR. Because CI tests "your branch merged into master", they surface as red on every PR that touches their paths — including #1422 and #1582, where they're currently masking whether those PRs are actually clean.

Neither failure is caused by any open PR. Both are verified by running the checks against `master` alone.

## 1. `Ansible static validation` — `yaml[indentation]` ×2

`playbook-deploy.yml`'s Docker data-root task has a `block:` / `always:` pair whose list items sit at the same indent as their key (10 spaces) instead of nested under it (12). `ansible-lint` flags this twice — at lines 436 and 801.

Re-indented both bodies by two spaces.

> **This is whitespace only.** YAML treats both forms identically, and the change is asserted safe: `yaml.safe_load(master) == yaml.safe_load(this branch)` is **True**, so no task, condition, `when:`, or ordering is altered. The diff looks large (≈348 lines shifted) purely because the block body is long.

## 2. `gatus-coverage` — `configurator` had no health check

`master` added a `configurator` compose service (the tenant-onboarding admin console) without registering a Gatus check. The coverage rule requires every serving service to have one, or be explicitly exempted with a reason — the rule exists because `egov-url-shortening` once sat DOWN for days unnoticed.

`configurator` is a **genuine serving dependency** — onboarding a new city goes through that SPA — so it gets a real check, not an exemption.

**Why it's gated on `GATUS_CONFIGURATOR`:** the service exists only in `docker-compose.egov-digit.yaml`, but *five* compose files mount this same Gatus config. An ungated check would sit permanently red on the other four stacks — which is how checks get ignored. So:

| Where | Value | Reason |
|---|---|---|
| `docker-compose.egov-digit.yaml` | `${GATUS_CONFIGURATOR:-true}` | service is present and ungated here |
| `docker-compose.yml`, `.registry.yml`, `.deploy.yaml`, `.db-migrations.yml` | `"false"` | no configurator service in these stacks |
| `k8s/tools/gatus.yaml` (Deployment env) | `"false"` | no configurator manifest in the k3s tier yet |

Per the tier-parity rule the endpoint is **defined in both** the compose and k3s configs with identical conditions, differing only in runtime enablement — matching how the existing `GATUS_PROFILE_*` toggles work. When a k8s configurator manifest lands, flip that one value to `"true"`; the endpoint block is already there.

## Validation

```
check-gatus-coverage.py  -> OK: 88 compose services, 23 k3s Services,
                            51 endpoints per tier, no drift, no dangling checks
ansible-lint             -> Passed (0 failures; 'production' profile)
ansible-playbook --syntax-check -> ok
```

Plus: every touched compose file parses, `docker compose config -q` accepts `docker-compose.egov-digit.yaml`, and the k3s manifest still parses as its 3 documents (ConfigMap / Deployment / Service — note plain `safe_load` fails on that file on master too, since it's multi-document).

## Not in scope

The other two red checks are left alone, as they need separate owners:

- **`test`** — fails repo-wide, including on PRs that touch none of this (#1584, #1567). Known cause is a stale `local-setup/db/full-dump.sql` missing records the tests expect.
- **`Config combination + infra contracts`** — the frozen `:latest` debt list in `static/infra-contracts.test.ts` still names pre-migration images (`curlimages/curl`, `twinproduction/gatus`, `edoburu/pgbouncer`, `tilt-demo-*`) while the compose files now use their `egovio/*` equivalents. Same images, renamed by the registry migration; the list just needs updating. Happy to fold that in here if you'd prefer one PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional health monitoring for the Configurator (DIGIT Studio) application.
  * Configurator monitoring checks its availability every 30 seconds and expects a successful response.
  * Configurator monitoring is enabled by default in eGov deployments and disabled in other deployment profiles.

* **Bug Fixes**
  * Improved deployment cleanup so temporary package startup settings are restored even if installation tasks fail.
  * Preserved reliable Docker setup, storage configuration, and service startup behavior across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->