### PR TITLE
feat(monitoring): enable external probing and repair the SSL alert

### DIFF
--- a/devops/deploy-as-code/charts/monitoring/monitoring-helmfile.yaml
+++ b/devops/deploy-as-code/charts/monitoring/monitoring-helmfile.yaml
@@ -38,6 +38,36 @@ releases:
   values:
   - ./values/prometheus.yaml
   - {{ .Values | toYaml | nindent 8 }}
+  # External probe target (#1649). values/prometheus.yaml probes a hardcoded
+  # https://unified-uat.digit.org/citizen/ — a FOREIGN environment carried in by
+  # the upstream import (#1619). Left as-is, enabling blackbox would start
+  # probing someone else's deployment and report its health as ours.
+  #
+  # This list REPLACES the one in values/prometheus.yaml (helm replaces lists,
+  # it does not merge them). Deliberate — the three jobs there were: this
+  # blackbox probe with the wrong target; `blackbox_exporter` self-metrics,
+  # kept below; and `nginx-ingress-metrics` against a Service name that never
+  # resolved, now superseded by the ServiceMonitor in #1648.
+  - prometheus:
+      prometheusSpec:
+        additionalScrapeConfigs:
+          - job_name: blackbox
+            metrics_path: /probe
+            params:
+              module: [http_2xx]
+            static_configs:
+              - targets:
+                  - https://{{ .Values.global.domain }}/
+            relabel_configs:
+              - source_labels: [__address__]
+                target_label: __param_target
+              - source_labels: [__param_target]
+                target_label: instance
+              - target_label: __address__
+                replacement: prometheus-blackbox-exporter:9115
+          - job_name: blackbox_exporter
+            static_configs:
+              - targets: ['prometheus-blackbox-exporter:9115']
 
 - name: jaeger
   installed: false
@@ -74,14 +104,38 @@ releases:
     - name: ingress.tls[0].hosts[0]
       value: {{ .Values.global.domain | quote }}
 
+# External probing (#1649). Everything else in this tier watches the platform
+# from the INSIDE — kubelet, pods, services. Nothing verified that a citizen can
+# actually reach the site: DNS, ingress, TLS, routing, end to end.
+#
+# Three things in the repo already depend on this exporter and have therefore
+# never worked:
+#   - the `blackbox` scrape job in values/prometheus.yaml
+#   - the `blackbox_exporter` self-metrics job
+#   - the SSLCertificateExpiring alert (values/prometheus.yaml:181), which
+#     matches instance="prometheus-blackbox-exporter:9115" — so certificate
+#     expiry has never been alertable here despite the rule existing
 - name: blackbox
-  installed: false
+  installed: true
   namespace: {{ .Values.namespace | default "default-namespace" }}
   chart: prometheus-community/prometheus-blackbox-exporter
   version: 8.2.0
   values:
   - ./values/blackbox-exporter.yaml
   - {{ .Values | toYaml | nindent 8 }}
+  set:
+    # Helm would name the Service <release>-<chart>, i.e.
+    # blackbox-prometheus-blackbox-exporter. The scrape jobs and the SSL alert
+    # all hardcode `prometheus-blackbox-exporter`, so without this override the
+    # exporter runs and nothing that references it resolves — the same
+    # never-resolving-name failure this issue exists to fix.
+    - name: fullnameOverride
+      value: prometheus-blackbox-exporter
+    # The chart's own comment: "set to true to add the release label so
+    # scraping of the servicemonitor with kube-prometheus-stack works out of
+    # the box". Same selector requirement as #1647 and #1648.
+    - name: releaseLabel
+      value: true
 
 - name: kafka-ui
   installed: true

--- a/devops/deploy-as-code/charts/monitoring/monitoring-helmfile.yaml
+++ b/devops/deploy-as-code/charts/monitoring/monitoring-helmfile.yaml
@@ -56,8 +56,20 @@ releases:
             params:
               module: [http_2xx]
             static_configs:
+              # /digit-ui/ and not the bare root: NOTHING in this tier serves
+              # `/`. Every ingress is a prefix on its own context
+              # (charts/common/templates/_ingress.yaml:48 renders
+              # `path: /<context>`) and the controller's defaultBackend is
+              # disabled (ingress-nginx/values.yaml:916), so a probe of `/`
+              # gets the controller's built-in 404 and probe_success is pinned
+              # at 0 forever -- a red panel that means nothing.
+              # /digit-ui/ is a real 2xx: the ingress passes the path through
+              # unrewritten (no rewrite-target annotation) and the SPA image's
+              # nginx serves `location /digit-ui` with
+              # `try_files $uri $uri/ /digit-ui/index.html`
+              # (frontend/micro-ui/web/docker/nginx.conf).
               - targets:
-                  - https://{{ .Values.global.domain }}/
+                  - https://{{ .Values.global.domain }}/digit-ui/
             relabel_configs:
               - source_labels: [__address__]
                 target_label: __param_target
@@ -131,11 +143,14 @@ releases:
     # never-resolving-name failure this issue exists to fix.
     - name: fullnameOverride
       value: prometheus-blackbox-exporter
-    # The chart's own comment: "set to true to add the release label so
-    # scraping of the servicemonitor with kube-prometheus-stack works out of
-    # the box". Same selector requirement as #1647 and #1648.
-    - name: releaseLabel
-      value: true
+    # NO releaseLabel here, unlike #1647 and #1648. Scraping is wired through
+    # the static additionalScrapeConfigs above, not through a ServiceMonitor:
+    # values/blackbox-exporter.yaml leaves both serviceMonitor.enabled and
+    # serviceMonitor.selfMonitor.enabled false with an empty `targets` list, so
+    # the chart emits no ServiceMonitor for the label to land on. And the label
+    # would be the wrong one anyway -- the chart writes
+    # `release: <.Release.Name>` (_helpers.tpl:43), which here is `blackbox`,
+    # not the `kube-prometheus-stack` the operator's selector matches.
 
 - name: kafka-ui
   installed: true

--- a/devops/deploy-as-code/charts/monitoring/values/prometheus.yaml
+++ b/devops/deploy-as-code/charts/monitoring/values/prometheus.yaml
@@ -177,8 +177,19 @@ additionalPrometheusRules:
    groups:
      - name: SSLCertificateAlerts
        rules:
+       # instance= deliberately NOT pinned (#1649). The blackbox scrape relabels
+       # instance to the PROBED URL (source_labels: [__param_target] ->
+       # target_label: instance); the exporter's own address only ever appears
+       # in __address__. So matching instance="prometheus-blackbox-exporter:9115"
+       # could never select a probe series — this alert has never been able to
+       # fire, independently of blackbox having been installed: false.
+       #
+       # NOTE: 2 days of warning is very little for a certificate. cert-manager
+       # renews at two-thirds of lifetime, so a renewal that silently stops
+       # leaves ~30 days of runway that this would not surface until the last
+       # 48 hours. Raising it is a deliberate decision, left out of this change.
        - alert: SSLCertificateExpiring
-         expr: probe_ssl_earliest_cert_expiry{job="blackbox", instance="prometheus-blackbox-exporter:9115"} - time() < 2*24*3600
+         expr: probe_ssl_earliest_cert_expiry{job="blackbox"} - time() < 2*24*3600
          for: 1m
          labels:
            severity: warning

--- a/devops/deploy-as-code/charts/monitoring/values/prometheus.yaml
+++ b/devops/deploy-as-code/charts/monitoring/values/prometheus.yaml
@@ -184,12 +184,16 @@ additionalPrometheusRules:
        # could never select a probe series — this alert has never been able to
        # fire, independently of blackbox having been installed: false.
        #
-       # NOTE: 2 days of warning is very little for a certificate. cert-manager
-       # renews at two-thirds of lifetime, so a renewal that silently stops
-       # leaves ~30 days of runway that this would not surface until the last
-       # 48 hours. Raising it is a deliberate decision, left out of this change.
+       # 10 days, not the 2 this rule carried. cert-manager renews at two-thirds
+       # of a 90-day lifetime, so a renewal that silently stops leaves ~30 days
+       # of runway; at 2 days the alert surfaced that in the last 48 hours, when
+       # the fix may need a DNS or ACME-account change and the on-call engineer
+       # may not be at a desk. 10 days is the sibling tier's already-reasoned
+       # number -- Gatus uses `[CERTIFICATE_EXPIRATION] > 240h` in #1632 against
+       # certbot's 30-day renewal -- so this is parity rather than a fresh
+       # guess, and it still cannot fire on a healthy renewal cycle.
        - alert: SSLCertificateExpiring
-         expr: probe_ssl_earliest_cert_expiry{job="blackbox"} - time() < 2*24*3600
+         expr: probe_ssl_earliest_cert_expiry{job="blackbox"} - time() < 10*24*3600
          for: 1m
          labels:
            severity: warning


### PR DESCRIPTION
Fixes #1649

## What

Everything in this tier watches the platform from the **inside** — kubelet, pods, services. Nothing verified that a citizen can actually reach the site: DNS, ingress, TLS, routing, end to end. That is the layer which catches *"every pod is healthy and the site is unusable"*.

The exporter that does it ships `installed: false`, while **three things already depend on it** and have therefore never worked:

- the `blackbox` scrape job
- the `blackbox_exporter` self-metrics job
- the `SSLCertificateExpiring` alert

That last one is worth flagging: I previously described certificate-expiry alerting as a capability where the production tier was **ahead** of the Ansible tier. That was wrong — the rule exists but has never been able to fire.

## Four faults, each of which alone would leave it silently useless

**1. `installed: false` → `true`.**

**2. The Service name would not have resolved.** Helm names it `<release>-<chart>` = `blackbox-prometheus-blackbox-exporter`, while every reference in the repo hardcodes `prometheus-blackbox-exporter`. `fullnameOverride` pins it so the scrape jobs and the alert line up.

**3. The probe target was a foreign domain.** `values/prometheus.yaml` probes `https://unified-uat.digit.org/citizen/`, carried in by the upstream import (#1619). Enabling blackbox without fixing this would have probed **someone else's deployment and reported its health as ours** — worse than no probe. Now templated from `global.domain`, at path `/digit-ui/`.

Not the bare root, which the first revision of this PR used and review caught. Nothing in this tier serves `/`: `charts/common/templates/_ingress.yaml:48` renders every ingress as `path: /<context>` with `pathType: Prefix`, and `defaultBackend.enabled` is `false`, so `/` gets the controller's built-in 404 and `probe_success` would have been pinned at 0 forever. `/digit-ui/` is a real 2xx — the ingress carries no `rewrite-target`, and the SPA image's nginx serves `location /digit-ui` with `try_files $uri $uri/ /digit-ui/index.html` (`frontend/micro-ui/web/docker/nginx.conf`).

**4. The SSL alert could never match.** It pinned `instance="prometheus-blackbox-exporter:9115"`, but the blackbox scrape relabels `instance` to the **probed URL** (`__param_target` → `instance`); the exporter address only ever lives in `__address__`. So the matcher selected nothing, independently of the exporter being disabled. Dropping the `instance` matcher makes the rule selectable.

Fault 4 is the one I would flag to a reviewer: it means fixing 1–3 alone would have produced a working probe and a still-dead alert, which looks like success.

## The scrape list replaces rather than merges

Helm replaces lists. That is intentional here — of the three jobs superseded: this probe with the wrong target, the self-metrics job (kept), and `nginx-ingress-metrics` against a Service name that never resolved, now covered by the ServiceMonitor in #1663.

## Two more, from review

**5. `releaseLabel: true` was inert, and would have been wrong.** `values/blackbox-exporter.yaml` leaves `serviceMonitor.enabled` and `serviceMonitor.selfMonitor.enabled` both `false` with an empty `targets` list, so this chart emits no ServiceMonitor at all — scraping is entirely via the static `additionalScrapeConfigs`. And unlike the kafka and ingress-nginx charts, this one hardcodes `release: {{ .Release.Name }}` (`_helpers.tpl:43`), which here is `blackbox`, not the `kube-prometheus-stack` the operator selects on. Removed, with the reason recorded so it isn't re-added by analogy with #1662 and #1663.

**6. The expiry threshold goes from 2 days to 10.** Originally scoped out of this PR as a judgement call. Changed on reflection, because this PR is what makes the alert able to fire at all — shipping the repair together with a window we already agree is too tight means the alert's first working configuration is the inadequate one.

10 days is not a fresh guess: the sibling Ansible tier reasoned the same number out in #1632 as Gatus `[CERTIFICATE_EXPIRATION] > 240h`, against certbot's 30-day renewal. Identical arithmetic here — cert-manager renews at two-thirds of a 90-day lifetime, so ~30 days of runway remain and a 10-day rule still cannot fire on a healthy cycle.

## Verified / not verified

- [x] `helmfile v0.140.0 -e env -l name=kube-prometheus-stack template`: the additional-scrape-configs Secret carries the `/digit-ui/` target, and the rendered PrometheusRule carries `probe_ssl_earliest_cert_expiry{job="blackbox"} - time() < 10*24*3600`
- [x] `helmfile ... -l name=blackbox template`: ServiceAccount, ConfigMap, Service and Deployment all named `prometheus-blackbox-exporter`, and no ServiceMonitor
- [x] `fullnameOverride` makes the Service name match all three existing references
- [x] Relabel chain traced to confirm what `instance` actually becomes
- [x] `/` proven non-2xx and `/digit-ui/` proven 2xx from the ingress templates and the SPA image's nginx config
- [ ] **Not verified on a cluster** — no access
- [ ] `probe_success` and `probe_ssl_earliest_cert_expiry` present for the deployment's own domain
- [ ] The SSL alert evaluates (check it appears in Prometheus → Alerts, not just that the series exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)