### PR TITLE
fix(grafana): require a login instead of anonymous Admin

### DIFF
--- a/local-setup/ansible/inventory/host_vars/_example.yml
+++ b/local-setup/ansible/inventory/host_vars/_example.yml
@@ -514,6 +514,28 @@ force_clean: false
 # is a Linux box running as root.
 install_claude_code: false
 
+# Let logged-out visitors read Grafana at https://<domain>/grafana/ with the
+# Viewer role (never Admin — the role is pinned in the compose file).
+#
+# READ THIS BEFORE ENABLING. Viewer is not a safe role on this stack, because
+# Grafana is not just dashboards:
+#   * the Loki datasource is provisioned with `access: proxy`, so Grafana's
+#     backend runs any Loki query a Viewer asks for;
+#   * promtail ships every container's stdout into Loki, including
+#     egov-user-proxy's nginx access log;
+#   * Kong's auth-enrichment calls that proxy as
+#     /user/_details?access_token=<live session token>, so those tokens are
+#     sitting in Loki as plain log text.
+# A logged-out visitor with Viewer can therefore harvest live bearer tokens and
+# replay them against the API. That is the same credential disclosure the login
+# form was turned on to stop; it just costs an extra query. Leave this false on
+# anything reachable from the internet unless you have first scrubbed
+# access_token out of the log pipeline.
+#
+# Set it here, not in /opt/digit/.env — the playbook regenerates that file from
+# templates/digit.env.j2 on every deploy, so a hand-edit there silently reverts.
+grafana_anonymous_enabled: false
+
 # ────────── nginx features (location blocks rendered into the host nginx site) ──────────
 
 nginx_features:
@@ -562,6 +584,9 @@ bootstrap_secrets:
   # in OpenBao. Read it back with:
   #   bao kv get -field=grafana_admin_password {{ secrets_path }}
   # grafana_admin_password: ""
+  #
+  # (Anonymous/logged-out Grafana access is a separate, top-level knob —
+  #  `grafana_anonymous_enabled`, documented further down. It is not a secret.)
   # Keycloak secrets — only consumed when enable_keycloak: true.
   # Leave empty on tenants without Keycloak; the playbook only resolves
   # these via `| mandatory` inside the digit.env.j2 keycloak block,

--- a/local-setup/ansible/inventory/host_vars/_example.yml
+++ b/local-setup/ansible/inventory/host_vars/_example.yml
@@ -557,6 +557,11 @@ bootstrap_secrets:
   minio_root_password: change-me-strong
   elasticsearch_master_password: "asd@#$@$!132123"  # see comment above
   egov_hrms_default_password: "eGov@123"
+  # Grafana admin login (user `admin`). OPTIONAL — leave it out and the
+  # playbook generates a 24-char password on first deploy and stores it here
+  # in OpenBao. Read it back with:
+  #   bao kv get -field=grafana_admin_password {{ secrets_path }}
+  # grafana_admin_password: ""
   # Keycloak secrets — only consumed when enable_keycloak: true.
   # Leave empty on tenants without Keycloak; the playbook only resolves
   # these via `| mandatory` inside the digit.env.j2 keycloak block,

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -100,6 +100,14 @@
       args:
         chdir: "{{ digit_dir }}"
         executable: /bin/bash
+      # GF_SECURITY_ADMIN_PASSWORD in the compose file is `${GF_ADMIN_PASSWORD:?}`
+      # (no default, on purpose — see the grafana service there). Compose
+      # interpolates for `down` too, so a box whose previous deploy aborted
+      # before .env got the real value would fail this teardown on an
+      # unresolvable variable. The value is irrelevant to `down`; feed it a
+      # placeholder rather than let a missing secret block a teardown.
+      environment:
+        GF_ADMIN_PASSWORD: unused-by-down
       register: clean_teardown
       changed_when: true
       when:
@@ -1577,6 +1585,30 @@
       when:
         - build_digit_ui | default(false)
 
+    # ---- Grafana admin password BEFORE the first compose-up ----
+    # docker-compose.egov-digit.yaml resolves GF_SECURITY_ADMIN_PASSWORD from
+    # ${GF_ADMIN_PASSWORD:?} — no default, so an unset variable aborts the whole
+    # compose invocation (that is the point: a `:-admin` default would ship
+    # admin/admin to anyone running the file standalone). But the authoritative
+    # value only exists further down, after the OpenBao bootstrap — which itself
+    # needs the stack up. Same ordering trap the KEYCLOAK/novu prep blocks below
+    # solve, and the same fix: put a value in .env before anything runs compose.
+    #
+    # It is random per run, not a fixed placeholder, because it IS the password
+    # Grafana seeds its admin row with on a first boot (GF_SECURITY_ADMIN_PASSWORD
+    # is only read when grafana_data is empty). If a deploy dies between here and
+    # the OpenBao block, the box is left with an unguessable admin password
+    # instead of admin/admin. The cost is that Grafana gets recreated once more
+    # per deploy, when the OpenBao value replaces this line further down.
+    - name: "Grafana prep — write a GF_ADMIN_PASSWORD into .env BEFORE compose-up"
+      ansible.builtin.lineinfile:
+        path: "{{ digit_dir }}/.env"
+        regexp: '^GF_ADMIN_PASSWORD='
+        line: "GF_ADMIN_PASSWORD={{ lookup('password', '/dev/null length=24 chars=ascii_letters,digits') }}"
+        create: true
+        mode: '0600'
+      no_log: true
+
     # ---- Keycloak readiness BEFORE the dependent compose-up (converge-abort fix) ----
     # The compose-up below waits on keycloak: service_healthy, but the keycloak DB
     # secret is otherwise written to .env only AFTER it (the OpenBao block further
@@ -2279,13 +2311,19 @@
     # first run the stored value is reused, which keeps the password stable
     # across deploys. Operators read it back with:
     #   bao kv get -field=grafana_admin_password {{ secrets_path }}
+    #
+    # `or`, not `ternary`. Jinja evaluates every filter argument before calling
+    # the filter, so `… | ternary(stored, lookup('password', …))` runs the
+    # generator on every deploy and throws the result away whenever OpenBao
+    # already has a value. `or` compiles to Python's `or` and short-circuits, so
+    # the lookup only runs when there is nothing stored — which is also what the
+    # task name claims. (default('', true) turns both "undefined" and "" into the
+    # falsey '' that `or` needs.)
     - name: "OpenBao — resolve Grafana admin password (generate if absent)"
       ansible.builtin.set_fact:
         grafana_admin_pw: >-
-          {{ bao_secrets.json.data.data.grafana_admin_password
-             | default('', true)
-             | ternary(bao_secrets.json.data.data.grafana_admin_password | default(''),
-                       lookup('password', '/dev/null length=24 chars=ascii_letters,digits')) }}
+          {{ bao_secrets.json.data.data.grafana_admin_password | default('', true)
+             or lookup('password', '/dev/null length=24 chars=ascii_letters,digits') }}
       no_log: true
 
     - name: "OpenBao — persist generated Grafana admin password"
@@ -2334,10 +2372,24 @@
           AWS_SECRETKEY={{ bao_secrets.json.data.data.minio_root_password }}
           ELASTICSEARCH_MASTER_PASSWORD={{ bao_secrets.json.data.data.elasticsearch_master_password }}
           EGOV_HRMS_DEFAULT_PASSWORD={{ bao_secrets.json.data.data.egov_hrms_default_password }}
-          GF_ADMIN_PASSWORD={{ grafana_admin_pw }}
         marker: "# {mark} TENANT SECRETS"
         create: false           # .env was already written by the digit.env.j2 template earlier
         mode: '0600'            # tighten — was 0644 from the template; secrets bump to 0600
+      no_log: true
+
+    # GF_ADMIN_PASSWORD is the one OpenBao-backed value that is NOT in the block
+    # above: "Grafana prep" already wrote a pre-boot line for it before the stack
+    # came up (the compose file has no default for it), and appending a second
+    # line inside the block would leave two GF_ADMIN_PASSWORD entries in .env
+    # with the winner decided by file order. Replace the existing line in place
+    # instead, so .env always has exactly one — now the authoritative value.
+    - name: "OpenBao — put the stored Grafana admin password into .env"
+      ansible.builtin.lineinfile:
+        path: "{{ digit_dir }}/.env"
+        regexp: '^GF_ADMIN_PASSWORD='
+        line: "GF_ADMIN_PASSWORD={{ grafana_admin_pw }}"
+        create: false
+        mode: '0600'
       no_log: true
 
     # Keycloak-tier secrets — appended as a separate marked block so the
@@ -4212,12 +4264,30 @@
     # the failure mode it leaves behind is silent: the UI keeps whatever password
     # the volume was seeded with, nobody can log in with the OpenBao value, and a
     # `failed_when: false` would bury that in a 4000-line deploy log.
+    #
+    # --password-from-stdin, NOT the positional argument. As an argument the
+    # password lands in the host's process table and the container's argv, and
+    # /proc/<pid>/cmdline is world-readable — so every `no_log` on the Ansible
+    # side is undone for the lifetime of the exec by any local user running
+    # `ps aux`. The CLI reads one line off stdin instead (bufio.Scanner in
+    # pkg/cmd/grafana-cli/commands/reset_password_command.go; present in the
+    # pinned grafana 11.4.0), and `docker exec -i` is what forwards it.
+    #
+    # failed_when is explicit because a non-zero rc is not the only failure:
+    # resetPasswordCommand returns nil when the admin user cannot be found, so
+    # the CLI exits 0 after printing "Admin user cannot be found". Gate on the
+    # success line so that case is loud too.
     - name: Grafana — align admin password with OpenBao (idempotent)
       ansible.builtin.command: >-
-        docker exec digit-grafana
-        grafana cli admin reset-admin-password {{ grafana_admin_pw }}
+        docker exec -i digit-grafana
+        grafana cli admin reset-admin-password --password-from-stdin
+      args:
+        stdin: "{{ grafana_admin_pw }}"
       register: grafana_pw_reset
       changed_when: false
+      failed_when: >-
+        grafana_pw_reset.rc != 0
+        or 'Admin password changed successfully' not in grafana_pw_reset.stdout
       no_log: true
       when: grafana_health.rc == 0
 
@@ -4229,9 +4299,11 @@
         msg: >-
           Grafana: {{ 'admin password aligned with OpenBao'
                       if grafana_health.rc == 0
-                      else 'UNHEALTHY — admin password NOT applied. Once it is up, rerun the deploy or:
-                            docker exec digit-grafana grafana cli admin reset-admin-password "$(bao kv get -field=grafana_admin_password '
-                           ~ secrets_path ~ ')"' }}
+                      else 'UNHEALTHY — admin password NOT applied. Once it is up, rerun the deploy or (piped, so the
+                            password stays out of ps aux):
+                            bao kv get -field=grafana_admin_password '
+                           ~ secrets_path ~
+                           ' | docker exec -i digit-grafana grafana cli admin reset-admin-password --password-from-stdin' }}
 
     # ==================== Claude Code Setup (opt-in) ====================
     # Installs Claude Code CLI on the target and syncs the controller's

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -2295,10 +2295,26 @@
         headers:
           X-Vault-Token: "{{ bao_root_token }}"
         body_format: json
-        body:
-          # Merge, never replace: a bare {grafana_admin_password: …} write would
-          # drop every other key in this tenant's secret.
-          data: "{{ bao_secrets.json.data.data | combine({'grafana_admin_password': grafana_admin_pw}) }}"
+        # The whole body is ONE template expression on purpose: Ansible preserves
+        # native types that way, so `cas` reaches OpenBao as a JSON number. Split
+        # across YAML keys it would render as the string "5" and the CAS check
+        # would depend on server-side weak decoding.
+        #
+        # cas = the version we just read. Without it this is a blind overwrite of
+        # the entire secret: anything written between our read and this write (a
+        # concurrent deploy, an operator running `bao kv put`) is silently lost,
+        # because `data` is built from the snapshot we read. With cas, a racing
+        # write makes OpenBao reject ours (400) and the deploy stops rather than
+        # clobbering. No retry loop: deploys are serialised per tenant, so a
+        # conflict means something genuinely unexpected touched the secret and a
+        # human should look before we overwrite it.
+        #
+        # `data` merges, never replaces — a bare {grafana_admin_password: …}
+        # write would drop every other key in this tenant's secret.
+        body: >-
+          {{ {'options': {'cas': bao_secrets.json.data.metadata.version | int},
+              'data': bao_secrets.json.data.data
+                      | combine({'grafana_admin_password': grafana_admin_pw})} }}
         status_code: [200]
       when: (bao_secrets.json.data.data.grafana_admin_password | default('', true)) | length == 0
       no_log: true
@@ -4191,22 +4207,31 @@
       changed_when: false
       ignore_errors: yes
 
+    # Fatal when it runs. Grafana is healthy at this point, so a failing reset is
+    # a genuine anomaly (wrong CLI path after an image bump, unwritable DB), and
+    # the failure mode it leaves behind is silent: the UI keeps whatever password
+    # the volume was seeded with, nobody can log in with the OpenBao value, and a
+    # `failed_when: false` would bury that in a 4000-line deploy log.
     - name: Grafana — align admin password with OpenBao (idempotent)
       ansible.builtin.command: >-
         docker exec digit-grafana
         grafana cli admin reset-admin-password {{ grafana_admin_pw }}
       register: grafana_pw_reset
       changed_when: false
-      failed_when: false
       no_log: true
       when: grafana_health.rc == 0
 
+    # Grafana never came up. Non-fatal, matching the Loki gate above — the
+    # dashboards are not a serving dependency — but say so loudly, because the
+    # stored password has NOT been applied to the running instance.
     - name: Show Grafana admin-password status
       debug:
         msg: >-
           Grafana: {{ 'admin password aligned with OpenBao'
-                      if (grafana_pw_reset.rc | default(1)) == 0
-                      else 'admin password NOT set — log in with the previous credentials and check `bao kv get ' ~ secrets_path ~ '`' }}
+                      if grafana_health.rc == 0
+                      else 'UNHEALTHY — admin password NOT applied. Once it is up, rerun the deploy or:
+                            docker exec digit-grafana grafana cli admin reset-admin-password "$(bao kv get -field=grafana_admin_password '
+                           ~ secrets_path ~ ')"' }}
 
     # ==================== Claude Code Setup (opt-in) ====================
     # Installs Claude Code CLI on the target and syncs the controller's

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -2273,6 +2273,36 @@
       register: bao_secrets
       no_log: true
 
+    # Grafana admin password. Tenants seeded BEFORE this key existed can't get
+    # it from the bootstrap seed above (that write is cas:0 — it only fires when
+    # no version exists yet), so generate one here and persist it. After the
+    # first run the stored value is reused, which keeps the password stable
+    # across deploys. Operators read it back with:
+    #   bao kv get -field=grafana_admin_password {{ secrets_path }}
+    - name: "OpenBao — resolve Grafana admin password (generate if absent)"
+      ansible.builtin.set_fact:
+        grafana_admin_pw: >-
+          {{ bao_secrets.json.data.data.grafana_admin_password
+             | default('', true)
+             | ternary(bao_secrets.json.data.data.grafana_admin_password | default(''),
+                       lookup('password', '/dev/null length=24 chars=ascii_letters,digits')) }}
+      no_log: true
+
+    - name: "OpenBao — persist generated Grafana admin password"
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:18200/v1/{{ secrets_path | regex_replace('^kv/', 'kv/data/') }}"
+        method: POST
+        headers:
+          X-Vault-Token: "{{ bao_root_token }}"
+        body_format: json
+        body:
+          # Merge, never replace: a bare {grafana_admin_password: …} write would
+          # drop every other key in this tenant's secret.
+          data: "{{ bao_secrets.json.data.data | combine({'grafana_admin_password': grafana_admin_pw}) }}"
+        status_code: [200]
+      when: (bao_secrets.json.data.data.grafana_admin_password | default('', true)) | length == 0
+      no_log: true
+
     - name: "OpenBao — write secrets into compose .env (idempotent block)"
       ansible.builtin.blockinfile:
         path: "{{ digit_dir }}/.env"
@@ -2288,6 +2318,7 @@
           AWS_SECRETKEY={{ bao_secrets.json.data.data.minio_root_password }}
           ELASTICSEARCH_MASTER_PASSWORD={{ bao_secrets.json.data.data.elasticsearch_master_password }}
           EGOV_HRMS_DEFAULT_PASSWORD={{ bao_secrets.json.data.data.egov_hrms_default_password }}
+          GF_ADMIN_PASSWORD={{ grafana_admin_pw }}
         marker: "# {mark} TENANT SECRETS"
         create: false           # .env was already written by the digit.env.j2 template earlier
         mode: '0600'            # tighten — was 0644 from the template; secrets bump to 0600
@@ -4145,6 +4176,37 @@
     - name: Show Loki health status
       debug:
         msg: "Loki: {{ 'HEALTHY' if loki_health.rc == 0 else 'UNHEALTHY (non-critical)' }}"
+
+    # GF_SECURITY_ADMIN_PASSWORD only seeds the admin user on the FIRST boot of a
+    # fresh grafana_data volume. Every box deployed before this change already has
+    # an admin row — from the era when the login form was disabled entirely — so
+    # without this reset they would keep unknown/legacy credentials and nobody
+    # could log in to the UI we just closed off.
+    - name: Wait for Grafana health (up to 2 min)
+      shell: curl -sf http://127.0.0.1:13000/api/health -o /dev/null
+      register: grafana_health
+      retries: 12
+      delay: 10
+      until: grafana_health.rc == 0
+      changed_when: false
+      ignore_errors: yes
+
+    - name: Grafana — align admin password with OpenBao (idempotent)
+      ansible.builtin.command: >-
+        docker exec digit-grafana
+        grafana cli admin reset-admin-password {{ grafana_admin_pw }}
+      register: grafana_pw_reset
+      changed_when: false
+      failed_when: false
+      no_log: true
+      when: grafana_health.rc == 0
+
+    - name: Show Grafana admin-password status
+      debug:
+        msg: >-
+          Grafana: {{ 'admin password aligned with OpenBao'
+                      if (grafana_pw_reset.rc | default(1)) == 0
+                      else 'admin password NOT set — log in with the previous credentials and check `bao kv get ' ~ secrets_path ~ '`' }}
 
     # ==================== Claude Code Setup (opt-in) ====================
     # Installs Claude Code CLI on the target and syncs the controller's

--- a/local-setup/ansible/templates/digit.env.j2
+++ b/local-setup/ansible/templates/digit.env.j2
@@ -3,6 +3,12 @@
 # Edit the inventory, not this file.
 GF_SERVER_DOMAIN={{ domain }}
 GF_SERVER_ROOT_URL=https://{{ domain }}/grafana/
+# Anonymous (logged-out) Grafana access. Off unless a tenant opts in with
+# `grafana_anonymous_enabled: true`. Read the warning in _example.yml before
+# flipping it: anonymous Viewers can read live bearer tokens out of Loki.
+# This line is why the knob lives in host_vars and not in /opt/digit/.env —
+# this file is regenerated on every deploy, so a hand-edit there is lost.
+GF_ANONYMOUS_ENABLED={{ grafana_anonymous_enabled | default(false) | string | lower }}
 
 # MCP image. Resolved by the "Resolve MCP image tag" task: a local-only
 # tag (digit-mcp:local) when build_mcp:true (deploy builds it itself, no

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -43,9 +43,19 @@ services:
     container_name: digit-grafana
     restart: unless-stopped
     environment:
-      GF_AUTH_ANONYMOUS_ENABLED: "true"
-      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
-      GF_AUTH_DISABLE_LOGIN_FORM: "true"
+      # Auth. Anonymous access is OFF by default: Grafana proxies the Loki
+      # datasource, and Kong access logs in Loki carry bearer tokens in query
+      # strings — so "read-only" anonymous is still credential disclosure.
+      # A tenant that wants a public board sets GF_ANONYMOUS_ENABLED=true in
+      # .env; the role stays Viewer, never Admin.
+      GF_AUTH_ANONYMOUS_ENABLED: ${GF_ANONYMOUS_ENABLED:-false}
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
+      GF_AUTH_DISABLE_LOGIN_FORM: "false"
+      # Admin password comes from OpenBao via .env (key: grafana_admin_password,
+      # auto-generated on first deploy). The compose fallback only applies to a
+      # bare `docker compose up` outside Ansible.
+      GF_SECURITY_ADMIN_USER: ${GF_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GF_ADMIN_PASSWORD:-admin}
       # Domain + root URL templated per tenant via /opt/digit/.env
       # (Ansible writes GF_SERVER_DOMAIN there from inventory `domain`).
       GF_SERVER_DOMAIN: ${GF_SERVER_DOMAIN:-api.egov.theflywheel.in}

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -2,7 +2,9 @@
 # Standalone compose — all images from the egovio Docker Hub org (plus upstream public registries)
 # Generated from docker-compose.deploy.yaml with registry-prefixed images and build: removed
 #
-# Usage: docker compose -f docker-compose.egov-digit.yaml up -d
+# Usage: GF_ADMIN_PASSWORD=<something-strong> docker compose -f docker-compose.egov-digit.yaml up -d
+#        (or put GF_ADMIN_PASSWORD in ./.env). It has no default — see the
+#        grafana service below for why.
 
 services:
   # ==================== Tracing Infrastructure ====================
@@ -43,19 +45,44 @@ services:
     container_name: digit-grafana
     restart: unless-stopped
     environment:
-      # Auth. Anonymous access is OFF by default: Grafana proxies the Loki
-      # datasource, and Kong access logs in Loki carry bearer tokens in query
-      # strings — so "read-only" anonymous is still credential disclosure.
-      # A tenant that wants a public board sets GF_ANONYMOUS_ENABLED=true in
-      # .env; the role stays Viewer, never Admin.
+      # ---- Auth ----
+      # Anonymous access is OFF by default, and "read-only" is NOT "safe" here.
+      # The Loki datasource is provisioned with `access: proxy`
+      # (otel/grafana/provisioning/datasources/tempo.yaml), so Grafana's backend
+      # queries Loki on behalf of whoever is logged in — Viewer included. And
+      # promtail ships EVERY container's stdout into Loki
+      # (otel/promtail-config.yaml), which includes egov-user-proxy's nginx
+      # access log, where Kong's auth-enrichment call lands as
+      #   GET /user/_details?access_token=<live session token>
+      # (kong/kong.yml puts the token in the query string). So turning the flag
+      # below on hands every anonymous visitor a token-harvesting console: the
+      # Admin *write* surface stays closed, but the credential *disclosure* this
+      # PR is closing comes straight back. Do not enable it on an
+      # internet-reachable box until access_token is scrubbed out of the log
+      # pipeline.
+      #
+      # Ansible tenants set `grafana_anonymous_enabled: true` in host_vars —
+      # hand-editing /opt/digit/.env does NOT survive the next deploy, because
+      # the playbook re-renders that file from templates/digit.env.j2.
       GF_AUTH_ANONYMOUS_ENABLED: ${GF_ANONYMOUS_ENABLED:-false}
       GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
       GF_AUTH_DISABLE_LOGIN_FORM: "false"
-      # Admin password comes from OpenBao via .env (key: grafana_admin_password,
-      # auto-generated on first deploy). The compose fallback only applies to a
-      # bare `docker compose up` outside Ansible.
+      # Admin login. Deliberately NO `:-admin` fallback: this file is also run
+      # standalone (see the Usage line in the header), and a silent fallback
+      # there ships the classic admin/admin behind the login form this PR just
+      # enabled — which is the same "guessable default nobody notices" hole in a
+      # narrower shape. Failing closed is the tradeoff: an unset variable aborts
+      # the WHOLE compose invocation, not just Grafana, so every path that runs
+      # this file must supply the value first.
+      #   - README quickstart (`docker compose up -d` → docker-compose.yml):
+      #     unaffected, that file has no grafana service.
+      #   - Ansible: playbook-deploy.yml writes GF_ADMIN_PASSWORD into
+      #     /opt/digit/.env in "Grafana prep — …BEFORE compose-up", ahead of the
+      #     first `up`; the OpenBao-backed value replaces it later in the same
+      #     run and `grafana cli admin reset-admin-password` applies it.
+      #   - standalone: export it, or put it in ./.env.
       GF_SECURITY_ADMIN_USER: ${GF_ADMIN_USER:-admin}
-      GF_SECURITY_ADMIN_PASSWORD: ${GF_ADMIN_PASSWORD:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: "${GF_ADMIN_PASSWORD:?required - export it or set it in ./.env, there is no default (see the grafana comment in this file)}"
       # Domain + root URL templated per tenant via /opt/digit/.env
       # (Ansible writes GF_SERVER_DOMAIN there from inventory `domain`).
       GF_SERVER_DOMAIN: ${GF_SERVER_DOMAIN:-api.egov.theflywheel.in}

--- a/local-setup/docker-compose.registry.yml
+++ b/local-setup/docker-compose.registry.yml
@@ -43,9 +43,15 @@ services:
     container_name: digit-grafana
     restart: unless-stopped
     environment:
-      GF_AUTH_ANONYMOUS_ENABLED: "true"
-      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
-      GF_AUTH_DISABLE_LOGIN_FORM: "true"
+      # Same posture as docker-compose.egov-digit.yaml. This file is NOT the
+      # Ansible path (no .env from OpenBao), so set GF_ADMIN_PASSWORD in your
+      # shell or a local .env before bringing the stack up — otherwise the
+      # admin login is admin/admin.
+      GF_AUTH_ANONYMOUS_ENABLED: ${GF_ANONYMOUS_ENABLED:-false}
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
+      GF_AUTH_DISABLE_LOGIN_FORM: "false"
+      GF_SECURITY_ADMIN_USER: ${GF_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GF_ADMIN_PASSWORD:-admin}
       GF_SERVER_DOMAIN: api.egov.theflywheel.in
       GF_SERVER_ROOT_URL: "https://api.egov.theflywheel.in/grafana/"
       GF_SERVER_SERVE_FROM_SUB_PATH: "true"

--- a/local-setup/docker-compose.registry.yml
+++ b/local-setup/docker-compose.registry.yml
@@ -1,8 +1,10 @@
-# docker-compose.egov-digit.yaml
+# docker-compose.registry.yml
 # Standalone compose — all images from public registry registry.preview.egov.theflywheel.in
 # Generated from docker-compose.deploy.yaml with registry-prefixed images and build: removed
 #
-# Usage: docker compose -f docker-compose.egov-digit.yaml up -d
+# Usage: GF_ADMIN_PASSWORD=<something-strong> docker compose -f docker-compose.registry.yml up -d
+#        (or put GF_ADMIN_PASSWORD in ./.env). It has no default — see the
+#        grafana service below for why.
 
 services:
   # ==================== Tracing Infrastructure ====================
@@ -43,17 +45,27 @@ services:
     container_name: digit-grafana
     restart: unless-stopped
     environment:
-      # Same posture as docker-compose.egov-digit.yaml. This file is NOT the
-      # Ansible path (no .env from OpenBao), so set GF_ADMIN_PASSWORD in your
-      # shell or a local .env before bringing the stack up — otherwise the
-      # admin login is admin/admin.
+      # Same posture as docker-compose.egov-digit.yaml — see the long comment on
+      # the grafana service there for why anonymous access is a credential-
+      # disclosure path (Loki proxy + promtail-captured access_token query
+      # strings) and why the admin password has no default. This file is NOT the
+      # Ansible path (the playbook never references it — see local-setup/README.md
+      # "What the Ansible playbook deploys"), so nothing populates .env for you:
+      # set GF_ADMIN_PASSWORD in your shell or a local .env, or compose refuses
+      # to start.
       GF_AUTH_ANONYMOUS_ENABLED: ${GF_ANONYMOUS_ENABLED:-false}
       GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
       GF_AUTH_DISABLE_LOGIN_FORM: "false"
       GF_SECURITY_ADMIN_USER: ${GF_ADMIN_USER:-admin}
-      GF_SECURITY_ADMIN_PASSWORD: ${GF_ADMIN_PASSWORD:-admin}
-      GF_SERVER_DOMAIN: api.egov.theflywheel.in
-      GF_SERVER_ROOT_URL: "https://api.egov.theflywheel.in/grafana/"
+      GF_SECURITY_ADMIN_PASSWORD: "${GF_ADMIN_PASSWORD:?required - export it or set it in ./.env, there is no default (see docker-compose.egov-digit.yaml)}"
+      # Overridable like every other host-specific value; the literal is only a
+      # convenience default for the preview box this file was cut from. On the
+      # Ansible path GF_SERVER_DOMAIN/GF_SERVER_ROOT_URL come from the tenant's
+      # `domain` via templates/digit.env.j2 — but that path uses
+      # docker-compose.egov-digit.yaml, not this file, so standalone users have
+      # to export them (or set them in ./.env) to point Grafana at their host.
+      GF_SERVER_DOMAIN: ${GF_SERVER_DOMAIN:-api.egov.theflywheel.in}
+      GF_SERVER_ROOT_URL: ${GF_SERVER_ROOT_URL:-https://api.egov.theflywheel.in/grafana/}
       GF_SERVER_SERVE_FROM_SUB_PATH: "true"
     volumes:
       - ./otel/grafana/provisioning:/etc/grafana/provisioning:ro


### PR DESCRIPTION
Fixes #1602

## What

Grafana shipped with anonymous access at org role **Admin**, the login form disabled, and no admin password set anywhere — on every tenant deployed from this repo. Anyone reaching the UI could edit datasources and query the Loki datasource, which holds Kong access logs containing bearer tokens in query strings.

## Changes

**`docker-compose.egov-digit.yaml`**
- `GF_AUTH_ANONYMOUS_ENABLED` → `${GF_ANONYMOUS_ENABLED:-false}` (opt-in per tenant)
- `GF_AUTH_ANONYMOUS_ORG_ROLE` → `Viewer` (never Admin, even when enabled)
- `GF_AUTH_DISABLE_LOGIN_FORM` → `"false"`
- new `GF_SECURITY_ADMIN_USER` / `GF_SECURITY_ADMIN_PASSWORD`, fed from `.env`

**`playbook-deploy.yml`**
- resolve `grafana_admin_password` from OpenBao; generate a 24-char one when absent and persist it back (merged into the existing secret map, never replacing it)
- write `GF_ADMIN_PASSWORD` into the existing `TENANT SECRETS` block in `.env`
- after the stack is up: wait for Grafana health, then `grafana cli admin reset-admin-password`

**`host_vars/_example.yml`** — documents the optional `grafana_admin_password` bootstrap secret.

## Why the generate-and-persist step

The `bootstrap_secrets` seed writes with `cas: 0` — it only fires when no version of the tenant secret exists. Tenants seeded before this key existed would therefore never receive one. Generating on first deploy and storing it back means no operator action, no shipped default password, and a value that stays stable across deploys.

Operators read it with:
```
bao kv get -field=grafana_admin_password <secrets_path>
```

## Why the reset task

`GF_SECURITY_ADMIN_PASSWORD` only seeds the admin user on the **first** boot of a fresh `grafana_data` volume. Every already-deployed box has an admin row from the era when the login form was disabled, so without the reset they would keep unknown legacy credentials for a UI this PR just closed off. The task is idempotent (`changed_when: false`) and gated on the health check.

## Testing

Not yet deployed. Needs a run on the localhost/WSL2 template box, then a scratch tenant, before any live box:

- [ ] fresh deploy: `/grafana/` shows a login page; OpenBao password works
- [ ] redeploy of an **existing** box: same, proving the reset path
- [ ] anonymous `GET /grafana/api/datasources` → 401
- [ ] provisioned dashboards + datasources still load after login
- [ ] `GF_ANONYMOUS_ENABLED=true` yields a Viewer-role anonymous board

## Notes

Pairs with #1604 (removes the unauthenticated Kong `/grafana` route and gates the nginx location). Either can merge first; together they make the login the only way in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent Grafana administrator password management, with automatic secure generation when no password is configured.
  * Added optional configuration for providing a Grafana administrator password.
  * Grafana credentials can now be configured through environment variables.

* **Security**
  * Disabled anonymous Grafana access by default.
  * Anonymous access, when enabled, is limited to viewer permissions.
  * Restored Grafana login form access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->