### PR TITLE
test: refresh two stale assertions that have master's CI red

### DIFF
--- a/local-setup/tests/static/deployment-contracts.test.ts
+++ b/local-setup/tests/static/deployment-contracts.test.ts
@@ -46,11 +46,16 @@ describe('ansible playbook-deploy.yml', () => {
 
   // HRMS crash-loops on non-pg tenants without the INTERNAL_USER system
   // user at state_root (its startup lookup is tenant-scoped).
+  // Asserts the BEHAVIOUR, not the task's display name. This test originally
+  // pinned the exact task title and the payload's YAML form; c0a21204 rewrote
+  // the task as a retrying curl POST — on the same day the test landed — and
+  // broke both assertions without changing what they were protecting. The
+  // invariant that matters is simply: INTERNAL_USER gets created at
+  // state_root. Pin that, so a rename or a re-implementation does not.
   test('seeds INTERNAL_USER on state_root after bootstrap', () => {
-    expect(playbook).toContain(
-      'post-bootstrap — seed INTERNAL_USER system user on state_root for HRMS'
-    );
-    expect(playbook).toContain('userName: INTERNAL_USER');
+    expect(playbook).toContain('seed INTERNAL_USER on state_root');
+    expect(playbook).toContain('"userName":"INTERNAL_USER"');
+    expect(playbook).toContain('"tenantId":"{{ state_root }}"');
   });
 
   // The HRMS prereq gate ships hardcoded to tenant pg; without the

--- a/local-setup/tests/static/infra-contracts.test.ts
+++ b/local-setup/tests/static/infra-contracts.test.ts
@@ -102,12 +102,19 @@ describe('image pin immutability', () => {
   // this many times, no more, no less — extras, duplicates, AND removals
   // all fail the test until this list is updated to match. The list IS
   // the changelog of this debt; it may shrink, never grow.
+  //
+  // Renamed wholesale to the `egovio/*` Docker Hub org by e6323a09
+  // ("chore(compose): move all image refs to egovio Docker Hub org"). The
+  // count is unchanged at seven — same images, same debt, new owner — so this
+  // update records a rename, not a relaxation. (Note the pre-rename names
+  // still appear in docker-compose.{yml,deploy.yaml,db-migrations.yml}, which
+  // this test does not read: it scans the base compose only.)
   const FROZEN_LATEST_DEBT: Record<string, number> = {
-    'edoburu/pgbouncer:latest': 1,
-    'tilt-demo-db-migrations:latest': 1,
-    'curlimages/curl:latest': 2, // two gate containers
-    'twinproduction/gatus:latest': 1,
-    'tilt-demo-jupyter:latest': 1,
+    'egovio/pgbouncer:latest': 1,
+    'egovio/tilt-demo-db-migrations:latest': 1,
+    'egovio/curl:latest': 2, // two gate containers
+    'egovio/gatus:latest': 1,
+    'egovio/tilt-demo-jupyter:latest': 1,
     'openbao/openbao:latest': 1,
     'egovio/novu-bridge-endpoint:latest': 1,
   };


### PR DESCRIPTION
## Why

`master` currently fails its own static test suite. Every PR runs those same tests, so **every PR shows red**, and a reviewer cannot distinguish "this PR broke something" from "master was already broken". With 17 open PRs that is not a cosmetic problem — I have had to write a paragraph of evidence into each one explaining which failures are pre-existing, which is a workaround for a ten-line fix.

There is a subtler cost too: a red baseline means a *genuine* new failure looks identical to the noise. The frozen-image test exists precisely to catch someone adding a `:latest` pin, and while it is red for unrelated reasons it cannot do that job.

**Neither failure reflects broken code.** Both are assertions that outlived the change they described.

## 1. `FROZEN_LATEST_DEBT` listed pre-rename image names

`e6323a09` ("chore(compose): move all image refs to egovio Docker Hub org") moved the base compose to the `egovio/*` org. The frozen list was not updated:

```
- 'edoburu/pgbouncer:latest'          + 'egovio/pgbouncer:latest'
- 'twinproduction/gatus:latest'       + 'egovio/gatus:latest'
- 'curlimages/curl:latest'            + 'egovio/curl:latest'
- 'tilt-demo-db-migrations:latest'    + 'egovio/tilt-demo-db-migrations:latest'
- 'tilt-demo-jupyter:latest'          + 'egovio/tilt-demo-jupyter:latest'
```

**The count is unchanged at seven** — same images, same debt, new owner. So this records a rename, not a relaxation of the policy the test enforces.

Worth noting for anyone checking: the pre-rename names *do* still appear in `docker-compose.yml`, `docker-compose.deploy.yaml` and `docker-compose.db-migrations.yml`. That is not a contradiction — this test reads the **base compose only** (`docker-compose.egov-digit.yaml`). Whether those other files should also move is a separate question.

## 2. The INTERNAL_USER test pinned a task title and a payload format

It asserted the playbook contained the exact task name `post-bootstrap — seed INTERNAL_USER system user on state_root for HRMS`, and `userName: INTERNAL_USER` in YAML form.

`c0a21204` rewrote that task as a retrying `curl` POST — **the same day the test landed** — which changed the title *and* moved the payload to JSON. Both assertions broke; neither thing they protected did.

Rather than re-pin the new title (which would break at the next rename), the test now asserts the invariant that actually matters:

```js
expect(playbook).toContain('seed INTERNAL_USER on state_root');
expect(playbook).toContain('"userName":"INTERNAL_USER"');
expect(playbook).toContain('"tenantId":"{{ state_root }}"');
```

The behaviour being protected is that INTERNAL_USER exists at `state_root` — that is what stops HRMS crash-looping on non-`pg` tenants, per the test's own comment. A rename or re-implementation will no longer break it; removing the seeding still will.

## Verified the guards still guard

A test that cannot fail is worse than no test, so I checked both catch a real regression rather than merely passing:

- adding a new `:latest` pin to the base compose → **fails**, naming `sneaky/newthing:latest`
- changing the seeded username in the playbook → **fails**

Both restored afterwards; the suite is 35/35 green.

## Result

```
Test Suites: 4 passed, 4 total
Tests:       35 passed, 35 total
```

Once this lands, a red check on any other PR means something again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
