### PR TITLE
fix(pgr): create-complaint crash — tenantId is not defined (regression from #1653)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
@@ -1688,7 +1688,7 @@ const CreatePGRFlowV2: React.FC = () => {
   // getPostalCodeErrorMessage() read FIRST. Without this, the v2 flow would
   // silently keep validating against the globalConfigs fallback while the
   // employee form honours the (higher-precedence) MDMS row.
-  Digit.Hooks.pgr.useMobileValidation(tenantId);
+  Digit.Hooks.pgr.useMobileValidation(baseTenant);
 
   // The single RAINMAKER-PGR.ComplaintHierarchy adjacency list (interior nodes
   // + leaf complaint types) is the only complaint-type master now. We derive:


### PR DESCRIPTION
## The crash
Every citizen **create-complaint** page (`/citizen/pgr/create-complaint/*`) throws at mount:
```
ReferenceError: tenantId is not defined
```
→ "Something went wrong". Live on cms-pilot now.

## Root cause — my #1653 master→moz merge
The promotion brought master's postal-code feature into `CreatePGRFlowV2.tsx`. Master's line `Digit.Hooks.pgr.useMobileValidation(tenantId)` was kept verbatim, but master's local `const tenantId = …` was **not** — moz's copy of the same component names that variable **`baseTenant`**. So `tenantId` was undefined at the call site and the component crashed on mount (the hook runs at the top, before any step renders, so it breaks the whole flow including the first `complaint-type` step).

## Fix
One line: `useMobileValidation(tenantId)` → `useMobileValidation(baseTenant)`.

`baseTenant` (line 1589) is `SessionStorage.get("CITIZEN.COMMON.HOME.CITY")?.code || Digit.ULBService.getCurrentTenantId()` — **byte-identical** to master's original `tenantId` definition, so the MDMS validation mirror receives exactly the tenant master intended.

## Verification
- Scope-audited the merged component: this was the **only** stray master variable. The merge's other addition (the postal Field's `effectivePincode` / `showPostalError`) is correctly defined in `Step2Location`.
- esbuild build clean.
- Runtime re-verify pending on cms-pilot after redeploy — local backend stack was down (would only have returned 502s), and I can't deploy to the box myself.

## Note
Not caused by #1688 (CCSD-2167); that only touched reopen/rate. This is purely the merge-resolution slip and is unrelated to the earlier "reopen blocked" report (which was the backend 10-day idle rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)