### PR TITLE
fix(pgr): make complaint location pin optional

### DIFF
--- a/backend/pgr-services/src/main/java/org/egov/pgr/repository/rowmapper/PGRRowMapper.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/repository/rowmapper/PGRRowMapper.java
@@ -101,8 +101,14 @@ public class PGRRowMapper implements ResultSetExtractor<List<Service>> {
 
         if(service.getAddress() == null){
 
-            Double latitude =  rs.getDouble("latitude");
+            Double latitude = rs.getDouble("latitude");
+            if (rs.wasNull()) {
+                latitude = null;
+            }
             Double longitude = rs.getDouble("longitude");
+            if (rs.wasNull()) {
+                longitude = null;
+            }
             Boundary locality = Boundary.builder().code(rs.getString("locality")).build();
 
             GeoLocation geoLocation = GeoLocation.builder().latitude(latitude).longitude(longitude).build();

--- a/backend/pgr-services/src/test/java/org/egov/pgr/repository/rowmapper/PGRRowMapperTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/repository/rowmapper/PGRRowMapperTest.java
@@ -1,0 +1,59 @@
+package org.egov.pgr.repository.rowmapper;
+
+import org.egov.pgr.web.models.Service;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.sql.ResultSet;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PGRRowMapperTest {
+
+    private final PGRRowMapper rowMapper = new PGRRowMapper();
+
+    @ParameterizedTest(name = "maps latitude {0} and longitude {1} without coercing null or zero")
+    @MethodSource("coordinates")
+    void preservesNullableCoordinates(Double latitude, Double longitude) throws Exception {
+        ResultSet resultSet = mock(ResultSet.class);
+        when(resultSet.next()).thenReturn(true, false);
+        when(resultSet.getString("ser_id")).thenReturn("service-id");
+        when(resultSet.getDouble("latitude")).thenReturn(latitude == null ? 0.0d : latitude);
+        when(resultSet.getDouble("longitude")).thenReturn(longitude == null ? 0.0d : longitude);
+        // The row mapper checks the nullable rating before reading coordinates.
+        // Return false for that first check, then model each coordinate read.
+        when(resultSet.wasNull()).thenReturn(false, latitude == null, longitude == null);
+
+        List<Service> services = rowMapper.extractData(resultSet);
+
+        var jdbcReads = inOrder(resultSet);
+        jdbcReads.verify(resultSet).getDouble("latitude");
+        jdbcReads.verify(resultSet).wasNull();
+        jdbcReads.verify(resultSet).getDouble("longitude");
+        jdbcReads.verify(resultSet).wasNull();
+
+        assertEquals(1, services.size());
+        assertNotNull(services.get(0).getAddress());
+        assertNotNull(services.get(0).getAddress().getGeoLocation());
+        assertEquals(latitude, services.get(0).getAddress().getGeoLocation().getLatitude());
+        assertEquals(longitude, services.get(0).getAddress().getGeoLocation().getLongitude());
+    }
+
+    private static Stream<Arguments> coordinates() {
+        return Stream.of(
+                Arguments.of(null, null),
+                Arguments.of(null, 36.8219d),
+                Arguments.of(-1.2921d, null),
+                Arguments.of(-1.2921d, 36.8219d),
+                Arguments.of(0.0d, 36.8219d),
+                Arguments.of(-1.2921d, 0.0d)
+        );
+    }
+}

--- a/digit-ui-esbuild/products/pgr/src/components/ComplaintLocationMap.js
+++ b/digit-ui-esbuild/products/pgr/src/components/ComplaintLocationMap.js
@@ -8,6 +8,7 @@ import booleanPointInPolygon from "@turf/boolean-point-in-polygon";
 import { point as turfPoint } from "@turf/helpers";
 import useMapConfig from "../hooks/pgr/useMapConfig";
 import useTenantBoundaries from "../hooks/pgr/useTenantBoundaries";
+import { hasUsableGeoLocation } from "../utils/geoLocation";
 
 // Fix default icon issue in React builds
 delete L.Icon.Default.prototype._getIconUrl;
@@ -55,15 +56,16 @@ const ComplaintLocationMap = ({ latitude, longitude, address }) => {
   // Null while the fetch is in flight; empty collection when the tenant has
   // no usable geometry (no overlay — never another tenant's static wards).
   const tenantBoundaries = useTenantBoundaries();
+  const hasLocation = hasUsableGeoLocation({ latitude, longitude });
 
   const matchedWard = useMemo(() => {
     const wardCollection = tenantBoundaries;
-    if (!latitude || !longitude || !wardCollection?.features?.length) return null;
+    if (!hasLocation || !wardCollection?.features?.length) return null;
     const pt = turfPoint([longitude, latitude]);
     return wardCollection.features.find((f) => {
       try { return booleanPointInPolygon(pt, f); } catch { return false; }
     }) || null;
-  }, [latitude, longitude, tenantBoundaries]);
+  }, [hasLocation, latitude, longitude, tenantBoundaries]);
 
   const wardLayerStyle = (feature) => {
     const isMatch = matchedWard && feature?.properties?.code === matchedWard.properties.code;
@@ -74,7 +76,7 @@ const ComplaintLocationMap = ({ latitude, longitude, address }) => {
 
   // Fetch address details based on lat/lng using reverse geocoding
   useEffect(() => {
-    if (!latitude || !longitude) return;
+    if (!hasLocation) return;
 
     const fetchAddressFromCoordinates = async () => {
       setIsLoadingAddress(true);
@@ -141,10 +143,10 @@ const ComplaintLocationMap = ({ latitude, longitude, address }) => {
     };
 
     fetchAddressFromCoordinates();
-  }, [latitude, longitude]);
+  }, [hasLocation, latitude, longitude]);
 
   // If no coordinates provided, don't render the map
-  if (!latitude || !longitude) {
+  if (!hasLocation) {
     return null;
   }
 

--- a/digit-ui-esbuild/products/pgr/src/components/GeoLocations.js
+++ b/digit-ui-esbuild/products/pgr/src/components/GeoLocations.js
@@ -9,6 +9,7 @@ import booleanPointInPolygon from "@turf/boolean-point-in-polygon";
 import { point as turfPoint } from "@turf/helpers";
 import useMapConfig from "../hooks/pgr/useMapConfig";
 import useTenantBoundaries from "../hooks/pgr/useTenantBoundaries";
+import { hasUsableGeoLocation } from "../utils/geoLocation";
 
 // Fix default icon issue in React builds
 delete L.Icon.Default.prototype._getIconUrl;
@@ -128,7 +129,7 @@ const GeoLocations = ({ t, config, onSelect, formData }) => {
   // citizen zooms in from. Clamped so it can't sit outside the tenant's bounds.
   const OVERVIEW_ZOOM = Math.max(minZoom, Math.min(5, maxZoom));
   const [coords, setCoords] = useState(DEFAULT_CENTER);
-  const [markerPos, setMarkerPos] = useState([DEFAULT_CENTER.lat, DEFAULT_CENTER.lng]);
+  const [markerPos, setMarkerPos] = useState(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [suggestions, setSuggestions] = useState([]);
   const [isSearching, setIsSearching] = useState(false);
@@ -150,6 +151,10 @@ const GeoLocations = ({ t, config, onSelect, formData }) => {
   // address back into formData via onSelect, and re-fetching on that write
   // turns one failure into an infinite request loop (CCRS#1380 symptom 4).
   const lastReverseAttempt = useRef(null);
+  // A clear or a newer selection invalidates earlier reverse-geocoding
+  // responses, preventing a slow response from restoring a location the user
+  // has already removed or replaced.
+  const locationRequestId = useRef(0);
 
   // Leaflet writes the stroke as an SVG DOM attribute, which doesn't resolve
   // CSS `var()`. Read the runtime accent at mount so the user-drawn polygon
@@ -188,29 +193,17 @@ const GeoLocations = ({ t, config, onSelect, formData }) => {
   // silently discard the tenant's configured starting position.
   useEffect(() => {
     if (!isReady || hasInitialized.current) return;
-    if (formData?.[config.key]) {
-      hasInitialized.current = true;
-    } else {
-      const savedLocation = Digit.SessionStorage.get("PGR_MAP_LOCATION");
-      if (savedLocation) {
-        hasInitialized.current = true;
-        const { lat, lng, address: savedAddress } = savedLocation;
-        setCoords({ lat, lng });
-        setMarkerPos([lat, lng]);
-        setAddress(savedAddress);
-        setSearchQuery(savedAddress);
-        onSelect(config.key, savedLocation);
-      } else {
-        hasInitialized.current = true;
-        setCoords(DEFAULT_CENTER);
-        setMarkerPos([DEFAULT_CENTER.lat, DEFAULT_CENTER.lng]);
-        mapRef.current?.setView([DEFAULT_CENTER.lat, DEFAULT_CENTER.lng], DEFAULT_ZOOM);
-        // Seed lat/lng immediately so a quick Next click still captures something.
-        onSelect(config.key, { lat: DEFAULT_CENTER.lat, lng: DEFAULT_CENTER.lng });
-        fetchAddress(DEFAULT_CENTER.lat, DEFAULT_CENTER.lng);
-      }
+    hasInitialized.current = true;
+    // This key was historically global to the browser session, so it could
+    // leak a pin from a previous complaint (and between citizen/employee
+    // flows). Wizard-local formData is the sole restoration source now.
+    Digit.SessionStorage.del("PGR_MAP_LOCATION");
+    if (!hasUsableGeoLocation(formData?.[config.key])) {
+      setCoords(DEFAULT_CENTER);
+      setMarkerPos(null);
+      mapRef.current?.setView([DEFAULT_CENTER.lat, DEFAULT_CENTER.lng], OVERVIEW_ZOOM);
     }
-  }, [isReady, DEFAULT_CENTER.lat, DEFAULT_CENTER.lng]);
+  }, [isReady, DEFAULT_CENTER.lat, DEFAULT_CENTER.lng, OVERVIEW_ZOOM]);
 
   // Sync FROM formData (wizard restore / re-entering the map step).
   //
@@ -228,9 +221,10 @@ const GeoLocations = ({ t, config, onSelect, formData }) => {
   const savedLng = savedPoint?.lng;
   const savedAddress = savedPoint?.address;
   useEffect(() => {
-    if (!savedLat || !savedLng) return;
+    if (!hasUsableGeoLocation(savedPoint)) return;
     setCoords({ lat: savedLat, lng: savedLng });
     setMarkerPos([savedLat, savedLng]);
+    mapRef.current?.setView([savedLat, savedLng], DEFAULT_ZOOM);
     // Restore saved address if available
     if (savedAddress) {
       setAddress(savedAddress);
@@ -248,7 +242,7 @@ const GeoLocations = ({ t, config, onSelect, formData }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [savedLat, savedLng, savedAddress]);
 
-  const fetchAddress = async (lat, lng) => {
+  const fetchAddress = async (lat, lng, requestId = ++locationRequestId.current) => {
     // Record the attempt BEFORE the request so even a throwing fetch marks
     // these coords as tried — the sync effect keys off this to avoid looping.
     lastReverseAttempt.current = `${lat},${lng}`;
@@ -260,6 +254,7 @@ const GeoLocations = ({ t, config, onSelect, formData }) => {
         { headers: { "Accept-Language": nominatimLang } }
       );
       const data = await response.json();
+      if (requestId !== locationRequestId.current) return;
       if (data && data.display_name) {
         setAddress(data.display_name);
         setSearchQuery(data.display_name); // Update search bar with fetched address
@@ -273,25 +268,31 @@ const GeoLocations = ({ t, config, onSelect, formData }) => {
           }
         }
         const locationData = { lat, lng, pincode, address: data.display_name, ward };
-        Digit.SessionStorage.set("PGR_MAP_LOCATION", locationData);
         onSelect(config.key, locationData);
       } else {
         const locationData = { lat, lng, ward };
-        Digit.SessionStorage.set("PGR_MAP_LOCATION", locationData);
         onSelect(config.key, locationData);
       }
     } catch (error) {
+      if (requestId !== locationRequestId.current) return;
       console.error("Error fetching address:", error);
       onSelect(config.key, { lat, lng, ward });
     }
   };
 
   const updateLocation = async (lat, lng) => {
+    if (!hasUsableGeoLocation({ lat, lng })) return;
+    const requestId = ++locationRequestId.current;
+    const ward = resolveWard(lat, lng, tenantBoundaries);
     setCoords({ lat, lng });
     setMarkerPos([lat, lng]);
+    setSelectedWard(ward?.code || null);
+    // Persist the explicit user selection before reverse geocoding so a quick
+    // Next click cannot lose the pin. Address/pincode enrichment follows.
+    onSelect(config.key, { lat, lng, ward });
     setIsSearching(true);
-    await fetchAddress(lat, lng);
-    setIsSearching(false);
+    await fetchAddress(lat, lng, requestId);
+    if (requestId === locationRequestId.current) setIsSearching(false);
   };
 
   const handleMapClick = (e) => {
@@ -424,12 +425,18 @@ const GeoLocations = ({ t, config, onSelect, formData }) => {
   };
 
   const clearSearch = () => {
+    locationRequestId.current += 1;
+    lastReverseAttempt.current = null;
+    debouncedFetchSuggestions.cancel();
+    Digit.SessionStorage.del("PGR_MAP_LOCATION");
     setSearchQuery("");
     setAddress("");
     setMarkerPos(null);
     setSuggestions([]);
     setPolygonPoints([]);
     setCoords(DEFAULT_CENTER);
+    setSelectedWard(null);
+    setIsSearching(false);
     if (mapRef.current) {
       mapRef.current.setView([DEFAULT_CENTER.lat, DEFAULT_CENTER.lng], OVERVIEW_ZOOM);
     }

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/ComplaintDetails.js
@@ -23,6 +23,7 @@ import TimeLine from "../../components/TimeLine";
 import ComplaintPhotos from "../../components/ComplaintPhotos";
 import ComplaintLocationMap from "../../components/ComplaintLocationMap";
 import useReopenWindow from "../../hooks/pgr/useReopenWindow";
+import { hasUsableGeoLocation } from "../../utils/geoLocation";
 
 const CLOSED_STATUSES = ["RESOLVED", "REJECTED", "CLOSEDAFTERREJECTION", "CLOSEDAFTERRESOLUTION"];
 const REJECTED_STATUSES = ["REJECTED", "CLOSEDAFTERREJECTION"];
@@ -353,7 +354,7 @@ const ComplaintDetailsPage = () => {
               ) : null}
             </Card>
 
-            {Number.isFinite(geoLocation?.latitude) && Number.isFinite(geoLocation?.longitude) ? (
+            {hasUsableGeoLocation(geoLocation) ? (
               <Card style={{ padding: "20px 24px", display: "flex", flexDirection: "column", gap: "12px" }}>
                 <SectionTitle>{t("CS_COMPLAINT_LOCATION")}</SectionTitle>
                 <ComplaintLocationMap

--- a/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
+++ b/digit-ui-esbuild/products/pgr/src/pages/citizen/Create/CreatePGRFlowV2.tsx
@@ -22,6 +22,7 @@ import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { complaintLabel } from "../../../utils/complaintLabel";
 import { isPostalCodeValid, getPostalCodeErrorMessage, isPostalCodeNumeric } from "../../../utils/postalCode";
+import { serializeGeoLocation } from "../../../utils/geoLocation";
 import { useDispatch } from "react-redux";
 import { useHistory } from "react-router-dom";
 import { useQueryClient } from "react-query";
@@ -153,17 +154,6 @@ function validateString(v: unknown): string {
   return typeof v === "string" && v.trim().length > 0 ? v : "";
 }
 
-function validateGeoLocation(v: { latitude?: number | null; longitude?: number | null }) {
-  if (
-    v &&
-    typeof v.latitude === "number" &&
-    typeof v.longitude === "number"
-  ) {
-    return { latitude: v.latitude, longitude: v.longitude };
-  }
-  return {};
-}
-
 function getEffectiveServiceCode(
   mainType: ServiceDef | null | undefined,
   subType: ServiceDef | null | undefined
@@ -210,10 +200,7 @@ function mapFormDataToRequest(formData: FormData, tenantId: string, user: any) {
             formData?.SelectedBoundary?.code ||
             "",
         },
-        geoLocation: validateGeoLocation({
-          latitude: geoLocation.lat ?? null,
-          longitude: geoLocation.lng ?? null,
-        }),
+        geoLocation: serializeGeoLocation(geoLocation),
       },
       additionalDetail: JSON.stringify(additionalDetail),
       auditDetails: {
@@ -264,7 +251,7 @@ function isFieldValid(data: FormData, fieldKey: keyof FormData | string): boolea
 // Mandatory fields per step (zero-indexed).
 const MANDATORY_BY_STEP: ReadonlyArray<ReadonlyArray<keyof FormData>> = [
   ["SelectComplaintType"], // 0 — type (sub-type is conditionally required, see stepIsValid)
-  ["GeoLocationsPoint"], // 1 — map pin: lat/lng required; auto-seeded on first load so the user just confirms
+  [], // 1 — exact map pin is optional; the administrative boundary remains required on the next step
   ["SelectedBoundary"], // 2 — combined location step: ward must be selected (map auto-fills it; manual fallback if auto-fill missed)
   ["description"], // 3 — description
   [], // 4 — photos (optional)

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
@@ -13,6 +13,7 @@ import ComplaintPhotos from "../../components/ComplaintPhotos";
 import { buildComplaintPath } from "../../utils/complaintHierarchyPath";
 import { selectServiceDefsFromComplaintHierarchy } from "../../utils";
 import useReopenWindow from "../../hooks/pgr/useReopenWindow";
+import { hasUsableGeoLocation } from "../../utils/geoLocation";
 
 // Action configurations used for handling different workflow actions like ASSIGN, REJECT, RESOLVE
 // TO DO: Move this to MDMS for handling Action Modal properties
@@ -727,8 +728,7 @@ const PGRDetails = () => {
                 : []
               ),
               // Conditionally include location section only if coordinates exist
-              ...(pgrData?.ServiceWrappers[0]?.service?.address?.geoLocation?.latitude &&
-                pgrData?.ServiceWrappers[0]?.service?.address?.geoLocation?.longitude
+              ...(hasUsableGeoLocation(pgrData?.ServiceWrappers[0]?.service?.address?.geoLocation)
                 ? [{
                   cardType: "primary",
                   fieldPairs: [

--- a/digit-ui-esbuild/products/pgr/src/utils/geoLocation.js
+++ b/digit-ui-esbuild/products/pgr/src/utils/geoLocation.js
@@ -1,0 +1,32 @@
+/**
+ * Return true when a complaint has coordinates that can be safely displayed
+ * or sent to PGR.
+ *
+ * Older PGR responses represented a missing database location as (0, 0).
+ * Keep treating that exact pair as absent during the backend rollout, while
+ * allowing valid locations on either the equator or prime meridian.
+ */
+export const hasUsableGeoLocation = (location) => {
+  const latitude = location?.latitude ?? location?.lat;
+  const longitude = location?.longitude ?? location?.lng;
+
+  return (
+    Number.isFinite(latitude) &&
+    Number.isFinite(longitude) &&
+    latitude >= -90 &&
+    latitude <= 90 &&
+    longitude >= -180 &&
+    longitude <= 180 &&
+    !(latitude === 0 && longitude === 0)
+  );
+};
+
+/** Convert the map picker's {lat, lng} shape to the PGR API shape. */
+export const serializeGeoLocation = (location) => {
+  if (!hasUsableGeoLocation(location)) return {};
+
+  return {
+    latitude: location.latitude ?? location.lat,
+    longitude: location.longitude ?? location.lng,
+  };
+};

--- a/digit-ui-esbuild/products/pgr/src/utils/index.js
+++ b/digit-ui-esbuild/products/pgr/src/utils/index.js
@@ -2,6 +2,7 @@ import _ from "lodash";
 import axios from "axios";
 import { CustomisedHooks } from "../hooks";
 import { UICustomizations } from "../configs/UICustomizations";
+import { serializeGeoLocation } from "./geoLocation";
 
 export const overrideHooks = () => {
   Object.keys(CustomisedHooks).map((ele) => {
@@ -199,7 +200,7 @@ export const formPayloadToCreateComplaint = (formData, tenantId, user) => {
         "locality": {
           "code": formData?.SelectedBoundary?.code || formData?.SelectLocality?.code,
         },
-        "geoLocation": {}
+        "geoLocation": serializeGeoLocation(formData?.GeoLocationsPoint)
       },
       "additionalDetail": JSON.stringify(additionalDetail),
       "auditDetails": {

--- a/tests/integration-tests/tests/citizen/complaint-detail-page.spec.ts
+++ b/tests/integration-tests/tests/citizen/complaint-detail-page.spec.ts
@@ -73,3 +73,88 @@ Catches the class of regressions where a service code has missing fields and the
   const crashErrors = pageErrors.filter(e => e.includes('Cannot read properties of undefined'));
   expect(crashErrors, `JS crash errors: ${crashErrors.join('; ')}`).toHaveLength(0);
 });
+
+test('complaint location section is hidden when absent and supports valid zero-axis coordinates (#1750)', {
+  annotation: {
+    type: 'description',
+    description: `End-to-end coordinate-display contract for citizen complaint details. API-files four complaints owned by the logged-in citizen: an empty geoLocation, the historical (0,0) sentinel, a point on the equator, and a point on the prime meridian. The whole Complaint Location card must be absent for the first two and must render a Leaflet marker for the latter two. This catches both the empty-header bug and truthiness guards that accidentally reject a legitimate zero coordinate.`,
+  },
+  tag: ['@area:pgr', '@ccrs:1750', '@kind:regression', '@layer:ui', '@persona:citizen'],
+}, async ({ page }) => {
+  test.setTimeout(180_000);
+
+  if (!readProvisionedCitizen()) {
+    test.skip(true, 'citizen-fixture.json missing — citizen-setup project did not run');
+    return;
+  }
+
+  let ids: { missing: string; legacyZero: string; equator: string; primeMeridian: string };
+  try {
+    const [missing, legacyZero, equator, primeMeridian] = await Promise.all([
+      seedComplaintAsCitizen({
+        description: 'PW #1750 missing geo-location detail test',
+        geoLocation: {},
+      }),
+      seedComplaintAsCitizen({
+        description: 'PW #1750 legacy zero geo-location detail test',
+        geoLocation: { latitude: 0, longitude: 0 },
+      }),
+      seedComplaintAsCitizen({
+        description: 'PW #1750 equator geo-location detail test',
+        geoLocation: { latitude: 0, longitude: 36.8 },
+      }),
+      seedComplaintAsCitizen({
+        description: 'PW #1750 prime-meridian geo-location detail test',
+        geoLocation: { latitude: -1.2, longitude: 0 },
+      }),
+    ]);
+    ids = {
+      missing: missing.srid,
+      legacyZero: legacyZero.srid,
+      equator: equator.srid,
+      primeMeridian: primeMeridian.srid,
+    };
+  } catch (error) {
+    test.skip(true, `complaint create blocked on this deployment: ${(error as Error).message.slice(0, 200)}`);
+    return;
+  }
+
+  await citizenOtpLogin(page);
+  await page.route('https://nominatim.openstreetmap.org/reverse**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ display_name: 'Playwright coordinate contract' }),
+    }),
+  );
+
+  const locationHeading = () =>
+    page.getByText(/^(Complaint Location|CS_COMPLAINT_LOCATION)$/i, { exact: true });
+  const locationMarker = () => page.locator('.leaflet-container .leaflet-marker-icon');
+  const openComplaint = async (srid: string) => {
+    await page.goto(`${BASE_URL}/digit-ui/citizen/pgr/complaints/${srid}`, {
+      waitUntil: 'domcontentloaded',
+      timeout: 30_000,
+    });
+    await expect(page.getByText('Complaint Summary', { exact: true })).toBeVisible({ timeout: 30_000 });
+  };
+
+  await openComplaint(ids.missing);
+  await expect(
+    locationHeading(),
+    'SQL NULL coordinates must hide the complete card, not leave an empty heading',
+  ).toHaveCount(0);
+  await expect(locationMarker()).toHaveCount(0);
+
+  await openComplaint(ids.legacyZero);
+  await expect(locationHeading(), 'historical (0,0) must remain treated as absent').toHaveCount(0);
+  await expect(locationMarker()).toHaveCount(0);
+
+  await openComplaint(ids.equator);
+  await expect(locationHeading(), 'latitude=0 with non-zero longitude is a valid location').toBeVisible();
+  await expect(locationMarker()).toHaveCount(1);
+
+  await openComplaint(ids.primeMeridian);
+  await expect(locationHeading(), 'longitude=0 with non-zero latitude is a valid location').toBeVisible();
+  await expect(locationMarker()).toHaveCount(1);
+});

--- a/tests/integration-tests/tests/citizen/file-complaint-wizard.spec.ts
+++ b/tests/integration-tests/tests/citizen/file-complaint-wizard.spec.ts
@@ -8,8 +8,8 @@
  *
  * Ground rules from the 2026-04-29 walk:
  *   - Step 1 (Complaint Details) requires Type + Subtype dropdowns.
- *   - Step 2 (Pin Complaint Location) — don't touch the map (CCRS#469).
- *   - Step 3 (Location Details) postal code is auto-filled from step 2.
+ *   - Step 2 (Pin Complaint Location) is optional and starts with no marker.
+ *   - Step 3 (Location Details) still requires the boundary cascade.
  *   - Step 4 (Complaint's Location) cascades County → Sub-County → Ward,
  *     gating each level (CCRS#477).
  *   - Step 5 description is required.
@@ -130,9 +130,14 @@ test.describe('Citizen file-complaint wizard', () => {
     options: {
       onAfterStep?: (label: string) => Promise<void>;
       assertPincodeToast?: boolean;
+      exerciseOptionalPinClear?: boolean;
     } = {},
   ): Promise<void> {
-    const { onAfterStep, assertPincodeToast = false } = options;
+    const {
+      onAfterStep,
+      assertPincodeToast = false,
+      exerciseOptionalPinClear = false,
+    } = options;
 
     // Modern digit-ui renders dropdowns as <button role="combobox"> (shadcn
     // style); older builds used `input.digit-dropdown-employee-select-wrap--elipses`.
@@ -244,10 +249,93 @@ test.describe('Citizen file-complaint wizard', () => {
 
     await clickNext();
 
-    // ── Step 2: Pin Complaint Location — DON'T touch the map ────────
+    // ── Step 2: Pin Complaint Location (optional) ──────────────────
     await page.waitForTimeout(2500);
     await onAfterStep?.('Step 2 – Pin Location');
+
+    const map = page.locator('.leaflet-container').first();
+    const marker = map.locator('.leaflet-marker-icon');
+    const mapNext = page.locator('button:visible').filter({ hasText: /^NEXT$/ }).first();
+    await expect(map, 'pin-location map must mount before its state is asserted').toBeVisible();
+    await expect(
+      marker,
+      'a fresh complaint must use the configured coordinates only as its viewport, not as a selected pin',
+    ).toHaveCount(0);
+    await expect(
+      mapNext,
+      'the exact map pin is optional; a citizen must be able to continue without one',
+    ).toBeEnabled();
+
+    if (exerciseOptionalPinClear) {
+      // Make reverse geocoding deterministic and deliberately slow. The old
+      // component accepted this response after Clear, patched the cleared
+      // GeoLocationsPoint back into formData, and restored the marker.
+      await page.route('https://nominatim.openstreetmap.org/reverse**', async (route) => {
+        await new Promise((resolve) => setTimeout(resolve, 1200));
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            display_name: 'Playwright delayed reverse-geocode result',
+            address: { postcode: '00100' },
+          }),
+        });
+      });
+      // Typing makes the clear control available immediately. Forward search
+      // is irrelevant to this interaction, so keep it deterministic too.
+      await page.route('https://nominatim.openstreetmap.org/search**', (route) =>
+        route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+      );
+
+      const searchInput = page.locator('input[type="text"]').first();
+      await expect(searchInput).toBeVisible();
+      await searchInput.fill('pin selected only to be cleared');
+
+      const bounds = await map.boundingBox();
+      expect(bounds, 'Leaflet map must have a measurable click target').not.toBeNull();
+      await map.click({
+        position: {
+          x: Math.max(20, Math.floor(bounds!.width * 0.62)),
+          y: Math.max(20, Math.floor(bounds!.height * 0.58)),
+        },
+      });
+      await expect(marker, 'clicking the map must create one explicit pin').toHaveCount(1);
+
+      // GeoLocations intentionally renders this icon-only control immediately
+      // after the search input. Trigger its actual React click handler through
+      // the DOM: the delayed-geocode loading veil otherwise intercepts pointer
+      // events, which is precisely the race this regression needs to exercise.
+      const clearControl = searchInput.locator('xpath=following-sibling::div[1]');
+      await expect(clearControl, 'the map search field must expose its clear control').toHaveCount(1);
+      await clearControl.evaluate((element: HTMLElement) => element.click());
+
+      await expect(marker, 'Clear must remove the explicitly selected pin').toHaveCount(0);
+      await expect(mapNext, 'clearing an optional pin must not disable Next').toBeEnabled();
+
+      // Wait beyond the delayed reverse response. It must be ignored rather
+      // than resurrecting the marker/form value or rewriting session storage.
+      await page.waitForTimeout(1600);
+      await expect(marker, 'a stale reverse-geocode response must not restore a cleared pin').toHaveCount(0);
+      await expect(mapNext).toBeEnabled();
+      const savedMapLocation = await page.evaluate(() =>
+        (window as any).Digit?.SessionStorage?.get?.('PGR_MAP_LOCATION') ?? null,
+      );
+      expect(savedMapLocation, 'Clear must remove the cross-complaint map cache').toBeNull();
+    }
+
     await clickNext();
+
+    if (exerciseOptionalPinClear) {
+      // Re-entering the map step exercises the wizard restore path. The
+      // cleared value must remain cleared after the component remounts.
+      const back = page.locator('button:visible').filter({ hasText: /^BACK$/ }).first();
+      await expect(back).toBeVisible();
+      await back.click();
+      await expect(map).toBeVisible();
+      await expect(marker, 'Back navigation must not restore a cleared/session-cached pin').toHaveCount(0);
+      await expect(mapNext).toBeEnabled();
+      await clickNext();
+    }
 
     if (assertPincodeToast) {
       // No "Pincode not serviceable" toast (CCRS#469 fix verified)
@@ -258,12 +346,10 @@ test.describe('Citizen file-complaint wizard', () => {
     }
 
     // ── Step 3: Location Details — fill EVERY cascade level to the leaf ──
-    // The map pin auto-resolves the boundary cascade only as deep as the
-    // deployment has boundary geometry (geojson). On tenants whose tree is
-    // deeper than the geometry (e.g. Maputo: geometry stops at Bairro but the
-    // hierarchy has a Quarteirão leaf below it), the deepest level(s) render
-    // EMPTY after the pin auto-fill and must be picked manually — the form's
-    // mandatory leaf gate won't enable NEXT until the true leaf is selected.
+    // With no exact pin, every administrative-boundary level is selected
+    // manually. If a caller did keep a pin, its boundary match may prefill
+    // only as deep as the deployment has geometry; this same loop skips those
+    // filled levels and continues to the real leaf.
     // Loop up to 8 levels (was 3 — Kenya's County→SubCounty→Ward) so any
     // number of cascade levels is filled; already-auto-filled levels are
     // skipped, empty ones (the leaf) get selected.
@@ -326,8 +412,8 @@ Steps:
 1. OTP-login as the provisioned citizen (readProvisionedCitizen / citizen-fixture.json).
 2. Open /digit-ui/citizen/pgr/create-complaint/complaint-type.
 3. Step 1 (Complaint Details): pick Type and Subtype from the dropdowns, click Next.
-4. Step 2 (Pin Location): accept the default pin — do NOT touch the map (CCRS#469 keeps the test stable).
-5. Step 3 (Location Details): assert postal code is auto-filled from step 2; click Next.
+4. Step 2 (Pin Location): assert there is no default marker and NEXT is enabled; select a pin, clear it while reverse geocoding is in flight, and assert it stays cleared.
+5. Step 3 (Location Details): complete the required administrative-boundary cascade and click Next.
 6. Step 4 (Complaint's Location): pick County → Sub-County → Ward (cascade gates each level — CCRS#477).
 7. Step 5 (Description): fill the required description, click Next.
 8. Step 6 (Photo): skip the optional dropzone, click SUBMIT.
@@ -349,7 +435,16 @@ Test timeout is 180s — six steps plus DOM settles plus the final POST regularl
     );
     await page.waitForTimeout(5000);
 
-    await walkWizard(page, { assertPincodeToast: true });
+    let createPayload: any = null;
+    page.on('request', (request) => {
+      if (request.method() !== 'POST' || !request.url().includes('/pgr-services/v2/request/_create')) return;
+      try { createPayload = request.postDataJSON(); } catch { /* assertion below reports the missing payload */ }
+    });
+
+    await walkWizard(page, {
+      assertPincodeToast: true,
+      exerciseOptionalPinClear: true,
+    });
 
     // ── Confirmation page contract ─────────────────────────────────
     // Gated on the declared capability, not a stray env hatch: whether a
@@ -373,6 +468,14 @@ Test timeout is 180s — six steps plus DOM settles plus the final POST regularl
 
     // Smoke: no error fallback rendered
     await expect(body).not.toContainText('Something went wrong');
+
+    expect(createPayload, 'the wizard must issue a PGR create request').not.toBeNull();
+    const geoLocation = createPayload?.service?.address?.geoLocation ?? {};
+    expect(
+      geoLocation,
+      'a pin that was cleared before submit must not leak coordinates into the create payload',
+    ).not.toHaveProperty('latitude');
+    expect(geoLocation).not.toHaveProperty('longitude');
   });
 
   test('no raw localization keys visible at any wizard step', {

--- a/tests/integration-tests/tests/citizen/postal-code-alnum-input.spec.ts
+++ b/tests/integration-tests/tests/citizen/postal-code-alnum-input.spec.ts
@@ -76,7 +76,7 @@ test.describe('Citizen v2 postal-code input — alnum/dash regression (PR #1315)
     }
     await clickNext();
 
-    // ── Step 2: Pin Location — don't touch the map (CCRS#469) ───────
+    // ── Step 2: optional Pin Location — continue without a pin ──────
     await page.waitForTimeout(2500);
     await clickNext();
   }
@@ -88,7 +88,7 @@ test.describe('Citizen v2 postal-code input — alnum/dash regression (PR #1315)
 
 Steps:
 1. OTP-login as the provisioned citizen.
-2. Navigate to /digit-ui/citizen/pgr/create-complaint/complaint-type and walk Steps 1-2 (complaint type + pin, don't touch the map).
+2. Navigate to /digit-ui/citizen/pgr/create-complaint/complaint-type and walk Steps 1-2 (complaint type, then continue without the optional pin).
 3. On Step 3 (Location Details), locate #postal-code and type an alnum probe with a space ("SW1A 1AA", the UK example from _example.yml).
 4. Assert the input's value is exactly "SW1A 1AA" — not stripped to only its digits ("11").
 5. Clear and type a dash-suffixed 10-char probe ("12345-6789", the US example from _example.yml).

--- a/tests/integration-tests/tests/citizen/wizard-pin-and-boundary-cascade.spec.ts
+++ b/tests/integration-tests/tests/citizen/wizard-pin-and-boundary-cascade.spec.ts
@@ -34,7 +34,7 @@ Steps:
 3. citizenOtpLogin (provisioned citizen); assert Citizen.token persisted.
 4. Navigate to /pgr/create-complaint/complaint-type, wait 6s for hydration.
 5. Step 1: open type dropdown → pick first item; if a subtype dropdown appears, pick its first item too. NEXT.
-6. Step 2: Pin Location — don't touch the map. NEXT.
+6. Step 2: Pin Location — assert the optional map starts with no marker and NEXT is enabled.
 7. Assert no "pincode not serviceable" toast appeared after step 2.
 8. Step 3 Location Details (cascade): assert exactly 1 cascade dropdown initially (top-level Region/County) — true on every tenant, regardless of hierarchy depth.
 9. Pick the top level; assert dropdown count grows to MORE than 1 (at least one child level appeared).
@@ -119,10 +119,14 @@ Long-running with explicit DOM count assertions to lock in the cascade gating co
     }
     await clickNext();
 
-    // ── Step 2: Pin Location — DON'T touch the map. Click Next. ─────
-    // Pre-fix this would trap the citizen at step 3 with a 40476
-    // toast; we want the wizard to advance straight through.
+    // ── Step 2: optional Pin Location — continue without a pin. ─────
+    // The configured centre is only a viewport. It must not create a marker,
+    // reverse-geocoded postal code, or mandatory-value gate.
     await page.waitForTimeout(2500);
+    const map = page.locator('.leaflet-container').first();
+    await expect(map).toBeVisible();
+    await expect(map.locator('.leaflet-marker-icon')).toHaveCount(0);
+    await expect(page.locator('button:visible').filter({ hasText: /^NEXT$/ }).first()).toBeEnabled();
     await clickNext();
 
     // ── Assert no pincode toast appeared after pin step ──────────────

--- a/tests/integration-tests/tests/employee/pgr-details.spec.ts
+++ b/tests/integration-tests/tests/employee/pgr-details.spec.ts
@@ -24,6 +24,7 @@ import { test, expect, type Page } from '@playwright/test';
 import { loginViaApi } from '../utils/auth';
 import { BASE_URL, TENANT } from '../utils/env';
 import { getPersona } from '../utils/personas';
+import { seedComplaintAsCitizen } from '../utils/seed';
 
 // getPersona('employee') asks the live deployment who actually holds
 // EMPLOYEE/SUPERUSER instead of assuming ADMIN — it tries FLOW5_EMPLOYEE_USER/
@@ -296,5 +297,57 @@ test.describe('PGR complaint details — Flow 5 render slice', () => {
     );
     await expect(takeAction.first()).toBeVisible({ timeout: 10_000 });
     await expect(takeAction.first()).toBeEnabled();
+  });
+
+  test('Story 5.location — optional coordinates hide/show the complete location card (#1750)', {
+    annotation: {
+      type: 'description',
+      description: `Files one complaint with no geoLocation and one at latitude=0/longitude=36.8, then opens each through employee PGR details. The missing location must render neither the card heading nor a map; the equator point must render both. This keeps employee details aligned with the citizen detail contract and prevents truthiness checks from rejecting a valid zero-axis coordinate.`,
+    },
+    tag: ['@area:pgr', '@ccrs:1750', '@kind:regression', '@layer:ui', '@persona:employee'],
+  }, async ({ page }) => {
+    test.setTimeout(180_000);
+
+    let missingId: string;
+    let equatorId: string;
+    try {
+      const [missing, equator] = await Promise.all([
+        seedComplaintAsCitizen({
+          description: 'PW #1750 employee detail without geo-location',
+          geoLocation: {},
+        }),
+        seedComplaintAsCitizen({
+          description: 'PW #1750 employee detail equator geo-location',
+          geoLocation: { latitude: 0, longitude: 36.8 },
+        }),
+      ]);
+      missingId = missing.srid;
+      equatorId = equator.srid;
+    } catch (error) {
+      test.skip(true, `complaint create blocked on this deployment: ${(error as Error).message.slice(0, 200)}`);
+      return;
+    }
+
+    await page.route('https://nominatim.openstreetmap.org/reverse**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ display_name: 'Playwright employee coordinate contract' }),
+      }),
+    );
+    const locationHeading = () =>
+      page.getByText(/^(Complaint Location|CS_COMPLAINT_LOCATION)$/i, { exact: true });
+    const locationMarker = () => page.locator('.leaflet-container .leaflet-marker-icon');
+
+    await openDetails(page, missingId, 'fresh no-location fixture creation failed');
+    await expect(
+      locationHeading(),
+      'employee details must hide the complete location card when coordinates are absent',
+    ).toHaveCount(0);
+    await expect(locationMarker()).toHaveCount(0);
+
+    await openDetails(page, equatorId, 'fresh equator fixture creation failed');
+    await expect(locationHeading(), 'employee details must accept latitude=0').toBeVisible();
+    await expect(locationMarker()).toHaveCount(1);
   });
 });

--- a/tests/integration-tests/tests/specs/pgr-geo-location-contract.spec.ts
+++ b/tests/integration-tests/tests/specs/pgr-geo-location-contract.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+// Production PGR helper is intentionally plain JavaScript; exercise the exact
+// predicate/serializer used by citizen details, employee details, and both
+// create payloads instead of copying its rules into the test suite.
+// @ts-expect-error -- the product package does not publish declarations for this JS utility
+import { hasUsableGeoLocation, serializeGeoLocation } from '../../../../digit-ui-esbuild/products/pgr/src/utils/geoLocation.js';
+
+test.describe('PGR optional geo-location contract (#1750)', () => {
+  test('distinguishes missing/legacy coordinates from valid zero-axis points', {
+    annotation: {
+      type: 'description',
+      description: `Locks the shared coordinate contract used by citizen and employee PGR surfaces. Missing values, malformed/out-of-range values, and the historical (0,0) sentinel are absent; an otherwise-valid point on the equator or prime meridian remains displayable.`,
+    },
+    tag: ['@area:pgr', '@ccrs:1750', '@kind:regression', '@layer:unit', '@persona:cross'],
+  }, () => {
+    const absent = [
+      null,
+      {},
+      { latitude: null, longitude: null },
+      { latitude: 0, longitude: 0 },
+      { latitude: Number.NaN, longitude: 36.8 },
+      { latitude: 91, longitude: 36.8 },
+      { latitude: -1.2, longitude: 181 },
+    ];
+    for (const location of absent) {
+      expect(hasUsableGeoLocation(location), JSON.stringify(location)).toBe(false);
+      expect(serializeGeoLocation(location), JSON.stringify(location)).toEqual({});
+    }
+
+    const usable = [
+      { latitude: 0, longitude: 36.8 },
+      { latitude: -1.2, longitude: 0 },
+      { lat: -1.2921, lng: 36.8219 },
+    ];
+    for (const location of usable) {
+      expect(hasUsableGeoLocation(location), JSON.stringify(location)).toBe(true);
+    }
+
+    expect(serializeGeoLocation(usable[0])).toEqual({ latitude: 0, longitude: 36.8 });
+    expect(serializeGeoLocation(usable[1])).toEqual({ latitude: -1.2, longitude: 0 });
+    expect(serializeGeoLocation(usable[2])).toEqual({ latitude: -1.2921, longitude: 36.8219 });
+  });
+});

--- a/tests/integration-tests/tests/utils/launch-fixes/api.ts
+++ b/tests/integration-tests/tests/utils/launch-fixes/api.ts
@@ -166,6 +166,10 @@ export interface PgrCreateParams {
   /** Optional: send extended_attributes in service body. Per user direction:
    *  content must stay empty {}. Defaults to undefined (omitted). */
   extendedAttributes?: Record<string, unknown>;
+  /** Optional geo-location override for map/detail contract tests. The legacy
+   * default remains (0,0) so existing fixture semantics do not change. Pass
+   * an empty object to exercise a genuinely missing persisted location. */
+  geoLocation?: { latitude?: number; longitude?: number };
 }
 
 export interface PgrCreateResult {
@@ -195,6 +199,7 @@ export async function pgrCreate(params: PgrCreateParams): Promise<PgrCreateResul
     citizenPhone,
     workflowAction = 'APPLY',
     extendedAttributes,
+    geoLocation,
   } = params;
 
   const serviceBody: Record<string, unknown> = {
@@ -205,7 +210,7 @@ export async function pgrCreate(params: PgrCreateParams): Promise<PgrCreateResul
     address: {
       city: tenantId,
       locality: { code: localityCode },
-      geoLocation: { latitude: 0, longitude: 0 },
+      geoLocation: geoLocation ?? { latitude: 0, longitude: 0 },
     },
     citizen: { name: citizenName, mobileNumber: citizenPhone },
   };

--- a/tests/integration-tests/tests/utils/seed.ts
+++ b/tests/integration-tests/tests/utils/seed.ts
@@ -111,6 +111,7 @@ export async function seedComplaintAsCitizen(opts?: {
   serviceCode?: string;
   localityCode?: string;
   description?: string;
+  geoLocation?: { latitude?: number; longitude?: number };
 }): Promise<{ srid: string; status: string }> {
   // Resolved only when the caller left something to resolve — a spec that pins
   // both is asking for one specific complaint and should not be gated on the
@@ -129,6 +130,7 @@ export async function seedComplaintAsCitizen(opts?: {
     description: opts?.description ?? `seed complaint — ${new Date().toISOString()}`,
     citizenName: who.name,
     citizenPhone: who.mobile,
+    geoLocation: opts?.geoLocation,
   });
   filedBy.set(result.serviceRequestId, who);
   return { srid: result.serviceRequestId, status: result.applicationStatus };


### PR DESCRIPTION
## Summary

- starts the shared citizen and employee complaint map without a selected marker; configured coordinates now control only the initial viewport
- keeps the citizen map step optional, clears stale map/session state, and prevents delayed reverse-geocoding responses from restoring a removed pin
- serializes only explicit citizen or CSR selections and keeps administrative boundary selection required
- uses one coordinate contract across citizen details, employee details, map rendering, and payloads; exact legacy (0,0) is absent while either zero axis remains valid
- preserves SQL NULL coordinates in the PGR row mapper instead of coercing them to 0.0
- adds backend and Playwright regression coverage for initial, clear, stale-response, payload, detail-card, and zero-axis cases

## Verification

- digit-ui-esbuild: npm run build — passed; existing repository warnings only
- pgr-services on JDK 17: 270 tests passed, 0 failures
- integration tests: npx tsc --noEmit — passed
- coordinate contract: 1 Playwright test passed with chromium and no setup dependencies
- targeted citizen and employee Playwright discovery: 17 tests listed successfully
- git diff --check — passed

## Sandbox QA gate

The live wizard and detail scenarios require deployment credentials and data, so after deployment verify:

- citizen and CSR create maps initially contain no marker
- citizen can continue without a pin and can select then clear a pin without disabling Next
- CSR submissions without a pin show no Complaint Location card on either details surface
- explicitly selected citizen and CSR pins persist and render on both details surfaces
- a fresh complaint does not inherit a previous complaint pin

Fixes #1750.