### PR TITLE
fix(pgr): uniform media-attachment size everywhere — 280x180 (CCSD-2153 follow-up)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/ComplaintPhotos.js
+++ b/digit-ui-esbuild/products/pgr/src/components/ComplaintPhotos.js
@@ -56,7 +56,7 @@ const MediaAttachment = ({ url, kind, label, downloadLabel }) => {
         src={url}
         aria-label={label}
         onError={() => setFailed(true)}
-        style={{ display: "block", width: "16rem", maxWidth: "100%" }}
+        style={{ display: "block", width: 280, maxWidth: "100%" }}
       />
     );
   }
@@ -66,10 +66,12 @@ const MediaAttachment = ({ url, kind, label, downloadLabel }) => {
       controls
       playsInline
       preload="metadata"
-      src={url}
+      // CCSD-2153: same size + first-frame still as the timeline tiles
+      // (280x180, #t=0.1) so video attachments look identical everywhere.
+      src={`${url}#t=0.1`}
       aria-label={label}
       onError={() => setFailed(true)}
-      style={{ display: "block", width: "13.75rem", maxWidth: "100%", maxHeight: "10rem", objectFit: "contain", borderRadius: 6, background: "#000" }}
+      style={{ display: "block", width: 280, maxWidth: "100%", maxHeight: 180, objectFit: "contain", borderRadius: 6, background: "#000" }}
     />
   );
 };

--- a/digit-ui-esbuild/products/pgr/src/components/TimeLineWrapper.js
+++ b/digit-ui-esbuild/products/pgr/src/components/TimeLineWrapper.js
@@ -138,7 +138,7 @@ const TimelineWrapper = ({ businessId, isWorkFlowLoading, workflowData, labelPre
                     if (url && entry?.kind === "audio") {
                         return (
                             <audio key={i} src={url} controls preload="metadata" aria-label={label}
-                                style={{ width: 200, maxWidth: "100%" }} />
+                                style={{ width: 280, maxWidth: "100%" }} />
                         );
                     }
                     return (


### PR DESCRIPTION
Delivers commit `c175d74e`, which was pushed moments after #1701 merged (same race as #1696 → #1701). One commit, small and final for CCSD-2153:

## Change — same size for every attachment player (QA request)
| Player | Before | After |
|---|---|---|
| Details "Anexos" video (ComplaintPhotos) | ~220×160 (`13.75rem×10rem`) | **280×180** + `#t=0.1` first-frame still |
| Timeline video tile (TimeLineWrapper) | 280×180 (from #1701) | unchanged — now identical |
| Audio (ComplaintPhotos) | `16rem` (~256) | **280** |
| Audio (TimeLineWrapper) | 200 | **280** |

## Verified locally (side-by-side screenshot)
Both video players render identical 280-wide boxes with the full control row at the bottom; audio aligns at 280.

**Note for merging:** this is the last CCSD-2153 commit — after this merges + deploys, the ticket is fully re-testable (fullscreen bottom bar from #1701, uniform sizes from this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)