### PR TITLE
fix(core): honour the configured default locale pt_PT on first load (CCSD-2161)

### DIFF
--- a/digit-ui-esbuild/packages/libraries/src/services/molecules/Store/service.js
+++ b/digit-ui-esbuild/packages/libraries/src/services/molecules/Store/service.js
@@ -166,7 +166,14 @@ export const StoreService = {
               ?.sort((x, y) => x?.order - y?.order) || [],
           uiHomePage: uiHomePage,
         };
-    initData.selectedLanguage = Digit.SessionStorage.get("locale") || initData.languages[0].value;
+    // CCSD-2161: on a fresh session (no stored "locale") fall back to the
+    // CONFIGURED default locale, NOT languages[0]. i18next's active language
+    // already resolves to getDefaultLanguage() (e.g. pt_PT); using
+    // languages[0] here (English — first in the StateInfo seed) fetched the
+    // en_IN bundle instead, so the app rendered English while the locale read
+    // pt_PT. Aligning both makes a fresh session render the default locale.
+    initData.selectedLanguage =
+      Digit.SessionStorage.get("locale") || Digit.Utils.getDefaultLanguage() || initData.languages[0].value;
 
     ApiCacheService.saveSetting(MdmsRes["DIGIT-UI"]?.ApiCachingSettings);
 

--- a/digit-ui-esbuild/src/index.js
+++ b/digit-ui-esbuild/src/index.js
@@ -23,7 +23,17 @@ initLibraries();
 window.Digit.Customizations = { PGR: {}};
 window.Digit.applyTheme = applyTheme;
 
-const DEFAULT_LOCALE = "en_IN";
+// CCSD-2161: derive the boot default from the deploy's configured locale
+// (globalConfigs LOCALE_DEFAULT/LOCALE_REGION — pt_PT on Moz) instead of a
+// hardcoded en_IN, which clobbered the "pt" that public/globalConfigs.js had
+// just written and forced every fresh session to English.
+const getDefaultLocale = () => {
+  try {
+    const d = window?.Digit?.Utils?.getDefaultLanguage?.();
+    if (d && !d.includes("undefined")) return d;
+  } catch (e) {}
+  return "en_IN";
+};
 
 const parseValue = (value) => {
   try { return JSON.parse(value); } catch (e) { return value; }
@@ -40,13 +50,22 @@ const getFromInfo = (info) => {
   return info?.tenantId || info?.tenantid || info?.userInfo?.tenantId || null;
 };
 
+// CCSD-2161: only seed defaults when the user has NO stored choice — the old
+// version unconditionally rewrote locale/selectedLanguage/i18nextLng to en_IN
+// on EVERY boot, overriding both the configured default and any prior manual
+// toggle's raw-localStorage traces. Crucially, also seed the wrapped
+// Digit.SessionStorage "locale" key: that is the ONE key both language paths
+// read (i18next's active lng via getCurrentLanguage(), and the bundle fetch
+// via initData.selectedLanguage). Nothing seeded it before, which is why the
+// active language said pt_PT while the en_IN bundle loaded.
 const normalizeLocale = () => {
-  window.localStorage.setItem("locale", DEFAULT_LOCALE);
-  window.localStorage.setItem("selectedLanguage", DEFAULT_LOCALE);
-  window.localStorage.setItem("i18nextLng", DEFAULT_LOCALE);
-  if (window?.Digit?.StoreData?.setCurrentLanguage) {
-    window.Digit.StoreData.setCurrentLanguage(DEFAULT_LOCALE);
-  }
+  const existing = window.Digit?.SessionStorage?.get?.("locale");
+  if (existing) return; // explicit user choice (manual toggle) always wins
+  const def = getDefaultLocale();
+  window.localStorage.setItem("locale", def);
+  window.localStorage.setItem("selectedLanguage", def);
+  window.localStorage.setItem("i18nextLng", def);
+  window.Digit?.SessionStorage?.set?.("locale", def);
 };
 
 async function bootstrap() {


### PR DESCRIPTION
## The bug
Fresh session → UI loads **English** (or locale reads PT while text is EN) until the user manually toggles the language. Exactly as CCSD-2161 reports.

## Root cause — two language sources that don't agree
On boot, the **active** i18next language and the **fetched localization bundle** resolve from different fallbacks:

| Path | Resolution on fresh session |
|---|---|
| active lng — `getCurrentLanguage()` | `SessionStorage("locale")` ‖ **`getDefaultLanguage()` → `pt_PT`** (globalConfigs) |
| bundle — `initData.selectedLanguage` | `SessionStorage("locale")` ‖ **`languages[0]` → `en_IN`** (English first in StateInfo seed) |

Nothing seeds `Digit.SessionStorage("locale")` — its only writer is a **manual toggle** (`LocalizationService.changeLanguage:189`). So the app *says* pt_PT while only the en_IN bundle is loaded. The toggle aligns both, which is the reported workaround.

Compounding: `src/index.js normalizeLocale()` hardcoded `en_IN` and **unconditionally rewrote** `locale`/`selectedLanguage`/`i18nextLng` on every boot, clobbering the `"pt"` that `public/globalConfigs.js` had just written. (Its `StoreData.setCurrentLanguage` branch was dead code — no such method exists.)

## Fix (either alone suffices; both remove the conflicting writer)
1. **`Store/service.js:169`** — `initData.selectedLanguage` falls back to `Digit.Utils.getDefaultLanguage()` before `languages[0]`, so the fetched bundle matches the active language.
2. **`src/index.js normalizeLocale()`** — default derives from `getDefaultLanguage()` (not hardcoded `en_IN`); seeds **only when the user has no stored choice** (manual toggle always wins); and seeds the effective `Digit.SessionStorage "locale"` key so both paths agree. Dead branch removed.

Verified symmetry: seed uses the same wrapper+TTL as `changeLanguage`'s own write; `normalizeLocale` runs after `initLibraries()` so `getDefaultLanguage` is available; a stored user choice short-circuits before any write.

## Data dependency (flagged on the ticket, not in this PR)
`common-masters StateInfo.languages` must include **pt_PT** for the language dropdown to show it selected — the DDH seed lists only `en_IN`/`hi_IN` today. Strings will render pt_PT after this fix regardless; the dropdown entry needs the seed/MDMS update.

## Risk
Low: only the fresh-session fallback changes; existing sessions/choices unaffected. On envs whose globalConfigs default is `en`/`IN`, behaviour is identical to before. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)