### PR TITLE
feat(grafana): provision capacity and error-trend alert rules (#1611)

### DIFF
--- a/local-setup/ansible/inventory/group_vars/digit.yml
+++ b/local-setup/ansible/inventory/group_vars/digit.yml
@@ -224,3 +224,10 @@ digit_ui_esbuild_branch: main
 # anyone holding the URL can post into the channel -- so prefer pulling it from
 # OpenBao via secrets_path rather than committing it here.
 gatus_slack_webhook_url: ""
+
+# Slack webhook for Grafana's provisioned alert rules (#1611) -- capacity and
+# error-trend alerts, as distinct from Gatus's up/down. Empty means "use
+# gatus_slack_webhook_url", so a tenant picks a channel once and both alerting
+# engines post to it. Set this only to route the two streams to different
+# channels. Same secret handling as gatus_slack_webhook_url: prefer OpenBao.
+grafana_slack_webhook_url: ""

--- a/local-setup/ansible/templates/digit.env.j2
+++ b/local-setup/ansible/templates/digit.env.j2
@@ -119,6 +119,18 @@ NOVU_BRIDGE_CHANNEL={{ novu_bridge_channel | default('sms') }}
 # by whoever mints the webhook; there is nothing else to configure.
 GATUS_SLACK_WEBHOOK_URL={{ gatus_slack_webhook_url | default('') }}
 
+# Same webhook, for Grafana's provisioned alert rules (#1611): capacity and
+# error-trend alerts, as opposed to Gatus's up/down. Defaults to whatever
+# gatus_slack_webhook_url is set to, so an operator picks a channel ONCE and
+# both engines post to it; override grafana_slack_webhook_url only to split
+# the two streams into different channels.
+#
+# Falls back to an unreachable RFC 2606 .invalid URL rather than an empty
+# string when neither is set. Grafana treats a provisioning file it cannot
+# validate as a FATAL startup error, so an empty webhook would risk
+# crash-looping Grafana on every tenant that has not configured Slack.
+GRAFANA_SLACK_WEBHOOK_URL={{ grafana_slack_webhook_url | default(gatus_slack_webhook_url, true) | default('https://example.invalid/grafana-slack-webhook-not-configured', true) }}
+
 GATUS_PROFILE_OTP={{ enable_otp_services | default(false) | lower }}
 GATUS_PROFILE_SEARCH={{ enable_search_stack | default(false) | lower }}
 GATUS_PROFILE_MCP={{ enable_mcp | default(false) | lower }}

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -51,6 +51,18 @@ services:
       GF_SERVER_DOMAIN: ${GF_SERVER_DOMAIN:-api.egov.theflywheel.in}
       GF_SERVER_ROOT_URL: ${GF_SERVER_ROOT_URL:-https://api.egov.theflywheel.in/grafana/}
       GF_SERVER_SERVE_FROM_SUB_PATH: "true"
+      # Slack webhook for the provisioned alert rules (#1611). Same webhook as
+      # Gatus uses -- one channel decision, not two.
+      #
+      # The default is an UNREACHABLE placeholder rather than an empty string,
+      # and that matters: Grafana expands $VAR with os.ExpandEnv (no ":-"
+      # defaults, unset becomes empty), and a provisioning file it cannot
+      # validate is FATAL at startup -- an empty webhook would risk
+      # crash-looping Grafana on every deployment that has not set up Slack.
+      # .invalid is reserved by RFC 2606 and can never resolve, so an
+      # unconfigured deployment logs a clean DNS failure if a rule ever fires
+      # instead of silently pretending to deliver.
+      GRAFANA_SLACK_WEBHOOK_URL: ${GRAFANA_SLACK_WEBHOOK_URL:-https://example.invalid/grafana-slack-webhook-not-configured}
     volumes:
       - ./otel/grafana/provisioning:/etc/grafana/provisioning:ro
       - grafana_data:/var/lib/grafana

--- a/local-setup/docker-compose.registry.yml
+++ b/local-setup/docker-compose.registry.yml
@@ -49,6 +49,18 @@ services:
       GF_SERVER_DOMAIN: api.egov.theflywheel.in
       GF_SERVER_ROOT_URL: "https://api.egov.theflywheel.in/grafana/"
       GF_SERVER_SERVE_FROM_SUB_PATH: "true"
+      # Slack webhook for the provisioned alert rules (#1611). Same webhook as
+      # Gatus uses -- one channel decision, not two.
+      #
+      # The default is an UNREACHABLE placeholder rather than an empty string,
+      # and that matters: Grafana expands $VAR with os.ExpandEnv (no ":-"
+      # defaults, unset becomes empty), and a provisioning file it cannot
+      # validate is FATAL at startup -- an empty webhook would risk
+      # crash-looping Grafana on every deployment that has not set up Slack.
+      # .invalid is reserved by RFC 2606 and can never resolve, so an
+      # unconfigured deployment logs a clean DNS failure if a rule ever fires
+      # instead of silently pretending to deliver.
+      GRAFANA_SLACK_WEBHOOK_URL: ${GRAFANA_SLACK_WEBHOOK_URL:-https://example.invalid/grafana-slack-webhook-not-configured}
     volumes:
       - ./otel/grafana/provisioning:/etc/grafana/provisioning:ro
       - grafana_data:/var/lib/grafana

--- a/local-setup/otel/grafana/provisioning/alerting/contactpoints.yaml
+++ b/local-setup/otel/grafana/provisioning/alerting/contactpoints.yaml
@@ -1,0 +1,37 @@
+# Grafana alerting contact point (#1611).
+#
+# Where alerts go. Deliberately the SAME Slack webhook Gatus uses (#1609) --
+# the channel is decided once, when someone mints the webhook, and both
+# alerting engines post to it. Nothing in this repo names a channel.
+#
+# WHY THE URL IS NEVER EMPTY HERE
+# Grafana interpolates $GRAFANA_SLACK_WEBHOOK_URL with plain os.ExpandEnv
+# semantics: no `${VAR:-default}` support, and an unset variable becomes an
+# EMPTY STRING. Unlike Gatus -- which shrugs off a broken provider and keeps
+# running -- a provisioning file Grafana cannot validate is FATAL at startup.
+# An empty webhook here would therefore risk crash-looping Grafana on every
+# deployment that has not configured Slack, which is most of them.
+#
+# So the default is supplied one level up, by the compose `environment:` block,
+# which does support `:-` defaults and substitutes an unreachable placeholder
+# under the .invalid TLD (reserved by RFC 2606, so it can never resolve). The
+# result: provisioning always validates, Grafana always starts, and an
+# unconfigured deployment simply logs a DNS failure if a rule ever fires --
+# a visible, self-describing symptom rather than a silent one.
+apiVersion: 1
+
+contactPoints:
+  - orgId: 1
+    name: slack
+    receivers:
+      - uid: slack-webhook
+        type: slack
+        # Interpolated by Grafana from the environment. Never a literal: anyone
+        # holding this URL can post into the channel.
+        settings:
+          url: $GRAFANA_SLACK_WEBHOOK_URL
+          title: '{{ template "default.title" . }}'
+          text: '{{ template "default.message" . }}'
+        # Send the recovery notification too. An alert with no all-clear leaves
+        # people checking by hand to find out whether it is still broken.
+        disableResolveMessage: false

--- a/local-setup/otel/grafana/provisioning/alerting/policies.yaml
+++ b/local-setup/otel/grafana/provisioning/alerting/policies.yaml
@@ -1,0 +1,27 @@
+# Grafana notification policy tree (#1611).
+#
+# ⚠ Provisioning the policy tree REPLACES it wholesale -- Grafana treats it as a
+# single resource, so anything created through the UI is overwritten on restart.
+# That is the intended behaviour here (the tree should live in git, like the
+# dashboards and datasources beside it), but it is why this file stays minimal:
+# every route added here is a route nobody can adjust from the UI.
+apiVersion: 1
+
+policies:
+  - orgId: 1
+    receiver: slack
+    # Group by rule and by the service/instance the rule fired for, so one bad
+    # service produces one thread rather than one message per series.
+    group_by:
+      - grafana_folder
+      - alertname
+      - service_name
+      - instance
+    # 30s of quiet before the first message, so a burst of related series lands
+    # as a single notification.
+    group_wait: 30s
+    group_interval: 5m
+    # Re-send an alert that is still firing every 4h. Long on purpose: these are
+    # slow-moving capacity trends, and a shorter repeat trains people to mute
+    # the channel, which is the failure mode this whole issue is about.
+    repeat_interval: 4h

--- a/local-setup/otel/grafana/provisioning/alerting/rules.yaml
+++ b/local-setup/otel/grafana/provisioning/alerting/rules.yaml
@@ -1,0 +1,268 @@
+# Grafana alert rules (#1611).
+#
+# Gatus answers "is it up?". These rules answer "is it about to stop being up?"
+# -- the gradual failures that actually take these boxes down: a disk filling,
+# memory running out, a JVM creeping toward its heap ceiling.
+#
+# THERE IS DELIBERATELY NO SERVICE-DOWN RULE HERE. That is Gatus's job (#1609).
+# Duplicating it would mean two Slack messages for one incident, which teaches
+# people to ignore both.
+#
+# ── noDataState: OK, everywhere ──
+# Every rule below reports OK rather than alerting when its series are missing.
+# That is deliberate. node-exporter lives in the docker-compose.monitoring.yml
+# OVERLAY, and the JVM metrics only exist once the OTEL pipeline is running, so
+# "no data" here usually means "this deployment does not run that component" --
+# a valid configuration, not an incident. Alerting on it would fire a permanent,
+# unfixable alert on every slim deployment, and a channel with a permanent red
+# alert in it is a muted channel. A monitoring component that has genuinely
+# died is caught by Gatus watching the monitoring stack (#1613), which is the
+# right place for it.
+#
+# execErrState is left at Alerting: a query that ERRORS is a broken rule, which
+# is worth surfacing, unlike an absent exporter.
+#
+# ── metric names ──
+# Taken from the queries in the dashboards provisioned beside this file
+# (jvm-services.json, node-exporter-full.json), not invented -- including the
+# mountpoint="/" matcher, which is what node-exporter-full.json uses and which
+# reflects node-exporter stripping its --path.rootfs prefix from the label.
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: capacity
+    folder: DIGIT Alerts
+    interval: 1m
+    rules:
+      # ────────────────────────────────────────────────────────────────
+      - uid: digit-host-disk-low
+        title: Host disk low
+        condition: C
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Root filesystem is below 15% free on {{ $labels.instance }}'
+          description: >-
+            Logs, database growth and image layers fill this disk. It is fine
+            until it abruptly is not: a full root filesystem takes down every
+            service on the box at once, and Postgres in particular fails in ways
+            that need manual recovery. Reclaim space now rather than at 3am.
+            Usual suspects: docker image/volume churn, and container logs if
+            log rotation is not capped.
+        data:
+          - refId: A
+            relativeTimeRange: {from: 600, to: 0}
+            datasourceUid: prometheus
+            model:
+              refId: A
+              instant: true
+              expr: >-
+                node_filesystem_avail_bytes{mountpoint="/", fstype!="rootfs"}
+                / node_filesystem_size_bytes{mountpoint="/", fstype!="rootfs"}
+          - refId: B
+            relativeTimeRange: {from: 600, to: 0}
+            datasourceUid: __expr__
+            model: {refId: B, type: reduce, expression: A, reducer: last}
+          - refId: C
+            relativeTimeRange: {from: 600, to: 0}
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator: {type: lt, params: [0.15]}
+        noDataState: OK
+        execErrState: Alerting
+        isPaused: false
+
+      # ────────────────────────────────────────────────────────────────
+      - uid: digit-host-memory-low
+        title: Host memory low
+        condition: C
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Less than 10% memory available on {{ $labels.instance }}'
+          description: >-
+            Sharper here than on a typical box: these tenant hosts have NO SWAP,
+            so the kernel does not degrade gracefully under memory pressure --
+            it goes straight to OOM-killing processes, and what it kills is
+            whichever JVM happens to be largest, not whichever is least
+            important. Severity is critical for that reason: there is no slow
+            middle ground between "tight" and "a service died".
+        data:
+          - refId: A
+            relativeTimeRange: {from: 600, to: 0}
+            datasourceUid: prometheus
+            model:
+              refId: A
+              instant: true
+              expr: node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes
+          - refId: B
+            relativeTimeRange: {from: 600, to: 0}
+            datasourceUid: __expr__
+            model: {refId: B, type: reduce, expression: A, reducer: last}
+          - refId: C
+            relativeTimeRange: {from: 600, to: 0}
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator: {type: lt, params: [0.10]}
+        noDataState: OK
+        execErrState: Alerting
+        isPaused: false
+
+      # ────────────────────────────────────────────────────────────────
+      - uid: digit-host-cpu-saturated
+        title: Host CPU saturated
+        condition: C
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'CPU above 90% for 15 minutes on {{ $labels.instance }}'
+          description: >-
+            Sustained saturation, not a spike -- 15 minutes is long enough to
+            rule out a deploy, a batch index or a JVM warming up. Past this
+            point request latency is already degraded even though every health
+            check still answers, so nothing else will tell you.
+        data:
+          - refId: A
+            relativeTimeRange: {from: 900, to: 0}
+            datasourceUid: prometheus
+            model:
+              refId: A
+              instant: true
+              expr: '1 - avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m]))'
+          - refId: B
+            relativeTimeRange: {from: 900, to: 0}
+            datasourceUid: __expr__
+            model: {refId: B, type: reduce, expression: A, reducer: last}
+          - refId: C
+            relativeTimeRange: {from: 900, to: 0}
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator: {type: gt, params: [0.90]}
+        noDataState: OK
+        execErrState: Alerting
+        isPaused: false
+
+      # ────────────────────────────────────────────────────────────────
+      - uid: digit-jvm-heap-headroom-low
+        title: JVM heap headroom low
+        condition: C
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: '{{ $labels.service_name }} is using over 90% of its heap limit'
+          description: >-
+            A service climbing toward its heap ceiling will eventually die and
+            restart, dropping in-flight requests. Ten minutes above 90% means
+            steady pressure rather than a GC sawtooth.
+            Caveat when reading this: the ratio is against jvm_memory_limit_bytes,
+            so a service that never publishes a heap limit produces NO series and
+            therefore cannot trigger this rule. Absence of this alert is not
+            proof of headroom -- check the DIGIT JVM Services dashboard.
+        data:
+          - refId: A
+            relativeTimeRange: {from: 600, to: 0}
+            datasourceUid: prometheus
+            model:
+              refId: A
+              instant: true
+              expr: >-
+                sum by (service_name) (jvm_memory_used_bytes{jvm_memory_type="heap"})
+                / sum by (service_name) (jvm_memory_limit_bytes{jvm_memory_type="heap"})
+          - refId: B
+            relativeTimeRange: {from: 600, to: 0}
+            datasourceUid: __expr__
+            model: {refId: B, type: reduce, expression: A, reducer: last}
+          - refId: C
+            relativeTimeRange: {from: 600, to: 0}
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator: {type: gt, params: [0.90]}
+        noDataState: OK
+        execErrState: Alerting
+        isPaused: false
+
+  - orgId: 1
+    name: errors
+    folder: DIGIT Alerts
+    interval: 1m
+    rules:
+      # ────────────────────────────────────────────────────────────────
+      # SHIPPED PAUSED ON PURPOSE. Read before unpausing.
+      #
+      # This is the rule that catches the failure Gatus structurally cannot see:
+      # a service answering /health perfectly while failing every real request.
+      # It is also the only rule here whose threshold cannot be derived from
+      # first principles. "500 errors in 5 minutes" is a guess -- the real number
+      # depends on how chatty these services are at baseline, and DIGIT services
+      # log exception stack traces during entirely normal operation.
+      #
+      # A wrong threshold is not a neutral outcome. Too low and the channel
+      # cries wolf until someone mutes it, which silently disables every OTHER
+      # rule in this file for that person. Too high and it never fires, which
+      # looks identical to "no errors".
+      #
+      # TO ENABLE: watch `sum by (service_name) (count_over_time(...))` on a real
+      # tenant for about a week, take the observed p95, set the threshold above
+      # it, then set isPaused: false. Do not skip the observation step.
+      - uid: digit-log-error-spike
+        title: Log error spike
+        condition: C
+        for: 5m
+        isPaused: true
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Error log volume is elevated for {{ $labels.service_name }}'
+          description: >-
+            This service is logging errors far above its normal rate while very
+            likely still passing health checks -- the failure mode where a
+            dashboard is entirely green and nothing works. Check the service's
+            logs in Explore, filtered to this service_name.
+            NOTE: the threshold on this rule is a placeholder that must be tuned
+            against an observed baseline; see the comment above the rule.
+        data:
+          - refId: A
+            relativeTimeRange: {from: 300, to: 0}
+            datasourceUid: loki
+            model:
+              refId: A
+              queryType: instant
+              expr: >-
+                sum by (service_name) (count_over_time({service_name=~".+"}
+                |~ "(?i)ERROR|Exception" [5m]))
+          - refId: B
+            relativeTimeRange: {from: 300, to: 0}
+            datasourceUid: __expr__
+            model: {refId: B, type: reduce, expression: A, reducer: last}
+          - refId: C
+            relativeTimeRange: {from: 300, to: 0}
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator: {type: gt, params: [500]}
+        noDataState: OK
+        execErrState: Alerting

--- a/local-setup/otel/grafana/provisioning/alerting/rules.yaml
+++ b/local-setup/otel/grafana/provisioning/alerting/rules.yaml
@@ -202,6 +202,69 @@ groups:
         execErrState: Alerting
         isPaused: false
 
+      # ────────────────────────────────────────────────────────────────
+      # Kafka consumer lag (#1623). NOT paused, unlike the error-spike rule
+      # below, and the difference is principled rather than a hunch: a consumer
+      # that is keeping up sits at ~0 lag, so the healthy baseline is known
+      # without observing it. Error-log volume has no such baseline -- DIGIT
+      # services log stack traces during normal operation -- which is why that
+      # rule ships paused and this one does not.
+      #
+      # This is the failure Gatus structurally cannot see: egov-persister falls
+      # behind, the API keeps returning 200, every check stays green, and
+      # complaints are never written to the database.
+      #
+      # 10k for 15m, not a tighter bound: bulk seeding and migrations move real
+      # backlogs through legitimately, and they drain. Sustained 15m above 10k
+      # is not a burst.
+      - uid: digit-kafka-consumer-lag
+        title: Kafka consumer lag high
+        condition: C
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: '{{ $labels.redpanda_group }} is more than 10k messages behind'
+          description: >-
+            Records are being accepted and not processed. Check whether the
+            consumer is slow or GONE -- the "Consumers per group" panel on the
+            DIGIT Kafka Consumer Lag dashboard reading 0 means the latter, which
+            needs the opposite fix. Lag concentrated on a single partition
+            usually means a poison record rather than an undersized consumer.
+        data:
+          - refId: A
+            relativeTimeRange: {from: 900, to: 0}
+            datasourceUid: prometheus
+            model:
+              refId: A
+              instant: true
+              # max_offset carries redpanda_namespace and no group; committed
+              # carries redpanda_group and no namespace. Hence the join on
+              # (topic, partition) with group_right() to keep the group label,
+              # and the namespace filter to exclude Redpanda's internal topics.
+              expr: >-
+                sum by (redpanda_group) (
+                  redpanda_kafka_max_offset{redpanda_namespace="kafka"}
+                  - on(redpanda_topic, redpanda_partition) group_right()
+                    redpanda_kafka_consumer_group_committed_offset
+                )
+          - refId: B
+            relativeTimeRange: {from: 900, to: 0}
+            datasourceUid: __expr__
+            model: {refId: B, type: reduce, expression: A, reducer: last}
+          - refId: C
+            relativeTimeRange: {from: 900, to: 0}
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator: {type: gt, params: [10000]}
+        noDataState: OK
+        execErrState: Alerting
+        isPaused: false
+
   - orgId: 1
     name: errors
     folder: DIGIT Alerts

--- a/local-setup/otel/grafana/provisioning/alerting/rules.yaml
+++ b/local-setup/otel/grafana/provisioning/alerting/rules.yaml
@@ -217,6 +217,19 @@ groups:
       # 10k for 15m, not a tighter bound: bulk seeding and migrations move real
       # backlogs through legitimately, and they drain. Sustained 15m above 10k
       # is not a burst.
+      #
+      # DEPENDS ON #1628 FOR ITS DATA. The redpanda_* series come from the
+      # Redpanda scrape job that #1628 adds to otel/prometheus.yml; this branch's
+      # prometheus.yml still scrapes only otel-collector and node. Until #1628 is
+      # in, this rule evaluates an empty vector and -- by the file-wide
+      # noDataState: OK above -- reports a healthy "ok" that is indistinguishable
+      # from "lag is fine" when it really means "nothing is being measured".
+      # It is left unpaused deliberately, so that it starts working the moment
+      # the scrape job lands rather than waiting on someone remembering to
+      # unpause it; the two are separate stacks off monitoring-fix and both are
+      # bound for it. If this one merges first, that window is the cost.
+      # The "DIGIT Kafka Consumer Lag" dashboard named in the description below
+      # arrives with #1678, which is stacked on #1628.
       - uid: digit-kafka-consumer-lag
         title: Kafka consumer lag high
         condition: C

--- a/local-setup/tests/package-lock.json
+++ b/local-setup/tests/package-lock.json
@@ -14,9 +14,11 @@
       "devDependencies": {
         "@playwright/test": "^1.48.0",
         "@types/jest": "^29.5.11",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.10.6",
         "@types/pg": "^8.10.9",
         "jest": "^29.7.0",
+        "js-yaml": "^4.3.1",
         "ts-jest": "^29.1.1",
         "typescript": "^5.3.3"
       }
@@ -534,6 +536,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -1022,6 +1048,13 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.31",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.31.tgz",
@@ -1125,14 +1158,11 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "license": "Python-2.0"
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -2754,14 +2784,23 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"

--- a/local-setup/tests/package.json
+++ b/local-setup/tests/package.json
@@ -14,12 +14,14 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.48.0",
     "@types/jest": "^29.5.11",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.10.6",
     "@types/pg": "^8.10.9",
     "jest": "^29.7.0",
+    "js-yaml": "^4.3.1",
     "ts-jest": "^29.1.1",
-    "typescript": "^5.3.3",
-    "@playwright/test": "^1.48.0"
+    "typescript": "^5.3.3"
   }
 }

--- a/local-setup/tests/static/grafana-alerting.test.ts
+++ b/local-setup/tests/static/grafana-alerting.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Grafana alerting provisioning contracts (#1611).
+ *
+ * Why these are worth a CI guard at all: unlike Gatus -- which drops a
+ * misconfigured alert provider with a warning and keeps running -- Grafana
+ * treats a provisioning file it cannot validate as a FATAL startup error. A
+ * typo in these files does not degrade alerting, it takes the whole dashboard
+ * down, and it does so on the deployed box rather than here. There is no
+ * `grafana --check-config`, so the invariants have to be asserted directly.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as yaml from 'js-yaml';
+
+const ALERTING = path.resolve(__dirname, '..', '..', 'otel', 'grafana', 'provisioning', 'alerting');
+const DATASOURCES = path.resolve(__dirname, '..', '..', 'otel', 'grafana', 'provisioning', 'datasources');
+
+const load = (f: string): any => yaml.load(fs.readFileSync(path.join(ALERTING, f), 'utf8'));
+
+const rules = load('rules.yaml');
+const contactPoints = load('contactpoints.yaml');
+const policies = load('policies.yaml');
+
+/** Every datasource uid Grafana will actually know about at runtime. */
+const provisionedUids = new Set<string>(
+  fs.readdirSync(DATASOURCES)
+    .filter((f) => /\.ya?ml$/.test(f))
+    .flatMap((f) => {
+      const doc: any = yaml.load(fs.readFileSync(path.join(DATASOURCES, f), 'utf8'));
+      return (doc?.datasources ?? []).map((d: any) => d.uid);
+    })
+    .filter(Boolean),
+);
+
+const allRules: any[] = (rules.groups ?? []).flatMap((g: any) => g.rules ?? []);
+
+describe('grafana alert rule provisioning', () => {
+  it('provisions at least one rule', () => {
+    expect(allRules.length).toBeGreaterThan(0);
+  });
+
+  /**
+   * Grafana rejects a group missing any of these and refuses to start.
+   * `interval` in particular is parsed with ParseDuration, which errors on "".
+   */
+  it('every group declares name, folder and interval', () => {
+    for (const g of rules.groups) {
+      expect(`${g.name}`).toBeTruthy();
+      expect(`${g.folder}`).toBeTruthy();
+      expect(`${g.interval}`).toMatch(/^\d+[smh]$/);
+    }
+  });
+
+  it('every rule declares uid, title, condition, for and non-empty data', () => {
+    for (const r of allRules) {
+      expect(r.uid).toBeTruthy();
+      expect(r.title).toBeTruthy();
+      expect(r.condition).toBeTruthy();
+      expect(`${r.for}`).toMatch(/^\d+[smh]$/);
+      expect(Array.isArray(r.data) && r.data.length > 0).toBe(true);
+    }
+  });
+
+  /** A duplicate uid makes provisioning fail; they are the identity Grafana keys on. */
+  it('rule uids are unique', () => {
+    const uids = allRules.map((r) => r.uid);
+    expect(new Set(uids).size).toBe(uids.length);
+  });
+
+  /**
+   * A rule whose `condition` names a refId that does not exist is accepted by
+   * YAML and then never fires -- indistinguishable from "nothing is wrong".
+   */
+  it('each rule condition references one of its own refIds', () => {
+    for (const r of allRules) {
+      const refs = new Set(r.data.map((d: any) => d.refId));
+      expect(refs.has(r.condition)).toBe(true);
+    }
+  });
+
+  it('expression nodes chain to a refId that exists in the same rule', () => {
+    for (const r of allRules) {
+      const refs = new Set(r.data.map((d: any) => d.refId));
+      for (const d of r.data) {
+        if (d.model?.expression) expect(refs.has(d.model.expression)).toBe(true);
+        // Grafana keys the query off model.refId, not the outer one; a mismatch
+        // silently evaluates the wrong node.
+        expect(d.model.refId).toBe(d.refId);
+      }
+    }
+  });
+
+  /**
+   * The uid must match a PROVISIONED datasource. Pointing at a uid that only
+   * exists on one operator's box is the classic way these files pass review and
+   * then produce a permanent DatasourceError on everyone else's.
+   */
+  it('every datasource uid is either provisioned or the builtin expression node', () => {
+    for (const r of allRules) {
+      for (const d of r.data) {
+        if (d.datasourceUid === '__expr__') continue;
+        expect(provisionedUids.has(d.datasourceUid)).toBe(true);
+      }
+    }
+  });
+
+  /**
+   * node-exporter ships in the docker-compose.monitoring.yml OVERLAY and the JVM
+   * metrics need the OTEL pipeline, so "no data" normally means "this deployment
+   * does not run that component" -- a valid configuration. Alerting on it would
+   * put a permanent unfixable alert in the channel, and a channel with a
+   * permanent alert gets muted, which disables every other rule here too.
+   */
+  it('no rule alerts on missing data', () => {
+    for (const r of allRules) expect(r.noDataState).toBe('OK');
+  });
+
+  /**
+   * Gatus owns up/down (#1609). A second engine alerting on the same outage
+   * means two messages per incident, which teaches people to ignore both.
+   */
+  it('does not duplicate Gatus by alerting on service availability', () => {
+    for (const r of allRules) {
+      for (const d of r.data) {
+        if (d.datasourceUid === '__expr__') continue;
+        expect(d.model.expr ?? '').not.toMatch(/\bup\s*==\s*0/);
+      }
+    }
+  });
+
+  /**
+   * The error-spike threshold cannot be derived from first principles -- it
+   * needs an observed baseline per tenant. Shipping it live with a guessed
+   * number either cries wolf until the channel is muted, or never fires and
+   * looks exactly like "no errors". It stays paused until someone tunes it.
+   */
+  it('the log error spike rule ships paused, with the reason documented', () => {
+    const spike = allRules.find((r) => r.uid === 'digit-log-error-spike');
+    expect(spike).toBeDefined();
+    expect(spike.isPaused).toBe(true);
+    expect(fs.readFileSync(path.join(ALERTING, 'rules.yaml'), 'utf8')).toContain('TO ENABLE:');
+  });
+});
+
+describe('grafana alerting delivery', () => {
+  it('routes to a contact point that is actually defined', () => {
+    const names = new Set(contactPoints.contactPoints.map((c: any) => c.name));
+    for (const p of policies.policies) expect(names.has(p.receiver)).toBe(true);
+  });
+
+  /**
+   * The webhook is a credential -- anyone holding it can post into the channel.
+   * It must arrive from the environment, never as a literal in a tracked file.
+   */
+  it('reads the webhook from the environment rather than committing it', () => {
+    for (const c of contactPoints.contactPoints) {
+      for (const r of c.receivers) {
+        const url = `${r.settings?.url ?? ''}`;
+        expect(url).toMatch(/^\$[A-Z_]+$/);
+        expect(url).not.toMatch(/hooks\.slack\.com/);
+      }
+    }
+  });
+
+  /**
+   * Grafana expands $VAR with os.ExpandEnv semantics: no `${VAR:-default}`, and
+   * an unset variable becomes an empty string. Since bad provisioning is fatal,
+   * the default has to come from compose -- and it has to be a syntactically
+   * valid, permanently unresolvable URL (RFC 2606 reserves .invalid) rather
+   * than an empty string, or an unconfigured deployment risks crash-looping
+   * Grafana instead of simply not delivering alerts.
+   */
+  it('compose supplies an unreachable default so an unset webhook cannot brick Grafana', () => {
+    const compose = fs.readFileSync(
+      path.resolve(__dirname, '..', '..', 'docker-compose.egov-digit.yaml'),
+      'utf8',
+    );
+    const line = compose
+      .split('\n')
+      .find((l) => l.includes('GRAFANA_SLACK_WEBHOOK_URL:'));
+    expect(line).toBeDefined();
+    expect(line).toMatch(/\$\{GRAFANA_SLACK_WEBHOOK_URL:-https:\/\/example\.invalid\//);
+  });
+});

--- a/local-setup/tests/static/grafana-alerting.test.ts
+++ b/local-setup/tests/static/grafana-alerting.test.ts
@@ -118,12 +118,28 @@ describe('grafana alert rule provisioning', () => {
   /**
    * Gatus owns up/down (#1609). A second engine alerting on the same outage
    * means two messages per incident, which teaches people to ignore both.
+   *
+   * The guard is on the METRIC, not on one spelling of the comparison. `up == 0`
+   * is merely the most obvious phrasing: `count(up) == 0`, `absent(up{job="x"})`,
+   * `min by (job) (up) < 1` and Blackbox's `probe_success == 0` are the same
+   * alert wearing a different hat, and a `/\bup\s*==\s*0/` regex lets every one
+   * of them through. Since no capacity or error-trend rule has any reason to
+   * read an availability metric, referencing one at all is the failure -- which
+   * is both stricter and simpler than trying to enumerate the comparisons.
+   *
+   * Label VALUES are stripped before matching, so a legitimate `{job="up-sync"}`
+   * is not mistaken for the `up` metric. Word boundaries keep `group_right()`
+   * and `sum by (redpanda_group)` clear: the "up" inside them is preceded by a
+   * word character, so `\bup\b` does not match.
    */
+  const AVAILABILITY_METRIC = /\b(up|probe_success)\b/;
+  const stripLabelValues = (expr: string): string => expr.replace(/"[^"]*"|'[^']*'/g, '""');
+
   it('does not duplicate Gatus by alerting on service availability', () => {
     for (const r of allRules) {
       for (const d of r.data) {
         if (d.datasourceUid === '__expr__') continue;
-        expect(d.model.expr ?? '').not.toMatch(/\bup\s*==\s*0/);
+        expect(stripLabelValues(d.model.expr ?? '')).not.toMatch(AVAILABILITY_METRIC);
       }
     }
   });


### PR DESCRIPTION
Closes #1611

> **Stacked on #1672** (`feat/1609-gatus-slack-alerting`). Review that one first — the diff here will shrink once it merges.

> **Also depends on #1628 for data.** The Kafka consumer-lag rule reads `redpanda_*` series that only exist once #1628 adds the Redpanda scrape job to `otel/prometheus.yml` (this branch scrapes only `otel-collector` and `node`). It is a *data* dependency, not a merge one — the two are separate stacks off `monitoring-fix`. If this merges first, that rule evaluates an empty vector and reports a healthy "ok" until #1628 lands. It is left unpaused deliberately so it starts working the moment the scrape job arrives, and the dependency is recorded on the rule itself. The "DIGIT Kafka Consumer Lag" dashboard its description links to arrives with #1678, stacked on #1628.

## Problem

Gatus answers *"is it up?"*. Nothing watched the gradual failures that actually take these boxes down: a disk filling, memory running out, a JVM creeping toward its heap ceiling, or a service answering `/health` perfectly while failing every real request.

All of that data was **already being collected** — Prometheus has host and JVM metrics, Loki has every container's logs, and the JVM dashboard already charts heap against limits. There was simply no alerting engine of any kind: no Alertmanager, no `rule_files`, and no `provisioning/alerting/` directory beside the `dashboards/` and `datasources/` that already exist.

## Why Grafana's built-in alerting, not Alertmanager

- No extra always-on container on a memory-tight box
- Grafana already has **both** datasources provisioned. The error-flood rule needs **Loki**, which Alertmanager cannot see at all
- Rules ship as provisioned files: reviewable in git, deployed automatically, consistent with how dashboards and datasources are already handled here

## The rules

Metric names are taken from the queries in the dashboards provisioned beside them (`jvm-services.json`, `node-exporter-full.json`), not invented — including the `mountpoint="/"` matcher, which is what the node-exporter dashboard already uses.

| Rule | Source | Threshold | For | Severity |
|---|---|---|---|---|
| Host disk low | Prometheus | < 15% free on `/` | 10m | warning |
| Host memory low | Prometheus | < 10% available | 5m | **critical** |
| Host CPU saturated | Prometheus | > 90% | 15m | warning |
| JVM heap headroom low | Prometheus | > 90% of `jvm_memory_limit_bytes` | 10m | warning |
| Kafka consumer lag high | Prometheus | > 10k messages behind | 15m | warning |
| Log error spike | **Loki** | placeholder | 5m | **paused** |

Memory is critical rather than warning because these boxes have **no swap** — the kernel does not degrade gracefully, it goes straight to OOM-killing whichever JVM is largest. There is no slow middle ground.

**There is deliberately no service-down rule.** That is Gatus's job (#1609); duplicating it means two messages per incident, which teaches people to ignore both. A test enforces this rather than trusting the comment.

## Two decisions worth your attention

**1. `noDataState: OK` on every rule.**
node-exporter ships in the `docker-compose.monitoring.yml` *overlay*, and the JVM metrics need the OTEL pipeline running. So "no data" here usually means *"this deployment does not run that component"* — a valid configuration, not an incident. Alerting on it would put a permanent, unfixable alert in the channel, and a channel with a permanent alert gets muted, which silently disables every **other** rule in this file for that person. A monitoring component that has genuinely died is caught by #1613.

`execErrState` stays at `Alerting`: a query that *errors* is a broken rule, which is worth surfacing.

**2. Log error spike ships `isPaused: true`.**
This is the rule that catches the failure Gatus structurally cannot see — green dashboard, nothing works. It is also the only rule whose threshold cannot be derived from first principles: DIGIT services log exception stack traces during entirely normal operation, so the number needs about a week of observed baseline per tenant.

A wrong threshold is not neutral. Too low and the channel cries wolf until someone mutes it; too high and it never fires, which looks identical to "no errors". To enable: observe `sum by (service_name) (count_over_time(...))` on a real tenant, take the p95, set above it, unpause.

## The crash-loop this avoids

Worth calling out because it is the opposite of how #1609 behaves, and I nearly got it wrong:

- **Gatus** drops a misconfigured alert provider with a warning and keeps running — so an empty webhook there is genuinely inert
- **Grafana** treats a provisioning file it cannot validate as **fatal at startup**
- Grafana expands `$VAR` with `os.ExpandEnv` semantics: **no `${VAR:-default}` support**, and unset becomes an **empty string**

So an empty webhook in the contact point would risk crash-looping Grafana on every deployment that has not configured Slack — taking down the dashboard to add alerting to it.

The default is therefore supplied one level up by **compose** (which does support `:-`), as an unreachable URL under the RFC 2606 `.invalid` TLD. Provisioning always validates, Grafana always starts, and an unconfigured deployment logs a clean DNS failure if a rule ever fires — a visible symptom rather than a silent one.

## One channel, not two

`grafana_slack_webhook_url` falls back to `gatus_slack_webhook_url` in the Ansible tier, so an operator sets **one** value and both engines post to the same place. Override it only to split the two streams.

## New CI guard

`static/grafana-alerting.test.ts` (13 tests). Justified by the failure mode: a typo in these files does not degrade alerting, it takes the dashboard down, on the deployed box rather than in CI — and there is no `grafana --check-config` to catch it. It asserts required fields, unique uids, that each `condition` resolves to a refId in its own rule, that every `datasourceUid` matches an actually-provisioned datasource, the two decisions above, and that no webhook is ever committed as a literal.

`js-yaml` was only present *transitively* via jest, so it is now an explicit devDependency rather than something a jest upgrade could silently remove.

## Verification

- static tests **48/48** (13 new)
- the new guard was **mutation-tested** — breaking a `condition` refId, unpausing the error-spike rule, and hardcoding a webhook each fail the expected test and only that test, so it is not passing vacuously
- `check-gatus-coverage.py` still passes
- the Ansible fallback chain was rendered through jinja2 for all three cases (neither set → placeholder, only gatus set → gatus value, both set → grafana value)

**Not verified:** actual Slack delivery, and a live Grafana startup against these files. Both need a running box — Docker was not available in this environment. Given that bad provisioning is fatal to startup, someone should bring Grafana up once on a scratch box before this reaches a tenant.

Targets `monitoring-fix` (the integration branch), not `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: runtime-verified, and the crash-loop is real

Docker became available, so this is no longer a prediction. Both cases run against the pinned `egovio/grafana:11.4.0` image with this exact provisioning directory.

**With the compose default (webhook not configured) — the case that matters most:**

Grafana reached `/api/health` 200 in 6s, `status=running, exitcode=0, restarts=0`, and the API confirms provisioning actually took effect rather than being silently skipped:

```
5 rules provisioned
  Host disk low           uid=digit-host-disk-low         paused=False noData=OK for=10m
  Host memory low         uid=digit-host-memory-low       paused=False noData=OK for=5m
  Host CPU saturated      uid=digit-host-cpu-saturated    paused=False noData=OK for=15m
  JVM heap headroom low   uid=digit-jvm-heap-headroom-low paused=False noData=OK for=10m
  Log error spike         uid=digit-log-error-spike       paused=True  noData=OK for=5m
```

Contact point `slack` created, URL redacted by Grafana as a secure setting. The error-spike rule is confirmed paused *by Grafana itself*, not just by the file.

**With the webhook genuinely unset — Grafana dies:**

```
level=error msg="Failed to provision alerting" error="failure to map file contactpoints.yaml:
  failure parsing contact points: slack: failed to validate integration \"slack\"
  (UID slack-webhook) of type \"slack\": recipient must be specified when using the Slack chat API"
```
`status=exited, exitcode=1`.

So the unreachable `.invalid` placeholder is **load-bearing, not defensive over-engineering**. Without it this PR would have taken Grafana down on every deployment that has not configured Slack — the exact opposite of the intent, and it would have been discovered on a tenant rather than here. Note the failure is not "empty URL" as I'd assumed but Grafana falling back to the Slack *chat API* path, which then demands a `recipient` — same outcome, different reason.

`docker compose config` confirms the default is actually delivered, with the variable unset in the environment:
```
GRAFANA_SLACK_WEBHOOK_URL: https://example.invalid/grafana-slack-webhook-not-configured
GATUS_SLACK_WEBHOOK_URL: ""
```
(The Gatus one is correctly empty — that engine fails open, and #1672 now has runtime evidence for it.)

**One pre-existing, unrelated warning** appears in both runs and is not caused by this PR:
```
logger=provisioning.plugins level=error msg="Failed to read plugin provisioning files from directory"
  path=/etc/grafana/provisioning/plugins error="...no such file or directory"
```
Grafana continues past it. There is simply no `plugins/` subdirectory in the provisioning tree.

Still not verified: delivery to a real Slack channel, and whether the rules fire against real data — both need a running stack with Prometheus and Loki populated.

