### PR TITLE
fix(moz): forgot-password tenant scope (CCSD-2150) + inbox name centering (CCSD-2086) + upload label/formats (CCSD-2071)

### DIFF
--- a/digit-ui-esbuild/packages/modules/core/src/pages/employee/ForgotPassword/forgotPassword.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/employee/ForgotPassword/forgotPassword.js
@@ -26,7 +26,7 @@ import { useTranslation } from "react-i18next";
 import { useHistory, useLocation } from "react-router-dom";
 import ImageComponent from "../../../components/ImageComponent";
 import { useLoginConfig } from "../../../hooks/useLoginConfig";
-import { V2LoginShell } from "../Login/login";
+import { V2LoginShell, scopeLoginTenants } from "../Login/login";
 
 const ForgotPassword = ({ config: propsConfig, t, stateCode }) => {
   const { t: trans } = useTranslation();
@@ -111,7 +111,11 @@ const ForgotPassword = ({ config: propsConfig, t, stateCode }) => {
     return <Loader page={true} variant="PageLoader" />;
   }
 
-  const cityOptions = (cities || []).map((c) => ({
+  // CCSD-2150: scope to the same tenant list the login screen shows — an
+  // allowlist (if configured) plus the testing-vs-production entrance filter.
+  // The raw useTenants() list is every platform tenant, so without this the
+  // forgot-password dropdown showed demo/other-state cities that can't log in.
+  const cityOptions = scopeLoginTenants(cities).map((c) => ({
     value: c.code,
     label: c.i18nKey ? trans(c.i18nKey) : c.code,
   }));

--- a/digit-ui-esbuild/packages/modules/core/src/pages/employee/Login/login.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/employee/Login/login.js
@@ -62,6 +62,20 @@ const isTenantVisibleOnEntrance = (tenantCode) => {
   return onTestingEntrance ? testing.has(tenantCode) : !testing.has(tenantCode);
 };
 
+// The exact tenant list the employee entrance may show: an optional
+// LOGIN_TENANT_ALLOWLIST (deploy config), then the testing-vs-production
+// entrance filter. Exported so every screen with a city/institution dropdown
+// (login AND forgot-password, and any future one) scopes it identically —
+// CCSD-2150 was the forgot-password dropdown listing every platform tenant
+// because it skipped this. Returns the raw tenant objects; callers map to
+// their own option shape.
+export const scopeLoginTenants = (tenants) => {
+  const all = Array.isArray(tenants) ? tenants : [];
+  const allow = window?.globalConfigs?.getConfig?.("LOGIN_TENANT_ALLOWLIST");
+  const allowed = Array.isArray(allow) && allow.length > 0 ? all.filter((tnt) => allow.includes(tnt.code)) : all;
+  return allowed.filter((tnt) => isTenantVisibleOnEntrance(tnt.code));
+};
+
 const setEmployeeDetail = (userObject, token) => {
   if (Digit.Utils.getMultiRootTenant() && process.env.NODE_ENV !== "development") return;
   let locale = JSON.parse(sessionStorage.getItem("Digit.locale"))?.value || Digit.Utils.getDefaultLanguage();
@@ -232,15 +246,9 @@ const Login = ({ config: propsConfig, t, isDisabled, loginOTPBased, appTenants }
   // legacy `select:` literal in config.js).
   const cityField = useMemo(() => propsConfig?.inputs?.find((f) => f?.key === "city"), [propsConfig]);
   const cityOptions = useMemo(() => {
-    const all = Array.isArray(cities) ? cities : [];
-    const allow = window?.globalConfigs?.getConfig?.("LOGIN_TENANT_ALLOWLIST");
-    const allowed = Array.isArray(allow) && allow.length > 0
-      ? all.filter((tnt) => allow.includes(tnt.code))
-      : all;
-    // Keep testing tenants off the production entrance (and non-testing
-    // tenants off /digit-ui-test) — matches the citizen dispatcher/list.
-    const filtered = allowed.filter((tnt) => isTenantVisibleOnEntrance(tnt.code));
-    return filtered.map((tnt) => ({
+    // Scoping (LOGIN_TENANT_ALLOWLIST + testing-vs-production entrance) is shared
+    // with forgot-password via scopeLoginTenants so the two dropdowns can't drift.
+    return scopeLoginTenants(cities).map((tnt) => ({
       value: tnt.code,
       label: tr(`TENANT_TENANTS_${Digit?.Utils?.locale?.getTransformedLocale?.(tnt.code) ?? tnt.code}`, tnt.name || tnt.code),
     }));

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRInbox.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRInbox.js
@@ -258,6 +258,15 @@ const PGRSearchInbox = () => {
 
   return (
     <div className="v2-pgr-inbox v2-scope">
+      {/* CCSD-2086: centre the system-name header in the inbox's left links card
+          (it read left-aligned). Scoped to .v2-pgr-inbox so the shared
+          InboxSearchComposer class isn't recentred for other modules; the
+          two-class selector outranks the component's own single-class rule
+          without needing !important. */}
+      <style>{`
+        .v2-pgr-inbox .digit-inbox-search-links-header { justify-content: center; text-align: center; }
+        .v2-pgr-inbox .digit-inbox-search-links-header-text { text-align: center; }
+      `}</style>
       <header className="v2-employee-page-header">
         <h1>{heading}</h1>
       </header>

--- a/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
@@ -751,7 +751,7 @@
     },
     {
         "code": "CS_ADDCOMPLAINT_UPLOAD_PHOTO",
-        "message": "Upload complaint photos or documents",
+        "message": "Upload complaint photos or documents (Optional)",
         "module": "rainmaker-pgr",
         "locale": "en_IN"
     },
@@ -7069,7 +7069,7 @@
     },
     {
         "code": "CS_UPLOAD_HINT",
-        "message": "Images, PDF, DOC, audio or video up to 5 MB each. You can upload up to 5 files.",
+        "message": "Accepted formats: JPG, PNG, PDF, DOC, DOCX, XLS, XLSX, MP4, MP3 (max 5 MB per file)",
         "module": "rainmaker-pgr",
         "locale": "en_IN"
     },

--- a/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
@@ -1585,13 +1585,13 @@
     },
     {
         "code": "CS_ADDCOMPLAINT_UPLOAD_PHOTO",
-        "message": "Enviar fotos ou documentos da reclamação",
+        "message": "Enviar fotos ou documentos da reclamação (Opcional)",
         "module": "rainmaker-pgr",
         "locale": "pt_PT"
     },
     {
         "code": "CS_UPLOAD_HINT",
-        "message": "Formatos permitidos: JPG, PNG, PDF, DOC, DOCX, XLS, XLSX. Até 5 MB por ficheiro.",
+        "message": "Formatos aceitos: JPG, PNG, PDF, DOC, DOCX, XLS, XLSX, MP4, MP3 (máximo 5 MB por ficheiro)",
         "module": "rainmaker-pgr",
         "locale": "pt_PT"
     },


### PR DESCRIPTION
Three CCSD-1914 tickets, one PR — each an independent, low-risk change. Verified on a live box, not just built.

## CCSD-2150 (HIGH) — forgot-password tenant dropdown showed every tenant
The employee login screen scopes its city dropdown (`LOGIN_TENANT_ALLOWLIST` + a testing-vs-production entrance filter). The **forgot-password** screen skipped both and mapped the raw `useTenants()` list — so it listed demo/other-state cities that can't log in, plus the testing tenant on the production entrance.

- Extracted login.js's filter into an exported **`scopeLoginTenants(tenants)`** and used it in **both** screens, so they can't drift again. login.js's own `cityOptions` now calls the shared helper — behaviour unchanged.
- **Verified (local):** API returns 4 tenants (`mz`, `mz.ige`, `mz.igsae`, `mz.igetesting`); the forgot-password dropdown now shows **3** — the testing tenant is dropped, matching login. Login page still renders with **0 console errors** through the same helper.

## CCSD-2086 — inbox-v2 system-name header not centered
Text (search label + "Fala Cidadão" system name) was already localized by QA; the only open item was Gurjeet's note that the name should be **centered in the box**. It read left-aligned.

- CSS scoped to **`.v2-pgr-inbox`** (the PGR inbox wrapper) so the shared `InboxSearchComposer` class isn't recentred for other modules' inboxes. Two-class selector outranks the component's own rule — no `!important`.
- **Verified (live rendered inbox):** header content sits flush-centered in its container — left gap == right gap == 0.

## CCSD-2071 — upload label + supported formats
- Seed (`pt_PT` + `en_IN`): label gains **"(Opcional)"/"(Optional)"**; the formats hint now matches the ticket wording **and lists video (MP4/MP3)** — CCSD-2027 enabled video upload but the old "JPG…XLSX only" text still omitted it. Surgical string edits, no JSON reformat.
- The two keys were **upserted live to cms-pilot + local and cache-busted** (verified read-back). **mctd is deliberately skipped** — deploy freeze in effect; it picks these up from the seed on the next migration.

## Notes
- FE code (2150, 2086) ships in the bundle; the loc (2071) is data + this seed change for future envs.
- No mctd changes (per current freeze). cms-pilot carries all three now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)