### PR TITLE
fix(gatus): mount /data in the four compose files missing it — gatus panics at startup

### DIFF
--- a/local-setup/docker-compose.db-migrations.yml
+++ b/local-setup/docker-compose.db-migrations.yml
@@ -1299,6 +1299,13 @@ services:
         condition: service_healthy
     volumes:
       - ./gatus/config.yaml:/config/config.yaml:ro
+      # sqlite store (#1610) — the config above is mounted read-only, so
+      # the database needs its own volume. Without this /data does not
+      # exist in the container and gatus panics at startup with
+      # "unable to open database file (14)" (SQLITE_CANTOPEN), taking the
+      # whole compose project down. #1630 added the storage block to the
+      # SHARED gatus/config.yaml but the volume to only one of five files.
+      - gatus_data:/data
     ports:
       - "127.0.0.1:18889:8080"
     environment:
@@ -1385,6 +1392,7 @@ networks:
     driver: bridge
 
 volumes:
+  gatus_data:
   postgres_data: null
   es_data: null
   filestore_data: null

--- a/local-setup/docker-compose.deploy.yaml
+++ b/local-setup/docker-compose.deploy.yaml
@@ -912,6 +912,13 @@ services:
         condition: service_healthy
     volumes:
       - ./gatus/config.yaml:/config/config.yaml:ro
+      # sqlite store (#1610) — the config above is mounted read-only, so
+      # the database needs its own volume. Without this /data does not
+      # exist in the container and gatus panics at startup with
+      # "unable to open database file (14)" (SQLITE_CANTOPEN), taking the
+      # whole compose project down. #1630 added the storage block to the
+      # SHARED gatus/config.yaml but the volume to only one of five files.
+      - gatus_data:/data
     ports:
       - "127.0.0.1:18889:8080"
     environment:
@@ -1007,5 +1014,6 @@ networks:
     driver: bridge
 
 volumes:
+  gatus_data:
   postgres_data: null
   minio_data: null

--- a/local-setup/docker-compose.registry.yml
+++ b/local-setup/docker-compose.registry.yml
@@ -1624,6 +1624,13 @@ services:
         condition: service_healthy
     volumes:
       - ./gatus/config.yaml:/config/config.yaml:ro
+      # sqlite store (#1610) — the config above is mounted read-only, so
+      # the database needs its own volume. Without this /data does not
+      # exist in the container and gatus panics at startup with
+      # "unable to open database file (14)" (SQLITE_CANTOPEN), taking the
+      # whole compose project down. #1630 added the storage block to the
+      # SHARED gatus/config.yaml but the volume to only one of five files.
+      - gatus_data:/data
     ports:
       - "127.0.0.1:18889:8080"
     environment:
@@ -1698,6 +1705,7 @@ networks:
     driver: bridge
 
 volumes:
+  gatus_data:
   postgres_data: null
   es_data: null
   filestore_data: null

--- a/local-setup/docker-compose.yml
+++ b/local-setup/docker-compose.yml
@@ -1133,6 +1133,13 @@ services:
         condition: service_healthy
     volumes:
       - ./gatus/config.yaml:/config/config.yaml:ro
+      # sqlite store (#1610) — the config above is mounted read-only, so
+      # the database needs its own volume. Without this /data does not
+      # exist in the container and gatus panics at startup with
+      # "unable to open database file (14)" (SQLITE_CANTOPEN), taking the
+      # whole compose project down. #1630 added the storage block to the
+      # SHARED gatus/config.yaml but the volume to only one of five files.
+      - gatus_data:/data
     ports:
       - "127.0.0.1:18889:8080"
     environment:
@@ -1246,5 +1253,6 @@ networks:
     driver: bridge
 
 volumes:
+  gatus_data:
   postgres_data: null
   minio_data: null


### PR DESCRIPTION
## `docker compose up` currently panics gatus on `monitoring-fix`

#1630 added sqlite storage to `local-setup/gatus/config.yaml`:

```yaml
storage:
  type: sqlite
  path: /data/gatus.db
```

That file is shared by **all five** compose files that define a `gatus` service,
but the `gatus_data` volume was added to only `docker-compose.egov-digit.yaml`.
In the other four, `/data` does not exist inside the container, so gatus cannot
create the database and panics at startup:

```
panic: unable to open database file (14)
main.initializeStorage(...)   /app/main.go:105
main.main()                   /app/main.go:34
```

`14` is `SQLITE_CANTOPEN`. The container exits 2 and takes the compose project
with it.

| compose file | defines gatus | mounted `/data` before |
|---|---|---|
| `docker-compose.egov-digit.yaml` | yes | **yes** |
| `docker-compose.yml` | yes | no |
| `docker-compose.deploy.yaml` | yes | no |
| `docker-compose.registry.yml` | yes | no |
| `docker-compose.db-migrations.yml` | yes | no |

`docker-compose.yml` is the default local-dev path and the one `tilt ci` uses, so
this breaks local development and the `tilt-test` check on `monitoring-fix` for
everyone — not only for the PR that introduced it.

## The fix

Two additions per file, mirroring what `egov-digit.yaml` already does: mount
`gatus_data:/data` on the service and declare the named volume.

## Verification

Same config run against `twinproduction/gatus:latest` both ways:

| | exit | outcome |
|---|---|---|
| without `gatus_data:/data` | **2** | panic in `initializeStorage` |
| with `gatus_data:/data` | 124 (timeout) | stayed up, shut down gracefully |

Also: `docker compose config -q` passes on all four patched files, all five now
both mount `/data` and declare the volume, and `check-gatus-coverage.py` reports
`89 compose services, 28 k3s Services, 57 endpoints per tier, no drift`.

## Why it looked verified

The devbox evidence for #1630 came through `docker-compose.egov-digit.yaml` — the
one file that already had the volume. The persistence claim was true on the path
that was exercised and false on the other four.

## Note

This same fix is also in #1734 (`monitoring-fix` → `master`). Landing it here
first is deliberate, so the breakage clears on `monitoring-fix` without waiting
for the whole queue to drain. The contents are identical, so #1734 will absorb it
cleanly.
