### PR TITLE
fix(citizen): backport OTP country code payload to master

### DIFF
--- a/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Login/index.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Login/index.js
@@ -276,6 +276,8 @@ const Login = ({ stateCode, isUserRegistered = true }) => {
         tenantId: stateCode,
         userType: getUserType(),
         ...name,
+        // Same country-code fix as selectMobileNumber / resendOtp.
+        ...(validationConfig.countryCode ? { countryCode: validationConfig.countryCode } : {}),
       };
       const [res, err] = await sendOtp({ otp: { ...data, ...TYPE_REGISTER } });
       if (res) {

--- a/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Login/index.js
+++ b/digit-ui-esbuild/packages/modules/core/src/pages/citizen/Login/index.js
@@ -165,6 +165,11 @@ const Login = ({ stateCode, isUserRegistered = true }) => {
       ...mobileNumber,
       tenantId: stateCode,
       userType: getUserType(),
+      // Pass the country code on OTP send. The user record stores the mobile
+      // with its country code (+258 for MZ); omitting it here left the SMS
+      // gateway without a routable prefix. Sourced from the same
+      // MobileNumberValidation / CORE_MOBILE_CONFIGS the field validation uses.
+      ...(validationConfig.countryCode ? { countryCode: validationConfig.countryCode } : {}),
     };
 
     if (isUserRegistered) {
@@ -369,6 +374,8 @@ const Login = ({ stateCode, isUserRegistered = true }) => {
       userName,
       tenantId: stateCode,
       userType: getUserType(),
+      // Same country-code fix as the initial send (see selectMobileNumber).
+      ...(validationConfig.countryCode ? { countryCode: validationConfig.countryCode } : {}),
     };
 
     if (!isUserRegistered && individualServicePath) {


### PR DESCRIPTION
## Summary

- pass the configured `countryCode` in citizen login and registration OTP-send payloads
- cover initial login/register, register-name, and resend payload builders
- preserve existing behavior when no country code is configured

This backports the Mozambique fix from #1692 to `master`.

Fixes #1711

## Validation

- `git diff --check`
- confirmed both cherry-picked patches and the resulting `Login/index.js` blob exactly match #1692

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OTP requests now include the configured country code during initial login, registration, and OTP resend flows.
  * Improved consistency with the application’s mobile number validation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->