### PR TITLE
fix(loc): upload label showed (Opcional) twice (CCSD-2071)

### DIFF
--- a/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
@@ -751,7 +751,7 @@
     },
     {
         "code": "CS_ADDCOMPLAINT_UPLOAD_PHOTO",
-        "message": "Upload complaint photos or documents (Optional)",
+        "message": "Upload complaint photos or documents",
         "module": "rainmaker-pgr",
         "locale": "en_IN"
     },

--- a/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
@@ -1585,7 +1585,7 @@
     },
     {
         "code": "CS_ADDCOMPLAINT_UPLOAD_PHOTO",
-        "message": "Enviar fotos ou documentos da reclamação (Opcional)",
+        "message": "Enviar fotos ou documentos da reclamação",
         "module": "rainmaker-pgr",
         "locale": "pt_PT"
     },


### PR DESCRIPTION
QA (Gurjeet) found the upload section shows **"(Opcional)" twice** after #1639.

## Cause
#1639 put `(Opcional)`/`(Optional)` **inside** the `CS_ADDCOMPLAINT_UPLOAD_PHOTO` label. But the citizen v2 create flow already appends the optional suffix itself:
```
CreatePGRFlowV2.tsx: <StepShell title={ CS_ADDCOMPLAINT_UPLOAD_PHOTO + " " + CS_OPTIONAL_SUFFIX }>
```
So it rendered `…reclamação (Opcional) (Opcional)`.

## Fix
Label is suffix-free again; the flow supplies `(Opcional)` by convention (same as the landmark / dynamic optional fields). Seed reverted to `Enviar fotos ou documentos da reclamação` / `Upload complaint photos or documents`. `CS_UPLOAD_HINT` (the formats list incl. video) is unchanged.

## Verified
Corrected value already **upserted live to cms-pilot** (+ cache-bust). Reproduced the exact StepShell title on the live bundle: `"Upload complaint photos or documents (Optional)"` → the suffix appears **once**. mctd is frozen (picks it up from this seed on the next migration); local backend was down so its live upsert is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)