### PR TITLE
docs(ansible): link Windows (WSL2) and macOS quickstarts from the Ansible README

### DIFF
--- a/local-setup/ansible/README.md
+++ b/local-setup/ansible/README.md
@@ -5,6 +5,13 @@ fully independent stack (~35 containers) on its own machine — same
 playbook, different `host_vars/<tenant>.yml`. Today: `nairobi`, `bomet`,
 plus `mh-iterations` (sandbox).
 
+> **Deploying from Windows?** Follow the
+> [Windows Quickstart (WSL2)](../../WINDOWS-QUICKSTART.md) — it walks the
+> same `./deploy.sh` flow end-to-end inside WSL2, including the
+> `localhost-slim` / `localhost-full` sizing templates for 16 GB and
+> 32 GB machines. On macOS, the equivalent is the
+> [macOS Quickstart (OrbStack)](../../MAC-QUICKSTART.md).
+
 ## Layout
 
 ```


### PR DESCRIPTION
## What

Adds a callout at the top of `local-setup/ansible/README.md` linking the two platform-specific quickstarts:

- [WINDOWS-QUICKSTART.md](../blob/master/WINDOWS-QUICKSTART.md) — the `./deploy.sh` flow via WSL2, including the `localhost-slim` / `localhost-full` sizing templates
- [MAC-QUICKSTART.md](../blob/master/MAC-QUICKSTART.md) — the macOS (OrbStack) equivalent

## Why

The Ansible README is the entry point for the deploy flow, but had no pointer to either quickstart — a Windows or Mac operator landing there would start following Linux-oriented instructions before discovering their platform doc. The README already references the macOS converge script (`mac-stack-up.sh`) without linking the doc that explains it. `local-setup/README.md` already links both quickstarts; this brings the Ansible README in line.

Docs-only change, no behavior impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)