### PR TITLE
[Dashboard] Restore table KPI contracts and recurring trends (#1760)

### DIFF
--- a/ansible/nairobi-mdms/mdms/dss/KpiDefinition.json
+++ b/ansible/nairobi-mdms/mdms/dss/KpiDefinition.json
@@ -2927,15 +2927,15 @@
       "id": "cl_table_ward_performance",
       "viz": {
         "pii": false,
-        "kind": "rankedList",
+        "kind": "table",
         "group": "complaint-landscape",
         "title": "Ward performance",
         "accent": "teal",
         "format": "integer",
         "columns": [
           {
-            "id": "wardLabel",
-            "type": "text",
+            "id": "ward_code",
+            "type": "dimension",
             "align": "left",
             "label": "Ward",
             "width": "24%"
@@ -2955,21 +2955,21 @@
             "width": "14%"
           },
           {
-            "id": "reopenRate",
+            "id": "reopen_rate",
             "type": "percent",
             "align": "left",
             "label": "Reopen %",
             "width": "16%"
           },
           {
-            "id": "ontimeRate",
+            "id": "ontime_rate",
             "type": "percent",
             "align": "left",
             "label": "On-time %",
             "width": "16%"
           },
           {
-            "id": "avgCsat",
+            "id": "avg_csat",
             "type": "rating",
             "align": "left",
             "label": "CSAT",
@@ -2988,8 +2988,7 @@
           "ontime_rate",
           "avg_csat"
         ],
-        "dimensionKey": "ward_code",
-        "tableProfile": "wardPerformance"
+        "dimensionKey": "ward_code"
       },
       "rbac": {
         "visibleTo": [
@@ -3012,6 +3011,13 @@
             "name": "created"
           },
           {
+            "agg": "count",
+            "name": "open",
+            "filter": {
+              "is_open": true
+            }
+          },
+          {
             "agg": "ratio",
             "name": "reopen_rate",
             "numerator": {
@@ -3019,18 +3025,12 @@
               "filter": {
                 "is_reopened": true,
                 "is_resolved": true
-              },
-              "window": {
-                "timeRole": "resolved_at"
               }
             },
             "denominator": {
               "agg": "count",
               "filter": {
                 "is_resolved": true
-              },
-              "window": {
-                "timeRole": "resolved_at"
               }
             }
           },
@@ -3042,18 +3042,12 @@
               "filter": {
                 "is_resolved": true,
                 "sla_breached": false
-              },
-              "window": {
-                "timeRole": "resolved_at"
               }
             },
             "denominator": {
               "agg": "count",
               "filter": {
                 "is_resolved": true
-              },
-              "window": {
-                "timeRole": "resolved_at"
               }
             }
           },
@@ -3064,9 +3058,6 @@
             "filter": {
               "has_rating": true,
               "is_resolved": true
-            },
-            "window": {
-              "timeRole": "resolved_at"
             }
           }
         ],
@@ -3088,7 +3079,7 @@
         }
       ],
       "status": "published",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "supportsSeries": false
     }
   },
@@ -3159,15 +3150,15 @@
       "id": "cl_table_service_quality_by_channel",
       "viz": {
         "pii": false,
-        "kind": "rankedList",
+        "kind": "table",
         "group": "complaint-landscape",
         "title": "Service quality by channel",
         "accent": "teal",
         "format": "integer",
         "columns": [
           {
-            "id": "channelLabel",
-            "type": "text",
+            "id": "source",
+            "type": "dimension",
             "align": "left",
             "label": "Channel",
             "width": "28%"
@@ -3180,14 +3171,14 @@
             "width": "20%"
           },
           {
-            "id": "resolutionRate",
+            "id": "resolution_rate",
             "type": "percent",
             "align": "left",
             "label": "Resolution",
             "width": "26%"
           },
           {
-            "id": "avgCsat",
+            "id": "avg_csat",
             "type": "rating",
             "align": "left",
             "label": "CSAT",
@@ -3201,11 +3192,10 @@
         "valueKey": "volume",
         "measureKeys": [
           "volume",
-          "resolved",
+          "resolution_rate",
           "avg_csat"
         ],
-        "dimensionKey": "source",
-        "tableProfile": "serviceQualityByChannel"
+        "dimensionKey": "source"
       },
       "rbac": {
         "visibleTo": [
@@ -3228,14 +3218,17 @@
             "name": "volume"
           },
           {
-            "agg": "count",
-            "name": "resolved",
-            "filter": {
-              "is_open": false,
-              "is_resolved": true
+            "agg": "ratio",
+            "name": "resolution_rate",
+            "numerator": {
+              "agg": "count",
+              "filter": {
+                "is_open": false,
+                "is_resolved": true
+              }
             },
-            "window": {
-              "timeRole": "resolved_at"
+            "denominator": {
+              "agg": "count"
             }
           },
           {
@@ -3245,9 +3238,6 @@
             "filter": {
               "has_rating": true,
               "is_resolved": true
-            },
-            "window": {
-              "timeRole": "resolved_at"
             }
           }
         ],
@@ -3269,7 +3259,7 @@
         }
       ],
       "status": "published",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "supportsSeries": false
     }
   },
@@ -3404,22 +3394,22 @@
       "id": "cl_table_recurring_ward_subtype",
       "viz": {
         "pii": false,
-        "kind": "rankedList",
+        "kind": "table",
         "group": "complaint-landscape",
         "title": "Recurring complaints by ward & sub-type",
         "accent": "teal",
         "format": "integer",
         "columns": [
           {
-            "id": "wardLabel",
-            "type": "text",
+            "id": "ward_code",
+            "type": "dimension",
             "align": "left",
             "label": "Ward",
             "width": "28%"
           },
           {
-            "id": "subtypeLabel",
-            "type": "text",
+            "id": "service_code",
+            "type": "dimension",
             "align": "left",
             "label": "Sub-type",
             "width": "32%"
@@ -3432,7 +3422,7 @@
             "width": "18%"
           },
           {
-            "id": "trendPct",
+            "id": "trend_pct",
             "type": "trend",
             "align": "left",
             "label": "Trend",
@@ -3440,17 +3430,28 @@
           }
         ],
         "compose": null,
-        "minCount": 3,
+        "comparison": {
+          "period": "prior",
+          "mode": "percentChange",
+          "joinBy": [
+            "ward_code",
+            "service_code"
+          ],
+          "valueKey": "total",
+          "outputKey": "trend_pct"
+        },
+        "rowFilter": {
+          "column": "total",
+          "gte": 3
+        },
         "subtitle": "Ward × subtype pairs with ≥ 3 complaints in period",
         "subtitleKey": "CMS-DASHBOARD.DASHBOARD_KPI_CL_TABLE_RECURRING_WARD_SUBTYPE_SUBTITLE",
         "titleKey": "CMS-DASHBOARD.DASHBOARD_KPI_CL_TABLE_RECURRING_WARD_SUBTYPE",
         "valueKey": "total",
-        "needsPrior": true,
         "measureKeys": [
           "total"
         ],
-        "dimensionKey": "ward_code",
-        "tableProfile": "wardSubtypeRecurring"
+        "dimensionKey": "ward_code"
       },
       "rbac": {
         "visibleTo": [
@@ -3508,7 +3509,7 @@
         }
       ],
       "status": "published",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "supportsSeries": false
     }
   }

--- a/digit-mcp/package.json
+++ b/digit-mcp/package.json
@@ -38,6 +38,7 @@
     "test:cli": "tsx test-cli.ts",
     "test:openapi": "tsx test-openapi-spec.ts",
     "test:safety": "tsx test-agent-safety.ts",
+    "test:dashboard-catalog": "node --test scripts/dashboard-catalog-contract.test.mjs",
     "engram": "tsx engram-agent.ts",
     "prepublishOnly": "npm run build"
   },

--- a/digit-mcp/scripts/dashboard-catalog-contract.mjs
+++ b/digit-mcp/scripts/dashboard-catalog-contract.mjs
@@ -1,0 +1,106 @@
+const TABLE_KINDS = new Set(['table', 'data-table']);
+const FILTER_OPERATORS = ['eq', 'gte', 'gt', 'lte', 'lt'];
+const LEGACY_TABLE_KEYS = ['tableProfile', 'needsPrior', 'minCount'];
+
+function outputColumns(definition) {
+  const query = definition.query || {};
+  return new Set([
+    ...(query.dimensions || []),
+    ...(query.measures || []).map((measure) => measure?.name).filter(Boolean),
+  ]);
+}
+
+function validateTable(definition, errors) {
+  const { id, viz = {}, query } = definition;
+  for (const key of LEGACY_TABLE_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(viz, key)) {
+      errors.push(`${id}: viz.${key} is not part of the dashboard table contract`);
+    }
+  }
+
+  if (!TABLE_KINDS.has(viz.kind) || !query) return;
+
+  const available = outputColumns(definition);
+  const derived = new Set();
+  const comparison = viz.comparison;
+  if (comparison) {
+    if (comparison.period !== 'prior' || comparison.mode !== 'percentChange') {
+      errors.push(`${id}: comparison must use prior/percentChange`);
+    }
+    if (!Array.isArray(comparison.joinBy) || comparison.joinBy.length === 0) {
+      errors.push(`${id}: comparison.joinBy must contain at least one dimension`);
+    } else {
+      for (const dimension of query.dimensions || []) {
+        if (!comparison.joinBy.includes(dimension)) {
+          errors.push(`${id}: comparison.joinBy must include query dimension ${dimension}`);
+        }
+      }
+      for (const key of comparison.joinBy) {
+        if (!(query.dimensions || []).includes(key)) {
+          errors.push(`${id}: comparison join key ${key} is not a query dimension`);
+        }
+      }
+    }
+    if (!available.has(comparison.valueKey)) {
+      errors.push(`${id}: comparison valueKey ${comparison.valueKey} is not a query output`);
+    }
+    if (!comparison.outputKey || available.has(comparison.outputKey)) {
+      errors.push(`${id}: comparison.outputKey must name a new derived column`);
+    } else {
+      derived.add(comparison.outputKey);
+    }
+  }
+
+  const columns = viz.columns || [];
+  for (const column of columns) {
+    if (!available.has(column?.id) && !derived.has(column?.id)) {
+      errors.push(`${id}: table column ${column?.id} is not produced by its query or comparison`);
+    }
+  }
+
+  if (viz.valueKey && !available.has(viz.valueKey)) {
+    errors.push(`${id}: viz.valueKey ${viz.valueKey} is not produced by its query`);
+  }
+
+  const rowFilter = viz.rowFilter;
+  if (rowFilter) {
+    if (!available.has(rowFilter.column) && !derived.has(rowFilter.column)) {
+      errors.push(`${id}: rowFilter column ${rowFilter.column} is not available`);
+    }
+    const operators = FILTER_OPERATORS.filter((operator) =>
+      Object.prototype.hasOwnProperty.call(rowFilter, operator)
+    );
+    if (operators.length !== 1) {
+      errors.push(`${id}: rowFilter must declare exactly one supported operator`);
+    }
+  }
+
+  for (const measure of query.measures || []) {
+    if (measure?.window || measure?.numerator?.window || measure?.denominator?.window) {
+      errors.push(`${id}: measure-level windows are unsupported; use the query window contract`);
+    }
+  }
+}
+
+export function dashboardCatalogContractErrors(definitions) {
+  const errors = [];
+  const seen = new Set();
+  for (const definition of definitions || []) {
+    const id = definition?.id;
+    if (!id || typeof id !== 'string') {
+      errors.push('every KpiDefinition record must carry a string id');
+      continue;
+    }
+    if (seen.has(id)) errors.push(`${id}: duplicate KPI id`);
+    seen.add(id);
+    validateTable(definition, errors);
+  }
+  return errors;
+}
+
+export function assertDashboardCatalogContract(definitions) {
+  const errors = dashboardCatalogContractErrors(definitions);
+  if (errors.length) {
+    throw new Error(`Dashboard catalog contract failed:\n- ${errors.join('\n- ')}`);
+  }
+}

--- a/digit-mcp/scripts/dashboard-catalog-contract.test.mjs
+++ b/digit-mcp/scripts/dashboard-catalog-contract.test.mjs
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  assertDashboardCatalogContract,
+  dashboardCatalogContractErrors,
+} from './dashboard-catalog-contract.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(HERE, '../..');
+const unwrap = (record) => record?.data || record;
+
+test('the canonical dashboard catalog satisfies the executable table contract', () => {
+  const records = JSON.parse(fs.readFileSync(
+    path.join(REPO, 'ansible/nairobi-mdms/mdms/dss/KpiDefinition.json'),
+    'utf8'
+  )).map(unwrap);
+  assert.doesNotThrow(() => assertDashboardCatalogContract(records));
+});
+
+test('dead aliases and columns that the query cannot produce are rejected', () => {
+  const errors = dashboardCatalogContractErrors([{
+    id: 'broken_table',
+    viz: {
+      kind: 'table',
+      valueKey: 'total',
+      tableProfile: 'customAdapterThatDoesNotExist',
+      columns: [{ id: 'renamedTotal' }],
+    },
+    query: {
+      dimensions: ['ward_code'],
+      measures: [{ agg: 'count', name: 'total' }],
+    },
+  }]);
+  assert.ok(errors.some((error) => error.includes('viz.tableProfile')));
+  assert.ok(errors.some((error) => error.includes('renamedTotal')));
+});
+
+test('comparison keys must cover the table grain and filters need one operator', () => {
+  const errors = dashboardCatalogContractErrors([{
+    id: 'broken_comparison',
+    viz: {
+      kind: 'table',
+      valueKey: 'total',
+      comparison: {
+        period: 'prior',
+        mode: 'percentChange',
+        joinBy: ['ward_code'],
+        valueKey: 'total',
+        outputKey: 'trend_pct',
+      },
+      rowFilter: { column: 'missing', gte: 3, lt: 9 },
+      columns: [{ id: 'trend_pct' }],
+    },
+    query: {
+      dimensions: ['ward_code', 'service_code'],
+      measures: [{ agg: 'count', name: 'total' }],
+    },
+  }]);
+  assert.ok(errors.some((error) => error.includes('service_code')));
+  assert.ok(errors.some((error) => error.includes('rowFilter column missing')));
+  assert.ok(errors.some((error) => error.includes('exactly one supported operator')));
+});

--- a/digit-mcp/scripts/gen-dashboard-catalog.mjs
+++ b/digit-mcp/scripts/gen-dashboard-catalog.mjs
@@ -27,6 +27,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { assertDashboardCatalogContract } from './dashboard-catalog-contract.mjs';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.resolve(HERE, '../..');
@@ -58,6 +59,7 @@ for (const [code, key] of [['dss.KpiDefinition', 'x-unique']]) {
 if (kpiDefinitions.some((k) => !k || typeof k.id !== 'string')) {
   throw new Error('every KpiDefinition record must carry a string id');
 }
+assertDashboardCatalogContract(kpiDefinitions);
 
 const banner = `/**
  * GENERATED — do not hand-edit. Regenerate with:

--- a/digit-mcp/src/tools/dashboard-catalog-seed.ts
+++ b/digit-mcp/src/tools/dashboard-catalog-seed.ts
@@ -184,6 +184,130 @@ export const DASHBOARD_CATALOG_SCHEMAS: Record<string, Record<string, unknown>> 
           },
           "dimensionKey": {
             "type": "string"
+          },
+          "columns": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "id",
+                "type"
+              ],
+              "anyOf": [
+                {
+                  "required": [
+                    "label"
+                  ]
+                },
+                {
+                  "required": [
+                    "labelKey"
+                  ]
+                }
+              ],
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "type": {
+                  "enum": [
+                    "text",
+                    "integer",
+                    "percent",
+                    "hours",
+                    "hoursDays",
+                    "rating",
+                    "trend",
+                    "tags",
+                    "officer",
+                    "department",
+                    "dimension"
+                  ],
+                  "type": "string"
+                },
+                "label": {
+                  "type": "string"
+                },
+                "labelKey": {
+                  "type": "string"
+                },
+                "align": {
+                  "enum": [
+                    "left",
+                    "center",
+                    "right"
+                  ],
+                  "type": "string"
+                },
+                "width": {
+                  "type": "string"
+                },
+                "dimension": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "comparison": {
+            "type": "object",
+            "required": [
+              "period",
+              "mode",
+              "joinBy",
+              "valueKey",
+              "outputKey"
+            ],
+            "properties": {
+              "period": {
+                "enum": [
+                  "prior"
+                ],
+                "type": "string"
+              },
+              "mode": {
+                "enum": [
+                  "percentChange"
+                ],
+                "type": "string"
+              },
+              "joinBy": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "string"
+                }
+              },
+              "valueKey": {
+                "type": "string"
+              },
+              "outputKey": {
+                "type": "string"
+              }
+            }
+          },
+          "rowFilter": {
+            "type": "object",
+            "required": [
+              "column"
+            ],
+            "properties": {
+              "column": {
+                "type": "string"
+              },
+              "eq": {},
+              "gte": {
+                "type": "number"
+              },
+              "gt": {
+                "type": "number"
+              },
+              "lte": {
+                "type": "number"
+              },
+              "lt": {
+                "type": "number"
+              }
+            }
           }
         }
       },
@@ -3204,15 +3328,15 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
     "id": "cl_table_ward_performance",
     "viz": {
       "pii": false,
-      "kind": "rankedList",
+      "kind": "table",
       "group": "complaint-landscape",
       "title": "Ward performance",
       "accent": "teal",
       "format": "integer",
       "columns": [
         {
-          "id": "wardLabel",
-          "type": "text",
+          "id": "ward_code",
+          "type": "dimension",
           "align": "left",
           "label": "Ward",
           "width": "24%"
@@ -3232,21 +3356,21 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
           "width": "14%"
         },
         {
-          "id": "reopenRate",
+          "id": "reopen_rate",
           "type": "percent",
           "align": "left",
           "label": "Reopen %",
           "width": "16%"
         },
         {
-          "id": "ontimeRate",
+          "id": "ontime_rate",
           "type": "percent",
           "align": "left",
           "label": "On-time %",
           "width": "16%"
         },
         {
-          "id": "avgCsat",
+          "id": "avg_csat",
           "type": "rating",
           "align": "left",
           "label": "CSAT",
@@ -3265,8 +3389,7 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
         "ontime_rate",
         "avg_csat"
       ],
-      "dimensionKey": "ward_code",
-      "tableProfile": "wardPerformance"
+      "dimensionKey": "ward_code"
     },
     "rbac": {
       "visibleTo": [
@@ -3289,6 +3412,13 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
           "name": "created"
         },
         {
+          "agg": "count",
+          "name": "open",
+          "filter": {
+            "is_open": true
+          }
+        },
+        {
           "agg": "ratio",
           "name": "reopen_rate",
           "numerator": {
@@ -3296,18 +3426,12 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
             "filter": {
               "is_reopened": true,
               "is_resolved": true
-            },
-            "window": {
-              "timeRole": "resolved_at"
             }
           },
           "denominator": {
             "agg": "count",
             "filter": {
               "is_resolved": true
-            },
-            "window": {
-              "timeRole": "resolved_at"
             }
           }
         },
@@ -3319,18 +3443,12 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
             "filter": {
               "is_resolved": true,
               "sla_breached": false
-            },
-            "window": {
-              "timeRole": "resolved_at"
             }
           },
           "denominator": {
             "agg": "count",
             "filter": {
               "is_resolved": true
-            },
-            "window": {
-              "timeRole": "resolved_at"
             }
           }
         },
@@ -3341,9 +3459,6 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
           "filter": {
             "has_rating": true,
             "is_resolved": true
-          },
-          "window": {
-            "timeRole": "resolved_at"
           }
         }
       ],
@@ -3365,7 +3480,7 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
       }
     ],
     "status": "published",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "supportsSeries": false
   },
   {
@@ -3430,15 +3545,15 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
     "id": "cl_table_service_quality_by_channel",
     "viz": {
       "pii": false,
-      "kind": "rankedList",
+      "kind": "table",
       "group": "complaint-landscape",
       "title": "Service quality by channel",
       "accent": "teal",
       "format": "integer",
       "columns": [
         {
-          "id": "channelLabel",
-          "type": "text",
+          "id": "source",
+          "type": "dimension",
           "align": "left",
           "label": "Channel",
           "width": "28%"
@@ -3451,14 +3566,14 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
           "width": "20%"
         },
         {
-          "id": "resolutionRate",
+          "id": "resolution_rate",
           "type": "percent",
           "align": "left",
           "label": "Resolution",
           "width": "26%"
         },
         {
-          "id": "avgCsat",
+          "id": "avg_csat",
           "type": "rating",
           "align": "left",
           "label": "CSAT",
@@ -3472,11 +3587,10 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
       "valueKey": "volume",
       "measureKeys": [
         "volume",
-        "resolved",
+        "resolution_rate",
         "avg_csat"
       ],
-      "dimensionKey": "source",
-      "tableProfile": "serviceQualityByChannel"
+      "dimensionKey": "source"
     },
     "rbac": {
       "visibleTo": [
@@ -3499,14 +3613,17 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
           "name": "volume"
         },
         {
-          "agg": "count",
-          "name": "resolved",
-          "filter": {
-            "is_open": false,
-            "is_resolved": true
+          "agg": "ratio",
+          "name": "resolution_rate",
+          "numerator": {
+            "agg": "count",
+            "filter": {
+              "is_open": false,
+              "is_resolved": true
+            }
           },
-          "window": {
-            "timeRole": "resolved_at"
+          "denominator": {
+            "agg": "count"
           }
         },
         {
@@ -3516,9 +3633,6 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
           "filter": {
             "has_rating": true,
             "is_resolved": true
-          },
-          "window": {
-            "timeRole": "resolved_at"
           }
         }
       ],
@@ -3540,7 +3654,7 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
       }
     ],
     "status": "published",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "supportsSeries": false
   },
   {
@@ -3669,22 +3783,22 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
     "id": "cl_table_recurring_ward_subtype",
     "viz": {
       "pii": false,
-      "kind": "rankedList",
+      "kind": "table",
       "group": "complaint-landscape",
       "title": "Recurring complaints by ward & sub-type",
       "accent": "teal",
       "format": "integer",
       "columns": [
         {
-          "id": "wardLabel",
-          "type": "text",
+          "id": "ward_code",
+          "type": "dimension",
           "align": "left",
           "label": "Ward",
           "width": "28%"
         },
         {
-          "id": "subtypeLabel",
-          "type": "text",
+          "id": "service_code",
+          "type": "dimension",
           "align": "left",
           "label": "Sub-type",
           "width": "32%"
@@ -3697,7 +3811,7 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
           "width": "18%"
         },
         {
-          "id": "trendPct",
+          "id": "trend_pct",
           "type": "trend",
           "align": "left",
           "label": "Trend",
@@ -3705,17 +3819,28 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
         }
       ],
       "compose": null,
-      "minCount": 3,
+      "comparison": {
+        "period": "prior",
+        "mode": "percentChange",
+        "joinBy": [
+          "ward_code",
+          "service_code"
+        ],
+        "valueKey": "total",
+        "outputKey": "trend_pct"
+      },
+      "rowFilter": {
+        "column": "total",
+        "gte": 3
+      },
       "subtitle": "Ward × subtype pairs with ≥ 3 complaints in period",
       "subtitleKey": "CMS-DASHBOARD.DASHBOARD_KPI_CL_TABLE_RECURRING_WARD_SUBTYPE_SUBTITLE",
       "titleKey": "CMS-DASHBOARD.DASHBOARD_KPI_CL_TABLE_RECURRING_WARD_SUBTYPE",
       "valueKey": "total",
-      "needsPrior": true,
       "measureKeys": [
         "total"
       ],
-      "dimensionKey": "ward_code",
-      "tableProfile": "wardSubtypeRecurring"
+      "dimensionKey": "ward_code"
     },
     "rbac": {
       "visibleTo": [
@@ -3773,7 +3898,7 @@ export const DASHBOARD_KPI_DEFINITIONS: Record<string, unknown>[] = [
       }
     ],
     "status": "published",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "supportsSeries": false
   }
 ];

--- a/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
@@ -40,6 +40,7 @@ import {
   isCardKind,
   isSparklineKind,
   isMapKind,
+  needsPriorComparison,
   buildRefs,
   buildRefsKey,
   buildPublicRefs,
@@ -287,7 +288,8 @@ function persistHierOverrides(overrides) {
  *
  * So we keep columns/rows/scope/asOf verbatim, and additionally hoist:
  *   value    <- base scalar (rows[0][valueKey] / single measure)
- *   prior    <- __prior scalar
+ *   prior    <- __prior scalar (cards)
+ *   priorRows<- __prior rows (comparison tables)
  *   sparkline<- __series rows -> ordered numeric series
  */
 function assembleResult(kpiId, def, results) {
@@ -315,6 +317,11 @@ function assembleResult(kpiId, def, results) {
       const p = scalarFromResult(priorRes, valueKey);
       if (p != null) assembled.prior = p;
     }
+  }
+
+  if (needsPriorComparison(def)) {
+    const priorRes = results?.[`${kpiId}__prior`];
+    assembled.priorRows = priorRes?.rows || [];
   }
 
   // Daily sparkline series.

--- a/digit-ui-esbuild/products/dashboard/src/components/KpiTile.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/KpiTile.jsx
@@ -12,6 +12,7 @@ import OpenComplaintsByGeographyWidget from './OpenComplaintsByGeographyWidget';
 import { evaluateCompose, requiresBackendComposition } from '../utils/composeKpi';
 import { applyGroupByToColumns } from '../utils/hierLevelGrouping';
 import { formatNumber } from '../utils/numberFormat';
+import { transformTableRows } from '../utils/tableRows';
 import {
   GEO_MAP_LAYER_KEYS,
   partitionPinsByLayer,
@@ -47,6 +48,7 @@ import { markFirstWidgetVisible } from '../services/dashboardMetrics';
  *     values,  // map of named scalars
  *     series,  // pre-shaped multi-series payload (line/stacked) when BE supplies it
  *     prior,   // prior-period scalar/series for deltas
+ *     priorRows, // prior-period rows for catalog-declared table comparisons
  *     sparkline, // daily series for sparkline cards
  *     asOf, scope }
  *
@@ -784,7 +786,7 @@ function renderTable(ctx) {
   // SLAs caveat at non-leaf levels is documented in the KPI catalog docs
   // (PR1), not surfaced in-cell.
   const columns = applyGroupByToColumns(viz.columns || deriveColumnsFromResult(result), groupBy);
-  const rows = result.rows || [];
+  const rows = transformTableRows(result, viz);
   if (loading && !rows.length) return <Placeholder message={t("DASHBOARD_COMMON_LOADING", "Loading…")} />;
   return <DashboardTable columns={columns} rows={rows} emptyMessage={viz.emptyMessage || t("DASHBOARD_COMMON_NO_DATA", "No data")} />;
 }

--- a/digit-ui-esbuild/products/dashboard/src/utils/queryPlan.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/queryPlan.js
@@ -7,7 +7,7 @@ import { complaintTypeParams } from "./complaintTypeTree";
  *
  * The tileKey convention for runKpiBatch refs:
  *   <kpiId>           base query (global params applied)
- *   <kpiId>__prior    delta cards: same params + compare:'prior'
+ *   <kpiId>__prior    delta cards/comparison tables: same params + compare:'prior'
  *   <kpiId>__series   sparkline cards: same params + series:'daily'
  *   <kpiId>__pins     map tiles: the per-complaint pin companion source
  */
@@ -66,6 +66,9 @@ export function isSparklineKind(kind) {
 export function isMapKind(kind) {
   return MAP_KINDS.has(kind);
 }
+export function needsPriorComparison(def) {
+  return def?.viz?.comparison?.period === "prior";
+}
 
 /**
  * Map the dashboard filter bar -> the KpiQueryComposer param names.
@@ -116,9 +119,9 @@ export function tileParams(def, filters, hierOverrides) {
 /**
  * Build the per-tile refs map for runKpiBatch.
  *
- * The prior/series refs are gated on viz.kind (the only series signal exposed by
- * the catalog tile — supportsSeries is not serialised), so non-card tiles only
- * issue the single base query.
+ * Series refs are gated on viz.kind (the only series signal exposed by the
+ * catalog tile — supportsSeries is not serialised). Prior refs are requested
+ * for scalar cards and for tables that explicitly declare viz.comparison.
  */
 export function buildRefs(tiles, kpis, filters, hierOverrides) {
   const refs = {};
@@ -132,7 +135,7 @@ export function buildRefs(tiles, kpis, filters, hierOverrides) {
 
     refs[kpiId] = { kpiId, params: { ...base } };
 
-    if (isCardKind(kind)) {
+    if (isCardKind(kind) || needsPriorComparison(def)) {
       refs[`${kpiId}__prior`] = { kpiId, params: { ...base, compare: "prior" } };
     }
     if (isSparklineKind(kind)) {
@@ -177,13 +180,14 @@ export function buildPublicRefsKey(tiles, kpis) {
  * Serialisable fingerprint of everything buildRefs reads, used as the batch
  * effect's dependency key. Includes each tile's viz.kind (a def flipping
  * card<->chart must re-trigger even when ids/params are unchanged) AND each
- * tile's applied hierLevel override — without the latter the batch effect
+ * tile's comparison contract and applied hierLevel override — without those the batch effect
  * would never refire on a "Group by" change (R7c).
  */
 export function buildRefsKey(tiles, kpis, filters, hierOverrides) {
   return JSON.stringify({
     ids: tiles.map((t) => t.kpiId),
     kinds: tiles.map((t) => kpis[t.kpiId]?.viz?.kind),
+    comparisons: tiles.map((t) => kpis[t.kpiId]?.viz?.comparison ?? null),
     gp: globalParams(filters),
     hier: tiles.map((t) => appliedHierLevel(kpis[t.kpiId], hierOverrides)),
     // A tenant whose catalog gains the per-layer pin def must refire the batch:

--- a/digit-ui-esbuild/products/dashboard/src/utils/tableRows.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/tableRows.js
@@ -1,0 +1,70 @@
+const FILTER_OPERATORS = {
+  eq: (value, expected) => value === expected,
+  gte: (value, expected) => Number(value) >= Number(expected),
+  gt: (value, expected) => Number(value) > Number(expected),
+  lte: (value, expected) => Number(value) <= Number(expected),
+  lt: (value, expected) => Number(value) < Number(expected),
+};
+
+function comparisonKey(row, joinBy) {
+  return joinBy.map((key) => String(row?.[key] ?? "")).join("\u001f");
+}
+
+function percentChange(current, prior) {
+  const currentValue = Number(current);
+  const priorValue = Number(prior);
+  if (!Number.isFinite(currentValue)) return null;
+  if (!Number.isFinite(priorValue) || priorValue === 0) return currentValue === 0 ? 0 : 100;
+  return ((currentValue - priorValue) / Math.abs(priorValue)) * 100;
+}
+
+function applyComparison(rows, priorRows, comparison) {
+  if (!comparison || comparison.period !== "prior" || comparison.mode !== "percentChange") {
+    return rows;
+  }
+
+  const joinBy = Array.isArray(comparison.joinBy) ? comparison.joinBy : [];
+  if (!joinBy.length || !comparison.valueKey || !comparison.outputKey) return rows;
+
+  const priorByKey = new Map(
+    (priorRows || []).map((row) => [comparisonKey(row, joinBy), row])
+  );
+  return rows.map((row) => {
+    const prior = priorByKey.get(comparisonKey(row, joinBy));
+    return {
+      ...row,
+      [comparison.outputKey]: percentChange(
+        row?.[comparison.valueKey],
+        prior?.[comparison.valueKey]
+      ),
+    };
+  });
+}
+
+function applyRowFilter(rows, rowFilter) {
+  if (!rowFilter?.column) return rows;
+  const entry = Object.entries(FILTER_OPERATORS).find(([operator]) =>
+    Object.prototype.hasOwnProperty.call(rowFilter, operator)
+  );
+  if (!entry) return rows;
+  const [operator, predicate] = entry;
+  return rows.filter((row) => predicate(row?.[rowFilter.column], rowFilter[operator]));
+}
+
+/**
+ * Apply catalog-declared, presentation-neutral table transforms. The result is
+ * still rendered by DashboardTable, so its chrome, sorting, localisation and
+ * cell formatting remain the single visual implementation for every table.
+ */
+export function transformTableRows(result, viz) {
+  const rows = Array.isArray(result?.rows) ? result.rows : [];
+  const compared = applyComparison(rows, result?.priorRows, viz?.comparison);
+  return applyRowFilter(compared, viz?.rowFilter).map((row, index) => ({
+    ...row,
+    id:
+      row?.id ??
+      (viz?.comparison?.joinBy?.length
+        ? comparisonKey(row, viz.comparison.joinBy)
+        : String(index)),
+  }));
+}

--- a/digit-ui-esbuild/products/dashboard/src/utils/tableRows.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/tableRows.test.js
@@ -1,0 +1,90 @@
+// Catalog-driven table comparison/filter transforms.
+// Run from digit-ui-esbuild/: node --test products/dashboard/src/utils/tableRows.test.js
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const esbuild = require("esbuild");
+
+function bundle(entry) {
+  const out = path.join(os.tmpdir(), `${path.basename(entry, ".js")}.cjs.${process.pid}.js`);
+  esbuild.buildSync({
+    entryPoints: [path.join(__dirname, entry)],
+    bundle: true,
+    format: "cjs",
+    platform: "neutral",
+    outfile: out,
+  });
+  process.on("exit", () => {
+    try { fs.unlinkSync(out); } catch (_) { /* already gone */ }
+  });
+  return require(out);
+}
+
+const { transformTableRows } = bundle("tableRows.js");
+const { buildRefs, buildRefsKey } = bundle("queryPlan.js");
+
+const recurringViz = {
+  comparison: {
+    period: "prior",
+    mode: "percentChange",
+    joinBy: ["ward_code", "service_code"],
+    valueKey: "total",
+    outputKey: "trend_pct",
+  },
+  rowFilter: { column: "total", gte: 3 },
+};
+
+test("joins prior rows by every declared dimension and applies the minimum count", () => {
+  const rows = transformTableRows({
+    rows: [
+      { ward_code: "W1", service_code: "A", total: 6 },
+      { ward_code: "W1", service_code: "B", total: 2 },
+      { ward_code: "W2", service_code: "A", total: 3 },
+    ],
+    priorRows: [
+      { ward_code: "W1", service_code: "A", total: 4 },
+      { ward_code: "W2", service_code: "A", total: 6 },
+    ],
+  }, recurringViz);
+
+  assert.deepEqual(rows.map(({ id, ...row }) => row), [
+    { ward_code: "W1", service_code: "A", total: 6, trend_pct: 50 },
+    { ward_code: "W2", service_code: "A", total: 3, trend_pct: -50 },
+  ]);
+  assert.equal(rows[0].id, "W1\u001fA");
+});
+
+test("new recurring pairs have a finite +100% trend and zero stays flat", () => {
+  const rows = transformTableRows({
+    rows: [
+      { ward_code: "W1", service_code: "A", total: 5 },
+      { ward_code: "W2", service_code: "B", total: 0 },
+    ],
+    priorRows: [],
+  }, { ...recurringViz, rowFilter: null });
+  assert.deepEqual(rows.map((row) => row.trend_pct), [100, 0]);
+});
+
+test("comparison tables request prior data; ordinary tables remain single-query", () => {
+  const tiles = [{ kpiId: "recurring" }, { kpiId: "ordinary" }];
+  const kpis = {
+    recurring: { viz: { kind: "table", comparison: recurringViz.comparison } },
+    ordinary: { viz: { kind: "table" } },
+  };
+  const refs = buildRefs(tiles, kpis, {}, {});
+  assert.deepEqual(Object.keys(refs), ["recurring", "recurring__prior", "ordinary"]);
+  assert.equal(refs.recurring__prior.params.compare, "prior");
+  assert.equal(refs.ordinary__prior, undefined);
+});
+
+test("the request fingerprint changes when comparison semantics change", () => {
+  const tiles = [{ kpiId: "recurring" }];
+  const base = { recurring: { viz: { kind: "table" } } };
+  const compared = {
+    recurring: { viz: { kind: "table", comparison: recurringViz.comparison } },
+  };
+  assert.notEqual(buildRefsKey(tiles, base, {}, {}), buildRefsKey(tiles, compared, {}, {}));
+});

--- a/local-setup/db/dss-mdms-seed/schemas/dss.KpiDefinition.json
+++ b/local-setup/db/dss-mdms-seed/schemas/dss.KpiDefinition.json
@@ -169,6 +169,130 @@
         },
         "dimensionKey": {
           "type": "string"
+        },
+        "columns": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "type"
+            ],
+            "anyOf": [
+              {
+                "required": [
+                  "label"
+                ]
+              },
+              {
+                "required": [
+                  "labelKey"
+                ]
+              }
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "text",
+                  "integer",
+                  "percent",
+                  "hours",
+                  "hoursDays",
+                  "rating",
+                  "trend",
+                  "tags",
+                  "officer",
+                  "department",
+                  "dimension"
+                ],
+                "type": "string"
+              },
+              "label": {
+                "type": "string"
+              },
+              "labelKey": {
+                "type": "string"
+              },
+              "align": {
+                "enum": [
+                  "left",
+                  "center",
+                  "right"
+                ],
+                "type": "string"
+              },
+              "width": {
+                "type": "string"
+              },
+              "dimension": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "comparison": {
+          "type": "object",
+          "required": [
+            "period",
+            "mode",
+            "joinBy",
+            "valueKey",
+            "outputKey"
+          ],
+          "properties": {
+            "period": {
+              "enum": [
+                "prior"
+              ],
+              "type": "string"
+            },
+            "mode": {
+              "enum": [
+                "percentChange"
+              ],
+              "type": "string"
+            },
+            "joinBy": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string"
+              }
+            },
+            "valueKey": {
+              "type": "string"
+            },
+            "outputKey": {
+              "type": "string"
+            }
+          }
+        },
+        "rowFilter": {
+          "type": "object",
+          "required": [
+            "column"
+          ],
+          "properties": {
+            "column": {
+              "type": "string"
+            },
+            "eq": {},
+            "gte": {
+              "type": "number"
+            },
+            "gt": {
+              "type": "number"
+            },
+            "lte": {
+              "type": "number"
+            },
+            "lt": {
+              "type": "number"
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
## What changed

Closes #1760.

- Restores **Ward performance**, **Service quality by channel**, and **Recurring complaints by ward & sub-type** as full catalog-driven tables.
- Aligns every table column with the analytics query output; adds the missing ward open count and makes service resolution a real ratio.
- Adds a generic `viz.comparison` + `viz.rowFilter` seam for prior-period row joins, trend calculation, and minimum-count filtering.
- Removes the dead `tableProfile`, `needsPrior`, and `minCount` aliases that the canonical UI never consumed.
- Adds an executable catalog contract check so mismatched table columns and unsupported aliases fail during catalog generation.
- Updates the KpiDefinition schema and regenerated tenant-bootstrap catalog.

## UI preservation

This reuses the existing `DashboardTable` end to end. There are no CSS or widget-specific markup changes, so the established table chrome, spacing, typography, sorting, localization, tenant number formats, and trend styling remain intact.

## Verification

- `node --test products/dashboard/src/utils/tableRows.test.js`
- `node --test products/dashboard/src/utils/complaintPins.test.js`
- `npm run build` in `digit-ui-esbuild`
- `node --test digit-mcp/scripts/dashboard-catalog-contract.test.mjs`
- `node digit-mcp/scripts/gen-dashboard-catalog.mjs --check`
- All current KpiDefinition records validated against `dss.KpiDefinition.json`

The `digit-mcp` TypeScript build could not run in the isolated worktree because its workspace dependencies are not installed (`tsc: command not found`); the code added there is plain Node ESM and its focused tests pass.

## Rollout note

The versioned definitions must be upserted to Bomet MDMS during deployment; changing the repo seed alone does not replace existing tenant records.

## Out of scope

Legacy `/dashboard` route handling is explicitly outside this effort.
