### PR TITLE
feat(ansible): make the observability stack modular

### DIFF
--- a/local-setup/ansible/inventory/group_vars/digit.yml
+++ b/local-setup/ansible/inventory/group_vars/digit.yml
@@ -48,6 +48,39 @@ digit_ui_mode: static
 # Off by default; tenants that use the inbox opt in via host_vars.
 enable_search_stack: false
 
+# ──────────────────────────────────────────────────────────────────────
+# How much observability to deploy (#1657)
+# ──────────────────────────────────────────────────────────────────────
+# Cumulative levels — each includes the ones above it. Default `traces`
+# is the whole stack, i.e. exactly what every tenant runs today, so this
+# knob only ever lets an operator take LESS.
+#
+#   metrics  gatus, prometheus, node-exporter, grafana, collector  ~1.2 GB
+#   logs     + loki, promtail                                       ~1.8 GB
+#   traces   + tempo                                                ~2.2 GB
+#
+# A gatus-only `uptime` level (~64 MB) is deliberately NOT offered yet.
+# 16 application services declare `depends_on: otel-collector`, so a level
+# that omits the collector risks failing the whole deploy rather than
+# shrinking it — whether compose auto-enables a dependency's profile or
+# errors is version-dependent, and that is not a thing to guess at on a
+# tenant box. Removing that dependency is the right fix (a telemetry sink
+# should never gate application startup) and is tracked separately.
+#
+# (Footprints are the mem_limit ceilings from #1612, not measured usage.)
+#
+# Why the collector sits in `metrics` and not `traces`: JVM metrics flow
+# OTLP → otel-collector → /metrics on :8889, which is what Prometheus
+# scrapes. Drop the collector and you lose per-service JVM metrics, not
+# just traces. Tempo is the only traces-exclusive component.
+#
+# This matters because the boxes are small: 29 services declare ~12.8 GB
+# of max heap on machines that are commonly 16 GB and have NO swap, so
+# memory pressure means OOM kills rather than slowdown. An operator who
+# wants uptime and metrics but cannot afford log and trace storage should
+# be able to say so.
+observability_level: traces
+
 # SPA configuration — stable cross-tenant defaults.
 context_path: digit-ui
 gmaps_api_key: ""

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -1413,7 +1413,32 @@
     # COMPOSE_PROFILES drives which optional service groups are included.
     # Today: `search` covers elasticsearch + egov-indexer + inbox-v2.
     # Default off; tenants opt in via `enable_search_stack: true`.
+    # Observability levels are CUMULATIVE (#1657): each includes the ones
+    # above it. Default `traces` yields all three profiles, i.e. exactly the
+    # stack every tenant runs today — this knob only ever removes.
+    - name: "Validate observability_level"
+      ansible.builtin.fail:
+        msg: >-
+          observability_level must be one of metrics|logs|traces, got
+          '{{ observability_level }}'. Levels are cumulative; `traces` is the
+          full stack and the default. A gatus-only level is not offered yet —
+          16 services depend_on otel-collector, so omitting it risks failing
+          the deploy rather than shrinking it.
+      when: (observability_level | default('traces')) not in ['metrics', 'logs', 'traces']
+
     - name: "Compute compose profiles for this tenant"
+      vars:
+        _obs: "{{ observability_level | default('traces') }}"
+        # collector lives in `metrics`, not `traces`: JVM metrics reach
+        # Prometheus via otel-collector:8889, so dropping it costs metrics too.
+        _obs_profiles: >-
+          {{
+            ([]
+              + (['obs-metrics'] if _obs in ['metrics', 'logs', 'traces'] else [])
+              + (['obs-logs']    if _obs in ['logs', 'traces']            else [])
+              + (['obs-traces']  if _obs == 'traces'                      else [])
+            )
+          }}
       ansible.builtin.set_fact:
         compose_profiles: >-
           {{
@@ -1423,6 +1448,7 @@
               + (['notifications'] if enable_novu          | default(false) else [])
               + (['keycloak']      if enable_keycloak      | default(false) else [])
               + (['otp']           if enable_otp_services  | default(false) else [])
+              + _obs_profiles
             ) | join(',')
           }}
 

--- a/local-setup/ansible/templates/digit.env.j2
+++ b/local-setup/ansible/templates/digit.env.j2
@@ -98,6 +98,17 @@ NOVU_BRIDGE_IDENTIFY_CACHE_TTL_MS={{ novu_bridge_identify_cache_ttl_ms | default
 NOVU_BRIDGE_CHANNEL={{ novu_bridge_channel | default('sms') }}
 {% endif %}
 
+# ── Observability level (#1657) ──
+# Stops the OTEL javaagent exporting into components this level does not
+# deploy. Without these, a `metrics`- or `logs`-level tenant would still ship
+# spans to an absent Tempo, and the collector would log export failures on a
+# loop.
+#
+# The compose files read these as ${OTEL_*_EXPORTER:-otlp}, so an unset value
+# means "full stack" — a bare `docker compose up` outside Ansible is unchanged.
+OTEL_TRACES_EXPORTER={{ 'otlp' if (observability_level | default('traces')) == 'traces' else 'none' }}
+OTEL_METRICS_EXPORTER={{ 'otlp' if (observability_level | default('traces')) in ['metrics', 'logs', 'traces'] else 'none' }}
+
 # ── Gatus profile toggles ──
 # These MUST mirror `compose_profiles` (playbook-deploy.yml "Compute compose
 # profiles for this tenant"): the same enable_* flag that starts an optional

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -9,6 +9,8 @@ services:
   otel-collector:
     image: egovio/opentelemetry-collector-contrib:0.114.0
     container_name: digit-otel-collector
+    # JVM metrics flow through it, not just traces (#1657)
+    profiles: [obs-metrics]
     restart: unless-stopped
     command: ["--config=/etc/otelcol-contrib/config.yaml"]
     volumes:
@@ -23,6 +25,8 @@ services:
   tempo:
     image: egovio/tempo:2.6.1
     container_name: digit-tempo
+    # trace store — the only traces-only component (#1657)
+    profiles: [obs-traces]
     restart: unless-stopped
     command: ["-config.file=/etc/tempo/config.yaml"]
     volumes:
@@ -41,6 +45,8 @@ services:
   grafana:
     image: egovio/grafana:11.4.0
     container_name: digit-grafana
+    # the only UI for any of it (#1657)
+    profiles: [obs-metrics]
     restart: unless-stopped
     environment:
       GF_AUTH_ANONYMOUS_ENABLED: "true"
@@ -61,11 +67,17 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    # Only prometheus, which shares grafana's profile (#1657). tempo and loki
+    # were hard dependencies here, which breaks two ways:
+    #   1. compose refuses to start a service whose depends_on target is
+    #      excluded by the active profiles — so `metrics` or `logs` level would
+    #      fail the deploy outright, not degrade;
+    #   2. even at full stack, `condition: service_healthy` made the dashboards
+    #      unreachable whenever the LOG store was unhealthy — a trace/log
+    #      backend being down is a reason to open Grafana, not to withhold it.
+    # Grafana needs neither at boot: an unreachable datasource surfaces as a
+    # panel error and recovers on its own once the backend appears.
     depends_on:
-      tempo:
-        condition: service_healthy
-      loki:
-        condition: service_healthy
       prometheus:
         condition: service_started
     networks:
@@ -77,6 +89,8 @@ services:
   prometheus:
     image: prom/prometheus:v2.55.1
     container_name: digit-prometheus
+    # metrics store (#1657)
+    profiles: [obs-metrics]
     restart: unless-stopped
     command:
       - --config.file=/etc/prometheus/prometheus.yml
@@ -306,11 +320,11 @@ services:
       SECURITY_BASIC_ENABLED: 'false'
       MANAGEMENT_SECURITY_ENABLED: 'false'
       MANAGEMENT_HEALTH_DB_ENABLED: 'false'
-      OTEL_TRACES_EXPORTER: otlp
+      OTEL_TRACES_EXPORTER: ${OTEL_TRACES_EXPORTER:-otlp}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_SERVICE_NAME: egov-indexer
-      OTEL_METRICS_EXPORTER: otlp
+      OTEL_METRICS_EXPORTER: ${OTEL_METRICS_EXPORTER:-otlp}
       OTEL_LOGS_EXPORTER: none
       # heap-tuned via JAVA_OPTS by patch-jvm-heaps.py for egov-indexer
       JAVA_OPTS: "-Xms192m -Xmx512m"
@@ -373,11 +387,11 @@ services:
       MANAGEMENT_SECURITY_ENABLED: 'false'
       # Accept unknown fields in userInfo (locale, active, permanentCity etc.)
       SPRING_JACKSON_DESERIALIZATION_FAIL_ON_UNKNOWN_PROPERTIES: 'false'
-      OTEL_TRACES_EXPORTER: otlp
+      OTEL_TRACES_EXPORTER: ${OTEL_TRACES_EXPORTER:-otlp}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_SERVICE_NAME: inbox
-      OTEL_METRICS_EXPORTER: otlp
+      OTEL_METRICS_EXPORTER: ${OTEL_METRICS_EXPORTER:-otlp}
       OTEL_LOGS_EXPORTER: none
       JAVA_OPTS: -Xms256m -Xmx256m
       JAVA_TOOL_OPTIONS: -javaagent:/otel/opentelemetry-javaagent.jar ${MAC_JVM_OPTS:-}
@@ -433,11 +447,11 @@ services:
       SPRING_FLYWAY_ENABLED: 'false'
       SPRING_FLYWAY_TABLE: enc_schema_version
       SERVER_PORT: 1234
-      OTEL_TRACES_EXPORTER: otlp
+      OTEL_TRACES_EXPORTER: ${OTEL_TRACES_EXPORTER:-otlp}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_SERVICE_NAME: egov-enc-service
-      OTEL_METRICS_EXPORTER: otlp
+      OTEL_METRICS_EXPORTER: ${OTEL_METRICS_EXPORTER:-otlp}
       OTEL_LOGS_EXPORTER: none
       MASTER_PASSWORD: ${ELASTICSEARCH_MASTER_PASSWORD:-asd@#$@$!132123}
       MASTER_SALT: qweasdzx
@@ -484,11 +498,11 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SPRING_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SERVER_PORT: 8094
-      OTEL_TRACES_EXPORTER: otlp
+      OTEL_TRACES_EXPORTER: ${OTEL_TRACES_EXPORTER:-otlp}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_SERVICE_NAME: mdms-backend
-      OTEL_METRICS_EXPORTER: otlp
+      OTEL_METRICS_EXPORTER: ${OTEL_METRICS_EXPORTER:-otlp}
       OTEL_LOGS_EXPORTER: none
       JAVA_TOOL_OPTIONS: -Xms512m -Xmx1024m -javaagent:/otel/opentelemetry-javaagent.jar ${MAC_JVM_OPTS:-}
     healthcheck:
@@ -557,11 +571,11 @@ services:
       AUTOCREATE_NEW_SEQ: 'true'
       KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SERVER_PORT: 8088
-      OTEL_TRACES_EXPORTER: otlp
+      OTEL_TRACES_EXPORTER: ${OTEL_TRACES_EXPORTER:-otlp}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_SERVICE_NAME: egov-idgen
-      OTEL_METRICS_EXPORTER: otlp
+      OTEL_METRICS_EXPORTER: ${OTEL_METRICS_EXPORTER:-otlp}
       OTEL_LOGS_EXPORTER: none
       MANAGEMENT_HEALTH_DB_ENABLED: 'false'
       JAVA_TOOL_OPTIONS: -Xms256m -Xmx512m -javaagent:/otel/opentelemetry-javaagent.jar ${MAC_JVM_OPTS:-}
@@ -693,11 +707,11 @@ services:
       EGOV_ACCESSCONTROL_HOST: http://egov-accesscontrol:8090
       EGOV_STATE_LEVEL_TENANT_ID: pg
       STATE_LEVEL_TENANT_ID: pg
-      OTEL_TRACES_EXPORTER: otlp
+      OTEL_TRACES_EXPORTER: ${OTEL_TRACES_EXPORTER:-otlp}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_SERVICE_NAME: egov-user
-      OTEL_METRICS_EXPORTER: otlp
+      OTEL_METRICS_EXPORTER: ${OTEL_METRICS_EXPORTER:-otlp}
       OTEL_LOGS_EXPORTER: none
       JAVA_TOOL_OPTIONS: -Xms128m -Xmx384m -javaagent:/otel/opentelemetry-javaagent.jar ${MAC_JVM_OPTS:-}
       CITIZEN_LOGIN_PASSWORD_OTP_FIXED_ENABLED: 'true'
@@ -770,11 +784,11 @@ services:
       EGOV_STATE_LEVEL_TENANT_ID: pg
       # Disable schema-per-tenant mode - use public schema for all tenants
       IS_ENVIRONMENT_CENTRAL_INSTANCE: 'false'
-      OTEL_TRACES_EXPORTER: otlp
+      OTEL_TRACES_EXPORTER: ${OTEL_TRACES_EXPORTER:-otlp}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_SERVICE_NAME: egov-workflow-v2
-      OTEL_METRICS_EXPORTER: otlp
+      OTEL_METRICS_EXPORTER: ${OTEL_METRICS_EXPORTER:-otlp}
       OTEL_LOGS_EXPORTER: none
       SPRING_THREADS_VIRTUAL_ENABLED: 'true'
       # Raise default search limit from 10 to 200 — PGR's internal workflow call
@@ -847,7 +861,7 @@ services:
       # OTEL export disabled — image has OTEL on classpath, but no agent attached
       # This avoids the ~200MB heap overhead from the javaagent while keeping OTEL JDBC driver happy
       OTEL_TRACES_EXPORTER: none
-      OTEL_METRICS_EXPORTER: otlp
+      OTEL_METRICS_EXPORTER: ${OTEL_METRICS_EXPORTER:-otlp}
       OTEL_LOGS_EXPORTER: none
       SPRING_THREADS_VIRTUAL_ENABLED: 'true'
       JAVA_OPTS: -Xms128m -Xmx512m
@@ -901,11 +915,11 @@ services:
       EGOV_IDGEN_HOST: http://egov-idgen:8088
       EGOV_LOCALIZATION_HOST: http://egov-localization:8096
       STATE_LEVEL_TENANT_ID: pg
-      OTEL_TRACES_EXPORTER: otlp
+      OTEL_TRACES_EXPORTER: ${OTEL_TRACES_EXPORTER:-otlp}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_SERVICE_NAME: boundary-service
-      OTEL_METRICS_EXPORTER: otlp
+      OTEL_METRICS_EXPORTER: ${OTEL_METRICS_EXPORTER:-otlp}
       OTEL_LOGS_EXPORTER: none
       OTEL_INSTRUMENTATION_JDBC_ENABLED: 'false'
       MANAGEMENT_HEALTH_DB_ENABLED: 'false'
@@ -948,11 +962,11 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SERVER_PORT: 8090
       EGOV_MDMS_HOST: http://egov-mdms-service:8094/
-      OTEL_TRACES_EXPORTER: otlp
+      OTEL_TRACES_EXPORTER: ${OTEL_TRACES_EXPORTER:-otlp}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_SERVICE_NAME: egov-accesscontrol
-      OTEL_METRICS_EXPORTER: otlp
+      OTEL_METRICS_EXPORTER: ${OTEL_METRICS_EXPORTER:-otlp}
       OTEL_LOGS_EXPORTER: none
       JAVA_TOOL_OPTIONS: -Xms256m -Xmx512m -javaagent:/otel/opentelemetry-javaagent.jar ${MAC_JVM_OPTS:-}
     ports:
@@ -990,11 +1004,11 @@ services:
       SPRING_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SERVER_PORT: 8091
       EGOV_PERSIST_YML_REPO_PATH: /persister-config/
-      OTEL_TRACES_EXPORTER: otlp
+      OTEL_TRACES_EXPORTER: ${OTEL_TRACES_EXPORTER:-otlp}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_SERVICE_NAME: egov-persister
-      OTEL_METRICS_EXPORTER: otlp
+      OTEL_METRICS_EXPORTER: ${OTEL_METRICS_EXPORTER:-otlp}
       OTEL_LOGS_EXPORTER: none
       JAVA_TOOL_OPTIONS: -Xms256m -Xmx512m -javaagent:/otel/opentelemetry-javaagent.jar ${MAC_JVM_OPTS:-}
       # Kafka consumer concurrency — process more messages in parallel
@@ -1045,11 +1059,11 @@ services:
       # replays V1 onto a populated database — 42P07 crash loop (#1586).
       SPRING_FLYWAY_ENABLED: 'false'
       SERVER_PORT: 8083
-      OTEL_TRACES_EXPORTER: otlp
+      OTEL_TRACES_EXPORTER: ${OTEL_TRACES_EXPORTER:-otlp}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_SERVICE_NAME: egov-filestore
-      OTEL_METRICS_EXPORTER: otlp
+      OTEL_METRICS_EXPORTER: ${OTEL_METRICS_EXPORTER:-otlp}
       OTEL_LOGS_EXPORTER: none
       JAVA_TOOL_OPTIONS: -Xms256m -Xmx512m -javaagent:/otel/opentelemetry-javaagent.jar ${MAC_JVM_OPTS:-}
       # MinIO/S3 storage (local S3-compatible storage for dev)
@@ -1154,11 +1168,11 @@ services:
       SPRING_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SPRING_KAFKA_CONSUMER_GROUP_ID: employee-group1
       SERVER_PORT: 8092
-      OTEL_TRACES_EXPORTER: otlp
+      OTEL_TRACES_EXPORTER: ${OTEL_TRACES_EXPORTER:-otlp}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_SERVICE_NAME: egov-hrms
-      OTEL_METRICS_EXPORTER: otlp
+      OTEL_METRICS_EXPORTER: ${OTEL_METRICS_EXPORTER:-otlp}
       OTEL_LOGS_EXPORTER: none
       JAVA_TOOL_OPTIONS: -Xms256m -Xmx512m -javaagent:/otel/opentelemetry-javaagent.jar ${MAC_JVM_OPTS:-}
       EGOV_MDMS_HOST: http://egov-mdms-service:8094
@@ -1488,11 +1502,11 @@ services:
       PGR_VISIBILITY_ENABLED: 'true'
       JAVA_OPTS: '-Xmx384m -Xms384m'
       JAVA_TOOL_OPTIONS: -javaagent:/otel/opentelemetry-javaagent.jar ${MAC_JVM_OPTS:-}
-      OTEL_TRACES_EXPORTER: otlp
+      OTEL_TRACES_EXPORTER: ${OTEL_TRACES_EXPORTER:-otlp}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_SERVICE_NAME: pgr-services
-      OTEL_METRICS_EXPORTER: otlp
+      OTEL_METRICS_EXPORTER: ${OTEL_METRICS_EXPORTER:-otlp}
       OTEL_LOGS_EXPORTER: none
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:8080/pgr-services/health >/dev/null 2>&1 || exit 1"]
@@ -1666,6 +1680,8 @@ services:
   loki:
     image: grafana/loki:3.4.2
     container_name: digit-loki
+    # log store (#1657)
+    profiles: [obs-logs]
     restart: unless-stopped
     command: ["-config.file=/etc/loki/config.yaml"]
     volumes:
@@ -1689,6 +1705,8 @@ services:
   promtail:
     image: grafana/promtail:3.4.2
     container_name: digit-promtail
+    # log shipper (#1657)
+    profiles: [obs-logs]
     restart: unless-stopped
     command: ["-config.file=/etc/promtail/config.yaml"]
     volumes:
@@ -2125,11 +2143,11 @@ services:
       # tenant has no schema of its own. Should match the deployment's
       # state-level tenant (set in host_vars).
       STATE_LEVEL_TENANT_ID: ${STATE_LEVEL_TENANT_ID:-pg}
-      OTEL_TRACES_EXPORTER: otlp
+      OTEL_TRACES_EXPORTER: ${OTEL_TRACES_EXPORTER:-otlp}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_SERVICE_NAME: digit-config-service
-      OTEL_METRICS_EXPORTER: otlp
+      OTEL_METRICS_EXPORTER: ${OTEL_METRICS_EXPORTER:-otlp}
       OTEL_LOGS_EXPORTER: none
       JAVA_TOOL_OPTIONS: -Xms128m -Xmx384m -javaagent:/otel/opentelemetry-javaagent.jar
     healthcheck:
@@ -2279,11 +2297,11 @@ services:
       # to the compose .env).
       NOVU_BASE_URL: ${NOVU_BASE_URL:-http://novu-api:3000}
       NOVU_API_KEY: ${NOVU_API_KEY:-changeme}
-      OTEL_TRACES_EXPORTER: otlp
+      OTEL_TRACES_EXPORTER: ${OTEL_TRACES_EXPORTER:-otlp}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_SERVICE_NAME: novu-bridge
-      OTEL_METRICS_EXPORTER: otlp
+      OTEL_METRICS_EXPORTER: ${OTEL_METRICS_EXPORTER:-otlp}
       OTEL_LOGS_EXPORTER: none
       JAVA_TOOL_OPTIONS: -Xms128m -Xmx384m -javaagent:/otel/opentelemetry-javaagent.jar
     healthcheck:

--- a/local-setup/docker-compose.monitoring.yml
+++ b/local-setup/docker-compose.monitoring.yml
@@ -22,6 +22,8 @@ services:
     # prom/prometheus) — not the registry.preview mirror.
     image: prom/node-exporter:v1.8.2
     container_name: digit-node-exporter
+    # host metrics — part of the metrics tier (#1657)
+    profiles: [obs-metrics]
     restart: unless-stopped
     # A containerised node-exporter sees only the container's namespaces
     # unless pointed at the host's. pid:host + the read-only /proc, /sys and /


### PR DESCRIPTION
Fixes #1657

## What

Every tenant gets the whole observability stack or nothing. All seven services had no `profiles:` key so they always start, and the monitoring overlay is layered unconditionally.

That matters on these boxes: 29 services declare **~12.8 GB** of configured JVM heap on machines commonly 16 GB, with **no swap** — so memory pressure means OOM kills, not slowdown. An operator who wants uptime and metrics but cannot afford log and trace storage had no supported option short of editing compose by hand, which the next deploy overwrites.

## Levels

Cumulative, using the profile mechanism already proven for the five optional stacks (`search`, `mcp`, `notifications`, `keycloak`, `otp`):

| `observability_level` | Adds | Footprint |
|---|---|---|
| `metrics` | gatus, prometheus, node-exporter, grafana, **collector** | ~1.2 GB |
| `logs` | + loki, promtail | ~1.8 GB |
| `traces` *(default)* | + tempo | ~2.2 GB |

**Default is `traces` — the full stack, exactly what runs today.** This only ever lets an operator take less; existing tenants see no change.

Footprints are the `mem_limit` ceilings from #1612, not measured usage. #1657's acceptance asks for real numbers from a box before publishing these as guidance.

## Why the collector is in `metrics`, not `traces`

JVM metrics flow OTLP → otel-collector → `:8889`, which is the endpoint Prometheus scrapes. Dropping the collector costs **per-service JVM metrics**, not just traces. Tempo is the only traces-exclusive component. Getting this backwards would have produced a "metrics" level with no application metrics.

## Two things that had to change for the lower levels to work rather than fail

**1. Grafana's `depends_on` would have failed the deploy.** It required `tempo` and `loki` as `service_healthy`. Compose refuses to start a service whose dependency is excluded by the active profiles, so `metrics` or `logs` would have failed outright rather than degraded. Reduced to `prometheus`.

This is a fix in its own right: the old condition made **the dashboards unreachable whenever the log store was unhealthy** — which is a reason to open Grafana, not to withhold it. An unreachable datasource surfaces as a panel error and recovers on its own.

**2. The agents would have exported into the void.** `OTEL_TRACES_EXPORTER` / `OTEL_METRICS_EXPORTER` now come from `.env` (defaulting to `otlp`), so a level without Tempo stops services shipping spans to an absent backend and the collector logging export failures on a loop. A bare `docker compose up` outside Ansible is unchanged.

## Deliberately NOT included: a gatus-only `uptime` level

It would be the most useful level for a constrained operator (~64 MB), and I have left it out.

**16 application services declare `depends_on: otel-collector`.** Whether Compose auto-enables a dependency's profile or errors is version-dependent, and I have no way to test it here. Getting it wrong means the level does not shrink the deploy — it **fails** it, on a tenant box.

The right fix is to remove that dependency: a telemetry sink should never gate application startup, and today a collector that fails to start blocks 16 core services. That deserves its own change and its own verification.

## Verified / not verified

- [x] All five touched files parse
- [x] Level → profile mapping simulated for every level
- [x] No cross-tier `depends_on` violations remain among observability services
- [x] Audited every non-observability service for dependencies on profiled ones — that is how the 16-service collector dependency surfaced
- [x] `check-gatus-coverage.py` passes; static suite 35/35
- [ ] **Not deployed.** Needs a real run at each level, confirming the expected containers start and nothing else changes
- [ ] Measured footprints at each level, to replace the estimates

## Follow-ups this creates

- **Gatus checks should track the level.** At `metrics`, the Loki and Tempo checks added by #1636 would go red for components deliberately not deployed — the exact failure the profile pattern exists to prevent. #1636 is not in this branch yet; wiring `GATUS_OBSERVABILITY` to the level belongs with whichever lands second.
- The `uptime` level, once the collector dependency is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
