### PR TITLE
feat(configurator): boot in the env's default locale — same globalConfigs mechanism as the portal

### DIFF
--- a/configurator/index.html
+++ b/configurator/index.html
@@ -8,6 +8,14 @@
   </head>
   <body>
     <div id="root"></div>
+    <!-- Same-origin runtime config shared with the portal (rendered by ansible
+         from globalConfigs.js.j2). Loaded so the Studio can honour the SAME
+         per-env settings the esbuild portal reads — first consumer is the
+         default locale (LOCALE_DEFAULT/LOCALE_REGION, i18nProvider). A classic
+         script tag executes before the module bundle, so window.globalConfigs
+         is defined by the time main.tsx runs. On a box without the portal the
+         request 404s and the app just falls back to its built-in defaults. -->
+    <script src="/digit-ui/globalConfigs.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/configurator/src/providers/i18nProvider.ts
+++ b/configurator/src/providers/i18nProvider.ts
@@ -32,6 +32,39 @@ export const AVAILABLE_LOCALES: Locale[] = [
   { locale: 'fr_FR', name: 'FR' },
 ];
 
+/**
+ * Boot locale — SAME mechanism as the esbuild portal. index.html loads the
+ * env's /digit-ui/globalConfigs.js (ansible-rendered from host_vars), and the
+ * default is derived from LOCALE_DEFAULT/LOCALE_REGION exactly like the
+ * portal's getDefaultLanguage(). One host_vars setting drives BOTH apps.
+ *
+ * Mapping: the portal's locale codes differ from the Studio's (portal
+ * Portuguese is pt_PT, the Studio ships pt_BR), so resolve exact first, then
+ * by language prefix ("pt" -> pt_BR). Unknown/absent config falls back to
+ * en_IN (previous hardcoded behaviour, and the right answer on boxes that
+ * don't serve the portal's globalConfigs at all). A user's manual language
+ * pick is persisted by react-admin's store and always wins over this default.
+ */
+export const resolveInitialLocale = (): string => {
+  try {
+    const getConfig = (window as unknown as {
+      globalConfigs?: { getConfig?: (key: string) => unknown };
+    })?.globalConfigs?.getConfig;
+    const lang = getConfig?.('LOCALE_DEFAULT');
+    if (typeof lang === 'string' && lang) {
+      const region = getConfig?.('LOCALE_REGION');
+      const codes = AVAILABLE_LOCALES.map((l) => l.locale);
+      const exact = typeof region === 'string' && region ? `${lang}_${region}` : lang;
+      if (codes.includes(exact)) return exact;
+      const byPrefix = codes.find((c) => c.startsWith(`${lang}_`));
+      if (byPrefix) return byPrefix;
+    }
+  } catch {
+    /* config script absent/broken — built-in default below */
+  }
+  return 'en_IN';
+};
+
 // ---------------------------------------------------------------------------
 // Bundled: English (full — ra.* from package + app.* as fallback)
 // ---------------------------------------------------------------------------
@@ -678,16 +711,31 @@ function buildSyncMessages(locale: string): TranslationMessages {
   return base as TranslationMessages;
 }
 
+// Resolved once at module load — index.html has already executed the classic
+// globalConfigs script by the time this module runs (module scripts are
+// deferred), so the env default is available here.
+const INITIAL_LOCALE = resolveInitialLocale();
+// Reflect the boot language on <html lang> (a11y: index.html ships lang="en";
+// screen readers and translators should see the real UI language). Also the
+// observable signal tests assert on.
+try {
+  if (typeof document !== 'undefined') document.documentElement.lang = INITIAL_LOCALE.replace('_', '-');
+} catch {
+  /* non-DOM context */
+}
+
 function getMessages(locale: string): TranslationMessages | Promise<TranslationMessages> {
-  // The default locale (en_IN) must resolve synchronously for polyglot's first
-  // render, so we can't await the network here. Instead we serve the bundled
-  // base immediately — overlaid with any backend app.* strings already in the
-  // localStorage cache — and kick off a background refresh so the next render
-  // (or locale switch) picks up edits made in the Localization UI. English is
-  // no longer a hardcoded-only locale: its app.* strings live in the
-  // `configurator-ui` backend module like every other locale, and the bundle
-  // is only a boot/offline fallback.
-  if (locale === 'en_IN' || locale === 'en') {
+  // The DEFAULT locale must resolve synchronously for polyglot's first render
+  // (ra-i18n-polyglot throws "returned a Promise for the messages of the
+  // default locale" otherwise — verified by booting with a pt default), so we
+  // can't await the network here. Serve the bundled base immediately — that
+  // locale's ra.* bundle over the English app.* base, overlaid with any
+  // backend app.* strings already in the localStorage cache — and kick off a
+  // background refresh so the next render (or locale switch) picks up edits
+  // made in the Localization UI. The default is no longer hardcoded en_IN:
+  // INITIAL_LOCALE comes from the env's globalConfigs (same mechanism as the
+  // esbuild portal), so the sync path must cover whichever locale that is.
+  if (locale === INITIAL_LOCALE || locale === 'en_IN' || locale === 'en') {
     const sync = memoryCache.get(locale) ?? buildSyncMessages(locale);
     void getMessagesAsync(locale);
     return sync;
@@ -700,7 +748,7 @@ function getMessages(locale: string): TranslationMessages | Promise<TranslationM
 // ---------------------------------------------------------------------------
 export const i18nProvider = polyglotI18nProvider(
   getMessages,
-  'en_IN',
+  INITIAL_LOCALE,
   AVAILABLE_LOCALES,
   { allowMissing: true },
 );

--- a/configurator/src/providers/resolveInitialLocale.test.ts
+++ b/configurator/src/providers/resolveInitialLocale.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { resolveInitialLocale } from './i18nProvider';
+
+// The Studio's boot locale mirrors the esbuild portal: index.html loads the
+// env's /digit-ui/globalConfigs.js and the default derives from
+// LOCALE_DEFAULT/LOCALE_REGION. These tests pin the mapping rules — exact
+// match first, then language-prefix (the portal says pt_PT, the Studio ships
+// pt_BR), then the en_IN fallback.
+
+const setConfig = (values: Record<string, unknown> | null) => {
+  (window as unknown as Record<string, unknown>).globalConfigs = values
+    ? { getConfig: (k: string) => values[k] }
+    : undefined;
+};
+
+afterEach(() => setConfig(null));
+
+describe('resolveInitialLocale', () => {
+  it('falls back to en_IN when no globalConfigs script is loaded', () => {
+    setConfig(null);
+    expect(resolveInitialLocale()).toBe('en_IN');
+  });
+
+  it('uses the exact locale when the portal default exists in the Studio list', () => {
+    setConfig({ LOCALE_DEFAULT: 'hi', LOCALE_REGION: 'IN' });
+    expect(resolveInitialLocale()).toBe('hi_IN');
+  });
+
+  it('maps by language prefix when regions differ (portal pt_PT -> Studio pt_BR)', () => {
+    setConfig({ LOCALE_DEFAULT: 'pt', LOCALE_REGION: 'PT' });
+    expect(resolveInitialLocale()).toBe('pt_BR');
+  });
+
+  it('maps a language with no region config by prefix too', () => {
+    setConfig({ LOCALE_DEFAULT: 'fr' });
+    expect(resolveInitialLocale()).toBe('fr_FR');
+  });
+
+  it('falls back to en_IN for a language the Studio does not ship', () => {
+    setConfig({ LOCALE_DEFAULT: 'sw', LOCALE_REGION: 'KE' });
+    expect(resolveInitialLocale()).toBe('en_IN');
+  });
+
+  it('ignores non-string/garbage config values', () => {
+    setConfig({ LOCALE_DEFAULT: 42, LOCALE_REGION: {} });
+    expect(resolveInitialLocale()).toBe('en_IN');
+  });
+
+  it('survives a getConfig that throws', () => {
+    (window as unknown as Record<string, unknown>).globalConfigs = {
+      getConfig: () => { throw new Error('boom'); },
+    };
+    expect(resolveInitialLocale()).toBe('en_IN');
+  });
+});


### PR DESCRIPTION
The Studio's boot locale was a **hardcoded `'en_IN'`** — every fresh browser got English on every env, regardless of deploy config. The esbuild portal derives its default from the env's `globalConfigs.js` (`LOCALE_DEFAULT`/`LOCALE_REGION`, ansible-rendered from host_vars). This PR gives the configurator the **same mechanism, same file** — one host_vars setting drives both apps.

## How
- `index.html` loads the same-origin **`/digit-ui/globalConfigs.js`** (classic script → executes before the deferred module bundle; 404s harmlessly on a box without the portal).
- `resolveInitialLocale()` maps the config onto the Studio's locale list: exact match → language-prefix (portal `pt_PT` → Studio `pt_BR`) → `en_IN`. A user's manual pick (react-admin store) still wins.
- **The bug that forced the original hardcode, fixed:** `ra-i18n-polyglot` requires the *default* locale's messages synchronously; `getMessages` only had a sync path for `en_IN`, so a `pt_BR` default threw *"returned a Promise for the messages of the default locale"* → blank app. The sync path now covers the resolved initial locale (bundled `ra.*` for that locale over the English `app.*` base; async API merge still runs).
- `<html lang>` now reflects the boot locale (a11y + test signal).

## Verified locally before push
| Test | Result |
|---|---|
| vitest unit — mapping rules (exact/prefix/no-region/unknown/garbage/throwing/absent) | 7/7 ✅ |
| Built dist + **pt/PT** config stub, fresh session | boots **pt-BR**, no polyglot error, renders ✅ |
| Config request **blocked at network level** | boots **en-IN**, login renders, no crash ✅ |

## To turn it on for Moz
Set the env's locale in host_vars/globalConfigs (`localeDefault: "pt"`, `localeRegion: "PT"`) — the same knob that flips the portal (#1698). No configurator-specific config needed.

## Pairs with CCSD-2157
`app.*` strings still come from the API with a 24h client cache — a pt boot shows Portuguese framework strings immediately, and Portuguese app strings once the `configurator-ui` pt rows are seeded and 2157's cache-invalidation lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)