### PR TITLE
fix(pgr): citizen rating must not be blocked by the terminal-assignee rejection (CCSD-2167)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Rating/SelectRating.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Rating/SelectRating.js
@@ -211,10 +211,26 @@ const SelectRating = ({ parentRoute }) => {
     try {
       // Await — Response.js reads the redux slice on mount and a race
       // here used to leave it blank (CCRS#473).
-      await updateComplaint({
-        service: complaintDetails.service,
-        workflow: complaintDetails.workflow,
-      });
+      try {
+        await updateComplaint({
+          service: complaintDetails.service,
+          workflow: complaintDetails.workflow,
+        });
+      } catch (err) {
+        // KNOWN BACKEND GAP fallback: the backend still rejects an assignee on
+        // the terminal RATE transition (400 INVALID_ASSIGNEE). Sending the
+        // case-manager id is the requirement — but a citizen must NEVER be
+        // unable to rate because of it. Retry once without the assignee; when
+        // the backend change lands this branch simply stops firing.
+        if (!caseManagerUuid) throw err;
+        console.warn("RATE with assignee rejected by backend (terminal-state gap) — retrying without assignee", err);
+        const { assignes, hrmsAssignes, ...workflowNoAssignee } = complaintDetails.workflow;
+        complaintDetails.workflow = workflowNoAssignee;
+        await updateComplaint({
+          service: complaintDetails.service,
+          workflow: workflowNoAssignee,
+        });
+      }
       // Invalidate the cached complaint-details + complaints-list
       // queries so when the citizen navigates back to /complaint-
       // details the page refetches with the freshly-saved rating.


### PR DESCRIPTION
Follow-up to #1716. Now that the assignee derivation actually works, the citizen **RATE** sends the Case Manager id — and the backend's known 400 on terminal-state assignees started **blocking rating entirely** (verified live on cms-pilot: derived uuid in payload → 400 → citizen stuck).

## Fix
Send the assignee as required; **on failure with an assignee present, retry once without it** (`console.warn`s the backend gap). Citizen can always rate. When the backend accepts terminal assignees, the retry branch stops firing on its own.

## Verified (real running app, citizen UI)
`_update RATE assignes=[caseManager]` → **400** → automatic retry without assignee → **200** → success page. Non-CMS workflows unaffected.

## Reminder — backend dependency still open
For the Case-Manager id to actually **persist** on RATE, egov-workflow/pgr must accept an assignee on the terminal transition. Until then this fallback keeps citizens unblocked while the FE keeps sending the id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)