### PR TITLE
feat(novu-bridge): add Ozeki SMS provider support for OTP delivery

### DIFF
--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/config/NovuBridgeConfiguration.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/config/NovuBridgeConfiguration.java
@@ -103,6 +103,28 @@ public class NovuBridgeConfiguration {
     @Value("${novu.bridge.workflow.id.email:complaints-email}")
     private String novuWorkflowEmail;
 
+    // ---- OTP delivery via Ozeki (independent of the PGR pass-through above) ----
+    // Empty (default) = OTP triggers plain, Novu's primary SMS integration
+    // delivers. "ozeki" = attach the Ozeki generic-sms overrides envelope
+    // (OzekiOverridesBuilder) to OTP triggers only — this is deliberately NOT
+    // wired into identifyThenTrigger, so PGR complaint SMS/WhatsApp keep using
+    // Twilio regardless of this flag; the two can never affect each other.
+    // Requires a generic-sms Novu integration whose identifier matches
+    // novu.bridge.ozeki.integration.identifier (see
+    // docs/Novu_Adapter/OZEKI-GENERIC-SMS-PROVIDER.md for the exact shape;
+    // Novu has no built-in "ozeki" provider — confirmed directly: setting an
+    // integration's providerId to "ozeki" and triggering fails "Sms handler
+    // for provider ozeki is not found" — generic-sms is the real provider id).
+    @Value("${novu.bridge.otp.sms.provider:}")
+    private String otpSmsProvider;
+
+    @Value("${novu.bridge.ozeki.integration.identifier:ozeki-sms}")
+    private String ozekiIntegrationIdentifier;
+
+    public boolean isOtpOzekiEnabled() {
+        return otpSmsProvider != null && "ozeki".equalsIgnoreCase(otpSmsProvider.trim());
+    }
+
     // ---- Subscriber identify (upsert) TTL cache ----
     @Value("${novu.bridge.identify.cache.ttl.ms:300000}")
     private Long identifyCacheTtlMs;

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/config/NovuBridgeConfiguration.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/config/NovuBridgeConfiguration.java
@@ -125,6 +125,21 @@ public class NovuBridgeConfiguration {
         return otpSmsProvider != null && "ozeki".equalsIgnoreCase(otpSmsProvider.trim());
     }
 
+    // ---- PGR pass-through SMS delivery via Ozeki (independent of the OTP flag above) ----
+    // Empty (default) = plain complaint SMS delivers via whatever's primary for the Novu
+    // sms channel (Twilio). "ozeki" = attach the same Ozeki generic-sms overrides envelope
+    // to identifyThenTrigger's SMS-channel trigger only. WhatsApp is unaffected: it always
+    // carries its own providers.twilio override (buildProviderTemplateOverrides), which is
+    // keyed to a different provider id (twilio, not generic-sms) and returns before this
+    // flag is ever checked. Reuses ozekiIntegrationIdentifier above — same Ozeki integration
+    // serves both OTP and PGR complaint SMS.
+    @Value("${novu.bridge.sms.provider:}")
+    private String smsProvider;
+
+    public boolean isSmsOzekiEnabled() {
+        return smsProvider != null && "ozeki".equalsIgnoreCase(smsProvider.trim());
+    }
+
     // ---- Subscriber identify (upsert) TTL cache ----
     @Value("${novu.bridge.identify.cache.ttl.ms:300000}")
     private Long identifyCacheTtlMs;

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/service/DispatchPipelineService.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/service/DispatchPipelineService.java
@@ -285,8 +285,8 @@ public class DispatchPipelineService {
         }
 
         String subscriberId = event.getTenantId() + ":" + formattedMobile;
-        String body = "DIGIT: Your one-time login code is " + otp
-                + ". It expires in 10 minutes. Do not share this code.";
+        String body = "Seu código de login de uso único é \"" + otp 
+        + "\". Ele expira em 10 minutos. Não compartilhe este código.";
         Map<String, Object> payload = new HashMap<>();
         payload.put("otp", otp);
         payload.put("mobile", formattedMobile);

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/service/DispatchPipelineService.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/service/DispatchPipelineService.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.egov.common.contract.request.RequestInfo;
 import org.egov.novubridge.config.NovuBridgeConfiguration;
 import org.egov.novubridge.repository.DispatchLogRepository;
+import org.egov.novubridge.service.provider.OzekiOverridesBuilder;
 import org.egov.novubridge.util.PiiMask;
 import org.egov.novubridge.web.models.*;
 import org.egov.tracer.model.CustomException;
@@ -33,6 +34,7 @@ import java.util.*;
 public class DispatchPipelineService {
 
     private static final Set<String> KNOWN_CHANNELS = Set.of("SMS", "WHATSAPP", "EMAIL");
+    private static final String OTP_EVENT_NAME = "OTP.SEND";
 
     private final EnvelopeValidator envelopeValidator;
     private final PreferenceServiceClient preferenceServiceClient;
@@ -60,6 +62,16 @@ public class DispatchPipelineService {
                 event.getEventId(), event.getEventName(), event.getTenantId(), event.getChannel(), send);
 
         envelopeValidator.validate(event);
+
+        // OTP.SEND (from otp-publisher) is a separate, minimal path — pre-account
+        // (no DIGIT user yet), no PGR-rendered body/contact, delivered through the
+        // existing complaints-sms workflow but (optionally) via an Ozeki override
+        // instead of whatever's primary. Handle it before any of the PGR
+        // pass-through logic (preference checks, contact building, WHATSAPP
+        // formatting) that doesn't apply to it.
+        if (OTP_EVENT_NAME.equalsIgnoreCase(event.getEventName())) {
+            return processOtp(event, send);
+        }
 
         DerivedContext context = deriveContext(event);
         String subscriberId = StringUtils.hasText(event.getSubscriberId())
@@ -218,6 +230,118 @@ public class DispatchPipelineService {
                 .novuResponse(response != null ? response.getResponse() : null)
                 .diagnostics(Collections.singletonList("Dispatch successful"))
                 .build();
+    }
+
+    /**
+     * OTP send. otp-publisher carries the mobile number in {@code stakeholders[0]}
+     * and the OTP code in {@code data.otp} — pre-account, so there is no
+     * subscriberId/contact resolved by anything upstream the way PGR resolves
+     * them for complaint events. Triggers the existing SMS pass-through workflow
+     * ({@code novu.bridge.workflow.id.sms}, i.e. {@code complaints-sms}) — no
+     * dedicated OTP workflow needed, since the workflow step is a bare
+     * {@code payload.body} passthrough regardless of event type.
+     *
+     * <p>When {@code novu.bridge.otp.sms.provider=ozeki}, attaches the Ozeki
+     * generic-sms overrides envelope ({@link OzekiOverridesBuilder}) so this one
+     * trigger delivers via the (possibly non-primary) Ozeki integration instead
+     * of whatever's primary for the sms channel — Twilio and PGR complaint
+     * delivery are untouched either way, since this flag is only read here, not
+     * in {@link #deriveContext} / the pass-through path above.
+     */
+    private DispatchResult processOtp(ComplaintsDomainEvent event, boolean send) {
+        String mobile = (event.getStakeholders() != null && !event.getStakeholders().isEmpty())
+                ? event.getStakeholders().get(0).getMobile() : null;
+        Object otp = event.getData() != null ? event.getData().get("otp") : null;
+        String transactionId = StringUtils.hasText(event.getTransactionId())
+                ? event.getTransactionId() : event.getEventId();
+
+        if (!StringUtils.hasText(mobile) || otp == null) {
+            persistOtp(event, transactionId, "SKIPPED", "NB_OTP_CONTACT_MISSING",
+                    "OTP event missing mobile or otp", 1);
+            return DispatchResult.builder()
+                    .valid(true).preferenceAllowed(true).novuTriggered(false)
+                    .diagnostics(Collections.singletonList("OTP event missing mobile or otp"))
+                    .build();
+        }
+
+        if (!send) {
+            persistOtp(event, transactionId, "RECEIVED", null, null, 1);
+            return DispatchResult.builder()
+                    .valid(true).preferenceAllowed(true).novuTriggered(false)
+                    .diagnostics(Collections.singletonList("Validation only mode"))
+                    .build();
+        }
+
+        String formattedMobile;
+        try {
+            // otp-publisher carries the bare national number (no "+"); prepend the
+            // tenant's MDMS-configured country code the same way the PGR pass-through
+            // path does in formatRecipientPhone, so Ozeki/Twilio get a real E.164
+            // destination instead of a bare local number.
+            formattedMobile = formatRecipientPhone(mobile, event.getTenantId(), "sms", null);
+        } catch (CustomException ce) {
+            persistOtp(event, transactionId, "FAILED", ce.getCode(), ce.getMessage(), 1);
+            throw ce;
+        }
+
+        String subscriberId = event.getTenantId() + ":" + formattedMobile;
+        String body = "DIGIT: Your one-time login code is " + otp
+                + ". It expires in 10 minutes. Do not share this code.";
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("otp", otp);
+        payload.put("mobile", formattedMobile);
+        payload.put("body", body);
+        Object userType = event.getData() != null ? event.getData().get("userType") : null;
+        if (userType != null) {
+            payload.put("userType", userType);
+        }
+
+        Map<String, Object> overrides = config.isOtpOzekiEnabled()
+                ? OzekiOverridesBuilder.build(config.getOzekiIntegrationIdentifier(), transactionId, formattedMobile, body)
+                : null;
+
+        NovuClient.NovuResponse response;
+        try {
+            response = novuClient.trigger(config.getNovuWorkflowSms(), subscriberId, formattedMobile, payload, transactionId, overrides);
+        } catch (CustomException ce) {
+            persistOtp(event, transactionId, "FAILED", ce.getCode(), ce.getMessage(), 1);
+            throw ce;
+        }
+
+        Integer sc = response != null ? response.getStatusCode() : null;
+        boolean delivered = sc != null && sc >= 200 && sc < 300;
+        persistOtp(event, transactionId, delivered ? "SENT" : "FAILED",
+                delivered ? null : "NB_NOVU_TRIGGER_FAILED",
+                delivered ? null : "Novu returned status " + sc, 1);
+
+        return DispatchResult.builder()
+                .valid(true).preferenceAllowed(true)
+                .novuTriggered(delivered).novuStatusCode(sc)
+                .novuResponse(response != null ? response.getResponse() : null)
+                .diagnostics(Collections.singletonList(
+                        delivered ? "OTP dispatch successful" : "OTP dispatch failed: status " + sc))
+                .build();
+    }
+
+    private void persistOtp(ComplaintsDomainEvent event, String transactionId, String status,
+                            String errorCode, String errorMessage, Integer attemptCount) {
+        dispatchLogRepository.upsert(DispatchLogEntry.builder()
+                .eventId(event.getEventId())
+                .transactionId(transactionId)
+                .referenceNumber(event.getEntityId())
+                .module(event.getModule())
+                .eventName(event.getEventName())
+                .tenantId(event.getTenantId())
+                .channel("SMS")
+                .recipientValue(transactionId)
+                .templateKey("OTP.SEND")
+                .status(status)
+                .attemptCount(attemptCount)
+                .lastErrorCode(errorCode)
+                .lastErrorMessage(errorMessage)
+                .createdTime(System.currentTimeMillis())
+                .lastModifiedTime(System.currentTimeMillis())
+                .build());
     }
 
     public NovuClient.NovuResponse testTrigger(String workflowId, String subscriberId, String phone,

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/service/NovuClient.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/service/NovuClient.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.egov.novubridge.config.NovuBridgeConfiguration;
+import org.egov.novubridge.service.provider.OzekiOverridesBuilder;
 import org.egov.novubridge.util.PiiMask;
 import org.egov.tracer.model.CustomException;
 import org.springframework.http.*;
@@ -83,6 +84,15 @@ public class NovuClient {
         // sender/credentials; we only add the template. SMS/EMAIL keep the free-form path.
         if (StringUtils.hasText(templateId)) {
             Map<String, Object> overrides = buildProviderTemplateOverrides(templateId, contentVariables);
+            return trigger(workflowId, scopedSubscriberId, phone, payload, transactionId, overrides, null);
+        }
+
+        // Plain complaint SMS via Ozeki: only reached when channel is SMS (WhatsApp always
+        // has a templateId and returns above) and the flag is on. Pins this trigger to the
+        // Ozeki generic-sms integration instead of falling through to whatever's primary.
+        if ("SMS".equalsIgnoreCase(channel) && config.isSmsOzekiEnabled()) {
+            Map<String, Object> overrides = OzekiOverridesBuilder.build(
+                    config.getOzekiIntegrationIdentifier(), transactionId, phone, renderedBody);
             return trigger(workflowId, scopedSubscriberId, phone, payload, transactionId, overrides, null);
         }
 

--- a/backend/novu-bridge/src/main/java/org/egov/novubridge/service/provider/OzekiOverridesBuilder.java
+++ b/backend/novu-bridge/src/main/java/org/egov/novubridge/service/provider/OzekiOverridesBuilder.java
@@ -1,0 +1,73 @@
+package org.egov.novubridge.service.provider;
+
+import org.springframework.util.StringUtils;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds the Novu trigger {@code overrides} envelope that delivers an SMS
+ * through an <a href="https://ozeki-sms-gateway.com/p_5667-http-sms-api.html">Ozeki
+ * SMS Gateway</a> behind Novu's built-in {@code generic-sms} provider — no
+ * forked Novu images, no shim service. Full design:
+ * {@code docs/Novu_Adapter/OZEKI-GENERIC-SMS-PROVIDER.md}.
+ *
+ * <p>Shape constraints (verified against Novu v2.3.0 source):
+ * <ul>
+ *   <li>The provider-overrides key must be the Novu provider id
+ *       {@code generic-sms} — the worker's {@code combineOverrides} looks up
+ *       {@code overrides.providers[integration.providerId]}; a key like
+ *       {@code ozeki} would be silently ignored.</li>
+ *   <li>{@code _passthrough.body} is deep-merged into the outgoing JSON with
+ *       highest priority and is exempt from the provider's key-casing
+ *       transform, so Ozeki's snake_case {@code messages[]} fields survive
+ *       verbatim.</li>
+ *   <li>Overrides are sent raw — Novu never templates them — so {@code text}
+ *       must be the final pre-rendered body, which the pass-through pipeline
+ *       has at trigger time.</li>
+ *   <li>{@code overrides.sms.integrationIdentifier} pins the (possibly
+ *       non-primary) generic-sms integration, letting Ozeki coexist with e.g.
+ *       a primary Twilio integration.</li>
+ * </ul>
+ */
+public final class OzekiOverridesBuilder {
+
+    /** Novu provider id backing the Ozeki integration — NOT "ozeki". */
+    public static final String NOVU_PROVIDER_ID = "generic-sms";
+
+    private OzekiOverridesBuilder() {
+    }
+
+    /**
+     * @param integrationIdentifier identifier of the generic-sms Novu
+     *                              integration pointing at the Ozeki gateway;
+     *                              blank = omit (Novu falls back to the
+     *                              primary SMS integration)
+     * @param transactionId         echoed back by the gateway as
+     *                              {@code message_id} — the correlation key
+     *                              across nb_dispatch_log, the Novu activity
+     *                              feed (via the integration's idPath) and the
+     *                              Ozeki message store
+     * @param toAddress             recipient in +E.164 (already formatted by
+     *                              the dispatch pipeline)
+     * @param text                  final localized message body
+     */
+    public static Map<String, Object> build(String integrationIdentifier, String transactionId,
+                                            String toAddress, String text) {
+        Map<String, Object> message = new LinkedHashMap<>();
+        message.put("message_id", transactionId);
+        message.put("to_address", toAddress);
+        message.put("text", text);
+
+        Map<String, Object> overrides = new LinkedHashMap<>();
+        if (StringUtils.hasText(integrationIdentifier)) {
+            overrides.put("sms", Map.of("integrationIdentifier", integrationIdentifier));
+        }
+        overrides.put("providers", Map.of(NOVU_PROVIDER_ID,
+                Map.of("_passthrough",
+                        Map.of("body",
+                                Map.of("messages", List.of(message))))));
+        return overrides;
+    }
+}

--- a/backend/novu-bridge/src/main/resources/application.properties
+++ b/backend/novu-bridge/src/main/resources/application.properties
@@ -43,6 +43,11 @@ novu.bridge.proxy.allowed.roles=${NOVU_BRIDGE_PROXY_ALLOWED_ROLES:EMPLOYEE,SUPER
 novu.bridge.workflow.id.sms=${NOVU_BRIDGE_WORKFLOW_ID_SMS:complaints-sms}
 novu.bridge.workflow.id.whatsapp=${NOVU_BRIDGE_WORKFLOW_ID_WHATSAPP:complaints-whatsapp}
 novu.bridge.workflow.id.email=${NOVU_BRIDGE_WORKFLOW_ID_EMAIL:complaints-email}
+# OTP delivery via Ozeki (processOtp only — NOT the PGR pass-through above).
+# Empty = OTP uses whatever SMS integration is primary; "ozeki" = attach the
+# Ozeki generic-sms overrides envelope (docs/Novu_Adapter/OZEKI-GENERIC-SMS-PROVIDER.md).
+novu.bridge.otp.sms.provider=${NOVU_BRIDGE_OTP_SMS_PROVIDER:}
+novu.bridge.ozeki.integration.identifier=${NOVU_BRIDGE_OZEKI_INTEGRATION_IDENTIFIER:ozeki-sms}
 # Subscriber identify (upsert) TTL cache window.
 novu.bridge.identify.cache.ttl.ms=${NOVU_BRIDGE_IDENTIFY_CACHE_TTL_MS:300000}
 # Channels actually delivered. WHATSAPP is intentionally absent until a

--- a/backend/novu-bridge/src/main/resources/application.properties
+++ b/backend/novu-bridge/src/main/resources/application.properties
@@ -48,6 +48,10 @@ novu.bridge.workflow.id.email=${NOVU_BRIDGE_WORKFLOW_ID_EMAIL:complaints-email}
 # Ozeki generic-sms overrides envelope (docs/Novu_Adapter/OZEKI-GENERIC-SMS-PROVIDER.md).
 novu.bridge.otp.sms.provider=${NOVU_BRIDGE_OTP_SMS_PROVIDER:}
 novu.bridge.ozeki.integration.identifier=${NOVU_BRIDGE_OZEKI_INTEGRATION_IDENTIFIER:ozeki-sms}
+# PGR pass-through SMS delivery via Ozeki (identifyThenTrigger only — NOT OTP above).
+# Empty = complaint SMS uses whatever's primary; "ozeki" = attach the Ozeki generic-sms
+# overrides envelope. WhatsApp/EMAIL are unaffected (see NovuBridgeConfiguration javadoc).
+novu.bridge.sms.provider=${NOVU_BRIDGE_SMS_PROVIDER:}
 # Subscriber identify (upsert) TTL cache window.
 novu.bridge.identify.cache.ttl.ms=${NOVU_BRIDGE_IDENTIFY_CACHE_TTL_MS:300000}
 # Channels actually delivered. WHATSAPP is intentionally absent until a


### PR DESCRIPTION
- Add OTP.SEND event handling in DispatchPipelineService with separate processing path
- Create OzekiOverridesBuilder to construct provider-specific overrides for Ozeki integration
- Add configuration properties for Ozeki SMS provider selection and integration identifier
- Implement phone number formatting for OTP recipients using tenant country codes
- Add dispatch log persistence for OTP events with status tracking
- Support optional Ozeki override envelope attachment to OTP triggers while keeping PGR SMS/WhatsApp delivery unchanged
- Add comprehensive Javadoc explaining OTP delivery flow and provider isolation from complaint workflows