### PR TITLE
feat(gatus): check public TLS certificate expiry

### DIFF
--- a/local-setup/ansible/templates/digit.env.j2
+++ b/local-setup/ansible/templates/digit.env.j2
@@ -120,7 +120,16 @@ NOVU_BRIDGE_CHANNEL={{ novu_bridge_channel | default('sms') }}
 # container cannot reach the public hostname from inside the host (hairpin NAT
 # is not universal), which would otherwise show as a false failure.
 GATUS_TLS={{ (gatus_tls_check | default(tls_enabled | default(true))) | lower }}
-GATUS_PUBLIC_URL={{ 'https://' + domain + '/' if (tls_enabled | default(true)) else '' }}
+# Always populated, even when the check is disabled. Gatus validates `url` on
+# EVERY endpoint regardless of `enabled:`, so an empty value here is not an inert
+# placeholder -- it makes gatus PANIC at startup ("you must specify an url for
+# each endpoint"), the container dies, and the whole health dashboard goes with
+# it (nginx /status/ 502s). Caught deploying this to a tenant with
+# tls_enabled: false.
+#
+# `enabled: ${GATUS_TLS}` is what actually gates the check. The URL only has to
+# be syntactically present; it is never dialled while the endpoint is disabled.
+GATUS_PUBLIC_URL={{ ('https://' if (tls_enabled | default(true)) else 'http://') + domain + '/' }}
 
 GATUS_PROFILE_OTP={{ enable_otp_services | default(false) | lower }}
 GATUS_PROFILE_SEARCH={{ enable_search_stack | default(false) | lower }}

--- a/local-setup/ansible/templates/digit.env.j2
+++ b/local-setup/ansible/templates/digit.env.j2
@@ -111,6 +111,17 @@ NOVU_BRIDGE_CHANNEL={{ novu_bridge_channel | default('sms') }}
 # Rendered unconditionally: the compose files read these as ${GATUS_PROFILE_*:-false},
 # and that fallback is what makes an unset toggle mean "off" rather than a red
 # check for a stack this tenant does not run.
+# Public TLS-certificate check (#1622). Every other Gatus check runs inside the
+# container network and never presents the public certificate, so an expired one
+# leaves the whole dashboard green while the site is unusable for everyone.
+#
+# Only meaningful when TLS actually terminates here, so it follows tls_enabled.
+# Override gatus_tls_check in host_vars to force it off — e.g. where the gatus
+# container cannot reach the public hostname from inside the host (hairpin NAT
+# is not universal), which would otherwise show as a false failure.
+GATUS_TLS={{ (gatus_tls_check | default(tls_enabled | default(true))) | lower }}
+GATUS_PUBLIC_URL={{ 'https://' + domain + '/' if (tls_enabled | default(true)) else '' }}
+
 GATUS_PROFILE_OTP={{ enable_otp_services | default(false) | lower }}
 GATUS_PROFILE_SEARCH={{ enable_search_stack | default(false) | lower }}
 GATUS_PROFILE_MCP={{ enable_mcp | default(false) | lower }}

--- a/local-setup/docker-compose.db-migrations.yml
+++ b/local-setup/docker-compose.db-migrations.yml
@@ -1314,7 +1314,12 @@ services:
       # true, which would leave a permanently-red check for a URL that does
       # not resolve.
       GATUS_TLS: "false"
-      GATUS_PUBLIC_URL: ""
+      # Non-empty on purpose. Gatus validates `url` on EVERY endpoint before it
+      # ever consults `enabled:`, so "" is not an inert placeholder -- it aborts
+      # startup with "you must specify an url for each endpoint" and takes the
+      # entire dashboard down with it. This value is only ever parsed by the
+      # config loader; the check is disabled, so it is never dialled.
+      GATUS_PUBLIC_URL: "https://localhost/"
     deploy:
       resources:
         limits:

--- a/local-setup/docker-compose.db-migrations.yml
+++ b/local-setup/docker-compose.db-migrations.yml
@@ -1309,6 +1309,12 @@ services:
       GATUS_AUDIT: "false"
       GATUS_PROXIES: "false"
       GATUS_SMS_PORT: "8080"
+      # No public hostname on this path — the TLS check (#1622) is off.
+      # Declared explicitly because Gatus treats an UNSET `enabled` var as
+      # true, which would leave a permanently-red check for a URL that does
+      # not resolve.
+      GATUS_TLS: "false"
+      GATUS_PUBLIC_URL: ""
     deploy:
       resources:
         limits:

--- a/local-setup/docker-compose.deploy.yaml
+++ b/local-setup/docker-compose.deploy.yaml
@@ -927,7 +927,12 @@ services:
       # true, which would leave a permanently-red check for a URL that does
       # not resolve.
       GATUS_TLS: "false"
-      GATUS_PUBLIC_URL: ""
+      # Non-empty on purpose. Gatus validates `url` on EVERY endpoint before it
+      # ever consults `enabled:`, so "" is not an inert placeholder -- it aborts
+      # startup with "you must specify an url for each endpoint" and takes the
+      # entire dashboard down with it. This value is only ever parsed by the
+      # config loader; the check is disabled, so it is never dialled.
+      GATUS_PUBLIC_URL: "https://localhost/"
     networks:
       - egov-network
 

--- a/local-setup/docker-compose.deploy.yaml
+++ b/local-setup/docker-compose.deploy.yaml
@@ -922,6 +922,12 @@ services:
       GATUS_AUDIT: "false"
       GATUS_PROXIES: "false"
       GATUS_SMS_PORT: "8080"
+      # No public hostname on this path — the TLS check (#1622) is off.
+      # Declared explicitly because Gatus treats an UNSET `enabled` var as
+      # true, which would leave a permanently-red check for a URL that does
+      # not resolve.
+      GATUS_TLS: "false"
+      GATUS_PUBLIC_URL: ""
     networks:
       - egov-network
 

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -1659,6 +1659,14 @@ services:
       GATUS_AUDIT: "true"
       GATUS_PROXIES: "true"
       GATUS_SMS_PORT: "8005"
+      # Public TLS-certificate check (#1622). Ansible renders both of these into
+      # .env from `domain` + `tls_enabled`; the defaults keep the check OFF for a
+      # bare `docker compose up` outside Ansible, where there is no public
+      # hostname. Off is the safe default: an unset `enabled` var reads as TRUE to
+      # Gatus, which would leave a permanently-red check against a URL that never
+      # resolves — and a red square nobody can fix is how dashboards get ignored.
+      GATUS_TLS: ${GATUS_TLS:-false}
+      GATUS_PUBLIC_URL: ${GATUS_PUBLIC_URL:-}
     networks:
       - egov-network
 

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -1666,7 +1666,14 @@ services:
       # Gatus, which would leave a permanently-red check against a URL that never
       # resolves — and a red square nobody can fix is how dashboards get ignored.
       GATUS_TLS: ${GATUS_TLS:-false}
-      GATUS_PUBLIC_URL: ${GATUS_PUBLIC_URL:-}
+      # The fallback is non-empty on purpose, and `:-` (not `-`) is load-bearing:
+      # it fires when the var is unset OR set-but-empty, so a stale .env carrying
+      # `GATUS_PUBLIC_URL=` cannot reintroduce the empty value. Gatus validates
+      # `url` on EVERY endpoint before it consults `enabled:`, so "" aborts
+      # startup with "you must specify an url for each endpoint" and takes the
+      # whole dashboard down (nginx /status/ then 502s). Only ever parsed here --
+      # with GATUS_TLS false the endpoint is never dialled.
+      GATUS_PUBLIC_URL: ${GATUS_PUBLIC_URL:-https://localhost/}
     networks:
       - egov-network
 

--- a/local-setup/docker-compose.registry.yml
+++ b/local-setup/docker-compose.registry.yml
@@ -1621,7 +1621,12 @@ services:
       # true, which would leave a permanently-red check for a URL that does
       # not resolve.
       GATUS_TLS: "false"
-      GATUS_PUBLIC_URL: ""
+      # Non-empty on purpose. Gatus validates `url` on EVERY endpoint before it
+      # ever consults `enabled:`, so "" is not an inert placeholder -- it aborts
+      # startup with "you must specify an url for each endpoint" and takes the
+      # entire dashboard down with it. This value is only ever parsed by the
+      # config loader; the check is disabled, so it is never dialled.
+      GATUS_PUBLIC_URL: "https://localhost/"
     networks:
       - egov-network
 

--- a/local-setup/docker-compose.registry.yml
+++ b/local-setup/docker-compose.registry.yml
@@ -1616,6 +1616,12 @@ services:
       GATUS_AUDIT: "false"
       GATUS_PROXIES: "true"
       GATUS_SMS_PORT: "8080"
+      # No public hostname on this path — the TLS check (#1622) is off.
+      # Declared explicitly because Gatus treats an UNSET `enabled` var as
+      # true, which would leave a permanently-red check for a URL that does
+      # not resolve.
+      GATUS_TLS: "false"
+      GATUS_PUBLIC_URL: ""
     networks:
       - egov-network
 

--- a/local-setup/docker-compose.yml
+++ b/local-setup/docker-compose.yml
@@ -1148,7 +1148,12 @@ services:
       # true, which would leave a permanently-red check for a URL that does
       # not resolve.
       GATUS_TLS: "false"
-      GATUS_PUBLIC_URL: ""
+      # Non-empty on purpose. Gatus validates `url` on EVERY endpoint before it
+      # ever consults `enabled:`, so "" is not an inert placeholder -- it aborts
+      # startup with "you must specify an url for each endpoint" and takes the
+      # entire dashboard down with it. This value is only ever parsed by the
+      # config loader; the check is disabled, so it is never dialled.
+      GATUS_PUBLIC_URL: "https://localhost/"
     deploy:
       resources:
         limits:

--- a/local-setup/docker-compose.yml
+++ b/local-setup/docker-compose.yml
@@ -1143,6 +1143,12 @@ services:
       GATUS_AUDIT: "false"
       GATUS_PROXIES: "true"
       GATUS_SMS_PORT: "8080"
+      # No public hostname on this path — the TLS check (#1622) is off.
+      # Declared explicitly because Gatus treats an UNSET `enabled` var as
+      # true, which would leave a permanently-red check for a URL that does
+      # not resolve.
+      GATUS_TLS: "false"
+      GATUS_PUBLIC_URL: ""
     deploy:
       resources:
         limits:

--- a/local-setup/gatus/config.yaml
+++ b/local-setup/gatus/config.yaml
@@ -472,3 +472,34 @@ endpoints:
     interval: 60s
     conditions:
       - "[STATUS] == 200"
+
+  # ==================== Public endpoint (TLS) ====================
+  # Every other check in this file runs INSIDE the container network and never
+  # traverses nginx, so none of them presents the public certificate. An expired
+  # cert therefore leaves this whole dashboard green while every citizen and
+  # employee gets a browser security warning — the dashboard would actively
+  # mislead whoever is diagnosing the outage (#1622).
+  #
+  # This is also the only check that exercises the REAL public path end to end:
+  # DNS, the host firewall, nginx, TLS termination and routing through to the
+  # app. Everything above bypasses all of it.
+  #
+  # Certificates are Let's Encrypt, renewed by certbot's systemd timer. Renewal
+  # is automatic and unverified: if it fails (expired ACME account, blocked
+  # HTTP-01 challenge, nginx not reloaded, disabled timer) the expiry is
+  # perfectly predictable 90 days ahead, and nothing currently notices.
+  #
+  # 240h ≈ 10 days of warning. Certbot renews at 30 days, so this only fires
+  # once renewal has genuinely failed, not on the normal renewal cycle.
+  #
+  # GATUS_TLS is false unless the deployment sets it: it needs a real public
+  # hostname AND the gatus container must be able to reach it from inside
+  # (hairpin NAT is not universal). Ansible enables it only when tls_enabled.
+  - name: TLS Certificate
+    group: Public Endpoint
+    enabled: ${GATUS_TLS}
+    url: "${GATUS_PUBLIC_URL}"
+    interval: 5m
+    conditions:
+      - "[CERTIFICATE_EXPIRATION] > 240h"
+      - "[STATUS] < 500"

--- a/local-setup/gatus/config.yaml
+++ b/local-setup/gatus/config.yaml
@@ -495,11 +495,27 @@ endpoints:
   # GATUS_TLS is false unless the deployment sets it: it needs a real public
   # hostname AND the gatus container must be able to reach it from inside
   # (hairpin NAT is not universal). Ansible enables it only when tls_enabled.
+  #
+  # GATUS_PUBLIC_URL is always rendered non-empty, even when GATUS_TLS is false.
+  # Gatus validates `url` on EVERY endpoint before it consults `enabled:`, so an
+  # empty value here does not disable the check -- it aborts startup entirely
+  # ("you must specify an url for each endpoint") and takes the dashboard with it.
+  #
+  # [CONNECTED] == true is what separates the two ways this can go red. On any
+  # TLS failure -- SAN mismatch, broken chain, wrong cert -- the handshake never
+  # completes, so [CERTIFICATE_EXPIRATION] resolves to 0s and [STATUS] to 0. With
+  # only the two conditions below, "0s > 240h" would fail and read exactly like a
+  # cert about to expire, sending on-call to chase a renewal that is not the
+  # problem. [CONNECTED] fails too in that case and not in the expiry case, so
+  # which condition is red says which fault it is. (It also closes a real gap:
+  # 0 < 500 is TRUE, so [STATUS] alone stays green on a dead connection.)
+  # Upstream pairs these two conditions in its own certificate examples.
   - name: TLS Certificate
     group: Public Endpoint
     enabled: ${GATUS_TLS}
     url: "${GATUS_PUBLIC_URL}"
     interval: 5m
     conditions:
+      - "[CONNECTED] == true"
       - "[CERTIFICATE_EXPIRATION] > 240h"
       - "[STATUS] < 500"

--- a/local-setup/k8s/tools/gatus.yaml
+++ b/local-setup/k8s/tools/gatus.yaml
@@ -500,12 +500,28 @@ data:
       #
       # OFF in this tier: it has no ingress and no public hostname (see #1618).
       # Defined here only to keep both catalogues identical, per the header.
+      #
+      # GATUS_PUBLIC_URL is still set to a non-empty placeholder on the Deployment
+      # below. Gatus validates `url` on EVERY endpoint before it consults
+      # `enabled:`, so an empty value here does not disable the check -- it aborts
+      # startup ("you must specify an url for each endpoint") and CrashLoopBackOffs.
+      #
+      # [CONNECTED] == true is what separates the two ways this can go red. On any
+      # TLS failure -- SAN mismatch, broken chain, wrong cert -- the handshake never
+      # completes, so [CERTIFICATE_EXPIRATION] resolves to 0s and [STATUS] to 0. With
+      # only the two conditions below, "0s > 240h" would fail and read exactly like a
+      # cert about to expire, sending on-call to chase a renewal that is not the
+      # problem. [CONNECTED] fails too in that case and not in the expiry case, so
+      # which condition is red says which fault it is. (It also closes a real gap:
+      # 0 < 500 is TRUE, so [STATUS] alone stays green on a dead connection.)
+      # Upstream pairs these two conditions in its own certificate examples.
       - name: TLS Certificate
         group: Public Endpoint
         enabled: ${GATUS_TLS}
         url: "${GATUS_PUBLIC_URL}"
         interval: 5m
         conditions:
+          - "[CONNECTED] == true"
           - "[CERTIFICATE_EXPIRATION] > 240h"
           - "[STATUS] < 500"
 
@@ -566,8 +582,13 @@ spec:
             # permanently-red check against a URL that never resolves.
             - name: GATUS_TLS
               value: "false"
+            # Non-empty on purpose. Gatus validates `url` on EVERY endpoint
+            # before it consults `enabled:`, so "" is not an inert placeholder --
+            # it aborts startup with "you must specify an url for each endpoint"
+            # and CrashLoopBackOffs the pod. Only ever parsed; with GATUS_TLS
+            # false this endpoint is never dialled.
             - name: GATUS_PUBLIC_URL
-              value: ""
+              value: "https://localhost/"
           resources:
             limits:
               memory: 64Mi

--- a/local-setup/k8s/tools/gatus.yaml
+++ b/local-setup/k8s/tools/gatus.yaml
@@ -487,6 +487,28 @@ data:
         interval: 60s
         conditions:
           - "[STATUS] == 200"
+
+      # ==================== Public endpoint (TLS) ====================
+      # Every other check in this file runs INSIDE the cluster network and never
+      # traverses the public ingress, so none of them presents the public
+      # certificate. An expired cert therefore leaves this whole dashboard green
+      # while every citizen and employee gets a browser security warning — the
+      # dashboard would actively mislead whoever is diagnosing the outage (#1622).
+      #
+      # This is also the only check that exercises the REAL public path end to
+      # end: DNS, firewall, TLS termination and routing through to the app.
+      #
+      # OFF in this tier: it has no ingress and no public hostname (see #1618).
+      # Defined here only to keep both catalogues identical, per the header.
+      - name: TLS Certificate
+        group: Public Endpoint
+        enabled: ${GATUS_TLS}
+        url: "${GATUS_PUBLIC_URL}"
+        interval: 5m
+        conditions:
+          - "[CERTIFICATE_EXPIRATION] > 240h"
+          - "[STATUS] < 500"
+
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -538,6 +560,14 @@ spec:
               value: "false"
             - name: GATUS_SMS_PORT
               value: "8080"
+            # No ingress and no public hostname in this tier (#1618), so the
+            # public TLS check stays off. Declared rather than omitted: Gatus
+            # reads an UNSET enabled-var as true, which would leave a
+            # permanently-red check against a URL that never resolves.
+            - name: GATUS_TLS
+              value: "false"
+            - name: GATUS_PUBLIC_URL
+              value: ""
           resources:
             limits:
               memory: 64Mi


### PR DESCRIPTION
Fixes #1622

## What

Nothing watched TLS certificate validity. Certificates are Let's Encrypt, renewed by certbot's systemd timer — automatically, and unverified. If renewal fails (expired ACME account, blocked HTTP-01 challenge, nginx not reloaded after renewal, disabled timer), the certificate expires silently and **every citizen and employee gets a browser security warning**. It is also the most predictable outage possible: the expiry date is known 90 days ahead, and certbot renews at 30.

## The existing monitoring structurally cannot catch it

Every one of the ~51 Gatus checks is `http://` or `tcp://` against a service name on the container network — **41 http, 10 tcp, zero external**. The Ansible validate tasks have the same blind spot, using `127.0.0.1` with a `Host:` header. Nothing traverses nginx, so nothing ever presents the public certificate.

With an expired certificate the dashboard therefore stays **entirely green** while the platform is unusable — actively misleading whoever is diagnosing it, because from the inside everything genuinely is healthy.

## Change

One endpoint, added to both tier catalogues:

```yaml
  - name: TLS Certificate
    group: Public Endpoint
    enabled: ${GATUS_TLS}
    url: "${GATUS_PUBLIC_URL}"
    interval: 5m
    conditions:
      - "[CERTIFICATE_EXPIRATION] > 240h"
      - "[STATUS] < 500"
```

Gatus supports certificate-expiry conditions natively, so this needs **no new component**.

Beyond certificates, this is the only check that exercises the **real public path end to end** — DNS, host firewall, nginx, TLS termination, and routing through to the app. Everything else bypasses all of it. 240h ≈ 10 days of warning, against certbot's 30-day renewal, so it fires only once renewal has genuinely failed rather than on the normal cycle.

## Off unless a deployment opts in

Ansible derives both variables from existing inventory (`digit.env.j2`):

```jinja
GATUS_TLS={{ (gatus_tls_check | default(tls_enabled | default(true))) | lower }}
GATUS_PUBLIC_URL={{ 'https://' + domain + '/' if (tls_enabled | default(true)) else '' }}
```

`gatus_tls_check` is a host_vars escape hatch for boxes where the Gatus container cannot reach its own public hostname from inside — hairpin NAT is not universal, and a permanent false red is precisely how dashboards get ignored.

## Why all five compose files and the k8s Deployment changed

This is required, not tidying. **Gatus reads an unset `enabled` variable as `true`** — the config header already warns about this — so omitting the toggle anywhere would enable the check with an unsubstituted `${GATUS_PUBLIC_URL}`, producing a permanently-red square nobody can fix. Every file that mounts this config now declares both variables explicitly:

| File | GATUS_TLS |
|---|---|
| `docker-compose.egov-digit.yaml` (tenant path) | `${GATUS_TLS:-false}` — Ansible supplies it |
| `docker-compose.yml`, `deploy.yaml`, `registry.yml`, `db-migrations.yml` | `"false"` — no public hostname |
| `k8s/tools/gatus.yaml` Deployment | `"false"` — no ingress in that tier (#1618) |

## Verification

- [x] All seven touched files parse; both tier catalogues carry an identical endpoint
- [x] `check-gatus-coverage.py` passes with self-test: **52 endpoints per tier, no drift, no dangling checks**
- [x] Every compose file and the k8s Deployment declare both variables
- [x] Repo static tests: same 2 failures as clean `master`, none new
- [ ] On a TLS tenant: the check appears and passes against the live certificate
- [ ] Gatus container can actually reach the public hostname from inside (the hairpin-NAT caveat)
- [ ] Forcing a near-expiry certificate turns it red, and alerts once #1609 lands

The last three need a real box; not yet deployed.

## Merge note

Touches `local-setup/gatus/config.yaml` / `k8s/tools/gatus.yaml`, as do #1630 (sqlite persistence) and #1609 (Slack alerting). Sequence them and keep both tiers in step in whichever order they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
