### PR TITLE
feat(pgr): send Supervisor/Case-Manager assignee on citizen reopen & rate (CCSD-2167)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Rating/SelectRating.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Rating/SelectRating.js
@@ -15,6 +15,7 @@ import {
 
 import { updateComplaints } from "../../../redux/actions/index";
 import { mergeAdditionalDetail } from "../../../utils/additionalDetail";
+import { findLatestAssigneeUuidByRole } from "../../../utils/workflowAssignee";
 
 // i18n fallback — when a translation key is unavailable, surface the
 // English copy instead of leaving a raw constant on screen.
@@ -180,10 +181,20 @@ const SelectRating = ({ parentRoute }) => {
       complaintDetails.service.additionalDetail,
       { ratingFeedback: selections.join(",") }
     );
+    // CCSD-2167: a rating routes the complaint to the CASE MANAGER who last
+    // handled it, found by walking the workflow history for CMS_CASE_MANAGER.
+    // Omit assignes entirely when none is found (a complaint with no case
+    // manager in its history, or the standard non-CMS workflow) so the payload
+    // stays identical to the pre-2167 behaviour. hrmsAssignes mirrors assignes,
+    // matching the employee ASSIGN payload (PGRDetails.js).
+    const stateCode = Digit.ULBService.getStateId();
+    const businessId = complaintDetails?.service?.serviceRequestId || id;
+    const caseManagerUuid = await findLatestAssigneeUuidByRole(stateCode, businessId, "CMS_CASE_MANAGER");
     complaintDetails.workflow = {
       action: "RATE",
       comments,
       verificationDocuments: [],
+      ...(caseManagerUuid ? { assignes: [caseManagerUuid], hrmsAssignes: [caseManagerUuid] } : {}),
     };
 
     try {

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ReopenComplaint/AddtionalDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ReopenComplaint/AddtionalDetails.js
@@ -9,6 +9,7 @@ import { BackButton, Card, CardHeader, CardText, CardLabelError, TextArea, Submi
 import { updateComplaints } from "../../../redux/actions/index";
 import { LOCALIZATION_KEY } from "../../../constants/Localization";
 import { mergeAdditionalDetail } from "../../../utils/additionalDetail";
+import { findLatestAssigneeUuidByRole } from "../../../utils/workflowAssignee";
 
 const AddtionalDetails = (props) => {
   const history = useHistory();
@@ -51,13 +52,19 @@ const AddtionalDetails = (props) => {
     [dispatch, queryClient]
   );
 
-  const getUpdatedWorkflow = (reopenDetails, type) => {
+  // CCSD-2167: reopen routes the complaint back to the SUPERVISOR who handled
+  // it. `assignes` defaults to [] so a complaint with no supervisor in its
+  // history (e.g. rejected at the screening stage, or the standard non-CMS
+  // workflow) keeps the pre-2167 behaviour. hrmsAssignes mirrors assignes,
+  // matching the employee ASSIGN payload (PGRDetails.js).
+  const getUpdatedWorkflow = (reopenDetails, type, assignes = []) => {
     switch (type) {
       case "REOPEN":
         return {
           action: "REOPEN",
           comments: reopenDetails.addtionalDetail,
-          assignes: [],
+          assignes,
+          hrmsAssignes: assignes,
           verificationDocuments: reopenDetails.verificationDocuments,
         };
       default:
@@ -65,7 +72,7 @@ const AddtionalDetails = (props) => {
     }
   };
 
-  function reopenComplaint() {
+  async function reopenComplaint() {
     // CCSD-2082 Issue 3: require a non-empty explanation before reopening.
     if (!details || !details.trim()) {
       setError(true);
@@ -73,10 +80,16 @@ const AddtionalDetails = (props) => {
     }
     let reopenDetails = Digit.SessionStorage.get(`reopen.${id}`);
     if (complaintDetails) {
+      // CCSD-2167: find the Supervisor from the complaint's workflow history.
+      const stateCode = Digit.ULBService.getStateId();
+      const businessId = complaintDetails?.service?.serviceRequestId || id;
+      const supervisorUuid = await findLatestAssigneeUuidByRole(stateCode, businessId, "CMS_SUPERVISOR");
+      const assignes = supervisorUuid ? [supervisorUuid] : [];
       complaintDetails.workflow = getUpdatedWorkflow(
         reopenDetails,
         // complaintDetails,
-        "REOPEN"
+        "REOPEN",
+        assignes
       );
       // CCSD-2012: MERGE the reopen reason into additionalDetail instead of
       // replacing the object. Replacing dropped the `department` stamped at

--- a/digit-ui-esbuild/products/pgr/src/utils/workflowAssignee.js
+++ b/digit-ui-esbuild/products/pgr/src/utils/workflowAssignee.js
@@ -1,0 +1,63 @@
+import { WorkflowService } from "../services/workflow/Workflow";
+
+// CCSD-2167 — derive a workflow assignee UUID from the complaint's own history.
+//
+// When a citizen reopens or rates a complaint, the resulting workflow action
+// must be routed to a specific staff member:
+//   - Reopen  -> the SUPERVISOR   (CMS_SUPERVISOR)   who handled it
+//   - Rate Us -> the CASE MANAGER (CMS_CASE_MANAGER) who last handled it
+//
+// The person is found by walking the application's workflow history
+// (/egov-workflow-v2/egov-wf/process/_search?history=true). Every history
+// step's `assignes[]` (the user the step was routed TO) and `assigner` (the
+// actor) carry a structured `roles: [{ code }]` array and a `uuid` — verified
+// live on cms-pilot for BOTH an employee and a CITIZEN token, so the citizen
+// flows can read it. In the CMS workflow the Supervisor is the assignee of the
+// REFERRED step and the Case Manager is the assignee of the INVESTIGATION step;
+// matching by ROLE (rather than by state name) keeps this correct even if the
+// state graph changes, and makes it a natural no-op on the standard GRO/LME
+// workflow, whose history never contains these CMS roles (returns null -> the
+// callers fall back to today's behaviour: no assignee).
+
+const rolesOf = (user) => ((user && Array.isArray(user.roles)) ? user.roles : []).map((r) => r && r.code).filter(Boolean);
+
+/**
+ * Most-recent workflow-history participant holding `roleCode`, as a bare user
+ * UUID (the shape the PGR workflow payload's `assignes` expects), or null.
+ *
+ * `assignes` (routed-to) is preferred over `assigner` (actor) because the
+ * ticket's intent is "the complaint was assigned to this person"; assigner is
+ * a fallback so a role that only ever appears as an actor is still found.
+ *
+ * @param {string} stateCode  state tenant (workflow is searched at state level)
+ * @param {string} businessId complaint serviceRequestId
+ * @param {string} roleCode   e.g. "CMS_SUPERVISOR" | "CMS_CASE_MANAGER"
+ * @returns {Promise<string|null>}
+ */
+export const findLatestAssigneeUuidByRole = async (stateCode, businessId, roleCode) => {
+  if (!stateCode || !businessId || !roleCode) return null;
+  let response;
+  try {
+    response = await WorkflowService.getByBusinessId(stateCode, businessId, {}, true);
+  } catch (e) {
+    // Never block the citizen's reopen/rate on a history-fetch failure —
+    // fall back to no assignee (the pre-2167 behaviour).
+    return null;
+  }
+  const instances = Array.isArray(response && response.ProcessInstances) ? response.ProcessInstances : [];
+  // Most-recent first: "last handled" wins when a role appears across several
+  // steps (reassignment, repeated investigation rounds).
+  const ordered = [...instances].sort(
+    (a, b) => (b?.auditDetails?.lastModifiedTime || 0) - (a?.auditDetails?.lastModifiedTime || 0)
+  );
+  for (const pi of ordered) {
+    for (const a of pi?.assignes || []) {
+      if (a?.uuid && rolesOf(a).includes(roleCode)) return a.uuid;
+    }
+  }
+  // Fallback: the role only surfaced as the actor of a step.
+  for (const pi of ordered) {
+    if (pi?.assigner?.uuid && rolesOf(pi.assigner).includes(roleCode)) return pi.assigner.uuid;
+  }
+  return null;
+};


### PR DESCRIPTION
Implements CCSD-2167 "Send Assignee from UI".

## What it does
When a citizen acts on a complaint, the workflow action now carries a real assignee derived from the complaint's **own workflow history**:
- **Reopen** → the **Supervisor** (`CMS_SUPERVISOR`) who handled it
- **Rate Us** → the **Case Manager** (`CMS_CASE_MANAGER`) who last handled it

Before, reopen sent `assignes: []` and rate sent no `assignes` at all.

## How
New `products/pgr/src/utils/workflowAssignee.js` → `findLatestAssigneeUuidByRole(stateCode, businessId, roleCode)` walks the history (`WorkflowService.getByBusinessId` → `process/_search?history=true`) and returns the UUID of the most-recent participant with that role.

- **Matches by ROLE, not state name.** Verified live on cms-pilot that every history step's `assignes[]` (and `assigner`) carries a structured `roles:[{code}]` array **and** `uuid`, for **both an employee and a CITIZEN token** — so the citizen flows can read it. In the CMS workflow the Supervisor is the `REFERRED`-step assignee and the Case Manager the `INVESTIGATION`-step assignee.
- `assignes` (routed-to) preferred, `assigner` (actor) as fallback. "Most recent" by `auditDetails.lastModifiedTime` resolves reassignments / repeated investigation rounds.
- Payload shape is the PGR convention — bare-uuid array `["<uuid>"]` — and sets `hrmsAssignes` alongside `assignes`, mirroring the employee ASSIGN payload.

## Safe by construction
When the role isn't in the history — a complaint **rejected at the screening stage** that never reached a Supervisor, or the **standard non-CMS** GRO/LME workflow (whose history never contains these roles) — the lookup returns `null` and the payload falls back to **exactly** the pre-2167 behaviour (`assignes: []` on reopen, no `assignes` on rate). A history-fetch error swallows to the same fallback, so reopen/rate is never blocked.

## Verified
- esbuild build clean.
- **9/9 unit cases** on the selector against fixtures mirroring real cms-pilot histories: supervisor-from-REFERRED, case-manager-from-INVESTIGATION, most-recent-wins, role-absent→null, assigner-fallback, assignes-preferred-over-assigner, malformed→null, uuid-less→null.

## Edge cases / open points for review (see the ticket thread)
1. **Reopen target-state mismatch (backend, out of this PR's scope):** in the CMS config `REOPEN` from `RESOLVED` → `PENDINGFORASSIGNMENT` (a Screening-Officer state), while from `REJECTED` → `REFERRED` (the Supervisor's state). This PR stamps the Supervisor as assignee regardless; whether a Supervisor can *act* on a `PENDINGFORASSIGNMENT` complaint is a workflow-routing question for @pradeepkumarcm-egov.
2. **Rate lands on a terminal CLOSED state** — the Case-Manager assignee there is a record/ownership stamp, not an actionable routing.
3. **`hrmsAssignes`** is sent with the same uuid as `assignes` (employee-parity); confirm backend needs it for HRMS ownership vs `assignes` alone.
4. Applies to the citizen path; the same code runs if a Reception Officer uses these screens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)