### PR TITLE
refactor(pgr): extract role-safe ABAC policy primitives

### DIFF
--- a/backend/pgr-services/pom.xml
+++ b/backend/pgr-services/pom.xml
@@ -141,6 +141,11 @@
             <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.github.jamsesso</groupId>
+            <artifactId>json-logic-java</artifactId>
+            <version>1.1.0</version>
+        </dependency>
     </dependencies>
     <repositories>
      		<repository>

--- a/backend/pgr-services/src/main/java/org/egov/pgr/policy/AccessPolicyRegistry.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/policy/AccessPolicyRegistry.java
@@ -1,0 +1,180 @@
+package org.egov.pgr.policy;
+
+import lombok.extern.slf4j.Slf4j;
+import org.egov.common.contract.request.RequestInfo;
+import org.egov.common.contract.request.Role;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Resolves and briefly caches role-visible policy actions.
+ *
+ * <p>The backing access-control lookup is role-scoped, so the complete canonical role set is part
+ * of the cache key. Omitting it would let one authorized role prime a tenant/URL entry for an
+ * unrelated role. Only successful, uniquely matched results are cached; denial and failures are
+ * retried on the next request and always remain fail-closed.
+ *
+ * <p>This core registry is intentionally not a Spring component yet. It performs policy lookup and
+ * caching, not authentication: callers must supply a previously authenticated, tenant-bound
+ * {@link RequestInfo}. A later integration supplies the concrete {@link AccessPolicySource} and
+ * wires the registry after that trusted-principal boundary.
+ */
+@Slf4j
+public class AccessPolicyRegistry {
+
+    static final Duration DEFAULT_TTL = Duration.ofMinutes(15);
+    static final int DEFAULT_MAX_ENTRIES = 4096;
+
+    private final AccessPolicySource source;
+    private final Clock clock;
+    private final long ttlMillis;
+    private final int maxEntries;
+    private final Map<CacheKey, CachedAction> cache = new ConcurrentHashMap<>();
+
+    public AccessPolicyRegistry(AccessPolicySource source) {
+        this(source, Clock.systemUTC(), DEFAULT_TTL, DEFAULT_MAX_ENTRIES);
+    }
+
+    public AccessPolicyRegistry(AccessPolicySource source, Clock clock, Duration ttl) {
+        this(source, clock, ttl, DEFAULT_MAX_ENTRIES);
+    }
+
+    AccessPolicyRegistry(AccessPolicySource source, Clock clock, Duration ttl, int maxEntries) {
+        if (ttl == null || ttl.isZero() || ttl.isNegative() || ttl.toMillis() == 0)
+            throw new IllegalArgumentException("ttl must be positive");
+        if (maxEntries <= 0)
+            throw new IllegalArgumentException("maxEntries must be positive");
+        this.source = java.util.Objects.requireNonNull(source, "source");
+        this.clock = java.util.Objects.requireNonNull(clock, "clock");
+        this.ttlMillis = ttl.toMillis();
+        this.maxEntries = maxEntries;
+    }
+
+    public PolicyResolution resolve(RequestInfo requestInfo, String tenantId, String method, String url) {
+        if (isMissingOrPadded(tenantId) || isMissingOrPadded(method) || isMissingOrPadded(url)) {
+            log.error("Cannot resolve access policy with a missing tenant, method, or URL");
+            return PolicyResolution.invalidRequest();
+        }
+
+        List<String> roleCodes;
+        try {
+            roleCodes = canonicalRoleCodes(requestInfo);
+        } catch (IllegalArgumentException e) {
+            log.error("Cannot resolve access policy with malformed role codes: {}", e.getMessage());
+            return PolicyResolution.invalidRequest();
+        }
+        if (roleCodes.isEmpty()) {
+            log.warn("Cannot resolve access policy for tenant='{}' method='{}' url='{}': caller has no roles",
+                    tenantId, method, url);
+            return PolicyResolution.notAuthorized();
+        }
+
+        String canonicalMethod = method.toUpperCase(Locale.ROOT);
+        CacheKey key = new CacheKey(tenantId, canonicalMethod, url, roleCodes);
+        long now = clock.millis();
+        CachedAction cached = cache.get(key);
+        if (cached != null && cached.expiresAtMillis > now)
+            return PolicyResolution.resolved(cached.action);
+        if (cached != null)
+            cache.remove(key, cached);
+
+        evictExpired(now);
+
+        List<PolicyAction> actions;
+        try {
+            actions = source.findActions(tenantId, canonicalMethod, url, roleCodes);
+        } catch (Exception e) {
+            log.error("Access-policy source failed for tenant='{}' method='{}' url='{}'; denying",
+                    tenantId, canonicalMethod, url, e);
+            return PolicyResolution.sourceUnavailable();
+        }
+
+        if (actions == null) {
+            log.error("Access-policy source violated its non-null result contract; denying invalid policy");
+            return PolicyResolution.invalidPolicy();
+        }
+        if (actions.isEmpty())
+            return PolicyResolution.notAuthorized();
+        if (actions.size() != 1) {
+            log.error("Access-policy source returned {} actions for tenant='{}' method='{}' url='{}'; denying ambiguous policy",
+                    actions.size(), tenantId, canonicalMethod, url);
+            return PolicyResolution.invalidPolicy();
+        }
+
+        PolicyAction action = actions.get(0);
+        if (action == null || !canonicalMethod.equals(action.method()) || !url.equals(action.url())) {
+            log.error("Access-policy source returned a mismatched action for tenant='{}' method='{}' url='{}'; denying",
+                    tenantId, canonicalMethod, url);
+            return PolicyResolution.invalidPolicy();
+        }
+
+        cacheResolved(key, action, now);
+        return PolicyResolution.resolved(action);
+    }
+
+    private static boolean isMissingOrPadded(String value) {
+        return value == null || value.isBlank() || !value.equals(value.trim());
+    }
+
+    private List<String> canonicalRoleCodes(RequestInfo requestInfo) {
+        if (requestInfo == null || requestInfo.getUserInfo() == null
+                || requestInfo.getUserInfo().getRoles() == null)
+            return List.of();
+
+        List<String> codes = new ArrayList<>();
+        for (Role role : requestInfo.getUserInfo().getRoles()) {
+            if (role == null || role.getCode() == null || role.getCode().isBlank())
+                throw new IllegalArgumentException("role codes must not be blank");
+            String code = role.getCode();
+            if (!code.equals(code.trim()))
+                throw new IllegalArgumentException("role codes must not contain surrounding whitespace");
+            codes.add(code);
+        }
+        Collections.sort(codes);
+        List<String> distinct = new ArrayList<>();
+        String previous = null;
+        for (String code : codes) {
+            if (!code.equals(previous))
+                distinct.add(code);
+            previous = code;
+        }
+        return List.copyOf(distinct);
+    }
+
+    private long expirationFrom(long now) {
+        try {
+            return Math.addExact(now, ttlMillis);
+        } catch (ArithmeticException e) {
+            return Long.MAX_VALUE;
+        }
+    }
+
+    private void evictExpired(long now) {
+        cache.entrySet().removeIf(entry -> entry.getValue().expiresAtMillis <= now);
+    }
+
+    private void cacheResolved(CacheKey key, PolicyAction action, long now) {
+        synchronized (cache) {
+            evictExpired(now);
+            if (cache.containsKey(key) || cache.size() < maxEntries)
+                cache.put(key, new CachedAction(action, expirationFrom(now)));
+            else
+                log.warn("Access-policy cache reached its {}-entry bound; returning uncached resolution", maxEntries);
+        }
+    }
+
+    private record CacheKey(String tenantId, String method, String url, List<String> roleCodes) {
+        private CacheKey {
+            roleCodes = List.copyOf(roleCodes);
+        }
+    }
+
+    private record CachedAction(PolicyAction action, long expiresAtMillis) { }
+}

--- a/backend/pgr-services/src/main/java/org/egov/pgr/policy/AccessPolicySource.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/policy/AccessPolicySource.java
@@ -1,0 +1,19 @@
+package org.egov.pgr.policy;
+
+import java.util.List;
+
+/**
+ * Source of access-control actions visible to a caller's exact role set.
+ *
+ * <p>The role list is canonical, immutable, and is the same list used by the registry's cache
+ * key. Policy selection must be a pure function of exactly these arguments. The registry's caller
+ * is responsible for authentication and tenant binding before lookup. An empty list means that the
+ * authenticated caller has no visible matching action. Implementations must never return
+ * {@code null}.
+ */
+@FunctionalInterface
+public interface AccessPolicySource {
+
+    List<PolicyAction> findActions(String tenantId, String method, String url,
+                                   List<String> roleCodes) throws Exception;
+}

--- a/backend/pgr-services/src/main/java/org/egov/pgr/policy/PolicyAction.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/policy/PolicyAction.java
@@ -1,0 +1,83 @@
+package org.egov.pgr.policy;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * One role-visible access-control action and its opaque policy document.
+ *
+ * <p>The registry treats {@code method} and {@code url} as the action's identity. The remaining
+ * document is intentionally opaque here so row, field, and analytics integrations can evolve
+ * their policy schema without teaching the cache about domain fields.
+ */
+public record PolicyAction(String method, String url, Map<String, Object> document) {
+
+    public PolicyAction {
+        Objects.requireNonNull(method, "method");
+        Objects.requireNonNull(url, "url");
+        Objects.requireNonNull(document, "document");
+        if (method.isBlank() || !method.equals(method.trim()))
+            throw new IllegalArgumentException("method must not be blank");
+        if (url.isBlank() || !url.equals(url.trim()))
+            throw new IllegalArgumentException("url must not be blank");
+
+        method = method.toUpperCase(Locale.ROOT);
+        document = immutableDocument(document);
+    }
+
+    /** Returns the parsed JsonLogic condition, or {@code null} when the policy omits it. */
+    public Object condition() {
+        return document.get("condition");
+    }
+
+    private static Map<String, Object> immutableDocument(Map<String, Object> source) {
+        Map<String, Object> copy = new LinkedHashMap<>();
+        for (Map.Entry<String, Object> entry : source.entrySet()) {
+            if (entry.getKey() == null)
+                throw new IllegalArgumentException("policy document keys must not be null");
+            copy.put(entry.getKey(), immutableJsonValue(entry.getValue()));
+        }
+        return Collections.unmodifiableMap(copy);
+    }
+
+    private static Object immutableJsonValue(Object value) {
+        if (value == null || value instanceof String || value instanceof Boolean)
+            return value;
+        if (value instanceof Float number) {
+            if (!Float.isFinite(number))
+                throw new IllegalArgumentException("policy document numbers must be finite");
+            return number;
+        }
+        if (value instanceof Double number) {
+            if (!Double.isFinite(number))
+                throw new IllegalArgumentException("policy document numbers must be finite");
+            return number;
+        }
+        if (value instanceof Byte || value instanceof Short || value instanceof Integer
+                || value instanceof Long || value instanceof BigInteger || value instanceof BigDecimal)
+            return value;
+        if (value instanceof Map<?, ?> map) {
+            Map<String, Object> copy = new LinkedHashMap<>();
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                if (!(entry.getKey() instanceof String key))
+                    throw new IllegalArgumentException("policy document map keys must be strings");
+                copy.put(key, immutableJsonValue(entry.getValue()));
+            }
+            return Collections.unmodifiableMap(copy);
+        }
+        if (value instanceof List<?> list) {
+            List<Object> copy = new ArrayList<>(list.size());
+            for (Object item : list)
+                copy.add(immutableJsonValue(item));
+            return Collections.unmodifiableList(copy);
+        }
+        throw new IllegalArgumentException("unsupported policy document value type: " + value.getClass().getName());
+    }
+}

--- a/backend/pgr-services/src/main/java/org/egov/pgr/policy/PolicyEvaluator.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/policy/PolicyEvaluator.java
@@ -1,0 +1,43 @@
+package org.egov.pgr.policy;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.jamsesso.jsonlogic.JsonLogic;
+import io.github.jamsesso.jsonlogic.JsonLogicException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+/** Evaluates JsonLogic policy conditions and fails closed on every invalid outcome. */
+@Component
+@Slf4j
+public class PolicyEvaluator {
+
+    private final JsonLogic jsonLogic = new JsonLogic();
+    private final ObjectMapper objectMapper;
+
+    public PolicyEvaluator(ObjectMapper objectMapper) {
+        this.objectMapper = java.util.Objects.requireNonNull(objectMapper, "objectMapper");
+    }
+
+    /**
+     * Evaluates a parsed JSON condition and returns true only when it produces the Boolean value
+     * {@code true}. JsonLogic's broader truthiness rules are useful for expressions, but accepting
+     * a truthy scalar as a final authorization verdict would contradict the fail-closed contract.
+     */
+    public boolean isAllowed(Object condition, Map<String, Object> data) {
+        if (condition == null || data == null) {
+            log.error("PolicyEvaluator: missing condition or input document; denying");
+            return false;
+        }
+        try {
+            String conditionJson = objectMapper.writeValueAsString(condition);
+            Object result = jsonLogic.apply(conditionJson, data);
+            return Boolean.TRUE.equals(result);
+        } catch (JsonProcessingException | JsonLogicException | RuntimeException e) {
+            log.error("PolicyEvaluator: condition evaluation failed; denying: {}", e.getMessage());
+            return false;
+        }
+    }
+}

--- a/backend/pgr-services/src/main/java/org/egov/pgr/policy/PolicyResolution.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/policy/PolicyResolution.java
@@ -1,0 +1,64 @@
+package org.egov.pgr.policy;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Explicit result of resolving an action for one tenant and role set.
+ *
+ * <p>Callers must allow only {@link Status#RESOLVED}. Keeping unavailable, malformed, and
+ * unauthorized outcomes distinct lets future field-masking consumers fail closed without
+ * confusing a policy-system failure with an intentionally absent field rule.
+ */
+public final class PolicyResolution {
+
+    public enum Status {
+        RESOLVED,
+        NOT_AUTHORIZED,
+        SOURCE_UNAVAILABLE,
+        INVALID_REQUEST,
+        INVALID_POLICY
+    }
+
+    private final Status status;
+    private final PolicyAction action;
+
+    private PolicyResolution(Status status, PolicyAction action) {
+        this.status = Objects.requireNonNull(status, "status");
+        this.action = action;
+        if ((status == Status.RESOLVED) != (action != null))
+            throw new IllegalArgumentException("only a resolved result may contain an action");
+    }
+
+    public static PolicyResolution resolved(PolicyAction action) {
+        return new PolicyResolution(Status.RESOLVED, Objects.requireNonNull(action, "action"));
+    }
+
+    public static PolicyResolution notAuthorized() {
+        return new PolicyResolution(Status.NOT_AUTHORIZED, null);
+    }
+
+    public static PolicyResolution sourceUnavailable() {
+        return new PolicyResolution(Status.SOURCE_UNAVAILABLE, null);
+    }
+
+    public static PolicyResolution invalidRequest() {
+        return new PolicyResolution(Status.INVALID_REQUEST, null);
+    }
+
+    public static PolicyResolution invalidPolicy() {
+        return new PolicyResolution(Status.INVALID_POLICY, null);
+    }
+
+    public Status status() {
+        return status;
+    }
+
+    public Optional<PolicyAction> action() {
+        return Optional.ofNullable(action);
+    }
+
+    public boolean isResolved() {
+        return status == Status.RESOLVED;
+    }
+}

--- a/backend/pgr-services/src/test/java/org/egov/pgr/policy/AccessPolicyRegistryTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/policy/AccessPolicyRegistryTest.java
@@ -1,0 +1,332 @@
+package org.egov.pgr.policy;
+
+import org.egov.common.contract.request.RequestInfo;
+import org.egov.common.contract.request.Role;
+import org.egov.common.contract.request.User;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AccessPolicyRegistryTest {
+
+    private static final String TENANT = "pg.city";
+    private static final String URL = "/pgr-services/v2/request/_search";
+
+    @Test
+    void anAllowedRoleCannotPrimeTheCacheForAnUnmappedRole() {
+        AtomicInteger calls = new AtomicInteger();
+        AccessPolicySource source = (tenantId, method, url, roleCodes) -> {
+            calls.incrementAndGet();
+            return roleCodes.contains("EMPLOYEE") ? List.of(action(method, url)) : List.of();
+        };
+        AccessPolicyRegistry registry = new AccessPolicyRegistry(source);
+
+        PolicyResolution allowed = registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+        PolicyResolution unmapped = registry.resolve(request("CITIZEN"), TENANT, "POST", URL);
+
+        assertEquals(PolicyResolution.Status.RESOLVED, allowed.status());
+        assertEquals(PolicyResolution.Status.NOT_AUTHORIZED, unmapped.status());
+        assertEquals(2, calls.get());
+    }
+
+    @Test
+    void roleOrderAndDuplicatesShareOneCanonicalCacheEntry() {
+        AtomicInteger calls = new AtomicInteger();
+        List<List<String>> observedRoles = new ArrayList<>();
+        AccessPolicySource source = (tenantId, method, url, roleCodes) -> {
+            calls.incrementAndGet();
+            observedRoles.add(roleCodes);
+            return List.of(action(method, url));
+        };
+        AccessPolicyRegistry registry = new AccessPolicyRegistry(source);
+
+        PolicyResolution first = registry.resolve(request("GRO", "EMPLOYEE", "GRO"), TENANT, "post", URL);
+        PolicyResolution second = registry.resolve(request("EMPLOYEE", "GRO"), TENANT, "POST", URL);
+
+        assertTrue(first.isResolved());
+        assertTrue(second.isResolved());
+        assertEquals(1, calls.get());
+        assertEquals(List.of("EMPLOYEE", "GRO"), observedRoles.get(0));
+        assertThrows(UnsupportedOperationException.class, () -> observedRoles.get(0).add("ADMIN"));
+        assertSame(first.action().orElseThrow(), second.action().orElseThrow());
+    }
+
+    @Test
+    void anAdditionalRoleCreatesADistinctCacheEntry() {
+        AtomicInteger calls = new AtomicInteger();
+        AccessPolicyRegistry registry = new AccessPolicyRegistry((tenantId, method, url, roleCodes) -> {
+            calls.incrementAndGet();
+            return List.of(action(method, url));
+        });
+
+        registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+        registry.resolve(request("EMPLOYEE", "GRO"), TENANT, "POST", URL);
+
+        assertEquals(2, calls.get());
+    }
+
+    @Test
+    void roleCodesRemainCaseSensitiveInTheCacheIdentity() {
+        AtomicInteger calls = new AtomicInteger();
+        AccessPolicyRegistry registry = new AccessPolicyRegistry((tenantId, method, url, roleCodes) -> {
+            calls.incrementAndGet();
+            return List.of(action(method, url));
+        });
+
+        registry.resolve(request("GRO"), TENANT, "POST", URL);
+        registry.resolve(request("gro"), TENANT, "POST", URL);
+
+        assertEquals(2, calls.get());
+    }
+
+    @Test
+    void tenantMethodAndExactUrlAreIndependentCacheAxes() {
+        AtomicInteger calls = new AtomicInteger();
+        AccessPolicyRegistry registry = new AccessPolicyRegistry((tenantId, method, url, roleCodes) -> {
+            calls.incrementAndGet();
+            return List.of(action(method, url));
+        });
+        RequestInfo principal = request("EMPLOYEE");
+
+        registry.resolve(principal, TENANT, "POST", URL);
+        registry.resolve(principal, "pg.other", "POST", URL);
+        registry.resolve(principal, TENANT, "GET", URL);
+        registry.resolve(principal, TENANT, "POST", URL + "/child");
+        registry.resolve(principal, TENANT, "post", URL);
+
+        assertEquals(4, calls.get());
+    }
+
+    @Test
+    void aSourceExceptionFailsClosedAndIsNotCached() {
+        AtomicInteger calls = new AtomicInteger();
+        AccessPolicyRegistry registry = new AccessPolicyRegistry((tenantId, method, url, roleCodes) -> {
+            calls.incrementAndGet();
+            throw new IllegalStateException("access-control unavailable");
+        });
+
+        PolicyResolution first = registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+        PolicyResolution second = registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+
+        assertEquals(PolicyResolution.Status.SOURCE_UNAVAILABLE, first.status());
+        assertEquals(PolicyResolution.Status.SOURCE_UNAVAILABLE, second.status());
+        assertEquals(2, calls.get());
+    }
+
+    @Test
+    void aCallerWithoutRolesIsDeniedWithoutConsultingTheSource() {
+        AtomicInteger calls = new AtomicInteger();
+        AccessPolicyRegistry registry = new AccessPolicyRegistry((tenantId, method, url, roleCodes) -> {
+            calls.incrementAndGet();
+            return List.of(action(method, url));
+        });
+
+        PolicyResolution result = registry.resolve(request(), TENANT, "POST", URL);
+
+        assertEquals(PolicyResolution.Status.NOT_AUTHORIZED, result.status());
+        assertFalse(result.action().isPresent());
+        assertEquals(0, calls.get());
+    }
+
+    @Test
+    void noMatchingActionIsDeniedAndNotCached() {
+        AtomicInteger calls = new AtomicInteger();
+        AccessPolicyRegistry registry = new AccessPolicyRegistry((tenantId, method, url, roleCodes) -> {
+            calls.incrementAndGet();
+            return List.of();
+        });
+
+        PolicyResolution first = registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+        PolicyResolution second = registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+
+        assertEquals(PolicyResolution.Status.NOT_AUTHORIZED, first.status());
+        assertEquals(PolicyResolution.Status.NOT_AUTHORIZED, second.status());
+        assertEquals(2, calls.get());
+    }
+
+    @Test
+    void aNullSourceResultIsInvalidPolicyAndNotAuthorizationDenial() {
+        AccessPolicyRegistry registry = new AccessPolicyRegistry((tenantId, method, url, roleCodes) -> null);
+
+        PolicyResolution result = registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+
+        assertEquals(PolicyResolution.Status.INVALID_POLICY, result.status());
+    }
+
+    @Test
+    void aMismatchedActionFailsClosedAndIsNotCached() {
+        AtomicInteger calls = new AtomicInteger();
+        AccessPolicyRegistry registry = new AccessPolicyRegistry((tenantId, method, url, roleCodes) -> {
+            calls.incrementAndGet();
+            return List.of(action("GET", url + "/wrong"));
+        });
+
+        PolicyResolution first = registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+        PolicyResolution second = registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+
+        assertEquals(PolicyResolution.Status.INVALID_POLICY, first.status());
+        assertEquals(PolicyResolution.Status.INVALID_POLICY, second.status());
+        assertEquals(2, calls.get());
+    }
+
+    @Test
+    void duplicateActionsFailClosedAsAmbiguous() {
+        AccessPolicyRegistry registry = new AccessPolicyRegistry((tenantId, method, url, roleCodes) ->
+                List.of(action(method, url), action(method, url)));
+
+        PolicyResolution result = registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+
+        assertEquals(PolicyResolution.Status.INVALID_POLICY, result.status());
+    }
+
+    @Test
+    void successfulEntriesExpireUsingTheInjectedClockAndTtl() {
+        AtomicInteger calls = new AtomicInteger();
+        MutableClock clock = new MutableClock(Instant.parse("2026-08-11T00:00:00Z"));
+        AccessPolicyRegistry registry = new AccessPolicyRegistry((tenantId, method, url, roleCodes) -> {
+            calls.incrementAndGet();
+            return List.of(action(method, url));
+        }, clock, Duration.ofSeconds(30));
+
+        registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+        clock.advance(Duration.ofSeconds(29));
+        registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+        clock.advance(Duration.ofSeconds(1));
+        registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+
+        assertEquals(2, calls.get());
+    }
+
+    @Test
+    void theCacheBoundPreventsUnboundedRoleAndActionCombinations() {
+        AtomicInteger calls = new AtomicInteger();
+        AccessPolicyRegistry registry = new AccessPolicyRegistry((tenantId, method, url, roleCodes) -> {
+            calls.incrementAndGet();
+            return List.of(action(method, url));
+        }, Clock.systemUTC(), Duration.ofMinutes(1), 1);
+        RequestInfo principal = request("EMPLOYEE");
+
+        registry.resolve(principal, TENANT, "POST", URL);
+        registry.resolve(principal, TENANT, "POST", URL + "/second");
+        registry.resolve(principal, TENANT, "POST", URL + "/second");
+
+        assertEquals(3, calls.get());
+    }
+
+    @Test
+    void theCacheBoundRemainsHardUnderConcurrentAdmission() throws Exception {
+        AtomicInteger calls = new AtomicInteger();
+        CyclicBarrier simultaneousMisses = new CyclicBarrier(2);
+        AccessPolicyRegistry registry = new AccessPolicyRegistry((tenantId, method, url, roleCodes) -> {
+            if (calls.incrementAndGet() <= 2)
+                simultaneousMisses.await(5, TimeUnit.SECONDS);
+            return List.of(action(method, url));
+        }, Clock.systemUTC(), Duration.ofMinutes(1), 1);
+        RequestInfo principal = request("EMPLOYEE");
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        try {
+            var first = executor.submit(() -> registry.resolve(principal, TENANT, "POST", URL));
+            var second = executor.submit(() ->
+                    registry.resolve(principal, TENANT, "POST", URL + "/second"));
+            first.get(5, TimeUnit.SECONDS);
+            second.get(5, TimeUnit.SECONDS);
+        } finally {
+            executor.shutdownNow();
+        }
+
+        registry.resolve(principal, TENANT, "POST", URL);
+        registry.resolve(principal, TENANT, "POST", URL + "/second");
+        assertEquals(3, calls.get());
+    }
+
+    @Test
+    void invalidLookupArgumentsAndTtlFailClosed() {
+        AccessPolicyRegistry registry = new AccessPolicyRegistry((tenantId, method, url, roleCodes) ->
+                List.of(action(method, url)));
+
+        assertEquals(PolicyResolution.Status.INVALID_REQUEST,
+                registry.resolve(request("EMPLOYEE"), null, "POST", URL).status());
+        assertEquals(PolicyResolution.Status.INVALID_REQUEST,
+                registry.resolve(request("EMPLOYEE"), TENANT, "", URL).status());
+        assertEquals(PolicyResolution.Status.INVALID_REQUEST,
+                registry.resolve(request("EMPLOYEE"), TENANT, "POST", "").status());
+        assertEquals(PolicyResolution.Status.INVALID_REQUEST,
+                registry.resolve(request(" EMPLOYEE"), TENANT, "POST", URL).status());
+        assertEquals(PolicyResolution.Status.INVALID_REQUEST,
+                registry.resolve(request("EMPLOYEE", ""), TENANT, "POST", URL).status());
+        assertEquals(PolicyResolution.Status.INVALID_REQUEST,
+                registry.resolve(request("EMPLOYEE"), " " + TENANT, "POST", URL).status());
+        assertEquals(PolicyResolution.Status.INVALID_REQUEST,
+                registry.resolve(request("EMPLOYEE"), TENANT, " POST", URL).status());
+        assertThrows(IllegalArgumentException.class,
+                () -> new AccessPolicyRegistry((tenant, method, url, roles) -> List.of(),
+                        Clock.systemUTC(), Duration.ZERO));
+        assertThrows(IllegalArgumentException.class,
+                () -> new AccessPolicyRegistry((tenant, method, url, roles) -> List.of(),
+                        Clock.systemUTC(), Duration.ofNanos(1)));
+        assertThrows(IllegalArgumentException.class,
+                () -> new AccessPolicyRegistry((tenant, method, url, roles) -> List.of(),
+                        Clock.systemUTC(), Duration.ofSeconds(1), 0));
+    }
+
+    private static PolicyAction action(String method, String url) {
+        return new PolicyAction(method, url, Map.of("condition", Map.of("==", List.of(1, 1))));
+    }
+
+    private static RequestInfo request(String... roleCodes) {
+        User user = new User();
+        List<Role> roles = new ArrayList<>();
+        for (String roleCode : roleCodes)
+            roles.add(Role.builder().code(roleCode).build());
+        user.setRoles(roles);
+        RequestInfo requestInfo = new RequestInfo();
+        requestInfo.setUserInfo(user);
+        return requestInfo;
+    }
+
+    private static final class MutableClock extends Clock {
+        private Instant instant;
+
+        private MutableClock(Instant instant) {
+            this.instant = instant;
+        }
+
+        private void advance(Duration duration) {
+            instant = instant.plus(duration);
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+    }
+}

--- a/backend/pgr-services/src/test/java/org/egov/pgr/policy/PolicyActionTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/policy/PolicyActionTest.java
@@ -1,0 +1,55 @@
+package org.egov.pgr.policy;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PolicyActionTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void policyDocumentsAreDeeplyCopiedAndImmutable() {
+        List<Object> operands = new ArrayList<>(List.of(1, 1));
+        Map<String, Object> condition = new LinkedHashMap<>();
+        condition.put("==", operands);
+        Map<String, Object> document = new LinkedHashMap<>();
+        document.put("condition", condition);
+
+        PolicyAction action = new PolicyAction("post", "/resource/_search", document);
+        operands.set(0, 2);
+        condition.put("extra", true);
+        document.put("resource", Map.of());
+
+        assertEquals("POST", action.method());
+        assertEquals(Map.of("condition", Map.of("==", List.of(1, 1))), action.document());
+
+        Map<String, Object> returnedCondition = (Map<String, Object>) action.document().get("condition");
+        List<Object> returnedOperands = (List<Object>) returnedCondition.get("==");
+        assertThrows(UnsupportedOperationException.class, () -> action.document().put("x", true));
+        assertThrows(UnsupportedOperationException.class, () -> returnedCondition.put("x", true));
+        assertThrows(UnsupportedOperationException.class, () -> returnedOperands.set(0, 2));
+    }
+
+    @Test
+    void invalidIdentityAndNonJsonValuesAreRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new PolicyAction(" POST", "/resource/_search", Map.of()));
+        assertThrows(IllegalArgumentException.class,
+                () -> new PolicyAction("POST", " /resource/_search", Map.of()));
+        assertThrows(IllegalArgumentException.class,
+                () -> new PolicyAction("POST", "/resource/_search", Map.of("bad", new Object())));
+        assertThrows(IllegalArgumentException.class,
+                () -> new PolicyAction("POST", "/resource/_search", Map.of("bad", Map.of(1, "x"))));
+        assertThrows(IllegalArgumentException.class,
+                () -> new PolicyAction("POST", "/resource/_search", Map.of("bad", new AtomicInteger(1))));
+        assertThrows(IllegalArgumentException.class,
+                () -> new PolicyAction("POST", "/resource/_search", Map.of("bad", Double.NaN)));
+    }
+}

--- a/backend/pgr-services/src/test/java/org/egov/pgr/policy/PolicyEvaluatorTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/policy/PolicyEvaluatorTest.java
@@ -1,0 +1,55 @@
+package org.egov.pgr.policy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PolicyEvaluatorTest {
+
+    private final PolicyEvaluator evaluator = new PolicyEvaluator(new ObjectMapper());
+
+    @Test
+    void allowsOnlyAnExplicitBooleanTrueVerdict() {
+        PolicyAction action = new PolicyAction("POST", "/resource/_search",
+                Map.of("condition", Map.of("==", List.of(1, 1))));
+
+        assertTrue(evaluator.isAllowed(action.condition(), Map.of()));
+        assertFalse(evaluator.isAllowed(Map.of("==", List.of(1, 2)), Map.of()));
+    }
+
+    @Test
+    void truthyNonBooleanResultsAreDenied() {
+        assertFalse(evaluator.isAllowed(1, Map.of()));
+        assertFalse(evaluator.isAllowed("allowed", Map.of()));
+        assertFalse(evaluator.isAllowed(List.of(1), Map.of()));
+        assertFalse(evaluator.isAllowed(Map.of("value", true), Map.of()));
+    }
+
+    @Test
+    void evaluatesVariablesAgainstTheProvidedDocument() {
+        Object condition = Map.of("in", List.of(
+                Map.of("var", "resource.department"), Map.of("var", "user.departments")));
+        Map<String, Object> allowed = Map.of(
+                "user", Map.of("departments", List.of("ROADS", "WATER")),
+                "resource", Map.of("department", "WATER"));
+        Map<String, Object> denied = Map.of(
+                "user", Map.of("departments", List.of("ROADS")),
+                "resource", Map.of("department", "WATER"));
+
+        assertTrue(evaluator.isAllowed(condition, allowed));
+        assertFalse(evaluator.isAllowed(condition, denied));
+    }
+
+    @Test
+    void missingOrMalformedConditionsFailClosed() {
+        assertFalse(evaluator.isAllowed(null, Map.of()));
+        assertFalse(evaluator.isAllowed(Map.of(), Map.of()));
+        assertFalse(evaluator.isAllowed(true, null));
+        assertFalse(evaluator.isAllowed(Map.of("var", "missing"), Map.of()));
+    }
+}

--- a/backend/pgr-services/src/test/java/org/egov/pgr/policy/PolicyResolutionTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/policy/PolicyResolutionTest.java
@@ -1,0 +1,34 @@
+package org.egov.pgr.policy;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PolicyResolutionTest {
+
+    @Test
+    void onlyResolvedResultsContainAnAction() {
+        PolicyAction action = new PolicyAction("POST", "/resource/_search", Map.of());
+        PolicyResolution resolved = PolicyResolution.resolved(action);
+
+        assertTrue(resolved.isResolved());
+        assertEquals(action, resolved.action().orElseThrow());
+
+        for (PolicyResolution denied : new PolicyResolution[] {
+                PolicyResolution.notAuthorized(), PolicyResolution.sourceUnavailable(),
+                PolicyResolution.invalidRequest(), PolicyResolution.invalidPolicy() }) {
+            assertFalse(denied.isResolved());
+            assertFalse(denied.action().isPresent());
+        }
+    }
+
+    @Test
+    void resolvedRequiresAnAction() {
+        assertThrows(NullPointerException.class, () -> PolicyResolution.resolved(null));
+    }
+}


### PR DESCRIPTION
## Summary

Part of #1050.

Extracts a behavior-neutral ABAC policy core from #1441 onto current master. This establishes the policy types and fail-closed invariants that later search, analytics, and dashboard integrations can share without changing any endpoint behavior in this PR.

The core provides:

- exact tenant, HTTP method, URL, and canonical role-set policy identity
- a pure access-policy source boundary whose inputs exactly match the cache key
- explicit resolved, unauthorized, unavailable, invalid-request, and invalid-policy outcomes
- deeply immutable JSON-compatible policy documents
- a parsed condition seam from PolicyAction to JsonLogic evaluation
- fail-closed evaluation requiring an explicit Boolean true verdict
- success-only TTL caching with role isolation, expiry, and a hard concurrent capacity bound
- deterministic regression coverage for cache and failure boundaries

## Why this is a draft

The stale #1441 branch combines policy transport, row scope, field masking, analytics, frontend behavior, seeds, and cleanup across a large diff. This draft separates the reusable policy boundary so its security semantics can be reviewed before those concerns are wired together.

This is the first slice of the cleanup program, not ABAC enforcement and not the final backend/frontend contract.

## Deliberately excluded

- an egov-accesscontrol transport adapter
- a Spring-managed registry or runtime call site
- trusted identity and tenant binding
- search, count, or plain-search enforcement
- department and jurisdiction scope derivation
- field masking and dashboard analytics authorization
- frontend rendering changes
- configurator or seed changes
- retirement of existing dashboard RBAC

The legacy action enabled field is intentionally not interpreted as an authorization kill switch. Existing role-mapped API actions, including the target PGR action, use enabled=false; role-visible source resolution remains authoritative until the platform contract is clarified.

## Backend/frontend direction

The desired split is still the target: the backend owns what data and presentation or masking instructions are permitted, while the frontend renders that contract without independently reconstructing authorization policy. This PR supplies only the backend policy-document primitive needed for that later envelope.

## Follow-up slices

1. Bind the registry to a validated principal and a concrete access-control adapter, initially in shadow mode.
2. Derive one canonical scope object and apply it consistently to search, count, plain search, and analytics.
3. Define the backend-owned field and presentation envelope; keep the frontend renderer declarative.
4. Gate analytics with the same policy boundary, reconcile seeds, then retire duplicate legacy RBAC paths.

## Security notes

- Roles still originate from supplied RequestInfo. This PR does not make identity trusted; callers must authenticate and tenant-bind it before lookup.
- Only a unique exact action resolves. Missing, duplicate, mismatched, malformed, and unavailable results fail closed.
- Denials and failures are not cached.
- A successful result can remain cached for up to 15 minutes. TTL and revocation policy must be made configurable or invalidatable before enforcement.

## Validation

- JDK 17 full pgr-services suite: 219 tests, 0 failures, 0 errors, 1 existing skip
- Focused policy plus existing scope/count regressions: 39 tests passed
- git diff --check passed
- No endpoint behavior changes