### PR TITLE
chore(local-setup): update postgres image registry and remove ddh ser…

### DIFF
--- a/local-setup/db/normalize/Dockerfile
+++ b/local-setup/db/normalize/Dockerfile
@@ -1,7 +1,7 @@
 # db-history-normalize — see docs/superpowers/specs/2026-07-13-ansible-flyway-history-normalization-design.md
 #
 # postgres:16 gives us psql; it does NOT ship python3, so install it.
-ARG POSTGRES_IMAGE=registry.preview.egov.theflywheel.in/postgres:16
+ARG POSTGRES_IMAGE=egovio/postgres:16
 FROM ${POSTGRES_IMAGE}
 
 RUN apt-get update \

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -966,37 +966,6 @@ services:
     networks:
     - egov-network
 
-  # Default Data Handler - seeds schemas and master data for new tenants.
-  # Image ref is wired through .env (DDH_IMAGE) so the deploy can either
-  # build it locally (`build_default_data_handler: true` in host_vars,
-  # tagged `default-data-handler:local`) or pull the registry image.
-  # See the MCP_IMAGE plumbing below for the parallel pattern.
-  default-data-handler:
-    image: ${DDH_IMAGE}
-    container_name: default-data-handler
-    depends_on:
-      mdms-backend:
-        condition: service_healthy
-      redpanda:
-        condition: service_healthy
-    environment:
-      SPRING_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
-      KAFKA_CONFIG_BOOTSTRAP_SERVER_CONFIG: redpanda:9092
-      # New tenants get the multi-tier CMS PGR workflow (CmsPgrWorkflowConfig.json).
-      # Set to "standard" for the classic GRO/LME single-tier workflow.
-      PGR_WORKFLOW_VARIANT: ${PGR_WORKFLOW_VARIANT:-cms}
-      EGOV_MDMS_HOST: http://mdms-backend:8094/
-      EGOV_LOCALIZATION_HOST: http://egov-localization:8096/
-      EGOV_USER_HOST: http://egov-user-proxy:8107/
-      EGOV_HRMS_HOST: http://egov-hrms:8092/
-      EGOV_WORKFLOW_HOST: http://egov-workflow-proxy:8109/
-      EGOV_BOUNDARY_HOST: http://boundary-service:8081/
-      STATE_LEVEL_TENANT_ID: pg
-      DEFAULT_TENANT_ID: pg
-      JAVA_OPTS: -Xms128m -Xmx256m
-    networks:
-      - egov-network
-
   egov-persister:
     image: egovio/egov-persister:maven-jdk21-9f83afb
     container_name: egov-persister


### PR DESCRIPTION
…vice

- Replace preview registry postgres image with egovio/postgres:16 in db-normalize Dockerfile
- Remove default-data-handler service from docker-compose.egov-digit.yaml
- Simplifies local setup by consolidating image sources and removing unused service configuration