### PR TITLE
fix(dashboard): close Portuguese localization gaps

### DIFF
--- a/digit-mcp/src/tools/dashboard-l10n-seed.ts
+++ b/digit-mcp/src/tools/dashboard-l10n-seed.ts
@@ -245,6 +245,11 @@ export const DASHBOARD_L10N_MESSAGES: { code: string; message: string; module: s
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "DASHBOARD_COMMON_UPDATED",
+    "message": "Updated",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "DASHBOARD_COMMON_UNASSIGNED",
     "message": "Unassigned",
     "module": "rainmaker-dashboard"
@@ -707,6 +712,11 @@ export const DASHBOARD_L10N_MESSAGES: { code: string; message: string; module: s
   {
     "code": "DASHBOARD_LOGIN_SIGNING_IN",
     "message": "Signing in…",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_LOGIN_SESSION_EXPIRED",
+    "message": "Your session has expired. Please sign in again.",
     "module": "rainmaker-dashboard"
   },
   {
@@ -1854,6 +1864,11 @@ export const DASHBOARD_L10N_MESSAGES_PT_PT: { code: string; message: string; mod
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "DASHBOARD_COMMON_UPDATED",
+    "message": "Atualizado",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "DASHBOARD_COMMON_UNASSIGNED",
     "message": "Sem atribuição",
     "module": "rainmaker-dashboard"
@@ -2316,6 +2331,11 @@ export const DASHBOARD_L10N_MESSAGES_PT_PT: { code: string; message: string; mod
   {
     "code": "DASHBOARD_LOGIN_SIGNING_IN",
     "message": "A iniciar sessão…",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_LOGIN_SESSION_EXPIRED",
+    "message": "A sua sessão expirou. Inicie sessão novamente.",
     "module": "rainmaker-dashboard"
   },
   {

--- a/digit-ui-esbuild/products/dashboard/Module.js
+++ b/digit-ui-esbuild/products/dashboard/Module.js
@@ -18,11 +18,12 @@ const DashboardModule = ({ stateCode }) => {
   // Lazy-load this module's localization bundles into the host i18next
   // (same pattern as PGRModule): rainmaker-dashboard for the dashboard's own
   // chrome/labels, rainmaker-pgr for complaint-type + workflow-status names,
+  // rainmaker-common for department/designation labels,
   // rainmaker-boundary-<hierarchy> for ward names on the map and filters.
   const hierarchyType = window?.globalConfigs?.getConfig("HIERARCHY_TYPE") || "ADMIN";
   const { isLoading } = Digit.Services.useStore({
     stateCode,
-    moduleCode: ["dashboard", "pgr", `boundary-${hierarchyType?.toString().toLowerCase()}`],
+    moduleCode: ["dashboard", "pgr", "common", `boundary-${hierarchyType?.toString().toLowerCase()}`],
     language: Digit.StoreData.getCurrentLanguage(),
     modulePrefix: "rainmaker",
   });

--- a/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
@@ -1051,7 +1051,10 @@ const AdminDashboardInner = ({ onSignOut, embedded = false, publicMode = false, 
                 {!selfHeaders && (
                   <header className={`${buildWidgetHeaderClassName(vizType)} dashboard-widget-header tw-min-w-0`}>
                     <div className="dashboard-widget-header-title-row tw-flex tw-min-w-0 tw-items-start tw-gap-2">
-                      <h2 className={`${SHARED_CHROME.dragHandleTitle} tw-min-w-0 tw-flex-1 tw-truncate`}>
+                      <h2
+                        className={`${SHARED_CHROME.dragHandleTitle} tw-min-w-0 tw-flex-1`}
+                        title={headerTitle}
+                      >
                         {headerTitle}
                       </h2>
                       {hasGroupBy && (

--- a/digit-ui-esbuild/products/dashboard/src/components/CardUpdatedStamp.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/CardUpdatedStamp.jsx
@@ -1,9 +1,13 @@
 import React from "react";
+import useDashboardT from "../i18n/useDashboardT";
 
-const CardUpdatedStamp = ({ label }) => (
-  <span className="dashboard-card-updated tw-pointer-events-none tw-absolute tw-bottom-1 tw-right-5 tw-z-[2] tw-rounded tw-bg-surface tw-px-1 tw-text-[10px] tw-leading-tight tw-text-muted-foreground">
-    Updated {label}
-  </span>
-);
+const CardUpdatedStamp = ({ label }) => {
+  const { t } = useDashboardT();
+  return (
+    <span className="dashboard-card-updated tw-pointer-events-none tw-absolute tw-bottom-1 tw-right-5 tw-z-[2] tw-rounded tw-bg-surface tw-px-1 tw-text-[10px] tw-leading-tight tw-text-muted-foreground">
+      {t("DASHBOARD_COMMON_UPDATED", "Updated")} {label}
+    </span>
+  );
+};
 
 export default CardUpdatedStamp;

--- a/digit-ui-esbuild/products/dashboard/src/components/CardUpdatedStamp.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/components/CardUpdatedStamp.test.js
@@ -1,0 +1,75 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const esbuild = require("esbuild");
+
+const ENTRY = `
+import React from "react";
+import ReactDOMServer from "react-dom/server";
+import CardUpdatedStamp from "./CardUpdatedStamp.jsx";
+
+export const renderStamp = (label) =>
+  ReactDOMServer.renderToStaticMarkup(React.createElement(CardUpdatedStamp, { label }));
+`;
+
+function bundleEntry() {
+  const out = path.join(os.tmpdir(), `card-updated-stamp.${process.pid}.cjs.js`);
+  esbuild.buildSync({
+    stdin: {
+      contents: ENTRY,
+      resolveDir: __dirname,
+      loader: "jsx",
+      sourcefile: "card-updated-stamp-entry.jsx",
+    },
+    bundle: true,
+    format: "cjs",
+    platform: "node",
+    loader: { ".jsx": "jsx", ".js": "jsx" },
+    outfile: out,
+    logLevel: "silent",
+    define: { "process.env.NODE_ENV": '"test"' },
+  });
+  process.on("exit", () => {
+    try {
+      fs.unlinkSync(out);
+    } catch (e) {
+      /* already gone */
+    }
+  });
+  return out;
+}
+
+const bundledEntry = bundleEntry();
+
+function renderIn(locale, messages) {
+  delete require.cache[bundledEntry];
+  global.window = {
+    i18next: {
+      language: locale,
+      exists: (key) => Object.prototype.hasOwnProperty.call(messages, key),
+      t: (key) => messages[key] ?? key,
+      on() {},
+      off() {},
+      store: { on() {}, off() {} },
+    },
+    localStorage: { getItem: () => locale },
+  };
+  try {
+    return require(bundledEntry).renderStamp("13 Aug, 14:30");
+  } finally {
+    delete global.window;
+  }
+}
+
+test("updated stamp resolves through the active dashboard locale", () => {
+  const html = renderIn("pt_PT", { DASHBOARD_COMMON_UPDATED: "Atualizado" });
+  assert.match(html, />Atualizado 13 Aug, 14:30</);
+  assert.doesNotMatch(html, />Updated /);
+});
+
+test("updated stamp retains the seeded English rendering", () => {
+  const html = renderIn("en_IN", { DASHBOARD_COMMON_UPDATED: "Updated" });
+  assert.match(html, />Updated 13 Aug, 14:30</);
+});

--- a/digit-ui-esbuild/products/dashboard/src/components/ComplaintsAtRiskTable.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/ComplaintsAtRiskTable.jsx
@@ -27,8 +27,8 @@ const buildColumns = (t) => [
 ];
 
 const ComplaintsAtRiskTable = ({ rows = [] }) => {
-  const { t, language } = useDashboardT();
-  const COLUMNS = useMemo(() => buildColumns(t), [t, language]);
+  const { t, language, i18nTick } = useDashboardT();
+  const COLUMNS = useMemo(() => buildColumns(t), [t, language, i18nTick]);
   const tableStyles = DATA_TABLE_STYLES;
   const slaStyles = SLA_RISK_TABLE_STYLES;
   const { sortState, handleSort, sortRows } = useTableSort(COLUMNS, {

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardTable.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardTable.jsx
@@ -212,12 +212,12 @@ function annotateRowsFromThresholds(rows, columns) {
 const DashboardTable = ({ columns, rows, emptyMessage }) => {
   // Subscribes to language/bundle changes; `language` also invalidates the
   // annotation memo so translated tag labels re-resolve on a language switch.
-  const { language } = useDashboardT();
+  const { language, i18nTick } = useDashboardT();
   const styles = DATA_TABLE_STYLES;
   const safeRows = rows ?? [];
   const annotatedRows = useMemo(
     () => annotateRowsFromThresholds(safeRows, columns),
-    [safeRows, columns, language]
+    [safeRows, columns, language, i18nTick]
   );
   const { sortState, handleSort, sortRows } = useTableSort(columns);
   const sortedRows = useMemo(() => sortRows(annotatedRows), [annotatedRows, sortRows]);

--- a/digit-ui-esbuild/products/dashboard/src/components/DepartmentBarChart.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DepartmentBarChart.jsx
@@ -53,7 +53,7 @@ const DepartmentBarChart = ({
   valueFormat = "count",
 }) => {
   // Subscribes to language changes so labels below re-render translated.
-  const { language } = useDashboardT();
+  const { language, i18nTick } = useDashboardT();
   // Per-locale numberFormat mask stamp (#1272): baked into the options memo
   // because react-apexcharts compares JSON.stringify(options), which drops
   // the data-label formatter closures — without a stringifiable delta a
@@ -70,7 +70,7 @@ const DepartmentBarChart = ({
 
   const chartData = useMemo(
     () => normalizeChartData(data, categoryOrder),
-    [data, categoryOrder, language]
+    [data, categoryOrder, language, i18nTick]
   );
 
   const { viewportRef, chartSize, isScrollable, isReady, scrollAxis } = useScrollableChartSize({
@@ -87,7 +87,7 @@ const DepartmentBarChart = ({
         : t("DASHBOARD_COMMON_COUNT", "Count"),
       data: chartData.map((d) => d.count),
     }],
-    [chartData, isPercent, language]
+    [chartData, isPercent, language, i18nTick]
   );
 
   const seriesMax = useMemo(

--- a/digit-ui-esbuild/products/dashboard/src/components/GeographyChoroplethMap.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/GeographyChoroplethMap.jsx
@@ -190,7 +190,7 @@ const GeographyChoroplethMap = ({
   layerTotal = 0,
   unmappedTotal = 0,
 }) => {
-  const { t, language } = useDashboardT();
+  const { t, language, i18nTick } = useDashboardT();
   const shellRef = useRef(null);
   const frameRef = useRef(null);
   const elRef = useRef(null);
@@ -285,18 +285,18 @@ const GeographyChoroplethMap = ({
   // ── data joins ───────────────────────────────────────────────────────────
   const joined = useMemo(
     () => joinWardMapData(wardCounts, boundaries),
-    [wardCounts, boundaries, language]
+    [wardCounts, boundaries, language, i18nTick]
   );
 
   // Parent-level joins for the zoom-driven boundary levels (counts rolled up to the
   // sub-county / county, joined against the seeded parent polygons).
   const subCountyJoined = useMemo(
     () => joinWardMapData(aggregateWardCountsToLevel(wardCounts, hierarchyIndex, 1), boundaries),
-    [wardCounts, hierarchyIndex, boundaries, language]
+    [wardCounts, hierarchyIndex, boundaries, language, i18nTick]
   );
   const countyJoined = useMemo(
     () => joinWardMapData(aggregateWardCountsToLevel(wardCounts, hierarchyIndex, 0), boundaries),
-    [wardCounts, hierarchyIndex, boundaries, language]
+    [wardCounts, hierarchyIndex, boundaries, language, i18nTick]
   );
   // Active level by zoom; fall back to wards if a level's parent polygons are missing.
   const activeJoined =
@@ -318,12 +318,12 @@ const GeographyChoroplethMap = ({
 
   const mapRootLabel = useMemo(
     () => resolveMapRootLabel(cityLabel, drillHierarchyIndex, wardCodes, boundaries),
-    [cityLabel, drillHierarchyIndex, wardCodes, boundaries, language]
+    [cityLabel, drillHierarchyIndex, wardCodes, boundaries, language, i18nTick]
   );
 
   const boundaryLabelIndex = useMemo(
     () => buildBoundaryLabelIndex(boundaries),
-    [boundaries, language]
+    [boundaries, language, i18nTick]
   );
 
   const focusedWard = useMemo(
@@ -369,7 +369,7 @@ const GeographyChoroplethMap = ({
   const legendItems = useMemo(
     () => getGeographyMapLegend(layerMode, createdBuckets),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [layerMode, language, createdScaleKey, getNumberFormatStamp()]
+    [layerMode, language, i18nTick, createdScaleKey, getNumberFormatStamp()]
   );
   // Kept OUT of legendItems on purpose: that array is a colour scale scanned by
   // range (getCreatedCountBucket), so the pin row renders as its own <li> below.
@@ -391,6 +391,7 @@ const GeographyChoroplethMap = ({
       pinsTruncated,
       unmappedTotal,
       language,
+      i18nTick,
       getNumberFormatStamp(),
     ]
   );
@@ -687,6 +688,7 @@ const GeographyChoroplethMap = ({
     // Leaflet tooltips are drawn imperatively — redraw layers on language switch
     // (#882 ward-tooltip precedent) so bound tooltip text picks up the new locale.
     language,
+    i18nTick,
     layerMode,
     createdScaleKey,
   ]);
@@ -814,7 +816,7 @@ const GeographyChoroplethMap = ({
     // language switch so pin tooltips re-render localized (#882 precedent).
     // `layerMode`: pin colour follows the layer. (The pin ARRAY also changes per
     // layer, but not on an 'open-only' catalog where all three are identical.)
-  }, [visibleComplaintPins, language, layerMode]);
+  }, [visibleComplaintPins, language, i18nTick, layerMode]);
 
   // ── initial fit ───────────────────────────────────────────────────────────
   useEffect(() => {

--- a/digit-ui-esbuild/products/dashboard/src/components/HorizontalBarChart.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/HorizontalBarChart.jsx
@@ -35,7 +35,7 @@ function breakEvenSeriesValues(value, breakEven) {
 }
 
 const HorizontalBarChart = ({ data = [], breakEven = 1, scrollKey }) => {
-  const { t, language } = useDashboardT();
+  const { t, language, i18nTick } = useDashboardT();
   // Per-locale numberFormat mask stamp (#1272): baked into the options memo
   // because react-apexcharts compares JSON.stringify(options), which drops
   // the total-label/tooltip formatter closures — `language` alone can miss a
@@ -49,7 +49,7 @@ const HorizontalBarChart = ({ data = [], breakEven = 1, scrollKey }) => {
         resolved: Number(entry.resolved),
         created: Number(entry.created),
       })),
-    [data, t, language]
+    [data, t, language, i18nTick]
   );
 
   const categories = useMemo(() => rows.map((d) => d.label), [rows]);
@@ -212,6 +212,7 @@ const HorizontalBarChart = ({ data = [], breakEven = 1, scrollKey }) => {
       rows,
       t,
       language,
+      i18nTick,
       numberFormatStamp,
     ]
   );
@@ -221,7 +222,7 @@ const HorizontalBarChart = ({ data = [], breakEven = 1, scrollKey }) => {
       { name: t("DASHBOARD_TILE_LEGEND_FALLING_BEHIND", "Falling behind (<1.0)"), data: belowSeries },
       { name: t("DASHBOARD_TILE_LEGEND_CATCHING_UP", "Catching up (≥1.0)"), data: aboveSeries },
     ],
-    [aboveSeries, belowSeries, t, language]
+    [aboveSeries, belowSeries, t, language, i18nTick]
   );
 
   const hasData = rows.length > 0;

--- a/digit-ui-esbuild/products/dashboard/src/components/OpenComplaintsByGeographyWidget.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/OpenComplaintsByGeographyWidget.jsx
@@ -13,7 +13,7 @@ import useDashboardT from "../i18n/useDashboardT";
 import GeographyChoroplethMap from "./GeographyChoroplethMap";
 
 const OpenComplaintsByGeographyWidget = ({ layers, loading = false }) => {
-  const { t, language } = useDashboardT();
+  const { t, language, i18nTick } = useDashboardT();
   const [activeLayer, setActiveLayer] = useState("created");
   const cityLabel = getMapCityLabel();
 
@@ -32,7 +32,7 @@ const OpenComplaintsByGeographyWidget = ({ layers, loading = false }) => {
               ? t("DASHBOARD_MAP_LAYER_RESOLVED", "Resolved")
               : t("DASHBOARD_MAP_LAYER_CREATED", "Created"),
       })),
-    [language] // eslint-disable-line react-hooks/exhaustive-deps
+    [language, i18nTick] // eslint-disable-line react-hooks/exhaustive-deps
   );
   const wardCounts = useMemo(() => {
     const series = layers?.[resolvedLayer] ?? [];

--- a/digit-ui-esbuild/products/dashboard/src/components/treeControls.rendersmoke.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/components/treeControls.rendersmoke.test.js
@@ -241,10 +241,9 @@ test("group-by smoke: settings gear icon button, no native select, menu semantic
   assert.match(html, /<svg/);
   assert.match(html, /aria-haspopup="menu"/);
   assert.match(html, /aria-expanded="false"/);
-  // accessible name + tooltip carry the label and the current value (the
-  // unseeded smoke runtime echoes the KEY for the label — copy is not what
-  // this smoke verifies; "Category" resolves from the level's own label)
-  assert.match(html, /aria-label="DASHBOARD_GROUPBY_LABEL"/);
-  assert.match(html, /title="DASHBOARD_GROUPBY_LABEL: Category"/);
+  // accessible name + tooltip carry the canonical-English fallback and the
+  // current value ("Category" resolves from the level's own label)
+  assert.match(html, /aria-label="Group by"/);
+  assert.match(html, /title="Group by: Category"/);
   assert.match(html, /dashboard-widget-settings-wrap/);
 });

--- a/digit-ui-esbuild/products/dashboard/src/config/geographyMapPresentation.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/geographyMapPresentation.test.js
@@ -214,16 +214,15 @@ test("the pin entry is NOT part of the colour scale", () => {
   }
 });
 
-// NOTE ON EXPECTED STRINGS: translate() renders the RAW KEY when no message
-// store is primed (localeRuntime has no test seam), so these assert the CODE
-// each branch selects — the English literals in the source are the seeded
-// fallbacks, verified by the l10n pack, not by this file.
+// No message store is primed in this unit test, so translate() exercises the
+// same canonical-English fallback used by a standalone dashboard while its
+// selected locale is missing a message.
 
 test("pin label and swatch follow the layer under per-layer semantics", () => {
   const of = (layer) => getGeographyMapPinLegendEntry(layer, { semantics: "per-layer" });
-  assert.equal(of("created").label, "DASHBOARD_MAP_LEGEND_PINS_CREATED");
-  assert.equal(of("open").label, "DASHBOARD_MAP_LEGEND_PINS_OPEN");
-  assert.equal(of("resolved").label, "DASHBOARD_MAP_LEGEND_PINS_RESOLVED");
+  assert.equal(of("created").label, "Pins: complaints filed");
+  assert.equal(of("open").label, "Pins: complaints still open");
+  assert.equal(of("resolved").label, "Pins: complaints resolved");
   assert.deepEqual(of("created").swatch, GEOGRAPHY_MAP_PIN_STYLES.created);
   assert.deepEqual(of("open").swatch, GEOGRAPHY_MAP_PIN_STYLES.open);
   assert.deepEqual(of("resolved").swatch, GEOGRAPHY_MAP_PIN_STYLES.resolved);
@@ -239,12 +238,12 @@ test("pin label and swatch follow the layer under per-layer semantics", () => {
 test("open-only semantics says so on EVERY layer", () => {
   for (const layer of ["created", "open", "resolved"]) {
     const entry = getGeographyMapPinLegendEntry(layer, { semantics: "open-only" });
-    assert.equal(entry.label, "DASHBOARD_MAP_LEGEND_PINS_OPEN_ONLY");
+    assert.equal(entry.label, "Pins: complaints still open — pins do not follow this layer");
   }
   // Anything that is not exactly 'open-only' is treated as per-layer.
   assert.equal(
     getGeographyMapPinLegendEntry("open", { semantics: "nonsense" }).label,
-    "DASHBOARD_MAP_LEGEND_PINS_OPEN"
+    "Pins: complaints still open"
   );
 });
 
@@ -256,7 +255,7 @@ test("the coverage note is composed by concatenation, never interpolation", () =
   });
   assert.equal(
     entry.note,
-    "42DASHBOARD_MAP_LEGEND_PINS_COVERAGE_OF137DASHBOARD_MAP_LEGEND_PINS_COVERAGE_SUFFIX"
+    "42 of 137 shown on the map (rest have no location)"
   );
   assert.ok(!/\{|\}|%s/.test(entry.note), "no interpolation placeholders");
   // Nothing to compare against -> no note at all rather than "0 of 0".
@@ -272,9 +271,9 @@ test("truncation and unmapped complaints are surfaced, not swallowed", () => {
     unmapped: 17,
   });
   assert.deepEqual(entry.note.split(" \u00b7 "), [
-    "1000DASHBOARD_MAP_LEGEND_PINS_COVERAGE_OF4200DASHBOARD_MAP_LEGEND_PINS_COVERAGE_SUFFIX",
-    "DASHBOARD_MAP_LEGEND_PINS_TRUNCATED",
-    "17DASHBOARD_MAP_LEGEND_PINS_UNMAPPED",
+    "1000 of 4200 shown on the map (rest have no location)",
+    "Showing the most recent 1,000 only",
+    "17 complaints have no ward and are not mapped",
   ]);
   // No cap hit, nothing unmapped -> just the coverage line.
   const clean = getGeographyMapPinLegendEntry("open", { shown: 3, total: 4, unmapped: 0 });

--- a/digit-ui-esbuild/products/dashboard/src/hooks/useFilterOptions.js
+++ b/digit-ui-esbuild/products/dashboard/src/hooks/useFilterOptions.js
@@ -100,7 +100,7 @@ export function useFilterOptions({ enabled = true } = {}) {
   // Raw fetch payload and derived labels are split so a language switch
   // re-labels from the cached rows without re-querying the backend.
   const [raw, setRaw] = useState({ results: null, hierarchyRecords: null, loading: true });
-  const { language } = useDashboardT();
+  const { language, i18nTick } = useDashboardT();
 
   useEffect(() => {
     if (!enabled) {
@@ -166,6 +166,8 @@ export function useFilterOptions({ enabled = true } = {}) {
       options: Object.keys(options).length ? options : null,
       loading: raw.loading,
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- language re-labels cached rows
-  }, [raw, language]);
+    // `languageChanged` can fire before the new message bundle is installed.
+    // i18nTick also advances on the later store `added` event, so cached rows
+    // are re-labelled once the selected locale is actually available (#1108).
+  }, [raw, language, i18nTick]);
 }

--- a/digit-ui-esbuild/products/dashboard/src/i18n/localeRuntime.js
+++ b/digit-ui-esbuild/products/dashboard/src/i18n/localeRuntime.js
@@ -51,54 +51,49 @@ export function exists(key) {
   if (key == null || key === "") return false;
   const host = hostI18next();
   if (host) return host.exists(String(key));
-  const map = standalone.messages[getLanguage()];
-  return !!map && Object.prototype.hasOwnProperty.call(map, String(key));
+  const k = String(key);
+  const active = standalone.messages[getLanguage()];
+  const english = standalone.messages[FALLBACK_LOCALE];
+  return (
+    (!!active && Object.prototype.hasOwnProperty.call(active, k)) ||
+    (!!english && Object.prototype.hasOwnProperty.call(english, k))
+  );
 }
 
 /**
- * Translate `key`, else echo the KEY — DIGIT's platform-wide behavior, so a
- * missing message surfaces as a visible localisation gap instead of being
- * papered over.
+ * Translate `key`, falling back to its canonical English copy when the active
+ * locale has not received the message yet. Standalone/public mode loads en_IN
+ * beside the active locale to reproduce the employee host's fallback chain.
  *
- * `seedEnglish` is NEVER rendered: it is the canonical English message for
- * the key, kept inline as the single source the generated en_IN seed pack
+ * `seedEnglish` is also the single source the generated en_IN seed pack
  * (digit-mcp dashboard-l10n-seed.ts) is script-extracted from. Keep it in
  * sync when changing copy, then regenerate the pack.
  */
-// eslint-disable-next-line no-unused-vars -- seedEnglish is extraction source, not runtime input
 export function translate(key, seedEnglish) {
   if (key == null || key === "") return "";
   const k = String(key);
   const host = hostI18next();
   if (host) {
-    return host.exists(k) ? host.t(k) : k;
+    return host.exists(k) ? host.t(k) : seedEnglish || k;
   }
-  const map = standalone.messages[getLanguage()];
-  if (map && Object.prototype.hasOwnProperty.call(map, k)) return map[k];
-  return k;
+  const active = standalone.messages[getLanguage()];
+  if (active && Object.prototype.hasOwnProperty.call(active, k)) return active[k];
+  const english = standalone.messages[FALLBACK_LOCALE];
+  if (english && Object.prototype.hasOwnProperty.call(english, k)) return english[k];
+  return seedEnglish || k;
 }
 
 const notifyStandalone = () => standalone.listeners.forEach((cb) => cb());
 
-/** No-op when embedded; in standalone, fetch the message bundles once per locale. */
-export function ensureMessages() {
-  if (hostI18next()) return;
-  const locale = getLanguage();
-  if (standalone.messages[locale] || standalone.pending[locale]) return;
-  let authToken = null;
-  if (!isPublicDashboardRuntime()) {
-    try {
-      authToken = window.localStorage.getItem("Employee.token");
-    } catch (e) {
-      /* ignore */
-    }
-  }
+function loadStandaloneMessages(locale, authToken) {
+  if (standalone.messages[locale]) return Promise.resolve();
+  if (standalone.pending[locale]) return standalone.pending[locale];
   const params = new URLSearchParams({
     module: STANDALONE_MODULES.join(","),
     locale,
     tenantId: getTenantId(),
   });
-  standalone.pending[locale] = fetch(`/localization/messages/v1/_search?${params}`, {
+  const request = fetch(`/localization/messages/v1/_search?${params}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -122,7 +117,28 @@ export function ensureMessages() {
     .catch(() => {
       standalone.messages[locale] = {};
       delete standalone.pending[locale];
+      notifyStandalone();
     });
+  standalone.pending[locale] = request;
+  return request;
+}
+
+/**
+ * No-op when embedded. Standalone loads the active locale plus en_IN so
+ * dynamic dimension keys have the same fallback behavior as host i18next.
+ */
+export function ensureMessages() {
+  if (hostI18next()) return Promise.resolve();
+  let authToken = null;
+  if (!isPublicDashboardRuntime()) {
+    try {
+      authToken = window.localStorage.getItem("Employee.token");
+    } catch (e) {
+      /* ignore */
+    }
+  }
+  const locales = [...new Set([getLanguage(), FALLBACK_LOCALE])];
+  return Promise.all(locales.map((locale) => loadStandaloneMessages(locale, authToken)));
 }
 
 /**

--- a/digit-ui-esbuild/products/dashboard/src/i18n/localeRuntimeFallback.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/i18n/localeRuntimeFallback.test.js
@@ -1,0 +1,89 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const esbuild = require("esbuild");
+
+const outfile = path.join(os.tmpdir(), `dashboard-locale-runtime.${process.pid}.cjs`);
+esbuild.buildSync({
+  stdin: {
+    contents: 'export { ensureMessages, exists, translate } from "./localeRuntime.js";',
+    resolveDir: __dirname,
+  },
+  bundle: true,
+  format: "cjs",
+  platform: "node",
+  outfile,
+  logLevel: "silent",
+});
+process.on("exit", () => {
+  try {
+    fs.unlinkSync(outfile);
+  } catch (error) {
+    /* already removed */
+  }
+});
+
+function runtime(windowValue) {
+  delete require.cache[outfile];
+  global.window = windowValue;
+  return require(outfile);
+}
+
+test("standalone locale gaps use canonical English instead of a raw key", () => {
+  const { translate } = runtime({
+    localStorage: { getItem: () => "fr_FR" },
+  });
+  try {
+    assert.equal(translate("DASHBOARD_COMMON_UPDATED", "Updated"), "Updated");
+  } finally {
+    delete global.window;
+  }
+});
+
+test("host translations win and host gaps retain the English fallback", () => {
+  const messages = { DASHBOARD_COMMON_UPDATED: "Atualizado" };
+  const { translate } = runtime({
+    i18next: {
+      exists: (key) => Object.hasOwn(messages, key),
+      t: (key) => messages[key],
+    },
+    localStorage: { getItem: () => "pt_PT" },
+  });
+  try {
+    assert.equal(translate("DASHBOARD_COMMON_UPDATED", "Updated"), "Atualizado");
+    assert.equal(translate("DASHBOARD_NEW_COPY", "New copy"), "New copy");
+  } finally {
+    delete global.window;
+  }
+});
+
+test("standalone dynamic labels resolve active locale before the en_IN pack", async () => {
+  const requests = [];
+  global.fetch = async (url) => {
+    const locale = new URL(url, "https://example.test").searchParams.get("locale");
+    requests.push(locale);
+    const messages =
+      locale === "pt_PT"
+        ? [{ code: "COMMON_MASTERS_DEPARTMENT_WATER", message: "Água" }]
+        : [
+            { code: "COMMON_MASTERS_DEPARTMENT_WATER", message: "Water" },
+            { code: "COMMON_MASTERS_DEPARTMENT_ADMIN", message: "Administration" },
+          ];
+    return { ok: true, json: async () => ({ messages }) };
+  };
+  const api = runtime({
+    localStorage: { getItem: (key) => (key === "Employee.locale" ? "pt_PT" : null) },
+  });
+  try {
+    await api.ensureMessages();
+    assert.deepEqual(requests.sort(), ["en_IN", "pt_PT"]);
+    assert.equal(api.translate("COMMON_MASTERS_DEPARTMENT_WATER"), "Água");
+    assert.equal(api.exists("COMMON_MASTERS_DEPARTMENT_ADMIN"), true);
+    assert.equal(api.translate("COMMON_MASTERS_DEPARTMENT_ADMIN"), "Administration");
+  } finally {
+    delete global.fetch;
+    delete global.window;
+  }
+});

--- a/digit-ui-esbuild/products/dashboard/src/i18n/localizationContract.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/i18n/localizationContract.test.js
@@ -1,0 +1,94 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const DASHBOARD_ROOT = path.resolve(__dirname, "../..");
+const REPO_ROOT = path.resolve(DASHBOARD_ROOT, "../../..");
+const L10N_ROOT = path.join(REPO_ROOT, "local-setup/db/dss-mdms-seed/l10n");
+
+function sourceFiles(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFiles(full);
+    return /\.(?:js|jsx)$/.test(entry.name) && !entry.name.endsWith(".test.js") ? [full] : [];
+  });
+}
+
+function literalDashboardKeys() {
+  const keys = new Set();
+  const call = /\b(?:t|tt|translate)\(\s*["'](DASHBOARD_[A-Z0-9_]+)["']/g;
+  for (const file of sourceFiles(DASHBOARD_ROOT)) {
+    const source = fs.readFileSync(file, "utf8");
+    for (const match of source.matchAll(call)) keys.add(match[1]);
+  }
+  return keys;
+}
+
+function literalCallsMissingEnglishFallback() {
+  const missing = [];
+  const call = /\b(?:t|tt|translate)\(\s*["'](DASHBOARD_[A-Z0-9_]+)["']\s*([,)])/g;
+  // DashboardCard.js uses the host DIGIT t() API (which owns its fallback
+  // chain); the inline fallback contract applies to our localeRuntime calls.
+  for (const file of sourceFiles(path.join(DASHBOARD_ROOT, "src"))) {
+    const source = fs.readFileSync(file, "utf8");
+    for (const match of source.matchAll(call)) {
+      if (match[2] === ")") missing.push(`${path.relative(DASHBOARD_ROOT, file)}: ${match[1]}`);
+    }
+  }
+  return missing;
+}
+
+function pack(locale) {
+  const messages = JSON.parse(fs.readFileSync(path.join(L10N_ROOT, `${locale}.json`), "utf8"));
+  return new Map(messages.map(({ code, message }) => [code, message]));
+}
+
+test("every literal dashboard translation call is seeded in en_IN and pt_PT", () => {
+  const used = literalDashboardKeys();
+  const english = pack("en_IN");
+  const portuguese = pack("pt_PT");
+  const missingEnglish = [...used].filter((key) => !english.has(key));
+  const missingPortuguese = [...used].filter((key) => !portuguese.has(key));
+
+  assert.deepEqual(missingEnglish, [], `missing en_IN keys: ${missingEnglish.join(", ")}`);
+  assert.deepEqual(missingPortuguese, [], `missing pt_PT keys: ${missingPortuguese.join(", ")}`);
+});
+
+test("Portuguese dashboard pack has exact key parity with en_IN", () => {
+  const english = pack("en_IN");
+  const portuguese = pack("pt_PT");
+  assert.deepEqual([...portuguese.keys()].sort(), [...english.keys()].sort());
+  for (const [code, message] of portuguese) {
+    assert.equal(typeof message, "string", `${code} must have a string message`);
+    assert.notEqual(message.trim(), "", `${code} must not have an empty Portuguese message`);
+  }
+});
+
+test("literal dashboard translations provide the standalone English fallback", () => {
+  assert.deepEqual(literalCallsMissingEnglishFallback(), []);
+});
+
+test("memoized localized surfaces refresh after late bundle installation", () => {
+  const surfaces = [
+    "components/ComplaintsAtRiskTable.jsx",
+    "components/DashboardTable.jsx",
+    "components/DepartmentBarChart.jsx",
+    "components/GeographyChoroplethMap.jsx",
+    "components/HorizontalBarChart.jsx",
+    "components/OpenComplaintsByGeographyWidget.jsx",
+  ];
+
+  for (const relative of surfaces) {
+    const source = fs.readFileSync(path.join(DASHBOARD_ROOT, "src", relative), "utf8");
+    const languageDependencyLists = [...source.matchAll(/\[[^\]]*\blanguage\b[^\]]*\]/gs)];
+    assert.ok(languageDependencyLists.length > 0, `${relative} must expose its locale dependencies`);
+    for (const [dependencies] of languageDependencyLists) {
+      assert.match(
+        dependencies,
+        /\bi18nTick\b/,
+        `${relative} language dependency must also react to late bundle installation`,
+      );
+    }
+  }
+});

--- a/digit-ui-esbuild/products/dashboard/src/i18n/useDashboardT.js
+++ b/digit-ui-esbuild/products/dashboard/src/i18n/useDashboardT.js
@@ -4,8 +4,8 @@ import { translate, exists, getLanguage, subscribe, ensureMessages } from "./loc
 /**
  * The dashboard's t() hook. `t(key, seedEnglish)` translates against the host
  * i18next when embedded (or the standalone store on the dev harness) and
- * echoes the KEY when unseeded — gaps surface, never the inline English
- * (which exists only as the seed pack's extraction source). `language` is
+ * uses the canonical inline English when the selected locale is missing the
+ * message. `language` is
  * included so imperatively-drawn surfaces (Leaflet layers, ApexCharts
  * instances) can re-key on it — the #882 ward-tooltip pattern.
  *

--- a/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
@@ -240,40 +240,8 @@
   content: none !important;
 }
 
-@media (max-width: 1023px) {
-  /* Public dashboards are read-only, so their configured desktop geometry
-       can become a normal responsive grid without sacrificing edit/drag
-       semantics. The backend still chooses the tiles and their source order;
-       the frontend owns fitting that content to the current viewport. */
-
-  .dashboard-kpi-list-item .dashboard-drag-handle-title,
-    .dashboard-kpi-card .dashboard-drag-handle-title {
-    overflow: visible;
-    text-overflow: unset;
-    white-space: normal;
-    overflow-wrap: anywhere;
-    word-break: break-word;
-  }
-
-  /* Public dashboards are read-only, so their configured desktop geometry
-       can become a normal responsive grid without sacrificing edit/drag
-       semantics. The backend still chooses the tiles and their source order;
-       the frontend owns fitting that content to the current viewport. */
-
-  .dashboard-kpi-list-item .dashboard-drag-handle-title,
-    .dashboard-kpi-card .dashboard-drag-handle-title {
-    overflow: visible;
-    text-overflow: unset;
-    white-space: normal;
-    overflow-wrap: anywhere;
-    word-break: break-word;
-  }
-}
-
 .dashboard-drag-handle-title{
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  min-width: 0px;
   font-weight: 600;
   color: var(--foreground);
   font-size: 18px;
@@ -281,46 +249,22 @@
   letter-spacing: normal;
   text-transform: none;
   margin: 0;
-}
-
-@media (max-width: 1023px) {
-  /* Public dashboards are read-only, so their configured desktop geometry
-       can become a normal responsive grid without sacrificing edit/drag
-       semantics. The backend still chooses the tiles and their source order;
-       the frontend owns fitting that content to the current viewport. */
-
-  .dashboard-kpi-list-item .dashboard-drag-handle-subtitle,
-    .dashboard-kpi-card .dashboard-drag-handle-subtitle {
-    overflow: visible;
-    text-overflow: unset;
-    white-space: normal;
-    overflow-wrap: anywhere;
-    word-break: break-word;
-  }
-
-  /* Public dashboards are read-only, so their configured desktop geometry
-       can become a normal responsive grid without sacrificing edit/drag
-       semantics. The backend still chooses the tiles and their source order;
-       the frontend owns fitting that content to the current viewport. */
-
-  .dashboard-kpi-list-item .dashboard-drag-handle-subtitle,
-    .dashboard-kpi-card .dashboard-drag-handle-subtitle {
-    overflow: visible;
-    text-overflow: unset;
-    white-space: normal;
-    overflow-wrap: anywhere;
-    word-break: break-word;
-  }
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .dashboard-drag-handle-subtitle{
   margin: 0px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  min-width: 0px;
   font-size: 11px;
   line-height: 1.25;
   color: var(--muted-foreground);
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .dashboard-external-drag .react-grid-item {
@@ -405,7 +349,7 @@
 .dashboard-kpi-card--metric{
   height: 100%;
   display: grid;
-  grid-template-rows: minmax(0, 1fr) 26px minmax(0, 1fr);
+  grid-template-rows: minmax(0, auto) 26px minmax(0, 1fr);
   gap: 0.25rem;
 }
 
@@ -418,6 +362,7 @@
   color: var(--foreground);
   font-size: 11px;
   line-height: 1.25;
+  overflow-wrap: anywhere;
 }
 
 .dashboard-kpi-card--metric .dashboard-kpi-title{
@@ -426,7 +371,7 @@
   padding-right: 1.25rem;
   display: -webkit-box;
   -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 3;
 }
 
 .dashboard-kpi-value{
@@ -470,7 +415,7 @@
   padding-right: 1.25rem;
   display: -webkit-box;
   -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 3;
 }
 
 .dashboard-kpi-card--delta .dashboard-kpi-value{
@@ -504,7 +449,7 @@
   padding-right: 1.25rem;
   display: -webkit-box;
   -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 3;
 }
 
 .dashboard-kpi-sparkline-value-row{

--- a/digit-ui-esbuild/products/dashboard/src/styles/input.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/input.css
@@ -167,17 +167,25 @@
   }
 
   .dashboard-drag-handle-title {
-    @apply tw-truncate tw-font-semibold tw-text-foreground;
+    @apply tw-min-w-0 tw-font-semibold tw-text-foreground;
 
     font-size: 18px;
     line-height: 1.3;
     letter-spacing: normal;
     text-transform: none;
     margin: 0;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+    overflow-wrap: anywhere;
+    white-space: normal;
   }
 
   .dashboard-drag-handle-subtitle {
-    @apply tw-m-0 tw-truncate tw-text-[11px] tw-leading-tight tw-text-muted-foreground;
+    @apply tw-m-0 tw-min-w-0 tw-text-[11px] tw-leading-tight tw-text-muted-foreground;
+    overflow-wrap: anywhere;
+    white-space: normal;
   }
 
   .kpi-inventory-item:active {
@@ -249,7 +257,7 @@
   .dashboard-kpi-card--metric {
     @apply tw-h-full;
     display: grid;
-    grid-template-rows: minmax(0, 1fr) 26px minmax(0, 1fr);
+    grid-template-rows: minmax(0, auto) 26px minmax(0, 1fr);
     gap: 0.25rem;
   }
 
@@ -257,6 +265,7 @@
     @apply tw-min-w-0 tw-w-full tw-font-medium tw-uppercase tw-tracking-wide tw-text-foreground;
     font-size: 11px;
     line-height: 1.25;
+    overflow-wrap: anywhere;
   }
 
   .dashboard-kpi-card--metric .dashboard-kpi-title {
@@ -264,7 +273,7 @@
     padding-right: 1.25rem;
     display: -webkit-box;
     -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2;
+    -webkit-line-clamp: 3;
   }
 
   .dashboard-kpi-value {
@@ -302,7 +311,7 @@
     padding-right: 1.25rem;
     display: -webkit-box;
     -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2;
+    -webkit-line-clamp: 3;
   }
 
   .dashboard-kpi-card--delta .dashboard-kpi-value {
@@ -332,7 +341,7 @@
     padding-right: 1.25rem;
     display: -webkit-box;
     -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2;
+    -webkit-line-clamp: 3;
   }
 
   .dashboard-kpi-sparkline-value-row {

--- a/digit-ui-esbuild/products/dashboard/src/styles/localizedTitleLayout.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/styles/localizedTitleLayout.test.js
@@ -1,0 +1,42 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const styles = fs.readFileSync(path.resolve(__dirname, "input.css"), "utf8");
+const dashboard = fs.readFileSync(path.resolve(__dirname, "../AdminDashboard.jsx"), "utf8");
+
+const cssRule = (selector) => {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = styles.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`));
+  assert.ok(match, `missing CSS rule for ${selector}`);
+  return match[1];
+};
+
+test("localized widget titles wrap instead of using the truncation utility", () => {
+  const titleRule = cssRule(".dashboard-drag-handle-title");
+
+  assert.doesNotMatch(titleRule, /tw-truncate/);
+  assert.match(titleRule, /-webkit-line-clamp:\s*2/);
+  assert.match(titleRule, /overflow-wrap:\s*anywhere/);
+  assert.match(titleRule, /white-space:\s*normal/);
+  assert.doesNotMatch(
+    dashboard,
+    /SHARED_CHROME\.dragHandleTitle[^\n]*tw-truncate/,
+  );
+});
+
+test("localized KPI titles have room for three lines at desktop widths", () => {
+  assert.match(
+    cssRule(".dashboard-kpi-card--metric"),
+    /grid-template-rows:\s*minmax\(0, auto\)/,
+  );
+
+  for (const variant of ["metric", "delta", "sparkline"]) {
+    assert.match(
+      cssRule(`.dashboard-kpi-card--${variant} .dashboard-kpi-title`),
+      /-webkit-line-clamp:\s*3/,
+      `${variant} KPI title should allow three lines`,
+    );
+  }
+});

--- a/local-setup/db/dss-mdms-seed/l10n/en_IN.json
+++ b/local-setup/db/dss-mdms-seed/l10n/en_IN.json
@@ -230,6 +230,11 @@
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "DASHBOARD_COMMON_UPDATED",
+    "message": "Updated",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "DASHBOARD_COMMON_UNASSIGNED",
     "message": "Unassigned",
     "module": "rainmaker-dashboard"
@@ -692,6 +697,11 @@
   {
     "code": "DASHBOARD_LOGIN_SIGNING_IN",
     "message": "Signing in…",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_LOGIN_SESSION_EXPIRED",
+    "message": "Your session has expired. Please sign in again.",
     "module": "rainmaker-dashboard"
   },
   {

--- a/local-setup/db/dss-mdms-seed/l10n/pt_PT.json
+++ b/local-setup/db/dss-mdms-seed/l10n/pt_PT.json
@@ -230,6 +230,11 @@
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "DASHBOARD_COMMON_UPDATED",
+    "message": "Atualizado",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "DASHBOARD_COMMON_UNASSIGNED",
     "message": "Sem atribuição",
     "module": "rainmaker-dashboard"
@@ -692,6 +697,11 @@
   {
     "code": "DASHBOARD_LOGIN_SIGNING_IN",
     "message": "A iniciar sessão…",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_LOGIN_SESSION_EXPIRED",
+    "message": "A sua sessão expirou. Inicie sessão novamente.",
     "module": "rainmaker-dashboard"
   },
   {


### PR DESCRIPTION
## Summary

Addresses the remaining source and responsive gaps for #1108 after auditing current `master`, Bomet, and the superseded #1407.

- localizes the hardcoded card `Updated` stamp and adds the missing en_IN/pt_PT seed entries
- adds the previously unseeded session-expiry message
- guarantees active-locale → en_IN → canonical-inline fallback in standalone/public mode (and canonical English in the host), so locale gaps do not expose raw keys
- loads `rainmaker-common` explicitly for department/designation labels
- re-labels memoized filters, charts, tables, and map surfaces after late locale-bundle arrival without re-querying or resetting filters
- wraps Portuguese widget headings and allows three-line KPI headings where Bomet currently clips them at 768px/1024px
- adds pack parity, literal-key coverage, English-fallback, stamp-rendering, and title-layout regression tests

This intentionally does not port #1407 wholesale: the live-mutating seeder, stale search/header work, layout persistence changes, and public-runtime side effects remain excluded.

## Verification

- `node --test` across all dashboard tests: **234 passed**
- `npm run build` in `digit-ui-esbuild`: passed (existing repository warnings only)
- `npm run build` in `digit-mcp`: passed
- `node local-setup/db/dss-mdms-seed/export-l10n.mjs --check`: passed
- `git diff --check`: passed

## Deployment QA gate

After deployment to Bomet, verify:

- pt_PT renders `Atualizado` on every tile and no raw `DASHBOARD_*` key
- employee language switching does not reload the page or reset active filters
- widget/KPI titles do not clip at 768px and 1024px
- en_IN, fr_FR and pt_PT all retain graceful English fallback for any unseeded message

Addresses #1108.
