### PR TITLE
fix(pgr): video fullscreen controls mid-screen + timeline thumbnail (CCSD-2153)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/ComplaintPhotos.js
+++ b/digit-ui-esbuild/products/pgr/src/components/ComplaintPhotos.js
@@ -69,7 +69,7 @@ const MediaAttachment = ({ url, kind, label, downloadLabel }) => {
       src={url}
       aria-label={label}
       onError={() => setFailed(true)}
-      style={{ display: "block", width: "13.75rem", maxWidth: "100%", maxHeight: "10rem", borderRadius: 6, background: "#000" }}
+      style={{ display: "block", width: "13.75rem", maxWidth: "100%", maxHeight: "10rem", objectFit: "contain", borderRadius: 6, background: "#000" }}
     />
   );
 };
@@ -179,6 +179,20 @@ const ComplaintPhotos = ({ t, serviceWrapper }) => {
 
     return (
         <React.Fragment>
+            {/* CCSD-2153: in native fullscreen the inline width/max-height on the
+                <video> below beat the browser's non-!important fullscreen UA rule,
+                so the video stayed a small box and its control bar sat mid-screen.
+                Release the size constraints in fullscreen so the video fills the
+                viewport and the controls pin to the true bottom. Inert otherwise.
+                Vendor selectors kept in separate rules — an engine that doesn't
+                know one prefixed pseudo would otherwise drop the whole group. */}
+            <style>
+                {`
+                video:fullscreen { width: 100% !important; height: 100% !important; max-width: none !important; max-height: none !important; object-fit: contain !important; }
+                video:-webkit-full-screen { width: 100% !important; height: 100% !important; max-width: none !important; max-height: none !important; object-fit: contain !important; }
+                video:-moz-full-screen { width: 100% !important; height: 100% !important; max-width: none !important; max-height: none !important; object-fit: contain !important; }
+                `}
+            </style>
             {thumbs.length > 0 && (
                 <DisplayPhotos srcs={thumbs} onClick={(src, index) => zoomImage(fullImages[index], index)} />
             )}

--- a/digit-ui-esbuild/products/pgr/src/components/TimeLineWrapper.js
+++ b/digit-ui-esbuild/products/pgr/src/components/TimeLineWrapper.js
@@ -93,6 +93,17 @@ const TimelineWrapper = ({ businessId, isWorkFlowLoading, workflowData, labelPre
         if (!Array.isArray(documents) || documents.length === 0) return null;
         return (
             <div key="docs" style={{ display: "flex", flexWrap: "wrap", gap: "0.4rem", marginTop: "0.25rem" }}>
+                {/* CCSD-2153: release the inline size in fullscreen so the video
+                    fills the screen and the control bar pins to the bottom (the
+                    browser's fullscreen UA rule isn't !important, so the inline
+                    max-height would otherwise win and center a small box). */}
+                <style>
+                    {`
+                    video:fullscreen { width: 100% !important; height: 100% !important; max-width: none !important; max-height: none !important; object-fit: contain !important; }
+                    video:-webkit-full-screen { width: 100% !important; height: 100% !important; max-width: none !important; max-height: none !important; object-fit: contain !important; }
+                    video:-moz-full-screen { width: 100% !important; height: 100% !important; max-width: none !important; max-height: none !important; object-fit: contain !important; }
+                    `}
+                </style>
                 <span style={{ fontSize: "0.78rem", color: "var(--color-text-secondary, #64748b)", width: "100%" }}>
                     {t("CS_TIMELINE_ATTACHMENTS")}
                 </span>
@@ -113,8 +124,13 @@ const TimelineWrapper = ({ businessId, isWorkFlowLoading, workflowData, labelPre
                     // several clips from pulling megabytes on render.
                     if (url && entry?.kind === "video") {
                         return (
-                            <video key={i} src={url} controls playsInline preload="metadata" aria-label={label}
-                                style={{ width: 160, maxWidth: "100%", maxHeight: 110, borderRadius: 6, background: "#000", border: "1px solid var(--color-border, #e2e8f0)" }} />
+                            // CCSD-2153: `#t=0.1` makes the browser seek to 0.1s and paint
+                            // that frame as the thumbnail (a bare preload=metadata <video> on
+                            // a remote presigned src shows only the black background). The
+                            // fragment is safe after the S3 ?X-Amz-… query. object-fit:contain
+                            // letterboxes the frame instead of stretching it.
+                            <video key={i} src={`${url}#t=0.1`} controls playsInline preload="metadata" aria-label={label}
+                                style={{ width: 160, maxWidth: "100%", maxHeight: 110, objectFit: "contain", borderRadius: 6, background: "#000", border: "1px solid var(--color-border, #e2e8f0)" }} />
                         );
                     }
                     if (url && entry?.kind === "audio") {


### PR DESCRIPTION
Two FE defects from the CCSD-2027 video-playback work (#1593), both confirmed in code.

## 1. Fullscreen controls appear mid-screen
The `<video>` has inline `width`/`max-height` (ComplaintPhotos ~13.75rem/10rem; TimeLineWrapper 160/110). Chrome's fullscreen UA rule sizes a fullscreen video 100%×100% but **without `!important`**, so the inline `max-height` wins — the video stays a small letterboxed box in the black viewport and the native control bar pins to *its* bottom (screen middle).

**Fix:** a `video:fullscreen` rule (with `!important`, plus `-webkit-`/`-moz-` variants in **separate** rules so an unknown prefixed pseudo can't drop the whole group) that releases the size constraints in fullscreen. Injected once at the root of each component that renders a player.

## 2. Timeline thumbnail blank/stretched
The timeline `<video>` had no `poster` and no `object-fit`, so a remote presigned src with `preload="metadata"` painted only its black background (or stretched the frame).

**Fix:** append `#t=0.1` to seek+paint the first frame as the thumbnail (safe after the S3 `?X-Amz-…` query — S3 ignores fragments) and set `object-fit:contain`. Added `object-fit:contain` to the ComplaintPhotos player too, for aspect-ratio parity.

## Feasibility / risk
FE-only (`ComplaintPhotos.js`, `TimeLineWrapper.js`); no backend/MDMS/config. Low risk — fullscreen rules are inert outside fullscreen; `#t=0.1` and `object-fit:contain` are no-ops where a frame already paints. Build clean; bundle carries the fullscreen rules, `#t=0.1`, and object-fit.

## Note
If the filestore/S3 presign disallows range requests, some browsers may still show a black first frame — the fully robust alternative is a server-generated poster (backend, out of FE scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)