### PR TITLE
fix(dashboard): restore scoped KPI layout persistence

### DIFF
--- a/digit-ui-esbuild/products/dashboard/src/hooks/useCatalogLayout.js
+++ b/digit-ui-esbuild/products/dashboard/src/hooks/useCatalogLayout.js
@@ -1,13 +1,18 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-  GRID_COLS,
-  UNIFORM_CHART_SIZE_CONSTRAINTS,
-  MAP_SIZE_CONSTRAINTS,
-  FULL_WIDTH_TABLE_GRID,
-  DEFAULT_CHART_GRID,
-  DROPPING_ITEM_ID,
-} from "../constants/layoutConfig";
+import { GRID_COLS, DROPPING_ITEM_ID } from "../constants/layoutConfig";
+import { getEmployeeInfo, getTenantId } from "../services/authService";
 import { createCatalogDragGeometry, isCatalogCard } from "../utils/catalogDragGeometry";
+import {
+  LEGACY_STORAGE_KEY,
+  storageKeyFor,
+  readSavedLayout,
+  persistLayout,
+  buildSeedLayout,
+  normalizeItem,
+  resolveInitialLayout,
+  sizeConstraintsForKpi,
+  defaultSizeForKpi,
+} from "../utils/layoutStore";
 
 /**
  * useCatalogLayout — catalog-world layout hook (kpiId-keyed).
@@ -17,55 +22,7 @@ import { createCatalogDragGeometry, isCatalogCard } from "../utils/catalogDragGe
  * swap + column-aware compaction on stop, RGL re-sync via moved flag.
  */
 
-const STORAGE_KEY = "ccrs.dashboard.catalog-layout.v1";
-
-const CARD_KINDS = new Set([
-  "number-tile-delta",
-  "number-tile",
-  "scalar",
-  "number-tile-sparkline",
-  "sparkline-card",
-]);
-
-const KPI_CARD_CONSTRAINTS = { minW: 2, minH: 2, maxW: 6, maxH: 3 };
-const LIST_CONSTRAINTS = { minW: 3, minH: 4, maxW: 12, maxH: 12 };
-
-export function sizeConstraintsForKpi(kpiId, kpis) {
-  const kind = kpis?.[kpiId]?.viz?.kind;
-  if (CARD_KINDS.has(kind)) return KPI_CARD_CONSTRAINTS;
-  switch (kind) {
-    case "map":
-    case "choropleth-map":
-      return MAP_SIZE_CONSTRAINTS;
-    case "sla-risk-table":
-    case "table":
-    case "data-table":
-      return {
-        minW: FULL_WIDTH_TABLE_GRID.minW,
-        minH: FULL_WIDTH_TABLE_GRID.minH,
-        maxW: FULL_WIDTH_TABLE_GRID.maxW,
-        maxH: FULL_WIDTH_TABLE_GRID.maxH,
-      };
-    case "rankedList":
-    case "dow":
-      return LIST_CONSTRAINTS;
-    default:
-      return UNIFORM_CHART_SIZE_CONSTRAINTS;
-  }
-}
-
-export function defaultSizeForKpi(kpiId, kpis) {
-  const kind = kpis?.[kpiId]?.viz?.kind;
-  if (CARD_KINDS.has(kind)) return { w: 2, h: 2 };
-  if (kind === "map" || kind === "choropleth-map") return { w: 8, h: 6 };
-  if (kind === "sla-risk-table" || kind === "table" || kind === "data-table") {
-    return { w: FULL_WIDTH_TABLE_GRID.w, h: FULL_WIDTH_TABLE_GRID.h };
-  }
-  if (kind === "rankedList" || kind === "dow") {
-    return { w: 6, h: 6 };
-  }
-  return { ...DEFAULT_CHART_GRID };
-}
+export { sizeConstraintsForKpi, defaultSizeForKpi };
 
 export function getDroppingItemForKpi(kpiId, kpis) {
   const c = sizeConstraintsForKpi(kpiId, kpis);
@@ -73,49 +30,17 @@ export function getDroppingItemForKpi(kpiId, kpis) {
   return { i: DROPPING_ITEM_ID, w, h, x: 0, y: 0, ...c };
 }
 
-function clampNum(v, min, max, fallback) {
-  const n = Number(v);
-  if (!Number.isFinite(n)) return fallback;
-  return Math.min(max, Math.max(min, n));
-}
-
-function normalizeItem(item, kpis) {
-  const c = sizeConstraintsForKpi(item.i, kpis);
-  const w = clampNum(item.w, c.minW, c.maxW, c.minW);
-  const h = clampNum(item.h, c.minH, c.maxH, c.minH);
-  const x = Math.min(clampNum(item.x, 0, GRID_COLS - 1, 0), GRID_COLS - w);
-  const y = clampNum(item.y, 0, Number.MAX_SAFE_INTEGER, 0);
-  return { i: item.i, x, y, w, h, ...c };
-}
-
-function buildSeedLayout(packLayout, kpis) {
-  return (packLayout || [])
-    .filter((item) => kpis[item.kpiId])
-    .map((item) =>
-      normalizeItem({ i: item.kpiId, x: item.x, y: item.y, w: item.w, h: item.h }, kpis)
-    );
+function scopedStorageKey() {
+  return storageKeyFor(getTenantId(), getEmployeeInfo()?.uuid);
 }
 
 function readSaved() {
-  try {
-    const raw = window.localStorage?.getItem(STORAGE_KEY);
-    if (raw == null) return null;
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed : null;
-  } catch {
-    return null;
-  }
-}
-
-function persistPositions(layout) {
-  try {
-    window.localStorage?.setItem(
-      STORAGE_KEY,
-      JSON.stringify(layout.map(({ i, x, y, w, h }) => ({ i, x, y, w, h })))
-    );
-  } catch {
-    /* ignore */
-  }
+  const scopedKey = scopedStorageKey();
+  return readSavedLayout(
+    window.localStorage,
+    scopedKey,
+    scopedKey === LEGACY_STORAGE_KEY ? undefined : LEGACY_STORAGE_KEY
+  );
 }
 
 /** Re-attach min/max constraints after geometry helpers strip them to positions only. */
@@ -131,12 +56,13 @@ function canonicalizeLayout(layout, kpis) {
 }
 
 function persist(layout) {
-  persistPositions(layout);
+  persistLayout(window.localStorage, scopedStorageKey(), layout);
 }
 
 export function useCatalogLayout(kpis, packLayout) {
   const seed = useMemo(() => buildSeedLayout(packLayout, kpis), [packLayout, kpis]);
   const geom = useMemo(() => createCatalogDragGeometry(kpis), [kpis]);
+  const catalogReady = Object.keys(kpis || {}).length > 0;
 
   const [layout, setLayout] = useState([]);
   const [gridSyncKey, setGridSyncKey] = useState(0);
@@ -149,19 +75,16 @@ export function useCatalogLayout(kpis, packLayout) {
   layoutRef.current = layout;
 
   useEffect(() => {
-    if (!seed.length) return;
+    if (!catalogReady) return;
     const saved = readSaved();
-    const source = saved !== null ? saved : seed;
-    const reconciled = source
-      .filter((item) => kpis[item.i])
-      .map((item) => normalizeItem(item, kpis));
+    const reconciled = resolveInitialLayout(saved, seed, kpis);
     const repaired = geom.hasOverlaps(reconciled)
       ? geom.resolveRemainingOverlaps(reconciled, [])
       : reconciled;
     setLayout(repaired);
     if (repaired !== reconciled) persist(repaired);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [seed, geom]);
+  }, [seed, catalogReady, geom]);
 
   const syncFlagRef = useRef(false);
   const stampSync = useCallback((next) => {
@@ -173,7 +96,7 @@ export function useCatalogLayout(kpis, packLayout) {
   const applyLayout = useCallback(
     (next) => {
       const normalized = canonicalizeLayout(next, kpis);
-      persistPositions(normalized);
+      persist(normalized);
       setLayout(stampSync(normalized));
     },
     [stampSync, kpis]

--- a/digit-ui-esbuild/products/dashboard/src/hooks/useCatalogLayout.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/hooks/useCatalogLayout.test.js
@@ -1,0 +1,140 @@
+// Hook-level regression coverage for #1276.
+// Run from digit-ui-esbuild/:
+//   node --test products/dashboard/src/hooks/useCatalogLayout.test.js
+
+const { test, before, beforeEach, after } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const esbuild = require("esbuild");
+
+const bundlePath = path.join(
+  os.tmpdir(),
+  `useCatalogLayout.cjs.${process.pid}.js`
+);
+
+let useCatalogLayout;
+
+before(async () => {
+  await esbuild.build({
+    entryPoints: [path.join(__dirname, "useCatalogLayout.js")],
+    bundle: true,
+    format: "cjs",
+    platform: "node",
+    outfile: bundlePath,
+    plugins: [
+      {
+        name: "hook-test-mocks",
+        setup(build) {
+          build.onResolve({ filter: /^react$/ }, () => ({
+            path: "react",
+            namespace: "hook-test",
+          }));
+          build.onResolve({ filter: /services\/authService$/ }, () => ({
+            path: "authService",
+            namespace: "hook-test",
+          }));
+          build.onLoad({ filter: /.*/, namespace: "hook-test" }, (args) => {
+            if (args.path === "authService") {
+              return {
+                contents: `
+                  export const getTenantId = () => globalThis.__catalogTestTenant;
+                  export const getEmployeeInfo = () => ({ uuid: globalThis.__catalogTestUser });
+                `,
+                loader: "js",
+              };
+            }
+            return {
+              contents: `
+                export const useMemo = (factory) => factory();
+                export const useCallback = (callback) => callback;
+                export const useRef = (value) => ({ current: value });
+                export const useEffect = (effect) => effect();
+                export const useState = (value) => {
+                  const index = globalThis.__catalogTestState.length;
+                  globalThis.__catalogTestState.push(value);
+                  return [value, (next) => {
+                    const current = globalThis.__catalogTestState[index];
+                    globalThis.__catalogTestState[index] =
+                      typeof next === "function" ? next(current) : next;
+                  }];
+                };
+              `,
+              loader: "js",
+            };
+          });
+        },
+      },
+    ],
+  });
+  ({ useCatalogLayout } = require(bundlePath));
+});
+
+after(() => {
+  try {
+    fs.unlinkSync(bundlePath);
+  } catch {
+    /* already gone */
+  }
+  delete globalThis.window;
+});
+
+function fakeStorage(initial = {}) {
+  const values = new Map(Object.entries(initial));
+  return {
+    getItem: (key) => (values.has(key) ? values.get(key) : null),
+    setItem: (key, value) => values.set(key, String(value)),
+  };
+}
+
+const KPIS = {
+  card_a: { kpiId: "card_a", viz: { kind: "number-tile" } },
+  chart_a: { kpiId: "chart_a", viz: { kind: "stacked-bar" } },
+};
+
+const storedItem = (i) => ({ i, x: 0, y: 0, w: 2, h: 2 });
+
+beforeEach(() => {
+  globalThis.__catalogTestTenant = "ke";
+  globalThis.__catalogTestUser = "user-a";
+  globalThis.__catalogTestState = [];
+});
+
+test("rehydrates a saved Add-KPI layout when the pack seed is empty", () => {
+  globalThis.window = {
+    localStorage: fakeStorage({
+      "ccrs.dashboard.catalog-layout.v1.ke.user-a": JSON.stringify([
+        storedItem("card_a"),
+      ]),
+    }),
+  };
+
+  useCatalogLayout(KPIS, []);
+
+  assert.deepEqual(
+    globalThis.__catalogTestState[0].map((item) => item.i),
+    ["card_a"]
+  );
+});
+
+test("hydrates only the current tenant and user's saved layout", () => {
+  globalThis.window = {
+    localStorage: fakeStorage({
+      "ccrs.dashboard.catalog-layout.v1.ke.user-a": JSON.stringify([
+        storedItem("card_a"),
+      ]),
+      "ccrs.dashboard.catalog-layout.v1.ke.user-b": JSON.stringify([
+        storedItem("chart_a"),
+      ]),
+    }),
+  };
+  globalThis.__catalogTestUser = "user-b";
+
+  useCatalogLayout(KPIS, []);
+
+  assert.deepEqual(
+    globalThis.__catalogTestState[0].map((item) => item.i),
+    ["chart_a"]
+  );
+});

--- a/digit-ui-esbuild/products/dashboard/src/utils/layoutStore.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/layoutStore.js
@@ -4,6 +4,7 @@ import {
   UNIFORM_CHART_SIZE_CONSTRAINTS,
   MAP_SIZE_CONSTRAINTS,
   FULL_WIDTH_TABLE_GRID,
+  DEFAULT_CHART_GRID,
   findFirstOpenPosition,
 } from "../constants/layoutConfig";
 import { compactVertically, compactAroundPinned } from "./gridGeometry";
@@ -72,13 +73,13 @@ export function sizeConstraintsForKpi(kpiId, kpis) {
 
 /** Default size for a freshly-added tile, by kind. */
 export function defaultSizeForKpi(kpiId, kpis) {
-  const c = sizeConstraintsForKpi(kpiId, kpis);
   const kind = kpis?.[kpiId]?.viz?.kind;
   if (CARD_KINDS.has(kind)) return { w: 2, h: 2 };
   if (kind === "map" || kind === "choropleth-map") return { w: 8, h: 6 };
   if (kind === "sla-risk-table" || kind === "table" || kind === "data-table")
-    return { w: 12, h: 5 };
-  return { w: Math.max(c.minW, 6), h: Math.max(c.minH, 6) };
+    return { w: FULL_WIDTH_TABLE_GRID.w, h: FULL_WIDTH_TABLE_GRID.h };
+  if (kind === "rankedList" || kind === "dow") return { w: 6, h: 6 };
+  return { ...DEFAULT_CHART_GRID };
 }
 
 function clampNum(v, min, max, fallback) {

--- a/digit-ui-esbuild/products/dashboard/src/utils/layoutStore.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/layoutStore.test.js
@@ -296,11 +296,11 @@ test("click add is UNCHANGED by drop-placement parity: appends at the first open
   assert.deepEqual({ x: untouched.x, y: untouched.y }, { x: 0, y: 0 });
 });
 
-test("defaultSizeForKpi sizes cards/charts/maps/tables distinctly", () => {
+test("defaultSizeForKpi preserves the existing add-KPI geometry contract", () => {
   assert.deepEqual(defaultSizeForKpi("card_a", KPIS), { w: 2, h: 2 });
   assert.deepEqual(defaultSizeForKpi("map_a", KPIS), { w: 8, h: 6 }); // incl. choropleth-map
-  assert.deepEqual(defaultSizeForKpi("table_a", KPIS), { w: 12, h: 5 });
-  assert.deepEqual(defaultSizeForKpi("chart_a", KPIS), { w: 6, h: 6 });
+  assert.deepEqual(defaultSizeForKpi("table_a", KPIS), { w: 12, h: 6 });
+  assert.deepEqual(defaultSizeForKpi("chart_a", KPIS), { w: 4, h: 6 });
 });
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
Fixes #1276.

## What changed

- reconnects `useCatalogLayout` to the existing tested `layoutStore` helpers instead of duplicating persistence and geometry logic
- hydrates saved Add-KPI layouts when the role-visible catalog is ready, even when the pack returns `defaultLayout: []`
- scopes layout storage by tenant and employee UUID, with the legacy global key retained as a read-only migration fallback
- adds hook-level regression coverage for empty-pack hydration and cross-user isolation

## Scope

This is the focused extraction from #1407. It deliberately excludes Portuguese localization, header/CSS changes, seed tooling, catalog fallback behavior, and auth transport rewrites.

The drag/drop attach path and empty-grid drop target from #1287/#1311 are unchanged.

## Validation

- `node --test $(rg --files products/dashboard -g "*.test.js")` — 176/176 passing
- `npm run build` — passing (existing repository warnings only)
- merged with #1703 locally and reran its expanded dashboard suite — 216/216 passing; employee and public bundles build

## Conflict check

`git merge-tree --write-tree` is clean against both active dashboard branches:

- #1695 (`fix/dashboard-business-calendar`)
- #1703 (`feat/1540-public-dashboard`), which now contains the pre-resolved combined hook behavior so either PR can land first

🤖 Scoped with Claude Code Sonnet agents.