### PR TITLE
feat(dashboard): land the CCSD-2171 geography drill-down FE (stranded by the #1762/#1763 merge race)

### DIFF
--- a/digit-ui-esbuild/products/dashboard/src/components/ComplaintTypeTreeFilter.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/ComplaintTypeTreeFilter.jsx
@@ -61,8 +61,22 @@ const TRAIL_MAX = 4;
  * The panel body. Exported (also for the ReactDOMServer render smoke): pure
  * React against the tree + applied code, owns only the transient browse
  * location. Mounted fresh on every open, so browse state self-resets.
+ *
+ * Hierarchy-agnostic via three optional props (defaults keep the
+ * complaint-type behaviour bit-for-bit; the geography drill-down passes its
+ * own — CCSD-2171): `labelFor(tree, code)` resolves a node's display label,
+ * `allLabel` is the virtual-root label ("All types" / "All wards"),
+ * `allInLabel` prefixes the subtree-apply row ("All in").
  */
-export function ComplaintTypeTreePanel({ tree, appliedCode, onApply, t }) {
+export function ComplaintTypeTreePanel({
+  tree,
+  appliedCode,
+  onApply,
+  t,
+  labelFor = nodeDisplayLabel,
+  allLabel,
+  allInLabel,
+}) {
   const [browseCode, setBrowseCode] = useState(() => browseBaseCode(tree, appliedCode));
   const rootRef = useRef(null);
   const mountedRef = useRef(false);
@@ -83,8 +97,9 @@ export function ComplaintTypeTreePanel({ tree, appliedCode, onApply, t }) {
     target?.focus();
   }, [browseCode]);
 
-  const allTypesLabel = t("DASHBOARD_FILTERS_ALL_TYPES", "All types");
-  const label = (c) => (c === ALL ? allTypesLabel : nodeDisplayLabel(tree, c));
+  const allTypesLabel = allLabel ?? t("DASHBOARD_FILTERS_ALL_TYPES", "All types");
+  const allInText = allInLabel ?? t("DASHBOARD_TYPE_FILTER_ALL_IN", "All in");
+  const label = (c) => (c === ALL ? allTypesLabel : labelFor(tree, c));
 
   const atRoot = browseCode === ALL || !nodeOf(tree, browseCode);
   const browse = atRoot ? ALL : browseCode;
@@ -146,10 +161,10 @@ export function ComplaintTypeTreePanel({ tree, appliedCode, onApply, t }) {
         {!atRoot && (
           <PopoverMenuItem
             selected={appliedCode === browse}
-            title={`${t("DASHBOARD_TYPE_FILTER_ALL_IN", "All in")} ${label(browse)}`}
+            title={`${allInText} ${label(browse)}`}
             onSelect={() => onApply(browse)}
           >
-            {`${t("DASHBOARD_TYPE_FILTER_ALL_IN", "All in")} ${label(browse)}`}
+            {`${allInText} ${label(browse)}`}
           </PopoverMenuItem>
         )}
         {children.map((child) => (

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardFilters.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardFilters.jsx
@@ -6,6 +6,7 @@ import {
   hasActiveFilters,
 } from "../config/globalFilterGroups";
 import ComplaintTypeTreeFilter from "./ComplaintTypeTreeFilter";
+import GeographyTreeFilter from "./GeographyTreeFilter";
 import PopoverMenu, { PopoverMenuItem, PopoverMenuGroupLabel } from "./ui/PopoverMenu";
 import useDashboardT from "../i18n/useDashboardT";
 
@@ -108,6 +109,7 @@ const DashboardFilters = ({
   const complaintTypeOptions =
     filterOptions?.complaintType ?? COMPLAINT_TYPE_OPTIONS;
   const complaintTypeTree = filterOptions?.complaintTypeTree ?? null;
+  const geographyTree = filterOptions?.geographyTree ?? null;
 
   // Date fallbacks resolve from buildDefaultFilters(timeZone) at render time — never
   // GLOBAL_FILTER_FIELDS' module-load defaultValue, which would freeze on whatever
@@ -166,26 +168,37 @@ const DashboardFilters = ({
           </div>
         </div>
 
-        <div className="dashboard-filter-inline-select-wrap">
-          <select
-            value={filterOptionsLoading && geographyOptions.length <= 1 ? "" : geography}
-            disabled={filterOptionsLoading && geographyOptions.length <= 1}
-            onChange={(e) => onFilterChange("geography", e.target.value)}
-            aria-label={t("DASHBOARD_FILTERS_WARD_FILTER", "Ward filter")}
-            className="dashboard-filter-inline-select"
-          >
-            {filterOptionsLoading && geographyOptions.length <= 1 ? (
-              <option value="">{t("DASHBOARD_COMMON_LOADING", "Loading…")}</option>
-            ) : (
-              geographyOptions.map((opt) => (
-                <option key={opt.id} value={opt.id}>
-                  {opt.label}
-                </option>
-              ))
-            )}
-          </select>
-          <FilterChevron />
-        </div>
+        {geographyTree ? (
+          // Boundary drill-down (CCSD-2171): Província → Distrito → Município
+          // via the shared tree panel; leaf → ward, interior → boundaryPath.
+          <GeographyTreeFilter
+            tree={geographyTree}
+            filters={filters}
+            onFilterChange={onFilterChange}
+            t={t}
+          />
+        ) : (
+          <div className="dashboard-filter-inline-select-wrap">
+            <select
+              value={filterOptionsLoading && geographyOptions.length <= 1 ? "" : geography}
+              disabled={filterOptionsLoading && geographyOptions.length <= 1}
+              onChange={(e) => onFilterChange("geography", e.target.value)}
+              aria-label={t("DASHBOARD_FILTERS_WARD_FILTER", "Ward filter")}
+              className="dashboard-filter-inline-select"
+            >
+              {filterOptionsLoading && geographyOptions.length <= 1 ? (
+                <option value="">{t("DASHBOARD_COMMON_LOADING", "Loading…")}</option>
+              ) : (
+                geographyOptions.map((opt) => (
+                  <option key={opt.id} value={opt.id}>
+                    {opt.label}
+                  </option>
+                ))
+              )}
+            </select>
+            <FilterChevron />
+          </div>
+        )}
 
         {complaintTypeTree ? (
           // ONE chip + traversal panel (trail, descend-in-place, "All in <X>",

--- a/digit-ui-esbuild/products/dashboard/src/components/GeographyTreeFilter.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/GeographyTreeFilter.jsx
@@ -1,0 +1,123 @@
+import React from "react";
+import useDashboardT from "../i18n/useDashboardT";
+import { dimensionLabel } from "../i18n/dimensionLabel";
+import PopoverMenu from "./ui/PopoverMenu";
+import { ComplaintTypeTreePanel } from "./ComplaintTypeTreeFilter";
+import { ALL, ancestorsOf, nodeOf } from "../utils/complaintTypeTree";
+import {
+  clearedGeographySelection,
+  geographySelectionFromCode,
+  humanizeBoundaryCode,
+} from "../utils/boundaryTree";
+
+/**
+ * The geography (ward) filter as a boundary drill-down — Província →
+ * Distrito → Município — instead of the flat ward list (CCSD-2171,
+ * "similar to complaint type dropdown"). Chip + traversal panel are the
+ * ComplaintTypeTreePanel verbatim (hierarchy-agnostic via labelFor/allLabel
+ * props); this wrapper owns only geography-specific labeling and the
+ * persisted-selection contract:
+ *
+ *   leaf (ward)          → { code, path, leaf:true }  → params.ward
+ *   interior ("All in")  → { code, path, leaf:false } → params.boundaryPath
+ *   "All wards" reset    → cleared trio
+ *
+ * Labels resolve through the same dimensionLabel("boundary") seam the flat
+ * select uses (localized boundary names), with a humanized last-segment
+ * fallback so a raw "municipio_maputo_katembe" never reaches the chip.
+ */
+
+export function boundaryDisplayLabel(tree, code) {
+  const node = nodeOf(tree, code);
+  const resolved = dimensionLabel(code, "boundary", node?.label);
+  return resolved === String(code) ? humanizeBoundaryCode(code) : resolved;
+}
+
+/** Chip content for the applied code: trailing segments + elision marker. */
+function chipModel(tree, code, allWardsLabel) {
+  const node = nodeOf(tree, code);
+  if (!node) return { segments: [allWardsLabel], elided: false, title: allWardsLabel };
+  const chain = [...ancestorsOf(tree, code), code].map((c) => boundaryDisplayLabel(tree, c));
+  const segments = chain.slice(-2);
+  return {
+    segments,
+    elided: chain.length > 2,
+    title: chain.join(" › "),
+  };
+}
+
+const GeographyTreeFilter = ({ tree, filters, onFilterChange, t: tProp }) => {
+  const { t: tHook } = useDashboardT();
+  const t = tProp || tHook;
+
+  const code = filters?.geography ?? ALL;
+  const allWardsLabel = t("DASHBOARD_FILTERS_ALL_WARDS", "All wards");
+  const { segments, elided, title } = chipModel(tree, code, allWardsLabel);
+
+  // Applies emit the selection trio through onFilterChange (leaf → ward,
+  // interior → boundaryPath); the flat fallback select's bare-string contract
+  // is untouched for tenants/failures without a tree.
+  const apply = (nextCode) => {
+    onFilterChange(
+      "geography",
+      nextCode === ALL ? clearedGeographySelection() : geographySelectionFromCode(tree, nextCode)
+    );
+  };
+
+  const chip = (
+    <span className="dashboard-popover-trigger-trail">
+      {elided && (
+        <>
+          <span className="dashboard-popover-trigger-seg dashboard-popover-trigger-seg--muted" aria-hidden>
+            …
+          </span>
+          <span className="dashboard-popover-trigger-sep" aria-hidden>
+            ›
+          </span>
+        </>
+      )}
+      {segments.map((segment, index) => (
+        <React.Fragment key={`${index}-${segment}`}>
+          {index > 0 && (
+            <span className="dashboard-popover-trigger-sep" aria-hidden>
+              ›
+            </span>
+          )}
+          <span
+            className={`dashboard-popover-trigger-seg${
+              index < segments.length - 1 ? " dashboard-popover-trigger-seg--muted" : ""
+            }`}
+          >
+            {segment}
+          </span>
+        </React.Fragment>
+      ))}
+    </span>
+  );
+
+  return (
+    <PopoverMenu
+      ariaLabel={t("DASHBOARD_FILTERS_WARD_FILTER", "Ward filter")}
+      chipTitle={title}
+      chip={chip}
+      panelWidth={288}
+    >
+      {({ close }) => (
+        <ComplaintTypeTreePanel
+          tree={tree}
+          appliedCode={code}
+          t={t}
+          labelFor={boundaryDisplayLabel}
+          allLabel={allWardsLabel}
+          allInLabel={t("DASHBOARD_GEO_FILTER_ALL_IN", "All in")}
+          onApply={(nextCode) => {
+            apply(nextCode);
+            close();
+          }}
+        />
+      )}
+    </PopoverMenu>
+  );
+};
+
+export default GeographyTreeFilter;

--- a/digit-ui-esbuild/products/dashboard/src/config/globalFilterGroups.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/globalFilterGroups.js
@@ -5,6 +5,11 @@ import {
   repairSelection,
 } from "../utils/complaintTypeTree";
 import {
+  clearedGeographySelection,
+  normalizeGeographyValue,
+  repairGeographySelection,
+} from "../utils/boundaryTree";
+import {
   DEFAULT_TIME_ZONE,
   isValidTimeZone,
   oneMonthEarlierYMD,
@@ -110,6 +115,13 @@ export function buildDefaultFilters(timeZone) {
   // (leaf → serviceCode, interior → complaintPath).
   defaults.complaintTypePath = null;
   defaults.complaintTypeLeaf = false;
+  // Geography drill-down companions (CCSD-2171), same contract: `geography`
+  // stays the selected node's code ("all" = cleared, back-compat with every
+  // consumer); path + leaf make the selection self-describing so the very
+  // first batch already sends the right param (leaf → ward, interior →
+  // boundaryPath).
+  defaults.geographyPath = null;
+  defaults.geographyLeaf = false;
   return defaults;
 }
 
@@ -154,8 +166,8 @@ export function sanitizeFilters(raw, dynamicOptions = {}, timeZone) {
     if (field.type === "date" && isValidISODate(value)) {
       next[field.id] = value;
     }
-    // complaintType is a tree node, not a flat option — handled below.
-    if (field.type === "select" && field.id !== "complaintType") {
+    // complaintType and geography are tree node selections — handled below.
+    if (field.type === "select" && field.id !== "complaintType" && field.id !== "geography") {
       const fieldOptions = options[field.id] ?? field.options;
       if (fieldOptions.some((opt) => opt.id === value)) {
         next[field.id] = value;
@@ -164,6 +176,7 @@ export function sanitizeFilters(raw, dynamicOptions = {}, timeZone) {
   }
 
   Object.assign(next, sanitizeComplaintTypeSelection(raw, options));
+  Object.assign(next, sanitizeGeographySelection(raw, options));
 
   if (["daily", "weekly", "monthly", "wow", "mom"].includes(raw.timeWindow)) {
     next.timeWindow = raw.timeWindow;
@@ -192,6 +205,36 @@ export function sanitizeFilters(raw, dynamicOptions = {}, timeZone) {
  *   persisted trio and let reconcileFiltersWithOptions repair it when the
  *   tree arrives — clearing here would forget the selection on every reload.
  */
+/**
+ * Sanitize/repair the geography node selection ({ geography, geographyPath,
+ * geographyLeaf }) — sanitizeComplaintTypeSelection's rules verbatim on the
+ * boundary tree (options.geographyTree as the authority; flat scoped ward
+ * list validates leaves only, interior selections HELD through tree-fetch
+ * hiccups; no options at all → trust the persisted trio).
+ */
+function sanitizeGeographySelection(raw, options) {
+  const stored = normalizeGeographyValue({
+    code: raw.geography,
+    path: raw.geographyPath,
+    leaf: raw.geographyLeaf,
+  });
+  let selection = stored;
+
+  if (options.geographyTree) {
+    selection = repairGeographySelection(options.geographyTree, stored);
+  } else if (options.geography && stored.leaf) {
+    selection = options.geography.some((opt) => opt.id === stored.code)
+      ? stored
+      : clearedGeographySelection();
+  }
+
+  return {
+    geography: selection.code,
+    geographyPath: selection.path,
+    geographyLeaf: selection.leaf,
+  };
+}
+
 function sanitizeComplaintTypeSelection(raw, options) {
   const stored = normalizeComplaintTypeValue({
     code: raw.complaintType,

--- a/digit-ui-esbuild/products/dashboard/src/hooks/useDashboardFilters.js
+++ b/digit-ui-esbuild/products/dashboard/src/hooks/useDashboardFilters.js
@@ -7,6 +7,7 @@ import {
   resolveSubMetricId as resolveSubMetricIdForMetric,
 } from "../config/dashboardFilters";
 import { normalizeComplaintTypeValue } from "../utils/complaintTypeTree";
+import { normalizeGeographyValue } from "../utils/boundaryTree";
 import { buildDefaultFilters } from "../config/globalFilterGroups";
 
 /** `timeZone` is the already-resolved dashboard config zone (see AdminDashboard). */
@@ -35,7 +36,20 @@ export function useDashboardFilters({ persistent = true, timeZone } = {}) {
     (groupId, value) => {
       setFilters((prev) => {
         let next;
-        if (groupId === "complaintType") {
+        if (groupId === "geography") {
+          // Geography drill-down (CCSD-2171): the tree widget sends the
+          // { code, path, leaf } node selection; the flat fallback select
+          // still sends a bare ward-code string. Persist the trio atomically
+          // so leaf → ward / interior → boundaryPath resolves without
+          // waiting for the boundary tree.
+          const selection = normalizeGeographyValue(value);
+          next = {
+            ...prev,
+            geography: selection.code,
+            geographyPath: selection.path,
+            geographyLeaf: selection.leaf,
+          };
+        } else if (groupId === "complaintType") {
           // Tree-traversal type filter: the widget sends the { code, path,
           // leaf } node selection (APPLY-ON-SELECT); the flat fallback select
           // still sends a bare leaf-code string. Persist the trio atomically

--- a/digit-ui-esbuild/products/dashboard/src/hooks/useFilterOptions.js
+++ b/digit-ui-esbuild/products/dashboard/src/hooks/useFilterOptions.js
@@ -4,10 +4,12 @@ import {
   buildComplaintTypeIndex,
   fetchComplaintHierarchyRecords,
 } from "../services/complaintHierarchyService";
+import { fetchBoundaryTreeRoots } from "../services/boundaryHierarchyService";
 import {
   buildComplaintTree,
   pruneComplaintTree,
 } from "../utils/complaintTypeTree";
+import { buildBoundaryTree, pruneBoundaryTree } from "../utils/boundaryTree";
 import { dimensionLabel } from "../i18n/dimensionLabel";
 import useDashboardT from "../i18n/useDashboardT";
 import {
@@ -99,28 +101,32 @@ function toComplaintTypeDecorator(hierarchyIndex) {
 export function useFilterOptions({ enabled = true } = {}) {
   // Raw fetch payload and derived labels are split so a language switch
   // re-labels from the cached rows without re-querying the backend.
-  const [raw, setRaw] = useState({ results: null, hierarchyRecords: null, loading: true });
+  const [raw, setRaw] = useState({
+    results: null, hierarchyRecords: null, boundaryRoots: null, loading: true,
+  });
   const { language, i18nTick } = useDashboardT();
 
   useEffect(() => {
     if (!enabled) {
-      setRaw({ results: null, hierarchyRecords: null, loading: false });
+      setRaw({ results: null, hierarchyRecords: null, boundaryRoots: null, loading: false });
       return undefined;
     }
     let cancelled = false;
     Promise.all([
       runBatchQueries(OPTION_QUERIES),
-      // Resolves null on any failure (never rejects) — labels then fall back
-      // to the humanizer and the list stays flat, exactly the old behavior.
+      // Both hierarchy fetches resolve null on any failure (never reject) —
+      // labels then fall back to the humanizer and the affected filter stays
+      // flat, exactly the old behavior.
       fetchComplaintHierarchyRecords(),
+      fetchBoundaryTreeRoots(),
     ])
-      .then(([res, hierarchyRecords]) => {
+      .then(([res, hierarchyRecords, boundaryRoots]) => {
         if (cancelled) return;
-        setRaw({ results: res?.results || {}, hierarchyRecords, loading: false });
+        setRaw({ results: res?.results || {}, hierarchyRecords, boundaryRoots, loading: false });
       })
       .catch(() => {
         // Never block the dashboard — the selects keep their placeholder lists.
-        if (!cancelled) setRaw({ results: null, hierarchyRecords: null, loading: false });
+        if (!cancelled) setRaw({ results: null, hierarchyRecords: null, boundaryRoots: null, loading: false });
       });
     return () => {
       cancelled = true;
@@ -157,10 +163,22 @@ export function useFilterOptions({ enabled = true } = {}) {
       buildComplaintTree(raw.hierarchyRecords),
       scopedLeafCodes
     );
+    // Geography drill-down (CCSD-2171): the boundary-relationships tree
+    // intersected with the same ABAC-scoped DISTINCT ward_code list the flat
+    // select is built from. Either input missing → null, and the filter
+    // degrades to the flat ward select — the complaint-type pattern verbatim.
+    const scopedWardCodes = (raw.results.wards?.rows || [])
+      .map((row) => String(row?.ward_code ?? "").trim())
+      .filter(Boolean);
+    const geographyTree = pruneBoundaryTree(
+      buildBoundaryTree(raw.boundaryRoots),
+      scopedWardCodes
+    );
     const options = {
       ...(geography && { geography }),
       ...(complaintType && { complaintType }),
       ...(complaintTypeTree && { complaintTypeTree }),
+      ...(geographyTree && { geographyTree }),
     };
     return {
       options: Object.keys(options).length ? options : null,

--- a/digit-ui-esbuild/products/dashboard/src/services/boundaryHierarchyService.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/boundaryHierarchyService.js
@@ -1,0 +1,83 @@
+import { authFetch, buildRequestInfo, getTenantId, hasAuth } from "./authService";
+import { withTraceHeaders } from "./dashboardMetrics";
+
+/**
+ * Boundary-hierarchy fetch for the geography drill-down filter (CCSD-2171).
+ *
+ * Returns the boundary-relationships root nodes (nested { code, boundaryType,
+ * children } — the input buildBoundaryTree expects), or null on ANY failure
+ * (never rejects): no auth, no hierarchy type resolvable, HTTP error, empty
+ * tree. Callers fall back to the flat ward select, exactly like the
+ * complaint-type tree's degrade path.
+ *
+ * The hierarchy type comes from the deployment's HIERARCHY_TYPE globalConfig
+ * (the same pin the PGR employee pages use — mz: "divisao_administrativa").
+ * When unset, it is discovered from boundary-hierarchy-definition/_search
+ * (first definition at the tenant), so flat/default deployments still work
+ * without config.
+ */
+
+function getConfiguredHierarchyType() {
+  const get = window.globalConfigs?.getConfig?.bind(window.globalConfigs);
+  const pin = get?.("HIERARCHY_TYPE");
+  return typeof pin === "string" && pin.trim() ? pin.trim() : null;
+}
+
+async function discoverHierarchyType(tenantId) {
+  try {
+    const response = await authFetch(
+      `/boundary-service/boundary-hierarchy-definition/_search`,
+      {
+        headers: withTraceHeaders({}),
+        // authFetch's contract is buildBody (re-invoked with a FRESH
+        // RequestInfo on 401-refresh replays) — a plain `body` is ignored.
+        buildBody: () => ({
+          RequestInfo: buildRequestInfo("dashboard-boundary"),
+          BoundaryTypeHierarchySearchCriteria: { tenantId },
+        }),
+        sessionCritical: false,
+      }
+    );
+    if (!response.ok) return null;
+    const payload = await response.json();
+    const first = payload?.BoundaryHierarchy?.[0]?.hierarchyType;
+    return typeof first === "string" && first.trim() ? first.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Fetch the full relationships tree for the tenant's hierarchy. */
+export async function fetchBoundaryTreeRoots() {
+  if (!hasAuth()) return null;
+  try {
+    const tenantId = getTenantId();
+    const hierarchyType =
+      getConfiguredHierarchyType() || (await discoverHierarchyType(tenantId));
+    if (!hierarchyType) return null;
+
+    const params = new URLSearchParams({
+      tenantId,
+      hierarchyType,
+      includeChildren: "true",
+    });
+    const response = await authFetch(
+      `/boundary-service/boundary-relationships/_search?${params}`,
+      {
+        headers: withTraceHeaders({}),
+        buildBody: () => ({ RequestInfo: buildRequestInfo("dashboard-boundary") }),
+        sessionCritical: false,
+      }
+    );
+    if (!response.ok) {
+      console.warn(`boundary-relationships _search failed (${response.status})`);
+      return null;
+    }
+    const payload = await response.json();
+    const roots = payload?.TenantBoundary?.[0]?.boundary;
+    return Array.isArray(roots) && roots.length ? roots : null;
+  } catch (error) {
+    console.warn("boundary-relationships _search error", error);
+    return null;
+  }
+}

--- a/digit-ui-esbuild/products/dashboard/src/utils/boundaryTree.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/boundaryTree.js
@@ -1,0 +1,222 @@
+import { ALL } from "./complaintTypeTree";
+
+/**
+ * Boundary (geography) tree helpers for the drill-down ward filter
+ * (CCSD-2171: Província → Distrito → Município instead of a flat ward list).
+ *
+ * Mirrors utils/complaintTypeTree.js on the boundary hierarchy. The tree
+ * shape is identical ({ byCode: Map, roots: node[] }, nodes carrying
+ * { code, path, parentCode, children, isLeaf }), so ALL of that module's
+ * traversal helpers (nodeOf / childrenOf / ancestorsOf / browseBaseCode /
+ * truncateTrail) work on this tree unchanged — only building, pruning and
+ * the selection→params mapping are boundary-specific:
+ *
+ *   - paths are PIPE-joined root-down code chains ("maputo_cidade|katembe|
+ *     municipio_maputo_katembe"), matching the analytics MV's boundary_path
+ *     column byte-for-byte (ancestralmaterializedpath || '|' || code — the
+ *     boundary-service relationships response is the same root-down chain,
+ *     verified live on cms-pilot against the facts grain);
+ *   - leaf (ward) selections keep today's wire shape (params.ward, exact
+ *     ward_code match — works on every backend); interior selections send
+ *     params.boundaryPath (subtree filter; backends without the param
+ *     silently ignore it, so the dashboard degrades to unfiltered for that
+ *     selection rather than erroring — the complaintPath precedent).
+ */
+
+/** The cleared geography selection trio ({ code, path, leaf }). */
+export function clearedGeographySelection() {
+  return { code: ALL, path: null, leaf: false };
+}
+
+/**
+ * Build the boundary tree from the boundary-relationships response's nested
+ * TenantBoundary[].boundary nodes ({ code, boundaryType, children: [...] }).
+ * Paths are derived root-down as pipe-joined code chains. Labels are left
+ * undefined — boundary display names live in localization (t(code), the
+ * same seam the flat ward list uses via dimensionLabel).
+ */
+export function buildBoundaryTree(rootNodes) {
+  const byCode = new Map();
+  const roots = [];
+
+  const walk = (raw, parent) => {
+    const code = String(raw?.code ?? "").trim();
+    if (!code || byCode.has(code)) return null; // dupes: first (shallowest) wins
+    const node = {
+      code,
+      boundaryType: String(raw?.boundaryType ?? "").trim() || undefined,
+      label: undefined,
+      path: parent ? `${parent.path}|${code}` : code,
+      parentCode: parent ? parent.code : null,
+      children: [],
+      isLeaf: true,
+    };
+    byCode.set(code, node);
+    for (const childRaw of Array.isArray(raw?.children) ? raw.children : []) {
+      const child = walk(childRaw, node);
+      if (child) {
+        node.children.push(child);
+        node.isLeaf = false;
+      }
+    }
+    return node;
+  };
+
+  for (const raw of Array.isArray(rootNodes) ? rootNodes : []) {
+    const root = walk(raw, null);
+    if (root) roots.push(root);
+  }
+  return byCode.size ? { byCode, roots } : null;
+}
+
+/**
+ * ABAC/data pruning — the complaint-tree rule verbatim: intersect the full
+ * boundary tree with the scoped DISTINCT ward_code list (the same analytics
+ * distinct the flat select is built from, so the server's row-scope applies).
+ * A node survives iff its own code is scoped OR a descendant survives.
+ * Scoped ward codes with no boundary record (stray/QA rows — visible in
+ * today's flat select) are attached as root-level leaves so no currently
+ * selectable ward is lost. Returns a NEW pruned tree or null (callers fall
+ * back to the flat select).
+ */
+export function pruneBoundaryTree(tree, scopedWardCodes) {
+  if (!tree) return null;
+  const scoped = new Set(
+    (Array.isArray(scopedWardCodes) ? scopedWardCodes : [...(scopedWardCodes || [])])
+      .map((c) => String(c ?? "").trim())
+      .filter(Boolean)
+  );
+  if (!scoped.size) return null;
+
+  const byCode = new Map();
+  const pruneNode = (node) => {
+    const children = node.children.map(pruneNode).filter(Boolean);
+    if (!children.length && !scoped.has(node.code)) return null;
+    const copy = { ...node, children, isLeaf: !children.length };
+    byCode.set(copy.code, copy);
+    return copy;
+  };
+  const roots = tree.roots.map(pruneNode).filter(Boolean);
+
+  for (const code of scoped) {
+    if (byCode.has(code)) continue;
+    const stray = {
+      code,
+      label: undefined,
+      path: code,
+      parentCode: null,
+      children: [],
+      isLeaf: true,
+    };
+    byCode.set(code, stray);
+    roots.push(stray);
+  }
+
+  return roots.length ? { byCode, roots } : null;
+}
+
+/** The persisted selection trio for applying a boundary node. */
+export function geographySelectionFromCode(tree, code) {
+  if (code == null || code === ALL) return clearedGeographySelection();
+  const node = tree?.byCode?.get(String(code)) || null;
+  if (!node) return clearedGeographySelection();
+  return { code: node.code, path: node.path, leaf: node.isLeaf };
+}
+
+/**
+ * The backend's boundaryPath validation (KpiQueryComposer): the complaint
+ * path alphabet plus '|' (the boundary_path segment delimiter), max 512.
+ * Sanitize CLIENT-side for the same reason as complaintPath — a per-entry
+ * invalid_param 400 would blank every tile over one exotic boundary code.
+ */
+const BOUNDARY_PATH_RE = /^[A-Za-z0-9._/|-]{1,512}$/;
+
+export function isValidBoundaryPath(path) {
+  return typeof path === "string" && BOUNDARY_PATH_RE.test(path);
+}
+
+/**
+ * Selection → KpiQueryComposer params:
+ *   root     → {}                   (filter cleared)
+ *   leaf     → { ward }             (exact ward_code match — today's wire
+ *               shape unchanged, works on every grain and every backend)
+ *   interior → { boundaryPath }     (the node's pipe-path; subtree match on
+ *               boundary_path. Backends without the param ignore it — the
+ *               dashboard degrades to unfiltered, never an error.)
+ * Legacy persisted string-only state (leaf flag undefined) behaves exactly
+ * like today: leaf ward.
+ */
+export function geographyParams(selection) {
+  const code = selection?.code;
+  if (!code || code === ALL) return {};
+  if (selection.leaf === false && selection.path) {
+    const path = String(selection.path);
+    return isValidBoundaryPath(path) ? { boundaryPath: path } : {};
+  }
+  return { ward: String(code) };
+}
+
+/**
+ * Repair a persisted geography selection against the (pruned) tree: exact
+ * node wins; a vanished node walks UP its stored pipe-path to the nearest
+ * surviving ancestor; nothing valid → cleared. Path-prefix matching (never
+ * segment splitting) for the same reason as the complaint tree — codes are
+ * matched at pipe boundaries only.
+ */
+export function repairGeographySelection(tree, selection) {
+  const code = String(selection?.code ?? "").trim();
+  if (!code || code === ALL) return clearedGeographySelection();
+  if (!tree) return clearedGeographySelection();
+  if (tree.byCode.has(code)) return geographySelectionFromCode(tree, code);
+
+  const path = String(selection?.path ?? "").trim();
+  if (path) {
+    let ancestor = null;
+    for (const node of tree.byCode.values()) {
+      const nodePath = String(node.path ?? "");
+      if (!nodePath || (nodePath !== path && !path.startsWith(`${nodePath}|`))) continue;
+      if (!ancestor || nodePath.length > String(ancestor.path).length) ancestor = node;
+    }
+    if (ancestor) return geographySelectionFromCode(tree, ancestor.code);
+  }
+  return clearedGeographySelection();
+}
+
+/**
+ * Normalise a filter-change value into the persisted trio. The tree widget
+ * sends the trio; the flat fallback <select> sends a bare ward-code string —
+ * exactly today's contract ("all" clears).
+ */
+export function normalizeGeographyValue(value) {
+  if (value && typeof value === "object") {
+    const code = String(value.code ?? "").trim() || ALL;
+    if (code === ALL) return clearedGeographySelection();
+    return {
+      code,
+      path: value.path != null ? String(value.path) : null,
+      leaf: value.leaf !== false,
+    };
+  }
+  const code = String(value ?? "").trim();
+  if (!code || code === ALL) return clearedGeographySelection();
+  return { code, path: null, leaf: true };
+}
+
+/**
+ * Humanised fallback for boundary codes with no localization message
+ * ("municipio_maputo_katembe" → "Municipio Maputo Katembe"). Display-only;
+ * params always carry the raw code/path.
+ */
+export function humanizeBoundaryCode(code) {
+  const raw = String(code ?? "").trim();
+  if (!raw) return raw;
+  const last = raw.split("|").pop();
+  return last
+    .replace(/[_\-./]+/g, " ")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .trim()
+    .replace(/\s+/g, " ")
+    .split(" ")
+    .map((w) => (w ? w[0].toUpperCase() + w.slice(1) : w))
+    .join(" ");
+}

--- a/digit-ui-esbuild/products/dashboard/src/utils/boundaryTree.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/boundaryTree.test.js
@@ -1,0 +1,193 @@
+// Unit tests for the geography drill-down filter state (CCSD-2171):
+// boundary tree build (pipe paths matching the analytics MV), ABAC pruning,
+// selection→params (leaf ward / interior boundaryPath), repair, normalize.
+// Run from digit-ui-esbuild/:  node --test products/dashboard/src/utils/boundaryTree.test.js
+//
+// Same ESM→CJS esbuild bundling idiom as complaintTypeTree.test.js.
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const esbuild = require("esbuild");
+
+function bundle(entry) {
+  const out = path.join(
+    os.tmpdir(),
+    `${path.basename(entry, ".js")}.cjs.${process.pid}.js`
+  );
+  esbuild.buildSync({
+    entryPoints: [path.join(__dirname, entry)],
+    bundle: true,
+    format: "cjs",
+    platform: "neutral",
+    outfile: out,
+  });
+  process.on("exit", () => {
+    try {
+      fs.unlinkSync(out);
+    } catch (e) {
+      /* already gone */
+    }
+  });
+  return require(out);
+}
+
+const {
+  buildBoundaryTree,
+  pruneBoundaryTree,
+  geographySelectionFromCode,
+  clearedGeographySelection,
+  geographyParams,
+  isValidBoundaryPath,
+  repairGeographySelection,
+  normalizeGeographyValue,
+  humanizeBoundaryCode,
+} = bundle("boundaryTree.js");
+
+// The live cms-pilot shape: Provincia roots (no country node), 3 levels —
+// exactly what boundary-relationships/_search?includeChildren=true returns.
+const API_ROOTS = [
+  {
+    code: "maputo_cidade",
+    boundaryType: "Provincia",
+    children: [
+      {
+        code: "katembe",
+        boundaryType: "Distrito",
+        children: [
+          { code: "municipio_maputo_katembe", boundaryType: "Municipio", children: [] },
+        ],
+      },
+      {
+        code: "kanyaka",
+        boundaryType: "Distrito",
+        children: [
+          { code: "municipio_maputo_kanyaka", boundaryType: "Municipio", children: [] },
+        ],
+      },
+    ],
+  },
+  {
+    code: "PROVINCIA_001",
+    boundaryType: "Provincia",
+    children: [
+      {
+        code: "DISTRITO_001",
+        boundaryType: "Distrito",
+        children: [{ code: "MUNICIPIO_001", boundaryType: "Municipio", children: [] }],
+      },
+    ],
+  },
+];
+
+test("buildBoundaryTree derives pipe paths matching the analytics MV boundary_path", () => {
+  const tree = buildBoundaryTree(API_ROOTS);
+  assert.equal(tree.roots.length, 2);
+  // Verified live: facts boundary_path = "maputo_cidade|kanyaka|municipio_maputo_kanyaka"
+  assert.equal(
+    tree.byCode.get("municipio_maputo_kanyaka").path,
+    "maputo_cidade|kanyaka|municipio_maputo_kanyaka"
+  );
+  assert.equal(tree.byCode.get("katembe").path, "maputo_cidade|katembe");
+  assert.equal(tree.byCode.get("maputo_cidade").isLeaf, false);
+  assert.equal(tree.byCode.get("MUNICIPIO_001").isLeaf, true);
+});
+
+test("buildBoundaryTree handles empty/missing input", () => {
+  assert.equal(buildBoundaryTree(null), null);
+  assert.equal(buildBoundaryTree([]), null);
+});
+
+test("pruneBoundaryTree keeps only branches with scoped wards, attaches strays", () => {
+  const tree = buildBoundaryTree(API_ROOTS);
+  const pruned = pruneBoundaryTree(tree, ["municipio_maputo_katembe", "stray_ward"]);
+  // katembe branch survives, kanyaka + the QA province do not
+  assert.ok(pruned.byCode.has("maputo_cidade"));
+  assert.ok(pruned.byCode.has("katembe"));
+  assert.ok(pruned.byCode.has("municipio_maputo_katembe"));
+  assert.ok(!pruned.byCode.has("kanyaka"));
+  assert.ok(!pruned.byCode.has("PROVINCIA_001"));
+  // scoped ward with no boundary record → root-level leaf, never lost
+  assert.ok(pruned.byCode.has("stray_ward"));
+  assert.equal(pruned.byCode.get("stray_ward").parentCode, null);
+  // pruning never mutates the input
+  assert.ok(tree.byCode.has("kanyaka"));
+});
+
+test("pruneBoundaryTree with no scoped wards / no tree → null (flat fallback)", () => {
+  const tree = buildBoundaryTree(API_ROOTS);
+  assert.equal(pruneBoundaryTree(tree, []), null);
+  assert.equal(pruneBoundaryTree(null, ["x"]), null);
+});
+
+test("geographyParams: leaf → ward (today's wire shape), interior → boundaryPath", () => {
+  const tree = buildBoundaryTree(API_ROOTS);
+  const leaf = geographySelectionFromCode(tree, "municipio_maputo_katembe");
+  assert.deepEqual(geographyParams(leaf), { ward: "municipio_maputo_katembe" });
+
+  const interior = geographySelectionFromCode(tree, "katembe");
+  assert.deepEqual(geographyParams(interior), { boundaryPath: "maputo_cidade|katembe" });
+
+  assert.deepEqual(geographyParams(clearedGeographySelection()), {});
+  // legacy persisted string-only state (leaf flag undefined) → leaf ward
+  assert.deepEqual(geographyParams({ code: "w1" }), { ward: "w1" });
+});
+
+test("interior path failing backend validation is NOT sent (unfiltered beats 400)", () => {
+  assert.deepEqual(
+    geographyParams({ code: "x", path: "bad path with spaces", leaf: false }),
+    {}
+  );
+});
+
+test("isValidBoundaryPath accepts pipe paths, rejects SQL-ish garbage", () => {
+  assert.ok(isValidBoundaryPath("maputo_cidade|katembe|municipio_maputo_katembe"));
+  assert.ok(isValidBoundaryPath("mz"));
+  for (const bad of ["a b", "x%y", "a;b", "x'y", "", null, "a".repeat(513)]) {
+    assert.equal(isValidBoundaryPath(bad), false, String(bad));
+  }
+});
+
+test("repairGeographySelection: exact wins, vanished walks up pipe path, else cleared", () => {
+  const tree = buildBoundaryTree(API_ROOTS);
+  const pruned = pruneBoundaryTree(tree, ["municipio_maputo_katembe"]);
+
+  // exact node survives
+  assert.equal(
+    repairGeographySelection(pruned, { code: "katembe", path: "maputo_cidade|katembe" }).code,
+    "katembe"
+  );
+  // vanished ward (kanyaka pruned) → nearest surviving ancestor by pipe-prefix
+  const repaired = repairGeographySelection(pruned, {
+    code: "municipio_maputo_kanyaka",
+    path: "maputo_cidade|kanyaka|municipio_maputo_kanyaka",
+  });
+  assert.equal(repaired.code, "maputo_cidade");
+  // nothing valid → cleared
+  assert.equal(
+    repairGeographySelection(pruned, { code: "ghost", path: "other|ghost" }).code,
+    "all"
+  );
+  // "all" / no tree → cleared, never throws
+  assert.equal(repairGeographySelection(pruned, { code: "all" }).code, "all");
+  assert.equal(repairGeographySelection(null, { code: "katembe" }).code, "all");
+});
+
+test("normalizeGeographyValue: trio object, legacy bare string, cleared", () => {
+  assert.deepEqual(normalizeGeographyValue("w1"), { code: "w1", path: null, leaf: true });
+  assert.deepEqual(normalizeGeographyValue("all"), clearedGeographySelection());
+  assert.deepEqual(normalizeGeographyValue(null), clearedGeographySelection());
+  assert.deepEqual(
+    normalizeGeographyValue({ code: "katembe", path: "maputo_cidade|katembe", leaf: false }),
+    { code: "katembe", path: "maputo_cidade|katembe", leaf: false }
+  );
+  assert.deepEqual(normalizeGeographyValue({ code: "all" }), clearedGeographySelection());
+});
+
+test("humanizeBoundaryCode never surfaces raw underscores/pipes", () => {
+  assert.equal(humanizeBoundaryCode("municipio_maputo_katembe"), "Municipio Maputo Katembe");
+  assert.equal(humanizeBoundaryCode("a|b|distrito_x"), "Distrito X");
+  assert.equal(humanizeBoundaryCode(""), "");
+});

--- a/digit-ui-esbuild/products/dashboard/src/utils/queryPlan.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/queryPlan.js
@@ -1,5 +1,6 @@
 import { appliedHierLevel } from "./hierLevelGrouping";
 import { complaintTypeParams } from "./complaintTypeTree";
+import { geographyParams } from "./boundaryTree";
 
 /**
  * Query-plan helpers for the catalog dashboard (extracted from
@@ -81,9 +82,19 @@ export function isMapKind(kind) {
  */
 export function globalParams(filters) {
   const params = {};
-  if (filters?.geography && filters.geography !== "all") {
-    params.ward = filters.geography;
-  }
+  // Geography node selection (CCSD-2171): leaf ward → ward (exact ward_code,
+  // today's wire shape), interior province/district → boundaryPath (subtree
+  // on boundary_path; pre-boundaryPath backends ignore the unknown param, so
+  // interior selections degrade to unfiltered, never an error). Legacy
+  // string-only persisted state (no path/leaf) behaves exactly like today.
+  Object.assign(
+    params,
+    geographyParams({
+      code: filters?.geography,
+      path: filters?.geographyPath,
+      leaf: filters?.geographyLeaf,
+    })
+  );
   Object.assign(
     params,
     complaintTypeParams({

--- a/local-setup/db/dss-mdms-seed/l10n/en_IN.json
+++ b/local-setup/db/dss-mdms-seed/l10n/en_IN.json
@@ -1215,6 +1215,11 @@
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "DASHBOARD_GEO_FILTER_ALL_IN",
+    "message": "All in",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "DASHBOARD_TYPE_FILTER_NOT_APPLIED",
     "message": "Type filter not applied",
     "module": "rainmaker-dashboard"

--- a/local-setup/db/dss-mdms-seed/l10n/pt_PT.json
+++ b/local-setup/db/dss-mdms-seed/l10n/pt_PT.json
@@ -1215,6 +1215,11 @@
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "DASHBOARD_GEO_FILTER_ALL_IN",
+    "message": "Tudo em",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "DASHBOARD_TYPE_FILTER_NOT_APPLIED",
     "message": "Filtro de tipo não aplicado",
     "module": "rainmaker-dashboard"


### PR DESCRIPTION
Jira: [CCSD-2171](https://digit-discuss.atlassian.net/browse/CCSD-2171)

#1762 and #1763 were merged 4 seconds apart — #1763 (the FE, stacked on #1762) merged into its original base branch before GitHub retargeted it to `release-v2.12-moz`. Result: the backend `boundaryPath` param is on moz (`943c42de`, image building), but the FE drill-down commit (`45ee087a`) is stranded on the feature branch.

This PR merges the feature branch (now backend + FE) into moz. The backend commit is already on moz, so the effective delta is exactly the reviewed-and-approved #1763 content — nothing new.

Merge this before rebuilding digit-ui on cms-pilot, or the bundle won't contain the drill-down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CCSD-2171]: https://digit-discuss.atlassian.net/browse/CCSD-2171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ