### PR TITLE
feat(otel): collector + opt-in javaagent for application metrics

### DIFF
--- a/devops/deploy-as-code/charts/common/templates/_deployment.yaml
+++ b/devops/deploy-as-code/charts/common/templates/_deployment.yaml
@@ -48,8 +48,14 @@ spec:
         runAsUser: {{ .Values.securityContext.runAsUser }}
       {{- end }}
     {{- end }}
-    {{- if or .Values.initContainers.gitSync.enabled .Values.extraVolumes }}     
+    {{- if or .Values.initContainers.gitSync.enabled .Values.extraVolumes .Values.otel.enabled }}     
       volumes:  
+    {{- if .Values.otel.enabled }}
+      # OTEL javaagent (#1646): the init container below copies the jar
+      # here, the app container mounts it read-only.
+      - name: otel-agent
+        emptyDir: {}
+    {{- end }}
     {{- if .Values.initContainers.gitSync.enabled }}  
       - name: git-secret
         secret:
@@ -77,6 +83,19 @@ spec:
       serviceAccountName: {{ .Values.serviceAccount }}    
     {{- end }}     
       initContainers:
+      {{- if .Values.otel.enabled }}
+      # Stage the javaagent into a shared emptyDir. An init container rather
+      # than baking it into every service image: these images are built
+      # upstream (egovio/*), so a bake would need 41 coordinated rebuilds and
+      # would pin the agent version per image.
+      - name: otel-agent
+        image: {{ .Values.otel.agentImage }}
+        imagePullPolicy: IfNotPresent
+        command: ['sh', '-c', 'cp {{ .Values.otel.agentJarPath }} /otel/opentelemetry-javaagent.jar']
+        volumeMounts:
+        - name: otel-agent
+          mountPath: /otel
+      {{- end }}
       {{- with .Values.initContainers.extraInitContainers }}
         {{- tpl . $ | nindent 8 }}
       {{- end }}
@@ -134,12 +153,17 @@ spec:
           lifecycle:
           {{- toYaml .Values.lifecycle | nindent 12 }}
         {{- end }}      
-        {{- if or .Values.initContainers.gitSync.enabled .Values.extraVolumeMounts }}
+        {{- if or .Values.initContainers.gitSync.enabled .Values.extraVolumeMounts .Values.otel.enabled }}
           volumeMounts:              
         {{- if .Values.initContainers.gitSync.enabled }}            
           - name: workdir
             mountPath: "/work-dir"
         {{- end }}             
+        {{- if .Values.otel.enabled }}
+          - name: otel-agent
+            mountPath: /otel
+            readOnly: true
+        {{- end }}
         {{- with .Values.extraVolumeMounts }}
           {{- tpl . $ | nindent 10 }}
         {{- end }}          

--- a/devops/deploy-as-code/charts/common/templates/_statefulset.yaml
+++ b/devops/deploy-as-code/charts/common/templates/_statefulset.yaml
@@ -40,8 +40,16 @@ spec:
       securityContext:
         fsGroup: 65533 # to make SSH key readable 
     {{- end }} 
-    {{- if or .Values.initContainers.gitSync.enabled .Values.extraVolumes }}     
+    {{- if or .Values.initContainers.gitSync.enabled .Values.extraVolumes .Values.otel.enabled }}     
       volumes:  
+    {{- if .Values.otel.enabled }}
+      # OTEL javaagent (#1646) — mirrors _deployment.yaml. Kept in step so a
+      # statefulset service cannot inherit JAVA_TOOL_OPTIONS from the shared
+      # extraEnv.java block without the jar being staged: a -javaagent path
+      # that does not exist makes the JVM fail at startup.
+      - name: otel-agent
+        emptyDir: {}
+    {{- end }}
     {{- if .Values.initContainers.gitSync.enabled }}  
       - name: git-secret
         secret:
@@ -69,6 +77,15 @@ spec:
       serviceAccountName: {{ .Values.serviceAccount }}    
     {{- end }}     
       initContainers:
+      {{- if .Values.otel.enabled }}
+      - name: otel-agent
+        image: {{ .Values.otel.agentImage }}
+        imagePullPolicy: IfNotPresent
+        command: ['sh', '-c', 'cp {{ .Values.otel.agentJarPath }} /otel/opentelemetry-javaagent.jar']
+        volumeMounts:
+        - name: otel-agent
+          mountPath: /otel
+      {{- end }}
       {{- with .Values.initContainers.extraInitContainers }}
         {{- tpl . $ | nindent 8 }}
       {{- end }}
@@ -126,12 +143,17 @@ spec:
           lifecycle:
           {{- toYaml .Values.lifecycle | nindent 12 }}
         {{- end }}      
-        {{- if or .Values.initContainers.gitSync.enabled .Values.extraVolumeMounts }}
+        {{- if or .Values.initContainers.gitSync.enabled .Values.extraVolumeMounts .Values.otel.enabled }}
           volumeMounts:              
         {{- if .Values.initContainers.gitSync.enabled }}            
           - name: workdir
             mountPath: "/work-dir"
         {{- end }} 
+        {{- if .Values.otel.enabled }}
+          - name: otel-agent
+            mountPath: /otel
+            readOnly: true
+        {{- end }}
         {{- if .Values.persistence.enabled }}            
         {{- with .Values.extraVolumeMounts }}
           {{- tpl . $ | nindent 10 }}

--- a/devops/deploy-as-code/charts/common/values.yaml
+++ b/devops/deploy-as-code/charts/common/values.yaml
@@ -326,6 +326,14 @@ otel:
   # /javaagent.jar. Pinned to match the Ansible tier's agent version
   # (local-setup/otel/download-agent.sh pins 2.11.0) so metric names and the
   # JVM dashboard line up across both tiers.
+  #
+  # The 2.11.0 tag is published and pullable — GHCR's package page only shows
+  # recent tags by default, so check the registry, not the page. Verified
+  # 2026-08-10 against ghcr.io/v2/.../manifests/2.11.0: an OCI image index at
+  # sha256:b32b2153611bb11a98006d8d34c3ee91d307f491fa754ab66f5b0aff31a93a1b
+  # covering linux/amd64, arm64, s390x and ppc64le. Re-check before bumping:
+  # otel.enabled adds this as an init container to every service, so a bad tag
+  # is ImagePullBackOff across the whole tier at once.
   agentImage: "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:2.11.0"
   # Path to the jar INSIDE agentImage. Configurable because it differs between
   # the operator image (/javaagent.jar) and a hand-built one.

--- a/devops/deploy-as-code/charts/common/values.yaml
+++ b/devops/deploy-as-code/charts/common/values.yaml
@@ -160,8 +160,30 @@ extraEnv:
           configMapKeyRef:
             name: egov-config
             key: spring-datasource-tomcat-initialSize
+      {{- if .Values.otel.enabled }}
+      # OTEL javaagent (#1646). JAVA_TOOL_OPTIONS is how the JVM picks the
+      # agent up without changing any service's entrypoint. Metrics AND traces
+      # travel one OTLP pipeline to the collector, which re-exposes metrics for
+      # Prometheus — so this single block is what gives 41 services JVM metrics.
+      - name: JAVA_TOOL_OPTIONS
+        value: "-javaagent:/otel/opentelemetry-javaagent.jar"
+      - name: OTEL_SERVICE_NAME
+        value: {{ template "common.name" . }}
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: {{ .Values.otel.endpoint | quote }}
+      - name: OTEL_EXPORTER_OTLP_PROTOCOL
+        value: "grpc"
+      - name: OTEL_METRICS_EXPORTER
+        value: "otlp"
+      - name: OTEL_TRACES_EXPORTER
+        value: {{ .Values.otel.tracesExporter | quote }}
+      # Logs stay on the promtail -> loki path this tier already uses.
+      - name: OTEL_LOGS_EXPORTER
+        value: "none"
+      {{- else }}
       - name: OTEL_TRACES_EXPORTER
         value: "none"
+      {{- end }}
       - name: SPRING_DATASOURCE_DRIVER_CLASS_NAME
         value: "org.postgresql.Driver"
       - name: SERVER_TOMCAT_MAX_THREADS
@@ -271,6 +293,43 @@ securityContext: {}
 
 service:
   additionalAnnotations: {}
+
+# ── Application telemetry (#1646) ──────────────────────────────────────
+# OFF BY DEFAULT, deliberately. Switching it on adds an init container and a
+# JAVA_TOOL_OPTIONS javaagent to EVERY java-spring service in the deployment —
+# the widest blast radius of any value in this chart. Enable it in env.yaml
+# for one environment, verify pods still start and metrics arrive, then roll
+# it wider.
+#
+# What it buys: JVM metrics for all 41 services, which this tier has none of
+# today (0 of 41 charts define a ServiceMonitor, and no service exposes a
+# micrometer/actuator endpoint for one to scrape). The agent exports OTLP to
+# the collector, which re-exposes everything on a SINGLE Prometheus endpoint —
+# so collection needs one ServiceMonitor, not 41.
+#
+# It also supersedes the Jaeger env this chart still injects (extraEnv.jaeger,
+# below): 25 live services point at a node-local jaeger agent that is not
+# deployed and, with useHostPort: false in the jaeger values, could not receive
+# them if it were. Remove that block once this is on everywhere.
+otel:
+  enabled: false
+  # Where the agent sends OTLP. Service name follows the collector release in
+  # charts/monitoring/monitoring-helmfile.yaml.
+  endpoint: "http://otel-collector-opentelemetry-collector.monitoring:4317"
+  # Traces need a backend. This tier has none yet (jaeger is installed: false
+  # and is a different architecture), so traces stay off while metrics flow.
+  # Flip to "otlp" when a trace store lands, and add the traces pipeline to
+  # the collector values at the same time.
+  tracesExporter: "none"
+  # Image carrying the javaagent jar. This is the image the OpenTelemetry
+  # Operator uses for Java auto-instrumentation; it ships the jar at
+  # /javaagent.jar. Pinned to match the Ansible tier's agent version
+  # (local-setup/otel/download-agent.sh pins 2.11.0) so metric names and the
+  # JVM dashboard line up across both tiers.
+  agentImage: "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:2.11.0"
+  # Path to the jar INSIDE agentImage. Configurable because it differs between
+  # the operator image (/javaagent.jar) and a hand-built one.
+  agentJarPath: "/javaagent.jar"
 
 serviceMonitor:
   honorLabels: true

--- a/devops/deploy-as-code/charts/monitoring/monitoring-helmfile.yaml
+++ b/devops/deploy-as-code/charts/monitoring/monitoring-helmfile.yaml
@@ -52,8 +52,24 @@ releases:
   chart: open-telemetry/opentelemetry-collector
   version: 0.108.0
   values:
+  # NO `{{ .Values | toYaml }}` passthrough on this release, unlike its
+  # siblings. This chart ships a values.schema.json with
+  # additionalProperties:false, and the passthrough hands every top-level
+  # env.yaml key -- ~30 service blocks -- to whichever chart is being installed.
+  # Helm rejects the lot:
+  #
+  #   Error: values don't meet the specifications of the schema(s) in the
+  #   following chart(s): opentelemetry-collector:
+  #   - at '': additional properties 'pgadmin', 'configmaps', 'egov-persister',
+  #     'prometheus', 'grafana', 'digit-ui', ... not allowed
+  #
+  # Nothing is lost by dropping it: values/otel-collector.yaml references no
+  # `.Values` at all, so the passthrough supplied this release nothing it reads.
+  # The release-level `namespace:` above is a helmfile field, not a chart value.
+  #
+  # This is also why most mis-paths in this tree go unnoticed -- charts without a
+  # schema silently discard unknown keys. This one refuses to install instead.
   - ./values/otel-collector.yaml
-  - {{ .Values | toYaml | nindent 8 }}
 
 - name: jaeger
   installed: false

--- a/devops/deploy-as-code/charts/monitoring/monitoring-helmfile.yaml
+++ b/devops/deploy-as-code/charts/monitoring/monitoring-helmfile.yaml
@@ -18,6 +18,8 @@ repositories:
   url: https://helm.elastic.co
 - name: apm-attacher
   url: https://helm.elastic.co
+- name: open-telemetry
+  url: https://open-telemetry.github.io/opentelemetry-helm-charts
 
 releases:
 - name: loki-stack
@@ -37,6 +39,20 @@ releases:
   disableValidation: true
   values:
   - ./values/prometheus.yaml
+  - {{ .Values | toYaml | nindent 8 }}
+
+# Application telemetry pipeline (#1646). Services attach the OTEL javaagent
+# and export OTLP here; the collector re-exposes everything on ONE Prometheus
+# endpoint, so collection needs a single ServiceMonitor rather than one per
+# service. Deploying this is inert until the agent is switched on in the common
+# chart (otel.enabled), so it is safe to land first.
+- name: otel-collector
+  installed: true
+  namespace: {{ .Values.namespace | default "default-namespace" }}
+  chart: open-telemetry/opentelemetry-collector
+  version: 0.108.0
+  values:
+  - ./values/otel-collector.yaml
   - {{ .Values | toYaml | nindent 8 }}
 
 - name: jaeger

--- a/devops/deploy-as-code/charts/monitoring/monitoring-helmfile.yaml
+++ b/devops/deploy-as-code/charts/monitoring/monitoring-helmfile.yaml
@@ -52,8 +52,13 @@ releases:
   chart: open-telemetry/opentelemetry-collector
   version: 0.108.0
   values:
-  # NO `{{ .Values | toYaml }}` passthrough on this release, unlike its
-  # siblings. This chart ships a values.schema.json with
+  # NO whole-values passthrough on this release, unlike its siblings -- the
+  # `.Values | toYaml` line every other release carries is deliberately absent
+  # here. (Written without the surrounding braces on purpose: helmfile renders
+  # this file as a Go template BEFORE parsing it as YAML, so an interpolation
+  # inside a comment is still expanded. Writing it literally here dumped the
+  # entire values tree into this line and broke the document, with a parse error
+  # pointing ~1500 lines away.) This chart ships a values.schema.json with
   # additionalProperties:false, and the passthrough hands every top-level
   # env.yaml key -- ~30 service blocks -- to whichever chart is being installed.
   # Helm rejects the lot:

--- a/devops/deploy-as-code/charts/monitoring/values/otel-collector.yaml
+++ b/devops/deploy-as-code/charts/monitoring/values/otel-collector.yaml
@@ -8,9 +8,14 @@
 # receives on a single Prometheus endpoint, with per-service labels preserved
 # via the `service.name` resource attribute. That is what turns "add a
 # ServiceMonitor to each of 41 charts" into "add one ServiceMonitor for the
-# collector" — see #1646. It also carries traces, so it closes the tracing gap
-# in the same move: 25 live services currently emit Jaeger spans to an agent
-# that is not deployed and could not receive them if it were.
+# collector" — see #1646.
+#
+# Metrics only for now. The OTLP receiver below already accepts traces, but the
+# pipeline that would forward them is deliberately absent until a trace backend
+# lands on this tier — see the NOTE under `service.pipelines`, and
+# `otel.tracesExporter: "none"` in charts/common/values.yaml. So this does not
+# yet close the tracing gap: 25 live services still emit Jaeger spans to an
+# agent that is not deployed and could not receive them if it were.
 mode: deployment
 replicaCount: 1
 

--- a/devops/deploy-as-code/charts/monitoring/values/otel-collector.yaml
+++ b/devops/deploy-as-code/charts/monitoring/values/otel-collector.yaml
@@ -1,0 +1,114 @@
+# OpenTelemetry collector for the production tier (#1646).
+#
+# Mirrors local-setup/otel/otel-collector-config.yaml, which is the working
+# arrangement on the Ansible tier, so both tiers converge on one telemetry
+# architecture rather than two.
+#
+# WHY THIS EXISTS AT ALL: the collector re-exposes every OTLP metric it
+# receives on a single Prometheus endpoint, with per-service labels preserved
+# via the `service.name` resource attribute. That is what turns "add a
+# ServiceMonitor to each of 41 charts" into "add one ServiceMonitor for the
+# collector" — see #1646. It also carries traces, so it closes the tracing gap
+# in the same move: 25 live services currently emit Jaeger spans to an agent
+# that is not deployed and could not receive them if it were.
+mode: deployment
+replicaCount: 1
+
+image:
+  repository: otel/opentelemetry-collector-contrib
+
+# The chart ships a default config; `config` here REPLACES the pipelines
+# wholesale, which is intended.
+config:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+
+  processors:
+    batch:
+      timeout: 5s
+      send_batch_size: 1024
+    memory_limiter:
+      check_interval: 5s
+      limit_mib: 400
+
+  exporters:
+    # Expose collected OTLP metrics in Prometheus scrape format. `service.name`
+    # from the OTLP resource attributes becomes the `job` label, so the Ansible
+    # tier's JVM dashboard groups panels by service without query changes.
+    prometheus:
+      endpoint: 0.0.0.0:8889
+      resource_to_telemetry_conversion:
+        enabled: true
+
+  extensions:
+    health_check:
+      endpoint: 0.0.0.0:13133
+
+  service:
+    extensions: [health_check]
+    pipelines:
+      metrics:
+        receivers: [otlp]
+        processors: [memory_limiter, batch]
+        exporters: [prometheus]
+      # NOTE: no traces pipeline yet. The Ansible tier exports traces to Tempo,
+      # which this tier does not deploy — jaeger is installed: false and is a
+      # different architecture besides. Adding a traces pipeline with no
+      # backend would make the collector log export failures on a loop, which
+      # is the failure mode #1649 documents for blackbox. Traces land when a
+      # backend does; the receiver above already accepts them.
+      # Likewise no logs pipeline: this tier ships logs via promtail -> loki
+      # (loki-stack), not via OTLP.
+
+ports:
+  otlp:
+    enabled: true
+    containerPort: 4317
+    servicePort: 4317
+    protocol: TCP
+  otlp-http:
+    enabled: true
+    containerPort: 4318
+    servicePort: 4318
+    protocol: TCP
+  # The Prometheus scrape target. Named `metrics` so the ServiceMonitor below
+  # can reference it by name rather than by number.
+  metrics:
+    enabled: true
+    containerPort: 8889
+    servicePort: 8889
+    protocol: TCP
+  # Not exposed: jaeger/zipkin receiver ports the chart enables by default.
+  jaeger-compact:
+    enabled: false
+  jaeger-thrift:
+    enabled: false
+  jaeger-grpc:
+    enabled: false
+  zipkin:
+    enabled: false
+
+# One ServiceMonitor, in place of 41. It MUST carry the release label:
+# prometheus runs with serviceMonitorSelectorNilUsesHelmValues true and an
+# empty selector, which renders as matchLabels {release: kube-prometheus-stack}.
+# Without it the object is created and silently never scraped — the trap
+# documented in #1646 and hit again in #1647 and #1648.
+serviceMonitor:
+  enabled: true
+  extraLabels:
+    release: kube-prometheus-stack
+  metricsEndpoints:
+    - port: metrics
+      interval: 30s
+
+resources:
+  limits:
+    memory: 512Mi
+  requests:
+    memory: 256Mi
+    cpu: 100m


### PR DESCRIPTION
Fixes #1646

> **Part 2 is DEFAULT OFF.** Merging this changes nothing about running services. Read "Rollout" before enabling.

## What

This tier produces **no application metrics**. Not "they are not collected" — they are not produced: no service exposes a micrometer or actuator Prometheus endpoint, and 0 of 41 charts define a `ServiceMonitor`, so even a correctly configured Prometheus has nothing to scrape.

Adopts the Ansible tier's approach rather than inventing a second one.

## The design point that shrank this

The collector **re-exposes every OTLP metric on a single Prometheus endpoint**, with per-service labels preserved via the `service.name` resource attribute.

So collection needs **one ServiceMonitor for the collector**, not 41 across 41 charts. The "0 of 41 charts define a ServiceMonitor" problem disappears rather than being solved 41 times — and the shared `common.servicemonitor` template, which is broken in three ways, does not need repairing at all.

## Two parts, one active

**1. The collector — deployed.** Added to the monitoring helmfile with values mirroring `local-setup/otel/otel-collector-config.yaml`. One ServiceMonitor, carrying `release=kube-prometheus-stack` — without that label Prometheus's default selector ignores it, the trap already hit in #1662 and #1663. Inert until part 2 is on.

**2. The agent — wired, gated `otel.enabled`, default off.** Enabling it adds an init container and a `JAVA_TOOL_OPTIONS` javaagent to **every** java-spring service. That is the widest blast radius of any value in this chart and I cannot test it from here, so it lands off: reviewable now, switchable per environment with verification.

## Decisions worth reviewing

**Init container, not baked into images.** The service images are built upstream (`egovio/*`), so baking the agent would need 41 coordinated rebuilds and would pin the agent version per image. The init container copies the jar from the OTel Operator's auto-instrumentation image into an `emptyDir`. `agentJarPath` is configurable because that path differs between the operator image and a hand-built one.

**A dedicated `otel:` block, not `extraVolumes`.** The obvious route was to reuse the chart's existing extension points — but **6 app charts already set `extraVolumes`/`extraVolumeMounts`**, and their values win over the library defaults. The agent would have silently failed to attach to exactly those six. That is a partial, invisible failure, so it needed its own gate.

**The statefulset template is wired identically**, even though no chart uses it today. `extraEnv.java` is **shared** between both templates, so a future statefulset service would otherwise inherit `JAVA_TOOL_OPTIONS` without the jar being staged — and a `-javaagent` path that does not exist makes the **JVM fail at startup**, not degrade.

**Traces stay off.** `otel.tracesExporter: none`, and the collector has no traces pipeline. This tier has no trace backend — jaeger is `installed: false` and is a different architecture — and exporting to an absent backend logs failures on a loop, the failure mode #1664 documents. Both flip on together when a trace store lands, which is also when the dead Jaeger env this chart still injects into 25 live services should be removed.

## Rollout

1. Merge — nothing changes.
2. Set `otel.enabled: true` for **one** environment in `env.yaml`.
3. Verify pods still start (the agent adds JVM startup time and ~100 MB heap overhead — the Ansible tier omits it from `egov-localization` for exactly that reason).
4. Confirm `jvm_*` series appear in Prometheus with a `job` label per service.
5. The Ansible tier's JVM dashboard should render unchanged — same agent, same metric names.

## Verified / not verified

- [x] All five touched files parse; both templates gate identically (5 `otel.enabled` guards each)
- [x] Default off — no otel artifacts render, `OTEL_TRACES_EXPORTER` falls through to the existing `"none"`
- [x] Audited `extraVolumes` usage across all app charts — that is how the 6-chart clash surfaced
- [x] Values-path guard from #1652 still clean
- [ ] **Not verified on a cluster.** In particular: the jar path inside the operator image, the collector's Service DNS name in `otel.endpoint`, and whether the chart's `serviceMonitor.extraLabels` key is spelled that way in this chart version — all three are the kind of detail that has been wrong twice today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
