### PR TITLE
fix(pgr): accept assignee on terminal workflow transitions + resolve latest assignee for notifications (CCSD-2167)

### DIFF
--- a/backend/pgr-services/src/main/java/org/egov/pgr/service/NotificationService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/service/NotificationService.java
@@ -676,9 +676,23 @@ public class NotificationService {
         if (CollectionUtils.isEmpty(processInstanceResponse.getProcessInstances()))
             throw new CustomException("WORKFLOW_NOT_FOUND", "The workflow object is not found");
 
-        for(ProcessInstance processInstance:processInstanceResponse.getProcessInstances()){
-            if(processInstance.getAction().equalsIgnoreCase(action))
-                processInstanceToReturn= processInstance;
+        // CCSD-2167: pick the NEWEST matching instance. The old loop kept
+        // overwriting on every match, so the LAST list element won — and the
+        // history search returns newest-first, meaning the OLDEST step was
+        // returned. On a rated complaint that resolved {emp_name}/assignee to
+        // the first ASSIGN's Supervisor instead of the Case Manager who last
+        // handled it (observed live: rating emails greeting the Supervisor).
+        long newestTime = Long.MIN_VALUE;
+        for (ProcessInstance processInstance : processInstanceResponse.getProcessInstances()) {
+            if (!processInstance.getAction().equalsIgnoreCase(action))
+                continue;
+            long time = (processInstance.getAuditDetails() != null
+                    && processInstance.getAuditDetails().getLastModifiedTime() != null)
+                    ? processInstance.getAuditDetails().getLastModifiedTime() : Long.MIN_VALUE;
+            if (time > newestTime || processInstanceToReturn.getId() == null) {
+                newestTime = time;
+                processInstanceToReturn = processInstance;
+            }
         }
         requestInfo.setUserInfo(userInfoCopy);
         return processInstanceToReturn;

--- a/backend/pgr-services/src/main/java/org/egov/pgr/service/WorkflowService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/service/WorkflowService.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 
 import static org.egov.pgr.util.PGRConstants.*;
 
+@lombok.extern.slf4j.Slf4j
 @org.springframework.stereotype.Service
 public class WorkflowService {
 
@@ -179,28 +180,75 @@ public class WorkflowService {
         Service service = request.getService();
         Workflow workflow = request.getWorkflow();
 
+        BusinessService businessService = getBusinessService(request);
+
         ProcessInstance processInstance = new ProcessInstance();
         processInstance.setBusinessId(service.getServiceRequestId());
         processInstance.setAction(request.getWorkflow().getAction());
         processInstance.setModuleName(PGR_MODULENAME);
         processInstance.setTenantId(service.getTenantId());
-        processInstance.setBusinessService(getBusinessService(request).getBusinessService());
+        processInstance.setBusinessService(businessService.getBusinessService());
         processInstance.setDocuments(request.getWorkflow().getVerificationDocuments());
         processInstance.setComment(workflow.getComments());
 
         if(!CollectionUtils.isEmpty(workflow.getAssignes())){
-            List<User> users = new ArrayList<>();
+            // CCSD-2167: egov-workflow-v2 validates every assignee as "can act on
+            // the TARGET state" — terminal states (e.g. RATE ->
+            // CLOSEDAFTERRESOLUTION / CLOSEDAFTERREJECTION) define no actions, so
+            // ANY assignee fails INVALID_ASSIGNEE and the whole transition 400s.
+            // Per requirement the FE sends the Case Manager uuid on RATE; keep it
+            // on request.getWorkflow() (the notification path and the kafka
+            // payload read it from there, so assignee-targeted notifications and
+            // {emp_name} resolve to the right person) but do NOT forward it to
+            // the engine when the transition lands on a terminal state.
+            if (isTargetStateTerminal(businessService, service.getApplicationStatus(), workflow.getAction())) {
+                log.info("Assignee(s) on action {} for {} kept for notifications but not forwarded to "
+                        + "workflow — target state is terminal and the engine would reject them",
+                        workflow.getAction(), service.getServiceRequestId());
+            } else {
+                List<User> users = new ArrayList<>();
 
-            workflow.getAssignes().forEach(uuid -> {
-                User user = new User();
-                user.setUuid(uuid);
-                users.add(user);
-            });
+                workflow.getAssignes().forEach(uuid -> {
+                    User user = new User();
+                    user.setUuid(uuid);
+                    users.add(user);
+                });
 
-            processInstance.setAssignes(users);
+                processInstance.setAssignes(users);
+            }
         }
 
         return processInstance;
+    }
+
+    /**
+     * True when taking {@code action} from the state whose applicationStatus (or
+     * state name — PENDINGFORREASSIGNMENT reports applicationStatus REASSIGND)
+     * equals {@code currentStatus} lands on a state flagged isTerminateState.
+     * Unknown states/actions return false: the engine stays the authority and
+     * behaviour is unchanged everywhere except the terminal-target case.
+     */
+    private boolean isTargetStateTerminal(BusinessService businessService, String currentStatus, String action) {
+        if (businessService == null || CollectionUtils.isEmpty(businessService.getStates())
+                || StringUtils.isBlank(action)) {
+            return false;
+        }
+        for (State state : businessService.getStates()) {
+            boolean matchesCurrent = currentStatus != null
+                    && (currentStatus.equalsIgnoreCase(state.getApplicationStatus())
+                        || currentStatus.equalsIgnoreCase(state.getState()));
+            if (!matchesCurrent || CollectionUtils.isEmpty(state.getActions()))
+                continue;
+            for (Action stateAction : state.getActions()) {
+                if (!action.equalsIgnoreCase(stateAction.getAction()))
+                    continue;
+                for (State target : businessService.getStates()) {
+                    if (target.getUuid() != null && target.getUuid().equals(stateAction.getNextState()))
+                        return Boolean.TRUE.equals(target.getIsTerminateState());
+                }
+            }
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
Jira: [CCSD-2167](https://digit-discuss.atlassian.net/browse/CCSD-2167), [CCSD-2169](https://digit-discuss.atlassian.net/browse/CCSD-2169)

## Scope

Workflow/notification changes only — 2 files, `WorkflowService.java` and `NotificationService.java`. Nothing else on the branch.

## Problem

1. **Terminal-state assignee rejection.** Citizen RATE moves `RESOLVED → CLOSEDAFTERRESOLUTION` (terminal). egov-workflow-v2 validates an assignee as "holds a role that can act on the *target* state" — terminal states have no actions, so **any** assignee is rejected with `400 INVALID_ASSIGNEE`. The FE (#1718) derives the Case Manager uuid from history and sends it, gets the 400, and retries without it — so the persisted RATE step always has `assignes: null` and assignee-targeted notification rows (`assigneeOnly: true`) can only resolve via history fallback.
2. **Wrong employee in emails.** `NotificationService.getEmployeeName` returned the **last** element of the `/process/_search?history=true` response matching the action — but history is newest-first, so it returned the **oldest** ASSIGN. That's why the rate email greeted "Prezado(a) Supervisor" instead of the Case Manager (observed on cms-pilot, P-2026-000118).

## Fix

- **WorkflowService**: new `isTargetStateTerminal(businessService, currentStatus, action)` — resolves the action's `nextState` from the already-fetched BusinessService (matching the current state by `applicationStatus` *or* state name, covering the `PENDINGFORREASSIGNMENT/REASSIGND` quirk) and checks `isTerminateState`. When true, `workflow.assignes` stays **on the request** (so notification routing / `{emp_name}` / `assigneeOnly` resolve to the actual person) but is **not forwarded** to the workflow engine. Unknown state/action → `false`, engine stays the authority. No extra API call — reuses the BusinessService fetch that was already there.
- **NotificationService.getEmployeeName**: select the newest matching process instance by `auditDetails.lastModifiedTime` instead of the last list element.

## Behaviour

| Flow | Before | After |
|---|---|---|
| Citizen RATE with derived Case-Manager uuid | 400 INVALID_ASSIGNEE → FE retry, `assignes: null` | Succeeds first try; `assigneeOnly` rows target the actual Case Manager |
| `{emp_name}` / history-fallback assignee | Oldest ASSIGN (wrong employee) | Newest matching transition (correct employee) |
| Non-terminal transitions (ASSIGN/REASSIGN/…) | unchanged | unchanged — assignees still forwarded to and validated by the engine |

## Verification

- Notification suites green: `NotificationGoldenOutputTest`, `NotificationRouterTest`, `TemplateRendererTest`, `SeedFixtureDriftTest` — 33 tests, 0 failures, no expectation changes.
- `mvn compile` (temurin-17): the two changed files produce **zero errors**. Note the base branch itself currently fails to compile on a **pre-existing, unrelated** issue — duplicate `createdBy` field in `RequestSearchCriteria` (`String` from the CCSD-2135 inbox commit + `Set<String>` from merge #1656; `variable createdBy is already defined`, verified on the pristine branch tip). Deliberately **not** touched in this PR; it must be resolved separately before any image can be built from the branch.
- No FE change needed: the existing try/catch retry in `SelectRating.js` simply stops firing once this is deployed.

## Deploy note

The image pinned on cms-pilot (`release-v2.12-moz-9deb7e0`) predates this change — needs a new pgr-services image build + pin update after merge (blocked on the pre-existing compile issue above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CCSD-2167]: https://digit-discuss.atlassian.net/browse/CCSD-2167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CCSD-2169]: https://digit-discuss.atlassian.net/browse/CCSD-2169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ