### PR TITLE
feat(analytics): boundaryPath subtree param for the geography drill-down (CCSD-2171)

### DIFF
--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java
@@ -236,18 +236,21 @@ public class AnalyticsPlanner {
                 parts.add(colKey + " LIKE ? || '%'");
                 continue;
             }
-            // subtree: delimiter-guarded subtree membership on a materialized dot-path column —
-            // the node itself OR any dot-descendant. Unlike a bare starts_with, the '.' guard
-            // prevents sibling-prefix collisions ('PGR' must not match 'PGRX.…'), and the eq arm
-            // keeps mixed interior+serviceable nodes (a complaint filed AT the node) in the
-            // subtree. Same allowlist as starts_with (prefix-filterable path columns only), same
-            // bound-param + LIKE-escape mechanics.
+            // subtree: delimiter-guarded subtree membership on a materialized path column —
+            // the node itself OR any descendant. Unlike a bare starts_with, the delimiter guard
+            // prevents sibling-prefix collisions ('PGR' must not match 'PGRX.…', a ward code must
+            // not match a same-prefix sibling ward), and the eq arm keeps rows attached AT the
+            // node itself in the subtree. Same allowlist as starts_with (prefix-filterable path
+            // columns only), same bound-param + LIKE-escape mechanics. The guard character is the
+            // column's own segment delimiter: complaint_node_path is dot-joined, boundary_path is
+            // pipe-joined (ancestralmaterializedpath || '|' || code — see the grain MV migration).
             if ("subtree".equals(op)) {
                 if (!prefixFilterable) throw new IllegalArgumentException(
                         "op_not_allowed: 'subtree' is only permitted on prefix-filterable path columns, not '" + colKey + "' on " + g.name);
+                String delim = "boundary_path".equals(colKey) ? "|" : ".";
                 params.add(v.asText());
                 params.add(escapeLike(v.asText()));
-                parts.add("(" + colKey + " = ? OR " + colKey + " LIKE ? || '.%')");
+                parts.add("(" + colKey + " = ? OR " + colKey + " LIKE ? || '" + delim + "%')");
                 continue;
             }
             if (!plainFilterable) throw new IllegalArgumentException(

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiQueryComposer.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiQueryComposer.java
@@ -59,6 +59,13 @@ import java.util.regex.Pattern;
  *       {@code paramsIgnored:["complaintPath"]} on the result envelope) so the FE can flag the
  *       widget as unfiltered. Rows with a NULL path (nodes whose own code contains '.', see the
  *       #1111 migration; flat tenants) never match a subtree filter.</li>
+ *   <li>{@code boundaryPath} — a boundary-hierarchy INTERIOR node's pipe-path (e.g.
+ *       {@code mz|maputo_cidade|distrito_x}; CCSD-2171 geography drill-down). Mirrors
+ *       {@code complaintPath} on the {@code boundary_path} column with a {@code |}-guarded
+ *       subtree predicate ({@code = ? OR LIKE ?||'|%'}); alphabet adds {@code |}, cap 512.
+ *       All three grains carry the column prefix-filterable, so unlike {@code complaintPath}
+ *       it applies on daily too. Leaf (ward) selections keep using {@code ward} (exact
+ *       {@code ward_code} eq) — this param is additive for interior nodes only.</li>
  *   <li>{@code compare: "prior"} — instead of the selected/default range, apply the
  *       <em>immediately-preceding equal-duration</em> range on the def's time column. Mirrors the FE
  *       {@code priorPeriodCreatedAtFilter()} (~1586) / {@code priorPeriodEndDateIso()} (~1360) and the
@@ -130,6 +137,19 @@ public class KpiQueryComposer {
      */
     private static final Pattern COMPLAINT_PATH_VALUE =
             Pattern.compile("^[A-Za-z0-9._/\\-]{1," + MAX_COMPLAINT_PATH_LENGTH + "}$");
+    /**
+     * {@code boundaryPath} length cap — boundary paths are longer than complaint paths
+     * (pipe-joined lowercase boundary codes, one segment per hierarchy level, each segment
+     * itself underscore-joined, e.g. {@code mz|maputo_cidade|distrito_x|municipio_maputo_katembe}).
+     */
+    static final int MAX_BOUNDARY_PATH_LENGTH = 512;
+    /**
+     * The boundary path alphabet: the complaint-path alphabet plus {@code |}, the
+     * boundary_relationship materialized-path segment delimiter. Same defense-in-depth reasoning
+     * as {@link #COMPLAINT_PATH_VALUE}.
+     */
+    private static final Pattern BOUNDARY_PATH_VALUE =
+            Pattern.compile("^[A-Za-z0-9._/|\\-]{1," + MAX_BOUNDARY_PATH_LENGTH + "}$");
 
     private final AnalyticsCatalog catalog;
 
@@ -274,6 +294,10 @@ public class KpiQueryComposer {
         if (params.hasNonNull("complaintPath")) {
             String path = params.get("complaintPath").asText();
             if (!path.isEmpty()) applyComplaintPath(next, g, path, paramsIgnoredOut);
+        }
+        if (params.hasNonNull("boundaryPath")) {
+            String path = params.get("boundaryPath").asText();
+            if (!path.isEmpty()) applyBoundaryPath(next, g, path, paramsIgnoredOut);
         }
 
         // ---- hierarchy-level rollup (#1111): rewrite service_code dimensions to the level expr ----
@@ -759,6 +783,31 @@ public class KpiQueryComposer {
             return;
         }
         mergeableFilterObject(query, "complaint_node_path").put("subtree", path);
+    }
+
+    /**
+     * Narrow to a boundary-hierarchy INTERIOR node's whole subtree (CCSD-2171: province/district
+     * selections on the dashboard's geography drill-down). Mirrors {@link #applyComplaintPath}
+     * on the {@code boundary_path} column: a delimiter-guarded {@code subtree} predicate
+     * ({@code = ? OR LIKE ?||'|%'} — boundary paths are pipe-joined, see the grain MV's
+     * {@code ancestralmaterializedpath || '|' || code}), hard {@code invalid_param} on a
+     * malformed value, and a REPORTED skip on a grain without the column. Today all three grains
+     * (facts/events/daily) carry {@code boundary_path} prefix-filterable, so the skip arm is a
+     * guard for future grains rather than a live path.
+     *
+     * <p>Leaf (ward) selections must keep using the existing {@code ward} param — exact
+     * {@code ward_code} match; {@code boundaryPath} is additive for interior nodes only.
+     */
+    private void applyBoundaryPath(ObjectNode query, Grain g, String path, List<String> paramsIgnoredOut) {
+        if (!BOUNDARY_PATH_VALUE.matcher(path).matches())
+            throw new IllegalArgumentException("invalid_param: boundaryPath must be a pipe-joined boundary path over"
+                    + " [A-Za-z0-9._/|-], at most " + MAX_BOUNDARY_PATH_LENGTH + " chars");
+        if (!g.prefixFilterable.contains("boundary_path")) {
+            log.debug("grain '{}' has no boundary_path; ignoring boundaryPath param (reported)", g.name);
+            reportIgnored(paramsIgnoredOut, "boundaryPath");
+            return;
+        }
+        mergeableFilterObject(query, "boundary_path").put("subtree", path);
     }
 
     // ---- narrowing eq filter ----

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiQueryComposerBoundaryPathTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiQueryComposerBoundaryPathTest.java
@@ -1,0 +1,178 @@
+package org.egov.pgr.analytics;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Pins the {@code boundaryPath} subtree-filter param (CCSD-2171: the dashboard geography
+ * drill-down's interior-node selections — province/district). Mirrors
+ * {@link KpiQueryComposerComplaintPathTest} on the {@code boundary_path} column with the
+ * boundary-specific deltas: the subtree guard is the PIPE delimiter (boundary paths are
+ * {@code ancestralmaterializedpath || '|' || code}), the alphabet admits {@code |}, and —
+ * unlike {@code complaint_node_path} — ALL THREE grains carry the column prefix-filterable,
+ * so the filter applies on daily instead of landing in {@code paramsIgnored}.
+ */
+public class KpiQueryComposerBoundaryPathTest {
+
+    private final ObjectMapper om = new ObjectMapper();
+    private final AnalyticsCatalog catalog = new AnalyticsCatalog();
+    private final KpiQueryComposer composer = new KpiQueryComposer(catalog);
+    private final AnalyticsPlanner planner = new AnalyticsPlanner(catalog);
+    private final AnalyticsScope stateScope = new AnalyticsScope("ke", true, null, null, null);
+    private final BusinessCalendar calendar =
+            BusinessCalendar.of(java.time.ZoneId.of("Africa/Nairobi"), 1_700_000_000_000L);
+
+    private JsonNode json(String s) {
+        try { return om.readTree(s); } catch (Exception e) { throw new RuntimeException(e); }
+    }
+
+    /** The seeded complaints-by-type base query (facts, service_code dimension). */
+    private JsonNode byTypeBase() {
+        return json("{\"grain\":\"facts\",\"window\":{\"name\":\"last_30d\",\"timeRole\":\"filed_at\"},"
+                + "\"dimensions\":[\"service_code\"],"
+                + "\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}],"
+                + "\"sort\":[{\"by\":\"total\",\"dir\":\"desc\"}],\"limit\":8}");
+    }
+
+    private JsonNode dailyBase() {
+        return json("{\"grain\":\"daily\",\"dimensions\":[\"service_code\"],"
+                + "\"measures\":[{\"name\":\"open\",\"agg\":\"count\"}]}");
+    }
+
+    // ---- SQL: the PIPE-guarded subtree predicate ----
+
+    @Test
+    public void sqlSnapshotForSubtreePredicate() {
+        JsonNode merged = composer.mergeParams(byTypeBase(),
+                json("{\"boundaryPath\":\"mz|maputo_cidade\"}"), calendar);
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope, calendar);
+        assertEquals("SELECT service_code AS service_code, count(*) AS total"
+                + " FROM complaint_facts"
+                + " WHERE (boundary_path = ? OR boundary_path LIKE ? || '|%')"
+                + " AND created_at >= ? AND created_at < ? AND tenant_id LIKE ?", p.sql.substring(0, p.sql.indexOf(" GROUP BY")));
+        // eq arm binds the raw path, the LIKE arm the LIKE-escaped path ('_' is a legal boundary
+        // code character but a LIKE metachar) — the '|' guard is in the SQL, so
+        // 'mz|maputo_cidade' can never match a 'mz|maputo_cidade2|…' sibling.
+        assertEquals("mz|maputo_cidade", p.params.get(0));
+        assertEquals("mz|maputo\\_cidade", p.params.get(1));
+    }
+
+    @Test
+    public void eventsGrainAppliesSubtree() {
+        JsonNode base = json("{\"grain\":\"events\",\"dimensions\":[\"service_code\"],"
+                + "\"measures\":[{\"name\":\"n\",\"agg\":\"count\"}]}");
+        JsonNode merged = composer.mergeParams(base,
+                json("{\"boundaryPath\":\"mz|maputo_cidade|distrito_kampfumo\"}"), calendar);
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope, calendar);
+        assertTrue(p.sql.contains("FROM complaint_events"));
+        assertTrue(p.sql.contains("(boundary_path = ? OR boundary_path LIKE ? || '|%')"));
+    }
+
+    // ---- daily grain: boundary_path EXISTS there — filter applies, nothing ignored ----
+
+    @Test
+    public void dailyGrainAppliesSubtreeAndReportsNothing() {
+        List<String> ignored = new ArrayList<>();
+        JsonNode merged = composer.mergeParams(dailyBase(),
+                json("{\"boundaryPath\":\"mz|maputo_cidade\"}"), ignored, calendar);
+        assertEquals("mz|maputo_cidade",
+                merged.get("filters").get("boundary_path").get("subtree").asText());
+        assertTrue(ignored.isEmpty(), "boundary_path is prefix-filterable on daily — no skip to report");
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope, calendar);
+        assertTrue(p.sql.contains("(boundary_path = ? OR boundary_path LIKE ? || '|%')"), p.sql);
+    }
+
+    // ---- sanitizer: path alphabet + length cap ----
+
+    @Test
+    public void sqlMeaningfulValuesAreRejected() {
+        for (String bad : new String[]{
+                "mz' OR '1'='1", "a b", "x%y", "a;b", "x)--", "a\\b", "path*", "a,b",
+                "x||'y", "a\"b", "café", "a\tb"}) {
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> composer.mergeParams(byTypeBase(), json(om.createObjectNode()
+                            .put("boundaryPath", bad).toString()), calendar),
+                    "boundaryPath '" + bad + "' must be rejected");
+            assertTrue(ex.getMessage().startsWith("invalid_param"), ex.getMessage());
+        }
+    }
+
+    @Test
+    public void overlongPathIsRejected() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 40; i++) sb.append("boundary_node|");
+        String tooLong = sb.append("leaf_node").toString();   // > 512 chars, alphabet-legal
+        assertTrue(tooLong.length() > KpiQueryComposer.MAX_BOUNDARY_PATH_LENGTH);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> composer.mergeParams(byTypeBase(), json("{\"boundaryPath\":\"" + tooLong + "\"}"), calendar));
+        assertTrue(ex.getMessage().startsWith("invalid_param"), ex.getMessage());
+    }
+
+    @Test
+    public void livePathShapesAreAccepted() {
+        // Real mz shapes: pipe-joined lowercase codes, segments underscore-joined; a bare root
+        // and a full Provincia|Distrito|Municipio path both pass.
+        for (String ok : new String[]{"mz", "mz|maputo_cidade",
+                "mz|maputo_cidade|distrito_kampfumo",
+                "mz|maputo_cidade|distrito_kampfumo|municipio_maputo_katembe"}) {
+            JsonNode merged = composer.mergeParams(byTypeBase(),
+                    json("{\"boundaryPath\":\"" + ok + "\"}"), calendar);
+            assertEquals(ok, merged.get("filters").get("boundary_path").get("subtree").asText());
+        }
+    }
+
+    @Test
+    public void emptyAndAbsentAreNoOps() {
+        assertEquals(byTypeBase(), composer.mergeParams(byTypeBase(), json("{\"boundaryPath\":\"\"}"), calendar));
+        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"window\":\"last_7d\"}"), calendar);
+        assertFalse(merged.has("filters"));
+    }
+
+    // ---- composition: leaf ward eq ⊥ interior boundaryPath; complaintPath orthogonal ----
+
+    @Test
+    public void leafWardParamStaysAnExactEq() {
+        // Leaf (ward) selections keep sending ward (exact ward_code match) — boundaryPath is
+        // additive for interior nodes, not a replacement.
+        JsonNode merged = composer.mergeParams(byTypeBase(),
+                json("{\"ward\":\"municipio_maputo_katembe\",\"boundaryPath\":\"mz|maputo_cidade\"}"), calendar);
+        assertEquals("municipio_maputo_katembe",
+                merged.get("filters").get("ward_code").get("eq").asText());
+        assertEquals("mz|maputo_cidade",
+                merged.get("filters").get("boundary_path").get("subtree").asText());
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope, calendar);
+        assertTrue(p.sql.contains("ward_code = ?"));
+    }
+
+    @Test
+    public void composesWithComplaintPathOnItsOwnColumn() {
+        JsonNode merged = composer.mergeParams(byTypeBase(),
+                json("{\"complaintPath\":\"SANITATION\",\"boundaryPath\":\"mz|maputo_cidade\"}"), calendar);
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope, calendar);
+        assertTrue(p.sql.contains("(complaint_node_path = ? OR complaint_node_path LIKE ? || '.%')"), p.sql);
+        assertTrue(p.sql.contains("(boundary_path = ? OR boundary_path LIKE ? || '|%')"), p.sql);
+    }
+
+    // ---- ABAC: params only narrow; row-scope is injected on top ----
+
+    @Test
+    public void abacRowScopeIsStillAppliedOnTopOfTheSubtreeFilter() {
+        AnalyticsScope constrained = new AnalyticsScope("ke.nairobi", false, null,
+                "KENYA.NAIROBI", java.util.List.of("DEPT_SANITATION"));
+        JsonNode merged = composer.mergeParams(byTypeBase(),
+                json("{\"boundaryPath\":\"mz|maputo_cidade\"}"), calendar);
+        AnalyticsPlanner.Planned p = planner.plan(merged, constrained, calendar);
+        assertTrue(p.sql.contains("(boundary_path = ? OR boundary_path LIKE ? || '|%')"), p.sql);
+        assertTrue(p.sql.contains("tenant_id = ?"), p.sql);                 // city tenant scope
+        assertTrue(p.sql.contains("boundary_path LIKE ?"), p.sql);          // jurisdiction subtree scope
+        assertTrue(p.sql.contains("department_code IN (?)"), p.sql);        // department scope
+        assertTrue(p.params.containsAll(java.util.List.of(
+                "mz|maputo_cidade", "ke.nairobi", "KENYA.NAIROBI%", "DEPT_SANITATION")), p.params.toString());
+    }
+}


### PR DESCRIPTION
Jira: [CCSD-2171](https://digit-discuss.atlassian.net/browse/CCSD-2171) — dashboard ward filter becomes a Província → Distrito → Município drill-down (like the complaint-type filter). **PR 1 of 2 (backend);** the FE tree widget follows in a separate PR and degrades gracefully until this is deployed.

## What

Interior-node selections (province/district) need "everything in this subtree" filtering. The complaint-type tree already has this via `complaintPath`; this PR adds the exact mirror for boundaries:

- **`boundaryPath` narrowing param** in `KpiQueryComposer` — validated (`[A-Za-z0-9._/|-]`, cap 512, malformed = hard `invalid_param`), applied as a `subtree` predicate on `boundary_path`, `paramsIgnored`-reported if a grain lacks the column (future-grain guard — all three grains carry it today, so unlike `complaintPath` it works on daily too). Leaf ward selections keep the existing `ward` param unchanged.
- **Planner `subtree` op delimiter fix** — the guard was hardcoded `'.'`; it's now the column's own delimiter (`'|'` for `boundary_path`, `'.'` for `complaint_node_path`), so a province can never match a same-prefix sibling (`maputo_cidade` vs `maputo_cidade2`).

## Why no schema change

The facts MV has stored `boundary_path` (`ancestralmaterializedpath || '|' || code`) since the V20260608 grain migration, and all three grains already list it prefix-filterable — the column just wasn't reachable from a KPI param until now.

## Verification

- New `KpiQueryComposerBoundaryPathTest` — **10 tests**: SQL snapshot with the `|` guard, LIKE-escape of `_` (legal in boundary codes, a LIKE metachar), daily-grain apply-not-ignore, alphabet/length rejection (SQLi shapes, overlong), live mz path shapes, composition with `ward` eq + `complaintPath`, ABAC row-scope still layered on top.
- Existing `KpiQueryComposerComplaintPathTest` — **16 tests, unchanged, green** (the delimiter refactor preserved the `.` behaviour bit-for-bit; the SQL snapshot test pins it).

## Deploy note

Needs a pgr-services image build + pin after merge, before the FE PR's interior selections work on-env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CCSD-2171]: https://digit-discuss.atlassian.net/browse/CCSD-2171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ