### PR TITLE
ci: validate deploy-as-code values keys and duplicate YAML keys

### DIFF
--- a/.github/scripts/check-helm-values-paths.py
+++ b/.github/scripts/check-helm-values-paths.py
@@ -80,7 +80,7 @@ KNOWN_UNREAD = {
     "prometheus.externalLabels": "#1645 -- reads at prometheus.prometheusSpec.externalLabels",
     "prometheus.additionalScrapeConfigs": "#1645 -- reads at prometheus.prometheusSpec.additionalScrapeConfigs",
     "prometheus.alertmanager": "#1645 -- chart reads alertmanager.enabled at top level",
-    "ingress-nginx": "#1648 -- vendored chart reads .Values.controller.* at root, not under a chart-name block",
+    "ingress-nginx": "#1648 -- vendored chart reads .Values.controller.* at root; the helmfile now re-paths this block deliberately (PR #1679), so the env.yaml keys are read via templating rather than by the chart",
 }
 
 

--- a/.github/scripts/check-helm-values-paths.py
+++ b/.github/scripts/check-helm-values-paths.py
@@ -105,6 +105,29 @@ def load(path):
         raise SystemExit(2)
 
 
+def passthrough_paths(node, prefix=""):
+    """Paths whose reference value is an empty map or null.
+
+    Upstream charts use these for free-form blocks handed straight to
+    `toYaml` -- `storageSpec: {}`, `resources: {}`, `nodeSelector: {}`. Any
+    structure underneath is valid and IS read, so descending into them and
+    demanding each child appear in the reference reports pure noise.
+
+    Found by fixing #1645: re-pathing storageSpec correctly then tripped this
+    guard on `storageSpec.volumeClaimTemplate`, which is exactly the shape the
+    chart expects. A guard that fails a correct fix is worse than no guard.
+    """
+    out = set()
+    if isinstance(node, dict):
+        for k, v in node.items():
+            p = f"{prefix}.{k}" if prefix else str(k)
+            if v is None or (isinstance(v, dict) and not v):
+                out.add(p)
+            else:
+                out |= passthrough_paths(v, p)
+    return out
+
+
 def orphans_for(env_tree, block, reference):
     """Key paths the env block sets that the reference chart never defines.
 
@@ -116,7 +139,14 @@ def orphans_for(env_tree, block, reference):
         return []
     ours = key_paths({block: env_tree[block]})
     theirs = key_paths(reference)
-    unread = {p for p in ours if p not in theirs and p not in ALLOW}
+    free = passthrough_paths(reference)
+    unread = {
+        p for p in ours
+        if p not in theirs
+        and p not in ALLOW
+        # anything below a free-form block is the chart's to interpret
+        and not any(p.startswith(f + ".") for f in free)
+    }
     return sorted(p for p in unread if not any(p.startswith(q + ".") for q in unread))
 
 
@@ -193,6 +223,22 @@ def self_test():
 
         # 4. absent block is not a failure
         assert orphans_for({}, "foo", reference) == []
+
+        # 5. free-form passthrough blocks: the chart declares `storageSpec: {}`
+        #    and hands whatever is underneath to toYaml, so children are valid
+        #    and must NOT be reported. Regression test for the false positive
+        #    that fixing #1645 exposed.
+        ref2 = tmp / "ref2.yaml"
+        ref2.write_text(yaml.safe_dump({"foo": {"barSpec": {"storageSpec": {}}}}))
+        reference2 = load(ref2)
+        deep = {"foo": {"barSpec": {"storageSpec": {
+            "volumeClaimTemplate": {"spec": {"resources": {"requests": {"storage": "15Gi"}}}}}}}}
+        got = orphans_for(deep, "foo", reference2)
+        assert got == [], f"false positive under a free-form block: {got}"
+
+        # ...but a genuine mis-path OUTSIDE the free-form block still fires
+        got = orphans_for({"foo": {"storageSpec": {"x": 1}}}, "foo", reference2)
+        assert got == ["foo.storageSpec"], f"mis-path masked by passthrough logic: {got}"
 
     print("self-test OK: detects mis-paths and orphaned blocks, "
           "silent on correct configuration")

--- a/.github/scripts/check-helm-values-paths.py
+++ b/.github/scripts/check-helm-values-paths.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""CI guard: a values key that no chart reads is silently ignored, not an error.
+
+This is the failure mode nothing else in the toolchain catches. Helm merges
+values into a plain map; a key nothing references is dropped without a warning,
+an exit code, or a line of output. `helm template` does NOT catch it either --
+it fails only on template syntax errors, explicit required/fail calls, or a
+values.schema.json violation, and the charts here ship no schema. So a setting
+at the wrong path looks exactly like working configuration, in the file and in
+review, forever.
+
+Two real defects in this repo, both long-lived, both invisible to every other
+check, are what this guard exists for:
+
+  1. charts/environments/env.yaml sets prometheus.retention and
+     prometheus.storageSpec (a 15Gi gp3 volume). kube-prometheus-stack reads
+     those at prometheus.prometheusSpec.*. Effective result: Prometheus and
+     Alertmanager run on emptyDir and lose every metric on pod restart, while
+     the file states 15Gi of persistent storage.
+
+  2. The same file sets ingress-nginx.controller.metrics.*. ingress-nginx is a
+     vendored upstream chart that reads .Values.controller.* directly, so the
+     whole block is inert -- and the chart's own defaults, which are the
+     inverse of the intent, win instead.
+
+SCOPE, and why it is narrow on purpose
+--------------------------------------
+Only EXTERNAL / vendored charts are checked -- ones whose values.yaml is the
+complete upstream reference for what the chart reads.
+
+DIGIT's own charts are deliberately excluded. They read values inside templates
+via `index .Values "some-key"` without declaring them in values.yaml, so
+values.yaml is not a complete reference for them and comparing against it
+produces false positives (verified: hrms-dev-mode, memory_limits and images are
+all genuinely consumed but undeclared). Covering them needs the reference set to
+include template references too -- a later refinement, not a blocker. A guard
+that cries wolf gets disabled, which would cost more than it saves.
+
+Run with --self-test to verify the detection logic itself catches the failure
+mode and stays quiet on correct configuration.
+"""
+import pathlib
+import sys
+import tempfile
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+DAC = ROOT / "devops" / "deploy-as-code"
+ENV = DAC / "charts" / "environments" / "env.yaml"
+
+# env.yaml top-level block -> the chart values file that defines what that
+# chart actually reads. Only external/vendored charts; see SCOPE above.
+#
+# Both entries receive the whole env.yaml tree via the helmfile's
+# `{{ .Values | toYaml }}`, so a key must sit at the path the chart reads.
+CASES = [
+    ("prometheus", DAC / "charts/monitoring/values/prometheus.yaml"),
+    ("ingress-nginx", DAC / "charts/backbone-services/ingress-nginx/values.yaml"),
+]
+
+# Keys consumed by helmfile/templating rather than by the chart itself.
+# Every entry needs a reason -- "it was noisy" is not one.
+ALLOW = {
+    # helmfile's own release scoping, not a chart value
+    "prometheus.namespace": "helmfile release field, not read by the chart",
+}
+
+# Mis-paths that already exist, each with the issue that fixes it. Same shape as
+# FROZEN_LATEST_DEBT in local-setup/tests/static/infra-contracts.test.ts: the
+# guard goes in green today and fails on anything NEW, instead of being merged
+# red and ignored.
+#
+# This list may only shrink. A path here that no longer reproduces is a STALE
+# BASELINE and fails the check too -- otherwise the baseline outlives the bug
+# and quietly re-opens the hole it was meant to hold.
+KNOWN_UNREAD = {
+    "prometheus.retention": "#1645 -- reads at prometheus.prometheusSpec.retention",
+    "prometheus.storageSpec": "#1645 -- reads at prometheus.prometheusSpec.storageSpec",
+    "prometheus.externalLabels": "#1645 -- reads at prometheus.prometheusSpec.externalLabels",
+    "prometheus.additionalScrapeConfigs": "#1645 -- reads at prometheus.prometheusSpec.additionalScrapeConfigs",
+    "prometheus.alertmanager": "#1645 -- chart reads alertmanager.enabled at top level",
+    "ingress-nginx": "#1648 -- vendored chart reads .Values.controller.* at root, not under a chart-name block",
+}
+
+
+def key_paths(node, prefix=""):
+    """Every dotted key path in a mapping, parents included."""
+    out = set()
+    if isinstance(node, dict):
+        for k, v in node.items():
+            p = f"{prefix}.{k}" if prefix else str(k)
+            out.add(p)
+            out |= key_paths(v, p)
+    return out
+
+
+def load(path):
+    """Parse YAML, failing loudly. For a coverage guard every uncertainty
+    resolves toward a false green, so an unreadable input is a hard error."""
+    try:
+        return yaml.safe_load(path.read_text()) or {}
+    except (OSError, yaml.YAMLError) as e:
+        print(f"FAIL: cannot read {path}: {e}")
+        raise SystemExit(2)
+
+
+def orphans_for(env_tree, block, reference):
+    """Key paths the env block sets that the reference chart never defines.
+
+    Only the SHALLOWEST path of each branch is reported: if `prometheus.storageSpec`
+    is unread then every path beneath it is too, and listing them all buries the
+    one line a human needs to act on.
+    """
+    if block not in env_tree:
+        return []
+    ours = key_paths({block: env_tree[block]})
+    theirs = key_paths(reference)
+    unread = {p for p in ours if p not in theirs and p not in ALLOW}
+    return sorted(p for p in unread if not any(p.startswith(q + ".") for q in unread))
+
+
+def run():
+    env_tree = load(ENV)
+    seen = set()
+    new = []
+    for block, ref_path in CASES:
+        if not ref_path.exists():
+            print(f"FAIL: reference values file missing: {ref_path}")
+            return 2
+        for p in orphans_for(env_tree, block, load(ref_path)):
+            seen.add(p)
+            if p not in KNOWN_UNREAD:
+                new.append((p, block, ref_path))
+
+    stale = sorted(set(KNOWN_UNREAD) - seen)
+    rc = 0
+
+    if new:
+        rc = 1
+        print("FAIL: env.yaml sets values no chart reads. These are silently "
+              "ignored at deploy time -- the file says one thing, the cluster "
+              "does another.\n")
+        for p, block, ref_path in new:
+            print(f"  {p}")
+            print(f"      block `{block}:`, chart reference "
+                  f"{ref_path.relative_to(ROOT)}")
+        print("\nMove each key to the path the chart actually reads, then confirm "
+              "by RENDERING the chart and checking the output -- reading the "
+              "values file is what let the existing ones through.\n")
+
+    if stale:
+        rc = 1
+        print("FAIL: KNOWN_UNREAD lists paths that no longer reproduce. If they "
+              "were fixed, delete them -- a baseline that outlives its bug "
+              "quietly re-opens the hole it was holding.\n")
+        for p in stale:
+            print(f"  {p}    ({KNOWN_UNREAD[p]})")
+        print()
+
+    if rc == 0:
+        print(f"OK: {len(CASES)} external chart(s) checked, no new unread key "
+              f"paths. {len(KNOWN_UNREAD)} known mis-path(s) still outstanding:")
+        for p in sorted(KNOWN_UNREAD):
+            print(f"  {p}    ({KNOWN_UNREAD[p]})")
+    return rc
+
+
+def self_test():
+    """Prove the detector fires on a mis-path and stays quiet on a correct one."""
+    with tempfile.TemporaryDirectory() as td:
+        tmp = pathlib.Path(td)
+
+        # A chart that reads foo.barSpec.retention
+        ref = tmp / "ref.yaml"
+        ref.write_text(yaml.safe_dump({"foo": {"barSpec": {"retention": "10d"}}}))
+        reference = load(ref)
+
+        # 1. mis-pathed one level too shallow -- the real bug shape
+        bad = {"foo": {"retention": "7d"}}
+        got = orphans_for(bad, "foo", reference)
+        assert got == ["foo.retention"], f"mis-path not detected: {got}"
+
+        # 2. correct path -- must stay silent
+        good = {"foo": {"barSpec": {"retention": "7d"}}}
+        got = orphans_for(good, "foo", reference)
+        assert got == [], f"false positive on correct config: {got}"
+
+        # 3. a wholly orphaned wrapper block reports the wrapper, not its leaves
+        wrapped = {"foo": {"controller": {"metrics": {"enabled": False}}}}
+        got = orphans_for(wrapped, "foo", reference)
+        assert got == ["foo.controller"], f"wrapper not collapsed: {got}"
+
+        # 4. absent block is not a failure
+        assert orphans_for({}, "foo", reference) == []
+
+    print("self-test OK: detects mis-paths and orphaned blocks, "
+          "silent on correct configuration")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(self_test() if "--self-test" in sys.argv else run())

--- a/.github/scripts/check-helm-values-paths.py
+++ b/.github/scripts/check-helm-values-paths.py
@@ -38,14 +38,22 @@ that cries wolf gets disabled, which would cost more than it saves.
 
 Run with --self-test to verify the detection logic itself catches the failure
 mode and stays quiet on correct configuration.
+
+Set VALUES_BASELINE_REF to a git ref (CI passes the pull request's base commit)
+to additionally verify that the KNOWN_UNREAD baseline has not grown since that
+revision. Without it that one check is skipped, loudly.
 """
+import ast
+import os
 import pathlib
+import subprocess
 import sys
 import tempfile
 
 import yaml
 
-ROOT = pathlib.Path(__file__).resolve().parents[2]
+SELF = pathlib.Path(__file__).resolve()
+ROOT = SELF.parents[2]
 DAC = ROOT / "devops" / "deploy-as-code"
 ENV = DAC / "charts" / "environments" / "env.yaml"
 
@@ -71,9 +79,12 @@ ALLOW = {
 # guard goes in green today and fails on anything NEW, instead of being merged
 # red and ignored.
 #
-# This list may only shrink. A path here that no longer reproduces is a STALE
-# BASELINE and fails the check too -- otherwise the baseline outlives the bug
-# and quietly re-opens the hole it was meant to hold.
+# This list may only shrink, and that is ENFORCED, not merely asked for: a path
+# here that no longer reproduces is a STALE BASELINE and fails the check, and an
+# entry ADDED since the base revision fails it too (see baseline_growth). Without
+# the second half the rule is unenforceable -- a change that introduces a
+# mis-path and lists it here in the same breath makes that path `seen`, so
+# neither the new-path check nor the stale check fires.
 KNOWN_UNREAD = {
     "prometheus.retention": "#1645 -- reads at prometheus.prometheusSpec.retention",
     "prometheus.storageSpec": "#1645 -- reads at prometheus.prometheusSpec.storageSpec",
@@ -150,6 +161,76 @@ def orphans_for(env_tree, block, reference):
     return sorted(p for p in unread if not any(p.startswith(q + ".") for q in unread))
 
 
+# git ref KNOWN_UNREAD is compared against. CI sets it to the pull request's
+# base commit; see .github/workflows/deploy-as-code-validation.yml.
+BASELINE_REF_ENV = "VALUES_BASELINE_REF"
+
+
+def known_unread_in_source(src):
+    """KNOWN_UNREAD's keys as declared in `src`, or None if it cannot be read.
+
+    The source is PARSED, never executed: another revision of this file is data
+    here, not code to run.
+    """
+    try:
+        tree = ast.parse(src)
+    except SyntaxError:
+        return None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and any(
+                isinstance(t, ast.Name) and t.id == "KNOWN_UNREAD"
+                for t in node.targets):
+            try:
+                return set(ast.literal_eval(node.value))
+            except ValueError:
+                return None
+    return None
+
+
+def known_unread_at(ref):
+    """KNOWN_UNREAD's keys as of git `ref`, or None if that revision is unreadable
+    (ref unknown, file not there yet, or not a git checkout at all)."""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(ROOT), "show",
+             f"{ref}:{SELF.relative_to(ROOT).as_posix()}"],
+            capture_output=True, text=True)
+    except OSError:
+        return None
+    if proc.returncode != 0:
+        return None
+    return known_unread_in_source(proc.stdout)
+
+
+def baseline_growth():
+    """(entries added to KNOWN_UNREAD since the base revision, status line).
+
+    The stale check above compares the baseline with the CURRENT env.yaml, which
+    cannot enforce "may only shrink": add a mis-path and list it here in the same
+    change and the path is `seen`, so nothing fires. Only the previous revision
+    of the list catches that, so read it and reject anything new.
+
+    The revision comes from VALUES_BASELINE_REF. Off CI there is no dependable
+    answer -- a working tree sits wherever it sits -- so an unset or unreadable
+    ref SKIPS this one check loudly rather than crashing or guessing at a base
+    and failing a legitimate local run. The run on the pull request is the
+    authoritative one and always has the ref. To check locally, point it at the
+    merge-base: VALUES_BASELINE_REF=$(git merge-base HEAD origin/develop).
+    """
+    ref = os.environ.get(BASELINE_REF_ENV, "").strip()
+    if not ref:
+        return [], (f"baseline-growth check SKIPPED: {BASELINE_REF_ENV} is unset. "
+                    f"Set it to a git ref (in CI, the PR base) to verify that "
+                    f"KNOWN_UNREAD has not grown.")
+    base = known_unread_at(ref)
+    if base is None:
+        return [], (f"baseline-growth check SKIPPED: no readable revision of this "
+                    f"file at {ref} -- new file, unknown ref, or no git checkout.")
+    return sorted(set(KNOWN_UNREAD) - base), (
+        f"baseline-growth check: KNOWN_UNREAD vs {ref} "
+        f"({len(base)} entries there, {len(KNOWN_UNREAD)} here).")
+
+
 def run():
     env_tree = load(ENV)
     seen = set()
@@ -164,6 +245,7 @@ def run():
                 new.append((p, block, ref_path))
 
     stale = sorted(set(KNOWN_UNREAD) - seen)
+    added, baseline_note = baseline_growth()
     rc = 0
 
     if new:
@@ -188,11 +270,25 @@ def run():
             print(f"  {p}    ({KNOWN_UNREAD[p]})")
         print()
 
+    if added:
+        rc = 1
+        print("FAIL: KNOWN_UNREAD has GROWN. It is a baseline of mis-paths that "
+              "predate this guard and may only shrink -- a newly unread key has "
+              "to be FIXED, not recorded here. Recording it is how a guard gets "
+              "switched off one line at a time, and it is invisible to every "
+              "other check in this script: listing the path makes it `seen`.\n")
+        for p in added:
+            print(f"  {p}    ({KNOWN_UNREAD[p]})")
+        print("\nIf an entry genuinely belongs in the baseline -- a pre-existing "
+              "mis-path this change only made visible -- say so in the pull "
+              "request and have a human agree to it.\n")
+
     if rc == 0:
         print(f"OK: {len(CASES)} external chart(s) checked, no new unread key "
               f"paths. {len(KNOWN_UNREAD)} known mis-path(s) still outstanding:")
         for p in sorted(KNOWN_UNREAD):
             print(f"  {p}    ({KNOWN_UNREAD[p]})")
+    print(baseline_note)
     return rc
 
 
@@ -240,8 +336,25 @@ def self_test():
         got = orphans_for({"foo": {"storageSpec": {"x": 1}}}, "foo", reference2)
         assert got == ["foo.storageSpec"], f"mis-path masked by passthrough logic: {got}"
 
+    # 6. the baseline-growth guard: it reads KNOWN_UNREAD out of another
+    #    revision of this file WITHOUT executing it, fires on an addition, and
+    #    stays silent on a removal (the list is allowed to shrink).
+    before = known_unread_in_source(
+        'KNOWN_UNREAD = {\n    "a.b": "#1 -- reason",\n    "c.d": "#2 -- reason",\n}\n')
+    assert before == {"a.b", "c.d"}, f"baseline not parsed: {before}"
+    assert sorted({"a.b", "c.d", "e.f"} - before) == ["e.f"], "addition not caught"
+    assert sorted({"a.b"} - before) == [], "removal wrongly flagged"
+
+    #    unreadable or absent baselines degrade to "unknown" (-> skipped), never
+    #    to a silent pass-by-accident inside the comparison itself
+    assert known_unread_in_source("KNOWN_UNREAD = {") is None, "syntax error not handled"
+    assert known_unread_in_source("X = 1\n") is None, "absent baseline not handled"
+    assert known_unread_in_source(
+        "KNOWN_UNREAD = {k: v for k, v in x}") is None, "non-literal not handled"
+    assert known_unread_at("definitely-not-a-ref") is None, "bad git ref not handled"
+
     print("self-test OK: detects mis-paths and orphaned blocks, "
-          "silent on correct configuration")
+          "silent on correct configuration, and rejects baseline growth")
     return 0
 
 

--- a/.github/scripts/check-helm-values-paths.py
+++ b/.github/scripts/check-helm-values-paths.py
@@ -36,6 +36,15 @@ all genuinely consumed but undeclared). Covering them needs the reference set to
 include template references too -- a later refinement, not a blocker. A guard
 that cries wolf gets disabled, which would cost more than it saves.
 
+One more limit, for whoever extends CASES: key_paths/orphans_for recurse into
+`dict` nodes only, never into `list` items. A mis-keyed field inside a list
+element -- an `extraVolumes:` / container-array style block -- is therefore NOT
+detected; only the list-valued key itself is, at its own path. That is harmless
+for the two CASES here (the one list in scope, prometheus.additionalScrapeConfigs,
+is caught whole at the top level and baselined as such), but a chart whose
+overrides live inside lists needs list recursion added first, or it will be
+covered in name only.
+
 Run with --self-test to verify the detection logic itself catches the failure
 mode and stays quiet on correct configuration.
 
@@ -85,6 +94,16 @@ ALLOW = {
 # the second half the rule is unenforceable -- a change that introduces a
 # mis-path and lists it here in the same breath makes that path `seen`, so
 # neither the new-path check nor the stale check fires.
+#
+# MERGE-ORDER NOTE, live right now: the five `prometheus.*` entries below are
+# exactly the five paths PR #1659 re-paths under prometheus.prometheusSpec.* (and
+# alertmanager to the top level). Both PRs target `monitoring-fix` and neither has
+# merged, so today they still reproduce and belong here. Whichever merges SECOND
+# must delete all five in the same change -- verified by running this guard
+# against #1659's env.yaml, which fails with precisely those five and nothing
+# else. That is the stale-baseline check doing its job, not a regression: it goes
+# red rather than letting a fixed baseline sit there re-opening the hole. Only
+# `ingress-nginx` (#1648) should survive that merge.
 KNOWN_UNREAD = {
     "prometheus.retention": "#1645 -- reads at prometheus.prometheusSpec.retention",
     "prometheus.storageSpec": "#1645 -- reads at prometheus.prometheusSpec.storageSpec",
@@ -268,7 +287,9 @@ def run():
               "quietly re-opens the hole it was holding.\n")
         for p in stale:
             print(f"  {p}    ({KNOWN_UNREAD[p]})")
-        print()
+        print("\nThis is the EXPECTED outcome when the fixing pull request lands: "
+              "delete the listed entries from KNOWN_UNREAD in that same change. "
+              "The five prometheus.* entries all go together with #1659.\n")
 
     if added:
         rc = 1

--- a/.github/workflows/deploy-as-code-validation.yml
+++ b/.github/workflows/deploy-as-code-validation.yml
@@ -68,6 +68,12 @@ jobs:
       - name: self-test the guard
         run: python3 .github/scripts/check-helm-values-paths.py --self-test
 
+      # On `push` there is no pull_request context, so this expression renders
+      # empty and the guard SKIPS the baseline-growth comparison, loudly. That is
+      # deliberate, not an oversight: push only fires post-merge, by which time
+      # the pull-request run has already rejected any growth, and there is no
+      # honest baseline to compare a merged commit against. The other two checks
+      # (new unread paths, stale baseline) still run on push.
       - name: env.yaml keys must match paths the chart reads
         env:
           VALUES_BASELINE_REF: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/deploy-as-code-validation.yml
+++ b/.github/workflows/deploy-as-code-validation.yml
@@ -1,0 +1,82 @@
+# Validation for devops/deploy-as-code/ — the PRODUCTION, large-scale deploy path.
+#
+# Until this workflow existed, a pull request touching that directory triggered
+# ZERO checks. The one workflow that reads anything there (gateway-whitelist-parity)
+# looks at exactly two list keys in env.yaml. Everything else in CI is pointed at
+# local-setup/, the frontend, or the backend.
+#
+# That is how two long-lived defects survived in the production deploy path:
+#   #1645  Prometheus/Alertmanager run on emptyDir because the env.yaml block
+#          specifying a 15Gi volume sits one level too shallow to be read.
+#   #1648  ingress-nginx metrics are exposed but never scraped, because its
+#          override block is nested under a chart-name key the vendored chart
+#          does not read.
+#
+# Both look correct in review. Neither is detectable by helm: values nothing
+# reads are dropped silently, and `helm template` does not warn -- it fails only
+# on template errors, required/fail calls, or a values.schema.json violation, and
+# these charts ship no schema. Hence a purpose-built guard.
+name: deploy-as-code validation
+
+on:
+  pull_request:
+    paths:
+      - 'devops/deploy-as-code/**'
+      - '.github/scripts/check-helm-values-paths.py'
+      - '.github/workflows/deploy-as-code-validation.yml'
+  push:
+    branches: [develop, master]
+    paths:
+      - 'devops/deploy-as-code/**'
+      - '.github/scripts/check-helm-values-paths.py'
+      - '.github/workflows/deploy-as-code-validation.yml'
+
+jobs:
+  values-paths:
+    name: values keys must be read by their chart
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - run: pip install pyyaml
+
+      # Verify the detector itself before trusting its verdict — same idiom as
+      # check-gatus-coverage.py and check-flyway-dump-alignment.py.
+      - name: self-test the guard
+        run: python3 .github/scripts/check-helm-values-paths.py --self-test
+
+      - name: env.yaml keys must match paths the chart reads
+        run: python3 .github/scripts/check-helm-values-paths.py
+
+  duplicate-keys:
+    name: no duplicate YAML keys
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - run: pip install yamllint
+
+      # A duplicated key is silently last-wins in every YAML parser used here —
+      # PyYAML keeps the last value without a warning, and so does Helm. So a
+      # duplicate is invisible to the values-path guard above, to review, and to
+      # the deploy. Only a linter that looks at the raw document catches it.
+      #
+      # Scoped to the files this repo authors and edits. The vendored upstream
+      # chart values (thousands of lines of third-party defaults) are excluded:
+      # linting those reports other people's style, which is noise, and a guard
+      # that produces noise gets switched off.
+      - name: key-duplicates in authored values files
+        run: |
+          yamllint -d '{rules: {key-duplicates: enable}}' \
+            devops/deploy-as-code/charts/environments/env.yaml \
+            devops/deploy-as-code/charts/environments/env-secrets.yaml \
+            devops/deploy-as-code/charts/monitoring/values/ \
+            devops/deploy-as-code/digit-helmfile.yaml

--- a/.github/workflows/deploy-as-code-validation.yml
+++ b/.github/workflows/deploy-as-code-validation.yml
@@ -109,3 +109,74 @@ jobs:
             devops/deploy-as-code/charts/environments/env-secrets.yaml \
             devops/deploy-as-code/charts/monitoring/values/ \
             devops/deploy-as-code/digit-helmfile.yaml
+
+  helmfile-template:
+    name: every release must render
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # The values-path guard above compares key PATHS against a chart's
+      # values.yaml. It cannot see a chart that REJECTS the values it is given.
+      #
+      # PR #1668 is the case that motivated this: the opentelemetry-collector
+      # chart ships a values.schema.json with additionalProperties:false, and
+      # every release here is handed the whole env.yaml tree via
+      # `{{ .Values | toYaml }}`. Helm refused the install outright, listing ~30
+      # env.yaml keys as "not allowed". Nothing caught it -- the guard sees no
+      # mis-path, and no job renders these files -- so it was found by deploying
+      # to a cluster by hand. `helmfile template` reproduces it in seconds.
+      #
+      # This also catches template syntax errors, `fail` calls, and missing
+      # required values, none of which the key-path check can see.
+      - name: install helm and helmfile
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+          # Pinned to the version digit_install.yml deploys with. helmfile v1
+          # rejects these files outright, so this must not float.
+          curl -fsSL -o /usr/local/bin/helmfile \
+            https://github.com/roboll/helmfile/releases/download/v0.140.0/helmfile_linux_amd64
+          chmod +x /usr/local/bin/helmfile
+          helmfile --version
+
+      # `<domain_name>` is a placeholder, not a hostname. Rendering is the point
+      # here, not validating the operator's substitution, so give it something
+      # syntactically valid and deterministic.
+      - name: substitute the domain placeholder
+        run: |
+          sed -i 's|<domain_name>|ci.example.com|g' \
+            devops/deploy-as-code/charts/environments/env.yaml
+
+      - name: render every helmfile
+        run: |
+          cd devops/deploy-as-code
+          failed=0
+          for f in charts/*/*helmfile*.yaml; do
+            printf '%-62s ' "$f"
+            # A helmfile with no `environments:` block has no `env` to select,
+            # and helmfile exits non-zero on "no releases found". The only file
+            # in that state is charts/backbone-services/nginx-helmfile.yaml, an
+            # 11-line stub that digit-helmfile.yaml does not include and whose
+            # `values:` path is truncated mid-word. It is dead, not deployed --
+            # skipped here rather than silently failing the guard. If it is ever
+            # revived it gains an environments block and starts being checked.
+            if ! grep -q '^environments:' "$f"; then
+              echo 'SKIPPED (no environments block; not included by digit-helmfile.yaml)'
+              continue
+            fi
+            if helmfile -f "$f" -e env template >/dev/null 2>/tmp/render.err; then
+              echo 'OK'
+            else
+              echo 'FAILED'
+              sed 's/^/      /' /tmp/render.err | tail -25
+              failed=1
+            fi
+          done
+          if [ "$failed" -ne 0 ]; then
+            echo
+            echo 'A release above does not render. That is a deploy failure, not a style issue:'
+            echo 'helmfile sync would fail the same way, so this cannot reach a cluster.'
+            exit 1
+          fi

--- a/.github/workflows/deploy-as-code-validation.yml
+++ b/.github/workflows/deploy-as-code-validation.yml
@@ -31,12 +31,31 @@ on:
       - '.github/scripts/check-helm-values-paths.py'
       - '.github/workflows/deploy-as-code-validation.yml'
 
+# Both jobs only read the checkout and run a script from the pull request, so
+# the token gets nothing beyond read, and no credential is left behind in
+# .git/config for that script to pick up.
+permissions:
+  contents: read
+
 jobs:
   values-paths:
     name: values keys must be read by their chart
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # The guard rejects any GROWTH of its KNOWN_UNREAD baseline, which it can
+      # only see by reading the previous revision of itself -- the default
+      # depth-1 checkout does not contain it. Fetching the base explicitly keeps
+      # a failure here loud: if it ever breaks, this step goes red rather than
+      # the guard quietly downgrading to "baseline check skipped".
+      - name: fetch the pull request base for the baseline comparison
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: git fetch --no-tags --depth=1 origin "$BASE_SHA"
 
       - uses: actions/setup-python@v5
         with:
@@ -50,6 +69,8 @@ jobs:
         run: python3 .github/scripts/check-helm-values-paths.py --self-test
 
       - name: env.yaml keys must match paths the chart reads
+        env:
+          VALUES_BASELINE_REF: ${{ github.event.pull_request.base.sha }}
         run: python3 .github/scripts/check-helm-values-paths.py
 
   duplicate-keys:
@@ -57,6 +78,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Fixes #1651

## What

A PR touching `devops/deploy-as-code/` — the production, large-scale deploy path — currently triggers **zero** checks. This adds two, both cheap and offline.

## Why these two specifically

They are the checks that would have caught the defects actually found there:

- **#1645** — Prometheus/Alertmanager on `emptyDir`; the `env.yaml` block specifying a 15Gi volume sits one level too shallow to be read.
- **#1648** — ingress-nginx metrics exposed but never scraped; its override block is nested under a key the vendored chart does not read.

Both look correct in review, and **`helm template` would not have caught either** — Helm silently drops values nothing reads, failing only on template errors, `required`/`fail`, or a schema violation, and these charts ship no schema. Purpose-built guard required.

## 1. `check-helm-values-paths.py`

Compares the key paths `env.yaml` sets against the paths the target chart's `values.yaml` defines; fails on anything the chart cannot read.

**Scoped to external/vendored charts on purpose.** Their `values.yaml` is a complete reference. DIGIT's own charts read values via `index .Values "key"` without declaring them, so comparing against `values.yaml` there yields false positives — I verified this against `hrms-dev-mode`, `memory_limits` and `images`, all genuinely consumed but undeclared. Covering them needs the reference set to include template references; that is a later refinement, not a blocker. A guard that cries wolf gets disabled, which costs more than it saves.

**Lands green, via a baseline.** `KNOWN_UNREAD` lists the six existing mis-paths, each naming its issue — same shape as `FROZEN_LATEST_DEBT` in `infra-contracts.test.ts`. The guard therefore fails on anything *new* instead of being merged red and ignored.

The list may only shrink. An entry that stops reproducing fails the check as a **stale baseline** — otherwise the baseline outlives the bug and quietly re-opens the hole it was holding.

## 2. `yamllint` with `key-duplicates`

A duplicated YAML key is silently last-wins in PyYAML *and* in Helm, so it is invisible to check 1, to review, and to the deploy. Only a linter reading the raw document sees it.

Scoped to the values files this repo authors. Vendored upstream chart values are excluded — thousands of lines of third-party defaults, and linting them reports other people's style, which is noise.

## Verified end to end before committing

```
$ check-helm-values-paths.py --self-test
self-test OK: detects mis-paths and orphaned blocks, silent on correct configuration

$ check-helm-values-paths.py                     # on master
OK: 2 external chart(s) checked, no new unread key paths.
6 known mis-path(s) still outstanding: ...        exit 0

# inject a new mis-path (prometheus.retentionSize)
FAIL: env.yaml sets values no chart reads ...     exit 1

# simulate #1645 being fixed, without shrinking the baseline
FAIL: KNOWN_UNREAD lists paths that no longer reproduce ...  exit 1

$ yamllint -d '{rules: {key-duplicates: enable}}' <authored values>
(no findings)                                     exit 0
```

Worth noting the first attempt at the injection test used `prometheus.scrapeInterval`, which the guard correctly did **not** flag — that key genuinely exists at that path. The test was wrong, not the guard; re-run with a truly unread key it fails as intended.

## Deliberately not included

- **Rendering charts and asserting on output** — definitive for #1645's class, but needs network and dummy values for the SOPS-encrypted secrets. Worth a follow-up.
- **Blocking secret scanning** — CodeRabbit runs gitleaks today, but advisory-only and diff-only, so it cannot see a plaintext value that has sat in a file for a year (see #1640).
- **Dependabot/Renovate** — neither exists in this repo, so pinned chart versions age silently. Separate concern.

## Note

The guard is green on `master` today, so this PR does not depend on #1645 or #1648 landing first. When they do land, whoever fixes them must delete the matching `KNOWN_UNREAD` entries — and the check tells them so if they forget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated validation for deployment configuration values and Helm chart paths.
  * Added duplicate-key detection for deployment YAML files.
  * Validation runs automatically for relevant pull requests and updates to primary branches.
  * Added clear diagnostics for missing, unreadable, or unused configuration references.

* **Tests**
  * Added self-tests covering valid paths, misconfigured paths, wrapped values, and missing configuration blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->