### PR TITLE
fix(pgr): align upload accepts + format hints with the real filestore allowlist (CCSD-2082)

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/components/PgrFileUpload.js
+++ b/digit-ui-esbuild/products/pgr/src/components/PgrFileUpload.js
@@ -13,12 +13,13 @@ import { parseFilestoreEntry } from "../utils/attachmentKind";
 // class names/rules as the wizard's WIZARD_CSS block, so double-injection on
 // the citizen page is harmless).
 
-// Per the Moz feedback doc (CCSD-1971): PDF, DOC, images, audio and video up
-// to 5 MB each. Server-side, filestore's allowed-format list for module
-// "property-upload" must also permit these (platform config).
+// CCSD-2082: aligned to what filestore ACTUALLY accepts on the env (verified
+// against the live allowlist): images, PDF, DOC/DOCX, XLS/XLSX and video.
+// Audio (mp3/wav/m4a/aac) is NOT in the server allowlist — advertising it let
+// users pick files that then failed server-side with an opaque error.
 const MAX_BYTES = 5 * 1024 * 1024; // 5 MB per file
 const DEFAULT_ACCEPT =
-  "image/*,.pdf,.doc,.docx,.mp3,.wav,.m4a,.aac,.mp4,.mov,.avi,.mkv";
+  "image/*,.pdf,.doc,.docx,.xls,.xlsx,.mp4,.mov,.avi,.mkv,.webm";
 
 function tr(t, key, fallback) {
   const v = typeof t === "function" ? t(key) : key;
@@ -336,7 +337,7 @@ const PgrFileUpload = ({ t, tenantId, value, onSelect, fieldKey, accept = DEFAUL
         {busy ? tr(t, "CS_UPLOADING", "Uploading…") : tr(t, "CS_UPLOAD_CHOOSE", "Choose files")}
       </span>
       <p className="pgr-upload-hint">
-        {hint || tr(t, "CS_UPLOAD_HINT", `Images, PDF, DOC, audio or video up to 5 MB each. You can upload up to ${maxFiles} files.`)}
+        {hint || tr(t, "CS_UPLOAD_HINT", `JPG, PNG, PDF, DOC, DOCX, XLS, XLSX, MP4, MOV, AVI, MKV up to 5 MB each. You can upload up to ${maxFiles} files.`)}
       </p>
     </div>
   );

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ReopenComplaint/UploadPhoto.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ReopenComplaint/UploadPhoto.js
@@ -26,7 +26,7 @@ const toDocument = (fileStoreId) => ({
 // CCSD-2082 Issue 2: accept images AND documents (PDF/DOC/DOCX) — and, per the
 // follow-up, audio/video too (same set as the create wizard / action modals,
 // CCSD-1971). Matches PgrFileUpload's default; kept explicit for clarity.
-const REOPEN_ACCEPT = "image/*,.pdf,.doc,.docx,.mp3,.wav,.m4a,.aac,.mp4,.mov,.avi,.mkv";
+const REOPEN_ACCEPT = "image/*,.pdf,.doc,.docx,.xls,.xlsx,.mp4,.mov,.avi,.mkv,.webm";
 
 const UploadPhoto = (props) => {
   const { t } = useTranslation();
@@ -60,7 +60,7 @@ const UploadPhoto = (props) => {
   // Hint mirrors the accepted types (images, PDF/DOC/DOCX, audio, video).
   const uploadHint =
     t("CS_REOPEN_UPLOAD_HINT") === "CS_REOPEN_UPLOAD_HINT"
-      ? "Images, PDF, DOC, audio or video up to 5 MB each. You can upload up to 5 files."
+      ? "JPG, PNG, PDF, DOC, DOCX, XLS, XLSX, MP4, MOV, AVI, MKV up to 5 MB each. You can upload up to 5 files."
       : t("CS_REOPEN_UPLOAD_HINT");
 
   return (

--- a/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/en_IN/rainmaker-pgr.json
@@ -7081,7 +7081,7 @@
     },
     {
         "code": "CS_UPLOAD_HINT",
-        "message": "Accepted formats: JPG, PNG, PDF, DOC, DOCX, XLS, XLSX, MP4 (max 5 MB per file)",
+        "message": "Accepted formats: JPG, PNG, PDF, DOC, DOCX, XLS, XLSX, MP4, MOV, AVI, MKV (max 5 MB per file)",
         "module": "rainmaker-pgr",
         "locale": "en_IN"
     },
@@ -8245,7 +8245,7 @@
     },
     {
         "code": "CS_REOPEN_UPLOAD_HINT",
-        "message": "Images, PDF, DOC, audio or video up to 5 MB each. You can upload up to 5 files.",
+        "message": "JPG, PNG, PDF, DOC, DOCX, XLS, XLSX, MP4, MOV, AVI, MKV up to 5 MB each. You can upload up to 5 files.",
         "module": "rainmaker-pgr",
         "locale": "en_IN"
     },

--- a/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
+++ b/utilities/default-data-handler/src/main/resources/localisations/pt_PT/rainmaker-pgr.json
@@ -1591,7 +1591,7 @@
     },
     {
         "code": "CS_UPLOAD_HINT",
-        "message": "Formatos aceitos: JPG, PNG, PDF, DOC, DOCX, XLS, XLSX, MP4 (máximo 5 MB por ficheiro)",
+        "message": "Formatos aceitos: JPG, PNG, PDF, DOC, DOCX, XLS, XLSX, MP4, MOV, AVI, MKV (máximo 5 MB por ficheiro)",
         "module": "rainmaker-pgr",
         "locale": "pt_PT"
     },
@@ -1681,7 +1681,7 @@
     },
     {
         "code": "CS_REOPEN_UPLOAD_HINT",
-        "message": "Imagens, PDF, DOC, áudio ou vídeo até 5 MB cada. Pode carregar até 5 ficheiros.",
+        "message": "JPG, PNG, PDF, DOC, DOCX, XLS, XLSX, MP4, MOV, AVI, MKV até 5 MB cada. Pode carregar até 5 ficheiros.",
         "module": "rainmaker-pgr",
         "locale": "pt_PT"
     },


### PR DESCRIPTION
Follow-up to Gurjeet's re-test findings on CCSD-2082 (DOCX fails; hint lists fewer formats than allowed).

## Probed the live filestore allowlist per-format
`[mp4, mov, avi, mkv, webm, pptx, jpg, jpeg, png, pdf, odt, ods, docx, doc, dxf, csv, txt, xlsx, xls, zip, geojson, json]`

| Finding | Fix |
|---|---|
| **Audio (mp3/wav/m4a/aac) not allowed server-side** but advertised by both accepts | removed from `DEFAULT_ACCEPT` + `REOPEN_ACCEPT` (matches the MP3 removal from the hint, #1733) |
| **XLS/XLSX allowed** but missing from accepts | added |
| Hint text narrower than reality | `CS_UPLOAD_HINT` + `CS_REOPEN_UPLOAD_HINT` (en+pt) now list the full set: JPG, PNG, PDF, DOC, DOCX, XLS, XLSX, MP4, MOV, AVI, MKV — **already upserted live on cms-pilot + cache-busted** |
| **DOCX rejected despite being allowlisted** (`EG_FILESTORE_INVALID_INPUT: Invalid Content Type`) | NOT an FE bug — the box's filestore extension→MIME map entry for docx is broken/missing (doc/xls/xlsx pass). Env fix documented on the ticket (same mechanism as CCSD-2027). |

New accepts: `image/*,.pdf,.doc,.docx,.xls,.xlsx,.mp4,.mov,.avi,.mkv,.webm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)