### PR TITLE
fix(pgr): RATE must not send an assignee — terminal transition 400s (CCSD-2167 follow-up)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Rating/SelectRating.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Rating/SelectRating.js
@@ -15,7 +15,6 @@ import {
 
 import { updateComplaints } from "../../../redux/actions/index";
 import { mergeAdditionalDetail } from "../../../utils/additionalDetail";
-import { findLatestAssigneeUuidByRole } from "../../../utils/workflowAssignee";
 
 // i18n fallback — when a translation key is unavailable, surface the
 // English copy instead of leaving a raw constant on screen.
@@ -181,20 +180,21 @@ const SelectRating = ({ parentRoute }) => {
       complaintDetails.service.additionalDetail,
       { ratingFeedback: selections.join(",") }
     );
-    // CCSD-2167: a rating routes the complaint to the CASE MANAGER who last
-    // handled it, found by walking the workflow history for CMS_CASE_MANAGER.
-    // Omit assignes entirely when none is found (a complaint with no case
-    // manager in its history, or the standard non-CMS workflow) so the payload
-    // stays identical to the pre-2167 behaviour. hrmsAssignes mirrors assignes,
-    // matching the employee ASSIGN payload (PGRDetails.js).
-    const stateCode = Digit.ULBService.getStateId();
-    const businessId = complaintDetails?.service?.serviceRequestId || id;
-    const caseManagerUuid = await findLatestAssigneeUuidByRole(stateCode, businessId, "CMS_CASE_MANAGER");
+    // CCSD-2167: the ticket asked for RATE to assign the complaint to the Case
+    // Manager. That is NOT achievable via the workflow: RATE transitions to a
+    // TERMINAL state (CLOSEDAFTERRESOLUTION / CLOSEDAFTERREJECTION), and
+    // egov-workflow-v2 rejects ANY assignee on a terminal transition —
+    // verified live on cms-pilot: sending the case-manager uuid returned
+    // 400 INVALID_ASSIGNEE ("Cannot assign to the user: <uuid>"), which would
+    // block the citizen's rating. So RATE sends no assignes (unchanged from
+    // pre-2167). Routing a rating to the Case Manager needs a backend change
+    // (allow an assignee on the RATE transition, or record it off-workflow) —
+    // tracked back to the ticket owner. The Reopen -> Supervisor half works and
+    // stays. See utils/workflowAssignee.js (still used by reopen).
     complaintDetails.workflow = {
       action: "RATE",
       comments,
       verificationDocuments: [],
-      ...(caseManagerUuid ? { assignes: [caseManagerUuid], hrmsAssignes: [caseManagerUuid] } : {}),
     };
 
     try {


### PR DESCRIPTION
Follow-up to #1688 (CCSD-2167). End-to-end verification on cms-pilot found the **Rate** half is not workflow-achievable.

## Finding
`RATE` transitions to a **terminal** state (`CLOSEDAFTERRESOLUTION` / `CLOSEDAFTERREJECTION`), and `egov-workflow-v2` rejects any assignee on a terminal transition. A real rate carrying the Case-Manager uuid returned:
```
400 INVALID_ASSIGNEE  "Cannot assign to the user: <uuid>"
```
Most resolved complaints **do** have a Case Manager in history (they were resolved from `INVESTIGATION`), so #1688's rate change would block the citizen's rating for the common case. A complaint with **no** case manager rated fine (the fallback path) — which is why the build + unit tests didn't catch it.

## Fix
Revert `RATE` to send no `assignes` (identical to pre-2167). Removes the now-unused import; `utils/workflowAssignee.js` stays (still used by reopen).

## Reopen half — verified working, untouched
Live on cms-pilot: reopening a RESOLVED complaint sent the supervisor uuid → **HTTP 200** → complaint moved to **REFERRED** with the **Supervisor as assignee**. (Reopen targets a non-terminal state, so the assignee is accepted.)

## Escalation for the ticket owner
"Rate → assign to the Case Manager" isn't possible through the workflow as it stands. It needs a backend decision:
- permit an assignee on the RATE transition, or
- record the Case Manager off-workflow (e.g. a service field), or
- drop that requirement.

Until then, RATE ships without an assignee (rating works); Reopen → Supervisor is delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)