### PR TITLE
fix(css): remove vendored 55% media-controls rule — the REAL CCSD-2153 fix (missed #1696's merge)

### DIFF
--- a/digit-ui-esbuild/packages/css/src/components/topbar.scss
+++ b/digit-ui-esbuild/packages/css/src/components/topbar.scss
@@ -142,12 +142,6 @@
   @apply flex items-center justify-end;
   min-width: 85px;
 }
-video::-webkit-media-controls-panel {
-  top: 55%;
-  position: absolute;
-  width: 100%;
-}
-
 .topbarOptionsClassName {
   right: -3rem !important
 }

--- a/digit-ui-esbuild/products/pgr/src/components/TimeLineWrapper.js
+++ b/digit-ui-esbuild/products/pgr/src/components/TimeLineWrapper.js
@@ -130,7 +130,9 @@ const TimelineWrapper = ({ businessId, isWorkFlowLoading, workflowData, labelPre
                             // fragment is safe after the S3 ?X-Amz-… query. object-fit:contain
                             // letterboxes the frame instead of stretching it.
                             <video key={i} src={`${url}#t=0.1`} controls playsInline preload="metadata" aria-label={label}
-                                style={{ width: 160, maxWidth: "100%", maxHeight: 110, objectFit: "contain", borderRadius: 6, background: "#000", border: "1px solid var(--color-border, #e2e8f0)" }} />
+                                // CCSD-2153: 280x180 (was 160x110) — the small tile cramped the
+                                // native controls and QA asked for a larger preview.
+                                style={{ width: 280, maxWidth: "100%", maxHeight: 180, objectFit: "contain", borderRadius: 6, background: "#000", border: "1px solid var(--color-border, #e2e8f0)" }} />
                         );
                     }
                     if (url && entry?.kind === "audio") {

--- a/digit-ui-esbuild/public/vendor/digit-ui-components-css.css
+++ b/digit-ui-esbuild/public/vendor/digit-ui-components-css.css
@@ -9749,11 +9749,6 @@ img {
   justify-content: flex-end;
   min-width: 5.313rem; }
 
-video::-webkit-media-controls-panel {
-  top: 55%;
-  position: absolute;
-  width: 100%; }
-
 .topbarOptionsClassName {
   right: -3rem !important; }
 

--- a/digit-ui-esbuild/public/vendor/digit-ui-css.css
+++ b/digit-ui-esbuild/public/vendor/digit-ui-css.css
@@ -4091,11 +4091,6 @@
   justify-content: flex-end;
   min-width: 85px; }
 
-video::-webkit-media-controls-panel {
-  top: 55%;
-  position: absolute;
-  width: 100%; }
-
 .topbarOptionsClassName {
   right: -3rem !important; }
 


### PR DESCRIPTION
**#1696 was merged before its corrective second commit landed** — so the merged PR carries only the first (insufficient) fix. This PR delivers the stranded commit `230cf374`, which is the *actual* fix.

## The real root cause (pixel-verified)
A global rule in the **vendored platform CSS** (origin `packages/css/src/components/topbar.scss`, orphaned, uncommented):
```css
video::-webkit-media-controls-panel { top: 55%; position: absolute; width: 100%; }
```
It pins Chrome's control panel at 55% of **every** video:
- fullscreen → control bar mid-screen (the reported bug)
- small timeline tiles → controls half out of the box (the "no controls" tile)

Proven by real element-fullscreen tests + a live CSS bisect: with all app CSS disabled the bar snaps to the bottom; removing this one rule reproduces that. The first commit's `video:fullscreen` override was a no-op against this (Chrome's fullscreen sizing already beats inline styles) — kept only as belt-and-braces.

## Also in this commit
- Timeline video tile enlarged **160×110 → 280×180** (QA request — the small tile cramped the controls).

## Verified locally before push (screenshots)
- Fullscreen: control bar at the **true bottom**, video fills the screen.
- Tiles: full control row (play/time/volume/fullscreen/menu) visible inside the tile.

Removed from the scss source and **both** vendored copies (`digit-ui-css.css`, `digit-ui-components-css.css`). Nothing in the repo references the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)