### PR TITLE
fix(auth): complete Keycloak logout from citizen sidebar

### DIFF
--- a/digit-ui-esbuild/packages/modules/core/src/components/TopBarSideBar/SideBar/StaticCitizenSideBar.js
+++ b/digit-ui-esbuild/packages/modules/core/src/components/TopBarSideBar/SideBar/StaticCitizenSideBar.js
@@ -121,10 +121,9 @@ const StaticCitizenSideBar = ({ linkData, islinkDataLoading }) => {
     toggleSidebar(false);
     setShowDialog(true);
   };
-  const handleOnSubmit = () => {
-    Digit.UserService.logout();
+  const handleOnSubmit = async () => {
     setShowDialog(false);
-    window.location.href = `/${window?.contextPath}/citizen/login`;
+    await Digit.UserService.logout();
   };
   const handleOnCancel = () => {
     setShowDialog(false);


### PR DESCRIPTION
## Summary

- remove the citizen sidebar hard redirect that races the authentication logout flow
- await UserService logout so the configured provider owns session cleanup and post-logout navigation
- preserve the legacy DIGIT logout path, which already handles its own redirect

## Root cause

The sidebar invoked UserService.logout and immediately assigned the citizen login URL. Under Keycloak authentication, that navigation could cancel the cross-origin end-session request before the Bomet Keycloak cookie was cleared. The subsequent silent SSO check then restored the session and returned the citizen to all services.

## Validation

- yarn check-aliases
- yarn build
- git diff --check

The build completes successfully with pre-existing warnings unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the logout experience by closing the logout dialog before processing the request.
  * Removed unnecessary redirection behavior after logout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->