### PR TITLE
fix(ci): repair the static-test and tilt-test checks failing on every PR

### DIFF
--- a/.github/workflows/tilt-ci.yaml
+++ b/.github/workflows/tilt-ci.yaml
@@ -231,8 +231,16 @@ jobs:
           # attached to an empty project, a missing start event is a real
           # regression; if containers were already running, it is not evidence
           # of anything.
-          RUNNING_AT_ATTACH=$(echo "$LOGS" | grep -oE 'running=[0-9]+' | head -1 | cut -d= -f2)
-          RUNNING_AT_ATTACH=${RUNNING_AT_ATTACH:-0}
+          # Matched in-shell rather than `grep ... | head -1`. head closes the
+          # pipe after the first line, so grep can take SIGPIPE and return 141 --
+          # harmless today (this workflow runs under `bash -e`, no pipefail) but
+          # it would abort the step the moment anyone adds pipefail, which four
+          # other workflows in this repo already set. No pipe, no race.
+          if [[ "$LOGS" =~ running=([0-9]+) ]]; then
+            RUNNING_AT_ATTACH="${BASH_REMATCH[1]}"
+          else
+            RUNNING_AT_ATTACH=0
+          fi
           START_COUNT=$(echo "$LOGS" | grep -c '\[telemetry\] +' || true)
           echo "  Container start events: $START_COUNT"
           if [ "$RUNNING_AT_ATTACH" -gt 0 ]; then

--- a/.github/workflows/tilt-ci.yaml
+++ b/.github/workflows/tilt-ci.yaml
@@ -219,11 +219,26 @@ jobs:
           # captures fewer events than the long-running docker compose job.
           # Verify the sidecar started and is capturing events (>=1 each).
 
-          # Must have at least 1 start event
+          # Start events are only observable if the sidecar attaches BEFORE the
+          # containers come up. Under `tilt ci` it usually does not: tilt brings
+          # the stack up and the sidecar then attaches to an already-running
+          # project, logging e.g. "running=29 containers" before it begins
+          # monitoring. There are no starts left to see, so asserting >=1
+          # unconditionally makes this job fail or pass on a race -- which is
+          # exactly what it has been doing across the repo.
+          #
+          # So assert it only when it is actually observable: if the sidecar
+          # attached to an empty project, a missing start event is a real
+          # regression; if containers were already running, it is not evidence
+          # of anything.
+          RUNNING_AT_ATTACH=$(echo "$LOGS" | grep -oE 'running=[0-9]+' | head -1 | cut -d= -f2)
+          RUNNING_AT_ATTACH=${RUNNING_AT_ATTACH:-0}
           START_COUNT=$(echo "$LOGS" | grep -c '\[telemetry\] +' || true)
           echo "  Container start events: $START_COUNT"
-          if [ "$START_COUNT" -lt 1 ]; then
-            echo "  FAIL: expected at least 1 start event"
+          if [ "$RUNNING_AT_ATTACH" -gt 0 ]; then
+            echo "  (not asserted — sidecar attached with $RUNNING_AT_ATTACH containers already running, so starts were unobservable)"
+          elif [ "$START_COUNT" -lt 1 ]; then
+            echo "  FAIL: expected at least 1 start event (sidecar attached to an empty project, so starts should have been visible)"
             FAIL=1
           fi
 

--- a/local-setup/tests/static/deployment-contracts.test.ts
+++ b/local-setup/tests/static/deployment-contracts.test.ts
@@ -46,11 +46,16 @@ describe('ansible playbook-deploy.yml', () => {
 
   // HRMS crash-loops on non-pg tenants without the INTERNAL_USER system
   // user at state_root (its startup lookup is tenant-scoped).
+  // Asserts the BEHAVIOUR, not the task's display name. This test originally
+  // pinned the exact task title and the payload's YAML form; c0a21204 rewrote
+  // the task as a retrying curl POST — on the same day the test landed — and
+  // broke both assertions without changing what they were protecting. The
+  // invariant that matters is simply: INTERNAL_USER gets created at
+  // state_root. Pin that, so a rename or a re-implementation does not.
   test('seeds INTERNAL_USER on state_root after bootstrap', () => {
-    expect(playbook).toContain(
-      'post-bootstrap — seed INTERNAL_USER system user on state_root for HRMS'
-    );
-    expect(playbook).toContain('userName: INTERNAL_USER');
+    expect(playbook).toContain('seed INTERNAL_USER on state_root');
+    expect(playbook).toContain('"userName":"INTERNAL_USER"');
+    expect(playbook).toContain('"tenantId":"{{ state_root }}"');
   });
 
   // The HRMS prereq gate ships hardcoded to tenant pg; without the

--- a/local-setup/tests/static/deployment-contracts.test.ts
+++ b/local-setup/tests/static/deployment-contracts.test.ts
@@ -46,16 +46,37 @@ describe('ansible playbook-deploy.yml', () => {
 
   // HRMS crash-loops on non-pg tenants without the INTERNAL_USER system
   // user at state_root (its startup lookup is tenant-scoped).
+  //
   // Asserts the BEHAVIOUR, not the task's display name. This test originally
   // pinned the exact task title and the payload's YAML form; c0a21204 rewrote
   // the task as a retrying curl POST — on the same day the test landed — and
-  // broke both assertions without changing what they were protecting. The
-  // invariant that matters is simply: INTERNAL_USER gets created at
-  // state_root. Pin that, so a rename or a re-implementation does not.
+  // broke both assertions without changing what they were protecting.
+  //
+  // Scoped to the request payload rather than scanning the whole playbook.
+  // Three loose `toContain` calls would pass if userName and tenantId lived in
+  // two unrelated tasks — they would prove both strings exist somewhere, not
+  // that INTERNAL_USER is created AT state_root, which is the actual invariant.
+  // Parsing the one payload that mentions INTERNAL_USER checks the fields
+  // together, and survives task renames, field reordering and whitespace.
   test('seeds INTERNAL_USER on state_root after bootstrap', () => {
-    expect(playbook).toContain('seed INTERNAL_USER on state_root');
-    expect(playbook).toContain('"userName":"INTERNAL_USER"');
-    expect(playbook).toContain('"tenantId":"{{ state_root }}"');
+    // The Jinja expressions sit inside JSON string values, so the body is
+    // still valid JSON — `{{ state_root }}` parses as a plain string.
+    const payloads = [...playbook.matchAll(/body='(\{.*?\})'\s*$/gm)]
+      .map((m) => m[1])
+      .filter((b) => b.includes('INTERNAL_USER'));
+
+    // Exactly one — two would mean a duplicate seed path, and this test would
+    // silently only be covering whichever came first.
+    expect(payloads).toHaveLength(1);
+
+    const user = JSON.parse(payloads[0]).User;
+    expect(user.userName).toBe('INTERNAL_USER');
+    expect(user.tenantId).toBe('{{ state_root }}');
+    // SYSTEM is what makes HRMS's startup lookup accept it.
+    expect(user.type).toBe('SYSTEM');
+    // The role is tenant-scoped too; on `pg` it would not satisfy the lookup.
+    const roleTenants = (user.roles as Array<{ tenantId: string }>).map((r) => r.tenantId);
+    expect(roleTenants).toEqual(['{{ state_root }}']);
   });
 
   // The HRMS prereq gate ships hardcoded to tenant pg; without the

--- a/local-setup/tests/static/infra-contracts.test.ts
+++ b/local-setup/tests/static/infra-contracts.test.ts
@@ -102,12 +102,19 @@ describe('image pin immutability', () => {
   // this many times, no more, no less — extras, duplicates, AND removals
   // all fail the test until this list is updated to match. The list IS
   // the changelog of this debt; it may shrink, never grow.
+  //
+  // Renamed wholesale to the `egovio/*` Docker Hub org by e6323a09
+  // ("chore(compose): move all image refs to egovio Docker Hub org"). The
+  // count is unchanged at seven — same images, same debt, new owner — so this
+  // update records a rename, not a relaxation. (Note the pre-rename names
+  // still appear in docker-compose.{yml,deploy.yaml,db-migrations.yml}, which
+  // this test does not read: it scans the base compose only.)
   const FROZEN_LATEST_DEBT: Record<string, number> = {
-    'edoburu/pgbouncer:latest': 1,
-    'tilt-demo-db-migrations:latest': 1,
-    'curlimages/curl:latest': 2, // two gate containers
-    'twinproduction/gatus:latest': 1,
-    'tilt-demo-jupyter:latest': 1,
+    'egovio/pgbouncer:latest': 1,
+    'egovio/tilt-demo-db-migrations:latest': 1,
+    'egovio/curl:latest': 2, // two gate containers
+    'egovio/gatus:latest': 1,
+    'egovio/tilt-demo-jupyter:latest': 1,
     'openbao/openbao:latest': 1,
     'egovio/novu-bridge-endpoint:latest': 1,
   };


### PR DESCRIPTION
**Fixes the two checks that this PR can actually turn green.** Step 0 of the merge plan in #1601.

> The `Local Setup CI / test` job is **deliberately out of scope** — see *Deferred* below. It fails on every PR in the repo today and continues to; this PR neither fixes nor worsens it.

---

## 1 · Static tests — two assertions describing a state the repo moved past

**Frozen `:latest` debt list.** `e6323a09` renamed every image to the `egovio/*` org; the list still named the old owners.

```diff
-    'edoburu/pgbouncer:latest': 1,
-    'curlimages/curl:latest': 2,
+    'egovio/pgbouncer:latest': 1,
+    'egovio/curl:latest': 2,
```

**Count unchanged at seven** — same images, same debt, new owner. A rename, not a relaxation.

**`INTERNAL_USER` seeding.** The test pinned the task's *display name*; `c0a21204` rewrote the task as a retrying curl POST — the same day the test landed — breaking it without changing what it protected.

Now scoped to the request payload. The Jinja expressions sit inside JSON string values, so the body is valid JSON and `{{ state_root }}` parses as a plain string:

```ts
const user = JSON.parse(payloads[0]).User;
expect(user.userName).toBe('INTERNAL_USER');
expect(user.tenantId).toBe('{{ state_root }}');
expect(user.type).toBe('SYSTEM');
```

Three loose `toContain` calls would have passed with the two fields in unrelated tasks — proving each string exists *somewhere*, not that the user is created **at** state_root.

**Mutation-tested:** user `tenantId` → `pg` **caught**; `type` → `CITIZEN` **caught**; role `tenantId` → `pg` **caught**; **task renamed → survives**, which was the original bug.

## 2 · `Tilt CI / tilt-test` — asserts an event that is usually unobservable

Required ≥1 container **start** event. Whether one exists is a race — the sidecar's own log says so immediately before the assertion:

```
[telemetry] running=29 containers
[telemetry] Monitoring container events...
```

`tilt ci` brings the stack up, *then* the sidecar attaches. With 29 containers already running there are no starts left to observe, so the check tested scheduling order. That produced fail on #1638/#1407/#1685 and pass on #1654/#1584, unrelated to the change under test.

Now asserted **only when observable**: empty project with no start still **fails** (a real regression); already-running **skips**, printing the count and reason.

| Scenario | Result |
|---|---|
| 29 running, 0 starts *(the observed failure)* | passes, reason printed |
| empty project, 0 starts | **fails** — regression still caught |
| empty project, 1 start | passes |

✅ **`tilt-test` now passes on this PR.**

---

## Deferred: `Local Setup CI / test`

Work on this job was removed from this PR and preserved on **`ci/test-job-deferred`** for a follow-up. Two commits, both verified but neither sufficient to turn the job green:

- **`5c0c842c`** — the localization check asserts `egov-user`, a module `full-dump.sql` has **never** contained (checked every revision back to 17 July). Failing since `22a1457c` on 1 June.
- **`1324fcd2`** — `smoke/pgr-tenant.test.ts` built its locality as `LOC_${city}_1`, which matches no seeded boundary. Resolving it from `boundary_relationship` fixed the create — verified against the boundary service's own query (`W1_ADMIN_WARD` → found; `LOC_CITYA_1` → empty).

Together those got the job from step 12 to step 18 and past complaint creation, where it now fails at `should exist in database (10013 ms)` — a persistence/timing problem one layer deeper.

**Each fix has revealed the next.** That job needs its own PR with room to work through the chain, rather than growing this one.

---

## Verification

Static tests **35/35** on master (was 2 failed / 33 passed). `tilt-ci.yaml` parses; race-guard present. Gatus-coverage and flyway-alignment OK. No production code touched — two test files and one workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment contract validation by checking key user and tenant details rather than relying on task titles or formatting.
  * Updated infrastructure checks to recognize renamed container images.
  * Improved telemetry verification for projects with containers already running, while retaining validation for newly started containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->