### PR TITLE
fix(compose): bind observability ports to loopback

### DIFF
--- a/docker-compose.egov-digit.yaml
+++ b/docker-compose.egov-digit.yaml
@@ -14,9 +14,9 @@ services:
     volumes:
       - ./otel/otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml:ro
     ports:
-      - "14317:4317"
-      - "14318:4318"
-      - "13133:13133"
+      - "127.0.0.1:14317:4317"
+      - "127.0.0.1:14318:4318"
+      - "127.0.0.1:13133:13133"
     networks:
       - egov-network
 
@@ -29,7 +29,7 @@ services:
       - ./otel/tempo-config.yaml:/etc/tempo/config.yaml:ro
       - tempo_data:/var/tempo
     ports:
-      - "13200:3200"
+      - "127.0.0.1:13200:3200"
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:3200/ready"]
       interval: 10s
@@ -55,7 +55,7 @@ services:
       - ./otel/grafana/provisioning:/etc/grafana/provisioning:ro
       - grafana_data:/var/lib/grafana
     ports:
-      - "13000:3000"
+      - "127.0.0.1:13000:3000"
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:3000/api/health"]
       interval: 10s
@@ -86,7 +86,7 @@ services:
       - ./otel/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus
     ports:
-      - "19090:9090"
+      - "127.0.0.1:19090:9090"
     networks:
       - egov-network
 
@@ -1521,7 +1521,7 @@ services:
     volumes:
       - ./gatus/config.yaml:/config/config.yaml:ro
     ports:
-      - "18889:8080"
+      - "127.0.0.1:18889:8080"
     environment:
       GATUS_CONFIG_PATH: /config/config.yaml
     networks:
@@ -1537,7 +1537,7 @@ services:
       - ./otel/loki-config.yaml:/etc/loki/config.yaml:ro
       - loki_data:/loki
     ports:
-      - "13100:3100"
+      - "127.0.0.1:13100:3100"
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:3100/ready"]
       interval: 10s

--- a/local-setup/docker-compose.db-migrations.yml
+++ b/local-setup/docker-compose.db-migrations.yml
@@ -1295,7 +1295,7 @@ services:
     volumes:
       - ./gatus/config.yaml:/config/config.yaml:ro
     ports:
-      - "18889:8080"
+      - "127.0.0.1:18889:8080"
     environment:
       GATUS_CONFIG_PATH: /config/config.yaml
       # These services are ungated in this file, so the toggles are fixed:

--- a/local-setup/docker-compose.deploy.yaml
+++ b/local-setup/docker-compose.deploy.yaml
@@ -908,7 +908,7 @@ services:
     volumes:
       - ./gatus/config.yaml:/config/config.yaml:ro
     ports:
-      - "18889:8080"
+      - "127.0.0.1:18889:8080"
     environment:
       GATUS_CONFIG_PATH: /config/config.yaml
       # These services are ungated in this file, so the toggles are fixed:

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -14,9 +14,9 @@ services:
     volumes:
       - ./otel/otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml:ro
     ports:
-      - "14317:4317"
-      - "14318:4318"
-      - "13133:13133"
+      - "127.0.0.1:14317:4317"
+      - "127.0.0.1:14318:4318"
+      - "127.0.0.1:13133:13133"
     networks:
       - egov-network
 
@@ -29,7 +29,7 @@ services:
       - ./otel/tempo-config.yaml:/etc/tempo/config.yaml:ro
       - tempo_data:/var/tempo
     ports:
-      - "13200:3200"
+      - "127.0.0.1:13200:3200"
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:3200/ready"]
       interval: 10s
@@ -55,7 +55,7 @@ services:
       - ./otel/grafana/provisioning:/etc/grafana/provisioning:ro
       - grafana_data:/var/lib/grafana
     ports:
-      - "13000:3000"
+      - "127.0.0.1:13000:3000"
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:3000/api/health"]
       interval: 10s
@@ -86,7 +86,7 @@ services:
       - ./otel/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus
     ports:
-      - "19090:9090"
+      - "127.0.0.1:19090:9090"
     networks:
       - egov-network
 
@@ -1645,7 +1645,7 @@ services:
     volumes:
       - ./gatus/config.yaml:/config/config.yaml:ro
     ports:
-      - "18889:8080"
+      - "127.0.0.1:18889:8080"
     environment:
       GATUS_CONFIG_PATH: /config/config.yaml
       # Profile-gated stacks: keep these beside COMPOSE_PROFILES in .env.
@@ -1672,7 +1672,7 @@ services:
       - ./otel/loki-config.yaml:/etc/loki/config.yaml:ro
       - loki_data:/loki
     ports:
-      - "13100:3100"
+      - "127.0.0.1:13100:3100"
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:3100/ready"]
       interval: 10s

--- a/local-setup/docker-compose.registry.yml
+++ b/local-setup/docker-compose.registry.yml
@@ -14,9 +14,9 @@ services:
     volumes:
       - ./otel/otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml:ro
     ports:
-      - "14317:4317"
-      - "14318:4318"
-      - "13133:13133"
+      - "127.0.0.1:14317:4317"
+      - "127.0.0.1:14318:4318"
+      - "127.0.0.1:13133:13133"
     networks:
       - egov-network
 
@@ -29,7 +29,7 @@ services:
       - ./otel/tempo-config.yaml:/etc/tempo/config.yaml:ro
       - tempo_data:/var/tempo
     ports:
-      - "13200:3200"
+      - "127.0.0.1:13200:3200"
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:3200/ready"]
       interval: 10s
@@ -53,7 +53,7 @@ services:
       - ./otel/grafana/provisioning:/etc/grafana/provisioning:ro
       - grafana_data:/var/lib/grafana
     ports:
-      - "13000:3000"
+      - "127.0.0.1:13000:3000"
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:3000/api/health"]
       interval: 10s
@@ -1602,7 +1602,7 @@ services:
     volumes:
       - ./gatus/config.yaml:/config/config.yaml:ro
     ports:
-      - "18889:8080"
+      - "127.0.0.1:18889:8080"
     environment:
       GATUS_CONFIG_PATH: /config/config.yaml
       # These services are ungated in this file, so the toggles are fixed:

--- a/local-setup/docker-compose.yml
+++ b/local-setup/docker-compose.yml
@@ -1129,7 +1129,7 @@ services:
     volumes:
       - ./gatus/config.yaml:/config/config.yaml:ro
     ports:
-      - "18889:8080"
+      - "127.0.0.1:18889:8080"
     environment:
       GATUS_CONFIG_PATH: /config/config.yaml
       # These services are ungated in this file, so the toggles are fixed:

--- a/local-setup/tests/static/infra-contracts.test.ts
+++ b/local-setup/tests/static/infra-contracts.test.ts
@@ -170,3 +170,65 @@ describe('per-tenant overlay services exist in the base compose', () => {
     expect(unknown).toEqual([]);
   });
 });
+
+describe('observability ports are loopback-bound in every compose file', () => {
+  /**
+   * Incident: #1603 — Grafana, Prometheus, Loki, Tempo, the otel-collector
+   * and the Gatus board were published on 0.0.0.0 (and [::]), so every one
+   * of them was reachable from the public internet on any box without a
+   * host firewall. Grafana additionally had no auth at the time.
+   *
+   * Fixed in #1606 — but the fix had to be applied in FOUR places, because
+   * these compose files are parallel full stacks rather than overlays of a
+   * single base (`docker-compose.yml`, `docker-compose.deploy.yaml` — which
+   * `performance/ansible/playbook-setup.yml` ships straight to hosts —
+   * `docker-compose.db-migrations.yml`, `docker-compose.registry.yml`, and
+   * the repo-root standalone `docker-compose.egov-digit.yaml`). YAML anchors
+   * can't span files, so there is no way to factor the mapping into one
+   * place; this contract is the substitute. Adding an observability port to
+   * a new compose file without the `127.0.0.1:` prefix fails here.
+   */
+  const REPO_ROOT = path.resolve(ROOT, '..');
+
+  // Host ports owned by the observability stack. Keyed by port so a service
+  // renamed or copied into another file is still caught.
+  const OBSERVABILITY_HOST_PORTS: Record<string, string> = {
+    '13000': 'grafana',
+    '13100': 'loki',
+    '13133': 'otel-collector health',
+    '13200': 'tempo',
+    '14317': 'otel-collector OTLP/gRPC',
+    '14318': 'otel-collector OTLP/HTTP',
+    '18889': 'gatus',
+    '19090': 'prometheus',
+  };
+
+  const composeFiles = [
+    ...fs
+      .readdirSync(ROOT)
+      .filter((f) => /^docker-compose\..*\.(yml|yaml)$/.test(f) || f === 'docker-compose.yml')
+      .map((f) => path.join(ROOT, f)),
+    path.join(REPO_ROOT, 'docker-compose.egov-digit.yaml'),
+  ].filter((f) => fs.existsSync(f));
+
+  test('every compose file that publishes one binds it to 127.0.0.1', () => {
+    const offenders: string[] = [];
+    for (const file of composeFiles) {
+      const text = fs.readFileSync(file, 'utf8');
+      for (const m of text.matchAll(/^\s*-\s*"([^"]+)"\s*(?:#.*)?$/gm)) {
+        const mapping = m[1];
+        // A published-port mapping is `[host-ip:]host-port:container-port`.
+        const parts = mapping.split(':');
+        const hostPort = parts.length >= 2 ? parts[parts.length - 2] : null;
+        if (!hostPort || !(hostPort in OBSERVABILITY_HOST_PORTS)) continue;
+        if (!mapping.startsWith('127.0.0.1:')) {
+          offenders.push(
+            `${path.relative(REPO_ROOT, file)}: "${mapping}" ` +
+              `(${OBSERVABILITY_HOST_PORTS[hostPort]}) is not loopback-bound`,
+          );
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #1603

## What

Every observability service published its port on `0.0.0.0`, reachable directly from off-box and bypassing both host nginx and Kong.

| Service | Was | Now |
|---|---|---|
| otel-collector | `14317`, `14318`, `13133` | `127.0.0.1:` on all three |
| tempo | `13200:3200` | `127.0.0.1:13200:3200` |
| grafana | `13000:3000` | `127.0.0.1:13000:3000` |
| prometheus | `19090:9090` | `127.0.0.1:19090:9090` |
| loki | `13100:3100` | `127.0.0.1:13100:3100` |
| gatus | `18889:8080` | `127.0.0.1:18889:8080` |

Loki is the sharpest case: `auth_enabled: false`, and it ingests Kong access logs which carry bearer tokens in query strings — so the port offered unauthenticated read *and* write over those logs.

## Why this is safe

Host nginx proxies to these over `127.0.0.1` (`nginx_upstream_host` defaults to loopback) and containers reach each other by service name on `egov-network`. `openbao` already binds `127.0.0.1:18200`; this applies the same pattern to the rest.

Public entry points are unchanged: nginx `/grafana/` and `/status/`, and Kong's rate-limited `/otel/v1/metrics` + `/otel/v1/logs` ingest routes, which travel over the container network and never touch a host port.

## Testing

Not yet deployed. Checklist for the template box → scratch tenant run:

- [ ] the eight mappings time out when probed from off-box over **IPv4** (`nc -4 -vz <public-v4> 13000 13100 13133 13200 14317 14318 18889 19090`)
- [ ] the eight mappings time out when probed from off-box over **IPv6** (`nc -6 -vz <public-v6> …`) — called out separately because the pre-fix listeners were on `0.0.0.0` *and* `[::]`. Naming an IPv4 host address in the mapping should leave the v6 socket unbound entirely rather than move it to `::1`, but that is the one part of this change that is daemon-version dependent, so probe it rather than assume it
- [ ] on-box, `ss -lntp | grep -E ':(13000|13100|13133|13200|14317|14318|18889|19090)\b'` shows **only** `127.0.0.1:` rows and no `[::]:` / `*:` rows
- [ ] Ansible validate tasks (already loopback-based) stay green
- [ ] browser dashboard telemetry still lands in Prometheus and Loki
- [ ] Grafana still loads through the domain
- [ ] Gatus `/status/` still renders where enabled

## Operator impact

Anyone curling these ports directly from their laptop now needs a tunnel:

```
ssh -L 13000:127.0.0.1:13000 <box>
```

Worth grepping tenant runbooks for `:13000` / `:19090` / `:13100` / `:18889` before this merges.

Note the tunnel target is `127.0.0.1`, not `localhost` — on a dual-stack box `localhost` can resolve to `::1` first, which is no longer bound.

`digit-mcp`'s tracing tools default to `localhost:13200`/`13133`/`13000`, which is a host-side path and unaffected. If the MCP **container** ever consumes them, set `TEMPO_URL=http://tempo:3200` on the service (currently unset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

