### PR TITLE
fix(dashboard): make analytics calendar tenant-configurable

### DIFF
--- a/ansible/nairobi-mdms/mdms/dss/DashboardConfig.json
+++ b/ansible/nairobi-mdms/mdms/dss/DashboardConfig.json
@@ -17,7 +17,8 @@
         "pt_PT": "#.##0,00",
         "fr_FR": "# ##0,00",
         "default": "#,##0.00"
-      }
+      },
+      "timeZone": "Africa/Nairobi"
     }
   }
 ]

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java
@@ -19,7 +19,6 @@ import java.util.stream.Collectors;
 @Component
 public class AnalyticsPlanner {
 
-    private static final ZoneId EAT = ZoneId.of("Africa/Nairobi");           // UTC+3
     private static final Pattern ALIAS = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]{0,63}$");
     private static final Set<String> BUCKETS = new HashSet<>(Arrays.asList("day","week","month","quarter","year"));
     private static final Pattern LAST_N_DAYS = Pattern.compile("^last_(\\d+)d$");
@@ -36,7 +35,7 @@ public class AnalyticsPlanner {
         }
     }
 
-    public Planned plan(JsonNode q, AnalyticsScope scope){
+    public Planned plan(JsonNode q, AnalyticsScope scope, BusinessCalendar calendar){
         String grainName = q.hasNonNull("grain") ? q.get("grain").asText() : inferGrain(q);
         Grain g = catalog.grain(grainName);
         if (g == null) throw new IllegalArgumentException("unknown_grain: " + grainName);
@@ -77,9 +76,13 @@ public class AnalyticsPlanner {
         if (window != null && window.hasNonNull("timeBucket")) {
             String unit = window.get("timeBucket").asText();
             if (!BUCKETS.contains(unit)) throw new IllegalArgumentException("invalid_param: timeBucket '" + unit + "'");
+            // The resolved tenant zone rides a JDBC-bound param (never string-concatenated) — the
+            // value is already ZoneId.of-validated by KpiCatalogService.resolveTimeZone, but binding
+            // it keeps this expression safe even if that validation is ever bypassed.
             String expr = g.isEpochMs(timeCol)
-                ? "date_trunc('" + unit + "', to_timestamp(" + timeCol + "/1000) AT TIME ZONE 'Etc/GMT-3')::date"
+                ? "date_trunc('" + unit + "', to_timestamp(" + timeCol + "/1000) AT TIME ZONE ?::text)::date"
                 : "date_trunc('" + unit + "', " + timeCol + ")::date";
+            if (g.isEpochMs(timeCol)) selectParams.add(calendar.zoneId.getId());
             String alias = "bucket";
             selectExprs.add(expr + " AS " + alias);
             groupExprs.add(expr);
@@ -107,7 +110,7 @@ public class AnalyticsPlanner {
                 conj.add(predicate(g, e.getKey(), e.getValue(), whereParams));
             }
         }
-        applyWindow(window, g, timeCol, conj, whereParams);
+        applyWindow(window, g, timeCol, conj, whereParams, calendar);
         applyScope(scope, g, conj, whereParams);
 
         // ---- assemble ----
@@ -285,8 +288,8 @@ public class AnalyticsPlanner {
     // ---------- window ----------
 
     /**
-     * Resolve a named window to its inclusive start instant (epoch-ms) in EAT. Every window ends at
-     * {@code now}, so the name alone fixes the interval {@code [start, now)}.
+     * Resolve a named window to its inclusive start instant (epoch-ms) in {@code zone}. Every window
+     * ends at {@code now}, so the name alone fixes the interval {@code [start, now)}.
      *
      * <p>Returns {@code null} for the boundless names ({@code all}) and for {@code live}, which is a
      * state predicate rather than a time interval — callers handle those before asking.
@@ -295,24 +298,25 @@ public class AnalyticsPlanner {
      * pinned window overlaps the dashboard's selected date range. Keeping one implementation means a
      * window can never mean one thing when planned and another when range-checked.
      */
-    static Long windowStartMs(String name, long now){
+    static Long windowStartMs(String name, long now, ZoneId zone){
         if (name == null || name.equals("all") || name.equals("live")) return null;
-        ZonedDateTime nowEat = Instant.ofEpochMilli(now).atZone(EAT);
+        ZonedDateTime nowZ = Instant.ofEpochMilli(now).atZone(zone);
         java.util.regex.Matcher lastN = LAST_N_DAYS.matcher(name);
         if (lastN.matches()) return now - Long.parseLong(lastN.group(1)) * 86400000L;
         switch (name) {
-            // dtd — day-to-date: the CALENDAR day in EAT, i.e. "today". Distinct from last_1d, which
-            // is a rolling 24h and drifts across midnight (#1462).
-            case "dtd": return nowEat.toLocalDate().atStartOfDay(EAT).toInstant().toEpochMilli();
-            case "wtd": return nowEat.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)).toLocalDate().atStartOfDay(EAT).toInstant().toEpochMilli();
-            case "mtd": return nowEat.withDayOfMonth(1).toLocalDate().atStartOfDay(EAT).toInstant().toEpochMilli();
-            case "qtd": return nowEat.toLocalDate().with(IsoFields.DAY_OF_QUARTER, 1L).atStartOfDay(EAT).toInstant().toEpochMilli();
-            case "ytd": return nowEat.withDayOfYear(1).toLocalDate().atStartOfDay(EAT).toInstant().toEpochMilli();
+            // dtd — day-to-date: the CALENDAR day in the resolved zone, i.e. "today". Distinct from
+            // last_1d, which is a rolling 24h and drifts across midnight (#1462).
+            case "dtd": return nowZ.toLocalDate().atStartOfDay(zone).toInstant().toEpochMilli();
+            case "wtd": return nowZ.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)).toLocalDate().atStartOfDay(zone).toInstant().toEpochMilli();
+            case "mtd": return nowZ.withDayOfMonth(1).toLocalDate().atStartOfDay(zone).toInstant().toEpochMilli();
+            case "qtd": return nowZ.toLocalDate().with(IsoFields.DAY_OF_QUARTER, 1L).atStartOfDay(zone).toInstant().toEpochMilli();
+            case "ytd": return nowZ.withDayOfYear(1).toLocalDate().atStartOfDay(zone).toInstant().toEpochMilli();
             default: throw new IllegalArgumentException("invalid_param: unknown window '" + name + "'");
         }
     }
 
-    private void applyWindow(JsonNode window, Grain g, String timeCol, List<String> conj, List<Object> params){
+    private void applyWindow(JsonNode window, Grain g, String timeCol, List<String> conj, List<Object> params,
+                             BusinessCalendar calendar){
         if (window == null || !window.hasNonNull("name")) return;
         String name = window.get("name").asText();
         if (name.equals("all")) return;
@@ -320,14 +324,14 @@ public class AnalyticsPlanner {
             if (g.filterable.contains("is_open")) conj.add("is_open = ?"); else return;
             params.add(true); return;
         }
-        long now = System.currentTimeMillis();
-        Long fromMs = windowStartMs(name, now);
+        long now = calendar.asOfMs;
+        Long fromMs = windowStartMs(name, now, calendar.zoneId);
         if (fromMs == null) return;
         if (g.isEpochMs(timeCol)) {
             conj.add(timeCol + " >= ?"); params.add(fromMs);
             conj.add(timeCol + " < ?");  params.add(now);
         } else { // sql date column (daily.snapshot_date)
-            conj.add(timeCol + " >= ?"); params.add(java.sql.Date.valueOf(Instant.ofEpochMilli(fromMs).atZone(EAT).toLocalDate()));
+            conj.add(timeCol + " >= ?"); params.add(java.sql.Date.valueOf(Instant.ofEpochMilli(fromMs).atZone(calendar.zoneId).toLocalDate()));
         }
     }
 

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java
@@ -324,7 +324,7 @@ public class AnalyticsPlanner {
             if (g.filterable.contains("is_open")) conj.add("is_open = ?"); else return;
             params.add(true); return;
         }
-        long now = calendar.asOfMs;
+        long now = calendar.nowMs;
         Long fromMs = windowStartMs(name, now, calendar.zoneId);
         if (fromMs == null) return;
         if (g.isEpochMs(timeCol)) {

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
@@ -71,6 +71,8 @@ public class AnalyticsService {
     private final KpiQueryComposer queryComposer;
     private final AnalyticsMetrics metrics;
     private final PGRConfiguration config;
+    /** Injectable request clock; captured once so every query in a batch shares one calendar. */
+    private java.util.function.LongSupplier requestClock = System::currentTimeMillis;
 
     @Autowired
     public AnalyticsService(AnalyticsPlanner planner, AnalyticsCatalog catalog, JdbcTemplate jdbc,
@@ -114,14 +116,17 @@ public class AnalyticsService {
         Set<String> callerRoles = extractRoles(requestInfo);
         boolean publicFloor = isPublicFloor(callerRoles);
 
-        // ONE resolved zone + ONE captured asOf for the whole batch (#29): composer, planner,
-        // compose ops and the response itself all read this same BusinessCalendar, so a request can
-        // never straddle two clock readings or disagree with its own echoed asOf/calendar.
-        long asOfMs = asOf();
-        BusinessCalendar calendar = BusinessCalendar.of(kpiCatalogService.resolveTimeZone(tenantId), asOfMs);
+        // Data freshness and request time are deliberately separate. factsAsOfMs may be null for an
+        // empty materialized view, while named windows must use the current request instant rather
+        // than becoming stale when the refresh scheduler stalls. Capture request time exactly once
+        // so planner, composer, compose ops and response calendar still share one coherent clock.
+        Long factsAsOfMs = asOf();
+        long requestNowMs = requestClock.getAsLong();
+        BusinessCalendar calendar = BusinessCalendar.of(
+                kpiCatalogService.resolveTimeZone(tenantId), requestNowMs);
 
         Map<String,Object> out = new LinkedHashMap<>();
-        out.put("asOf", asOfMs);
+        out.put("asOf", factsAsOfMs);
         out.put("calendar", calendarInfo(calendar));
         out.put("scope", scopeInfo(scope));
 
@@ -465,25 +470,25 @@ public class AnalyticsService {
     private double orZero(Double d) { return d == null ? 0.0 : d; }
 
     /**
-     * FE elapsedDaysSince(startOfWeek(asOf), asOf): max(1, floor((asOf-weekStart)/day)). Preserves
+     * FE elapsedDaysSince(startOfWeek(now), now): max(1, floor((now-weekStart)/day)). Preserves
      * the existing Sunday week-start semantic (FE {@code getDay()}) for THIS operation only — wtd
      * elsewhere in the planner/composer uses Monday; that is a separate, intentionally distinct
      * product semantic and is left unchanged (#29 requirement: don't silently unify week starts).
-     * Measured from the request's shared {@code asOf}/zone, not wall-clock. Package-private for tests.
+     * Measured from the request's captured wall clock and shared zone. Package-private for tests.
      */
     long elapsedDaysSinceStartOfWeek(BusinessCalendar calendar) {
-        java.time.ZonedDateTime now = java.time.Instant.ofEpochMilli(calendar.asOfMs).atZone(calendar.zoneId);
+        java.time.ZonedDateTime now = java.time.Instant.ofEpochMilli(calendar.nowMs).atZone(calendar.zoneId);
         java.time.ZonedDateTime weekStart = now.toLocalDate()
                 .with(java.time.temporal.TemporalAdjusters.previousOrSame(java.time.DayOfWeek.SUNDAY))
                 .atStartOfDay(calendar.zoneId);
-        long ms = calendar.asOfMs - weekStart.toInstant().toEpochMilli();
+        long ms = calendar.nowMs - weekStart.toInstant().toEpochMilli();
         return Math.max(1, ms / 86_400_000L);
     }
 
-    /** FE elapsedHoursSince(startOfDay(asOf), asOf): max(1, floor((asOf-dayStart)/hour)). Package-private for tests. */
+    /** FE elapsedHoursSince(startOfDay(now), now): max(1, floor((now-dayStart)/hour)). Package-private for tests. */
     long elapsedHoursSinceStartOfDay(BusinessCalendar calendar) {
         long dayStart = calendar.businessDate.atStartOfDay(calendar.zoneId).toInstant().toEpochMilli();
-        long ms = calendar.asOfMs - dayStart;
+        long ms = calendar.nowMs - dayStart;
         return Math.max(1, ms / 3_600_000L);
     }
 

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
@@ -114,8 +114,15 @@ public class AnalyticsService {
         Set<String> callerRoles = extractRoles(requestInfo);
         boolean publicFloor = isPublicFloor(callerRoles);
 
+        // ONE resolved zone + ONE captured asOf for the whole batch (#29): composer, planner,
+        // compose ops and the response itself all read this same BusinessCalendar, so a request can
+        // never straddle two clock readings or disagree with its own echoed asOf/calendar.
+        long asOfMs = asOf();
+        BusinessCalendar calendar = BusinessCalendar.of(kpiCatalogService.resolveTimeZone(tenantId), asOfMs);
+
         Map<String,Object> out = new LinkedHashMap<>();
-        out.put("asOf", asOf());
+        out.put("asOf", asOfMs);
+        out.put("calendar", calendarInfo(calendar));
         out.put("scope", scopeInfo(scope));
 
         if (body.has("queries") && body.get("queries").isObject()) {
@@ -137,11 +144,11 @@ public class AnalyticsService {
                         continue;
                     }
                     // D1a: backend-composed defs (query:null + viz.compose) resolve recursively here.
-                    Map<String,Object> composed = maybeComposeResult(queryNode, scope, tenantId, callerRoles, tel, name);
+                    Map<String,Object> composed = maybeComposeResult(queryNode, scope, tenantId, callerRoles, tel, name, calendar);
                     if (composed != null) { results.put(name, composed); continue; }
 
                     List<String> paramsIgnored = new ArrayList<>();
-                    JsonNode actualQueryNode = resolveKpiRef(queryNode, tenantId, callerRoles, paramsIgnored);
+                    JsonNode actualQueryNode = resolveKpiRef(queryNode, tenantId, callerRoles, paramsIgnored, calendar);
                     if (actualQueryNode == null) {
                         partial = true;
                         results.put(name, Map.of("error", "kpi_forbidden",
@@ -157,7 +164,7 @@ public class AnalyticsService {
                                 "message", "inline query projects officer-PII dimension(s); role not authorized"));
                         continue;
                     }
-                    Map<String,Object> result = runOne(actualQueryNode, scope, tel, name, kpiContext(queryNode));
+                    Map<String,Object> result = runOne(actualQueryNode, scope, tel, name, kpiContext(queryNode), calendar);
                     if (!paramsIgnored.isEmpty()) result.put("paramsIgnored", paramsIgnored);
                     results.put(name, result);
                 } catch (Exception ex) {
@@ -171,15 +178,15 @@ public class AnalyticsService {
             JsonNode queryNode = body.get("query");
             if (publicFloor && !queryNode.has("kpiId"))
                 throw new IllegalArgumentException("kpi_forbidden: public access is limited to published PUBLIC KPIs");
-            Map<String,Object> composed = maybeComposeResult(queryNode, scope, tenantId, callerRoles, tel, "query");
+            Map<String,Object> composed = maybeComposeResult(queryNode, scope, tenantId, callerRoles, tel, "query", calendar);
             if (composed != null) { out.putAll(composed); return out; }
             List<String> paramsIgnored = new ArrayList<>();
-            JsonNode actualQueryNode = resolveKpiRef(queryNode, tenantId, callerRoles, paramsIgnored);
+            JsonNode actualQueryNode = resolveKpiRef(queryNode, tenantId, callerRoles, paramsIgnored, calendar);
             if (actualQueryNode == null)
                 throw new IllegalArgumentException("kpi_forbidden: KPI not found or not authorized");
             if (!queryNode.has("kpiId") && projectsForbiddenPii(actualQueryNode, callerRoles))
                 throw new IllegalArgumentException("pii_forbidden: inline query projects officer-PII dimension(s); role not authorized");
-            out.putAll(runOne(actualQueryNode, scope, tel, "query", kpiContext(queryNode)));
+            out.putAll(runOne(actualQueryNode, scope, tel, "query", kpiContext(queryNode), calendar));
             if (!paramsIgnored.isEmpty()) out.put("paramsIgnored", paramsIgnored);
         } else {
             throw new IllegalArgumentException("invalid_param: body must contain 'query' or 'queries'");
@@ -204,7 +211,7 @@ public class AnalyticsService {
      *                      {@code paramsIgnored:[...]}
      */
     private JsonNode resolveKpiRef(JsonNode queryNode, String tenantId, Set<String> callerRoles,
-                                   List<String> paramsIgnored) {
+                                   List<String> paramsIgnored, BusinessCalendar calendar) {
         // Inline path: the suppression marker is composer-internal, so a caller-supplied one is
         // stripped rather than trusted. Replaying a logged effective query (which legitimately
         // carries it) must still be planned and validated, not short-circuited into a clean empty
@@ -232,7 +239,7 @@ public class AnalyticsService {
             // D1a backend-composed defs are intercepted by maybeComposeResult before this point;
             // a query:null def WITHOUT a valid compose op is a genuine misconfiguration.
             throw new IllegalArgumentException("invalid_kpi: KPI '" + kpiId + "' has no query defined");
-        return queryComposer.mergeParams(storedQuery, effectiveParams, paramsIgnored);
+        return queryComposer.mergeParams(storedQuery, effectiveParams, paramsIgnored, calendar);
     }
 
     /**
@@ -315,7 +322,8 @@ public class AnalyticsService {
      */
     private Map<String,Object> maybeComposeResult(JsonNode queryNode, AnalyticsScope scope,
                                                   String tenantId, Set<String> callerRoles,
-                                                  QueryTelemetry tel, String entryName) {
+                                                  QueryTelemetry tel, String entryName,
+                                                  BusinessCalendar calendar) {
         if (queryNode == null || !queryNode.has("kpiId")) return null;
         String kpiId = queryNode.get("kpiId").asText();
         Optional<KpiDefinition> defOpt = kpiCatalogService.getDef(kpiId, tenantId);
@@ -343,10 +351,10 @@ public class AnalyticsService {
         List<String> paramsIgnored = new ArrayList<>();   // deduped in resolveKpiRef/composer
         for (JsonNode srcId : compose.get("sourceKpiIds")) {
             JsonNode srcRef = synthRef(srcId.asText(), params);
-            JsonNode srcQuery = resolveKpiRef(srcRef, tenantId, callerRoles, paramsIgnored);
+            JsonNode srcQuery = resolveKpiRef(srcRef, tenantId, callerRoles, paramsIgnored, calendar);
             if (srcQuery == null)
                 throw new IllegalArgumentException("kpi_forbidden: compose source '" + srcId.asText() + "' not authorized");
-            Map<String,Object> r = runOne(srcQuery, scope, tel, entryName, srcId.asText());
+            Map<String,Object> r = runOne(srcQuery, scope, tel, entryName, srcId.asText(), calendar);
             // A suppressed source is UNANSWERABLE, not zero. firstRow() would flatten it to {} and
             // computeCompose would read a missing measure as 0 — netBacklogDaily would then publish a
             // confident number derived from a period the filter excludes. Propagate instead.
@@ -364,7 +372,7 @@ public class AnalyticsService {
             sourceRows.add(firstRow(r));
         }
 
-        Double value = computeCompose(type, compose, sourceRows);
+        Double value = computeCompose(type, compose, sourceRows, calendar);
         String valueKey = def.getViz().getValueKey() != null ? def.getViz().getValueKey() : "value";
         Map<String,Object> row = new LinkedHashMap<>();
         row.put(valueKey, value);
@@ -420,10 +428,11 @@ public class AnalyticsService {
     /**
      * Compute the compose op against the source rows. Faithful port of {@code composeKpi.js}:
      * the *_Avg ops divide the source total by the elapsed days/hours since the start of the
-     * current week/day (in the dashboard EAT zone), measured from {@link #asOf()} (server clock
-     * authority, mirroring the FE's use of {@code results[..].asOf}).
+     * current week/day in the request's resolved {@link BusinessCalendar} zone (mirroring the
+     * FE's use of {@code results[..].asOf}). Package-private for tests.
      */
-    private Double computeCompose(String type, JsonNode compose, List<Map<String,Object>> src) {
+    Double computeCompose(String type, JsonNode compose, List<Map<String,Object>> src,
+                          BusinessCalendar calendar) {
         switch (type) {
             case "openRateComplement": {
                 // pct is a 0..1 ratio (the planner's round(.. ,4)); complement -> percentage points.
@@ -439,13 +448,13 @@ public class AnalyticsService {
             case "dailyAvgFromWeekly": {
                 double total = orZero(num(src.get(0), "total"));
                 if (!compose.path("elapsedFromAsOf").asBoolean(false)) return null;
-                long elapsed = elapsedDaysSinceStartOfWeek(asOf());
+                long elapsed = elapsedDaysSinceStartOfWeek(calendar);
                 return elapsed > 0 ? total / elapsed : null;
             }
             case "hourlyAvgFromDaily": {
                 double total = orZero(num(src.get(0), "total"));
                 if (!compose.path("elapsedFromAsOf").asBoolean(false)) return null;
-                long elapsed = elapsedHoursSinceStartOfDay(asOf());
+                long elapsed = elapsedHoursSinceStartOfDay(calendar);
                 return elapsed > 0 ? total / elapsed : null;
             }
             default:
@@ -455,25 +464,26 @@ public class AnalyticsService {
 
     private double orZero(Double d) { return d == null ? 0.0 : d; }
 
-    /** EAT zone for week/day-start, matching {@link AnalyticsPlanner}/{@link KpiQueryComposer}. */
-    private static final java.time.ZoneId EAT = java.time.ZoneId.of("Africa/Nairobi");
-
-    /** FE elapsedDaysSince(startOfWeek(asOf), asOf): max(1, floor((asOf-weekStart)/day)). startOfWeek = Sunday (JS getDay). */
-    private long elapsedDaysSinceStartOfWeek(long asOfMs) {
-        java.time.ZonedDateTime now = java.time.Instant.ofEpochMilli(asOfMs).atZone(EAT);
-        // FE startOfWeek: d.getDate() - d.getDay() => previous (or same) Sunday at local midnight.
+    /**
+     * FE elapsedDaysSince(startOfWeek(asOf), asOf): max(1, floor((asOf-weekStart)/day)). Preserves
+     * the existing Sunday week-start semantic (FE {@code getDay()}) for THIS operation only — wtd
+     * elsewhere in the planner/composer uses Monday; that is a separate, intentionally distinct
+     * product semantic and is left unchanged (#29 requirement: don't silently unify week starts).
+     * Measured from the request's shared {@code asOf}/zone, not wall-clock. Package-private for tests.
+     */
+    long elapsedDaysSinceStartOfWeek(BusinessCalendar calendar) {
+        java.time.ZonedDateTime now = java.time.Instant.ofEpochMilli(calendar.asOfMs).atZone(calendar.zoneId);
         java.time.ZonedDateTime weekStart = now.toLocalDate()
                 .with(java.time.temporal.TemporalAdjusters.previousOrSame(java.time.DayOfWeek.SUNDAY))
-                .atStartOfDay(EAT);
-        long ms = asOfMs - weekStart.toInstant().toEpochMilli();
+                .atStartOfDay(calendar.zoneId);
+        long ms = calendar.asOfMs - weekStart.toInstant().toEpochMilli();
         return Math.max(1, ms / 86_400_000L);
     }
 
-    /** FE elapsedHoursSince(startOfDay(asOf), asOf): max(1, floor((asOf-dayStart)/hour)). */
-    private long elapsedHoursSinceStartOfDay(long asOfMs) {
-        java.time.ZonedDateTime now = java.time.Instant.ofEpochMilli(asOfMs).atZone(EAT);
-        long dayStart = now.toLocalDate().atStartOfDay(EAT).toInstant().toEpochMilli();
-        long ms = asOfMs - dayStart;
+    /** FE elapsedHoursSince(startOfDay(asOf), asOf): max(1, floor((asOf-dayStart)/hour)). Package-private for tests. */
+    long elapsedHoursSinceStartOfDay(BusinessCalendar calendar) {
+        long dayStart = calendar.businessDate.atStartOfDay(calendar.zoneId).toInstant().toEpochMilli();
+        long ms = calendar.asOfMs - dayStart;
         return Math.max(1, ms / 3_600_000L);
     }
 
@@ -517,7 +527,7 @@ public class AnalyticsService {
      * @param kpiId     the resolved KPI id, or {@code "inline"} for inline-grammar queries
      */
     private Map<String,Object> runOne(JsonNode q, AnalyticsScope scope, QueryTelemetry tel,
-                                      String entryName, String kpiId){
+                                      String entryName, String kpiId, BusinessCalendar calendar){
         // #1462: a pinned-window def whose interval falls outside the selected date range is
         // unanswerable, not empty-by-filter. Return no rows WITHOUT running SQL, flagged so the tile
         // renders "no data for the applied filters" rather than a zero the user would read as fact.
@@ -531,7 +541,7 @@ public class AnalyticsService {
             r.put("tookMs", 0L);
             return r;
         }
-        AnalyticsPlanner.Planned p = planner.plan(q, scope);
+        AnalyticsPlanner.Planned p = planner.plan(q, scope, calendar);
         long t0 = System.currentTimeMillis();
         List<Map<String,Object>> rows = jdbc.queryForList(p.sql, p.params.toArray());
         long tookMs = System.currentTimeMillis() - t0;
@@ -640,6 +650,14 @@ public class AnalyticsService {
     private long configCacheTtlMs() {
         Long v = config == null ? null : config.getAnalyticsConfigCacheTtlMs();
         return v != null ? v : PGRConfiguration.DEFAULT_ANALYTICS_CONFIG_CACHE_TTL_MS;
+    }
+
+    /** Additive top-level response metadata (#29): the resolved zone + businessDate the whole batch used. */
+    private Map<String,Object> calendarInfo(BusinessCalendar c){
+        Map<String,Object> m = new LinkedHashMap<>();
+        m.put("timeZone", c.zoneId.getId());
+        m.put("businessDate", c.businessDate.toString());
+        return m;
     }
 
     private Map<String,Object> scopeInfo(AnalyticsScope s){

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/BusinessCalendar.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/BusinessCalendar.java
@@ -1,0 +1,39 @@
+package org.egov.pgr.analytics;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+/**
+ * One immutable, per-request analytics calendar: the validated {@link ZoneId} the tenant's
+ * DashboardConfig resolves to, and the single {@code asOf} epoch-ms instant the whole batch is
+ * judged against.
+ *
+ * <p>{@link AnalyticsService#doQuery} resolves exactly ONE instance per request and threads it
+ * through every downstream consumer — {@link AnalyticsPlanner}, {@link KpiQueryComposer}, and the
+ * D1a compose operations — so a named window (dtd/wtd/…), a pinned-window suppression decision, an
+ * explicit dateFrom/dateTo bound, and the response's own {@code asOf}/{@code calendar} fields can
+ * never straddle two different clock readings or two different zones within the same batch.
+ *
+ * <p>{@link #businessDate} is {@code asOf} converted to a calendar date in {@link #zoneId} — the
+ * "today" every named window and pinned-window decision is measured against.
+ */
+public final class BusinessCalendar {
+
+    /** Documented migration-compatibility fallback zone for tenants with no valid configured zone. */
+    public static final ZoneId DEFAULT_ZONE = ZoneId.of("Africa/Nairobi");
+
+    public final ZoneId zoneId;
+    public final long asOfMs;
+    public final LocalDate businessDate;
+
+    private BusinessCalendar(ZoneId zoneId, long asOfMs) {
+        this.zoneId = zoneId;
+        this.asOfMs = asOfMs;
+        this.businessDate = Instant.ofEpochMilli(asOfMs).atZone(zoneId).toLocalDate();
+    }
+
+    public static BusinessCalendar of(ZoneId zoneId, long asOfMs) {
+        return new BusinessCalendar(zoneId == null ? DEFAULT_ZONE : zoneId, asOfMs);
+    }
+}

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/BusinessCalendar.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/BusinessCalendar.java
@@ -6,16 +6,17 @@ import java.time.ZoneId;
 
 /**
  * One immutable, per-request analytics calendar: the validated {@link ZoneId} the tenant's
- * DashboardConfig resolves to, and the single {@code asOf} epoch-ms instant the whole batch is
+ * DashboardConfig resolves to, and the single wall-clock epoch-ms instant the whole batch is
  * judged against.
  *
  * <p>{@link AnalyticsService#doQuery} resolves exactly ONE instance per request and threads it
  * through every downstream consumer — {@link AnalyticsPlanner}, {@link KpiQueryComposer}, and the
  * D1a compose operations — so a named window (dtd/wtd/…), a pinned-window suppression decision, an
- * explicit dateFrom/dateTo bound, and the response's own {@code asOf}/{@code calendar} fields can
- * never straddle two different clock readings or two different zones within the same batch.
+ * explicit dateFrom/dateTo bound, and the response's {@code calendar} field can never straddle
+ * two different clock readings or two different zones within the same batch. The response's
+ * top-level {@code asOf} is separate: it reports materialized-view freshness and may be null.
  *
- * <p>{@link #businessDate} is {@code asOf} converted to a calendar date in {@link #zoneId} — the
+ * <p>{@link #businessDate} is {@link #nowMs} converted to a calendar date in {@link #zoneId} — the
  * "today" every named window and pinned-window decision is measured against.
  */
 public final class BusinessCalendar {
@@ -24,16 +25,16 @@ public final class BusinessCalendar {
     public static final ZoneId DEFAULT_ZONE = ZoneId.of("Africa/Nairobi");
 
     public final ZoneId zoneId;
-    public final long asOfMs;
+    public final long nowMs;
     public final LocalDate businessDate;
 
-    private BusinessCalendar(ZoneId zoneId, long asOfMs) {
+    private BusinessCalendar(ZoneId zoneId, long nowMs) {
         this.zoneId = zoneId;
-        this.asOfMs = asOfMs;
-        this.businessDate = Instant.ofEpochMilli(asOfMs).atZone(zoneId).toLocalDate();
+        this.nowMs = nowMs;
+        this.businessDate = Instant.ofEpochMilli(nowMs).atZone(zoneId).toLocalDate();
     }
 
-    public static BusinessCalendar of(ZoneId zoneId, long asOfMs) {
-        return new BusinessCalendar(zoneId == null ? DEFAULT_ZONE : zoneId, asOfMs);
+    public static BusinessCalendar of(ZoneId zoneId, long nowMs) {
+        return new BusinessCalendar(zoneId == null ? DEFAULT_ZONE : zoneId, nowMs);
     }
 }

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiCatalogService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiCatalogService.java
@@ -39,11 +39,32 @@ public class KpiCatalogService {
 
     /** The only departmentScoping value that turns employee department scoping OFF (#1280). */
     private static final String DEPT_SCOPING_DISABLED = "disabled";
-    /** stateRoot -> [Boolean disabled, Long expiresAtMs]. Mirrors AnalyticsService.recordCountCache. */
-    private final java.util.concurrent.ConcurrentHashMap<String, Object[]> deptScopingCache =
+
+    /**
+     * Documented backward-compatible fallback zone (#29 timezone addendum) — used ONLY when a
+     * tenant's state-root {@code dss.DashboardConfig.timeZone} is absent, malformed (not a valid
+     * IANA zone id), or MDMS is unreachable. Matches the historical hardcoded EAT behavior every
+     * unconfigured tenant already had, so an unconfigured deployment sees no change.
+     */
+    static final java.time.ZoneId DEFAULT_TIME_ZONE = BusinessCalendar.DEFAULT_ZONE;
+
+    /**
+     * ONE cached fetch of the state-root's {@code dss.DashboardConfig} record, shared by
+     * {@link #isDepartmentScopingDisabled} and {@link #resolveTimeZone} so the two config axes
+     * never trigger duplicate MDMS calls or run parallel cache implementations (#29 requirement).
+     * stateRoot -> [Map<String,Object> record-or-null, Long expiresAtMs].
+     */
+    private final java.util.concurrent.ConcurrentHashMap<String, Object[]> dashboardConfigCache =
             new java.util.concurrent.ConcurrentHashMap<>();
     /** Injectable clock for cache-expiry tests (see KpiCatalogServiceDeptScopingTest). */
     private java.util.function.LongSupplier configClock = System::currentTimeMillis;
+    /**
+     * TTL-bounded warning gate for {@link #resolveTimeZone}'s fallback logging — see
+     * {@link #shouldWarnTimeZoneFallback}. stateRoot -> the {@code dashboardConfigCache}
+     * generation (expiresAtMs) already warned for.
+     */
+    private final java.util.concurrent.ConcurrentHashMap<String, Long> timeZoneFallbackWarnedGeneration =
+            new java.util.concurrent.ConcurrentHashMap<>();
 
     private final PGRConfiguration config;
     private final ServiceRequestRepository serviceRequestRepository;
@@ -130,22 +151,13 @@ public class KpiCatalogService {
     public boolean isDepartmentScopingDisabled(String tenantId) {
         try {
             if (tenantId == null || tenantId.isEmpty()) return false;
-            String stateRoot = multiStateInstanceUtil.getStateLevelTenant(tenantId);
-            long now = configClock.getAsLong();
-            Object[] cached = deptScopingCache.get(stateRoot);
-            if (cached != null && (Long) cached[1] > now) return (Boolean) cached[0];
-
-            boolean disabled = false;
-            List<Map<String, Object>> records =
-                    fetchMaster(stateRoot, MASTER_CONFIG, new TypeReference<List<Map<String, Object>>>() {});
-            if (!records.isEmpty()) {
-                Object v = records.get(0).get("departmentScoping");
-                disabled = v instanceof String && DEPT_SCOPING_DISABLED.equalsIgnoreCase(((String) v).trim());
-            }
+            Map<String, Object> record = dashboardConfig(tenantId);
+            if (record == null) return false;
+            Object v = record.get("departmentScoping");
+            boolean disabled = v instanceof String && DEPT_SCOPING_DISABLED.equalsIgnoreCase(((String) v).trim());
             if (disabled)
                 log.info("dss.DashboardConfig.departmentScoping=disabled at {} — employee department scoping OFF",
-                        stateRoot);
-            deptScopingCache.put(stateRoot, new Object[]{disabled, now + configCacheTtlMs()});
+                        multiStateInstanceUtil.getStateLevelTenant(tenantId));
             return disabled;
         } catch (Exception e) {
             // Fail-safe: any unexpected error means "enforced" (current behavior), never a throw
@@ -153,6 +165,163 @@ public class KpiCatalogService {
             log.warn("departmentScoping lookup failed for tenant {}; treating as enforced", tenantId, e);
             return false;
         }
+    }
+
+    /**
+     * Resolve the IANA {@link java.time.ZoneId} {@code dss.DashboardConfig.timeZone} declares for
+     * this tenant's state root (#29 timezone addendum) — the single source of the analytics
+     * calendar zone every downstream consumer (planner, composer, compose ops, response) uses.
+     *
+     * <p>Falls back to {@link #DEFAULT_TIME_ZONE} (Africa/Nairobi, documented migration
+     * compatibility default) when the record/field is absent, the value fails
+     * {@link java.time.ZoneId#of}, or MDMS is unreachable (fetchMaster resolves that to "no
+     * record" — see {@link #fetchMaster}). Logged at WARN, gated by {@link #shouldWarnTimeZoneFallback}
+     * so it fires at most once per {@link #dashboardConfigEntry} cache generation (i.e. once per
+     * TTL window) per state root, then again the first request after that generation's config
+     * refresh — never once per request. The rare genuine-exception path (e.g. state-root
+     * resolution itself throwing) is not TTL-gated; it is not expected to repeat every request.
+     * Never throws; never consults the browser or JVM default zone.
+     */
+    public java.time.ZoneId resolveTimeZone(String tenantId) {
+        try {
+            if (tenantId == null || tenantId.isEmpty()) return DEFAULT_TIME_ZONE;
+            String stateRoot = multiStateInstanceUtil.getStateLevelTenant(tenantId);
+            Object[] entry = dashboardConfigEntry(tenantId);
+            @SuppressWarnings("unchecked")
+            Map<String, Object> record = (Map<String, Object>) entry[0];
+            long generation = (Long) entry[1];
+            if (record == null) {
+                if (shouldWarnTimeZoneFallback(stateRoot, generation)) {
+                    log.warn("dss.DashboardConfig not found at {} — falling back to {} (migration compatibility default)",
+                            stateRoot, DEFAULT_TIME_ZONE);
+                }
+                return DEFAULT_TIME_ZONE;
+            }
+            Object v = record.get("timeZone");
+            if (!(v instanceof String) || ((String) v).trim().isEmpty()) {
+                if (shouldWarnTimeZoneFallback(stateRoot, generation)) {
+                    log.warn("dss.DashboardConfig.timeZone not configured at {} — falling back to {}",
+                            stateRoot, DEFAULT_TIME_ZONE);
+                }
+                return DEFAULT_TIME_ZONE;
+            }
+            try {
+                return java.time.ZoneId.of(((String) v).trim());
+            } catch (java.time.DateTimeException ex) {
+                if (shouldWarnTimeZoneFallback(stateRoot, generation)) {
+                    log.warn("dss.DashboardConfig.timeZone '{}' at {} is not a valid IANA zone — falling back to {}",
+                            v, stateRoot, DEFAULT_TIME_ZONE);
+                }
+                return DEFAULT_TIME_ZONE;
+            }
+        } catch (Exception e) {
+            log.warn("timeZone lookup failed for tenant {}; falling back to {}", tenantId, DEFAULT_TIME_ZONE, e);
+            return DEFAULT_TIME_ZONE;
+        }
+    }
+
+    /**
+     * Per-state-root TTL-bounded warning gate for {@link #resolveTimeZone}'s fallback branches
+     * (#29 review fix): {@code generation} is the owning cache entry's {@code expiresAtMs} (see
+     * {@link #dashboardConfigEntry}) — a stable id for "this fetch" that changes only when the
+     * TTL expires and the config is re-fetched. Returns {@code true} (and atomically records
+     * {@code generation} as warned) the FIRST time a given state root/generation pair asks;
+     * every subsequent call for the same still-cached generation returns {@code false}, so a
+     * missing/invalid config warns once per TTL window, then again only after the next refresh.
+     *
+     * <p>{@code ConcurrentHashMap#compute} makes the check-and-set atomic per key, so concurrent
+     * requests racing the same state root's first warning cannot both win. Keyed 1:1 with
+     * {@link #dashboardConfigCache}'s own state-root key set — no separate unbounded retention;
+     * an entry here lives exactly as long as its config-cache counterpart is relevant.
+     */
+    private boolean shouldWarnTimeZoneFallback(String stateRoot, long generation) {
+        boolean[] shouldWarn = {false};
+        timeZoneFallbackWarnedGeneration.compute(stateRoot, (root, warnedGeneration) -> {
+            if (warnedGeneration == null || warnedGeneration != generation) {
+                shouldWarn[0] = true;
+                return generation;
+            }
+            return warnedGeneration;
+        });
+        return shouldWarn[0];
+    }
+
+    /**
+     * THE single cached fetch of the state-root's {@code dss.DashboardConfig} record — the shared
+     * seam {@link #isDepartmentScopingDisabled} and {@link #resolveTimeZone} both read, so a
+     * request touching both axes issues exactly one MDMS call, and a config flip (either field)
+     * takes effect together within one {@link #configCacheTtlMs()} window. Returns {@code null}
+     * (cached) when no record exists; never throws — callers apply their own field-specific
+     * fallback.
+     */
+    private Map<String, Object> dashboardConfig(String tenantId) {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> record = (Map<String, Object>) dashboardConfigEntry(tenantId)[0];
+        return record;
+    }
+
+    /**
+     * Same cached fetch as {@link #dashboardConfig}, additionally exposing the cache entry's
+     * {@code expiresAtMs} as its generation id ({@link #shouldWarnTimeZoneFallback} needs it to
+     * tell "still the same TTL window" apart from "config was just re-fetched"). Returns
+     * {@code Object[]{Map<String,Object> record-or-null, Long expiresAtMs}}.
+     */
+    private Object[] dashboardConfigEntry(String tenantId) {
+        String stateRoot = multiStateInstanceUtil.getStateLevelTenant(tenantId);
+        long now = configClock.getAsLong();
+        Object[] cached = dashboardConfigCache.get(stateRoot);
+        if (cached != null && (Long) cached[1] > now) return cached;
+
+        List<Map<String, Object>> records =
+                fetchMaster(stateRoot, MASTER_CONFIG, new TypeReference<List<Map<String, Object>>>() {});
+        Map<String, Object> selected = selectDashboardConfigRecord(records);
+        // Unmodifiable: this same Map instance is cached and handed to every caller/thread until the
+        // TTL expires, so a caller mutating it (however unlikely today) must never corrupt the cache.
+        Map<String, Object> record = selected == null ? null : Collections.unmodifiableMap(selected);
+        Object[] entry = new Object[]{record, now + configCacheTtlMs()};
+        dashboardConfigCache.put(stateRoot, entry);
+        return entry;
+    }
+
+    /**
+     * Deterministic dashboard-config record selection when MDMS returns more than one active
+     * {@code dss.DashboardConfig} record for a state root (duplicate/malformed data) — the same
+     * rule applied by the {@code pgr_dashboard_tenant_timezone} SQL view (ORDER BY) and the FE's
+     * {@code useDashboardConfig.js}, so every layer picks the identical record from identical
+     * data. Depends only on fields present in the MDMS data object itself:
+     * <ol>
+     *   <li>the record whose (trimmed) {@code id} equals {@code "default"} wins;</li>
+     *   <li>else the record with the lexicographically smallest nonblank (trimmed) {@code id};</li>
+     *   <li>else the first record in API response order (stable — no reordering).</li>
+     * </ol>
+     * Deliberately does NOT consult API ordering guarantees or audit metadata
+     * (lastModifiedTime etc.) unavailable on this Java data map. Returns {@code null} for an
+     * empty list; a single record is always returned unchanged.
+     */
+    static Map<String, Object> selectDashboardConfigRecord(List<Map<String, Object>> records) {
+        if (records == null || records.isEmpty()) return null;
+        if (records.size() == 1) return records.get(0);
+
+        for (Map<String, Object> r : records) {
+            if ("default".equals(trimmedId(r))) return r;
+        }
+
+        Map<String, Object> smallest = null;
+        String smallestId = null;
+        for (Map<String, Object> r : records) {
+            String id = trimmedId(r);
+            if (id == null || id.isEmpty()) continue;
+            if (smallestId == null || id.compareTo(smallestId) < 0) {
+                smallestId = id;
+                smallest = r;
+            }
+        }
+        return smallest != null ? smallest : records.get(0);
+    }
+
+    private static String trimmedId(Map<String, Object> record) {
+        Object id = record == null ? null : record.get("id");
+        return id instanceof String ? ((String) id).trim() : null;
     }
 
     /**

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiCatalogService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiCatalogService.java
@@ -65,6 +65,9 @@ public class KpiCatalogService {
      */
     private final java.util.concurrent.ConcurrentHashMap<String, Long> timeZoneFallbackWarnedGeneration =
             new java.util.concurrent.ConcurrentHashMap<>();
+    /** Same per-cache-generation gate for the department-scoping-disabled INFO line. */
+    private final java.util.concurrent.ConcurrentHashMap<String, Long> deptScopingDisabledLoggedGeneration =
+            new java.util.concurrent.ConcurrentHashMap<>();
 
     private final PGRConfiguration config;
     private final ServiceRequestRepository serviceRequestRepository;
@@ -151,13 +154,16 @@ public class KpiCatalogService {
     public boolean isDepartmentScopingDisabled(String tenantId) {
         try {
             if (tenantId == null || tenantId.isEmpty()) return false;
-            Map<String, Object> record = dashboardConfig(tenantId);
+            String stateRoot = multiStateInstanceUtil.getStateLevelTenant(tenantId);
+            Object[] entry = dashboardConfigEntry(tenantId);
+            @SuppressWarnings("unchecked")
+            Map<String, Object> record = (Map<String, Object>) entry[0];
             if (record == null) return false;
             Object v = record.get("departmentScoping");
             boolean disabled = v instanceof String && DEPT_SCOPING_DISABLED.equalsIgnoreCase(((String) v).trim());
-            if (disabled)
+            if (disabled && shouldLogDepartmentScopingDisabled(stateRoot, (Long) entry[1]))
                 log.info("dss.DashboardConfig.departmentScoping=disabled at {} — employee department scoping OFF",
-                        multiStateInstanceUtil.getStateLevelTenant(tenantId));
+                        stateRoot);
             return disabled;
         } catch (Exception e) {
             // Fail-safe: any unexpected error means "enforced" (current behavior), never a throw
@@ -247,23 +253,26 @@ public class KpiCatalogService {
     }
 
     /**
-     * THE single cached fetch of the state-root's {@code dss.DashboardConfig} record — the shared
-     * seam {@link #isDepartmentScopingDisabled} and {@link #resolveTimeZone} both read, so a
-     * request touching both axes issues exactly one MDMS call, and a config flip (either field)
-     * takes effect together within one {@link #configCacheTtlMs()} window. Returns {@code null}
-     * (cached) when no record exists; never throws — callers apply their own field-specific
-     * fallback.
+     * Returns true once per state-root DashboardConfig cache generation, preventing the
+     * department-scoping-disabled INFO line from becoming a per-request log.
      */
-    private Map<String, Object> dashboardConfig(String tenantId) {
-        @SuppressWarnings("unchecked")
-        Map<String, Object> record = (Map<String, Object>) dashboardConfigEntry(tenantId)[0];
-        return record;
+    private boolean shouldLogDepartmentScopingDisabled(String stateRoot, long generation) {
+        boolean[] shouldLog = {false};
+        deptScopingDisabledLoggedGeneration.compute(stateRoot, (root, loggedGeneration) -> {
+            if (loggedGeneration == null || loggedGeneration != generation) {
+                shouldLog[0] = true;
+                return generation;
+            }
+            return loggedGeneration;
+        });
+        return shouldLog[0];
     }
 
     /**
-     * Same cached fetch as {@link #dashboardConfig}, additionally exposing the cache entry's
-     * {@code expiresAtMs} as its generation id ({@link #shouldWarnTimeZoneFallback} needs it to
-     * tell "still the same TTL window" apart from "config was just re-fetched"). Returns
+     * THE single cached fetch of the state-root's {@code dss.DashboardConfig} record — the shared
+     * seam {@link #isDepartmentScopingDisabled} and {@link #resolveTimeZone} both read. Also exposes
+     * the cache entry's {@code expiresAtMs} as its generation id so logging gates can distinguish
+     * "still the same TTL window" from "config was just re-fetched". Returns
      * {@code Object[]{Map<String,Object> record-or-null, Long expiresAtMs}}.
      */
     private Object[] dashboardConfigEntry(String tenantId) {
@@ -291,8 +300,7 @@ public class KpiCatalogService {
      * data. Depends only on fields present in the MDMS data object itself:
      * <ol>
      *   <li>the record whose (trimmed) {@code id} equals {@code "default"} wins;</li>
-     *   <li>else the record with the lexicographically smallest nonblank (trimmed) {@code id};</li>
-     *   <li>else the first record in API response order (stable — no reordering).</li>
+     *   <li>else the first record in API response order (the historical behavior).</li>
      * </ol>
      * Deliberately does NOT consult API ordering guarantees or audit metadata
      * (lastModifiedTime etc.) unavailable on this Java data map. Returns {@code null} for an
@@ -306,17 +314,7 @@ public class KpiCatalogService {
             if ("default".equals(trimmedId(r))) return r;
         }
 
-        Map<String, Object> smallest = null;
-        String smallestId = null;
-        for (Map<String, Object> r : records) {
-            String id = trimmedId(r);
-            if (id == null || id.isEmpty()) continue;
-            if (smallestId == null || id.compareTo(smallestId) < 0) {
-                smallestId = id;
-                smallest = r;
-            }
-        }
-        return smallest != null ? smallest : records.get(0);
+        return records.get(0);
     }
 
     private static String trimmedId(Map<String, Object> record) {

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiQueryComposer.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiQueryComposer.java
@@ -404,7 +404,7 @@ public class KpiQueryComposer {
         JsonNode window = query.get("window");
         if (window == null || !window.isObject()
                 || !window.hasNonNull("name") || !window.path("pinned").asBoolean(false)) return null;
-        long now = calendar.asOfMs;
+        long now = calendar.nowMs;
         Long startMs = AnalyticsPlanner.windowStartMs(window.get("name").asText(), now, calendar.zoneId);
         if (startMs == null) {
             log.debug("ignoring pinned:true on boundless window '{}' — nothing to pin", window.get("name").asText());
@@ -538,11 +538,11 @@ public class KpiQueryComposer {
 
     /**
      * This calendar week's Monday 00:00 in the resolved tenant zone, mirroring the FE local-time
-     * Monday. Measured from the request's shared {@code asOf} (not wall-clock {@code now()}), so it
+     * Monday. Measured from the request's single captured wall-clock instant, so it
      * agrees with every other window decision in the same batch.
      */
     private LocalDate thisMonday(BusinessCalendar calendar) {
-        return Instant.ofEpochMilli(calendar.asOfMs).atZone(calendar.zoneId).toLocalDate()
+        return Instant.ofEpochMilli(calendar.nowMs).atZone(calendar.zoneId).toLocalDate()
                 .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
     }
 

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiQueryComposer.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiQueryComposer.java
@@ -12,8 +12,6 @@ import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAdjusters;
 import java.util.List;
@@ -109,8 +107,6 @@ import java.util.regex.Pattern;
 @Slf4j
 public class KpiQueryComposer {
 
-    /** Dashboard canonical zone (UTC+3), matching {@link AnalyticsPlanner}'s EAT for window math. */
-    private static final ZoneId EAT = ZoneId.of("Africa/Nairobi");
     private static final long MS_PER_DAY = 86_400_000L;
     /** Sparkline daily-series safety cap, matching the FE {@code Math.min(366, ...)}. */
     private static final int MAX_SERIES_DAYS = 366;
@@ -144,13 +140,16 @@ public class KpiQueryComposer {
      * Produce the effective query by layering the request's {@code params} (dashboard globals) onto
      * the def's base {@code query}. Returns the base query unchanged when {@code params} is absent /
      * empty. Never mutates {@code baseQuery}.
+     *
+     * @param calendar the ONE request-scoped {@link BusinessCalendar} (resolved zone + shared asOf)
+     *                 every window/bounds/prior-period computation in this merge is judged against.
      */
-    public JsonNode mergeParams(JsonNode baseQuery, JsonNode params) {
-        return mergeParams(baseQuery, params, null);
+    public JsonNode mergeParams(JsonNode baseQuery, JsonNode params, BusinessCalendar calendar) {
+        return mergeParams(baseQuery, params, null, calendar);
     }
 
     /**
-     * As {@link #mergeParams(JsonNode, JsonNode)}, additionally reporting into
+     * As {@link #mergeParams(JsonNode, JsonNode, BusinessCalendar)}, additionally reporting into
      * {@code paramsIgnoredOut} (nullable) the name of any supplied param that could NOT be applied
      * to this def's grain and whose skip the FE must be told about. Today only
      * {@code complaintPath} reports (the daily grain has no {@code complaint_node_path}, so a
@@ -158,7 +157,8 @@ public class KpiQueryComposer {
      * silent no-ops ({@code ward} on ward-less grains, {@code hierLevel} on daily) keep their
      * behaviour unchanged.
      */
-    public JsonNode mergeParams(JsonNode baseQuery, JsonNode params, List<String> paramsIgnoredOut) {
+    public JsonNode mergeParams(JsonNode baseQuery, JsonNode params, List<String> paramsIgnoredOut,
+                                BusinessCalendar calendar) {
         if (baseQuery == null || !baseQuery.isObject()) return baseQuery;
         if (params == null || !params.isObject() || params.size() == 0) return baseQuery;
 
@@ -168,6 +168,7 @@ public class KpiQueryComposer {
         if (g == null) return baseQuery;   // planner will reject; don't mask the error here.
 
         ObjectNode next = (ObjectNode) baseQuery.deepCopy();
+        ZoneId zone = calendar.zoneId;
 
         boolean hasDateRange = params.hasNonNull("dateFrom") && params.hasNonNull("dateTo");
         boolean prior  = "prior".equals(textOrNull(params, "compare"));
@@ -177,8 +178,10 @@ public class KpiQueryComposer {
         // operate on these bounds; null means "no explicit range" (rolling window or whole-history).
         // C2: a present-but-unparseable dateFrom/dateTo must NOT silently fall back to the base/window
         // query (that returned the wrong, un-narrowed scalar). Surface a per-entry invalid_param instead.
+        // dateFrom/dateTo are LOCAL calendar dates in the resolved tenant zone (never UTC midnight) —
+        // the same zone the planner's window math and this def's grain use.
         Bounds bounds = hasDateRange
-                ? parseBounds(params.get("dateFrom").asText(), params.get("dateTo").asText())
+                ? parseBounds(params.get("dateFrom").asText(), params.get("dateTo").asText(), zone)
                 : null;
         if (hasDateRange && bounds == null)
             throw new IllegalArgumentException("invalid_param: dateFrom/dateTo is not a valid yyyy-MM-dd range");
@@ -198,7 +201,7 @@ public class KpiQueryComposer {
         // interval, so a range that does not COVER that interval makes the tile unanswerable rather
         // than merely unfiltered. That case is SUPPRESSED: no value, so the tile can render an empty
         // state instead of quietly reporting a number for a period the filter excludes.
-        PinnedWindow pinned = pinnedWindow(next);
+        PinnedWindow pinned = pinnedWindow(next, calendar);
         if (pinned != null) {
             if (series && !prior) {
                 // The sparkline is trend CONTEXT for the pinned value, not the value itself, and a
@@ -211,9 +214,9 @@ public class KpiQueryComposer {
             } else {
                 // Decided BEFORE the window is consumed below, and from the SAME clock reading the
                 // bounds are materialized with, so the suppression verdict and the executed SQL can
-                // never straddle EAT midnight and disagree.
+                // never straddle the resolved zone's midnight and disagree.
                 boolean suppress = bounds != null && !rangeCoversPinnedWindow(pinned, bounds);
-                if (prior) applyPinnedPrior(next, g, pinned);
+                if (prior) applyPinnedPrior(next, g, pinned, zone);
                 else       materializePinnedWindow(next, g, pinned);
                 if (suppress) next.put(SUPPRESSED, true);
                 // The window param cannot override a pin — say so, rather than silently ignoring it
@@ -235,7 +238,7 @@ public class KpiQueryComposer {
 
         if (prior) {
             // ---- prior-period: shift the (selected | default-week) range back one equal duration ----
-            applyPrior(next, g, bounds);
+            applyPrior(next, g, bounds, calendar);
         } else if (bounds != null && !liveOpenSnapshot) {
             // ---- explicit date range -> gte/lt filter on the grain's time column ----
             applyDateRange(next, g, bounds);
@@ -297,29 +300,37 @@ public class KpiQueryComposer {
 
     // ---- date range ----
 
-    /** Half-open epoch-ms range [fromMs, toMs), with the inclusive ISO start/end dates retained. */
+    /**
+     * Half-open epoch-ms range [fromMs, toMs), with the inclusive ISO start/end dates retained.
+     * {@code dateFrom}/{@code dateTo} are LOCAL calendar dates in the resolved tenant zone — bounds
+     * are start-of-day in THAT zone, not UTC midnight, so they line up with the planner's window
+     * math and the grain's zone-derived date columns.
+     */
     private static final class Bounds {
         final LocalDate fromDate;       // inclusive
         final LocalDate toExclusive;    // exclusive (day after dateTo)
-        final long fromMs;              // UTC-midnight epoch-ms of fromDate (FE isoDateToStartMs)
-        final long toMs;                // UTC-midnight epoch-ms of toExclusive (FE isoDateToEndExclusiveMs)
-        Bounds(LocalDate fromDate, LocalDate toExclusive) {
+        final long fromMs;              // zone-midnight epoch-ms of fromDate
+        final long toMs;                // zone-midnight epoch-ms of toExclusive
+        Bounds(LocalDate fromDate, LocalDate toExclusive, ZoneId zone) {
             this.fromDate = fromDate; this.toExclusive = toExclusive;
-            this.fromMs = fromDate.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli();
-            this.toMs   = toExclusive.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli();
+            this.fromMs = fromDate.atStartOfDay(zone).toInstant().toEpochMilli();
+            this.toMs   = toExclusive.atStartOfDay(zone).toInstant().toEpochMilli();
         }
         long durationMs() { return toMs - fromMs; }
         /** FE countDaysInDateRange: max(1, ceil(duration / day)). */
         int dayCount() { return (int) Math.max(1, (durationMs() + MS_PER_DAY - 1) / MS_PER_DAY); }
     }
 
-    /** Parse the FE {@code dateFrom}/{@code dateTo} (ISO, inclusive) into half-open {@link Bounds}; null if unparseable. */
-    private Bounds parseBounds(String dateFrom, String dateTo) {
+    /**
+     * Parse {@code dateFrom}/{@code dateTo} (ISO, inclusive) as LOCAL calendar dates in {@code zone}
+     * into half-open {@link Bounds}; null if unparseable.
+     */
+    private Bounds parseBounds(String dateFrom, String dateTo, ZoneId zone) {
         try {
             LocalDate from = LocalDate.parse(dateFrom);
             LocalDate toExclusive = LocalDate.parse(dateTo).plusDays(1);
             if (toExclusive.isBefore(from)) return null;   // nonsensical range
-            return new Bounds(from, toExclusive);
+            return new Bounds(from, toExclusive, zone);
         } catch (DateTimeParseException ex) {
             log.debug("ignoring date range with unparseable bounds dateFrom='{}' dateTo='{}'", dateFrom, dateTo);
             return null;
@@ -360,20 +371,20 @@ public class KpiQueryComposer {
     // ---- pinned window (#1462) ----
 
     /**
-     * A pinned window RESOLVED against one clock reading: its start, "now", and the EAT calendar days
-     * either maps to. Every downstream decision — suppression, the materialized SQL bounds, the prior
-     * period — reads this single snapshot, so a request cannot be judged against one calendar day and
-     * executed against the next.
+     * A pinned window RESOLVED against one clock reading: its start, "now", and the resolved-zone
+     * calendar days either maps to. Every downstream decision — suppression, the materialized SQL
+     * bounds, the prior period — reads this single snapshot, so a request cannot be judged against
+     * one calendar day and executed against the next.
      */
     private static final class PinnedWindow {
         final long nowMs, startMs;
         final LocalDate startDate, today;
-        PinnedWindow(long nowMs, long startMs) {
+        PinnedWindow(long nowMs, long startMs, ZoneId zone) {
             this.nowMs = nowMs; this.startMs = startMs;
-            this.startDate = Instant.ofEpochMilli(startMs).atZone(EAT).toLocalDate();
-            this.today = Instant.ofEpochMilli(nowMs).atZone(EAT).toLocalDate();
+            this.startDate = Instant.ofEpochMilli(startMs).atZone(zone).toLocalDate();
+            this.today = Instant.ofEpochMilli(nowMs).atZone(zone).toLocalDate();
         }
-        /** Span in whole EAT days, inclusive of both ends — 1 for {@code dtd}. */
+        /** Span in whole zone-local days, inclusive of both ends — 1 for {@code dtd}. */
         long spanDays() { return Math.max(1, java.time.temporal.ChronoUnit.DAYS.between(startDate, today) + 1); }
     }
 
@@ -389,17 +400,17 @@ public class KpiQueryComposer {
      * against — pinning them is ignored and they take the ordinary path rather than silently
      * degrading into a query whose prior equals its current.
      */
-    private PinnedWindow pinnedWindow(JsonNode query) {
+    private PinnedWindow pinnedWindow(JsonNode query, BusinessCalendar calendar) {
         JsonNode window = query.get("window");
         if (window == null || !window.isObject()
                 || !window.hasNonNull("name") || !window.path("pinned").asBoolean(false)) return null;
-        long now = System.currentTimeMillis();
-        Long startMs = AnalyticsPlanner.windowStartMs(window.get("name").asText(), now);
+        long now = calendar.asOfMs;
+        Long startMs = AnalyticsPlanner.windowStartMs(window.get("name").asText(), now, calendar.zoneId);
         if (startMs == null) {
             log.debug("ignoring pinned:true on boundless window '{}' — nothing to pin", window.get("name").asText());
             return null;
         }
-        return new PinnedWindow(now, startMs);
+        return new PinnedWindow(now, startMs, calendar.zoneId);
     }
 
     /**
@@ -411,7 +422,7 @@ public class KpiQueryComposer {
      * Monday–Friday under a two-day filter — which is the same wrong-period-number class #1462 exists
      * to remove. For the {@code dtd} case both rules coincide: the range must contain today.
      *
-     * <p>Comparison is on EAT calendar days, the zone the planner buckets in, so a range ending
+     * <p>Comparison is on resolved-zone calendar days, the same zone the planner buckets in, so a range ending
      * "today" covers today regardless of clock time.
      */
     private boolean rangeCoversPinnedWindow(PinnedWindow pinned, Bounds bounds) {
@@ -437,14 +448,14 @@ public class KpiQueryComposer {
      * span, NOT the FE's prior-equal-duration-of-the-selected-range (which would compare "today"
      * against a month). For {@code dtd} this is yesterday — matching the tile's "vs yesterday" label.
      */
-    private void applyPinnedPrior(ObjectNode query, Grain g, PinnedWindow pinned) {
+    private void applyPinnedPrior(ObjectNode query, Grain g, PinnedWindow pinned, ZoneId zone) {
         String col = dateFilterColumn(query, g);
         if (col == null || !g.filterable.contains(col)) {
             log.debug("grain '{}' has no filterable time column for a pinned compare:prior; skipping", g.name);
             return;
         }
         LocalDate priorStart = pinned.startDate.minusDays(pinned.spanDays());
-        bindPinnedBounds(query, col, priorStart, priorStart.atStartOfDay(EAT).toInstant().toEpochMilli(),
+        bindPinnedBounds(query, col, priorStart, priorStart.atStartOfDay(zone).toInstant().toEpochMilli(),
                 pinned.startDate, pinned.startMs);
         query.remove("window");   // the explicit prior bounds now govern the time axis.
     }
@@ -485,10 +496,10 @@ public class KpiQueryComposer {
      * {@code priorPeriodEndDateIso} (the single day before the range start, ~1360) for the daily grain.
      *
      * <p>With no range: mirrors the FE no-{@code __dateRange} fallback (~1973) — the prior calendar
-     * week ({@code priorPeriodWeek}, last-Monday .. this-Monday), computed in EAT to match the
-     * planner's window zone.
+     * week ({@code priorPeriodWeek}, last-Monday .. this-Monday), computed in the resolved tenant
+     * zone (from the request's shared {@code asOf}) to match the planner's window zone.
      */
-    private void applyPrior(ObjectNode query, Grain g, Bounds bounds) {
+    private void applyPrior(ObjectNode query, Grain g, Bounds bounds, BusinessCalendar calendar) {
         String col = dateFilterColumn(query, g);
         if (col == null || !g.filterable.contains(col)) {
             log.debug("grain '{}' has no filterable time column for compare:prior; skipping", g.name);
@@ -500,11 +511,11 @@ public class KpiQueryComposer {
             if ("snapshot_date".equals(col)) {
                 // No FE analogue for a daily prior-week scalar; the day before this-Monday is the
                 // closest faithful "preceding snapshot". Bind the single prior day.
-                LocalDate thisMonday = eatThisMonday();
+                LocalDate thisMonday = thisMonday(calendar);
                 ObjectNode bound = mergeableFilterObject(query, col);
                 bound.put("eq", thisMonday.minusDays(1).toString());
             } else {
-                long[] wk = priorWeekMs();
+                long[] wk = priorWeekMs(calendar);
                 ObjectNode bound = mergeableFilterObject(query, col);
                 bound.put("gte", wk[0]);
                 bound.put("lt", wk[1]);
@@ -525,17 +536,22 @@ public class KpiQueryComposer {
         query.remove("window");
     }
 
-    /** This calendar week's Monday 00:00 in EAT, mirroring the FE local-time Monday. */
-    private LocalDate eatThisMonday() {
-        return ZonedDateTime.now(EAT).toLocalDate().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+    /**
+     * This calendar week's Monday 00:00 in the resolved tenant zone, mirroring the FE local-time
+     * Monday. Measured from the request's shared {@code asOf} (not wall-clock {@code now()}), so it
+     * agrees with every other window decision in the same batch.
+     */
+    private LocalDate thisMonday(BusinessCalendar calendar) {
+        return Instant.ofEpochMilli(calendar.asOfMs).atZone(calendar.zoneId).toLocalDate()
+                .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
     }
 
-    /** Epoch-ms [lastMonday, thisMonday) in EAT — the FE priorWeekCreatedAtFilter equivalent. */
-    private long[] priorWeekMs() {
-        LocalDate thisMonday = eatThisMonday();
+    /** Epoch-ms [lastMonday, thisMonday) in the resolved zone — the FE priorWeekCreatedAtFilter equivalent. */
+    private long[] priorWeekMs(BusinessCalendar calendar) {
+        LocalDate thisMonday = thisMonday(calendar);
         LocalDate lastMonday = thisMonday.minusDays(7);
-        long lo = lastMonday.atStartOfDay(EAT).toInstant().toEpochMilli();
-        long hi = thisMonday.atStartOfDay(EAT).toInstant().toEpochMilli();
+        long lo = lastMonday.atStartOfDay(calendar.zoneId).toInstant().toEpochMilli();
+        long hi = thisMonday.atStartOfDay(calendar.zoneId).toInstant().toEpochMilli();
         return new long[]{ lo, hi };
     }
 

--- a/backend/pgr-services/src/main/java/org/egov/pgr/service/DashboardRefreshScheduler.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/service/DashboardRefreshScheduler.java
@@ -48,15 +48,29 @@ public class DashboardRefreshScheduler {
     // Daily backlog snapshot: one row per still-open complaint per day. Runs AFTER complaint_facts
     // is refreshed. ON CONFLICT keeps the first snapshot captured for each (day, complaint), so
     // re-running within the same day is a no-op — the day's backlog is fixed at its first capture.
+    //
+    // #29 timezone addendum: snapshot_date is each complaint's TENANT-LOCAL calendar date, not a
+    // single server-wide CURRENT_DATE — joined against the same pgr_dashboard_tenant_timezone view
+    // the V2 grain MVs use (V20260810000000__tenant_business_calendar_grains.sql), keyed by the
+    // complaint's own state-root tenant, falling back to Africa/Nairobi when that tenant has no
+    // configured/valid timeZone. Because this snapshot is an append-only historical table, a later
+    // timeZone change never rewrites a date already captured — only snapshots taken after the
+    // change use the new zone.
     private static final String DAILY_SNAPSHOT_UPSERT =
             "INSERT INTO complaint_open_state_daily "
           + "(snapshot_date, service_request_id, tenant_id, is_open, sla_breached, sla_status_bucket, "
           + " aging_bucket, boundary_path, ward_code, zone_code, service_code, current_assignee_uuid, "
           + " department_code, account_id) "
-          + "SELECT CURRENT_DATE, service_request_id, tenant_id, is_open, sla_breached, sla_status_bucket, "
-          + "       aging_bucket, boundary_path, ward_code, zone_code, service_code, current_assignee_uuid, "
-          + "       department_code, account_id "
-          + "FROM complaint_facts WHERE is_open "
+          + "SELECT (CURRENT_TIMESTAMP AT TIME ZONE COALESCE(tz.resolved_zone, 'Africa/Nairobi'))::date AS snapshot_date, "
+          + "       cf.service_request_id AS service_request_id, cf.tenant_id AS tenant_id, cf.is_open AS is_open, "
+          + "       cf.sla_breached AS sla_breached, cf.sla_status_bucket AS sla_status_bucket, "
+          + "       cf.aging_bucket AS aging_bucket, cf.boundary_path AS boundary_path, cf.ward_code AS ward_code, "
+          + "       cf.zone_code AS zone_code, cf.service_code AS service_code, "
+          + "       cf.current_assignee_uuid AS current_assignee_uuid, cf.department_code AS department_code, "
+          + "       cf.account_id AS account_id "
+          + "FROM complaint_facts cf "
+          + "LEFT JOIN pgr_dashboard_tenant_timezone tz ON tz.state_root_tenant_id = split_part(cf.tenant_id, '.', 1) "
+          + "WHERE cf.is_open "
           + "ON CONFLICT (snapshot_date, service_request_id) DO NOTHING";
 
     @Autowired

--- a/backend/pgr-services/src/main/resources/db/migration/main/V20260810000000__tenant_business_calendar_grains.sql
+++ b/backend/pgr-services/src/main/resources/db/migration/main/V20260810000000__tenant_business_calendar_grains.sql
@@ -56,9 +56,8 @@
 -- from identical data: the record whose btrim(data->>'id') = 'default' wins
 -- (matching the master's own "single-record master" contract -- see
 -- local-setup/db/dss-mdms-seed/schemas/dss.DashboardConfig.json), else the
--- record with the lexicographically smallest nonblank (trimmed) data->>'id',
--- else the lowest internal id (stable first-occurrence proxy -- eg_mdms_data.id
--- is assigned in insertion order).
+-- lowest internal id (stable first-occurrence proxy -- eg_mdms_data.id is
+-- assigned in insertion order), preserving the historical API-first behavior.
 DROP VIEW IF EXISTS pgr_dashboard_tenant_timezone CASCADE;
 CREATE VIEW pgr_dashboard_tenant_timezone AS
 WITH selected AS (
@@ -70,7 +69,6 @@ WITH selected AS (
     AND d.isactive
   ORDER BY d.tenantid,
            (btrim(d.data->>'id') = 'default') DESC,
-           NULLIF(btrim(d.data->>'id'), '') ASC NULLS LAST,
            d.id
 )
 SELECT s.tenantid                 AS state_root_tenant_id,

--- a/backend/pgr-services/src/main/resources/db/migration/main/V20260810000000__tenant_business_calendar_grains.sql
+++ b/backend/pgr-services/src/main/resources/db/migration/main/V20260810000000__tenant_business_calendar_grains.sql
@@ -1,0 +1,535 @@
+-- ============================================================================
+-- #29 timezone addendum: resolve the V2 grain MVs' calendar buckets (occurred/
+-- created/resolved date, week, month, hour, day-of-week, weekend, business-hour)
+-- from each row's own tenant's configured dss.DashboardConfig.timeZone, instead
+-- of the fixed 'Etc/GMT-3' (EAT) offset every earlier migration hardcoded.
+--
+-- FALLBACK: a tenant with no dss.DashboardConfig record, an absent/blank
+-- timeZone field, or a value that is not a valid IANA zone id (per
+-- pg_timezone_names) falls back to Africa/Nairobi -- the same wall-clock EAT
+-- behavior every previously-unconfigured tenant already had, so an
+-- unconfigured deployment sees byte-identical output after this migration.
+-- Matches KpiCatalogService.DEFAULT_TIME_ZONE / BusinessCalendar.DEFAULT_ZONE
+-- on the Java analytics-request path (#29 timezone addendum) -- this migration
+-- gives the DB-refreshed grains (and the daily snapshot; see
+-- DashboardRefreshScheduler) the same fallback for the tenants whose config is
+-- missing or invalid.
+--
+-- REFRESH LAG: pgr_dashboard_tenant_timezone is read fresh on every MV refresh
+-- (REFRESH MATERIALIZED VIEW CONCURRENTLY complaint_events / complaint_facts,
+-- on DashboardRefreshScheduler's own cadence, pgr.dashboard.refresh.interval.ms
+-- -- default 5 minutes). A timeZone edit in DashboardConfig therefore only
+-- takes effect for a grain row from that row's NEXT scheduled refresh onward;
+-- it does NOT rewrite any already-materialized row until that row is
+-- recomputed. complaint_open_state_daily is coarser still: it is an
+-- append-only historical snapshot TABLE (not a view or MV), so a timeZone
+-- change NEVER rewrites a snapshot_date already captured for a prior day --
+-- only snapshot rows captured AFTER the change use the new zone. Historical
+-- complaint_open_state_daily rows are not, and cannot be, corrected by this
+-- migration; this is a known, accepted limitation, not a bug.
+--
+-- HISTORY: complaint_events / complaint_facts were last (re)created by
+-- V20260731000000__repoint_grain_mvs_to_complainthierarchy.sql, which itself
+-- superseded V20260717000000, V20260716000000, V20260708000000,
+-- V20260629000000 and V20260608000000 in turn. Flyway migrations are
+-- append-only -- an already-applied file cannot be edited without breaking
+-- deployed checksums -- so this migration recreates BOTH materialized views IN
+-- FULL, changing ONLY the fixed 'Etc/GMT-3' AT TIME ZONE literals (replaced
+-- with COALESCE(tz.resolved_zone, 'Africa/Nairobi')) and adding one LEFT JOIN
+-- to the new pgr_dashboard_tenant_timezone view per MV, at that MV's primary
+-- tenant source (tx for complaint_events, s for complaint_facts). Every
+-- column, CTE, index and unique index is otherwise byte-identical to
+-- V20260731000000 -- recreate BOTH MVs again in any future shape change.
+-- ============================================================================
+
+
+-- ---- reusable per-state-root timezone resolver ------------------------------
+-- One deterministic row per state-root tenant: the validated IANA zone id that
+-- tenant's dss.DashboardConfig.timeZone declares, or no row at all when the
+-- config is absent, blank, or not a valid zone (checked against the server's
+-- own pg_timezone_names catalog) -- callers COALESCE against 'Africa/Nairobi'
+-- at the join site, so an invalid zone id is NEVER passed to AT TIME ZONE
+-- (which would error the whole refresh). Multiple active dss.DashboardConfig
+-- records for one state root (duplicate/malformed data) are deduped by the
+-- SAME rule KpiCatalogService.selectDashboardConfigRecord (Java) and
+-- useDashboardConfig.js (FE) apply, so every layer picks the identical record
+-- from identical data: the record whose btrim(data->>'id') = 'default' wins
+-- (matching the master's own "single-record master" contract -- see
+-- local-setup/db/dss-mdms-seed/schemas/dss.DashboardConfig.json), else the
+-- record with the lexicographically smallest nonblank (trimmed) data->>'id',
+-- else the lowest internal id (stable first-occurrence proxy -- eg_mdms_data.id
+-- is assigned in insertion order).
+DROP VIEW IF EXISTS pgr_dashboard_tenant_timezone CASCADE;
+CREATE VIEW pgr_dashboard_tenant_timezone AS
+WITH selected AS (
+  SELECT DISTINCT ON (d.tenantid)
+         d.tenantid,
+         d.data
+  FROM eg_mdms_data d
+  WHERE d.schemacode = 'dss.DashboardConfig'
+    AND d.isactive
+  ORDER BY d.tenantid,
+           (btrim(d.data->>'id') = 'default') DESC,
+           NULLIF(btrim(d.data->>'id'), '') ASC NULLS LAST,
+           d.id
+)
+SELECT s.tenantid                 AS state_root_tenant_id,
+       btrim(s.data->>'timeZone') AS resolved_zone
+FROM selected s
+WHERE s.data->>'timeZone' IS NOT NULL
+  AND btrim(s.data->>'timeZone') <> ''
+  AND btrim(s.data->>'timeZone') IN (SELECT name FROM pg_timezone_names);
+
+
+-- ---- grain 1: complaint_events ----------------------------------------------
+DROP MATERIALIZED VIEW IF EXISTS complaint_events CASCADE;
+CREATE MATERIALIZED VIEW complaint_events AS
+WITH RECURSIVE svc AS (
+  SELECT s.servicerequestid, s.id AS pgr_id, s.tenantid, s.servicecode, s.accountid,
+         s.source, s.createdtime AS complaint_created_at, s.createdby AS filed_by_uuid,
+         a.locality AS locality_code, a.latitude, a.longitude,
+         (a.latitude IS NOT NULL AND a.longitude IS NOT NULL) AS has_geo_pin
+  FROM eg_pgr_service_v2 s
+  LEFT JOIN eg_pgr_address_v2 a ON a.parentid = s.id
+),
+bnd0 AS (   -- one row per boundary code: full root->leaf path + the node's own (leaf) type,
+            -- tenant and hierarchy; longest ancestral path wins (as before)
+  SELECT DISTINCT ON (code) code, tenantid, hierarchytype,
+         boundarytype AS leaf_type,
+         (ancestralmaterializedpath || '|' || code) AS boundary_path
+  FROM boundary_relationship
+  ORDER BY code, length(ancestralmaterializedpath) DESC
+),
+btype AS (  -- per-node level type (same dedupe rule), to type every path segment
+  SELECT DISTINCT ON (code) code, boundarytype
+  FROM boundary_relationship
+  ORDER BY code, length(ancestralmaterializedpath) DESC
+),
+wardlvl AS (   -- #1079: the tenant's 'Ward' level and the level directly above it,
+               -- from the boundary_hierarchy level registry
+  SELECT DISTINCT ON (h.tenantid, h.hierarchytype) h.tenantid, h.hierarchytype,
+         lvl->>'boundaryType'       AS ward_type,
+         lvl->>'parentBoundaryType' AS zone_type
+  FROM boundary_hierarchy h
+  CROSS JOIN LATERAL jsonb_array_elements(h.boundaryhierarchy) lvl
+  WHERE lower(lvl->>'boundaryType') = 'ward'
+),
+bnd AS (   -- #1079: registry-resolved named levels per boundary code.
+           -- FALLBACK (no Ward level in the tenant's hierarchy): leaf / parent-of-leaf.
+  SELECT b.code, b.boundary_path,
+         b.code      AS boundary_leaf_code,
+         b.leaf_type AS boundary_leaf_type,
+         CASE WHEN w.ward_type IS NOT NULL THEN seg.ward_seg
+              ELSE segs.arr[array_length(segs.arr,1)] END     AS ward_code,
+         CASE WHEN w.ward_type IS NOT NULL THEN seg.zone_seg
+              ELSE segs.arr[array_length(segs.arr,1)-1] END   AS zone_code
+  FROM bnd0 b
+  LEFT JOIN wardlvl w ON w.tenantid = b.tenantid AND w.hierarchytype = b.hierarchytype
+  CROSS JOIN LATERAL (SELECT string_to_array(b.boundary_path,'|') AS arr) segs
+  LEFT JOIN LATERAL (
+    SELECT max(s.seg) FILTER (WHERE lower(bt.boundarytype) = lower(w.ward_type)) AS ward_seg,
+           max(s.seg) FILTER (WHERE lower(bt.boundarytype) = lower(w.zone_type)) AS zone_seg
+    FROM unnest(segs.arr) s(seg)
+    LEFT JOIN btype bt ON bt.code = s.seg
+  ) seg ON true
+),
+bs AS (
+  SELECT DISTINCT ON (tenantid, businessservice) tenantid, businessservice, businessservicesla
+  FROM eg_wf_businessservice_v2
+),
+asg AS (
+  SELECT processinstanceid, count(*) AS assignee_count,
+         (array_agg(assignee ORDER BY assignee))[1] AS assignee_uuid
+  FROM eg_wf_assignee_v2 GROUP BY processinstanceid
+),
+mdms AS (   -- #1494: ComplaintHierarchy LEAF rows (was RAINMAKER-PGR.ServiceDefs).
+            -- Dedupe by code preferring the root (shortest) tenant, as before.
+            -- Leaf detection is by levelCode against the registry's isLeafServiceCode
+            -- level, NOT by "department IS NOT NULL" — a leaf may legitimately carry no
+            -- department (the configurator writes 'NA' for a blank onboarding cell), and
+            -- filtering on department would drop those complaint types out of the grain
+            -- entirely rather than merely leaving department_code NULL.
+            -- The "no department" sentinels are normalised to NULL so they never reach a
+            -- dashboard as a label. Match ServiceRequestValidator:185-186, which treats
+            -- NULL, blank/whitespace and any case of 'NA' as "no department constraint".
+            -- The surviving value keeps its ORIGINAL case: department codes are mixed-case
+            -- in practice (e.g. 'zambezia_csrep' alongside 'CENTER') and are compared
+            -- verbatim against the department master and the HRMS codes in RBAC scoping,
+            -- so folding case here would break both.
+  SELECT DISTINCT ON (data->>'code')
+         data->>'code' AS service_code,
+         CASE WHEN upper(btrim(coalesce(data->>'department', data->'departments'->>0))) IN ('NA','')
+              THEN NULL
+              ELSE btrim(coalesce(data->>'department', data->'departments'->>0))
+         END AS department_code
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.ComplaintHierarchy' AND isactive
+    AND data->>'levelCode' IN (SELECT level_code FROM chlvl)   -- WITH RECURSIVE: forward ref is legal
+  ORDER BY data->>'code', length(tenantid), tenantid
+),
+chlvl AS (   -- #1079: levelCodes flagged isLeafServiceCode in ComplaintHierarchyDefinition
+  SELECT DISTINCT lvl->>'levelCode' AS level_code
+  FROM eg_mdms_data d
+  CROSS JOIN LATERAL jsonb_array_elements(d.data->'levels') lvl
+  WHERE d.schemacode = 'RAINMAKER-PGR.ComplaintHierarchyDefinition' AND d.isactive
+    AND (lvl->>'isLeafServiceCode')::boolean
+),
+ch AS (   -- ComplaintHierarchy nodes; dedupe by code preferring leaf-level records
+          -- (registry leaf detection), then the root (shortest) tenant
+  SELECT DISTINCT ON (data->>'code')
+         data->>'code'                  AS code,
+         NULLIF(data->>'path','')       AS node_path,
+         NULLIF(data->>'parentCode','') AS parent_code
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.ComplaintHierarchy' AND isactive
+  ORDER BY data->>'code',
+           (data->>'levelCode' IN (SELECT level_code FROM chlvl)) DESC,
+           length(tenantid)
+),
+chwalk AS (   -- recursive parentCode walk (robust fallback when path is absent)
+  SELECT code AS leaf_code, code, parent_code, code::text AS built_path, 1 AS depth
+  FROM ch
+  UNION ALL
+  SELECT w.leaf_code, p.code, p.parent_code, (p.code || '.' || w.built_path), w.depth + 1
+  FROM chwalk w
+  JOIN ch p ON p.code = w.parent_code
+  WHERE w.depth < 12
+),
+cnp AS (   -- #1079: complaint_node_path per code = master path, else recursive build.
+           -- #1111/R5: NULL when the matched node's OWN code contains '.' — legacy flat
+           -- imports carry dots INSIDE one code, so any '.'-split of their path would
+           -- fabricate garbage level buckets; NULL path => the query-time level expr
+           -- falls back to the leaf service_code instead.
+           -- R5 widening: ALSO NULL when a dotted code/parentCode appears ANYWHERE in the
+           -- node's ancestor chain (chwalk carries the node itself at depth 1, so this
+           -- strictly contains the old node+parent predicate) — clean-code nodes anywhere
+           -- under a dotted legacy code inherit a polluted path/built_path and would
+           -- otherwise survive as the same garbage buckets.
+  SELECT ch.code,
+         CASE WHEN EXISTS (
+                SELECT 1 FROM chwalk w
+                WHERE w.leaf_code = ch.code
+                  AND (position('.' IN w.code) > 0
+                       OR position('.' IN coalesce(w.parent_code, '')) > 0)
+              ) THEN NULL
+              ELSE coalesce(ch.node_path, walk.built_path) END AS complaint_node_path
+  FROM ch
+  LEFT JOIN LATERAL (
+    SELECT w.built_path FROM chwalk w WHERE w.leaf_code = ch.code
+    ORDER BY w.depth DESC LIMIT 1
+  ) walk ON true
+),
+tx AS (
+  SELECT pi.id AS event_id, pi.businessid AS service_request_id, pi.tenantid,
+         pi.businessservice, pi.action, pi.assigner AS actor_uuid,
+         pi.escalated, pi.rating AS event_rating, pi.comment,
+         pi.createdtime AS entered_at,
+         st.state AS status, st.seq AS status_seq, st.sla AS state_sla_ms,
+         st.isterminatestate AS status_is_terminal,
+         lead(pi.createdtime) OVER w AS exited_at,
+         lag(st.state)        OVER w AS previous_status,
+         lag(st.seq)          OVER w AS previous_status_seq,
+         row_number()         OVER w AS seq_no,
+         (lead(pi.id) OVER w IS NULL) AS is_current_state
+  FROM eg_wf_processinstance_v2 pi
+  LEFT JOIN eg_wf_state_v2 st ON st.uuid = pi.status
+  WINDOW w AS (PARTITION BY pi.businessid ORDER BY pi.createdtime, pi.id)
+)
+SELECT
+  tx.event_id, tx.service_request_id, tx.tenantid AS tenant_id,
+  tx.businessservice AS business_service, tx.seq_no, tx.is_current_state,
+  tx.action, tx.status, tx.previous_status,
+  coalesce(tx.status_is_terminal,false)        AS status_is_terminal,
+  (NOT coalesce(tx.status_is_terminal,false))  AS status_is_open,
+  tx.actor_uuid, asg.assignee_uuid,
+  (ua.type = 'SYSTEM')                         AS actor_is_system,
+  tx.entered_at, tx.exited_at,
+  (tx.exited_at - tx.entered_at)               AS dwell_ms,
+  tx.status_seq, tx.previous_status_seq,
+  (tx.status_seq - tx.previous_status_seq)     AS seq_delta,
+  (tx.status_seq < tx.previous_status_seq)     AS is_backward_transition,
+  tx.state_sla_ms,
+  CASE WHEN tx.state_sla_ms IS NOT NULL AND tx.exited_at IS NOT NULL
+       THEN (tx.exited_at - tx.entered_at) > tx.state_sla_ms END AS state_sla_breached_on_exit,
+  bs.businessservicesla                        AS business_sla_ms,
+  (tx.action IN ('ASSIGN','REASSIGN'))         AS is_assignment,
+  (tx.action = 'REOPEN')                       AS is_reopen,
+  coalesce(tx.escalated,false)                 AS is_escalation,
+  CASE WHEN coalesce(tx.escalated,false)
+       THEN (CASE WHEN ua.type='SYSTEM' THEN 'auto' ELSE 'manual' END) END AS escalation_source,
+  (tx.comment IS NOT NULL AND tx.comment <> '') AS has_comment,
+  length(tx.comment)                           AS comment_length,
+  tx.event_rating,
+  coalesce(asg.assignee_count,0)               AS assignee_count,
+  (coalesce(asg.assignee_count,0) > 1)         AS has_multiple_assignees,
+  svc.accountid AS account_id, svc.source, svc.servicecode AS service_code,
+  m.department_code,                                                      -- S2: department row-scope axis
+  cnp.complaint_node_path,                                                -- #1079: complaint taxonomy axis
+  array_length(string_to_array(cnp.complaint_node_path,'.'),1)::smallint AS complaint_depth,
+  svc.locality_code, svc.has_geo_pin,
+  svc.complaint_created_at,
+  (tx.entered_at - svc.complaint_created_at)   AS complaint_age_at_event_ms,
+  bnd.boundary_path,
+  bnd.zone_code,                               -- #1079: registry-resolved (was split_part pos 2)
+  bnd.ward_code,                               -- #1079: registry-resolved (was split_part pos 3)
+  bnd.boundary_leaf_code,                      -- #1079: leaf node, depth-agnostic
+  bnd.boundary_leaf_type,
+  (to_timestamp(tx.entered_at/1000) AT TIME ZONE COALESCE(tz.resolved_zone, 'Africa/Nairobi'))::date AS occurred_date,
+  date_trunc('week',(to_timestamp(tx.entered_at/1000) AT TIME ZONE COALESCE(tz.resolved_zone, 'Africa/Nairobi')))::date AS occurred_week_start,
+  to_char((to_timestamp(tx.entered_at/1000) AT TIME ZONE COALESCE(tz.resolved_zone, 'Africa/Nairobi')),'YYYY-MM') AS occurred_month,
+  extract(hour   FROM (to_timestamp(tx.entered_at/1000) AT TIME ZONE COALESCE(tz.resolved_zone, 'Africa/Nairobi')))::smallint AS occurred_hour,
+  extract(isodow FROM (to_timestamp(tx.entered_at/1000) AT TIME ZONE COALESCE(tz.resolved_zone, 'Africa/Nairobi')))::smallint AS occurred_dow,
+  (extract(isodow FROM (to_timestamp(tx.entered_at/1000) AT TIME ZONE COALESCE(tz.resolved_zone, 'Africa/Nairobi'))) IN (6,7)) AS occurred_is_weekend,
+  (extract(hour  FROM (to_timestamp(tx.entered_at/1000) AT TIME ZONE COALESCE(tz.resolved_zone, 'Africa/Nairobi'))) BETWEEN 8 AND 17) AS occurred_is_business_hr
+FROM tx
+LEFT JOIN pgr_dashboard_tenant_timezone tz ON tz.state_root_tenant_id = split_part(tx.tenantid,'.',1)
+LEFT JOIN svc ON svc.servicerequestid = tx.service_request_id
+LEFT JOIN bnd ON bnd.code = svc.locality_code
+LEFT JOIN cnp ON cnp.code = svc.servicecode
+LEFT JOIN LATERAL (                          -- #1028 fix 3: exact tenant, else state root
+  SELECT b.businessservicesla
+  FROM bs b
+  WHERE b.businessservice = tx.businessservice
+    AND b.tenantid IN (tx.tenantid, split_part(tx.tenantid,'.',1))
+  ORDER BY length(b.tenantid) DESC
+  LIMIT 1
+) bs ON true
+LEFT JOIN asg ON asg.processinstanceid = tx.event_id
+LEFT JOIN mdms m ON m.service_code = svc.servicecode
+LEFT JOIN eg_user ua ON ua.uuid = tx.actor_uuid;
+
+CREATE UNIQUE INDEX ux_complaint_events ON complaint_events(event_id);
+CREATE INDEX ix_ce_timeline ON complaint_events(service_request_id, seq_no);
+CREATE INDEX ix_ce_status   ON complaint_events(status);
+CREATE INDEX ix_ce_assignee ON complaint_events(assignee_uuid);
+CREATE INDEX ix_ce_week     ON complaint_events(occurred_week_start);
+CREATE INDEX ix_ce_dept     ON complaint_events(department_code);
+
+-- ---- grain 2: complaint_facts (CASCADE dropped by the events recreate) ------
+DROP MATERIALIZED VIEW IF EXISTS complaint_facts CASCADE;
+CREATE MATERIALIZED VIEW complaint_facts AS
+WITH RECURSIVE clock AS (SELECT (extract(epoch FROM now())*1000)::bigint AS now_ms),
+roll AS (
+  SELECT service_request_id,
+         min(entered_at)                                            AS created_at,
+         max(entered_at)                                            AS last_transition_at,
+         count(*)                                                   AS transition_count,
+         count(*) FILTER (WHERE is_assignment)                      AS assignment_count,
+         count(*) FILTER (WHERE is_escalation)                      AS escalation_count,
+         count(*) FILTER (WHERE is_reopen)                          AS reopen_count,
+         count(DISTINCT assignee_uuid)                              AS distinct_assignee_count,
+         count(DISTINCT actor_uuid)                                 AS distinct_actor_count,
+         count(*) FILTER (WHERE actor_is_system)                    AS system_transition_count,
+         count(*) FILTER (WHERE NOT actor_is_system)                AS manual_transition_count,
+         bool_or(status IN ('REJECTED','CLOSEDAFTERREJECTION'))     AS was_rejected,
+         min(entered_at) FILTER (WHERE is_assignment)               AS first_assigned_at,
+         min(entered_at) FILTER (WHERE status IN ('RESOLVED','CLOSEDAFTERRESOLUTION')) AS resolved_at,
+         max(entered_at) FILTER (WHERE is_escalation)               AS last_escalated_at,
+         min(entered_at) FILTER (WHERE is_escalation)               AS first_escalated_at,
+         max(dwell_ms)                                              AS max_dwell_ms,
+         sum(dwell_ms) FILTER (WHERE assignee_uuid IS NOT NULL)     AS assigned_dwell_ms,
+         sum(dwell_ms) FILTER (WHERE assignee_uuid IS NULL)         AS unassigned_dwell_ms
+  FROM complaint_events GROUP BY service_request_id
+),
+cur AS (
+  SELECT service_request_id, status AS application_status, status_seq AS current_state_seq,
+         status_is_open AS is_open, assignee_uuid AS current_assignee_uuid,
+         state_sla_ms AS current_state_sla_ms, business_sla_ms,
+         boundary_path, ward_code, zone_code,
+         boundary_leaf_code, boundary_leaf_type                     -- #1079
+  FROM complaint_events WHERE is_current_state
+),
+mdms AS (   -- #1494: ComplaintHierarchy LEAF rows (was RAINMAKER-PGR.ServiceDefs).
+            -- See the matching CTE in complaint_events above for the leaf-detection and
+            -- 'NA' rationale. legacy_service_group was ServiceDefs.menuPath, which the
+            -- #917 migration consumed and did NOT carry onto the new master — grouping is
+            -- parentCode-driven now, so the fallback is retired to NULL and service_group
+            -- resolves from the hierarchy path alone (see the coalesce below).
+  SELECT DISTINCT ON (data->>'code')
+         data->>'code'                   AS service_code,
+         (data->>'slaHours')::int        AS mdms_sla_hours,
+         NULL::text                      AS legacy_service_group,   -- #1494: retired with menuPath
+         (data->>'order')::smallint      AS service_order,
+         CASE WHEN upper(btrim(coalesce(data->>'department', data->'departments'->>0))) IN ('NA','')
+              THEN NULL
+              ELSE btrim(coalesce(data->>'department', data->'departments'->>0))
+         END AS department_code
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.ComplaintHierarchy' AND isactive
+    AND data->>'levelCode' IN (SELECT level_code FROM chlvl)   -- WITH RECURSIVE: forward ref is legal
+  ORDER BY data->>'code', length(tenantid), tenantid
+),
+chlvl AS (   -- #1079: levelCodes flagged isLeafServiceCode in ComplaintHierarchyDefinition
+  SELECT DISTINCT lvl->>'levelCode' AS level_code
+  FROM eg_mdms_data d
+  CROSS JOIN LATERAL jsonb_array_elements(d.data->'levels') lvl
+  WHERE d.schemacode = 'RAINMAKER-PGR.ComplaintHierarchyDefinition' AND d.isactive
+    AND (lvl->>'isLeafServiceCode')::boolean
+),
+ch AS (   -- ComplaintHierarchy nodes; dedupe by code preferring leaf-level records
+          -- (registry leaf detection), then the root (shortest) tenant
+  SELECT DISTINCT ON (data->>'code')
+         data->>'code'                  AS code,
+         NULLIF(data->>'path','')       AS node_path,
+         NULLIF(data->>'parentCode','') AS parent_code
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.ComplaintHierarchy' AND isactive
+  ORDER BY data->>'code',
+           (data->>'levelCode' IN (SELECT level_code FROM chlvl)) DESC,
+           length(tenantid)
+),
+chwalk AS (   -- recursive parentCode walk (robust fallback when path is absent)
+  SELECT code AS leaf_code, code, parent_code, code::text AS built_path, 1 AS depth
+  FROM ch
+  UNION ALL
+  SELECT w.leaf_code, p.code, p.parent_code, (p.code || '.' || w.built_path), w.depth + 1
+  FROM chwalk w
+  JOIN ch p ON p.code = w.parent_code
+  WHERE w.depth < 12
+),
+cnp AS (   -- #1079: complaint_node_path per code = master path, else recursive build.
+           -- #1111/R5: NULL when the matched node's OWN code contains '.' — legacy flat
+           -- imports carry dots INSIDE one code, so any '.'-split of their path would
+           -- fabricate garbage level buckets; NULL path => the query-time level expr
+           -- falls back to the leaf service_code instead.
+           -- R5 widening: ALSO NULL when a dotted code/parentCode appears ANYWHERE in the
+           -- node's ancestor chain (chwalk carries the node itself at depth 1, so this
+           -- strictly contains the old node+parent predicate) — clean-code nodes anywhere
+           -- under a dotted legacy code inherit a polluted path/built_path and would
+           -- otherwise survive as the same garbage buckets.
+  SELECT ch.code,
+         CASE WHEN EXISTS (
+                SELECT 1 FROM chwalk w
+                WHERE w.leaf_code = ch.code
+                  AND (position('.' IN w.code) > 0
+                       OR position('.' IN coalesce(w.parent_code, '')) > 0)
+              ) THEN NULL
+              ELSE coalesce(ch.node_path, walk.built_path) END AS complaint_node_path
+  FROM ch
+  LEFT JOIN LATERAL (
+    SELECT w.built_path FROM chwalk w WHERE w.leaf_code = ch.code
+    ORDER BY w.depth DESC LIMIT 1
+  ) walk ON true
+),
+esc AS (   -- #1028 fix 2: EscalationConfig ladder source (one record per tenant, at state root)
+  SELECT tenantid,
+         data->'overrides'         AS overrides,
+         data->'defaultSlaByLevel' AS default_levels
+  FROM eg_mdms_data
+  WHERE schemacode = 'RAINMAKER-PGR.EscalationConfig' AND isactive
+),
+seq AS (
+  SELECT id, row_number() OVER (PARTITION BY accountid ORDER BY createdtime, id) AS complaint_seq_for_citizen
+  FROM eg_pgr_service_v2
+)
+SELECT
+  s.servicerequestid AS service_request_id, s.id AS pgr_id, s.tenantid AS tenant_id,
+  s.accountid AS account_id, 'PGR'::text AS business_service,
+  s.servicecode AS service_code, cur.application_status, s.source, s.rating AS rating_raw, s.active,
+  length(s.description) AS description_length,
+  (s.description IS NOT NULL AND s.description <> '') AS has_description,
+  s.createdby AS filed_by_uuid, (s.createdby <> s.accountid) AS filed_on_behalf,
+  a.locality AS locality_code, a.pincode, a.city, a.latitude, a.longitude,
+  (a.latitude IS NOT NULL AND a.longitude IS NOT NULL) AS has_geo_pin,
+  (a.parentid IS NOT NULL) AS has_address,
+  cur.boundary_path,
+  (length(coalesce(cur.boundary_path,'')) - length(replace(coalesce(cur.boundary_path,''),'|','')) + 1)::smallint AS boundary_depth,
+  cur.ward_code, cur.zone_code,
+  cur.boundary_leaf_code, cur.boundary_leaf_type,                          -- #1079
+  cnp.complaint_node_path,                                                 -- #1079
+  cx.complaint_depth,                                                      -- #1079
+  coalesce(cx.root_code, m.legacy_service_group) AS service_group,         -- #1079: ROOT category
+  cx.service_parent_code,                                                  -- #1079: immediate parent
+  m.service_order, m.mdms_sla_hours, m.department_code,
+  cur.current_state_seq, cur.current_state_sla_ms, tgt.sla_target_ms,      -- #1028: COALESCE'd target
+  (m.mdms_sla_hours IS NOT NULL AND cur.business_sla_ms IS NOT NULL
+    AND m.mdms_sla_hours::bigint*3600000 <> cur.business_sla_ms) AS sla_config_mismatch,
+  roll.created_at, roll.first_assigned_at, roll.first_assigned_at AS first_response_at,
+  roll.resolved_at, roll.last_transition_at, roll.first_escalated_at, roll.last_escalated_at,
+  roll.transition_count, roll.assignment_count, roll.escalation_count, roll.reopen_count,
+  roll.distinct_assignee_count, roll.distinct_actor_count,
+  roll.system_transition_count, roll.manual_transition_count,
+  roll.was_rejected, (roll.reopen_count > 0) AS is_reopened,
+  cur.is_open, (roll.resolved_at IS NOT NULL) AS is_resolved,
+  roll.max_dwell_ms, roll.assigned_dwell_ms, roll.unassigned_dwell_ms,
+  cur.current_assignee_uuid,
+  (roll.resolved_at - roll.created_at)                            AS resolution_ms,
+  (roll.first_assigned_at - roll.created_at)                      AS time_to_assign_ms,
+  CASE WHEN cur.is_open THEN clock.now_ms - roll.created_at END   AS open_age_ms,
+  CASE WHEN cur.is_open THEN clock.now_ms - roll.last_transition_at END AS current_state_age_ms,
+  (roll.first_escalated_at - roll.created_at)                     AS first_escalation_ms,
+  CASE WHEN cur.is_open  THEN (tgt.sla_target_ms IS NOT NULL AND (clock.now_ms - roll.created_at) > tgt.sla_target_ms)
+       WHEN roll.resolved_at IS NOT NULL THEN (tgt.sla_target_ms IS NOT NULL AND (roll.resolved_at - roll.created_at) > tgt.sla_target_ms)
+       ELSE false END                                            AS sla_breached,
+  (cur.is_open AND cur.current_state_sla_ms IS NOT NULL
+    AND (clock.now_ms - roll.last_transition_at) > cur.current_state_sla_ms) AS current_state_sla_breached,
+  CASE WHEN NOT cur.is_open THEN NULL
+       WHEN (clock.now_ms - roll.created_at) < 86400000  THEN '<1d'
+       WHEN (clock.now_ms - roll.created_at) < 259200000 THEN '1-3d'
+       WHEN (clock.now_ms - roll.created_at) < 604800000 THEN '3-7d'
+       ELSE '>7d' END                                            AS aging_bucket,
+  CASE WHEN NOT cur.is_open OR tgt.sla_target_ms IS NULL THEN NULL
+       WHEN (clock.now_ms - roll.created_at) > tgt.sla_target_ms       THEN 'breached'
+       WHEN (clock.now_ms - roll.created_at) > 0.8*tgt.sla_target_ms   THEN 'approaching'
+       ELSE 'within' END                                         AS sla_status_bucket,
+  (s.rating IS NOT NULL) AS has_rating, s.rating, (s.rating IS NOT NULL AND s.rating <= 2) AS is_negative_rating,
+  seq.complaint_seq_for_citizen, (seq.complaint_seq_for_citizen = 1) AS is_first_time_complainant,
+  (to_timestamp(roll.created_at/1000) AT TIME ZONE COALESCE(tz.resolved_zone, 'Africa/Nairobi'))::date AS created_date,
+  date_trunc('week',(to_timestamp(roll.created_at/1000) AT TIME ZONE COALESCE(tz.resolved_zone, 'Africa/Nairobi')))::date AS created_week_start,
+  to_char((to_timestamp(roll.created_at/1000) AT TIME ZONE COALESCE(tz.resolved_zone, 'Africa/Nairobi')),'YYYY-MM') AS created_month,
+  extract(year FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE COALESCE(tz.resolved_zone, 'Africa/Nairobi')))::smallint AS created_year,
+  to_char((to_timestamp(roll.created_at/1000) AT TIME ZONE COALESCE(tz.resolved_zone, 'Africa/Nairobi')),'YYYY-"Q"Q') AS created_quarter,
+  extract(hour FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE COALESCE(tz.resolved_zone, 'Africa/Nairobi')))::smallint AS created_hour,
+  extract(isodow FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE COALESCE(tz.resolved_zone, 'Africa/Nairobi')))::smallint AS created_dow,
+  (extract(isodow FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE COALESCE(tz.resolved_zone, 'Africa/Nairobi'))) IN (6,7)) AS created_is_weekend,
+  (extract(hour FROM (to_timestamp(roll.created_at/1000) AT TIME ZONE COALESCE(tz.resolved_zone, 'Africa/Nairobi'))) BETWEEN 8 AND 17) AS created_is_business_hr,
+  (to_timestamp(roll.resolved_at/1000) AT TIME ZONE COALESCE(tz.resolved_zone, 'Africa/Nairobi'))::date AS resolved_date,
+  to_char((to_timestamp(roll.resolved_at/1000) AT TIME ZONE COALESCE(tz.resolved_zone, 'Africa/Nairobi')),'YYYY-MM') AS resolved_month,
+  clock.now_ms AS facts_built_at
+FROM eg_pgr_service_v2 s
+LEFT JOIN pgr_dashboard_tenant_timezone tz ON tz.state_root_tenant_id = split_part(s.tenantid,'.',1)
+CROSS JOIN clock
+LEFT JOIN eg_pgr_address_v2 a ON a.parentid = s.id
+LEFT JOIN roll ON roll.service_request_id = s.servicerequestid
+LEFT JOIN cur  ON cur.service_request_id  = s.servicerequestid
+LEFT JOIN mdms m ON m.service_code = s.servicecode
+LEFT JOIN cnp ON cnp.code = s.servicecode
+CROSS JOIN LATERAL (                         -- #1079: path-derived complaint-axis fields
+  SELECT x.arr[1]                            AS root_code,
+         array_length(x.arr,1)::smallint     AS complaint_depth,
+         x.arr[array_length(x.arr,1)-1]      AS service_parent_code
+  FROM (SELECT string_to_array(cnp.complaint_node_path,'.') AS arr) x
+) cx
+LEFT JOIN LATERAL (                          -- #1028 fix 2: ladder total for this complaint's
+  SELECT CASE                                -- service code, from the nearest EscalationConfig
+           WHEN jsonb_typeof(e.overrides -> s.servicecode) = 'array'   -- (exact tenant, else state root)
+             THEN (SELECT sum(v.value::numeric)::bigint
+                   FROM jsonb_array_elements_text(e.overrides -> s.servicecode) v)
+           WHEN jsonb_typeof(e.default_levels) = 'array'
+             THEN (SELECT sum(v.value::numeric)::bigint
+                   FROM jsonb_array_elements_text(e.default_levels) v)
+         END AS ladder_sla_ms
+  FROM esc e
+  WHERE e.tenantid IN (s.tenantid, split_part(s.tenantid,'.',1))
+  ORDER BY length(e.tenantid) DESC
+  LIMIT 1
+) lad ON true
+CROSS JOIN LATERAL (                         -- #1028: the decided SLA-target precedence
+  SELECT coalesce(m.mdms_sla_hours::bigint * 3600000,   -- 1) ComplaintHierarchy leaf slaHours
+                  lad.ladder_sla_ms,                    -- 2) escalation-ladder total
+                  cur.business_sla_ms                   -- 3) workflow SLA (state-root fallback)
+         ) AS sla_target_ms
+) tgt
+LEFT JOIN seq ON seq.id = s.id
+WHERE s.active = true;
+
+CREATE UNIQUE INDEX ux_complaint_facts ON complaint_facts(service_request_id);
+CREATE INDEX ix_cf_service ON complaint_facts(service_code);
+CREATE INDEX ix_cf_status  ON complaint_facts(application_status);
+CREATE INDEX ix_cf_created ON complaint_facts(created_week_start);
+CREATE INDEX ix_cf_open    ON complaint_facts(is_open) WHERE is_open;
+CREATE INDEX ix_cf_ward    ON complaint_facts(ward_code);
+-- #1494: department is an RBAC scope axis — applyScope adds `department_code IN (...)`
+-- to EVERY facts query for a department-scoped principal, and it is a grouping
+-- dimension for the department tiles. The events grain already has ix_ce_dept.
+CREATE INDEX ix_cf_dept    ON complaint_facts(department_code);

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsPlannerTimeZoneTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsPlannerTimeZoneTest.java
@@ -1,0 +1,194 @@
+package org.egov.pgr.analytics;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * #29: pins the analytics calendar at the planner boundary — named windows resolve day
+ * boundaries at the RESOLVED TENANT zone's midnight (not UTC, not a hardcoded EAT), across a
+ * whole-hour offset (Africa/Nairobi, Africa/Maputo) and a non-whole-hour offset (Asia/Kolkata,
+ * UTC+5:30), survive a DST transition without throwing, and the runtime {@code timeBucket} SQL
+ * binds the resolved zone as a JDBC param at the correct position (never string-concatenated).
+ */
+public class AnalyticsPlannerTimeZoneTest {
+
+    private final ObjectMapper om = new ObjectMapper();
+    private final AnalyticsCatalog catalog = new AnalyticsCatalog();
+    private final AnalyticsPlanner planner = new AnalyticsPlanner(catalog);
+    private final AnalyticsScope stateScope = new AnalyticsScope("ke", true, null, null, null);
+
+    private JsonNode json(String s) {
+        try { return om.readTree(s); } catch (Exception e) { throw new RuntimeException(e); }
+    }
+
+    // ---- named windows resolve day boundaries at the TENANT zone's midnight ----
+
+    /**
+     * One fixed UTC instant (22:30 UTC) is already "tomorrow" in Asia/Kolkata (UTC+5:30, local
+     * 04:00 next day) but still "today" in Africa/Nairobi (UTC+3, local 01:30 next day... actually
+     * also tomorrow) and Africa/Maputo (UTC+2). Pick an instant where the three zones disagree on
+     * the calendar day to prove {@code dtd} is genuinely zone-sensitive, not a UTC day dressed up.
+     */
+    @Test
+    public void dtdMidnightIsTheResolvedZonesLocalDayNotUtcs() {
+        // 2024-06-14T21:30:00Z: Nairobi (+3) & Maputo (+2) are still June 15 00:30/23:30... pick
+        // precisely so each zone's local date differs. Use 20:30 UTC on 2024-06-14:
+        //   Nairobi (+3) -> 2024-06-14 23:30 local -> "today" = 2024-06-14
+        //   Kolkata (+5:30) -> 2024-06-15 02:00 local -> "today" = 2024-06-15
+        long now = Instant.parse("2024-06-14T20:30:00Z").toEpochMilli();
+
+        ZoneId nairobi = ZoneId.of("Africa/Nairobi");
+        ZoneId kolkata = ZoneId.of("Asia/Kolkata");
+
+        long dtdNairobi = AnalyticsPlanner.windowStartMs("dtd", now, nairobi);
+        long dtdKolkata = AnalyticsPlanner.windowStartMs("dtd", now, kolkata);
+
+        assertEquals(java.time.LocalDate.of(2024, 6, 14),
+                Instant.ofEpochMilli(dtdNairobi).atZone(nairobi).toLocalDate());
+        assertEquals(java.time.LocalDate.of(2024, 6, 15),
+                Instant.ofEpochMilli(dtdKolkata).atZone(kolkata).toLocalDate());
+        assertNotEquals(dtdNairobi, dtdKolkata,
+                "the same instant must resolve to two different local midnights in two different zones");
+    }
+
+    /** Africa/Maputo (UTC+2) vs Africa/Nairobi (UTC+3): a one-hour offset difference must shift dtd by exactly 1h. */
+    @Test
+    public void oneHourOffsetDifferenceShiftsDtdByExactlyOneHour() {
+        long now = Instant.parse("2024-06-15T12:00:00Z").toEpochMilli();
+        long dtdNairobi = AnalyticsPlanner.windowStartMs("dtd", now, ZoneId.of("Africa/Nairobi"));
+        long dtdMaputo = AnalyticsPlanner.windowStartMs("dtd", now, ZoneId.of("Africa/Maputo"));
+        // Nairobi's clock reads 1h ahead of Maputo's, so Nairobi's local midnight occurs 1h
+        // EARLIER in absolute/UTC time than Maputo's local midnight for the same instant.
+        assertEquals(3_600_000L, dtdMaputo - dtdNairobi,
+                "Maputo's local midnight is exactly 1h after Nairobi's for the same UTC instant");
+    }
+
+    /** Asia/Kolkata's UTC+5:30 offset is not a whole hour — dtd must still land exactly on local midnight. */
+    @Test
+    public void nonWholeHourOffsetStillLandsOnExactLocalMidnight() {
+        ZoneId kolkata = ZoneId.of("Asia/Kolkata");
+        long now = ZonedDateTime.of(2024, 6, 15, 14, 45, 0, 0, kolkata).toInstant().toEpochMilli();
+        long dtd = AnalyticsPlanner.windowStartMs("dtd", now, kolkata);
+        assertEquals(ZonedDateTime.of(2024, 6, 15, 0, 0, 0, 0, kolkata).toInstant().toEpochMilli(), dtd);
+        // sanity: the offset itself is +5:30, not a whole hour
+        assertEquals(5 * 3_600_000L + 30 * 60_000L,
+                kolkata.getRules().getOffset(Instant.ofEpochMilli(now)).getTotalSeconds() * 1000L);
+    }
+
+    /** wtd/mtd must resolve at the SAME resolved-zone midnight semantics as dtd, not UTC. */
+    @Test
+    public void wtdAndMtdAlsoResolveAtTheResolvedZonesMidnight() {
+        ZoneId kolkata = ZoneId.of("Asia/Kolkata");
+        // 2024-06-15 is a Saturday; the week (Monday-start) began 2024-06-10.
+        long now = ZonedDateTime.of(2024, 6, 15, 1, 0, 0, 0, kolkata).toInstant().toEpochMilli();
+        long wtd = AnalyticsPlanner.windowStartMs("wtd", now, kolkata);
+        long mtd = AnalyticsPlanner.windowStartMs("mtd", now, kolkata);
+        assertEquals(ZonedDateTime.of(2024, 6, 10, 0, 0, 0, 0, kolkata).toInstant().toEpochMilli(), wtd);
+        assertEquals(ZonedDateTime.of(2024, 6, 1, 0, 0, 0, 0, kolkata).toInstant().toEpochMilli(), mtd);
+    }
+
+    // ---- DST transition ----
+
+    /**
+     * America/New_York springs forward 2024-03-10 (02:00 -> 03:00 local, clocks skip 2:00-3:00am).
+     * Midnight itself is unaffected by the spring-forward gap, so dtd on the transition day and the
+     * day after must still resolve cleanly (no throw, correct calendar date) even though the
+     * transition day is only 23 wall-clock hours long.
+     */
+    @Test
+    public void dstSpringForwardTransitionDoesNotBreakDtd() {
+        ZoneId nyc = ZoneId.of("America/New_York");
+        // Noon on transition day (America/New_York EST->EDT, 2024-03-10).
+        long onTransitionDay = ZonedDateTime.of(2024, 3, 10, 12, 0, 0, 0, nyc).toInstant().toEpochMilli();
+        long dtd = AnalyticsPlanner.windowStartMs("dtd", onTransitionDay, nyc);
+        assertEquals(java.time.LocalDate.of(2024, 3, 10),
+                Instant.ofEpochMilli(dtd).atZone(nyc).toLocalDate());
+
+        // The day after: the elapsed wall-clock time from the prior midnight is only 23h, but dtd
+        // must still be exactly the NEXT calendar midnight, not offset by the missing hour.
+        long dayAfter = ZonedDateTime.of(2024, 3, 11, 12, 0, 0, 0, nyc).toInstant().toEpochMilli();
+        long dtdAfter = AnalyticsPlanner.windowStartMs("dtd", dayAfter, nyc);
+        assertEquals(ZonedDateTime.of(2024, 3, 11, 0, 0, 0, 0, nyc).toInstant().toEpochMilli(), dtdAfter);
+        // The two midnights are 23h apart in absolute time (the skipped hour), not 24h.
+        assertEquals(23 * 3_600_000L, dtdAfter - dtd);
+    }
+
+    /** last_Nd stays a pure rolling-24h-multiple window, unaffected by DST (by design, unlike dtd/wtd/mtd). */
+    @Test
+    public void rollingWindowIsUnaffectedByDst() {
+        ZoneId nyc = ZoneId.of("America/New_York");
+        long now = ZonedDateTime.of(2024, 3, 11, 12, 0, 0, 0, nyc).toInstant().toEpochMilli();
+        assertEquals(now - 86_400_000L, AnalyticsPlanner.windowStartMs("last_1d", now, nyc));
+    }
+
+    /** A window whose interval spans the DST transition still plans into a valid, non-throwing query. */
+    @Test
+    public void windowSpanningADstTransitionStillPlans() {
+        ZoneId nyc = ZoneId.of("America/New_York");
+        long now = ZonedDateTime.of(2024, 3, 12, 9, 0, 0, 0, nyc).toInstant().toEpochMilli();
+        BusinessCalendar calendar = BusinessCalendar.of(nyc, now);
+        JsonNode q = json("{\"grain\":\"facts\",\"window\":{\"name\":\"last_7d\",\"timeRole\":\"filed_at\"},"
+                + "\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}]}");
+        AnalyticsPlanner.Planned p = planner.plan(q, stateScope, calendar);
+        assertTrue(p.sql.contains("created_at >= ?") && p.sql.contains("created_at < ?"));
+        assertEquals(now - 7 * 86_400_000L, p.params.get(0));
+    }
+
+    // ---- timeBucket: the zone rides a JDBC-bound param, at the correct position ----
+
+    @Test
+    public void timeBucketBindsZoneAsFirstParamBeforeSelectAndWhereParams() {
+        ZoneId kolkata = ZoneId.of("Asia/Kolkata");
+        long now = ZonedDateTime.of(2024, 6, 15, 12, 0, 0, 0, kolkata).toInstant().toEpochMilli();
+        BusinessCalendar calendar = BusinessCalendar.of(kolkata, now);
+
+        JsonNode q = json("{\"grain\":\"facts\","
+                + "\"dimensions\":[\"ward_code\"],"
+                + "\"window\":{\"name\":\"last_7d\",\"timeRole\":\"filed_at\",\"timeBucket\":\"day\"},"
+                + "\"filters\":{\"ward_code\":{\"eq\":\"W1\"}},"
+                + "\"measures\":[{\"name\":\"total\",\"agg\":\"count\",\"filter\":{\"is_open\":{\"eq\":true}}}]}");
+        AnalyticsPlanner.Planned p = planner.plan(q, stateScope, calendar);
+
+        // The zone id is interpolated as a bound '?' inside the AT TIME ZONE expression — never
+        // string-concatenated into the SQL text itself.
+        assertTrue(p.sql.contains("AT TIME ZONE ?::text"), p.sql);
+        assertFalse(p.sql.contains(kolkata.getId()), "zone id must never appear literally in the SQL text");
+
+        // Placeholder count must exactly match the bound param count (no drift).
+        long placeholders = p.sql.chars().filter(c -> c == '?').count();
+        assertEquals(placeholders, p.params.size(), "every '?' must have exactly one bound param: " + p.sql);
+
+        // Param order mirrors left-to-right '?' appearance in the assembled SQL: the timeBucket's
+        // zone (first '?', in SELECT) precedes the measure's FILTER predicate (SELECT), which
+        // precedes the WHERE-clause params (explicit filter, window bounds, RBAC scope).
+        assertEquals(kolkata.getId(), p.params.get(0), "zone must be the first bound param");
+        assertEquals(true, p.params.get(1), "measure FILTER predicate binds next, still inside SELECT");
+        assertEquals("W1", p.params.get(2), "explicit filter is the first WHERE param");
+        // window gte/lt bounds follow, then the RBAC tenant-scope param last.
+        assertEquals(now - 7 * 86_400_000L, p.params.get(3));
+        assertEquals(now, p.params.get(4));
+        assertEquals("ke%", p.params.get(5));
+        assertEquals(6, p.params.size());
+    }
+
+    @Test
+    public void timeBucketOnSqlDateColumnNeedsNoZoneParam() {
+        // daily.snapshot_date is a SQL date, not epoch-ms — no AT TIME ZONE conversion, so no
+        // zone-binding param is added for the bucket expression at all.
+        BusinessCalendar calendar = BusinessCalendar.of(ZoneId.of("Africa/Nairobi"), 1_700_000_000_000L);
+        JsonNode q = json("{\"grain\":\"daily\","
+                + "\"window\":{\"timeBucket\":\"day\"},"
+                + "\"measures\":[{\"name\":\"open\",\"agg\":\"count\"}]}");
+        AnalyticsPlanner.Planned p = planner.plan(q, stateScope, calendar);
+        assertFalse(p.sql.contains("AT TIME ZONE"), p.sql);
+        long placeholders = p.sql.chars().filter(c -> c == '?').count();
+        assertEquals(placeholders, p.params.size());
+    }
+}

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsServiceCalendarTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsServiceCalendarTest.java
@@ -1,0 +1,195 @@
+package org.egov.pgr.analytics;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.egov.common.contract.request.RequestInfo;
+import org.egov.common.contract.request.Role;
+import org.egov.common.contract.request.User;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * #29: pins the one-calendar-per-request contract in {@link AnalyticsService#doQuery} — a batch of
+ * N queries resolves the tenant zone and captures {@code asOf} EXACTLY ONCE and threads that same
+ * {@link BusinessCalendar} into every entry's {@link AnalyticsPlanner#plan}, and the response's
+ * top-level {@code asOf}/{@code calendar} agree with what was actually used to plan every entry —
+ * never a per-entry re-resolution that could straddle two clock readings. Also pins the
+ * {@code composeKpi.js}-mirroring elapsed-time math {@link AnalyticsService#computeCompose} uses.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class AnalyticsServiceCalendarTest {
+
+    private final ObjectMapper om = new ObjectMapper();
+
+    @Mock private AnalyticsPlanner planner;
+    @Mock private JdbcTemplate jdbc;
+    @Mock private KpiCatalogService kpiCatalogService;
+    @Mock private PrincipalScopeResolver scopeResolver;
+
+    private JsonNode json(String s) {
+        try { return om.readTree(s); } catch (Exception e) { throw new RuntimeException(e); }
+    }
+
+    private RequestInfo requestInfoWithRole(String role) {
+        User u = User.builder().uuid("u1").roles(List.of(Role.builder().code(role).build())).build();
+        return RequestInfo.builder().userInfo(u).build();
+    }
+
+    // ---- batch: one resolved zone + one captured asOf, shared by every entry ----
+
+    @Test
+    public void batchEntriesShareExactlyOneCalendarAndOneAsOfResolution() {
+        AnalyticsService service = new AnalyticsService(planner, null, jdbc, kpiCatalogService,
+                scopeResolver, null, new AnalyticsMetrics(), null);
+
+        long fixedAsOf = 1_718_442_000_000L;   // 2024-06-15T12:00:00+03:00 (arbitrary, fixed)
+        when(jdbc.queryForObject(eq("SELECT max(facts_built_at) FROM complaint_facts"), eq(Long.class)))
+                .thenReturn(fixedAsOf);
+        when(kpiCatalogService.resolveTimeZone("ke")).thenReturn(ZoneId.of("Asia/Kolkata"));
+        when(scopeResolver.resolve(any(), eq("ke"), anyInt()))
+                .thenReturn(new AnalyticsScope("ke", true, null, null, null));
+        when(planner.plan(any(), any(), any()))
+                .thenReturn(new AnalyticsPlanner.Planned("SELECT 1", List.of(), List.of("total"), "facts"));
+        when(jdbc.queryForList(anyString(), any(Object[].class))).thenReturn(List.of());
+
+        JsonNode body = json("{\"queries\":{"
+                + "\"a\":{\"grain\":\"facts\",\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}]},"
+                + "\"b\":{\"grain\":\"facts\",\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}]},"
+                + "\"c\":{\"grain\":\"facts\",\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}]}"
+                + "}}");
+
+        Map<String, Object> out = service.query(body, requestInfoWithRole("SUPERVISOR"), "ke", 1);
+
+        // resolveTimeZone and the asOf query each fire exactly once per request, not once per entry.
+        verify(kpiCatalogService, times(1)).resolveTimeZone("ke");
+        verify(jdbc, times(1)).queryForObject(eq("SELECT max(facts_built_at) FROM complaint_facts"), eq(Long.class));
+
+        ArgumentCaptor<BusinessCalendar> cal = ArgumentCaptor.forClass(BusinessCalendar.class);
+        verify(planner, times(3)).plan(any(), any(), cal.capture());
+        List<BusinessCalendar> seen = cal.getAllValues();
+        assertSame(seen.get(0), seen.get(1), "every batch entry must plan against the SAME calendar instance");
+        assertSame(seen.get(1), seen.get(2), "every batch entry must plan against the SAME calendar instance");
+        assertEquals(fixedAsOf, seen.get(0).asOfMs);
+        assertEquals(ZoneId.of("Asia/Kolkata"), seen.get(0).zoneId);
+
+        // The response's own top-level asOf/calendar must agree with what every entry was planned against.
+        assertEquals(fixedAsOf, out.get("asOf"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> calendarInfo = (Map<String, Object>) out.get("calendar");
+        assertEquals("Asia/Kolkata", calendarInfo.get("timeZone"));
+        assertEquals(Instant.ofEpochMilli(fixedAsOf).atZone(ZoneId.of("Asia/Kolkata")).toLocalDate().toString(),
+                calendarInfo.get("businessDate"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> results = (Map<String, Object>) out.get("results");
+        assertEquals(3, results.size());
+        assertFalse((Boolean) out.get("partial"));
+    }
+
+    @Test
+    public void singleQueryArmAlsoResolvesTheCalendarExactlyOnce() {
+        AnalyticsService service = new AnalyticsService(planner, null, jdbc, kpiCatalogService,
+                scopeResolver, null, new AnalyticsMetrics(), null);
+
+        when(jdbc.queryForObject(eq("SELECT max(facts_built_at) FROM complaint_facts"), eq(Long.class)))
+                .thenReturn(1_700_000_000_000L);
+        when(kpiCatalogService.resolveTimeZone("ke")).thenReturn(ZoneId.of("Africa/Nairobi"));
+        when(scopeResolver.resolve(any(), eq("ke"), anyInt()))
+                .thenReturn(new AnalyticsScope("ke", true, null, null, null));
+        when(planner.plan(any(), any(), any()))
+                .thenReturn(new AnalyticsPlanner.Planned("SELECT 1", List.of(), List.of("total"), "facts"));
+        when(jdbc.queryForList(anyString(), any(Object[].class))).thenReturn(List.of());
+
+        JsonNode body = json("{\"query\":{\"grain\":\"facts\",\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}]}}");
+        service.query(body, requestInfoWithRole("SUPERVISOR"), "ke", 1);
+
+        verify(kpiCatalogService, times(1)).resolveTimeZone("ke");
+        verify(jdbc, times(1)).queryForObject(eq("SELECT max(facts_built_at) FROM complaint_facts"), eq(Long.class));
+    }
+
+    // ---- compose elapsed math (composeKpi.js parity) ----
+
+    private BusinessCalendar calAt(ZoneId zone, int y, int mo, int d, int h) {
+        return BusinessCalendar.of(zone, ZonedDateTime.of(y, mo, d, h, 0, 0, 0, zone).toInstant().toEpochMilli());
+    }
+
+    @Test
+    public void dailyAvgFromWeeklyDividesByElapsedDaysSinceSundayWeekStart() {
+        AnalyticsService service = new AnalyticsService(null, null, null, null, null, null, new AnalyticsMetrics(), null);
+        // 2024-06-19 is a Wednesday; the FE-semantic Sunday week start is 2024-06-16.
+        // elapsed = floor((Wed 15:00 - Sun 00:00) / 1 day) = 3 (Sun->Mon->Tue->Wed is 3 full days, + 15h).
+        BusinessCalendar cal = calAt(ZoneId.of("Africa/Nairobi"), 2024, 6, 19, 15);
+        assertEquals(3L, service.elapsedDaysSinceStartOfWeek(cal));
+
+        JsonNode compose = json("{\"type\":\"dailyAvgFromWeekly\",\"elapsedFromAsOf\":true}");
+        Double v = service.computeCompose("dailyAvgFromWeekly", compose,
+                List.of(Map.of("total", 90.0)), cal);
+        assertEquals(30.0, v, 1e-9);
+    }
+
+    @Test
+    public void dailyAvgFromWeeklyWithoutElapsedFlagIsNull() {
+        AnalyticsService service = new AnalyticsService(null, null, null, null, null, null, new AnalyticsMetrics(), null);
+        BusinessCalendar cal = calAt(ZoneId.of("Africa/Nairobi"), 2024, 6, 19, 15);
+        JsonNode compose = json("{\"type\":\"dailyAvgFromWeekly\"}");
+        assertNull(service.computeCompose("dailyAvgFromWeekly", compose, List.of(Map.of("total", 70.0)), cal));
+    }
+
+    @Test
+    public void hourlyAvgFromDailyDividesByElapsedHoursSinceMidnight() {
+        AnalyticsService service = new AnalyticsService(null, null, null, null, null, null, new AnalyticsMetrics(), null);
+        BusinessCalendar cal = calAt(ZoneId.of("Asia/Kolkata"), 2024, 6, 15, 15);   // 15:00 local
+        assertEquals(15L, service.elapsedHoursSinceStartOfDay(cal));
+
+        JsonNode compose = json("{\"type\":\"hourlyAvgFromDaily\",\"elapsedFromAsOf\":true}");
+        Double v = service.computeCompose("hourlyAvgFromDaily", compose, List.of(Map.of("total", 30.0)), cal);
+        assertEquals(2.0, v, 1e-9);
+    }
+
+    @Test
+    public void elapsedTimesAreClampedToAtLeastOne() {
+        AnalyticsService service = new AnalyticsService(null, null, null, null, null, null, new AnalyticsMetrics(), null);
+        // Just after midnight: both elapsed-day and elapsed-hour must floor to >= 1, never 0
+        // (a 0 divisor would blow up the *_Avg ratio).
+        BusinessCalendar justAfterMidnight = BusinessCalendar.of(ZoneId.of("Africa/Nairobi"),
+                ZonedDateTime.of(2024, 6, 16, 0, 0, 1, 0, ZoneId.of("Africa/Nairobi")).toInstant().toEpochMilli());
+        assertEquals(1L, service.elapsedDaysSinceStartOfWeek(justAfterMidnight));
+        assertEquals(1L, service.elapsedHoursSinceStartOfDay(justAfterMidnight));
+    }
+
+    @Test
+    public void openRateComplementUsesPctThenFallsBackToTotal() {
+        AnalyticsService service = new AnalyticsService(null, null, null, null, null, null, new AnalyticsMetrics(), null);
+        BusinessCalendar cal = calAt(ZoneId.of("Africa/Nairobi"), 2024, 6, 15, 12);
+        JsonNode compose = json("{\"type\":\"openRateComplement\"}");
+        assertEquals(75.0, service.computeCompose("openRateComplement", compose, List.of(Map.of("pct", 0.25)), cal), 1e-9);
+        assertEquals(60.0, service.computeCompose("openRateComplement", compose, List.of(Map.of("total", 0.4)), cal), 1e-9);
+    }
+
+    @Test
+    public void netBacklogDailyIsInflowMinusOutflow() {
+        AnalyticsService service = new AnalyticsService(null, null, null, null, null, null, new AnalyticsMetrics(), null);
+        BusinessCalendar cal = calAt(ZoneId.of("Africa/Nairobi"), 2024, 6, 15, 12);
+        JsonNode compose = json("{\"type\":\"netBacklogDaily\"}");
+        Double v = service.computeCompose("netBacklogDaily", compose,
+                List.of(Map.of("total", 100.0), Map.of("total", 40.0)), cal);
+        assertEquals(60.0, v, 1e-9);
+    }
+}

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsServiceCalendarTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsServiceCalendarTest.java
@@ -13,12 +13,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.function.LongSupplier;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -26,9 +28,9 @@ import static org.mockito.Mockito.*;
 
 /**
  * #29: pins the one-calendar-per-request contract in {@link AnalyticsService#doQuery} — a batch of
- * N queries resolves the tenant zone and captures {@code asOf} EXACTLY ONCE and threads that same
+ * N queries resolves the tenant zone and captures request time EXACTLY ONCE and threads that same
  * {@link BusinessCalendar} into every entry's {@link AnalyticsPlanner#plan}, and the response's
- * top-level {@code asOf}/{@code calendar} agree with what was actually used to plan every entry —
+ * top-level {@code asOf} reports fact freshness independently of the request-time calendar —
  * never a per-entry re-resolution that could straddle two clock readings. Also pins the
  * {@code composeKpi.js}-mirroring elapsed-time math {@link AnalyticsService#computeCompose} uses.
  */
@@ -52,14 +54,16 @@ public class AnalyticsServiceCalendarTest {
         return RequestInfo.builder().userInfo(u).build();
     }
 
-    // ---- batch: one resolved zone + one captured asOf, shared by every entry ----
+    // ---- batch: one resolved zone + one request clock reading, shared by every entry ----
 
     @Test
     public void batchEntriesShareExactlyOneCalendarAndOneAsOfResolution() {
         AnalyticsService service = new AnalyticsService(planner, null, jdbc, kpiCatalogService,
                 scopeResolver, null, new AnalyticsMetrics(), null);
 
-        long fixedAsOf = 1_718_442_000_000L;   // 2024-06-15T12:00:00+03:00 (arbitrary, fixed)
+        long fixedAsOf = 1_700_000_000_000L;   // deliberately stale fact refresh timestamp
+        long fixedNow = 1_718_442_000_000L;    // request wall clock
+        ReflectionTestUtils.setField(service, "requestClock", (LongSupplier) () -> fixedNow);
         when(jdbc.queryForObject(eq("SELECT max(facts_built_at) FROM complaint_facts"), eq(Long.class)))
                 .thenReturn(fixedAsOf);
         when(kpiCatalogService.resolveTimeZone("ke")).thenReturn(ZoneId.of("Asia/Kolkata"));
@@ -86,21 +90,47 @@ public class AnalyticsServiceCalendarTest {
         List<BusinessCalendar> seen = cal.getAllValues();
         assertSame(seen.get(0), seen.get(1), "every batch entry must plan against the SAME calendar instance");
         assertSame(seen.get(1), seen.get(2), "every batch entry must plan against the SAME calendar instance");
-        assertEquals(fixedAsOf, seen.get(0).asOfMs);
+        assertEquals(fixedNow, seen.get(0).nowMs);
         assertEquals(ZoneId.of("Asia/Kolkata"), seen.get(0).zoneId);
 
-        // The response's own top-level asOf/calendar must agree with what every entry was planned against.
+        // asOf remains fact freshness; calendar/businessDate comes from current request time.
         assertEquals(fixedAsOf, out.get("asOf"));
         @SuppressWarnings("unchecked")
         Map<String, Object> calendarInfo = (Map<String, Object>) out.get("calendar");
         assertEquals("Asia/Kolkata", calendarInfo.get("timeZone"));
-        assertEquals(Instant.ofEpochMilli(fixedAsOf).atZone(ZoneId.of("Asia/Kolkata")).toLocalDate().toString(),
+        assertEquals(Instant.ofEpochMilli(fixedNow).atZone(ZoneId.of("Asia/Kolkata")).toLocalDate().toString(),
                 calendarInfo.get("businessDate"));
 
         @SuppressWarnings("unchecked")
         Map<String, Object> results = (Map<String, Object>) out.get("results");
         assertEquals(3, results.size());
         assertFalse((Boolean) out.get("partial"));
+    }
+
+    @Test
+    public void emptyFactsKeepNullableAsOfWithoutBreakingRequestCalendar() {
+        AnalyticsService service = new AnalyticsService(planner, null, jdbc, kpiCatalogService,
+                scopeResolver, null, new AnalyticsMetrics(), null);
+        long fixedNow = 1_718_442_000_000L;
+        ReflectionTestUtils.setField(service, "requestClock", (LongSupplier) () -> fixedNow);
+
+        when(jdbc.queryForObject(eq("SELECT max(facts_built_at) FROM complaint_facts"), eq(Long.class)))
+                .thenReturn((Long) null);
+        when(kpiCatalogService.resolveTimeZone("ke")).thenReturn(ZoneId.of("Asia/Kolkata"));
+        when(scopeResolver.resolve(any(), eq("ke"), anyInt()))
+                .thenReturn(new AnalyticsScope("ke", true, null, null, null));
+        when(planner.plan(any(), any(), any()))
+                .thenReturn(new AnalyticsPlanner.Planned("SELECT 1", List.of(), List.of("total"), "facts"));
+        when(jdbc.queryForList(anyString(), any(Object[].class))).thenReturn(List.of());
+
+        JsonNode body = json("{\"query\":{\"grain\":\"facts\",\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}]}}");
+        Map<String, Object> out = service.query(body, requestInfoWithRole("SUPERVISOR"), "ke", 1);
+
+        assertTrue(out.containsKey("asOf"));
+        assertNull(out.get("asOf"));
+        ArgumentCaptor<BusinessCalendar> calendar = ArgumentCaptor.forClass(BusinessCalendar.class);
+        verify(planner).plan(any(), any(), calendar.capture());
+        assertEquals(fixedNow, calendar.getValue().nowMs);
     }
 
     @Test

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiCatalogServiceDeptScopingTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiCatalogServiceDeptScopingTest.java
@@ -200,4 +200,18 @@ public class KpiCatalogServiceDeptScopingTest {
 
         verify(repo, times(1)).fetchResult(any(), any());
     }
+
+    @Test
+    public void disabledInfoGateFiresOnceThenAgainOnlyAfterCacheRefresh() {
+        assertTrue((Boolean) ReflectionTestUtils.invokeMethod(
+                service, "shouldLogDepartmentScopingDisabled", "ke", 1000L));
+        assertFalse((Boolean) ReflectionTestUtils.invokeMethod(
+                service, "shouldLogDepartmentScopingDisabled", "ke", 1000L));
+        assertFalse((Boolean) ReflectionTestUtils.invokeMethod(
+                service, "shouldLogDepartmentScopingDisabled", "ke", 1000L));
+        assertTrue((Boolean) ReflectionTestUtils.invokeMethod(
+                service, "shouldLogDepartmentScopingDisabled", "ke", 2000L));
+        assertFalse((Boolean) ReflectionTestUtils.invokeMethod(
+                service, "shouldLogDepartmentScopingDisabled", "ke", 2000L));
+    }
 }

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiCatalogServiceTimeZoneTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiCatalogServiceTimeZoneTest.java
@@ -1,0 +1,334 @@
+package org.egov.pgr.analytics;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.egov.common.utils.MultiStateInstanceUtil;
+import org.egov.pgr.config.PGRConfiguration;
+import org.egov.pgr.repository.ServiceRequestRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * #29: pins {@code dss.DashboardConfig.timeZone} resolution as read by
+ * {@link KpiCatalogService#resolveTimeZone} — a configured valid IANA zone wins; missing
+ * module/record/field, a malformed value, and an MDMS error ALL fall back to
+ * {@link KpiCatalogService#DEFAULT_TIME_ZONE} (Africa/Nairobi, migration-compatibility default,
+ * never thrown). Also pins the ONE shared {@code dashboardConfig} cache/fetch
+ * {@link KpiCatalogService#isDepartmentScopingDisabled} and {@link KpiCatalogService#resolveTimeZone}
+ * both read — a request touching both axes issues exactly one MDMS call, and a config flip on
+ * either field takes effect together within one TTL window (mirrors
+ * {@link KpiCatalogServiceDeptScopingTest}'s cache coverage for the sibling axis).
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class KpiCatalogServiceTimeZoneTest {
+
+    @Mock private PGRConfiguration config;
+    @Mock private ServiceRequestRepository repo;
+    @Mock private MultiStateInstanceUtil multiStateInstanceUtil;
+
+    private KpiCatalogService service;
+    private final AtomicLong clock = new AtomicLong(1_000_000L);
+
+    @BeforeEach
+    public void setUp() {
+        when(config.getMdmsHost()).thenReturn("http://mdms-v2:8080");
+        when(config.getMdmsEndPoint()).thenReturn("/mdms-v2/v1/_search");
+        when(config.getAnalyticsConfigCacheTtlMs())
+                .thenReturn(PGRConfiguration.DEFAULT_ANALYTICS_CONFIG_CACHE_TTL_MS);
+        when(multiStateInstanceUtil.getStateLevelTenant(anyString()))
+                .thenAnswer(inv -> inv.getArgument(0, String.class).split("\\.")[0]);
+        service = new KpiCatalogService(config, repo, multiStateInstanceUtil, new ObjectMapper());
+        ReflectionTestUtils.setField(service, "configClock", (LongSupplier) clock::get);
+    }
+
+    private static Map<String, Object> mdmsResult(Map<String, Object>... records) {
+        Map<String, Object> res = new HashMap<>();
+        res.put("MdmsRes", Map.of("dss", Map.of("DashboardConfig", List.of(records))));
+        return res;
+    }
+
+    private static Map<String, Object> record(Object timeZone) {
+        Map<String, Object> r = new HashMap<>();
+        r.put("timeZone", timeZone);
+        return r;
+    }
+
+    // ---- happy path ----
+
+    @Test
+    public void configuredValidZoneWins() {
+        when(repo.fetchResult(any(), any())).thenReturn(mdmsResult(record("Asia/Kolkata")));
+        assertEquals(ZoneId.of("Asia/Kolkata"), service.resolveTimeZone("ke.bomet"));
+    }
+
+    @Test
+    public void leadingTrailingWhitespaceIsTrimmed() {
+        when(repo.fetchResult(any(), any())).thenReturn(mdmsResult(record("  Africa/Maputo  ")));
+        assertEquals(ZoneId.of("Africa/Maputo"), service.resolveTimeZone("ke.bomet"));
+    }
+
+    // ---- fail-safe fallback: everything else -> DEFAULT_TIME_ZONE, never throws ----
+
+    @Test
+    public void noDssModuleFallsBackToDefault() {
+        when(repo.fetchResult(any(), any())).thenReturn(Map.of("MdmsRes", Map.of()));
+        assertEquals(KpiCatalogService.DEFAULT_TIME_ZONE, service.resolveTimeZone("ke.bomet"));
+    }
+
+    @Test
+    public void noRecordFallsBackToDefault() {
+        when(repo.fetchResult(any(), any())).thenReturn(mdmsResult());
+        assertEquals(KpiCatalogService.DEFAULT_TIME_ZONE, service.resolveTimeZone("ke.bomet"));
+    }
+
+    @Test
+    public void missingFieldFallsBackToDefault() {
+        when(repo.fetchResult(any(), any())).thenReturn(mdmsResult(new HashMap<>()));
+        assertEquals(KpiCatalogService.DEFAULT_TIME_ZONE, service.resolveTimeZone("ke.bomet"));
+    }
+
+    @Test
+    public void malformedValuesFallBackToDefault() {
+        for (Object malformed : new Object[]{"Not/AZone", "EAT", "", "   ", 42, Boolean.TRUE, null}) {
+            service = new KpiCatalogService(config, repo, multiStateInstanceUtil, new ObjectMapper());
+            ReflectionTestUtils.setField(service, "configClock", (LongSupplier) clock::get);
+            when(repo.fetchResult(any(), any())).thenReturn(mdmsResult(record(malformed)));
+            assertEquals(KpiCatalogService.DEFAULT_TIME_ZONE, service.resolveTimeZone("ke.bomet"),
+                    "value '" + malformed + "' must fall back to the default zone");
+        }
+    }
+
+    @Test
+    public void mdmsErrorFallsBackToDefaultAndNeverThrows() {
+        when(repo.fetchResult(any(), any())).thenThrow(new RuntimeException("mdms down"));
+        assertEquals(KpiCatalogService.DEFAULT_TIME_ZONE, service.resolveTimeZone("ke.bomet"));
+    }
+
+    @Test
+    public void nullOrEmptyTenantFallsBackWithoutFetching() {
+        assertEquals(KpiCatalogService.DEFAULT_TIME_ZONE, service.resolveTimeZone(null));
+        assertEquals(KpiCatalogService.DEFAULT_TIME_ZONE, service.resolveTimeZone(""));
+        verifyNoInteractions(repo);
+    }
+
+    // ---- the shared cache: ONE fetch serves both departmentScoping and timeZone ----
+
+    @Test
+    public void oneFetchServesBothConfigAxes() {
+        Map<String, Object> combined = new HashMap<>();
+        combined.put("departmentScoping", "disabled");
+        combined.put("timeZone", "Asia/Kolkata");
+        when(repo.fetchResult(any(), any())).thenReturn(mdmsResult(combined));
+
+        assertTrue(service.isDepartmentScopingDisabled("ke.bomet"));
+        assertEquals(ZoneId.of("Asia/Kolkata"), service.resolveTimeZone("ke.bomet"));
+
+        verify(repo, times(1)).fetchResult(any(), any());
+    }
+
+    @Test
+    public void oneFetchServesBothConfigAxesRegardlessOfCallOrder() {
+        Map<String, Object> combined = new HashMap<>();
+        combined.put("departmentScoping", "enforced");
+        combined.put("timeZone", "Africa/Maputo");
+        when(repo.fetchResult(any(), any())).thenReturn(mdmsResult(combined));
+
+        assertEquals(ZoneId.of("Africa/Maputo"), service.resolveTimeZone("ke.bomet"));
+        assertFalse(service.isDepartmentScopingDisabled("ke.bomet"));
+
+        verify(repo, times(1)).fetchResult(any(), any());
+    }
+
+    @Test
+    public void secondCallWithinTtlServesFromCache() {
+        when(repo.fetchResult(any(), any())).thenReturn(mdmsResult(record("Asia/Kolkata")));
+
+        assertEquals(ZoneId.of("Asia/Kolkata"), service.resolveTimeZone("ke.bomet"));
+        clock.addAndGet(4 * 60_000L + 59_000L);   // 4m59s later — still inside the 5m TTL
+        assertEquals(ZoneId.of("Asia/Kolkata"), service.resolveTimeZone("ke.bomet"));
+
+        verify(repo, times(1)).fetchResult(any(), any());
+    }
+
+    @Test
+    public void cacheExpiresAfterFiveMinutesAndPicksUpFlip() {
+        when(repo.fetchResult(any(), any()))
+                .thenReturn(mdmsResult(record("Asia/Kolkata")))
+                .thenReturn(mdmsResult(record("Africa/Maputo")));
+
+        assertEquals(ZoneId.of("Asia/Kolkata"), service.resolveTimeZone("ke.bomet"));
+        clock.addAndGet(5 * 60_000L + 1L);        // past the TTL
+        assertEquals(ZoneId.of("Africa/Maputo"), service.resolveTimeZone("ke.bomet"));   // flip applied
+
+        verify(repo, times(2)).fetchResult(any(), any());
+    }
+
+    @Test
+    public void cacheIsSharedAcrossTenantsOfOneStateRoot() {
+        when(repo.fetchResult(any(), any())).thenReturn(mdmsResult(record("Asia/Kolkata")));
+
+        assertEquals(ZoneId.of("Asia/Kolkata"), service.resolveTimeZone("ke"));
+        assertEquals(ZoneId.of("Asia/Kolkata"), service.resolveTimeZone("ke.bomet"));
+
+        verify(repo, times(1)).fetchResult(any(), any());
+    }
+
+    @Test
+    public void noRecordOutcomeIsCachedToo() {
+        when(repo.fetchResult(any(), any())).thenReturn(mdmsResult());
+
+        assertEquals(KpiCatalogService.DEFAULT_TIME_ZONE, service.resolveTimeZone("ke.bomet"));
+        assertEquals(KpiCatalogService.DEFAULT_TIME_ZONE, service.resolveTimeZone("ke.bomet"));
+
+        verify(repo, times(1)).fetchResult(any(), any());
+    }
+
+    // ---- deterministic multi-record selection (selectDashboardConfigRecord) ----
+    // Same rule as the pgr_dashboard_tenant_timezone SQL view and useDashboardConfig.js:
+    // id=="default" wins; else lexicographically smallest nonblank id; else first occurrence.
+
+    private static Map<String, Object> recordWithId(Object id, String timeZone) {
+        Map<String, Object> r = new HashMap<>();
+        r.put("id", id);
+        r.put("timeZone", timeZone);
+        return r;
+    }
+
+    @Test
+    public void selectDashboardConfigRecordReturnsNullForEmptyList() {
+        assertNull(KpiCatalogService.selectDashboardConfigRecord(List.of()));
+    }
+
+    @Test
+    public void selectDashboardConfigRecordPreservesSingleRecordBehavior() {
+        Map<String, Object> only = recordWithId("zz", "Asia/Kolkata");
+        assertSame(only, KpiCatalogService.selectDashboardConfigRecord(List.of(only)));
+    }
+
+    @Test
+    public void selectDashboardConfigRecordPrefersDefaultIdRegardlessOfPosition() {
+        Map<String, Object> aaa = recordWithId("aaa", "Africa/Maputo");
+        Map<String, Object> def = recordWithId("default", "Asia/Kolkata");
+        Map<String, Object> zzz = recordWithId("zzz", "UTC");
+        assertSame(def, KpiCatalogService.selectDashboardConfigRecord(List.of(aaa, def, zzz)));
+        assertSame(def, KpiCatalogService.selectDashboardConfigRecord(List.of(def, aaa, zzz)));
+    }
+
+    @Test
+    public void selectDashboardConfigRecordFallsBackToLexicographicallySmallestNonblankId() {
+        Map<String, Object> zzz = recordWithId("zzz", "UTC");
+        Map<String, Object> aaa = recordWithId("aaa", "Africa/Maputo");
+        Map<String, Object> bbb = recordWithId("bbb", "Asia/Kolkata");
+        assertSame(aaa, KpiCatalogService.selectDashboardConfigRecord(List.of(zzz, aaa, bbb)));
+    }
+
+    @Test
+    public void selectDashboardConfigRecordIgnoresBlankAndMissingIdsWhenComparing() {
+        Map<String, Object> blank = recordWithId("   ", "Africa/Maputo");
+        Map<String, Object> missing = new HashMap<>();
+        missing.put("timeZone", "UTC");
+        Map<String, Object> real = recordWithId("abc", "Asia/Kolkata");
+        assertSame(real, KpiCatalogService.selectDashboardConfigRecord(List.of(blank, missing, real)));
+    }
+
+    @Test
+    public void selectDashboardConfigRecordFallsBackToFirstOccurrenceWhenNoUsableId() {
+        Map<String, Object> first = recordWithId(null, "Africa/Maputo");
+        Map<String, Object> second = recordWithId("   ", "UTC");
+        assertSame(first, KpiCatalogService.selectDashboardConfigRecord(List.of(first, second)));
+    }
+
+    @Test
+    public void resolveTimeZonePicksLexicographicallySmallestIdWhenNoDefaultAmongDuplicates() {
+        when(repo.fetchResult(any(), any())).thenReturn(mdmsResult(
+                recordWithId("zzz", "UTC"),
+                recordWithId("aaa", "Africa/Maputo")));
+
+        assertEquals(ZoneId.of("Africa/Maputo"), service.resolveTimeZone("ke.bomet"));
+    }
+
+    // ---- TTL-bounded fallback warning gate (#29 review fix) ----
+    // No established log-capture test pattern in this module (grep found none) — verified via
+    // the gate's own return value / cached state (ReflectionTestUtils) instead of brittle log
+    // assertions, per the reviewer's instruction.
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Long> warnedGenerations() {
+        return (Map<String, Long>) ReflectionTestUtils.getField(service, "timeZoneFallbackWarnedGeneration");
+    }
+
+    @Test
+    public void shouldWarnTimeZoneFallbackGateFiresOnceThenAgainOnlyForANewGeneration() {
+        assertTrue((Boolean) ReflectionTestUtils.invokeMethod(service, "shouldWarnTimeZoneFallback", "ke", 1000L));
+        assertFalse((Boolean) ReflectionTestUtils.invokeMethod(service, "shouldWarnTimeZoneFallback", "ke", 1000L));
+        assertFalse((Boolean) ReflectionTestUtils.invokeMethod(service, "shouldWarnTimeZoneFallback", "ke", 1000L));
+        assertTrue((Boolean) ReflectionTestUtils.invokeMethod(service, "shouldWarnTimeZoneFallback", "ke", 2000L));
+        assertFalse((Boolean) ReflectionTestUtils.invokeMethod(service, "shouldWarnTimeZoneFallback", "ke", 2000L));
+    }
+
+    @Test
+    public void shouldWarnTimeZoneFallbackGateIsPerStateRoot() {
+        assertTrue((Boolean) ReflectionTestUtils.invokeMethod(service, "shouldWarnTimeZoneFallback", "ke", 1000L));
+        assertTrue((Boolean) ReflectionTestUtils.invokeMethod(service, "shouldWarnTimeZoneFallback", "mz", 1000L));
+    }
+
+    @Test
+    public void resolveTimeZoneMissingConfigWarnsOnceWithinOneTtlWindowThenAgainAfterRefresh() {
+        when(repo.fetchResult(any(), any())).thenReturn(mdmsResult());   // no record -> "not found" fallback
+
+        service.resolveTimeZone("ke.bomet");
+        service.resolveTimeZone("ke.bomet");
+        service.resolveTimeZone("ke.bomet");
+        assertEquals(1, warnedGenerations().size(), "only one generation should be recorded as warned so far");
+        Long firstWarnedGeneration = warnedGenerations().get("ke");
+        assertNotNull(firstWarnedGeneration);
+
+        clock.addAndGet(5 * 60_000L + 1L);   // past the TTL -> next call re-fetches (new generation)
+        service.resolveTimeZone("ke.bomet");
+
+        Long secondWarnedGeneration = warnedGenerations().get("ke");
+        assertNotEquals(firstWarnedGeneration, secondWarnedGeneration,
+                "a config refresh must grant one more warning opportunity (new generation)");
+
+        service.resolveTimeZone("ke.bomet");
+        assertEquals(secondWarnedGeneration, warnedGenerations().get("ke"),
+                "still within the new TTL window -> no further generation bump");
+        verify(repo, times(2)).fetchResult(any(), any());
+    }
+
+    @Test
+    public void resolveTimeZoneWarningGateDoesNotAffectDepartmentScopingCaching() {
+        // Regression guard: the shared dashboardConfig fetch/cache (and isDepartmentScopingDisabled's
+        // use of it) must be byte-for-byte unaffected by the resolveTimeZone-only warning gate.
+        Map<String, Object> combined = new HashMap<>();
+        combined.put("departmentScoping", "disabled");
+        combined.put("timeZone", "Asia/Kolkata");
+        when(repo.fetchResult(any(), any())).thenReturn(mdmsResult(combined));
+
+        assertTrue(service.isDepartmentScopingDisabled("ke.bomet"));
+        assertEquals(ZoneId.of("Asia/Kolkata"), service.resolveTimeZone("ke.bomet"));
+        assertTrue(service.isDepartmentScopingDisabled("ke.bomet"));
+        assertEquals(ZoneId.of("Asia/Kolkata"), service.resolveTimeZone("ke.bomet"));
+
+        verify(repo, times(1)).fetchResult(any(), any());
+        assertTrue(warnedGenerations().isEmpty(), "a valid, configured record must never enter the warning gate");
+    }
+}

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiCatalogServiceTimeZoneTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiCatalogServiceTimeZoneTest.java
@@ -203,7 +203,7 @@ public class KpiCatalogServiceTimeZoneTest {
 
     // ---- deterministic multi-record selection (selectDashboardConfigRecord) ----
     // Same rule as the pgr_dashboard_tenant_timezone SQL view and useDashboardConfig.js:
-    // id=="default" wins; else lexicographically smallest nonblank id; else first occurrence.
+    // id=="default" wins; otherwise preserve the historical first API record.
 
     private static Map<String, Object> recordWithId(Object id, String timeZone) {
         Map<String, Object> r = new HashMap<>();
@@ -233,20 +233,20 @@ public class KpiCatalogServiceTimeZoneTest {
     }
 
     @Test
-    public void selectDashboardConfigRecordFallsBackToLexicographicallySmallestNonblankId() {
+    public void selectDashboardConfigRecordPreservesFirstApiRecordWhenNoDefaultExists() {
         Map<String, Object> zzz = recordWithId("zzz", "UTC");
         Map<String, Object> aaa = recordWithId("aaa", "Africa/Maputo");
         Map<String, Object> bbb = recordWithId("bbb", "Asia/Kolkata");
-        assertSame(aaa, KpiCatalogService.selectDashboardConfigRecord(List.of(zzz, aaa, bbb)));
+        assertSame(zzz, KpiCatalogService.selectDashboardConfigRecord(List.of(zzz, aaa, bbb)));
     }
 
     @Test
-    public void selectDashboardConfigRecordIgnoresBlankAndMissingIdsWhenComparing() {
+    public void selectDashboardConfigRecordPreservesFirstRecordEvenWhenItsIdIsBlank() {
         Map<String, Object> blank = recordWithId("   ", "Africa/Maputo");
         Map<String, Object> missing = new HashMap<>();
         missing.put("timeZone", "UTC");
         Map<String, Object> real = recordWithId("abc", "Asia/Kolkata");
-        assertSame(real, KpiCatalogService.selectDashboardConfigRecord(List.of(blank, missing, real)));
+        assertSame(blank, KpiCatalogService.selectDashboardConfigRecord(List.of(blank, missing, real)));
     }
 
     @Test
@@ -257,12 +257,12 @@ public class KpiCatalogServiceTimeZoneTest {
     }
 
     @Test
-    public void resolveTimeZonePicksLexicographicallySmallestIdWhenNoDefaultAmongDuplicates() {
+    public void resolveTimeZonePreservesFirstApiRecordWhenNoDefaultAmongDuplicates() {
         when(repo.fetchResult(any(), any())).thenReturn(mdmsResult(
                 recordWithId("zzz", "UTC"),
                 recordWithId("aaa", "Africa/Maputo")));
 
-        assertEquals(ZoneId.of("Africa/Maputo"), service.resolveTimeZone("ke.bomet"));
+        assertEquals(ZoneId.of("UTC"), service.resolveTimeZone("ke.bomet"));
     }
 
     // ---- TTL-bounded fallback warning gate (#29 review fix) ----

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiQueryComposerComplaintPathTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiQueryComposerComplaintPathTest.java
@@ -25,6 +25,9 @@ public class KpiQueryComposerComplaintPathTest {
     private final KpiQueryComposer composer = new KpiQueryComposer(catalog);
     private final AnalyticsPlanner planner = new AnalyticsPlanner(catalog);
     private final AnalyticsScope stateScope = new AnalyticsScope("ke", true, null, null, null);
+    /** complaintPath filtering doesn't depend on wall-clock time; one fixed calendar keeps the suite deterministic. */
+    private final BusinessCalendar calendar =
+            BusinessCalendar.of(java.time.ZoneId.of("Africa/Nairobi"), 1_700_000_000_000L);
 
     private JsonNode json(String s) {
         try { return om.readTree(s); } catch (Exception e) { throw new RuntimeException(e); }
@@ -47,8 +50,8 @@ public class KpiQueryComposerComplaintPathTest {
 
     @Test
     public void sqlSnapshotForSubtreePredicate() {
-        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"complaintPath\":\"SANITATION\"}"));
-        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope);
+        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"complaintPath\":\"SANITATION\"}"), calendar);
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope, calendar);
         assertEquals("SELECT service_code AS service_code, count(*) AS total"
                 + " FROM complaint_facts"
                 + " WHERE (complaint_node_path = ? OR complaint_node_path LIKE ? || '.%')"
@@ -64,8 +67,8 @@ public class KpiQueryComposerComplaintPathTest {
     public void eventsGrainAppliesSubtree() {
         JsonNode base = json("{\"grain\":\"events\",\"dimensions\":[\"service_code\"],"
                 + "\"measures\":[{\"name\":\"n\",\"agg\":\"count\"}]}");
-        JsonNode merged = composer.mergeParams(base, json("{\"complaintPath\":\"SANITATION.SEWAGE\"}"));
-        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope);
+        JsonNode merged = composer.mergeParams(base, json("{\"complaintPath\":\"SANITATION.SEWAGE\"}"), calendar);
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope, calendar);
         assertTrue(p.sql.contains("FROM complaint_events"));
         assertTrue(p.sql.contains("(complaint_node_path = ? OR complaint_node_path LIKE ? || '.%')"));
     }
@@ -74,8 +77,8 @@ public class KpiQueryComposerComplaintPathTest {
     public void likeMetacharactersInPathAreEscapedInTheLikeArm() {
         // '_' is a legal path character (UPPER_SNAKE codes) but a LIKE metachar — the LIKE arm
         // must receive the escaped literal while the eq arm gets the raw path.
-        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"complaintPath\":\"ROAD_WORKS\"}"));
-        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope);
+        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"complaintPath\":\"ROAD_WORKS\"}"), calendar);
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope, calendar);
         assertEquals("ROAD_WORKS", p.params.get(0));
         assertEquals("ROAD\\_WORKS", p.params.get(1));
     }
@@ -89,7 +92,7 @@ public class KpiQueryComposerComplaintPathTest {
                 "x||'y", "a\"b", "café", "a\tb"}) {
             IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
                     () -> composer.mergeParams(byTypeBase(), json(om.createObjectNode()
-                            .put("complaintPath", bad).toString())),
+                            .put("complaintPath", bad).toString()), calendar),
                     "complaintPath '" + bad + "' must be rejected");
             assertTrue(ex.getMessage().startsWith("invalid_param"), ex.getMessage());
         }
@@ -102,7 +105,7 @@ public class KpiQueryComposerComplaintPathTest {
         String tooLong = sb.append("LEAFNODE").toString();   // > 256 chars, alphabet-legal
         assertTrue(tooLong.length() > KpiQueryComposer.MAX_COMPLAINT_PATH_LENGTH);
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                () -> composer.mergeParams(byTypeBase(), json("{\"complaintPath\":\"" + tooLong + "\"}")));
+                () -> composer.mergeParams(byTypeBase(), json("{\"complaintPath\":\"" + tooLong + "\"}"), calendar));
         assertTrue(ex.getMessage().startsWith("invalid_param"), ex.getMessage());
     }
 
@@ -111,15 +114,15 @@ public class KpiQueryComposerComplaintPathTest {
         for (String ok : new String[]{"SANITATION", "SANITATION.SEWAGE",
                 "ROADS-AND-TRANSPORT.POTHOLES_1", "infra/roads.SUB"}) {
             JsonNode merged = composer.mergeParams(byTypeBase(),
-                    json("{\"complaintPath\":\"" + ok + "\"}"));
+                    json("{\"complaintPath\":\"" + ok + "\"}"), calendar);
             assertEquals(ok, merged.get("filters").get("complaint_node_path").get("subtree").asText());
         }
     }
 
     @Test
     public void emptyAndAbsentAreNoOps() {
-        assertEquals(byTypeBase(), composer.mergeParams(byTypeBase(), json("{\"complaintPath\":\"\"}")));
-        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"window\":\"last_7d\"}"));
+        assertEquals(byTypeBase(), composer.mergeParams(byTypeBase(), json("{\"complaintPath\":\"\"}"), calendar));
+        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"window\":\"last_7d\"}"), calendar);
         assertFalse(merged.has("filters"));
     }
 
@@ -128,7 +131,7 @@ public class KpiQueryComposerComplaintPathTest {
     @Test
     public void dailyGrainSkipsFilterAndReportsParamsIgnored() {
         List<String> ignored = new ArrayList<>();
-        JsonNode merged = composer.mergeParams(dailyBase(), json("{\"complaintPath\":\"SANITATION\"}"), ignored);
+        JsonNode merged = composer.mergeParams(dailyBase(), json("{\"complaintPath\":\"SANITATION\"}"), ignored, calendar);
         assertEquals(dailyBase(), merged);                       // no filter injected — daily has no path column
         assertEquals(List.of("complaintPath"), ignored);         // …but the skip is reported to the caller
     }
@@ -137,8 +140,8 @@ public class KpiQueryComposerComplaintPathTest {
     public void dailyGrainSkipIsIdempotentInTheCollector() {
         // The compose path reuses one collector across several source KPIs — no duplicates.
         List<String> ignored = new ArrayList<>();
-        composer.mergeParams(dailyBase(), json("{\"complaintPath\":\"SANITATION\"}"), ignored);
-        composer.mergeParams(dailyBase(), json("{\"complaintPath\":\"SANITATION\"}"), ignored);
+        composer.mergeParams(dailyBase(), json("{\"complaintPath\":\"SANITATION\"}"), ignored, calendar);
+        composer.mergeParams(dailyBase(), json("{\"complaintPath\":\"SANITATION\"}"), ignored, calendar);
         assertEquals(List.of("complaintPath"), ignored);
     }
 
@@ -148,17 +151,19 @@ public class KpiQueryComposerComplaintPathTest {
         List<String> ignored = new ArrayList<>();
         JsonNode eventsBase = json("{\"grain\":\"daily\",\"dimensions\":[\"service_code\"],"
                 + "\"measures\":[{\"name\":\"open\",\"agg\":\"count\"}]}");
-        composer.mergeParams(eventsBase, json("{\"ward\":\"W1\",\"complaintPath\":\"SANITATION\"}"), ignored);
+        composer.mergeParams(eventsBase, json("{\"ward\":\"W1\",\"complaintPath\":\"SANITATION\"}"), ignored, calendar);
         assertEquals(List.of("complaintPath"), ignored);
         // a malformed path is invalid_param even on the grain that would skip the filter —
         // garbage is rejected, never half-applied.
         assertThrows(IllegalArgumentException.class,
-                () -> composer.mergeParams(dailyBase(), json("{\"complaintPath\":\"x; DROP TABLE y\"}"), new ArrayList<>()));
+                () -> composer.mergeParams(dailyBase(), json("{\"complaintPath\":\"x; DROP TABLE y\"}"), new ArrayList<>(), calendar));
     }
 
     @Test
-    public void legacyTwoArgOverloadStaysSafeWithoutACollector() {
-        JsonNode merged = composer.mergeParams(dailyBase(), json("{\"complaintPath\":\"SANITATION\"}"));
+    public void noCollectorOverloadStaysSafeWithoutACollector() {
+        // The 3-arg (baseQuery, params, calendar) overload still requires an explicit calendar —
+        // it is not a "silently create a new clock" convenience, just an opt-in-collector-less form.
+        JsonNode merged = composer.mergeParams(dailyBase(), json("{\"complaintPath\":\"SANITATION\"}"), calendar);
         assertEquals(dailyBase(), merged);   // no NPE, same skip — reporting is opt-in
     }
 
@@ -168,8 +173,8 @@ public class KpiQueryComposerComplaintPathTest {
     public void composesWithHierLevelFilterPlusRollup() {
         // "Filter the Sanitation subtree, grouped at level 2" — WHERE prefix + GROUP BY level expr.
         JsonNode merged = composer.mergeParams(byTypeBase(),
-                json("{\"hierLevel\":\"2\",\"complaintPath\":\"SANITATION\"}"));
-        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope);
+                json("{\"hierLevel\":\"2\",\"complaintPath\":\"SANITATION\"}"), calendar);
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope, calendar);
         assertTrue(p.sql.contains("split_part(complaint_node_path,'.',least(2,complaint_depth))"),
                 p.sql);   // the rollup dimension survived
         assertTrue(p.sql.contains("(complaint_node_path = ? OR complaint_node_path LIKE ? || '.%')"),
@@ -182,12 +187,12 @@ public class KpiQueryComposerComplaintPathTest {
         // Leaf selections keep sending serviceCode (exact match) — complaintPath is additive for
         // interior nodes, not a replacement.
         JsonNode merged = composer.mergeParams(byTypeBase(),
-                json("{\"serviceCode\":\"GarbageNeedsTobeCleared\",\"complaintPath\":\"SANITATION\"}"));
+                json("{\"serviceCode\":\"GarbageNeedsTobeCleared\",\"complaintPath\":\"SANITATION\"}"), calendar);
         assertEquals("GarbageNeedsTobeCleared",
                 merged.get("filters").get("service_code").get("eq").asText());
         assertEquals("SANITATION",
                 merged.get("filters").get("complaint_node_path").get("subtree").asText());
-        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope);
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope, calendar);
         assertTrue(p.sql.contains("service_code = ?"));
     }
 
@@ -197,8 +202,8 @@ public class KpiQueryComposerComplaintPathTest {
     public void abacRowScopeIsStillAppliedOnTopOfTheSubtreeFilter() {
         AnalyticsScope constrained = new AnalyticsScope("ke.nairobi", false, null,
                 "KENYA.NAIROBI", java.util.List.of("DEPT_SANITATION"));
-        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"complaintPath\":\"SANITATION\"}"));
-        AnalyticsPlanner.Planned p = planner.plan(merged, constrained);
+        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"complaintPath\":\"SANITATION\"}"), calendar);
+        AnalyticsPlanner.Planned p = planner.plan(merged, constrained, calendar);
         assertTrue(p.sql.contains("(complaint_node_path = ? OR complaint_node_path LIKE ? || '.%')"), p.sql);
         assertTrue(p.sql.contains("tenant_id = ?"), p.sql);                 // city tenant scope
         assertTrue(p.sql.contains("boundary_path LIKE ?"), p.sql);          // jurisdiction subtree scope
@@ -216,7 +221,7 @@ public class KpiQueryComposerComplaintPathTest {
                 + "\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}],"
                 + "\"filters\":{\"service_code\":{\"subtree\":\"SANITATION\"}}}");
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                () -> planner.plan(inline, stateScope));
+                () -> planner.plan(inline, stateScope, calendar));
         assertTrue(ex.getMessage().startsWith("op_not_allowed"), ex.getMessage());
     }
 
@@ -226,6 +231,6 @@ public class KpiQueryComposerComplaintPathTest {
         JsonNode inline = json("{\"grain\":\"daily\","
                 + "\"measures\":[{\"name\":\"open\",\"agg\":\"count\"}],"
                 + "\"filters\":{\"complaint_node_path\":{\"subtree\":\"SANITATION\"}}}");
-        assertThrows(IllegalArgumentException.class, () -> planner.plan(inline, stateScope));
+        assertThrows(IllegalArgumentException.class, () -> planner.plan(inline, stateScope, calendar));
     }
 }

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiQueryComposerHierLevelTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiQueryComposerHierLevelTest.java
@@ -20,6 +20,9 @@ public class KpiQueryComposerHierLevelTest {
     private final KpiQueryComposer composer = new KpiQueryComposer(catalog);
     private final AnalyticsPlanner planner = new AnalyticsPlanner(catalog);
     private final AnalyticsScope stateScope = new AnalyticsScope("ke", true, null, null, null);
+    /** hierLevel behavior doesn't depend on wall-clock time; one fixed calendar keeps the suite deterministic. */
+    private final BusinessCalendar calendar =
+            BusinessCalendar.of(java.time.ZoneId.of("Africa/Nairobi"), 1_700_000_000_000L);
 
     private JsonNode json(String s) {
         try { return om.readTree(s); } catch (Exception e) { throw new RuntimeException(e); }
@@ -37,13 +40,13 @@ public class KpiQueryComposerHierLevelTest {
 
     @Test
     public void leafIsNoOp() {
-        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"hierLevel\":\"leaf\"}"));
+        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"hierLevel\":\"leaf\"}"), calendar);
         assertEquals(byTypeBase(), merged);
     }
 
     @Test
     public void absentIsNoOp() {
-        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"window\":\"last_7d\"}"));
+        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"window\":\"last_7d\"}"), calendar);
         assertEquals("service_code", merged.get("dimensions").get(0).asText());
     }
 
@@ -51,7 +54,7 @@ public class KpiQueryComposerHierLevelTest {
     public void dailyGrainWithoutPathColumnIsNoOp() {
         JsonNode base = json("{\"grain\":\"daily\",\"dimensions\":[\"service_code\"],"
                 + "\"measures\":[{\"name\":\"open\",\"agg\":\"count\"}]}");
-        JsonNode merged = composer.mergeParams(base, json("{\"hierLevel\":\"2\"}"));
+        JsonNode merged = composer.mergeParams(base, json("{\"hierLevel\":\"2\"}"), calendar);
         assertEquals(base, merged);   // param inapplicable on daily — graceful skip, like ward
     }
 
@@ -59,7 +62,7 @@ public class KpiQueryComposerHierLevelTest {
     public void queryWithoutServiceCodeDimensionIsNoOp() {
         JsonNode base = json("{\"grain\":\"facts\",\"dimensions\":[\"ward_code\",\"service_group\"],"
                 + "\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}]}");
-        JsonNode merged = composer.mergeParams(base, json("{\"hierLevel\":\"1\"}"));
+        JsonNode merged = composer.mergeParams(base, json("{\"hierLevel\":\"1\"}"), calendar);
         assertEquals(base, merged);   // nothing to roll up; service_group untouched
     }
 
@@ -67,7 +70,7 @@ public class KpiQueryComposerHierLevelTest {
 
     @Test
     public void levelRewritesServiceCodeDimensionToInternalMarker() {
-        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"hierLevel\":\"2\"}"));
+        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"hierLevel\":\"2\"}"), calendar);
         JsonNode dim = merged.get("dimensions").get(0);
         assertTrue(dim.isObject());
         assertEquals(2, dim.get(AnalyticsCatalog.HIER_DIM_LEVEL_FIELD).asInt());
@@ -84,7 +87,7 @@ public class KpiQueryComposerHierLevelTest {
         JsonNode base = json("{\"grain\":\"facts\",\"dimensions\":[\"service_code\",\"service_group\"],"
                 + "\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}],"
                 + "\"sort\":[{\"by\":\"service_group\",\"dir\":\"asc\"},{\"by\":\"total\",\"dir\":\"desc\"}]}");
-        JsonNode merged = composer.mergeParams(base, json("{\"hierLevel\":\"1\"}"));
+        JsonNode merged = composer.mergeParams(base, json("{\"hierLevel\":\"1\"}"), calendar);
         assertEquals(1, merged.get("dimensions").size());   // service_group gone
         assertTrue(merged.get("dimensions").get(0).isObject());
         // sort referencing the dropped dimension is removed; the rest survives
@@ -96,21 +99,21 @@ public class KpiQueryComposerHierLevelTest {
     public void serviceGroupKeptAtLeaf() {
         JsonNode base = json("{\"grain\":\"facts\",\"dimensions\":[\"service_code\",\"service_group\"],"
                 + "\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}]}");
-        JsonNode merged = composer.mergeParams(base, json("{\"hierLevel\":\"leaf\"}"));
+        JsonNode merged = composer.mergeParams(base, json("{\"hierLevel\":\"leaf\"}"), calendar);
         assertEquals(base, merged);
     }
 
     @Test
     public void composesWithWindowWardAndServiceCodeParams() {
         JsonNode merged = composer.mergeParams(byTypeBase(),
-                json("{\"hierLevel\":\"1\",\"window\":\"last_7d\",\"ward\":\"W1\",\"serviceCode\":\"StreetLightNotWorking\"}"));
+                json("{\"hierLevel\":\"1\",\"window\":\"last_7d\",\"ward\":\"W1\",\"serviceCode\":\"StreetLightNotWorking\"}"), calendar);
         assertEquals("last_7d", merged.get("window").get("name").asText());
         assertEquals("W1", merged.get("filters").get("ward_code").get("eq").asText());
         assertEquals("StreetLightNotWorking", merged.get("filters").get("service_code").get("eq").asText());
         assertTrue(merged.get("dimensions").get(0).isObject());
         // ...and the planner accepts the combination (WHERE on raw service_code column,
         // SELECT/GROUP BY on the aliased level expression — verified non-colliding).
-        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope);
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope, calendar);
         assertTrue(p.sql.contains("service_code = ?"));
         assertTrue(p.sql.contains("AS service_code"));
     }
@@ -121,7 +124,7 @@ public class KpiQueryComposerHierLevelTest {
     public void malformedLevelsAreRejected() {
         for (String bad : new String[]{"0", "13", "abc", "-1", "1.5", "1e1", "1; DROP TABLE x"}) {
             IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                    () -> composer.mergeParams(byTypeBase(), json("{\"hierLevel\":\"" + bad + "\"}")),
+                    () -> composer.mergeParams(byTypeBase(), json("{\"hierLevel\":\"" + bad + "\"}"), calendar),
                     "hierLevel '" + bad + "' must be rejected");
             assertTrue(ex.getMessage().startsWith("invalid_param"), ex.getMessage());
         }
@@ -130,7 +133,7 @@ public class KpiQueryComposerHierLevelTest {
     @Test
     public void boundaryLevelsAreAccepted() {
         for (String ok : new String[]{"1", "12"}) {
-            JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"hierLevel\":\"" + ok + "\"}"));
+            JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"hierLevel\":\"" + ok + "\"}"), calendar);
             assertTrue(merged.get("dimensions").get(0).isObject());
         }
     }
@@ -139,8 +142,8 @@ public class KpiQueryComposerHierLevelTest {
 
     @Test
     public void plannerSqlSnapshotForLevelQuery() {
-        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"hierLevel\":\"1\"}"));
-        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope);
+        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"hierLevel\":\"1\"}"), calendar);
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope, calendar);
         assertEquals("SELECT coalesce(nullif(split_part(complaint_node_path,'.',least(1,complaint_depth)),''),"
                 + " service_code) AS service_code, count(*) AS total"
                 + " FROM complaint_facts"
@@ -153,16 +156,16 @@ public class KpiQueryComposerHierLevelTest {
     public void sqlCarriesLeafFallbackForNullPathRows() {
         // Flat/legacy tenants materialize complaint_node_path NULL — the expr's
         // coalesce(nullif(...),''), service_code) makes those rows roll up as themselves.
-        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"hierLevel\":\"2\"}"));
-        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope);
+        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"hierLevel\":\"2\"}"), calendar);
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope, calendar);
         assertTrue(p.sql.contains("coalesce(nullif(split_part(complaint_node_path,'.',"));
         assertTrue(p.sql.contains(",''), service_code) AS service_code"));
     }
 
     @Test
     public void sqlClampsLevelToRowDepth() {
-        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"hierLevel\":\"4\"}"));
-        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope);
+        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"hierLevel\":\"4\"}"), calendar);
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope, calendar);
         assertTrue(p.sql.contains("least(4,complaint_depth)"));
     }
 
@@ -170,8 +173,8 @@ public class KpiQueryComposerHierLevelTest {
     public void eventsGrainSupportsLevelRollup() {
         JsonNode base = json("{\"grain\":\"events\",\"dimensions\":[\"service_code\"],"
                 + "\"measures\":[{\"name\":\"n\",\"agg\":\"count\"}]}");
-        JsonNode merged = composer.mergeParams(base, json("{\"hierLevel\":\"1\"}"));
-        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope);
+        JsonNode merged = composer.mergeParams(base, json("{\"hierLevel\":\"1\"}"), calendar);
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope, calendar);
         assertTrue(p.sql.contains("FROM complaint_events"));
         assertTrue(p.sql.contains("least(1,complaint_depth)"));
     }
@@ -187,7 +190,7 @@ public class KpiQueryComposerHierLevelTest {
                 + "\"" + AnalyticsCatalog.HIER_DIM_TOKEN_FIELD + "\":\"forged-token\"}],"
                 + "\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}]}");
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                () -> planner.plan(forged, stateScope));
+                () -> planner.plan(forged, stateScope, calendar));
         assertTrue(ex.getMessage().startsWith("unknown_column"), ex.getMessage());
     }
 
@@ -202,7 +205,7 @@ public class KpiQueryComposerHierLevelTest {
         dim.put(AnalyticsCatalog.HIER_DIM_LEVEL_FIELD, 13);
         dim.put(AnalyticsCatalog.HIER_DIM_TOKEN_FIELD, AnalyticsCatalog.HIER_DIM_TOKEN);
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                () -> planner.plan(q, stateScope));
+                () -> planner.plan(q, stateScope, calendar));
         assertTrue(ex.getMessage().startsWith("invalid_param"), ex.getMessage());
     }
 }

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiQueryComposerPinnedWindowTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiQueryComposerPinnedWindowTest.java
@@ -73,7 +73,7 @@ public class KpiQueryComposerPinnedWindowTest {
     /** dtd is the calendar day in EAT — NOT last_1d's rolling 24h, which drifts across midnight. */
     @Test
     public void dtdIsTheCalendarDayNotARollingDay() {
-        long now = CAL.asOfMs;
+        long now = CAL.nowMs;
         long dtd = AnalyticsPlanner.windowStartMs("dtd", now, EAT);
         long rolling = AnalyticsPlanner.windowStartMs("last_1d", now, EAT);
 
@@ -94,7 +94,7 @@ public class KpiQueryComposerPinnedWindowTest {
     @Test
     public void unknownWindowNameStillRejected() {
         assertThrows(IllegalArgumentException.class,
-                () -> AnalyticsPlanner.windowStartMs("dtd_", CAL.asOfMs, EAT));
+                () -> AnalyticsPlanner.windowStartMs("dtd_", CAL.nowMs, EAT));
     }
 
     // ---- pinning beats the dashboard globals ----

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiQueryComposerPinnedWindowTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiQueryComposerPinnedWindowTest.java
@@ -4,12 +4,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -24,10 +23,18 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  * {@code compare:"prior"} meaning yesterday rather than a prior-equal-duration-of-the-range, the
  * sparkline staying answerable, non-time params still narrowing a pinned query, and — the
  * regression guard that matters most — that every UNPINNED def behaves exactly as before.
+ *
+ * <p>Deterministic (#29): every case is judged against ONE fixed {@link BusinessCalendar}
+ * ({@code CAL}, a Saturday, EAT) rather than the wall clock — the request-scoped calendar this
+ * class exists to make possible. This also removes the old two-clock race between the test's own
+ * {@code today()} read and the composer's separate internal clock read.
  */
 public class KpiQueryComposerPinnedWindowTest {
 
     private static final ZoneId EAT = ZoneId.of("Africa/Nairobi");
+    /** Fixed "now": 2024-06-15 12:00 EAT (a Saturday), mid-day so no test is a midnight boundary case. */
+    private static final BusinessCalendar CAL =
+            BusinessCalendar.of(EAT, ZonedDateTime.of(2024, 6, 15, 12, 0, 0, 0, EAT).toInstant().toEpochMilli());
 
     private final ObjectMapper om = new ObjectMapper();
     private final AnalyticsCatalog catalog = new AnalyticsCatalog();
@@ -39,20 +46,7 @@ public class KpiQueryComposerPinnedWindowTest {
         try { return om.readTree(s); } catch (Exception e) { throw new RuntimeException(e); }
     }
 
-    private LocalDate today() { return Instant.now().atZone(EAT).toLocalDate(); }
-
-    /**
-     * Run a day-sensitive assertion and abandon it (rather than fail) if EAT midnight passed while it
-     * ran. The composer reads its own clock, so a case that computes an expectation from {@code today()}
-     * and then merges is inherently a two-clock comparison — around 21:00 UTC that is a real CI window.
-     * Aborting keeps the suite honest: it never passes on a stale day, and never fails for one either.
-     */
-    private void onAStableDay(Supplier<LocalDate> body) {
-        LocalDate before = today();
-        LocalDate used = body.get();
-        assumeTrue(before.equals(today()), "EAT midnight passed mid-test; day-boundary case abandoned");
-        assertEquals(before, used, "test helper must exercise the day it captured");
-    }
+    private LocalDate today() { return CAL.businessDate; }
 
     /** The seeded "complaints created today" def, post-fix: a pinned calendar-day window. */
     private JsonNode createdTodayBase() {
@@ -67,7 +61,7 @@ public class KpiQueryComposerPinnedWindowTest {
     }
 
     private JsonNode merge(JsonNode base, String params) {
-        return composer.mergeParams(base, json(params), new ArrayList<>());
+        return composer.mergeParams(base, json(params), new ArrayList<>(), CAL);
     }
 
     private boolean suppressed(JsonNode merged) {
@@ -79,9 +73,9 @@ public class KpiQueryComposerPinnedWindowTest {
     /** dtd is the calendar day in EAT — NOT last_1d's rolling 24h, which drifts across midnight. */
     @Test
     public void dtdIsTheCalendarDayNotARollingDay() {
-        long now = System.currentTimeMillis();
-        long dtd = AnalyticsPlanner.windowStartMs("dtd", now);
-        long rolling = AnalyticsPlanner.windowStartMs("last_1d", now);
+        long now = CAL.asOfMs;
+        long dtd = AnalyticsPlanner.windowStartMs("dtd", now, EAT);
+        long rolling = AnalyticsPlanner.windowStartMs("last_1d", now, EAT);
 
         assertEquals(today().atStartOfDay(EAT).toInstant().toEpochMilli(), dtd,
                 "dtd must start at EAT midnight of the current day");
@@ -92,7 +86,7 @@ public class KpiQueryComposerPinnedWindowTest {
     /** dtd plans into a real time predicate, so a pinned tile still filters on its own axis. */
     @Test
     public void dtdPlansIntoATimePredicate() {
-        AnalyticsPlanner.Planned p = planner.plan(createdTodayBase(), stateScope);
+        AnalyticsPlanner.Planned p = planner.plan(createdTodayBase(), stateScope, CAL);
         assertTrue(p.sql.contains("created_at >= ?") && p.sql.contains("created_at < ?"),
                 "expected a bounded created_at predicate, got: " + p.sql);
     }
@@ -100,7 +94,7 @@ public class KpiQueryComposerPinnedWindowTest {
     @Test
     public void unknownWindowNameStillRejected() {
         assertThrows(IllegalArgumentException.class,
-                () -> AnalyticsPlanner.windowStartMs("dtd_", System.currentTimeMillis()));
+                () -> AnalyticsPlanner.windowStartMs("dtd_", CAL.asOfMs, EAT));
     }
 
     // ---- pinning beats the dashboard globals ----
@@ -108,27 +102,24 @@ public class KpiQueryComposerPinnedWindowTest {
     /** The whole bug: a selected range must not redefine what "today" means. */
     @Test
     public void dateRangeDoesNotRewriteAPinnedWindow() {
-        onAStableDay(() -> {
-            LocalDate t = today();
-            JsonNode merged = merge(createdTodayBase(),
-                    "{\"dateFrom\":\"" + t.minusDays(30) + "\",\"dateTo\":\"" + t + "\"}");
+        LocalDate t = today();
+        JsonNode merged = merge(createdTodayBase(),
+                "{\"dateFrom\":\"" + t.minusDays(30) + "\",\"dateTo\":\"" + t + "\"}");
 
-            // The pin is now materialized into explicit bounds instead of being left as a window node
-            // for the planner to re-resolve, so assert on the bound interval rather than window.name.
-            assertFalse(merged.has("window"), "the pinned window is baked into explicit bounds");
-            assertEquals(t.atStartOfDay(EAT).toInstant().toEpochMilli(),
-                    merged.path("filters").path("created_at").path("gte").asLong(),
-                    "bounds must start at EAT midnight TODAY, not at the range start");
-            assertFalse(suppressed(merged), "the range covers today, so the tile is answerable");
-            return t;
-        });
+        // The pin is now materialized into explicit bounds instead of being left as a window node
+        // for the planner to re-resolve, so assert on the bound interval rather than window.name.
+        assertFalse(merged.has("window"), "the pinned window is baked into explicit bounds");
+        assertEquals(t.atStartOfDay(EAT).toInstant().toEpochMilli(),
+                merged.path("filters").path("created_at").path("gte").asLong(),
+                "bounds must start at EAT midnight TODAY, not at the range start");
+        assertFalse(suppressed(merged), "the range covers today, so the tile is answerable");
     }
 
     /** The window param (the FE's per-tile default) must not override a pin either. */
     @Test
     public void windowParamDoesNotOverrideAPinnedWindowAndIsReported() {
         List<String> ignored = new ArrayList<>();
-        JsonNode merged = composer.mergeParams(createdTodayBase(), json("{\"window\":\"last_30d\"}"), ignored);
+        JsonNode merged = composer.mergeParams(createdTodayBase(), json("{\"window\":\"last_30d\"}"), ignored, CAL);
 
         long midnight = today().atStartOfDay(EAT).toInstant().toEpochMilli();
         assertEquals(midnight, merged.path("filters").path("created_at").path("gte").asLong(),
@@ -142,37 +133,28 @@ public class KpiQueryComposerPinnedWindowTest {
     /** Range entirely in the past: today cannot be in it, so the tile has no answer. */
     @Test
     public void rangeEndingBeforeTodaySuppresses() {
-        onAStableDay(() -> {
-            LocalDate t = today();
-            JsonNode merged = merge(createdTodayBase(),
-                    "{\"dateFrom\":\"" + t.minusDays(30) + "\",\"dateTo\":\"" + t.minusDays(1) + "\"}");
-            assertTrue(suppressed(merged), "a range ending yesterday excludes today");
-            return t;
-        });
+        LocalDate t = today();
+        JsonNode merged = merge(createdTodayBase(),
+                "{\"dateFrom\":\"" + t.minusDays(30) + "\",\"dateTo\":\"" + t.minusDays(1) + "\"}");
+        assertTrue(suppressed(merged), "a range ending yesterday excludes today");
     }
 
     /** Range entirely in the future: same. */
     @Test
     public void rangeStartingAfterTodaySuppresses() {
-        onAStableDay(() -> {
-            LocalDate t = today();
-            JsonNode merged = merge(createdTodayBase(),
-                    "{\"dateFrom\":\"" + t.plusDays(1) + "\",\"dateTo\":\"" + t.plusDays(7) + "\"}");
-            assertTrue(suppressed(merged), "a range starting tomorrow excludes today");
-            return t;
-        });
+        LocalDate t = today();
+        JsonNode merged = merge(createdTodayBase(),
+                "{\"dateFrom\":\"" + t.plusDays(1) + "\",\"dateTo\":\"" + t.plusDays(7) + "\"}");
+        assertTrue(suppressed(merged), "a range starting tomorrow excludes today");
     }
 
     /** A single-day range on today is the boundary case — inclusive, so answerable. */
     @Test
     public void rangeOfExactlyTodayIsNotSuppressed() {
-        onAStableDay(() -> {
-            LocalDate t = today();
-            JsonNode merged = merge(createdTodayBase(),
-                    "{\"dateFrom\":\"" + t + "\",\"dateTo\":\"" + t + "\"}");
-            assertFalse(suppressed(merged));
-            return t;
-        });
+        LocalDate t = today();
+        JsonNode merged = merge(createdTodayBase(),
+                "{\"dateFrom\":\"" + t + "\",\"dateTo\":\"" + t + "\"}");
+        assertFalse(suppressed(merged));
     }
 
     /** No range at all (the dashboard default) — nothing to conflict with. */
@@ -190,7 +172,7 @@ public class KpiQueryComposerPinnedWindowTest {
         assertTrue(suppressed(merged));
         // The planner ignores it rather than emitting it — the service short-circuits before planning,
         // but a stray plan() call must still never produce a __suppressed column or predicate.
-        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope);
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope, CAL);
         assertFalse(p.sql.contains("__suppressed"), "marker leaked into SQL: " + p.sql);
     }
 
@@ -199,18 +181,15 @@ public class KpiQueryComposerPinnedWindowTest {
     /** "vs yesterday" must mean yesterday, not the prior 30 days because a month was selected. */
     @Test
     public void priorOnAPinnedDayMeansYesterday() {
-        onAStableDay(() -> {
-            LocalDate t = today();
-            JsonNode merged = merge(createdTodayBase(),
-                    "{\"compare\":\"prior\",\"dateFrom\":\"" + t.minusDays(30) + "\",\"dateTo\":\"" + t + "\"}");
+        LocalDate t = today();
+        JsonNode merged = merge(createdTodayBase(),
+                "{\"compare\":\"prior\",\"dateFrom\":\"" + t.minusDays(30) + "\",\"dateTo\":\"" + t + "\"}");
 
-            long expectedFrom = t.minusDays(1).atStartOfDay(EAT).toInstant().toEpochMilli();
-            long expectedTo = t.atStartOfDay(EAT).toInstant().toEpochMilli();
-            assertEquals(expectedFrom, merged.path("filters").path("created_at").path("gte").asLong());
-            assertEquals(expectedTo, merged.path("filters").path("created_at").path("lt").asLong());
-            assertFalse(merged.has("window"), "explicit prior bounds replace the window");
-            return t;
-        });
+        long expectedFrom = t.minusDays(1).atStartOfDay(EAT).toInstant().toEpochMilli();
+        long expectedTo = t.atStartOfDay(EAT).toInstant().toEpochMilli();
+        assertEquals(expectedFrom, merged.path("filters").path("created_at").path("gte").asLong());
+        assertEquals(expectedTo, merged.path("filters").path("created_at").path("lt").asLong());
+        assertFalse(merged.has("window"), "explicit prior bounds replace the window");
     }
 
     // ---- sparkline ----
@@ -245,22 +224,20 @@ public class KpiQueryComposerPinnedWindowTest {
     /** A pinned WEEK under a two-day filter must not report the whole week: coverage, not overlap. */
     @Test
     public void partialOverlapOfAMultiDayPinIsSuppressed() {
-        onAStableDay(() -> {
-            LocalDate t = today();
-            JsonNode weekly = json("{\"grain\":\"facts\",\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}],"
-                    + "\"window\":{\"name\":\"wtd\",\"timeRole\":\"filed_at\",\"pinned\":true}}");
-            JsonNode merged = merge(weekly,
-                    "{\"dateFrom\":\"" + t.minusDays(1) + "\",\"dateTo\":\"" + t + "\"}");
+        LocalDate t = today();
+        JsonNode weekly = json("{\"grain\":\"facts\",\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}],"
+                + "\"window\":{\"name\":\"wtd\",\"timeRole\":\"filed_at\",\"pinned\":true}}");
+        JsonNode merged = merge(weekly,
+                "{\"dateFrom\":\"" + t.minusDays(1) + "\",\"dateTo\":\"" + t + "\"}");
 
-            LocalDate weekStart = t.with(java.time.temporal.TemporalAdjusters.previousOrSame(java.time.DayOfWeek.MONDAY));
-            // Only meaningful from Wednesday on: earlier in the week the 2-day range genuinely covers
-            // the whole week-to-date, so there is nothing partial to assert.
-            assumeTrue(t.minusDays(1).isAfter(weekStart),
-                    "early in the week the range covers the pinned window; nothing partial to test");
-            assertTrue(suppressed(merged),
-                    "a range covering only part of the pinned week must not report the full week");
-            return t;
-        });
+        LocalDate weekStart = t.with(java.time.temporal.TemporalAdjusters.previousOrSame(java.time.DayOfWeek.MONDAY));
+        // Only meaningful from Wednesday on: earlier in the week the 2-day range genuinely covers
+        // the whole week-to-date, so there is nothing partial to assert. CAL is a fixed Saturday, so
+        // this always exercises the real case rather than skipping.
+        assumeTrue(t.minusDays(1).isAfter(weekStart),
+                "early in the week the range covers the pinned window; nothing partial to test");
+        assertTrue(suppressed(merged),
+                "a range covering only part of the pinned week must not report the full week");
     }
 
     /** Pinning something boundless has no meaning; it must degrade to the ordinary path, not to a lie. */
@@ -307,7 +284,7 @@ public class KpiQueryComposerPinnedWindowTest {
                 "empty params must remain a no-op");
         JsonNode merged = merge(createdTodayBase(), "{\"serviceCode\":\"Pothole\"}");
         assertFalse(merged.has("window"), "the window must be consumed into explicit bounds");
-        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope);
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope, CAL);
         assertTrue(p.sql.contains("created_at >= ?") && p.sql.contains("created_at < ?"),
                 "materialized bounds must still produce the same bounded predicate: " + p.sql);
     }
@@ -322,7 +299,9 @@ public class KpiQueryComposerPinnedWindowTest {
                 "{\"dateFrom\":\"" + t.minusDays(30) + "\",\"dateTo\":\"" + t + "\"}");
 
         assertFalse(merged.has("window"), "range must still remove an unpinned window");
-        assertEquals(t.minusDays(30).atStartOfDay(java.time.ZoneOffset.UTC).toInstant().toEpochMilli(),
+        // Bounds are computed in the resolved TENANT zone (EAT here), not UTC (#29) — a range
+        // dateFrom/dateTo is a local calendar date wherever the tenant is configured.
+        assertEquals(t.minusDays(30).atStartOfDay(EAT).toInstant().toEpochMilli(),
                 merged.path("filters").path("created_at").path("gte").asLong());
         assertFalse(suppressed(merged), "unpinned defs are never suppressed");
     }

--- a/backend/pgr-services/src/test/java/org/egov/pgr/service/DashboardRefreshSchedulerTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/service/DashboardRefreshSchedulerTest.java
@@ -1,0 +1,90 @@
+package org.egov.pgr.service;
+
+import org.egov.pgr.config.PGRConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * #29 timezone addendum: pins that the daily backlog snapshot resolves snapshot_date per
+ * complaint's own tenant-local calendar day (via pgr_dashboard_tenant_timezone, falling back to
+ * Africa/Nairobi) instead of a single server-wide CURRENT_DATE, and that the refresh ordering
+ * (events -> facts -> snapshot -> legacy MVs) is unchanged.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class DashboardRefreshSchedulerTest {
+
+    @Mock private JdbcTemplate jdbc;
+
+    private PGRConfiguration config;
+    private DashboardRefreshScheduler scheduler;
+
+    @BeforeEach
+    public void setUp() {
+        config = new PGRConfiguration();
+        config.setDashboardRefreshEnabled(true);
+        scheduler = new DashboardRefreshScheduler(jdbc, config);
+    }
+
+    @Test
+    public void disabledConfigSkipsEveryRefresh() {
+        config.setDashboardRefreshEnabled(false);
+
+        scheduler.refreshMaterializedViews();
+
+        verifyNoInteractions(jdbc);
+    }
+
+    @Test
+    public void dailySnapshotResolvesTenantLocalDateNotServerCurrentDate() {
+        scheduler.refreshMaterializedViews();
+
+        ArgumentCaptor<String> sql = ArgumentCaptor.forClass(String.class);
+        verify(jdbc).update(sql.capture());
+        String upsert = sql.getValue().replaceAll("\\s+", " ");
+
+        assertFalse(upsert.contains("CURRENT_DATE"),
+                "snapshot_date must not come from a single server-wide CURRENT_DATE");
+        assertTrue(upsert.contains("CURRENT_TIMESTAMP AT TIME ZONE COALESCE(tz.resolved_zone, 'Africa/Nairobi')"),
+                "snapshot_date must resolve per tenant via the shared timezone view, falling back to Africa/Nairobi");
+        assertTrue(upsert.contains("LEFT JOIN pgr_dashboard_tenant_timezone tz"),
+                "must join the same SQL timezone view the V2 grain MVs use");
+        assertTrue(upsert.contains("tz.state_root_tenant_id = split_part(cf.tenant_id, '.', 1)"),
+                "must resolve the zone from the complaint's own state-root tenant");
+        assertTrue(upsert.contains("FROM complaint_facts cf"));
+        assertTrue(upsert.contains("WHERE cf.is_open"));
+        assertTrue(upsert.contains("ON CONFLICT (snapshot_date, service_request_id) DO NOTHING"),
+                "idempotent per (day, complaint) upsert must be preserved");
+        assertTrue(upsert.contains("(snapshot_date, service_request_id, tenant_id, is_open, sla_breached, "
+                        + "sla_status_bucket, aging_bucket, boundary_path, ward_code, zone_code, service_code, "
+                        + "current_assignee_uuid, department_code, account_id)"),
+                "insert column list must be unchanged");
+    }
+
+    @Test
+    public void refreshesEventsThenFactsThenSnapshotThenLegacyMvs() {
+        scheduler.refreshMaterializedViews();
+
+        InOrder order = inOrder(jdbc);
+        order.verify(jdbc).execute(eq("REFRESH MATERIALIZED VIEW CONCURRENTLY complaint_events"));
+        order.verify(jdbc).execute(eq("REFRESH MATERIALIZED VIEW CONCURRENTLY complaint_facts"));
+        order.verify(jdbc).update(anyString());
+        order.verify(jdbc).execute(eq("REFRESH MATERIALIZED VIEW CONCURRENTLY pgr_mv_kpi"));
+        order.verify(jdbc).execute(eq("REFRESH MATERIALIZED VIEW CONCURRENTLY pgr_mv_monthly"));
+        order.verify(jdbc).execute(eq("REFRESH MATERIALIZED VIEW CONCURRENTLY pgr_mv_monthly_source"));
+        order.verify(jdbc).execute(eq("REFRESH MATERIALIZED VIEW CONCURRENTLY pgr_mv_dimension"));
+    }
+}

--- a/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
@@ -24,6 +24,7 @@ import DashboardLogin, {
 } from "./components/DashboardLogin";
 import { useDashboardConfig } from "../useDashboardConfig";
 import { resolveNumberFormatMask, setNumberFormatMask } from "./utils/numberFormat";
+import { resolveConfiguredTimeZone } from "./utils/dashboardTimeZone";
 
 import useDashboardT from "./i18n/useDashboardT";
 import { resolveTitle, resolveSubtitle } from "./i18n/textResolver";
@@ -176,6 +177,10 @@ const AdminDashboard = ({ embedded = false }) => {
   const { config: dashboardConfig, loading: dashboardConfigLoading } =
     useDashboardConfig();
   setNumberFormatMask(resolveNumberFormatMask(dashboardConfig?.numberFormat, language));
+  // Resolved once dashboardConfig settles (dashboardConfigLoading gates AdminDashboardInner's
+  // mount below), then threaded explicitly through every default-date consumer — no
+  // module-global mutable timezone state, unlike the numberFormat mask above.
+  const timeZone = resolveConfiguredTimeZone(dashboardConfig);
 
   const handleLogin = useCallback(() => {
     window.location.reload();
@@ -190,7 +195,13 @@ const AdminDashboard = ({ embedded = false }) => {
   if (dashboardConfigLoading) {
     return <div className="kpi-tile kpi-tile--loading"><div className="kpi-tile__skeleton" /></div>;
   }
-  return <AdminDashboardInner embedded={embedded} onSignOut={embedded ? undefined : handleSignOut} />;
+  return (
+    <AdminDashboardInner
+      embedded={embedded}
+      onSignOut={embedded ? undefined : handleSignOut}
+      timeZone={timeZone}
+    />
+  );
 };
 
 /* -------------------------------------------------------------------------- */
@@ -373,7 +384,7 @@ function seriesToPoints(rows, viz, valueKey, columns) {
 /* Inner dashboard                                                             */
 /* -------------------------------------------------------------------------- */
 
-const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
+const AdminDashboardInner = ({ onSignOut, embedded = false, timeZone }) => {
   // Render-lag instrumentation (#1110): begin the load SYNCHRONOUSLY at mount.
   useState(() => {
     dashboardMetrics.beginLoad();
@@ -382,7 +393,7 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
   useEffect(() => () => dashboardMetrics.flush("unmount"), []);
   const { t, language, i18nTick } = useDashboardT();
   const { filters, setFilter, clearFilters, applyFilterOptions } =
-    useDashboardFilters();
+    useDashboardFilters(timeZone);
   const { options: filterOptions, loading: filterOptionsLoading } =
     useFilterOptions();
   const tenantId = useMemo(() => getTenantId(), []);
@@ -425,6 +436,8 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
     results: {},
     errors: null,
     partial: false,
+    asOf: null,
+    calendar: null,
   });
   const reqIdRef = useRef(0);
 
@@ -689,7 +702,7 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
 
   useEffect(() => {
     if (!pack || !tiles.length) {
-      setBatch({ loading: false, results: {}, errors: null, partial: false });
+      setBatch({ loading: false, results: {}, errors: null, partial: false, asOf: null, calendar: null });
       return;
     }
     const refs = buildRefs(tiles, kpis, filters, hierOverrides);
@@ -705,6 +718,10 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
           results: res?.results || {},
           errors: res?.errors || null,
           partial: Boolean(res?.partial),
+          // Batch authority for "Last updated" (#29): the response's own top-level
+          // asOf/calendar, never a fresh client-side clock reading.
+          asOf: typeof res?.asOf === "number" ? res.asOf : null,
+          calendar: res?.calendar || null,
         });
         dashboardMetrics.markAllWidgetsReady(
           countErrorWidgets(res?.errors, tiles.length),
@@ -718,6 +735,8 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
           results: {},
           errors: { __batch: err?.message || t("DASHBOARD_COMMON_BATCH_FAILED", "Batch query failed") },
           partial: true,
+          asOf: null,
+          calendar: null,
         });
         dashboardMetrics.markAllWidgetsReady(tiles.length, reqId);
       });
@@ -725,16 +744,21 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [refsKey, pack, tenantId]);
 
-  const lastUpdatedLabel = useMemo(
-    () =>
-      new Date().toLocaleString(language?.replace("_", "-"), {
-        day: "numeric",
-        month: "short",
-        hour: "numeric",
-        minute: "2-digit",
-      }),
-    [batch.results, language]
-  );
+  // "Last updated" reads the batch's OWN echoed asOf/calendar (#29) — the single
+  // clock reading every tile in this batch was judged against — never a fresh
+  // new Date() at render time, which would drift from what's actually on screen.
+  // No stamp (rather than a fabricated "now") when the batch hasn't supplied one.
+  const lastUpdatedLabel = useMemo(() => {
+    if (batch.asOf == null) return null;
+    const zone = batch.calendar?.timeZone || timeZone;
+    return new Date(batch.asOf).toLocaleString(language?.replace("_", "-"), {
+      day: "numeric",
+      month: "short",
+      hour: "numeric",
+      minute: "2-digit",
+      ...(zone ? { timeZone: zone } : {}),
+    });
+  }, [batch.asOf, batch.calendar, timeZone, language]);
 
   // RGL reads min/max W/H straight off each layout item (the hook bakes in the
   // viz.kind-derived constraints), so the grid layout passes items through verbatim.
@@ -849,6 +873,7 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
       filters={filters}
       onFilterChange={handleFilterChange}
       onClearFilters={handleClearFilters}
+      timeZone={timeZone}
       filterOptions={filterOptions}
       filterOptionsLoading={filterOptionsLoading}
       kpiCardData={{}}
@@ -937,7 +962,7 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
                   {removeBtn}
                   {renderTile(item.i)}
                   {ignoredNote}
-                  <CardUpdatedStamp label={lastUpdatedLabel} />
+                  {lastUpdatedLabel && <CardUpdatedStamp label={lastUpdatedLabel} />}
                 </div>
               );
             }
@@ -999,7 +1024,7 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
                   {renderTile(item.i, groupBy.info)}
                 </div>
                 {ignoredNote}
-                <CardUpdatedStamp label={lastUpdatedLabel} />
+                {lastUpdatedLabel && <CardUpdatedStamp label={lastUpdatedLabel} />}
                 <ResizeGrip />
               </section>
             );

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardFilters.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardFilters.jsx
@@ -1,8 +1,8 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import {
   COMPLAINT_TYPE_OPTIONS,
   GEOGRAPHY_OPTIONS,
-  GLOBAL_FILTER_FIELDS,
+  buildDefaultFilters,
   hasActiveFilters,
 } from "../config/globalFilterGroups";
 import ComplaintTypeTreeFilter from "./ComplaintTypeTreeFilter";
@@ -97,19 +97,24 @@ const DashboardFilters = ({
   filters,
   onFilterChange,
   onClearFilters,
+  timeZone,
   filterOptions,
   filterOptionsLoading = false,
 }) => {
   const { t } = useDashboardT();
-  const canClear = hasActiveFilters(filters);
+  const canClear = hasActiveFilters(filters, timeZone);
 
   const geographyOptions = filterOptions?.geography ?? GEOGRAPHY_OPTIONS;
   const complaintTypeOptions =
     filterOptions?.complaintType ?? COMPLAINT_TYPE_OPTIONS;
   const complaintTypeTree = filterOptions?.complaintTypeTree ?? null;
 
-  const dateFrom = filters?.dateFrom ?? GLOBAL_FILTER_FIELDS.find((f) => f.id === "dateFrom")?.defaultValue;
-  const dateTo = filters?.dateTo ?? GLOBAL_FILTER_FIELDS.find((f) => f.id === "dateTo")?.defaultValue;
+  // Date fallbacks resolve from buildDefaultFilters(timeZone) at render time — never
+  // GLOBAL_FILTER_FIELDS' module-load defaultValue, which would freeze on whatever
+  // calendar day the JS bundle happened to first evaluate in the browser's local zone.
+  const defaultFilters = useMemo(() => buildDefaultFilters(timeZone), [timeZone]);
+  const dateFrom = filters?.dateFrom ?? defaultFilters.dateFrom;
+  const dateTo = filters?.dateTo ?? defaultFilters.dateTo;
   const geography = filters?.geography ?? "all";
   const complaintType = filters?.complaintType ?? "all";
 

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardLayout.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardLayout.jsx
@@ -16,6 +16,7 @@ const DashboardLayout = ({
   filters,
   onFilterChange,
   onClearFilters,
+  timeZone,
   filterOptions,
   filterOptionsLoading,
   kpiCardData,
@@ -77,6 +78,7 @@ const DashboardLayout = ({
             filters={filters}
             onFilterChange={onFilterChange}
             onClearFilters={onClearFilters}
+            timeZone={timeZone}
             filterOptions={filterOptions}
             filterOptionsLoading={filterOptionsLoading}
           />

--- a/digit-ui-esbuild/products/dashboard/src/config/dashboardFilters.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/dashboardFilters.js
@@ -15,7 +15,7 @@ function loadLegacySubMetricSelection() {
   }
 }
 
-function migrateTimeWindowFromLegacy() {
+function migrateTimeWindowFromLegacy(timeZone) {
   const legacy = loadLegacySubMetricSelection();
   for (const metricId of TIME_WINDOW_METRIC_IDS) {
     const subId = legacy[metricId];
@@ -23,40 +23,40 @@ function migrateTimeWindowFromLegacy() {
       return subId;
     }
   }
-  return buildDefaultFilters().timeWindow;
+  return buildDefaultFilters(timeZone).timeWindow;
 }
 
-export function loadDashboardFilters() {
+export function loadDashboardFilters(timeZone) {
   try {
     const raw = localStorage.getItem(getFiltersStorageKey());
     if (raw) {
-      return sanitizeFilters(JSON.parse(raw));
+      return sanitizeFilters(JSON.parse(raw), {}, timeZone);
     }
   } catch {
     /* fall through */
   }
 
-  return sanitizeFilters({ timeWindow: migrateTimeWindowFromLegacy() });
+  return sanitizeFilters({ timeWindow: migrateTimeWindowFromLegacy(timeZone) }, {}, timeZone);
 }
 
-export function clearDashboardFilters() {
-  return buildDefaultFilters();
+export function clearDashboardFilters(timeZone) {
+  return buildDefaultFilters(timeZone);
 }
 
-export function persistDashboardFilters(filters, dynamicOptions) {
+export function persistDashboardFilters(filters, dynamicOptions, timeZone) {
   localStorage.setItem(
     getFiltersStorageKey(),
-    JSON.stringify(sanitizeFilters(filters, dynamicOptions))
+    JSON.stringify(sanitizeFilters(filters, dynamicOptions, timeZone))
   );
 }
 
-export function reconcileFiltersWithOptions(filters, filterOptions) {
+export function reconcileFiltersWithOptions(filters, filterOptions, timeZone) {
   if (!filterOptions) return filters;
 
   // filters can be momentarily null (e.g. a rapid external date-input change racing
   // the options effect); fall back to defaults so we never read .geography off null.
-  const safe = filters ?? buildDefaultFilters();
-  const next = sanitizeFilters(safe, filterOptions);
+  const safe = filters ?? buildDefaultFilters(timeZone);
+  const next = sanitizeFilters(safe, filterOptions, timeZone);
   const changed =
     next.geography !== safe.geography ||
     next.complaintType !== safe.complaintType ||

--- a/digit-ui-esbuild/products/dashboard/src/config/globalFilterGroups.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/globalFilterGroups.js
@@ -4,23 +4,12 @@ import {
   normalizeComplaintTypeValue,
   repairSelection,
 } from "../utils/complaintTypeTree";
-
-function todayISO() {
-  const d = new Date();
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
-}
-
-function oneMonthAgoISO() {
-  const d = new Date();
-  d.setMonth(d.getMonth() - 1);
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
-}
+import {
+  DEFAULT_TIME_ZONE,
+  isValidTimeZone,
+  oneMonthEarlierYMD,
+  zonedYMD,
+} from "../utils/dashboardTimeZone";
 
 // Labels resolve lazily (getters call translate() at property-access time) so
 // they react to language switches while keeping the flat {id,label} contract
@@ -47,6 +36,13 @@ export const COMPLAINT_TYPE_OPTIONS = [
 /**
  * Global dashboard filters — shared dimensions across KPIs and charts.
  * timeWindow is retained for volume KPI sub-metric resolution until date-range API wiring.
+ *
+ * The date fields carry NO computed defaultValue: a module-load `new Date()` would freeze
+ * on whatever instant/browser-local zone the bundle first evaluated in, then silently
+ * disagree with the resolved dashboard timeZone for the rest of the session. buildDefaultFilters(timeZone)
+ * is the ONLY source of date defaults, computed fresh (zone-correct) every time it's called;
+ * these placeholders exist solely so `.find(f => f.id === "dateFrom")`-style field lookups
+ * (options, labels, type) stay valid without implying a usable date default.
  */
 export const GLOBAL_FILTER_FIELDS = [
   {
@@ -55,7 +51,7 @@ export const GLOBAL_FILTER_FIELDS = [
     get label() {
       return translate("DASHBOARD_FILTERS_FROM", "From");
     },
-    defaultValue: oneMonthAgoISO(),
+    defaultValue: null,
   },
   {
     id: "dateTo",
@@ -63,7 +59,7 @@ export const GLOBAL_FILTER_FIELDS = [
     get label() {
       return translate("DASHBOARD_FILTERS_TO", "To");
     },
-    defaultValue: todayISO(),
+    defaultValue: null,
   },
   {
     id: "geography",
@@ -88,9 +84,16 @@ export const GLOBAL_FILTER_FIELDS = [
 /** @deprecated use GLOBAL_FILTER_FIELDS */
 export const GLOBAL_FILTER_GROUPS = GLOBAL_FILTER_FIELDS.filter((f) => f.type === "select");
 
-export function buildDefaultFilters() {
-  const today = todayISO();
-  const monthAgo = oneMonthAgoISO();
+/**
+ * `timeZone` should be an already-resolved zone (resolveConfiguredTimeZone
+ * output); an invalid/missing value here falls back to DEFAULT_TIME_ZONE too,
+ * so every caller — threaded or not — degrades the same way the backend does.
+ */
+export function buildDefaultFilters(timeZone) {
+  const zone = isValidTimeZone(timeZone) ? timeZone : DEFAULT_TIME_ZONE;
+  const now = new Date();
+  const today = zonedYMD(now, zone);
+  const monthAgo = oneMonthEarlierYMD(now, zone);
   const defaults = Object.fromEntries(
     GLOBAL_FILTER_FIELDS.map((field) => {
       if (field.id === "dateFrom") return [field.id, monthAgo];
@@ -110,9 +113,9 @@ export function buildDefaultFilters() {
   return defaults;
 }
 
-export function hasActiveFilters(filters) {
+export function hasActiveFilters(filters, timeZone) {
   if (!filters) return false;
-  const defaults = buildDefaultFilters();
+  const defaults = buildDefaultFilters(timeZone);
   const geography = filters.geography ?? defaults.geography;
   const complaintType = filters.complaintType ?? defaults.complaintType;
   const dateFrom = filters.dateFrom ?? defaults.dateFrom;
@@ -132,8 +135,8 @@ function isValidISODate(value) {
   return typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value);
 }
 
-export function sanitizeFilters(raw, dynamicOptions = {}) {
-  const defaults = buildDefaultFilters();
+export function sanitizeFilters(raw, dynamicOptions = {}, timeZone) {
+  const defaults = buildDefaultFilters(timeZone);
   if (!raw || typeof raw !== "object") {
     return defaults;
   }

--- a/digit-ui-esbuild/products/dashboard/src/config/globalFilterGroups.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/globalFilterGroups.test.js
@@ -1,0 +1,133 @@
+// Unit tests for buildDefaultFilters / hasActiveFilters (#29 timezone addendum,
+// review fix): date defaults must resolve from the RESOLVED dashboard timeZone at
+// call time, never a module-load browser-clock snapshot. Pins non-Nairobi
+// active/clear/default behavior right at a UTC midnight crossing, where a
+// zone-blind implementation and a zone-correct one disagree.
+// Run from digit-ui-esbuild/:  node --test products/dashboard/src/config/globalFilterGroups.test.js
+//
+// globalFilterGroups.js is ESM (like the rest of products/), so the test bundles it to
+// CJS with the repo's own esbuild — same idiom as dashboardTimeZone.test.js.
+
+const { test, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const esbuild = require("esbuild");
+
+const ENTRY = path.join(__dirname, "globalFilterGroups.js");
+const OUT = path.join(os.tmpdir(), `globalFilterGroups.cjs.${process.pid}.js`);
+
+esbuild.buildSync({
+  entryPoints: [ENTRY],
+  bundle: true,
+  format: "cjs",
+  platform: "neutral",
+  outfile: OUT,
+});
+process.on("exit", () => {
+  try {
+    fs.unlinkSync(OUT);
+  } catch (e) {
+    /* already gone */
+  }
+});
+
+const { buildDefaultFilters, hasActiveFilters } = require(OUT);
+
+// clearDashboardFilters (config/dashboardFilters.js) is a thin buildDefaultFilters(timeZone)
+// wrapper — bundled separately here since it also pulls in dashboardConfig.js's
+// localStorage-key helpers (unused by clearDashboardFilters itself, but present at
+// import time), keeping this file's own bundle free of that dependency.
+const CLEAR_ENTRY = path.join(__dirname, "..", "config", "dashboardFilters.js");
+const CLEAR_OUT = path.join(os.tmpdir(), `dashboardFilters.cjs.${process.pid}.js`);
+esbuild.buildSync({
+  entryPoints: [CLEAR_ENTRY],
+  bundle: true,
+  format: "cjs",
+  platform: "neutral",
+  outfile: CLEAR_OUT,
+});
+process.on("exit", () => {
+  try {
+    fs.unlinkSync(CLEAR_OUT);
+  } catch (e) {
+    /* already gone */
+  }
+});
+const { clearDashboardFilters } = require(CLEAR_OUT);
+
+// 2026-03-01T21:30:00Z: already 2026-03-02 local in Africa/Nairobi (UTC+3) but
+// still 2026-03-01 local in Africa/Maputo (UTC+2) — see dashboardTimeZone.test.js's
+// zonedYMD coverage of the same instant. Pinning "now" here (rather than trusting
+// module-load state) is what proves the fix: no code under test may read a
+// pre-computed default that was frozen at a different instant/zone.
+const NEAR_MIDNIGHT_UTC_MS = Date.UTC(2026, 2, 1, 21, 30, 0);
+
+let RealDate;
+
+before(() => {
+  RealDate = global.Date;
+  class FakeDate extends RealDate {
+    constructor(...args) {
+      if (args.length === 0) super(NEAR_MIDNIGHT_UTC_MS);
+      else super(...args);
+    }
+    static now() {
+      return NEAR_MIDNIGHT_UTC_MS;
+    }
+  }
+  global.Date = FakeDate;
+});
+
+after(() => {
+  global.Date = RealDate;
+});
+
+test("buildDefaultFilters: Maputo and Nairobi disagree on 'today' at the same instant", () => {
+  const maputo = buildDefaultFilters("Africa/Maputo");
+  const nairobi = buildDefaultFilters("Africa/Nairobi");
+  assert.equal(maputo.dateTo, "2026-03-01");
+  assert.equal(maputo.dateFrom, "2026-02-01");
+  assert.equal(nairobi.dateTo, "2026-03-02");
+  assert.equal(nairobi.dateFrom, "2026-02-02");
+});
+
+test("buildDefaultFilters: unresolved/invalid timeZone falls back to Nairobi, not browser local", () => {
+  const noZone = buildDefaultFilters(undefined);
+  const bogusZone = buildDefaultFilters("Not/AZone");
+  const nairobi = buildDefaultFilters("Africa/Nairobi");
+  assert.deepEqual(noZone, nairobi);
+  assert.deepEqual(bogusZone, nairobi);
+});
+
+test("hasActiveFilters: filters equal to the SAME zone's defaults are inactive", () => {
+  const maputoDefaults = buildDefaultFilters("Africa/Maputo");
+  assert.equal(hasActiveFilters(maputoDefaults, "Africa/Maputo"), false);
+});
+
+test("hasActiveFilters: another zone's default date range reads as an active filter", () => {
+  // A Nairobi-shaped filter set evaluated against Maputo's resolved zone must NOT be
+  // silently treated as "no filter applied" — this is the exact confusion a
+  // module-load (single fixed zone) default would produce.
+  const nairobiDefaults = buildDefaultFilters("Africa/Nairobi");
+  assert.equal(hasActiveFilters(nairobiDefaults, "Africa/Maputo"), true);
+});
+
+test("hasActiveFilters: null/undefined filters (not yet loaded) are inactive", () => {
+  assert.equal(hasActiveFilters(null, "Africa/Maputo"), false);
+  assert.equal(hasActiveFilters(undefined, "Africa/Maputo"), false);
+});
+
+test("hasActiveFilters: a manually widened date range against the resolved zone is active", () => {
+  const defaults = buildDefaultFilters("Africa/Maputo");
+  const widened = { ...defaults, dateFrom: "2020-01-01" };
+  assert.equal(hasActiveFilters(widened, "Africa/Maputo"), true);
+});
+
+test("clearDashboardFilters: resets to the RESOLVED zone's default, not a stale/browser one", () => {
+  assert.deepEqual(clearDashboardFilters("Africa/Maputo"), buildDefaultFilters("Africa/Maputo"));
+  const cleared = clearDashboardFilters("Africa/Maputo");
+  assert.equal(cleared.dateTo, "2026-03-01");
+  assert.equal(hasActiveFilters(cleared, "Africa/Maputo"), false);
+});

--- a/digit-ui-esbuild/products/dashboard/src/hooks/useDashboardFilters.js
+++ b/digit-ui-esbuild/products/dashboard/src/hooks/useDashboardFilters.js
@@ -8,20 +8,21 @@ import {
 } from "../config/dashboardFilters";
 import { normalizeComplaintTypeValue } from "../utils/complaintTypeTree";
 
-export function useDashboardFilters() {
-  const [filters, setFilters] = useState(loadDashboardFilters);
+/** `timeZone` is the already-resolved dashboard config zone (see AdminDashboard). */
+export function useDashboardFilters(timeZone) {
+  const [filters, setFilters] = useState(() => loadDashboardFilters(timeZone));
   const [optionLists, setOptionLists] = useState(null);
 
   useEffect(() => {
     if (!optionLists) return;
     setFilters((prev) => {
-      const next = reconcileFiltersWithOptions(prev, optionLists);
+      const next = reconcileFiltersWithOptions(prev, optionLists, timeZone);
       if (next !== prev) {
-        persistDashboardFilters(next, optionLists);
+        persistDashboardFilters(next, optionLists, timeZone);
       }
       return next;
     });
-  }, [optionLists]);
+  }, [optionLists, timeZone]);
 
   const applyFilterOptions = useCallback((filterOptions) => {
     setOptionLists(filterOptions);
@@ -50,18 +51,18 @@ export function useDashboardFilters() {
         if (groupId === "dateFrom" || groupId === "dateTo") {
           next.dateRangeActive = true;
         }
-        persistDashboardFilters(next, optionLists);
+        persistDashboardFilters(next, optionLists, timeZone);
         return next;
       });
     },
-    [optionLists]
+    [optionLists, timeZone]
   );
 
   const clearFilters = useCallback(() => {
-    const next = clearDashboardFilters();
-    persistDashboardFilters(next, optionLists);
+    const next = clearDashboardFilters(timeZone);
+    persistDashboardFilters(next, optionLists, timeZone);
     setFilters(next);
-  }, [optionLists]);
+  }, [optionLists, timeZone]);
 
   const resolveSubMetricId = useCallback(
     (metric) => resolveSubMetricIdForMetric(metric, filters),

--- a/digit-ui-esbuild/products/dashboard/src/utils/composeKpi.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/composeKpi.js
@@ -9,7 +9,7 @@
  */
 export function evaluateCompose(compose, results) {
   if (!compose || !compose.type) return null;
-  const { type, sourceKpiIds, elapsedFromAsOf } = compose;
+  const { type, sourceKpiIds } = compose;
 
   const sourceData = sourceKpiIds.map(id => {
     const r = results[id];
@@ -28,43 +28,17 @@ export function evaluateCompose(compose, results) {
       const outflow = sourceData[1]?.total ?? 0;
       return inflow - outflow;
     }
-    case 'dailyAvgFromWeekly': {
-      const total = sourceData[0].total ?? 0;
-      if (!elapsedFromAsOf) return null;
-      // Get asOf from the source result to avoid client clock authority
-      const asOf = results[sourceKpiIds[0]]?.asOf;
-      const daysElapsed = asOf ? elapsedDaysSince(startOfWeek(new Date(asOf)), new Date(asOf)) : null;
-      return daysElapsed && daysElapsed > 0 ? total / daysElapsed : null;
-    }
-    case 'hourlyAvgFromDaily': {
-      const total = sourceData[0].total ?? 0;
-      if (!elapsedFromAsOf) return null;
-      const asOf = results[sourceKpiIds[0]]?.asOf;
-      const hoursElapsed = asOf ? elapsedHoursSince(startOfDay(new Date(asOf)), new Date(asOf)) : null;
-      return hoursElapsed && hoursElapsed > 0 ? total / hoursElapsed : null;
-    }
+    // 'dailyAvgFromWeekly' / 'hourlyAvgFromDaily': the backend's D1a composition (calendar-
+    // aware, tenant-timeZone-correct — see BusinessCalendar / #29) is now the sole authority
+    // for these averages. This engine must NEVER recompute an "elapsed periods since asOf"
+    // average with browser-local Date math (setDate/setHours/new Date() are all local-clock
+    // reads that silently disagree with the tenant's configured calendar). Returning null
+    // here is intentional: KpiTile's resolveScalar falls through to the backend's
+    // result.value whenever evaluateCompose yields null.
+    case 'dailyAvgFromWeekly':
+    case 'hourlyAvgFromDaily':
+      return null;
     default:
       return null;
   }
-}
-
-function startOfWeek(d) {
-  const start = new Date(d);
-  start.setDate(d.getDate() - d.getDay());
-  start.setHours(0, 0, 0, 0);
-  return start;
-}
-
-function startOfDay(d) {
-  const start = new Date(d);
-  start.setHours(0, 0, 0, 0);
-  return start;
-}
-
-function elapsedDaysSince(start, now) {
-  return Math.max(1, Math.floor((now - start) / 86400000));
-}
-
-function elapsedHoursSince(start, now) {
-  return Math.max(1, Math.floor((now - start) / 3600000));
 }

--- a/digit-ui-esbuild/products/dashboard/src/utils/composeKpi.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/composeKpi.test.js
@@ -1,0 +1,92 @@
+// Unit tests for evaluateCompose (#29 review fix): dailyAvgFromWeekly / hourlyAvgFromDaily
+// must never recompute an "elapsed periods since asOf" average with browser-local Date math —
+// the backend's D1a composition is now the sole authority for those two types, so this engine
+// must return null and let KpiTile's resolveScalar fall through to the backend's result.value.
+// Run from digit-ui-esbuild/:  node --test products/dashboard/src/utils/composeKpi.test.js
+//
+// composeKpi.js is ESM (like the rest of products/), so the test bundles it to CJS with the
+// repo's own esbuild — same idiom as dashboardTimeZone.test.js.
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const esbuild = require("esbuild");
+
+const ENTRY = path.join(__dirname, "composeKpi.js");
+const OUT = path.join(os.tmpdir(), `composeKpi.cjs.${process.pid}.js`);
+
+esbuild.buildSync({
+  entryPoints: [ENTRY],
+  bundle: true,
+  format: "cjs",
+  platform: "neutral",
+  outfile: OUT,
+});
+process.on("exit", () => {
+  try {
+    fs.unlinkSync(OUT);
+  } catch (e) {
+    /* already gone */
+  }
+});
+
+const { evaluateCompose } = require(OUT);
+
+test("evaluateCompose: no compose or no type returns null", () => {
+  assert.equal(evaluateCompose(null, {}), null);
+  assert.equal(evaluateCompose({}, {}), null);
+});
+
+test("evaluateCompose: sources not yet loaded returns null", () => {
+  const compose = { type: "netBacklogDaily", sourceKpiIds: ["inflow", "outflow"] };
+  assert.equal(evaluateCompose(compose, {}), null);
+});
+
+test("evaluateCompose: dailyAvgFromWeekly ALWAYS returns null, even with elapsedFromAsOf/asOf/rows present", () => {
+  const compose = { type: "dailyAvgFromWeekly", sourceKpiIds: ["weeklyTotal"], elapsedFromAsOf: true };
+  const results = {
+    weeklyTotal: { rows: [{ total: 140 }], asOf: Date.UTC(2026, 2, 4, 12, 0, 0) },
+  };
+  assert.equal(evaluateCompose(compose, results), null);
+});
+
+test("evaluateCompose: hourlyAvgFromDaily ALWAYS returns null, even with elapsedFromAsOf/asOf/rows present", () => {
+  const compose = { type: "hourlyAvgFromDaily", sourceKpiIds: ["dailyTotal"], elapsedFromAsOf: true };
+  const results = {
+    dailyTotal: { rows: [{ total: 48 }], asOf: Date.UTC(2026, 2, 4, 12, 0, 0) },
+  };
+  assert.equal(evaluateCompose(compose, results), null);
+});
+
+test("evaluateCompose: dailyAvgFromWeekly/hourlyAvgFromDaily return null even without elapsedFromAsOf", () => {
+  const daily = { type: "dailyAvgFromWeekly", sourceKpiIds: ["weeklyTotal"] };
+  const hourly = { type: "hourlyAvgFromDaily", sourceKpiIds: ["dailyTotal"] };
+  const results = {
+    weeklyTotal: { rows: [{ total: 140 }] },
+    dailyTotal: { rows: [{ total: 48 }] },
+  };
+  assert.equal(evaluateCompose(daily, results), null);
+  assert.equal(evaluateCompose(hourly, results), null);
+});
+
+test("evaluateCompose: other compose types are preserved (openRateComplement)", () => {
+  const compose = { type: "openRateComplement", sourceKpiIds: ["openRate"] };
+  const results = { openRate: { rows: [{ pct: 0.3 }] } };
+  assert.equal(evaluateCompose(compose, results), 70);
+});
+
+test("evaluateCompose: other compose types are preserved (netBacklogDaily)", () => {
+  const compose = { type: "netBacklogDaily", sourceKpiIds: ["inflow", "outflow"] };
+  const results = {
+    inflow: { rows: [{ total: 12 }] },
+    outflow: { rows: [{ total: 5 }] },
+  };
+  assert.equal(evaluateCompose(compose, results), 7);
+});
+
+test("evaluateCompose: unknown compose type returns null", () => {
+  const compose = { type: "somethingUnrecognized", sourceKpiIds: ["x"] };
+  assert.equal(evaluateCompose(compose, { x: { rows: [{ total: 1 }] } }), null);
+});

--- a/digit-ui-esbuild/products/dashboard/src/utils/dashboardTimeZone.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/dashboardTimeZone.js
@@ -1,0 +1,85 @@
+/**
+ * Deterministic, zone-safe calendar-date math for the dashboard's default
+ * date-range filters and "Last updated" stamp (#29 timezone addendum).
+ *
+ * Mirrors the backend's BusinessCalendar (org.egov.pgr.analytics.BusinessCalendar):
+ * every calendar day is derived from Intl.DateTimeFormat#formatToParts in the
+ * RESOLVED zone, never the browser's local zone, never UTC-as-a-stand-in. No
+ * module-global mutable zone state lives here — callers thread the resolved
+ * zone string through explicitly.
+ */
+
+/** Documented migration-compatibility fallback zone, matching BusinessCalendar.DEFAULT_ZONE. */
+export const DEFAULT_TIME_ZONE = "Africa/Nairobi";
+
+/** Defensive IANA zone-id validation via the runtime's own Intl database. */
+export function isValidTimeZone(timeZone) {
+  if (typeof timeZone !== "string" || !timeZone.trim()) return false;
+  try {
+    // eslint-disable-next-line no-new -- constructing throws RangeError on an invalid zone id
+    new Intl.DateTimeFormat("en-US", { timeZone: timeZone.trim() });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve `dashboardConfig.timeZone` (dss.DashboardConfig) to a validated
+ * IANA zone id, falling back to DEFAULT_TIME_ZONE exactly like the backend's
+ * KpiCatalogService.resolveTimeZone — absent, empty, or invalid all resolve
+ * the same way, never to the browser's local zone.
+ */
+export function resolveConfiguredTimeZone(dashboardConfig) {
+  const raw = dashboardConfig?.timeZone;
+  return isValidTimeZone(raw) ? raw.trim() : DEFAULT_TIME_ZONE;
+}
+
+function zonedDateParts(date, timeZone) {
+  const zone = isValidTimeZone(timeZone) ? timeZone : DEFAULT_TIME_ZONE;
+  const instant = date instanceof Date ? date : new Date(date);
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: zone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(instant);
+  const out = {};
+  for (const part of parts) {
+    if (part.type !== "literal") out[part.type] = Number(part.value);
+  }
+  return out; // { year, month, day } — month is 1-12
+}
+
+function formatYMD(year, month, day) {
+  return `${String(year).padStart(4, "0")}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+/** Days in `month` (1-12) of `year` — a neutral UTC pivot, no zone conversion involved. */
+function daysInMonth(year, month) {
+  return new Date(Date.UTC(year, month, 0)).getUTCDate();
+}
+
+/** yyyy-MM-dd for `date` (a Date instance or epoch ms) as a calendar day in `timeZone`. */
+export function zonedYMD(date, timeZone) {
+  const { year, month, day } = zonedDateParts(date, timeZone);
+  return formatYMD(year, month, day);
+}
+
+/**
+ * yyyy-MM-dd one calendar month before `date`'s zoned calendar day, clamped to
+ * the shorter target month's last day (e.g. Mar 31 -> Feb 28, or Feb 29 in a
+ * leap year). Computed entirely from the zoned {year,month,day} triple, so it
+ * never leaks the browser's local zone into the result.
+ */
+export function oneMonthEarlierYMD(date, timeZone) {
+  const { year, month, day } = zonedDateParts(date, timeZone);
+  let targetYear = year;
+  let targetMonth = month - 1;
+  if (targetMonth < 1) {
+    targetMonth = 12;
+    targetYear -= 1;
+  }
+  const clampedDay = Math.min(day, daysInMonth(targetYear, targetMonth));
+  return formatYMD(targetYear, targetMonth, clampedDay);
+}

--- a/digit-ui-esbuild/products/dashboard/src/utils/dashboardTimeZone.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/dashboardTimeZone.test.js
@@ -1,0 +1,136 @@
+// Unit tests for the deterministic, zone-safe calendar-date math backing the
+// dashboard's default date-range filters (#29 timezone addendum).
+// Run from digit-ui-esbuild/:  node --test products/dashboard/src/utils/dashboardTimeZone.test.js
+//
+// dashboardTimeZone.js is ESM (like the rest of products/), so the test
+// bundles it to CJS with the repo's own esbuild — same idiom as
+// hierLevelGrouping.test.js / numberFormat.test.js.
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const esbuild = require("esbuild");
+
+const ENTRY = path.join(__dirname, "dashboardTimeZone.js");
+const OUT = path.join(os.tmpdir(), `dashboardTimeZone.cjs.${process.pid}.js`);
+
+esbuild.buildSync({
+  entryPoints: [ENTRY],
+  bundle: true,
+  format: "cjs",
+  platform: "neutral",
+  outfile: OUT,
+});
+process.on("exit", () => {
+  try {
+    fs.unlinkSync(OUT);
+  } catch (e) {
+    /* already gone */
+  }
+});
+
+const {
+  DEFAULT_TIME_ZONE,
+  isValidTimeZone,
+  resolveConfiguredTimeZone,
+  zonedYMD,
+  oneMonthEarlierYMD,
+} = require(OUT);
+
+/* ------------------------------------------------------------------ */
+/* Validation / fallback                                               */
+/* ------------------------------------------------------------------ */
+
+test("DEFAULT_TIME_ZONE matches the backend's migration-compatibility default", () => {
+  assert.equal(DEFAULT_TIME_ZONE, "Africa/Nairobi");
+});
+
+test("isValidTimeZone: valid IANA ids accepted, garbage rejected", () => {
+  assert.equal(isValidTimeZone("Africa/Nairobi"), true);
+  assert.equal(isValidTimeZone("Africa/Maputo"), true);
+  assert.equal(isValidTimeZone("Asia/Kolkata"), true);
+  assert.equal(isValidTimeZone("UTC"), true);
+  assert.equal(isValidTimeZone("Not/AZone"), false);
+  assert.equal(isValidTimeZone(""), false);
+  assert.equal(isValidTimeZone("   "), false);
+  assert.equal(isValidTimeZone(null), false);
+  assert.equal(isValidTimeZone(undefined), false);
+  assert.equal(isValidTimeZone(42), false);
+});
+
+test("resolveConfiguredTimeZone: falls back to Africa/Nairobi when missing/invalid", () => {
+  assert.equal(resolveConfiguredTimeZone({ timeZone: "Asia/Kolkata" }), "Asia/Kolkata");
+  assert.equal(resolveConfiguredTimeZone({ timeZone: "  Africa/Maputo  " }), "Africa/Maputo");
+  assert.equal(resolveConfiguredTimeZone({ timeZone: "bogus" }), DEFAULT_TIME_ZONE);
+  assert.equal(resolveConfiguredTimeZone({ timeZone: "" }), DEFAULT_TIME_ZONE);
+  assert.equal(resolveConfiguredTimeZone({}), DEFAULT_TIME_ZONE);
+  assert.equal(resolveConfiguredTimeZone(null), DEFAULT_TIME_ZONE);
+  assert.equal(resolveConfiguredTimeZone(undefined), DEFAULT_TIME_ZONE);
+});
+
+/* ------------------------------------------------------------------ */
+/* zonedYMD                                                             */
+/* ------------------------------------------------------------------ */
+
+test("zonedYMD: Africa/Nairobi (UTC+3) vs Africa/Maputo (UTC+2) disagree around midnight", () => {
+  const instant = Date.UTC(2026, 2, 1, 21, 30, 0); // 2026-03-01T21:30:00Z
+  assert.equal(zonedYMD(instant, "Africa/Nairobi"), "2026-03-02");
+  assert.equal(zonedYMD(instant, "Africa/Maputo"), "2026-03-01");
+});
+
+test("zonedYMD: Asia/Kolkata half-hour offset", () => {
+  const instant = Date.UTC(2026, 0, 15, 18, 35, 0); // 2026-01-15T18:35:00Z
+  assert.equal(zonedYMD(instant, "Asia/Kolkata"), "2026-01-16");
+  assert.equal(zonedYMD(instant, "UTC"), "2026-01-15");
+});
+
+test("zonedYMD: invalid zone falls back to Africa/Nairobi rather than throwing", () => {
+  const instant = Date.UTC(2026, 2, 1, 21, 30, 0);
+  assert.equal(zonedYMD(instant, "Not/AZone"), zonedYMD(instant, "Africa/Nairobi"));
+});
+
+test("zonedYMD: accepts a Date instance too", () => {
+  const d = new Date(Date.UTC(2026, 5, 10, 12, 0, 0));
+  assert.equal(zonedYMD(d, "UTC"), "2026-06-10");
+});
+
+/* ------------------------------------------------------------------ */
+/* oneMonthEarlierYMD — month-end clamp / leap year / zone-derived day */
+/* ------------------------------------------------------------------ */
+
+test("oneMonthEarlierYMD: clamps end-of-month into a non-leap February", () => {
+  const instant = Date.UTC(2026, 2, 31, 12, 0, 0); // 2026-03-31 UTC noon
+  assert.equal(oneMonthEarlierYMD(instant, "UTC"), "2026-02-28");
+});
+
+test("oneMonthEarlierYMD: clamps to Feb 29 in a leap year", () => {
+  const instant = Date.UTC(2024, 2, 31, 12, 0, 0); // 2024-03-31 UTC noon
+  assert.equal(oneMonthEarlierYMD(instant, "UTC"), "2024-02-29");
+});
+
+test("oneMonthEarlierYMD: crosses a year boundary (Jan -> prior Dec)", () => {
+  const instant = Date.UTC(2026, 0, 31, 12, 0, 0); // 2026-01-31
+  assert.equal(oneMonthEarlierYMD(instant, "UTC"), "2025-12-31");
+});
+
+test("oneMonthEarlierYMD: no clamp needed on a mid-month date", () => {
+  const instant = Date.UTC(2026, 5, 15, 12, 0, 0); // 2026-06-15
+  assert.equal(oneMonthEarlierYMD(instant, "UTC"), "2026-05-15");
+});
+
+test("oneMonthEarlierYMD: computed from the ZONED calendar day, not UTC's", () => {
+  // 2026-03-01T21:30:00Z is already 2026-03-02 local in Nairobi (UTC+3) — one
+  // month earlier in Nairobi's calendar is 2026-02-02, not a UTC-day-derived value.
+  const instant = Date.UTC(2026, 2, 1, 21, 30, 0);
+  assert.equal(oneMonthEarlierYMD(instant, "Africa/Nairobi"), "2026-02-02");
+});
+
+test("oneMonthEarlierYMD: invalid zone falls back to Africa/Nairobi rather than throwing", () => {
+  const instant = Date.UTC(2026, 2, 31, 12, 0, 0);
+  assert.equal(
+    oneMonthEarlierYMD(instant, "Not/AZone"),
+    oneMonthEarlierYMD(instant, "Africa/Nairobi")
+  );
+});

--- a/digit-ui-esbuild/products/dashboard/useDashboardConfig.js
+++ b/digit-ui-esbuild/products/dashboard/useDashboardConfig.js
@@ -38,11 +38,9 @@
  * pgr_dashboard_tenant_timezone SQL view (ORDER BY) apply, so every layer
  * picks the identical record from identical data:
  *   1) the record whose (trimmed) id equals "default" wins;
- *   2) else the record with the lexicographically smallest nonblank
- *      (trimmed) id;
- *   3) else the first record in API response order (stable — no reordering).
- * Depends only on fields present on the record itself — never API ordering
- * guarantees or audit metadata the FE payload doesn't carry.
+ *   2) else the first record in API response order (the historical behavior).
+ * The explicit default is the single-record contract; preserving response
+ * order for malformed duplicates avoids silently changing existing tenants.
  */
 export function selectDashboardConfigRecord(records) {
   if (!Array.isArray(records) || records.length === 0) return null;
@@ -53,17 +51,7 @@ export function selectDashboardConfigRecord(records) {
   const withDefault = records.find((r) => trimmedId(r) === "default");
   if (withDefault) return withDefault;
 
-  let smallest = null;
-  let smallestId = null;
-  for (const r of records) {
-    const id = trimmedId(r);
-    if (!id) continue;
-    if (smallestId === null || id < smallestId) {
-      smallestId = id;
-      smallest = r;
-    }
-  }
-  return smallest || records[0];
+  return records[0];
 }
 
 export const useDashboardConfig = () => {

--- a/digit-ui-esbuild/products/dashboard/useDashboardConfig.js
+++ b/digit-ui-esbuild/products/dashboard/useDashboardConfig.js
@@ -24,12 +24,48 @@
  * never to a retry spinner.
  *
  * @returns {{ config: object|null, loading: boolean }}
- *   - config: the "default" record (else the first record); null when the
- *     master is unseeded / unreadable / malformed. Consumers treat null as
- *     "keep built-in behavior".
+ *   - config: the deterministic record selectDashboardConfigRecord() picks
+ *     (see below); null when the master is unseeded / unreadable / malformed.
+ *     Consumers treat null as "keep built-in behavior".
  *   - loading: query in flight — consumers must HOLD rendering while true so
  *     configured behavior never flashes in after a default-rendered frame.
  */
+
+/**
+ * Deterministic dashboard-config record selection when MDMS returns more than
+ * one active dss.DashboardConfig record (duplicate/malformed data) — the SAME
+ * rule KpiCatalogService.selectDashboardConfigRecord (Java) and the
+ * pgr_dashboard_tenant_timezone SQL view (ORDER BY) apply, so every layer
+ * picks the identical record from identical data:
+ *   1) the record whose (trimmed) id equals "default" wins;
+ *   2) else the record with the lexicographically smallest nonblank
+ *      (trimmed) id;
+ *   3) else the first record in API response order (stable — no reordering).
+ * Depends only on fields present on the record itself — never API ordering
+ * guarantees or audit metadata the FE payload doesn't carry.
+ */
+export function selectDashboardConfigRecord(records) {
+  if (!Array.isArray(records) || records.length === 0) return null;
+  if (records.length === 1) return records[0];
+
+  const trimmedId = (r) => (typeof r?.id === "string" ? r.id.trim() : null);
+
+  const withDefault = records.find((r) => trimmedId(r) === "default");
+  if (withDefault) return withDefault;
+
+  let smallest = null;
+  let smallestId = null;
+  for (const r of records) {
+    const id = trimmedId(r);
+    if (!id) continue;
+    if (smallestId === null || id < smallestId) {
+      smallestId = id;
+      smallest = r;
+    }
+  }
+  return smallest || records[0];
+}
+
 export const useDashboardConfig = () => {
   // Standalone harness (DashboardLogin dev mode): no Digit runtime and no
   // react-query provider exist. window.Digit is initialized before React
@@ -56,10 +92,10 @@ export const useDashboardConfig = () => {
   );
 
   // Shape-guard everything: Kong's cjson pre-function can flatten an empty
-  // array to {}, and a hand-seeded master may carry extra records — prefer the
-  // "default" record, tolerate anything else by falling back.
+  // array to {}, and a hand-seeded master may carry extra records — resolve
+  // deterministically via selectDashboardConfigRecord.
   const records = Array.isArray(data) ? data : [];
-  const record = records.find((r) => r?.id === "default") || records[0];
+  const record = selectDashboardConfigRecord(records);
 
   return { config: record || null, loading: isLoading };
 };

--- a/digit-ui-esbuild/products/dashboard/useDashboardConfig.test.js
+++ b/digit-ui-esbuild/products/dashboard/useDashboardConfig.test.js
@@ -1,0 +1,72 @@
+// Unit tests for selectDashboardConfigRecord — the deterministic dss.DashboardConfig
+// record selection shared (by rule, not code) with KpiCatalogService.selectDashboardConfigRecord
+// (Java) and the pgr_dashboard_tenant_timezone SQL view's ORDER BY.
+// Run from digit-ui-esbuild/:  node --test products/dashboard/useDashboardConfig.test.js
+//
+// useDashboardConfig.js is ESM (like the rest of products/), so the test bundles it to
+// CJS with the repo's own esbuild — same idiom as dashboardTimeZone.test.js.
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const esbuild = require("esbuild");
+
+const ENTRY = path.join(__dirname, "useDashboardConfig.js");
+const OUT = path.join(os.tmpdir(), `useDashboardConfig.cjs.${process.pid}.js`);
+
+esbuild.buildSync({
+  entryPoints: [ENTRY],
+  bundle: true,
+  format: "cjs",
+  platform: "neutral",
+  outfile: OUT,
+});
+process.on("exit", () => {
+  try {
+    fs.unlinkSync(OUT);
+  } catch (e) {
+    /* already gone */
+  }
+});
+
+const { selectDashboardConfigRecord } = require(OUT);
+
+test("selectDashboardConfigRecord: empty list returns null", () => {
+  assert.equal(selectDashboardConfigRecord([]), null);
+  assert.equal(selectDashboardConfigRecord(undefined), null);
+});
+
+test("selectDashboardConfigRecord: single record is returned unchanged", () => {
+  const only = { id: "zz", timeZone: "Asia/Kolkata" };
+  assert.equal(selectDashboardConfigRecord([only]), only);
+});
+
+test("selectDashboardConfigRecord: id 'default' wins regardless of position", () => {
+  const aaa = { id: "aaa", timeZone: "Africa/Maputo" };
+  const def = { id: "default", timeZone: "Asia/Kolkata" };
+  const zzz = { id: "zzz", timeZone: "UTC" };
+  assert.equal(selectDashboardConfigRecord([aaa, def, zzz]), def);
+  assert.equal(selectDashboardConfigRecord([def, aaa, zzz]), def);
+});
+
+test("selectDashboardConfigRecord: no default -> lexicographically smallest nonblank id", () => {
+  const zzz = { id: "zzz", timeZone: "UTC" };
+  const aaa = { id: "aaa", timeZone: "Africa/Maputo" };
+  const bbb = { id: "bbb", timeZone: "Asia/Kolkata" };
+  assert.equal(selectDashboardConfigRecord([zzz, aaa, bbb]), aaa);
+});
+
+test("selectDashboardConfigRecord: blank/missing ids are ignored when comparing", () => {
+  const blank = { id: "   ", timeZone: "Africa/Maputo" };
+  const missing = { timeZone: "UTC" };
+  const real = { id: "abc", timeZone: "Asia/Kolkata" };
+  assert.equal(selectDashboardConfigRecord([blank, missing, real]), real);
+});
+
+test("selectDashboardConfigRecord: no usable id anywhere -> first occurrence (stable)", () => {
+  const first = { timeZone: "Africa/Maputo" };
+  const second = { id: "   ", timeZone: "UTC" };
+  assert.equal(selectDashboardConfigRecord([first, second]), first);
+});

--- a/digit-ui-esbuild/products/dashboard/useDashboardConfig.test.js
+++ b/digit-ui-esbuild/products/dashboard/useDashboardConfig.test.js
@@ -51,18 +51,18 @@ test("selectDashboardConfigRecord: id 'default' wins regardless of position", ()
   assert.equal(selectDashboardConfigRecord([def, aaa, zzz]), def);
 });
 
-test("selectDashboardConfigRecord: no default -> lexicographically smallest nonblank id", () => {
+test("selectDashboardConfigRecord: no default -> preserves first API record", () => {
   const zzz = { id: "zzz", timeZone: "UTC" };
   const aaa = { id: "aaa", timeZone: "Africa/Maputo" };
   const bbb = { id: "bbb", timeZone: "Asia/Kolkata" };
-  assert.equal(selectDashboardConfigRecord([zzz, aaa, bbb]), aaa);
+  assert.equal(selectDashboardConfigRecord([zzz, aaa, bbb]), zzz);
 });
 
-test("selectDashboardConfigRecord: blank/missing ids are ignored when comparing", () => {
+test("selectDashboardConfigRecord: first API record wins even when its id is blank", () => {
   const blank = { id: "   ", timeZone: "Africa/Maputo" };
   const missing = { timeZone: "UTC" };
   const real = { id: "abc", timeZone: "Asia/Kolkata" };
-  assert.equal(selectDashboardConfigRecord([blank, missing, real]), real);
+  assert.equal(selectDashboardConfigRecord([blank, missing, real]), blank);
 });
 
 test("selectDashboardConfigRecord: no usable id anywhere -> first occurrence (stable)", () => {

--- a/docs/dashboard-configuration/20-packs-and-rbac.md
+++ b/docs/dashboard-configuration/20-packs-and-rbac.md
@@ -113,6 +113,41 @@ Operator consequences:
   serviceCode; complaints whose type has no department are excluded for department-scoped users
   (NULL never matches an `IN` list).
 
+#### Tenant-configurable calendar zone — `dss.DashboardConfig.timeZone` (#29)
+
+Every analytics request resolves ONE IANA time zone from this OPTIONAL field on the same
+`dss.DashboardConfig` record (composes additively with `departmentScoping`/`numberFormat`/
+`allowedRoles` on that record) and builds exactly one `BusinessCalendar` (a resolved `ZoneId` +
+a single captured `asOf` instant) that every downstream consumer of the request shares — the
+planner's named windows (`dtd`/`wtd`/`mtd`/`qtd`/`ytd`), the `#1462` pinned-window
+suppression/prior decision, an explicit `dateFrom`/`dateTo` range, the runtime `timeBucket` SQL,
+and the compose `*_Avg` elapsed-time math. The response's own `asOf`/`calendar` fields
+(`{timeZone, businessDate}`) echo exactly this same resolved calendar.
+
+**Fail-safe**: absent, empty, or a value that fails `ZoneId.of(...)` (not a valid IANA zone id)
+falls back to `Africa/Nairobi` — the zone every unconfigured tenant already behaved as before
+this field existed (a migration-compatibility default, not an assertion that EAT is the "right"
+default for new tenants). The fallback is logged at WARN (once per cache TTL window per state
+root); it never throws and never falls back to the server's JVM/OS zone.
+
+Read at the tenant's **state root** and served from the SAME cached fetch/TTL as
+`departmentScoping` (one MDMS call resolves both axes together; see the shared-cache note above)
+— a config flip on either field takes effect within one `pgr.analytics.config-cache-ttl-ms`
+window (default 5 minutes) without a redeploy.
+
+**DB-refresh lag is separate from calendar resolution.** The calendar itself (window boundaries,
+`businessDate`) is computed once per request from the resolved `timeZone` value. A config change
+therefore reaches the request path on the first request after the shared config cache refreshes
+(within the TTL above). What can lag further is the underlying DATA: `complaint_facts` /
+`complaint_events` are materialized views refreshed by `DashboardRefreshScheduler` on its own
+cadence (`pgr.dashboard.refresh.interval.ms`, default 5 min — see `60-operations.md`), so a
+DB-derived tile's numbers reflect a `timeZone` change (e.g. it shifting which rows fall in
+"today") only from that view's next refresh onward, not instantaneously.
+
+Seed note: `ansible/nairobi-mdms/mdms/dss/DashboardConfig.json` carries
+`"timeZone": "Africa/Nairobi"` for the canonical `ke` tenant — the explicit value matches what
+absence would already resolve to, kept explicit so the seed is self-documenting.
+
 ### Layer 2 — Catalog visibility (`rbac.visibleTo`)
 
 Per-KPI role ceiling, evaluated in `KpiDefinition.isVisibleTo`:

--- a/local-setup/db/dss-mdms-seed/schemas/dss.DashboardConfig.json
+++ b/local-setup/db/dss-mdms-seed/schemas/dss.DashboardConfig.json
@@ -51,6 +51,10 @@
         "disabled"
       ],
       "description": "Whether analytics scopes employees to their HRMS department. 'disabled' widens visibility to all employees on the tenant \u2014 temporary, pending department enrichment (#1280). Absent = enforced."
+    },
+    "timeZone": {
+      "type": "string",
+      "description": "IANA time zone id (e.g. \"Africa/Nairobi\", \"Africa/Maputo\", \"Asia/Kolkata\") the analytics engine resolves ONE BusinessCalendar from per request \u2014 every named window (dtd/wtd/mtd/qtd/ytd), pinned-window suppression decision, explicit dateFrom/dateTo bound, timeBucket, and compose elapsed-time calculation is judged against this zone's calendar day, not UTC or the server's JVM zone (#29). Optional: absent, empty, or not a valid IANA zone id falls back to Africa/Nairobi (the historical hardcoded default every unconfigured tenant already behaved as \u2014 a migration-compatibility default, not a real default timezone). The request path sees a configuration change after the shared analytics config-cache TTL expires. The underlying complaint_facts/complaint_events materialized views are refreshed by DashboardRefreshScheduler on its own cadence (pgr.dashboard.refresh.interval.ms), so a DB-derived tile's data reflects a timeZone change only from its NEXT refresh onward, not instantaneously."
     }
   }
 }


### PR DESCRIPTION
## Context

This is the first implementation slice from the dashboard current-state review:

- Reference issue: https://github.com/KDwevedi/Citizen-Complaint-Resolution-System/issues/29
- Timezone addendum: https://github.com/KDwevedi/Citizen-Complaint-Resolution-System/issues/29#issuecomment-5236519283

The review found three competing calendar authorities: fixed EAT literals in the backend and database, UTC parsing in parts of the query path, and browser-local date math in the dashboard. This PR makes the backend authoritative for the analytics business calendar while keeping the esbuild frontend responsible for presentation.

## What changes

- Adds optional `dss.DashboardConfig.timeZone` as an IANA zone, resolved at the tenant state root with the existing analytics config TTL.
- Resolves one immutable `BusinessCalendar` per analytics request and threads the same zone and `asOf` through named windows, explicit date ranges, pinned-window decisions, runtime buckets, composed KPIs, and response metadata.
- Adds additive response metadata: `calendar: { timeZone, businessDate }`; the existing `asOf` and all calculations use that same captured calendar.
- Moves elapsed daily/hourly average authority to `pgr-services`; the esbuild FE no longer recomputes those values using browser-local dates.
- Uses the configured zone for default/reset filters and Last Updated rendering in `digit-ui-esbuild/products/dashboard`.
- Adds a forward Flyway migration that resolves per-tenant zones, recreates the active grain materialized views, and makes daily snapshots tenant-calendar-aware. Existing applied migrations are unchanged.
- Aligns deterministic `DashboardConfig` record selection across Java, SQL, and FE.
- Seeds `Africa/Nairobi` for `ke` and documents fallback, cache, refresh, and historical-snapshot behavior.

## Compatibility and failure behavior

- Missing, blank, invalid, or unavailable configuration falls back to `Africa/Nairobi`, preserving the previous effective behavior without consulting JVM or browser local time.
- Fallback warnings are bounded to once per state-root cache generation.
- The API change is additive.
- Existing historical `complaint_open_state_daily` rows are not rewritten; only snapshots captured after a timezone change use the new zone.

## Validation

- `pgr-services`: full Maven suite, 241 tests passed.
- `digit-ui-esbuild/products/dashboard`: full Node suite, 208 tests passed.
- `digit-ui-esbuild`: production build passed. Existing unrelated duplicate-key/direct-eval warnings remain.
- New Flyway migration parsed successfully as 19 PostgreSQL statements with `pglast`.
- `git diff --check` passed after rebasing on current `master`.

A live PostgreSQL/Flyway apply and materialized-view refresh could not be run locally because no PostgreSQL service or Docker daemon was available. CI or a deployment test environment should retain that as the final database integration gate.

## Follow-up boundary

This PR fixes the calendar authority first. The broader dashboard cleanup from issue #29 remains separate: a server-provided render/view model, removal of duplicated FE KPI/filter semantics, consolidation of the batch contract, and retirement or isolation of the legacy dashboard route.
