### PR TITLE
fix(loc): employee sidebar hamburger menu Portuguese (CCSD-2083)

### DIFF
--- a/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-common.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-common.json
@@ -1,5 +1,35 @@
 [
     {
+        "code": "Home",
+        "message": "Home",
+        "module": "rainmaker-common",
+        "locale": "en_IN"
+    },
+    {
+        "code": "Create Complaint",
+        "message": "Create Complaint",
+        "module": "rainmaker-common",
+        "locale": "en_IN"
+    },
+    {
+        "code": "Search Complaint",
+        "message": "Search Complaint",
+        "module": "rainmaker-common",
+        "locale": "en_IN"
+    },
+    {
+        "code": "Dashboard viewer",
+        "message": "Dashboard viewer",
+        "module": "rainmaker-common",
+        "locale": "en_IN"
+    },
+    {
+        "code": "Search",
+        "message": "Search",
+        "module": "rainmaker-common",
+        "locale": "en_IN"
+    },
+    {
         "code": "AADHAAR_IS_REQUIRED",
         "message": "Aadhaar number is required",
         "module": "rainmaker-common",

--- a/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-common.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-common.json
@@ -1,5 +1,35 @@
 [
     {
+        "code": "Home",
+        "message": "Início",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "Create Complaint",
+        "message": "Criar Reclamação",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "Search Complaint",
+        "message": "Pesquisar Reclamação",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "Dashboard viewer",
+        "message": "Visualizador do Painel",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
+        "code": "Search",
+        "message": "Pesquisar",
+        "module": "rainmaker-common",
+        "locale": "pt_PT"
+    },
+    {
         "code": "CS_HOME_HEADER",
         "message": "Todos os Serviços",
         "module": "rainmaker-common",


### PR DESCRIPTION
QA (Gurjeet) re-reported the employee **hamburger menu** still in English in Portuguese mode ("Home", "Create Complaint", "Search Complaint", "Dashboard viewer").

## Cause
The sidebar renders `t(action.displayName)` ([EmployeeSideBar.js:177]) — the loc **key is the raw displayName string** ("Home", "Create Complaint", …). Those keys had **no pt_PT value in any loaded module**, so `t()` echoed the English. (My earlier fix added `ACTION_TEST_*` keys — which the sidebar never uses, so it didn't help.)

## Fix
Seed pt_PT (and explicit en_IN) for those keys in **`rainmaker-common`** — confirmed a module the employee app loads (`Digit.Locale.List = [rainmaker-common, digit-ui, digit-tenants, rainmaker-mz]`):

| key | pt_PT |
|---|---|
| Home | Início |
| Create Complaint | Criar Reclamação |
| Search Complaint | Pesquisar Reclamação |
| Dashboard viewer | Visualizador do Painel |
| Search | Pesquisar |

## Verified
Already **upserted live to cms-pilot** (rainmaker-common, pt_PT) + cache-bust — read-back confirms all five. Confirmed the resolution path (rainmaker-common loaded + sidebar `t(displayName)`), so in Portuguese these now resolve to the values above. mctd is frozen (gets it from this seed); local backend was down so its live upsert is deferred.

Note for QA: hard-refresh once on cms-pilot to clear the ~24h browser loc cache before re-testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)