### PR TITLE
fix(loc): drop MP3 from the CS_UPLOAD_HINT accepted-formats hint

### DIFF
--- a/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
@@ -7081,7 +7081,7 @@
     },
     {
         "code": "CS_UPLOAD_HINT",
-        "message": "Accepted formats: JPG, PNG, PDF, DOC, DOCX, XLS, XLSX, MP4, MP3 (max 5 MB per file)",
+        "message": "Accepted formats: JPG, PNG, PDF, DOC, DOCX, XLS, XLSX, MP4 (max 5 MB per file)",
         "module": "rainmaker-pgr",
         "locale": "en_IN"
     },

--- a/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
@@ -1591,7 +1591,7 @@
     },
     {
         "code": "CS_UPLOAD_HINT",
-        "message": "Formatos aceitos: JPG, PNG, PDF, DOC, DOCX, XLS, XLSX, MP4, MP3 (máximo 5 MB por ficheiro)",
+        "message": "Formatos aceitos: JPG, PNG, PDF, DOC, DOCX, XLS, XLSX, MP4 (máximo 5 MB por ficheiro)",
         "module": "rainmaker-pgr",
         "locale": "pt_PT"
     },


### PR DESCRIPTION
Removes "MP3" from the comma-separated accepted-formats hint (`CS_UPLOAD_HINT`, module `rainmaker-pgr`) in both **en_IN** and **pt_PT** seed files.

- Text-only: the uploader's actual accept/MIME list is untouched.
- Already **live on cms-pilot** (both locales upserted + `cache-bust`, verified served by the API). This PR keeps the seed in sync so redeploys/new tenants don't resurrect the old string.
- Browsers cache loc bundles ~24h — testers should hard-refresh (Ctrl+Shift+R) to see it immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)