### PR TITLE
fix(prometheus): put the storage/retention block where the chart reads it

### DIFF
--- a/devops/deploy-as-code/charts/environments/env.yaml
+++ b/devops/deploy-as-code/charts/environments/env.yaml
@@ -305,44 +305,42 @@ grafana:
 # <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 ### Prometheus & Alertmanager >>>>>>>>>>>>>>>>>>>>
+# kube-prometheus-stack reads these under prometheus.prometheusSpec.*, NOT
+# directly under prometheus.* (#1645). Set one level too shallow they are
+# silently ignored -- helm drops values nothing reads, with no warning and no
+# exit code -- so this block previously read as "15Gi of persistent metrics"
+# while Prometheus actually ran on an emptyDir and lost everything on restart.
 prometheus:
-  retention: 7d
-  storageSpec:
-    volumeClaimTemplate:
-      spec:
-        storageClassName: gp3
-        accessModes: ["ReadWriteOnce"]
-        resources:
-          requests:
-            storage: 15Gi
-  alertmanager:
-    enabled: true
-  externalLabels:
-    cluster: urban
-  additionalScrapeConfigs:
-    - job_name: 'nginx-ingress-metrics'
-      static_configs:
-        - targets: [ 'release-name-ingress-nginx-controller-metrics.egov:10254' ]
-    - job_name: 'redis-exporter'
-      static_configs:
-        - targets: [ 'prometheus-redis-exporter.backbone:9121' ]
-    - job_name: 'blackbox'
-      metrics_path: /probe
-      params:
-        module: [ http_2xx ]
-      static_configs:
-        - targets:
-            - https://unified-uat.digit.org/citizen/
-      relabel_configs:
-        - source_labels: [ __address__ ]
-          target_label: __param_target
-        - source_labels: [ __param_target ]
-          target_label: instance
-        - target_label: __address__
-          replacement: prometheus-blackbox-exporter:9115
-    - job_name: 'blackbox_exporter'
-      static_configs:
-        - targets: [ 'prometheus-blackbox-exporter:9115' ]
+  prometheusSpec:
+    retention: 7d
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: gp3
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 15Gi
+    externalLabels:
+      cluster: urban
+
+  # NOTE: additionalScrapeConfigs deliberately NOT moved here (#1645).
+  # The list that used to sit at this path named four jobs, and making them
+  # effective would have ADDED broken targets rather than fixed anything:
+  #   - redis-exporter -> prometheus-redis-exporter.backbone:9121, a Service
+  #     that does not exist (the deployed redis chart ships no exporter)
+  #   - blackbox -> probes https://unified-uat.digit.org/citizen/, a FOREIGN
+  #     domain carried in by the upstream import, against a blackbox exporter
+  #     that is installed: false
+  #   - nginx-ingress-metrics -> a Service name that does not resolve either
+  # The effective list remains the one in charts/monitoring/values/prometheus.yaml.
+  # Correcting the gateway target is #1648; enabling blackbox is #1649.
+
+# Top-level, not under prometheus: (#1645). Already true in
+# values/prometheus.yaml, so this is belt-and-braces rather than a behaviour
+# change -- but at the previous path it asserted nothing at all.
+alertmanager:
+  enabled: true
 # <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 ### loki-stack >>>>>>>>>>>>>>>>>>>>

--- a/devops/deploy-as-code/charts/environments/env.yaml
+++ b/devops/deploy-as-code/charts/environments/env.yaml
@@ -341,6 +341,20 @@ prometheus:
 # change -- but at the previous path it asserted nothing at all.
 alertmanager:
   enabled: true
+  # Alertmanager was in exactly the same position as Prometheus: the vendored
+  # values leave alertmanager.alertmanagerSpec.storage at {} (values/prometheus.yaml:882),
+  # so the silence list and the notification log lived on an emptyDir and were
+  # lost on every restart -- a restart could re-page for everything currently
+  # silenced. 2Gi is ample: Alertmanager stores silences and nflog, not series.
+  alertmanagerSpec:
+    storage:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: gp3
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 2Gi
 # <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 ### loki-stack >>>>>>>>>>>>>>>>>>>>


### PR DESCRIPTION
Fixes #1645

## What

Prometheus and Alertmanager have been running on **emptyDir**, losing every metric on pod restart, while `env.yaml` stated 7d retention on a 15Gi gp3 volume. The block sat one level too shallow: kube-prometheus-stack reads `prometheus.prometheusSpec.*`, not `prometheus.*`.

Verified by pulling chart 56.6.2 and grepping its templates — only `.Values.prometheus.prometheusSpec.{retention,storageSpec,externalLabels}` are referenced. The shallower paths appear nowhere.

Moves `retention`, `storageSpec` and `externalLabels` under `prometheusSpec`, and `alertmanager.enabled` to the top level.

## The part worth reviewing: `additionalScrapeConfigs` is deliberately NOT moved

Re-pathing that list would have **added broken targets rather than fixing anything**:

- `redis-exporter` → `prometheus-redis-exporter.backbone:9121`, a Service that does not exist (the deployed redis chart ships no exporter)
- `blackbox` → probes `https://unified-uat.digit.org/citizen/`, a **foreign domain** carried in by the upstream import, via an exporter that is `installed: false`
- `nginx-ingress-metrics` → a Service name that does not resolve

So the naive fix would have started a permanently-failing probe against someone else's environment. The effective list stays the one in `values/prometheus.yaml`; the block is removed from `env.yaml` with a comment recording why, and the two targets that should exist are tracked in #1648 (gateway) and #1649 (blackbox).

## Risk

`storageClassName: gp3` — the same class is already used by pgadmin in this file, so it is present on the target clusters. Worth confirming on the specific cluster before rollout: if `gp3` is absent, Prometheus moves from "loses data on restart" to "does not schedule". That is a louder failure, but it is a failure.

This is also the first time Prometheus will claim a PVC on these clusters. Expect a one-off pod recreation on the next apply.

## Merge-order dependency with #1652

This interacts with the values-path guard in #1652, and the interaction is by design.

That guard ships a `KNOWN_UNREAD` baseline listing these five mis-paths. Once this PR lands they no longer reproduce, so the guard fails with **"KNOWN_UNREAD lists paths that no longer reproduce"** and names the exact lines to delete. Whichever of the two merges second, someone must remove those five entries from `.github/scripts/check-helm-values-paths.py`:

```
prometheus.retention
prometheus.storageSpec
prometheus.externalLabels
prometheus.additionalScrapeConfigs
prometheus.alertmanager
```

Leaving `ingress-nginx`, which #1648 will clear.

This is the baseline behaving as intended — it refuses to outlive the bug it was holding — but it does mean a red build until the entries go.

## Alertmanager gets a volume too

Added after review. The original change moved only the Prometheus block, but `alertmanager.alertmanagerSpec.storage` is `{}` in the vendored values (`values/prometheus.yaml:882`) and #1645 asks for both — acceptance criterion 2 is "The rendered `Alertmanager` resource shows a storage block". Without it a restart drops every active silence and the notification log, and re-pages for everything currently suppressed.

2Gi, not the 50Gi in the chart's commented-out example: Alertmanager persists silences and nflog, not time series.

## Verified / not verified

- [x] `env.yaml` parses; keys land at `prometheus.prometheusSpec.*` and top-level `alertmanager`
- [x] The corrected values-path guard reports no unread paths for this block
- [x] **Rendered**, not just grepped. `helm template` of kube-prometheus-stack 56.6.2 in the helmfile's merge order (`values/prometheus.yaml` then `env.yaml`) gives the `Prometheus` resource `retention: 7d`, `storage.volumeClaimTemplate` (gp3, 15Gi) and `externalLabels.cluster: urban`, and the `Alertmanager` resource `storage.volumeClaimTemplate` (gp3, 2Gi)
- [ ] **Not verified on a cluster** — this tier has none
- [ ] A pod restart preserves metric history
- [ ] `gp3` resolves on the target cluster

## Related

While implementing this I hit a false positive in the guard from #1652 — it flagged `storageSpec.volumeClaimTemplate`, because upstream declares `storageSpec: {}` as a free-form passthrough. Fixed on that PR; a guard that fails a correct fix is worse than no guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)