### PR TITLE
fix(pgr): history-derived assignee was inert — broken URL key + wrong search tenant (CCSD-2167)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Rating/SelectRating.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Rating/SelectRating.js
@@ -195,9 +195,12 @@ const SelectRating = ({ parentRoute }) => {
     // as required; the backend will be changed to accept the assignee on the
     // RATE transition. Until that lands, rating a complaint that HAS a case
     // manager in history will 400 on this env — expected and tracked.
-    const stateCode = Digit.ULBService.getStateId();
+    // Search at the COMPLAINT's tenant (its process instances live where it
+    // was filed, e.g. mz.ige) — a state-tenant search silently finds nothing
+    // on city-tenanted complaints and the derivation becomes a no-op.
+    const wfTenant = complaintDetails?.service?.tenantId || Digit.ULBService.getStateId();
     const businessId = complaintDetails?.service?.serviceRequestId || id;
-    const caseManagerUuid = await findLatestAssigneeUuidByRole(stateCode, businessId, "CMS_CASE_MANAGER");
+    const caseManagerUuid = await findLatestAssigneeUuidByRole(wfTenant, businessId, "CMS_CASE_MANAGER");
     complaintDetails.workflow = {
       action: "RATE",
       comments,

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ReopenComplaint/AddtionalDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ReopenComplaint/AddtionalDetails.js
@@ -81,9 +81,10 @@ const AddtionalDetails = (props) => {
     let reopenDetails = Digit.SessionStorage.get(`reopen.${id}`);
     if (complaintDetails) {
       // CCSD-2167: find the Supervisor from the complaint's workflow history.
-      const stateCode = Digit.ULBService.getStateId();
+      // Complaint's tenant, not the state root — see SelectRating.js note.
+      const wfTenant = complaintDetails?.service?.tenantId || Digit.ULBService.getStateId();
       const businessId = complaintDetails?.service?.serviceRequestId || id;
-      const supervisorUuid = await findLatestAssigneeUuidByRole(stateCode, businessId, "CMS_SUPERVISOR");
+      const supervisorUuid = await findLatestAssigneeUuidByRole(wfTenant, businessId, "CMS_SUPERVISOR");
       const assignes = supervisorUuid ? [supervisorUuid] : [];
       complaintDetails.workflow = getUpdatedWorkflow(
         reopenDetails,

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
@@ -364,9 +364,12 @@ const PGRDetails = () => {
     const derivedRole = HISTORY_DERIVED_ASSIGNEE_ROLE[selectedAction.action];
     let assigneeUuid = pickedUuid;
     if (!pickedUuid && derivedRole) {
-      const stateCode = Digit.ULBService.getStateId();
+      // Search history at the COMPLAINT's tenant: its process instances live
+      // where it was filed (e.g. mz.ige), and a state-tenant search silently
+      // returns nothing there — the resolver then derived null every time.
+      const wfTenant = baseService?.tenantId || Digit.ULBService.getStateId();
       const businessId = baseService?.serviceRequestId;
-      assigneeUuid = await findLatestAssigneeUuidByRole(stateCode, businessId, derivedRole);
+      assigneeUuid = await findLatestAssigneeUuidByRole(wfTenant, businessId, derivedRole);
     }
     // Parse (object OR stringified) so stamping never discards existing keys
     // like supervisorName / serviceName that older flows stored as a string.

--- a/digit-ui-esbuild/products/pgr/src/services/workflow/Workflow.js
+++ b/digit-ui-esbuild/products/pgr/src/services/workflow/Workflow.js
@@ -39,7 +39,13 @@ export const WorkflowService = {
       },
       getByBusinessId: (stateCode, businessIds, params = {}, history = true) => {
         return Request({
-          url: Urls.WorkFlowProcessSearch,
+          // CCSD-2167: was `Urls.WorkFlowProcessSearch` — a key that has never
+          // existed in this module's urls.js (the real one is
+          // Urls.workflow.processSearch), so every call fetched `undefined` and
+          // callers that swallowed the error silently got nothing. This is why
+          // the history-derived assignee (reopen/rate/reassign) never reached
+          // the payload despite the logic being right.
+          url: Urls.workflow.processSearch,
           useCache: false,
           method: "POST",
           params: { tenantId: stateCode, businessIds: businessIds, ...params, history },

--- a/digit-ui-esbuild/products/pgr/src/utils/urls.js
+++ b/digit-ui-esbuild/products/pgr/src/utils/urls.js
@@ -18,7 +18,9 @@ const Urls = {
     update: `/pgr-services/v2/request/_update`,
   },
   workflow: {
-    processSearch: `egov-workflow-v2/egov-wf/process/_search`,
+    // Leading slash matters: Request() joins this onto the host, and the
+    // unslashed form produced a relative (broken) URL. (CCSD-2167)
+    processSearch: `/egov-workflow-v2/egov-wf/process/_search`,
     businessServiceSearch:  `/egov-workflow-v2/egov-wf/businessservice/_search`,
   }
 };

--- a/digit-ui-esbuild/products/pgr/src/utils/workflowAssignee.js
+++ b/digit-ui-esbuild/products/pgr/src/utils/workflowAssignee.js
@@ -40,8 +40,11 @@ export const findLatestAssigneeUuidByRole = async (stateCode, businessId, roleCo
   try {
     response = await WorkflowService.getByBusinessId(stateCode, businessId, {}, true);
   } catch (e) {
-    // Never block the citizen's reopen/rate on a history-fetch failure —
-    // fall back to no assignee (the pre-2167 behaviour).
+    // Never block the reopen/rate/reassign on a history-fetch failure — fall
+    // back to no assignee (the pre-2167 behaviour). But say so: this catch
+    // silently masked a broken URL (Urls.WorkFlowProcessSearch never existed)
+    // for days, making the whole derivation a no-op in every browser.
+    console.warn(`workflowAssignee: history fetch failed for ${businessId}; sending no assignee`, e);
     return null;
   }
   const instances = Array.isArray(response && response.ProcessInstances) ? response.ProcessInstances : [];


### PR DESCRIPTION
Delivers commit `4d268d8f` (pushed after #1715 merged). **This is the commit that makes the whole CCSD-2167 assignee derivation actually work** — deep verification on cms-pilot showed the derived assignee never reached the payload, and an XHR trace pinned two independent bugs:

## Bug 1 — a URL key that never existed
`products/pgr` `WorkflowService.getByBusinessId` fetched **`Urls.WorkFlowProcessSearch`** — no such key in this module's `urls.js` (real key: `Urls.workflow.processSearch`, which was *also* missing its leading slash). Request → garbage URL → the resolver's **silent catch** swallowed it → derivation returned `null` **every time, in every browser** (citizen reopen/rate AND employee route-backs). Only the resolver uses this copy of the service (timelines use the `libraries` copy), so nothing else ever noticed.

## Bug 2 — searching history at the wrong tenant
The resolver searched at the **state** tenant (`getStateId()`), but a complaint's process instances live at the complaint's own tenant (e.g. `mz.ige`) — zero results, null again. All three call sites now pass **`service.tenantId`** (state id only as fallback).

Also: the resolver's catch now `console.warn`s — the silent catch is what masked Bug 1 completely.

## Proof it was broken (cms-pilot, live)
- UI send-back stored `assignes=[]`; API replay of the same REASSIGN **with an explicit assignee persisted fine** → backend accepts it, FE never sent it.
- XHR trace: **no history search fired before `_update`**.

## Proof it's fixed (real running app, exact reported scenario)
EMP417 (screening officer, dept *central*) assigned `P-2026-000041` → EMP315 (pure supervisor, *defence* dept). EMP315 clicked **Re-assign** in the UI, picked nobody, submitted:
- history search fired **before** the update, at `tenantId=mz.ige` ✅
- update payload carried `assignes=[EMP417 uuid]` ✅
- stored workflow: `REASSIGN → PENDINGFORREASSIGNMENT, assignes=[EMP417 (CMS_SCREENING_OFFICER)]` ✅

## Impact
- Employee send-back/REASSIGN → screening officer: **works after this**
- Citizen reopen → supervisor: now genuinely derived in-browser
- Citizen/employee RATE → case manager: FE sends it; still needs the backend to accept an assignee on the terminal RATE (unchanged dependency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)