### PR TITLE
feat(k3s): add the monitoring stack, phases 1 and 2 (#1618)

### DIFF
--- a/local-setup/Tiltfile.k8s
+++ b/local-setup/Tiltfile.k8s
@@ -15,6 +15,15 @@ PGR_PATH = CCRS_PATH + '/backend/pgr-services'
 # CI mode: use pre-built Docker Hub images, no live reload
 CI_MODE = os.getenv('CI', '') != '' or os.getenv('TILT_CI', '') != ''
 
+# Monitoring stack (#1618). OFF by default and opt-in via MONITORING=true, for
+# the same reason the production tier's components default to installed:false --
+# Prometheus, Grafana, Loki and a Promtail DaemonSet are a real resource cost,
+# and turning them on for every `tilt up` would change what a plain local
+# bring-up means. Never on in CI: the tier's CI run asserts a fixed set of
+# resources come up healthy, and adding five more would slow it and broaden
+# what can flake without testing anything CI is there to test.
+MONITORING = os.getenv('MONITORING', '').lower() in ('1', 'true', 'yes') and not CI_MODE
+
 # ==================== ConfigMaps from files ====================
 # Generated dynamically so edits to source files auto-apply on tilt up
 # NB: the directory is configs/egov-persister, not configs/persister. 09a8ec2e renamed
@@ -38,6 +47,43 @@ k8s_yaml(local('kubectl create configmap nginx-configs --from-file=mdms-proxy.co
 # impossible by construction. That invariant is now enforced mechanically instead,
 # by .github/workflows/gatus-coverage.yml, which fails a PR when the two tiers'
 # endpoint catalogues diverge.
+
+# ==================== Monitoring ConfigMaps (#1618) ====================
+# Generated from local-setup/otel/, the SAME files the compose tier uses, so the
+# two tiers cannot drift in scrape config, retention or what the dashboards show.
+# Same pattern as the persister/kong/nginx maps above.
+#
+# One ConfigMap PER DASHBOARD, not one combined: node-exporter-full.json alone is
+# 456 KB against Kubernetes' ~1 MiB per-object limit, so a combined map would
+# apply cleanly today and fail on whoever adds the next dashboard -- with an
+# error that does not obviously point at the size.
+#
+# Promtail is the exception and is NOT generated from otel/promtail-config.yaml:
+# that config discovers containers over the Docker socket, which k3s (containerd)
+# does not have. Its k8s rewrite lives in k8s/monitoring/promtail.yaml.
+if MONITORING:
+    k8s_yaml(local('kubectl create configmap loki-config --from-file=config.yaml=otel/loki-config.yaml -n monitoring --dry-run=client -o yaml'))
+    k8s_yaml(local('kubectl create configmap grafana-datasources --from-file=otel/grafana/provisioning/datasources/ -n monitoring --dry-run=client -o yaml'))
+    k8s_yaml(local('kubectl create configmap grafana-dashboards-provider --from-file=dashboards.yaml=otel/grafana/provisioning/dashboards/dashboards.yaml -n monitoring --dry-run=client -o yaml'))
+    k8s_yaml(local('kubectl create configmap grafana-dash-jvm --from-file=otel/grafana/provisioning/dashboards/jvm-services.json -n monitoring --dry-run=client -o yaml'))
+    # node-exporter-full.json (456 KB) is applied SERVER-SIDE, outside Tilt.
+    #
+    # Client-side `kubectl apply` -- which is what Tilt does -- stores a copy of
+    # the entire object in the kubectl.kubernetes.io/last-applied-configuration
+    # ANNOTATION, and annotations are capped at 256 KiB. So this fails:
+    #   ConfigMap "grafana-dash-node" is invalid: metadata.annotations:
+    #   Too long: must have at most 262144 bytes
+    # even though the ConfigMap is comfortably under the ~1 MiB object limit.
+    # Splitting one map per dashboard (#1618 item 4) does NOT avoid this -- the
+    # single largest dashboard already exceeds the annotation cap on its own.
+    #
+    # Server-side apply does not use that annotation. The cost is that Tilt does
+    # not manage this one, so editing that dashboard needs a re-run rather than
+    # hot-reloading; the other three stay Tilt-managed and reload normally.
+    local('kubectl create namespace monitoring --dry-run=client -o yaml | kubectl apply -f -')
+    local('kubectl create configmap grafana-dash-node --from-file=otel/grafana/provisioning/dashboards/node-exporter-full.json -n monitoring --dry-run=client -o yaml | kubectl apply --server-side -f -')
+    k8s_yaml(local('kubectl create configmap grafana-dash-loki --from-file=otel/grafana/provisioning/dashboards/loki-logs.json -n monitoring --dry-run=client -o yaml'))
+    k8s_yaml(local('kubectl create configmap grafana-dash-tempo --from-file=otel/grafana/provisioning/dashboards/tempo-traces.json -n monitoring --dry-run=client -o yaml'))
 
 # ==================== K8s Manifests ====================
 k8s_yaml([
@@ -72,6 +118,16 @@ k8s_yaml([
     # Tools
     'k8s/tools/gatus.yaml',
 ])
+
+# Monitoring manifests, loaded only when MONITORING is on (#1618).
+if MONITORING:
+    k8s_yaml([
+        'k8s/monitoring/prometheus.yaml',
+        'k8s/monitoring/node-exporter.yaml',
+        'k8s/monitoring/grafana.yaml',
+        'k8s/monitoring/loki.yaml',
+        'k8s/monitoring/promtail.yaml',
+    ])
 
 # ==================== PGR Services ====================
 if CI_MODE:

--- a/local-setup/k8s/monitoring/README.md
+++ b/local-setup/k8s/monitoring/README.md
@@ -1,0 +1,95 @@
+# k3s monitoring stack (#1618)
+
+Until this landed, the **only** observability manifest in `local-setup/k8s/` was
+`tools/gatus.yaml`. That was confusing rather than merely incomplete: the Gatus
+config is kept byte-identical across tiers with CI enforcing it — signalling
+"these tiers should match" — while every other observability component silently
+did not exist here.
+
+**Off by default.** Set `MONITORING=true` before `tilt up -f Tiltfile.k8s`.
+Never enabled in CI: that run asserts a fixed set of resources come up healthy,
+and five more would slow it and broaden what can flake without testing anything
+CI exists to test.
+
+## Phase status
+
+| Phase | State |
+|---|---|
+| 1 · Metrics — Prometheus, node-exporter, Grafana | **done** |
+| 2 · Logs — Loki, Promtail | **done** |
+| 3 · Traces — otel-collector, Tempo, per-service OTEL env | **not done** |
+| 4 · Gatus wire-up — `GATUS_OBSERVABILITY: true` | **blocked** |
+
+### Why phase 3 is not done
+
+Deploying a collector alone yields empty dashboards. `grep OTEL_ k8s/{core,app}-services/*.yaml`
+returns nothing, so **no service in this tier emits telemetry**. Making traces
+real means adding the javaagent mount plus `OTEL_SERVICE_NAME` /
+`OTEL_EXPORTER_OTLP_ENDPOINT` / exporter vars to each of ~20 Deployments,
+including the compose tier's deliberate exceptions (`egov-localization` runs
+metrics-only to avoid ~200 MB of agent heap; the OTP/SMS services are off
+entirely).
+
+That is the same work as #1646 on the production tier and should follow the
+same decisions, so it is tracked separately rather than guessed at here. The
+Tempo datasource is provisioned and will simply fail queries until then — the
+`otel-collector` scrape target likewise shows **down**, which is honest: absent
+rather than silently missing.
+
+### Why phase 4 is blocked
+
+`GATUS_OBSERVABILITY` is introduced by #1613 (PR #1636), which is not merged.
+When it is, note that **the Gatus endpoints will need namespaced DNS**: Gatus
+runs in `digit`, this stack in `monitoring`, so `http://grafana:3000` does not
+resolve across namespaces — it needs `grafana.monitoring.svc.cluster.local`.
+
+## Two things that cost real time
+
+**Prometheus and `--web.enable-lifecycle=false`.** Passing it explicitly does
+not work: the flag parser rejects it with `unexpected false` and Prometheus
+crash-loops. Omission is the only correct spelling, and the default is already
+off — which is what we want, since enabling it exposes unauthenticated
+`/-/reload` and `/-/quit` (the defect #1608 fixes on the compose tier).
+
+**The 456 KB dashboard cannot be applied client-side.** `kubectl apply` stores a
+copy of the whole object in the `last-applied-configuration` **annotation**, and
+annotations cap at **256 KiB**:
+
+```
+ConfigMap "grafana-dash-node" is invalid: metadata.annotations:
+Too long: must have at most 262144 bytes
+```
+
+The object is well under the ~1 MiB object limit, so one-ConfigMap-per-dashboard
+(#1618 item 4) does **not** avoid this — the single largest dashboard already
+exceeds the annotation cap alone. `Tiltfile.k8s` applies that one **server-side**,
+which does not use the annotation.
+
+## Config reuse
+
+Everything is generated from `local-setup/otel/` — the same files the compose
+tier uses — so the tiers cannot drift. Two deliberate exceptions:
+
+- **Promtail** — the compose config discovers containers over the Docker socket;
+  k3s runs containerd. The discovery half is rewritten
+  (`kubernetes_sd_configs`, `cri:` pipeline stage); the Loki-facing half and,
+  crucially, the `service_name` label the dashboards select on are preserved.
+- **Prometheus** — same job *names* so dashboards carry over, but node-exporter
+  is discovered as a DaemonSet rather than named, and `kubelet-cadvisor` is
+  added because container CPU/memory comes from the kubelet here, not a Docker
+  daemon.
+
+Grafana's dashboard ConfigMaps are mounted as **subdirectories of the provider
+path**, because Grafana's file provider recurses — that is what lets
+`dashboards.yaml` be reused verbatim. Mounting them elsewhere fails *silently*:
+Grafana starts happily and shows no dashboards.
+
+## Before enabling
+
+```
+kubectl -n monitoring create secret generic grafana-admin \
+  --from-literal=password='<choose one>'
+```
+
+Grafana requires login here — anonymous access is off and the login form is
+enabled, so this tier does not reintroduce what #1602 closed.

--- a/local-setup/k8s/monitoring/grafana.yaml
+++ b/local-setup/k8s/monitoring/grafana.yaml
@@ -1,0 +1,119 @@
+# Grafana for the k3s tier (#1618, phase 1).
+#
+# Provisioning (datasources + dashboards) is NOT duplicated here. Tiltfile.k8s
+# generates ConfigMaps straight from local-setup/otel/grafana/provisioning/,
+# the same files the compose tier uses, via the `kubectl create configmap
+# --from-file` pattern already established in that file for persister/kong/nginx.
+# One source of truth, so the tiers cannot drift in what they display.
+#
+# That works verbatim only because the Services in this namespace are named
+# `prometheus`, `loki` and `tempo` -- exactly the hostnames the datasource files
+# already point at. Renaming a Service here silently breaks the datasources.
+#
+# Dashboards get ONE ConfigMap EACH (#1618 item 4): node-exporter-full.json is
+# 456 KB against Kubernetes' ~1 MiB per-object limit, so a combined map would
+# work today and fail on whoever adds the next dashboard.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grafana-data
+  namespace: monitoring
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  replicas: 1
+  # ReadWriteOnce PVC -- a rolling update would deadlock on the volume.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      securityContext:
+        fsGroup: 472        # the grafana user in the official image
+        runAsUser: 472
+        runAsNonRoot: true
+      containers:
+        - name: grafana
+          image: egovio/grafana:11.4.0
+          env:
+            # Authenticated by default. The compose tier shipped anonymous
+            # Admin with the login form hidden (#1602); this tier must not
+            # reintroduce what that closed, so anonymous access is OFF and an
+            # admin password is required.
+            - name: GF_AUTH_ANONYMOUS_ENABLED
+              value: "false"
+            - name: GF_AUTH_DISABLE_LOGIN_FORM
+              value: "false"
+            - name: GF_SECURITY_ADMIN_USER
+              value: admin
+            # From a Secret, never a literal. Create it before deploying:
+            #   kubectl -n monitoring create secret generic grafana-admin \
+            #     --from-literal=password='<choose one>'
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-admin
+                  key: password
+          ports:
+            - containerPort: 3000
+              name: http
+          volumeMounts:
+            - {name: datasources, mountPath: /etc/grafana/provisioning/datasources}
+            - {name: dashboards-provider, mountPath: /etc/grafana/provisioning/dashboards}
+            # Nested UNDER the provider directory on purpose. dashboards.yaml
+            # sets options.path: /etc/grafana/provisioning/dashboards, and
+            # Grafana's file provider walks that path recursively -- so mounting
+            # each dashboard ConfigMap as a subdirectory of it lets the provider
+            # config be reused from the compose tier VERBATIM.
+            # Mounting them elsewhere (e.g. /var/lib/grafana/dashboards) needs a
+            # k3s-only provider file, which is a drift point for no gain; it
+            # also fails silently -- Grafana starts happily and simply shows no
+            # dashboards, which is how this was caught.
+            - {name: dash-jvm, mountPath: /etc/grafana/provisioning/dashboards/jvm}
+            - {name: dash-node, mountPath: /etc/grafana/provisioning/dashboards/node}
+            - {name: dash-loki, mountPath: /etc/grafana/provisioning/dashboards/loki}
+            - {name: dash-tempo, mountPath: /etc/grafana/provisioning/dashboards/tempo}
+            - {name: data, mountPath: /var/lib/grafana}
+          readinessProbe:
+            httpGet: {path: /api/health, port: 3000}
+            initialDelaySeconds: 10
+          resources:
+            requests: {cpu: 100m, memory: 128Mi}
+            limits: {memory: 512Mi}
+      volumes:
+        - {name: datasources, configMap: {name: grafana-datasources}}
+        - {name: dashboards-provider, configMap: {name: grafana-dashboards-provider}}
+        - {name: dash-jvm, configMap: {name: grafana-dash-jvm}}
+        - {name: dash-node, configMap: {name: grafana-dash-node}}
+        - {name: dash-loki, configMap: {name: grafana-dash-loki}}
+        - {name: dash-tempo, configMap: {name: grafana-dash-tempo}}
+        - name: data
+          persistentVolumeClaim:
+            claimName: grafana-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  selector:
+    app: grafana
+  ports:
+    - port: 3000
+      targetPort: 3000
+      name: http

--- a/local-setup/k8s/monitoring/loki.yaml
+++ b/local-setup/k8s/monitoring/loki.yaml
@@ -1,0 +1,72 @@
+# Loki for the k3s tier (#1618, phase 2).
+#
+# Config is reused VERBATIM from local-setup/otel/loki-config.yaml -- it is
+# runtime-identical, containing no Docker-specific assumptions. Tiltfile.k8s
+# generates the ConfigMap from that file, so the tiers cannot drift in
+# retention or ingestion limits.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: loki-data
+  namespace: monitoring
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loki
+  namespace: monitoring
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: loki
+  template:
+    metadata:
+      labels:
+        app: loki
+    spec:
+      securityContext:
+        fsGroup: 10001
+        runAsUser: 10001
+        runAsNonRoot: true
+      containers:
+        - name: loki
+          image: grafana/loki:3.4.2
+          args: ["-config.file=/etc/loki/config.yaml"]
+          ports:
+            - containerPort: 3100
+              name: http
+          volumeMounts:
+            - {name: config, mountPath: /etc/loki}
+            - {name: data, mountPath: /loki}
+          readinessProbe:
+            httpGet: {path: /ready, port: 3100}
+            initialDelaySeconds: 20
+          resources:
+            requests: {cpu: 100m, memory: 128Mi}
+            limits: {memory: 512Mi}
+      volumes:
+        - {name: config, configMap: {name: loki-config}}
+        - name: data
+          persistentVolumeClaim:
+            claimName: loki-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki
+  namespace: monitoring
+spec:
+  selector:
+    app: loki
+  ports:
+    - port: 3100
+      targetPort: 3100
+      name: http

--- a/local-setup/k8s/monitoring/node-exporter.yaml
+++ b/local-setup/k8s/monitoring/node-exporter.yaml
@@ -1,0 +1,88 @@
+# Host metrics for the k3s tier (#1618, phase 1).
+#
+# The compose tier runs this as a single container in
+# docker-compose.monitoring.yml. Here it is a DaemonSet: one pod per node, which
+# is the actual difference between the tiers -- compose has one host by
+# definition, a cluster does not.
+#
+# Same image and the same --path.* rebasing as the compose overlay, so
+# node_filesystem_* mountpoints come out identically and the Node Exporter Full
+# dashboard works unchanged across tiers.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-exporter
+  namespace: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: node-exporter
+  template:
+    metadata:
+      labels:
+        app: node-exporter
+    spec:
+      # A containerised node-exporter sees only its own namespaces unless
+      # pointed at the host's -- same reason the compose overlay sets pid: host.
+      hostPID: true
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      # Must run on every node, including control-plane ones: a node whose
+      # metrics are missing looks identical to a healthy one.
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: node-exporter
+          image: prom/node-exporter:v1.8.2
+          args:
+            - --path.procfs=/host/proc
+            - --path.sysfs=/host/sys
+            - --path.rootfs=/host/root
+            # Drop pseudo/virtual mounts and container layers so the filesystem
+            # panels show real volumes rather than per-container churn.
+            - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+|run/k3s/.+)($|/)
+          ports:
+            - containerPort: 9100
+              name: metrics
+              hostPort: 9100
+          securityContext:
+            runAsUser: 65534
+            runAsNonRoot: true
+          resources:
+            requests: {cpu: 50m, memory: 32Mi}
+            limits: {memory: 128Mi}
+          volumeMounts:
+            - {name: proc, mountPath: /host/proc, readOnly: true}
+            - {name: sys, mountPath: /host/sys, readOnly: true}
+            # No mountPropagation, deliberately. The compose overlay uses
+            # rslave so mounts appearing AFTER start propagate in, and the
+            # upstream node-exporter DaemonSet sets HostToContainer for the same
+            # reason -- but that requires / on the node to be a shared or slave
+            # mount. Where it is not (notably k3s running inside Docker, which
+            # is how this tier is developed locally) the kubelet refuses to
+            # create the container at all:
+            #   path "/" is mounted on "/" but it is not a shared or slave mount
+            # A node-exporter that cannot start reports nothing; one that misses
+            # a filesystem mounted after boot reports slightly less. The second
+            # is the better failure.
+            - {name: root, mountPath: /host/root, readOnly: true}
+      volumes:
+        - {name: proc, hostPath: {path: /proc}}
+        - {name: sys, hostPath: {path: /sys}}
+        - {name: root, hostPath: {path: /}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: node-exporter
+  namespace: monitoring
+  labels:
+    app: node-exporter
+spec:
+  clusterIP: None
+  selector:
+    app: node-exporter
+  ports:
+    - port: 9100
+      targetPort: 9100
+      name: metrics

--- a/local-setup/k8s/monitoring/prometheus.yaml
+++ b/local-setup/k8s/monitoring/prometheus.yaml
@@ -1,0 +1,200 @@
+# Metrics for the k3s tier (#1618, phase 1).
+#
+# Until now the ONLY observability manifest in local-setup/k8s/ was
+# tools/gatus.yaml -- no Prometheus, Grafana, Loki, Promtail, Tempo,
+# otel-collector or node-exporter. That was confusing rather than merely
+# incomplete: the Gatus config is kept byte-identical across tiers with CI
+# enforcing it, which signals "these tiers should match", while every other
+# observability component silently did not.
+#
+# Config is kept behaviourally identical to local-setup/otel/prometheus.yml
+# wherever it can be -- same job NAMES especially, so dashboards carry over --
+# and differs only where the runtime genuinely differs. Those differences are
+# annotated inline rather than left for a reader to infer.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+---
+# Prometheus needs to discover pods and proxy to node metrics endpoints. It is
+# read-only: get/list/watch, no write verbs anywhere.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+  - apiGroups: [""]
+    resources: [nodes, nodes/proxy, nodes/metrics, services, endpoints, pods]
+    verbs: [get, list, watch]
+  - nonResourceURLs: ["/metrics", "/metrics/cadvisor"]
+    verbs: [get]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: monitoring
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: monitoring
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+      evaluation_interval: 15s
+
+    scrape_configs:
+      # Mirrors local-setup/otel/prometheus.yml. Same two jobs, same job names, so
+      # the dashboards provisioned from that tier resolve here unchanged.
+      - job_name: otel-collector
+        static_configs:
+          - targets: ['otel-collector.monitoring.svc.cluster.local:8889']
+
+      # node-exporter. In compose this is a container reached by DNS name; here it
+      # is a DaemonSet, so targets are discovered rather than named -- one pod per
+      # node instead of one container.
+      - job_name: node
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names: [monitoring]
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_label_app]
+            action: keep
+            regex: node-exporter
+          # `instance` should name the NODE, not the ephemeral pod -- otherwise
+          # every pod reschedule looks like a new host and breaks continuity on
+          # the Node Exporter Full dashboard.
+          - source_labels: [__meta_kubernetes_pod_node_name]
+            target_label: instance
+
+      # No compose equivalent: kubelet/cAdvisor is where container CPU and memory
+      # live in this tier. In compose that data comes from the Docker daemon, which
+      # k3s does not run.
+      - job_name: kubelet-cadvisor
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+          - role: node
+        relabel_configs:
+          - action: labelmap
+            regex: __meta_kubernetes_node_label_(.+)
+          - target_label: __address__
+            replacement: kubernetes.default.svc:443
+          - source_labels: [__meta_kubernetes_node_name]
+            regex: (.+)
+            target_label: __metrics_path__
+            replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+---
+# First PersistentVolumeClaim in this tier (#1618 item 3). k3s ships the
+# local-path provisioner, so no storage class needs configuring -- but this
+# establishes a pattern the tier has not needed before.
+#
+# Without it, metrics vanish on every pod restart, which is the same defect
+# #1645 fixes on the production tier.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prometheus-data
+  namespace: monitoring
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: monitoring
+spec:
+  replicas: 1
+  # Recreate, not RollingUpdate: the PVC is ReadWriteOnce, so a rolling update
+  # would deadlock waiting for a volume the outgoing pod still holds.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      serviceAccountName: prometheus
+      securityContext:
+        # The image runs as nobody(65534); the PVC must be group-writable by it
+        # or Prometheus cannot create its TSDB and crash-loops on first start.
+        fsGroup: 65534
+        runAsUser: 65534
+        runAsNonRoot: true
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v2.53.0
+          args:
+            - --config.file=/etc/prometheus/prometheus.yml
+            - --storage.tsdb.path=/prometheus
+            - --storage.tsdb.retention.time=15d
+            # No --web.enable-lifecycle. It defaults to OFF, and that is what we
+            # want: enabling it exposes unauthenticated /-/reload and /-/quit,
+            # which is the defect #1608 fixes on the compose tier. Passing
+            # `--web.enable-lifecycle=false` to be explicit does NOT work -- the
+            # flag parser rejects it with "unexpected false" and Prometheus
+            # crash-loops. Omission is the only correct spelling.
+          ports:
+            - containerPort: 9090
+              name: http
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus
+            - name: data
+              mountPath: /prometheus
+          readinessProbe:
+            httpGet: {path: /-/ready, port: 9090}
+            initialDelaySeconds: 10
+          livenessProbe:
+            httpGet: {path: /-/healthy, port: 9090}
+            initialDelaySeconds: 30
+          resources:
+            requests: {cpu: 100m, memory: 256Mi}
+            limits: {memory: 1Gi}
+      volumes:
+        - name: config
+          configMap:
+            name: prometheus-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: prometheus-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: monitoring
+spec:
+  selector:
+    app: prometheus
+  ports:
+    - port: 9090
+      targetPort: 9090
+      name: http

--- a/local-setup/k8s/monitoring/promtail.yaml
+++ b/local-setup/k8s/monitoring/promtail.yaml
@@ -1,0 +1,149 @@
+# Promtail for the k3s tier (#1618, phase 2).
+#
+# This is the one config that could NOT be reused verbatim. The compose version
+# discovers containers through the Docker socket:
+#
+#     docker_sd_configs:
+#       - host: unix:///var/run/docker.sock
+#
+# k3s runs containerd. There is no Docker socket, so the discovery half is a
+# rewrite: kubernetes_sd_configs over pods, reading /var/log/pods.
+#
+# The Loki-facing half carries over unchanged, and so does the OUTPUT contract,
+# which is the part that actually matters: `service_name` is the only label the
+# loki-logs.json dashboard selects on, so it is reproduced here from the pod's
+# app label (falling back to the container name). Get that wrong and the
+# dashboard silently returns nothing on this tier while looking identical.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: promtail
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: promtail
+rules:
+  - apiGroups: [""]
+    resources: [nodes, nodes/proxy, services, endpoints, pods]
+    verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: promtail
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: promtail
+subjects:
+  - kind: ServiceAccount
+    name: promtail
+    namespace: monitoring
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: promtail-config
+  namespace: monitoring
+data:
+  config.yaml: |
+    server:
+      http_listen_port: 9080
+      grpc_listen_port: 0
+
+    positions:
+      filename: /run/promtail/positions.yaml
+
+    clients:
+      - url: http://loki:3100/loki/api/v1/push
+
+    # As in the compose config: reject_old_samples belongs in Loki's config,
+    # not here -- promtail's limits_config schema rejects it outright.
+    scrape_configs:
+      - job_name: kubernetes-pods
+        kubernetes_sd_configs:
+          - role: pod
+        pipeline_stages:
+          # containerd writes CRI format, not Docker JSON. This is the direct
+          # counterpart of the compose config's `docker: {}` stage.
+          - cri: {}
+        relabel_configs:
+          # Only this node's pods -- each DaemonSet pod reads its own node's
+          # /var/log/pods, so without this every log line is ingested N times.
+          - source_labels: [__meta_kubernetes_pod_node_name]
+            target_label: __host__
+          - action: keep
+            source_labels: [__meta_kubernetes_pod_node_name]
+            regex: ^${HOSTNAME}$
+          # The dashboard contract. OTLP-emitted entries already carry their own
+          # service_name from OTEL resource attributes; both populate the same
+          # Loki label, exactly as compose_service does in the compose tier.
+          - source_labels: [__meta_kubernetes_pod_label_app]
+            target_label: service_name
+          - source_labels: [__meta_kubernetes_pod_container_name]
+            target_label: container
+          # Fall back to the container name when a pod carries no app label,
+          # so an unlabelled pod's logs are still queryable rather than
+          # arriving with an empty selector.
+          - source_labels: [service_name]
+            regex: ^$
+            replacement: $1
+            target_label: service_name
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: pod
+          # Where the log files actually are, keyed by the UID/container path
+          # kubelet uses.
+          - source_labels: [__meta_kubernetes_pod_uid, __meta_kubernetes_pod_container_name]
+            separator: /
+            target_label: __path__
+            replacement: /var/log/pods/*$1/*.log
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: promtail
+  namespace: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: promtail
+  template:
+    metadata:
+      labels:
+        app: promtail
+    spec:
+      serviceAccountName: promtail
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: promtail
+          image: grafana/promtail:3.4.2
+          args:
+            - -config.file=/etc/promtail/config.yaml
+            # Lets ${HOSTNAME} in the config resolve, which is what scopes
+            # discovery to this node.
+            - -config.expand-env=true
+          env:
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - {name: config, mountPath: /etc/promtail}
+            - {name: positions, mountPath: /run/promtail}
+            - {name: pods, mountPath: /var/log/pods, readOnly: true}
+            # /var/log/pods entries are symlinks into here; without it the
+            # tail resolves to a dangling link and silently reads nothing.
+            - {name: containers, mountPath: /var/log/containers, readOnly: true}
+          resources:
+            requests: {cpu: 50m, memory: 64Mi}
+            limits: {memory: 256Mi}
+      volumes:
+        - {name: config, configMap: {name: promtail-config}}
+        - {name: positions, hostPath: {path: /run/promtail, type: DirectoryOrCreate}}
+        - {name: pods, hostPath: {path: /var/log/pods}}
+        - {name: containers, hostPath: {path: /var/log/containers}}


### PR DESCRIPTION
Part of #1618 — phases 1 and 2 of 4.

## The problem

Until now the **only** observability manifest in `local-setup/k8s/` was `tools/gatus.yaml`. No Prometheus, Grafana, Loki, Promtail, Tempo, otel-collector or node-exporter.

That was confusing rather than merely incomplete: the Gatus config is kept byte-identical across tiers *with CI enforcing it* — signalling "these tiers should match" — while every other observability component silently did not exist here.

## What this adds

| Phase | State |
|---|---|
| 1 · Metrics — Prometheus, node-exporter DaemonSet, Grafana | **done** |
| 2 · Logs — Loki, Promtail DaemonSet | **done** |
| 3 · Traces | not done — see below |
| 4 · Gatus wire-up | blocked — see below |

Off by default behind `MONITORING=true`, and never in CI: that run asserts a fixed set of resources come up healthy, and five more would slow it and broaden what can flake without testing anything CI exists to test.

Config is generated from `local-setup/otel/` — the same files the compose tier uses — so the tiers cannot drift. Two deliberate exceptions, both annotated inline: **Promtail's discovery half is rewritten** (k3s runs containerd; there is no Docker socket), and **Prometheus adds a kubelet/cadvisor job** because container CPU/memory comes from the kubelet here, not a Docker daemon. Job *names* are preserved so existing dashboards resolve unchanged.

## Validated by running it, not by dry-run

I stood up a real k3s cluster and deployed against it. That is the only reason the following were caught — every one of them is silent or misleading on paper:

**1. `--web.enable-lifecycle=false` crash-loops Prometheus.** The flag parser rejects the explicit `false` with `unexpected false`. Omission is the only correct spelling — and the default is already off, which is what #1608 wants anyway.

**2. `mountPropagation: HostToContainer` on `/` makes the kubelet refuse to create the node-exporter container** wherever `/` is not a shared or slave mount — notably k3s inside Docker, which is how this tier is developed locally:
```
path "/" is mounted on "/" but it is not a shared or slave mount
```
Dropped. A node-exporter that cannot start reports nothing; one that misses a later-mounted filesystem reports slightly less.

**3. Grafana loaded ZERO dashboards while appearing perfectly healthy** — `Running`, `1/1`, health endpoint 200 — because the JSONs were mounted outside the provider's path. They are now mounted as *subdirectories of* that path, which the file provider walks recursively, so `dashboards.yaml` is reused verbatim rather than forked for this tier.

**4. The 456 KB node-exporter dashboard cannot be applied client-side at all.** This one the issue predicted but under-diagnosed. `kubectl apply` copies the whole object into the `last-applied-configuration` **annotation**, capped at **256 KiB**:
```
ConfigMap "grafana-dash-node" is invalid: metadata.annotations:
Too long: must have at most 262144 bytes
```
It fails well below the ~1 MiB *object* limit — so one-ConfigMap-per-dashboard (#1618 item 4) does **not** avoid it: the largest single dashboard already exceeds the annotation cap on its own. `Tiltfile.k8s` applies that one **server-side**, which does not use the annotation.

## Evidence from the cluster

- all **5 pods Running, 0 restarts**, from a clean from-scratch apply
- Prometheus targets `node` and `kubelet-cadvisor` **up**, with `instance` relabelled to the **node name** (not the ephemeral pod, which would break dashboard continuity on every reschedule)
- node-exporter serving **73** host metric series
- Loki receiving logs with **`service_name` populated** — `[coredns, grafana, local-path-provisioner, loki, node-exporter, prometheus, promtail]`. That label is the *only* one `loki-logs.json` selects on, so getting it wrong would leave the dashboard silently empty on this tier
- Grafana loading **all 4 dashboards**, provisioning **all 3 datasources**, and **refusing anonymous access with 401** — this tier does not reintroduce what #1602 closed
- `check-gatus-coverage.py` still passes; static tests 35/35

## Deliberately not done

**Phase 3 (traces).** Deploying a collector alone yields empty dashboards: `grep OTEL_ k8s/{core,app}-services/*.yaml` returns nothing, so no service in this tier emits telemetry. Making it real means per-service OTEL env across ~20 Deployments, including the compose tier's deliberate exceptions (`egov-localization` metrics-only to avoid ~200 MB of agent heap; OTP/SMS off entirely). That is the same work as #1646 and should follow the same decisions rather than be guessed at here. The `otel-collector` scrape target correspondingly shows **down** — honest rather than silently absent.

**Phase 4 (Gatus wire-up).** `GATUS_OBSERVABILITY` is introduced by #1613 (PR #1636), not merged. Flagged for whoever does it: **the endpoints will need namespaced DNS** — Gatus runs in `digit`, this stack in `monitoring`, so `http://grafana:3000` does not resolve; it needs `grafana.monitoring.svc.cluster.local`.

## Before enabling

```
kubectl -n monitoring create secret generic grafana-admin \
  --from-literal=password='<choose one>'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
