### PR TITLE
fix(compose): disable embedded Flyway in the Ansible base so partial redeploys can't replay V1 (#1586)

### DIFF
--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -291,13 +291,8 @@ services:
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
       SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE: "5"
       SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE: "2"
-      SPRING_FLYWAY_URL: jdbc:postgresql://postgres:5432/egov
-      SPRING_FLYWAY_USER: egov
-      SPRING_FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
-      SPRING_FLYWAY_BASELINE_ON_MIGRATE: 'true'
-      SPRING_FLYWAY_VALIDATE_ON_MIGRATE: 'false'
-      SPRING_FLYWAY_ENABLED: 'true'
-      SPRING_FLYWAY_TABLE: egov_indexer_schema
+      # Embedded Flyway off — egov-indexer-migration (docker-compose.migrations.yml) owns this schema (#1586)
+      SPRING_FLYWAY_ENABLED: 'false'
       KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SPRING_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SERVER_PORT: 8080
@@ -484,13 +479,8 @@ services:
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
       SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE: "20"
       SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE: "5"
-      SPRING_FLYWAY_URL: jdbc:postgresql://postgres:5432/egov
-      SPRING_FLYWAY_USER: egov
-      SPRING_FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
-      SPRING_FLYWAY_BASELINE_ON_MIGRATE: 'true'
-      SPRING_FLYWAY_VALIDATE_ON_MIGRATE: 'false'
-      SPRING_FLYWAY_ENABLED: 'true'
-      SPRING_FLYWAY_TABLE: mdms_schema_version
+      # Embedded Flyway off — mdms-backend-migration (docker-compose.migrations.yml) owns this schema (#1586)
+      SPRING_FLYWAY_ENABLED: 'false'
       KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SPRING_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SERVER_PORT: 8094
@@ -763,13 +753,8 @@ services:
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
       SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE: "10"
       SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE: "2"
-      SPRING_FLYWAY_URL: jdbc:postgresql://postgres:5432/egov
-      SPRING_FLYWAY_USER: egov
-      SPRING_FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
-      SPRING_FLYWAY_BASELINE_ON_MIGRATE: 'true'
-      SPRING_FLYWAY_VALIDATE_ON_MIGRATE: 'false'
-      SPRING_FLYWAY_ENABLED: 'true'
-      SPRING_FLYWAY_TABLE: workflow_schema_version
+      # Embedded Flyway off — egov-workflow-v2-migration (docker-compose.migrations.yml) owns this schema (#1586)
+      SPRING_FLYWAY_ENABLED: 'false'
       KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SPRING_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SERVER_PORT: 8109
@@ -904,13 +889,8 @@ services:
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
       SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE: "5"
       SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE: "2"
-      SPRING_FLYWAY_URL: jdbc:postgresql://postgres:5432/egov
-      SPRING_FLYWAY_USER: egov
-      SPRING_FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
-      SPRING_FLYWAY_BASELINE_ON_MIGRATE: 'true'
-      SPRING_FLYWAY_VALIDATE_ON_MIGRATE: 'false'
-      SPRING_FLYWAY_ENABLED: 'true'
-      SPRING_FLYWAY_TABLE: boundary_schema_version
+      # Embedded Flyway off — boundary-service-migration (docker-compose.migrations.yml) owns this schema (#1586)
+      SPRING_FLYWAY_ENABLED: 'false'
       KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SPRING_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SERVER_PORT: 8081
@@ -963,13 +943,8 @@ services:
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
       SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE: "5"
       SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE: "2"
-      SPRING_FLYWAY_URL: jdbc:postgresql://postgres:5432/egov
-      SPRING_FLYWAY_USER: egov
-      SPRING_FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
-      SPRING_FLYWAY_BASELINE_ON_MIGRATE: 'true'
-      SPRING_FLYWAY_VALIDATE_ON_MIGRATE: 'false'
-      SPRING_FLYWAY_ENABLED: 'true'
-      SPRING_FLYWAY_TABLE: accesscontrol_schema_version
+      # Embedded Flyway off — egov-accesscontrol-migration (docker-compose.migrations.yml) owns this schema (#1586)
+      SPRING_FLYWAY_ENABLED: 'false'
       KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SERVER_PORT: 8090
       EGOV_MDMS_HOST: http://egov-mdms-service:8094/
@@ -1063,12 +1038,12 @@ services:
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
       SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE: "5"
       SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE: "2"
-      SPRING_FLYWAY_URL: jdbc:postgresql://postgres:5432/egov
-      SPRING_FLYWAY_USER: egov
-      SPRING_FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
-      SPRING_FLYWAY_BASELINE_ON_MIGRATE: 'true'
-      SPRING_FLYWAY_ENABLED: 'true'
-      SPRING_FLYWAY_TABLE: filestore_schema_version
+      # Embedded Flyway must stay OFF: egov-filestore-migration in
+      # docker-compose.migrations.yml owns this schema under the canonical
+      # egov_filestore_schema history table. With it ON, a partial redeploy that
+      # skips the overlay baselines a fresh legacy-named history at version 1 and
+      # replays V1 onto a populated database — 42P07 crash loop (#1586).
+      SPRING_FLYWAY_ENABLED: 'false'
       SERVER_PORT: 8083
       OTEL_TRACES_EXPORTER: otlp
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
@@ -1173,12 +1148,8 @@ services:
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
       SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE: "5"
       SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE: "2"
-      SPRING_FLYWAY_URL: jdbc:postgresql://postgres:5432/egov
-      SPRING_FLYWAY_USER: egov
-      SPRING_FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
-      SPRING_FLYWAY_BASELINE_ON_MIGRATE: 'true'
-      SPRING_FLYWAY_ENABLED: 'true'
-      SPRING_FLYWAY_TABLE: hrms_schema_version
+      # Embedded Flyway off — egov-hrms-migration (docker-compose.migrations.yml) owns this schema (#1586)
+      SPRING_FLYWAY_ENABLED: 'false'
       KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SPRING_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SPRING_KAFKA_CONSUMER_GROUP_ID: employee-group1
@@ -1451,13 +1422,8 @@ services:
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
       SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE: "10"
       SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE: "2"
-      SPRING_FLYWAY_URL: jdbc:postgresql://postgres:5432/egov
-      SPRING_FLYWAY_USER: egov
-      SPRING_FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
-      SPRING_FLYWAY_ENABLED: 'true'
-      SPRING_FLYWAY_BASELINE_ON_MIGRATE: 'true'
-      SPRING_FLYWAY_VALIDATE_ON_MIGRATE: 'false'
-      SPRING_FLYWAY_TABLE: pgr_services_schema
+      # Embedded Flyway off — pgr-services-migration (docker-compose.migrations.yml) owns this schema (#1586)
+      SPRING_FLYWAY_ENABLED: 'false'
       KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SPRING_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SPRING_KAFKA_CONSUMER_GROUP_ID: egov-pgr-services
@@ -2141,11 +2107,8 @@ services:
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
       # application.properties keeps Flyway URL separate from datasource;
       # both env vars must be set or Flyway falls back to localhost.
-      SPRING_FLYWAY_URL: jdbc:postgresql://postgres:5432/egov
-      SPRING_FLYWAY_USER: egov
-      SPRING_FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
-      SPRING_FLYWAY_ENABLED: 'true'
-      SPRING_FLYWAY_TABLE: digit_config_service_schema
+      # Embedded Flyway off — digit-config-service-migration (docker-compose.migrations.yml) owns this schema (#1586)
+      SPRING_FLYWAY_ENABLED: 'false'
       SERVER_PORT: '8080'
       SERVER_SERVLET_CONTEXT_PATH: /config-service
       CONFIG_DEFAULT_OFFSET: '0'
@@ -2244,11 +2207,8 @@ services:
       # application.properties hardcodes spring.flyway.url to localhost
       # without an env placeholder — relaxed binding to SPRING_FLYWAY_*
       # is the only way to override.
-      SPRING_FLYWAY_URL: jdbc:postgresql://postgres:5432/egov
-      SPRING_FLYWAY_USER: egov
-      SPRING_FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
-      SPRING_FLYWAY_ENABLED: 'true'
-      SPRING_FLYWAY_TABLE: novu_bridge_schema
+      # Embedded Flyway off — novu-bridge-migration (docker-compose.migrations.yml) owns this schema (#1586)
+      SPRING_FLYWAY_ENABLED: 'false'
       SPRING_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       # application.properties also reads kafka.config.bootstrap_server_config
       # (an egov-services-common convention); set both so any path that


### PR DESCRIPTION
Fixes #1586.

## Root cause

`local-setup/docker-compose.egov-digit.yaml` — the base file the Ansible playbook ships to every box — still enabled **embedded** Flyway for 10 services, with legacy history-table names and `SPRING_FLYWAY_BASELINE_ON_MIGRATE: 'true'`:

egov-indexer, mdms-backend, egov-workflow-v2, boundary-service, egov-accesscontrol, **egov-filestore**, egov-hrms, pgr-services, digit-config-service, novu-bridge.

A full `./deploy.sh <tenant>` run is safe: `docker-compose.migrations.yml` is always layered after the base and flips every app to `SPRING_FLYWAY_ENABLED: "false"`, handing migrations to the `*-migration` init containers (canonical table names, gated on `db-history-normalize`). But a **partial redeploy that skips the overlay** — e.g. on the box:

```
docker compose -f docker-compose.egov-digit.yaml up -d --force-recreate egov-filestore
```

— runs the app's own Flyway against a history-table name the dump never shipped (`filestore_schema_version` vs the dump's canonical `egov_filestore_schema`). Flyway finds no history, baselines a fresh table at version 1, treats every timestamp-versioned migration as pending, replays V1 onto a populated schema, and crash-loops on `42P07 relation "eg_filestoremap" already exists`. That is exactly the failure in #1586 (image tag, Flyway URL, and Postgres version in the reported log all match this file).

## Change

For those 10 services, remove the embedded-Flyway env block (`SPRING_FLYWAY_URL/USER/PASSWORD/TABLE/BASELINE_ON_MIGRATE/VALIDATE_ON_MIGRATE`) and pin `SPRING_FLYWAY_ENABLED: 'false'` with a comment pointing at the owning migrator. A partial redeploy is now inert instead of destructive; the full stack's merged config is unchanged (already `false` everywhere via the overlay).

## Why this is safe

- Every one of the 10 services has a `*-migration` init container in `docker-compose.migrations.yml` that owns its schema — verified against the overlay's `SCHEMA_TABLE` list and `db/flyway-history-map.yml` canonicals.
- `docker compose config` validates on the base file alone and on the full base + fast-path + migrations + monitoring stack; the merged stack contains zero `SPRING_FLYWAY_ENABLED: "true"` entries, same as before this change.
- This closes the invariant documented in `db/flyway-history-map.yml`: "there is no `embedded` escape hatch." Until now the base file itself was that escape hatch.

## Deliberately out of scope

- The **root-level** `docker-compose.egov-digit.yaml` also enables embedded Flyway (including for egov-enc-service), but that stack has no migrations overlay — embedded Flyway is its only migration mechanism, so disabling it there would break fresh installs. Needs its own decision (adopt the overlay or retire the stack).
- The legacy `local-setup/docker-compose.db-migrations.yml` + `migrate-all.sh` have the same pattern (plus a third history-table name, `egov_filestore_schema_version`) and should be retired or aligned in a follow-up.

## Note for anyone hitting #1586 today

The failed run leaves a stray baseline-only legacy history table behind; `db-history-normalize` will then deliberately abort the next deploy ("ambiguous: canonical AND legacy both exist") until it is dropped. Remediation steps are in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated local setup to use external database migration services for several backend components.
  * Removed embedded migration settings and service-specific migration credentials from the local environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->