### PR TITLE
fix(configurator): propagate localization edits on save (CCSD-2157)

### DIFF
--- a/configurator/src/admin/DigitEdit.tsx
+++ b/configurator/src/admin/DigitEdit.tsx
@@ -41,6 +41,11 @@ export interface DigitEditProps {
   redirect?: 'list' | 'edit' | 'show' | false;
   /** Optional pre-submit transform */
   transform?: TransformData;
+  /** Optional post-success side-effect — runs after update succeeds, before
+   *  the redirect (mirrors DigitCreate.afterCreate). Used e.g. to invalidate
+   *  the localization cache so an edited translation actually propagates.
+   *  Failures are surfaced as a toast; the redirect still fires. */
+  afterUpdate?: (data: RaRecord) => void | Promise<void>;
 }
 
 function DigitEditContent({
@@ -162,7 +167,7 @@ function DigitEditContent({
   );
 }
 
-export function DigitEdit({ title, children, resource, id, redirect = 'list', transform }: DigitEditProps) {
+export function DigitEdit({ title, children, resource, id, redirect = 'list', transform, afterUpdate }: DigitEditProps) {
   const { info, capture, clear } = useMutationError();
   const contextResource = useResourceContext();
   const redirectTo = useRedirect();
@@ -178,13 +183,24 @@ export function DigitEdit({ title, children, resource, id, redirect = 'list', tr
       transform={transform}
       mutationOptions={{
         onError: (err) => capture(err),
-        onSuccess: (data) => {
+        onSuccess: async (data) => {
           clear();
           const label = pickRecordLabel(data);
           toast({
             title: `${prettyResourceSingular(effectiveResource)} updated`,
             description: label !== 'Record' ? label : undefined,
           });
+          if (afterUpdate && data) {
+            try {
+              await afterUpdate(data as RaRecord);
+            } catch (e) {
+              toast({
+                title: 'Post-update step failed',
+                description: e instanceof Error ? e.message : String(e),
+                variant: 'destructive',
+              });
+            }
+          }
           if (redirect && effectiveResource) {
             redirectTo(redirect, effectiveResource, (data as RaRecord | undefined)?.id, data as RaRecord | undefined);
           }

--- a/configurator/src/resources/localization/LocalizationCreate.tsx
+++ b/configurator/src/resources/localization/LocalizationCreate.tsx
@@ -2,8 +2,13 @@ import { useMemo } from 'react';
 import { DigitCreate, DigitFormCodeInput, DigitFormInput, DigitFormSelect, v } from '@/admin';
 import { useAvailableLocales } from '@/hooks/useAvailableLocales';
 import { useLocalizationModules } from '@/hooks/useLocalizationModules';
+import { useLocalizationSaveRefresh } from './useLocalizationSaveRefresh';
 
-const DEFAULT_MODULE = 'rainmaker-common';
+// CCSD-2157: default new rows to configurator-ui — the module the Studio reads
+// with PRECEDENCE (see i18nProvider.fetchAppTranslations). A correction typed
+// against rainmaker-common was shadowed by any existing configurator-ui row for
+// the same code, so it appeared to "not save".
+const DEFAULT_MODULE = 'configurator-ui';
 
 const defaultRecord = {
   locale: 'en_IN',
@@ -16,6 +21,7 @@ export function LocalizationCreate() {
   // list view's paginated rows, which truncate at perPage and drop modules.
   const { modules } = useLocalizationModules(defaultRecord.locale);
   const { locales } = useAvailableLocales();
+  const refreshAfterSave = useLocalizationSaveRefresh();
 
   const moduleChoices = useMemo(
     () => modules.map((m) => ({ value: m, label: m })),
@@ -25,7 +31,7 @@ export function LocalizationCreate() {
   const localeChoices = locales.map((l) => ({ value: l.value, label: l.label }));
 
   return (
-    <DigitCreate title="Create Localization Message" record={defaultRecord}>
+    <DigitCreate title="Create Localization Message" record={defaultRecord} afterCreate={refreshAfterSave}>
       <DigitFormCodeInput source="code" label="Code" validate={v.codeRequired} />
       <DigitFormInput source="message" label="Message" validate={v.required} />
       <DigitFormSelect

--- a/configurator/src/resources/localization/LocalizationEdit.tsx
+++ b/configurator/src/resources/localization/LocalizationEdit.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { DigitEdit, DigitFormInput, DigitFormSelect, v } from '@/admin';
 import { useGetList } from 'ra-core';
 import { useAvailableLocales } from '@/hooks/useAvailableLocales';
+import { useLocalizationSaveRefresh } from './useLocalizationSaveRefresh';
 
 export function LocalizationEdit() {
   const { data } = useGetList('localization', {
@@ -9,6 +10,7 @@ export function LocalizationEdit() {
     sort: { field: 'module', order: 'ASC' },
   });
   const { locales } = useAvailableLocales();
+  const refreshAfterSave = useLocalizationSaveRefresh();
 
   const moduleChoices = useMemo(() => {
     if (!data || data.length === 0) {
@@ -21,7 +23,7 @@ export function LocalizationEdit() {
   const localeChoices = locales.map((l) => ({ value: l.value, label: l.label }));
 
   return (
-    <DigitEdit title="Edit Localization Message">
+    <DigitEdit title="Edit Localization Message" afterUpdate={refreshAfterSave}>
       <DigitFormInput source="code" label="Code" disabled />
       <DigitFormInput source="message" label="Message" validate={v.required} />
       <DigitFormSelect

--- a/configurator/src/resources/localization/useLocalizationSaveRefresh.ts
+++ b/configurator/src/resources/localization/useLocalizationSaveRefresh.ts
@@ -1,0 +1,43 @@
+import { useCallback } from 'react';
+import { useLocaleState } from 'ra-core';
+import { localizationService } from '@/api';
+import { clearTranslationCache } from '@/providers/bridge';
+
+/**
+ * CCSD-2157: after a Localization create/update, make the edit actually
+ * propagate to the rendered UI. Three caches sit between a saved row and the
+ * screen and none were being invalidated on save:
+ *
+ *   1. egov-localization's server-side assembled-response cache (Redis) — the
+ *      /_search the app calls keeps serving the pre-write snapshot until it is
+ *      busted (localizationService.cacheBust()).
+ *   2. the configurator's own localStorage translation cache (24h TTL) — read
+ *      on every boot, only cleared on login / tenant change, so a saved edit
+ *      stayed invisible for up to a day / until re-login.
+ *   3. react-admin's in-memory polyglot messages — loaded once per locale, so
+ *      even after 1+2 the current session keeps the stale strings until the
+ *      locale is reloaded.
+ *
+ * This hook returns a callback that clears all three: bust the server cache,
+ * clear the FE translation cache, then re-set the active locale so ra-core
+ * re-invokes the i18nProvider and re-fetches fresh messages (the app re-renders
+ * with the corrected string — no manual reload / re-login needed).
+ */
+export function useLocalizationSaveRefresh(): () => Promise<void> {
+  const [locale, setLocale] = useLocaleState();
+  return useCallback(async () => {
+    // 1. server cache — best-effort; a failure here still lets 2+3 run so a
+    //    reload picks up the change once the server TTL lapses.
+    try {
+      await localizationService.cacheBust();
+    } catch {
+      /* non-fatal */
+    }
+    // 2. FE localStorage + in-memory translation cache.
+    clearTranslationCache();
+    // 3. force ra-core to re-fetch messages for the active locale. changeLocale
+    //    runs regardless of whether the value changed, so the (now cache-cleared)
+    //    fetch hits the API and the tree re-renders with the new string.
+    if (locale) setLocale(locale);
+  }, [locale, setLocale]);
+}


### PR DESCRIPTION
Fixes the FE-fixable core of CCSD-2157: editing a Portuguese string in the Studio's **Localization** settings saved successfully but **never reached the rendered UI** (until re-login or the 24h cache TTL).

## Root cause — three caches, none invalidated on save
`clearTranslationCache` was only wired to login / tenant-change / `resetProviders`, never to the create/update path. So between a saved row and the screen:
1. **egov-localization server cache** (Redis) — `/_search` kept serving the pre-write snapshot
2. **configurator localStorage cache** (24h TTL) — read on every boot
3. **react-admin in-memory polyglot** — loaded once per locale

Plus the Create form defaulted new rows to `rainmaker-common`, while the Studio reads **`configurator-ui` with precedence** — so a correction was shadowed by any existing `configurator-ui` row and looked like it "didn't save".

## Fix (FE-only, `configurator/src`)
- New `useLocalizationSaveRefresh` hook: on save → **cache-bust** (server) + **clearTranslationCache** (FE, all locales) + **re-set active locale** so ra-core re-fetches and the tree re-renders with the correction.
- Wired via `DigitCreate.afterCreate` and a **new `DigitEdit.afterUpdate`** hook on `LocalizationCreate` / `LocalizationEdit`.
- Create default module `rainmaker-common` → **`configurator-ui`**.

## Verified in the real running app
Local mz stack, `ADMIN@mz` (SUPERUSER), Management mode:
- Create form now defaults **module = configurator-ui** ✅
- On Save the network shows **`_upsert` → `cache-bust` → `_search`** (re-fetch) ✅
- All `digit-i18n-*` localStorage cache keys **cleared** ✅

→ edits now propagate immediately, no re-login / 24h wait.

## Out of scope (documented on the ticket)
The **"cannot be edited"** strings — `ra.*` framework bundle, the hardcoded Documentation panel, the static browser tab title — are a separate, larger refactor onto i18n keys, not in this PR. Also: the `configurator-ui` pt rows must actually be **seeded** for a tenant, and a server-side upsert done outside the Studio still needs its own `cache-bust` (both infra, not FE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)