### PR TITLE
fix(ui): employee sidebar search typed text invisible (CCSD-2170)

### DIFF
--- a/digit-ui-esbuild/public/vendor/overrides.css
+++ b/digit-ui-esbuild/public/vendor/overrides.css
@@ -2191,15 +2191,25 @@ button[class*="toast-close"] svg,
 .employee .digit-sidebar .digit-sidebar-item.selected svg path {
   fill: var(--color-sidebar-selected-text, #FFFFFF) !important;
 }
-/* Search input inside the expanded sidebar — translucent on dark surface */
-.employee .digit-sidebar .digit-sidebar-search-container,
-.employee .digit-sidebar .digit-sidebar-search-container input {
+/* Search inside the expanded sidebar (CCSD-2170): the container strip stays
+ * translucent on the dark surface, but the INPUT itself renders as a solid
+ * white field — so its text must be dark. The previous combined rule forced
+ * white text on the input with 3-class !important specificity, beating the
+ * dark-text fix injected by EmployeeSideBar (CCSD-1947, 1 class): typed text
+ * came out white-on-white and was invisible. */
+.employee .digit-sidebar .digit-sidebar-search-container {
   background: rgba(255, 255, 255, 0.06) !important;
-  color: var(--color-sidebar-selected-text, #FFFFFF) !important;
   border-color: rgba(255, 255, 255, 0.18) !important;
 }
-.employee .digit-sidebar .digit-sidebar-search-container ::placeholder {
-  color: var(--color-sidebar-text-default, rgba(255, 255, 255, 0.55)) !important;
+.employee .digit-sidebar .digit-sidebar-search-container input {
+  background: #fff !important;
+  color: #363636 !important;
+  caret-color: #363636 !important;
+  border-color: rgba(255, 255, 255, 0.18) !important;
+}
+.employee .digit-sidebar .digit-sidebar-search-container input::placeholder {
+  color: #787878 !important;
+  opacity: 1 !important;
 }
 
 /* Sidebar position — vendor `top: 0` + topbar height 72 + sidebar


### PR DESCRIPTION
Jira: [CCSD-2170](https://digit-discuss.atlassian.net/browse/CCSD-2170)

## Problem

In the employee left hamburger menu, text typed into the search box is invisible (Gurjeet's screencast). Reproduced live on cms-pilot: the input renders as a solid white field with **white** typed text.

Root cause is a clash between two `!important` rules, each winning one property:

- `overrides.css` (written for the old translucent-on-dark search style) forces `color: #FFFFFF !important` on the input with 3-class specificity (`.employee .digit-sidebar .digit-sidebar-search-container input`).
- The CCSD-1947 fix injected by `EmployeeSideBar` forces `background: #fff !important` with 1-class specificity — it wins background but **loses color** to the overrides rule.

Result: white text on a white field.

## Fix

One-file change in `overrides.css` — split the combined container+input rule:

- container strip: stays translucent on the dark sidebar (unchanged look)
- input: solid white field, dark text `#363636`, dark caret, grey placeholder — consistent with the CCSD-1947 injected style, so there is no longer a fight.

## Verification

Reproduced and then verified the exact corrected CSS **live on cms-pilot** by injecting it into the running employee UI: typed text ("Complaint") clearly visible. Before/after screenshots attached to the Jira ticket.

## Deploy note

`overrides.css` ships with the digit-ui static bundle — cms-pilot needs a digit-ui rebuild/deploy after merge for Gurjeet to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CCSD-2170]: https://digit-discuss.atlassian.net/browse/CCSD-2170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ