### PR TITLE
fix(configurator): backport landing-page resource counts to master (#1707)

### DIFF
--- a/configurator/packages/data-provider/src/client/DigitApiClient.test.ts
+++ b/configurator/packages/data-provider/src/client/DigitApiClient.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach } from 'node:test';
 import * as assert from 'node:assert/strict';
 import { DigitApiClient } from './DigitApiClient.js';
-import { isSessionExpired } from './errors.js';
+import { ApiClientError, isSessionExpired } from './errors.js';
 
 describe('DigitApiClient', () => {
   let client: DigitApiClient;
@@ -143,6 +143,55 @@ describe('DigitApiClient paged-search guard', () => {
       /truncated after 200 pages/,
     );
     assert.equal(calls, DigitApiClient.SEARCH_MAX_PAGES);
+  });
+});
+
+describe('DigitApiClient.request session handling', () => {
+  it('routes a bodyless 401 to the session-expired handler instead of a JSON parse error', async () => {
+    const client = new DigitApiClient({ url: 'https://test.example.com' });
+    let expired = 0;
+    DigitApiClient.setSessionExpiredHandler(() => { expired += 1; });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response(null, { status: 401 })) as typeof fetch;
+
+    try {
+      await assert.rejects(
+        () => client.mdmsSearch('ke', 'common-masters.Department'),
+        (err: unknown) => {
+          assert.ok(err instanceof ApiClientError);
+          assert.equal(err.statusCode, 401);
+          assert.equal(err.errors[0].code, 'SESSION_EXPIRED');
+          return true;
+        },
+      );
+      assert.equal(expired, 1);
+    } finally {
+      globalThis.fetch = originalFetch;
+      DigitApiClient.setSessionExpiredHandler(null);
+    }
+  });
+
+  it('reports an HTML error page as an HTTP error, not a parse failure', async () => {
+    const client = new DigitApiClient({ url: 'https://test.example.com' });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response('<html>404 Not Found</html>', {
+      status: 404,
+      headers: { 'Content-Type': 'text/html' },
+    })) as typeof fetch;
+
+    try {
+      await assert.rejects(
+        () => client.mdmsSearch('ke', 'common-masters.Department'),
+        (err: unknown) => {
+          assert.ok(err instanceof ApiClientError);
+          assert.equal(err.statusCode, 404);
+          assert.equal(err.errors[0].code, 'HTTP_404');
+          return true;
+        },
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });
 

--- a/configurator/packages/data-provider/src/client/DigitApiClient.test.ts
+++ b/configurator/packages/data-provider/src/client/DigitApiClient.test.ts
@@ -91,6 +91,61 @@ describe('DigitApiClient.mdmsCreate phantom-200', () => {
   });
 });
 
+describe('DigitApiClient.boundaryHierarchySearch pagination', () => {
+  it('walks offset until a short page when listing all types', async () => {
+    const client = new DigitApiClient({ url: 'https://test.example.com' });
+    const first = Array.from({ length: 100 }, (_, i) => ({ hierarchyType: `PW_${i}` }));
+    const second = [{ hierarchyType: 'ADMIN' }];
+    const offsets: number[] = [];
+    (client as unknown as { request: (...args: unknown[]) => Promise<unknown> }).request =
+      async (_path: unknown, body: Record<string, unknown>) => {
+        const criteria = body.BoundaryTypeHierarchySearchCriteria as { offset: number; limit: number };
+        offsets.push(criteria.offset);
+        return { BoundaryHierarchy: criteria.offset === 0 ? first : second };
+      };
+
+    const result = await client.boundaryHierarchySearch('ke');
+    assert.equal(result.length, 101);
+    assert.deepEqual(offsets, [0, 100]);
+    assert.equal(result[100].hierarchyType, 'ADMIN');
+  });
+
+  it('does not page when looking up a single hierarchyType', async () => {
+    const client = new DigitApiClient({ url: 'https://test.example.com' });
+    let calls = 0;
+    (client as unknown as { request: (...args: unknown[]) => Promise<unknown> }).request =
+      async () => {
+        calls += 1;
+        return { BoundaryHierarchy: [{ hierarchyType: 'ADMIN' }] };
+      };
+    const result = await client.boundaryHierarchySearch('ke', 'ADMIN');
+    assert.equal(calls, 1);
+    assert.equal(result[0].hierarchyType, 'ADMIN');
+  });
+});
+
+describe('DigitApiClient.mdmsSearchAll pagination', () => {
+  it('walks offset until a short page', async () => {
+    const client = new DigitApiClient({ url: 'https://test.example.com' });
+    const rows = Array.from({ length: 250 }, (_, i) => ({
+      id: `id-${i}`,
+      tenantId: 'ke',
+      schemaCode: 'common-masters.Department',
+      uniqueIdentifier: `DEPT_${i}`,
+      data: { code: `DEPT_${i}` },
+      isActive: true,
+    }));
+    (client as unknown as { request: (...args: unknown[]) => Promise<unknown> }).request =
+      async (_path: unknown, body: Record<string, unknown>) => {
+        const criteria = body.MdmsCriteria as { offset: number; limit: number };
+        return { mdms: rows.slice(criteria.offset, criteria.offset + criteria.limit) };
+      };
+
+    const result = await client.mdmsSearchAll('ke', 'common-masters.Department', { isActive: true });
+    assert.equal(result.length, 250);
+  });
+});
+
 describe('isSessionExpired', () => {
   it('matches InvalidAccessTokenException from access-control / Kong', () => {
     assert.equal(

--- a/configurator/packages/data-provider/src/client/DigitApiClient.test.ts
+++ b/configurator/packages/data-provider/src/client/DigitApiClient.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach } from 'node:test';
 import * as assert from 'node:assert/strict';
 import { DigitApiClient } from './DigitApiClient.js';
+import { isSessionExpired } from './errors.js';
 
 describe('DigitApiClient', () => {
   let client: DigitApiClient;
@@ -86,6 +87,21 @@ describe('DigitApiClient.mdmsCreate phantom-200', () => {
     await assert.rejects(
       () => client.mdmsCreate('pg', 'RAINMAKER-PGR.NotificationRouting', 'PGR.ASSIGN.PENDINGATLME.CITIZEN.SMS', {}),
       /MDMS_DUPLICATE/,
+    );
+  });
+});
+
+describe('isSessionExpired', () => {
+  it('matches InvalidAccessTokenException from access-control / Kong', () => {
+    assert.equal(
+      isSessionExpired(400, [{ code: 'InvalidAccessTokenException', message: 'InvalidAccessTokenException' }]),
+      true,
+    );
+  });
+  it('does not match ordinary validation errors', () => {
+    assert.equal(
+      isSessionExpired(400, [{ code: 'INVALID_SEARCH', message: 'tenantId is required' }]),
+      false,
     );
   });
 });

--- a/configurator/packages/data-provider/src/client/DigitApiClient.test.ts
+++ b/configurator/packages/data-provider/src/client/DigitApiClient.test.ts
@@ -124,25 +124,25 @@ describe('DigitApiClient.boundaryHierarchySearch pagination', () => {
   });
 });
 
-describe('DigitApiClient.mdmsSearchAll pagination', () => {
-  it('walks offset until a short page', async () => {
+describe('DigitApiClient paged-search guard', () => {
+  it('throws rather than returning a truncated total when the page guard is hit', async () => {
     const client = new DigitApiClient({ url: 'https://test.example.com' });
-    const rows = Array.from({ length: 250 }, (_, i) => ({
-      id: `id-${i}`,
-      tenantId: 'ke',
-      schemaCode: 'common-masters.Department',
-      uniqueIdentifier: `DEPT_${i}`,
-      data: { code: `DEPT_${i}` },
-      isActive: true,
-    }));
+    let calls = 0;
     (client as unknown as { request: (...args: unknown[]) => Promise<unknown> }).request =
-      async (_path: unknown, body: Record<string, unknown>) => {
-        const criteria = body.MdmsCriteria as { offset: number; limit: number };
-        return { mdms: rows.slice(criteria.offset, criteria.offset + criteria.limit) };
+      async () => {
+        calls += 1;
+        return {
+          BoundaryHierarchy: Array.from({ length: DigitApiClient.SEARCH_PAGE_SIZE }, (_, i) => ({
+            hierarchyType: `TYPE_${calls}_${i}`,
+          })),
+        };
       };
 
-    const result = await client.mdmsSearchAll('ke', 'common-masters.Department', { isActive: true });
-    assert.equal(result.length, 250);
+    await assert.rejects(
+      () => client.boundaryHierarchySearch('ke'),
+      /truncated after 200 pages/,
+    );
+    assert.equal(calls, DigitApiClient.SEARCH_MAX_PAGES);
   });
 });
 

--- a/configurator/packages/data-provider/src/client/DigitApiClient.ts
+++ b/configurator/packages/data-provider/src/client/DigitApiClient.ts
@@ -204,6 +204,8 @@ export class DigitApiClient {
 
   /** Default page size for DIGIT search APIs that omit a total. */
   static readonly SEARCH_PAGE_SIZE = 100;
+  /** Infinite-loop guard when offset is ignored. Hitting this with a full last page is an error, not a silent truncate. */
+  static readonly SEARCH_MAX_PAGES = 200;
 
   /**
    * Walk offset/limit until a short page. MDMS v2 and boundary-hierarchy
@@ -214,17 +216,20 @@ export class DigitApiClient {
     fetchPage: (limit: number, offset: number) => Promise<T[]>,
   ): Promise<T[]> {
     const pageSize = DigitApiClient.SEARCH_PAGE_SIZE;
+    const maxPages = DigitApiClient.SEARCH_MAX_PAGES;
     const all: T[] = [];
     let offset = 0;
-    // Guard against an API that ignores offset and always returns a full page.
-    const maxPages = 200;
+    let lastWasFull = false;
     for (let i = 0; i < maxPages; i++) {
       const page = await fetchPage(pageSize, offset);
       all.push(...page);
-      if (page.length < pageSize) break;
+      lastWasFull = page.length === pageSize;
+      if (!lastWasFull) return all;
       offset += pageSize;
     }
-    return all;
+    throw new Error(
+      `DIGIT search truncated after ${maxPages} pages (${all.length} rows); refusing to report a partial total`,
+    );
   }
 
   async mdmsSearch(tenantId: string, schemaCode: string, options?: {

--- a/configurator/packages/data-provider/src/client/DigitApiClient.ts
+++ b/configurator/packages/data-provider/src/client/DigitApiClient.ts
@@ -94,7 +94,11 @@ export class DigitApiClient {
       const response = await fetch(url, { method: 'POST', headers, body: jsonBody });
 
       if (!DigitApiClient.RETRY_STATUS_CODES.has(response.status)) {
-        const data = await response.json() as Record<string, unknown>;
+        // Kong rejects an expired token with a bodyless (or HTML) 401, so
+        // parsing before classifying threw SyntaxError and the session-expired
+        // handler never ran — the UI showed "Unexpected end of JSON input"
+        // instead of bouncing to login.
+        const data = await this.parseJsonBody(response);
         if (!response.ok || (data.Errors as ApiError[] | undefined)?.length) {
           const errors: ApiError[] = (data.Errors as ApiError[]) || [
             { code: `HTTP_${response.status}`, message: (data.message as string) || `Request failed: ${response.status}` },
@@ -122,11 +126,23 @@ export class DigitApiClient {
       }
     }
 
-    const data = await lastResponse!.json().catch(() => ({})) as Record<string, unknown>;
+    const data = await this.parseJsonBody(lastResponse!);
     const errors: ApiError[] = (data.Errors as ApiError[]) || [
       { code: `HTTP_${lastResponse!.status}`, message: (data.message as string) || `Request failed after ${DigitApiClient.MAX_RETRIES} retries` },
     ];
     throw new ApiClientError(errors, lastResponse!.status);
+  }
+
+  /** Empty or non-JSON payloads (gateway 401s, HTML error pages) read as `{}`. */
+  private async parseJsonBody(response: Response): Promise<Record<string, unknown>> {
+    const text = await response.text().catch(() => '');
+    if (!text) return {};
+    try {
+      const parsed = JSON.parse(text) as unknown;
+      return parsed && typeof parsed === 'object' ? parsed as Record<string, unknown> : {};
+    } catch {
+      return {};
+    }
   }
 
   // --- Login ---

--- a/configurator/packages/data-provider/src/client/DigitApiClient.ts
+++ b/configurator/packages/data-provider/src/client/DigitApiClient.ts
@@ -202,6 +202,31 @@ export class DigitApiClient {
 
   // --- MDMS v2 ---
 
+  /** Default page size for DIGIT search APIs that omit a total. */
+  static readonly SEARCH_PAGE_SIZE = 100;
+
+  /**
+   * Walk offset/limit until a short page. MDMS v2 and boundary-hierarchy
+   * search do not return a total, so a single `limit: 100` (or 500) call
+   * silently truncates.
+   */
+  private async collectPages<T>(
+    fetchPage: (limit: number, offset: number) => Promise<T[]>,
+  ): Promise<T[]> {
+    const pageSize = DigitApiClient.SEARCH_PAGE_SIZE;
+    const all: T[] = [];
+    let offset = 0;
+    // Guard against an API that ignores offset and always returns a full page.
+    const maxPages = 200;
+    for (let i = 0; i < maxPages; i++) {
+      const page = await fetchPage(pageSize, offset);
+      all.push(...page);
+      if (page.length < pageSize) break;
+      offset += pageSize;
+    }
+    return all;
+  }
+
   async mdmsSearch(tenantId: string, schemaCode: string, options?: {
     limit?: number; offset?: number; uniqueIdentifiers?: string[]; isActive?: boolean;
   }): Promise<MdmsRecord[]> {
@@ -346,12 +371,23 @@ export class DigitApiClient {
   }
 
   async boundaryHierarchySearch(tenantId: string, hierarchyType?: string): Promise<Record<string, unknown>[]> {
-    const criteria: Record<string, unknown> = { tenantId, limit: 100, offset: 0 };
-    if (hierarchyType) criteria.hierarchyType = hierarchyType;
-    const data = await this.request<{ BoundaryHierarchy?: Record<string, unknown>[] }>(this.endpoint('BOUNDARY_HIERARCHY_SEARCH'), {
-      RequestInfo: this.buildRequestInfo(), BoundaryTypeHierarchySearchCriteria: criteria,
+    // A typed lookup fits on one page. Unscoped discovery must walk every
+    // page — Playwright onboarding leaves 200+ PW_* stubs that fill the
+    // first page and hide ADMIN.
+    if (hierarchyType) {
+      const data = await this.request<{ BoundaryHierarchy?: Record<string, unknown>[] }>(this.endpoint('BOUNDARY_HIERARCHY_SEARCH'), {
+        RequestInfo: this.buildRequestInfo(),
+        BoundaryTypeHierarchySearchCriteria: { tenantId, hierarchyType, limit: DigitApiClient.SEARCH_PAGE_SIZE, offset: 0 },
+      });
+      return data.BoundaryHierarchy || [];
+    }
+    return this.collectPages(async (limit, offset) => {
+      const data = await this.request<{ BoundaryHierarchy?: Record<string, unknown>[] }>(this.endpoint('BOUNDARY_HIERARCHY_SEARCH'), {
+        RequestInfo: this.buildRequestInfo(),
+        BoundaryTypeHierarchySearchCriteria: { tenantId, limit, offset },
+      });
+      return data.BoundaryHierarchy || [];
     });
-    return data.BoundaryHierarchy || [];
   }
 
   async boundaryCreate(tenantId: string, boundaries: { code: string; geometry?: Record<string, unknown> }[]): Promise<Record<string, unknown>[]> {

--- a/configurator/packages/data-provider/src/client/DigitApiClient.ts
+++ b/configurator/packages/data-provider/src/client/DigitApiClient.ts
@@ -1,5 +1,5 @@
 import { ENDPOINTS, OAUTH_CONFIG } from './endpoints.js';
-import { ApiClientError } from './errors.js';
+import { ApiClientError, isSessionExpired } from './errors.js';
 import type {
   RequestInfo, UserInfo, MdmsRecord, ApiError,
 } from './types.js';
@@ -19,6 +19,12 @@ export class DigitApiClient {
 
   private static readonly RETRY_STATUS_CODES = new Set([429, 503]);
   private static readonly MAX_RETRIES = 3;
+  // Survives `new DigitApiClient()` on URL change (configureDigitClient).
+  private static onSessionExpired: (() => void) | null = null;
+
+  static setSessionExpiredHandler(handler: (() => void) | null): void {
+    DigitApiClient.onSessionExpired = handler;
+  }
 
   constructor(config: DigitApiClientConfig) {
     this.baseUrl = config.url;
@@ -93,6 +99,16 @@ export class DigitApiClient {
           const errors: ApiError[] = (data.Errors as ApiError[]) || [
             { code: `HTTP_${response.status}`, message: (data.message as string) || `Request failed: ${response.status}` },
           ];
+          // HRMS / PGR / access-control enforce the token; MDMS and localization
+          // often don't. An expired session therefore looks like "employees=0,
+          // access roles crashed" while tenants still load. Bounce to login.
+          if (isSessionExpired(response.status, errors)) {
+            DigitApiClient.onSessionExpired?.();
+            throw new ApiClientError(
+              [{ code: 'SESSION_EXPIRED', message: 'Your session has expired. Please log in again to continue.' }],
+              response.status,
+            );
+          }
           throw new ApiClientError(errors, response.status);
         }
         return data as T;

--- a/configurator/packages/data-provider/src/client/errors.ts
+++ b/configurator/packages/data-provider/src/client/errors.ts
@@ -6,6 +6,15 @@ function deriveErrorCategory(statusCode: number): ErrorCategory {
   return 'api';
 }
 
+/** True when the gateway/service rejected the session, not the payload. */
+export function isSessionExpired(statusCode: number, errors: ApiError[]): boolean {
+  if (statusCode === 401) return true;
+  return errors.some((e) =>
+    /invalid.?access.?token|access token.*(expired|invalid)/i.test(`${e?.code || ''} ${e?.message || ''}`)
+    || /userinfo[\s\S]*must not be null/i.test(e?.message || ''),
+  );
+}
+
 export class ApiClientError extends Error {
   public errors: ApiError[];
   public statusCode: number;

--- a/configurator/packages/data-provider/src/providers/dataProvider.test.ts
+++ b/configurator/packages/data-provider/src/providers/dataProvider.test.ts
@@ -334,4 +334,66 @@ describe('createDigitDataProvider', () => {
       /did not finish paging/,
     );
   });
+
+  it('getList(departments) total is exact past 500 rows and with perPage 1', async () => {
+    // Dashboard cards pass perPage: 1. A 500-row cap would report 500 for a
+    // 550-row master. Page through offset until a short page.
+    const rows = Array.from({ length: 550 }, (_, i) => ({
+      id: `id-${i}`,
+      tenantId: 'ke',
+      schemaCode: 'common-masters.Department',
+      uniqueIdentifier: `DEPT_${i}`,
+      data: { code: `DEPT_${String(i).padStart(3, '0')}`, name: `Dept ${i}`, active: true },
+      isActive: true,
+      auditDetails: { createdBy: 'x', lastModifiedBy: 'x', createdTime: 1, lastModifiedTime: 1 },
+    }));
+    let calls = 0;
+    mock.method(client, 'mdmsSearch', async (_t: string, _s: string, opts?: { limit?: number; offset?: number }) => {
+      calls += 1;
+      const offset = opts?.offset ?? 0;
+      const limit = opts?.limit ?? 100;
+      return rows.slice(offset, offset + limit);
+    });
+
+    const dp = createDigitDataProvider(client, 'ke');
+    const result = await dp.getList('departments', {
+      pagination: { page: 1, perPage: 1 },
+      sort: { field: 'code', order: 'ASC' },
+      filter: {},
+    });
+
+    assert.equal(result.total, 550);
+    assert.equal(result.data.length, 1);
+    assert.ok(calls >= 6, `should walk past a 500-row cap, got ${calls} pages`);
+  });
+
+  it('getList(boundaries) skips PW_* stubs and still queries ADMIN', async () => {
+    const stubs = Array.from({ length: 212 }, (_, i) => ({ hierarchyType: `PW_HIER_${i}` }));
+    mock.method(client, 'boundaryHierarchySearch', async () => [
+      ...stubs,
+      { hierarchyType: 'ADMIN' },
+      { hierarchyType: 'REVENUE' },
+    ]);
+    const queried: string[] = [];
+    mock.method(client, 'boundaryRelationshipSearch', async (_t: string, ht?: string) => {
+      queried.push(ht ?? '');
+      if (ht === 'ADMIN') {
+        return [{ tenantId: 'ke', hierarchyType: 'ADMIN', boundary: [{ code: 'KE', children: [] }] }];
+      }
+      return [];
+    });
+
+    const dp = createDigitDataProvider(client, 'ke.bomet');
+    const result = await dp.getList('boundaries', {
+      pagination: { page: 1, perPage: 25 },
+      sort: { field: 'code', order: 'ASC' },
+      filter: {},
+    });
+
+    assert.equal(result.total, 1);
+    assert.equal(result.data[0].id, 'KE');
+    assert.ok(!queried.some((ht) => /^PW_/i.test(ht)), 'must not query PW_* trees');
+    assert.ok(queried.includes('ADMIN'));
+    assert.ok(queried.includes('REVENUE'));
+  });
 });

--- a/configurator/packages/data-provider/src/providers/dataProvider.test.ts
+++ b/configurator/packages/data-provider/src/providers/dataProvider.test.ts
@@ -396,4 +396,5 @@ describe('createDigitDataProvider', () => {
     assert.ok(queried.includes('ADMIN'));
     assert.ok(queried.includes('REVENUE'));
   });
+
 });

--- a/configurator/packages/data-provider/src/providers/dataProvider.test.ts
+++ b/configurator/packages/data-provider/src/providers/dataProvider.test.ts
@@ -347,9 +347,9 @@ describe('createDigitDataProvider', () => {
       isActive: true,
       auditDetails: { createdBy: 'x', lastModifiedBy: 'x', createdTime: 1, lastModifiedTime: 1 },
     }));
-    let calls = 0;
+    const requestedLimits: number[] = [];
     mock.method(client, 'mdmsSearch', async (_t: string, _s: string, opts?: { limit?: number; offset?: number }) => {
-      calls += 1;
+      requestedLimits.push(opts?.limit ?? 100);
       const offset = opts?.offset ?? 0;
       const limit = opts?.limit ?? 100;
       return rows.slice(offset, offset + limit);
@@ -364,7 +364,7 @@ describe('createDigitDataProvider', () => {
 
     assert.equal(result.total, 550);
     assert.equal(result.data.length, 1);
-    assert.ok(calls >= 6, `should walk past a 500-row cap, got ${calls} pages`);
+    assert.ok(requestedLimits.some((limit) => limit > 500), 'must not retain the old 500-row cap');
   });
 
   it('getList(boundaries) skips PW_* stubs and still queries ADMIN', async () => {
@@ -397,4 +397,40 @@ describe('createDigitDataProvider', () => {
     assert.ok(queried.includes('REVENUE'));
   });
 
+  it('getList(gender-types) sorts a shuffled generic-MDMS response across pages', async () => {
+    // MDMS v2 has no ordering criterion, so rows arrive in arbitrary order and
+    // sorting must span the whole master, not the current page.
+    const codes = ['DELTA', 'ALPHA', 'ECHO', 'CHARLIE', 'BRAVO'];
+    const rows = codes.map((code, i) => ({
+      id: `id-${i}`,
+      tenantId: 'ke',
+      schemaCode: 'common-masters.GenderType',
+      uniqueIdentifier: code,
+      data: { code },
+      isActive: true,
+      auditDetails: { createdBy: 'x', lastModifiedBy: 'x', createdTime: 1, lastModifiedTime: 1 },
+    }));
+    mock.method(client, 'mdmsSearch', async (_t: string, _s: string, opts?: { limit?: number; offset?: number }) => {
+      const offset = opts?.offset ?? 0;
+      const limit = opts?.limit ?? 100;
+      return rows.slice(offset, offset + limit);
+    });
+
+    const dp = createDigitDataProvider(client, 'ke');
+    const asc = await dp.getList('gender-types', {
+      pagination: { page: 1, perPage: 2 },
+      sort: { field: 'code', order: 'ASC' },
+      filter: {},
+    });
+    assert.deepEqual(asc.data.map((r) => r.code), ['ALPHA', 'BRAVO']);
+    assert.equal(asc.total, 5);
+
+    const descPage2 = await dp.getList('gender-types', {
+      pagination: { page: 2, perPage: 2 },
+      sort: { field: 'code', order: 'DESC' },
+      filter: {},
+    });
+    assert.deepEqual(descPage2.data.map((r) => r.code), ['CHARLIE', 'BRAVO']);
+    assert.equal(descPage2.total, 5);
+  });
 });

--- a/configurator/packages/data-provider/src/providers/dataProvider.test.ts
+++ b/configurator/packages/data-provider/src/providers/dataProvider.test.ts
@@ -174,6 +174,32 @@ describe('createDigitDataProvider', () => {
     assert.equal((captured as { reActivateEmployee: unknown }).reActivateEmployee, false);
   });
 
+  it('getList(localization) does not drop rows when the list pins locales[]', async () => {
+    // LocalizationList writes `{ locales: ['en_IN', 'hi_IN', …] }` as a fetcher
+    // control. Matching that array against a record field stringifies it to
+    // "en_in,hi_in,…" and, because no row has a `locales` column, clientFilter
+    // used to return []. Dashboard (filter: {}) kept the real count.
+    mock.method(client, 'localizationSearch', async (_tenant: string, locale: string) => {
+      if (locale === 'en_IN') {
+        return [{ code: 'HELLO', message: 'Hello', module: 'rainmaker-common', locale }];
+      }
+      return [{ code: 'HELLO', message: 'Bonjour', module: 'rainmaker-common', locale }];
+    });
+
+    const dp = createDigitDataProvider(client, 'ke');
+    const result = await dp.getList('localization', {
+      pagination: { page: 1, perPage: 25 },
+      sort: { field: 'code', order: 'ASC' },
+      filter: { locales: ['en_IN', 'fr_FR'] },
+    });
+
+    assert.equal(result.total, 1);
+    assert.equal(result.data.length, 1);
+    assert.equal(result.data[0].code, 'HELLO');
+    assert.equal((result.data[0] as { msg__en_IN: string }).msg__en_IN, 'Hello');
+    assert.equal((result.data[0] as { msg__fr_FR: string }).msg__fr_FR, 'Bonjour');
+  });
+
   it('uses the real mdmsCount total for a generic MDMS list, not a page-size heuristic (issue #953)', async () => {
     // Departments/Designations previously faked `total` from the page just fetched
     // (`offset + perPage + 1` while a full page kept coming back), so the "X of Y"
@@ -187,7 +213,6 @@ describe('createDigitDataProvider', () => {
       isActive: true,
       auditDetails: { createdBy: 'x', lastModifiedBy: 'x', createdTime: 1, lastModifiedTime: 1 },
     }));
-
     mock.method(client, 'mdmsSearch', async (_t: string, _s: string, options?: { limit?: number; offset?: number }) => {
       const offset = options?.offset ?? 0;
       const limit = options?.limit ?? 100;

--- a/configurator/packages/data-provider/src/providers/dataProvider.ts
+++ b/configurator/packages/data-provider/src/providers/dataProvider.ts
@@ -253,7 +253,17 @@ function clientFilter(records: RaRecord[], filter: Record<string, unknown>): RaR
       // choose which locales to pivot; they are not record fields, so they must
       // not participate in record-level filtering (else every pivoted row, which
       // has msg__<locale> fields but no `locales`/`locale` field, gets dropped).
+      // `locales.0` etc. appear when an array filter is objectified by ra-core
+      // / flattenFilterSources; those must be skipped too.
       if (key === 'locale' || key === 'locale2' || key === 'locales') return true;
+      if (key.startsWith('locale.') || key.startsWith('locale2.') || key.startsWith('locales.')) return true;
+      // Sentinel from LocalizationList's "All modules" Select — never a real module.
+      if (key === 'module' && (value === '__all__' || value === '')) return true;
+      // Arrays/objects are fetcher control data (e.g. locales: ['en_IN', …]).
+      // Matching them against a missing record field stringifies to
+      // "en_in,hi_in,…" / "[object Object]" and drops every row — that's how
+      // /manage/localization showed 0 against a dashboard count of thousands.
+      if (value !== null && typeof value === 'object') return true;
       if (key === 'q' && typeof value === 'string') {
         const q = value.toLowerCase();
         return JSON.stringify(record).toLowerCase().includes(q);
@@ -419,11 +429,16 @@ async function boundaryGetList(client: DigitApiClient, config: ResourceConfig, t
   // tree and left the Boundary picker blank). Falls back to "ADMIN" when no
   // hierarchy definitions are found.
   async function flatForTenant(t: string): Promise<RaRecord[]> {
+    // Playwright onboarding specs leave hundreds of PW_* hierarchy stubs on
+    // live tenants (bomet ke has 214 types, 212 of them PW_*). Searching
+    // only the first page of those (limit 100, newest first) never reaches
+    // ADMIN, every stub tree is empty, and the dashboard shows 0 boundaries
+    // even though the real ADMIN tree has dozens of nodes.
     const hierarchies = await client.boundaryHierarchySearch(t).catch(() => []);
-    const hierarchyTypes = (hierarchies as Record<string, unknown>[])
+    const discovered = (hierarchies as Record<string, unknown>[])
       .map((h) => (typeof h.hierarchyType === 'string' ? h.hierarchyType : ''))
-      .filter(Boolean);
-    const types = hierarchyTypes.length > 0 ? hierarchyTypes : ['ADMIN'];
+      .filter((ht) => ht && !/^PW_/i.test(ht));
+    const types = Array.from(new Set(['ADMIN', ...discovered]));
     const treeLists = await Promise.all(
       types.map((ht) => client.boundaryRelationshipSearch(t, ht).catch(() => [])),
     );
@@ -566,22 +581,31 @@ async function pgrGetList(client: DigitApiClient, config: ResourceConfig, tenant
   });
 }
 
+/** Parse the localization list's `locales` control value into locale codes. */
+function parseLocalesFilter(raw: unknown): string[] {
+  if (raw == null || raw === '') return [];
+  if (Array.isArray(raw)) return raw.map((l) => String(l).trim()).filter(Boolean);
+  // ra-core / flattenFilterSources may objectify an array into {0: 'en_IN', …}.
+  if (typeof raw === 'object') {
+    return Object.values(raw as Record<string, unknown>).map((l) => String(l).trim()).filter(Boolean);
+  }
+  return String(raw).split(',').map((l) => l.trim()).filter(Boolean);
+}
+
 async function localizationGetList(client: DigitApiClient, config: ResourceConfig, tenantId: string, filter?: Record<string, unknown>): Promise<RaRecord[]> {
   // Side-by-side pivot of two locales. The list view picks the locales via
   // dropdowns and passes them as `locale` (left column) and `locale2` (right
   // column). localeB is empty until the user explicitly picks a second locale
   // so the right column starts as all-missing rather than defaulting to a
   // hardcoded locale that may not exist on the tenant.
-  const module = filter?.module ? String(filter.module) : undefined;
+  const module = filter?.module && filter.module !== '__all__' ? String(filter.module) : undefined;
   // Multi-locale pivot: when the caller passes `locales` (array or CSV) the
   // grid wants one editable column per locale (msg__<locale>) instead of the
   // 2-way message/message2 compare — so every language can be edited side by
   // side. Rows are keyed by code+module; a code present in one locale but not
   // another still appears (its missing columns stay empty).
-  const localesRaw = filter?.locales;
-  if (localesRaw) {
-    const locales = (Array.isArray(localesRaw) ? localesRaw : String(localesRaw).split(','))
-      .map((l) => String(l).trim()).filter(Boolean);
+  const locales = parseLocalesFilter(filter?.locales);
+  if (locales.length > 0) {
     const perLocale = await Promise.all(locales.map((l) => client.localizationSearch(tenantId, l, module)));
     const pivotN = new Map<string, Record<string, unknown>>();
     locales.forEach((loc, i) => {

--- a/configurator/packages/data-provider/src/providers/dataProvider.ts
+++ b/configurator/packages/data-provider/src/providers/dataProvider.ts
@@ -430,9 +430,10 @@ async function boundaryGetList(client: DigitApiClient, config: ResourceConfig, t
   // hierarchy definitions are found.
   async function flatForTenant(t: string): Promise<RaRecord[]> {
     // Playwright onboarding specs leave hundreds of PW_* hierarchy stubs on
-    // live tenants (bomet ke has 214 types, 212 of them PW_*). The client
-    // pages through every hierarchy definition; we still skip PW_* so we
-    // do not issue 200 empty tree queries. Always include ADMIN.
+    // live tenants (bomet ke has 214 types, 212 of them PW_*).
+    // DigitApiClient.boundaryHierarchySearch paginates every page (not the
+    // first 100); we still skip PW_* so we do not issue 200 empty tree
+    // queries. Always include ADMIN.
     const hierarchies = await client.boundaryHierarchySearch(t).catch(() => []);
     const discovered = (hierarchies as Record<string, unknown>[])
       .map((h) => (typeof h.hierarchyType === 'string' ? h.hierarchyType : ''))

--- a/configurator/packages/data-provider/src/providers/dataProvider.ts
+++ b/configurator/packages/data-provider/src/providers/dataProvider.ts
@@ -430,10 +430,9 @@ async function boundaryGetList(client: DigitApiClient, config: ResourceConfig, t
   // hierarchy definitions are found.
   async function flatForTenant(t: string): Promise<RaRecord[]> {
     // Playwright onboarding specs leave hundreds of PW_* hierarchy stubs on
-    // live tenants (bomet ke has 214 types, 212 of them PW_*). Searching
-    // only the first page of those (limit 100, newest first) never reaches
-    // ADMIN, every stub tree is empty, and the dashboard shows 0 boundaries
-    // even though the real ADMIN tree has dozens of nodes.
+    // live tenants (bomet ke has 214 types, 212 of them PW_*). The client
+    // pages through every hierarchy definition; we still skip PW_* so we
+    // do not issue 200 empty tree queries. Always include ADMIN.
     const hierarchies = await client.boundaryHierarchySearch(t).catch(() => []);
     const discovered = (hierarchies as Record<string, unknown>[])
       .map((h) => (typeof h.hierarchyType === 'string' ? h.hierarchyType : ''))

--- a/configurator/src/App.tsx
+++ b/configurator/src/App.tsx
@@ -39,7 +39,7 @@ import { NotificationConfigure } from '@/resources/notification-configure/Notifi
 import PgrDashboard from './pages/PgrDashboard';
 import OrgChartPage from './pages/org-chart/OrgChartPage';
 import PublicDashboardConfigure from './resources/public-dashboard/PublicDashboardConfigure';
-import { getGenericMdmsResources, getDataProvider, getAuthProvider, configureDigitClient, digitClient, resetProviders, i18nProvider } from '@/providers/bridge';
+import { getGenericMdmsResources, getDataProvider, getAuthProvider, configureDigitClient, digitClient, resetProviders, i18nProvider, DigitApiClient } from '@/providers/bridge';
 import { ThemeProvider } from '@/providers/ThemeProvider';
 import HelpModal from './components/ui/HelpModal';
 // UndoToast removed — see CCRS#417. The previous Undo button only popped
@@ -280,7 +280,7 @@ function App() {
   // token surfaces only on the first write, as a cryptic downstream NPE, with
   // the UI still pretending to be logged in.
   useEffect(() => {
-    apiClient.setSessionExpiredHandler(() => {
+    const expire = () => {
       try { sessionStorage.setItem(SESSION_EXPIRED_KEY, '1'); } catch { /* ignore */ }
       clearUser();
       localStorage.removeItem(AUTH_STORAGE_KEY);
@@ -288,7 +288,12 @@ function App() {
       digitClient.clearAuth();
       resetProviders();
       setState(s => ({ ...s, isAuthenticated: false, user: null }));
-    });
+    };
+    apiClient.setSessionExpiredHandler(expire);
+    // Management lists (employees / complaints / access-roles) go through
+    // digitClient, not apiClient — without this they show InvalidAccessTokenException
+    // while MDMS cards keep working (those routes don't enforce the token).
+    DigitApiClient.setSessionExpiredHandler(expire);
   }, []);
 
   // Re-sync apiClient on every render if authenticated (handles HMR)
@@ -320,7 +325,11 @@ function App() {
   // Persist auth state to localStorage
   useEffect(() => {
     if (state.isAuthenticated && state.user) {
-            const authData = {
+      const token = apiClient.getAuth().token;
+      // Never persist a blank token over a good session (HMR can run this
+      // before apiClient is restored and would log the operator out).
+      if (!token) return;
+      const authData = {
         isAuthenticated: state.isAuthenticated,
         user: state.user,
         environment: state.environment,
@@ -329,7 +338,7 @@ function App() {
         mode: state.mode,
         currentPhase: state.currentPhase,
         completedPhases: state.completedPhases,
-        authToken: apiClient.getAuth().token,
+        authToken: token,
       };
       localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(authData));
     }

--- a/configurator/src/admin/DigitDashboard.tsx
+++ b/configurator/src/admin/DigitDashboard.tsx
@@ -31,22 +31,20 @@ const ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
 };
 
 /**
- * Page size for the card fetch. MDMS now returns an exact `total` (capped at
- * 500). Always DISPLAY `total`, never `data.length`: PGR `_search` is a page
- * while `_count` is the real number, and localization paginates a 7k+ pivot
- * down to this page size — using `data.length` made those two cards disagree
- * with their list pages.
+ * Cards only render `total`, never `data.length`. Keep perPage at 1 so PGR
+ * `_search` / other paged APIs do not pull a 500-row payload just to badge
+ * a count — MDMS v2 still walks every page inside getList because it has
+ * no total field.
  *
  * LocalizationList pins every AVAILABLE_LOCALES column, so the card must use
  * the same `locales` filter or it counts only en_IN and the list counts the
  * union across languages.
  */
-const DASHBOARD_COUNT_PAGE = 500;
 const LOCALIZATION_LOCALES = AVAILABLE_LOCALES.map((l) => l.locale);
 
 function ResourceCard({ resource }: { resource: string }) {
   const { total, isPending, error } = useGetList(resource, {
-    pagination: { page: 1, perPage: DASHBOARD_COUNT_PAGE },
+    pagination: { page: 1, perPage: 1 },
     sort: { field: 'id', order: 'ASC' },
     filter: resource === 'localization' ? { locales: LOCALIZATION_LOCALES } : {},
   });

--- a/configurator/src/admin/DigitDashboard.tsx
+++ b/configurator/src/admin/DigitDashboard.tsx
@@ -3,6 +3,7 @@ import { DigitCard } from '@/components/digit/DigitCard';
 import { useNavigate } from 'react-router-dom';
 import { getDedicatedResources } from '@/providers/bridge';
 import { useResourceLabel } from '@/providers/useResourceLabel';
+import { AVAILABLE_LOCALES } from '@/providers/i18nProvider';
 import {
   Building2,
   MapPin,
@@ -29,11 +30,25 @@ const ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
   'access-roles': Shield,
 };
 
+/**
+ * Page size for the card fetch. MDMS now returns an exact `total` (capped at
+ * 500). Always DISPLAY `total`, never `data.length`: PGR `_search` is a page
+ * while `_count` is the real number, and localization paginates a 7k+ pivot
+ * down to this page size — using `data.length` made those two cards disagree
+ * with their list pages.
+ *
+ * LocalizationList pins every AVAILABLE_LOCALES column, so the card must use
+ * the same `locales` filter or it counts only en_IN and the list counts the
+ * union across languages.
+ */
+const DASHBOARD_COUNT_PAGE = 500;
+const LOCALIZATION_LOCALES = AVAILABLE_LOCALES.map((l) => l.locale);
+
 function ResourceCard({ resource }: { resource: string }) {
-  const { total, isPending } = useGetList(resource, {
-    pagination: { page: 1, perPage: 1 },
+  const { total, isPending, error } = useGetList(resource, {
+    pagination: { page: 1, perPage: DASHBOARD_COUNT_PAGE },
     sort: { field: 'id', order: 'ASC' },
-    filter: {},
+    filter: resource === 'localization' ? { locales: LOCALIZATION_LOCALES } : {},
   });
 
   const navigate = useNavigate();
@@ -53,8 +68,13 @@ function ResourceCard({ resource }: { resource: string }) {
           </div>
           <div>
             <p className="text-2xl font-bold text-foreground">
-              {isPending ? '...' : (total ?? 0)}
+              {isPending ? '...' : error ? '—' : (total ?? 0)}
             </p>
+            {error ? (
+              <p className="text-xs text-destructive mt-0.5 truncate max-w-[14rem]" title={error instanceof Error ? error.message : String(error)}>
+                {error instanceof Error ? error.message : 'Error loading data'}
+              </p>
+            ) : null}
             <p className="text-sm text-muted-foreground">{label}</p>
           </div>
         </div>

--- a/configurator/src/providers/bridge.ts
+++ b/configurator/src/providers/bridge.ts
@@ -22,6 +22,7 @@ export {
   REGISTRY,
 } from '@digit-mcp/data-provider';
 export type { ResourceConfig } from '@digit-mcp/data-provider';
+export { DigitApiClient } from '@digit-mcp/data-provider';
 
 // Singleton client -- mirrors the existing apiClient pattern.
 // Created with an empty URL; configured later when the user logs in

--- a/configurator/src/resources/localization/LocalizationList.tsx
+++ b/configurator/src/resources/localization/LocalizationList.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { useListContext } from 'ra-core';
 import { DigitList, DigitDatagrid } from '@/admin';
 import type { DigitColumn } from '@/admin';
@@ -62,19 +61,6 @@ function ModuleSelector() {
   );
 }
 
-/** Pins the list to fetch every supported locale so the data provider pivots
- *  one msg__<locale> column per language. Runs once on mount. */
-function LocalesFilterSetup() {
-  const { filterValues, setFilters } = useListContext();
-  useEffect(() => {
-    if (!filterValues.locales) {
-      setFilters({ ...filterValues, locales: LOCALE_CODES }, undefined, true);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-  return null;
-}
-
 /** One editable column per locale (msg__<locale>) so every language can be
  *  edited inline, side by side. */
 function MultiLocaleDatagrid() {
@@ -105,9 +91,12 @@ export function LocalizationList() {
       hasCreate
       sort={{ field: 'code', order: 'ASC' }}
       actions={<LocalizationToolbar />}
+      // Permanent filter so the FIRST getList already pivots every locale.
+      // LocalesFilterSetup used to apply this in a debounced effect, so the
+      // badge flashed en_IN-only (~7900) then the union (~14000).
+      filter={{ locales: LOCALE_CODES }}
     >
       <ModuleSelector />
-      <LocalesFilterSetup />
       <MultiLocaleDatagrid />
     </DigitList>
   );

--- a/configurator/vite.config.ts
+++ b/configurator/vite.config.ts
@@ -19,6 +19,10 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      // Always the package source — dist lags `npm run build` in the package,
+      // and a stale clientFilter is what made /manage/localization show 0 rows
+      // against a live dashboard count.
+      '@digit-mcp/data-provider': path.resolve(__dirname, './packages/data-provider/src/index.ts'),
     },
   },
   server: {


### PR DESCRIPTION
## Summary

Backports #1731 to `master` so the production/master configurator receives the landing-page count fix for #1707.

- Replays the four reviewed #1731 commits on current `master`.
- Preserves the master-only public-dashboard configuration route while adding the shared `DigitApiClient` session-expiry handler.
- Keeps the reviewed MDMS/hierarchy pagination, exact totals, cross-page sorting, localization parity, and bodyless-401 handling intact.

## Validation

- 67/67 applicable offline data-provider tests pass.
- `@digit-mcp/data-provider` TypeScript build passes.
- Production Vite build passes.
- `git diff --check` passes.

Original PR: #1731
Fixes: #1707