### PR TITLE
fix(security): stop shipping fixed-OTP and dev-mode defaults in production charts (#1643)

### DIFF
--- a/devops/deploy-as-code/charts/core-services/egov-user/values.yaml
+++ b/devops/deploy-as-code/charts/core-services/egov-user/values.yaml
@@ -55,8 +55,21 @@ default-password-expiry: "90"
 mobile-number-validation: "false"
 roles-state-level: "true"
 citizen-registration-withlogin: "true"
-citizen-otp-fixed: "123456"
-citizen-otp-fixed-enabled: "true"
+# Fixed OTP — a TEST convenience, off by default (#1643).
+#
+# When enabled the platform stops generating a per-login code and accepts one
+# constant for EVERY citizen account, so anyone who knows a phone number can
+# pass verification for it. These keys previously defaulted to "123456"/"true"
+# HERE, in the chart, which is why "operators are expected to override it in
+# env.yaml" was not a sufficient answer: deleting the env.yaml block left the
+# feature on.
+#
+# Absent = off: the injection below is conditional on the key existing, so a
+# deployment that does not set them ships neither env var and the service uses
+# its normal OTP path. Set both in a non-production environment only.
+#
+#   citizen-otp-fixed: "123456"
+#   citizen-otp-fixed-enabled: "true"
 heap: "-Xmx384m -Xms256m"
 java-args: ""
 
@@ -176,9 +189,13 @@ env: |
   - name: CITIZEN_LOGIN_PASSWORD_OTP_FIXED_VALUE
     value: {{ index .Values "citizen-otp-fixed" | quote }}
   {{- end }}
-  {{- if index .Values "citizen-otp-fixed-enabled" }}
+  {{- /* eq "true" rather than a bare truthiness test: every non-empty string
+         is truthy in Go templates, so `citizen-otp-fixed-enabled: "false"`
+         previously still injected the variable and left the outcome to however
+         the service parses it. Now "false" genuinely disables it here. */}}
+  {{- if eq (index .Values "citizen-otp-fixed-enabled" | default "false" | toString) "true" }}
   - name: CITIZEN_LOGIN_PASSWORD_OTP_FIXED_ENABLED
-    value: {{ index .Values "citizen-otp-fixed-enabled" | quote }}
+    value: "true"
   {{- end }}
   - name: JAVA_OPTS
     value: {{ index .Values "heap" | quote }}

--- a/devops/deploy-as-code/charts/core-services/egov-user/values.yaml
+++ b/devops/deploy-as-code/charts/core-services/egov-user/values.yaml
@@ -185,15 +185,22 @@ env: |
   - name: CITIZEN_REGISTRATION_WITHLOGIN_ENABLED
     value: {{ index .Values "citizen-registration-withlogin" | quote }}
   {{- end }}
+  {{- /* eq "true" rather than a bare truthiness test: every non-empty string
+         is truthy in Go templates, so `citizen-otp-fixed-enabled: "false"`
+         previously still injected the variable and left the outcome to however
+         the service parses it. Now "false" genuinely disables it here.
+
+         Both env vars hang off this one switch. The fixed value used to be
+         injected on its own presence check, so a config that set
+         `citizen-otp-fixed` and forgot `-enabled` still shipped the constant
+         into the pod's environment — readable by anyone with exec/describe,
+         and live for any consumer that keys off the value rather than the
+         flag. Off means neither variable is emitted. */}}
+  {{- if eq (index .Values "citizen-otp-fixed-enabled" | default "false" | toString) "true" }}
   {{- if index .Values "citizen-otp-fixed" }}
   - name: CITIZEN_LOGIN_PASSWORD_OTP_FIXED_VALUE
     value: {{ index .Values "citizen-otp-fixed" | quote }}
   {{- end }}
-  {{- /* eq "true" rather than a bare truthiness test: every non-empty string
-         is truthy in Go templates, so `citizen-otp-fixed-enabled: "false"`
-         previously still injected the variable and left the outcome to however
-         the service parses it. Now "false" genuinely disables it here. */}}
-  {{- if eq (index .Values "citizen-otp-fixed-enabled" | default "false" | toString) "true" }}
   - name: CITIZEN_LOGIN_PASSWORD_OTP_FIXED_ENABLED
     value: "true"
   {{- end }}

--- a/devops/deploy-as-code/charts/environments/env.yaml
+++ b/devops/deploy-as-code/charts/environments/env.yaml
@@ -20,8 +20,10 @@ configmaps:
       state-level-tenant-id: <tenant_id> ###### Replace with your own tenant ID if you are not using the default tenant ID (pg)
       host-map: "{'<tenant_id>':'https://<domain_name>/'}" # update state tenant-id & domain
 
-      ### make it false in production
-      dev-enabled: "true"
+      # Was "true" with a `### make it false in production` comment above it —
+      # a comment is not a control (#1643). Defaults to false; flip it in a
+      # non-production environment's own env.yaml.
+      dev-enabled: "false"
       egov-mdms-search-endpoint: /mdms-v2/v1/_search
 
   egov-service-host:
@@ -108,8 +110,10 @@ egov-user:
   mobile-number-validation: "false"
   roles-state-level: "true"
   citizen-registration-withlogin: "true"
-  citizen-otp-fixed: "123456"
-  citizen-otp-fixed-enabled: "true"
+  # Fixed OTP is a TEST convenience and is now off by default (#1643). Enable it
+  # ONLY in a non-production environment, by uncommenting both:
+  #   citizen-otp-fixed: "123456"
+  #   citizen-otp-fixed-enabled: "true"
   egov-state-level-tenant-id: <tenant_id>
 
 
@@ -231,7 +235,8 @@ egov-hrms:
   java-args: -Dspring.profiles.active=monitoring
   heap: "-Xmx192m -Xms192m"
   memory_limits: 386Mi
-  hrms-dev-mode: "true"
+  # Dev mode off by default (#1643) — same reasoning as dev-enabled above.
+  hrms-dev-mode: "false"
 
 
 boundary-service:


### PR DESCRIPTION
Closes #1643

## What was wrong

`charts/core-services/egov-user/values.yaml` shipped these as **chart defaults**:

```yaml
citizen-otp-fixed: "123456"
citizen-otp-fixed-enabled: "true"
```

Fixed OTP means every citizen login accepts `123456`. Knowing any citizen's mobile number is then enough to log in as them — the OTP stops being a second factor at all.

The guard that was supposed to gate it tested for **key presence**, not truthiness:

```
{{- if index .Values "citizen-otp-fixed-enabled" }}
```

So setting it to `"false"` did not turn it off. The only way to disable it was to delete the key entirely — which is not what an operator reading `false` in a values file would expect. An operator who explicitly wrote `false` got fixed OTP anyway.

`env.yaml` also carried `dev-enabled: "true"` and `hrms-dev-mode: "true"`.

## Changes

- Remove the two fixed-OTP keys from the chart defaults so nothing is enabled unless a deployment opts in
- Fix the guard to test the value:
  ```
  {{- if eq (index .Values "citizen-otp-fixed-enabled" | default "false" | toString) "true" }}
  ```
  `| toString` matters — YAML `false` is a boolean, and comparing a boolean to the string `"true"` would fail the template rather than evaluate cleanly
- `env.yaml`: `dev-enabled: "false"`, `hrms-dev-mode: "false"`, fixed-OTP keys commented out with an explanation

## Exposure

**Nothing live is affected.** No cluster currently runs the `deploy-as-code` tier, so this default never reached a deployment — confirmed with the repo owner rather than assumed. This is a preventive fix: it stops the first real deployment from inheriting fixed OTP.

If that ever changes and you need to check an existing cluster:

```
kubectl get deploy egov-user -o yaml | grep -i CITIZEN_LOGIN_PASSWORD_OTP_FIXED
```

Targets `monitoring-fix` (the integration branch), not `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
