### PR TITLE
fix(configurator): align Phase 2 continue icon (#1555)

### DIFF
--- a/configurator/src/pages/Phase2Page.tsx
+++ b/configurator/src/pages/Phase2Page.tsx
@@ -1617,7 +1617,7 @@ out skel qt;`;
             <SubmitBar
               label="Continue to Common Masters"
               onSubmit={handleContinue}
-              icon={<ChevronRight className="w-5 h-5 ml-2" />}
+              icon={<ChevronRight className="w-4 h-4" />}
             />
           </div>
         </DigitCard>


### PR DESCRIPTION
## Summary

- normalize the OSM Phase 2 completion chevron to the same 16px size used by the other continuation actions
- remove the redundant icon margin because `SubmitBar` already supplies consistent flex spacing

Closes #1555

## Validation

- `npm run build --prefix packages/data-provider && npm run build`
- `npm test` (107 tests passed)
- `git diff --check`

`npm run lint` remains red on the current `master` baseline with 154 pre-existing errors across unrelated files.