### PR TITLE
test(kc): UI-only PGR lifecycle spec + Keycloak parity harness

### DIFF
--- a/local-setup/.gitignore
+++ b/local-setup/.gitignore
@@ -35,3 +35,5 @@ tmp/
 
 # OTEL Java Agent (21MB binary - use otel/download-agent.sh instead)
 otel/opentelemetry-javaagent.jar
+tests/test-results*/
+tests/playwright-report/

--- a/local-setup/tests/README.md
+++ b/local-setup/tests/README.md
@@ -5,6 +5,7 @@
 - `e2e/specs/` — Playwright end-to-end tests against a running DIGIT UI + backend stack.
 - `e2e/utils/` — shared helpers (e.g. `auth.ts`'s `loginViaApi`, which injects a token via `localStorage` instead of driving the login form).
 - `e2e/pages/` — page objects used by some specs.
+- `e2e/kc-parity/` — UI-only PGR lifecycle spec plus the Keycloak-parity harness. Writes real data, so it is excluded from the default collection and only runs with `BASE_URL` set. See [`e2e/kc-parity/README.md`](e2e/kc-parity/README.md).
 - Jest-based schema/smoke tests live alongside the Playwright config at the top level (see `package.json`).
 
 ## Running the E2E suite

--- a/local-setup/tests/e2e/kc-parity/README.md
+++ b/local-setup/tests/e2e/kc-parity/README.md
@@ -1,0 +1,179 @@
+# PGR UI lifecycle + Keycloak parity harness
+
+Two things live here:
+
+1. **`pgr-ui-lifecycle.spec.ts`** — drives a PGR complaint **raise → assign →
+   resolve entirely through the UI**. No API shortcuts anywhere, including login.
+2. **The parity harness** (`run-parity.sh`, `capture.js`, `diff.js`, `probe-*.js`)
+   — captures the same journey on two deployments of the identical build and
+   diffs what DIGIT actually receives.
+
+The UI-only constraint is the point. A Keycloak adapter changes *what the browser
+holds* and *how each XHR is authorised*, so a test that acquires a token over the
+API or seeds users out-of-band cannot see the class of bug this catches.
+
+> **These write real data.** The spec files, assigns and resolves an actual
+> complaint on whatever you point it at. It is excluded from the default
+> `npx playwright test` collection and self-skips unless `BASE_URL` is set.
+
+## Run
+
+The lifecycle spec, against one deployment:
+
+```bash
+cd local-setup/tests
+BASE_URL=https://<your-deployment> EMP_USER=ADMIN EMP_PASS=<password> \
+  npx playwright test e2e/kc-parity/pgr-ui-lifecycle.spec.ts --project=chromium --workers=1
+```
+
+Useful knobs: `CID=<complaint-id>` reuses an existing complaint so the assign and
+resolve steps can be iterated without re-running the ~3-minute citizen wizard
+(step 1 then self-skips); `TOKEN_AUDIT=out/audit.json` records the credential
+shape of every authenticated call; `EMP_CITY`, `AREA_MATCH`, `CITIZEN_MOBILE`,
+`OTP`, `ASSIGNEE_MATCH` adapt it to a tenant's seed data.
+
+The parity diff needs two deployments of the same build, one native-auth and one
+Keycloak-fronted:
+
+```bash
+export BASELINE_URL=https://<native-auth-deployment>
+export KC_URL=https://<keycloak-deployment>
+./e2e/kc-parity/run-parity.sh boot
+./e2e/kc-parity/run-parity.sh citizen  --mobile=<mobile> --otp=<otp>
+./e2e/kc-parity/run-parity.sh employee --user=ADMIN --pass=<password> --city="<City>"
+```
+
+Outputs `out/<journey>-{baseline,kc}.json`, a screenshot per run, and
+`out/<journey>-report.json`. Exit code 1 when a divergence survives.
+
+Optional video capture of a full run, for demos or review:
+
+```bash
+BASELINE_URL=... KC_URL=... ./e2e/kc-parity/record-lifecycle.sh both
+```
+
+## What the parity harness compares
+
+Per request: method, normalized path, status, **credential kind** (uuid = native
+DIGIT vs jwt = Keycloak), request-body key shape (incl. `RequestInfo`), plus the
+resulting localStorage session. Secrets and PII are never recorded — key names and
+token *shapes* only.
+
+Classification:
+- **auth-plane** (`/auth/realms/*`, `/kc/realms/*`, `/user/oauth/token`) — the login
+  mechanism itself, expected to differ.
+- **by-design translation** — `/kc/<api>` is the same endpoint as `<api>`; the
+  browser sends a JWT and the exchange service forwards a DIGIT uuid token
+  upstream (confirm in its `[UPSTREAM]` log).
+- **divergence** — MISSING / EXTRA / STATUS / AUTH_SHAPE / BODY_SHAPE.
+
+`probe-browser-tokens.js` answers the related question directly: under Keycloak
+every credential slot the SPA stores (`token`, `Citizen.token`, `Employee.token`,
+`Digit.User.access_token`) holds a JWT, and the DIGIT token is never serialized to
+the browser at all. The uuids visible in storage are the user's *identity* uuid,
+not a session token.
+
+## Known failure modes this harness detects
+
+1. **`/kc` routed via Kong 401s** (`InvalidAccessTokenException`) — Kong's global
+   DIGIT auth plugin rejects the Keycloak JWT *before* the exchange service can
+   swap it. `/kc/` must proxy straight to the exchange service.
+2. **Realm brute-force settings** — `quickLoginCheckMilliSeconds=1000` trips the
+   legitimate fail→provision→retry pattern. Set to 0 (brute-force detection and
+   failureFactor can stay).
+3. **Session built from JWT claims alone** drops
+   `id`/`userName`/`mobileNumber`/`locale`/`permanentCity`/`active`, and DIGIT
+   components branch on those. Build it from the resolved DIGIT user instead.
+4. **Never preset `CITIZEN.COMMON.HOME.CITY`** — `TopBar` gates its
+   `events/notifications/_count` on `getCitizenCurrentTenant(true)`, i.e. on that
+   key existing. Native citizen login leaves the home city unselected, so seeding
+   it makes the SSO session issue a call the default UI never sends.
+5. **Write paths validate the role on the token**, not on `RequestInfo.userInfo`.
+   Forwarding a shared system token while setting `userInfo` to the acting user
+   passes reads and fails writes with `INVALID_ROLE`.
+
+## Fixes this required outside the test suite
+
+Recorded here because the harness is what found them; the code lives elsewhere.
+
+**`KeycloakAuthAdapter.js`** (`digit-ui-esbuild/packages/libraries/src/services/auth/`)
+— two defects, both still present on `master`:
+
+- *Employee type is never resolved.* The adapter never reads the exchange
+  service's `digit_user_type` / `digit_roles`, and `login()` ends in
+  `window.location.replace()`, which discards in-memory state — so every SSO user
+  is classified `CITIZEN` and an employee session can never be built. Capture
+  those fields at login and rehydrate after the redirect.
+- *Citizen session tenant.* `const tenantId = this._tenantId || defaultCityTenant`
+  with `defaultCityTenant = stateTenant + ".citya"`. A citizen signing in through
+  Keycloak never sees the employee tenant dropdown, so `this._tenantId` is null and
+  the session falls through to a synthesized `<state>.citya` that exists on no real
+  deployment. Every downstream boundary lookup then offers another tenant's wards
+  and PGR rejects the complaint with `INVALID_BOUNDARY_CODE`. Prefer the tenant of
+  the DIGIT user the exchange service already resolved.
+
+**Token exchange service** (external repo) — a compatibility rewrite forced
+`tenantId=<default-city>` and `boundaryType=City` onto every `/boundary-service/`
+call. Both are demo-specific: where `DIGIT_DEFAULT_TENANT` is unset the `pg.citya`
+default survives and rewrites an already-correct tenant, and a hierarchy rooted at
+something other than `City` has every real node filtered away. Guard it with
+`if (!cityTenant.startsWith(stateTenant + '.')) return next();`.
+
+## Gotchas
+
+Hard-won while building this; all cost real time.
+
+**Routes that do not exist.** Two employee routes are easy to get wrong, and an
+unmatched `PrivateRoute` still renders the chrome and a breadcrumb — so a route
+miss looks *exactly* like a broken screen (body text "Home", no buttons, no rows).
+
+| wrong | actual |
+|---|---|
+| `/employee/pgr/inbox` | `/employee/pgr/inbox-v2` |
+| `/employee/pgr/complaint/details/:id` | `/employee/pgr/complaint-details/:id` |
+
+**There is no PGR Inbox card, by design.** `PGRCard.js` renders exactly two links:
+`create-complaint` (CSR only) and `ACTION_TEST_SEARCH_COMPLAINT → inbox-v2`.
+"Search Complaint" *is* the inbox.
+
+**`inbox-v2` opens on the "My Complaints" tab**, which is empty until something is
+assigned to you. An unassigned complaint only appears under "All Complaints".
+
+**Status is a localised label, not a code.** Assert on "Pending for assignment" /
+"Pending at last mile employee" / "Resolved", never `PENDINGATLME`.
+
+**Selectors.** Employee login is `#emp-username` / `#emp-password`; the city is an
+`<li>`; the privacy checkbox toggles **only** via
+`label[for="privacy-component-check"]`; a first-login language screen follows. The
+complaint wizard is an N-level cascade (`AUTHORITY_TYPE → MAIN_CATEGORY → SECTOR →
+SUB_TYPE`) of `<button>`s reading `Select…` — but later steps read `Select County`,
+so the matcher must be `/^Select(…|\s|$)/`.
+
+**HRMS.** `_create` fails `ERR_HRMS_GENERATE_ID_ERROR` unless you pass an explicit
+`code`; it validates roles against its own master, so a full admin role set is
+rejected with `ERR_HRMS_INVALID_ROLE` (send `GRO`/`PGR_LME`/`EMPLOYEE`); and
+`_update` rejects jurisdiction *removals*
+(`ERR_HRMS_UPDATE_JURISDICTION_INCOSISTENT`) — always append.
+
+**PGR assignment rules** (not Keycloak-related; native auth enforces them
+identically): the assignee must be an HRMS employee whose **department matches the
+complaint type's department**, and an account with no HRMS department can never be
+an assignee.
+
+## Expected result when the harness is green
+
+| journey | verdict |
+|---|---|
+| boot | full parity |
+| citizen | full parity |
+| employee | full parity — lands on `/digit-ui/employee`, same DIGIT endpoints |
+| inbox | full parity |
+
+DIGIT receives byte-identical traffic; the only difference is the credential the
+*browser* holds, which the exchange service swaps for a native uuid token before
+anything reaches DIGIT.
+
+The `citizen` journey is mildly flaky: native citizen auto-registration
+(`POST /user/citizen/_create`) fires on some fresh sessions and has no Keycloak
+equivalent, since the exchange service provisions the user. Re-run before
+believing a divergence there.

--- a/local-setup/tests/e2e/kc-parity/capture.js
+++ b/local-setup/tests/e2e/kc-parity/capture.js
@@ -1,0 +1,333 @@
+#!/usr/bin/env node
+'use strict';
+/*
+ * ============================================================================
+ * capture.js — record every network call a DIGIT UI journey makes
+ * ============================================================================
+ *
+ * Drives the SAME user journey against two deployments of the SAME digit-ui
+ * build that differ only in globalConfigs auth provider:
+ *
+ *   baseline : authProvider=digit    (native-auth deployment)
+ *   kc       : authProvider=keycloak (keycloak deployment)
+ *
+ * Keycloak is meant to be a pass-through: token-exchange-svc should make the
+ * app emit the SAME downstream DIGIT calls the default UI does. This captures
+ * the evidence; diff.js turns two captures into a parity verdict.
+ *
+ * Usage:
+ *   node capture.js --base=https://host --journey=boot|citizen|employee \
+ *                   --out=file.json [--user=U --pass=P] [--mobile=M --otp=123456]
+ *                   [--headed] [--timeout=60000]
+ * ============================================================================
+ */
+const fs = require('fs');
+const path = require('path');
+const { chromium } = require(resolvePlaywright());
+
+function resolvePlaywright() {
+  // playwright lives in local-setup/tests/node_modules
+  const candidates = [
+    path.resolve(__dirname, '../../node_modules/playwright'),
+    path.resolve(__dirname, '../../../node_modules/playwright'),
+    'playwright',
+  ];
+  for (const c of candidates) { try { require.resolve(c); return c; } catch { /* next */ } }
+  throw new Error('playwright not found — run npm i in local-setup/tests');
+}
+
+// ---------------------------------------------------------------- args
+const args = {};
+for (const a of process.argv.slice(2)) {
+  const m = a.match(/^--([^=]+)(?:=(.*))?$/);
+  if (m) args[m[1]] = m[2] === undefined ? true : m[2];
+}
+const BASE = (args.base || '').replace(/\/$/, '');
+const JOURNEY = args.journey || 'boot';
+const OUT = args.out || `capture-${JOURNEY}.json`;
+const TIMEOUT = parseInt(args.timeout || '60000', 10);
+if (!BASE) { console.error('ERROR: --base=<url> required'); process.exit(2); }
+
+// ------------------------------------------------------- normalization
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const JWT_RE = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+
+/** Collapse volatile path segments so two runs are comparable. */
+function normalizePath(pathname) {
+  return pathname
+    .split('/')
+    .map((seg) => {
+      if (!seg) return seg;
+      if (UUID_RE.test(seg)) return ':uuid';
+      if (/^\d+$/.test(seg)) return ':n';
+      if (/^[A-Z]{2}-[A-Z]+-\d{4}-\d{2}-\d{2}-\d+$/.test(seg)) return ':complaintId';
+      return seg;
+    })
+    .join('/');
+}
+
+/** What KIND of credential is this — the crux of the KC-vs-DIGIT comparison. */
+function tokenShape(tok) {
+  if (!tok) return 'none';
+  if (JWT_RE.test(tok)) return 'jwt';       // Keycloak RS256 access token
+  if (UUID_RE.test(tok)) return 'uuid';     // native DIGIT (egov-user) token
+  return 'other';
+}
+
+/** Structural fingerprint of a JSON body: keys only, never values (no PII/secrets). */
+function bodyShape(raw) {
+  if (!raw) return null;
+  let obj;
+  try { obj = JSON.parse(raw); } catch {
+    // form-urlencoded (login posts). Record keys + the non-secret discriminators
+    // that decide DIGIT behaviour — never the password.
+    if (/^[^=&]+=[^&]*(&|$)/.test(raw)) {
+      const p = new URLSearchParams(raw);
+      const form = { _form: true, keys: [...p.keys()].sort() };
+      for (const k of ['grant_type', 'tenantId', 'userType', 'scope', 'client_id']) {
+        if (p.has(k)) form[k] = p.get(k);
+      }
+      if (p.has('username')) form.usernameLen = (p.get('username') || '').length;
+      return form;
+    }
+    return { _nonJson: true, _len: raw.length };
+  }
+  if (!obj || typeof obj !== 'object') return { _scalar: typeof obj };
+  const shape = { keys: Object.keys(obj).sort() };
+  const ri = obj.RequestInfo;
+  if (ri && typeof ri === 'object') {
+    shape.RequestInfo = {
+      keys: Object.keys(ri).sort(),
+      authTokenShape: tokenShape(ri.authToken),
+      hasUserInfo: !!ri.userInfo,
+      userInfoKeys: ri.userInfo && typeof ri.userInfo === 'object'
+        ? Object.keys(ri.userInfo).sort() : undefined,
+      userInfoRoleCount: Array.isArray(ri.userInfo && ri.userInfo.roles)
+        ? ri.userInfo.roles.length : undefined,
+      userInfoTenantId: ri.userInfo ? ri.userInfo.tenantId : undefined,
+    };
+  }
+  return shape;
+}
+
+// ------------------------------------------------------------ journeys
+async function journeyBoot(page) {
+  await page.goto(`${BASE}/digit-ui/citizen`, { waitUntil: 'domcontentloaded', timeout: TIMEOUT });
+  await page.waitForTimeout(6000); // let boot MDMS/localization settle
+  return 'loaded citizen landing (unauthenticated boot)';
+}
+
+async function journeyCitizen(page) {
+  const mobile = args.mobile || '9999999999';
+  const otp = args.otp || '123456';
+  await page.goto(`${BASE}/digit-ui/citizen/login`, { waitUntil: 'domcontentloaded', timeout: TIMEOUT });
+  await page.waitForTimeout(3000);
+  const mob = page.locator('input[name="mobileNumber"], input[type="tel"]').first();
+  if (await mob.count()) {
+    await mob.fill(mobile);
+    await page.locator('button[type="submit"], button:has-text("Continue"), button:has-text("CONTINUE")').first().click();
+    await page.waitForTimeout(5000);
+    const otpBoxes = page.locator('input[type="tel"], input[name*="otp" i], input[maxlength="1"]');
+    const n = await otpBoxes.count();
+    if (n >= 6) { for (let i = 0; i < 6; i++) await otpBoxes.nth(i).fill(otp[i]); }
+    else if (n >= 1) { await otpBoxes.first().fill(otp); }
+    const next = page.locator('button[type="submit"], button:has-text("Continue"), button:has-text("Verify")').first();
+    if (await next.count()) await next.click();
+    await page.waitForTimeout(7000);
+  }
+  // Put both sessions in the SAME state before measuring. The Keycloak adapter
+  // auto-selects the citizen's home city at login; a native login leaves it
+  // unset until the citizen picks one on /citizen/select-location. Comparing
+  // "has a home city" against "hasn't" measures onboarding state, not the auth
+  // path -- and the home-city key is what gates TopBar's notification-count
+  // request. So perform the normal selection on both runs (idempotent where the
+  // adapter already did it).
+  try {
+    await page.goto(`${BASE}/digit-ui/citizen/select-location`, { waitUntil: 'domcontentloaded', timeout: TIMEOUT });
+    await page.waitForTimeout(5000);
+    const city = page.locator(`text=${args.city || 'Bomet County'}`).first();
+    if (await city.count()) { await city.click({ timeout: 8000 }); await page.waitForTimeout(1200); }
+    const cont = page.locator('button:has-text("Continue")').first();
+    if (await cont.count()) await cont.click({ timeout: 8000 });
+    await page.waitForTimeout(9000);
+  } catch { /* best effort */ }
+
+  await page.waitForTimeout(12000);
+  return `citizen login attempted (mobile=${mobile})`;
+}
+
+async function journeyEmployee(page) {
+  const user = args.user || 'bometadmin';
+  const pass = args.pass || 'eGov@123';
+  const city = args.city || '';
+  await page.goto(`${BASE}/digit-ui/employee/user/login`, { waitUntil: 'domcontentloaded', timeout: TIMEOUT });
+  await page.waitForTimeout(6000);
+  const u = page.locator('#emp-username, input[name="username"]').first();
+  if (await u.count()) {
+    await u.fill(user);
+    await page.locator('#emp-password, input[name="password"]').first().fill(pass);
+
+    // City is a button-driven <li> dropdown and is mandatory.
+    try {
+      const cityBtn = page.locator('button:has-text("Select city")').first();
+      if (await cityBtn.count()) {
+        await cityBtn.click({ timeout: 5000 });
+        await page.waitForTimeout(1200);
+        await page.locator(`li:has-text("${city}")`).first().click({ timeout: 6000 });
+      }
+    } catch { /* best effort */ }
+
+    // Privacy consent gates the submit button. The <input> is React-controlled —
+    // only a click on its <label> actually toggles it.
+    try {
+      const lbl = page.locator('label[for="privacy-component-check"]').first();
+      if (await lbl.count()) await lbl.click({ timeout: 5000 });
+    } catch { /* best effort */ }
+
+    await page.waitForTimeout(800);
+    const submit = page.locator('button[type="submit"]').first();
+    if (await submit.isEnabled().catch(() => false)) {
+      await submit.click({ timeout: 15000 });
+      await page.waitForTimeout(12000);
+    } else {
+      throw new Error('login submit stayed disabled (city/privacy/creds not satisfied)');
+    }
+
+    // Post-login interstitial: the language-selection screen appears on first
+    // login for a session. Clear it so both runs reach the same home screen —
+    // otherwise the run that stops here looks like it "never called" the
+    // home-screen APIs and the diff reports phantom divergences.
+    for (let i = 0; i < 3; i++) {
+      if (!/language-selection/.test(page.url())) break;
+      try {
+        // a language must be chosen before Continue does anything
+        const lang = page.locator(`button:has-text("${args.lang || 'English'}")`).first();
+        if (await lang.count()) { await lang.click({ timeout: 6000 }); await page.waitForTimeout(800); }
+        const cont = page.locator('button:has-text("Continue"), button:has-text("CONTINUE")').first();
+        if (await cont.count()) await cont.click({ timeout: 8000 });
+      } catch { /* best effort */ }
+      await page.waitForTimeout(7000);
+    }
+  }
+  // exercise an authenticated screen so post-login API calls are captured
+  try {
+    await page.goto(`${BASE}/digit-ui/employee`, { waitUntil: 'domcontentloaded', timeout: TIMEOUT });
+    await page.waitForTimeout(5000);
+  } catch { /* best effort */ }
+  return `employee login attempted (user=${user})`;
+}
+
+/**
+ * The surface an officer actually works on: inbox list, then a complaint detail
+ * page (which pulls workflow history, HRMS actors, boundary and MDMS config).
+ * Far more DIGIT calls than login, so it's the real parity test.
+ */
+async function journeyInbox(page) {
+  const note = await journeyEmployee(page);
+  const seen = [];
+  for (const path of ['/digit-ui/employee/pgr/inbox', '/digit-ui/employee']) {
+    try {
+      await page.goto(`${BASE}${path}`, { waitUntil: 'domcontentloaded', timeout: TIMEOUT });
+      await page.waitForTimeout(9000);
+      seen.push(`${path} -> ${page.url().replace(BASE, '')}`);
+      // open the first complaint if the inbox rendered any
+      const link = page.locator('a[href*="pgr/complaint"], a[href*="/complaint/"]').first();
+      if (await link.count()) {
+        await link.click({ timeout: 8000 });
+        await page.waitForTimeout(9000);
+        seen.push(`opened -> ${page.url().replace(BASE, '')}`);
+        break;
+      }
+    } catch { /* best effort */ }
+  }
+  return `${note}; ${seen.join(' | ')}`;
+}
+
+const JOURNEYS = { boot: journeyBoot, citizen: journeyCitizen, employee: journeyEmployee, inbox: journeyInbox };
+
+// ---------------------------------------------------------------- main
+(async () => {
+  if (!JOURNEYS[JOURNEY]) { console.error(`ERROR: unknown journey ${JOURNEY}`); process.exit(2); }
+  const browser = await chromium.launch({ headless: !args.headed, args: ['--no-sandbox'] });
+  const ctx = await browser.newContext({ ignoreHTTPSErrors: true, viewport: { width: 1400, height: 900 } });
+  const page = await ctx.newPage();
+
+  const calls = [];
+  const consoleErrors = [];
+  const byReq = new Map();
+
+  page.on('request', (req) => { byReq.set(req, Date.now()); });
+
+  page.on('requestfinished', async (req) => {
+    try {
+      const url = new URL(req.url());
+      const rt = req.resourceType();
+      if (['image', 'font', 'media', 'stylesheet'].includes(rt)) return;
+      let status = null;
+      try { const r = await req.response(); status = r ? r.status() : null; } catch { /* ignore */ }
+      const authHeader = (req.headers()['authorization'] || '').replace(/^Bearer\s+/i, '');
+      calls.push({
+        method: req.method(),
+        origin: url.origin,
+        path: url.pathname,
+        normPath: normalizePath(url.pathname),
+        searchKeys: [...url.searchParams.keys()].sort(),
+        resourceType: rt,
+        status,
+        authHeaderShape: tokenShape(authHeader),
+        body: bodyShape(req.postData()),
+      });
+    } catch { /* ignore */ }
+  });
+
+  page.on('requestfailed', (req) => {
+    try {
+      const url = new URL(req.url());
+      calls.push({
+        method: req.method(), origin: url.origin, path: url.pathname,
+        normPath: normalizePath(url.pathname), searchKeys: [...url.searchParams.keys()].sort(),
+        resourceType: req.resourceType(), status: 'FAILED',
+        failure: (req.failure() || {}).errorText, authHeaderShape: 'none', body: bodyShape(req.postData()),
+      });
+    } catch { /* ignore */ }
+  });
+
+  page.on('console', (m) => { if (m.type() === 'error') consoleErrors.push(m.text().slice(0, 300)); });
+
+  let note = '', error = null;
+  try { note = await JOURNEYS[JOURNEY](page); }
+  catch (e) { error = String(e && e.message || e); }
+
+  // post-journey session evidence (does the app consider itself logged in?)
+  let session = {};
+  try {
+    session = await page.evaluate(() => {
+      const pick = (k) => { try { return localStorage.getItem(k); } catch { return null; } };
+      const tok = pick('token') || pick('Citizen.token') || pick('Employee.token');
+      const ui = pick('user-info') || pick('Citizen.user-info') || pick('Employee.user-info');
+      let parsedUi = null; try { parsedUi = ui ? JSON.parse(ui) : null; } catch { /* */ }
+      return {
+        hasToken: !!tok,
+        tokenLen: tok ? tok.length : 0,
+        tokenSample: tok ? tok.slice(0, 12) : null,
+        userInfoKeys: parsedUi ? Object.keys(parsedUi).sort() : null,
+        userTenantId: parsedUi ? parsedUi.tenantId : null,
+        userRoleCount: parsedUi && Array.isArray(parsedUi.roles) ? parsedUi.roles.length : null,
+        url: location.href,
+      };
+    });
+  } catch { /* ignore */ }
+  if (session.tokenSample) session.tokenShape = tokenShape(session.tokenSample.length >= 12 ? null : null) || undefined;
+
+  try { await page.screenshot({ path: OUT.replace(/\.json$/, '.png'), fullPage: false }); } catch { /* */ }
+
+  const out = {
+    meta: { base: BASE, journey: JOURNEY, note, error, at: new Date().toISOString(), finalUrl: session.url || null },
+    session,
+    consoleErrors: consoleErrors.slice(0, 25),
+    calls,
+  };
+  fs.writeFileSync(OUT, JSON.stringify(out, null, 2));
+  console.log(`captured ${calls.length} calls -> ${OUT}${error ? `  (journey error: ${error})` : ''}`);
+  await browser.close();
+})();

--- a/local-setup/tests/e2e/kc-parity/diff.js
+++ b/local-setup/tests/e2e/kc-parity/diff.js
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+'use strict';
+/*
+ * ============================================================================
+ * diff.js — parity verdict: does the Keycloak path emit the SAME DIGIT calls?
+ * ============================================================================
+ *
+ * Keycloak is a pass-through. token-exchange-svc is supposed to make the
+ * KC-enabled UI behave EXACTLY like the default one from DIGIT's point of
+ * view. Anything this reports as a divergence must be fixed in
+ * token-exchange-svc or the Keycloak realm — never in the UI.
+ *
+ *   node diff.js baseline.json kc.json [--json=report.json]
+ *
+ * Divergence classes (in severity order):
+ *   MISSING      endpoint the baseline calls that KC never does
+ *   EXTRA        endpoint only the KC run calls (KC/overlay traffic is
+ *                classified separately as EXPECTED-AUTH, not a failure)
+ *   STATUS       same endpoint, different response status (e.g. 200 -> 401)
+ *   AUTH_SHAPE   same endpoint, different credential kind (uuid vs jwt) —
+ *                DIGIT services expect the native uuid token
+ *   BODY_SHAPE   same endpoint, different request payload keys / RequestInfo
+ * ============================================================================
+ */
+const fs = require('fs');
+
+const files = process.argv.slice(2).filter((a) => !a.startsWith('--'));
+const flags = Object.fromEntries(process.argv.slice(2).filter((a) => a.startsWith('--'))
+  .map((a) => { const m = a.match(/^--([^=]+)(?:=(.*))?$/); return [m[1], m[2] === undefined ? true : m[2]]; }));
+if (files.length < 2) { console.error('usage: diff.js baseline.json kc.json [--json=report.json]'); process.exit(2); }
+
+const A = JSON.parse(fs.readFileSync(files[0], 'utf8')); // baseline (digit auth)
+const B = JSON.parse(fs.readFileSync(files[1], 'utf8')); // kc
+
+/**
+ * Auth-plane traffic — the login mechanism itself, which is EXPECTED to differ:
+ * the default UI mints a session at /user/oauth/token, the KC build does it via
+ * Keycloak + the token-exchange overlay. Parity is about the DIGIT calls that
+ * come AFTER login, not about how the session was obtained.
+ */
+function isAuthPlane(c) {
+  const p = c.normPath;
+  return /\/auth\/realms\//.test(p) || /\/token-exchange\//.test(p)
+      || /openid-connect/.test(p) || /\/realms\//.test(p)
+      || /^\/user\/oauth\/token$/.test(p);
+}
+
+/**
+ * The KC build prefixes DIGIT calls with /kc so token-exchange-svc sees them
+ * first, swaps the Keycloak JWT for a real DIGIT token, and forwards the SAME
+ * request upstream. So /kc/user/_search IS /user/_search from DIGIT's point of
+ * view — compare on the effective endpoint, or every proxied call would look
+ * like a divergence.
+ */
+function effectivePath(c) { return c.normPath.replace(/^\/kc(?=\/)/, ''); }
+
+/**
+ * Paths the KC deployment routes through token-exchange-svc. /kc/* is explicit
+ * in the URL; others (e.g. /mdms-v2/) are routed at the nginx layer and so look
+ * identical to the browser. On these the browser legitimately presents a KC JWT
+ * while DIGIT still receives a native uuid token.
+ */
+const OVERLAY_PATHS = String(flags['overlay-paths'] || '/kc/,/mdms-v2/,/localization/')
+  .split(',').map((x) => x.trim()).filter(Boolean);
+function isOverlayRouted(c) {
+  return OVERLAY_PATHS.some((pre) => c.normPath.startsWith(pre));
+}
+/** Static asset / app shell noise we don't want in the verdict. */
+function isAppNoise(c) {
+  return c.resourceType === 'document' || /\.(js|css|map|json|svg|png|ico|woff2?)$/i.test(c.path)
+      || /^\/digit-ui\//.test(effectivePath(c));
+}
+/** The DIGIT API surface — what parity is actually about. */
+function isDigitApi(c) { return !isAuthPlane(c) && !isAppNoise(c); }
+
+const key = (c) => `${c.method} ${effectivePath(c)}`;
+
+function index(cap) {
+  const m = new Map();
+  for (const c of cap.calls) {
+    if (!isDigitApi(c)) continue;
+    const k = key(c);
+    if (!m.has(k)) m.set(k, []);
+    m.get(k).push(c);
+  }
+  return m;
+}
+const ia = index(A), ib = index(B);
+const findings = [];
+const proxied = [];  // by-design overlay translations (browser jwt -> DIGIT uuid)
+
+// endpoints the baseline exercises that KC does not
+for (const [k, aCalls] of ia) {
+  if (!ib.has(k)) { findings.push({ type: 'MISSING', endpoint: k, detail: `baseline called it ${aCalls.length}x; KC never did` }); }
+}
+// endpoints only KC makes (non-auth-plane => genuinely extra)
+for (const [k, bCalls] of ib) {
+  if (!ia.has(k)) { findings.push({ type: 'EXTRA', endpoint: k, detail: `KC-only call (${bCalls.length}x, status ${[...new Set(bCalls.map((c) => c.status))].join('/')})` }); }
+}
+// shared endpoints: compare status / credential kind / payload shape
+for (const [k, aCalls] of ia) {
+  const bCalls = ib.get(k); if (!bCalls) continue;
+  const sA = [...new Set(aCalls.map((c) => String(c.status)))].sort().join(',');
+  const sB = [...new Set(bCalls.map((c) => String(c.status)))].sort().join(',');
+  if (sA !== sB) findings.push({ type: 'STATUS', endpoint: k, detail: `baseline=${sA} kc=${sB}` });
+
+  const tA = [...new Set(aCalls.map((c) => (c.body && c.body.RequestInfo && c.body.RequestInfo.authTokenShape) || c.authHeaderShape || 'none'))].sort().join(',');
+  const tB = [...new Set(bCalls.map((c) => (c.body && c.body.RequestInfo && c.body.RequestInfo.authTokenShape) || c.authHeaderShape || 'none'))].sort().join(',');
+  // A jwt-vs-uuid difference on an overlay-proxied (/kc/...) call is BY DESIGN:
+  // the browser legitimately holds a Keycloak JWT, and token-exchange-svc swaps
+  // it for a native DIGIT token before forwarding. What DIGIT receives is the
+  // uuid token — verify that in the overlay's [UPSTREAM] log lines, not here.
+  const allProxied = bCalls.every(isOverlayRouted);
+  if (tA !== tB) {
+    // On overlay-routed paths the ONLY legitimate difference is the credential
+    // kind: wherever the default UI sends a DIGIT uuid, the KC build sends a KC
+    // jwt (unauthenticated calls stay 'none' on both). If substituting uuid for
+    // jwt makes the two sets identical, nothing else diverged.
+    const tBasIfTranslated = tB.split(',').map((x) => (x === 'jwt' ? 'uuid' : x)).sort().join(',');
+    if (allProxied && tBasIfTranslated === tA.split(',').sort().join(',')) {
+      proxied.push({ endpoint: k, detail: `browser sends jwt; token-exchange-svc forwards a DIGIT uuid token upstream` });
+    } else {
+      findings.push({ type: 'AUTH_SHAPE', endpoint: k, detail: `baseline token=${tA} kc token=${tB}` });
+    }
+  }
+
+  const shape = (calls) => [...new Set(calls.map((c) => (c.body && c.body.keys ? c.body.keys.join('+') : '-')))].sort().join(' | ');
+  const kA = shape(aCalls), kB = shape(bCalls);
+  if (kA !== kB) findings.push({ type: 'BODY_SHAPE', endpoint: k, detail: `baseline keys=[${kA}] kc keys=[${kB}]` });
+}
+
+// ------------------------------------------------------------- report
+const authPlane = B.calls.filter(isAuthPlane);
+const order = { MISSING: 0, STATUS: 1, AUTH_SHAPE: 2, BODY_SHAPE: 3, EXTRA: 4 };
+findings.sort((x, y) => order[x.type] - order[y.type] || x.endpoint.localeCompare(y.endpoint));
+
+const line = '='.repeat(78);
+console.log(line);
+console.log(`KC PARITY REPORT — journey=${A.meta.journey}`);
+console.log(`  baseline : ${A.meta.base}  (${A.calls.length} calls, ${ia.size} DIGIT endpoints)`);
+console.log(`  keycloak : ${B.meta.base}  (${B.calls.length} calls, ${ib.size} DIGIT endpoints)`);
+console.log(line);
+
+console.log('\nSESSION (did the app end up authenticated?)');
+const sess = (c, s) => `  ${c.padEnd(9)} token=${s.hasToken ? 'YES' : 'NO '} len=${String(s.tokenLen || 0).padEnd(5)} tenant=${s.userTenantId || '-'} roles=${s.userRoleCount ?? '-'} url=${(s.url || '-').replace(/^https?:\/\/[^/]+/, '')}`;
+console.log(sess('baseline', A.session || {}));
+console.log(sess('keycloak', B.session || {}));
+
+console.log(`\nAUTH-PLANE CALLS (KC-only, expected): ${authPlane.length}`);
+for (const c of [...new Map(authPlane.map((c) => [key(c), c])).values()].slice(0, 12)) {
+  console.log(`  ${String(c.status).padEnd(6)} ${c.method} ${c.normPath}`);
+}
+
+if (proxied.length) {
+  console.log(`\nBY-DESIGN OVERLAY TRANSLATIONS: ${proxied.length} (browser JWT -> DIGIT uuid, same endpoint)`);
+  for (const p of proxied) console.log(`  ${p.endpoint}\n               ${p.detail}`);
+}
+
+if (!findings.length) {
+  console.log('\n✅ FULL PARITY — the Keycloak build emits the same DIGIT calls as the default UI.');
+} else {
+  console.log(`\n❌ ${findings.length} DIVERGENCE(S) — fix in token-exchange-svc or realm settings only:\n`);
+  for (const f of findings) console.log(`  [${f.type.padEnd(10)}] ${f.endpoint}\n               ${f.detail}`);
+}
+
+if (A.meta.error || B.meta.error) {
+  console.log('\nJOURNEY ERRORS');
+  if (A.meta.error) console.log(`  baseline: ${A.meta.error}`);
+  if (B.meta.error) console.log(`  keycloak: ${B.meta.error}`);
+}
+if ((B.consoleErrors || []).length) {
+  console.log('\nKC CONSOLE ERRORS (first 5)');
+  for (const e of B.consoleErrors.slice(0, 5)) console.log(`  - ${e}`);
+}
+console.log(`\n${line}`);
+
+if (flags.json) {
+  fs.writeFileSync(flags.json, JSON.stringify({
+    journey: A.meta.journey, baseline: A.meta.base, kc: B.meta.base,
+    sessions: { baseline: A.session, kc: B.session },
+    authPlaneCount: authPlane.length, findings,
+  }, null, 2));
+  console.log(`report -> ${flags.json}`);
+}
+process.exit(findings.length ? 1 : 0);

--- a/local-setup/tests/e2e/kc-parity/lifecycle-through-kc.sh
+++ b/local-setup/tests/e2e/kc-parity/lifecycle-through-kc.sh
@@ -1,0 +1,44 @@
+set -uo pipefail
+KC="${KC_URL:?set KC_URL to the Keycloak-fronted deployment}"
+TEN="${TENANT:-ke.bomet}"; ROOT="${ROOT_TENANT:-ke}"
+say(){ printf "  %-40s %s\n" "$1" "$2"; }
+tok(){ curl -s -X POST "$KC/kc/realms/ke/protocol/openid-connect/token" -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=password&client_id=digit-ui&username=$1&password=$2&tenantId=$3" \
+  | python3 -c "import json,sys;d=json.load(sys.stdin);print(json.dumps({'t':d.get('access_token',''),'u':d.get('digit_user') or {}}))"; }
+
+CJ=$(tok 712345678 123456 ke);  CIT=$(echo "$CJ"|python3 -c "import json,sys;print(json.load(sys.stdin)['t'])"); CU=$(echo "$CJ"|python3 -c "import json,sys;print(json.dumps(json.load(sys.stdin)['u']))")
+EJ=$(tok ADMIN eGov@123 ke);    EMP=$(echo "$EJ"|python3 -c "import json,sys;print(json.load(sys.stdin)['t'])"); EU=$(echo "$EJ"|python3 -c "import json,sys;print(json.dumps(json.load(sys.stdin)['u']))")
+say "citizen / employee KC tokens" "len=${#CIT} / ${#EMP}"
+EUUID=$(echo "$EU"|python3 -c "import json,sys;print(json.load(sys.stdin).get('uuid',''))")
+
+RI(){ echo "{\"apiId\":\"Rainmaker\",\"msgId\":\"$(date +%s)000|en_IN\",\"authToken\":\"$1\",\"userInfo\":$2}"; }
+
+CREATE=$(curl -s -X POST "$KC/kc/pgr-services/v2/request/_create?tenantId=$TEN" -H "Content-Type: application/json" -H "Authorization: Bearer $CIT" -d "$(python3 -c "
+import json,sys,time
+cu=json.loads('''$CU''')
+print(json.dumps({'RequestInfo':{'apiId':'Rainmaker','msgId':f'{int(time.time())}000|en_IN','authToken':'$CIT','userInfo':cu},
+ 'service':{'tenantId':'$TEN','serviceCode':'${SERVICE:-DamagedRoad}','description':'kc lifecycle probe','source':'web',
+   'address':{'city':'$TEN','locality':{'code':'BOMET_BOMET_CENTRAL_MUTARAKWA','name':'Chesoen'},'geoLocation':{'latitude':-0.7813,'longitude':35.3416}},
+   'citizen':{'name':cu.get('name','Citizen'),'mobileNumber':cu.get('mobileNumber'),'countryCode':cu.get('countryCode'),'emailId':cu.get('emailId'),'type':'CITIZEN','tenantId':'$ROOT','uuid':cu.get('uuid')}},
+ 'workflow':{'action':'APPLY'}}))")")
+SRID=$(echo "$CREATE"|python3 -c "import json,sys;print((json.load(sys.stdin).get('ServiceWrappers') or [{}])[0].get('service',{}).get('serviceRequestId',''))" 2>/dev/null)
+say "APPLY (citizen files)" "${SRID:-FAILED: $(echo "$CREATE"|head -c 110)}"
+[ -z "$SRID" ] && exit 1
+
+step(){ # action token userinfo extra
+  local S=$(curl -s -X POST "$KC/kc/pgr-services/v2/request/_search?tenantId=$TEN&serviceRequestId=$SRID" -H "Content-Type: application/json" -H "Authorization: Bearer $2" -d "{\"RequestInfo\":$(RI "$2" "$3")}" \
+    | python3 -c "import json,sys
+w=(json.load(sys.stdin).get('ServiceWrappers') or [{}])[0]; s=w.get('service',{}); s.pop('processInstance',None); print(json.dumps(s))" 2>/dev/null)
+  [ -z "$S" ] && { say "$1" "search FAILED"; return; }
+  local R=$(curl -s -w '\n%{http_code}' -X POST "$KC/kc/pgr-services/v2/request/_update?tenantId=$TEN" -H "Content-Type: application/json" -H "Authorization: Bearer $2" \
+    -d "{\"RequestInfo\":$(RI "$2" "$3"),\"service\":$S,\"workflow\":{\"action\":\"$1\",\"comments\":\"kc lifecycle\"$4}}")
+  local C=$(echo "$R"|tail -1)
+  local ST=$(echo "$R"|sed '$d'|python3 -c "import json,sys;w=(json.load(sys.stdin).get('ServiceWrappers') or [{}])[0];print(w.get('service',{}).get('applicationStatus',''))" 2>/dev/null)
+  say "$1" "http=$C  status=${ST:-$(echo "$R"|sed '$d'|head -c 300)}"
+}
+step ASSIGN  "$EMP" "$EU" ",\"assignes\":[\"${ASSIGNEE:-$EUUID}\"]"
+step RESOLVE "$EMP" "$EU" ""
+step RATE    "$CIT" "$CU" ""
+FIN=$(curl -s -X POST "$KC/kc/pgr-services/v2/request/_search?tenantId=$TEN&serviceRequestId=$SRID" -H "Content-Type: application/json" -H "Authorization: Bearer $CIT" -d "{\"RequestInfo\":$(RI "$CIT" "$CU")}" \
+ | python3 -c "import json,sys;w=(json.load(sys.stdin).get('ServiceWrappers') or [{}])[0];print(w.get('service',{}).get('applicationStatus',''))" 2>/dev/null)
+say "FINAL STATUS ($SRID)" "$FIN"

--- a/local-setup/tests/e2e/kc-parity/pgr-ui-lifecycle.spec.ts
+++ b/local-setup/tests/e2e/kc-parity/pgr-ui-lifecycle.spec.ts
@@ -1,0 +1,363 @@
+/**
+ * PGR lifecycle, UI ONLY — raise → assign → resolve.
+ *
+ * Every step is performed by clicking through the SPA; nothing is done over the
+ * API. That is the point: it is the only way to prove the Keycloak build really
+ * behaves like the default one, because the adapter changes what the browser
+ * holds and how each XHR is authorised.
+ *
+ * BASE_URL is required — this suite files, assigns and resolves a REAL complaint
+ * on whatever it points at, so it self-skips rather than defaulting to a host:
+ *   BASE_URL=https://<native-auth-deployment> npx playwright test pgr-ui-lifecycle
+ *   BASE_URL=https://<keycloak-deployment>    npx playwright test pgr-ui-lifecycle
+ * Run the same spec unmodified against both; any difference is an auth-path bug.
+ *
+ * Iterating on steps 2/3 only? Pass CID=<existing complaint> to skip the wizard.
+ *
+ * Env: CITIZEN_MOBILE, OTP, EMP_USER, EMP_PASS, EMP_CITY, AREA_MATCH, CID,
+ *      ASSIGNEE_MATCH, RESOLVER_USER, RESOLVER_PASS
+ */
+import { test, expect, Page } from '@playwright/test';
+import * as fs from 'fs';
+
+/**
+ * Token transport audit (inert unless TOKEN_AUDIT=<path.json> is set).
+ *
+ * Rides the real lifecycle rather than a synthetic flow, so it reports what the
+ * browser actually sends on every DIGIT call across all three steps. Under
+ * Keycloak the browser should hold a JWT and token-exchange-svc should swap it
+ * for a DIGIT uuid upstream; under native auth the browser holds the uuid itself.
+ */
+const AUDIT = process.env.TOKEN_AUDIT;
+const audit: Array<Record<string, unknown>> = [];
+let auditStep = '';
+
+function tokenShape(t?: string | null): 'none' | 'jwt' | 'uuid' | 'other' {
+  if (!t) return 'none';
+  if (/^ey[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\./.test(t)) return 'jwt';
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(t)) return 'uuid';
+  return 'other';
+}
+
+const BASE = (process.env.BASE_URL || 'http://localhost:18080').replace(/\/$/, '');
+const MOBILE = process.env.CITIZEN_MOBILE || '712345678';
+const OTP = process.env.OTP || '123456';
+const EMP_USER = process.env.EMP_USER || 'ADMIN';
+const EMP_PASS = process.env.EMP_PASS || 'eGov@123';
+const EMP_CITY = process.env.EMP_CITY || 'Bomet County';
+// Whoever resolves must be the complaint's assignee, so by default the same
+// officer assigns it to themselves and then resolves it.
+const RESOLVER_USER = process.env.RESOLVER_USER || EMP_USER;
+const RESOLVER_PASS = process.env.RESOLVER_PASS || EMP_PASS;
+
+/**
+ * The registered employee routes are `pgr/inbox-v2` and `pgr/complaint-details/:id`.
+ * `pgr/inbox` and `pgr/complaint/details/:id` are NOT routes — an unmatched
+ * PrivateRoute renders the chrome and a breadcrumb and nothing else, which looks
+ * exactly like a broken screen. Keep these in one place so that never recurs.
+ */
+const detailUrl = (id: string) => `${BASE}/digit-ui/employee/pgr/complaint-details/${id}`;
+const inboxUrl = `${BASE}/digit-ui/employee/pgr/inbox-v2`;
+
+test.describe.configure({ mode: 'serial' });
+
+let complaintId = process.env.CID || '';
+
+async function citizenLogin(page: Page) {
+  await page.goto(`${BASE}/digit-ui/citizen/login`, { waitUntil: 'domcontentloaded', timeout: 90_000 });
+  await page.waitForTimeout(5000);
+  await page.locator('input[type="tel"], input[name="mobileNumber"]').first().fill(MOBILE);
+  await page.locator('button:has-text("Continue"), button[type="submit"]').first().click();
+  await page.waitForTimeout(6000);
+  const boxes = page.locator('input[type="tel"], input[maxlength="1"]');
+  const n = await boxes.count();
+  if (n >= 6) { for (let i = 0; i < 6; i++) await boxes.nth(i).fill(OTP[i]); }
+  else if (n >= 1) { await boxes.first().fill(OTP); }
+  const next = page.locator('button:has-text("Continue"), button:has-text("Verify"), button[type="submit"]').first();
+  if (await next.count()) await next.click();
+  await page.waitForTimeout(10_000);
+}
+
+async function employeeLogin(page: Page, user = EMP_USER, pass = EMP_PASS) {
+  await page.goto(`${BASE}/digit-ui/employee/user/login`, { waitUntil: 'domcontentloaded', timeout: 90_000 });
+  await page.waitForTimeout(6000);
+  await page.locator('#emp-username, input[name="username"]').first().fill(user);
+  await page.locator('#emp-password, input[name="password"]').first().fill(pass);
+  const cityBtn = page.locator('button:has-text("Select city")').first();
+  if (await cityBtn.count()) {
+    await cityBtn.click();
+    await page.waitForTimeout(1200);
+    await page.locator(`li:has-text("${EMP_CITY}")`).first().click({ timeout: 8000 });
+  }
+  // React-controlled checkbox: only a click on the <label> toggles it
+  const lbl = page.locator('label[for="privacy-component-check"]').first();
+  if (await lbl.count()) await lbl.click();
+  await page.waitForTimeout(800);
+  await page.locator('button[type="submit"]').first().click();
+  await page.waitForTimeout(12_000);
+  // first-login language interstitial
+  for (let i = 0; i < 3 && /language-selection/.test(page.url()); i++) {
+    const lang = page.locator('button:has-text("English")').first();
+    if (await lang.count()) { await lang.click(); await page.waitForTimeout(800); }
+    const cont = page.locator('button:has-text("Continue")').first();
+    if (await cont.count()) await cont.click();
+    await page.waitForTimeout(7000);
+  }
+  expect(page.url(), 'employee should be logged in').not.toContain('/user/login');
+}
+
+/**
+ * The complaint form is an N-level cascade (AUTHORITY_TYPE -> MAIN_CATEGORY ->
+ * SECTOR -> SUB_TYPE) rendered as <button>s reading "Select…"; each level only
+ * becomes selectable once its parent is chosen. Later steps read "Select County",
+ * so the matcher has to allow a trailing word, not just the ellipsis.
+ */
+async function fillCascade(page: Page, match?: RegExp, maxLevels = 6): Promise<string[]> {
+  const picked: string[] = [];
+  for (let level = 0; level < maxLevels; level++) {
+    const trigger = page.locator('button', { hasText: /^Select(…|\s|$)/ }).first();
+    if (!(await trigger.count())) break;
+    if (!(await trigger.isEnabled().catch(() => false))) break;
+    await trigger.click();
+    await page.waitForTimeout(1200);
+
+    const opts = page.locator('li, [role="option"], .digit-dropdown-item');
+    const count = await opts.count();
+    if (!count) break;
+
+    let idx = 0;
+    if (match) {
+      for (let i = 0; i < count; i++) {
+        const t = (await opts.nth(i).innerText().catch(() => '')) || '';
+        if (match.test(t)) { idx = i; break; }
+      }
+    }
+    const label = ((await opts.nth(idx).innerText().catch(() => '')) || '').trim();
+    await opts.nth(idx).click();
+    await page.waitForTimeout(1800);
+    picked.push(label);
+  }
+  return picked;
+}
+
+/**
+ * Drive the whole FormComposer wizard generically instead of hardcoding a step
+ * order: at each screen fill whatever it asks for (cascade selects, postal code,
+ * landmark, description), then press NEXT — and SUBMIT on the last screen. The
+ * wizard's shape is tenant-configurable, so this survives config changes.
+ */
+async function advanceWizard(page: Page, description: string, maxSteps = 10) {
+  for (let step = 0; step < maxSteps; step++) {
+    // 1. any cascade on this screen. Prefer a Bomet-matching option so the
+    // complaint lands inside the officers' jurisdiction — otherwise it is filed
+    // in whatever boundary happens to be first and no inbox will ever show it.
+    await fillCascade(page, new RegExp(process.env.AREA_MATCH || 'bomet', 'i')).catch(() => []);
+
+    // 2. required free-text fields
+    const postal = page.locator('#postal-code');
+    if (await postal.count() && !(await postal.inputValue().catch(() => ''))) {
+      await postal.fill(process.env.POSTAL || '20400');
+    }
+    const landmark = page.locator('#landmark');
+    if (await landmark.count() && !(await landmark.inputValue().catch(() => ''))) {
+      await landmark.fill('Near the market');
+    }
+    const ta = page.locator('textarea').first();
+    if (await ta.count() && !(await ta.inputValue().catch(() => ''))) {
+      await ta.fill(description);
+    }
+    await page.waitForTimeout(1200);
+
+    // 3. advance
+    const btn = page.locator('button').filter({ hasText: /^(NEXT|SUBMIT|CS_COMMON_NEXT|CS_COMMON_SUBMIT)$/i }).last();
+    if (!(await btn.count())) break;
+    const label = ((await btn.innerText().catch(() => '')) || '').trim();
+    if (!(await btn.isEnabled().catch(() => false))) {
+      const txt = (await page.locator('body').innerText()).slice(0, 200).replace(/\n+/g, ' | ');
+      throw new Error(`wizard stuck: "${label}" disabled at step ${step}. Screen: ${txt}`);
+    }
+    await btn.click();
+    await page.waitForTimeout(6500);
+
+    if (/complaint\/response|success/i.test(page.url())) break;
+    const body = await page.locator('body').innerText();
+    if (/[A-Z]{2}-[A-Z]+-\d{4}-\d{2}-\d{2}-\d+/.test(body)) break;
+  }
+}
+
+/** The detail page renders the workflow state as a localised label, not a code. */
+async function currentStatus(page: Page): Promise<string> {
+  const body = await page.locator('body').innerText();
+  const m = body.match(/Current Status\s*\n\s*([^\n]+)/);
+  return (m ? m[1] : '').trim();
+}
+
+async function openDetail(page: Page, id: string) {
+  await page.goto(detailUrl(id), { waitUntil: 'domcontentloaded', timeout: 90_000 });
+  await page.waitForTimeout(11_000);
+  await expect(
+    page.locator('button').filter({ hasText: /Take action|CS_COMMON_TAKE_ACTION/i }).first(),
+    'the complaint detail screen must render a Take action button'
+  ).toBeVisible({ timeout: 30_000 });
+}
+
+/** Open "Take action" and pick one of Reject / Assign / Escalate / Resolve. */
+async function chooseAction(page: Page, action: RegExp) {
+  await page.locator('button').filter({ hasText: /Take action|CS_COMMON_TAKE_ACTION/i }).first().click();
+  await page.waitForTimeout(1800);
+  const options = page.locator('.header-dropdown-option');
+  const labels: string[] = [];
+  const n = await options.count();
+  for (let i = 0; i < n; i++) labels.push(((await options.nth(i).innerText().catch(() => '')) || '').trim());
+  const idx = labels.findIndex((l) => action.test(l));
+  expect(idx, `action ${action} must be offered. Menu had: ${labels.join(', ') || '(empty)'}`).toBeGreaterThanOrEqual(0);
+  await options.nth(idx).click();
+  await page.waitForTimeout(4000);
+  return labels;
+}
+
+/** Fill and submit the workflow modal; returns nothing, throws with the screen on failure. */
+async function submitModal(page: Page, comment: string, assigneeMatch?: RegExp) {
+  const modal = page.locator('.popup-module');
+  await modal.waitFor({ state: 'visible', timeout: 25_000 });
+
+  const assignee = modal.locator('.assignee-dropdown-container');
+  if (await assignee.count()) {
+    await assignee.locator('input').first().click();
+    await page.waitForTimeout(2000);
+    const opts = page.locator('.digit-dropdown-item, .employee-select-wrap li, li');
+    const count = await opts.count();
+    expect(count, 'an eligible assignee must exist for this complaint type\'s department').toBeGreaterThan(0);
+    let idx = 0;
+    if (assigneeMatch) {
+      for (let i = 0; i < count; i++) {
+        const t = (await opts.nth(i).innerText().catch(() => '')) || '';
+        if (assigneeMatch.test(t)) { idx = i; break; }
+      }
+    }
+    console.log(`  assignee: ${((await opts.nth(idx).innerText().catch(() => '')) || '').trim()}`);
+    await opts.nth(idx).click();
+    await page.waitForTimeout(1200);
+  }
+
+  const comments = modal.locator('textarea').first();
+  if (await comments.count()) await comments.fill(comment);
+  await page.waitForTimeout(600);
+
+  const submit = modal.locator('button').filter({ hasText: /^(SUBMIT|Submit|CS_COMMON_SUBMIT)$/ }).first();
+  if (!(await submit.isEnabled().catch(() => false))) {
+    const txt = (await modal.innerText()).slice(0, 300).replace(/\n+/g, ' | ');
+    throw new Error(`modal SUBMIT disabled. Modal: ${txt}`);
+  }
+  await submit.click();
+  await page.waitForTimeout(14_000);
+}
+
+test.describe('PGR lifecycle via UI only', () => {
+  // This suite files, assigns and resolves a REAL complaint on whatever it is
+  // pointed at, so it must never run by accident against a default host.
+  test.skip(
+    () => !process.env.BASE_URL,
+    'Set BASE_URL to a running DIGIT deployment — this suite writes a real complaint',
+  );
+
+  test.beforeEach(async ({ page }, info) => {
+    if (!AUDIT) return;
+    auditStep = info.title.split('—')[0].trim();
+    page.on('response', (res) => {
+      const req = res.request();
+      if (req.method() !== 'POST') return;
+      let path = '';
+      try { path = new URL(res.url()).pathname; } catch { return; }
+      if (/\.(js|css|png|jpe?g|svg|woff2?|ico|map)$/.test(path)) return;
+
+      let bodyTok: string | null = null;
+      try {
+        const j = JSON.parse(req.postData() || '{}');
+        bodyTok = (j && j.RequestInfo && j.RequestInfo.authToken) || null;
+      } catch { /* not JSON */ }
+
+      const auth = req.headers()['authorization'] || '';
+      audit.push({
+        step: auditStep,
+        path,
+        status: res.status(),
+        header: tokenShape(auth.replace(/^Bearer\s+/i, '')),
+        body: tokenShape(bodyTok),
+      });
+    });
+  });
+
+  test.afterAll(() => {
+    if (AUDIT) fs.writeFileSync(AUDIT, JSON.stringify(audit, null, 1));
+  });
+
+  test('1 — citizen files a complaint through the wizard', async ({ page }) => {
+    test.setTimeout(300_000);
+    test.skip(!!process.env.CID, 'CID supplied — reusing an existing complaint');
+
+    await citizenLogin(page);
+    expect(page.url(), 'citizen should be logged in').not.toContain('/citizen/login');
+
+    await page.goto(`${BASE}/digit-ui/citizen/pgr/create-complaint`, { waitUntil: 'domcontentloaded', timeout: 90_000 });
+    await page.waitForTimeout(9000);
+
+    await advanceWizard(page, `UI lifecycle probe ${Date.now()}`);
+    await page.waitForTimeout(6000);
+
+    const body = await page.locator('body').innerText();
+    const m = body.match(/[A-Z]{2}-[A-Z]+-\d{4}-\d{2}-\d{2}-\d+/);
+    expect(m, `complaint id should appear on the response screen. Got: ${body.slice(0, 300)}`).toBeTruthy();
+    complaintId = m![0];
+    console.log(`  filed: ${complaintId}`);
+  });
+
+  test('2 — employee finds it in the inbox and assigns it', async ({ page }) => {
+    test.setTimeout(360_000);
+    expect(complaintId, 'needs a complaint from step 1 (or CID=)').toBeTruthy();
+    await employeeLogin(page);
+
+    // Reach the complaint the way an officer does. inbox-v2 opens on the "My
+    // Complaints" tab, which is empty until something is assigned to you, so an
+    // unassigned complaint only appears under "All Complaints".
+    await page.goto(inboxUrl, { waitUntil: 'domcontentloaded', timeout: 90_000 });
+    await page.waitForTimeout(12_000);
+    const allTab = page.locator('div, button, li, span').filter({ hasText: /^(All Complaints|ALL)$/i }).first();
+    if (await allTab.count()) {
+      await allTab.click({ force: true });
+      await page.waitForTimeout(10_000);
+    }
+    const links = page.locator(`a[href*="complaint-details"]`);
+    expect(await links.count(), 'the All Complaints tab must list complaints').toBeGreaterThan(0);
+
+    await openDetail(page, complaintId);
+    expect(await currentStatus(page), 'a fresh complaint starts unassigned').toMatch(/Pending for assignment/i);
+
+    await chooseAction(page, /Assign/i);
+    // Assign to the acting officer where possible, so the same session can
+    // resolve it in step 3 without provisioning a second account.
+    await submitModal(page, 'assigned via UI lifecycle probe', new RegExp(process.env.ASSIGNEE_MATCH || EMP_USER, 'i'));
+
+    await openDetail(page, complaintId);
+    const status = await currentStatus(page);
+    console.log(`  after assign: ${status}`);
+    expect(status, 'assignment should move it out of Pending for assignment').not.toMatch(/Pending for assignment/i);
+    expect(status).toMatch(/Pending at|Assigned/i);
+  });
+
+  test('3 — the assignee resolves it', async ({ page }) => {
+    test.setTimeout(360_000);
+    expect(complaintId).toBeTruthy();
+    await employeeLogin(page, RESOLVER_USER, RESOLVER_PASS);
+    await openDetail(page, complaintId);
+
+    await chooseAction(page, /Resolve/i);
+    // The resolve modal has no assignee picker, just comments.
+    await submitModal(page, 'resolved via UI lifecycle probe');
+
+    await openDetail(page, complaintId);
+    const status = await currentStatus(page);
+    console.log(`  ${complaintId} final status: ${status}`);
+    expect(status, 'complaint should be resolved').toMatch(/Resolved/i);
+  });
+});

--- a/local-setup/tests/e2e/kc-parity/probe-browser-tokens.js
+++ b/local-setup/tests/e2e/kc-parity/probe-browser-tokens.js
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * Does the browser ever hold a DIGIT uuid token under Keycloak?
+ *
+ * The request audit only proves what is SENT. token-exchange-svc resolves and
+ * caches the acting user's DIGIT token server-side, so the question worth asking
+ * is whether any of it is handed back to the SPA — in an auth response body, or
+ * in localStorage / sessionStorage.
+ *
+ * Values are never printed, only their shape.
+ *
+ *   B=https://<keycloak-deployment> WHO=citizen node probe-browser-tokens.js
+ */
+const path = require('path');
+const { chromium } = require(path.resolve(__dirname, '../../node_modules/playwright'));
+
+const B = (process.env.B || 'http://localhost:18080').replace(/\/$/, '');
+const WHO = process.env.WHO || 'citizen';
+const MOBILE = process.env.CITIZEN_MOBILE || '712345678';
+const OTP = process.env.OTP || '123456';
+const EMP_USER = process.env.EMP_USER || 'ADMIN';
+const EMP_PASS = process.env.EMP_PASS || 'eGov@123';
+const EMP_CITY = process.env.EMP_CITY || 'Bomet County';
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const JWT = /^ey[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\./;
+
+function shape(v) {
+  if (typeof v !== 'string' || !v) return null;
+  if (JWT.test(v)) return 'jwt';
+  if (UUID.test(v)) return 'uuid';
+  return null;
+}
+
+/** Walk parsed JSON looking for uuid/jwt-shaped strings, reporting their paths. */
+function scan(obj, prefix, hits, depth = 0) {
+  if (depth > 6 || obj === null || obj === undefined) return;
+  if (typeof obj === 'string') {
+    const s = shape(obj);
+    if (s) hits.push(`${prefix} = <${s}>`);
+    return;
+  }
+  if (Array.isArray(obj)) {
+    obj.forEach((v, i) => scan(v, `${prefix}[${i}]`, hits, depth + 1));
+    return;
+  }
+  if (typeof obj === 'object') {
+    for (const [k, v] of Object.entries(obj)) scan(v, prefix ? `${prefix}.${k}` : k, hits, depth + 1);
+  }
+}
+
+(async () => {
+  const b = await chromium.launch({ headless: true, args: ['--no-sandbox'] });
+  const p = await b.newPage({ ignoreHTTPSErrors: true });
+
+  // Any auth-ish response that could hand a DIGIT token back to the SPA.
+  p.on('response', async (r) => {
+    if (!/oauth\/token|openid-connect\/token|_login|authenticate|token-exchange/.test(r.url())) return;
+    try {
+      const j = await r.json();
+      const hits = [];
+      scan(j, '', hits);
+      console.log(`RESPONSE ${r.status()} ${r.url().replace(/\?.*$/, '')}`);
+      console.log('  top-level keys:', JSON.stringify(Object.keys(j)));
+      console.log('  token-shaped values:', hits.length ? JSON.stringify(hits) : '(none)');
+    } catch (_) { /* not JSON */ }
+  });
+
+  try {
+    if (WHO === 'citizen') {
+      await p.goto(`${B}/digit-ui/citizen/login`, { waitUntil: 'domcontentloaded', timeout: 90000 });
+      await p.waitForTimeout(6000);
+      await p.locator('input[type="tel"], input[name="mobileNumber"]').first().fill(MOBILE);
+      await p.locator('button:has-text("Continue"), button[type="submit"]').first().click();
+      await p.waitForTimeout(7000);
+      const boxes = p.locator('input[type="tel"], input[maxlength="1"]');
+      const n = await boxes.count();
+      if (n >= 6) { for (let i = 0; i < 6; i++) await boxes.nth(i).fill(OTP[i]); }
+      else if (n >= 1) { await boxes.first().fill(OTP); }
+      const next = p.locator('button:has-text("Continue"), button:has-text("Verify"), button[type="submit"]').first();
+      if (await next.count()) await next.click();
+      await p.waitForTimeout(12000);
+    } else {
+      await p.goto(`${B}/digit-ui/employee/user/login`, { waitUntil: 'domcontentloaded', timeout: 90000 });
+      await p.waitForTimeout(6000);
+      await p.locator('#emp-username').first().fill(EMP_USER);
+      await p.locator('#emp-password').first().fill(EMP_PASS);
+      const cityBtn = p.locator('button:has-text("Select city")').first();
+      if (await cityBtn.count()) {
+        await cityBtn.click(); await p.waitForTimeout(1200);
+        await p.locator(`li:has-text("${EMP_CITY}")`).first().click({ timeout: 8000 }).catch(() => {});
+      }
+      const lbl = p.locator('label[for="privacy-component-check"]').first();
+      if (await lbl.count()) await lbl.click();
+      await p.waitForTimeout(700);
+      await p.locator('button[type="submit"]').first().click();
+      await p.waitForTimeout(12000);
+      for (let i = 0; i < 3 && /language-selection/.test(p.url()); i++) {
+        const l = p.locator('button:has-text("English")').first();
+        if (await l.count()) { await l.click(); await p.waitForTimeout(900); }
+        const c = p.locator('button:has-text("Continue")').first();
+        if (await c.count()) await c.click();
+        await p.waitForTimeout(7000);
+      }
+    }
+    console.log('landed:', p.url());
+
+    const store = await p.evaluate(() => {
+      const dump = (s) => {
+        const out = {};
+        for (let i = 0; i < s.length; i++) {
+          const k = s.key(i);
+          out[k] = s.getItem(k);
+        }
+        return out;
+      };
+      return { local: dump(window.localStorage), session: dump(window.sessionStorage) };
+    });
+
+    for (const [where, bag] of Object.entries(store)) {
+      console.log(`\n--- ${where}Storage: ${Object.keys(bag).length} keys`);
+      for (const [k, raw] of Object.entries(bag)) {
+        const hits = [];
+        const direct = shape(raw);
+        if (direct) hits.push(`<${direct}>`);
+        try { scan(JSON.parse(raw), '', hits); } catch (_) { /* plain string */ }
+        if (hits.length) console.log(`  ${k}: ${JSON.stringify(hits)}`);
+      }
+      const uuidKeys = Object.entries(bag).filter(([, raw]) => {
+        if (shape(raw) === 'uuid') return true;
+        try { const h = []; scan(JSON.parse(raw), '', h); return h.some((x) => x.endsWith('<uuid>')); }
+        catch (_) { return false; }
+      }).map(([k]) => k);
+      console.log(`  >> uuid-shaped values present in ${where}Storage: ${uuidKeys.length ? JSON.stringify(uuidKeys) : 'NONE'}`);
+    }
+  } catch (e) {
+    console.log('ERROR:', String((e && e.message) || e).slice(0, 250));
+  }
+  await b.close();
+})();

--- a/local-setup/tests/e2e/kc-parity/probe-cascade.js
+++ b/local-setup/tests/e2e/kc-parity/probe-cascade.js
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+/**
+ * Wizard cascade probe. Logs in as a citizen, opens the create-complaint form,
+ * then walks the N-level "Select…" cascade printing what each level offers.
+ * Debugging the spec through this is far faster than through Playwright's runner.
+ *
+ *   B=https://<your-deployment> node probe-cascade.js
+ */
+const path = require('path');
+const { chromium } = require(path.resolve(__dirname, '../../node_modules/playwright'));
+
+const B = (process.env.B || 'http://localhost:18080').replace(/\/$/, '');
+const MOBILE = process.env.MOBILE || '712345678';
+const OTP = process.env.OTP || '123456';
+const WANT = new RegExp(process.env.WANT || 'garbage', 'i');
+
+(async () => {
+  const b = await chromium.launch({ headless: true, args: ['--no-sandbox'] });
+  const p = await b.newPage({ ignoreHTTPSErrors: true });
+  try {
+    await p.goto(`${B}/digit-ui/citizen/login`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await p.waitForTimeout(4000);
+    await p.locator('input[type="tel"]').first().fill(MOBILE);
+    await p.locator('button:has-text("Continue")').first().click();
+    await p.waitForTimeout(5000);
+    const bx = p.locator('input[type="tel"], input[maxlength="1"]');
+    const n = await bx.count();
+    if (n >= 6) { for (let i = 0; i < 6; i++) await bx.nth(i).fill(OTP[i]); }
+    else if (n >= 1) await bx.first().fill(OTP);
+    const nx = p.locator('button:has-text("Continue"), button:has-text("Verify"), button[type=submit]').first();
+    if (await nx.count()) await nx.click();
+    await p.waitForTimeout(9000);
+    console.log('  after login:', p.url());
+
+    await p.goto(`${B}/digit-ui/citizen/pgr/create-complaint`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await p.waitForTimeout(9000);
+
+    for (let lvl = 0; lvl < 6; lvl++) {
+      const trig = p.locator('button', { hasText: /^Select(…|\s|$)/ }).first();
+      if (!(await trig.count())) { console.log(`  L${lvl}: no 'Select…' left`); break; }
+      if (!(await trig.isEnabled().catch(() => false))) { console.log(`  L${lvl}: disabled`); break; }
+      await trig.click();
+      await p.waitForTimeout(1500);
+      const opts = p.locator('li, [role="option"], .digit-dropdown-item');
+      const oc = await opts.count();
+      const sample = [];
+      for (let i = 0; i < Math.min(oc, 8); i++) sample.push(((await opts.nth(i).innerText().catch(() => '')) || '').trim().slice(0, 26));
+      console.log(`  L${lvl}: options=${oc} ${JSON.stringify(sample)}`);
+      if (!oc) break;
+      let idx = 0;
+      for (let i = 0; i < oc; i++) {
+        const t = ((await opts.nth(i).innerText().catch(() => '')) || '');
+        if (WANT.test(t)) { idx = i; break; }
+      }
+      await opts.nth(idx).click();
+      await p.waitForTimeout(2000);
+      console.log(`      picked[${idx}]="${sample[idx] || ''}"`);
+    }
+
+    // Walk the wizard steps, showing what each one requires before NEXT enables.
+    for (let step = 0; step < 6; step++) {
+      const dump = await p.evaluate(() => ({
+        text: document.body.innerText.slice(0, 220).replace(/\n+/g, ' | '),
+        inputs: [...document.querySelectorAll('input,textarea')].map((i) => ({ t: i.type || i.tagName, n: i.name, id: i.id, ph: i.placeholder, v: (i.value||'').slice(0,14) })).slice(0, 8),
+        sel: [...document.querySelectorAll('button')].filter((x) => /^Select(…|\s|$)/.test((x.innerText||'').trim())).length,
+        next: (() => { const b=[...document.querySelectorAll('button')].find(x=>/^(NEXT|SUBMIT)$/i.test((x.innerText||'').trim())); return b?{t:b.innerText.trim(),d:b.disabled}:null; })(),
+      }));
+      console.log(`  STEP${step}: next=${JSON.stringify(dump.next)} selects=${dump.sel}`);
+      if (/Pin Complaint Location/i.test(dump.text)) {
+        const sb = p.locator('input[placeholder="Search here"]').first();
+        if (await sb.count()) {
+          await sb.click();
+          await sb.fill('');
+          await sb.pressSequentially(process.env.PLACE || 'Bomet', { delay: 120 });
+          await p.waitForTimeout(3500);
+          const sug = p.locator('li, [role="option"], [class*="suggestion" i], [class*="result" i]');
+          const sc = await sug.count();
+          const names = [];
+          for (let i=0;i<Math.min(sc,5);i++) names.push(((await sug.nth(i).innerText().catch(()=>''))||'').trim().slice(0,30));
+          console.log(`     map suggestions=${sc} ${JSON.stringify(names)}`);
+          if (sc) { await sug.first().click(); await p.waitForTimeout(4000); console.log('     picked first suggestion'); }
+          else {
+            const box = await p.locator('canvas, [class*="map" i]').first().boundingBox().catch(()=>null);
+            if (box) { await p.mouse.click(box.x + box.width/2, box.y + box.height/2); await p.waitForTimeout(3500); console.log('     clicked map centre'); }
+          }
+        }
+      }
+      if (/Location Details/i.test(dump.text)) {
+        const full = await p.evaluate(() => document.body.innerText.replace(/\n+/g,' | ').slice(0, 700));
+        console.log(`     FULL Location Details: ${full}`);
+      }
+      console.log(`     text: ${dump.text}`);
+      console.log(`     inputs: ${JSON.stringify(dump.inputs)}`);
+      if (!dump.next) break;
+      if (dump.next.d) {
+        console.log('     >>> NEXT DISABLED — filling fields to see what unlocks it');
+        // fill() sets .value but React may never see it; real keystrokes + blur do.
+        for (const mode of ['type+blur', 'fill+blur', 'type-only']) {
+          const el = p.locator('#postal-code');
+          const lm = p.locator('#landmark');
+          if (await el.count()) {
+            await el.click(); await el.press('Control+a').catch(()=>{}); await el.press('Backspace').catch(()=>{});
+            if (mode.startsWith('type')) await el.pressSequentially('20400', { delay: 90 });
+            else await el.fill('20400');
+          }
+          if (await lm.count()) {
+            await lm.click();
+            if (mode.startsWith('type')) await lm.pressSequentially('Near the market', { delay: 30 });
+            else await lm.fill('Near the market');
+          }
+          if (mode.endsWith('blur')) { await p.keyboard.press('Tab'); }
+          const pc = mode;
+          await p.waitForTimeout(1800);
+          const st2 = await p.evaluate(() => ({
+            d: (() => { const b=[...document.querySelectorAll('button')].find(x=>/^(NEXT|SUBMIT)$/i.test((x.innerText||'').trim())); return b?b.disabled:null; })(),
+            errs: [...document.querySelectorAll('[class*=error i],[class*=Error]')].map(e=>(e.innerText||'').trim()).filter(Boolean).slice(0,3),
+            sel: [...document.querySelectorAll('button')].filter(x=>/^Select(…|\s|$)/.test((x.innerText||'').trim())).length,
+            inputs: [...document.querySelectorAll('input,textarea')].map(i=>({id:i.id, v:(i.value||'').slice(0,12)})).slice(0,8),
+          }));
+          console.log(`     postal="${pc}" -> nextDisabled=${st2.d} selects=${st2.sel} errs=${JSON.stringify(st2.errs)} inputs=${JSON.stringify(st2.inputs)}`);
+          if (st2.d === false) { console.log('     >>> UNLOCKED with postal=' + pc); break; }
+        }
+        const again = await p.evaluate(() => { const b=[...document.querySelectorAll('button')].find(x=>/^(NEXT|SUBMIT)$/i.test((x.innerText||'').trim())); return b?b.disabled:true; });
+        if (again) break;
+      }
+      const nb = p.locator('button').filter({ hasText: /^(NEXT|SUBMIT)$/i }).last();
+      await nb.click();
+      await p.waitForTimeout(6000);
+    }
+  } catch (e) {
+    console.log('  ERROR:', String(e && e.message || e).slice(0, 200));
+  }
+  await b.close();
+})();

--- a/local-setup/tests/e2e/kc-parity/probe-city-index.js
+++ b/local-setup/tests/e2e/kc-parity/probe-city-index.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * Bomet's employee login lists TWO cities labelled "Bomet County" — one bound to
+ * the state tenant `ke`, one to `ke.bomet`. Picking the wrong one silently fails
+ * the login (the form just re-renders). This tries each matching entry in turn
+ * and reports which index actually logs the user in.
+ *
+ *   B=<url> EMP_USER=... EMP_PASS=... node probe-city-index.js
+ */
+const path = require('path');
+const { chromium } = require(path.resolve(__dirname, '../../node_modules/playwright'));
+
+const B = (process.env.B || 'http://localhost:18080').replace(/\/$/, '');
+const USER = process.env.EMP_USER || 'ADMIN';
+const PASS = process.env.EMP_PASS || 'eGov@123';
+const LABEL = process.env.EMP_CITY || 'Bomet County';
+
+(async () => {
+  for (let idx = 0; idx < 3; idx++) {
+    const b = await chromium.launch({ headless: true, args: ['--no-sandbox'] });
+    const p = await b.newPage({ ignoreHTTPSErrors: true });
+    try {
+      await p.goto(`${B}/digit-ui/employee/user/login`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+      await p.waitForTimeout(6000);
+      await p.locator('#emp-username').first().fill(USER);
+      await p.locator('#emp-password').first().fill(PASS);
+      await p.locator('button:has-text("Select city")').first().click();
+      await p.waitForTimeout(1500);
+      const opts = p.locator(`li:has-text("${LABEL}")`);
+      const n = await opts.count();
+      if (idx === 0) console.log(`  "${LABEL}" entries: ${n}`);
+      if (idx >= n) { await b.close(); break; }
+      await opts.nth(idx).click();
+      await p.waitForTimeout(800);
+      const lbl = p.locator('label[for="privacy-component-check"]').first();
+      if (await lbl.count()) await lbl.click();
+      await p.waitForTimeout(600);
+      await p.locator('button[type="submit"]').first().click();
+      await p.waitForTimeout(11000);
+      const ok = !/user\/login/.test(p.url());
+      console.log(`  index ${idx}: ${ok ? 'LOGGED IN' : 'failed'} -> ${p.url().replace(B, '')}`);
+      if (ok) { await b.close(); break; }
+    } catch (e) {
+      console.log(`  index ${idx}: ERROR ${String((e && e.message) || e).slice(0, 90)}`);
+    }
+    await b.close();
+  }
+})();

--- a/local-setup/tests/e2e/kc-parity/probe-employee-v2.js
+++ b/local-setup/tests/e2e/kc-parity/probe-employee-v2.js
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * Employee probe against the REAL routes.
+ *
+ * The earlier probe used `/pgr/inbox` and `/pgr/complaint/details/:id`, neither of
+ * which is registered. An unmatched PrivateRoute renders the chrome and nothing
+ * else — which is why the screens looked "broken" (no buttons, 0 rows) when they
+ * were simply never reached. The registered routes are:
+ *     /digit-ui/employee/pgr/inbox-v2
+ *     /digit-ui/employee/pgr/complaint-details/:id
+ * and "Search Complaint" on the home page is the link to inbox-v2.
+ *
+ * inbox-v2 also defaults to the MY tab, so an employee with nothing assigned to
+ * them sees 0 rows until ALL is selected.
+ *
+ *   B=... EMP_USER=ADMIN EMP_PASS=... CID=PG-PGR-... node probe-employee-v2.js
+ */
+const path = require('path');
+const { chromium } = require(path.resolve(__dirname, '../../node_modules/playwright'));
+
+const B = (process.env.B || 'http://localhost:18080').replace(/\/$/, '');
+const CID = process.env.CID || '';
+const USER = process.env.EMP_USER || 'ADMIN';
+const PASS = process.env.EMP_PASS || 'eGov@123';
+const CITY = process.env.EMP_CITY || 'Bomet County';
+
+const dump = (o) => JSON.stringify(o);
+
+(async () => {
+  const b = await chromium.launch({ headless: true, args: ['--no-sandbox'] });
+  const p = await b.newPage({ ignoreHTTPSErrors: true });
+  const errs = [];
+  p.on('pageerror', (e) => errs.push('PAGEERROR ' + String(e.message).slice(0, 200)));
+  p.on('response', (r) => {
+    if (r.status() >= 400 && /pgr|inbox|workflow|access|mdms|hrms/i.test(r.url())) {
+      errs.push(`HTTP ${r.status()} ${r.url().slice(0, 140)}`);
+    }
+  });
+
+  try {
+    await p.goto(`${B}/digit-ui/employee/user/login`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await p.waitForTimeout(6000);
+    await p.locator('#emp-username, input[name="username"]').first().fill(USER);
+    await p.locator('#emp-password, input[name="password"]').first().fill(PASS);
+    const cityBtn = p.locator('button:has-text("Select city")').first();
+    if (await cityBtn.count()) {
+      await cityBtn.click();
+      await p.waitForTimeout(1200);
+      await p.locator(`li:has-text("${CITY}")`).first().click({ timeout: 8000 }).catch(() => {});
+    }
+    const lbl = p.locator('label[for="privacy-component-check"]').first();
+    if (await lbl.count()) await lbl.click();
+    await p.waitForTimeout(700);
+    await p.locator('button[type="submit"]').first().click();
+    await p.waitForTimeout(12000);
+    for (let i = 0; i < 3 && /language-selection/.test(p.url()); i++) {
+      const lang = p.locator('button:has-text("English")').first();
+      if (await lang.count()) { await lang.click(); await p.waitForTimeout(900); }
+      const cont = p.locator('button:has-text("Continue")').first();
+      if (await cont.count()) await cont.click();
+      await p.waitForTimeout(7000);
+    }
+    console.log('login landed:', p.url());
+
+    // --- the real inbox ---
+    await p.goto(`${B}/digit-ui/employee/pgr/inbox-v2`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await p.waitForTimeout(12000);
+    const inbox = await p.evaluate(() => ({
+      url: location.href,
+      text: document.body.innerText.slice(0, 500).replace(/\n+/g, ' | '),
+      tabs: [...document.querySelectorAll('button,div,li,span')]
+        .map((e) => (e.innerText || '').trim())
+        .filter((t) => /^(MY|ALL|My Complaints|All Complaints)$/i.test(t)),
+      links: [...new Set([...document.querySelectorAll('a[href]')]
+        .map((a) => a.getAttribute('href'))
+        .filter((h) => h && /complaint/i.test(h)))].slice(0, 8),
+      rows: document.querySelectorAll('tr').length,
+    }));
+    console.log('inbox-v2:', dump(inbox));
+
+    // switch to the ALL tab — MY is the default and will be empty for a fresh officer
+    const allTab = p.locator('button,div,li,span').filter({ hasText: /^(ALL|All Complaints)$/i }).first();
+    if (await allTab.count()) {
+      await allTab.click({ force: true }).catch(() => {});
+      await p.waitForTimeout(10000);
+      const after = await p.evaluate(() => ({
+        rows: document.querySelectorAll('tr').length,
+        links: [...new Set([...document.querySelectorAll('a[href]')]
+          .map((a) => a.getAttribute('href'))
+          .filter((h) => h && /complaint/i.test(h)))].slice(0, 8),
+        text: document.body.innerText.slice(0, 400).replace(/\n+/g, ' | '),
+      }));
+      console.log('inbox-v2 ALL tab:', dump(after));
+    } else {
+      console.log('inbox-v2 ALL tab: not found');
+    }
+
+    // --- the real detail route ---
+    if (CID) {
+      await p.goto(`${B}/digit-ui/employee/pgr/complaint-details/${CID}`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+      await p.waitForTimeout(12000);
+      const d = await p.evaluate(() => ({
+        url: location.href,
+        buttons: [...document.querySelectorAll('button')].map((x) => (x.innerText || '').trim()).filter(Boolean).slice(0, 16),
+        headings: [...document.querySelectorAll('h1,h2,h3')].map((x) => (x.innerText || '').trim()).filter(Boolean).slice(0, 8),
+        text: document.body.innerText.slice(0, 600).replace(/\n+/g, ' | '),
+      }));
+      console.log('complaint-details:', dump(d));
+
+      // open the action menu so we can see the real ASSIGN/RESOLVE option labels
+      const ta = p.locator('button').filter({ hasText: /Take Action|ACTION/i }).first();
+      if (await ta.count()) {
+        await ta.click({ force: true }).catch(() => {});
+        await p.waitForTimeout(3000);
+        const menu = await p.evaluate(() => ({
+          options: [...document.querySelectorAll('.header-dropdown-option, [role="menuitem"], li')]
+            .map((x) => (x.innerText || '').trim()).filter(Boolean).slice(0, 14),
+        }));
+        console.log('action menu:', dump(menu));
+      } else {
+        console.log('action menu: no Take Action button');
+      }
+    }
+    console.log('errors:', dump(errs.slice(0, 12)));
+  } catch (e) {
+    console.log('ERROR:', String((e && e.message) || e).slice(0, 250));
+    console.log('errors:', dump(errs.slice(0, 12)));
+  }
+  await b.close();
+})();

--- a/local-setup/tests/e2e/kc-parity/probe-employee.js
+++ b/local-setup/tests/e2e/kc-parity/probe-employee.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Employee-side probe: log in, open a complaint's detail page, and dump what is
+ * actually rendered (URL, buttons, headings). Used to pin down the assign/resolve
+ * interactions without paying for a full Playwright spec run.
+ *
+ *   B=https://<native-auth-deployment> CID=PG-PGR-... node probe-employee.js
+ */
+const path = require('path');
+const { chromium } = require(path.resolve(__dirname, '../../node_modules/playwright'));
+
+const B = (process.env.B || 'http://localhost:18080').replace(/\/$/, '');
+const CID = process.env.CID || '';
+const USER = process.env.EMP_USER || 'ADMIN';
+const PASS = process.env.EMP_PASS || 'eGov@123';
+const CITY = process.env.EMP_CITY || 'Bomet County';
+
+(async () => {
+  const b = await chromium.launch({ headless: true, args: ['--no-sandbox'] });
+  const p = await b.newPage({ ignoreHTTPSErrors: true });
+  try {
+    await p.goto(`${B}/digit-ui/employee/user/login`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await p.waitForTimeout(6000);
+    await p.locator('#emp-username, input[name="username"]').first().fill(USER);
+    await p.locator('#emp-password, input[name="password"]').first().fill(PASS);
+    const cityBtn = p.locator('button:has-text("Select city")').first();
+    if (await cityBtn.count()) {
+      await cityBtn.click(); await p.waitForTimeout(1200);
+      await p.locator(`li:has-text("${CITY}")`).first().click({ timeout: 8000 });
+    }
+    const lbl = p.locator('label[for="privacy-component-check"]').first();
+    if (await lbl.count()) await lbl.click();
+    await p.waitForTimeout(800);
+    await p.locator('button[type="submit"]').first().click();
+    await p.waitForTimeout(12000);
+    for (let i = 0; i < 3 && /language-selection/.test(p.url()); i++) {
+      const lang = p.locator('button:has-text("English")').first();
+      if (await lang.count()) { await lang.click(); await p.waitForTimeout(800); }
+      const cont = p.locator('button:has-text("Continue")').first();
+      if (await cont.count()) await cont.click();
+      await p.waitForTimeout(7000);
+    }
+    console.log('  after employee login:', p.url());
+
+    // what does the employee home actually offer this user?
+    await p.goto(`${B}/digit-ui/employee`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await p.waitForTimeout(11000);
+    const home = await p.evaluate(() => ({
+      url: location.href,
+      text: document.body.innerText.slice(0, 400).replace(/\n+/g, ' | '),
+      links: [...new Set([...document.querySelectorAll('a[href]')].map((a) => a.getAttribute('href')).filter((h) => h && h.includes('/employee')))].slice(0, 20),
+    }));
+    console.log('  home url:', home.url);
+    console.log('  home text:', home.text);
+    console.log('  home links:', JSON.stringify(home.links));
+
+    // inbox first — confirms the employee can see work at all
+    await p.goto(`${B}/digit-ui/employee/pgr/inbox`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await p.waitForTimeout(9000);
+    const inbox = await p.evaluate(() => ({
+      url: location.href,
+      rows: document.querySelectorAll('a[href*="pgr/complaint"], tr').length,
+      text: document.body.innerText.slice(0, 200).replace(/\n+/g, ' | '),
+    }));
+    console.log('  inbox:', JSON.stringify(inbox));
+
+    // The Inbox is jurisdiction-scoped; "Search Complaint" is not. Try reaching
+    // the complaint that way, which is what a real officer would do.
+    if (CID) {
+      // The home "cards" are divs, not links — click the ancestor that actually
+      // handles the navigation, and report where it lands.
+      const searchCard = p.locator('div,span,a,button').filter({ hasText: /^Search Complaint$/i }).last();
+      if (await searchCard.count()) {
+        await searchCard.click({ force: true }).catch(() => {});
+        await p.waitForTimeout(8000);
+        console.log('  search page:', p.url());
+        const sp = await p.evaluate(() => ({
+          text: document.body.innerText.slice(0, 260).replace(/\n+/g, ' | '),
+          inputs: [...document.querySelectorAll('input')].map((i) => ({ id: i.id, ph: i.placeholder })).slice(0, 8),
+        }));
+        console.log('  search screen:', JSON.stringify(sp));
+        const inp = p.locator('input[type="text"]').first();
+        if (await inp.count()) {
+          await inp.fill(CID);
+          const go = p.locator('button').filter({ hasText: /Search|SEARCH/i }).first();
+          if (await go.count()) await go.click();
+          await p.waitForTimeout(8000);
+          const res = await p.evaluate(() => ({
+            url: location.href,
+            links: [...document.querySelectorAll('a[href*="complaint"]')].map((a) => a.getAttribute('href')).slice(0, 5),
+            text: document.body.innerText.slice(0, 300).replace(/\n+/g, ' | '),
+          }));
+          console.log('  search result:', JSON.stringify(res));
+          const link = p.locator('a[href*="complaint"]').first();
+          if (await link.count()) { await link.click(); await p.waitForTimeout(9000); console.log('  opened via search:', p.url()); }
+        }
+      }
+    }
+
+    if (CID) {
+      await p.goto(`${B}/digit-ui/employee/pgr/complaint/details/${CID}`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+      await p.waitForTimeout(11000);
+      const d = await p.evaluate(() => ({
+        url: location.href,
+        text: document.body.innerText.slice(0, 500).replace(/\n+/g, ' | '),
+        buttons: [...document.querySelectorAll('button')].map((x) => (x.innerText || '').trim()).filter(Boolean).slice(0, 14),
+      }));
+      console.log('  detail url:', d.url);
+      console.log('  detail buttons:', JSON.stringify(d.buttons));
+      console.log('  detail text:', d.text);
+    }
+  } catch (e) {
+    console.log('  ERROR:', String((e && e.message) || e).slice(0, 220));
+  }
+  await b.close();
+})();

--- a/local-setup/tests/e2e/kc-parity/record-lifecycle.sh
+++ b/local-setup/tests/e2e/kc-parity/record-lifecycle.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Record the UI-only PGR lifecycle on both deployments and stitch each run's
+# three steps into one reviewable mp4.
+#
+#   ./record-lifecycle.sh            # both deployments
+#   ./record-lifecycle.sh baseline   # just one
+#
+# Output: out/video/{baseline,kc}-lifecycle.mp4 plus the individual step clips.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TESTS="$(cd "$HERE/../.." && pwd)"
+OUT="$HERE/out/video"
+mkdir -p "$OUT"
+
+BASELINE_URL="${BASELINE_URL:?set BASELINE_URL to the native-auth deployment}"
+KC_URL="${KC_URL:?set KC_URL to the Keycloak-fronted deployment}"
+
+record() {
+  local name="$1" url="$2"
+  local raw="$TESTS/test-results-video-$name"
+  rm -rf "$raw"
+  echo "=== recording $name ($url)"
+  (
+    cd "$TESTS" || exit 1
+    BASE_URL="$url" EMP_USER="${EMP_USER:-ADMIN}" EMP_PASS="${EMP_PASS:-eGov@123}" \
+    VIDEO_OUT="$raw" \
+      npx playwright test e2e/kc-parity/pgr-ui-lifecycle.spec.ts \
+        --config=playwright.video.config.ts --project=chromium --workers=1 --reporter=list
+  )
+  local rc=$?
+  echo "=== $name playwright exit=$rc"
+
+  # Tests run serially, so modification time is execution order — more reliable
+  # than the hashed directory names Playwright generates.
+  mapfile -t clips < <(find "$raw" -name '*.webm' -printf '%T@ %p\n' 2>/dev/null | sort -n | cut -d' ' -f2-)
+  if [ "${#clips[@]}" -eq 0 ]; then
+    echo "=== $name: no video captured"
+    return 1
+  fi
+  echo "=== $name: ${#clips[@]} clip(s)"
+
+  local list="$OUT/$name-list.txt"
+  : > "$list"
+  local i=1
+  for c in "${clips[@]}"; do
+    cp "$c" "$OUT/$name-step$i.webm"
+    printf "file '%s'\n" "$OUT/$name-step$i.webm" >> "$list"
+    i=$((i + 1))
+  done
+
+  # Re-encode on concat: the clips are VP8 and we want one seekable H.264 file.
+  ffmpeg -y -loglevel error -f concat -safe 0 -i "$list" \
+    -c:v libx264 -preset veryfast -crf 26 -pix_fmt yuv420p -r 12 \
+    -vf "scale=1280:720:force_original_aspect_ratio=decrease,pad=1280:720:(ow-iw)/2:(oh-ih)/2" \
+    "$OUT/$name-lifecycle.mp4" && echo "=== wrote $OUT/$name-lifecycle.mp4"
+  rm -f "$list"
+  return $rc
+}
+
+case "${1:-both}" in
+  baseline) record baseline "$BASELINE_URL" ;;
+  kc)       record kc "$KC_URL" ;;
+  both)     record baseline "$BASELINE_URL"; record kc "$KC_URL" ;;
+  *) echo "usage: $0 [baseline|kc|both]"; exit 2 ;;
+esac
+
+echo
+ls -lh "$OUT"/*.mp4 2>/dev/null

--- a/local-setup/tests/e2e/kc-parity/run-parity.sh
+++ b/local-setup/tests/e2e/kc-parity/run-parity.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# run-parity.sh — capture the same journey on both deployments and diff them.
+#
+#   BASELINE = the default citizen/employee UI (authProvider=digit)
+#   KC       = the parallel instance (authProvider=keycloak)
+#
+# Both serve the IDENTICAL digit-ui build; only globalConfigs differs. Any
+# divergence is therefore a token-exchange-svc / Keycloak realm problem.
+#
+#   ./run-parity.sh boot
+#   ./run-parity.sh employee --user=bometadmin --pass=eGov@123
+#   ./run-parity.sh citizen  --mobile=712345678 --otp=123456
+# ---------------------------------------------------------------------------
+set -uo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+JOURNEY="${1:-boot}"; shift || true
+
+BASELINE="${BASELINE_URL:?set BASELINE_URL to the native-auth deployment}"
+KC="${KC_URL:?set KC_URL to the Keycloak-fronted deployment}"
+OUTDIR="${OUTDIR:-$DIR/out}"
+mkdir -p "$OUTDIR"
+
+echo "▶ journey=$JOURNEY"
+echo "  baseline: $BASELINE"
+echo "  keycloak: $KC"
+echo
+
+node "$DIR/capture.js" --base="$BASELINE" --journey="$JOURNEY" --out="$OUTDIR/$JOURNEY-baseline.json" "$@"
+node "$DIR/capture.js" --base="$KC"       --journey="$JOURNEY" --out="$OUTDIR/$JOURNEY-kc.json"       "$@"
+echo
+node "$DIR/diff.js" "$OUTDIR/$JOURNEY-baseline.json" "$OUTDIR/$JOURNEY-kc.json" --json="$OUTDIR/$JOURNEY-report.json"

--- a/local-setup/tests/e2e/kc-parity/token-audit-report.js
+++ b/local-setup/tests/e2e/kc-parity/token-audit-report.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * Summarise what the browser sends on every DIGIT call, per deployment.
+ *
+ *   node token-audit-report.js out/audit-kc.json out/audit-baseline.json
+ *
+ * The interesting question is not "is a token present" but "what SHAPE is it":
+ * under Keycloak the browser must hold a JWT on every authenticated call, and
+ * token-exchange-svc must swap it for a DIGIT uuid before Kong ever sees it.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const files = process.argv.slice(2);
+if (!files.length) {
+  console.error('usage: node token-audit-report.js <audit.json> [audit2.json ...]');
+  process.exit(2);
+}
+
+for (const f of files) {
+  const name = path.basename(f).replace(/^audit-|\.json$/g, '');
+  const rows = JSON.parse(fs.readFileSync(f, 'utf8'));
+  console.log(`\n=== ${name.toUpperCase()} — ${rows.length} authenticated POST calls`);
+
+  const tally = (key) =>
+    rows.reduce((a, r) => ((a[r[key]] = (a[r[key]] || 0) + 1), a), {});
+  console.log('  Authorization header :', JSON.stringify(tally('header')));
+  console.log('  body RequestInfo.authToken:', JSON.stringify(tally('body')));
+
+  // Per step, so a regression can be localised to raise / assign / resolve.
+  const steps = [...new Set(rows.map((r) => r.step))];
+  for (const s of steps) {
+    const sr = rows.filter((r) => r.step === s);
+    const h = sr.reduce((a, r) => ((a[r.header] = (a[r.header] || 0) + 1), a), {});
+    const b = sr.reduce((a, r) => ((a[r.body] = (a[r.body] || 0) + 1), a), {});
+    console.log(`   step ${s}: ${sr.length} calls  header=${JSON.stringify(h)} body=${JSON.stringify(b)}`);
+  }
+
+  // Anything that carried no credential at all, or a non-200.
+  const anon = rows.filter((r) => r.header === 'none' && r.body === 'none');
+  if (anon.length) {
+    console.log(`  calls with NO token (${anon.length}):`);
+    for (const r of [...new Set(anon.map((r) => r.path))]) console.log(`     ${r}`);
+  }
+  const bad = rows.filter((r) => r.status >= 400);
+  console.log(`  non-2xx: ${bad.length}${bad.length ? ' -> ' + bad.map((r) => r.status + ' ' + r.path).join(', ') : ''}`);
+
+  const mixed = rows.filter((r) => r.header !== 'none' && r.body !== 'none' && r.header !== r.body);
+  if (mixed.length) {
+    console.log(`  header/body SHAPE MISMATCH on ${mixed.length} call(s):`);
+    for (const r of mixed.slice(0, 8)) console.log(`     ${r.path}  header=${r.header} body=${r.body}`);
+  }
+}
+console.log();

--- a/local-setup/tests/playwright.config.ts
+++ b/local-setup/tests/playwright.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './e2e',
+  // kc-parity is an opt-in harness: it files, assigns and resolves a REAL
+  // complaint on whatever BASE_URL points at. Keep it out of the default suite
+  // entirely, but let an explicit `BASE_URL=... npx playwright test <file>` in.
+  // (testIgnore is applied at collection even for a path given on the CLI, so
+  // this has to be conditional rather than absolute.)
+  testIgnore: process.env.BASE_URL ? [] : ['**/kc-parity/**'],
   timeout: 90_000,
   retries: 0,
   globalSetup: require.resolve('./global-setup'),

--- a/local-setup/tests/playwright.video.config.ts
+++ b/local-setup/tests/playwright.video.config.ts
@@ -1,0 +1,24 @@
+/**
+ * Same harness as playwright.config.ts, but records video for every test.
+ *
+ * Kept separate so normal runs stay fast — video capture costs wall-clock and
+ * disk on a suite that already takes minutes per run.
+ *
+ *   BASE_URL=... npx playwright test e2e/kc-parity/pgr-ui-lifecycle.spec.ts \
+ *     --config=playwright.video.config.ts --project=chromium --workers=1
+ */
+import { defineConfig } from '@playwright/test';
+import base from './playwright.config';
+
+export default defineConfig({
+  ...base,
+  // base excludes kc-parity from the default suite; this config exists to run
+  // it deliberately, so the exclusion has to be lifted here.
+  testIgnore: [],
+  outputDir: process.env.VIDEO_OUT || './test-results-video',
+  use: {
+    ...base.use,
+    viewport: { width: 1280, height: 720 },
+    video: { mode: 'on', size: { width: 1280, height: 720 } },
+  },
+});


### PR DESCRIPTION
## What & why

Adds a Playwright spec that drives a full PGR complaint **raise → assign → resolve** entirely by clicking through the SPA — no API shortcuts anywhere, including login — plus the harness used to prove a Keycloak-fronted deployment behaves identically to a native-auth one.

The UI-only constraint is the whole point. A Keycloak adapter changes *what the browser holds* and *how each XHR is authorised*, so any test that acquires a token over the API or seeds users out-of-band cannot detect the class of bug this catches.

### How this differs from what's already here

| Existing | Overlap | Difference |
|---|---|---|
| `e2e/specs/full-pgr-lifecycle.spec.ts` | same 3-state PGR journey | that spec does user creation and token acquisition over the API; this one makes **zero** direct API calls |
| `e2e/specs/keycloak-login.spec.ts` | Keycloak | that covers the login redirect; this covers a full authorised **write** journey through the exchanged token |

## What's added

- **`e2e/kc-parity/pgr-ui-lifecycle.spec.ts`** — the spec (3 serial tests).
- **`e2e/kc-parity/run-parity.sh` + `capture.js` + `diff.js`** — capture the same journey on two deployments and diff method / normalised path / status / **credential kind** (uuid = native DIGIT vs jwt = Keycloak) / request-body key shape / resulting localStorage session. Records key names and token *shapes* only — never secrets or PII.
- **`probe-*.js`** — diagnostics for the specific traps documented in the README.
- **`record-lifecycle.sh` + `playwright.video.config.ts`** — optional video capture of a run.
- **`e2e/kc-parity/README.md`** — how to run it, the failure modes it detects, and a Gotchas section (route-name trap, working selectors, HRMS error codes, `inbox-v2` tab default).

## This adds no executable CI surface

The spec files, assigns and resolves a **real** complaint on whatever it points at, so it must never run by accident:

- `playwright.config.ts` excludes `kc-parity` from collection unless `BASE_URL` is set,
- and the suite additionally `test.skip`s without `BASE_URL`.

`npx playwright test` collects **103 tests before and after** this change. `npx jest --listTests` is unchanged. `tsc --noEmit -p e2e/tsconfig.json` passes with the spec in the program.

## How to run

```bash
cd local-setup/tests && npm ci
BASE_URL=https://<your-deployment> EMP_USER=ADMIN EMP_PASS=<password> \
  npx playwright test e2e/kc-parity/pgr-ui-lifecycle.spec.ts --project=chromium --workers=1
```

Two-deployment parity diff:

```bash
BASELINE_URL=... KC_URL=... ./e2e/kc-parity/run-parity.sh employee --user=ADMIN --pass=<password>
```

## Follow-ups (deliberately NOT in this PR)

The harness surfaced two real defects in `digit-ui-esbuild/packages/libraries/src/services/auth/KeycloakAuthAdapter.js`, both still present on `master`. They are described in `e2e/kc-parity/README.md` and left for a separate change — mixing an untested auth behaviour change into a test-only PR would not be reviewable:

1. **Employee type is never resolved.** The adapter never reads `digit_user_type` / `digit_roles`, and `login()` ends in `window.location.replace()`, discarding in-memory state — so every SSO user is classified `CITIZEN` and an employee session can never be built.
2. **Citizen session tenant** (`:264`, `const defaultCityTenant = stateTenant + ".citya"; // TODO: make configurable`). A citizen signing in via Keycloak never sees the employee tenant dropdown, so the session falls through to a synthesized `<state>.citya` that exists on no real deployment. Downstream boundary lookups then offer another tenant's wards and PGR rejects the complaint with `INVALID_BOUNDARY_CODE`.

## Scope limits — please read before reviewing

This is a narrow, honest happy-path oracle, not PGR coverage.

- **One complaint type, one ward.** Both env-overridable, but only one combination has been exercised.
- **Self-assign only.** The same officer assigns the complaint to themselves and resolves it. There is **no multi-officer handoff**, and no test that a *different* assignee can resolve.
- **Reopen, escalate, reject, rate: untested.**
- **Validated on one deployment pair.** It has not been run against a stock `pg`/`citya` local-setup, which is why it sits in `e2e/kc-parity/` and is excluded from `npm run test:e2e` rather than added to `e2e/specs/`. Better opt-in and honest than in the canonical suite and flaky.
- Serial, single worker, ~5 min per run; generous fixed waits rather than tight polling.
- The parity half only means anything if you have two parallel deployments of the same build. It is included because the diagnostics and the documented gotchas are the expensive part.

Note: `Local Setup CI` is currently red on `master` independently of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end UI coverage for the complete complaint lifecycle, including creation, assignment, resolution, and rating.
  * Added parity testing across standard and Keycloak deployments, with journey capture, comparison reports, token audits, and browser diagnostics.
  * Added optional lifecycle video recording and configurable test execution settings.

* **Documentation**
  * Added setup and usage guidance for the new parity and lifecycle test tools.

* **Chores**
  * Parity test outputs and reports are now excluded from version control and skipped by default unless a deployment URL is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->