### PR TITLE
docs(observability): add an alerting runbook (#1609, #1611)

### DIFF
--- a/docs/observability/alerting-runbook.md
+++ b/docs/observability/alerting-runbook.md
@@ -1,0 +1,159 @@
+# Alerting runbook
+
+What alerts exist, what each one means, and what to do when one fires.
+
+Alerting ships **off**. Nothing here sends anything until someone sets a webhook — see [Turning it on](#turning-it-on). That is deliberate: an alert channel nobody reads is worse than no alerting, because it looks like coverage.
+
+---
+
+## Who receives these
+
+**Undecided at the time of writing.** No team or channel has been named.
+
+That is a real gap, not a formality: every rule below assumes a human eventually looks. Until an owner exists, treat enabling alerting as incomplete, and record the decision here when it is made — otherwise the next person rediscovers the question rather than the answer.
+
+There is no channel name anywhere in the repo, and there should not be. The channel is chosen by whoever mints the webhook.
+
+---
+
+## Two engines, deliberately
+
+| | Gatus | Grafana |
+|---|---|---|
+| Answers | *is it up?* | *is it about to stop being up?* |
+| Source | HTTP/TCP checks | Prometheus + Loki |
+| Fires on | a service not responding | disk, memory, CPU, JVM heap, Kafka lag, error floods |
+
+**Gatus owns up/down. Grafana deliberately has no service-down rule.** Duplicating it would mean two messages per incident, which teaches people to ignore both. A test enforces this rather than trusting the comment.
+
+---
+
+## Turning it on
+
+The webhook URL is a **credential** — anyone holding it can post into the channel. It is read from the environment in every tier and never committed.
+
+**Compose**
+```bash
+# in .env
+GATUS_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
+GRAFANA_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
+```
+
+**Ansible** — set one value; Grafana falls back to the Gatus webhook, so a tenant picks a channel once:
+```yaml
+# host_vars/<tenant>.yml — prefer sourcing from OpenBao
+gatus_slack_webhook_url: "https://hooks.slack.com/services/..."
+```
+
+**k3s** — an optional Secret; create it to switch alerting on, no manifest edit:
+```bash
+kubectl -n digit create secret generic gatus-alerting \
+  --from-literal=slack-webhook-url='https://hooks.slack.com/services/...'
+```
+
+### Two behaviours that differ, and matter
+
+**Gatus fails open.** An unset webhook becomes an empty string, Gatus logs `Ignoring provider=slack due to error=webhook-url not set`, drops the provider and keeps serving. Verified at runtime.
+
+**Grafana fails closed.** It expands `$VAR` with no `${VAR:-default}` support, and treats provisioning it cannot validate as **fatal at startup**. An empty webhook makes it exit 1 with `recipient must be specified when using the Slack chat API` — it does not start.
+
+That is why the Compose default is an unreachable `https://example.invalid/...` URL rather than an empty string. **Do not "tidy" it to empty.** If you see Grafana crash-looping after touching alerting config, this is the first thing to check.
+
+---
+
+## Gatus alerts
+
+One alert per monitored endpoint, after **3 consecutive failures** (~90s at the 30s interval) — long enough that a single dropped check or a rolling restart does not page anyone. A recovery message follows.
+
+**When one fires:** the alert names the endpoint and group. Check the Gatus board first (`/status/`) to see whether it is one service or many — many at once usually means the box, not the service.
+
+---
+
+## Grafana alerts
+
+### Host disk low · `< 15% free on /` for 10m · warning
+
+Fine until it abruptly is not: a full root filesystem takes down every service at once, and Postgres in particular fails in ways needing manual recovery.
+
+Usual causes: Docker image/volume churn, and container logs if rotation is not capped.
+
+```bash
+df -h /
+docker system df
+du -sh /var/lib/docker/containers/* | sort -h | tail
+```
+
+### Host memory low · `< 10% available` for 5m · **critical**
+
+Critical rather than warning because **these boxes have no swap**. The kernel does not degrade gracefully under pressure — it goes straight to OOM-killing, and it kills whichever JVM is largest, not whichever is least important. There is no slow middle ground between "tight" and "a service died".
+
+```bash
+free -m
+docker stats --no-stream
+dmesg -T | grep -i 'killed process'   # confirm whether it has already happened
+```
+
+### Host CPU saturated · `> 90%` for 15m · warning
+
+Sustained, not a spike — 15 minutes rules out a deploy, a batch index or a JVM warming up. Past this point request latency is already degraded even though every health check still answers, so nothing else will tell you.
+
+### JVM heap headroom low · `> 90% of limit` for 10m · warning
+
+A service climbing toward its ceiling will eventually die and restart, dropping in-flight requests. Ten minutes above 90% means steady pressure rather than a GC sawtooth.
+
+**Reading this one carefully:** the ratio is against `jvm_memory_limit_bytes`, so a service that never publishes a heap limit produces **no series and cannot trigger the rule**. Absence of this alert is not proof of headroom — check the *DIGIT JVM Services* dashboard.
+
+### Kafka consumer lag high · `> 10k` for 15m · warning
+
+The failure Gatus structurally cannot see: `egov-persister` falls behind, the API keeps returning 200, every check stays green, and complaints are **never written to the database**.
+
+First question is *slow or gone*: the **Consumers per group** panel on the *DIGIT Kafka Consumer Lag* dashboard reading **0** means the consumer has died, which needs the opposite fix from a slow one. Lag concentrated on a single partition usually means a poison record, not an undersized consumer.
+
+10k/15m is deliberately loose — bulk seeding and migrations move real backlogs through legitimately, and they drain.
+
+### Log error spike · **ships paused**
+
+Catches a service answering `/health` perfectly while failing every real request — green dashboard, nothing works.
+
+**It is paused on purpose and must be tuned before use.** Its threshold cannot be derived from first principles: DIGIT services log exception stack traces during entirely normal operation. Shipped live with a guessed number it would either cry wolf until someone mutes the channel — silently disabling every *other* rule for that person — or never fire, which looks exactly like "no errors".
+
+**To enable:**
+1. On a real tenant, watch for about a week:
+   ```
+   sum by (service_name) (count_over_time({service_name=~".+"} |~ "(?i)ERROR|Exception" [5m]))
+   ```
+2. Take the observed p95 and set the threshold comfortably above it.
+3. Set `isPaused: false` in `local-setup/otel/grafana/provisioning/alerting/rules.yaml`.
+
+Do not skip step 1.
+
+---
+
+## Why every rule reports OK on missing data
+
+`noDataState: OK` throughout. node-exporter ships in the `docker-compose.monitoring.yml` **overlay** and JVM metrics need the OTEL pipeline, so "no data" usually means *this deployment does not run that component* — a valid configuration, not an incident.
+
+Alerting on it would put a permanent, unfixable alert in the channel, and a channel with a permanent alert gets muted — which disables every other rule too. A monitoring component that has genuinely died is Gatus's job (#1613).
+
+`execErrState` stays at `Alerting`: a query that *errors* is a broken rule, and that is worth surfacing.
+
+---
+
+## Changing the rules
+
+They are provisioned files, so they are **read-only in the Grafana UI** — edit `local-setup/otel/grafana/provisioning/alerting/rules.yaml` and redeploy.
+
+Two traps:
+
+- **Provisioning the policy tree replaces it wholesale.** Anything created through the UI is overwritten on restart.
+- **A malformed rule file does not degrade alerting — it stops Grafana starting.** There is no `grafana --check-config`, which is why `local-setup/tests/static/grafana-alerting.test.ts` asserts the invariants in CI. Run it before deploying:
+  ```bash
+  cd local-setup/tests && npx jest static/grafana-alerting
+  ```
+
+---
+
+## Related
+
+- `enabling-monitoring.md` — which components to deploy and how
+- `dashboard-metrics.md` — what the dashboard instrumentation measures

--- a/docs/observability/alerting-runbook.md
+++ b/docs/observability/alerting-runbook.md
@@ -4,15 +4,34 @@ What alerts exist, what each one means, and what to do when one fires.
 
 Alerting ships **off**. Nothing here sends anything until someone sets a webhook — see [Turning it on](#turning-it-on). That is deliberate: an alert channel nobody reads is worse than no alerting, because it looks like coverage.
 
+> **The rules this documents are not merged yet.** `local-setup/otel/grafana/provisioning/alerting/`
+> (`rules.yaml`, `contactpoints.yaml`, `policies.yaml`) and
+> `local-setup/tests/static/grafana-alerting.test.ts` arrive with **#1673**, stacked on
+> **#1609** — a different branch chain from this one, so they are not in this PR's tree
+> and will not be until both land. Every threshold, `noDataState` and `isPaused` value
+> below was read off #1673's `rules.yaml`; the file paths are where those files will be.
+
 ---
 
 ## Who receives these
 
 **Undecided at the time of writing.** No team or channel has been named.
 
-That is a real gap, not a formality: every rule below assumes a human eventually looks. Until an owner exists, treat enabling alerting as incomplete, and record the decision here when it is made — otherwise the next person rediscovers the question rather than the answer.
+That is a real gap, not a formality: every rule below assumes a human eventually looks. #1601 calls it a hard blocker in as many words — *"an alert stream with no named owner gets muted within a week"* — and names where it gets settled: **#1609 needs two decisions before it ships, which Slack channel and webhook, and who triages per tenant. #1611 reuses the same channel — decide once, in #1609.**
 
-There is no channel name anywhere in the repo, and there should not be. The channel is chosen by whoever mints the webhook.
+So the next step is not a new issue, it is **#1609**, and this page is where the answer lands:
+
+- [ ] Owner / triage rota decided in **#1609**, then written into the table below.
+
+| Tier | Channel | Owner | Decided in |
+|---|---|---|---|
+| Compose | *unset* | *unset* | #1609 |
+| Ansible (per tenant) | *unset* | *unset* | #1609 |
+| k3s | *unset* | *unset* | #1609 |
+
+Do not turn alerting on for a tenant while those rows are empty — an unowned stream gets muted, and a muted channel silently disables every rule on this page, not just the noisy one.
+
+There is no channel name anywhere in the repo, and there should not be. The channel is chosen by whoever mints the webhook; only the *owner* belongs in the table.
 
 ---
 
@@ -107,7 +126,19 @@ A service climbing toward its ceiling will eventually die and restart, dropping 
 
 The failure Gatus structurally cannot see: `egov-persister` falls behind, the API keeps returning 200, every check stays green, and complaints are **never written to the database**.
 
-First question is *slow or gone*: the **Consumers per group** panel on the *DIGIT Kafka Consumer Lag* dashboard reading **0** means the consumer has died, which needs the opposite fix from a slow one. Lag concentrated on a single partition usually means a poison record, not an undersized consumer.
+First question is *slow or gone*, and a dead consumer needs the opposite fix from a slow one.
+
+**Neither the data nor the dashboard exists yet — both are #1623.** The rule's own description sends you to the *Consumers per group* panel on a *DIGIT Kafka Consumer Lag* board. That board arrives with **#1678**; `local-setup/otel/grafana/provisioning/dashboards/` currently holds only `jvm-services`, `node-exporter-full`, `loki-logs` and `tempo-traces` (plus `pgr-analytics`, once #1634 lands). The `redpanda_*` series it queries arrive with **#1628**, the Redpanda scrape job.
+
+Read that order carefully, because it is the one place on this page where `noDataState: OK` lies. Until #1628 lands, this rule evaluates an empty vector and reports a healthy **ok** that is indistinguishable from "lag is fine" when it actually means *nothing is being measured*. It ships unpaused anyway, deliberately, so it starts working the moment the scrape job appears rather than waiting on someone remembering to unpause it — but do not read a green Kafka rule as evidence the persister is keeping up until #1628 is in the tree.
+
+Meanwhile, answer *slow or gone* from the broker instead — the same call `digit-mcp`'s `kafka_lag` tool makes:
+
+```bash
+docker exec digit-redpanda rpk group describe egov-persister
+```
+
+`LAG` per partition, and an empty member list means gone. Lag concentrated on a single partition usually means a poison record, not an undersized consumer.
 
 10k/15m is deliberately loose — bulk seeding and migrations move real backlogs through legitimately, and they drain.
 
@@ -131,9 +162,13 @@ Do not skip step 1.
 
 ## Why every rule reports OK on missing data
 
-`noDataState: OK` throughout. node-exporter ships in the `docker-compose.monitoring.yml` **overlay** and JVM metrics need the OTEL pipeline, so "no data" usually means *this deployment does not run that component* — a valid configuration, not an incident.
+`noDataState: OK` throughout. node-exporter ships in the `docker-compose.monitoring.yml` **overlay**, JVM metrics need the OTEL pipeline, and below `observability_level: metrics` several of these components are not deployed at all — so "no data" usually means *this deployment does not run that component*, a valid configuration rather than an incident.
 
-Alerting on it would put a permanent, unfixable alert in the channel, and a channel with a permanent alert gets muted — which disables every other rule too. A monitoring component that has genuinely died is Gatus's job (#1613).
+Alerting on it would put a permanent, unfixable alert in the channel, and a channel with a permanent alert gets muted — which disables every other rule too.
+
+**The cost of that choice: an OK is not a positive signal.** A rule reading ok means *either* healthy *or* not measured, and nothing distinguishes them from the channel. The Kafka lag rule is the live example — see above; it will report ok until #1628 gives it data. Confirm a rule has series behind it before treating its silence as reassurance.
+
+**And nothing catches a monitoring component that has genuinely died.** That is meant to be Gatus's job, but Gatus does not check any of them: `grafana`, `prometheus`, `loki`, `tempo`, `otel-collector`, `node-exporter` and `promtail` are all exempted in `.github/scripts/check-gatus-coverage.py` as observability plumbing. Closing that is **#1613**, which has no PR. Today a dead Prometheus is discovered by noticing the graphs stopped.
 
 `execErrState` stays at `Alerting`: a query that *errors* is a broken rule, and that is worth surfacing.
 

--- a/docs/observability/enabling-monitoring.md
+++ b/docs/observability/enabling-monitoring.md
@@ -12,7 +12,8 @@ Written for the question an operator actually has: **"how much can I afford, and
 > |---|---|
 > | `observability_level` and the `obs-*` compose profiles | #1657, plus the three defect fixes in #1687 |
 > | `.github/scripts/check-helm-values-paths.py` in CI | #1652 |
-> | The Kubernetes tier's `monitoring.*` toggles | #1675 — until it lands the helmfile line really is commented out, as the Kubernetes section below describes |
+> | The Kubernetes tier's wired-in helmfile and `monitoring.*` toggles | #1675 — until it lands the helmfile line is still commented out and `env.yaml` has no `monitoring:` block |
+| Grafana alert rules, contact points and the alerting test | #1673, stacked on #1609 — a different branch chain from this one |
 >
 > None of those had merged when this was written. Everything else here — what each
 > component does, the Gatus coverage rules, the Kubernetes layout — is current.
@@ -25,7 +26,7 @@ Written for the question an operator actually has: **"how much can I afford, and
 |---|---|---|
 | Used for | **small-scale** deployments, one tenant per box | **large-scale**, production Kubernetes |
 | Lives in | `local-setup/` | `devops/deploy-as-code/` |
-| Monitoring is | **on by default**, sized by `observability_level` | **off by default** — one commented line |
+| Monitoring is | **on by default**, sized by `observability_level` | **off by default** — six per-component booleans, all `false` |
 
 If you only run one of them, read only that section.
 
@@ -133,7 +134,14 @@ longer runs.
 
 ## Kubernetes tier: wired in, every component off by default
 
-`devops/deploy-as-code/digit-helmfile.yaml` lists the tiers to install. The monitoring line **used to be commented out entirely**; as of #1675 it is present, and each component is gated instead:
+> **This section describes #1675, which has not merged.** On `monitoring-fix` today
+> the helmfile line is still commented out and `charts/environments/env.yaml` has no
+> `monitoring:` block, so the toggles below do not exist yet. #1675 and this PR both
+> target `monitoring-fix` and neither depends on the other's merge, so whichever lands
+> first, expect a window where the tree and this page disagree. Nothing here is wrong
+> about the intended shape — it is the timing that is unsettled.
+
+`devops/deploy-as-code/digit-helmfile.yaml` lists the tiers to install. The monitoring line **used to be commented out entirely**; #1675 makes it present, and gates each component instead:
 
 ```yaml
   - path: ./charts/auxiliary-services/auxiliary-helmfile.yaml

--- a/docs/observability/enabling-monitoring.md
+++ b/docs/observability/enabling-monitoring.md
@@ -72,51 +72,62 @@ At `metrics` and `logs`, `OTEL_TRACES_EXPORTER` is set to `none` — otherwise e
 
 ---
 
-## Kubernetes tier: it is off by default
+## Kubernetes tier: wired in, every component off by default
 
-`devops/deploy-as-code/digit-helmfile.yaml` lists the tiers to install. The monitoring line is commented out:
+`devops/deploy-as-code/digit-helmfile.yaml` lists the tiers to install. The monitoring line **used to be commented out entirely**; as of #1675 it is present, and each component is gated instead:
 
 ```yaml
   - path: ./charts/auxiliary-services/auxiliary-helmfile.yaml
-#  - path: ./charts/monitoring/monitoring-helmfile.yaml
+  - path: ./charts/monitoring/monitoring-helmfile.yaml
 ```
 
-So a standard deploy installs **no** Prometheus, Grafana, Loki or Alertmanager.
+A standard deploy still installs **no** Prometheus, Grafana, Loki or Alertmanager — the path being listed changes nothing on its own, because every release defaults to `installed: false`.
 
-### Why it is commented out
+### Why it was commented out
 
 Not a decision anyone here took. `deploy-as-code` was imported wholesale from upstream `egovernments/DIGIT-DevOps`, and the line **arrived already commented** — directly beside `#  - path: ./charts/sanitation/sanitation-helmfile.yaml`, an unrelated business module. The file's convention is "commented = a module this deployment does not use", and monitoring was categorised the same way and never revisited.
 
-That history also explains values you will find pointing at other environments (`unified-qa`, `unified-uat.digit.org`, a `#unified-qa-alerts` Slack channel): they came in with the import and were never adapted.
+The practical consequence was that every monitoring fix in the tree edited files nothing deployed.
+
+That history also explains values you will find pointing at other environments (`unified-qa`, `unified-uat.digit.org`, `urban-lts.digit.org`, a `#unified-qa-alerts` Slack channel): they came in with the import and were never adapted.
 
 ### Enabling it
 
-Uncomment the line. That installs the releases in `charts/monitoring/monitoring-helmfile.yaml`.
+Set the toggles in `devops/deploy-as-code/charts/environments/env.yaml`:
 
-**Check these first** — enabling it as-is deploys a stack with known gaps, each tracked:
-
-- Prometheus and Alertmanager persistence (#1645) — without it, metrics vanish on every pod restart
-- Grafana login and admin password (#1650)
-- Dashboards fetched from GitHub `master` at pod start rather than vendored (#1650)
-- No application metrics until the OTEL agent work lands (#1646)
-- `kafka-ui` is published with **no authentication**
+```yaml
+monitoring:
+  metrics: true      # kube-prometheus-stack — Prometheus, Alertmanager, node-exporter
+  dashboards: true   # Grafana
+  logs: true         # Loki + Promtail
+  probes: false      # blackbox-exporter — external HTTP/TLS probing
+  traces: false      # Jaeger — needs an Elasticsearch backend; much the most expensive
+  kafkaUi: false     # Kafka admin console — see the warning below
+```
 
 ### Running a subset
 
-This tier is modular per component — every release carries its own `installed:` flag:
+Rough order of value if you are picking only some:
 
-```yaml
-- name: loki-stack
-  installed: true      # logs
-- name: kube-prometheus-stack
-  installed: true      # metrics + Alertmanager
-- name: grafana
-  installed: true      # dashboards
-- name: blackbox
-  installed: true      # external probes
-```
+1. **`metrics`** — without it nothing else has data to work from
+2. **`dashboards`** — makes the metrics legible; on its own it has nothing to query
+3. **`logs`** — answers *why*, once metrics tell you *what*
+4. **`probes`** — catches TLS expiry and outside-in failures
+5. **`traces`** — only worth it when chasing latency across services
 
-Set any to `false` to leave it out. The same dependency applies as on the Ansible tier: Grafana without Prometheus or Loki is an empty dashboard.
+`kafkaUi` is not observability at all: it is a **write-capable Kafka admin console**, published with no authentication. Treat enabling it as an access-control decision.
+
+### Known gaps before you enable it
+
+Each is tracked:
+
+- **No application metrics** until the OTEL agent work lands (#1646) — you get cluster and infra views, not per-service ones
+- Prometheus and Alertmanager persistence (#1645) — without it, metrics vanish on every pod restart
+- Alertmanager email needs its SMTP secret created first (#1640):
+  ```
+  kubectl -n monitoring create secret generic alertmanager-smtp \
+    --from-literal=password='<smtp-app-password>'
+  ```
 
 ---
 
@@ -132,6 +143,7 @@ Being explicit, because a gap you chose is different from one you missed.
 
 ## Related
 
+- `alerting-runbook.md` — what each alert means, what to do when it fires, and how to turn alerting on
 - `dashboard-metrics.md` — what the dashboard instrumentation measures, client and server side
 - `local-setup/README.md` — what the Ansible playbook deploys
 - `local-setup/ansible/README.md` — deploy stages, including the health gates


### PR DESCRIPTION
Part of #1609 / #1611. Stacked on #1667.

## Why

The alerting PRs (#1672, #1673) deliver rules. Nothing told anyone what to **do** when one fires — which is the difference between alerting and a noisier dashboard.

## What it covers

Each of the six rules: what it means, why its threshold is what it is, and the first commands to run. Plus how to turn alerting on in each tier, and why every rule reports OK on missing data.

## Three things it records that were otherwise easy to lose

**1. The owner is undecided.** No team or channel has been named. The runbook says so plainly rather than implying coverage exists — every rule assumes a human eventually looks, and until one does, enabling alerting is incomplete.

**2. The Gatus/Grafana asymmetry**, because it bites. Gatus fails **open** on an unset webhook (warns, drops the provider, keeps serving); Grafana fails **closed** (exits 1, does not start). That is why the Compose default is an unreachable `.invalid` URL rather than empty — and the runbook says not to "tidy" it to empty, with the exact error to recognise if someone does.

**3. The tuning procedure for the paused error-spike rule** — observe p95 for ~a week on a real tenant, then set above it. Left implicit, someone would eventually unpause it with the placeholder threshold, and it would either cry wolf until the channel is muted (silently disabling every *other* rule for that person) or never fire.

## Also updates `enabling-monitoring.md`

Its Kubernetes section said the monitoring helmfile is commented out. #1675 changes that — the path is now wired in with each component gated on `monitoring.*`. The section now documents the toggles, a suggested order for picking a subset, and that `kafkaUi` is a **write-capable admin console with no authentication**, not observability.

## Verification

Checked mechanically rather than by eye: every rule title in `rules.yaml` appears in the runbook, and the only rule shipping paused is the one the runbook describes as paused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)