### PR TITLE
fix(novu): terminate TLS and stop shipping example signing secrets (#1644)

### DIFF
--- a/devops/deploy-as-code/charts/backbone-services/backboneservices-helmfile.yaml
+++ b/devops/deploy-as-code/charts/backbone-services/backboneservices-helmfile.yaml
@@ -136,3 +136,29 @@ releases:
   values:
     - ./novu/values.yaml
     - {{ .Values | toYaml | nindent 8 }}
+    # Serve on THIS deployment's domain over TLS (#1644). The chart default
+    # named another environment's hostname and had no tls block at all, so the
+    # dashboard was reachable only by Host-header and only over plain HTTP.
+    # Same <domain>-tls-certs name every other ingress here uses -- but note
+    # TLS secrets are namespace-scoped and novu runs in its OWN namespace, not
+    # `backbone`/`egov` where the other copies live. So the cluster-issuer
+    # annotation is REQUIRED here, not decorative: it is what makes cert-manager
+    # issue a certificate into the novu namespace. Without it the name would
+    # resolve to nothing locally and ingress-nginx would fall back to its
+    # --default-ssl-certificate (egov/<domain>-tls-certs).
+    - ingress:
+        annotations:
+          cert-manager.io/cluster-issuer: {{ index .Values "root-ingress" "cert-issuer" | quote }}
+        host: {{ .Values.global.domain | quote }}
+        tls:
+          - secretName: {{ printf "%s-tls-certs" .Values.global.domain | quote }}
+            hosts:
+              - {{ .Values.global.domain | quote }}
+    # Signing/encryption secrets from the SOPS-covered file rather than the
+    # chart's example values. jwtSecret signs sessions; a known value is a
+    # forged login.
+    - novu:
+        secrets:
+          jwtSecret: {{ .Values.secrets.novu.jwtSecret | quote }}
+          storeEncryptionKey: {{ .Values.secrets.novu.storeEncryptionKey | quote }}
+          novuSecretKey: {{ .Values.secrets.novu.novuSecretKey | quote }}

--- a/devops/deploy-as-code/charts/backbone-services/novu/templates/ingress.yaml
+++ b/devops/deploy-as-code/charts/backbone-services/novu/templates/ingress.yaml
@@ -12,6 +12,16 @@ spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
+  {{- /* TLS (#1644). This ingress previously had no tls: block at all, so the
+         Novu dashboard — which manages notification templates, subscribers and
+         the SMS/email provider credentials — was served over plain HTTP: login
+         and session cookie in the clear. Every other ingress in this tree
+         terminates TLS on <domain>-tls-certs, issued by the existing
+         cert-manager ClusterIssuer; this follows that convention. */}}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
   rules:
     - host: {{ .Values.ingress.host | quote }}
       http:

--- a/devops/deploy-as-code/charts/backbone-services/novu/values.yaml
+++ b/devops/deploy-as-code/charts/backbone-services/novu/values.yaml
@@ -9,8 +9,15 @@ ingress:
   annotations:
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/rewrite-target: "/$2"
-  host: "pgroneclick.digit.org"
+  # Overridden per deployment from global.domain by the helmfile (#1644).
+  # This default named pgroneclick.digit.org — a hostname belonging to a
+  # DIFFERENT environment, inherited from the upstream import — so the
+  # dashboard did not serve on the deployment's own domain at all.
+  host: "domain.com"
   path: "/novu(/|$)(.*)"
+  # Populated per deployment by the helmfile, same secret every other ingress
+  # in this tree uses.
+  tls: []
   pathType: "ImplementationSpecific"
   service:
     name: "novu-dashboard"
@@ -23,10 +30,18 @@ global:
   nodeEnv: "local"
 
 novu:
+  # These are the upstream project's EXAMPLE values and must not survive into a
+  # deployment (#1644). jwtSecret signs session tokens, so a known value lets a
+  # session be forged outright — no password needed and nothing to intercept.
+  # storeEncryptionKey encrypts the stored SMS/email provider credentials, so a
+  # known value makes them readable.
+  #
+  # Overridden per deployment from secrets.novu.* by the helmfile, which is the
+  # SOPS-covered file. Left here only so the chart renders standalone.
   secrets:
-    jwtSecret: "your-secret"
-    storeEncryptionKey: "change-this-key-32-characters!!!"
-    novuSecretKey: "change-this-secret-key"
+    jwtSecret: "change-me"
+    storeEncryptionKey: "change-me-exactly-32-characters!"
+    novuSecretKey: "change-me"
   subscriberWidgetJwtExpirationTime: "15d"
   aws:
     accessKeyId: "test"

--- a/devops/deploy-as-code/charts/environments/env-secrets.yaml
+++ b/devops/deploy-as-code/charts/environments/env-secrets.yaml
@@ -109,6 +109,15 @@ secrets:
             -----END RSA PRIVATE KEY-----
 
         known_hosts: github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=
+    # Novu (#1644). The chart ships the upstream project's EXAMPLE values;
+    # generate real ones per deployment. jwtSecret signs session tokens — a
+    # known value lets a session be forged with no password. storeEncryptionKey
+    # encrypts the stored SMS/email provider credentials and MUST be exactly
+    # 32 characters. Rotate anything encrypted under a placeholder key.
+    novu:
+        jwtSecret: change-me-strong
+        storeEncryptionKey: change-me-exactly-32-characters!
+        novuSecretKey: change-me-strong
     grafana:
         clientID: cdabbaabcdefghi
         clientSecret: 8292723f0e1d596d234abc123def456


### PR DESCRIPTION
Closes #1644

## What was wrong

**1. No TLS at all.** `charts/backbone-services/novu/templates/ingress.yaml` had `rules:` with a `host:` but no `tls:` block. The Novu dashboard manages notification templates, subscribers, and the stored SMS/email provider credentials — all of it was served over plain HTTP, login and session cookie included. ingress-nginx only applies its default `ssl-redirect` when an ingress declares TLS, so there was not even a redirect to https.

**2. Wrong hostname.** `host` was hardcoded to `pgroneclick.digit.org` — a hostname belonging to a *different* environment, inherited from the upstream import. The dashboard did not serve on the deployment’s own domain at all.

**3. Published signing secrets.** The chart shipped the upstream project’s example values:

```yaml
novu:
  secrets:
    jwtSecret: "your-secret"
    storeEncryptionKey: "change-this-key-32-characters!!!"
    novuSecretKey: "change-this-secret-key"
```

`jwtSecret` signs session tokens, so a known value lets a session be **forged outright** — no password to guess and nothing to intercept, which is why this is worse than the missing TLS. `storeEncryptionKey` encrypts the stored SMS/email provider credentials.

## Changes

- **ingress template**: optional `tls:` block, omitted unless configured so the chart still renders standalone
- **helmfile**: `host` from `global.domain`; terminate on `<domain>-tls-certs`, the same secret name the other ingresses use
- **helmfile**: add `cert-manager.io/cluster-issuer`. This one is **required, not decorative** — TLS secrets are namespace-scoped and Novu runs in its own `novu` namespace, not the `backbone`/`egov` namespaces holding the other copies of that secret. Without the annotation the name resolves to nothing locally and ingress-nginx silently falls back to its `--default-ssl-certificate`
- **helmfile**: source the three secrets from `secrets.novu.*` in the SOPS-covered `env-secrets.yaml`
- **values.yaml**: example secrets replaced with `change-me` placeholders, documented by what each protects

## Verification

Rendered the chart with `helm template`:
- the cert-manager annotation **merges** with the pre-existing nginx `use-regex` / `rewrite-target` annotations rather than replacing them
- the `tls:` block is absent on a default render
- overridden secrets do reach `JWT_SECRET` / `STORE_ENCRYPTION_KEY` / `NOVU_SECRET_KEY` — worth checking explicitly, because `values.yaml` carries those env blocks as `tpl`-rendered template strings rather than as chart templates, so nothing in `templates/` references the keys directly

## Exposure

**Nothing live is affected.** No cluster currently runs the `deploy-as-code` tier, so the example secrets were never in service — confirmed with the repo owner rather than assumed. This is preventive.

When Novu is first deployed, generate all three values fresh. `storeEncryptionKey` must be **exactly 32 characters** or Novu will not start.

## Known remaining gap (not in scope here)

These values render as **plaintext `env:` entries on the Deployment**, not as a Kubernetes Secret — so they are readable via `kubectl get deploy -o yaml` by anyone with namespace read access. Moving them to a `secretKeyRef` is a chart change worth doing separately; this PR fixes the published-value problem.

Targets `monitoring-fix` (the integration branch), not `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
