### PR TITLE
feat(gateway): scrape ingress-nginx metrics

### DIFF
--- a/devops/deploy-as-code/charts/backbone-services/backboneservices-helmfile.yaml
+++ b/devops/deploy-as-code/charts/backbone-services/backboneservices-helmfile.yaml
@@ -127,31 +127,50 @@ releases:
     - ./ingress-nginx/values.yaml
     - {{ .Values | toYaml | nindent 8 }}
     - domain: {{ .Values.global.domain }}
-  # Gateway metrics (#1648). Every citizen request crosses this controller and
-  # it contributes nothing to Prometheus, so "are we returning errors, and on
-  # which route?" can only be answered by reading logs.
-  #
-  # Set HERE, not in env.yaml. This is a vendored upstream chart that reads
-  # .Values.controller.* directly (39 templates) with no chart-name hoisting,
-  # so env.yaml's `ingress-nginx:` block lands one level too deep and is
-  # ignored in full — which is the wider defect #1648 tracks. And it must not
-  # move to a top-level `controller:` key either: kafka-kraft reads
-  # .Values.controller too (13 templates, its own controller block), so the
-  # override would leak into the broker.
-  set:
-    # Already effectively true via the chart default, but the env.yaml block
-    # tries to set it FALSE. Pinning it here means the deployed state stops
-    # depending on which of two ignored/honoured paths wins.
-    - name: controller.metrics.enabled
-      value: true
-    - name: controller.metrics.serviceMonitor.enabled
-      value: true
-    # Prometheus selects only ServiceMonitors carrying its release name
-    # (serviceMonitorSelectorNilUsesHelmValues true + empty selector renders as
-    # matchLabels {release: kube-prometheus-stack}). Without this the object
-    # exists and is never scraped.
-    - name: controller.metrics.serviceMonitor.additionalLabels.release
-      value: kube-prometheus-stack
+    # Gateway metrics (#1648). Every citizen request crosses this controller and
+    # it contributes nothing to Prometheus, so "are we returning errors, and on
+    # which route?" can only be answered by reading logs.
+    #
+    # Written into the `ingress-nginx:` subtree, and NOT via `set:`, because of
+    # a local modification to this vendored chart. templates/_helpers.tpl:6-9
+    # (absent from upstream 4.10.0) does, inside "ingress-nginx.name":
+    #
+    #   $envOverrides := index .Values .Chart.Name
+    #   mustMergeOverwrite . (dict "Values" (mustMergeOverwrite $baseValues $envOverrides))
+    #
+    # mergeOverwrite mutates its destination, and the destination here is the
+    # root context -- so the first template to render a label permanently
+    # merges .Values["ingress-nginx"] OVER .Values for the whole render. That
+    # happens at TEMPLATE time, after every values file and after --set, so
+    # anything named in env.yaml's block wins over both. Verified: with
+    # env.yaml present, `--set controller.metrics.enabled=true` renders NO
+    # metrics Service, because env.yaml says `enabled: false` one level down.
+    #
+    # Which is also why this cannot move to a root `controller:` key: the
+    # subtree would still overwrite it, and kafka-kraft reads .Values.controller
+    # for its own broker block off the same shared passthrough.
+    - ingress-nginx:
+        controller:
+          metrics:
+            enabled: true
+            serviceMonitor:
+              enabled: true
+              # Prometheus selects only ServiceMonitors carrying its release
+              # name (serviceMonitorSelectorNilUsesHelmValues true + empty
+              # selector renders as matchLabels {release: kube-prometheus-stack}).
+              # Without this the object exists and is never scraped.
+              additionalLabels:
+                release: kube-prometheus-stack
+            # MUST stay false while `prometheusRule.rules` is [] in
+            # ingress-nginx/values.yaml. The template emits `spec:` with no
+            # body when the list is empty, so the object renders as
+            # `spec: null` -- and the PrometheusRule CRD marks spec required
+            # and typed object, so the API server rejects it and the whole
+            # release apply fails. env.yaml asks for true; it was harmless only
+            # because metrics.enabled gated it off. Turning metrics on is what
+            # makes it dangerous.
+            prometheusRule:
+              enabled: false
 
 - name: novu
   installed: true

--- a/devops/deploy-as-code/charts/backbone-services/backboneservices-helmfile.yaml
+++ b/devops/deploy-as-code/charts/backbone-services/backboneservices-helmfile.yaml
@@ -127,6 +127,31 @@ releases:
     - ./ingress-nginx/values.yaml
     - {{ .Values | toYaml | nindent 8 }}
     - domain: {{ .Values.global.domain }}
+  # Gateway metrics (#1648). Every citizen request crosses this controller and
+  # it contributes nothing to Prometheus, so "are we returning errors, and on
+  # which route?" can only be answered by reading logs.
+  #
+  # Set HERE, not in env.yaml. This is a vendored upstream chart that reads
+  # .Values.controller.* directly (39 templates) with no chart-name hoisting,
+  # so env.yaml's `ingress-nginx:` block lands one level too deep and is
+  # ignored in full — which is the wider defect #1648 tracks. And it must not
+  # move to a top-level `controller:` key either: kafka-kraft reads
+  # .Values.controller too (13 templates, its own controller block), so the
+  # override would leak into the broker.
+  set:
+    # Already effectively true via the chart default, but the env.yaml block
+    # tries to set it FALSE. Pinning it here means the deployed state stops
+    # depending on which of two ignored/honoured paths wins.
+    - name: controller.metrics.enabled
+      value: true
+    - name: controller.metrics.serviceMonitor.enabled
+      value: true
+    # Prometheus selects only ServiceMonitors carrying its release name
+    # (serviceMonitorSelectorNilUsesHelmValues true + empty selector renders as
+    # matchLabels {release: kube-prometheus-stack}). Without this the object
+    # exists and is never scraped.
+    - name: controller.metrics.serviceMonitor.additionalLabels.release
+      value: kube-prometheus-stack
 
 - name: novu
   installed: true

--- a/devops/deploy-as-code/charts/environments/env.yaml
+++ b/devops/deploy-as-code/charts/environments/env.yaml
@@ -168,12 +168,19 @@ ingress-nginx:
   ssl-ecdh-curve: "X25519:prime256v1:secp521r1:secp384r1"
   controller:
     replicas: 1
+    # Unlike the keys around it, this subtree IS read: the vendored chart's
+    # templates/_helpers.tpl merges .Values["ingress-nginx"] over the root
+    # context (a local modification, not in upstream 4.10.0). So `enabled:
+    # false` here was really switching gateway metrics off (#1648), and it beat
+    # even a --set on the release. The helmfile pins the same three values.
     metrics:
-      enabled: false
+      enabled: true
       serviceMonitor:
         enabled: true
+      # Deliberately false: the chart's prometheusRule.rules list is empty, so
+      # this renders a PrometheusRule whose spec is null, which the CRD rejects.
       prometheusRule:
-        enabled: true
+        enabled: false
     addHeaders:
       X-Content-Type-Options: "nosniff"
       X-Frame-Options: "SAMEORIGIN"


### PR DESCRIPTION
Part 1 of #1648.

> **Revised after review.** The first version of this PR pinned the values with a release-scoped `set:` and did not work: through helmfile it rendered **zero** metrics objects. Cause and fix below; the review threads have the full trail ([1](https://github.com/egovernments/Citizen-Complaint-Resolution-System/pull/1663#discussion_r3748087599), [2](https://github.com/egovernments/Citizen-Complaint-Resolution-System/pull/1663#discussion_r3748089346)).

## What

Every citizen request crosses the ingress-nginx controller, and it contributes nothing to Prometheus — so "are we returning errors, and on which route?" can only be answered by reading logs.

## The metrics are exposed by the image; nothing collects them

| Setting | env.yaml | Chart default | Effective before this PR |
|---|---|---|---|
| `controller.metrics.enabled` | `false` | `true` | **`false`** — env.yaml wins, see below |
| `controller.metrics.serviceMonitor.enabled` | `true` | `false` | irrelevant while metrics are off |
| `controller.metrics.prometheusRule.enabled` | `true` | `false` | gated off by `metrics.enabled` |

The static scrape job in `values/prometheus.yaml` targets `nginx-ingress-metrics.egov:10254`, while the Service is `<release>-ingress-nginx-controller-metrics` — a name that has never resolved. So there was no collection path at all.

## Why `set:` did not work

The vendored chart carries a **local modification** to `templates/_helpers.tpl` (lines 6-9), absent from upstream ingress-nginx 4.10.0:

```gotemplate
{{- $envOverrides := index .Values (tpl (default .Chart.Name .Values.name) .) -}}
{{- $baseValues := .Values | deepCopy -}}
{{- $values := dict "Values" (mustMergeOverwrite $baseValues $envOverrides) -}}
{{- with mustMergeOverwrite . $values -}}
```

`mergeOverwrite` mutates its destination in place, and the destination is the root context. The first template that renders a label therefore merges `.Values["ingress-nginx"]` over `.Values` for the entire render — at **template** time, which is after every values file and after `--set`.

Reproduced minimally with `helm template`:

| Inputs | metrics Service rendered |
|---|---|
| `ingress-nginx.controller.metrics.enabled: false` + `--set controller.metrics.enabled=true` | **no** |
| `--set controller.metrics.enabled=true`, no `ingress-nginx:` key | yes |
| same as row 1, chart renamed to `zzz-nginx` | yes |

So `env.yaml`'s `false` beat the release's `set:`. Row 3 pins the behaviour to `.Chart.Name` and rules out anything Helm does natively.

## What this PR now does

Writes the pins into the `ingress-nginx:` subtree — the path that actually wins — and corrects `env.yaml` so the operator-facing file agrees with the deployed state instead of contradicting it:

```yaml
- ingress-nginx:
    controller:
      metrics:
        enabled: true
        serviceMonitor:
          enabled: true
          additionalLabels:
            release: kube-prometheus-stack
        prometheusRule:
          enabled: false
```

`release: kube-prometheus-stack` is required by Prometheus's default selector (`serviceMonitorSelectorNilUsesHelmValues: true` with an empty selector). Note this chart spells the key `additionalLabels`; kafka-kraft (#1662) spells it `labels`.

This cannot move to a root `controller:` key either: the subtree would overwrite it, and **kafka-kraft reads `.Values.controller` too** (13 templates, its own controller block) off the same shared passthrough.

## `prometheusRule` must be pinned false

`env.yaml` asks for `true`, and — per the hoist above — that value was live all along. It was harmless only because the template is gated on `metrics.enabled`, which was false. **Turning metrics on un-gates it**, and the chart's `prometheusRule.rules` is `[]`, so the template emits the key with no body:

```yaml
kind: PrometheusRule
spec: null
```

The CRD (`crd-prometheusrules.yaml`, kube-prometheus-stack 56.6.2) declares `required: ['spec']` with `spec.type: object`, so the API server rejects that and the whole release apply fails. Left alone, this PR would have broken the deploy rather than merely rendering an empty rule.

## Deliberately not in this PR

The security headers and TLS restrictions in the same `env.yaml` block — that is #1679, stacked on this branch. It also corrects two values naming a foreign environment (`Access-Control-Allow-Origin`, `setSslTls`), which need per-key review rather than a wholesale apply.

## Verified / not verified

- [x] `helmfile v0.140.0 -e env -l name=ingress-nginx template` renders `controller-service-metrics` and a ServiceMonitor labelled `release: kube-prometheus-stack`, and no PrometheusRule
- [x] The same command on the previous commit renders **none** of those — the regression this revision fixes
- [x] `_helpers.tpl` hoist diffed against upstream 4.10.0 and isolated with a chart rename
- [x] `.github/scripts/check-helm-values-paths.py` (#1652) against this branch: no new unread key paths
- [ ] **Not verified on a cluster** — this tier has none
- [ ] `nginx_ingress_controller_requests` present in Prometheus
- [ ] Per-route status codes and latency visible
- [ ] The stale `nginx-ingress-metrics.egov` static job removed or corrected once the ServiceMonitor works (#1649 replaces that list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)