### PR TITLE
fix(prometheus): reload by SIGHUP, drop --web.enable-lifecycle

### DIFF
--- a/docker-compose.egov-digit.yaml
+++ b/docker-compose.egov-digit.yaml
@@ -81,7 +81,10 @@ services:
     command:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.retention.time=15d
-      - --web.enable-lifecycle
+      # NOTE: no --web.enable-lifecycle (#1608) — it exposes POST /-/reload
+      # AND POST /-/quit unauthenticated. The Ansible deploy reloads by
+      # SIGHUP instead. (This root-level copy is separately tracked for
+      # removal or CI drift-checking in #1617.)
     volumes:
       - ./otel/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus

--- a/docker-compose.egov-digit.yaml
+++ b/docker-compose.egov-digit.yaml
@@ -83,8 +83,10 @@ services:
       - --storage.tsdb.retention.time=15d
       # NOTE: no --web.enable-lifecycle (#1608) — it exposes POST /-/reload
       # AND POST /-/quit unauthenticated. The Ansible deploy reloads by
-      # SIGHUP instead. (This root-level copy is separately tracked for
-      # removal or CI drift-checking in #1617.)
+      # SIGHUP instead. (This whole root-level file is deleted by #1637,
+      # which closes drift issue #1617. If #1637 lands first this hunk is
+      # moot; if it lands second, resolve the modify/delete by taking the
+      # delete. The live copy is local-setup/docker-compose.egov-digit.yaml.)
     volumes:
       - ./otel/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -1844,16 +1844,22 @@
     # live Prometheus keeps its old in-memory config and never picks up a newly
     # added scrape job (e.g. the `node` job for node-exporter) until it happens
     # to restart. A fresh deploy is unaffected — Prometheus boots with the new
-    # config. Prometheus runs with --web.enable-lifecycle, so POST /-/reload
-    # rereads the file in place. Best-effort: on a first deploy Prometheus may
-    # not be up yet (and already loaded fresh config), so a failure here is fine.
+    # config.
+    #
+    # Reload is by SIGHUP, not POST /-/reload (#1608). The HTTP lifecycle
+    # endpoints are enabled by --web.enable-lifecycle, which also exposes
+    # POST /-/quit — an unauthenticated remote shutdown of the metrics store.
+    # SIGHUP is Prometheus's documented equivalent for re-reading config and
+    # carries no HTTP surface, so the flag is gone from the compose file.
+    # `docker kill` only DELIVERS the signal despite its name; HUP does not
+    # terminate the process.
+    #
+    # Best-effort: on a first deploy Prometheus may not be up yet (and has
+    # already loaded fresh config), so a failure here is fine.
     - name: Reload Prometheus config (pick up new scrape jobs without a recreate)
-      ansible.builtin.uri:
-        url: http://127.0.0.1:19090/-/reload
-        method: POST
-        status_code: [200]
+      ansible.builtin.command: docker kill -s HUP digit-prometheus
       register: prometheus_reload
-      changed_when: prometheus_reload.status == 200
+      changed_when: prometheus_reload.rc == 0
       failed_when: false
 
     # ==================== digit-ui mode convergence ====================

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -81,7 +81,11 @@ services:
     command:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.retention.time=15d
-      - --web.enable-lifecycle
+      # NOTE: no --web.enable-lifecycle (#1608). That flag exposes
+      # POST /-/reload AND POST /-/quit with no authentication — a remote
+      # shutdown for the metrics store. The deploy reloads config by sending
+      # SIGHUP instead (playbook-deploy.yml, "Reload Prometheus config"),
+      # which is Prometheus's documented equivalent and has no HTTP surface.
     volumes:
       - ./otel/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus


### PR DESCRIPTION
Fixes #1608

## What

Prometheus ran with `--web.enable-lifecycle`, which enables two **unauthenticated** HTTP endpoints:

- `POST /-/reload` — re-read the config file
- `POST /-/quit` — **shut Prometheus down**

The second is a remote kill switch for the metrics store, available to anyone who can reach the port. Today that is the internet, since the port is published on `0.0.0.0` (fixed separately in #1606); after that lands, it is still available to anything running on the host.

## Why the flag was there

Exactly one deploy step used it, and for a real reason: `docker compose up -d` recreates a container only when its service *spec* changes, so editing the bind-mounted `otel/prometheus.yml` does not restart Prometheus. On a redeploy the live process keeps its old in-memory config and silently ignores a newly added scrape job — which is precisely what the node-exporter job in #1335 ran into.

## Change

Prometheus re-reads its configuration on **SIGHUP**, which is documented and equivalent to `POST /-/reload`, and carries no HTTP surface.

```diff
-    - name: Reload Prometheus config (pick up new scrape jobs without a recreate)
-      ansible.builtin.uri:
-        url: http://127.0.0.1:19090/-/reload
-        method: POST
-        status_code: [200]
+    - name: Reload Prometheus config (pick up new scrape jobs without a recreate)
+      ansible.builtin.command: docker kill -s HUP digit-prometheus
       register: prometheus_reload
-      changed_when: prometheus_reload.status == 200
+      changed_when: prometheus_reload.rc == 0
       failed_when: false
```

and `--web.enable-lifecycle` is removed from the Prometheus command, replaced by a comment recording why it must not come back.

`docker kill` only **delivers** a signal despite its name; HUP does not terminate the process.

`failed_when: false` is kept deliberately: on a first deploy Prometheus may not be up yet, and in that case it has already booted with the current config, so a failed signal is not an error.

## Also touches the root-level copy

The drifted root `docker-compose.egov-digit.yaml` carried the same flag. Leaving it would keep the exposed endpoint for anyone deploying from the repo root, so the same change is applied there. That copy's wider drift is tracked by issue #1617, and the file is **deleted outright by PR #1637** (`chore/1617-remove-root-duplicate-configs`, base `monitoring-fix`), which removes the root `docker-compose.egov-digit.yaml` and the root `otel/` tree. This PR does not attempt to reconcile the drift.

**Merge order:** #1637 and this PR both touch that file, so one direction is a modify/delete conflict — resolve it by **taking the delete**. If #1637 lands first, this hunk is moot and should simply be dropped; if this PR lands first, #1637's delete absorbs it (deleting a file whose comment differs is semantically identical).

## Verification

- [x] No live `--web.enable-lifecycle` remains in any compose file (only explanatory comments)
- [x] All three modified files parse as YAML
- [ ] Redeploy with a new scrape job → target appears in Prometheus without a container recreate (the #1335 scenario)
- [ ] `POST http://127.0.0.1:19090/-/reload` returns 404 **from on the host** — proving the endpoint is gone, not merely unreachable
- [ ] Existing dashboards and metrics unaffected

The last three need a real box; not yet deployed.

## Note

Unlike the Grafana password fallback in #1605, there is no tradeoff here — SIGHUP is a strictly equivalent replacement, so the capability is removed outright rather than restricted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

