### PR TITLE
fix(otel): sync the root promtail config, which was fatally invalid

### DIFF
--- a/otel/promtail-config.yaml
+++ b/otel/promtail-config.yaml
@@ -13,12 +13,12 @@ positions:
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
-limits_config:
-  # Drop log entries older than 7 days (matches Loki's reject threshold) so
-  # the first sweep over historical /var/lib/docker/containers/*-json.log
-  # files doesn't hammer Loki with 400s.
-  reject_old_samples: true
-  reject_old_samples_max_age: 168h
+# Note: `reject_old_samples` / `reject_old_samples_max_age` belong in
+# Loki's loki-config.yaml, NOT here — promtail's limits_config schema
+# doesn't accept them and rejects the whole config with a fatal:
+#   "field reject_old_samples not found in type limit.Config"
+# Loki already enforces the 7-day rejection on its side, so there's
+# nothing to mirror in promtail.
 
 scrape_configs:
   - job_name: docker


### PR DESCRIPTION
Part 1 of #1617.

## What

The root-level `otel/promtail-config.yaml` still contained:

```yaml
limits_config:
  reject_old_samples: true
  reject_old_samples_max_age: 168h
```

Promtail's `limits_config` schema has no such fields. It does not warn or ignore them — it refuses the entire config:

```
field reject_old_samples not found in type limit.Config
```

and the process never starts.

The deployed copy under `local-setup/` was fixed some time ago and documents the reason in place. The root copy was left behind. Anyone deploying from the repo root — following an older doc, or reasonably assuming the root compose file is the primary one — gets a stack where **log collection is silently dead**: everything else comes up healthy, Grafana works, and the logs dashboard is simply empty forever with nothing explaining why.

## Change

One file, copied verbatim from `local-setup/otel/promtail-config.yaml`. The two are now byte-identical.

## Verification

```
$ diff otel/promtail-config.yaml local-setup/otel/promtail-config.yaml
(empty)

$ python3 -c "import yaml; d=yaml.safe_load(open('otel/promtail-config.yaml')); print(d.get('limits_config'))"
None
```

Top-level keys are now `server`, `positions`, `clients`, `scrape_configs` — no `limits_config` block at all. (Note the phrase `reject_old_samples` still appears in the file as *explanatory comment text*, which is intended: it documents why the keys must not be reintroduced.)

## Risk

None to anything deployed. The Ansible playbook uses the `local-setup/` copy, which is unchanged by this PR. This only repairs a file that is currently guaranteed to fail if used.

## Deliberately not included

Part 2 of #1617 — deciding whether the root copies should exist at all, and the remaining drift in `otel/loki-config.yaml` and `docker-compose.egov-digit.yaml` — is a separate change. It needs a discussion about repository layout, and defusing the landmine should not wait behind that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated log collection configuration to remove unsupported sample-rejection settings.
  * Clarified that sample age limits are enforced by the log storage service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->