### PR TITLE
fix(ansible): make config changes actually reach running containers (#1683)

### DIFF
--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -1882,6 +1882,51 @@
         | list | length > 0
       changed_when: true
 
+    # Same failure mode as Kong, one hop further down (#1683). The OpenTelemetry
+    # Collector reads --config once at startup and does not watch the file, and
+    # nothing else recreates it on a routine redeploy: unlike gatus/grafana it
+    # declares no `environment:` at all, so the ".env changed" recreate above
+    # never selects it. Result: otel-collector-config.yaml now correctly lands
+    # on disk and inside the container -- and is still not applied.
+    #
+    # Gatus is deliberately NOT restarted here. It watches its config file and
+    # reloads itself, which the --inplace sync above is what makes possible: the
+    # watcher follows the mounted inode, so the old rename-over-the-top swap was
+    # invisible to it. A restart would also drop its uptime history for no gain.
+    # prometheus.yml is handled separately by its own SIGHUP reload (#1608).
+    #
+    # A restart, not a reload: the collector has no reload signal or admin
+    # endpoint. It is a few seconds of dropped telemetry, which is why the gate
+    # below is on the ONE file that matters rather than on the otel/ directory
+    # as a whole -- that directory also holds prometheus.yml, the Loki/Tempo/
+    # Promtail configs, the javaagent jar and every Grafana dashboard JSON, so a
+    # directory-level gate would bounce the collector on any dashboard tweak.
+    #
+    # synchronize's per-file itemized output is what makes the narrow gate
+    # possible: stdout_lines carries one rsync `>f.st...... <name>` line per
+    # changed file, and is empty when the dir is unchanged. Verified locally
+    # against ansible.posix.synchronize 2.2.2 + rsync 3.4.4: editing only
+    # prometheus.yml leaves this gate false while the item still reports
+    # changed=true; editing otel-collector-config.yaml flips it true.
+    - name: "OTEL Collector — restart when its config changed (#1683)"
+      ansible.builtin.shell: |
+        set -e
+        if [ -z "$(docker ps -q -f name='^digit-otel-collector$')" ]; then
+          echo "NOCHANGE collector not running"
+          exit 0
+        fi
+        docker restart digit-otel-collector
+      args:
+        executable: /bin/bash
+      register: otel_collector_restart
+      changed_when: "'NOCHANGE' not in otel_collector_restart.stdout"
+      when: >-
+        config_sync.results | default([])
+        | selectattr('item.key', 'equalto', 'otel')
+        | map(attribute='stdout_lines') | flatten
+        | select('search', 'otel-collector-config')
+        | list | length > 0
+
     # ==================== Wait for Persister (Kafka consumer) ====================
     - name: Wait for egov-persister to be healthy
       shell: docker inspect --format '{{ "{{" }}.State.Health.Status{{ "}}" }}' egov-persister

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -1200,6 +1200,44 @@
       synchronize:
         src: "{{ item.value }}/"
         dest: "{{ digit_dir }}/{{ item.key }}/"
+        # --inplace is load-bearing (#1683), not a performance tweak.
+        #
+        # rsync's default is to write a temp file and rename it over the
+        # destination. That REPLACES THE INODE. Several of these files are
+        # bind-mounted into containers individually (kong.yml, gatus/config.yaml,
+        # otel-collector-config.yaml, prometheus.yml, the nginx *-proxy.conf
+        # files), and a single-file bind mount is bound to the inode it was
+        # created with -- not to the path. Once rsync swaps the inode, the
+        # running container keeps reading the OLD file forever.
+        #
+        # This is a silent-success failure: the file on disk is correct, the
+        # playbook is green, and `kong reload` even reports success, while the
+        # gateway carries on serving the previous policy. It was found with Kong
+        # running an 11-day-old kong.yml -- still proxying routes that had been
+        # deleted -- because nothing recreates Kong when only kong.yml changes.
+        # Most other services self-heal only because they happen to be recreated
+        # by the "Recreate services with the new env" task below.
+        #
+        # --inplace writes into the existing file, so the inode survives and the
+        # container sees the update. Verified on a real box: default rsync
+        # changed the inode and the container never saw the new content;
+        # --inplace kept it (6665 -> 6665) and the container saw it immediately.
+        #
+        # The trade: an interrupted transfer can leave a partially-written
+        # config where the default would have left the previous file intact. For
+        # small text configs written by a deploy that health-checks afterwards,
+        # a config that is actually applied beats one that is atomically stale.
+        #
+        # delay_updates MUST be false alongside it. ansible's synchronize adds
+        # --delay-updates by default, and rsync refuses the combination outright:
+        #   "rsync: --inplace cannot be used with --delay-updates"
+        # which fails every item in this loop and aborts the deploy at this task.
+        # (--delay-updates is the very batch-then-rename behaviour we are
+        # removing, so turning it off is the point, not a workaround.)
+        delay_updates: false
+        rsync_opts:
+          - "--inplace"
+      register: config_sync
       loop: "{{ digit_config_dirs | dict2items }}"
       vars:
         digit_config_dirs:
@@ -1819,6 +1857,30 @@
       delay: 10
       until: kong_health.stdout == 'healthy'
       changed_when: false
+
+    # Kong is DB-less: it loads kong.yml once at startup and does not watch it.
+    # So a changed kong.yml is PRESENT but not APPLIED until Kong re-reads it,
+    # and nothing else in this playbook recreates Kong when only its config
+    # changed (unlike the app services, which the recreate task above covers).
+    #
+    # Without this, a tightened auth or RBAC rule silently does not take effect
+    # -- the file is right, the deploy is green, and the gateway keeps serving
+    # the previous policy (#1683).
+    #
+    # `kong reload` is used rather than a container recreate because it is
+    # Kong's documented zero-downtime path: workers are replaced gracefully, so
+    # in-flight API calls are not dropped. It only works because the --inplace
+    # sync above keeps the mounted file current; with the default rsync the
+    # reload re-reads a stale inode and reports success while changing nothing.
+    - name: "Kong — reload declarative config when kong.yml changed (#1683)"
+      ansible.builtin.command:
+        cmd: docker exec kong-gateway kong reload
+      when: >-
+        config_sync.results | default([])
+        | selectattr('item.key', 'equalto', 'kong')
+        | selectattr('changed', 'defined') | selectattr('changed')
+        | list | length > 0
+      changed_when: true
 
     # ==================== Wait for Persister (Kafka consumer) ====================
     - name: Wait for egov-persister to be healthy


### PR DESCRIPTION
Closes #1683

Found while verifying #1607 on the devbox — the fix was correct but had no effect on a running deployment.

## The bug

After a green deploy, Kong was still serving routes deleted from `kong.yml`. The container was reading an **11-day-old copy**, and `kong reload` reported success while changing nothing, because it re-read that same stale file.

**Cause:** the config-dir sync uses rsync, which writes a temp file and renames it over the destination — **replacing the inode**. Several of these files are bind-mounted into containers *individually* (`kong.yml`, `gatus/config.yaml`, `otel-collector-config.yaml`, `prometheus.yml`, the nginx `*-proxy.conf` files), and a single-file bind mount is bound to the **inode, not the path**. Once rsync swaps it, the container keeps reading the old file forever.

Proven in isolation rather than inferred:

| Write method | Container sees |
|---|---|
| in-place (`>` redirect) | new content ✅ |
| **atomic (temp + rename)** | **old content** ❌ |
| after container recreate | new content ✅ |

| rsync mode | Host inode | Container sees update |
|---|---|---|
| default | changed | **no** |
| `--inplace` | **unchanged** (6665 → 6665) | **yes** |

## Why it matters

It's a **silent-success** failure — file on disk correct, playbook green, reload reporting OK, gateway running the old policy. Worst for `kong.yml`, which carries the **auth and RBAC policy**: a tightened rule can appear deployed and simply not be in force. That's precisely what the RBAC work in #1255 needs to be able to trust.

Most services self-heal only because they happen to be recreated by the "Recreate services with the new env" task. **Nothing recreates Kong when only its config changed.**

## The change

1. **`--inplace`** on the config sync, so updates keep the inode and reach running containers.
   **`delay_updates: false` is required with it** — ansible's `synchronize` adds `--delay-updates` by default and rsync rejects the combination outright (`--inplace cannot be used with --delay-updates`), failing every item and aborting the deploy at that task. I hit exactly that on the first run; it's why this needs a real deploy to validate, not just review.
2. **Reload Kong when `kong.yml` changed**, so the policy is applied rather than merely present. `kong reload` rather than a recreate — it's Kong's documented zero-downtime path, and it only works because `--inplace` keeps the mounted file current.

## Trade-off, stated plainly

`--inplace` writes directly into the destination, so an interrupted transfer can leave a **partially-written config** where the default would have left the previous file intact. For small text configs written by a deploy that health-checks afterwards, a config that is actually applied beats one that is atomically stale. But it is a real trade, not a free win.

## Verified end to end on the devbox

Renamed a live Kong route in source and deployed:

- in-container file updated with **no recreate** — Kong stayed `Up 22 minutes`
- host and container copies **identical** afterwards
- old path → **404**, new path → served
- real API routes (`/egov-mdms-service/health`) → **200** across the reload
- the new task fires **only on change** (`changed: [karun]`)
- full run **ok=126, changed=20, failed=0**; 43 containers, 0 unhealthy
- #1605 / #1606 / #1607 / #1625 all still holding afterwards

## Note for anyone auditing this themselves

Several images are distroless, so `docker exec md5sum` fails and its error text can be mistaken for a hash mismatch — that produced a false positive on my first sweep. Compare with `docker cp` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
