### PR TITLE
ci: run local-setup CI on PRs targeting the monitoring-fix branch

### DIFF
--- a/.github/workflows/local-setup-ci.yaml
+++ b/.github/workflows/local-setup-ci.yaml
@@ -6,7 +6,13 @@ on:
     paths:
       - 'local-setup/**'
   pull_request:
-    branches: [main, master, develop]
+    # `monitoring-fix` is a temporary integration branch collecting the
+    # monitoring work before it goes to master as one change. Without it here
+    # this workflow does NOT run on those PRs — a branch filter is a silent
+    # skip, not a failure, so retargeting them dropped `Config combination +
+    # infra contracts`, `test` and `Ansible static validation` while the PRs
+    # merely looked cleaner. Remove this entry once the branch is merged.
+    branches: [main, master, develop, monitoring-fix]
     paths:
       - 'local-setup/**'
   workflow_dispatch:


### PR DESCRIPTION
## The problem this fixes

Retargeting the monitoring PRs from `master` to the `monitoring-fix` integration branch **silently switched off most of their CI**.

`local-setup-ci.yaml` filters on `branches: [main, master, develop]`. A branch filter is a **skip, not a failure** — the workflow simply never runs and no check appears. So three jobs disappeared from every retargeted PR:

- `Config combination + infra contracts`
- `test`
- `Ansible static validation`

Check count went from **12 to 5**. The PRs looked *cleaner* as a direct result of being tested less. That is the false-green failure mode, and it is worse than a red build because nothing signals it.

Caught by noticing that `Config combination + infra contracts` — the check this whole integration branch was created to turn green — was absent from PR #1635 rather than passing.

## The change

Adds `monitoring-fix` to the `pull_request` branch filter, with a comment recording why and when to remove it.

## Also worth knowing

The four CodeQL `Analyze (...)` jobs stopped too. Those come from GitHub's **default setup** rather than a workflow file in this repo, so they cannot be re-enabled by a commit here. If CodeQL coverage on the integration branch matters, it needs a settings change; otherwise it resumes when the work reaches `master`.

Three other workflows carry the same style of filter but are irrelevant to this work: `dataloader-tests.yml`, `digit-mcp-ci.yml`, `publishAllPackages.yml`.

## After this merges

The retargeted PRs need a push to pick up the restored checks — a workflow re-run replays the original event and will not re-evaluate the trigger. Rebasing them onto `monitoring-fix` again is the simplest way, and they rebase cleanly today.

## General note

Worth remembering for any future integration branch in this repo: **retargeting PRs changes which workflows apply.** Branch filters make that invisible, so the check to run afterwards is "did the number of checks go down?", not "are the checks green?".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
