### PR TITLE
docs(operations): system-failure SOP handbook for operator teams

### DIFF
--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,0 +1,172 @@
+# DIGIT / CCRS — Operations & Support Handbook
+
+**Audience:** the team that operates a deployed DIGIT / CCRS instance — the IT or
+infrastructure staff inside the department, council or ministry that owns the server.
+
+**Purpose:** to help you find out *what* broke without waiting for us, and to make it easy
+to hand us a report we can act on straight away.
+
+---
+
+## Start here — which page do you need?
+
+| You are | Go to |
+|---|---|
+| **On the service desk**, someone has just reported a problem | **[l1-first-response.md](l1-first-response.md)** — the checklist |
+| **Operating the deployment**, and a ticket has reached you | **[l2-diagnosis.md](l2-diagnosis.md)** — the diagnosis runbook |
+| **Looking for something already seen before** | **[known-issues.md](known-issues.md)** |
+| **About to report something to us** | **[incident-report.md](incident-report.md)** |
+| **Mid-incident and want one page** | **[cheatsheet.md](cheatsheet.md)** |
+| **Setting up monitoring** so you hear about problems first | **[alerts-setup.md](alerts-setup.md)** and **[alert-channels.md](alert-channels.md)** |
+| **Looking something up** | **[reference.md](reference.md)** |
+
+The handbook assumes a first line and a second line, and the two runbooks are written for
+those roles. If your team doesn't split that way, read them as "the checklist" and "the deep
+dive" and ignore the labels — nothing else depends on them.
+
+---
+
+## How a problem moves
+
+```
+   Report  ─▶  L1 first response  ─▶  known issue?  ─── yes ──▶  resolve, log it
+                                            │
+                                            no
+                                            ▼
+                                     Part A ─▶  L2 diagnosis  ─▶  config / restart fix
+                                                      │
+                                                 product defect
+                                                 or deployment change
+                                                      ▼
+                                            Part A+B+C ─▶  us
+```
+
+The report template is **one document filled in three stages** — L1 completes Part A, L2
+adds Part B, and Part C is added when it comes to us. Nothing is re-typed at a handover.
+
+Where the boundary between the tiers sits — what L1 is allowed to do, who may restart a
+service, who carries the phone — is your team's call. This handbook describes the work, not
+the org chart.
+
+---
+
+## Your four URLs
+
+Replace `<your-domain>` with your deployment's domain throughout this handbook.
+
+| What | URL | Use it for |
+|---|---|---|
+| **Health dashboard** (Gatus) | `https://<your-domain>/status/` | *Is everything up?* — ~50 live checks, red/green, refreshed every 30s |
+| **Grafana** | `https://<your-domain>/grafana/` | Metrics, logs, traces, alerts |
+| **Logs** | `https://<your-domain>/grafana/d/digit-loki-logs/` | The actual error text |
+| **Service metrics** | `https://<your-domain>/grafana/d/digit-jvm/` | Memory, CPU, restarts, OOM |
+
+> **Access note.** Grafana on these deployments is configured with anonymous access at
+> **Admin** level (`GF_AUTH_ANONYMOUS_ENABLED=true`, login form disabled). You do not need a
+> password — but it also means anyone who knows the URL has full Grafana access. If your
+> deployment is reachable from the public internet, raise it with us and we will put it
+> behind your VPN or an authentication proxy. See
+> [alerts-setup.md § Before you start](alerts-setup.md#before-you-start).
+
+---
+
+## What a good report contains
+
+Five facts let us start work immediately instead of starting with questions. All five are
+obtainable in a few minutes, from a browser, without server access:
+
+| # | Question | Where you get it |
+|---|---|---|
+| 1 | **What** is broken (URL, screen, action, API) | your own observation |
+| 2 | **When** it started, and whether it's still happening | Health dashboard / Grafana time picker |
+| 3 | **Who/how many** are affected (one user, one office, everyone) | your own observation |
+| 4 | **Which service** is unhealthy or restarting | Health dashboard + Grafana |
+| 5 | **The error text** from that service's logs | Grafana → Logs (Loki) |
+
+If you can only get some of them, send what you have — a partial report early is more useful
+than a complete one late.
+
+---
+
+## Report it early — the evidence expires
+
+Observability data on these deployments is deliberately short-lived, so it costs no disk.
+The trade-off is that **a problem reported late may no longer have any evidence behind it**.
+
+| Data | Where | Kept for | What that means for you |
+|---|---|---|---|
+| **Traces** (per-request timing) | Tempo | **24 hours** | Slowness reports older than a day can't be diagnosed from traces |
+| **Logs** | Loki | **72 hours (3 days)** | The error text is gone after 3 days |
+| **Metrics** (memory, CPU, restarts) | Prometheus | **15 days** | Trends and restart history survive two weeks |
+| Health check history | Gatus | in-memory, **lost on restart** | Worth screenshotting while it's red |
+
+If a problem happened over a weekend, the logs may already have rolled off by Monday — just
+say so in the report so we know what's available.
+
+---
+
+## Severity
+
+Use these labels in the subject line of your report; they set our response. Response times
+and who is on call are yours to define.
+
+| Severity | Definition | Examples |
+|---|---|---|
+| **S1 — Critical** | Citizens or staff cannot use the system at all | Site down, login broken for everyone, no complaint can be filed |
+| **S2 — Major** | A core function is broken for many users, with no workaround | Complaints can be filed but not assigned; notifications not going out; dashboard empty for all supervisors |
+| **S3 — Minor** | Degraded or broken for some users, workaround exists | One office's boundary missing; a report is slow; one screen mis-labelled |
+| **S4 — Question / request** | Not broken; a change, a doubt, a new tenant, a data load | "How do I add a department?" |
+
+Keeping S1 for genuine full-stop outages is what keeps the S1 path fast for everyone.
+
+**A quick check before escalating to S1:** confirm the problem isn't local to one machine —
+try a different network (mobile hotspot), a different browser in private mode, and a
+different user account. Client-side DNS and stale logins produce symptoms that look
+identical to an outage, and ruling them out takes a minute.
+
+---
+
+## Escalating to us
+
+1. Fill in the template in **[incident-report.md](incident-report.md)** — Parts A, B and C.
+2. Attach the evidence it asks for (log excerpts, screenshots, trace IDs, the queries and
+   time ranges you used).
+3. Post it in the agreed support channel; for S1, also use the phone/escalation path.
+4. **If you can, capture the evidence before restarting or redeploying.** A restart often
+   clears the symptom and the logs together, which leaves us without much to work from. If
+   you do need to restart to get users moving — that is usually the right call — just note
+   in the report that you did, and when.
+
+Details we'll ask for if they're missing, so they're worth including up front: the **exact
+time** (with timezone), the **tenant / city code**, the **complaint or user ID** involved,
+and whether it is **reproducible on demand**.
+
+---
+
+## Document map
+
+| Document | For | Read it when |
+|---|---|---|
+| **README.md** (this file) | everyone | Start here. Routing, severity, URLs, escalation |
+| **[cheatsheet.md](cheatsheet.md)** | everyone | Mid-incident. One printable page |
+| **[l1-first-response.md](l1-first-response.md)** | L1 | A problem has just been reported. Checklist, what to capture, when to hand over |
+| **[l2-diagnosis.md](l2-diagnosis.md)** | L2 | A ticket has reached you. Layer model, deeper queries, host, server commands |
+| **[known-issues.md](known-issues.md)** | L1 + L2 | Before diagnosing anything. Symptom → known resolution |
+| **[incident-report.md](incident-report.md)** | L1 + L2 | At every handover. The three-part template and evidence checklist |
+| **[alerts-setup.md](alerts-setup.md)** | L2 | Making the system tell you first. Rules, thresholds, provisioning |
+| **[alert-channels.md](alert-channels.md)** | L2 | Where alerts land — Slack, Chat, Teams, email, WhatsApp, SMS |
+| **[reference.md](reference.md)** | everyone | Lookup: service catalogue, coverage, retention, queries, glossary |
+
+---
+
+## What this handbook does not cover
+
+- **Deploying or upgrading** the stack — that is `local-setup/ansible/`, and normally ours.
+- **Onboarding a city, boundaries, departments or employees** — see
+  [`../migration/operator-runbook.md`](../migration/operator-runbook.md) and the XLSX
+  onboarding flow.
+- **Changing application configuration** (complaint types, SLAs, branding) — that is the
+  Configurator, not an incident.
+
+If you're not sure whether your problem is an incident or a configuration question, file it
+as **S4** and we will re-classify it.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -67,6 +67,11 @@ Replace `<your-domain>` with your deployment's domain throughout this handbook.
 > deployment is reachable from the public internet, raise it with us and we will put it
 > behind your VPN or an authentication proxy. See
 > [alerts-setup.md § Before you start](alerts-setup.md#before-you-start).
+>
+> **Credentials.** Nothing in the first-response checklist needs a password. For the things
+> that do — the Novu notification dashboard, the SMS/WhatsApp provider console, or server
+> access — **ask your system administrator**. Never send credentials in a ticket or a chat
+> message, including to us.
 
 ---
 

--- a/docs/operations/alert-channels.md
+++ b/docs/operations/alert-channels.md
@@ -1,0 +1,412 @@
+# Alert delivery — where alerts go and who answers them
+
+Setting up the *channel*: Slack, Google Chat, Teams, email, WhatsApp, SMS — plus routing,
+quiet hours, and the on-call rota that turns a notification into a fix.
+
+← back to **[Operations handbook](README.md)** · what to alert on:
+**[alerts-setup.md](alerts-setup.md)**
+
+---
+
+## Contents
+
+- [Choosing a channel](#choosing-a-channel)
+- [Check this first: can the server reach the internet?](#check-this-first-can-the-server-reach-the-internet)
+- [Option A — Grafana contact points](#option-a--grafana-contact-points)
+  - [Slack](#slack-recommended-if-you-use-slack)
+  - [Google Chat](#google-chat-recommended-if-you-use-google-workspace)
+  - [Microsoft Teams](#microsoft-teams-recommended-if-you-use-microsoft-365)
+  - [Telegram](#telegram)
+  - [Email](#email-needs-work-before-it-will-send)
+  - [PagerDuty / Opsgenie](#pagerduty--opsgenie-for-a-real-on-call-rota)
+  - [Generic webhook](#generic-webhook-the-escape-hatch)
+- [Option B — Gatus native alerting (endpoint down)](#option-b--gatus-native-alerting-endpoint-down)
+- [WhatsApp and SMS](#whatsapp-and-sms)
+- [Routing: getting the right alert to the right person](#routing-getting-the-right-alert-to-the-right-person)
+- [Quiet hours, maintenance windows and silences](#quiet-hours-maintenance-windows-and-silences)
+- [The on-call rota](#the-on-call-rota)
+- [Escalating to us](#escalating-to-us)
+- [Message hygiene](#message-hygiene)
+
+---
+
+## Choosing a channel
+
+Pick **one primary chat channel** and **one wake-someone-up channel**. Two is enough; more
+splits attention and nothing gets read.
+
+| Channel | Effort | Good for | Watch out for |
+|---|---|---|---|
+| **Slack** | 10 min | Everything, if your team lives in Slack | Free-tier message retention; a noisy channel tends to get muted |
+| **Google Chat** | 10 min | Google Workspace departments | Space webhooks must be enabled by the Workspace admin |
+| **Microsoft Teams** | 10 min | Microsoft 365 departments | Office 365 connectors are being retired — use a **Workflows / Power Automate** webhook |
+| **Telegram** | 15 min | Teams without Slack/Teams; works well on personal phones | It is a consumer app; consider whether infrastructure details may leave department control |
+| **Email** | 30 min | Records, wide distribution, escalation trail | **Needs SMTP configuration — not set up today.** Slow, easily buried |
+| **PagerDuty / Opsgenie** | 1 hour | A genuine 24×7 rota with escalation and acknowledgement | Licence cost |
+| **WhatsApp** | Half a day+ | Reaching people who read nothing else | No native Grafana support; see [below](#whatsapp-and-sms) |
+| **SMS** | Half a day+ | Last resort when data is unavailable | Per-message cost; no context in 160 characters |
+
+**Recommended starting configuration for a government IT team:**
+
+1. **Primary:** the chat tool the department already uses (Google Chat or Teams for most),
+   one dedicated channel — `#digit-alerts`. All `warning` and `critical` alerts land here.
+2. **Wake-up:** `critical` only, additionally to a WhatsApp group or SMS to the two on-call
+   phones.
+3. **Heartbeat:** an external free uptime monitor watching `https://<your-domain>/status/`,
+   so you still find out when the whole box is gone.
+
+The third one is worth the ten minutes it takes. Everything running on the server — Grafana,
+the alert rules, the contact points — goes down with the server, so **only something outside
+it can tell you the server is down.**
+
+---
+
+## Check this first: can the server reach the internet?
+
+Every chat integration works by the server making an outbound HTTPS call. Government servers
+are frequently behind an egress firewall or a proxy, in which case none of this will work
+and Grafana will fail silently apart from a line in its own log.
+
+Test it before you spend an hour on configuration:
+
+```bash
+sudo docker exec digit-grafana wget -qO- --timeout=10 https://slack.com >/dev/null \
+  && echo "egress OK" || echo "EGRESS BLOCKED — talk to your network team"
+```
+
+If it is blocked, your options are: ask the network team to allow outbound HTTPS to the
+specific webhook host; route through your corporate proxy (Grafana honours `HTTP_PROXY` /
+`HTTPS_PROXY` environment variables); or use an **internal** SMTP relay for email, which is
+usually already permitted.
+
+If Grafana appears configured but nothing arrives, its own log tells you why:
+
+```logql
+{compose_service="grafana"} |~ `(?i)alerting|notifier|contact|webhook|error`
+```
+
+---
+
+## Option A — Grafana contact points
+
+All of these live at `https://<your-domain>/grafana/` → **Alerting** → **Contact points** →
+**+ Add contact point**. Give each one a name you will recognise in a routing rule
+(`chat-ops`, `oncall-critical`), pick the integration, fill in the fields, and press
+**Test** before saving.
+
+### Slack (recommended if you use Slack)
+
+1. In Slack: **Apps → Incoming WebHooks → Add to Slack**, choose the channel, copy the
+   webhook URL (`https://hooks.slack.com/services/...`).
+2. In Grafana: contact point type **Slack**, paste it into **Webhook URL**.
+3. Optional but worth doing — set **Title** and **Text Body** so the message is readable
+   at a glance:
+   - Title: `{{ .Status | toUpper }}: {{ .CommonLabels.alertname }}`
+   - Text: `{{ range .Alerts }}{{ .Annotations.summary }}\n{{ .Annotations.description }}\n{{ end }}`
+4. **Test**, confirm it lands in the channel, **Save**.
+
+> The webhook URL is a credential — anyone with it can post into your channel as you. Do not
+> paste it into a ticket, a shared document, or a git repository.
+
+### Google Chat (recommended if you use Google Workspace)
+
+1. In the Google Chat space: **Space name → Apps & integrations → Webhooks → Add webhook**,
+   name it `DIGIT Alerts`, copy the URL.
+2. In Grafana: contact point type **Google Hangouts Chat**, paste into **URL**.
+3. Test and save.
+
+Your Workspace administrator may have webhooks disabled organisation-wide; if the option is
+missing, that is why.
+
+### Microsoft Teams (recommended if you use Microsoft 365)
+
+Microsoft is retiring the old Office 365 connectors, so use the Workflows route:
+
+1. In Teams: the channel's **⋯ → Workflows → "Post to a channel when a webhook request is
+   received"**. Complete it and copy the generated HTTPS URL.
+2. In Grafana: contact point type **Microsoft Teams**, paste into **URL**.
+3. Test and save.
+
+If your tenant still offers **Connectors → Incoming Webhook**, that works too, but plan to
+migrate.
+
+### Telegram
+
+1. Message `@BotFather` → `/newbot` → copy the **bot token**.
+2. Create a group and add the bot, then send one message in the group so there is something
+   to read. Get the **chat ID** from a terminal — not from a browser:
+
+   ```bash
+   read -rs TG_TOKEN     # paste the token at the prompt; it is not echoed
+   curl -s "https://api.telegram.org/bot$TG_TOKEN/getUpdates" \
+     | python3 -c 'import json,sys; print(*{u["message"]["chat"]["id"] for u in json.load(sys.stdin)["result"] if "message" in u})'
+   unset TG_TOKEN
+   ```
+
+   Group chat IDs are negative. Clear the shell history line afterwards if your shell
+   records it.
+3. In Grafana: contact point type **Telegram**, fill in **BOT API Token** and **Chat ID**.
+
+> **Keep the token out of the browser.** Opening the `getUpdates` URL in the address bar
+> writes the bot token into browser history and any synced profile, and it can reach proxy
+> logs, corporate TLS inspection and screenshots. Anyone holding the token can post as the
+> bot. The response body also contains the group's message text. Treat it like a password.
+
+Cheap, reliable, and it reaches personal phones. Consider whether hostnames and error
+messages should be leaving departmental systems onto a consumer platform before you
+standardise on it.
+
+### Email (needs work before it will send)
+
+**Email does not work on a stock deployment.** Grafana has no SMTP server configured
+(`GF_SMTP_*` is unset), and the default contact point points at the literal placeholder
+`<example@email.com>`.
+
+To enable it, the following must be added to the Grafana container's environment — this is a
+deployment change, so **raise it with us** rather than editing files on the box:
+
+```
+GF_SMTP_ENABLED=true
+GF_SMTP_HOST=smtp.yourdepartment.gov:587
+GF_SMTP_USER=<user>
+GF_SMTP_PASSWORD=<password>
+GF_SMTP_FROM_ADDRESS=digit-alerts@yourdepartment.gov
+GF_SMTP_FROM_NAME=DIGIT Alerts
+```
+
+An **internal** departmental relay is usually the easiest thing to get approved, and often
+the only outbound path the firewall permits. Once SMTP works, edit the existing
+`email receiver` contact point and replace the placeholder address with a **distribution
+list**, never an individual — people change roles.
+
+Email is a poor primary channel (slow, easily buried) and a good secondary one (it creates a
+record and reaches people outside the chat tool). Use it for `warning`, not `critical`.
+
+### PagerDuty / Opsgenie (for a real on-call rota)
+
+If the deployment is genuinely 24×7 and you need acknowledgement, escalation and a schedule,
+use a paging product rather than building one out of chat. Grafana has native contact points
+for both: create a service in PagerDuty/Opsgenie, copy its integration key, paste it into
+the contact point. Route only `severity=critical` there.
+
+### Generic webhook (the escape hatch)
+
+Type **Webhook** posts Grafana's alert JSON to any URL you control. This is how you reach
+anything without a native integration — an internal ticketing system, a departmental SMS
+gateway, a WhatsApp relay, a heartbeat monitor. Grafana supports HTTP basic auth and a
+bearer token on the request.
+
+---
+
+## Option B — Gatus native alerting (endpoint down)
+
+The health dashboard at `/status/` already checks ~50 endpoints every 30 seconds. It can
+notify you directly, and it is the **only thing watching the containers that emit no
+metrics** — Postgres, Redis, Kafka, Kong, Elasticsearch, Keycloak, nginx. That makes it the
+highest-value alerting you can add, and the fastest.
+
+It is configured in `local-setup/gatus/config.yaml`, which currently has alerting commented
+out. The change looks like this:
+
+```yaml
+alerting:
+  slack:
+    webhook-url: "https://hooks.slack.com/services/..."
+    default-alert:
+      failure-threshold: 3      # 3 consecutive failed checks ≈ 90 seconds
+      success-threshold: 2      # 2 passes before it says "recovered"
+      send-on-resolved: true
+```
+
+...and then each endpoint opts in with `alerts: [{type: slack}]`. Gatus also supports
+Google Chat, Teams, Telegram, Discord, PagerDuty, Opsgenie, email and generic webhooks with
+the same shape.
+
+Two things to know:
+
+- **The file is part of the deployment, not the running box.** Editing it on the server is
+  overwritten at the next deployment, and the same catalogue is mirrored in the Kubernetes
+  configuration with CI enforcing that the two match. **Send us the webhook URL and which
+  endpoints you want alerts on, and we will ship it.**
+- **Threshold discipline still applies.** With 50 endpoints, alerting on every one at a
+  failure-threshold of 1 will bury you during a deployment. Start with the *Infrastructure*
+  group plus `PGR Services`, `DIGIT UI` and `Kong Gateway`, at a threshold of 3.
+
+---
+
+## WhatsApp and SMS
+
+Neither has a native Grafana integration. Both are reachable through a **generic webhook**,
+and both need a relay in between. Be clear-eyed about the effort: this is half a day of
+work, not a settings change.
+
+### WhatsApp — the honest picture
+
+WhatsApp does not accept arbitrary outbound messages. Business messaging goes through the
+WhatsApp Business API (Meta directly, or a provider such as Twilio or 360dialog), and
+outside a 24-hour window opened by the *recipient*, you may only send **pre-approved
+template messages**. Alerts are by definition unsolicited, so:
+
+> **You must register and get approval for an alert template before any of this works.**
+> Something like `DIGIT alert: {{1}} — {{2}} at {{3}}`. Approval takes a day or two. Plan
+> for it; it is the part that catches people out.
+
+Three routes, most to least sensible:
+
+1. **Reuse the notification stack that is already there.** These deployments already run a
+   Novu + Twilio pipeline for citizen SMS/email/WhatsApp, so the credentials, the provider
+   account and the template-approval workflow already exist. A small relay endpoint that
+   accepts Grafana's webhook and triggers a WhatsApp workflow is the least new machinery.
+   **Talk to us before building it** — we know what is wired.
+2. **A standalone relay to the Twilio WhatsApp API.** Grafana webhook → a ~30-line service →
+   Twilio. Independent of the DIGIT stack, which is a genuine advantage: if DIGIT is broken,
+   your alerting path is not. This is our recommendation if you want WhatsApp to be the
+   wake-up channel.
+3. **A third-party "WhatsApp webhook" service.** Fastest to set up. Note that your server
+   names and error messages would transit a provider you have no contract with, which for a
+   government system is usually worth a procurement or security review first.
+
+### SMS
+
+Same shape, simpler: Grafana webhook → your department's SMS gateway or Twilio → the on-call
+phones. Worth it as the `critical`-only path in places where mobile data is unreliable.
+Keep the message to the alert name and the host — nobody debugs from 160 characters, and the
+message is just there to make someone open a laptop.
+
+### Before you build either
+
+Worth checking whether you need it. Telegram reaches the same phones, takes fifteen minutes
+and costs nothing. If your staff genuinely only use WhatsApp, that's a real constraint and
+route 2 above is the answer. If what you're after is a channel that *feels* more urgent than
+chat, severity routing and a separate critical channel usually get you there for far less
+work.
+
+---
+
+## Routing: getting the right alert to the right person
+
+**Alerting → Notification policies.** The default policy currently sends everything to
+`grafana-default-email`, which cannot deliver — so this needs changing whatever else you do.
+
+A structure that works:
+
+```
+Default policy  ──▶  contact point: chat-ops          (your #digit-alerts channel)
+  group by: alertname, grafana_folder, service_name
+  group wait: 30s · group interval: 5m · repeat interval: 4h
+  │
+  ├─ severity = critical   ──▶  oncall-critical       (WhatsApp / SMS / PagerDuty)
+  │     continue matching: ON   (so it also lands in chat)
+  │     repeat interval: 30m
+  │
+  └─ severity = watchdog   ──▶  heartbeat-webhook     (external heartbeat monitor)
+        group wait: 0s · repeat interval: 5m
+```
+
+The settings that matter:
+
+- **Group by** — alerts sharing these labels arrive as one message. `alertname` plus
+  `service_name` means "pgr-services is out of memory" is one notification, not one per
+  container. Never group by nothing; never group by everything.
+- **Group wait** (30s) — how long to collect related alerts before the first message. When a
+  host dies, ten rules fire within seconds; this makes them one notification.
+- **Group interval** (5m) — how long before *new* alerts joining an existing group trigger
+  another message.
+- **Repeat interval** — how often an unresolved alert is re-sent. **4 hours for chat, 30
+  minutes for critical.** Too short and people mute the channel; too long and a weekend
+  outage goes unnoticed.
+- **Continue matching** — on the critical route, leave this ON so criticals appear in the
+  chat channel too. The chat channel should be a complete record.
+
+**Add nested routes only when someone would act differently.** A `team=notifications` route
+to the team that owns SMS delivery is worth it; a route per service is not.
+
+---
+
+## Quiet hours, maintenance windows and silences
+
+Three different tools; people reach for the wrong one.
+
+**Mute timings** (Alerting → Notification policies → **Mute timings**) — a recurring
+schedule during which a route sends nothing. Use this for your **deployment window**. If
+your deployment runs nightly at 02:30, every service restarts and `ServiceRestarted` fires
+for all sixteen. Create a mute timing `deployment-window` covering 02:00–03:30 daily and
+attach it to the route carrying `warning`.
+
+> **Never mute-time your `critical` route.** If the deployment breaks the system, the
+> deployment window is precisely when you need to hear about it. Mute the noise, not the
+> alarm.
+
+**Silences** (Alerting → **Silences**) — a one-off, time-bounded suppression matching
+specific labels. Use this for planned work: "silence everything with
+`service_name=egov-indexer` for the next 2 hours while we rebuild the index." Always set an
+expiry, always write the reason in the comment.
+
+**Pausing a rule** — stops evaluation entirely. Use only for a rule that is broken and being
+fixed. A paused rule is invisible in the alert list and is forgotten within a week; if a
+rule is wrong, fix or delete it.
+
+Quiet hours in the "do not disturb overnight" sense should be built from **severity**, not
+silence: `warning` to a chat channel that nobody has to read at night, `critical` to the
+phone. Suppressing by time of day suppresses the outages too.
+
+---
+
+## The on-call rota
+
+The technology is the easy half. Write these down somewhere everyone can find them —
+a pinned message in the alert channel is fine:
+
+| Question | Write down the answer |
+|---|---|
+| Who is on call this week? | Name and phone number, and how the rota rotates |
+| What hours? | Office hours only, or 24×7? Worth stating explicitly, so nobody is relying on cover that isn't there |
+| What does the first responder do? | Acknowledge in the channel, then work through [l2-diagnosis.md](l2-diagnosis.md). The acknowledgement is the important half — it stops two people debugging the same thing and reminds someone to update users |
+| When do they escalate internally? | e.g. "no diagnosis in 30 minutes for an S1" |
+| When do they escalate to us? | See below |
+| Who tells the users? | Somebody must. A holding message on the portal beats silence |
+| Where is the incident log? | One place where every alert that fired gets a line: what it was, what was done, was it real |
+
+**The single most valuable habit:** when an alert fires, someone posts in the channel
+*within a few minutes*, even if it is only "seen, looking". It stops duplicate work, and it
+tells you which alerts nobody is reading.
+
+---
+
+## Escalating to us
+
+Alerts tell you something is wrong. **[incident-report.md](incident-report.md)** is how you
+tell us. An alert on its own tells us *what tripped*; the report adds *what is broken, for
+whom, since when* — so please send both rather than just forwarding the alert.
+
+Escalate when:
+
+- It is **S1 or S2** ([severity definitions](README.md#severity)).
+- The same alert has fired **three times in a week** — that is a systemic problem, not an
+  incident.
+- The fix would need a **deployment change**: more memory for a service, an extra container,
+  a configuration value, node-exporter, an SMTP relay, a Gatus alerting change.
+- You are about to do something on the destroy-list in
+  [l2-diagnosis.md](l2-diagnosis.md#commands-that-are-destructive). Ask first.
+
+When you escalate, include **the alert name and the exact time it fired**, plus everything
+the report template asks for. The alert name maps directly to a rule and a runbook on our
+side, which saves a round trip.
+
+---
+
+## Message hygiene
+
+What appears in a notification decides whether it gets acted on.
+
+- **Every rule needs a `summary` annotation** that names the thing and the number:
+  `Disk /dev/sda1 is 96% full on digit-prod-1`. Not `HostDiskSpaceCritical firing`.
+- **Every rule needs a runbook link** in the `description`.
+- **Use labels people recognise** — `service_name`, `instance`, `mountpoint`. The person
+  reading at 3am should not have to open Grafana to find out which server it is.
+- **Turn on resolved notifications.** A channel that only reports failure gives you no way
+  to know an incident is over.
+- **Do not put citizen data in an alert.** Alerts go to chat tools and phones outside the
+  system's access controls. Alert on rates and counts, never on the content of a complaint.
+  See [incident-report.md § Redaction](incident-report.md#redaction--what-not-to-send-us).
+- **One channel, not five.** Split by severity, not by service.

--- a/docs/operations/alert-channels.md
+++ b/docs/operations/alert-channels.md
@@ -70,9 +70,13 @@ and Grafana will fail silently apart from a line in its own log.
 Test it before you spend an hour on configuration:
 
 ```bash
-sudo docker exec digit-grafana wget -qO- --timeout=10 https://slack.com >/dev/null \
+sudo docker exec digit-grafana curl -sS --max-time 10 -o /dev/null https://slack.com \
   && echo "egress OK" || echo "EGRESS BLOCKED — talk to your network team"
 ```
+
+(`curl` is the client the Grafana container's own healthcheck uses, so it is present in the
+image. Substitute the host your webhook actually points at — reaching `slack.com` says
+nothing about `chat.googleapis.com`.)
 
 If it is blocked, your options are: ask the network team to allow outbound HTTPS to the
 specific webhook host; route through your corporate proxy (Grafana honours `HTTP_PROXY` /

--- a/docs/operations/alert-channels.md
+++ b/docs/operations/alert-channels.md
@@ -206,7 +206,7 @@ bearer token on the request.
 
 The health dashboard at `/status/` already checks ~50 endpoints every 30 seconds. It can
 notify you directly, and it is the **only thing watching the containers that emit no
-metrics** — Postgres, Redis, Kafka, Kong, Elasticsearch, Keycloak, nginx. That makes it the
+metrics** — Postgres, Redis, Kafka, Kong, Elasticsearch, nginx and the sign-in service. That makes it the
 highest-value alerting you can add, and the fastest.
 
 It is configured in `local-setup/gatus/config.yaml`, which currently has alerting commented

--- a/docs/operations/alerts-setup.md
+++ b/docs/operations/alerts-setup.md
@@ -79,15 +79,26 @@ up
 | Result | Meaning |
 |---|---|
 | `job="otel-collector"` **and** `job="node"` | Host metrics available. Skip to the next section. |
-| `job="otel-collector"` only | **No host metrics.** The `Node Exporter Full` dashboard will be empty and the host alerts below cannot be created. |
+| `job="otel-collector"` only | **No host metrics right now.** The `Node Exporter Full` dashboard will be empty and the host alerts below cannot be created. Two different causes — see below. |
 
-`node-exporter` was added to the platform on **2026-07-22**. Deployments installed before
-that date do not have it, and it is not something you can add by hand safely — it needs the
-monitoring overlay wired into the Compose stack and a Prometheus scrape job.
+**Missing `node` has two causes, and they need different fixes.** Check them in this order,
+because the second is a one-minute fix and the first is a redeploy:
 
-**Ask us to enable it.** It is a redeploy with `docker-compose.monitoring.yml` layered in,
-plus the `node` scrape job in `otel/prometheus.yml`; both already ship with the platform.
-Reference them by name when you raise the request and it will be quick.
+1. **Prometheus is running an older copy of its configuration.** The scrape job is in the
+   file on disk, but Prometheus has not re-read it since it was added. This is easy to hit,
+   because the config is bind-mounted — the file can change under a running Prometheus
+   without it noticing. **Confirm:** the file `/opt/digit/otel/prometheus.yml` contains a
+   `job_name: node`, and `docker ps` shows a `node-exporter` container up. If both are true,
+   this is your case. **Fix:** L2 reloads the config in place, no restart and no downtime —
+   see [l2-diagnosis.md](l2-diagnosis.md#the-host-itself-cpu-ram-disk).
+2. **`node-exporter` genuinely isn't there.** It was added to the platform on
+   **2026-07-22**; deployments installed before that date and never re-converged do not have
+   it. **Confirm:** no `node-exporter` container in `docker ps -a`, and no `node` job in the
+   config file. **Fix:** ask us — it is a redeploy with `docker-compose.monitoring.yml`
+   layered in, plus the `node` scrape job in `otel/prometheus.yml`; both already ship with
+   the platform. Naming them in the request makes it quick.
+
+Re-run `up` after either fix; `job="node"` at value `1` means you are done.
 
 Until then you have the **service, application and synthetic alerts only**: service crashes, OOM, restarts, error rates and
 latency — which is still most of what actually pages you. Disk filling up, however, is the

--- a/docs/operations/alerts-setup.md
+++ b/docs/operations/alerts-setup.md
@@ -1,0 +1,457 @@
+# Setting up alerts
+
+How to make the system tell you it is unwell, before a citizen does.
+
+← back to **[Operations handbook](README.md)** · where alerts are delivered:
+**[alert-channels.md](alert-channels.md)**
+
+---
+
+## Contents
+
+- [Before you start](#before-you-start)
+- [Prerequisite — turn on host metrics](#prerequisite--turn-on-host-metrics)
+- [How Grafana alerting fits together](#how-grafana-alerting-fits-together)
+- [Creating your first rule, click by click](#creating-your-first-rule-click-by-click)
+- [The rule catalogue](#the-rule-catalogue)
+  - [Host alerts](#host-alerts-cpu-ram-disk)
+  - [Service alerts](#service-alerts-crashes-memory-restarts)
+  - [Application alerts](#application-alerts-errors-latency-queues)
+  - [Synthetic alerts](#synthetic-alerts-and-the-dead-mans-switch)
+- [Getting "No Data" right](#getting-no-data-right-the-mistake-everyone-makes)
+- [Shipping alerts as code](#shipping-alerts-as-code-so-they-survive-a-rebuild)
+- [Avoiding alert fatigue](#avoiding-alert-fatigue)
+- [Testing that alerting actually works](#testing-that-alerting-actually-works)
+
+---
+
+## Before you start
+
+**Current state on a stock deployment**, verified against a running instance:
+
+- Grafana **11.4.0** with unified alerting available.
+- **Zero alert rules configured.** Nothing is watching anything today.
+- One contact point exists — `email receiver` pointing at the literal placeholder
+  `<example@email.com>`. It cannot deliver.
+- The default notification policy routes everything to `grafana-default-email`.
+- **No SMTP server is configured** (`GF_SMTP_*` is unset), so email alerts will not send
+  even after you fix the address. Start with a chat webhook instead —
+  see [alert-channels.md](alert-channels.md).
+
+So: everything in this document is something you are creating from scratch. That is
+expected.
+
+**Two things to know about access:**
+
+- Grafana is configured for **anonymous Admin access with the login form disabled**. You can
+  create alert rules immediately, with no account. The flip side is that there is no user
+  identity — Grafana cannot tell who created or silenced a rule, and anyone with the URL
+  has the same power. **Keep a written change log of who changed which alert.** If the
+  instance is reachable from the public internet, ask us to put it behind your VPN or an
+  authenticating proxy.
+- Rules you create in the UI are stored in Grafana's own database inside the
+  `grafana_data` Docker volume. They survive restarts and redeployments. They do **not**
+  survive `docker compose down -v` — which is one more reason that command appears on the
+  destroy-list in [l2-diagnosis.md](l2-diagnosis.md#commands-that-are-destructive).
+  For rules that must survive anything, see
+  [Shipping alerts as code](#shipping-alerts-as-code-so-they-survive-a-rebuild).
+
+---
+
+## Prerequisite — turn on host metrics
+
+**Most of the alerts you want — 90% CPU, 90% RAM, disk filling up — need the
+`node-exporter` container.** Check whether you have it. Grafana → **Explore** →
+datasource **Prometheus** → run:
+
+```promql
+up
+```
+
+| Result | Meaning |
+|---|---|
+| `job="otel-collector"` **and** `job="node"` | Host metrics available. Skip to the next section. |
+| `job="otel-collector"` only | **No host metrics.** The `Node Exporter Full` dashboard will be empty and the host alerts below cannot be created. |
+
+`node-exporter` was added to the platform on **2026-07-22**. Deployments installed before
+that date do not have it, and it is not something you can add by hand safely — it needs the
+monitoring overlay wired into the Compose stack and a Prometheus scrape job.
+
+**Ask us to enable it.** It is a redeploy with `docker-compose.monitoring.yml` layered in,
+plus the `node` scrape job in `otel/prometheus.yml`; both already ship with the platform.
+Reference them by name when you raise the request and it will be quick.
+
+Until then you have the **service, application and synthetic alerts only**: service crashes, OOM, restarts, error rates and
+latency — which is still most of what actually pages you. Disk filling up, however, is the
+single most common cause of a total outage, and you cannot alert on it without this. Treat
+it as a priority.
+
+---
+
+## How Grafana alerting fits together
+
+Five pieces. You will meet all of them in the UI:
+
+```
+  Rule                Evaluation group        Labels          Notification policy     Contact point
+  ────                ────────────────        ──────          ───────────────────     ─────────────
+  a query +      →    how often it's     →    severity=  →    routing rules      →    Slack / email /
+  a threshold         checked, and how        critical        match on labels         webhook / etc.
+                      long it must stay
+                      true before firing
+```
+
+- **Rule** — a query (PromQL or LogQL) plus a threshold. Fires when the threshold is
+  breached.
+- **Pending period** (`for`) — how long the breach must persist before the alert fires. This
+  is your main defence against noise. A CPU spike for 40 seconds is normal; for 15 minutes
+  it is not.
+- **Evaluation group** — a folder + interval. Rules in a group are evaluated together, e.g.
+  every 1 minute.
+- **Labels** — key/value tags on the alert, most importantly `severity`. Routing is done on
+  labels, so **set `severity` on every rule** or your routing has nothing to work with.
+- **Notification policy** — matches labels and decides which contact point receives it, plus
+  grouping and repeat intervals. Covered in [alert-channels.md](alert-channels.md).
+- **Contact point** — Slack, Google Chat, Teams, webhook, email, PagerDuty.
+
+Set up **one contact point first** ([alert-channels.md](alert-channels.md)) so your first
+rule has somewhere to go, then come back here.
+
+---
+
+## Creating your first rule, click by click
+
+We will build **HostDiskSpaceCritical** — the alert that matters most. If you do not have
+host metrics yet, build **ServiceOutOfMemory** from [Service alerts](#service-alerts-crashes-memory-restarts)
+instead; the steps are identical.
+
+1. Go to `https://<your-domain>/grafana/` → **Alerting** → **Alert rules** → **+ New alert rule**.
+
+2. **Name**: `HostDiskSpaceCritical`. Use the exact names from the catalogue below — when
+   an alert reaches us, a consistent name tells us immediately what it means.
+
+3. **Define query and alert condition**
+   - Datasource: **Prometheus**
+   - Query **A**, switch to **Code** mode, paste:
+     ```promql
+     100 - (node_filesystem_avail_bytes{fstype!~"tmpfs|overlay|squashfs"}
+            / node_filesystem_size_bytes{fstype!~"tmpfs|overlay|squashfs"} * 100)
+     ```
+   - Set the **threshold** to `IS ABOVE` `95`.
+   - If you are in the advanced/expression view, the shape is: `A` (query) →
+     `B` = **Reduce**, function `Last`, input `A` → `C` = **Threshold**, input `B`, above `95`,
+     and `C` is the alert condition.
+   - Click **Preview** — you should see one row per mounted filesystem with its current
+     percentage. If you see nothing, your query is wrong or node-exporter is missing.
+
+4. **Set evaluation behaviour**
+   - **Folder**: create one called `DIGIT Alerts` and keep everything in it. The folder name
+     becomes the `grafana_folder` label, which the default policy groups on.
+   - **Evaluation group**: create `1m` (evaluated every minute).
+   - **Pending period**: `5m`. Disk does not un-fill itself, so a short pending period is
+     fine and buys you five extra minutes of warning.
+   - **Configure no data and error handling** → set **"Alert state if no data"** to
+     **`OK`** for this rule. (Read
+     [Getting "No Data" right](#getting-no-data-right-the-mistake-everyone-makes) before you
+     accept the default on any rule.)
+
+5. **Configure labels and notifications**
+   - Add label `severity` = `critical`.
+   - Add label `team` = `ops` (useful later for routing).
+   - Choose your contact point, or leave it to the notification policy.
+
+6. **Add annotations**
+   - **Summary**: `Disk {{ $labels.mountpoint }} is {{ humanize $values.B }}% full on {{ $labels.instance }}`
+   - **Description**: `Postgres will refuse writes when the disk fills. Check large Docker log files and Elasticsearch indices. Runbook: https://<your-runbook-host>/operations/l2-diagnosis#the-host-itself-cpu-ram-disk`
+   - **Always put the runbook link in the description**, and make it an **absolute URL the
+     recipient can click**. A repository-relative path like `docs/operations/…` is not a
+     link in Slack, email or a paging app, and the person on call may not have the repo
+     checked out. Substitute wherever your team actually hosts this handbook — an internal
+     wiki, a docs site, or the file's permalink on your git host. At 3am, the person
+     reading the alert is not the person who wrote it.
+
+7. **Save rule and exit.** It appears under **Alerting → Alert rules** with its current
+   state (`Normal`, `Pending`, `Alerting`, `No Data`).
+
+---
+
+## The rule catalogue
+
+Suggested thresholds and durations. They are deliberately conservative — better to start
+here and tighten once you know what your box's normal looks like.
+
+**Severity convention used below** — `critical` = wake someone up; `warning` = look at it
+during working hours.
+
+### Host alerts (CPU, RAM, disk)
+
+*Requires node-exporter — see [Prerequisite](#prerequisite--turn-on-host-metrics).*
+Datasource: **Prometheus**.
+
+| Rule name | Query | Fires when | Pending | Severity |
+|---|---|---|---|---|
+| **HostCpuHigh** | `100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)` | `> 90` | **15m** | warning |
+| **HostCpuCritical** | same as above | `> 95` | **30m** | critical |
+| **HostMemoryHigh** | `100 * (1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)` | `> 90` | **10m** | critical |
+| **HostSwapping** | `100 * (1 - node_memory_SwapFree_bytes / node_memory_SwapTotal_bytes)` | `> 10` | **15m** | warning |
+| **HostDiskSpaceWarning** | `100 - (node_filesystem_avail_bytes{fstype!~"tmpfs\|overlay\|squashfs"} / node_filesystem_size_bytes{fstype!~"tmpfs\|overlay\|squashfs"} * 100)` | `> 85` | **10m** | warning |
+| **HostDiskSpaceCritical** | same as above | `> 95` | **5m** | critical |
+| **HostDiskWillFillIn4h** | `predict_linear(node_filesystem_avail_bytes{fstype!~"tmpfs\|overlay\|squashfs"}[6h], 4*3600)` | `< 0` | **30m** | critical |
+| **HostInodesLow** | `100 * (node_filesystem_files_free / node_filesystem_files)` | `< 10` | **15m** | warning |
+| **HostLoadHigh** | `node_load15 / count without (cpu, mode) (node_cpu_seconds_total{mode="idle"})` | `> 1.5` | **15m** | warning |
+| **HostDown** | `up{job="node"}` | `< 1` | **5m** | critical |
+
+Notes worth reading:
+
+- **`HostDiskWillFillIn4h` is the best alert on this page.** It looks at the last six hours
+  of free space, extrapolates, and tells you *before* you hit 95% — often a day early on a
+  slow leak. `predict_linear` returning a negative value means "projected to hit zero inside
+  the window".
+- **The `fstype` exclusions matter.** Without them you will alert on Docker's overlay layers
+  and tmpfs mounts, which are meaningless and always noisy. If you still get noise, add the
+  specific `mountpoint` to the exclusion.
+- **Why 15 minutes for CPU?** Deployments, database migrations and nightly jobs legitimately
+  peg the CPU for several minutes. Anything shorter and you will be paged by your own
+  maintenance.
+- **`HostMemoryHigh` uses `MemAvailable`, not `MemFree`.** Linux uses free RAM as cache;
+  `MemFree` is near zero on a healthy box and would alert constantly.
+
+### Service alerts (crashes, memory, restarts)
+
+*Works on every deployment today.* Datasource as noted.
+
+| Rule name | Datasource | Query | Fires when | Pending | Severity |
+|---|---|---|---|---|---|
+| **ServiceHeapHigh** | Prometheus | `100 * sum by (service_name) (jvm_memory_used_bytes{jvm_memory_type="heap"}) / sum by (service_name) (jvm_memory_limit_bytes{jvm_memory_type="heap"})` | `> 90` | **10m** | warning |
+| **ServiceGcThrashing** | Prometheus | `sum by (service_name) (rate(jvm_gc_duration_seconds_sum[5m]))` | `> 0.25` | **10m** | warning |
+| **ServiceStoppedReporting** | Prometheus | `count by (service_name) (jvm_thread_count offset 15m) unless count by (service_name) (jvm_thread_count)` | `>= 1` | **5m** | critical |
+| **ServiceThreadLeak** | Prometheus | `sum by (service_name) (jvm_thread_count)` | `> 400` | **30m** | warning |
+| **ServiceOutOfMemory** | Loki | `sum by (compose_service) (count_over_time({compose_project="digit", compose_service!~"grafana\|loki"} \|~ "(?i)outofmemoryerror\|java heap space\|gc overhead limit" [5m]))` | `> 0` | **0m** | critical |
+| **ServiceRestarted** | Loki | `sum by (compose_service) (count_over_time({compose_project="digit", compose_service!="loki"} \|~ "Started .+Application in" [10m]))` | `> 0` | **0m** | warning |
+| **ServiceRestartLoop** | Loki | same query with `[1h]` | `> 3` | **0m** | critical |
+| **ErrorLogSpike** | Loki | `sum by (compose_service) (count_over_time({compose_project="digit"} \|~ "(?i)error\|exception" [5m]))` | `> 50` | **10m** | warning |
+
+Notes:
+
+- **`ServiceStoppedReporting` is your "a service died" alert.** All metrics are pushed
+  through the OpenTelemetry collector, so `up` only ever tells you about the collector
+  itself — a dead service simply stops producing series. This query says "which services
+  were reporting 15 minutes ago and are not reporting now", which is exactly the signal you
+  want, and it needs no per-service configuration.
+- **`ServiceRestarted` deserves a maintenance window.** Every Java service logs
+  `Started XyzApplication in N seconds` once per boot, so a deployment fires this for every
+  service at once. Suppress it during your deployment window with a Grafana
+  **mute timing** — see [alert-channels.md](alert-channels.md#quiet-hours-maintenance-windows-and-silences).
+- **`ServiceRestartLoop` is the one that matters.** Four boots of the same service in an
+  hour means it is crash-looping and is not going to recover on its own.
+- **Exclude `grafana` and `loki` from the OOM rule.** Both log your search text back into
+  the log stream, so an un-excluded rule alerts on its own query. Elasticsearch also uses
+  the phrase "out of memory" in routine circuit-breaker messages — if it becomes noisy, add
+  `compose_service!="elasticsearch"`.
+- **`ErrorLogSpike`'s threshold of 50 is a placeholder.** Before enabling it, run the query
+  in Explore over a normal week and set the threshold above the observed peak. A deployment
+  with a chatty service will need a higher number, or a per-service threshold.
+- **`ServiceHeapHigh` will not fire for every service.** One of the sixteen instrumented
+  services does not report a heap limit, so it is silently excluded. That is acceptable —
+  `ServiceOutOfMemory` catches it after the fact.
+
+### Application alerts (errors, latency, queues)
+
+Datasource: **Prometheus**.
+
+| Rule name | Query | Fires when | Pending | Severity |
+|---|---|---|---|---|
+| **Http5xxRate** | `sum by (service_name) (rate(http_server_request_duration_seconds_count{http_response_status_code=~"5.."}[5m]))` | `> 0.1` | **10m** | warning |
+| **Http5xxRateCritical** | same | `> 1` | **5m** | critical |
+| **LatencyP95High** | `histogram_quantile(0.95, sum by (le, service_name) (rate(http_server_request_duration_seconds_bucket[5m])))` | `> 3` | **15m** | warning |
+| **DbPoolSaturated** | `db_client_connections_pending_requests` | `> 0` | **5m** | critical |
+| **DbConnectionTimeouts** | `rate(db_client_connections_timeouts_total[5m])` | `> 0` | **5m** | critical |
+| **KafkaConsumerLag** | `max by (service_name, client_id) (kafka_consumer_records_lag_max)` | `> 1000` | **15m** | warning |
+| **KafkaConsumerStalled** | `max by (service_name, client_id) (kafka_consumer_records_lag_max)` | `> 10000` | **10m** | critical |
+
+Notes:
+
+- **`> 0.1` errors per second is roughly six failed requests a minute** — low enough to
+  catch a genuine regression, high enough to ignore a single user's bad request.
+- **`DbPoolSaturated` deserves the critical label** even though nothing is "down". Requests
+  queuing for a database connection is what "the whole system is slow but everything is
+  green" looks like from the inside.
+- **Kafka lag thresholds are volume-dependent.** On a quiet deployment, a lag of 1000 means
+  something is stuck. On a busy one during bulk import it is normal. Watch
+  `kafka_consumer_records_lag_max` for a week before committing to a number — and remember
+  that lag *trending upward without recovering* is the real signal, which is what the
+  15-minute pending period approximates.
+- Consider adding **`PgrAnalyticsSlow`** if supervisors complain about the dashboard:
+  `histogram_quantile(0.95, sum by (le) (rate(pgr_analytics_query_duration_ms_bucket[5m]))) > 5000`.
+
+### Synthetic alerts and the dead-man's switch
+
+**Endpoint checks.** The Gatus health dashboard at `/status/` already probes ~50 endpoints
+every 30 seconds, but it does not notify anyone by default. Turning on **Gatus's own
+alerting** gives you "service X is down" notifications without any Grafana rules at all —
+it is the cheapest coverage you can add, and it is the only thing that watches the
+non-Java containers (Postgres, Redis, Kafka, Kong, Elasticsearch). See
+[alert-channels.md § Gatus](alert-channels.md#option-b--gatus-native-alerting-endpoint-down).
+
+**Who watches the watcher?** If the whole box dies, Grafana dies with it and you get
+silence — which looks exactly like "everything is fine". The fix is a **dead-man's switch**:
+
+1. Create an always-firing rule, `Watchdog`: Prometheus query `vector(1)`, condition
+   `IS ABOVE 0`, pending `0m`, severity `watchdog`.
+2. Route `severity=watchdog` to a heartbeat monitor (Healthchecks.io, Better Stack,
+   Uptime Kuma — all have free tiers) with a repeat interval of 5 minutes.
+3. Configure that monitor to alert you when the heartbeat **stops**.
+
+Now silence itself is an alarm. Pair it with an **external** uptime check on
+`https://<your-domain>/status/` from outside the network, so you also learn about DNS, TLS
+expiry and network failures that no on-box alert can see.
+
+---
+
+## Getting "No Data" right (the mistake everyone makes)
+
+When a service dies, its metrics do not go to zero — **they disappear**. Grafana then puts
+the rule into `No Data`, not `Alerting`. If you leave the default, your "service down"
+alert stays silent at exactly the moment it is needed.
+
+Each rule has **"Configure no data and error handling"**. Set it deliberately:
+
+| Rule kind | "Alert state if no data" | Why |
+|---|---|---|
+| Down/absence detection (`ServiceStoppedReporting`, `HostDown`) | **Alerting** | Missing data *is* the failure |
+| Threshold on a always-present metric (CPU, RAM, disk, heap) | **OK** or **No Data** | Missing data means a scrape hiccup, not an incident. `OK` keeps it quiet; `No Data` surfaces it as a distinct, non-paging state |
+| Loki count rules (`ServiceOutOfMemory`, `ServiceRestarted`) | **OK** | "No matching log lines" is the healthy case and must not alert |
+
+The Loki ones are the easiest to get wrong: a rule counting OOM messages reports `No Data`
+whenever there are no OOMs — i.e. nearly always — so setting that to `Alerting` produces an
+alarm that fires when everything is fine, and the channel quickly stops being read.
+
+Set **"Alert state if execution error"** to `Alerting` on critical rules — a rule that
+cannot run is not a rule that passed.
+
+---
+
+## Shipping alerts as code (so they survive a rebuild)
+
+UI-created rules live in the `grafana_data` volume. That is fine for most purposes, but
+rules that matter should live in the platform repository, where they are version-controlled,
+reviewed, and reapplied on every deployment.
+
+Grafana reads provisioning files from `/etc/grafana/provisioning`, which is bind-mounted
+read-only from **`otel/grafana/provisioning/`** in the repo. Datasources and dashboards are
+already provisioned this way; alerting slots in beside them:
+
+```
+otel/grafana/provisioning/
+├── dashboards/     ← already there
+├── datasources/    ← already there
+└── alerting/       ← add this
+    ├── rules.yaml
+    ├── contact-points.yaml
+    └── policies.yaml
+```
+
+A worked example — `rules.yaml`, one rule, the disk-critical one:
+
+```yaml
+apiVersion: 1
+groups:
+  - orgId: 1
+    name: host-1m
+    folder: DIGIT Alerts
+    interval: 1m
+    rules:
+      - uid: host-disk-critical
+        title: HostDiskSpaceCritical
+        condition: C
+        for: 5m
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: prometheus
+            model:
+              refId: A
+              instant: true
+              expr: >-
+                100 - (node_filesystem_avail_bytes{fstype!~"tmpfs|overlay|squashfs"}
+                / node_filesystem_size_bytes{fstype!~"tmpfs|overlay|squashfs"} * 100)
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [95] }
+        noDataState: OK
+        execErrState: Alerting
+        labels:
+          severity: critical
+          team: ops
+        annotations:
+          summary: 'Disk {{ $labels.mountpoint }} above 95% on {{ $labels.instance }}'
+          description: 'Postgres refuses writes when the disk fills. Runbook: https://<your-runbook-host>/operations/l2-diagnosis'
+```
+
+The fastest way to author these is to **build the rule in the UI first, confirm it fires,
+then export it**: Alerting → Alert rules → the rule's **⋮** menu → **Export** → **YAML**.
+Paste the result into the file.
+
+Two caveats:
+
+- **Provisioned rules are read-only in the UI.** That is the point, but it surprises people
+  — you can no longer edit or delete them from Grafana, only from the file.
+- **Never commit webhook URLs or SMTP passwords.** A Slack webhook URL is a credential:
+  anyone holding it can post into your channel. Reference an environment variable
+  (`url: ${SLACK_WEBHOOK_URL}`) and keep the value in the deployment's `.env`.
+
+Send us the files and we will fold them into the deployment, or keep them locally and apply
+them yourself — either works.
+
+---
+
+## Avoiding alert fatigue
+
+An alert nobody reads is worse than no alert, because it creates the *belief* that something
+is watching. Rules that hold up in practice:
+
+1. **Start with five rules, not thirty.** In order of value:
+   `HostDiskSpaceCritical`, `ServiceStoppedReporting`, `ServiceOutOfMemory`,
+   `HostMemoryHigh`, `ServiceRestartLoop`. Live with them for two weeks. Add more only when
+   an incident happens that they did not catch — that incident tells you exactly which rule
+   was missing.
+2. **Every `critical` must be actionable at 3am.** If the honest response is "look at it
+   tomorrow", it is a `warning`. Route the two severities to different places
+   ([alert-channels.md](alert-channels.md)).
+3. **Tune the pending period, not the threshold.** Most noise is transient spikes. Making
+   the threshold higher hides real problems; making the duration longer only hides brief
+   ones.
+4. **Every alert needs a runbook link in its description.** No exceptions.
+5. **Review monthly.** For each alert that fired: was it real, and did anyone act? An alert
+   that fires often and is always ignored should be deleted or fixed the same day you notice
+   the pattern.
+6. **Suppress your own maintenance.** Deployments cause restarts, CPU spikes and brief
+   outages. Set a mute timing for the deployment window instead of retraining the team to
+   ignore alerts.
+
+---
+
+## Testing that alerting actually works
+
+An untested alert path is an assumption. Test it the day you set it up, and again after
+any change to the deployment.
+
+1. **Test the contact point.** Alerting → Contact points → your contact point →
+   **Test**. A message should arrive within seconds; if it doesn't, fix this before going
+   any further, since every rule depends on it.
+2. **Test a real rule end to end.** Temporarily lower a threshold so it must fire — e.g.
+   set `HostDiskSpaceWarning` to `> 1` — save, wait for the pending period, and confirm the
+   notification arrives in the channel with the summary text you wrote. **Then put the
+   threshold back.** Note the round trip: rules and thresholds are easy to change back, but
+   write down what you changed before you change it.
+3. **Check the resolved message arrives too.** A channel that reports failures but never
+   recoveries trains people to ignore it.
+4. **Confirm severity routing.** Fire one `warning` and one `critical` and check they land
+   in different places, if that is how you configured it.
+5. **Record the result** — date, who tested, what arrived where. When an incident is missed
+   six months later, this is the first thing anyone will want to see.

--- a/docs/operations/alerts-setup.md
+++ b/docs/operations/alerts-setup.md
@@ -43,12 +43,20 @@ expected.
 
 **Two things to know about access:**
 
-- Grafana is configured for **anonymous Admin access with the login form disabled**. You can
-  create alert rules immediately, with no account. The flip side is that there is no user
-  identity — Grafana cannot tell who created or silenced a rule, and anyone with the URL
-  has the same power. **Keep a written change log of who changed which alert.** If the
-  instance is reachable from the public internet, ask us to put it behind your VPN or an
-  authenticating proxy.
+- Grafana is configured for **anonymous Admin access with the login form disabled**
+  (`GF_AUTH_ANONYMOUS_ORG_ROLE: Admin`, `GF_AUTH_DISABLE_LOGIN_FORM: true`). You should be
+  able to create alert rules immediately, with no account. Two consequences worth knowing
+  before you start:
+  - **There is no user identity.** Grafana cannot record who created, edited or silenced a
+    rule, and anyone with the URL has the same power. **Keep your own written change log.**
+    If the instance is reachable from the public internet, ask us to put it behind your VPN
+    or an authenticating proxy.
+  - **There is also no way to sign in as a real user through the UI**, because the login
+    form is switched off. So before you invest an afternoon in building rules, do step 1 of
+    [Creating your first rule](#creating-your-first-rule-click-by-click) and **press Save
+    once**. If saving is rejected, don't work around it — tell us, and use the
+    [alerts-as-code path](#shipping-alerts-as-code-so-they-survive-a-rebuild) instead, which
+    does not depend on the UI at all.
 - Rules you create in the UI are stored in Grafana's own database inside the
   `grafana_data` Docker volume. They survive restarts and redeployments. They do **not**
   survive `docker compose down -v` — which is one more reason that command appears on the

--- a/docs/operations/cheatsheet.md
+++ b/docs/operations/cheatsheet.md
@@ -1,0 +1,129 @@
+# Cheat sheet
+
+One page. Print it, or pin it in the alert channel.
+
+← full handbook: **[README.md](README.md)**
+
+---
+
+## URLs
+
+| | |
+|---|---|
+| Health dashboard | `https://<your-domain>/status/` |
+| Grafana | `https://<your-domain>/grafana/` |
+| Logs | `https://<your-domain>/grafana/d/digit-loki-logs/` |
+| Service metrics | `https://<your-domain>/grafana/d/digit-jvm/` |
+
+---
+
+## The ladder
+
+Steps 0–4 are the [first-response checklist](l1-first-response.md) — browser only, nothing
+changes state. Step 5 onward is [diagnosis](l2-diagnosis.md).
+
+```
+ 0. DETAILS   What action, what happened instead, when, which city, complaint number.
+    │
+    ▼
+ 1. SCOPE     Private window + second account + different network.
+    │         Works for you? → their machine.  Fails for you too? → continue.
+    ▼
+ 2. HEALTH    /status/     Any red tile? Screenshot it NOW — this page keeps no history.
+    │                      Infrastructure red → stop, escalate.
+    ▼
+ 3. RESTARTS  Grafana → DIGIT JVM Services → "OOM events (current range)" above 0?
+    │         Then Explore → Loki, the restart query below.
+    │         Same service repeating = stuck restarting. Mind the maintenance window.
+    │         Record what you saw — reading the heap graphs is L2's job.
+    ▼
+ 4. ERRORS    Grafana → DIGIT — Logs (Loki)
+    │         Time range = 10 min BEFORE it started. level = ERROR.
+    │         Copy the OLDEST error, not the newest.
+    │
+    ├──────▶  Known issue? → known-issues.md, resolve, log it.
+    └──────▶  Otherwise → hand over Part A of incident-report.md.
+    ▼
+ 5. DEEPER    Layer model, slow-vs-failing, DB pool, Kafka lag, traces  → l2-diagnosis.md
+ 6. HOST      Grafana → Node Exporter Full   (CPU / RAM / disk)
+              Empty dashboard = host metrics not installed. Not a fault.
+```
+
+---
+
+## Escalate immediately, don't finish the ladder
+
+- Infrastructure red on the health dashboard
+- Nobody can log in, or the site doesn't load
+- No complaint can be filed by anyone
+- "No space left on device" anywhere
+
+Screenshot the health dashboard first, then hand over.
+
+---
+
+## Two queries worth memorising
+
+Grafana → **Explore** → **Loki**:
+
+```logql
+# Is anything stuck restarting? (one line per service boot)
+{compose_project="digit", compose_service!="loki"} |~ `Started .+Application in`
+
+# Which service is producing the most errors right now?
+sum by (compose_service) (count_over_time({compose_project="digit"} |~ `(?i)error|exception` [5m]))
+```
+
+---
+
+## Evidence expires
+
+| Traces | 24 hours |
+|---|---|
+| **Logs** | **72 hours** |
+| **Metrics** | **15 days** |
+| **Health-check history** | **lost on restart — screenshot it** |
+
+---
+
+## Never run
+
+```
+docker compose down -v            → deletes the database and every volume
+docker system prune -a --volumes  → same
+docker compose up -d              → without service names, re-seeds master data
+```
+
+---
+
+## Capture before you restart
+
+A restart usually clears the symptom and the logs together.
+
+```bash
+sudo docker logs --tail 500 --timestamps <container> > /tmp/evidence.log
+```
+
+---
+
+## Where things live
+
+| | |
+|---|---|
+| L1 checklist | [l1-first-response.md](l1-first-response.md) |
+| L2 diagnosis | [l2-diagnosis.md](l2-diagnosis.md) |
+| Known issues | [known-issues.md](known-issues.md) |
+| Report template | [incident-report.md](incident-report.md) |
+| Lookup / glossary | [reference.md](reference.md) |
+
+---
+
+## Fill these in for your deployment
+
+| | |
+|---|---|
+| Domain | |
+| L2 contact | |
+| Escalation channel | |
+| Vendor escalation | |
+| Deployment / maintenance window | |

--- a/docs/operations/cheatsheet.md
+++ b/docs/operations/cheatsheet.md
@@ -46,7 +46,7 @@ changes state. Step 5 onward is [diagnosis](l2-diagnosis.md).
     ▼
  5. DEEPER    Layer model, slow-vs-failing, DB pool, Kafka lag, traces  → l2-diagnosis.md
  6. HOST      Grafana → Node Exporter Full   (CPU / RAM / disk)
-              Empty dashboard = host metrics not installed. Not a fault.
+              Empty dashboard = host metrics not being collected. Not a fault — tell L2.
 ```
 
 ---

--- a/docs/operations/incident-report.md
+++ b/docs/operations/incident-report.md
@@ -297,7 +297,7 @@ Two specific traps:
 - **OTP and login flows log phone numbers.** If you are sending `egov-user` or `novu-worker`
   logs, scan for them.
 
-**Never send us:** passwords, API keys, `.env` files, database dumps, or Keycloak client
+**Never send us:** passwords, API keys, `.env` files, database dumps, or any service's client
 secrets. If you think we need a credential to diagnose something, say so and we will arrange
 a proper channel — do not paste it into a ticket or a chat.
 

--- a/docs/operations/incident-report.md
+++ b/docs/operations/incident-report.md
@@ -1,0 +1,344 @@
+# The incident report
+
+One document, filled in three stages. **Part A** travels from L1 to L2, **Part B** is added
+during diagnosis, and **Part C** is added when it comes to us. Nothing is re-typed at a
+handover, and a blank section shows immediately where the ticket is.
+
+← back to **[Operations handbook](README.md)** · L1 checklist:
+**[l1-first-response.md](l1-first-response.md)** · L2 runbook:
+**[l2-diagnosis.md](l2-diagnosis.md)**
+
+---
+
+## Why the detail helps
+
+We cannot see your deployment. Every question we have to come back with adds a round trip,
+and across timezones that is usually a day. A report carrying Parts A–C is normally enough
+for us to identify the cause without a further exchange.
+
+Bear in mind too that **the evidence expires**: traces last 24 hours, logs 72 hours, metrics
+15 days. A report filed today with a few gaps beats a thorough one filed next week, when the
+logs have rolled off.
+
+---
+
+## Part A — captured at first response
+
+Everything here comes from [l1-first-response.md](l1-first-response.md). This is the
+handover to L2, and it is also the top of the report if it later reaches us.
+
+```
+SEVERITY: [S1 Critical / S2 Major / S3 Minor / S4 Question]
+DEPLOYMENT: [domain, e.g. digit.yourdepartment.gov]
+TENANT / CITY: [tenant code(s) affected, e.g. <state>.<city> — or "all"]
+LOGGED BY: [name + how to reach you]
+
+--- WHAT ---
+1. What action fails:
+   [As specific as you can be, e.g. "A citizen taps Submit on the new-complaint
+    form." The narrower the action, the faster it can be reproduced.]
+
+2. What happens instead:
+   [Exact error text on screen, or "spins forever", or the HTTP status.
+    If available from browser dev tools (F12 -> Network): the failing request
+    URL and status code.]
+
+3. What should happen:
+   [One line.]
+
+--- WHEN ---
+4. First noticed:            [date + time + TIMEZONE]
+5. Last known working:       [date + time + TIMEZONE, or "unknown"]
+6. Still happening now?      [yes / no / intermittent]
+7. Reproducible on demand?   [yes — steps below / no / sometimes]
+8. Anything change around then?
+   [deployment, config change, data import, power/network event, new user batch,
+    certificate renewal. "Nothing that we know of" is a valid and useful answer.]
+
+--- WHO ---
+9.  Scope:            [one user / one office / one city / everyone]
+10. Verified how:     [private window? second account? different network?
+                       e.g. "tried 3 accounts in 2 offices, all fail"]
+11. Numbers affected: [approximate is fine]
+
+--- WHAT THE DASHBOARDS SHOW ---
+12. Health dashboard (/status/):
+    [ ] all green   [ ] red tiles: __________________________
+13. Restarts in the last 24h ("Started ... Application" query):
+    [ ] none        [ ] yes: service ________ at ________
+14. OOM events in the range:
+    [ ] none        [ ] yes: service ________
+15. First ERROR seen in the logs before the symptom:
+    [paste 5-20 lines with timestamps, and note the service + time range used.
+     The FIRST error, not the last. "No ERROR lines between HH:MM and HH:MM"
+     is a useful answer too.]
+
+--- KNOWN ISSUE? ---
+16. Checked known-issues.md:  [ ] not listed   [ ] listed, resolution didn't work
+                              [ ] listed, needs a tier that can apply it
+
+--- REPRODUCTION (if reproducible) ---
+[numbered steps, starting from login, including the role/user type used]
+
+--- ATTACHED ---
+[ ] Health dashboard screenshot (if anything is red)
+[ ] Screenshot of the failing screen, ideally with dev-tools Network tab open
+[ ] Log excerpt as TEXT + the query and time range used
+[ ] Complaint number / user ID involved
+```
+
+---
+
+## Part B — added during diagnosis
+
+Filled in by whoever works [l2-diagnosis.md](l2-diagnosis.md).
+
+```
+--- LAYER ---
+17. Which layer:  [ ] edge  [ ] application  [ ] core platform
+                  [ ] backbone (db/cache/broker)  [ ] host  [ ] not established
+
+--- FINDINGS ---
+18. Suspect service, and why:
+    [e.g. "egov-indexer — kafka lag climbing since 09:12, never drains"]
+
+19. First error traced to its origin:
+    [the earliest error in the responsible service, with timestamp — not the
+     downstream error that surfaced first]
+
+20. Restart / crash history for that service (last 24h):
+
+21. Memory: heap %, headroom, OOM events:
+
+22. Host state:
+    [ ] normal  [ ] CPU ____  [ ] RAM ____  [ ] disk ____
+    [ ] node-exporter not installed, host metrics unavailable
+
+23. Database pool (db_client_connections_pending_requests / timeouts):
+
+24. Kafka lag, if relevant:
+
+--- ACTIONS TAKEN ---
+25. What was tried, with times:
+    [Restarting to get users moving is usually the right call — just record it,
+     because it changes what the logs show.]
+
+26. Did it resolve the symptom?  [yes / no / temporarily]
+
+27. Anything captured before the restart?  [log files, screenshots — attach them]
+```
+
+---
+
+## Part C — added when escalating to us
+
+```
+--- HYPOTHESIS ---
+28. What you believe is happening, and what rules out the alternatives:
+
+29. Why this needs us rather than a config change:
+    [ ] product code / data-model defect
+    [ ] deployment change needed (heap size, extra container, env value,
+        node-exporter, SMTP relay, Gatus catalogue)
+    [ ] recurs after restart, cause not found
+    [ ] not sure — need a second opinion
+
+--- EVIDENCE ---
+30. Trace ID(s), for anything about speed:      [within 24h or they're gone]
+31. Failing endpoint (http_route) + status code:
+32. Log excerpts, as text, with time ranges:
+33. Grafana panel screenshots for anything anomalous:
+
+--- IMPACT ---
+34. Business impact:
+    [One or two lines. "The central office cannot register walk-in complaints;
+     ~40 citizens turned away since 09:00." This is what tells us how to
+     prioritise it.]
+
+35. Workaround in place?  [what it is, and what it costs]
+```
+
+---
+
+## The evidence checklist
+
+Attach **text**, not photographs of screens — text can be searched.
+
+### Always
+
+1. **Health dashboard screenshot** — if something is red. Gatus keeps its history in memory
+   and loses it on restart, so capture it the moment you see it.
+2. **The failing request** — browser F12 → **Network** → reproduce → click the red row →
+   screenshot showing the **URL, status code and response body**. This one attachment
+   identifies the responsible service more often than anything else.
+3. **The log excerpt** — see below.
+
+### The log excerpt (how to get it as text)
+
+In Grafana → **Explore** → datasource **Loki**:
+
+1. Set the time range to **10 minutes before** the symptom through **5 minutes after**.
+2. Run the query — start broad, narrow if it is too much:
+   ```logql
+   {compose_project="digit"} |~ `(?i)error|exception|timeout|refused`
+   ```
+   or for one service:
+   ```logql
+   {compose_service="pgr-services"} |~ `(?i)error|exception`
+   ```
+3. Use the **Download logs** button (top right of the logs panel) → **txt**, or select and
+   copy the lines.
+4. **Send the query and the time range you used**, along with the output. If the query found
+   nothing, that is a finding — send it so we know what was ruled out.
+
+Rules of thumb: **the first error, not the last** (everything after the first is usually
+cascade). **20 lines of context around it**, not 5000 lines of everything. **Timestamps
+included** — a log line without a timestamp is nearly useless.
+
+### For "it's slow" reports
+
+- A **Trace ID** from Grafana → `DIGIT — Traces (Tempo)` → **Slow traces** panel → click a
+  row → copy the ID. Within 24 hours, or it is gone.
+- Screenshot of the **95th-percentile latency** query from
+  [l2-diagnosis.md](l2-diagnosis.md#slow--latency).
+- `db_client_connections_pending_requests` — the current value.
+
+### For "the site is down" reports
+
+- Does `https://<your-domain>/status/` load at all? (If not, it is the edge or the network,
+  not DIGIT.)
+- The output of, from any machine:
+  ```bash
+  curl -sS -o /dev/null -w 'http=%{http_code} dns=%{time_namelookup}s connect=%{time_connect}s total=%{time_total}s\n' https://<your-domain>/
+  ```
+- Certificate expiry — click the padlock in the browser. An expired certificate looks
+  exactly like an outage to users.
+
+### For "notifications not delivered"
+
+- Which channel (SMS / email / WhatsApp), which recipient (**redacted** — see below), which
+  complaint number, what time.
+- `novu-bridge` and `novu-worker` logs for that minute.
+- Whether the provider account still has credit and valid credentials. Worth checking first
+  — expired credentials and exhausted credit account for a good share of these reports.
+
+### If you have server access — the one-shot evidence bundle
+
+Read-only. Produces one tarball to attach. Run it while the problem is happening, and
+**before** any restart:
+
+```bash
+#!/usr/bin/env bash
+# DIGIT evidence bundle — read-only, safe to run during an incident.
+set -u
+OUT="/tmp/digit-evidence-$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$OUT"
+{
+  date -Is
+  echo "--- uptime/load ---";        uptime
+  echo "--- disk ---";               df -h
+  echo "--- inodes ---";             df -i
+  echo "--- memory ---";             free -h
+  echo "--- top ---";                top -b -n1 | head -25
+} > "$OUT/host.txt" 2>&1
+
+sudo docker ps -a --format 'table {{.Names}}\t{{.Status}}\t{{.Image}}' > "$OUT/containers.txt" 2>&1
+sudo docker stats --no-stream                                          > "$OUT/stats.txt" 2>&1
+
+# Exit code, OOM flag and restart count for every container
+for c in $(sudo docker ps -aq); do
+  sudo docker inspect --format \
+    '{{.Name}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}} restarts={{.RestartCount}} started={{.State.StartedAt}}' \
+    "$c"
+done > "$OUT/container-state.txt" 2>&1
+
+# Last 30 minutes of logs from every container
+mkdir -p "$OUT/logs"
+for c in $(sudo docker ps -a --format '{{.Names}}'); do
+  sudo docker logs --since 30m --timestamps "$c" > "$OUT/logs/$c.log" 2>&1
+done
+
+if ! tar czf "$OUT.tar.gz" -C /tmp "$(basename "$OUT")"; then
+  echo "FAILED to create the evidence bundle. Raw files left in: $OUT" >&2
+  exit 1
+fi
+rm -rf "$OUT"
+echo "Attach this file: $OUT.tar.gz"
+```
+
+**Read the logs before sending them** — see redaction below.
+
+---
+
+## Redaction — what not to send us
+
+This is a citizen complaint system. Its logs and screens contain **personal data of members
+of the public**: names, phone numbers, addresses, national ID numbers, and the text of
+complaints, which can be sensitive in itself. Incident handling sits inside your data
+protection obligations, not outside them, so a little care with attachments goes a long way.
+
+| Keep it — we need it | Redact it |
+|---|---|
+| Complaint numbers (`PGR-2026-...`) | Citizen names |
+| User **UUIDs** | Phone numbers, email addresses |
+| Tenant / city codes | Physical addresses, GPS coordinates |
+| Service names, timestamps, stack traces | National ID / passport numbers |
+| HTTP status codes, URLs, trace IDs | The complaint description text |
+| Error messages and exception classes | Photographs attached to complaints |
+
+Replace rather than delete, so the flow is still followable:
+`phone=+254712345678` → `phone=<REDACTED-1>`, using the same placeholder for the same value
+throughout.
+
+Two specific traps:
+
+- **Screenshots leak more than you think** — a browser tab bar, an inbox behind a modal, a
+  name in the corner. Crop, or blur.
+- **OTP and login flows log phone numbers.** If you are sending `egov-user` or `novu-worker`
+  logs, scan for them.
+
+**Never send us:** passwords, API keys, `.env` files, database dumps, or Keycloak client
+secrets. If you think we need a credential to diagnose something, say so and we will arrange
+a proper channel — do not paste it into a ticket or a chat.
+
+---
+
+## Where to send it
+
+1. **The agreed support channel**, with the severity in the subject line:
+   `[S1] <city> — complaint submission failing for all users since 09:15 EAT`.
+2. **For S1, also use the escalation phone path.** Outside working hours a chat message on
+   its own may not be seen for some time.
+3. **One thread per incident.** Add updates to the same thread rather than opening new ones
+   — recovery, workarounds tried, changes in scope.
+
+Tell us in the thread when it **resolves on its own**, too. A problem that fixed itself is
+still a problem, and it is much easier to diagnose while the logs still exist.
+
+---
+
+## What happens next
+
+We will normally come back with one of:
+
+- **A diagnosis and a fix** — a configuration change, a restart with specific instructions,
+  or a code change scheduled for a release.
+- **A workaround plus a longer fix** — so users are unblocked meanwhile.
+- **A request for one specific extra thing.** If we find ourselves asking for more than one,
+  this template has a gap — tell us and we'll fix the document.
+
+What helps us most, in rough order:
+
+1. The **exact time with timezone**, and whether it still happens.
+2. The **first** error line, with its timestamp.
+3. The **failing request** from the browser Network tab.
+4. Confirmation of **scope** — tested with more than one account.
+5. The trace ID, for anything about speed.
+
+And what tends to add a round trip: log excerpts sent as photographs rather than text (we
+can't search them), reports where the evidence was captured after a restart, and reports
+that arrive several days later, once the logs have rolled off. None of these are blockers —
+send what you have and we'll work with it.
+
+Once an incident is closed, if the cause and fix are worth remembering, add them to
+[known-issues.md](known-issues.md).

--- a/docs/operations/incident-report.md
+++ b/docs/operations/incident-report.md
@@ -112,7 +112,7 @@ Filled in by whoever works [l2-diagnosis.md](l2-diagnosis.md).
 
 22. Host state:
     [ ] normal  [ ] CPU ____  [ ] RAM ____  [ ] disk ____
-    [ ] node-exporter not installed, host metrics unavailable
+    [ ] host metrics unavailable (no `node` job — see l2-diagnosis.md)
 
 23. Database pool (db_client_connections_pending_requests / timeouts):
 

--- a/docs/operations/known-issues.md
+++ b/docs/operations/known-issues.md
@@ -76,7 +76,7 @@ Worth knowing so nobody spends an hour on them.
 
 | Looks like | Actually |
 |---|---|
-| `Node Exporter Full` dashboard is completely empty | `node-exporter` isn't installed on deployments made before 2026-07-22. Not a fault; see [alerts-setup.md](alerts-setup.md#prerequisite--turn-on-host-metrics) |
+| `Node Exporter Full` dashboard is completely empty | Either `node-exporter` isn't installed (deployments made before 2026-07-22), **or** it is running and Prometheus simply hasn't re-read its config. Not an incident either way — L2 tells them apart in one minute, and the second is fixed by a config reload with no downtime. See [alerts-setup.md](alerts-setup.md#prerequisite--turn-on-host-metrics) |
 | A log search for "OutOfMemoryError" returns a hit from `grafana` or `loki` | Those tools log your search text back into the log stream. Filter them out |
 | Elasticsearch logs mention "out of memory" | Routine circuit-breaker messages, not a crash |
 | Every service restarts at the same time overnight | A scheduled redeploy, if this deployment has one. Confirm the window before treating it as an incident |

--- a/docs/operations/known-issues.md
+++ b/docs/operations/known-issues.md
@@ -20,6 +20,16 @@ values below are a starting suggestion, assuming L1 has dashboards only and no s
 access. Change them to match how you work, and treat the column as authoritative once you
 have.
 
+Two markers appear in that column because the fix needs access beyond the dashboards:
+
+- **†** — needs an **admin login to the Configurator or HRMS**. The
+  [first-response checklist](l1-first-response.md) does not assume one. If your service desk
+  doesn't have it, these are L2's.
+- **‡** — needs the **notification provider's console** (the SMS/WhatsApp account). Usually
+  held by whoever owns the provider contract, which may be neither tier.
+
+Worth settling both before an incident rather than during one.
+
 A good entry has all five: the **symptom as a user describes it**, how to **confirm** it's
 this and not something that looks like it, the **resolution**, who **applies** it, and the
 **underlying cause** if known.
@@ -31,8 +41,8 @@ this and not something that looks like it, the **resolution**, who **applies** i
 | Symptom | Confirm it's this | Resolution | Applied by |
 |---|---|---|---|
 | One user sees errors everywhere, others fine | Works in a private window / on another account | Sign out fully and back in; clear site data for the domain | L1 |
-| One user gets "unauthorised" or sees no menu items | Other users with the same role are fine | Check the user's roles and tenant in HRMS / Configurator; missing role assignment | L1 |
-| User can log in but their office's complaints are missing | Another user in the same office sees the same gap | Check the employee's jurisdiction/boundary assignment in HRMS | L1 |
+| One user gets "unauthorised" or sees no menu items | Other users with the same role are fine | Check the user's roles and tenant in HRMS / Configurator; missing role assignment | L1 **†** |
+| User can log in but their office's complaints are missing | Another user in the same office sees the same gap | Check the employee's jurisdiction/boundary assignment in HRMS | L1 **†** |
 | Site "down" for one person only | Loads for you on another network | Their DNS or network. Test with a phone hotspot | L1 |
 
 ---
@@ -41,8 +51,8 @@ this and not something that looks like it, the **resolution**, who **applies** i
 
 | Symptom | Confirm it's this | Resolution | Applied by |
 |---|---|---|---|
-| OTP or SMS not delivered, everything else works | Health dashboard *Notifications* green; `novu-worker` logs show a provider rejection | Provider account out of credit, or credentials expired. Check the provider console | L1 |
-| A complaint type, department or locality is missing from a dropdown | Present for another tenant | Master data not seeded for that tenant — add it via the Configurator | L1 |
+| OTP or SMS not delivered, everything else works | Health dashboard *Notifications* green; `novu-worker` logs show a provider rejection | Provider account out of credit, or credentials expired. Check the provider console | L1 **‡** |
+| A complaint type, department or locality is missing from a dropdown | Present for another tenant | Master data not seeded for that tenant — add it via the Configurator | L1 **†** |
 | Dashboard or reports show nothing | Empty for a second account too, and for a wider date range | Usually a filter or a role scope, not a fault. If the date range is wide and roles are right, escalate | L1 |
 | Works in one city, not another | Same action, two tenant codes, different outcome | Tenant configuration or data difference. Diff the two tenants' masters | L2 |
 

--- a/docs/operations/known-issues.md
+++ b/docs/operations/known-issues.md
@@ -1,0 +1,86 @@
+# Known issues
+
+Symptoms that have been seen before, with the resolution that worked. Check here **before**
+diagnosing — if the symptom is listed, you may not need to investigate at all.
+
+← back to **[Operations handbook](README.md)**
+
+---
+
+## How to use and grow this file
+
+This starts small on purpose. It only contains things that have actually been observed and
+resolved — nothing speculative. **Its value comes from your team adding to it**: every time
+an incident is diagnosed, the symptom and the fix belong here, so the next occurrence is a
+lookup rather than an investigation.
+
+**About the "Applied by" column.** Which tier is permitted to apply which fix is your team's
+decision, not ours — it depends on what access L1 has and how you'd rather run things. The
+values below are a starting suggestion, assuming L1 has dashboards only and no server
+access. Change them to match how you work, and treat the column as authoritative once you
+have.
+
+A good entry has all five: the **symptom as a user describes it**, how to **confirm** it's
+this and not something that looks like it, the **resolution**, who **applies** it, and the
+**underlying cause** if known.
+
+---
+
+## Browser and account — no server involvement
+
+| Symptom | Confirm it's this | Resolution | Applied by |
+|---|---|---|---|
+| One user sees errors everywhere, others fine | Works in a private window / on another account | Sign out fully and back in; clear site data for the domain | L1 |
+| One user gets "unauthorised" or sees no menu items | Other users with the same role are fine | Check the user's roles and tenant in HRMS / Configurator; missing role assignment | L1 |
+| User can log in but their office's complaints are missing | Another user in the same office sees the same gap | Check the employee's jurisdiction/boundary assignment in HRMS | L1 |
+| Site "down" for one person only | Loads for you on another network | Their DNS or network. Test with a phone hotspot | L1 |
+
+---
+
+## Configuration and data — no code change
+
+| Symptom | Confirm it's this | Resolution | Applied by |
+|---|---|---|---|
+| OTP or SMS not delivered, everything else works | Health dashboard *Notifications* green; `novu-worker` logs show a provider rejection | Provider account out of credit, or credentials expired. Check the provider console | L1 |
+| A complaint type, department or locality is missing from a dropdown | Present for another tenant | Master data not seeded for that tenant — add it via the Configurator | L1 |
+| Dashboard or reports show nothing | Empty for a second account too, and for a wider date range | Usually a filter or a role scope, not a fault. If the date range is wide and roles are right, escalate | L1 |
+| Works in one city, not another | Same action, two tenant codes, different outcome | Tenant configuration or data difference. Diff the two tenants' masters | L2 |
+
+---
+
+## Service-level — needs server access
+
+| Symptom | Confirm it's this | Resolution | Applied by |
+|---|---|---|---|
+| Complaints are filed successfully but never appear in the inbox | `kafka_consumer_records_lag_max` climbing for `egov-indexer`; complaint exists via API | Indexing pipeline stalled — restart `egov-indexer`, then confirm lag drains | L2 |
+| Inbox unavailable immediately after a from-scratch deployment | Only on a first deploy; `digit-inbox` exited | Known start-order race — `docker start digit-inbox`. Does not recur on later deploys | L2 |
+| A service is stuck restarting | `Started .+Application in` repeating for one service | Read that service's log from the *first* boot attempt. If it's an OOM, the heap needs raising — that's a deployment change, escalate | L2 |
+| Everything slow, nothing red | `db_client_connections_pending_requests` above 0 | Connection pool exhausted. Identify the slow query or the leak; a restart clears the symptom, not the cause | L2 |
+| Disk filling up | `df -h` above 85% | Docker JSON log files are the usual cause: `sudo find /var/lib/docker/containers -type f -name '*-json.log' -exec truncate -s 0 {} +` (the `find` form is required — a shell glob expands before `sudo` and fails). Note that this deletes logs you may still need | L2 |
+
+---
+
+## Not faults — expected behaviour that looks like one
+
+Worth knowing so nobody spends an hour on them.
+
+| Looks like | Actually |
+|---|---|
+| `Node Exporter Full` dashboard is completely empty | `node-exporter` isn't installed on deployments made before 2026-07-22. Not a fault; see [alerts-setup.md](alerts-setup.md#prerequisite--turn-on-host-metrics) |
+| A log search for "OutOfMemoryError" returns a hit from `grafana` or `loki` | Those tools log your search text back into the log stream. Filter them out |
+| Elasticsearch logs mention "out of memory" | Routine circuit-breaker messages, not a crash |
+| Every service restarts at the same time overnight | A scheduled redeploy, if this deployment has one. Confirm the window before treating it as an incident |
+| PgBouncer green while PostgreSQL is red | Both are checked deliberately — the pooler accepts connections to a database that isn't answering. Treat as Infrastructure red |
+| An *API Tests* tile is red while its service tile is green | The process is alive but its API is failing — usually data or configuration, not a crash |
+
+---
+
+## Template for new entries
+
+```markdown
+| Symptom as reported | How to confirm it's this one | What fixed it | Which tier |
+```
+
+Also record, in the entry or alongside it: **what caused it**, and whether a permanent fix
+is outstanding on our side. An entry that keeps getting used is a signal the underlying
+defect should be raised with us rather than worked around indefinitely.

--- a/docs/operations/known-issues.md
+++ b/docs/operations/known-issues.md
@@ -22,9 +22,13 @@ have.
 
 Two markers appear in that column because the fix needs access beyond the dashboards:
 
-- **†** — needs an **admin login to the Configurator or HRMS**. The
-  [first-response checklist](l1-first-response.md) does not assume one. If your service desk
-  doesn't have it, these are L2's.
+- **†** — needs an **admin login to the Configurator or HRMS**. These are screen-based tasks
+  — creating users, fixing a role, adding a missing master-data entry — so where a team has
+  decided that anything with a UI belongs to first line, they are L1's, and that is the usual
+  split. The [first-response checklist](l1-first-response.md) does not *assume* the login
+  exists, so confirm your service desk actually has it; without it these fall to L2 by
+  default. Work that needs the backend — a database query, a container, a config file — stays
+  with L2 regardless.
 - **‡** — needs the **notification provider's console** (the SMS/WhatsApp account). Usually
   held by whoever owns the provider contract, which may be neither tier.
 
@@ -66,7 +70,8 @@ this and not something that looks like it, the **resolution**, who **applies** i
 | Inbox unavailable immediately after a from-scratch deployment | Only on a first deploy; `digit-inbox` exited | Known start-order race — `docker start digit-inbox`. Does not recur on later deploys | L2 |
 | A service is stuck restarting | `Started .+Application in` repeating for one service | Read that service's log from the *first* boot attempt. If it's an OOM, the heap needs raising — that's a deployment change, escalate | L2 |
 | Everything slow, nothing red | `db_client_connections_pending_requests` above 0 | Connection pool exhausted. Identify the slow query or the leak; a restart clears the symptom, not the cause | L2 |
-| Disk filling up | `df -h` above 85% | Docker JSON log files are the usual cause: `sudo find /var/lib/docker/containers -type f -name '*-json.log' -exec truncate -s 0 {} +` (the `find` form is required — a shell glob expands before `sudo` and fails). Note that this deletes logs you may still need | L2 |
+| Disk filling up | `df -h` above 85% | Container logs are the usual cause. Truncate to reclaim now: `sudo find /var/lib/docker/containers -type f -name '*-json.log' -exec truncate -s 0 {} +` (the `find` form is required — a shell glob expands before `sudo` and fails). This deletes logs you may still need. **Then check whether the rotation cap is actually applied** — it only takes effect on containers created after it was set, so long-lived containers can grow without limit. See [l2-diagnosis.md](l2-diagnosis.md#container-logs--the-usual-reason-the-disk-fills) | L2 |
+| A monitoring service is down (grafana, prometheus, loki, tempo, gatus) | Its tile or dashboard is unavailable; complaints still work normally | Not a citizen-facing outage — nobody is blocked. But data generated while Loki, Prometheus or Tempo is down is **lost permanently**, so restart it promptly and note the gap. Restarting a monitoring container is safe | L2 |
 
 ---
 

--- a/docs/operations/l1-first-response.md
+++ b/docs/operations/l1-first-response.md
@@ -13,6 +13,19 @@ that's L2's work — capture what you've found and pass it on.
 Everything here is done from a browser. You need no server access, and nothing on this page
 changes anything.
 
+**What you need before your first call** — check you actually have these, and ask L2 for
+anything missing. Each one is assumed by a step below:
+
+| You need | Used in | If you don't have it |
+|---|---|---|
+| The `/status/` and `/grafana/` URLs, reachable from your desk | Steps 2–4 | Ask L2 — Grafana may sit behind the VPN |
+| A **login of your own** for the system | Step 1 | You cannot confirm scope; say so in the ticket rather than guessing |
+| A **second test login**, ideally in a different office | Step 1 | Ask a colleague to try instead, and note whose account was used |
+| The **maintenance window**, written on your [cheat sheet](cheatsheet.md) | Step 3 | Ask L2 before reporting restarts |
+
+An admin login to the Configurator or HRMS is **not** assumed anywhere here. Some entries in
+[known-issues.md](known-issues.md) need one — if yours doesn't have it, those are L2's.
+
 ← back to **[Operations handbook](README.md)** · one-page version:
 **[cheatsheet.md](cheatsheet.md)**
 
@@ -52,13 +65,22 @@ If the caller can send a screenshot, ask for one **with the error visible**.
 
 Before anything else, find out whether this is one machine or the system.
 
-1. Open the site yourself, in a **private/incognito window**.
-2. If you can, try a **second account**, and a **different network** (a phone hotspot).
+1. **Open the site yourself, in a private/incognito window**, and try the same action. This
+   one test is the important one, and it needs nothing but your own login.
+2. If you can, also vary **the account** (a second test login, or ask a colleague in another
+   office to try) and **the network** (a phone hotspot).
 
 | Result | What it means | Do this |
 |---|---|---|
 | Works for you, fails for them | Their browser, network or account | Try the browser-side items in [known-issues.md](known-issues.md) |
 | Fails for you too | Server-side | Continue to Step 2 |
+| You can't test it yourself | Unknown scope | Say so explicitly in the ticket — "could not reproduce, no second account" is information; silence reads as "not checked" |
+
+**If you can reproduce it, capture the failing request while you're there** — it is the
+single most useful attachment and the caller cannot get it for you. Press **F12** → the
+**Network** tab → repeat the action → click the red row → screenshot the **URL and status
+code**. If you cannot reproduce it, skip this; do not talk a caller through developer tools
+on the phone.
 
 Skipping this step is the most common way a single stale login turns into a system-wide
 alarm.
@@ -83,7 +105,9 @@ What the groups mean:
 | **Application** | The complaint system itself |
 | **Search** | Inbox and search break; filing complaints still works |
 | **Notifications** | SMS / email / WhatsApp not going out; everything else fine |
-| **Keycloak / OTP** | Login and OTP paths |
+| **Keycloak** | Sign-in / identity |
+| **OTP** | OTP delivery for login |
+| **MCP** | Integration tooling — no effect on citizens or staff using the system |
 | **API Tests** | The service is running but its API is failing — usually data or configuration |
 
 Two things worth knowing:

--- a/docs/operations/l1-first-response.md
+++ b/docs/operations/l1-first-response.md
@@ -1,0 +1,203 @@
+# L1 — first response
+
+**For:** the service desk. The person who takes the call from a clerk, a supervisor or a
+citizen.
+
+**Your job in one line:** work the checklist below, resolve it if it's on the
+[known-issues list](known-issues.md), and if it isn't, hand L2 a filled-in Part A of the
+[incident report](incident-report.md).
+
+**Not your job:** working out *why*. If you find yourself forming a theory about the cause,
+that's L2's work — capture what you've found and pass it on.
+
+Everything here is done from a browser. You need no server access, and nothing on this page
+changes anything.
+
+← back to **[Operations handbook](README.md)** · one-page version:
+**[cheatsheet.md](cheatsheet.md)**
+
+---
+
+## Contents
+
+- [Step 0 — take the details](#step-0--take-the-details)
+- [Step 1 — is it just this one person?](#step-1--is-it-just-this-one-person)
+- [Step 2 — is everything up?](#step-2--is-everything-up)
+- [Step 3 — did something crash or run out of memory?](#step-3--did-something-crash-or-run-out-of-memory)
+- [Step 4 — what does the log say?](#step-4--what-does-the-log-say)
+- [Step 5 — resolve or escalate](#step-5--resolve-or-escalate)
+- [What to capture, always](#what-to-capture-always)
+
+---
+
+## Step 0 — take the details
+
+Ask for these while the caller is still on the line. Going back for them later is the main
+reason a ticket stalls.
+
+| Ask | Why it matters |
+|---|---|
+| **What exactly were you doing?** The screen, the button, the action | Narrows it to one service |
+| **What happened instead?** The exact message on screen | Often names the failure outright |
+| **When did it start?** Date, time, timezone | Everything downstream is a time-range search |
+| **Is it still happening right now?** | Decides whether evidence is still live |
+| **Which city / office / login?** | Tenant and role scope |
+| **Complaint number**, if there is one | Lets any tier trace it end to end |
+
+If the caller can send a screenshot, ask for one **with the error visible**.
+
+---
+
+## Step 1 — is it just this one person?
+
+Before anything else, find out whether this is one machine or the system.
+
+1. Open the site yourself, in a **private/incognito window**.
+2. If you can, try a **second account**, and a **different network** (a phone hotspot).
+
+| Result | What it means | Do this |
+|---|---|---|
+| Works for you, fails for them | Their browser, network or account | Try the browser-side items in [known-issues.md](known-issues.md) |
+| Fails for you too | Server-side | Continue to Step 2 |
+
+Skipping this step is the most common way a single stale login turns into a system-wide
+alarm.
+
+---
+
+## Step 2 — is everything up?
+
+Open **`https://<your-domain>/status/`** — the health dashboard. It checks around 50 parts
+of the system every 30 seconds. Green means responding, red means not.
+
+**Screenshot anything red immediately.** This page keeps no history — if the page reloads,
+the red is gone and cannot be recovered.
+
+What the groups mean:
+
+| Group is red | What's affected |
+|---|---|
+| **Infrastructure** | Database, cache or message broker. Nothing else will work — this is the most serious thing on the page |
+| **Core Services** | A platform service. Expect several unrelated-looking symptoms at once |
+| **API Gateway** | Requests can't be routed; users see "502" or a blank screen |
+| **Application** | The complaint system itself |
+| **Search** | Inbox and search break; filing complaints still works |
+| **Notifications** | SMS / email / WhatsApp not going out; everything else fine |
+| **Keycloak / OTP** | Login and OTP paths |
+| **API Tests** | The service is running but its API is failing — usually data or configuration |
+
+Two things worth knowing:
+
+- **PostgreSQL and PgBouncer are listed separately.** If PgBouncer is green and PostgreSQL
+  is red, the system is still accepting connections to a database that isn't answering.
+  Treat it as Infrastructure red.
+- **An *API Tests* tile red while everything else is green is a useful signal**, not a
+  contradiction. Note it and pass it on.
+
+**Record the exact names of the red tiles.** That list is most of what L2 needs.
+
+---
+
+## Step 3 — did something crash or run out of memory?
+
+Two readings. Write down what they say and leave what they *mean* to L2.
+
+**a. Out-of-memory count.** Open **Grafana → `DIGIT JVM Services`**
+(`https://<your-domain>/grafana/d/digit-jvm/`) and set the time range (top right) to
+**Last 6 hours**, or wider if the problem started earlier.
+
+Read **"OOM events (current range)"** — a single number. Anything above `0` means a service
+ran out of memory somewhere in that window. The panel below it, *"Incidents — OOM /
+heap-space errors"*, names the service and carries the error. Copy those lines into the
+ticket.
+
+**b. Restarts.** Open **Grafana → Explore**, choose **Loki** from the datasource dropdown,
+and paste this in:
+
+```logql
+{compose_project="digit", compose_service!="loki"} |~ `Started .+Application in`
+```
+
+Each line it returns is one service starting up. Widen the range to 24 hours. **The same
+service appearing over and over is a service stuck restarting** — that is the single most
+useful thing you can report.
+
+> **Check the maintenance window before you report restarts.** If this deployment redeploys
+> on a schedule, every service restarts then and this query fills with normal activity. The
+> window should be written on your [cheat sheet](cheatsheet.md) — restarts *outside* it are
+> the interesting ones. If that blank has never been filled in, ask L2 what the window is
+> before treating restarts as a finding.
+
+**Record it, don't conclude from it.** `OOM events: 3 — egov-indexer, 09:12` is the right
+note. "The system crashed because it ran out of memory" is not — the OOM may be a
+consequence of the real fault, or unrelated to what the caller reported. Say what you saw
+rather than what it means, to the ticket and to the caller.
+
+Reading the heap graphs and the right-sizing table is L2's work
+([l2-diagnosis.md](l2-diagnosis.md#reading-the-evidence-l1-captured)): telling an ordinary
+memory sawtooth from a crash needs to know what that service's normal looks like.
+
+---
+
+## Step 4 — what does the log say?
+
+Open **Grafana → `DIGIT — Logs (Loki)`**
+(`https://<your-domain>/grafana/d/digit-loki-logs/`).
+
+You don't need to write a query. Use the three dropdowns at the top:
+
+- **service** — pick the one you suspect from Step 2 or 3. If you have no suspect, leave it
+  as `.+` for all of them.
+- **level** — set it to `ERROR`.
+- **q** — leave empty, or paste a complaint number to follow one case.
+
+Then set the time range to **start ten minutes before the problem began**.
+
+**Copy the oldest error you can see, not the newest.** When something breaks, other things
+fail after it — the first error is the one that matters. Copy 10–20 lines around it **as
+text**, and note the time range you used.
+
+If you see no errors at all, that's a real finding. Write "no ERROR lines between HH:MM and
+HH:MM" in the ticket — it rules a lot out.
+
+---
+
+## Step 5 — resolve or escalate
+
+**Check [known-issues.md](known-issues.md) first.** If your symptom is in that table and
+the resolution is marked as one you're able to apply, do it and close the ticket, adding a
+line to the incident log.
+
+Otherwise, escalate to L2 with **Part A** of [incident-report.md](incident-report.md)
+filled in. Part A is exactly what you gathered above, so it should be a copy-paste job.
+
+Escalate straight away, without finishing the steps, if any of these are true:
+
+- **Infrastructure is red** on the health dashboard.
+- **Nobody can log in**, or the site doesn't load at all.
+- **No complaint can be filed** by anyone.
+- **A disk-full or "no space left on device" message** appears anywhere.
+
+For those, do Step 2 (screenshot the red tiles) and hand over immediately. The remaining
+steps can be done by L2 while you're notifying people.
+
+---
+
+## What to capture, always
+
+Attach these to every ticket you pass on. Text, not photographs of a screen — text can be
+searched.
+
+- [ ] The answers from **Step 0**
+- [ ] **Scope** — did it fail for you too, in a private window, on another account?
+- [ ] **Health dashboard screenshot**, if anything was red
+- [ ] Any **red tile names**
+- [ ] **Restart / OOM findings** from Step 3, with times
+- [ ] The **error text** from Step 4, plus the time range and service you used
+- [ ] The **complaint number / user ID**, if there is one
+- [ ] A screenshot of the failing screen — and if the caller can manage it, with the browser
+      developer tools **Network** tab open (F12), showing the failed request
+
+One thing to be aware of before attaching anything: logs and screenshots from this system
+can contain citizens' names, phone numbers and complaint text. The redaction guidance in
+[incident-report.md](incident-report.md#redaction--what-not-to-send-us) covers what to strip.

--- a/docs/operations/l1-first-response.md
+++ b/docs/operations/l1-first-response.md
@@ -10,15 +10,54 @@ citizen.
 **Not your job:** working out *why*. If you find yourself forming a theory about the cause,
 that's L2's work — capture what you've found and pass it on.
 
-Everything here is done from a browser. You need no server access, and nothing on this page
-changes anything.
+You do all of this from a web browser. You never touch the server, and **nothing in this
+checklist changes anything** — every step is looking, not changing. You cannot break the
+system by following this page.
 
-**What you need before your first call** — check you actually have these, and ask L2 for
-anything missing. Each one is assumed by a step below:
+---
+
+## Before you start
+
+### Logins and passwords
+
+The two pages you'll use — the health dashboard and Grafana — **need no login on these
+deployments**. You open the URL and you're in. That is deliberate, so the service desk is
+never blocked waiting for an account.
+
+Everything else, ask your **system administrator** for:
+
+| If you need | Ask your system administrator |
+|---|---|
+| A password prompt appears on the health dashboard or Grafana | They'll tell you the right URL, or add you to the VPN |
+| The **Novu** notification dashboard (to see if a message was sent) | Access is not part of the service desk by default |
+| The **SMS / WhatsApp provider console** (to check credit or credentials) | Usually held by whoever owns the provider contract |
+| Access to the **server itself** | That is L2's, not yours — you never need it for this checklist |
+
+**Never put a password, API key or token in a ticket**, even if someone asks you to. If you
+think a credential is part of the problem, say *which* credential, not what it is.
+
+### The two pages, and what they are
+
+Bookmark these two. **They are the only URLs on this page** — after this, everything is
+described as menu clicks, so you don't have to memorise addresses.
+
+| Page | URL | What it is |
+|---|---|---|
+| **Health dashboard** | `https://<your-domain>/status/` | A page that automatically tries about 50 parts of the system every 30 seconds and colours each one green or red |
+| **Grafana** | `https://<your-domain>/grafana/` | The system's own recordings — memory, errors, logs — shown as charts and lists |
+
+**About Grafana**, because it looks intimidating the first time: it is a *viewer*. It reads
+recordings the system already made and draws them on screen. It does not control the
+system, and clicking around in it cannot start, stop or change anything. Explore it freely.
+
+### What you need before your first call
+
+Check you actually have these, and ask L2 for anything missing. Each one is assumed by a
+step below.
 
 | You need | Used in | If you don't have it |
 |---|---|---|
-| The `/status/` and `/grafana/` URLs, reachable from your desk | Steps 2–4 | Ask L2 — Grafana may sit behind the VPN |
+| The two URLs above, reachable from your desk | Steps 2–4 | Ask L2 — Grafana may sit behind the VPN |
 | A **login of your own** for the system | Step 1 | You cannot confirm scope; say so in the ticket rather than guessing |
 | A **second test login**, ideally in a different office | Step 1 | Ask a colleague to try instead, and note whose account was used |
 | The **maintenance window**, written on your [cheat sheet](cheatsheet.md) | Step 3 | Ask L2 before reporting restarts |
@@ -63,12 +102,15 @@ If the caller can send a screenshot, ask for one **with the error visible**.
 
 ## Step 1 — is it just this one person?
 
-Before anything else, find out whether this is one machine or the system.
+Before opening any dashboard, find out whether this is one person's machine or the whole
+system. This costs a minute and decides everything that follows.
 
 1. **Open the site yourself, in a private/incognito window**, and try the same action. This
    one test is the important one, and it needs nothing but your own login.
 2. If you can, also vary **the account** (a second test login, or ask a colleague in another
    office to try) and **the network** (a phone hotspot).
+
+### What the result means, and what to do
 
 | Result | What it means | Do this |
 |---|---|---|
@@ -89,34 +131,66 @@ alarm.
 
 ## Step 2 — is everything up?
 
-Open **`https://<your-domain>/status/`** — the health dashboard. It checks around 50 parts
-of the system every 30 seconds. Green means responding, red means not.
+### What this page is
 
-**Screenshot anything red immediately.** This page keeps no history — if the page reloads,
-the red is gone and cannot be recovered.
+The **health dashboard** is a page that tries about 50 different parts of the system every
+30 seconds and shows the result as a coloured tile. Green means that part answered. Red
+means it did not. You don't run anything — the page is already doing it continuously, and
+you're reading the latest result.
 
-What the groups mean:
+### How to get there
+
+Open the health dashboard URL from [Before you start](#before-you-start). There is nothing
+to click — the tiles are the page.
+
+### What you're looking at
+
+Tiles are grouped by what part of the system they belong to. Scan for **any red tile**, and
+note its **exact name and group**.
+
+> **Screenshot anything red immediately, before you do anything else.** This page keeps no
+> history — it only knows the last few minutes. If the page reloads or the service recovers,
+> the red is gone for good and cannot be recovered by anyone, including L2.
+
+### What each group means
 
 | Group is red | What's affected |
 |---|---|
-| **Infrastructure** | Database, cache or message broker. Nothing else will work — this is the most serious thing on the page |
-| **Core Services** | A platform service. Expect several unrelated-looking symptoms at once |
-| **API Gateway** | Requests can't be routed; users see "502" or a blank screen |
+| **Infrastructure** | The database, cache or message queue. Nothing else can work without these — this is the most serious thing on the page |
+| **Core Services** | A shared platform service. Expect several unrelated-looking symptoms at once |
+| **API Gateway** | The traffic director. Requests can't be routed; users see "502" or a blank screen |
 | **Application** | The complaint system itself |
 | **Search** | Inbox and search break; filing complaints still works |
 | **Notifications** | SMS / email / WhatsApp not going out; everything else fine |
-| **Keycloak** | Sign-in / identity |
-| **OTP** | OTP delivery for login |
-| **MCP** | Integration tooling — no effect on citizens or staff using the system |
-| **API Tests** | The service is running but its API is failing — usually data or configuration |
+| **Sign-in / identity** | People cannot log in |
+| **OTP** | One-time passcodes for login aren't being delivered |
+| **MCP** | Integration tooling. No effect on citizens or staff using the system |
+| **API Tests** | See below — this one means something different |
 
-Two things worth knowing:
+### Two things that confuse people
 
-- **PostgreSQL and PgBouncer are listed separately.** If PgBouncer is green and PostgreSQL
-  is red, the system is still accepting connections to a database that isn't answering.
-  Treat it as Infrastructure red.
-- **An *API Tests* tile red while everything else is green is a useful signal**, not a
-  contradiction. Note it and pass it on.
+**The API Tests group is not like the others.** Every other group asks a service *"are you
+alive?"* — the service replies, the tile goes green. The API Tests group instead makes a
+**real request**, the same kind the application makes: searching for a city, generating a
+complaint number, fetching a translated message. So it proves the service can actually do
+its job, not just that it's running.
+
+That means a **green service tile with a red API Tests tile is not a contradiction** — it
+tells you the service is alive but not working, which is usually a data or configuration
+problem rather than a crash. Note it and pass it on; it points L2 somewhere quite different.
+
+**PostgreSQL and PgBouncer are listed separately on purpose.** PgBouncer sits in front of the
+database. It can keep answering happily while the database behind it is dead. If PgBouncer
+is green and PostgreSQL is red, treat it as **Infrastructure red**.
+
+### What to do about it
+
+| What you see | Do this |
+|---|---|
+| **Any Infrastructure tile red** | **Screenshot it and escalate immediately.** Do not continue the checklist — nothing above the database can be trusted, and the remaining steps will just be noise |
+| Any other red tile | Screenshot, write down the exact tile names, continue to Step 3 |
+| An API Tests tile red, service tiles green | Note it explicitly as "alive but API failing", continue to Step 3 |
+| Everything green | The parts are all running, so the problem is inside one of them or in the data. Continue to Step 3 |
 
 **Record the exact names of the red tiles.** That list is most of what L2 needs.
 
@@ -124,27 +198,70 @@ Two things worth knowing:
 
 ## Step 3 — did something crash or run out of memory?
 
-Two readings. Write down what they say and leave what they *mean* to L2.
+### What you're checking, and the words for it
 
-**a. Out-of-memory count.** Open **Grafana → `DIGIT JVM Services`**
-(`https://<your-domain>/grafana/d/digit-jvm/`) and set the time range (top right) to
-**Last 6 hours**, or wider if the problem started earlier.
+Most of this system is written in Java. Every Java service is given a fixed amount of memory
+to work in — that allowance is called the **heap**. If a service needs more than its heap
+allows, it cannot continue and fails with an error called **OOM**, short for
+*out of memory*. When a service fails this way it usually **restarts** — it stops and starts
+again from scratch, which takes it out of service for a minute or two.
 
-Read **"OOM events (current range)"** — a single number. Anything above `0` means a service
-ran out of memory somewhere in that window. The panel below it, *"Incidents — OOM /
-heap-space errors"*, names the service and carries the error. Copy those lines into the
-ticket.
+You are checking two things, and only reading numbers:
 
-**b. Restarts.** Open **Grafana → Explore**, choose **Loki** from the datasource dropdown,
-and paste this in:
+- **Did anything run out of memory?**
+- **Is anything restarting over and over?**
+
+### a. Out-of-memory count
+
+**How to get there:** open **Grafana** → in the left menu click **Dashboards** → open
+**DIGIT JVM Services**.
+
+**Set the time window first.** At the **top right** there is a time control — it usually
+says something like *Last 6 hours*. Everything on the screen is only about that window, so
+if you set it wrong you will see nothing and think all is well. Set it to **Last 6 hours**,
+or wider if the caller says the problem started earlier.
+
+Now find the panel called **"OOM events (current range)"**. It is a **stat panel**, meaning
+it shows one single large number — the count of out-of-memory failures inside the time
+window you chose.
+
+| Reading | What it means |
+|---|---|
+| **0** | Normal. Nothing ran out of memory in that window |
+| **Anything above 0** | A service ran out of memory. This is a real finding |
+
+If it is above zero, look at the panel directly below it, **"Incidents — OOM / heap-space
+errors"**. That lists the actual error lines and names the service.
+
+**What to do about it:**
+
+> If **OOM events is above 0** — copy the error lines from the panel below it, note the
+> **service name** and the **time**, and **escalate to L2**. Do not try to fix it. Do not
+> restart anything. Fixing an out-of-memory usually means giving the service a bigger
+> allowance, which is a deployment change and not something the service desk can or should
+> do.
+
+### b. Restarts
+
+**How to get there:** in Grafana's left menu click **Explore**. At the top of the Explore
+screen there is a datasource dropdown — choose **Loki** from it.
+
+Then copy this line into the query box and press **Run query** (or Shift+Enter). You don't
+need to understand it — it is a search filter, and it's the same every time:
 
 ```logql
 {compose_project="digit", compose_service!="loki"} |~ `Started .+Application in`
 ```
 
-Each line it returns is one service starting up. Widen the range to 24 hours. **The same
-service appearing over and over is a service stuck restarting** — that is the single most
-useful thing you can report.
+Every Java service writes one line when it starts up. This search finds those lines, so
+**each result is one service starting**. Widen the time range at the top right to **Last 24
+hours**.
+
+| Reading | What it means |
+|---|---|
+| A cluster of many services all starting at the same time | Normal, if that time is your maintenance window — the whole system was redeployed |
+| The **same service** appearing over and over through the day | Not normal. That service is failing and restarting repeatedly |
+| Nothing at all | Nothing restarted in that window. Also a useful finding |
 
 > **Check the maintenance window before you report restarts.** If this deployment redeploys
 > on a schedule, every service restarts then and this query fills with normal activity. The
@@ -152,37 +269,68 @@ useful thing you can report.
 > the interesting ones. If that blank has never been filled in, ask L2 what the window is
 > before treating restarts as a finding.
 
-**Record it, don't conclude from it.** `OOM events: 3 — egov-indexer, 09:12` is the right
-note. "The system crashed because it ran out of memory" is not — the OOM may be a
-consequence of the real fault, or unrelated to what the caller reported. Say what you saw
-rather than what it means, to the ticket and to the caller.
+**What to do about it:**
 
-Reading the heap graphs and the right-sizing table is L2's work
-([l2-diagnosis.md](l2-diagnosis.md#reading-the-evidence-l1-captured)): telling an ordinary
-memory sawtooth from a crash needs to know what that service's normal looks like.
+> If the **same service keeps appearing** outside the maintenance window — copy the list of
+> times, note the service name, and **escalate to L2** with the words **"possible restart
+> loop"**. That phrase tells L2 exactly where to start. Do not restart anything yourself.
+
+### Record it, don't conclude from it
+
+`OOM events: 3 — egov-indexer, 09:12` is the right note.
+"The system crashed because it ran out of memory" is not.
+
+The out-of-memory may be a *consequence* of the real fault, or unrelated to what the caller
+reported. Say what you saw rather than what it means — in the ticket, and to the caller.
+
+The other panels on that dashboard — the heap graphs and the right-sizing table — are L2's
+work ([l2-diagnosis.md](l2-diagnosis.md#reading-the-evidence-l1-captured)). Reading them
+correctly means knowing what normal looks like for each individual service, and a normal
+memory pattern looks alarming until you've seen a few. Leave them alone.
 
 ---
 
 ## Step 4 — what does the log say?
 
-Open **Grafana → `DIGIT — Logs (Loki)`**
-(`https://<your-domain>/grafana/d/digit-loki-logs/`).
+### What a log is
 
-You don't need to write a query. Use the three dropdowns at the top:
+Every part of the system writes a running diary of what it is doing — each thing it starts,
+finishes, or fails at, with a timestamp. That diary is the **log**. When something breaks,
+the log usually says so in plain words, and that sentence is the single most useful thing
+you can put in a ticket.
 
-- **service** — pick the one you suspect from Step 2 or 3. If you have no suspect, leave it
-  as `.+` for all of them.
-- **level** — set it to `ERROR`.
-- **q** — leave empty, or paste a complaint number to follow one case.
+Logs are kept for **72 hours**, so a problem from last week has no log left. This is why
+reporting quickly matters.
 
-Then set the time range to **start ten minutes before the problem began**.
+### How to get there
+
+Open **Grafana** → left menu **Dashboards** → open **DIGIT — Logs (Loki)**.
+
+**You do not need to write a query here.** This dashboard has three dropdowns across the
+top; set them and the logs appear underneath.
+
+| Control | Set it to |
+|---|---|
+| **service** | The service you suspect, from Step 2 or Step 3. If you have no suspect, leave it as `.+`, which means "all of them" |
+| **level** | `ERROR` — this hides routine chatter and shows only failures |
+| **q** | Leave empty. Or paste a complaint number here to follow one specific case through the system |
+
+Then set the **time range** (top right) to **start ten minutes before the problem began**.
+Not when the caller rang — when it started. Failures cascade, and you want to catch the
+first one.
+
+### What you're looking at, and what to do
 
 **Copy the oldest error you can see, not the newest.** When something breaks, other things
-fail after it — the first error is the one that matters. Copy 10–20 lines around it **as
-text**, and note the time range you used.
+fail after it in a chain. The first error is the cause; the rest are consequences. Scroll to
+the *bottom* of the list, which is the earliest entry in your window.
 
-If you see no errors at all, that's a real finding. Write "no ERROR lines between HH:MM and
-HH:MM" in the ticket — it rules a lot out.
+| What you see | Do this |
+|---|---|
+| Errors are present | Copy the **oldest** one, with **10–20 lines around it**, as text. Note the service and the exact time range you used. **Escalate to L2** |
+| No errors at all | This is a real finding, not a dead end. Write it down explicitly: *"no ERROR lines between 09:00 and 09:30 for all services"*. It rules out a great deal for L2 |
+
+Copy the text, not a photograph of the screen — text can be searched, a screenshot cannot.
 
 ---
 
@@ -195,15 +343,24 @@ line to the incident log.
 Otherwise, escalate to L2 with **Part A** of [incident-report.md](incident-report.md)
 filled in. Part A is exactly what you gathered above, so it should be a copy-paste job.
 
-Escalate straight away, without finishing the steps, if any of these are true:
+### Escalate immediately, without finishing the checklist
 
-- **Infrastructure is red** on the health dashboard.
+Stop and hand over right away if any of these are true:
+
+- **An Infrastructure tile is red** on the health dashboard.
 - **Nobody can log in**, or the site doesn't load at all.
 - **No complaint can be filed** by anyone.
 - **A disk-full or "no space left on device" message** appears anywhere.
 
-For those, do Step 2 (screenshot the red tiles) and hand over immediately. The remaining
-steps can be done by L2 while you're notifying people.
+For those, do Step 2 (screenshot the red tiles) and hand over. The remaining steps can be
+done by L2 while you're notifying people.
+
+### And if everything looked normal
+
+Say so, clearly. *"All health tiles green, OOM events 0, no restarts outside the maintenance
+window, no ERROR lines between 09:00 and 09:30"* is a genuinely valuable ticket — it rules
+out most of what L2 would otherwise spend an hour checking. An empty checklist reads as
+"nobody looked"; a filled-in one that found nothing reads as "we know where it isn't".
 
 ---
 

--- a/docs/operations/l2-diagnosis.md
+++ b/docs/operations/l2-diagnosis.md
@@ -1,0 +1,389 @@
+# L2 — diagnosis
+
+**For:** the engineers who own the deployment. You have server access and can restart
+services, read logs across the whole stack, and change configuration.
+
+**Your job:** take what L1 captured and identify **which component is failing and why** —
+far enough that the fix is either yours to apply or clearly a product defect to send on.
+
+This assumes [L1 first response](l1-first-response.md) has been worked, or that you're
+starting cold and have done it yourself. Every query and panel name here is real and was run
+against a live deployment.
+
+← back to **[Operations handbook](README.md)**
+
+---
+
+## Contents
+
+- [How the stack is layered](#how-the-stack-is-layered)
+- [Reading the evidence L1 captured](#reading-the-evidence-l1-captured)
+- [Going deeper on logs](#going-deeper-on-logs)
+- [Is it slow, or is it failing?](#is-it-slow-or-is-it-failing)
+- [The host itself](#the-host-itself-cpu-ram-disk)
+- [Symptom → playbook](#symptom--playbook)
+- [Working on the server itself](#working-on-the-server-itself)
+- [Commands that are destructive](#commands-that-are-destructive)
+- [Query cookbook](#query-cookbook)
+- [When to escalate to us](#when-to-escalate-to-us)
+
+---
+
+## How the stack is layered
+
+A deployment runs roughly 40 containers. Almost every failure sits in one of five layers,
+and the layer tells you where to look:
+
+| Layer | What's in it | Fails as | Look at |
+|---|---|---|---|
+| **Edge** | nginx (host), Kong gateway | 502 / 504, site won't load, some APIs 404 | Health dashboard → *API Gateway*; nginx + kong logs |
+| **Application** | pgr-services, digit-ui, configurator, inbox, dashboard | A screen or action breaks, others fine | Health dashboard → *Application*; that service's logs |
+| **Core platform** | user, workflow, mdms, hrms, boundary, localization, idgen, accesscontrol, filestore, persister, indexer | Many features break at once; login fails | Health dashboard → *Core Services* |
+| **Backbone** | Postgres, PgBouncer, Redis, Redpanda (Kafka), MinIO, Elasticsearch | Everything degrades or hangs | Health dashboard → *Infrastructure* |
+| **Host** | CPU, RAM, disk, network, Docker | Random restarts, OOM kills, "no space left on device" | Node Exporter Full dashboard, or SSH |
+
+**Causation runs downward.** If a Core Service is red, there is little point debugging the
+application sitting on top of it — start with the core service. If Infrastructure is red,
+nothing above it can be trusted.
+
+---
+
+## Reading the evidence L1 captured
+
+Part A of the report should give you red tiles, restart/OOM findings and a first error. Work
+from those before opening anything new.
+
+### Restarts
+
+A service that crashed and restarted shows as a heap line dropping to zero and climbing
+again on **`DIGIT JVM Services` → "Heap used (MB) — by service"**. The definitive version is
+in the logs:
+
+```logql
+{compose_project="digit", compose_service!="loki"} |~ `Started .+Application in`
+```
+
+Every Java service logs `Started XyzApplication in N seconds` once per boot. Widen to 24
+hours: a service appearing repeatedly is crash-looping, and that is the headline.
+
+Expect one cluster at your deployment window if the deployment redeploys on a schedule.
+Restarts outside that window are the interesting ones.
+
+### Memory
+
+- **"OOM events (current range)"** above `0` means a real `OutOfMemoryError` or
+  `GC overhead limit exceeded` in the range. The panel below it carries the stack traces.
+- **"Right-sizing snapshot"** — headroom below 10% means the service will OOM under load;
+  it needs a bigger heap, which is a deployment change.
+- **"GC pause time (s/s)"** sustained above ~0.2 means the service spends 20% of its time
+  collecting garbage. It will look hung while being technically alive.
+- **"Live threads"** climbing without bound is a thread leak, usually caused by something
+  downstream being slow or dead.
+- **"JVM CPU — recent utilization"** at `1.0` is one full core. Sustained high CPU with no
+  traffic is a spin loop.
+
+> **Coverage limit.** JVM metrics exist only for the **16 Java services carrying the
+> OpenTelemetry agent**: boundary-service, digit-config-service, egov-accesscontrol,
+> egov-enc-service, egov-filestore, egov-hrms, egov-idgen, egov-indexer, egov-persister,
+> egov-user, egov-workflow-v2, inbox, mdms-backend, novu-bridge, pgr-services, plus dashboard
+> web metrics. **Postgres, Redis, Kafka, Kong, Elasticsearch, Keycloak, nginx and the Node
+> services have no metrics at all** — for those, the health dashboard and the logs are the
+> only signals, and both cover them fully.
+
+---
+
+## Going deeper on logs
+
+Logs cover **every container** — all ~44 — including the ones with no metrics.
+
+The method:
+
+1. **Start ten minutes before the symptom**, not at the moment it was noticed.
+2. **Read the oldest error in the range.** Failures cascade; everything after the first is
+   usually consequence.
+3. **Follow the error down a layer.** `pgr-services` reporting
+   `Connection refused: egov-workflow-v2` is not a pgr-services bug — read egov-workflow-v2's
+   logs for the same minute.
+4. **Search by identifier** when one case is broken: put the complaint number in the **q**
+   box with service `.+` and you'll see every service that touched it.
+
+Which service is producing the most errors — run this first when the whole system is
+unwell, it points straight at the origin:
+
+```logql
+sum by (compose_service) (count_over_time({compose_project="digit"} |~ `(?i)error|exception` [5m]))
+```
+
+Then narrow:
+
+```logql
+{compose_service="pgr-services"} |~ `(?i)error|exception`
+{compose_service=~"postgres-db|pgbouncer"} |~ `(?i)fatal|error|too many clients|deadlock|out of memory`
+{compose_service="kong"} |~ `(?i)502|503|504|no route|upstream`
+{compose_project="digit"} |= `PGR-2026-01-000123`
+```
+
+> **Two false-positive traps.** Grafana logs your search text back into the log stream, so a
+> search for "OutOfMemoryError" matches Grafana's own line — ignore hits where
+> `compose_service` is `grafana` or `loki`. Elasticsearch also uses the phrase "out of
+> memory" in routine circuit-breaker messages.
+
+---
+
+## Is it slow, or is it failing?
+
+Different problems, different evidence. Establish which one you have.
+
+### Failing — HTTP 5xx
+
+Grafana → **Explore** → **Prometheus**:
+
+```promql
+sum by (service_name) (rate(http_server_request_duration_seconds_count{http_response_status_code=~"5.."}[5m]))
+```
+
+Break it down to the exact endpoint:
+
+```promql
+sum by (service_name, http_route, http_response_status_code) (
+  rate(http_server_request_duration_seconds_count{http_response_status_code=~"5.."}[5m])
+)
+```
+
+### Slow — latency
+
+```promql
+histogram_quantile(0.95, sum by (le, service_name) (rate(http_server_request_duration_seconds_bucket[5m])))
+histogram_quantile(0.95, sum by (le, service_name, http_route) (rate(http_server_request_duration_seconds_bucket[5m])))
+```
+
+### Slow because of the database
+
+The connection pool is the usual cause of "everything hangs but nothing is down":
+
+```promql
+db_client_connections_pending_requests          # queued waiting for a connection — should be 0
+db_client_connections_usage
+db_client_connections_max
+rate(db_client_connections_timeouts_total[5m])  # any non-zero = pool exhausted
+```
+
+`pending_requests` above zero, or any increase in `timeouts_total`, means the pool is
+exhausted — either a query got slow or something leaked connections.
+
+### Slow because of the message queue
+
+Complaints, notifications and indexing move through Kafka. A stuck consumer means complaints
+are filed but never appear in the inbox or trigger a notification:
+
+```promql
+max by (service_name, client_id) (kafka_consumer_records_lag_max)
+```
+
+Lag that climbs without recovering is the signal — `egov-indexer`, `egov-persister` or
+`novu-bridge` are the usual candidates.
+
+### Slow — which part of the request?
+
+Grafana → **`DIGIT — Traces (Tempo)`**:
+
+- **"Slow traces — duration > 500ms"** — genuinely slow requests.
+- **"Error traces (status = error)"** — requests that failed.
+
+Click any row for the waterfall: which service, and which database call, consumed the time.
+**Copy the Trace ID into the report** — it is the most useful single item for a slowness
+escalation, and **traces are kept for 24 hours only**.
+
+---
+
+## The host itself (CPU, RAM, disk)
+
+**Grafana → `Node Exporter Full`.**
+
+> ### If this dashboard is empty
+>
+> Host metrics come from a `node-exporter` container added to the platform on
+> **2026-07-22**. Deployments installed before that date do not have it. Check with:
+>
+> ```promql
+> up
+> ```
+>
+> If the only result is `job="otel-collector"`, node-exporter isn't running; `job="node"`
+> alongside it means you have host metrics. Enabling it is a redeploy, not a manual step —
+> see [alerts-setup.md § Prerequisite](alerts-setup.md#prerequisite--turn-on-host-metrics).
+> Until then, `df -h` over SSH is your only disk view.
+
+| Panel | Concerning | Why it breaks things |
+|---|---|---|
+| **CPU Busy** | >90% sustained | Everything slows; health checks time out and services get killed as unhealthy |
+| **RAM Used** | >90% | The Linux OOM killer starts killing containers, usually the largest JVM |
+| **Swap** | any sustained use | Out of RAM; latency rises by orders of magnitude |
+| **Disk Space Used** | >85% warn, >95% critical | **Postgres refuses writes when the disk fills — the most common cause of a total outage.** Docker logs and Elasticsearch indices are the usual culprits |
+| **Disk IOPS / IO time** | pegged | Queries queue behind disk |
+| **Load average** | above core count, sustained | More work queued than the box can do |
+
+Disk fails slowly and then all at once, and it takes the database with it.
+
+---
+
+## Symptom → playbook
+
+| Symptom | Most likely | Check, in this order |
+|---|---|---|
+| **Site won't load at all** (browser error, not a DIGIT page) | nginx down, TLS certificate expired, DNS | Try the health dashboard URL — if that also fails, it's the edge, not DIGIT. Check certificate expiry in the browser padlock |
+| **502 / 504 Bad Gateway** | Kong or the upstream service down or restarting | Health dashboard *API Gateway* + *Application* → restarts → Kong logs |
+| **Login fails for everyone** | egov-user, Keycloak, Redis, or accesscontrol | Health dashboard *Core Services* + *Keycloak* → logs for `egov-user` and `keycloak` |
+| **Login fails for one user** | Wrong tenant, disabled account, role missing | Usually a data question rather than an outage — check the user in HRMS/Configurator |
+| **OTP not received** | Notification/SMS provider, not DIGIT | Health dashboard *OTP* + *Notifications* → logs for `egov-user-proxy`, `novu-worker`. Check provider credit/credentials |
+| **Complaint submit fails** | pgr-services, workflow, idgen, or Postgres | Browser Network tab → failing URL → that service's logs → Health dashboard *Infrastructure* |
+| **Complaint filed but not in the inbox** | Indexing pipeline, not the write path | `kafka_consumer_records_lag_max`; logs for `egov-indexer`, `elasticsearch`, `inbox` |
+| **Notifications not delivered** | Novu chain or provider | Health dashboard *Notifications* → logs for `novu-bridge`, `novu-worker` → provider console |
+| **Dashboard / reports empty** | Analytics query, roles, or no data for the filter | Confirm with a second account and a wider date range first → logs for `pgr-services` → `pgr_analytics_query_duration_ms` |
+| **Everything is slow** | Host CPU/RAM/disk, or the DB pool | Host panels → `db_client_connections_pending_requests` → Tempo slow traces |
+| **Works for one city, not another** | Tenant configuration or data rather than code | File with both tenant codes so we can diff them |
+| **A service restarts every few minutes** | OOM, failed health check, or a bad config/env value | OOM panels → that service's logs from the *first* boot attempt onward |
+| **"No space left on device"** anywhere | Disk full | Host panels or `df -h`. Postgres may already be refusing writes |
+
+---
+
+## Working on the server itself
+
+The deployment lives in **`/opt/digit`** and runs as Docker Compose project `digit`. These
+are the **read-only** commands:
+
+```bash
+# Which containers exist, and are any of them restarting?
+sudo docker ps -a --format 'table {{.Names}}\t{{.Status}}\t{{.Image}}'
+
+# Anything not "Up" — all six non-running states, not just the two obvious ones
+sudo docker ps -a --filter 'status=created'    --filter 'status=restarting' \
+                  --filter 'status=removing'   --filter 'status=paused' \
+                  --filter 'status=exited'     --filter 'status=dead'
+
+# Running but failing its own healthcheck — invisible to the command above
+sudo docker ps --filter 'health=unhealthy'
+
+# Live CPU / memory per container
+sudo docker stats --no-stream
+
+# Why did this container die? (exit code 137 = killed, usually OOM)
+sudo docker inspect --format '{{.State.ExitCode}} {{.State.OOMKilled}} {{.RestartCount}}' <container>
+
+# Recent logs from one container
+sudo docker logs --tail 200 --timestamps <container>
+
+# Disk
+df -h
+sudo du -h --max-depth=1 /var/lib/docker/containers | sort -h | tail -10
+```
+
+Container names follow two patterns — `digit-egov-user-1` (compose default) and
+`boundary-service` (explicitly named). `sudo docker ps` shows the truth.
+
+To restart **one** service, pass the full compose file stack, or Compose computes a
+different — wrong — configuration:
+
+```bash
+cd /opt/digit
+C="sudo docker compose -f docker-compose.egov-digit.yaml \
+                       -f docker-compose.migrations.yml \
+                       -f docker-compose.migrations.ansible.yml \
+                       -f docker-compose.monitoring.yml"
+# add -f docker-compose.<tenant>.yml if this deployment has a per-tenant overlay
+
+eval "$C restart pgr-services"        # name the service explicitly, always
+```
+
+**Capture the logs before restarting** (`docker logs --tail 500 <container> > /tmp/x.log`).
+A restart clears the container's log buffer along with the symptom, and without it the next
+step is usually reproducing the failure from scratch.
+
+---
+
+## Commands that are destructive
+
+Worth reading once before working on the server — several of these are easy to reach for
+during an incident and have no undo.
+
+| Command | What actually happens |
+|---|---|
+| `docker compose down -v` | **Deletes every data volume — the entire Postgres database, MinIO files, Grafana dashboards and alert rules.** Complaints, users, everything |
+| `docker system prune -a --volumes` | Same outcome by a different route |
+| A bare `docker compose up -d` (no service names) | Revives the `default-data-handler` container, which re-seeds master data and can overwrite configuration. Always name the services |
+| `docker compose up -d` with a partial `-f` list | Compose recomputes the stack from an incomplete definition and can recreate containers with the wrong image, env or volumes |
+| Editing files in `/opt/digit` by hand | Overwritten on the next deployment. Config changes belong in the inventory |
+| `rm` anything under `/var/lib/docker/volumes` | Silent, permanent data loss |
+| Deleting Postgres WAL files to free space | Corrupts the database |
+
+If a disk is full and you need space immediately, the safe target is Docker's log files
+rather than volumes:
+
+```bash
+sudo find /var/lib/docker/containers -type f -name '*-json.log' -exec truncate -s 0 {} +
+```
+
+Note it in the report — it removes the logs that would otherwise have been read.
+
+> Use the `find` form, not a shell glob. `/var/lib/docker/containers` is not readable by a
+> normal user, so `sudo truncate … /var/lib/docker/containers/*/*-json.log` expands the
+> wildcard in *your* shell before `sudo` runs, matches nothing, and fails. `find` runs
+> under `sudo` and does the matching as root.
+
+---
+
+## Query cookbook
+
+Paste into **Grafana → Explore** with the matching datasource. The fuller list, including
+host queries, is in [reference.md](reference.md#query-cookbook).
+
+```promql
+# Which services are reporting at all
+count by (service_name) (jvm_thread_count)
+
+# Reporting 15 min ago but not now — i.e. something died
+count by (service_name) (jvm_thread_count offset 15m) unless count by (service_name) (jvm_thread_count)
+
+# Heap usage % per service
+100 * sum by (service_name) (jvm_memory_used_bytes{jvm_memory_type="heap"})
+    / sum by (service_name) (jvm_memory_limit_bytes{jvm_memory_type="heap"})
+
+# Time spent in garbage collection (>0.2 = trouble)
+sum by (service_name) (rate(jvm_gc_duration_seconds_sum[5m]))
+
+# Server errors by service and endpoint
+sum by (service_name, http_route) (rate(http_server_request_duration_seconds_count{http_response_status_code=~"5.."}[5m]))
+```
+
+```logql
+# Error volume by service
+sum by (compose_service) (count_over_time({compose_project="digit"} |~ `(?i)error|exception` [5m]))
+
+# Service starts — repeats mean a restart loop
+{compose_project="digit", compose_service!="loki"} |~ `Started .+Application in`
+
+# Genuine out-of-memory events
+{compose_project="digit", compose_service!~"grafana|loki"} |~ `(?i)outofmemoryerror|java heap space|gc overhead limit`
+
+# Log rate per service — a spike or a drop to silence are both signals
+sum by (compose_service) (rate({compose_project="digit"}[1m]))
+```
+
+---
+
+## When to escalate to us
+
+Send **Parts A + B + C** of [incident-report.md](incident-report.md) when:
+
+- The cause is in product code or the data model rather than configuration.
+- The fix needs a **deployment change** — more memory for a service, an extra container, a
+  configuration value, node-exporter, an SMTP relay, a change to the Gatus catalogue.
+- The same failure keeps recurring after a restart.
+- You're about to do something on the destructive list above and want a second opinion.
+
+If you worked all the way through and found nothing wrong, say exactly that — "all health
+checks green, no ERROR lines in the 30 minutes around 14:05, no restarts in 24h" rules out
+a large part of what we would otherwise check.
+
+Anything you diagnose and fix is worth adding to [known-issues.md](known-issues.md) so it
+lands with L1 next time.

--- a/docs/operations/l2-diagnosis.md
+++ b/docs/operations/l2-diagnosis.md
@@ -202,17 +202,42 @@ escalation, and **traces are kept for 24 hours only**.
 
 > ### If this dashboard is empty
 >
-> Host metrics come from a `node-exporter` container added to the platform on
-> **2026-07-22**. Deployments installed before that date do not have it. Check with:
+> Start with:
 >
 > ```promql
 > up
 > ```
 >
-> If the only result is `job="otel-collector"`, node-exporter isn't running; `job="node"`
-> alongside it means you have host metrics. Enabling it is a redeploy, not a manual step —
-> see [alerts-setup.md § Prerequisite](alerts-setup.md#prerequisite--turn-on-host-metrics).
-> Until then, `df -h` over SSH is your only disk view.
+> `job="node"` alongside `job="otel-collector"` means host metrics are fine and the problem
+> is elsewhere. If only `otel-collector` comes back, work out which of the two causes you
+> have — **check the cheap one first:**
+>
+> ```bash
+> sudo docker ps --filter 'name=node-exporter' --format '{{.Names}}\t{{.Status}}'
+> sudo grep -n 'job_name' /opt/digit/otel/prometheus.yml
+> ```
+>
+> **Container up and `job_name: node` present** → Prometheus is running an older copy of its
+> config. The file is bind-mounted, so it can change under a running Prometheus without it
+> re-reading. Reload it in place — no restart, no downtime (`--web.enable-lifecycle` is
+> already enabled):
+>
+> ```bash
+> sudo docker exec digit-grafana curl -sS -XPOST http://prometheus:9090/-/reload
+> ```
+>
+> Give it a few seconds, then re-run `up`. Confirm the target is actually healthy rather than
+> merely configured:
+>
+> ```bash
+> sudo docker exec digit-grafana curl -sS 'http://prometheus:9090/api/v1/targets?state=active'
+> ```
+>
+> **No container and no `node` job** → `node-exporter` genuinely isn't installed. It was added
+> to the platform on **2026-07-22**; older deployments that were never re-converged lack it.
+> That is a redeploy, not a manual step — see
+> [alerts-setup.md § Prerequisite](alerts-setup.md#prerequisite--turn-on-host-metrics).
+> Until it's done, `df -h` over SSH is your only disk view.
 
 | Panel | Concerning | Why it breaks things |
 |---|---|---|

--- a/docs/operations/l2-diagnosis.md
+++ b/docs/operations/l2-diagnosis.md
@@ -21,6 +21,8 @@ against a live deployment.
 - [Going deeper on logs](#going-deeper-on-logs)
 - [Is it slow, or is it failing?](#is-it-slow-or-is-it-failing)
 - [The host itself](#the-host-itself-cpu-ram-disk)
+- [Container logs — the usual reason the disk fills](#container-logs--the-usual-reason-the-disk-fills)
+- [Raising CPU or memory for a service](#raising-cpu-or-memory-for-a-service)
 - [Symptom → playbook](#symptom--playbook)
 - [Working on the server itself](#working-on-the-server-itself)
 - [Commands that are destructive](#commands-that-are-destructive)
@@ -252,6 +254,133 @@ Disk fails slowly and then all at once, and it takes the database with it.
 
 ---
 
+## Container logs — the usual reason the disk fills
+
+Container logs are the single largest reclaimable thing on these boxes, and the cap on them
+is easy to believe in and not actually have.
+
+### How the cap is supposed to work
+
+The Docker daemon is configured with log rotation in `/etc/docker/daemon.json`:
+
+```json
+"log-driver": "json-file",
+"log-opts": { "max-size": "100m", "max-file": "10" }
+```
+
+That is **1 GB per container** (10 files × 100 MB), oldest rotated out. With ~44 containers
+the ceiling is roughly **40 GB even when rotation is working correctly** — worth knowing when
+sizing a disk, because it is not a small number.
+
+### The catch: the cap only applies to containers created after it was set
+
+Docker fixes a container's logging options **at creation time**. Changing `daemon.json` — or
+restarting the daemon — does **not** retrofit the cap onto containers that already exist, and
+neither does `docker restart`, which preserves the container's existing configuration. A
+long-lived container created before the setting was applied will grow **without limit**.
+
+Check how many containers are actually capped:
+
+```bash
+sudo docker ps -aq | while read c; do
+  sudo docker inspect "$c" --format '{{.HostConfig.LogConfig.Config}}'
+done | sort | uniq -c
+```
+
+`map[]` means **no cap on that container**. `map[max-file:10 max-size:100m]` means capped.
+
+Find the offenders and who owns them:
+
+```bash
+# largest log files
+sudo find /var/lib/docker/containers -name '*-json.log' -printf '%s\t%p\n' \
+  | sort -rn | head -10 | awk -F'\t' '{printf "%8.1f MB  %s\n", $1/1048576, $2}'
+
+# map a container id back to a name
+sudo docker inspect <container-id> \
+  --format '{{.Name}} created={{.Created}} logopts={{.HostConfig.LogConfig.Config}}'
+```
+
+> **This is not hypothetical.** On a box checked while writing this, container logs occupied
+> **65 GB of a 301 GB disk** — 30 of 81 containers had no cap, and a single uncapped
+> container's log had reached **54 GB** on its own. Reclaiming it moved the disk from 77% to
+> around 55%.
+
+### Corrective action
+
+**1 — Reclaim the space now** (safe, and the only thing that is urgent when a disk is
+filling). Truncate rather than delete: the file must keep existing for the running container.
+
+```bash
+sudo find /var/lib/docker/containers -type f -name '*-json.log' -exec truncate -s 0 {} +
+```
+
+Use the `find` form, not a shell glob — see
+[Commands that are destructive](#commands-that-are-destructive). Note in your report that you
+did this: it removes logs that would otherwise have been read, and anything not already
+shipped to Loki is gone for good.
+
+**2 — Make the cap stick.** The container has to be **recreated**, not restarted, for the
+daemon's log options to apply. That is a redeploy — it recreates containers — so raise it with
+us rather than removing containers by hand. Confirm afterwards with the `uniq -c` check above:
+every container should show `max-file:10 max-size:100m`.
+
+**3 — If one service is producing logs far faster than the rest**, that is a finding in its
+own right, not just a disk problem. Report which service and the rate:
+
+```logql
+sum by (compose_service) (rate({compose_project="digit"}[5m]))
+```
+
+A service logging at debug level in production, or looping on an error, will refill the disk
+within days of any cleanup.
+
+---
+
+## Raising CPU or memory for a service
+
+When the evidence says a service is starved — OOM events, heap headroom under 10%, sustained
+GC above ~0.2 s/s, or CPU pinned at `1.0` with no traffic — the fix is more resources. **This
+is a deployment change, not something to apply on the box**, because anything edited under
+`/opt/digit` is overwritten on the next deploy.
+
+### What can actually be changed
+
+| Limit | Where it lives | Notes |
+|---|---|---|
+| **JVM heap** (`-Xmx`) | `JAVA_TOOL_OPTIONS` or `JAVA_OPTS` per service in the compose file | This is the ceiling that actually causes `OutOfMemoryError`. Currently ~6.3 GB of heap is allocated across the JVM services |
+| **Container memory** | not set today | The deployed compose has **no `mem_limit` on any container**, so a container can use as much host RAM as it asks for. Only the JVM heap bounds it |
+| **Container CPU** | not set today | No `cpus` limit either — services compete freely for host CPU |
+| **Host size** | your infrastructure | If the host itself is short of RAM or cores, no per-service change helps |
+
+Two consequences worth understanding before asking for more:
+
+- **Heap is not the whole footprint.** A JVM's actual memory use runs well above `-Xmx` —
+  metaspace, thread stacks, code cache and direct buffers typically add a few hundred MB per
+  service. Raising every heap by 512 MB costs the host considerably more than the sum of the
+  increases.
+- **With no container memory limit, a leak takes the host down rather than the container.**
+  The Linux OOM killer then picks a victim, usually the largest JVM, which may not be the
+  service at fault.
+
+### What to send us
+
+Raising a limit blindly moves the problem rather than fixing it, so include the evidence:
+
+- **Which service**, and the heap figures from the JVM dashboard's *Right-sizing snapshot* —
+  current, 1-hour peak, committed, limit, and headroom %.
+- **Whether it OOMs or just runs hot.** An `OutOfMemoryError` in the logs is a different case
+  from steady 85% heap usage.
+- **How long it has been like this**, and whether it correlates with load, a data import, or a
+  particular operation.
+- **Host headroom** — total RAM and current usage from the Node Exporter dashboard. If the
+  host is already at 90%, more heap is the wrong answer.
+
+We will come back with a specific value rather than a guess, and it ships as a normal
+redeploy.
+
+---
+
 ## Symptom → playbook
 
 | Symptom | Most likely | Check, in this order |
@@ -268,7 +397,9 @@ Disk fails slowly and then all at once, and it takes the database with it.
 | **Everything is slow** | Host CPU/RAM/disk, or the DB pool | Host panels → `db_client_connections_pending_requests` → Tempo slow traces |
 | **Works for one city, not another** | Tenant configuration or data rather than code | File with both tenant codes so we can diff them |
 | **A service restarts every few minutes** | OOM, failed health check, or a bad config/env value | OOM panels → that service's logs from the *first* boot attempt onward |
-| **"No space left on device"** anywhere | Disk full | Host panels or `df -h`. Postgres may already be refusing writes |
+| **"No space left on device"** anywhere | Disk full — usually container logs | Host panels or `df -h`, then [Container logs](#container-logs--the-usual-reason-the-disk-fills). Postgres may already be refusing writes |
+| **Disk climbing steadily with no new usage** | An uncapped container log | [Container logs](#container-logs--the-usual-reason-the-disk-fills) — check which containers lack the rotation cap |
+| **A service is starved (OOM, low headroom, GC thrash)** | Under-provisioned heap | [Raising CPU or memory](#raising-cpu-or-memory-for-a-service) — gather the evidence, then raise it with us |
 
 ---
 

--- a/docs/operations/l2-diagnosis.md
+++ b/docs/operations/l2-diagnosis.md
@@ -86,7 +86,7 @@ Restarts outside that window are the interesting ones.
 > OpenTelemetry agent**: boundary-service, digit-config-service, egov-accesscontrol,
 > egov-enc-service, egov-filestore, egov-hrms, egov-idgen, egov-indexer, egov-persister,
 > egov-user, egov-workflow-v2, inbox, mdms-backend, novu-bridge, pgr-services, plus dashboard
-> web metrics. **Postgres, Redis, Kafka, Kong, Elasticsearch, Keycloak, nginx and the Node
+> web metrics. **Postgres, Redis, Kafka, Kong, Elasticsearch, nginx, the sign-in service and the Node
 > services have no metrics at all** — for those, the health dashboard and the logs are the
 > only signals, and both cover them fully.
 
@@ -233,7 +233,7 @@ Disk fails slowly and then all at once, and it takes the database with it.
 |---|---|---|
 | **Site won't load at all** (browser error, not a DIGIT page) | nginx down, TLS certificate expired, DNS | Try the health dashboard URL — if that also fails, it's the edge, not DIGIT. Check certificate expiry in the browser padlock |
 | **502 / 504 Bad Gateway** | Kong or the upstream service down or restarting | Health dashboard *API Gateway* + *Application* → restarts → Kong logs |
-| **Login fails for everyone** | egov-user, Keycloak, Redis, or accesscontrol | Health dashboard *Core Services* + *Keycloak* → logs for `egov-user` and `keycloak` |
+| **Login fails for everyone** | egov-user, the sign-in service, Redis, or accesscontrol | Health dashboard *Core Services* + the sign-in group → logs for `egov-user` and the sign-in containers |
 | **Login fails for one user** | Wrong tenant, disabled account, role missing | Usually a data question rather than an outage — check the user in HRMS/Configurator |
 | **OTP not received** | Notification/SMS provider, not DIGIT | Health dashboard *OTP* + *Notifications* → logs for `egov-user-proxy`, `novu-worker`. Check provider credit/credentials |
 | **Complaint submit fails** | pgr-services, workflow, idgen, or Postgres | Browser Network tab → failing URL → that service's logs → Health dashboard *Infrastructure* |

--- a/docs/operations/l2-diagnosis.md
+++ b/docs/operations/l2-diagnosis.md
@@ -281,21 +281,35 @@ sudo du -h --max-depth=1 /var/lib/docker/containers | sort -h | tail -10
 Container names follow two patterns — `digit-egov-user-1` (compose default) and
 `boundary-service` (explicitly named). `sudo docker ps` shows the truth.
 
-To restart **one** service, pass the full compose file stack, or Compose computes a
-different — wrong — configuration:
+To restart **one** wedged service, use plain `docker restart` — **not** `docker compose`:
 
 ```bash
-cd /opt/digit
-C="sudo docker compose -f docker-compose.egov-digit.yaml \
-                       -f docker-compose.migrations.yml \
-                       -f docker-compose.migrations.ansible.yml \
-                       -f docker-compose.monitoring.yml"
-# add -f docker-compose.<tenant>.yml if this deployment has a per-tenant overlay
-
-eval "$C restart pgr-services"        # name the service explicitly, always
+sudo docker restart <container>       # the name from `docker ps`, e.g. pgr-services
 ```
 
-**Capture the logs before restarting** (`docker logs --tail 500 <container> > /tmp/x.log`).
+`docker restart` stops and starts the container that is already there, with the image,
+environment and volumes it already has. It cannot recreate anything with the wrong
+configuration, and it needs no knowledge of which compose files this deployment uses. For
+"the service is stuck, bounce it" — the only restart an incident normally needs — this is
+the right command.
+
+> **Why not `docker compose restart`.** Compose only behaves correctly when handed the
+> *exact* file stack the deployment was built with, and that stack varies per box: the
+> monitoring overlay only exists on deployments made from 2026-07-22 onward, the fast-path
+> overlay only when it was enabled, and some deployments carry a per-tenant overlay as well.
+> A hard-coded `-f` list will either fail outright on a missing file or, worse, compute a
+> configuration that differs from the one the box is running. If you need to check what this
+> deployment actually has:
+>
+> ```bash
+> ls /opt/digit/docker-compose*.y*ml
+> ```
+>
+> Anything that genuinely requires re-reading configuration — an env change, a new image, an
+> added container — is a **redeploy**, not a hand-assembled compose command. Raise it with us
+> rather than reconstructing the stack by hand.
+
+**Capture the logs before restarting** (`sudo docker logs --tail 500 <container> > /tmp/x.log`).
 A restart clears the container's log buffer along with the symptom, and without it the next
 step is usually reproducing the failure from scratch.
 

--- a/docs/operations/reference.md
+++ b/docs/operations/reference.md
@@ -1,7 +1,12 @@
 # Reference
 
-Lookup tables for the other documents in this handbook: URLs, what each service does, what
-breaks when it stops, retention, and a query cookbook.
+Lookup tables for the other documents in this handbook: URLs, what the dashboards show and
+what the readings mean, what each service does, what breaks when it stops, retention, and a
+query cookbook.
+
+Written to be readable without prior knowledge of monitoring tools — where a term appears
+for the first time it is explained, and the [glossary](#glossary) at the end collects them
+all.
 
 ← back to **[Operations handbook](README.md)**
 
@@ -10,8 +15,9 @@ breaks when it stops, retention, and a query cookbook.
 ## Contents
 
 - [URLs](#urls)
+- [Credentials — who to ask](#credentials--who-to-ask)
 - [The observability stack](#the-observability-stack)
-- [Grafana dashboards](#grafana-dashboards)
+- [Grafana dashboards — what each one shows](#grafana-dashboards--what-each-one-shows)
 - [What each service does](#what-each-service-does)
 - [Metric and log coverage — what is and isn't watched](#metric-and-log-coverage--what-is-and-isnt-watched)
 - [Data retention](#data-retention)
@@ -24,31 +30,63 @@ breaks when it stops, retention, and a query cookbook.
 
 Replace `<your-domain>` with your deployment's domain.
 
-| Path | What it is | Notes |
+| Path | What it is | When you'd open it |
 |---|---|---|
-| `/` | Citizen / employee UI | |
-| `/status/` | **Gatus health dashboard** | ~50 endpoint checks, 30s interval. `/gatus/` redirects here |
-| `/grafana/` | **Grafana** | Metrics, logs, traces, alerting |
-| `/configurator/` | Configurator (masters, branding, providers) | |
-| `/citizen` | Citizen-facing entry point | |
-| `/auth/` | Keycloak authentication | |
-| `/novu/` | Notification platform admin | Only where notifications are enabled |
+| `/digit-ui/employee` | **The staff app.** Where clerks, supervisors and grievance officers log in to see, assign and resolve complaints | **Most reported problems are here.** Open it first to reproduce what the caller is describing |
+| `/digit-ui/citizen` | **The citizen app.** The public-facing site where a member of the public files a complaint and tracks it | When the report comes from a citizen, or is about filing / tracking rather than processing |
+| `/status/` | **Health dashboard** (a tool called Gatus). Around 50 automated checks — one per service — re-run every 30 seconds. Green means the service answered, red means it did not | Every incident, first thing. It tells you in one screen whether something is actually down |
+| `/grafana/` | **Grafana** — the window onto the system's own data: memory, logs, request timings, and alerts | When the health dashboard is all green but something is still wrong, and you need the error text |
+| `/configurator/` | **Configurator** — admin screens for master data (complaint types, departments, localities), branding and notification providers | When a dropdown is missing an option, or something looks mis-configured rather than broken. Needs an admin login |
+| `/novu/` | **Notification platform admin** — where SMS / email / WhatsApp delivery is set up and delivery attempts can be inspected | Only on deployments where notifications are enabled, and only for "the SMS never arrived" reports. Needs a login |
 
-**Host ports** (not normally exposed publicly — nginx proxies them):
+`/gatus/` is an old address for the health dashboard and redirects to `/status/`.
+
+**Host ports.** Each service also listens on a port on the server itself. These are not
+normally reachable from outside — the web server in front proxies the paths above to them.
+You will only need this table if someone on the call refers to a port number.
 
 | Port | Service |
 |---|---|
 | 13000 | Grafana |
-| 18889 | Gatus |
-| 18000 | Kong gateway |
-| 13100 | Loki |
-| 13101 | MCP |
-| 18080 | esbuild UI |
-| 19000 | MinIO |
+| 18889 | Gatus (health dashboard) |
+| 18000 | Kong (the API gateway every request passes through) |
+| 13100 | Loki (log storage) |
+| 13101 | MCP (integration tooling) |
+| 18080 | esbuild UI (the front-end build server) |
+| 19000 | MinIO (file/photo storage) |
+
+---
+
+## Credentials — who to ask
+
+**Grafana and the health dashboard need no login.** On these deployments they are open to
+anyone who has the URL, so you can start work immediately. Nothing you do on either page
+changes the system — they only display data.
+
+Anything else that asks for a username and password is **not** yours to obtain on your own:
+
+| Needs credentials | Ask |
+|---|---|
+| Notification platform admin (`/novu/`) | Your system administrator |
+| The SMS / WhatsApp / email provider console | Your system administrator — it is usually held by whoever owns the provider contract |
+| Configurator admin screens | Your system administrator |
+| Server / SSH access | Not applicable to first-line work. This is L2's |
+
+Two rules that do not bend:
+
+- **Never share credentials in a ticket, an email or a chat message**, even internally. If a
+  password is needed to progress, hand the task to whoever already holds it.
+- **Never ask a caller for their password**, and never accept one if offered. You do not
+  need it to investigate anything in this handbook.
 
 ---
 
 ## The observability stack
+
+> **For L2.** This section explains *how* the monitoring data is collected and where it is
+> stored. First-line work never needs it — if you are on the service desk, skip straight to
+> [Grafana dashboards](#grafana-dashboards--what-each-one-shows), which is about *reading*
+> the data rather than plumbing it.
 
 ```
    Java services ──OTLP──▶ otel-collector ──┬──▶ Prometheus  (metrics, 15d)
@@ -70,27 +108,150 @@ Gatus and Loki.
 
 ---
 
-## Grafana dashboards
+## Grafana dashboards — what each one shows
 
-| Dashboard | URL | Use it for |
+### First, the words you will see on every screen
+
+Grafana is one website showing several different collections of data. A few terms recur, and
+knowing them makes every dashboard readable:
+
+| Term | What it means |
+|---|---|
+| **Dashboard** | One page of charts about one subject. You pick it from the menu or open it by URL |
+| **Panel** | One box on that page — a single chart, number or table. Each panel answers one question |
+| **Time range** | **Top right of every dashboard.** Everything on the page describes the window you choose here — "Last 6 hours", "Last 24 hours", or a specific start and end. **Getting this right matters more than anything else**: if the problem happened at 09:15 and your range is "Last 5 minutes", every panel will look perfectly healthy |
+| **Datasource** | Where a panel's numbers come from. Three exist: **Prometheus** (measurements over time), **Loki** (log messages), **Tempo** (request timings). You rarely pick one on a dashboard; you do in Explore |
+| **Explore** | A menu item in the left sidebar. A blank page where you pick a datasource and run one query, instead of viewing a pre-built dashboard. Used when this handbook gives you a query to paste |
+| **Refresh** | Dashboards do not update by themselves unless set to. Use the refresh icon beside the time range if you are watching something live |
+
+**Panel shapes**, because the same data looks different depending on the shape:
+
+| Shape | Looks like | Read it as |
 |---|---|---|
-| **DIGIT JVM Services** | `/grafana/d/digit-jvm/` | Heap, restarts, OOM, GC, threads, JVM CPU |
-| **DIGIT — Logs (Loki)** | `/grafana/d/digit-loki-logs/` | Error text, per-service log volume, free-text search |
-| **DIGIT — Traces (Tempo)** | `/grafana/d/digit-tempo-traces/` | Slow requests, error traces, per-request waterfall |
-| **Node Exporter Full** | `/grafana/d/node-exporter-full/` | Host CPU, RAM, disk, network — **empty unless node-exporter is installed** |
+| **Stat** | One big number | A total or current value for the whole time range. Fast to read, no detail |
+| **Timeseries** | A line graph, time along the bottom | How something changed. One coloured line per service, named in the legend |
+| **Table** | Rows and columns | One row per service, several values side by side. Best for comparing services |
+| **Logs** | Scrolling text lines with timestamps | The actual messages the software wrote |
 
-Panels worth knowing by name:
+**Jargon that appears in the panel names themselves:**
 
-| Panel | Dashboard | Answers |
+- **JVM** — the Java runtime. Most services here are Java programs, and each runs inside its
+  own JVM.
+- **Heap** — the pool of memory a Java service is allowed to use for its work. Every service
+  is given a fixed ceiling. Normal behaviour is for heap use to rise and fall repeatedly.
+- **OOM ("out of memory")** — the service needed more memory than its heap ceiling allowed
+  and **crashed**. Not a slowdown; a stop.
+- **GC ("garbage collection")** — the JVM periodically clears out memory it no longer needs.
+  This is routine and constant. It only matters when a service spends so much time doing it
+  that it has little time left to serve requests — then it *looks* frozen while technically
+  alive.
+- **Thread** — one unit of work happening inside a service. Many run at once.
+- **Trace** — the complete record of one request as it travelled through several services,
+  showing how long each step took.
+
+---
+
+### DIGIT JVM Services — `/grafana/d/digit-jvm/`
+
+**What it is:** the memory and health of the Java services, one line or row per service.
+
+**The question it answers:** *did something crash, restart, or run out of memory — and
+when?*
+
+**Who uses it:** L1 reads two panels from it (see
+[l1-first-response.md](l1-first-response.md)). L2 uses the rest.
+
+| Panel | Shape | What it shows and what the reading means |
 |---|---|---|
-| Right-sizing snapshot | JVM | Which service is close to its heap limit |
-| OOM events (current range) | JVM | Did anything run out of memory |
-| Heap used (MB) — by service | JVM | Did anything crash and restart (line drops to zero) |
-| GC pause time (s/s) | JVM | Is a service thrashing rather than working |
-| Errors / Exceptions (current range) | Logs | How bad is it, right now |
-| Log volume by service | Logs | Which service suddenly went quiet or loud |
-| Slow traces — duration > 500ms | Traces | Which requests are slow, and where the time goes |
-| Error traces (status = error) | Traces | Which requests failed |
+| **OOM events (current range)** | Stat | A count of out-of-memory crashes in your chosen time range. **`0` is the healthy answer.** Anything above `0` means a service ran out of memory and crashed during that window. This is the single easiest panel on the dashboard to read |
+| **Incidents — OOM / heap-space errors (last range)** | Logs | The actual crash messages behind the number above, naming the service. If the stat panel is above zero, this is where you copy the evidence from |
+| **Right-sizing snapshot — heap profile per service (heap, MB)** | Table | One row per service: memory in use now, its peak in the last hour, and its ceiling. The **headroom** column is the useful one — the percentage of its allowance still free. Low headroom means the service is close to crashing. This is a capacity judgement, so it is L2's to act on |
+| **Heap used (MB) — by service** | Timeseries | Memory in use over time, one line per service. A healthy line **rises and falls repeatedly** — that is normal. A line that **drops to zero and then climbs again from the bottom** is a service that crashed and restarted at that moment. Reading this correctly needs to know what that service normally looks like, so it is L2's panel |
+| **Heap committed vs used (MB) — by service** | Timeseries | Two lines per service: memory reserved versus actually used. When "used" sits right against "committed" for a long time, the service is under real pressure |
+| **JVM CPU — recent utilization (ratio)** | Timeseries | How much processor each service is consuming. **`1.0` means one whole CPU core.** `0.05` is idle chatter. A service sitting high with no users on the system is stuck in a loop |
+| **GC pause time (s/s)** | Timeseries | Seconds per second spent on garbage collection. `0.05` is routine. **Sustained above about `0.2`** means the service is spending a fifth of its life tidying memory rather than working — users experience this as the system hanging |
+| **Live threads** | Timeseries | How many pieces of work are in flight. A steady number is fine. A line **climbing and never coming back down** means work is piling up, usually because something it depends on is slow or dead |
+| **Loaded classes** | Timeseries | How much program code the service has loaded. Rarely useful in an incident; it flattens out shortly after start-up |
+
+---
+
+### DIGIT — Logs (Loki) — `/grafana/d/digit-loki-logs/`
+
+**What it is:** the messages the software itself writes as it runs — the closest thing to
+the system explaining what went wrong, in its own words.
+
+**The question it answers:** *what is the actual error?*
+
+**Who uses it:** everyone. This is the most valuable dashboard on the system, and unlike the
+JVM dashboard it covers **every** container, not just the Java ones.
+
+**Three controls sit across the top of the page.** You do not need to write a query — set
+these and read the result:
+
+| Control | What to do with it |
+|---|---|
+| **service** | Choose which service's messages to show. Leave it as `.+` to see all of them at once |
+| **level** | How serious a message is. Set it to **`ERROR`** to hide routine chatter and see only failures. `WARN` is "worth noticing", `INFO` is normal running commentary |
+| **q** | A free-text filter. Paste a complaint number or a user ID here to follow one specific case across every service that touched it |
+
+| Panel | Shape | What it shows and what the reading means |
+|---|---|---|
+| **Log lines (current range)** | Stat | How many messages were written in your time range. Context only — a large number is not itself a problem |
+| **Errors / Exceptions (current range)** | Stat | How many of those were failures. **This is the "how bad is it" number.** Compare it against a quiet period to judge whether it is unusual |
+| **Log volume by service (rate / sec)** | Timeseries | How talkative each service is over time. **Both directions are signals**: a sudden spike means something started failing repeatedly; a line **dropping to silence** means a service stopped running altogether |
+| **Logs** | Logs | The messages themselves, newest at the top. **Scroll to the oldest one in your range and read that first** — when something breaks, everything downstream fails afterwards, so the earliest error is the cause and the rest are consequences |
+
+---
+
+### DIGIT — Traces (Tempo) — `/grafana/d/digit-tempo-traces/`
+
+**What it is:** timings for individual requests. A **trace** follows one click — one complaint
+submission, say — through every service it touched, and shows how long each step took.
+
+**The question it answers:** *why was this slow, and which step took the time?*
+
+**Who uses it:** mainly L2. L1's involvement is usually to copy a **Trace ID** into the
+ticket, which is enormously useful and takes seconds.
+
+| Panel | Shape | What it shows and what the reading means |
+|---|---|---|
+| **Services with traces (last 30m)** | Stat | How many services are currently reporting timings. A sanity check that trace collection is working at all |
+| **Recent traces** | Table | The most recent requests. Click any row to open its breakdown |
+| **Slow traces — duration > 500ms (last range)** | Table | Requests that took longer than half a second. **This is the panel to use for a "the system is slow" report.** Click a row and you see which service and which database call consumed the time |
+| **Error traces (status = error)** | Table | Requests that failed outright rather than merely being slow |
+| **Trace by ID** | Trace view | Paste a Trace ID here to see one specific request laid out as a waterfall — each service as a bar, its width being time spent |
+
+> **Traces are kept for 24 hours only.** A slowness report raised on Monday about something
+> that happened on Friday cannot be answered from traces. If you have one, copy the Trace ID
+> into the ticket the same day.
+
+---
+
+### Node Exporter Full — `/grafana/d/node-exporter-full/`
+
+**What it is:** the health of the physical machine everything runs on — processor, memory,
+and above all **disk space** — as opposed to the individual services.
+
+**The question it answers:** *is the server itself running out of something?*
+
+**Who uses it:** L2.
+
+> **If this dashboard is completely empty, that is expected on some deployments and is not a
+> fault.** The component that reports machine statistics (`node-exporter`) was added to the
+> platform on **2026-07-22**; installations older than that do not have it, so there is
+> nothing for the dashboard to draw. Do not raise it as an incident — it is a known gap that
+> needs a redeploy to close. See
+> [alerts-setup.md](alerts-setup.md#prerequisite--turn-on-host-metrics).
+
+When it does have data, the readings that matter:
+
+| Reading | Concerning when | Why it matters |
+|---|---|---|
+| **CPU Busy** | Above 90% for a sustained period | Everything slows down; health checks start timing out and services get killed for being unresponsive |
+| **RAM Used** | Above 90% | The operating system begins killing containers to reclaim memory, usually the largest one, without warning |
+| **Swap** | Any sustained use | The machine has run out of real memory and is using disk as a substitute. Everything becomes dramatically slower |
+| **Disk Space Used** | Above 85% (warning), above 95% (critical) | **The most common cause of a complete outage.** The database refuses to accept new data when the disk fills, so complaints stop saving |
+| **Load average** | Higher than the number of CPU cores, sustained | More work is queued than the machine can get through |
 
 ---
 
@@ -116,8 +277,7 @@ Grouped as the health dashboard groups them.
 
 | Service | Role | When it's down |
 |---|---|---|
-| `egov-user` | User accounts, authentication | Nobody can log in |
-| `keycloak` + `token-exchange-svc` | Identity provider | Login flows fail |
+| `egov-user` | User accounts and sign-in / identity | Nobody can log in |
 | `egov-workflow-v2` | Complaint state machine | Complaints cannot change state or be assigned |
 | `egov-mdms-service` / `mdms-backend` | Master data (complaint types, departments, config) | Forms come up empty; most services fail to start |
 | `egov-hrms` | Employees, departments, reporting hierarchy | Assignment and inbox visibility break |
@@ -159,7 +319,7 @@ If notifications stop, check in this order: the provider account (credit, creden
 
 | Signal | Covers | Does not cover |
 |---|---|---|
-| **JVM metrics** (Prometheus) | The 16 instrumented Java services: `boundary-service`, `digit-config-service`, `egov-accesscontrol`, `egov-enc-service`, `egov-filestore`, `egov-hrms`, `egov-idgen`, `egov-indexer`, `egov-persister`, `egov-user`, `egov-workflow-v2`, `inbox`, `mdms-backend`, `novu-bridge`, `pgr-services`, plus dashboard web metrics | Postgres, Redis, Kafka, Kong, Elasticsearch, Keycloak, MinIO, nginx, Node services |
+| **JVM metrics** (Prometheus) | The 16 instrumented Java services: `boundary-service`, `digit-config-service`, `egov-accesscontrol`, `egov-enc-service`, `egov-filestore`, `egov-hrms`, `egov-idgen`, `egov-indexer`, `egov-persister`, `egov-user`, `egov-workflow-v2`, `inbox`, `mdms-backend`, `novu-bridge`, `pgr-services`, plus dashboard web metrics | Postgres, Redis, Kafka, Kong, Elasticsearch, MinIO, nginx, the sign-in / identity service, Node services |
 | **Logs** (Loki) | **Every container** — around 44 of them | Nothing, as long as promtail is running |
 | **Traces** (Tempo) | Requests through instrumented Java services and Kong | Direct database or broker activity |
 | **Health checks** (Gatus) | ~50 endpoints across every group, including infrastructure | Anything not in the endpoint catalogue |

--- a/docs/operations/reference.md
+++ b/docs/operations/reference.md
@@ -17,7 +17,9 @@ all.
 - [URLs](#urls)
 - [Credentials — who to ask](#credentials--who-to-ask)
 - [The observability stack](#the-observability-stack)
+- [Are the monitoring services important to keep up?](#are-the-monitoring-services-important-to-keep-up)
 - [Grafana dashboards — what each one shows](#grafana-dashboards--what-each-one-shows)
+- [The health dashboard's groups](#the-health-dashboards-groups)
 - [What each service does](#what-each-service-does)
 - [Metric and log coverage — what is and isn't watched](#metric-and-log-coverage--what-is-and-isnt-watched)
 - [Data retention](#data-retention)
@@ -105,6 +107,44 @@ Two rules that do not bend:
 The consequence worth remembering: **metrics cover the Java services; logs cover
 everything.** If a container has no metrics, that does not mean it is unmonitored — check
 Gatus and Loki.
+
+---
+
+## Are the monitoring services important to keep up?
+
+Short answer: **none of them is citizen- or staff-facing.** If every one stopped at once,
+citizens would still file complaints, clerks would still work them, and notifications would
+still go out. Nothing anybody does in the product depends on these services.
+
+What you lose is **visibility, not function** — and for most of them, data that cannot be
+recovered afterwards.
+
+| Service | What stops working if it goes down | Is data lost? |
+|---|---|---|
+| **gatus** | The health dashboard at `/status/` is unreachable — you lose the fastest "is anything down" check | Yes — its history is held in memory only, so the record of what was red is gone |
+| **grafana** | You cannot view *anything*: no dashboards, no logs, no metrics. Alert rules stop being evaluated too | **No.** Collection carries on regardless, and everything reappears when Grafana returns |
+| **prometheus** | Nothing records measurements — memory, CPU, restarts, request timings | Yes — a permanent gap in the graphs covering the period it was down |
+| **loki** | Log messages are not stored | **Yes, and this is the costly one.** Anything written while it is down is gone for good |
+| **promtail** | Nothing ships logs into Loki, even though Loki itself is healthy | Yes — same effect as Loki being down |
+| **tempo** | Request timings are not recorded | Yes — a gap in traces for that period |
+| **otel-collector** | The Java services have nowhere to send metrics and traces, so both stop arriving | Yes — gaps in both metrics and traces |
+| **node-exporter** | Machine statistics stop being reported, so the host dashboard goes blank | Yes — a gap in the CPU, memory and disk graphs |
+
+**Why the data loss matters more than the downtime.** Logs, metrics and traces are a running
+recording, not a query against something stored elsewhere. Nothing buffers them while the
+receiver is away, and they cannot be back-filled later. A monitoring service that was down
+for three hours leaves a three-hour hole that nobody can fill in afterwards.
+
+**How to treat it in practice:**
+
+- **On its own, a monitoring service being down is S3.** Nobody is blocked, nothing is broken
+  for a citizen or a clerk, and it can wait for working hours.
+- **While you are already handling an incident it matters much more**, because losing your
+  visibility mid-outage costs you the evidence you need. Say so explicitly in the report —
+  "Loki has been down since 09:00, so there are no logs for the window you are asking about"
+  is essential context, not a footnote.
+- **Restarting one is safe.** It does not touch the product and cannot affect a citizen or a
+  clerk. It is L2's call, not first line's.
 
 ---
 
@@ -256,6 +296,39 @@ When it does have data, the readings that matter:
 
 ---
 
+## The health dashboard's groups
+
+The health dashboard sorts its ~50 checks into ten groups. Which group a red tile sits in
+tells you how serious it is before you know anything else about it.
+
+| Group | What's in it | A red tile here means |
+|---|---|---|
+| **Infrastructure** | Database, connection pooler, cache, message broker, file storage | **The most serious thing on the page.** Nothing above it can work — treat it as an outage and escalate immediately |
+| **Core Services** | The shared platform: user accounts, workflow, master data, employees, boundaries, translations, ID generation, authorisation, encryption, file metadata, and the two Kafka writers | A service many features depend on. Expect several unrelated-looking symptoms at once |
+| **API Gateway** | Kong and its proxies — every API request in the system passes through here | Requests cannot be routed. Users see "502" or a blank screen |
+| **Application** | The complaint service itself and the web front end | The product people actually use |
+| **Search** | Elasticsearch, the indexer and the inbox service | Inbox and search break. Filing complaints still works |
+| **Notifications** | The notification platform, its bridge, and the config and preference services | SMS / email / WhatsApp stop going out. Everything else is unaffected |
+| **OTP** | One-time-password delivery for sign-in | Users cannot receive the code they need to log in |
+| **Sign-in / identity** | The identity provider, its database, and the token exchange service | Signing in fails |
+| **MCP** | Integration tooling | No effect on citizens or staff using the system |
+| **API Tests** | Real calls against live APIs — different from the rest, see below | Read the note below before acting on it |
+
+**API Tests is the group worth understanding.** Every other group asks a service one simple
+question — *are you alive?* — by calling its health endpoint. A service can answer that
+perfectly while being completely unable to do any real work.
+
+The API Tests group instead makes **genuine API calls**: searching for a tenant, generating a
+complaint number, fetching a translated message. That gives it a different meaning:
+
+- **Service tile green but API Tests tile red** — the service is running but cannot do its
+  job. This is almost always a **data or configuration** problem rather than a crash, and it
+  needs a completely different fix from restarting something.
+- It is also the group most likely to catch a failure that every other check misses, because
+  it is the only one exercising the real path.
+
+---
+
 ## What each service does
 
 Grouped as the health dashboard groups them.
@@ -333,15 +406,40 @@ Loki tells you why it isn't.** There are no metrics-based alerts to be had for t
 
 ## Data retention
 
+Nothing here is kept for long. Knowing the numbers is what tells you whether a problem
+reported today can still be investigated at all.
+
 | Data | Store | Retention |
 |---|---|---|
 | Metrics | Prometheus | **15 days** |
-| Logs | Loki | **72 hours** |
+| Logs — searchable, in Grafana | Loki | **72 hours (3 days)** |
 | Traces | Tempo | **24 hours** |
-| Health-check history | Gatus | in-memory; lost when the container restarts |
+| Health-check history | Gatus | in-memory; lost the moment the container restarts |
+| Container logs — the raw files on the server | Docker, on disk | Capped by the Docker daemon at **10 files × 100 MB = 1 GB per container**, oldest rotated away first |
 
-Promtail also refuses log entries older than 7 days, so back-filling old logs is not
-possible.
+Two consequences worth knowing:
+
+- **Promtail refuses log entries older than 7 days**, so old logs cannot be back-filled into
+  Loki. If Loki missed something — because it was down, or because the message has aged out —
+  it is missed permanently as far as Grafana is concerned.
+- **The raw files on the server often outlast Loki's 72 hours.** For a busy service the 1 GB
+  cap may hold less than three days; for a quiet one it may hold weeks. So when something has
+  aged out of Grafana, L2 can sometimes still find it with `docker logs` on the box. It is
+  the only remaining copy, and only until it rotates.
+
+**These figures are deliberate** — short retention is what keeps the monitoring stack from
+consuming disk. Changing any of them is a **deployment change**, not something to edit on the
+server; anything edited there is overwritten on the next deploy.
+
+| To change | Lives in |
+|---|---|
+| Loki's log retention | `retention_period` in `otel/loki-config.yaml` |
+| Prometheus's metric retention | the `--storage.tsdb.retention.time` flag on the Prometheus container |
+| Tempo's trace retention | `block_retention` in `otel/tempo-config.yaml` |
+| Docker's per-container log cap | `log-opts` in `/etc/docker/daemon.json` |
+
+Raise it with us if you need longer, and weigh the trade first: **longer retention means more
+disk**, and a full disk is the most common cause of a complete outage.
 
 ---
 

--- a/docs/operations/reference.md
+++ b/docs/operations/reference.md
@@ -1,0 +1,308 @@
+# Reference
+
+Lookup tables for the other documents in this handbook: URLs, what each service does, what
+breaks when it stops, retention, and a query cookbook.
+
+← back to **[Operations handbook](README.md)**
+
+---
+
+## Contents
+
+- [URLs](#urls)
+- [The observability stack](#the-observability-stack)
+- [Grafana dashboards](#grafana-dashboards)
+- [What each service does](#what-each-service-does)
+- [Metric and log coverage — what is and isn't watched](#metric-and-log-coverage--what-is-and-isnt-watched)
+- [Data retention](#data-retention)
+- [Query cookbook](#query-cookbook)
+- [Glossary](#glossary)
+
+---
+
+## URLs
+
+Replace `<your-domain>` with your deployment's domain.
+
+| Path | What it is | Notes |
+|---|---|---|
+| `/` | Citizen / employee UI | |
+| `/status/` | **Gatus health dashboard** | ~50 endpoint checks, 30s interval. `/gatus/` redirects here |
+| `/grafana/` | **Grafana** | Metrics, logs, traces, alerting |
+| `/configurator/` | Configurator (masters, branding, providers) | |
+| `/citizen` | Citizen-facing entry point | |
+| `/auth/` | Keycloak authentication | |
+| `/novu/` | Notification platform admin | Only where notifications are enabled |
+
+**Host ports** (not normally exposed publicly — nginx proxies them):
+
+| Port | Service |
+|---|---|
+| 13000 | Grafana |
+| 18889 | Gatus |
+| 18000 | Kong gateway |
+| 13100 | Loki |
+| 13101 | MCP |
+| 18080 | esbuild UI |
+| 19000 | MinIO |
+
+---
+
+## The observability stack
+
+```
+   Java services ──OTLP──▶ otel-collector ──┬──▶ Prometheus  (metrics, 15d)
+        (16 of them)                        └──▶ Tempo       (traces, 24h)
+
+   ALL containers ──stdout──▶ promtail ──────▶ Loki        (logs, 72h)
+
+   node-exporter ────────────────────────────▶ Prometheus  (host CPU/RAM/disk)
+        (only on deployments from 2026-07-22 onward)
+
+   Gatus ──HTTP/TCP probes──▶ every service    (health, in-memory)
+
+   Grafana reads Prometheus + Loki + Tempo, and is where alerts are defined.
+```
+
+The consequence worth remembering: **metrics cover the Java services; logs cover
+everything.** If a container has no metrics, that does not mean it is unmonitored — check
+Gatus and Loki.
+
+---
+
+## Grafana dashboards
+
+| Dashboard | URL | Use it for |
+|---|---|---|
+| **DIGIT JVM Services** | `/grafana/d/digit-jvm/` | Heap, restarts, OOM, GC, threads, JVM CPU |
+| **DIGIT — Logs (Loki)** | `/grafana/d/digit-loki-logs/` | Error text, per-service log volume, free-text search |
+| **DIGIT — Traces (Tempo)** | `/grafana/d/digit-tempo-traces/` | Slow requests, error traces, per-request waterfall |
+| **Node Exporter Full** | `/grafana/d/node-exporter-full/` | Host CPU, RAM, disk, network — **empty unless node-exporter is installed** |
+
+Panels worth knowing by name:
+
+| Panel | Dashboard | Answers |
+|---|---|---|
+| Right-sizing snapshot | JVM | Which service is close to its heap limit |
+| OOM events (current range) | JVM | Did anything run out of memory |
+| Heap used (MB) — by service | JVM | Did anything crash and restart (line drops to zero) |
+| GC pause time (s/s) | JVM | Is a service thrashing rather than working |
+| Errors / Exceptions (current range) | Logs | How bad is it, right now |
+| Log volume by service | Logs | Which service suddenly went quiet or loud |
+| Slow traces — duration > 500ms | Traces | Which requests are slow, and where the time goes |
+| Error traces (status = error) | Traces | Which requests failed |
+
+---
+
+## What each service does
+
+Grouped as the health dashboard groups them.
+
+### Infrastructure — everything depends on these
+
+| Service | Role | When it's down |
+|---|---|---|
+| `postgres-db` | The database | Total outage. Nothing works |
+| `pgbouncer` (alias `postgres`) | Connection pooler in front of Postgres | Services cannot get connections; looks like a total outage |
+| `redis` | Cache and session store | Logins and cached lookups fail |
+| `redpanda` | Kafka-compatible message broker | Writes still succeed, but indexing, notifications and persistence stall |
+| `minio` | Object storage for complaint photos and documents | Uploads and attachment downloads fail |
+| `elasticsearch` | Search index behind the inbox | Inbox and search break; filing complaints still works |
+
+> `postgres` is a network alias for **PgBouncer**, not for the database. The database is
+> `postgres-db`. Gatus checks both, so a dead database cannot hide behind a healthy pooler.
+
+### Core platform
+
+| Service | Role | When it's down |
+|---|---|---|
+| `egov-user` | User accounts, authentication | Nobody can log in |
+| `keycloak` + `token-exchange-svc` | Identity provider | Login flows fail |
+| `egov-workflow-v2` | Complaint state machine | Complaints cannot change state or be assigned |
+| `egov-mdms-service` / `mdms-backend` | Master data (complaint types, departments, config) | Forms come up empty; most services fail to start |
+| `egov-hrms` | Employees, departments, reporting hierarchy | Assignment and inbox visibility break |
+| `boundary-service` / `egov-bndry-mgmnt` | Wards, localities, jurisdictions | Location pickers empty; inbox filtering breaks |
+| `egov-localization` | UI translations | Screens show raw message codes |
+| `egov-idgen` | Complaint number generation | New complaints cannot be created |
+| `egov-accesscontrol` | Role/action authorisation | Users get "unauthorised" everywhere |
+| `egov-enc-service` | Encryption of personal data | Reads/writes of protected fields fail |
+| `egov-filestore` | File metadata in front of MinIO | Attachments fail |
+| `egov-persister` | Kafka → Postgres writer | Complaints appear to save but never persist |
+| `egov-indexer` | Kafka → Elasticsearch writer | Complaints exist but never appear in the inbox |
+| `egov-url-shortening` | Short links in notifications | Links in SMS break |
+| `audit-service` | Audit trail | Audit history stops recording |
+
+### Application
+
+| Service | Role | When it's down |
+|---|---|---|
+| `pgr-services` | The complaint service itself — filing, search, inbox, analytics | The core product is down |
+| `digit-ui` | The web frontend | Blank or unreachable UI |
+| `configurator` + `digit-config-service` | Admin configuration screens | Admins cannot change configuration; runtime unaffected |
+| `inbox` | Aggregated inbox queries | Inbox screen fails; complaints still exist |
+| `kong` | API gateway — every API call passes through it | 502s everywhere |
+
+### Notifications
+
+| Service | Role |
+|---|---|
+| `novu-api`, `novu-worker`, `novu-mongo`, `novu-ws` | Notification platform; `novu-worker` is what actually calls the SMS/email/WhatsApp provider |
+| `novu-bridge` | Consumes complaint events from Kafka and triggers notifications |
+| `digit-user-preferences-service` | Per-user notification consent |
+
+If notifications stop, check in this order: the provider account (credit, credentials) →
+`novu-worker` logs → `novu-bridge` logs → Kafka lag.
+
+---
+
+## Metric and log coverage — what is and isn't watched
+
+| Signal | Covers | Does not cover |
+|---|---|---|
+| **JVM metrics** (Prometheus) | The 16 instrumented Java services: `boundary-service`, `digit-config-service`, `egov-accesscontrol`, `egov-enc-service`, `egov-filestore`, `egov-hrms`, `egov-idgen`, `egov-indexer`, `egov-persister`, `egov-user`, `egov-workflow-v2`, `inbox`, `mdms-backend`, `novu-bridge`, `pgr-services`, plus dashboard web metrics | Postgres, Redis, Kafka, Kong, Elasticsearch, Keycloak, MinIO, nginx, Node services |
+| **Logs** (Loki) | **Every container** — around 44 of them | Nothing, as long as promtail is running |
+| **Traces** (Tempo) | Requests through instrumented Java services and Kong | Direct database or broker activity |
+| **Health checks** (Gatus) | ~50 endpoints across every group, including infrastructure | Anything not in the endpoint catalogue |
+| **Host metrics** (node-exporter) | CPU, RAM, disk, network, filesystem | **Not present on deployments installed before 2026-07-22** |
+
+The practical takeaway: for the non-Java containers, **Gatus tells you if it is alive and
+Loki tells you why it isn't.** There are no metrics-based alerts to be had for them.
+
+---
+
+## Data retention
+
+| Data | Store | Retention |
+|---|---|---|
+| Metrics | Prometheus | **15 days** |
+| Logs | Loki | **72 hours** |
+| Traces | Tempo | **24 hours** |
+| Health-check history | Gatus | in-memory; lost when the container restarts |
+
+Promtail also refuses log entries older than 7 days, so back-filling old logs is not
+possible.
+
+---
+
+## Query cookbook
+
+**Grafana → Explore**, then pick the datasource.
+
+### Prometheus (metrics)
+
+```promql
+# Which services are reporting at all
+count by (service_name) (jvm_thread_count)
+
+# Which services were reporting 15 min ago and are not now  (i.e. something died)
+count by (service_name) (jvm_thread_count offset 15m) unless count by (service_name) (jvm_thread_count)
+
+# Heap usage % per service
+100 * sum by (service_name) (jvm_memory_used_bytes{jvm_memory_type="heap"})
+    / sum by (service_name) (jvm_memory_limit_bytes{jvm_memory_type="heap"})
+
+# CPU per service (1.0 = one full core)
+sum by (service_name) (jvm_cpu_recent_utilization_ratio)
+
+# Garbage-collection time (>0.2 s/s means trouble)
+sum by (service_name) (rate(jvm_gc_duration_seconds_sum[5m]))
+
+# Server errors, by service and endpoint
+sum by (service_name, http_route) (rate(http_server_request_duration_seconds_count{http_response_status_code=~"5.."}[5m]))
+
+# 95th-percentile latency
+histogram_quantile(0.95, sum by (le, service_name) (rate(http_server_request_duration_seconds_bucket[5m])))
+
+# Database connection pool
+db_client_connections_pending_requests
+db_client_connections_usage
+db_client_connections_max
+rate(db_client_connections_timeouts_total[5m])
+
+# Kafka consumer lag
+max by (service_name, client_id) (kafka_consumer_records_lag_max)
+
+# Host metrics — only if node-exporter is installed
+100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)
+100 * (1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)
+100 - (node_filesystem_avail_bytes{fstype!~"tmpfs|overlay|squashfs"} / node_filesystem_size_bytes{fstype!~"tmpfs|overlay|squashfs"} * 100)
+
+# Which scrape jobs exist (tells you whether node-exporter is present)
+up
+```
+
+### Loki (logs)
+
+Labels available: `compose_project`, `compose_service`, `container`, `service_name`,
+`stream`.
+
+```logql
+# Error volume by service — run this first when everything feels wrong
+sum by (compose_service) (count_over_time({compose_project="digit"} |~ `(?i)error|exception` [5m]))
+
+# Everything erroring, most recent first
+{compose_project="digit"} |~ `(?i)error|exception|timeout|refused`
+
+# One service
+{compose_service="pgr-services"} |~ `(?i)error|exception`
+
+# Service starts — one line per boot; repeats mean a restart loop
+{compose_project="digit", compose_service!="loki"} |~ `Started .+Application in`
+
+# Genuine out-of-memory events (excluding tools that echo the search text)
+{compose_project="digit", compose_service!~"grafana|loki"} |~ `(?i)outofmemoryerror|java heap space|gc overhead limit`
+
+# Follow one complaint / user / request through every service
+{compose_project="digit"} |= `<paste the identifier>`
+
+# Database
+{compose_service=~"postgres-db|pgbouncer"} |~ `(?i)fatal|error|too many clients|deadlock`
+
+# Gateway / 502s
+{compose_service="kong"} |~ `(?i)502|503|504|no route|upstream`
+
+# Grafana's own alerting problems (why didn't my alert send?)
+{compose_service="grafana"} |~ `(?i)alerting|notifier|contact|webhook|error`
+
+# Log rate per service — a sudden spike or a drop to silence are both signals
+sum by (compose_service) (rate({compose_project="digit"}[1m]))
+```
+
+### Tempo (traces)
+
+```traceql
+{ duration > 2s }
+{ status = error }
+{ resource.service.name = "pgr-services" && duration > 1s }
+```
+
+---
+
+## Glossary
+
+| Term | Meaning |
+|---|---|
+| **Container** | One running service. ~44 of them make up a deployment |
+| **Compose / Docker Compose** | What starts and stops the containers on a single-server deployment |
+| **Gatus** | The health dashboard at `/status/` |
+| **Grafana** | The UI where metrics, logs, traces and alerts live |
+| **Prometheus** | Stores numeric metrics; queried with PromQL |
+| **Loki** | Stores logs; queried with LogQL |
+| **Tempo** | Stores traces; queried with TraceQL |
+| **Promtail** | Ships every container's output into Loki |
+| **OTEL / OpenTelemetry** | The instrumentation standard; the collector receives metrics and traces from the Java services |
+| **node-exporter** | Reports host CPU/RAM/disk to Prometheus |
+| **Trace / Trace ID** | The record of one request as it passes through several services, and its identifier |
+| **Heap** | The memory a Java service is allowed to use. Full heap → `OutOfMemoryError` → crash |
+| **OOM** | Out of memory. Either the JVM hit its heap limit, or Linux killed the container |
+| **GC** | Garbage collection. Excessive GC makes a service appear hung |
+| **Kafka lag** | How far behind a consumer is. Growing lag = a stuck pipeline |
+| **Connection pool** | The fixed set of database connections shared by a service. Exhaustion looks like "everything is slow but nothing is down" |
+| **Tenant** | A city or administrative unit within the deployment |
+| **MDMS** | Master Data Management Service — complaint types, departments, configuration |
+| **PGR** | Public Grievance Redressal — the complaint service |
+| **HRMS** | The employee, department and reporting-hierarchy service |
+| **Pending period** | How long an alert condition must hold before the alert fires |
+| **Contact point** | Where Grafana sends an alert (Slack, email, webhook…) |
+| **Notification policy** | The rules deciding which alert goes to which contact point |
+| **Silence / mute timing** | One-off vs. recurring suppression of notifications |

--- a/docs/operations/reference.md
+++ b/docs/operations/reference.md
@@ -236,11 +236,12 @@ and above all **disk space** — as opposed to the individual services.
 
 **Who uses it:** L2.
 
-> **If this dashboard is completely empty, that is expected on some deployments and is not a
-> fault.** The component that reports machine statistics (`node-exporter`) was added to the
-> platform on **2026-07-22**; installations older than that do not have it, so there is
-> nothing for the dashboard to draw. Do not raise it as an incident — it is a known gap that
-> needs a redeploy to close. See
+> **If this dashboard is completely empty, that is not a fault and not an incident.** Either
+> the component that reports machine statistics (`node-exporter`) isn't installed — it was
+> added to the platform on **2026-07-22**, so older installations lack it — or it is running
+> and the collector simply hasn't picked it up yet. Both are known, both are for L2 to sort
+> out, and neither is worth a ticket on its own. Mention it if you were asked to check CPU,
+> memory or disk and couldn't. See
 > [alerts-setup.md](alerts-setup.md#prerequisite--turn-on-host-metrics).
 
 When it does have data, the readings that matter:


### PR DESCRIPTION
Closes #1597.

Adds a six-document operations handbook under `docs/operations/` for the teams that operate a deployed CCRS instance — partner and government IT staff, not us. It takes them from "something is broken" to a report we can act on without a round trip.

Everything in it is grounded in what the stack actually exposes: **every PromQL and LogQL query, panel name, Loki label, service name and retention figure was verified against a running deployment** before being written down. No invented metric names.

**Docs only — no application, deployment or test code is touched.**

---

## What changed, and why

| File | What it is |
|---|---|
| `docs/operations/README.md` | Entry point. The four operator URLs (`/status/`, `/grafana/`, the logs and JVM dashboards), a five-minute triage ladder, S1–S4 severity definitions, the evidence-retention windows, and the escalation path. |
| `docs/operations/debugging.md` | The debugging runbook. Five-layer stack model (edge / application / core / backbone / host), step-by-step triage across Gatus → JVM dashboard → Loki → Tempo → host, a symptom→playbook table covering the 13 most common reports, read-only host commands, and the destructive commands to avoid mid-incident (`down -v`, a bare `up -d`). |
| `docs/operations/alerts-setup.md` | What to alert on. 26 rules across four tiers (host, service, application, synthetic) with queries, thresholds and pending periods; how to get Grafana's no-data handling right; and how to provision alerts as code under `otel/grafana/provisioning/alerting/` so they survive a rebuild. |
| `docs/operations/alert-channels.md` | Where alerts go. Slack, Google Chat, Teams, Telegram, email, PagerDuty, WhatsApp and SMS, plus Gatus's own alerting, notification-policy design, maintenance windows and silences, and the on-call rota. |
| `docs/operations/incident-report.md` | The report template, a per-symptom evidence checklist, a read-only evidence-bundle script, and PII redaction guidance — this is a citizen complaint system, and its logs carry names, phone numbers and complaint text. |
| `docs/operations/reference.md` | Lookup: service catalogue with the failure mode for each service, the metric/log coverage matrix, retention table, query cookbook and glossary. |

**Why now.** Every fact missing from a report costs a round trip, and across timezones that is a day. Observability data here is short-lived by design — Tempo 24h, Loki 72h, Prometheus 15d — so a report filed late often has no evidence left behind it. The handbook front-loads the five facts we always end up asking for, and says plainly how long the operator has to capture them.

---

## Three gaps this surfaced

Found while verifying the docs against a running instance. Each needs a **deployment change rather than an operator action**, so each is called out in place — an operator should not be left hunting for a dashboard that cannot work. Not fixed here; flagging for follow-up.

1. **`node-exporter` is absent on any box deployed before c5399c07 (2026-07-22).** Prometheus scrapes only `otel-collector`, so the `Node Exporter Full` dashboard is empty and **the host CPU / RAM / disk alerts cannot be created at all** on those boxes. Disk filling up is the most common cause of a total outage, so this is the highest-value item. `alerts-setup.md` opens with a one-query check for it and marks Tier 1 as blocked until a redeploy layers in `docker-compose.monitoring.yml`.
2. **Grafana ships with zero alert rules**, a placeholder contact point (`email receiver` → `<example@email.com>`), and **no `GF_SMTP_*` configuration** in `docker-compose.egov-digit.yaml` — so email alerting cannot deliver even once the address is corrected. The docs therefore route operators to chat webhooks first, which need no SMTP.
3. **Gatus's own alerting is still commented out** in `local-setup/gatus/config.yaml`, even though it is the only signal covering the non-JVM containers — Postgres, Redis, Redpanda, Kong, Elasticsearch, Keycloak and nginx have no Prometheus metrics at all. Turning it on is the cheapest real coverage available.

A fourth, worth a decision rather than a fix: Grafana runs with `GF_AUTH_ANONYMOUS_ORG_ROLE: Admin` and the login form disabled. Convenient for operator teams (no account needed to create alerts), but it means anyone with the URL has full Admin and no change is attributable. The docs note it and suggest raising it where the instance is internet-reachable.

---

## Reviewing this

The tone is aimed at an external operator who is not a DIGIT engineer, so it is deliberately explanatory rather than terse. Two things worth a reviewer's eye:

- **Thresholds** in `alerts-setup.md` are conservative starting points, not tuned values. The `ErrorLogSpike` and Kafka-lag thresholds in particular are marked in the text as placeholders to be calibrated per deployment.
- **The service catalogue** in `reference.md` lists what breaks when each service goes down. Corrections welcome — it was written from the compose stack and the Gatus endpoint catalogue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive operations and support handbook for deployed instances.
  - Documented incident response, first-response triage, escalation, diagnosis, and incident reporting.
  - Added guidance for Grafana alerting, notification channels, routing, silences, and monitoring.
  - Added operational references for dashboards, service health, logs, traces, retention, and common queries.
  - Added a concise operations cheat sheet and known-issues guide with troubleshooting guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->