### PR TITLE
feat(pgr): add access-control policy source

### DIFF
--- a/backend/pgr-services/pom.xml
+++ b/backend/pgr-services/pom.xml
@@ -141,6 +141,11 @@
             <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.github.jamsesso</groupId>
+            <artifactId>json-logic-java</artifactId>
+            <version>1.1.0</version>
+        </dependency>
     </dependencies>
     <repositories>
      		<repository>

--- a/backend/pgr-services/src/main/java/org/egov/pgr/config/PGRConfiguration.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/config/PGRConfiguration.java
@@ -127,6 +127,22 @@ public class PGRConfiguration {
     @Value("${egov.mdms.search.endpoint}")
     private String mdmsEndPoint;
 
+    // Access-control policy source
+    @Value("${egov.accesscontrol.host}")
+    private String accessControlHost;
+
+    @Value("${egov.accesscontrol.actions.mdms.get.path}")
+    private String accessControlActionsMdmsGetPath;
+
+    @Value("${egov.accesscontrol.actions.master}")
+    private String accessControlActionsMaster;
+
+    @Value("${egov.accesscontrol.connect.timeout.millis}")
+    private Long accessControlConnectTimeoutMillis;
+
+    @Value("${egov.accesscontrol.read.timeout.millis}")
+    private Long accessControlReadTimeoutMillis;
+
     //HRMS
     @Value("${egov.hrms.host}")
     private String hrmsHost;

--- a/backend/pgr-services/src/main/java/org/egov/pgr/policy/AccessControlPolicySource.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/policy/AccessControlPolicySource.java
@@ -1,0 +1,215 @@
+package org.egov.pgr.policy;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.egov.pgr.config.PGRConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Role-scoped policy transport backed by egov-accesscontrol's MDMS action endpoint.
+ *
+ * <p>This component is intentionally only a source. {@link AccessPolicyRegistry} remains an
+ * explicitly constructed, non-Spring type, so registering this bean does not activate policy
+ * evaluation or change any request path.
+ *
+ * <p>The request deliberately omits {@code RequestInfo}: the endpoint requires only tenant and
+ * roles, and forwarding caller identity through the shared tracing client would expose more data
+ * than policy discovery needs. It also deliberately omits the {@code enabled} filter and preserves
+ * the returned value. The current ABAC document (action 2008) is disabled as a navigation action,
+ * but remains the role-mapped policy source of truth.
+ */
+@Component
+@Lazy
+public class AccessControlPolicySource implements AccessPolicySource {
+
+    private static final TypeReference<LinkedHashMap<String, Object>> DOCUMENT_TYPE =
+            new TypeReference<>() { };
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private final URI endpoint;
+    private final String actionMaster;
+
+    @Autowired
+    public AccessControlPolicySource(RestTemplateBuilder restTemplateBuilder,
+                                     ObjectMapper objectMapper,
+                                     PGRConfiguration config) {
+        this(buildClient(restTemplateBuilder,
+                        config.getAccessControlConnectTimeoutMillis(),
+                        config.getAccessControlReadTimeoutMillis()),
+                objectMapper,
+                endpoint(config.getAccessControlHost(), config.getAccessControlActionsMdmsGetPath()),
+                requiredUnpadded(config.getAccessControlActionsMaster(), "action master"));
+    }
+
+    AccessControlPolicySource(RestTemplate restTemplate, ObjectMapper objectMapper,
+                              URI endpoint, String actionMaster) {
+        this.restTemplate = Objects.requireNonNull(restTemplate, "restTemplate");
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper").copy()
+                .enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
+        this.endpoint = Objects.requireNonNull(endpoint, "endpoint");
+        this.actionMaster = requiredUnpadded(actionMaster, "action master");
+    }
+
+    @Override
+    public List<PolicyAction> findActions(String tenantId, String method, String url,
+                                          List<String> roleCodes) {
+        String exactTenant = requiredUnpadded(tenantId, "tenantId");
+        String exactMethod = requiredUnpadded(method, "method");
+        String exactUrl = requiredUnpadded(url, "url");
+        if (!exactMethod.equals(exactMethod.toUpperCase(Locale.ROOT)))
+            throw new IllegalArgumentException("method must be canonical uppercase");
+        List<String> exactRoleCodes = requireCanonicalRoles(roleCodes);
+
+        Map<String, Object> request = new LinkedHashMap<>();
+        request.put("roleCodes", exactRoleCodes);
+        request.put("tenantId", exactTenant);
+        request.put("actionMaster", actionMaster);
+
+        String responseBody = restTemplate.postForObject(endpoint, request, String.class);
+        return parseResponse(responseBody, exactMethod, exactUrl);
+    }
+
+    List<PolicyAction> parseResponse(String responseBody, String method, String url) {
+        JsonNode response;
+        try {
+            response = responseBody == null ? null : objectMapper.readTree(responseBody);
+        } catch (JsonProcessingException e) {
+            throw new MalformedPolicySourceResponseException(
+                    "access-control response must contain valid JSON without duplicate keys", e);
+        }
+        return parseActions(response, method, url);
+    }
+
+    List<PolicyAction> parseActions(JsonNode response, String method, String url) {
+        if (response == null || !response.isObject())
+            throw new MalformedPolicySourceResponseException(
+                    "access-control response must be a JSON object");
+        JsonNode actions = response.get("actions");
+        if (actions == null || !actions.isArray())
+            throw new MalformedPolicySourceResponseException(
+                    "access-control response must contain an actions array");
+
+        List<PolicyAction> matches = new ArrayList<>();
+        for (int index = 0; index < actions.size(); index++) {
+            JsonNode action = actions.get(index);
+            if (!action.isObject())
+                throw invalidAction(index, "must be a JSON object");
+
+            JsonNode methodNode = action.get("method");
+            if (methodNode == null || methodNode.isNull())
+                continue; // Ignore legacy non-policy actions, including their default/blank URLs.
+
+            // The endpoint returns every role-visible action. An unrelated service's malformed
+            // policy metadata must not deny this URL, while a candidate for this exact URL is
+            // validated strictly below.
+            JsonNode urlNode = action.get("url");
+            if (urlNode != null && urlNode.isTextual() && !url.equals(urlNode.textValue()))
+                continue;
+            String actionUrl = requiredText(action, "url", index);
+
+            if (!methodNode.isTextual())
+                throw invalidAction(index, "method must be a string when present");
+            String actionMethod;
+            try {
+                actionMethod = requiredUnpadded(methodNode.textValue(), "method");
+            } catch (IllegalArgumentException e) {
+                throw invalidAction(index, e.getMessage());
+            }
+            if (!actionMethod.equals(actionMethod.toUpperCase(Locale.ROOT)))
+                throw invalidAction(index, "method must be canonical uppercase");
+
+            if (!method.equals(actionMethod) || !url.equals(actionUrl))
+                continue;
+
+            Map<String, Object> document;
+            try {
+                document = objectMapper.convertValue(action, DOCUMENT_TYPE);
+            } catch (IllegalArgumentException e) {
+                throw new MalformedPolicySourceResponseException(
+                        "invalid access-control actions[" + index + "]: cannot preserve JSON document", e);
+            }
+            matches.add(new PolicyAction(actionMethod, actionUrl, document));
+        }
+        return List.copyOf(matches);
+    }
+
+    private static String requiredText(JsonNode action, String field, int index) {
+        JsonNode value = action.get(field);
+        if (value == null || !value.isTextual())
+            throw invalidAction(index, field + " must be a string");
+        try {
+            return requiredUnpadded(value.textValue(), "actions[" + index + "]." + field);
+        } catch (IllegalArgumentException e) {
+            throw invalidAction(index, e.getMessage());
+        }
+    }
+
+    private static MalformedPolicySourceResponseException invalidAction(int index, String detail) {
+        return new MalformedPolicySourceResponseException(
+                "invalid access-control actions[" + index + "]: " + detail);
+    }
+
+    private static List<String> requireCanonicalRoles(List<String> roleCodes) {
+        if (roleCodes == null || roleCodes.isEmpty())
+            throw new IllegalArgumentException("roleCodes must not be empty");
+        List<String> exact = List.copyOf(roleCodes);
+        for (String code : exact)
+            requiredUnpadded(code, "role code");
+
+        List<String> canonical = exact.stream().distinct().sorted().toList();
+        if (!exact.equals(canonical))
+            throw new IllegalArgumentException("roleCodes must be sorted and distinct");
+        return exact;
+    }
+
+    private static RestTemplate buildClient(RestTemplateBuilder builder,
+                                            Long connectTimeoutMillis,
+                                            Long readTimeoutMillis) {
+        Objects.requireNonNull(builder, "restTemplateBuilder");
+        return builder
+                .setConnectTimeout(positiveTimeout(connectTimeoutMillis, "connect timeout"))
+                .setReadTimeout(positiveTimeout(readTimeoutMillis, "read timeout"))
+                .build();
+    }
+
+    private static Duration positiveTimeout(Long millis, String name) {
+        if (millis == null || millis <= 0)
+            throw new IllegalArgumentException(name + " must be positive");
+        return Duration.ofMillis(millis);
+    }
+
+    private static URI endpoint(String host, String path) {
+        String exactHost = requiredUnpadded(host, "access-control host");
+        String exactPath = requiredUnpadded(path, "access-control path");
+        String joined = exactHost.replaceAll("/+$", "") + "/" + exactPath.replaceFirst("^/+", "");
+        URI endpoint = URI.create(joined);
+        if (!endpoint.isAbsolute() || endpoint.getHost() == null
+                || !("http".equalsIgnoreCase(endpoint.getScheme())
+                || "https".equalsIgnoreCase(endpoint.getScheme())))
+            throw new IllegalArgumentException("access-control endpoint must be an absolute HTTP(S) URI");
+        return endpoint;
+    }
+
+    private static String requiredUnpadded(String value, String name) {
+        if (value == null || value.isBlank() || !value.equals(value.trim()))
+            throw new IllegalArgumentException(name + " must not be blank or padded");
+        return value;
+    }
+}

--- a/backend/pgr-services/src/main/java/org/egov/pgr/policy/AccessPolicyRegistry.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/policy/AccessPolicyRegistry.java
@@ -90,9 +90,15 @@ public class AccessPolicyRegistry {
         List<PolicyAction> actions;
         try {
             actions = source.findActions(tenantId, canonicalMethod, url, roleCodes);
+        } catch (MalformedPolicySourceResponseException e) {
+            log.error("Access-policy source returned malformed policy data for tenant='{}' method='{}' url='{}'; denying",
+                    tenantId, canonicalMethod, url);
+            return PolicyResolution.invalidPolicy();
         } catch (Exception e) {
-            log.error("Access-policy source failed for tenant='{}' method='{}' url='{}'; denying",
-                    tenantId, canonicalMethod, url, e);
+            // Do not log exception messages or response bodies: HTTP clients commonly include the
+            // complete upstream body in both, and that body may itself contain policy data.
+            log.error("Access-policy source failed for tenant='{}' method='{}' url='{}' with {}; denying",
+                    tenantId, canonicalMethod, url, e.getClass().getName());
             return PolicyResolution.sourceUnavailable();
         }
 

--- a/backend/pgr-services/src/main/java/org/egov/pgr/policy/AccessPolicyRegistry.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/policy/AccessPolicyRegistry.java
@@ -1,0 +1,180 @@
+package org.egov.pgr.policy;
+
+import lombok.extern.slf4j.Slf4j;
+import org.egov.common.contract.request.RequestInfo;
+import org.egov.common.contract.request.Role;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Resolves and briefly caches role-visible policy actions.
+ *
+ * <p>The backing access-control lookup is role-scoped, so the complete canonical role set is part
+ * of the cache key. Omitting it would let one authorized role prime a tenant/URL entry for an
+ * unrelated role. Only successful, uniquely matched results are cached; denial and failures are
+ * retried on the next request and always remain fail-closed.
+ *
+ * <p>This core registry is intentionally not a Spring component yet. It performs policy lookup and
+ * caching, not authentication: callers must supply a previously authenticated, tenant-bound
+ * {@link RequestInfo}. A later integration supplies the concrete {@link AccessPolicySource} and
+ * wires the registry after that trusted-principal boundary.
+ */
+@Slf4j
+public class AccessPolicyRegistry {
+
+    static final Duration DEFAULT_TTL = Duration.ofMinutes(15);
+    static final int DEFAULT_MAX_ENTRIES = 4096;
+
+    private final AccessPolicySource source;
+    private final Clock clock;
+    private final long ttlMillis;
+    private final int maxEntries;
+    private final Map<CacheKey, CachedAction> cache = new ConcurrentHashMap<>();
+
+    public AccessPolicyRegistry(AccessPolicySource source) {
+        this(source, Clock.systemUTC(), DEFAULT_TTL, DEFAULT_MAX_ENTRIES);
+    }
+
+    public AccessPolicyRegistry(AccessPolicySource source, Clock clock, Duration ttl) {
+        this(source, clock, ttl, DEFAULT_MAX_ENTRIES);
+    }
+
+    AccessPolicyRegistry(AccessPolicySource source, Clock clock, Duration ttl, int maxEntries) {
+        if (ttl == null || ttl.isZero() || ttl.isNegative() || ttl.toMillis() == 0)
+            throw new IllegalArgumentException("ttl must be positive");
+        if (maxEntries <= 0)
+            throw new IllegalArgumentException("maxEntries must be positive");
+        this.source = java.util.Objects.requireNonNull(source, "source");
+        this.clock = java.util.Objects.requireNonNull(clock, "clock");
+        this.ttlMillis = ttl.toMillis();
+        this.maxEntries = maxEntries;
+    }
+
+    public PolicyResolution resolve(RequestInfo requestInfo, String tenantId, String method, String url) {
+        if (isMissingOrPadded(tenantId) || isMissingOrPadded(method) || isMissingOrPadded(url)) {
+            log.error("Cannot resolve access policy with a missing tenant, method, or URL");
+            return PolicyResolution.invalidRequest();
+        }
+
+        List<String> roleCodes;
+        try {
+            roleCodes = canonicalRoleCodes(requestInfo);
+        } catch (IllegalArgumentException e) {
+            log.error("Cannot resolve access policy with malformed role codes: {}", e.getMessage());
+            return PolicyResolution.invalidRequest();
+        }
+        if (roleCodes.isEmpty()) {
+            log.warn("Cannot resolve access policy for tenant='{}' method='{}' url='{}': caller has no roles",
+                    tenantId, method, url);
+            return PolicyResolution.notAuthorized();
+        }
+
+        String canonicalMethod = method.toUpperCase(Locale.ROOT);
+        CacheKey key = new CacheKey(tenantId, canonicalMethod, url, roleCodes);
+        long now = clock.millis();
+        CachedAction cached = cache.get(key);
+        if (cached != null && cached.expiresAtMillis > now)
+            return PolicyResolution.resolved(cached.action);
+        if (cached != null)
+            cache.remove(key, cached);
+
+        evictExpired(now);
+
+        List<PolicyAction> actions;
+        try {
+            actions = source.findActions(tenantId, canonicalMethod, url, roleCodes);
+        } catch (Exception e) {
+            log.error("Access-policy source failed for tenant='{}' method='{}' url='{}'; denying",
+                    tenantId, canonicalMethod, url, e);
+            return PolicyResolution.sourceUnavailable();
+        }
+
+        if (actions == null) {
+            log.error("Access-policy source violated its non-null result contract; denying invalid policy");
+            return PolicyResolution.invalidPolicy();
+        }
+        if (actions.isEmpty())
+            return PolicyResolution.notAuthorized();
+        if (actions.size() != 1) {
+            log.error("Access-policy source returned {} actions for tenant='{}' method='{}' url='{}'; denying ambiguous policy",
+                    actions.size(), tenantId, canonicalMethod, url);
+            return PolicyResolution.invalidPolicy();
+        }
+
+        PolicyAction action = actions.get(0);
+        if (action == null || !canonicalMethod.equals(action.method()) || !url.equals(action.url())) {
+            log.error("Access-policy source returned a mismatched action for tenant='{}' method='{}' url='{}'; denying",
+                    tenantId, canonicalMethod, url);
+            return PolicyResolution.invalidPolicy();
+        }
+
+        cacheResolved(key, action, now);
+        return PolicyResolution.resolved(action);
+    }
+
+    private static boolean isMissingOrPadded(String value) {
+        return value == null || value.isBlank() || !value.equals(value.trim());
+    }
+
+    private List<String> canonicalRoleCodes(RequestInfo requestInfo) {
+        if (requestInfo == null || requestInfo.getUserInfo() == null
+                || requestInfo.getUserInfo().getRoles() == null)
+            return List.of();
+
+        List<String> codes = new ArrayList<>();
+        for (Role role : requestInfo.getUserInfo().getRoles()) {
+            if (role == null || role.getCode() == null || role.getCode().isBlank())
+                throw new IllegalArgumentException("role codes must not be blank");
+            String code = role.getCode();
+            if (!code.equals(code.trim()))
+                throw new IllegalArgumentException("role codes must not contain surrounding whitespace");
+            codes.add(code);
+        }
+        Collections.sort(codes);
+        List<String> distinct = new ArrayList<>();
+        String previous = null;
+        for (String code : codes) {
+            if (!code.equals(previous))
+                distinct.add(code);
+            previous = code;
+        }
+        return List.copyOf(distinct);
+    }
+
+    private long expirationFrom(long now) {
+        try {
+            return Math.addExact(now, ttlMillis);
+        } catch (ArithmeticException e) {
+            return Long.MAX_VALUE;
+        }
+    }
+
+    private void evictExpired(long now) {
+        cache.entrySet().removeIf(entry -> entry.getValue().expiresAtMillis <= now);
+    }
+
+    private void cacheResolved(CacheKey key, PolicyAction action, long now) {
+        synchronized (cache) {
+            evictExpired(now);
+            if (cache.containsKey(key) || cache.size() < maxEntries)
+                cache.put(key, new CachedAction(action, expirationFrom(now)));
+            else
+                log.warn("Access-policy cache reached its {}-entry bound; returning uncached resolution", maxEntries);
+        }
+    }
+
+    private record CacheKey(String tenantId, String method, String url, List<String> roleCodes) {
+        private CacheKey {
+            roleCodes = List.copyOf(roleCodes);
+        }
+    }
+
+    private record CachedAction(PolicyAction action, long expiresAtMillis) { }
+}

--- a/backend/pgr-services/src/main/java/org/egov/pgr/policy/AccessPolicySource.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/policy/AccessPolicySource.java
@@ -1,0 +1,19 @@
+package org.egov.pgr.policy;
+
+import java.util.List;
+
+/**
+ * Source of access-control actions visible to a caller's exact role set.
+ *
+ * <p>The role list is canonical, immutable, and is the same list used by the registry's cache
+ * key. Policy selection must be a pure function of exactly these arguments. The registry's caller
+ * is responsible for authentication and tenant binding before lookup. An empty list means that the
+ * authenticated caller has no visible matching action. Implementations must never return
+ * {@code null}.
+ */
+@FunctionalInterface
+public interface AccessPolicySource {
+
+    List<PolicyAction> findActions(String tenantId, String method, String url,
+                                   List<String> roleCodes) throws Exception;
+}

--- a/backend/pgr-services/src/main/java/org/egov/pgr/policy/MalformedPolicySourceResponseException.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/policy/MalformedPolicySourceResponseException.java
@@ -1,0 +1,16 @@
+package org.egov.pgr.policy;
+
+/**
+ * Signals that an access-policy source returned a successful HTTP response whose body cannot be
+ * interpreted as a valid policy document.
+ */
+public class MalformedPolicySourceResponseException extends RuntimeException {
+
+    public MalformedPolicySourceResponseException(String message) {
+        super(message);
+    }
+
+    public MalformedPolicySourceResponseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/pgr-services/src/main/java/org/egov/pgr/policy/PolicyAction.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/policy/PolicyAction.java
@@ -1,0 +1,83 @@
+package org.egov.pgr.policy;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * One role-visible access-control action and its opaque policy document.
+ *
+ * <p>The registry treats {@code method} and {@code url} as the action's identity. The remaining
+ * document is intentionally opaque here so row, field, and analytics integrations can evolve
+ * their policy schema without teaching the cache about domain fields.
+ */
+public record PolicyAction(String method, String url, Map<String, Object> document) {
+
+    public PolicyAction {
+        Objects.requireNonNull(method, "method");
+        Objects.requireNonNull(url, "url");
+        Objects.requireNonNull(document, "document");
+        if (method.isBlank() || !method.equals(method.trim()))
+            throw new IllegalArgumentException("method must not be blank");
+        if (url.isBlank() || !url.equals(url.trim()))
+            throw new IllegalArgumentException("url must not be blank");
+
+        method = method.toUpperCase(Locale.ROOT);
+        document = immutableDocument(document);
+    }
+
+    /** Returns the parsed JsonLogic condition, or {@code null} when the policy omits it. */
+    public Object condition() {
+        return document.get("condition");
+    }
+
+    private static Map<String, Object> immutableDocument(Map<String, Object> source) {
+        Map<String, Object> copy = new LinkedHashMap<>();
+        for (Map.Entry<String, Object> entry : source.entrySet()) {
+            if (entry.getKey() == null)
+                throw new IllegalArgumentException("policy document keys must not be null");
+            copy.put(entry.getKey(), immutableJsonValue(entry.getValue()));
+        }
+        return Collections.unmodifiableMap(copy);
+    }
+
+    private static Object immutableJsonValue(Object value) {
+        if (value == null || value instanceof String || value instanceof Boolean)
+            return value;
+        if (value instanceof Float number) {
+            if (!Float.isFinite(number))
+                throw new IllegalArgumentException("policy document numbers must be finite");
+            return number;
+        }
+        if (value instanceof Double number) {
+            if (!Double.isFinite(number))
+                throw new IllegalArgumentException("policy document numbers must be finite");
+            return number;
+        }
+        if (value instanceof Byte || value instanceof Short || value instanceof Integer
+                || value instanceof Long || value instanceof BigInteger || value instanceof BigDecimal)
+            return value;
+        if (value instanceof Map<?, ?> map) {
+            Map<String, Object> copy = new LinkedHashMap<>();
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                if (!(entry.getKey() instanceof String key))
+                    throw new IllegalArgumentException("policy document map keys must be strings");
+                copy.put(key, immutableJsonValue(entry.getValue()));
+            }
+            return Collections.unmodifiableMap(copy);
+        }
+        if (value instanceof List<?> list) {
+            List<Object> copy = new ArrayList<>(list.size());
+            for (Object item : list)
+                copy.add(immutableJsonValue(item));
+            return Collections.unmodifiableList(copy);
+        }
+        throw new IllegalArgumentException("unsupported policy document value type: " + value.getClass().getName());
+    }
+}

--- a/backend/pgr-services/src/main/java/org/egov/pgr/policy/PolicyEvaluator.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/policy/PolicyEvaluator.java
@@ -1,0 +1,43 @@
+package org.egov.pgr.policy;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.jamsesso.jsonlogic.JsonLogic;
+import io.github.jamsesso.jsonlogic.JsonLogicException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+/** Evaluates JsonLogic policy conditions and fails closed on every invalid outcome. */
+@Component
+@Slf4j
+public class PolicyEvaluator {
+
+    private final JsonLogic jsonLogic = new JsonLogic();
+    private final ObjectMapper objectMapper;
+
+    public PolicyEvaluator(ObjectMapper objectMapper) {
+        this.objectMapper = java.util.Objects.requireNonNull(objectMapper, "objectMapper");
+    }
+
+    /**
+     * Evaluates a parsed JSON condition and returns true only when it produces the Boolean value
+     * {@code true}. JsonLogic's broader truthiness rules are useful for expressions, but accepting
+     * a truthy scalar as a final authorization verdict would contradict the fail-closed contract.
+     */
+    public boolean isAllowed(Object condition, Map<String, Object> data) {
+        if (condition == null || data == null) {
+            log.error("PolicyEvaluator: missing condition or input document; denying");
+            return false;
+        }
+        try {
+            String conditionJson = objectMapper.writeValueAsString(condition);
+            Object result = jsonLogic.apply(conditionJson, data);
+            return Boolean.TRUE.equals(result);
+        } catch (JsonProcessingException | JsonLogicException | RuntimeException e) {
+            log.error("PolicyEvaluator: condition evaluation failed; denying: {}", e.getMessage());
+            return false;
+        }
+    }
+}

--- a/backend/pgr-services/src/main/java/org/egov/pgr/policy/PolicyResolution.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/policy/PolicyResolution.java
@@ -1,0 +1,64 @@
+package org.egov.pgr.policy;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Explicit result of resolving an action for one tenant and role set.
+ *
+ * <p>Callers must allow only {@link Status#RESOLVED}. Keeping unavailable, malformed, and
+ * unauthorized outcomes distinct lets future field-masking consumers fail closed without
+ * confusing a policy-system failure with an intentionally absent field rule.
+ */
+public final class PolicyResolution {
+
+    public enum Status {
+        RESOLVED,
+        NOT_AUTHORIZED,
+        SOURCE_UNAVAILABLE,
+        INVALID_REQUEST,
+        INVALID_POLICY
+    }
+
+    private final Status status;
+    private final PolicyAction action;
+
+    private PolicyResolution(Status status, PolicyAction action) {
+        this.status = Objects.requireNonNull(status, "status");
+        this.action = action;
+        if ((status == Status.RESOLVED) != (action != null))
+            throw new IllegalArgumentException("only a resolved result may contain an action");
+    }
+
+    public static PolicyResolution resolved(PolicyAction action) {
+        return new PolicyResolution(Status.RESOLVED, Objects.requireNonNull(action, "action"));
+    }
+
+    public static PolicyResolution notAuthorized() {
+        return new PolicyResolution(Status.NOT_AUTHORIZED, null);
+    }
+
+    public static PolicyResolution sourceUnavailable() {
+        return new PolicyResolution(Status.SOURCE_UNAVAILABLE, null);
+    }
+
+    public static PolicyResolution invalidRequest() {
+        return new PolicyResolution(Status.INVALID_REQUEST, null);
+    }
+
+    public static PolicyResolution invalidPolicy() {
+        return new PolicyResolution(Status.INVALID_POLICY, null);
+    }
+
+    public Status status() {
+        return status;
+    }
+
+    public Optional<PolicyAction> action() {
+        return Optional.ofNullable(action);
+    }
+
+    public boolean isResolved() {
+        return status == Status.RESOLVED;
+    }
+}

--- a/backend/pgr-services/src/main/resources/application.properties
+++ b/backend/pgr-services/src/main/resources/application.properties
@@ -55,6 +55,13 @@ egov.localization.statelevel=true
 egov.mdms.host=http://localhost:8082
 egov.mdms.search.endpoint=/egov-mdms-service/v1/_search
 
+# Access-control policy lookup. The source bean is dormant until an AccessPolicyRegistry is wired.
+egov.accesscontrol.host=http://localhost:8080
+egov.accesscontrol.actions.mdms.get.path=/access/v1/actions/mdms/_get
+egov.accesscontrol.actions.master=actions-test
+egov.accesscontrol.connect.timeout.millis=2000
+egov.accesscontrol.read.timeout.millis=5000
+
 #hrms urls
 egov.hrms.host=https://pgr-demo.digit.org
 egov.hrms.search.endpoint=/egov-hrms/employees/_search

--- a/backend/pgr-services/src/test/java/org/egov/pgr/policy/AccessControlPolicySourceTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/policy/AccessControlPolicySourceTest.java
@@ -1,0 +1,253 @@
+package org.egov.pgr.policy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.egov.pgr.config.PGRConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.client.ExpectedCount.once;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class AccessControlPolicySourceTest {
+
+    private static final URI ENDPOINT = URI.create("http://access-control:8090/access/v1/actions/mdms/_get");
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private RestTemplate restTemplate;
+    private MockRestServiceServer server;
+    private AccessControlPolicySource source;
+
+    @BeforeEach
+    void setUp() {
+        restTemplate = new RestTemplate();
+        server = MockRestServiceServer.bindTo(restTemplate).build();
+        source = new AccessControlPolicySource(restTemplate, objectMapper, ENDPOINT, "actions-test");
+    }
+
+    @Test
+    void postsExactRoleScopedPayloadAndPreservesTheMatchingDocument() {
+        server.expect(once(), requestTo(ENDPOINT))
+                .andExpect(method(org.springframework.http.HttpMethod.POST))
+                .andExpect(content().json("""
+                        {
+                          "roleCodes": ["CITIZEN", "GRO"],
+                          "tenantId": "pg.citya",
+                          "actionMaster": "actions-test"
+                        }
+                        """, true))
+                .andExpect(jsonPath("$.enabled").doesNotExist())
+                .andExpect(jsonPath("$.RequestInfo").doesNotExist())
+                .andRespond(withSuccess("""
+                        {
+                          "responseInfo": {"status": "OK"},
+                          "actions": [
+                            {"id": 1, "url": "/other", "method": "POST", "condition": true},
+                            {"id": 2, "url": "/pgr-services/v2/request/_search"},
+                            {"id": 3, "url": "/pgr-services/v2/request/_search", "method": "GET"},
+                            {
+                              "id": 2008,
+                              "enabled": false,
+                              "url": "/pgr-services/v2/request/_search",
+                              "method": "POST",
+                              "resource": {"complaint": {"attributes": ["citizen.mobileNumber"]}},
+                              "condition": {"and": [{"==": [{"var": "user.tenantId"}, "pg.citya"]}, true]}
+                            }
+                          ]
+                        }
+                        """, MediaType.APPLICATION_JSON));
+
+        List<PolicyAction> result = source.findActions(
+                "pg.citya", "POST", "/pgr-services/v2/request/_search", List.of("CITIZEN", "GRO"));
+
+        assertEquals(1, result.size());
+        PolicyAction action = result.get(0);
+        assertEquals("POST", action.method());
+        assertEquals("/pgr-services/v2/request/_search", action.url());
+        assertEquals(2008, action.document().get("id"));
+        assertEquals(false, action.document().get("enabled"));
+        assertEquals("citizen.mobileNumber", nestedAttribute(action.document()));
+        assertTrue(action.condition() instanceof Map);
+        assertThrows(UnsupportedOperationException.class,
+                () -> ((List<Object>) nestedComplaint(action.document()).get("attributes")).add("citizen.name"));
+        server.verify();
+    }
+
+    @Test
+    void returnsEveryExactMatchSoTheRegistryCanRejectAmbiguousPolicies() {
+        server.expect(requestTo(ENDPOINT)).andRespond(withSuccess("""
+                {"actions": [
+                  {"id": 1, "url": "/search", "method": "POST"},
+                  {"id": 2, "url": "/search", "method": "POST"}
+                ]}
+                """, MediaType.APPLICATION_JSON));
+
+        List<PolicyAction> result = source.findActions("pg", "POST", "/search", List.of("CITIZEN"));
+
+        assertEquals(2, result.size());
+        server.verify();
+    }
+
+    @Test
+    void aValidEmptyActionListIsACleanAuthorizationDenial() {
+        server.expect(requestTo(ENDPOINT))
+                .andRespond(withSuccess("{\"actions\":[]}", MediaType.APPLICATION_JSON));
+
+        List<PolicyAction> result =
+                source.findActions("pg", "POST", "/search", List.of("CITIZEN"));
+
+        assertTrue(result.isEmpty());
+        server.verify();
+    }
+
+    @Test
+    void rejectsMalformedResponseShapesInsteadOfTreatingThemAsNoPolicy() throws Exception {
+        List<String> malformed = List.of(
+                "null",
+                "{}",
+                "{\"actions\":{}}",
+                "{\"actions\":[false]}",
+                "{\"actions\":[{\"method\":\"POST\"}]}",
+                "{\"actions\":[{\"url\":\"/search\",\"method\":false}]}",
+                "{\"actions\":[{\"url\":\"/search\",\"method\":\" POST\"}]}",
+                "{\"actions\":[{\"url\":\"/search\",\"method\":\"post\"}]}"
+        );
+
+        for (String json : malformed) {
+            JsonNode response = objectMapper.readTree(json);
+            assertThrows(MalformedPolicySourceResponseException.class,
+                    () -> source.parseActions(response, "POST", "/search"), json);
+        }
+    }
+
+    @Test
+    void classifiesSyntacticallyInvalidSuccessfulBodiesAsMalformedPolicy() {
+        server.expect(requestTo(ENDPOINT))
+                .andRespond(withSuccess("{\"actions\": [", MediaType.APPLICATION_JSON));
+
+        assertThrows(MalformedPolicySourceResponseException.class,
+                () -> source.findActions("pg", "POST", "/search", List.of("CITIZEN")));
+        server.verify();
+    }
+
+    @Test
+    void rejectsDuplicateJsonKeysWithoutChangingTheSharedObjectMapper() throws Exception {
+        String duplicateKeys = """
+                {"actions": [{"id": 2008, "url": "/search", "url": "/other", "method": "POST"}]}
+                """;
+
+        assertThrows(MalformedPolicySourceResponseException.class,
+                () -> source.parseResponse(duplicateKeys, "POST", "/search"));
+        JsonNode parsedBySharedMapper = objectMapper.readTree(duplicateKeys);
+        assertEquals("/other", parsedBySharedMapper.get("actions").get(0).get("url").textValue());
+    }
+
+    @Test
+    void ignoresLegacyRowsBeforeValidatingTheirDefaultUrls() throws Exception {
+        JsonNode response = objectMapper.readTree("""
+                {"actions": [
+                  {"id": 1, "url": ""},
+                  {"id": 2},
+                  {"id": 2008, "enabled": false, "url": "/search", "method": "POST"}
+                ]}
+                """);
+
+        List<PolicyAction> result = source.parseActions(response, "POST", "/search");
+
+        assertEquals(1, result.size());
+        assertEquals(2008, result.get(0).document().get("id"));
+        assertEquals(false, result.get(0).document().get("enabled"));
+    }
+
+    @Test
+    void ignoresMalformedPolicyMetadataForAnUnrelatedUrl() throws Exception {
+        JsonNode response = objectMapper.readTree("""
+                {"actions": [
+                  {"id": 1, "url": "/unrelated", "method": false},
+                  {"id": 2, "url": "/also-unrelated", "method": "post"},
+                  {"id": 2008, "url": "/search", "method": "POST", "condition": true}
+                ]}
+                """);
+
+        List<PolicyAction> result = source.parseActions(response, "POST", "/search");
+
+        assertEquals(1, result.size());
+        assertEquals(2008, result.get(0).document().get("id"));
+    }
+
+    @Test
+    void propagatesHttpFailures() {
+        server.expect(requestTo(ENDPOINT))
+                .andRespond(withStatus(HttpStatus.SERVICE_UNAVAILABLE)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{\"error\":\"unavailable\"}"));
+
+        assertThrows(HttpServerErrorException.ServiceUnavailable.class,
+                () -> source.findActions("pg", "POST", "/search", List.of("CITIZEN")));
+        server.verify();
+    }
+
+    @Test
+    void rejectsNonCanonicalRoleListsWithoutRewritingTheCacheIdentity() {
+        assertThrows(IllegalArgumentException.class,
+                () -> source.findActions("pg", "POST", "/search", List.of("GRO", "CITIZEN")));
+        assertThrows(IllegalArgumentException.class,
+                () -> source.findActions("pg", "POST", "/search", List.of("CITIZEN", "CITIZEN")));
+    }
+
+    @Test
+    void buildsADedicatedClientWithTheConfiguredTimeouts() {
+        PGRConfiguration config = new PGRConfiguration();
+        config.setAccessControlHost("http://access-control:8090/");
+        config.setAccessControlActionsMdmsGetPath("/access/v1/actions/mdms/_get");
+        config.setAccessControlActionsMaster("actions-test");
+        config.setAccessControlConnectTimeoutMillis(1234L);
+        config.setAccessControlReadTimeoutMillis(5678L);
+        RestTemplateBuilder builder = new RestTemplateBuilder()
+                .requestFactory(SimpleClientHttpRequestFactory::new);
+
+        AccessControlPolicySource configuredSource =
+                new AccessControlPolicySource(builder, objectMapper, config);
+
+        RestTemplate configuredClient = (RestTemplate) ReflectionTestUtils.getField(configuredSource, "restTemplate");
+        SimpleClientHttpRequestFactory requestFactory =
+                (SimpleClientHttpRequestFactory) configuredClient.getRequestFactory();
+        assertEquals(1234, ReflectionTestUtils.getField(requestFactory, "connectTimeout"));
+        assertEquals(5678, ReflectionTestUtils.getField(requestFactory, "readTimeout"));
+        assertEquals(URI.create("http://access-control:8090/access/v1/actions/mdms/_get"),
+                ReflectionTestUtils.getField(configuredSource, "endpoint"));
+        assertTrue(AccessControlPolicySource.class.isAnnotationPresent(Lazy.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    private String nestedAttribute(Map<String, Object> document) {
+        return (String) ((List<Object>) nestedComplaint(document).get("attributes")).get(0);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> nestedComplaint(Map<String, Object> document) {
+        Map<String, Object> resource = (Map<String, Object>) document.get("resource");
+        return (Map<String, Object>) resource.get("complaint");
+    }
+}

--- a/backend/pgr-services/src/test/java/org/egov/pgr/policy/AccessPolicyRegistryTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/policy/AccessPolicyRegistryTest.java
@@ -1,10 +1,17 @@
 package org.egov.pgr.policy;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.core.read.ListAppender;
 import org.egov.common.contract.request.RequestInfo;
 import org.egov.common.contract.request.Role;
 import org.egov.common.contract.request.User;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpServerErrorException;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -128,6 +135,50 @@ class AccessPolicyRegistryTest {
 
         assertEquals(PolicyResolution.Status.SOURCE_UNAVAILABLE, first.status());
         assertEquals(PolicyResolution.Status.SOURCE_UNAVAILABLE, second.status());
+        assertEquals(2, calls.get());
+    }
+
+    @Test
+    void anHttpFailureDoesNotLeakItsResponseBodyIntoRegistryLogs() {
+        String sensitiveBody = "policy-secret-that-must-not-be-logged";
+        AccessPolicyRegistry registry = new AccessPolicyRegistry((tenantId, method, url, roleCodes) -> {
+            throw HttpServerErrorException.create(HttpStatus.SERVICE_UNAVAILABLE, "unavailable",
+                    HttpHeaders.EMPTY, sensitiveBody.getBytes(StandardCharsets.UTF_8),
+                    StandardCharsets.UTF_8);
+        });
+        Logger logger = (Logger) LoggerFactory.getLogger(AccessPolicyRegistry.class);
+        ListAppender<ch.qos.logback.classic.spi.ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+
+        try {
+            PolicyResolution result = registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+
+            assertEquals(PolicyResolution.Status.SOURCE_UNAVAILABLE, result.status());
+            String logs = appender.list.stream()
+                    .map(ch.qos.logback.classic.spi.ILoggingEvent::getFormattedMessage)
+                    .reduce("", (left, right) -> left + right);
+            assertFalse(logs.contains(sensitiveBody));
+            assertTrue(logs.contains(HttpServerErrorException.ServiceUnavailable.class.getName()));
+        } finally {
+            logger.detachAppender(appender);
+            appender.stop();
+        }
+    }
+
+    @Test
+    void aMalformedSuccessfulSourceResponseIsInvalidPolicyAndIsNotCached() {
+        AtomicInteger calls = new AtomicInteger();
+        AccessPolicyRegistry registry = new AccessPolicyRegistry((tenantId, method, url, roleCodes) -> {
+            calls.incrementAndGet();
+            throw new MalformedPolicySourceResponseException("actions must be an array");
+        });
+
+        PolicyResolution first = registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+        PolicyResolution second = registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+
+        assertEquals(PolicyResolution.Status.INVALID_POLICY, first.status());
+        assertEquals(PolicyResolution.Status.INVALID_POLICY, second.status());
         assertEquals(2, calls.get());
     }
 

--- a/backend/pgr-services/src/test/java/org/egov/pgr/policy/AccessPolicyRegistryTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/policy/AccessPolicyRegistryTest.java
@@ -1,0 +1,332 @@
+package org.egov.pgr.policy;
+
+import org.egov.common.contract.request.RequestInfo;
+import org.egov.common.contract.request.Role;
+import org.egov.common.contract.request.User;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AccessPolicyRegistryTest {
+
+    private static final String TENANT = "pg.city";
+    private static final String URL = "/pgr-services/v2/request/_search";
+
+    @Test
+    void anAllowedRoleCannotPrimeTheCacheForAnUnmappedRole() {
+        AtomicInteger calls = new AtomicInteger();
+        AccessPolicySource source = (tenantId, method, url, roleCodes) -> {
+            calls.incrementAndGet();
+            return roleCodes.contains("EMPLOYEE") ? List.of(action(method, url)) : List.of();
+        };
+        AccessPolicyRegistry registry = new AccessPolicyRegistry(source);
+
+        PolicyResolution allowed = registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+        PolicyResolution unmapped = registry.resolve(request("CITIZEN"), TENANT, "POST", URL);
+
+        assertEquals(PolicyResolution.Status.RESOLVED, allowed.status());
+        assertEquals(PolicyResolution.Status.NOT_AUTHORIZED, unmapped.status());
+        assertEquals(2, calls.get());
+    }
+
+    @Test
+    void roleOrderAndDuplicatesShareOneCanonicalCacheEntry() {
+        AtomicInteger calls = new AtomicInteger();
+        List<List<String>> observedRoles = new ArrayList<>();
+        AccessPolicySource source = (tenantId, method, url, roleCodes) -> {
+            calls.incrementAndGet();
+            observedRoles.add(roleCodes);
+            return List.of(action(method, url));
+        };
+        AccessPolicyRegistry registry = new AccessPolicyRegistry(source);
+
+        PolicyResolution first = registry.resolve(request("GRO", "EMPLOYEE", "GRO"), TENANT, "post", URL);
+        PolicyResolution second = registry.resolve(request("EMPLOYEE", "GRO"), TENANT, "POST", URL);
+
+        assertTrue(first.isResolved());
+        assertTrue(second.isResolved());
+        assertEquals(1, calls.get());
+        assertEquals(List.of("EMPLOYEE", "GRO"), observedRoles.get(0));
+        assertThrows(UnsupportedOperationException.class, () -> observedRoles.get(0).add("ADMIN"));
+        assertSame(first.action().orElseThrow(), second.action().orElseThrow());
+    }
+
+    @Test
+    void anAdditionalRoleCreatesADistinctCacheEntry() {
+        AtomicInteger calls = new AtomicInteger();
+        AccessPolicyRegistry registry = new AccessPolicyRegistry((tenantId, method, url, roleCodes) -> {
+            calls.incrementAndGet();
+            return List.of(action(method, url));
+        });
+
+        registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+        registry.resolve(request("EMPLOYEE", "GRO"), TENANT, "POST", URL);
+
+        assertEquals(2, calls.get());
+    }
+
+    @Test
+    void roleCodesRemainCaseSensitiveInTheCacheIdentity() {
+        AtomicInteger calls = new AtomicInteger();
+        AccessPolicyRegistry registry = new AccessPolicyRegistry((tenantId, method, url, roleCodes) -> {
+            calls.incrementAndGet();
+            return List.of(action(method, url));
+        });
+
+        registry.resolve(request("GRO"), TENANT, "POST", URL);
+        registry.resolve(request("gro"), TENANT, "POST", URL);
+
+        assertEquals(2, calls.get());
+    }
+
+    @Test
+    void tenantMethodAndExactUrlAreIndependentCacheAxes() {
+        AtomicInteger calls = new AtomicInteger();
+        AccessPolicyRegistry registry = new AccessPolicyRegistry((tenantId, method, url, roleCodes) -> {
+            calls.incrementAndGet();
+            return List.of(action(method, url));
+        });
+        RequestInfo principal = request("EMPLOYEE");
+
+        registry.resolve(principal, TENANT, "POST", URL);
+        registry.resolve(principal, "pg.other", "POST", URL);
+        registry.resolve(principal, TENANT, "GET", URL);
+        registry.resolve(principal, TENANT, "POST", URL + "/child");
+        registry.resolve(principal, TENANT, "post", URL);
+
+        assertEquals(4, calls.get());
+    }
+
+    @Test
+    void aSourceExceptionFailsClosedAndIsNotCached() {
+        AtomicInteger calls = new AtomicInteger();
+        AccessPolicyRegistry registry = new AccessPolicyRegistry((tenantId, method, url, roleCodes) -> {
+            calls.incrementAndGet();
+            throw new IllegalStateException("access-control unavailable");
+        });
+
+        PolicyResolution first = registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+        PolicyResolution second = registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+
+        assertEquals(PolicyResolution.Status.SOURCE_UNAVAILABLE, first.status());
+        assertEquals(PolicyResolution.Status.SOURCE_UNAVAILABLE, second.status());
+        assertEquals(2, calls.get());
+    }
+
+    @Test
+    void aCallerWithoutRolesIsDeniedWithoutConsultingTheSource() {
+        AtomicInteger calls = new AtomicInteger();
+        AccessPolicyRegistry registry = new AccessPolicyRegistry((tenantId, method, url, roleCodes) -> {
+            calls.incrementAndGet();
+            return List.of(action(method, url));
+        });
+
+        PolicyResolution result = registry.resolve(request(), TENANT, "POST", URL);
+
+        assertEquals(PolicyResolution.Status.NOT_AUTHORIZED, result.status());
+        assertFalse(result.action().isPresent());
+        assertEquals(0, calls.get());
+    }
+
+    @Test
+    void noMatchingActionIsDeniedAndNotCached() {
+        AtomicInteger calls = new AtomicInteger();
+        AccessPolicyRegistry registry = new AccessPolicyRegistry((tenantId, method, url, roleCodes) -> {
+            calls.incrementAndGet();
+            return List.of();
+        });
+
+        PolicyResolution first = registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+        PolicyResolution second = registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+
+        assertEquals(PolicyResolution.Status.NOT_AUTHORIZED, first.status());
+        assertEquals(PolicyResolution.Status.NOT_AUTHORIZED, second.status());
+        assertEquals(2, calls.get());
+    }
+
+    @Test
+    void aNullSourceResultIsInvalidPolicyAndNotAuthorizationDenial() {
+        AccessPolicyRegistry registry = new AccessPolicyRegistry((tenantId, method, url, roleCodes) -> null);
+
+        PolicyResolution result = registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+
+        assertEquals(PolicyResolution.Status.INVALID_POLICY, result.status());
+    }
+
+    @Test
+    void aMismatchedActionFailsClosedAndIsNotCached() {
+        AtomicInteger calls = new AtomicInteger();
+        AccessPolicyRegistry registry = new AccessPolicyRegistry((tenantId, method, url, roleCodes) -> {
+            calls.incrementAndGet();
+            return List.of(action("GET", url + "/wrong"));
+        });
+
+        PolicyResolution first = registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+        PolicyResolution second = registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+
+        assertEquals(PolicyResolution.Status.INVALID_POLICY, first.status());
+        assertEquals(PolicyResolution.Status.INVALID_POLICY, second.status());
+        assertEquals(2, calls.get());
+    }
+
+    @Test
+    void duplicateActionsFailClosedAsAmbiguous() {
+        AccessPolicyRegistry registry = new AccessPolicyRegistry((tenantId, method, url, roleCodes) ->
+                List.of(action(method, url), action(method, url)));
+
+        PolicyResolution result = registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+
+        assertEquals(PolicyResolution.Status.INVALID_POLICY, result.status());
+    }
+
+    @Test
+    void successfulEntriesExpireUsingTheInjectedClockAndTtl() {
+        AtomicInteger calls = new AtomicInteger();
+        MutableClock clock = new MutableClock(Instant.parse("2026-08-11T00:00:00Z"));
+        AccessPolicyRegistry registry = new AccessPolicyRegistry((tenantId, method, url, roleCodes) -> {
+            calls.incrementAndGet();
+            return List.of(action(method, url));
+        }, clock, Duration.ofSeconds(30));
+
+        registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+        clock.advance(Duration.ofSeconds(29));
+        registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+        clock.advance(Duration.ofSeconds(1));
+        registry.resolve(request("EMPLOYEE"), TENANT, "POST", URL);
+
+        assertEquals(2, calls.get());
+    }
+
+    @Test
+    void theCacheBoundPreventsUnboundedRoleAndActionCombinations() {
+        AtomicInteger calls = new AtomicInteger();
+        AccessPolicyRegistry registry = new AccessPolicyRegistry((tenantId, method, url, roleCodes) -> {
+            calls.incrementAndGet();
+            return List.of(action(method, url));
+        }, Clock.systemUTC(), Duration.ofMinutes(1), 1);
+        RequestInfo principal = request("EMPLOYEE");
+
+        registry.resolve(principal, TENANT, "POST", URL);
+        registry.resolve(principal, TENANT, "POST", URL + "/second");
+        registry.resolve(principal, TENANT, "POST", URL + "/second");
+
+        assertEquals(3, calls.get());
+    }
+
+    @Test
+    void theCacheBoundRemainsHardUnderConcurrentAdmission() throws Exception {
+        AtomicInteger calls = new AtomicInteger();
+        CyclicBarrier simultaneousMisses = new CyclicBarrier(2);
+        AccessPolicyRegistry registry = new AccessPolicyRegistry((tenantId, method, url, roleCodes) -> {
+            if (calls.incrementAndGet() <= 2)
+                simultaneousMisses.await(5, TimeUnit.SECONDS);
+            return List.of(action(method, url));
+        }, Clock.systemUTC(), Duration.ofMinutes(1), 1);
+        RequestInfo principal = request("EMPLOYEE");
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        try {
+            var first = executor.submit(() -> registry.resolve(principal, TENANT, "POST", URL));
+            var second = executor.submit(() ->
+                    registry.resolve(principal, TENANT, "POST", URL + "/second"));
+            first.get(5, TimeUnit.SECONDS);
+            second.get(5, TimeUnit.SECONDS);
+        } finally {
+            executor.shutdownNow();
+        }
+
+        registry.resolve(principal, TENANT, "POST", URL);
+        registry.resolve(principal, TENANT, "POST", URL + "/second");
+        assertEquals(3, calls.get());
+    }
+
+    @Test
+    void invalidLookupArgumentsAndTtlFailClosed() {
+        AccessPolicyRegistry registry = new AccessPolicyRegistry((tenantId, method, url, roleCodes) ->
+                List.of(action(method, url)));
+
+        assertEquals(PolicyResolution.Status.INVALID_REQUEST,
+                registry.resolve(request("EMPLOYEE"), null, "POST", URL).status());
+        assertEquals(PolicyResolution.Status.INVALID_REQUEST,
+                registry.resolve(request("EMPLOYEE"), TENANT, "", URL).status());
+        assertEquals(PolicyResolution.Status.INVALID_REQUEST,
+                registry.resolve(request("EMPLOYEE"), TENANT, "POST", "").status());
+        assertEquals(PolicyResolution.Status.INVALID_REQUEST,
+                registry.resolve(request(" EMPLOYEE"), TENANT, "POST", URL).status());
+        assertEquals(PolicyResolution.Status.INVALID_REQUEST,
+                registry.resolve(request("EMPLOYEE", ""), TENANT, "POST", URL).status());
+        assertEquals(PolicyResolution.Status.INVALID_REQUEST,
+                registry.resolve(request("EMPLOYEE"), " " + TENANT, "POST", URL).status());
+        assertEquals(PolicyResolution.Status.INVALID_REQUEST,
+                registry.resolve(request("EMPLOYEE"), TENANT, " POST", URL).status());
+        assertThrows(IllegalArgumentException.class,
+                () -> new AccessPolicyRegistry((tenant, method, url, roles) -> List.of(),
+                        Clock.systemUTC(), Duration.ZERO));
+        assertThrows(IllegalArgumentException.class,
+                () -> new AccessPolicyRegistry((tenant, method, url, roles) -> List.of(),
+                        Clock.systemUTC(), Duration.ofNanos(1)));
+        assertThrows(IllegalArgumentException.class,
+                () -> new AccessPolicyRegistry((tenant, method, url, roles) -> List.of(),
+                        Clock.systemUTC(), Duration.ofSeconds(1), 0));
+    }
+
+    private static PolicyAction action(String method, String url) {
+        return new PolicyAction(method, url, Map.of("condition", Map.of("==", List.of(1, 1))));
+    }
+
+    private static RequestInfo request(String... roleCodes) {
+        User user = new User();
+        List<Role> roles = new ArrayList<>();
+        for (String roleCode : roleCodes)
+            roles.add(Role.builder().code(roleCode).build());
+        user.setRoles(roles);
+        RequestInfo requestInfo = new RequestInfo();
+        requestInfo.setUserInfo(user);
+        return requestInfo;
+    }
+
+    private static final class MutableClock extends Clock {
+        private Instant instant;
+
+        private MutableClock(Instant instant) {
+            this.instant = instant;
+        }
+
+        private void advance(Duration duration) {
+            instant = instant.plus(duration);
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+    }
+}

--- a/backend/pgr-services/src/test/java/org/egov/pgr/policy/PolicyActionTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/policy/PolicyActionTest.java
@@ -1,0 +1,55 @@
+package org.egov.pgr.policy;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PolicyActionTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void policyDocumentsAreDeeplyCopiedAndImmutable() {
+        List<Object> operands = new ArrayList<>(List.of(1, 1));
+        Map<String, Object> condition = new LinkedHashMap<>();
+        condition.put("==", operands);
+        Map<String, Object> document = new LinkedHashMap<>();
+        document.put("condition", condition);
+
+        PolicyAction action = new PolicyAction("post", "/resource/_search", document);
+        operands.set(0, 2);
+        condition.put("extra", true);
+        document.put("resource", Map.of());
+
+        assertEquals("POST", action.method());
+        assertEquals(Map.of("condition", Map.of("==", List.of(1, 1))), action.document());
+
+        Map<String, Object> returnedCondition = (Map<String, Object>) action.document().get("condition");
+        List<Object> returnedOperands = (List<Object>) returnedCondition.get("==");
+        assertThrows(UnsupportedOperationException.class, () -> action.document().put("x", true));
+        assertThrows(UnsupportedOperationException.class, () -> returnedCondition.put("x", true));
+        assertThrows(UnsupportedOperationException.class, () -> returnedOperands.set(0, 2));
+    }
+
+    @Test
+    void invalidIdentityAndNonJsonValuesAreRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new PolicyAction(" POST", "/resource/_search", Map.of()));
+        assertThrows(IllegalArgumentException.class,
+                () -> new PolicyAction("POST", " /resource/_search", Map.of()));
+        assertThrows(IllegalArgumentException.class,
+                () -> new PolicyAction("POST", "/resource/_search", Map.of("bad", new Object())));
+        assertThrows(IllegalArgumentException.class,
+                () -> new PolicyAction("POST", "/resource/_search", Map.of("bad", Map.of(1, "x"))));
+        assertThrows(IllegalArgumentException.class,
+                () -> new PolicyAction("POST", "/resource/_search", Map.of("bad", new AtomicInteger(1))));
+        assertThrows(IllegalArgumentException.class,
+                () -> new PolicyAction("POST", "/resource/_search", Map.of("bad", Double.NaN)));
+    }
+}

--- a/backend/pgr-services/src/test/java/org/egov/pgr/policy/PolicyEvaluatorTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/policy/PolicyEvaluatorTest.java
@@ -1,0 +1,55 @@
+package org.egov.pgr.policy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PolicyEvaluatorTest {
+
+    private final PolicyEvaluator evaluator = new PolicyEvaluator(new ObjectMapper());
+
+    @Test
+    void allowsOnlyAnExplicitBooleanTrueVerdict() {
+        PolicyAction action = new PolicyAction("POST", "/resource/_search",
+                Map.of("condition", Map.of("==", List.of(1, 1))));
+
+        assertTrue(evaluator.isAllowed(action.condition(), Map.of()));
+        assertFalse(evaluator.isAllowed(Map.of("==", List.of(1, 2)), Map.of()));
+    }
+
+    @Test
+    void truthyNonBooleanResultsAreDenied() {
+        assertFalse(evaluator.isAllowed(1, Map.of()));
+        assertFalse(evaluator.isAllowed("allowed", Map.of()));
+        assertFalse(evaluator.isAllowed(List.of(1), Map.of()));
+        assertFalse(evaluator.isAllowed(Map.of("value", true), Map.of()));
+    }
+
+    @Test
+    void evaluatesVariablesAgainstTheProvidedDocument() {
+        Object condition = Map.of("in", List.of(
+                Map.of("var", "resource.department"), Map.of("var", "user.departments")));
+        Map<String, Object> allowed = Map.of(
+                "user", Map.of("departments", List.of("ROADS", "WATER")),
+                "resource", Map.of("department", "WATER"));
+        Map<String, Object> denied = Map.of(
+                "user", Map.of("departments", List.of("ROADS")),
+                "resource", Map.of("department", "WATER"));
+
+        assertTrue(evaluator.isAllowed(condition, allowed));
+        assertFalse(evaluator.isAllowed(condition, denied));
+    }
+
+    @Test
+    void missingOrMalformedConditionsFailClosed() {
+        assertFalse(evaluator.isAllowed(null, Map.of()));
+        assertFalse(evaluator.isAllowed(Map.of(), Map.of()));
+        assertFalse(evaluator.isAllowed(true, null));
+        assertFalse(evaluator.isAllowed(Map.of("var", "missing"), Map.of()));
+    }
+}

--- a/backend/pgr-services/src/test/java/org/egov/pgr/policy/PolicyResolutionTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/policy/PolicyResolutionTest.java
@@ -1,0 +1,34 @@
+package org.egov.pgr.policy;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PolicyResolutionTest {
+
+    @Test
+    void onlyResolvedResultsContainAnAction() {
+        PolicyAction action = new PolicyAction("POST", "/resource/_search", Map.of());
+        PolicyResolution resolved = PolicyResolution.resolved(action);
+
+        assertTrue(resolved.isResolved());
+        assertEquals(action, resolved.action().orElseThrow());
+
+        for (PolicyResolution denied : new PolicyResolution[] {
+                PolicyResolution.notAuthorized(), PolicyResolution.sourceUnavailable(),
+                PolicyResolution.invalidRequest(), PolicyResolution.invalidPolicy() }) {
+            assertFalse(denied.isResolved());
+            assertFalse(denied.action().isPresent());
+        }
+    }
+
+    @Test
+    void resolvedRequiresAnAction() {
+        assertThrows(NullPointerException.class, () -> PolicyResolution.resolved(null));
+    }
+}


### PR DESCRIPTION
## Summary

Adds the concrete, role-scoped transport behind the policy primitives in #1723.

- introduces a lazy `AccessControlPolicySource` for `POST /access/v1/actions/mdms/_get`
- sends the exact canonical role set, tenant, and `actionMaster`; deliberately sends neither caller `RequestInfo` nor `enabled`
- uses a dedicated client with explicit 2s connect / 5s read timeouts
- filters on exact method + URL while ignoring legacy method-less actions
- preserves the full opaque policy document, including nested resource/condition values and `enabled:false`
- rejects malformed/duplicate-key successful responses as `INVALID_POLICY`
- keeps network/HTTP failures distinct as `SOURCE_UNAVAILABLE` and clean empty results as `NOT_AUTHORIZED`
- preserves duplicate exact matches so the registry rejects ambiguous policies
- prevents upstream response bodies/policy data from leaking through registry error logs

## Runtime boundary

This slice is intentionally dormant. The source bean is lazy, `AccessPolicyRegistry` is still not a Spring bean, and there is no request-path call site or enforcement change.

It does **not** solve trusted identity. No caller-authored `RequestInfo` is used or forwarded.

## Stack and rollout dependencies

- stacked on and depends on #1723; until that merges, this PR shows both commits
- wire response depends on Digit-Core [#1403](https://github.com/egovernments/Digit-Core/pull/1403) projecting `method`, `resource`, and `condition`
- the enriched `actions-test` policy seed must be deployed before enforcement
- the activation PR must wire `EGOV_ACCESSCONTROL_HOST` for PGR Compose/Kubernetes/Helm deployments
- live-probe a multi-role response before enforcement to confirm the endpoint does not duplicate role-visible actions unexpectedly
- trusted-principal resolution and registry/call-site wiring remain later slices

`enabled` is intentionally omitted: the canonical policy action 2008 is `enabled:false` as a navigation action but remains the role-mapped ABAC policy document.

Tracks #1050.

## Verification

- Java 17 focused policy tests: 36 passed
- Java 17 full PGR suite: 232 tests, 0 failures, 0 errors, 1 existing skip
- `git diff --check`
- independent correctness/security and integration re-reviews: no blockers
- Claude read-only review run without a configured budget cap; its startup-inertness and unrelated-row findings were incorporated
