### PR TITLE
fix(dashboard): surface analytics batch errors

### DIFF
--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
@@ -119,9 +119,12 @@ public class AnalyticsService {
         out.put("scope", scopeInfo(scope));
 
         if (body.has("queries") && body.get("queries").isObject()) {
-            // batch dict form: { name -> queryNode } => { results: { name -> result }, partial }
+            // Batch dict form. Error entries stay inline under results for wire compatibility,
+            // and are also indexed under the additive top-level errors map consumed by the
+            // dashboard. This lets old callers keep working while data and errors have an
+            // unambiguous transport seam for new callers.
             Map<String,Object> results = new LinkedHashMap<>();
-            boolean partial = false;
+            Map<String,Object> errors = new LinkedHashMap<>();
             Iterator<Map.Entry<String,JsonNode>> it = body.get("queries").fields();
             while (it.hasNext()) {
                 Map.Entry<String,JsonNode> e = it.next();
@@ -131,20 +134,22 @@ public class AnalyticsService {
                     // Public floor: only published PUBLIC-eligible KPIs, by reference. No inline (an
                     // inline body bypasses the catalog's PUBLIC opt-in + publish-time PII check).
                     if (publicFloor && !queryNode.has("kpiId")) {
-                        partial = true;
-                        results.put(name, Map.of("error", "kpi_forbidden",
+                        putBatchError(results, errors, name, Map.of("error", "kpi_forbidden",
                                 "message", "public access is limited to published PUBLIC KPIs"));
                         continue;
                     }
                     // D1a: backend-composed defs (query:null + viz.compose) resolve recursively here.
                     Map<String,Object> composed = maybeComposeResult(queryNode, scope, tenantId, callerRoles, tel, name);
-                    if (composed != null) { results.put(name, composed); continue; }
+                    if (composed != null) {
+                        results.put(name, composed);
+                        if (isErrorResult(composed)) errors.put(name, composed);
+                        continue;
+                    }
 
                     List<String> paramsIgnored = new ArrayList<>();
                     JsonNode actualQueryNode = resolveKpiRef(queryNode, tenantId, callerRoles, paramsIgnored);
                     if (actualQueryNode == null) {
-                        partial = true;
-                        results.put(name, Map.of("error", "kpi_forbidden",
+                        putBatchError(results, errors, name, Map.of("error", "kpi_forbidden",
                                 "message", "KPI not found or not authorized for role set"));
                         continue;
                     }
@@ -152,8 +157,7 @@ public class AnalyticsService {
                     // body (no kpiId) bypasses that, so block inline projection of officer-PII dimensions
                     // unless the caller holds an officer-PII-authorized role.
                     if (!queryNode.has("kpiId") && projectsForbiddenPii(actualQueryNode, callerRoles)) {
-                        partial = true;
-                        results.put(name, Map.of("error", "pii_forbidden",
+                        putBatchError(results, errors, name, Map.of("error", "pii_forbidden",
                                 "message", "inline query projects officer-PII dimension(s); role not authorized"));
                         continue;
                     }
@@ -161,12 +165,12 @@ public class AnalyticsService {
                     if (!paramsIgnored.isEmpty()) result.put("paramsIgnored", paramsIgnored);
                     results.put(name, result);
                 } catch (Exception ex) {
-                    partial = true;
-                    results.put(name, err(ex));
+                    putBatchError(results, errors, name, err(ex));
                 }
             }
             out.put("results", results);
-            out.put("partial", partial);
+            out.put("errors", errors);
+            out.put("partial", !errors.isEmpty());
         } else if (body.has("query")) {
             JsonNode queryNode = body.get("query");
             if (publicFloor && !queryNode.has("kpiId"))
@@ -658,6 +662,18 @@ public class AnalyticsService {
         String code = msg.contains(":") ? msg.substring(0, msg.indexOf(':')) : "query_failed";
         m.put("error", code); m.put("message", msg);
         return m;
+    }
+
+    /** Retain the legacy inline entry while also publishing the canonical batch error index. */
+    private void putBatchError(Map<String,Object> results, Map<String,Object> errors,
+                               String name, Map<String,Object> error) {
+        results.put(name, error);
+        errors.put(name, error);
+    }
+
+    /** Backend-composed KPI resolution can itself return the same per-entry error envelope. */
+    private boolean isErrorResult(Map<String,Object> result) {
+        return result != null && result.get("error") instanceof String;
     }
 
     /**

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsServiceBatchErrorContractTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsServiceBatchErrorContractTest.java
@@ -1,0 +1,140 @@
+package org.egov.pgr.analytics;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.egov.common.contract.request.RequestInfo;
+import org.egov.common.contract.request.Role;
+import org.egov.common.contract.request.User;
+import org.egov.pgr.analytics.model.KpiDefinition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pins the additive batch error contract: legacy inline errors remain under results while the
+ * canonical top-level errors index makes every failed entry visible to the dashboard.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class AnalyticsServiceBatchErrorContractTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Mock private AnalyticsPlanner planner;
+    @Mock private JdbcTemplate jdbc;
+    @Mock private KpiCatalogService kpiCatalogService;
+    @Mock private PrincipalScopeResolver scopeResolver;
+    @Mock private KpiQueryComposer queryComposer;
+
+    private AnalyticsService service;
+    private RequestInfo requestInfo;
+
+    @BeforeEach
+    public void setUp() {
+        service = new AnalyticsService(planner, null, jdbc, kpiCatalogService, scopeResolver,
+                queryComposer, new AnalyticsMetrics(), null);
+        requestInfo = RequestInfo.builder()
+                .userInfo(User.builder().uuid("employee-1").type("EMPLOYEE")
+                        .roles(Collections.singletonList(Role.builder().code("PGR_ADMIN").build()))
+                        .build())
+                .build();
+        when(scopeResolver.resolve(same(requestInfo), eq("ke.bomet"), eq(1)))
+                .thenReturn(new AnalyticsScope("ke.bomet", false, null, null, null));
+    }
+
+    @Test
+    public void mixedBatchKeepsLegacyInlineErrorAndAddsTopLevelIndex() throws Exception {
+        AnalyticsPlanner.Planned planned = new AnalyticsPlanner.Planned(
+                "SELECT 7", Collections.emptyList(), Collections.singletonList("total"), "facts");
+        when(planner.plan(any(JsonNode.class), any(AnalyticsScope.class))).thenReturn(planned);
+        when(jdbc.queryForList(eq("SELECT 7"), any(Object[].class)))
+                .thenReturn(Collections.singletonList(Map.of("total", 7)));
+        when(kpiCatalogService.getDef("missing", "ke.bomet")).thenReturn(Optional.empty());
+
+        Map<String,Object> response = query("{\"queries\":{"
+                + "\"ok\":{\"grain\":\"facts\",\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}]},"
+                + "\"denied\":{\"kpiId\":\"missing\"}}}");
+
+        Map<String,Object> results = map(response.get("results"));
+        Map<String,Object> errors = map(response.get("errors"));
+        assertTrue(results.containsKey("ok"));
+        assertEquals("kpi_forbidden", map(results.get("denied")).get("error"),
+                "legacy inline error must remain during the compatibility period");
+        assertEquals(map(results.get("denied")), map(errors.get("denied")));
+        assertEquals(Boolean.TRUE, response.get("partial"));
+    }
+
+    @Test
+    public void caughtEntryExceptionIsIndexedWithoutFailingWholeBatch() throws Exception {
+        when(planner.plan(any(JsonNode.class), any(AnalyticsScope.class)))
+                .thenThrow(new IllegalArgumentException("invalid_param: bad window"));
+
+        Map<String,Object> response = query("{\"queries\":{"
+                + "\"invalid\":{\"grain\":\"facts\",\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}]}}}");
+
+        Map<String,Object> error = map(map(response.get("errors")).get("invalid"));
+        assertEquals("invalid_param", error.get("error"));
+        assertEquals("invalid_param: bad window", error.get("message"));
+        assertEquals(error, map(map(response.get("results")).get("invalid")));
+        assertEquals(Boolean.TRUE, response.get("partial"));
+    }
+
+    @Test
+    public void forbiddenComposedKpiAlsoMarksBatchPartial() throws Exception {
+        KpiDefinition hiddenCompose = mapper.readValue("{"
+                + "\"id\":\"hidden_compose\",\"status\":\"draft\","
+                + "\"viz\":{\"compose\":{\"type\":\"netBacklogDaily\","
+                + "\"sourceKpiIds\":[\"source_a\",\"source_b\"]}}}", KpiDefinition.class);
+        when(kpiCatalogService.getDef("hidden_compose", "ke.bomet"))
+                .thenReturn(Optional.of(hiddenCompose));
+
+        Map<String,Object> response = query(
+                "{\"queries\":{\"tile\":{\"kpiId\":\"hidden_compose\"}}}");
+
+        Map<String,Object> resultError = map(map(response.get("results")).get("tile"));
+        Map<String,Object> indexedError = map(map(response.get("errors")).get("tile"));
+        assertEquals("kpi_forbidden", resultError.get("error"));
+        assertEquals(resultError, indexedError);
+        assertEquals(Boolean.TRUE, response.get("partial"),
+                "the composed-result fast path must not bypass partial/error accounting");
+    }
+
+    @Test
+    public void successfulBatchHasEmptyErrorIndexAndIsNotPartial() throws Exception {
+        AnalyticsPlanner.Planned planned = new AnalyticsPlanner.Planned(
+                "SELECT 1", Collections.emptyList(), Collections.singletonList("total"), "facts");
+        when(planner.plan(any(JsonNode.class), any(AnalyticsScope.class))).thenReturn(planned);
+        when(jdbc.queryForList(eq("SELECT 1"), any(Object[].class)))
+                .thenReturn(Collections.singletonList(Map.of("total", 1)));
+
+        Map<String,Object> response = query("{\"queries\":{"
+                + "\"ok\":{\"grain\":\"facts\",\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}]}}}");
+
+        assertTrue(map(response.get("errors")).isEmpty());
+        assertEquals(Boolean.FALSE, response.get("partial"));
+        assertEquals(1, ((List<?>) map(map(response.get("results")).get("ok")).get("rows")).size());
+    }
+
+    private Map<String,Object> query(String json) throws Exception {
+        return service.query(mapper.readTree(json), requestInfo, "ke.bomet", 1);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String,Object> map(Object value) {
+        return (Map<String,Object>) value;
+    }
+}

--- a/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
@@ -32,6 +32,7 @@ import { useFilterOptions } from "./hooks/useFilterOptions";
 import { useCatalog } from "./hooks/useCatalog";
 import { useCatalogLayout, getDroppingItemForKpi, defaultSizeForKpi } from "./hooks/useCatalogLayout";
 import { runKpiBatch, getTenantId } from "./services/analyticsService";
+import { errorForTile } from "./services/analyticsBatch";
 import { fetchComplaintHierarchyLevels } from "./services/complaintHierarchyService";
 import * as dashboardMetrics from "./services/dashboardMetrics";
 import { GRID_COLS, KPI_ROW_HEIGHT, DROPPING_ITEM, DROPPING_ITEM_ID } from "./constants/layoutConfig";
@@ -716,7 +717,12 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
         setBatch({
           loading: false,
           results: {},
-          errors: { __batch: err?.message || t("DASHBOARD_COMMON_BATCH_FAILED", "Batch query failed") },
+          errors: {
+            __batch: {
+              code: "batch_failed",
+              message: err?.message || t("DASHBOARD_COMMON_BATCH_FAILED", "Batch query failed"),
+            },
+          },
           partial: true,
         });
         dashboardMetrics.markAllWidgetsReady(tiles.length, reqId);
@@ -745,8 +751,7 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
     if (!def) return null;
 
     const assembled = assembleResult(kpiId, def, batch.results);
-    const errCode = batch.errors && batch.errors[kpiId];
-    const tileError = errCode ? { code: errCode, message: String(errCode) } : null;
+    const tileError = errorForTile(batch.errors, kpiId);
 
     return (
       <KpiTile
@@ -867,7 +872,7 @@ const AdminDashboardInner = ({ onSignOut, embedded = false }) => {
       )}
       {batch.errors && batch.errors.__batch && (
         <div className="tw-mb-4 tw-rounded-md tw-border tw-border-[color-mix(in_srgb,var(--destructive)_30%,transparent)] tw-bg-status-breach-bg tw-px-4 tw-py-3 tw-text-sm tw-text-destructive">
-          {batch.errors.__batch}
+          {batch.errors.__batch.message}
         </div>
       )}
 

--- a/digit-ui-esbuild/products/dashboard/src/services/analyticsBatch.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/analyticsBatch.js
@@ -1,0 +1,84 @@
+/** Companion query keys emitted by queryPlan.js for one rendered tile. */
+const COMPANION_SUFFIXES = ["__prior", "__series", "__pins"];
+const hasOwn = (value, key) => Object.prototype.hasOwnProperty.call(value, key);
+
+function objectMap(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+/**
+ * Convert every supported wire error into the shape KpiTile renders.
+ *
+ * The current backend uses {error,message} inline under results, while the
+ * intended batch contract uses a top-level errors map. During the additive
+ * migration an errors-map value may therefore be a code string, {error,...},
+ * or {code,...}. Keeping that compatibility here stops transport history from
+ * leaking into the renderer.
+ */
+function canonicalError(value, fallback = null) {
+  const fallbackError = fallback && typeof fallback === "object" ? fallback : null;
+  if (typeof value === "string" && value) {
+    const fallbackCode = fallbackError?.code || fallbackError?.error;
+    return {
+      code: value,
+      message: String(fallbackCode === value && fallbackError?.message ? fallbackError.message : value),
+    };
+  }
+  if (value && typeof value === "object") {
+    const code = value.code || value.error || fallbackError?.code || fallbackError?.error || "query_failed";
+    const fallbackCode = fallbackError?.code || fallbackError?.error;
+    return {
+      code: String(code),
+      message: String(
+        value.message || (String(fallbackCode) === String(code) && fallbackError?.message) || code
+      ),
+    };
+  }
+  if (fallbackError) return canonicalError(fallbackError);
+  return { code: "query_failed", message: "query_failed" };
+}
+
+/**
+ * Normalize legacy and current analytics batch payloads without mutating them.
+ * Successful result envelopes retain their original identity; only the error
+ * index is copied/canonicalized. Inline errors stay in results for the duration
+ * of the backend's wire-compatibility period.
+ */
+export function normalizeAnalyticsBatch(payload) {
+  const source = objectMap(payload);
+  const results = objectMap(source.results);
+  const explicitErrors = objectMap(source.errors);
+  const errors = Object.create(null);
+
+  for (const [key, result] of Object.entries(results)) {
+    if (result && typeof result === "object" && typeof result.error === "string") {
+      errors[key] = canonicalError(result);
+    }
+  }
+
+  // The explicit contract is authoritative. When it contains only a code,
+  // retain the richer legacy inline message as a compatibility fallback.
+  for (const [key, error] of Object.entries(explicitErrors)) {
+    errors[key] = canonicalError(error, errors[key]);
+  }
+
+  const hasErrors = Object.keys(errors).length > 0;
+  return {
+    ...source,
+    results,
+    errors: hasErrors ? errors : null,
+    partial: Boolean(source.partial) || hasErrors,
+  };
+}
+
+/** Return the first failure that makes a rendered tile incomplete. */
+export function errorForTile(errors, kpiId) {
+  if (!errors || !kpiId) return null;
+  if (hasOwn(errors, kpiId) && errors[kpiId]) return errors[kpiId];
+  for (const suffix of COMPANION_SUFFIXES) {
+    const key = `${kpiId}${suffix}`;
+    const companion = hasOwn(errors, key) ? errors[key] : null;
+    if (companion) return companion;
+  }
+  return null;
+}

--- a/digit-ui-esbuild/products/dashboard/src/services/analyticsBatch.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/analyticsBatch.test.js
@@ -1,0 +1,141 @@
+// Run from digit-ui-esbuild/:
+//   node --test products/dashboard/src/services/analyticsBatch.test.js
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const esbuild = require("esbuild");
+
+const ENTRY = path.join(__dirname, "analyticsBatch.js");
+const OUT = path.join(os.tmpdir(), `analyticsBatch.cjs.${process.pid}.js`);
+
+esbuild.buildSync({
+  entryPoints: [ENTRY],
+  bundle: true,
+  format: "cjs",
+  platform: "neutral",
+  outfile: OUT,
+});
+process.on("exit", () => {
+  try {
+    fs.unlinkSync(OUT);
+  } catch (e) {
+    /* already gone */
+  }
+});
+
+const { normalizeAnalyticsBatch, errorForTile } = require(OUT);
+
+test("legacy inline errors become canonical without disturbing successful results", () => {
+  const ok = { columns: ["total"], rows: [{ total: 7 }] };
+  const payload = {
+    results: {
+      ok,
+      denied: { error: "kpi_forbidden", message: "not authorized" },
+    },
+    partial: true,
+  };
+
+  const normalized = normalizeAnalyticsBatch(payload);
+
+  assert.equal(normalized.results.ok, ok, "successful result identity is preserved");
+  assert.deepEqual(normalized.errors.denied, {
+    code: "kpi_forbidden",
+    message: "not authorized",
+  });
+  assert.equal(normalized.partial, true);
+});
+
+test("explicit string and object errors normalize, with the explicit code authoritative", () => {
+  const payload = {
+    results: {
+      denied: { error: "legacy_code", message: "specific backend explanation" },
+      same: { error: "kpi_forbidden", message: "matching inline explanation" },
+    },
+    errors: {
+      denied: "kpi_forbidden",
+      same: "kpi_forbidden",
+      invalid: { error: "invalid_param", message: "bad window" },
+      scoped: { code: "scope_incomplete", message: "scope unavailable" },
+    },
+    partial: false,
+  };
+
+  const normalized = normalizeAnalyticsBatch(payload);
+
+  assert.deepEqual(normalized.errors.denied, {
+    code: "kpi_forbidden",
+    message: "kpi_forbidden",
+  });
+  assert.deepEqual(normalized.errors.same, {
+    code: "kpi_forbidden",
+    message: "matching inline explanation",
+  });
+  assert.deepEqual(normalized.errors.invalid, { code: "invalid_param", message: "bad window" });
+  assert.deepEqual(normalized.errors.scoped, {
+    code: "scope_incomplete",
+    message: "scope unavailable",
+  });
+  assert.equal(normalized.partial, true, "an error repairs a stale/missing partial flag");
+});
+
+test("empty rows are successful data, not an inferred error", () => {
+  const result = { columns: ["total"], rows: [], rowCount: 0 };
+  const normalized = normalizeAnalyticsBatch({ results: { empty: result }, partial: false });
+
+  assert.equal(normalized.results.empty, result);
+  assert.equal(normalized.errors, null);
+  assert.equal(normalized.partial, false);
+});
+
+test("companion failures resolve to the rendered base tile", () => {
+  const errors = {
+    card__prior: { code: "invalid_param", message: "bad comparison" },
+    spark__series: { code: "scope_incomplete", message: "no daily scope" },
+    map__pins: { code: "kpi_forbidden", message: "pins restricted" },
+  };
+
+  assert.equal(errorForTile(errors, "card"), errors.card__prior);
+  assert.equal(errorForTile(errors, "spark"), errors.spark__series);
+  assert.equal(errorForTile(errors, "map"), errors.map__pins);
+  assert.equal(errorForTile(errors, "other"), null);
+});
+
+test("a base error wins over companion errors", () => {
+  const errors = {
+    tile: { code: "kpi_forbidden", message: "base" },
+    tile__prior: { code: "invalid_param", message: "prior" },
+  };
+
+  assert.equal(errorForTile(errors, "tile"), errors.tile);
+});
+
+test("normalization never mutates legacy or new response maps", () => {
+  const payload = {
+    results: { denied: { error: "kpi_forbidden", message: "legacy" } },
+    errors: { denied: { error: "kpi_forbidden", message: "new" } },
+    partial: false,
+  };
+  const before = JSON.parse(JSON.stringify(payload));
+
+  const normalized = normalizeAnalyticsBatch(payload);
+
+  assert.deepEqual(payload, before);
+  assert.notEqual(normalized, payload);
+  assert.notEqual(normalized.errors, payload.errors);
+});
+
+test("reserved tile keys remain ordinary own keys and never match object prototypes", () => {
+  const payload = JSON.parse('{"results":{"__proto__":{"error":"kpi_forbidden","message":"denied"}}}');
+
+  const normalized = normalizeAnalyticsBatch(payload);
+
+  assert.deepEqual(normalized.errors.__proto__, {
+    code: "kpi_forbidden",
+    message: "denied",
+  });
+  assert.equal(errorForTile(normalized.errors, "__proto__").code, "kpi_forbidden");
+  assert.equal(errorForTile({}, "constructor"), null);
+});

--- a/digit-ui-esbuild/products/dashboard/src/services/analyticsService.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/analyticsService.js
@@ -5,6 +5,7 @@ import {
   getTenantId,
   toRequestError,
 } from "./authService";
+import { normalizeAnalyticsBatch } from "./analyticsBatch";
 
 // Re-exported for existing importers; authService is the definition.
 export { getTenantId };
@@ -83,8 +84,9 @@ export function fetchCatalog(tenantId) {
 /**
  * POST /v2/analytics/_query — data, by kpiId reference (not inline).
  * refs: { [tileKey]: { kpiId, params } }
- * Returns { results: { [tileKey]: { columns, rows, asOf, scope } }, partial, errors }
+ * Returns { results, partial, errors: { [tileKey]: { code, message } } | null }.
+ * Legacy inline and additive top-level backend errors are normalized at this boundary.
  */
 export function runKpiBatch(refs, tenantId) {
-  return postAnalytics("/_query", { tenantId, queries: refs });
+  return postAnalytics("/_query", { tenantId, queries: refs }).then(normalizeAnalyticsBatch);
 }


### PR DESCRIPTION
## Summary

Part of #1050.

Fixes a backend/frontend analytics contract mismatch that currently lets authorization and query failures render as No data.

The backend has always returned per-entry failures inline:

    results.tile = { error, message }

The dashboard instead reads a top-level errors map that the backend never emitted. As a result:

- kpi_forbidden and pii_forbidden can bypass the existing tile error UI
- companion query failures can remain silent
- dashboard error-widget telemetry reports zero
- composed-KPI denial can leave partial=false

## Backend compatibility

Batch analytics responses now additively emit an errors index while retaining every legacy inline error entry:

    {
      results: {
        ok: { rows: [] },
        denied: { error: kpi_forbidden, message: ... }
      },
      errors: {
        denied: { error: kpi_forbidden, message: ... }
      },
      partial: true
    }

The legacy results shape is unchanged for existing consumers. partial is derived from the canonical error index, including the composed-result fast path.

Single-query responses are unchanged.

## Frontend compatibility

runKpiBatch now normalizes at the transport boundary:

- legacy inline errors
- new top-level string errors
- top-level {error,message} errors
- top-level {code,message} errors
- base and __prior, __series, or __pins companion failures
- partial repair when any error exists
- no mutation of source payloads
- reserved keys such as __proto__ and constructor are handled as ordinary own keys

runBatchQueries remains raw, so filter-option fallback behavior continues to consume the legacy inline result shape.

AdminDashboard passes the canonical {code,message} directly to the existing KpiTile error branch and uses the same shape for whole-batch failures.

## Why this precedes ABAC enforcement

ABAC denials must be distinguishable from valid empty datasets before policy evaluation is connected to analytics. Treating denied as empty is both misleading to users and invisible to observability.

This PR changes error presentation and accounting only. It does not change which KPI is authorized, query planning, SQL, scope calculation, or catalog visibility.

## Tests

Backend contract tests cover:

- mixed success and kpi_forbidden
- caught per-entry exceptions
- composed-KPI denial
- successful empty error index and partial=false
- retention of legacy inline errors

Frontend tests cover:

- legacy and new error shapes
- explicit-error precedence
- valid empty rows
- base and companion resolution
- non-mutation
- reserved object-property keys

## Validation

- full pgr-services suite on JDK 17: 200 passed, 1 existing skip
- full dashboard Node suite: 181 passed
- production npm run build: succeeded
- git diff --check: passed
- build emits only the repository existing duplicate-key and direct-eval warnings