### PR TITLE
refactor(dashboard): extract KPI result adapters

### DIFF
--- a/digit-ui-esbuild/products/dashboard/src/components/KpiTile.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/KpiTile.jsx
@@ -9,27 +9,34 @@ import LineChart from './LineChart';
 import DashboardTable from './DashboardTable';
 import ComplaintsAtRiskTable from './ComplaintsAtRiskTable';
 import OpenComplaintsByGeographyWidget from './OpenComplaintsByGeographyWidget';
-import { evaluateCompose, requiresBackendComposition } from '../utils/composeKpi';
 import { applyGroupByToColumns } from '../utils/hierLevelGrouping';
-import { formatNumber } from '../utils/numberFormat';
 import { transformTableRows } from '../utils/tableRows';
 import {
-  GEO_MAP_LAYER_KEYS,
-  partitionPinsByLayer,
-  summarizeWardRows,
-} from '../utils/complaintPins';
-import { getNumberTileDeltaClass, formatOfficerLabel, dimensionKindForName } from '../config/kpiDisplay';
-import {
-  resolveSlaRiskPresentation,
-  computeBreachDurationMs,
-  formatBreachDurationCompact,
-  formatWorkflowStatusLabel,
-  normalizeWorkflowStatusKey,
-} from '../config/complaintsAtRiskPresentation';
+  adaptBarRows,
+  adaptDow,
+  adaptHorizontalRows,
+  adaptLine,
+  adaptMapLayers,
+  adaptPie,
+  adaptRanked,
+  adaptSlaRiskRows,
+  adaptStacked,
+  applyFormat,
+  computeDelta,
+  defScrollKey,
+  deriveColumnsFromResult,
+  errorLabel,
+  formatDeltaDisplay,
+  resolveDeltaClass,
+  resolvePrior,
+  resolveScalar,
+  resolveSparkline,
+  resolveTileStatus,
+  statusToSeriesColor,
+} from '../utils/tileResultAdapters';
 import useDashboardT from '../i18n/useDashboardT';
-import { dimensionLabel } from '../i18n/dimensionLabel';
 import { translate as t } from '../i18n/localeRuntime';
-import { resolveTitle, resolveSubtitle, seriesEntryLabel, resolveSeriesLabel } from '../i18n/textResolver';
+import { resolveTitle, resolveSubtitle } from '../i18n/textResolver';
 import { markFirstWidgetVisible } from '../services/dashboardMetrics';
 
 /**
@@ -198,177 +205,10 @@ function renderByKind(kind, ctx) {
 }
 
 // ---------------------------------------------------------------------------
-// Column-role helpers (zero hardcoded column names)
-// ---------------------------------------------------------------------------
-
-function dimensionColumns(result, viz) {
-  const cols = (result.columns || []).filter((c) => c.role === 'dimension');
-  if (cols.length) return cols;
-  if (viz.dimensionKey) return [{ name: viz.dimensionKey }];
-  return [];
-}
-
-function measureColumns(result, viz) {
-  const cols = (result.columns || []).filter((c) => c.role === 'measure');
-  if (cols.length) return cols;
-  const keys = viz.measureKeys || (viz.measureKey ? [viz.measureKey] : []);
-  return keys.map((name) => ({ name }));
-}
-
-function primaryDimensionKey(result, viz) {
-  return dimensionColumns(result, viz)[0]?.name || viz.dimensionKey || 'label';
-}
-
-function primaryMeasure(result, viz) {
-  return measureColumns(result, viz)[0] || { name: viz.measureKey || 'total' };
-}
-
-// ---------------------------------------------------------------------------
 // Scalar / delta cards  -> KpiCard
 // Ports the formatSubMetricValue + WoW delta shaping into a generic adapter
 // driven by viz.format / viz.valueKey / viz.priorKey / viz.compose.
 // ---------------------------------------------------------------------------
-
-function resolveScalar(ctx) {
-  const { viz, result, results } = ctx;
-  // Calendar-aware averages are composed by pgr-services. If a malformed KPI definition
-  // combines one with a raw query, fail closed instead of rendering that query's total as
-  // an average. A valid backend-composed response always supplies result.value.
-  if (requiresBackendComposition(viz.compose)) {
-    return result.value != null ? Number(result.value) : null;
-  }
-  if (viz.compose && results) {
-    const composed = evaluateCompose(viz.compose, results);
-    if (composed != null) return composed;
-  }
-  if (result.value != null) return result.value;
-  if (result.values && viz.valueKey != null && result.values[viz.valueKey] != null) {
-    return Number(result.values[viz.valueKey]);
-  }
-  if (result.values) {
-    const first = Object.values(result.values)[0];
-    if (first != null) return Number(first);
-  }
-  const row0 = result.rows?.[0];
-  if (row0) {
-    const key = viz.valueKey || primaryMeasure(result, viz).name;
-    if (row0[key] != null) return Number(row0[key]);
-  }
-  return null;
-}
-
-function resolvePrior(ctx) {
-  const { viz, result } = ctx;
-  if (result.prior != null) return Number(result.prior);
-  if (viz.priorKey != null) {
-    if (result.values && result.values[viz.priorKey] != null) return Number(result.values[viz.priorKey]);
-    const row0 = result.rows?.[0];
-    if (row0 && row0[viz.priorKey] != null) return Number(row0[viz.priorKey]);
-  }
-  return null;
-}
-
-/**
- * Generalized WoW delta — mirrors resolveSparklineDelta / computeWowPercent:
- * percent metrics use a percentage-point delta, everything else a % change.
- */
-function computeDelta(current, prior, format, mode) {
-  if (current == null || prior == null || !Number.isFinite(current) || !Number.isFinite(prior)) {
-    return null;
-  }
-  // viz.delta.mode (when set) decides the unit; otherwise fall back to the format.
-  const eff = mode || (isPercentFormat(format) ? 'percentPoint' : 'percent');
-  if (eff === 'percentPoint') return normalizePct(current) - normalizePct(prior);
-  if (eff === 'days') return (current - prior) / 86400000; // ms -> whole days
-  if (eff === 'duration') return current - prior; // raw ms difference
-  if (eff === 'rating') return current - prior; // rating points
-  if (prior === 0) return null;
-  return ((current - prior) / Math.abs(prior)) * 100; // relative %
-}
-
-// Delta numbers route their NUMERIC part through the tenant mask
-// (formatNumber, null when unconfigured -> the pre-#1213 expression); the
-// arrow and pp/%/day/hr unit suffixes stay here.
-function formatDeltaDisplay(delta, format, mode) {
-  if (delta == null || !Number.isFinite(delta)) return null;
-  const arrow = delta >= 0 ? '▲' : '▼';
-  const abs = Math.abs(delta);
-  const eff = mode || (isPercentFormat(format) ? 'percentPoint' : 'percent');
-  if (eff === 'duration') {
-    return abs >= 86400000
-      ? `${arrow} ${formatNumber(abs / 86400000, { decimals: 1 }) ?? (abs / 86400000).toFixed(1)} ${t("DASHBOARD_UNIT_DAYS", "days")}`
-      : `${arrow} ${formatNumber(abs / 3600000, { decimals: 1 }) ?? (abs / 3600000).toFixed(1)} ${t("DASHBOARD_UNIT_HRS", "hrs")}`;
-  }
-  const rounded = Math.round(abs * 10) / 10;
-  const formatted =
-    formatNumber(rounded, { decimals: 1, trim: true }) ??
-    (Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1));
-  if (eff === 'days') return `${arrow} ${formatted} ${rounded === 1 ? t("DASHBOARD_UNIT_DAY", "day") : t("DASHBOARD_UNIT_DAYS", "days")}`;
-  if (eff === 'rating') return `${arrow} ${formatted}`;
-  const unit = eff === 'percentPoint' ? 'pp' : '%';
-  return `${arrow} ${formatted}${unit}`;
-}
-
-function deltaClassFor(delta) {
-  if (delta == null || !Number.isFinite(delta) || delta === 0) return undefined;
-  return delta > 0 ? 'dashboard-delta-up' : 'dashboard-delta-down';
-}
-
-// ---------------------------------------------------------------------------
-// Threshold-driven status for number cards. Ports kpiDisplay.resolveThresholdStatus
-// so the catalog can carry the on-track / breaching bands per def via
-//   viz.threshold = { kind, higherIsBetter, onTrack, breaching }
-// and the KpiCard/KpiSparklineCard value (and sparkline) colour at parity with the
-// live AdminDashboard path. When no threshold is present we fall back to the
-// static viz.accent (legacy behaviour) so non-card tiles are unaffected.
-// ---------------------------------------------------------------------------
-
-const KPI_STATUS = { ON_TRACK: 'on_track', NORMAL: 'normal', BREACHING: 'breaching' };
-
-function thresholdStatus(threshold, value) {
-  if (!threshold || value == null || !Number.isFinite(Number(value))) return null;
-  // Percent metrics come back as a 0..1 ratio from the composer; the thresholds
-  // (e.g. onTrack: 70) are expressed in display units, so normalise to 0..100.
-  const n = threshold.kind === 'percent' ? normalizePct(value) : Number(value);
-  const { higherIsBetter, onTrack, breaching } = threshold;
-  if (higherIsBetter) {
-    if (n >= onTrack) return KPI_STATUS.ON_TRACK;
-    if (n <= breaching) return KPI_STATUS.BREACHING;
-    return KPI_STATUS.NORMAL;
-  }
-  if (n <= onTrack) return KPI_STATUS.ON_TRACK;
-  if (n >= breaching) return KPI_STATUS.BREACHING;
-  return KPI_STATUS.NORMAL;
-}
-
-/** 3-state threshold status when viz.threshold is set, else the static accent. */
-function resolveTileStatus(viz, value) {
-  return thresholdStatus(viz.threshold, value) ?? viz.accent;
-}
-
-/**
- * Delta colour. With a threshold the live path colours the delta by status
- * (resolveKpiDeltaClass -> getNumberTileDeltaClass), so we hand KpiCard the same
- * status token and let it resolve the colour. Without a threshold we keep the
- * directional up/down class so legacy delta tiles are unchanged.
- */
-function resolveDeltaClass(viz, value, delta) {
-  const status = thresholdStatus(viz.threshold, value);
-  if (status) {
-    const unavailable = value == null || !Number.isFinite(Number(value));
-    return getNumberTileDeltaClass(status, { unavailable });
-  }
-  return deltaClassFor(delta);
-}
-
-/** Series stroke colour mirrors the live KpiSparklineCard status-derived colour. */
-function statusToSeriesColor(status) {
-  switch (status) {
-    case KPI_STATUS.ON_TRACK: return 'var(--status-resolved)';
-    case KPI_STATUS.BREACHING: return 'var(--status-breach)';
-    default: return null;
-  }
-}
 
 function renderNumberTileDelta(ctx) {
   const { viz, title, loading, onRemove, locale } = ctx;
@@ -395,24 +235,6 @@ function renderNumberTileDelta(ctx) {
 // Ports parseSparkline7d's "sort by date, map measure -> point" shaping into a
 // generic adapter keyed off viz.sparklineKey / viz.dateKey / viz.measureKey.
 // ---------------------------------------------------------------------------
-
-function resolveSparkline(ctx) {
-  const { viz, result } = ctx;
-  if (Array.isArray(result.sparkline)) return result.sparkline.map((n) => Number(n) || 0);
-
-  // Long-form rows -> ordered numeric series.
-  const seriesRows = viz.sparklineKey && result[viz.sparklineKey]?.rows
-    ? result[viz.sparklineKey].rows
-    : result.rows;
-  if (!seriesRows?.length) return [];
-
-  const dateKey = viz.dateKey || dimensionColumns(result, viz)[0]?.name || 'created_date';
-  const measureKey = viz.sparklineMeasureKey || primaryMeasure(result, viz).name;
-
-  return [...seriesRows]
-    .sort((a, b) => String(a[dateKey] ?? '').localeCompare(String(b[dateKey] ?? '')))
-    .map((row) => Number(row[measureKey]) || 0);
-}
 
 function renderNumberTileSparkline(ctx) {
   const { viz, title, loading, onRemove, locale } = ctx;
@@ -441,37 +263,6 @@ function renderNumberTileSparkline(ctx) {
 // dimension -> { label, count }, optionally ranked by measure desc.
 // ---------------------------------------------------------------------------
 
-function adaptBarRows(ctx) {
-  const { viz, result, locale } = ctx;
-  const dimKey = primaryDimensionKey(result, viz);
-  const measure = primaryMeasure(result, viz);
-  const isPercent = viz.format === 'percent' || viz.format === 'percentOneDecimal';
-
-  let rows = (result.rows || []).map((row) => ({
-    label: formatDimLabel(row[dimKey], viz, dimKey, locale),
-    count: percentToChartScale(Number(row[measure.name]) || 0, isPercent),
-  }));
-
-  // Histograms keep the backend bucket order; bars rank by value desc unless
-  // the descriptor pins an explicit category order.
-  if (viz.kind !== 'histogram' && !viz.categoryOrder && viz.sort !== 'none') {
-    rows = rows.sort((a, b) => b.count - a.count);
-  }
-  // Explicit category order (e.g. age buckets <1d,1-3d,3-7d,>7d) — apply it so the
-  // backend's arbitrary row order doesn't scramble an ordered axis. Substring match
-  // tolerates label formatting; unknown labels sink to the end.
-  if (viz.categoryOrder) {
-    const ord = viz.categoryOrder;
-    const idx = (l) => {
-      const i = ord.findIndex((o) => l === o || l.includes(o) || o.includes(l));
-      return i < 0 ? ord.length : i;
-    };
-    rows = rows.slice().sort((a, b) => idx(a.label) - idx(b.label));
-  }
-  if (viz.limit) rows = rows.slice(0, viz.limit);
-  return rows;
-}
-
 function renderBar(ctx, { histogram }) {
   const { viz, loading } = ctx;
   const data = adaptBarRows(ctx);
@@ -484,7 +275,7 @@ function renderBar(ctx, { histogram }) {
       colors={viz.colors}
       histogram={histogram}
       valueFormat={viz.format === 'percent' || viz.format === 'percentOneDecimal' ? 'percent' : 'count'}
-      scrollKey={histogram ? undefined : def_scrollKey(ctx)}
+      scrollKey={histogram ? undefined : defScrollKey(ctx)}
     />
   );
 }
@@ -493,43 +284,6 @@ function renderBar(ctx, { histogram }) {
 // Horizontal bar  -> HorizontalBarChart
 // Ports parseDepartmentFlowRatioBarChart: dimension -> { label, value, resolved, created }.
 // ---------------------------------------------------------------------------
-
-function adaptHorizontalRows(ctx) {
-  const { viz, result, locale } = ctx;
-  const dimKey = primaryDimensionKey(result, viz);
-  const valueKey = viz.measureKey || primaryMeasure(result, viz).name;
-  const numeratorKey = viz.numeratorKey;   // e.g. resolved
-  const denominatorKey = viz.denominatorKey; // e.g. created
-  // Roll up to display grain when several source rows share a dimension value
-  // (e.g. service_code rows -> one department_code). Mirrors the reference
-  // parseDepartmentFlowRatioBarChart roll-up; numerator/denominator sum, then
-  // value is recomputed as the ratio.
-  const grouped = new Map();
-  for (const row of result.rows || []) {
-    const key = String(row[dimKey] ?? 'Unknown');
-    const bucket = grouped.get(key) || { num: 0, den: 0, val: 0 };
-    if (numeratorKey != null) bucket.num += Number(row[numeratorKey]) || 0;
-    if (denominatorKey != null) bucket.den += Number(row[denominatorKey]) || 0;
-    bucket.val += Number(row[valueKey]) || 0;
-    grouped.set(key, bucket);
-  }
-  const isRatio = numeratorKey != null && denominatorKey != null;
-  let rows = [...grouped.entries()].map(([key, b]) => ({
-    label: formatDimLabel(key, viz, dimKey, locale),
-    value: isRatio ? (b.den > 0 ? b.num / b.den : 0) : b.val,
-    resolved: numeratorKey != null ? b.num : undefined,
-    created: denominatorKey != null ? b.den : undefined,
-  }));
-  // Drop zero-denominator categories (reference filters created<=0).
-  // Only hide zero *values* for ratio charts (e.g. flow ratio) — count bars
-  // should still show an explicit zero bar (#1028 / review on #1311).
-  if (isRatio) {
-    rows = rows.filter((r) => (r.created || 0) > 0 && Number(r.value) > 0);
-  }
-  if (viz.sort !== 'none') rows = rows.sort((a, b) => a.value - b.value);
-  if (viz.limit) rows = rows.slice(0, viz.limit);
-  return rows;
-}
 
 function renderHorizontalBar(ctx) {
   const { viz, loading } = ctx;
@@ -540,7 +294,7 @@ function renderHorizontalBar(ctx) {
     <HorizontalBarChart
       data={data}
       breakEven={viz.breakEven ?? 1}
-      scrollKey={def_scrollKey(ctx)}
+      scrollKey={defScrollKey(ctx)}
     />
   );
 }
@@ -552,73 +306,6 @@ function renderHorizontalBar(ctx) {
 //  - else pivot long-form rows (category x stackKey -> measure) into series,
 //    keyed off viz.stackSeries [{ key, label, color }].
 // ---------------------------------------------------------------------------
-
-function adaptStacked(ctx) {
-  const { viz, result, locale } = ctx;
-
-  // BE-shaped passthrough.
-  if (result.series && Array.isArray(result.series) && result.categories) {
-    return { categories: result.categories, series: result.series, colors: result.colors || viz.colors || [] };
-  }
-
-  const dimKey = primaryDimensionKey(result, viz);
-  const stackKey = viz.stackKey;
-  const measureKey = viz.measureKey || 'total';
-  const stackSeries = viz.stackSeries; // [{ key, label, color }]
-
-  // Single-series stacked (e.g. complaints-by-type "Filed").
-  if (!stackKey || !stackSeries?.length) {
-    let rows = (result.rows || []).map((row) => ({
-      label: formatDimLabel(row[dimKey], viz, dimKey, locale),
-      value: Number(row[measureKey]) || 0,
-    }));
-    if (viz.sort !== 'none') rows = rows.sort((a, b) => b.value - a.value);
-    if (viz.limit) rows = rows.slice(0, viz.limit);
-    return {
-      categories: rows.map((r) => r.label),
-      series: [{ name: resolveSeriesLabel(viz, viz.seriesLabel || t("DASHBOARD_COMMON_COUNT", "Count")), data: rows.map((r) => r.value) }],
-      colors: viz.colors || ['var(--chart-1)'],
-    };
-  }
-
-  // Pivot long-form rows into per-segment series.
-  const segKeys = new Set(stackSeries.map((d) => normalizeSeg(d.key)));
-  const categoryMap = new Map();
-  for (const row of result.rows || []) {
-    const seg = normalizeSeg(row[stackKey]);
-    if (!segKeys.has(seg)) continue;
-    const category = String(row[dimKey] ?? 'Unknown');
-    if (!categoryMap.has(category)) categoryMap.set(category, {});
-    const bucket = categoryMap.get(category);
-    const value = viz.valueTransform === 'msToHours'
-      ? msToHours(row[measureKey])
-      : Number(row[measureKey]) || 0;
-    bucket[seg] = viz.aggregate === 'set' ? value : (bucket[seg] ?? 0) + value;
-  }
-
-  let entries = [...categoryMap.entries()].map(([key, segments]) => ({
-    key,
-    segments,
-    total: Object.values(segments).reduce((s, v) => s + v, 0),
-  }));
-  entries = entries.filter((e) => e.total > 0).sort((a, b) => {
-    if (viz.sortBySegment) {
-      const d = (b.segments[normalizeSeg(viz.sortBySegment)] ?? 0) - (a.segments[normalizeSeg(viz.sortBySegment)] ?? 0);
-      if (d !== 0) return d;
-    }
-    return b.total - a.total;
-  });
-  if (viz.limit) entries = entries.slice(0, viz.limit);
-
-  return {
-    categories: entries.map((e) => formatDimLabel(e.key, viz, dimKey, locale)),
-    series: stackSeries.map((def) => ({
-      name: seriesEntryLabel(def, def.label),
-      data: entries.map((e) => e.segments[normalizeSeg(def.key)] ?? 0),
-    })),
-    colors: stackSeries.map((def) => def.color),
-  };
-}
 
 function renderStackedBar(ctx) {
   const { viz, loading } = ctx;
@@ -633,7 +320,7 @@ function renderStackedBar(ctx) {
       colors={colors}
       horizontal={viz.orientation === 'horizontal'}
       valueFormat={viz.valueFormat || (viz.valueTransform === 'msToHours' ? 'hours' : undefined)}
-      scrollKey={def_scrollKey(ctx)}
+      scrollKey={defScrollKey(ctx)}
     />
   );
 }
@@ -642,59 +329,6 @@ function renderStackedBar(ctx) {
 // Pie  -> PieChart
 // Ports parseOpenComplaintsByChannelPieChart: dimension -> { label, count, color }.
 // ---------------------------------------------------------------------------
-
-function adaptPie(ctx) {
-  const { viz, result, locale } = ctx;
-  const dimKey = primaryDimensionKey(result, viz);
-  const measure = primaryMeasure(result, viz);
-  const colors = viz.colors || [];
-  // Optional source->channel rollup (parity with parseOpenComplaintsByChannelPieChart):
-  // when viz.channelMap is present, fold raw `source` rows into named channels
-  // with fixed colours/labels before slicing.
-  if (viz.channelMap?.length) {
-    return adaptChannelPie(result, dimKey, measure, viz);
-  }
-  let rows = (result.rows || [])
-    .map((row, i) => ({
-      label: formatDimLabel(row[dimKey], viz, dimKey, locale),
-      count: Number(row[measure.name]) || 0,
-      color: colors[i],
-    }))
-    .filter((s) => s.count > 0);
-  if (viz.sort !== 'none') rows = rows.sort((a, b) => b.count - a.count);
-  return rows;
-}
-
-/** source -> channel rollup with verbatim COMPLAINT_CHANNELS labels/colours. */
-function adaptChannelPie(result, dimKey, measure, viz) {
-  const channels = viz.channelMap; // [{ id, label, color, sources:[...] }]
-  const sourceToChannel = new Map();
-  for (const ch of channels) {
-    for (const src of ch.sources || []) {
-      sourceToChannel.set(normalizeSourceKey(src), ch.id);
-    }
-  }
-  const totals = new Map(channels.map((c) => [c.id, 0]));
-  for (const row of result.rows || []) {
-    const count = Number(row[measure.name]) || 0;
-    if (count <= 0) continue;
-    const key = normalizeSourceKey(row[dimKey]);
-    const id = key ? (sourceToChannel.get(key) ?? 'other') : 'other';
-    if (totals.has(id)) totals.set(id, totals.get(id) + count);
-  }
-  return channels
-    .map((c) => ({
-      label: seriesEntryLabel(c, dimensionLabel(c.id, 'channel', c.label)),
-      count: totals.get(c.id) ?? 0,
-      color: c.color,
-    }))
-    .filter((s) => s.count > 0)
-    .sort((a, b) => (b.count - a.count) || a.label.localeCompare(b.label));
-}
-
-function normalizeSourceKey(source) {
-  return String(source ?? '').trim().toLowerCase().replace(/-/g, '_');
-}
 
 function renderPie(ctx) {
   const { loading } = ctx;
@@ -710,56 +344,6 @@ function renderPie(ctx) {
 // rewriting (daily/weekly/monthly) is a BE-side concern; the engine only needs
 // the BE-shaped { periods, defaultPeriod } or a flat { categories, series }.
 // ---------------------------------------------------------------------------
-
-function adaptLine(ctx) {
-  const { viz, result, title, locale } = ctx;
-  if (result.periods) {
-    return { periods: result.periods, defaultPeriod: result.defaultPeriod || viz.defaultPeriod || 'daily', headerTitle: result.title || title };
-  }
-  if (result.series && result.categories) {
-    return { categories: result.categories, series: result.series };
-  }
-  const dimKey = primaryDimensionKey(result, viz);
-  const rows = [...(result.rows || [])].sort((a, b) =>
-    String(a[dimKey] ?? '').localeCompare(String(b[dimKey] ?? ''))
-  );
-  const categories = rows.map((r) => formatDimLabel(r[dimKey], viz, dimKey, locale));
-
-  // Descriptor-driven multi-series with per-series colour / dual y-axis grouping.
-  // Each seriesDef is either a direct measure ({ measureKey }) or a computed
-  // ratio percent ({ numeratorKey, denominatorKey }) — ports the reference
-  // COMPLAINTS_OVER_TIME_SERIES_DEFS (Created / Resolved counts + Resolution
-  // rate / SLA compliance percents on a second axis).
-  if (viz.seriesDefs?.length) {
-    return {
-      categories,
-      series: viz.seriesDefs.map((def) => ({
-        name: seriesEntryLabel(def, def.name),
-        color: def.color,
-        yAxisGroup: def.yAxisGroup,
-        dashArray: def.dashArray ?? 0,
-        data: rows.map((r) => {
-          if (def.numeratorKey != null && def.denominatorKey != null) {
-            const num = Number(r[def.numeratorKey]) || 0;
-            const den = Number(r[def.denominatorKey]) || 0;
-            return den > 0 ? Math.round((num / den) * 1000) / 10 : 0;
-          }
-          return Number(r[def.measureKey]) || 0;
-        }),
-      })),
-    };
-  }
-
-  // Long-form fallback -> single/multi series keyed off viz.measureKeys.
-  const measures = measureColumns(result, viz);
-  return {
-    categories,
-    series: measures.map((m) => ({
-      name: seriesEntryLabel(m, m.label || m.name),
-      data: rows.map((r) => Number(r[m.name]) || 0),
-    })),
-  };
-}
 
 function renderLine(ctx) {
   const { loading } = ctx;
@@ -791,82 +375,11 @@ function renderTable(ctx) {
   return <DashboardTable columns={columns} rows={rows} emptyMessage={viz.emptyMessage || t("DASHBOARD_COMMON_NO_DATA", "No data")} />;
 }
 
-function deriveColumnsFromResult(result) {
-  return (result.columns || []).map((c) => ({
-    id: c.name,
-    label: c.label || c.name,
-    labelKey: c.labelKey,
-    align: c.role === 'measure' ? 'right' : 'left',
-    type: mapFormatToCellType(c.format),
-    thresholdKey: c.thresholdKey,
-  }));
-}
-
-function mapFormatToCellType(format) {
-  switch (format) {
-    case 'integer': return 'integer';
-    case 'percent':
-    case 'percentOneDecimal':
-    case 'percentInteger': return 'percent';
-    case 'hoursDecimal': return 'hours';
-    case 'hoursDays': return 'hoursDays';
-    case 'ratingOutOfFive': return 'rating';
-    default: return 'text';
-  }
-}
-
 // ---------------------------------------------------------------------------
 // SLA-risk table  -> ComplaintsAtRiskTable
 // The component owns its own columns; rows already carry the per-row display
 // shape (id, typeLabel, ownerName, slaLabel, breachDurationLabel, ...).
 // ---------------------------------------------------------------------------
-
-/**
- * Shape the generic at-risk grain rows into the ComplaintsAtRiskTable row
- * contract. Ports config/kpiQueries.parseComplaintsAtRiskTable verbatim (it
- * relies only on the pure presentation helpers, which survive the inversion),
- * so the inverted engine renders the rich SLA-risk table at parity with the
- * reference instead of a degraded ranked list.
- */
-function adaptSlaRiskRows(ctx) {
-  const { viz, result } = ctx;
-  const limit = viz.limit || 50;
-  return (result.rows || [])
-    .map((row, index) => {
-      const complaintId = String(row.service_request_id ?? '').trim();
-      if (!complaintId || complaintId === 'null') return null;
-
-      const slaBucket = String(row.sla_status_bucket ?? '');
-      const { slaLabel, slaLevel } = resolveSlaRiskPresentation(slaBucket);
-      const breachDurationMs = computeBreachDurationMs(
-        row.open_age_ms,
-        row.sla_target_ms,
-        slaBucket
-      );
-      const applicationStatus = String(row.application_status ?? '');
-      const subtypeKey = String(row.service_code ?? '');
-      const typeKey = String(row.service_group ?? '');
-
-      return {
-        id: complaintId,
-        typeLabel: typeKey ? dimensionLabel(typeKey, 'complaintType') : '—',
-        subtypeLabel: subtypeKey ? dimensionLabel(subtypeKey, 'complaintType') : '—',
-        locality: row.ward_code ? dimensionLabel(String(row.ward_code), 'boundary') : '—',
-        ownerName: formatOfficerLabel(row.current_assignee_uuid),
-        ownerRole: '—',
-        status: normalizeWorkflowStatusKey(applicationStatus),
-        statusLabel: formatWorkflowStatusLabel(applicationStatus),
-        slaLabel,
-        slaLevel,
-        breachDurationMs,
-        breachDurationLabel: formatBreachDurationCompact(breachDurationMs),
-        _rowKey: `risk-${index}-${complaintId}`,
-      };
-    })
-    .filter(Boolean)
-    .sort((left, right) => (right.breachDurationMs ?? -1) - (left.breachDurationMs ?? -1))
-    .slice(0, limit);
-}
 
 function renderSlaRiskTable(ctx) {
   const { loading } = ctx;
@@ -885,55 +398,6 @@ function renderSlaRiskTable(ctx) {
 // (previously the same open-only array was pinned to all three, so the Resolved
 // layer shaded "0 resolved" underneath still-open complaints).
 // ---------------------------------------------------------------------------
-
-function adaptMapLayers(ctx) {
-  const { viz, result } = ctx;
-  const dimKey = viz.dimensionKey || 'ward_code';
-  // The map tile's query returns filed/open/resolved per ward. Her map colours the
-  // Created layer by `count`, and the Open/Resolved layers by `openPct`/`resolvedPct`
-  // (share of filed, 0–100). One ward series carries all three so any layer renders.
-  const wards = (result.rows || [])
-    .filter((row) => {
-      const code = String(row[dimKey] ?? '').trim();
-      return code && code !== 'null';
-    })
-    .map((row) => {
-      const wardCode = String(row[dimKey]);
-      const filed = Number(row.filed) || 0;
-      const open = Number(row.open) || 0;
-      const resolved = Number(row.resolved) || 0;
-      return {
-        wardCode,
-        label: dimensionLabel(wardCode, 'boundary'),
-        count: filed,
-        total: filed,
-        // named counts so the choropleth hover tooltip (reads created/open/resolved) has values
-        created: filed,
-        open,
-        resolved,
-        openPct: filed > 0 ? (open / filed) * 100 : 0,
-        resolvedPct: filed > 0 ? (resolved / filed) * 100 : 0,
-      };
-    });
-  const pins = result.pins || [];
-  const statusKnown = result.pinsStatusKnown === true;
-  const { layerTotals, unmapped } = summarizeWardRows(result.rows || [], dimKey);
-  const layers = {
-    wardDetails: {},
-    complaintPinsByLayer: partitionPinsByLayer(pins, statusKnown),
-    complaintPinsError: null,
-    // 'open-only' = the tenant's catalog still has the legacy pin def, so pins
-    // cannot follow the layer; the legend says so instead of lying by omission.
-    pinSemantics: statusKnown ? 'per-layer' : 'open-only',
-    pinsTruncated: result.pinsTruncated === true,
-    layerTotals,
-    unmapped,
-  };
-  for (const key of GEO_MAP_LAYER_KEYS) {
-    layers[key] = wards;
-  }
-  return layers;
-}
 
 /**
  * The map branch is memoized on its own inputs: adaptMapLayers re-derives fresh
@@ -957,30 +421,6 @@ function renderChoroplethMap(ctx) {
 // ---------------------------------------------------------------------------
 // Ranked list + day-of-week  -> KpiTile internal displays (kept generic)
 // ---------------------------------------------------------------------------
-
-function adaptRanked(ctx) {
-  const { viz, result, locale } = ctx;
-  const dimKey = primaryDimensionKey(result, viz);
-  const measure = primaryMeasure(result, viz);
-  let rows = (result.rows || []).map((row) => ({
-    label: formatDimLabel(row[dimKey], viz, dimKey, locale),
-    value: Number(row[measure.name]) || 0,
-  }));
-  if (viz.sort !== 'none') rows = rows.sort((a, b) => b.value - a.value);
-  rows = rows.slice(0, viz.limit || 10);
-  return { rows, format: measure.format || viz.format };
-}
-
-function adaptDow(ctx) {
-  const { viz, result } = ctx;
-  const dimKey = primaryDimensionKey(result, viz);
-  const measure = primaryMeasure(result, viz);
-  const rows = (result.rows || []).map((row) => ({
-    dow: Number(row[dimKey]),
-    value: Number(row[measure.name]) || 0,
-  }));
-  return { rows, format: measure.format || viz.format };
-}
 
 function RankedListDisplay({ rows, format }) {
   const { language } = useDashboardT();
@@ -1024,150 +464,6 @@ function DowDisplay({ rows, format }) {
       ))}
     </div>
   );
-}
-
-// ---------------------------------------------------------------------------
-// Formatting (ported from formatSubMetricValue / DashboardTable formatters)
-// ---------------------------------------------------------------------------
-
-const MS_PER_DAY = 86400000;
-const MS_PER_HOUR = 3600000;
-
-// Every case routes its NUMERIC part through the tenant mask via formatNumber
-// (utils/numberFormat.js): null when no dss.DashboardConfig.numberFormat is
-// configured, so each `??` fallback keeps the pre-#1213 expression untouched.
-// Unit suffixes (%, /5, h, hr/hrs/day/days, ordinal) stay here — the mask
-// contributes separators only, decimal counts stay per-format (R3); durations
-// take the mask decimal separator too (R7).
-function applyFormat(val, format, locale) {
-  if (val == null || !Number.isFinite(Number(val))) return '—';
-  const n = Number(val);
-  switch (format) {
-    case 'integer':           return formatNumber(n, 'integer') ?? Math.round(n).toLocaleString(locale);
-    case 'percentInteger':
-    case 'percentNoDecimal':  return `${formatNumber(normalizePct(n), 'percentInteger') ?? Math.round(normalizePct(n))}%`;
-    case 'percentOneDecimal':
-    case 'percent':           return `${formatNumber(normalizePct(n), 'percent') ?? normalizePct(n).toFixed(1)}%`;
-    case 'decimalOne':        return formatNumber(n, 'decimalOne') ?? n.toFixed(1);
-    case 'decimalTwo':        return formatNumber(n, 'decimalTwo') ?? n.toFixed(2);
-    case 'ratingOutOfFive':   return `${formatNumber(n, 'ratingOutOfFive') ?? n.toFixed(1)}/5`;
-    case 'hoursDays': {
-      const hours = n / MS_PER_HOUR;
-      if (hours < 48) {
-        const r = Math.round(hours * 10) / 10;
-        const num = formatNumber(r, { decimals: 1, trim: true }) ?? (Number.isInteger(r) ? r : r.toFixed(1));
-        return `${num} ${r === 1 ? t("DASHBOARD_UNIT_HR", "hr") : t("DASHBOARD_UNIT_HRS", "hrs")}`;
-      }
-      const days = n / MS_PER_DAY;
-      const r = Math.round(days * 10) / 10;
-      const num = formatNumber(r, { decimals: 1, trim: true }) ?? (Number.isInteger(r) ? r : r.toFixed(1));
-      return `${num} ${r === 1 ? t("DASHBOARD_UNIT_DAY", "day") : t("DASHBOARD_UNIT_DAYS", "days")}`;
-    }
-    case 'hoursDecimal':      return `${formatNumber(n / MS_PER_HOUR, 'hoursDecimal') ?? (n / MS_PER_HOUR).toFixed(1)}h`;
-    case 'signedInteger':     return `${n >= 0 ? '+' : ''}${formatNumber(n, 'signedInteger') ?? Math.round(n).toLocaleString(locale)}`;
-    case 'ordinal': {
-      const v = Math.round(n) % 100;
-      const s = ['th', 'st', 'nd', 'rd'];
-      return (formatNumber(n, 'integer') ?? Math.round(n)) + (s[(v - 20) % 10] || s[v] || s[0]);
-    }
-    default: return String(val);
-  }
-}
-
-function isPercentFormat(format) {
-  return (
-    format === 'percent' ||
-    format === 'percentInteger' ||
-    format === 'percentNoDecimal' ||
-    format === 'percentOneDecimal'
-  );
-}
-
-function normalizePct(value) {
-  const n = Number(value);
-  if (!Number.isFinite(n)) return 0;
-  return n <= 1 ? n * 100 : n;
-}
-
-// DepartmentBarChart's percent mode plots 0..100, so scale ratios up.
-function percentToChartScale(value, isPercent) {
-  return isPercent ? normalizePct(value) : value;
-}
-
-function msToHours(ms) {
-  const hours = Number(ms) / MS_PER_HOUR;
-  if (!Number.isFinite(hours) || hours <= 0) return 0;
-  return Math.round(hours * 10) / 10;
-}
-
-function formatLabel(value) {
-  const s = String(value ?? '');
-  if (!s || s === 'null' || s === 'undefined') return t("DASHBOARD_COMMON_UNKNOWN", "Unknown");
-  return s;
-}
-
-/**
- * Dimension-label formatter keyed off `viz.labelFormat`. Ports the reference
- * client-side label shaping (kpiQueries.formatDimensionLabel /
- * formatOfficerStackedLabel) into the engine so chart categories match the
- * reference verbatim without per-tile code.
- *   - "dimension": localize via the dimensionLabel seam (kind derived from the
- *     query dimension name `dim`), falling back to the legacy humaniser
- *   - "officer":   mask an assignee UUID -> "Officer …<last6>" / "Unassigned"
- * No labelFormat => identity (formatLabel).
- */
-function formatDimLabel(value, viz, dim, locale) {
-  switch (viz?.labelFormat) {
-    case 'dimension': {
-      const kind = dimensionKindForName(dim);
-      return kind ? dimensionLabel(value, kind) : String(value);
-    }
-    case 'department': return dimensionLabel(value, 'department');
-    case 'officer':    return formatOfficerLabel(value);
-    case 'date-dow':   return formatDateDow(value, locale);
-    default:           return formatLabel(value);
-  }
-}
-
-// Port of kpiQueries.formatOverTimeDailyLabel: epoch-ms / yyyy-MM-dd -> short weekday.
-function formatDateDow(value, locale) {
-  const key = epochOrIsoToDateKey(value);
-  if (!key) return formatLabel(value);
-  const d = new Date(`${key}T12:00:00`);
-  if (Number.isNaN(d.getTime())) return key;
-  return d.toLocaleDateString(locale, { weekday: 'short' });
-}
-
-function epochOrIsoToDateKey(value) {
-  if (value == null || value === '') return '';
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    return new Date(value).toISOString().slice(0, 10);
-  }
-  const s = String(value).trim();
-  if (/^\d{13}$/.test(s)) return new Date(Number(s)).toISOString().slice(0, 10);
-  const iso = s.match(/^(\d{4}-\d{2}-\d{2})/);
-  return iso ? iso[1] : s;
-}
-
-function normalizeSeg(value) {
-  return String(value ?? '').toUpperCase();
-}
-
-function errorLabel(code) {
-  switch (code) {
-    case 'pii_forbidden': return t("DASHBOARD_TILE_ERR_RESTRICTED", "Restricted");
-    case 'kpi_forbidden': return t("DASHBOARD_TILE_ERR_NO_ACCESS", "No access");
-    case 'scope_forbidden': return t("DASHBOARD_TILE_ERR_OUT_OF_SCOPE", "Out of scope");
-    default: return code || t("DASHBOARD_TILE_ERR_GENERIC", "ERROR");
-  }
-}
-
-function def_scrollKey(ctx) {
-  return ctx.def?.kpiId || ctx.def?.id || undefined;
-}
-
-function formatAsOf(asOf, locale) {
-  try { return new Date(asOf).toLocaleString(locale); } catch { return String(asOf); }
 }
 
 const Placeholder = ({ message }) => (

--- a/digit-ui-esbuild/products/dashboard/src/utils/tileResultAdapters.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/tileResultAdapters.js
@@ -1,0 +1,624 @@
+/**
+ * React-free result-to-view-model adapters used by KpiTile.
+ *
+ * This module deliberately preserves the renderer's existing interpretation of
+ * catalog viz descriptors and analytics results. Keeping these transformations
+ * free of React makes the legacy result contract characterizable while the
+ * backend presentation envelope is introduced incrementally.
+ */
+
+import { formatNumber } from './numberFormat';
+import {
+  GEO_MAP_LAYER_KEYS,
+  partitionPinsByLayer,
+  summarizeWardRows,
+} from './complaintPins';
+import { evaluateCompose, requiresBackendComposition } from './composeKpi';
+import { getNumberTileDeltaClass, formatOfficerLabel, dimensionKindForName } from '../config/kpiDisplay';
+import {
+  resolveSlaRiskPresentation,
+  computeBreachDurationMs,
+  formatBreachDurationCompact,
+  formatWorkflowStatusLabel,
+  normalizeWorkflowStatusKey,
+} from '../config/complaintsAtRiskPresentation';
+import { dimensionLabel } from '../i18n/dimensionLabel';
+import { translate as t } from '../i18n/localeRuntime';
+import { seriesEntryLabel, resolveSeriesLabel } from '../i18n/textResolver';
+
+export function dimensionColumns(result, viz) {
+  const cols = (result.columns || []).filter((c) => c.role === 'dimension');
+  if (cols.length) return cols;
+  if (viz.dimensionKey) return [{ name: viz.dimensionKey }];
+  return [];
+}
+
+export function measureColumns(result, viz) {
+  const cols = (result.columns || []).filter((c) => c.role === 'measure');
+  if (cols.length) return cols;
+  const keys = viz.measureKeys || (viz.measureKey ? [viz.measureKey] : []);
+  return keys.map((name) => ({ name }));
+}
+
+export function primaryDimensionKey(result, viz) {
+  return dimensionColumns(result, viz)[0]?.name || viz.dimensionKey || 'label';
+}
+
+export function primaryMeasure(result, viz) {
+  return measureColumns(result, viz)[0] || { name: viz.measureKey || 'total' };
+}
+
+export function resolveScalar(ctx) {
+  const { viz, result, results } = ctx;
+  // Calendar-aware averages are backend-owned. A malformed definition that
+  // combines one with a raw query must fail closed instead of displaying a total.
+  if (requiresBackendComposition(viz.compose)) {
+    return result.value != null ? Number(result.value) : null;
+  }
+  if (viz.compose && results) {
+    const composed = evaluateCompose(viz.compose, results);
+    if (composed != null) return composed;
+  }
+  if (result.value != null) return result.value;
+  if (result.values && viz.valueKey != null && result.values[viz.valueKey] != null) {
+    return Number(result.values[viz.valueKey]);
+  }
+  if (result.values) {
+    const first = Object.values(result.values)[0];
+    if (first != null) return Number(first);
+  }
+  const row0 = result.rows?.[0];
+  if (row0) {
+    const key = viz.valueKey || primaryMeasure(result, viz).name;
+    if (row0[key] != null) return Number(row0[key]);
+  }
+  return null;
+}
+
+export function resolvePrior(ctx) {
+  const { viz, result } = ctx;
+  if (result.prior != null) return Number(result.prior);
+  if (viz.priorKey != null) {
+    if (result.values && result.values[viz.priorKey] != null) return Number(result.values[viz.priorKey]);
+    const row0 = result.rows?.[0];
+    if (row0 && row0[viz.priorKey] != null) return Number(row0[viz.priorKey]);
+  }
+  return null;
+}
+
+export function computeDelta(current, prior, format, mode) {
+  if (current == null || prior == null || !Number.isFinite(current) || !Number.isFinite(prior)) {
+    return null;
+  }
+  const eff = mode || (isPercentFormat(format) ? 'percentPoint' : 'percent');
+  if (eff === 'percentPoint') return normalizePct(current) - normalizePct(prior);
+  if (eff === 'days') return (current - prior) / 86400000;
+  if (eff === 'duration') return current - prior;
+  if (eff === 'rating') return current - prior;
+  if (prior === 0) return null;
+  return ((current - prior) / Math.abs(prior)) * 100;
+}
+
+export function formatDeltaDisplay(delta, format, mode) {
+  if (delta == null || !Number.isFinite(delta)) return null;
+  const arrow = delta >= 0 ? '▲' : '▼';
+  const abs = Math.abs(delta);
+  const eff = mode || (isPercentFormat(format) ? 'percentPoint' : 'percent');
+  if (eff === 'duration') {
+    return abs >= 86400000
+      ? `${arrow} ${formatNumber(abs / 86400000, { decimals: 1 }) ?? (abs / 86400000).toFixed(1)} ${t("DASHBOARD_UNIT_DAYS", "days")}`
+      : `${arrow} ${formatNumber(abs / 3600000, { decimals: 1 }) ?? (abs / 3600000).toFixed(1)} ${t("DASHBOARD_UNIT_HRS", "hrs")}`;
+  }
+  const rounded = Math.round(abs * 10) / 10;
+  const formatted =
+    formatNumber(rounded, { decimals: 1, trim: true }) ??
+    (Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1));
+  if (eff === 'days') return `${arrow} ${formatted} ${rounded === 1 ? t("DASHBOARD_UNIT_DAY", "day") : t("DASHBOARD_UNIT_DAYS", "days")}`;
+  if (eff === 'rating') return `${arrow} ${formatted}`;
+  const unit = eff === 'percentPoint' ? 'pp' : '%';
+  return `${arrow} ${formatted}${unit}`;
+}
+
+export function deltaClassFor(delta) {
+  if (delta == null || !Number.isFinite(delta) || delta === 0) return undefined;
+  return delta > 0 ? 'dashboard-delta-up' : 'dashboard-delta-down';
+}
+
+export const KPI_STATUS = { ON_TRACK: 'on_track', NORMAL: 'normal', BREACHING: 'breaching' };
+
+export function thresholdStatus(threshold, value) {
+  if (!threshold || value == null || !Number.isFinite(Number(value))) return null;
+  const n = threshold.kind === 'percent' ? normalizePct(value) : Number(value);
+  const { higherIsBetter, onTrack, breaching } = threshold;
+  if (higherIsBetter) {
+    if (n >= onTrack) return KPI_STATUS.ON_TRACK;
+    if (n <= breaching) return KPI_STATUS.BREACHING;
+    return KPI_STATUS.NORMAL;
+  }
+  if (n <= onTrack) return KPI_STATUS.ON_TRACK;
+  if (n >= breaching) return KPI_STATUS.BREACHING;
+  return KPI_STATUS.NORMAL;
+}
+
+export function resolveTileStatus(viz, value) {
+  return thresholdStatus(viz.threshold, value) ?? viz.accent;
+}
+
+export function resolveDeltaClass(viz, value, delta) {
+  const status = thresholdStatus(viz.threshold, value);
+  if (status) {
+    const unavailable = value == null || !Number.isFinite(Number(value));
+    return getNumberTileDeltaClass(status, { unavailable });
+  }
+  return deltaClassFor(delta);
+}
+
+export function statusToSeriesColor(status) {
+  switch (status) {
+    case KPI_STATUS.ON_TRACK: return 'var(--status-resolved)';
+    case KPI_STATUS.BREACHING: return 'var(--status-breach)';
+    default: return null;
+  }
+}
+
+export function resolveSparkline(ctx) {
+  const { viz, result } = ctx;
+  if (Array.isArray(result.sparkline)) return result.sparkline.map((n) => Number(n) || 0);
+  const seriesRows = viz.sparklineKey && result[viz.sparklineKey]?.rows
+    ? result[viz.sparklineKey].rows
+    : result.rows;
+  if (!seriesRows?.length) return [];
+  const dateKey = viz.dateKey || dimensionColumns(result, viz)[0]?.name || 'created_date';
+  const measureKey = viz.sparklineMeasureKey || primaryMeasure(result, viz).name;
+  return [...seriesRows]
+    .sort((a, b) => String(a[dateKey] ?? '').localeCompare(String(b[dateKey] ?? '')))
+    .map((row) => Number(row[measureKey]) || 0);
+}
+
+export function adaptBarRows(ctx) {
+  const { viz, result, locale } = ctx;
+  const dimKey = primaryDimensionKey(result, viz);
+  const measure = primaryMeasure(result, viz);
+  const isPercent = viz.format === 'percent' || viz.format === 'percentOneDecimal';
+  let rows = (result.rows || []).map((row) => ({
+    label: formatDimLabel(row[dimKey], viz, dimKey, locale),
+    count: percentToChartScale(Number(row[measure.name]) || 0, isPercent),
+  }));
+  if (viz.kind !== 'histogram' && !viz.categoryOrder && viz.sort !== 'none') {
+    rows = rows.sort((a, b) => b.count - a.count);
+  }
+  if (viz.categoryOrder) {
+    const ord = viz.categoryOrder;
+    const idx = (l) => {
+      const i = ord.findIndex((o) => l === o || l.includes(o) || o.includes(l));
+      return i < 0 ? ord.length : i;
+    };
+    rows = rows.slice().sort((a, b) => idx(a.label) - idx(b.label));
+  }
+  if (viz.limit) rows = rows.slice(0, viz.limit);
+  return rows;
+}
+
+export function adaptHorizontalRows(ctx) {
+  const { viz, result, locale } = ctx;
+  const dimKey = primaryDimensionKey(result, viz);
+  const valueKey = viz.measureKey || primaryMeasure(result, viz).name;
+  const numeratorKey = viz.numeratorKey;
+  const denominatorKey = viz.denominatorKey;
+  const grouped = new Map();
+  for (const row of result.rows || []) {
+    const key = String(row[dimKey] ?? 'Unknown');
+    const bucket = grouped.get(key) || { num: 0, den: 0, val: 0 };
+    if (numeratorKey != null) bucket.num += Number(row[numeratorKey]) || 0;
+    if (denominatorKey != null) bucket.den += Number(row[denominatorKey]) || 0;
+    bucket.val += Number(row[valueKey]) || 0;
+    grouped.set(key, bucket);
+  }
+  const isRatio = numeratorKey != null && denominatorKey != null;
+  let rows = [...grouped.entries()].map(([key, b]) => ({
+    label: formatDimLabel(key, viz, dimKey, locale),
+    value: isRatio ? (b.den > 0 ? b.num / b.den : 0) : b.val,
+    resolved: numeratorKey != null ? b.num : undefined,
+    created: denominatorKey != null ? b.den : undefined,
+  }));
+  if (isRatio) {
+    rows = rows.filter((r) => (r.created || 0) > 0 && Number(r.value) > 0);
+  }
+  if (viz.sort !== 'none') rows = rows.sort((a, b) => a.value - b.value);
+  if (viz.limit) rows = rows.slice(0, viz.limit);
+  return rows;
+}
+
+export function adaptStacked(ctx) {
+  const { viz, result, locale } = ctx;
+  if (result.series && Array.isArray(result.series) && result.categories) {
+    return { categories: result.categories, series: result.series, colors: result.colors || viz.colors || [] };
+  }
+  const dimKey = primaryDimensionKey(result, viz);
+  const stackKey = viz.stackKey;
+  const measureKey = viz.measureKey || 'total';
+  const stackSeries = viz.stackSeries;
+  if (!stackKey || !stackSeries?.length) {
+    let rows = (result.rows || []).map((row) => ({
+      label: formatDimLabel(row[dimKey], viz, dimKey, locale),
+      value: Number(row[measureKey]) || 0,
+    }));
+    if (viz.sort !== 'none') rows = rows.sort((a, b) => b.value - a.value);
+    if (viz.limit) rows = rows.slice(0, viz.limit);
+    return {
+      categories: rows.map((r) => r.label),
+      series: [{ name: resolveSeriesLabel(viz, viz.seriesLabel || t("DASHBOARD_COMMON_COUNT", "Count")), data: rows.map((r) => r.value) }],
+      colors: viz.colors || ['var(--chart-1)'],
+    };
+  }
+  const segKeys = new Set(stackSeries.map((d) => normalizeSeg(d.key)));
+  const categoryMap = new Map();
+  for (const row of result.rows || []) {
+    const seg = normalizeSeg(row[stackKey]);
+    if (!segKeys.has(seg)) continue;
+    const category = String(row[dimKey] ?? 'Unknown');
+    if (!categoryMap.has(category)) categoryMap.set(category, {});
+    const bucket = categoryMap.get(category);
+    const value = viz.valueTransform === 'msToHours'
+      ? msToHours(row[measureKey])
+      : Number(row[measureKey]) || 0;
+    bucket[seg] = viz.aggregate === 'set' ? value : (bucket[seg] ?? 0) + value;
+  }
+  let entries = [...categoryMap.entries()].map(([key, segments]) => ({
+    key,
+    segments,
+    total: Object.values(segments).reduce((sum, value) => sum + value, 0),
+  }));
+  entries = entries.filter((entry) => entry.total > 0).sort((left, right) => {
+    if (viz.sortBySegment) {
+      const difference =
+        (right.segments[normalizeSeg(viz.sortBySegment)] ?? 0) -
+        (left.segments[normalizeSeg(viz.sortBySegment)] ?? 0);
+      if (difference !== 0) return difference;
+    }
+    return right.total - left.total;
+  });
+  if (viz.limit) entries = entries.slice(0, viz.limit);
+  return {
+    categories: entries.map((entry) => formatDimLabel(entry.key, viz, dimKey, locale)),
+    series: stackSeries.map((def) => ({
+      name: seriesEntryLabel(def, def.label),
+      data: entries.map((entry) => entry.segments[normalizeSeg(def.key)] ?? 0),
+    })),
+    colors: stackSeries.map((def) => def.color),
+  };
+}
+
+export function adaptPie(ctx) {
+  const { viz, result, locale } = ctx;
+  const dimKey = primaryDimensionKey(result, viz);
+  const measure = primaryMeasure(result, viz);
+  const colors = viz.colors || [];
+  if (viz.channelMap?.length) return adaptChannelPie(result, dimKey, measure, viz);
+  let rows = (result.rows || [])
+    .map((row, index) => ({
+      label: formatDimLabel(row[dimKey], viz, dimKey, locale),
+      count: Number(row[measure.name]) || 0,
+      color: colors[index],
+    }))
+    .filter((slice) => slice.count > 0);
+  if (viz.sort !== 'none') rows = rows.sort((left, right) => right.count - left.count);
+  return rows;
+}
+
+export function adaptChannelPie(result, dimKey, measure, viz) {
+  const channels = viz.channelMap;
+  const sourceToChannel = new Map();
+  for (const channel of channels) {
+    for (const source of channel.sources || []) {
+      sourceToChannel.set(normalizeSourceKey(source), channel.id);
+    }
+  }
+  const totals = new Map(channels.map((channel) => [channel.id, 0]));
+  for (const row of result.rows || []) {
+    const count = Number(row[measure.name]) || 0;
+    if (count <= 0) continue;
+    const key = normalizeSourceKey(row[dimKey]);
+    const id = key ? (sourceToChannel.get(key) ?? 'other') : 'other';
+    if (totals.has(id)) totals.set(id, totals.get(id) + count);
+  }
+  return channels
+    .map((channel) => ({
+      label: seriesEntryLabel(channel, dimensionLabel(channel.id, 'channel', channel.label)),
+      count: totals.get(channel.id) ?? 0,
+      color: channel.color,
+    }))
+    .filter((slice) => slice.count > 0)
+    .sort((left, right) => (right.count - left.count) || left.label.localeCompare(right.label));
+}
+
+export function normalizeSourceKey(source) {
+  return String(source ?? '').trim().toLowerCase().replace(/-/g, '_');
+}
+
+export function adaptLine(ctx) {
+  const { viz, result, title, locale } = ctx;
+  if (result.periods) {
+    return { periods: result.periods, defaultPeriod: result.defaultPeriod || viz.defaultPeriod || 'daily', headerTitle: result.title || title };
+  }
+  if (result.series && result.categories) {
+    return { categories: result.categories, series: result.series };
+  }
+  const dimKey = primaryDimensionKey(result, viz);
+  const rows = [...(result.rows || [])].sort((left, right) =>
+    String(left[dimKey] ?? '').localeCompare(String(right[dimKey] ?? ''))
+  );
+  const categories = rows.map((row) => formatDimLabel(row[dimKey], viz, dimKey, locale));
+  if (viz.seriesDefs?.length) {
+    return {
+      categories,
+      series: viz.seriesDefs.map((def) => ({
+        name: seriesEntryLabel(def, def.name),
+        color: def.color,
+        yAxisGroup: def.yAxisGroup,
+        dashArray: def.dashArray ?? 0,
+        data: rows.map((row) => {
+          if (def.numeratorKey != null && def.denominatorKey != null) {
+            const numerator = Number(row[def.numeratorKey]) || 0;
+            const denominator = Number(row[def.denominatorKey]) || 0;
+            return denominator > 0 ? Math.round((numerator / denominator) * 1000) / 10 : 0;
+          }
+          return Number(row[def.measureKey]) || 0;
+        }),
+      })),
+    };
+  }
+  const measures = measureColumns(result, viz);
+  return {
+    categories,
+    series: measures.map((measure) => ({
+      name: seriesEntryLabel(measure, measure.label || measure.name),
+      data: rows.map((row) => Number(row[measure.name]) || 0),
+    })),
+  };
+}
+
+export function deriveColumnsFromResult(result) {
+  return (result.columns || []).map((column) => ({
+    id: column.name,
+    label: column.label || column.name,
+    labelKey: column.labelKey,
+    align: column.role === 'measure' ? 'right' : 'left',
+    type: mapFormatToCellType(column.format),
+    thresholdKey: column.thresholdKey,
+  }));
+}
+
+export function mapFormatToCellType(format) {
+  switch (format) {
+    case 'integer': return 'integer';
+    case 'percent':
+    case 'percentOneDecimal':
+    case 'percentInteger': return 'percent';
+    case 'hoursDecimal': return 'hours';
+    case 'hoursDays': return 'hoursDays';
+    case 'ratingOutOfFive': return 'rating';
+    default: return 'text';
+  }
+}
+
+export function adaptSlaRiskRows(ctx) {
+  const { viz, result } = ctx;
+  const limit = viz.limit || 50;
+  return (result.rows || [])
+    .map((row, index) => {
+      const complaintId = String(row.service_request_id ?? '').trim();
+      if (!complaintId || complaintId === 'null') return null;
+      const slaBucket = String(row.sla_status_bucket ?? '');
+      const { slaLabel, slaLevel } = resolveSlaRiskPresentation(slaBucket);
+      const breachDurationMs = computeBreachDurationMs(
+        row.open_age_ms,
+        row.sla_target_ms,
+        slaBucket
+      );
+      const applicationStatus = String(row.application_status ?? '');
+      const subtypeKey = String(row.service_code ?? '');
+      const typeKey = String(row.service_group ?? '');
+      return {
+        id: complaintId,
+        typeLabel: typeKey ? dimensionLabel(typeKey, 'complaintType') : '—',
+        subtypeLabel: subtypeKey ? dimensionLabel(subtypeKey, 'complaintType') : '—',
+        locality: row.ward_code ? dimensionLabel(String(row.ward_code), 'boundary') : '—',
+        ownerName: formatOfficerLabel(row.current_assignee_uuid),
+        ownerRole: '—',
+        status: normalizeWorkflowStatusKey(applicationStatus),
+        statusLabel: formatWorkflowStatusLabel(applicationStatus),
+        slaLabel,
+        slaLevel,
+        breachDurationMs,
+        breachDurationLabel: formatBreachDurationCompact(breachDurationMs),
+        _rowKey: `risk-${index}-${complaintId}`,
+      };
+    })
+    .filter(Boolean)
+    .sort((left, right) => (right.breachDurationMs ?? -1) - (left.breachDurationMs ?? -1))
+    .slice(0, limit);
+}
+
+export function adaptMapLayers(ctx) {
+  const { viz, result } = ctx;
+  const dimKey = viz.dimensionKey || 'ward_code';
+  const wards = (result.rows || [])
+    .filter((row) => {
+      const code = String(row[dimKey] ?? '').trim();
+      return code && code !== 'null';
+    })
+    .map((row) => {
+      const wardCode = String(row[dimKey]);
+      const filed = Number(row.filed) || 0;
+      const open = Number(row.open) || 0;
+      const resolved = Number(row.resolved) || 0;
+      return {
+        wardCode,
+        label: dimensionLabel(wardCode, 'boundary'),
+        count: filed,
+        total: filed,
+        created: filed,
+        open,
+        resolved,
+        openPct: filed > 0 ? (open / filed) * 100 : 0,
+        resolvedPct: filed > 0 ? (resolved / filed) * 100 : 0,
+      };
+    });
+  const pins = result.pins || [];
+  const statusKnown = result.pinsStatusKnown === true;
+  const { layerTotals, unmapped } = summarizeWardRows(result.rows || [], dimKey);
+  const layers = {
+    wardDetails: {},
+    complaintPinsByLayer: partitionPinsByLayer(pins, statusKnown),
+    complaintPinsError: null,
+    pinSemantics: statusKnown ? 'per-layer' : 'open-only',
+    pinsTruncated: result.pinsTruncated === true,
+    layerTotals,
+    unmapped,
+  };
+  for (const key of GEO_MAP_LAYER_KEYS) layers[key] = wards;
+  return layers;
+}
+
+export function adaptRanked(ctx) {
+  const { viz, result, locale } = ctx;
+  const dimKey = primaryDimensionKey(result, viz);
+  const measure = primaryMeasure(result, viz);
+  let rows = (result.rows || []).map((row) => ({
+    label: formatDimLabel(row[dimKey], viz, dimKey, locale),
+    value: Number(row[measure.name]) || 0,
+  }));
+  if (viz.sort !== 'none') rows = rows.sort((left, right) => right.value - left.value);
+  rows = rows.slice(0, viz.limit || 10);
+  return { rows, format: measure.format || viz.format };
+}
+
+export function adaptDow(ctx) {
+  const { viz, result } = ctx;
+  const dimKey = primaryDimensionKey(result, viz);
+  const measure = primaryMeasure(result, viz);
+  const rows = (result.rows || []).map((row) => ({
+    dow: Number(row[dimKey]),
+    value: Number(row[measure.name]) || 0,
+  }));
+  return { rows, format: measure.format || viz.format };
+}
+
+const MS_PER_DAY = 86400000;
+const MS_PER_HOUR = 3600000;
+
+export function applyFormat(val, format, locale) {
+  if (val == null || !Number.isFinite(Number(val))) return '—';
+  const n = Number(val);
+  switch (format) {
+    case 'integer':           return formatNumber(n, 'integer') ?? Math.round(n).toLocaleString(locale);
+    case 'percentInteger':
+    case 'percentNoDecimal':  return `${formatNumber(normalizePct(n), 'percentInteger') ?? Math.round(normalizePct(n))}%`;
+    case 'percentOneDecimal':
+    case 'percent':           return `${formatNumber(normalizePct(n), 'percent') ?? normalizePct(n).toFixed(1)}%`;
+    case 'decimalOne':        return formatNumber(n, 'decimalOne') ?? n.toFixed(1);
+    case 'decimalTwo':        return formatNumber(n, 'decimalTwo') ?? n.toFixed(2);
+    case 'ratingOutOfFive':   return `${formatNumber(n, 'ratingOutOfFive') ?? n.toFixed(1)}/5`;
+    case 'hoursDays': {
+      const hours = n / MS_PER_HOUR;
+      if (hours < 48) {
+        const rounded = Math.round(hours * 10) / 10;
+        const number = formatNumber(rounded, { decimals: 1, trim: true }) ?? (Number.isInteger(rounded) ? rounded : rounded.toFixed(1));
+        return `${number} ${rounded === 1 ? t("DASHBOARD_UNIT_HR", "hr") : t("DASHBOARD_UNIT_HRS", "hrs")}`;
+      }
+      const days = n / MS_PER_DAY;
+      const rounded = Math.round(days * 10) / 10;
+      const number = formatNumber(rounded, { decimals: 1, trim: true }) ?? (Number.isInteger(rounded) ? rounded : rounded.toFixed(1));
+      return `${number} ${rounded === 1 ? t("DASHBOARD_UNIT_DAY", "day") : t("DASHBOARD_UNIT_DAYS", "days")}`;
+    }
+    case 'hoursDecimal':      return `${formatNumber(n / MS_PER_HOUR, 'hoursDecimal') ?? (n / MS_PER_HOUR).toFixed(1)}h`;
+    case 'signedInteger':     return `${n >= 0 ? '+' : ''}${formatNumber(n, 'signedInteger') ?? Math.round(n).toLocaleString(locale)}`;
+    case 'ordinal': {
+      const value = Math.round(n) % 100;
+      const suffix = ['th', 'st', 'nd', 'rd'];
+      return (formatNumber(n, 'integer') ?? Math.round(n)) + (suffix[(value - 20) % 10] || suffix[value] || suffix[0]);
+    }
+    default: return String(val);
+  }
+}
+
+export function isPercentFormat(format) {
+  return (
+    format === 'percent' ||
+    format === 'percentInteger' ||
+    format === 'percentNoDecimal' ||
+    format === 'percentOneDecimal'
+  );
+}
+
+export function normalizePct(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return 0;
+  return number <= 1 ? number * 100 : number;
+}
+
+export function percentToChartScale(value, isPercent) {
+  return isPercent ? normalizePct(value) : value;
+}
+
+export function msToHours(ms) {
+  const hours = Number(ms) / MS_PER_HOUR;
+  if (!Number.isFinite(hours) || hours <= 0) return 0;
+  return Math.round(hours * 10) / 10;
+}
+
+export function formatLabel(value) {
+  const string = String(value ?? '');
+  if (!string || string === 'null' || string === 'undefined') return t("DASHBOARD_COMMON_UNKNOWN", "Unknown");
+  return string;
+}
+
+export function formatDimLabel(value, viz, dim, locale) {
+  switch (viz?.labelFormat) {
+    case 'dimension': {
+      const kind = dimensionKindForName(dim);
+      return kind ? dimensionLabel(value, kind) : String(value);
+    }
+    case 'department': return dimensionLabel(value, 'department');
+    case 'officer':    return formatOfficerLabel(value);
+    case 'date-dow':   return formatDateDow(value, locale);
+    default:           return formatLabel(value);
+  }
+}
+
+export function formatDateDow(value, locale) {
+  const key = epochOrIsoToDateKey(value);
+  if (!key) return formatLabel(value);
+  const date = new Date(`${key}T12:00:00`);
+  if (Number.isNaN(date.getTime())) return key;
+  return date.toLocaleDateString(locale, { weekday: 'short' });
+}
+
+export function epochOrIsoToDateKey(value) {
+  if (value == null || value === '') return '';
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return new Date(value).toISOString().slice(0, 10);
+  }
+  const string = String(value).trim();
+  if (/^\d{13}$/.test(string)) return new Date(Number(string)).toISOString().slice(0, 10);
+  const iso = string.match(/^(\d{4}-\d{2}-\d{2})/);
+  return iso ? iso[1] : string;
+}
+
+export function normalizeSeg(value) {
+  return String(value ?? '').toUpperCase();
+}
+
+export function errorLabel(code) {
+  switch (code) {
+    case 'pii_forbidden': return t("DASHBOARD_TILE_ERR_RESTRICTED", "Restricted");
+    case 'kpi_forbidden': return t("DASHBOARD_TILE_ERR_NO_ACCESS", "No access");
+    case 'scope_forbidden': return t("DASHBOARD_TILE_ERR_OUT_OF_SCOPE", "Out of scope");
+    default: return code || t("DASHBOARD_TILE_ERR_GENERIC", "ERROR");
+  }
+}
+
+export function defScrollKey(ctx) {
+  return ctx.def?.kpiId || ctx.def?.id || undefined;
+}

--- a/digit-ui-esbuild/products/dashboard/src/utils/tileResultAdapters.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/tileResultAdapters.test.js
@@ -1,0 +1,318 @@
+// Characterizes the legacy KpiTile result adapters after their behavior-neutral extraction.
+// Run from digit-ui-esbuild/:
+//   node --test products/dashboard/src/utils/tileResultAdapters.test.js
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const esbuild = require("esbuild");
+
+function bundle(entry) {
+  const out = path.join(os.tmpdir(), `${path.basename(entry, ".js")}.cjs.${process.pid}.js`);
+  esbuild.buildSync({
+    entryPoints: [path.join(__dirname, entry)],
+    bundle: true,
+    format: "cjs",
+    platform: "neutral",
+    outfile: out,
+  });
+  process.on("exit", () => {
+    try {
+      fs.unlinkSync(out);
+    } catch (error) {
+      /* already gone */
+    }
+  });
+  return require(out);
+}
+
+const adapters = bundle("tileResultAdapters.js");
+
+test("column inference preserves typed-column precedence and viz fallbacks", () => {
+  const typed = {
+    columns: [
+      { name: "ward_code", role: "dimension" },
+      { name: "total", role: "measure", format: "integer" },
+    ],
+  };
+  const conflictingViz = { dimensionKey: "service_code", measureKey: "count" };
+  assert.equal(adapters.primaryDimensionKey(typed, conflictingViz), "ward_code");
+  assert.equal(adapters.primaryMeasure(typed, conflictingViz).name, "total");
+
+  // The current backend emits string columns, so the renderer deliberately
+  // falls back to the catalog descriptor instead of inferring roles.
+  const strings = { columns: ["ward_code", "total"] };
+  assert.equal(adapters.primaryDimensionKey(strings, conflictingViz), "service_code");
+  assert.equal(adapters.primaryMeasure(strings, conflictingViz).name, "count");
+});
+
+test("scalar, prior, percent normalization, delta modes, and threshold boundaries stay exact", () => {
+  assert.equal(
+    adapters.resolveScalar({
+      viz: { valueKey: "total" },
+      result: { value: 9, values: { total: 8 }, rows: [{ total: 7 }] },
+    }),
+    9
+  );
+  assert.equal(
+    adapters.resolveScalar({ viz: { valueKey: "total" }, result: { rows: [{ total: "7" }] } }),
+    7
+  );
+  assert.equal(
+    adapters.resolveScalar({
+      viz: {
+        valueKey: "total",
+        compose: { type: "netBacklogDaily", sourceKpiIds: ["in", "out"] },
+      },
+      result: { value: 99 },
+      results: { in: { rows: [{ total: 12 }] }, out: { rows: [{ total: 5 }] } },
+    }),
+    7,
+    "the legacy FE compose result still precedes the pre-shaped scalar"
+  );
+  assert.equal(
+    adapters.resolvePrior({ viz: { priorKey: "previous" }, result: { values: { previous: "4" } } }),
+    4
+  );
+  assert.equal(adapters.normalizePct(0.75), 75);
+  assert.equal(adapters.normalizePct(1), 100);
+  assert.equal(adapters.normalizePct(1.01), 1.01);
+  assert.equal(adapters.computeDelta(0.8, 0.7, "percentOneDecimal"), 10);
+  assert.equal(adapters.computeDelta(120, 100, "integer"), 20);
+  assert.equal(adapters.computeDelta(120, 0, "integer"), null);
+  assert.equal(adapters.computeDelta(172800000, 86400000, "hoursDays", "days"), 1);
+  assert.equal(adapters.formatDeltaDisplay(1, "hoursDays", "days"), "▲ 1 day");
+
+  const highGood = { kind: "percent", higherIsBetter: true, onTrack: 85, breaching: 60 };
+  assert.equal(adapters.thresholdStatus(highGood, 0.85), "on_track");
+  assert.equal(adapters.thresholdStatus(highGood, 0.6), "breaching");
+  assert.equal(adapters.thresholdStatus(highGood, 0.7), "normal");
+  assert.equal(adapters.resolveTileStatus({ accent: "amber" }, 5), "amber");
+});
+
+test("sparkline, bar, histogram, ranked-list, and DOW adapters preserve ordering rules", () => {
+  assert.deepEqual(
+    adapters.resolveSparkline({
+      viz: { dateKey: "created_date", sparklineMeasureKey: "total" },
+      result: {
+        rows: [
+          { created_date: "2026-01-02", total: "2" },
+          { created_date: "2026-01-01", total: "1" },
+        ],
+      },
+    }),
+    [1, 2]
+  );
+
+  const barResult = {
+    columns: [
+      { name: "bucket", role: "dimension" },
+      { name: "pct", role: "measure" },
+    ],
+    rows: [
+      { bucket: "low", pct: 0.1 },
+      { bucket: "high", pct: 0.8 },
+      { bucket: "mid", pct: 0.4 },
+    ],
+  };
+  assert.deepEqual(
+    adapters.adaptBarRows({ viz: { kind: "bar", format: "percent" }, result: barResult }),
+    [
+      { label: "high", count: 80 },
+      { label: "mid", count: 40 },
+      { label: "low", count: 10 },
+    ]
+  );
+  assert.deepEqual(
+    adapters.adaptBarRows({
+      viz: { kind: "histogram", categoryOrder: ["low", "mid", "high"] },
+      result: barResult,
+    }).map((row) => row.label),
+    ["low", "mid", "high"]
+  );
+
+  const simple = {
+    columns: [
+      { name: "label", role: "dimension" },
+      { name: "total", role: "measure", format: "integer" },
+    ],
+    rows: [{ label: "B", total: 2 }, { label: "A", total: 5 }],
+  };
+  assert.deepEqual(adapters.adaptRanked({ viz: { limit: 1 }, result: simple }).rows, [
+    { label: "A", value: 5 },
+  ]);
+  assert.deepEqual(
+    adapters.adaptDow({ viz: {}, result: { ...simple, rows: [{ label: "2", total: "3" }] } }).rows,
+    [{ dow: 2, value: 3 }]
+  );
+});
+
+test("horizontal-bar adapter preserves grouped ratio math, filtering, ascending sort, and limit", () => {
+  const result = {
+    rows: [
+      { department_code: "A", filed: 5, resolved: 2 },
+      { department_code: "A", filed: 5, resolved: 3 },
+      { department_code: "B", filed: 4, resolved: 1 },
+      { department_code: "C", filed: 0, resolved: 2 },
+    ],
+  };
+  const rows = adapters.adaptHorizontalRows({
+    viz: {
+      dimensionKey: "department_code",
+      measureKey: "resolved",
+      numeratorKey: "resolved",
+      denominatorKey: "filed",
+      limit: 2,
+    },
+    result,
+  });
+  assert.deepEqual(rows, [
+    { label: "B", value: 0.25, resolved: 1, created: 4 },
+    { label: "A", value: 0.5, resolved: 5, created: 10 },
+  ]);
+});
+
+test("stacked and line adapters preserve BE-shaped passthrough and long-form pivots", () => {
+  const passthrough = {
+    categories: ["A"],
+    series: [{ name: "Total", data: [3] }],
+    colors: ["red"],
+  };
+  assert.deepEqual(
+    adapters.adaptStacked({ viz: {}, result: passthrough }),
+    passthrough
+  );
+
+  const pivoted = adapters.adaptStacked({
+    viz: {
+      dimensionKey: "service_code",
+      stackKey: "application_status",
+      measureKey: "total",
+      stackSeries: [
+        { key: "OPEN", label: "Open", color: "orange" },
+        { key: "CLOSED", label: "Closed", color: "green" },
+      ],
+    },
+    result: {
+      rows: [
+        { service_code: "A", application_status: "open", total: 2 },
+        { service_code: "A", application_status: "closed", total: 3 },
+        { service_code: "B", application_status: "open", total: 6 },
+      ],
+    },
+  });
+  assert.deepEqual(pivoted.categories, ["B", "A"]);
+  assert.deepEqual(pivoted.series.map((series) => series.data), [[6, 2], [0, 3]]);
+
+  const linePassthrough = { categories: ["d1"], series: [{ name: "Filed", data: [4] }] };
+  assert.deepEqual(adapters.adaptLine({ viz: {}, result: linePassthrough }), linePassthrough);
+  const computedLine = adapters.adaptLine({
+    viz: {
+      dimensionKey: "date",
+      seriesDefs: [{ name: "Rate", numeratorKey: "resolved", denominatorKey: "filed" }],
+    },
+    result: { rows: [{ date: "2026-01-02", filed: 4, resolved: 3 }] },
+  });
+  assert.deepEqual(computedLine.series[0].data, [75]);
+});
+
+test("pie channel rollup preserves source taxonomy, colors, zero filtering, and order", () => {
+  const data = adapters.adaptPie({
+    viz: {
+      dimensionKey: "source",
+      measureKey: "total",
+      channelMap: [
+        { id: "web", label: "Web", color: "blue", sources: ["web", "online-portal"] },
+        { id: "phone", label: "Phone", color: "green", sources: ["phone"] },
+        { id: "other", label: "Other", color: "gray", sources: [] },
+      ],
+    },
+    result: {
+      rows: [
+        { source: "ONLINE_PORTAL", total: 3 },
+        { source: "web", total: 2 },
+        { source: "walk_in", total: 4 },
+        { source: "phone", total: 0 },
+      ],
+    },
+  });
+  assert.deepEqual(data, [
+    { label: "Web", count: 5, color: "blue" },
+    { label: "Other", count: 4, color: "gray" },
+  ]);
+});
+
+test("table, SLA-risk, and map adapters preserve their current domain row contracts", () => {
+  assert.deepEqual(
+    adapters.deriveColumnsFromResult({
+      columns: [
+        { name: "service_code", role: "dimension", label: "Subtype" },
+        { name: "pct", role: "measure", format: "percentOneDecimal" },
+      ],
+    }),
+    [
+      { id: "service_code", label: "Subtype", labelKey: undefined, align: "left", type: "text", thresholdKey: undefined },
+      { id: "pct", label: "pct", labelKey: undefined, align: "right", type: "percent", thresholdKey: undefined },
+    ]
+  );
+
+  const riskRows = adapters.adaptSlaRiskRows({
+    viz: { limit: 1 },
+    result: {
+      rows: [
+        {
+          service_request_id: "CR-1",
+          service_code: "road",
+          service_group: "works",
+          ward_code: "W1",
+          application_status: "PENDINGATLME",
+          sla_status_bucket: "breached",
+          current_assignee_uuid: null,
+          open_age_ms: 10800000,
+          sla_target_ms: 3600000,
+        },
+        { service_request_id: "", sla_status_bucket: "breached" },
+      ],
+    },
+  });
+  assert.equal(riskRows.length, 1);
+  assert.equal(riskRows[0].id, "CR-1");
+  assert.equal(riskRows[0].status, "assigned");
+  assert.equal(riskRows[0].slaLevel, "breached");
+  assert.equal(riskRows[0].breachDurationMs, 7200000);
+
+  const layers = adapters.adaptMapLayers({
+    viz: { dimensionKey: "ward_code" },
+    result: {
+      rows: [
+        { ward_code: "W1", filed: 10, open: 4, resolved: 5 },
+        { ward_code: null, filed: 2, open: 1, resolved: 1 },
+      ],
+      pinsStatusKnown: true,
+      pinsTruncated: true,
+      pins: [
+        { id: "o", isOpen: true, isResolved: false },
+        { id: "r", isOpen: false, isResolved: true },
+      ],
+    },
+  });
+  assert.equal(layers.pinSemantics, "per-layer");
+  assert.equal(layers.pinsTruncated, true);
+  assert.deepEqual(layers.open.map((row) => row.wardCode), ["W1"]);
+  assert.deepEqual(layers.layerTotals, { filed: 10, open: 4, resolved: 5 });
+  assert.deepEqual(layers.unmapped, { filed: 2, open: 1, resolved: 1 });
+  assert.deepEqual(layers.complaintPinsByLayer.open.map((pin) => pin.id), ["o"]);
+  assert.deepEqual(layers.complaintPinsByLayer.resolved.map((pin) => pin.id), ["r"]);
+});
+
+test("format and ABAC error-label boundaries remain stable", () => {
+  assert.equal(adapters.applyFormat(null, "integer", "en-US"), "—");
+  assert.equal(adapters.applyFormat(0.425, "percentOneDecimal", "en-US"), "42.5%");
+  assert.equal(adapters.applyFormat(3600000, "hoursDecimal", "en-US"), "1.0h");
+  assert.equal(adapters.errorLabel("pii_forbidden"), "Restricted");
+  assert.equal(adapters.errorLabel("kpi_forbidden"), "No access");
+  assert.equal(adapters.errorLabel("scope_forbidden"), "Out of scope");
+  assert.equal(adapters.errorLabel("query_failed"), "query_failed");
+});


### PR DESCRIPTION
## Summary

Part of #1050.

Performs the first behavior-neutral breakup of the canonical esbuild dashboard KpiTile. The component is reduced from 1,171 lines to 473 lines by moving its result-to-view-model transformations into a React-free, directly testable adapter module.

This PR keeps KpiTile responsible for:

- loading, empty, and error lifecycle rendering
- viz-kind dispatch
- composing existing child chart and card components
- render-time memoization and wrapper chrome

The extracted adapter seam now names and characterizes:

- column, scalar, prior, and sparkline inference
- delta, threshold, status, and formatting rules
- bar, histogram, horizontal-bar, stacked, pie, and line shaping
- table, SLA-risk, map, ranked-list, and day-of-week shaping
- current ABAC error labels

## Why this belongs in the ABAC cleanup

The backend catalog already selects viz.kind, but the frontend still reconstructs substantial business meaning: compose precedence, threshold math, rollups, pivots, channel taxonomy, SLA state, map semantics, and officer labels.

This extraction does not move those decisions yet. It makes them an explicit compatibility boundary that a versioned backend presentation envelope can replace incrementally, while keeping the final React renderer declarative.

The removed micro-ui dashboard is not touched. digit-ui-esbuild/products/dashboard remains the single canonical implementation.

## Behavior boundary

This is intentionally a structural refactor:

- no endpoint or wire-contract changes
- no catalog or seed changes
- no authorization changes
- no chart, table, card, map, formatting, sorting, or localization changes
- unknown viz kinds retain the existing table fallback
- existing backend-shaped series passthroughs remain intact

## Characterization coverage

The new tests pin representative legacy behavior for:

- typed-column precedence and current string-column fallbacks
- scalar, frontend-compose, prior, percent, delta, and threshold boundaries
- sparkline and category ordering
- ratio rollups and zero filtering
- stacked pivots and backend-shaped series passthrough
- line ratios and passthrough
- channel taxonomy rollups
- table, SLA-risk, and map row contracts
- number formatting and ABAC error labels

## Deliberately excluded follow-ups

- normalizing backend inline per-result errors so kpi_forbidden and pii_forbidden cannot render as No data
- extracting the viz-kind registry and embedded ranked-list/day-of-week renderers
- introducing the versioned backend presentation envelope
- moving compose, delta/status, chart rollup, SLA-risk, map, and authorized officer-display semantics backend-side
- deleting legacy adapters after envelope coverage is proven

The inline-error compatibility issue discovered during this refactor will be handled in a separate behavior-changing PR.

## Validation

- dashboard Node suite: 182 tests passed
- production npm run build: succeeded
- git diff --check: passed
- build emits only the repository existing duplicate-key and direct-eval warnings