### PR TITLE
fix(gateway): drop unauthenticated Kong observability routes

### DIFF
--- a/local-setup/ansible/inventory/group_vars/digit.yml
+++ b/local-setup/ansible/inventory/group_vars/digit.yml
@@ -106,6 +106,11 @@ nginx_features:
   configurator: false       # /configurator + /configurator/assets
   configurator_caching: false  # /configurator/assets/ long-cache headers
   status: false             # /status/ Gatus board (sub_filter rewrites)
+  grafana: true             # /grafana/ dashboards — the only public path to
+                            # Grafana (#1604). Default on: it carries a real
+                            # login since #1602. Set false to take Grafana off
+                            # the internet entirely (reach it over an SSH
+                            # tunnel to 127.0.0.1:13000 instead).
   api_pgr: false            # /api/pgr/ proxied to MCP for the dashboard
   mcp: false                # /mcp HTTP transport — see CLAUDE.md security note
   # Note: `/` routing is derived from `digit_ui_mode`:

--- a/local-setup/ansible/templates/nginx-site.conf.j2
+++ b/local-setup/ansible/templates/nginx-site.conf.j2
@@ -124,7 +124,14 @@ server {
 {% endif %}
 
 {% endif %}
-  # Grafana dashboard
+{# `| default(true)` is load-bearing: host_vars override nginx_features as a
+   whole dict (hash_behaviour=replace), so every tenant file written before
+   this key existed has no `grafana` member. Without the default those deploys
+   would fail rendering this template. Same reason as digit_ui_v2 below. #}
+{% if nginx_features.grafana | default(true) %}
+  # Grafana dashboard. This is the ONLY public path to Grafana — the Kong
+  # /grafana route was removed in #1604, so turning this flag off makes the
+  # UI genuinely unreachable from outside rather than merely unlinked.
   location /grafana/ {
     proxy_pass http://{{ nginx_upstream_host | default('127.0.0.1') }}:{{ upstream_grafana_port }};
     proxy_set_header Host $host;
@@ -136,6 +143,7 @@ server {
     proxy_set_header Connection "upgrade";
   }
 
+{% endif %}
 {% if nginx_features.status %}
   # Gatus health page — public path /status/, SPA assets rewritten on the fly.
   # Gatus's index.html / JS reference assets and the API as absolute paths

--- a/local-setup/kong/kong.yml
+++ b/local-setup/kong/kong.yml
@@ -670,24 +670,6 @@ services:
     paths:
     - /jupyter
     strip_path: false
-- name: grafana-service
-  url: http://grafana:3000
-  tags:
-  - observability
-  host: grafana
-  port: 3000
-  routes:
-  - name: grafana-route
-    paths:
-    - /grafana
-    strip_path: false
-    preserve_host: true
-  plugins:
-  - name: request-transformer
-    config:
-      add:
-        headers:
-        - "X-Forwarded-Proto:https"
 - name: indexer-service
   url: http://egov-indexer:8080
   tags:
@@ -706,18 +688,16 @@ services:
     paths:
     - /inbox
     strip_path: false
-- name: tempo-service
-  url: http://tempo:3200
-  tags:
-  - observability
-  routes:
-  - name: tempo-route
-    paths:
-    - /tempo
-    strip_path: true
+# NOTE: the /grafana and /tempo routes were removed (#1604). Both proxied to
+# the observability stack with no auth, and the Grafana one also created a
+# fall-through: host nginx's `location /` catch-all forwards to Kong, so a
+# tenant that disabled the nginx /grafana/ location was still served Grafana
+# through here. Grafana is now reachable only via the nginx location (gated on
+# nginx_features.grafana) and Tempo only via Grafana's server-side datasource.
+#
 # Browser -> otel-collector OTLP/HTTP ingest for the dashboard render-lag
-# instrumentation (#1110). Same-origin (follows the /tempo and /grafana
-# observability precedent) so the SPA needs no CORS work and no new host port.
+# instrumentation (#1110). Same-origin so the SPA needs no CORS work and no
+# new host port.
 # Security posture (R8): EXACT paths, POST only, /v1/traces deliberately NOT
 # exposed; per-route 1MB size cap + 60/min-per-IP rate limit; both paths are
 # whitelisted in the pre-function's AUTH_OPTIONAL above. No ingest token in v1


### PR DESCRIPTION
Fixes #1604

> [!IMPORTANT]
> **Depends on #1684 — merge that first, or merge the two together.**
>
> This PR only edits `kong/kong.yml`. On an *existing* deployment that file never reaches the running Kong container: the config-dir sync is a plain `synchronize`/rsync (`playbook-deploy.yml:1199`, `kong: ../kong`), rsync's default temp-file-plus-rename replaces the inode, and compose bind-mounts the file *individually* (`./kong/kong.yml:/kong/kong.yml:ro`), so the mount stays pinned to the old inode. Nothing in the playbook recreates or reloads Kong when only its config changed. The result is silent success: correct file on disk, green playbook, old routes still being served.
>
> #1684 fixes both halves (`--inplace` on the sync, plus a `kong reload` when `kong.yml` changed). Until it lands, this PR is only effective on a full stack recreate (`docker compose down` + `up`) or a fresh box.

## What

Kong proxied `/grafana` and `/tempo` straight to the observability stack with no auth plugin.

`/tempo` exposed the entire trace API and has no legitimate consumer — Grafana queries Tempo server-side over the container network, and the browser never touches it.

`/grafana` additionally created a **fall-through**: in static UI mode host nginx's `location /` catch-all forwards to Kong, so a tenant that removed or disabled the nginx `/grafana/` location was still served Grafana through Kong. Any nginx-level gating was cosmetic while that route existed.

## Changes

- **`kong/kong.yml`** — remove `grafana-service`/`grafana-route` (with its `request-transformer` plugin) and `tempo-service`/`tempo-route`. A comment records why, so the pattern isn't reintroduced. The `/otel/v1/*` ingest routes are untouched.
- **`nginx-site.conf.j2`** — wrap the `/grafana/` location in `{% if nginx_features.grafana | default(true) %}`.
- **`group_vars/digit.yml`** — add `grafana: true` to `nginx_features`.

## The `| default(true)` is load-bearing

`host_vars` files override `nginx_features` as a whole dict and Ansible's `hash_behaviour` is the default `replace`, so every tenant file written before this key existed (`pg.citya.yml`, `maputo.yml.example`, `localhost-full.yml.example`, …) has no `grafana` member. Without the default, rendering this template would fail on those tenants and take the deploy down. Same pattern as the existing `digit_ui_v2` and `root_to_digit_ui` flags.

## Default is on, deliberately

Grafana carries a real login as of #1602, and `/grafana/` is the team's dashboard entry point — defaulting it off would break the workflow for every tenant on upgrade. Tenants that want Grafana off the internet entirely set `nginx_features.grafana: false` and reach it over an SSH tunnel to `127.0.0.1:13000`.

## Testing

Not yet deployed. Checklist:

- [ ] `https://<domain>/tempo/api/search` → 404
- [ ] with the flag **false**, `https://<domain>/grafana/` → 404 (confirms no Kong fall-through)
- [ ] with the flag **true**, Grafana loads and shows its login page
- [ ] Kong still boots and its config parses after the route removal
- [ ] **with #1684 in place**, a plain redeploy (no stack recreate) is enough for the removed routes to stop answering — without it, verify only after `docker compose down && up`
- [ ] existing tenants (`pg.citya`) render nginx without error despite having no `grafana` key

## Notes

Pairs with #1602, which puts the login behind this path. Blocked on #1684 for delivery (see the note at the top) — that bug was found while verifying this PR on the devbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

