### PR TITLE
fix(local-setup): align legacy Flyway history-table names to canonical

### DIFF
--- a/local-setup/docker-compose.db-migrations.yml
+++ b/local-setup/docker-compose.db-migrations.yml
@@ -194,7 +194,10 @@ services:
       SPRING_FLYWAY_BASELINE_ON_MIGRATE: 'true'
       SPRING_FLYWAY_VALIDATE_ON_MIGRATE: 'false'
       SPRING_FLYWAY_ENABLED: 'true'
-      SPRING_FLYWAY_TABLE: enc_schema_version
+      # egov_enc_service_schema is the canonical name (db/flyway-history-map.yml);
+      # enc_schema_version is a legacy alias that must never be (re)created,
+      # or db-history-normalize aborts the next canonical deploy on ambiguity.
+      SPRING_FLYWAY_TABLE: egov_enc_service_schema
       SERVER_PORT: 1234
       OTEL_TRACES_EXPORTER: none
       # DEV ONLY - override via .env or environment for non-local use
@@ -244,7 +247,10 @@ services:
       SPRING_FLYWAY_BASELINE_ON_MIGRATE: 'true'
       SPRING_FLYWAY_VALIDATE_ON_MIGRATE: 'false'
       SPRING_FLYWAY_ENABLED: 'true'
-      SPRING_FLYWAY_TABLE: mdms_schema_version
+      # mdms_v2_schema is the canonical name (db/flyway-history-map.yml);
+      # mdms_schema_version is a legacy alias that must never be (re)created,
+      # or db-history-normalize aborts the next canonical deploy on ambiguity.
+      SPRING_FLYWAY_TABLE: mdms_v2_schema
       KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SPRING_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SERVER_PORT: 8094
@@ -553,7 +559,10 @@ services:
       SPRING_FLYWAY_BASELINE_ON_MIGRATE: 'true'
       SPRING_FLYWAY_VALIDATE_ON_MIGRATE: 'false'
       SPRING_FLYWAY_ENABLED: 'true'
-      SPRING_FLYWAY_TABLE: workflow_schema_version
+      # egov_workflow_v2_schema is the canonical name (db/flyway-history-map.yml);
+      # workflow_schema_version is a legacy alias that must never be (re)created,
+      # or db-history-normalize aborts the next canonical deploy on ambiguity.
+      SPRING_FLYWAY_TABLE: egov_workflow_v2_schema
       KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SPRING_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SERVER_PORT: 8109
@@ -649,7 +658,10 @@ services:
       SPRING_FLYWAY_BASELINE_ON_MIGRATE: 'true'
       SPRING_FLYWAY_VALIDATE_ON_MIGRATE: 'false'
       SPRING_FLYWAY_ENABLED: 'true'
-      SPRING_FLYWAY_TABLE: boundary_schema_version
+      # boundary_service_schema is the canonical name (db/flyway-history-map.yml);
+      # boundary_schema_version is a legacy alias that must never be (re)created,
+      # or db-history-normalize aborts the next canonical deploy on ambiguity.
+      SPRING_FLYWAY_TABLE: boundary_service_schema
       KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SPRING_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SERVER_PORT: 8081
@@ -788,7 +800,10 @@ services:
       SPRING_FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
       SPRING_FLYWAY_BASELINE_ON_MIGRATE: 'true'
       SPRING_FLYWAY_ENABLED: 'true'
-      SPRING_FLYWAY_TABLE: filestore_schema_version
+      # egov_filestore_schema is the canonical name (db/flyway-history-map.yml);
+      # filestore_schema_version is a legacy alias that must never be (re)created,
+      # or db-history-normalize aborts the next canonical deploy on ambiguity.
+      SPRING_FLYWAY_TABLE: egov_filestore_schema
       SERVER_PORT: 8083
       OTEL_TRACES_EXPORTER: none
       JAVA_TOOL_OPTIONS: -Xms64m -Xmx192m
@@ -884,7 +899,10 @@ services:
       SPRING_FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
       SPRING_FLYWAY_BASELINE_ON_MIGRATE: 'true'
       SPRING_FLYWAY_ENABLED: 'true'
-      SPRING_FLYWAY_TABLE: hrms_schema_version
+      # egov_hrms_schema is the canonical name (db/flyway-history-map.yml);
+      # hrms_schema_version is a legacy alias that must never be (re)created,
+      # or db-history-normalize aborts the next canonical deploy on ambiguity.
+      SPRING_FLYWAY_TABLE: egov_hrms_schema
       KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SPRING_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SPRING_KAFKA_CONSUMER_GROUP_ID: employee-group1

--- a/local-setup/docker-compose.registry.yml
+++ b/local-setup/docker-compose.registry.yml
@@ -392,7 +392,10 @@ services:
       SPRING_FLYWAY_BASELINE_ON_MIGRATE: 'true'
       SPRING_FLYWAY_VALIDATE_ON_MIGRATE: 'false'
       SPRING_FLYWAY_ENABLED: 'true'
-      SPRING_FLYWAY_TABLE: enc_schema_version
+      # egov_enc_service_schema is the canonical name (db/flyway-history-map.yml);
+      # enc_schema_version is a legacy alias that must never be (re)created,
+      # or db-history-normalize aborts the next canonical deploy on ambiguity.
+      SPRING_FLYWAY_TABLE: egov_enc_service_schema
       SERVER_PORT: 1234
       OTEL_TRACES_EXPORTER: otlp
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
@@ -444,7 +447,10 @@ services:
       SPRING_FLYWAY_BASELINE_ON_MIGRATE: 'true'
       SPRING_FLYWAY_VALIDATE_ON_MIGRATE: 'false'
       SPRING_FLYWAY_ENABLED: 'true'
-      SPRING_FLYWAY_TABLE: mdms_schema_version
+      # mdms_v2_schema is the canonical name (db/flyway-history-map.yml);
+      # mdms_schema_version is a legacy alias that must never be (re)created,
+      # or db-history-normalize aborts the next canonical deploy on ambiguity.
+      SPRING_FLYWAY_TABLE: mdms_v2_schema
       KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SPRING_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SERVER_PORT: 8094
@@ -782,7 +788,10 @@ services:
       SPRING_FLYWAY_BASELINE_ON_MIGRATE: 'true'
       SPRING_FLYWAY_VALIDATE_ON_MIGRATE: 'false'
       SPRING_FLYWAY_ENABLED: 'true'
-      SPRING_FLYWAY_TABLE: workflow_schema_version
+      # egov_workflow_v2_schema is the canonical name (db/flyway-history-map.yml);
+      # workflow_schema_version is a legacy alias that must never be (re)created,
+      # or db-history-normalize aborts the next canonical deploy on ambiguity.
+      SPRING_FLYWAY_TABLE: egov_workflow_v2_schema
       KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SPRING_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SERVER_PORT: 8109
@@ -912,7 +921,10 @@ services:
       SPRING_FLYWAY_BASELINE_ON_MIGRATE: 'true'
       SPRING_FLYWAY_VALIDATE_ON_MIGRATE: 'false'
       SPRING_FLYWAY_ENABLED: 'true'
-      SPRING_FLYWAY_TABLE: boundary_schema_version
+      # boundary_service_schema is the canonical name (db/flyway-history-map.yml);
+      # boundary_schema_version is a legacy alias that must never be (re)created,
+      # or db-history-normalize aborts the next canonical deploy on ambiguity.
+      SPRING_FLYWAY_TABLE: boundary_service_schema
       KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SPRING_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SERVER_PORT: 8081
@@ -1064,7 +1076,10 @@ services:
       SPRING_FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
       SPRING_FLYWAY_BASELINE_ON_MIGRATE: 'true'
       SPRING_FLYWAY_ENABLED: 'true'
-      SPRING_FLYWAY_TABLE: filestore_schema_version
+      # egov_filestore_schema is the canonical name (db/flyway-history-map.yml);
+      # filestore_schema_version is a legacy alias that must never be (re)created,
+      # or db-history-normalize aborts the next canonical deploy on ambiguity.
+      SPRING_FLYWAY_TABLE: egov_filestore_schema
       SERVER_PORT: 8083
       OTEL_TRACES_EXPORTER: otlp
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
@@ -1164,7 +1179,10 @@ services:
       SPRING_FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-egov123}
       SPRING_FLYWAY_BASELINE_ON_MIGRATE: 'true'
       SPRING_FLYWAY_ENABLED: 'true'
-      SPRING_FLYWAY_TABLE: hrms_schema_version
+      # egov_hrms_schema is the canonical name (db/flyway-history-map.yml);
+      # hrms_schema_version is a legacy alias that must never be (re)created,
+      # or db-history-normalize aborts the next canonical deploy on ambiguity.
+      SPRING_FLYWAY_TABLE: egov_hrms_schema
       KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SPRING_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       SPRING_KAFKA_CONSUMER_GROUP_ID: employee-group1

--- a/local-setup/docker/db-migrations/migrate-all.sh
+++ b/local-setup/docker/db-migrations/migrate-all.sh
@@ -31,27 +31,37 @@ run_migration() {
 }
 
 # Run migrations for each service
-# Each service has its own schema_version table to track migrations independently
+#
+# Table names below MUST match the `canonical` name in
+# ../../db/flyway-history-map.yml, not a legacy *_schema_version alias. This
+# script and docker-compose.egov-digit.yaml's dedicated per-service migrators
+# (docker-compose.migrations.yml) write history for the SAME services — a
+# name mismatch here creates a second, unrecognized history table alongside
+# the canonical one, which db-history-normalize then aborts on ("ambiguous:
+# canonical AND legacy both exist") the next time the canonical migrator
+# runs against this database. See db/flyway-history-map.yml's header comment:
+# there is deliberately no "embedded migrator" escape hatch from that design,
+# and this script is exactly that escape hatch if its names drift.
 
 # Core services - order matters for dependencies
 if [ -d "/flyway/sql/egov-user" ]; then
-    run_migration "egov-user" "egov_user_schema_version" "filesystem:/flyway/sql/egov-user"
+    run_migration "egov-user" "egov_user_schema" "filesystem:/flyway/sql/egov-user"
 fi
 
 if [ -d "/flyway/sql/egov-idgen" ]; then
-    run_migration "egov-idgen" "egov_idgen_schema_version" "filesystem:/flyway/sql/egov-idgen"
+    run_migration "egov-idgen" "egov_idgen_schema" "filesystem:/flyway/sql/egov-idgen"
 fi
 
 if [ -d "/flyway/sql/egov-localization" ]; then
-    run_migration "egov-localization" "egov_localization_schema_version" "filesystem:/flyway/sql/egov-localization"
+    run_migration "egov-localization" "egov_localization_schema" "filesystem:/flyway/sql/egov-localization"
 fi
 
 if [ -d "/flyway/sql/egov-accesscontrol" ]; then
-    run_migration "egov-accesscontrol" "egov_accesscontrol_schema_version" "filesystem:/flyway/sql/egov-accesscontrol"
+    run_migration "egov-accesscontrol" "accesscontrol_schema_version" "filesystem:/flyway/sql/egov-accesscontrol"
 fi
 
 if [ -d "/flyway/sql/egov-filestore" ]; then
-    run_migration "egov-filestore" "egov_filestore_schema_version" "filesystem:/flyway/sql/egov-filestore"
+    run_migration "egov-filestore" "egov_filestore_schema" "filesystem:/flyway/sql/egov-filestore"
 fi
 
 if [ -d "/flyway/sql/egov-data-uploader" ]; then


### PR DESCRIPTION
## Summary

Fixes #1720.

`docker-compose.db-migrations.yml`, `docker-compose.registry.yml`, and `docker/db-migrations/migrate-all.sh` still wrote Flyway history under pre-refactor legacy table names (e.g. `mdms_schema_version`, `egov_user_schema_version`) instead of the canonical names declared in `local-setup/db/flyway-history-map.yml`. If either of those parallel-stack paths ever runs against a Postgres volume that a canonical-model deploy (`docker-compose.egov-digit.yaml` + `docker-compose.migrations.yml`) also manages, it plants a second, differently-named history table for the same service. `db-history-normalize` then correctly refuses to proceed on the next canonical deploy:

```
egov-user: ambiguous: canonical 'egov_user_schema' AND legacy 'egov_user_schema_version' both exist. Cannot tell which history is authoritative.
```

This is exactly the failure mode `flyway-history-map.yml`'s own header comment says the canonical-migrator design was meant to close ("no embedded escape hatch"). This PR realigns all 8 affected services to their canonical names, each with a comment pointing back at `flyway-history-map.yml` so it doesn't drift again:

- egov-user, mdms-backend, egov-idgen, egov-localization, egov-accesscontrol, egov-filestore, egov-workflow-v2, egov-hrms, egov-enc-service, boundary-service

Left `pgr-services` / `egov-indexer` / `egov-accesscontrol` alone (table name already matched canonical), and left `docker-compose.fast-path.yml`'s `egov-url-shortening` override untouched — that one is a deliberate, documented adaptation to the pre-baked `db/full-dump.sql`, not drift.

## Verification

- Found via a real deploy failure on a local `testtenant` box; root-caused to two stray single-row legacy history tables (`egov_user_schema_version`, `mdms_schema_version`) sitting alongside fully-populated canonical ones.
- Dropped the two stray tables to unblock that box, then applied this fix so the same drift can't recur going forward.
- `python3 -c "import yaml; yaml.safe_load(...)"` — both edited compose files parse.
- `docker compose -f local-setup/docker-compose.db-migrations.yml config --quiet` and same for `registry.yml` — both valid.
- `sh -n local-setup/docker/db-migrations/migrate-all.sh` — valid.
- `python3 .github/scripts/check-flyway-dump-alignment.py` — still passes (`OK: Flyway history tables aligned with the dump`).

## Known gap (follow-up, not in this PR)

No CI guard currently catches this class of drift recurring — `check-flyway-dump-alignment.py` only validates the canonical migrators' table names, not the embedded `SPRING_FLYWAY_TABLE` overrides in the parallel-stack compose files. Tracked as a follow-up note on #1720.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized database migration history tracking across core services.
  * Prevented legacy migration tables from being recreated or causing ambiguity.
  * Improved migration reliability by aligning table names with canonical service schemas.

* **Documentation**
  * Added guidance for using canonical migration history table names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->