### PR TITLE
fix(pgr): align the inbox system-name card (left-aligned, vertically centred) + heading gutter (CCSD-2086)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRInbox.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRInbox.js
@@ -273,6 +273,13 @@ const PGRSearchInbox = () => {
           text up when there are no links below it. */}
       <style>{`
         .v2-pgr-inbox .digit-inbox-search-links-container {
+          /* The links card (.digit-section.links) is a flex ROW item that the
+             sections grid stretches to match the search column's height, but
+             its default align-items:flex-start pins THIS container to the top
+             and percentage-height won't resolve against a grid-stretched
+             parent. align-self:stretch makes the container fill that height so
+             justify-content:center actually centres in the visible card. */
+          align-self: stretch;
           height: 100%;
           box-sizing: border-box;
           padding: 1.5rem 1rem;

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRInbox.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRInbox.js
@@ -258,13 +258,29 @@ const PGRSearchInbox = () => {
 
   return (
     <div className="v2-pgr-inbox v2-scope">
-      {/* CCSD-2086: centre the system-name header in the inbox's left links card
-          (it read left-aligned). Scoped to .v2-pgr-inbox so the shared
-          InboxSearchComposer class isn't recentred for other modules; the
+      {/* CCSD-2086: the system-name card in the inbox's left links panel read
+          flush top-left. The shipped digit-inbox-search-links-container has NO
+          padding / height / centering rule (only the legacy non-"digit-"
+          prefixed .inbox-search-links-container scss did), so the header text
+          sat in the top-left corner with the rest of the card empty below it.
+          Give the container real padding and make it a full-height flex column
+          that centres its content vertically, and centre the header row + text
+          horizontally. Scoped to .v2-pgr-inbox so the shared
+          InboxSearchComposer classes aren't restyled for other modules; the
           two-class selector outranks the component's own single-class rule
-          without needing !important. */}
+          without !important. margin-bottom:0 on the header stops the stock
+          1.5rem gap (meant to separate header from links) from nudging the
+          text up when there are no links below it. */}
       <style>{`
-        .v2-pgr-inbox .digit-inbox-search-links-header { justify-content: center; text-align: center; }
+        .v2-pgr-inbox .digit-inbox-search-links-container {
+          height: 100%;
+          box-sizing: border-box;
+          padding: 1.5rem 1rem;
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+        }
+        .v2-pgr-inbox .digit-inbox-search-links-header { justify-content: center; text-align: center; margin-bottom: 0; }
         .v2-pgr-inbox .digit-inbox-search-links-header-text { text-align: center; }
       `}</style>
       <header className="v2-employee-page-header">

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRInbox.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRInbox.js
@@ -282,7 +282,7 @@ const PGRSearchInbox = () => {
           align-self: stretch;
           height: 100%;
           box-sizing: border-box;
-          padding: 1.5rem 1rem;
+          padding: 1.5rem 1rem 1.5rem 0;
           display: flex;
           flex-direction: column;
           justify-content: center;

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRInbox.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRInbox.js
@@ -287,18 +287,15 @@ const PGRSearchInbox = () => {
           flex-direction: column;
           justify-content: center;
         }
-        .v2-pgr-inbox .digit-inbox-search-links-header { justify-content: center; text-align: center; margin-bottom: 0; }
-        .v2-pgr-inbox .digit-inbox-search-links-header-text { text-align: center; }
-        /* When there's no logo icon the logo span is empty but still reserves
-           2rem, shoving the centred title ~11px right of the link below it.
-           Collapse it when empty so title and link share the same centre. */
+        /* Title and quick-links (e.g. "New Complaint") are both LEFT-aligned and
+           share the same left edge, so they line up. The card content is still
+           vertically centred (container justify-content:center below); only the
+           horizontal alignment is left. Collapse the empty logo span so the
+           title starts at the true left edge, matching the link. */
+        .v2-pgr-inbox .digit-inbox-search-links-header { justify-content: flex-start; text-align: left; margin-bottom: 0; }
+        .v2-pgr-inbox .digit-inbox-search-links-header-text { text-align: left; }
         .v2-pgr-inbox .digit-inbox-search-links-header-logo:empty { display: none; }
-        /* Centre the quick-links (e.g. "New Complaint") too — the header was
-           centred but the links list defaulted to left-aligned, so title and
-           link were mismatched. :not(:empty) keeps a gap below the title ONLY
-           when links actually render (empty otherwise on roles without them,
-           preserving the pure-title vertical centring). */
-        .v2-pgr-inbox .digit-inbox-search-links-contents { align-items: center; text-align: center; }
+        .v2-pgr-inbox .digit-inbox-search-links-contents { align-items: flex-start; text-align: left; }
         .v2-pgr-inbox .digit-inbox-search-links-contents:not(:empty) { margin-top: 1rem; }
         /* Page title sat flush in the top-left corner (header padding 12px 0 8px
            — no left gutter), 24px left of the card content below it. Give it a

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRInbox.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRInbox.js
@@ -289,6 +289,21 @@ const PGRSearchInbox = () => {
         }
         .v2-pgr-inbox .digit-inbox-search-links-header { justify-content: center; text-align: center; margin-bottom: 0; }
         .v2-pgr-inbox .digit-inbox-search-links-header-text { text-align: center; }
+        /* When there's no logo icon the logo span is empty but still reserves
+           2rem, shoving the centred title ~11px right of the link below it.
+           Collapse it when empty so title and link share the same centre. */
+        .v2-pgr-inbox .digit-inbox-search-links-header-logo:empty { display: none; }
+        /* Centre the quick-links (e.g. "New Complaint") too — the header was
+           centred but the links list defaulted to left-aligned, so title and
+           link were mismatched. :not(:empty) keeps a gap below the title ONLY
+           when links actually render (empty otherwise on roles without them,
+           preserving the pure-title vertical centring). */
+        .v2-pgr-inbox .digit-inbox-search-links-contents { align-items: center; text-align: center; }
+        .v2-pgr-inbox .digit-inbox-search-links-contents:not(:empty) { margin-top: 1rem; }
+        /* Page title sat flush in the top-left corner (header padding 12px 0 8px
+           — no left gutter), 24px left of the card content below it. Give it a
+           left gutter that lines up with the card and a little more top room. */
+        .v2-pgr-inbox .v2-employee-page-header { padding: 1rem 1.5rem 0.75rem; }
       `}</style>
       <header className="v2-employee-page-header">
         <h1>{heading}</h1>


### PR DESCRIPTION
Fixes the layout of the left "system-name" card on the PGR **Search Citizen Complaint** screen (`/employee/pgr/inbox-v2`) plus the page heading. Iterated against real QA feedback and **verified in the actual running app** (local mz stack), not just a harness.

## Final design (agreed after review)
- **System-name title** and the **quick-link** ("New Complaint") are **left-aligned on the same edge**, and lined up with the **page heading** — all three at the same left gutter (measured x=124, one clean vertical column).
- The card content is **vertically centred** in the card (was pinned to the top).
- Page heading (`.v2-employee-page-header`) given a left gutter + top padding (it was flush in the corner with no left padding).

## Root causes fixed along the way
1. Shipped `digit-inbox-search-links-container` has **no padding/height/centering** (only the legacy non-`digit-` scss did) → content sat at the top-left origin.
2. The container is a flex-row item the sections grid stretches to the search column's height, but `align-items:flex-start` pinned the content to the top; **percentage height won't resolve against a grid-stretched parent** → used `align-self: stretch` to fill it, so `justify-content:center` centres in the *visible* card.
3. Links list defaulted to left while the title was (initially) centred; empty logo span reserved 2rem and skewed alignment. Reconciled to a single left-aligned column.

## Scope / safety
All rules scoped to `.v2-pgr-inbox` (no other module's `InboxSearchComposer` affected); two-class selectors win without `!important`.

## Verification (real app, measured)
- heading left = title left = link left = **124** (aligned column)
- title & link share the same left edge; content **vertically centred** (equal top/bottom gap)
- built bundle deployed into the running `digit-ui` container and eyeballed on the live screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)