### PR TITLE
fix(citizen): pass countryCode on the login/register OTP send

### DIFF
--- a/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Login/index.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Login/index.js
@@ -276,6 +276,8 @@ const Login = ({ stateCode, isUserRegistered = true }) => {
         tenantId: stateCode,
         userType: getUserType(),
         ...name,
+        // Same country-code fix as selectMobileNumber / resendOtp.
+        ...(validationConfig.countryCode ? { countryCode: validationConfig.countryCode } : {}),
       };
       const [res, err] = await sendOtp({ otp: { ...data, ...TYPE_REGISTER } });
       if (res) {

--- a/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Login/index.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Login/index.js
@@ -165,6 +165,11 @@ const Login = ({ stateCode, isUserRegistered = true }) => {
       ...mobileNumber,
       tenantId: stateCode,
       userType: getUserType(),
+      // Pass the country code on OTP send. The user record stores the mobile
+      // with its country code (+258 for MZ); omitting it here left the SMS
+      // gateway without a routable prefix. Sourced from the same
+      // MobileNumberValidation / CORE_MOBILE_CONFIGS the field validation uses.
+      ...(validationConfig.countryCode ? { countryCode: validationConfig.countryCode } : {}),
     };
 
     if (isUserRegistered) {
@@ -369,6 +374,8 @@ const Login = ({ stateCode, isUserRegistered = true }) => {
       userName,
       tenantId: stateCode,
       userType: getUserType(),
+      // Same country-code fix as the initial send (see selectMobileNumber).
+      ...(validationConfig.countryCode ? { countryCode: validationConfig.countryCode } : {}),
     };
 
     if (!isUserRegistered && individualServicePath) {


### PR DESCRIPTION
## Problem
The citizen login/register **OTP-send** request omits the country code. Captured live on cms-pilot:
```
POST /user-otp/v1/_send
{ "otp": { "mobileNumber":"841234567", "tenantId":"mz", "userType":"citizen", "type":"login" } }
```
No `countryCode`. The user record stores the mobile **with** its country code (`+258` for MZ), and a real SMS gateway needs the prefix to route the message — so sending the bare number is wrong.

## Fix
The country code is already computed in the component — `validationConfig.countryCode`, resolved from `common-masters.MobileNumberValidation` → `CORE_MOBILE_CONFIGS` (both give `+258` on cms-pilot) — but it was never added to the OTP `data`. Add it to **both** send paths:
- `selectMobileNumber` — initial login/register send
- `resendOtp` — the resend

Guarded (`...(validationConfig.countryCode ? {countryCode} : {})`) so on an env with no configured country code the payload is unchanged.

## Verify
esbuild build clean; both OTP-send data objects now carry `countryCode` when available. Runtime check pending on cms-pilot after deploy — will capture the `/user-otp/v1/_send` body showing `"countryCode":"+258"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)