### PR TITLE
fix(pgr): remove duplicate createdBy field breaking the release-v2.12-moz build

### DIFF
--- a/backend/pgr-services/src/main/java/org/egov/pgr/repository/rowmapper/PGRQueryBuilder.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/repository/rowmapper/PGRQueryBuilder.java
@@ -114,13 +114,6 @@ public class PGRQueryBuilder {
             preparedStmtList.add(criteria.getDepartment());
         }
 
-        // Audit creator (reception-officer inbox: "complaints I filed").
-        if (StringUtils.hasText(criteria.getCreatedBy())) {
-            addClauseIfRequired(preparedStmtList, builder);
-            builder.append(" ser.createdby = ? ");
-            preparedStmtList.add(criteria.getCreatedBy());
-        }
-
         //When UI tries to fetch "escalated" complaints count.
         if(criteria.getSlaDeltaMaxLimit() != null && criteria.getSlaDeltaMinLimit() == null){
             addClauseIfRequired(preparedStmtList, builder);

--- a/backend/pgr-services/src/main/java/org/egov/pgr/web/models/RequestSearchCriteria.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/web/models/RequestSearchCriteria.java
@@ -123,14 +123,6 @@ public class RequestSearchCriteria {
     @JsonProperty("department")
     private String department;
 
-    // Filters on the complaint's audit creator (eg_pgr_service_v2.createdby).
-    // Drives the reception-officer inbox: a CMS_RECEPTION_OFFICER files
-    // complaints on citizens' behalf and needs to track the ones THEY created
-    // (they are neither the accountId — that's the citizen — nor an assignee).
-    @SafeHtml
-    @JsonProperty("createdBy")
-    private String createdBy;
-
     @JsonIgnore
     private Set<String> serviceRequestIds;
 


### PR DESCRIPTION
Jira: [CCSD-2135](https://digit-discuss.atlassian.net/browse/CCSD-2135) (origin of one flavour), tracked on [CCSD-2169](https://digit-discuss.atlassian.net/browse/CCSD-2169)

## Problem

Every pgr-services build from `release-v2.12-moz` fails in GitHub Actions:

```
[ERROR] RequestSearchCriteria.java:[132,20] variable createdBy is already defined
        in class org.egov.pgr.web.models.RequestSearchCriteria
```

followed by ~12 "cannot find symbol" cascade errors (analytics/*, IdGenRepository, ServiceRequestRepository, AdminComplaintSearchService, HrmsProjectionService…) — those are secondary: the duplicate field makes Lombok abandon `RequestSearchCriteria`, so its getters are never generated and every class using them fails.

Root cause: two PRs each added a `createdBy` filter for the **same column** (`eg_pgr_service_v2.createdby`) and git merged them without a textual conflict, leaving the class with two fields of the same name:

- `String createdBy` + `ser.createdby = ?` block — CCSD-2135 reception-officer "complaints I filed" inbox (on the branch first)
- `Set<String> createdBy` + `ser.createdby IN (...)` block — merge #1656

The branch has not compiled since merge `331b8a04`; it went unnoticed because no image build was attempted until now.

## Fix

**Pure deletion — 15 lines removed, 0 added.** The `String` flavour and its single-value query block are deleted; the surviving `Set<String>` code is #1656's exactly as merged, untouched.

## Why no behaviour changes

- Both flavours bind from the same JSON property (`"createdBy"`) and filter the same column. A single uuid binds into `Set<String>` as a one-element set, and `IN (uuid)` matches the same rows as `= uuid` — the CCSD-2135 reception-officer inbox keeps working unchanged.
- The deleted code has never run in any environment: no image was ever built from the broken branch (deployed pin `release-v2.12-moz-9deb7e0` predates the merge).

## Verification

- `mvn compile` on `maven:3.9-eclipse-temurin-17`: **BUILD SUCCESS**, 0 errors (fails with the exact CI error without this change).
- Full `mvn -B package` (same as the CI Dockerfile step) run locally — result posted as a PR comment.

## Merge order

Merge this **before** #1746 (CCSD-2167 workflow changes) — #1746's CI is red on this same pre-existing error; once this lands, rebasing/rerunning #1746 should go green and image builds unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CCSD-2135]: https://digit-discuss.atlassian.net/browse/CCSD-2135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CCSD-2169]: https://digit-discuss.atlassian.net/browse/CCSD-2169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ