### PR TITLE
fix(ci): unblock the two checks that fail on every PR

### DIFF
--- a/.github/workflows/tilt-ci.yaml
+++ b/.github/workflows/tilt-ci.yaml
@@ -219,11 +219,26 @@ jobs:
           # captures fewer events than the long-running docker compose job.
           # Verify the sidecar started and is capturing events (>=1 each).
 
-          # Must have at least 1 start event
+          # Start events are only observable if the sidecar attaches BEFORE the
+          # containers come up. Under `tilt ci` it usually does not: tilt brings
+          # the stack up and the sidecar then attaches to an already-running
+          # project, logging e.g. "running=29 containers" before it begins
+          # monitoring. There are no starts left to see, so asserting >=1
+          # unconditionally makes this job fail or pass on a race -- which is
+          # exactly what it has been doing across the repo.
+          #
+          # So assert it only when it is actually observable: if the sidecar
+          # attached to an empty project, a missing start event is a real
+          # regression; if containers were already running, it is not evidence
+          # of anything.
+          RUNNING_AT_ATTACH=$(echo "$LOGS" | grep -oE 'running=[0-9]+' | head -1 | cut -d= -f2)
+          RUNNING_AT_ATTACH=${RUNNING_AT_ATTACH:-0}
           START_COUNT=$(echo "$LOGS" | grep -c '\[telemetry\] +' || true)
           echo "  Container start events: $START_COUNT"
-          if [ "$START_COUNT" -lt 1 ]; then
-            echo "  FAIL: expected at least 1 start event"
+          if [ "$RUNNING_AT_ATTACH" -gt 0 ]; then
+            echo "  (not asserted — sidecar attached with $RUNNING_AT_ATTACH containers already running, so starts were unobservable)"
+          elif [ "$START_COUNT" -lt 1 ]; then
+            echo "  FAIL: expected at least 1 start event (sidecar attached to an empty project, so starts should have been visible)"
             FAIL=1
           fi
 

--- a/local-setup/scripts/ci-localization-check.sh
+++ b/local-setup/scripts/ci-localization-check.sh
@@ -17,10 +17,26 @@ echo ""
 
 # Core modules that must have messages for PGR to function.
 # These are the modules actually seeded by the full-dump.sql load.
+#
+# `egov-user` was listed here from the start (22a1457c) and has never passed:
+# full-dump.sql contains NO egov-user rows, and never has -- checked back
+# through every revision of the dump. The module distribution it does carry is
+# rainmaker-pgr (852), rainmaker-common (734), rainmaker-hr (244),
+# rainmaker-workbench (228), digit-privacy-policy (5), egov-hrms (2).
+#
+# So this check has failed on every PR in the repo since it landed, which is
+# worse than not having it: a check that is always red is one nobody reads, and
+# it masked the real signal on ~37 monitoring PRs.
+#
+# Removed rather than "fixed" by seeding, because nothing appears to want it --
+# the SPA requests rainmaker-common, rainmaker-pgr, rainmaker-dashboard,
+# rainmaker-boundary-admin, egov-hrms and egov-mdms-service, not egov-user.
+# If those messages ARE required, seeding them is a dump change and belongs in
+# its own PR; this list is documented as "modules actually seeded", so it should
+# describe reality either way.
 MODULES=(
   "rainmaker-common"
   "rainmaker-pgr"
-  "egov-user"
 )
 
 LOCALE="en_IN"


### PR DESCRIPTION
Two checks fail on **every** PR in this repo, including ones touching nothing related. Neither is caused by the change under test, and between them they have been masking the real signal on ~37 PRs in flight.

Verified they are repo-wide before touching anything:

| PR | author | `test` | `tilt-test` |
|---|---|---|---|
| #1638 | @dhruv-1001 | fail | fail |
| #1654 | @ChakshuGautam | fail | pass |
| #1584 | @Hari-egov | fail | pass |
| #1407 | @soniikajal | fail | fail |

---

## 1. `Local Setup CI / test` — asserts a module that was never seeded

```
[FAIL] egov-user — 0 messages (module not seeded)
```

`ci-localization-check.sh` requires three modules to have messages. **`full-dump.sql` contains no `egov-user` rows, and never has** — I checked every revision of the dump back through 17 July; all zero. So this has failed since it landed in `22a1457c` on 1 June.

What the dump actually carries:

| module | rows |
|---|---|
| `rainmaker-pgr` | 852 |
| `rainmaker-common` | 734 |
| `rainmaker-hr` | 244 |
| `rainmaker-workbench` | 228 |
| `digit-privacy-policy` | 5 |
| `egov-hrms` | 2 |

The list's own comment claims it names *"the modules actually seeded by the full-dump.sql load"* — untrue for `egov-user`.

**Removed rather than seeded**, because nothing appears to want it: the SPA requests `rainmaker-common`, `rainmaker-pgr`, `rainmaker-dashboard`, `rainmaker-boundary-admin`, `egov-hrms` and `egov-mdms-service` — not `egov-user`. If those messages *are* required, seeding them is a dump change and belongs in its own PR. Either way the list should describe reality.

The two remaining modules are the substantial ones (1,586 rows between them) and still catch what this check exists for: a dump that did not load.

## 2. `Tilt CI / tilt-test` — asserts an event that is usually unobservable

The job requires ≥1 container **start** event from the telemetry sidecar. Whether one exists is a race — `tilt ci` brings the stack up, and the sidecar then attaches to an already-running project. Its own log says so, immediately before the assertion:

```
[telemetry] running=29 containers
[telemetry] Monitoring container events...
```

With 29 containers already up there are no starts left to see, so the check tests scheduling order rather than the sidecar. The comment directly above it already acknowledged that `tilt ci` "captures fewer events" — then required one anyway. That is exactly the pass/fail split in the table above.

Now asserted **only when observable**:

- sidecar attached to an **empty** project, no start event → still **fails** (a real regression)
- containers already running → **skipped**, with the count and reason printed so nothing is lost

Healthy-event and setup-event assertions are unchanged.

## Verification

The shell logic was extracted and run against all three shapes using the real log format:

| Scenario | Result |
|---|---|
| 29 running, 0 starts *(the observed failure)* | passes, reason printed |
| empty project, 0 starts | **fails** — regression still caught |
| empty project, 1 start | passes |

Localization script passes `bash -n`; the workflow parses as YAML.

## What this does not do

It does not make `egov-user` localization exist. If PGR genuinely needs those messages, this PR makes that gap *visible as a gap* rather than as permanent CI noise — but someone should decide, and seeding is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
