### PR TITLE
feat(pgr): make escalation status states configurable

### DIFF
--- a/backend/pgr-services/src/main/java/org/egov/pgr/config/PGRConfiguration.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/config/PGRConfiguration.java
@@ -333,6 +333,9 @@ public class PGRConfiguration {
     @Value("${pgr.escalation.kafka.topic}")
     private String escalationKafkaTopic;
 
+    @Value("${pgr.escalation.states:PENDINGATLME,PENDINGFORASSIGNMENT}")
+    private String escalationStates;
+
     // Dashboard
     @Value("${pgr.dashboard.refresh.enabled:true}")
     private Boolean dashboardRefreshEnabled;

--- a/backend/pgr-services/src/main/java/org/egov/pgr/service/EscalationScheduler.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/service/EscalationScheduler.java
@@ -71,8 +71,14 @@ public class EscalationScheduler {
         List<Long> defaultSlaByLevel = getDefaultSlaByLevel(escalationConfig);
         Map<String, List<Long>> overrides = getOverrides(escalationConfig);
 
-        // Search for complaints in PENDINGATLME and PENDINGFORASSIGNMENT
-        Set<String> statuses = new HashSet<>(Arrays.asList(PENDINGATLME, PENDINGFORASSIGNMENT));
+        // Search for complaints in the configured applicationStatus values
+        // (pgr.escalation.states) — deployments customize this to match
+        // whichever states in their BusinessService workflow carry a named
+        // assignee and have an ESCALATE action wired on them.
+        Set<String> statuses = Arrays.stream(config.getEscalationStates().split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toSet());
 
         // Get all tenants — for now, use the state-level tenant from config
         // In a multi-tenant setup, this would iterate over all tenants

--- a/backend/pgr-services/src/main/resources/application.properties
+++ b/backend/pgr-services/src/main/resources/application.properties
@@ -178,6 +178,12 @@ pgr.escalation.batch.size=100
 pgr.escalation.default.sla.ms=432000000
 pgr.escalation.max.depth=3
 pgr.escalation.kafka.topic=pgr-escalation-events
+# Comma-separated applicationStatus values the escalation scan searches for
+# candidate complaints. Must match states that actually carry a named
+# assignee in the deployed BusinessService workflow (the scheduler skips any
+# complaint with no current assignee) and that have an ESCALATE action wired
+# on them — otherwise the workflow transition is rejected and nothing moves.
+pgr.escalation.states=PENDINGATLME,PENDINGFORASSIGNMENT
 
 # Dashboard MV refresh
 pgr.dashboard.refresh.enabled=true

--- a/docs/pgr-escalation/RUNBOOK.md
+++ b/docs/pgr-escalation/RUNBOOK.md
@@ -1,0 +1,167 @@
+# PGR auto-escalation — runbook
+
+Enable `pgr-services`' `EscalationScheduler` (auto-reassign an overdue complaint to the
+current assignee's HRMS supervisor) on a **running** DIGIT/CMS deployment. Terse; every
+command here was run and verified on a real box (tenant `mz`).
+
+**Script** — [`enable-escalation.sh`](../../local-setup/scripts/enable-escalation.sh) is the
+runnable form of everything below: six independent, idempotent steps you can run individually,
+in any subset, in any order (`--only`, `--from`, `--to`), or all at once.
+
+---
+
+## 1. What has to be true for a complaint to actually escalate
+
+Four independent things, all required — missing any one means the scheduler either does
+nothing or errors on that complaint:
+
+| # | What | Where it lives | Failure mode if missing |
+|---|---|---|---|
+| 1 | `pgr.escalation.enabled=true` + `pgr.escalation.states=<comma states>` | `pgr-services` env (`PGR_ESCALATION_ENABLED`, `PGR_ESCALATION_STATES`) | Scheduler never runs, or scans states your workflow doesn't use |
+| 2 | An `ESCALATE` action wired on each scanned state, role matching the scheduler's request | `egov-workflow-v2`'s `eg_wf_action_v2` (per tenant, per `BusinessService`) | `_transition` call rejected — "action not found" / role mismatch |
+| 3 | The complaint has a **named assignee** at that state (not a role-pool state) | `eg_wf_assignee_v2` | Silently skipped — `getCurrentAssignees()` returns empty, nothing logged as an error |
+| 4 | That assignee has `reportingTo` set on their **current** HRMS assignment | `eg_hrms_assignment.reportingto` | `WARN: No supervisor found for any assignee`, skipped |
+
+There is a **fifth**, easy-to-miss one: the scheduler authenticates every transition as a
+`SYSTEM` user whose UUID comes from `egov.internal.microservice.user.uuid`
+(`EGOV_INTERNAL_MICROSERVICE_USER_UUID` env). The property's baked-in default
+(`4fef6612-07a8-4751-97e9-0e0ac0687ebe`) is a **placeholder that does not exist** in any real
+tenant's `egov-user` — every escalation attempt 400s with
+`INVALID UUID: User not found for uuid: ...` until this is set to the tenant's actual
+`INTERNAL_MICROSERVICE_ROLE` SYSTEM user (different per tenant/install — the script discovers
+it live, see step 4 below).
+
+### SLA / level semantics
+
+`RAINMAKER-PGR.EscalationConfig` (MDMS, module `RAINMAKER-PGR`) controls timing, independent
+of the workflow config above:
+```json
+{ "maxDepth": 3, "defaultSlaByLevel": [3600000, 14400000, 86400000], "overrides": {} }
+```
+- `defaultSlaByLevel[i]` = how long the complaint must sit **since its last escalation**
+  before hop `i+1` fires (here: 1h before hop 1, 4h before hop 2, 24h before hop 3).
+- `maxDepth` = hard ceiling on hops per complaint, regardless of SLA.
+- `overrides.<serviceCode>` = a different SLA array for a specific complaint type.
+- The workflow's own `state.sla` / `businessServiceSla` columns are **not** read by this
+  feature at all — don't bother setting them for escalation's sake, they drive something else.
+- **Self-loop design**: this setup wires `ESCALATE` as `currentState == nextState` (assignee
+  changes, `applicationStatus` doesn't). That one action definition covers every level
+  automatically, since the complaint stays in the scanned state after each hop — no
+  per-level or per-"seniority" config needed. The trade-off: nothing visible to a citizen
+  changes on escalation; if you want that, you need a different (state-per-level) design —
+  out of scope for this script.
+
+---
+
+## 2. Run it
+
+```bash
+cd local-setup/scripts
+PGR_SERVICES_IMAGE=<your pushed image tag> \
+EMPLOYEE_UUID=<assignee uuid to link>  SUPERVISOR_UUID=<their new supervisor uuid> \
+TENANT=mz \
+./enable-escalation.sh
+```
+
+`PGR_SERVICES_IMAGE`, `EMPLOYEE_UUID`, `SUPERVISOR_UUID` have **no default** — this script
+never builds an image (bring your own, already pushed) and never guesses your org chart.
+Everything else is a tunable env var with a sane default; see the CONFIG block at the top of
+the script for the full list (`BUSINESS_SERVICE`, `ESCALATE_STATE`, `ESCALATE_ROLE`,
+`PGR_ESCALATION_STATES`, `DB_CONTAINER`, …).
+
+**See what it would do first**: prefix with `DRY_RUN=true` — every step prints the exact
+command/API call/SQL it would run without touching anything.
+
+### The six steps
+
+| Step | Does | Idempotent? |
+|---|---|---|
+| `workflow-action` | Adds `ESCALATE` (self-loop, role `ESCALATE_ROLE`) to `ESCALATE_STATE` on `BUSINESS_SERVICE` for `TENANT` | Yes — checks for an existing `ESCALATE` action on that state first, skips if present |
+| `mdms-check` | Reports whether `RAINMAKER-PGR.EscalationConfig` exists for `TENANT`; seeds it (schema+data, `MAX_DEPTH`/`SLA_BY_LEVEL`) only if `ESCALATION_SEED=true` | Yes — read-only unless seeding, and seeding checks first too |
+| `hrms-link` | Sets `EMPLOYEE_UUID`'s current HRMS assignment `reportingTo = SUPERVISOR_UUID` | Yes — plain `UPDATE`, safe to rerun with the same values |
+| `lookup-system-user` | Read-only: finds the tenant's real `INTERNAL_MICROSERVICE_ROLE` SYSTEM user uuid | Always (read-only) |
+| `deploy` | Sets `PGR_SERVICES_IMAGE` (`.env`) + `PGR_ESCALATION_STATES` / `EGOV_INTERNAL_MICROSERVICE_USER_UUID` (compose file), recreates `pgr-services` (`--no-deps`), waits for healthy | Yes — replaces existing lines in place, never appends duplicates |
+| `verify` | Polls `pgr-services` logs for the latest `Escalation scan complete` line | Read-only |
+
+Run just one:
+```bash
+TENANT=mz ./enable-escalation.sh --only workflow-action
+TENANT=mz ESCALATION_SEED=true ./enable-escalation.sh --only mdms-check
+EMPLOYEE_UUID=... SUPERVISOR_UUID=... ./enable-escalation.sh --only hrms-link
+./enable-escalation.sh --only lookup-system-user
+PGR_SERVICES_IMAGE=... ./enable-escalation.sh --only deploy
+./enable-escalation.sh --only verify
+```
+Or a range: `--from deploy` (deploy + verify), `--to hrms-link` (the first three).
+
+### Worked example (tenant `mz`, live run)
+```
+==> [workflow-action] Add ESCALATE (INVESTIGATION self-loop, role SYSTEM) to PGR / mz
+   [ OK ] ESCALATE already present on INVESTIGATION — nothing to do
+==> [mdms-check] Check RAINMAKER-PGR.EscalationConfig for mz
+   [ OK ] EscalationConfig already present for mz (1 row(s))
+==> [hrms-link] Link EMPLOYEE_UUID -> SUPERVISOR_UUID in HRMS reportingTo
+   [ OK ] verified: eca6a910-... now reports to 97430b68-...
+==> [lookup-system-user] Discover INTERNAL_MICROSERVICE_ROLE user uuid for mz
+   [ OK ] INTERNAL_MICROSERVICE_ROLE uuid for mz: a3efc86f-93e7-43b9-9361-8dd77c94423d
+==> [deploy] Deploy pgr-services with escalation config
+   [ OK ] digit-pgr-services-1 is healthy
+==> [verify] Check pgr-services logs for the latest escalation scan
+   [ OK ] Escalation scan complete: scanned=8, escalated=6, skipped=2
+```
+The 2 skipped there are real complaints whose case managers had no `reportingTo` set yet —
+exactly item 4 in the table above, not a bug.
+
+---
+
+## 3. Troubleshooting
+
+**`INVALID UUID: User not found for uuid: 4fef6612-...`** — the property default (item 5
+above). Fix: `./enable-escalation.sh --only deploy` (it self-resolves the real UUID via
+`lookup-system-user` when `SYSTEM_USER_UUID` is unset).
+
+**`NullPointerException: ... "responeMap" is null` from `egov-workflow-v2`** — usually not a
+workflow-v2 bug in itself; it's `UserService.parseResponse` choking because `egov-user` 502'd
+underneath the proxy. Check `docker ps -a` for `digit-egov-user-1` sitting in `Created` (never
+started) — a leftover from a `docker compose up` that aborted on an unrelated one-shot
+migration container before reaching it. `docker start digit-egov-user-1` fixes it. The
+`egov-user-proxy` container reporting "healthy" does **not** mean the backend behind it is up —
+its healthcheck only checks nginx itself.
+
+**`db-migrations` / `db-history-normalize` "didn't complete successfully: exit 1"` aborts a
+plain `docker compose up -d <service>`** — those one-shot containers aren't idempotent for a
+second run. Either include the full compose overlay set the original deploy used
+(`fast-path.yml migrations.yml monitoring.yml bomet.yml`), or scope the `up` with `--no-deps`
+(what `deploy` does) so dependent one-shots are never re-triggered for a config-only change.
+
+**A step's own postcondition check fails right after a real write succeeds** (e.g.
+`workflow-action` reports "ESCALATE action not found after update" but the DB shows it exists
+moments later) — `egov-workflow-v2` persists business-service writes asynchronously; the API
+response lands before the DB write is visible. Both `workflow-action` and `verify` poll with a
+short retry for this reason — if you hit it anyway, the fix is to wait and re-check, not to
+assume the write failed.
+
+**Complaints keep getting skipped forever, not escalated** — check which of the four
+preconditions in §1 is missing for that specific complaint: no assignee (common for
+role-pool states like `PENDINGFORASSIGNMENT`), no `reportingTo` on the assignee, no
+`ESCALATE` action on that state, or `escalationLevel >= maxDepth` already.
+
+---
+
+## 4. Design notes / known gaps
+
+- **Adding a new state to the chain** needs *two* changes together, not one:
+  `ESCALATE_STATE=<state>` on `workflow-action` (wires the transition) **and**
+  `PGR_ESCALATION_STATES` including that state (so the scheduler actually scans it). Adding
+  either alone leaves it half-configured — looks done, does nothing.
+- **Multi-hop escalation** (level 1→2→3) only continues if the state an escalation lands in is
+  itself in `PGR_ESCALATION_STATES` *and* the new assignee also has `reportingTo` set. With the
+  self-loop design this is automatic for hops within the same state; it stops the moment either
+  condition breaks, silently (a `WARN` log, not an error).
+- **This is a local-machine `/opt/digit` runbook, not a cloud-VM one.** A fresh
+  `./deploy.sh <tenant>` (see `local-setup/ansible/`) overwrites the compose file from this
+  repo's checked-in `docker-compose.egov-digit.yaml`, which does not yet carry
+  `PGR_ESCALATION_STATES` / the `EGOV_INTERNAL_MICROSERVICE_USER_UUID` fix. Until that's added
+  to the canonical file (and a real `pgr-services` image with the `pgr.escalation.states`
+  support is built and pushed by CI), re-running this script is what makes it work on this box,
+  but a fresh cloud deploy would need those source changes first.

--- a/local-setup/scripts/enable-escalation.sh
+++ b/local-setup/scripts/enable-escalation.sh
@@ -1,0 +1,506 @@
+#!/usr/bin/env bash
+# =============================================================================
+# enable-escalation.sh
+#
+# Turn on pgr-services auto-escalation (EscalationScheduler) on a *running*
+# DIGIT / CMS deployment. This is the scripted form of the runbook validated
+# live against tenant `mz`. It does NOT build the pgr-services image — you
+# provide an already-built/pushed image tag (PGR_SERVICES_IMAGE) — and it
+# does NOT guess your org chart — you provide the case-manager -> supervisor
+# UUID pair to link in HRMS (EMPLOYEE_UUID / SUPERVISOR_UUID).
+#
+# Each step is independent and non-dependent on the others having run in the
+# same invocation: every step re-derives whatever it needs (a fresh token,
+# a fresh business-service fetch, a fresh env read) rather than relying on
+# in-memory state from an earlier step. Run them in any order, any subset,
+# any number of times.
+#
+# Steps:
+#   1. workflow-action     Add ESCALATE (self-loop, role SYSTEM) to a state
+#                           on the target BusinessService. Idempotent — skips
+#                           if that state already has an ESCALATE action.
+#   2. mdms-check           Report whether RAINMAKER-PGR.EscalationConfig
+#                           exists for TENANT. With ESCALATION_SEED=true,
+#                           creates it (schema + data) from the committed
+#                           JSON in utilities/default-data-handler if missing.
+#   3. hrms-link            Point EMPLOYEE_UUID's current HRMS assignment at
+#                           SUPERVISOR_UUID (reportingTo). Required inputs,
+#                           no defaults — this is org-chart data, not a knob.
+#   4. lookup-system-user   Discover the tenant's INTERNAL_MICROSERVICE_ROLE
+#                           user uuid via egov-user (prints it; does not
+#                           mutate anything). Feeds step 5 unless you already
+#                           know SYSTEM_USER_UUID.
+#   5. deploy               Set PGR_SERVICES_IMAGE / PGR_ESCALATION_STATES /
+#                           EGOV_INTERNAL_MICROSERVICE_USER_UUID in the
+#                           deployed compose + .env, then recreate pgr-services
+#                           (--no-deps, so one-shot migration containers that
+#                           already ran once are never re-triggered).
+#   6. verify               Tail pgr-services logs for an escalation scan and
+#                           report the last scan's scanned/escalated/skipped.
+#
+# Usage:
+#   ./enable-escalation.sh --list                     # print steps + exit
+#   ./enable-escalation.sh --only workflow-action      # just step 1
+#   ./enable-escalation.sh --only hrms-link            # just step 3
+#   ./enable-escalation.sh --from deploy               # steps 5..6
+#   ./enable-escalation.sh --dry-run                   # print, run nothing
+#
+#   PGR_SERVICES_IMAGE=egovio/pgr-services:my-tag \
+#   EMPLOYEE_UUID=eca6a910-... SUPERVISOR_UUID=97430b68-... \
+#     ./enable-escalation.sh
+#
+# NOTE: PGR_SERVICES_IMAGE (step 5), EMPLOYEE_UUID + SUPERVISOR_UUID (step 3)
+# have NO default — they must be supplied. Every other step/variable is
+# tunable via env vars in the CONFIG block below.
+# =============================================================================
+
+set -euo pipefail
+
+# -----------------------------------------------------------------------------
+# CONFIG — every tunable is an env var with a sane default and a "# what it is".
+# -----------------------------------------------------------------------------
+
+# Filesystem + gateway.
+DIGIT_HOME="${DIGIT_HOME:-/opt/digit}"                    # where the compose stack + .env live
+DIGIT_URL="${DIGIT_URL:-http://localhost:18000}"          # in-box Kong gateway origin
+
+# Tenant + admin identity.
+TENANT="${TENANT:-mz}"                                    # tenant to operate on
+ADMIN_USER="${ADMIN_USER:-ADMIN}"                         # admin user
+ADMIN_PASS="${ADMIN_PASS:-eGov@123}"                      # admin password
+
+# Workflow target (step 1).
+BUSINESS_SERVICE="${BUSINESS_SERVICE:-PGR}"               # BusinessService code to patch
+ESCALATE_STATE="${ESCALATE_STATE:-INVESTIGATION}"         # state to add the ESCALATE action to (self-loop)
+ESCALATE_ROLE="${ESCALATE_ROLE:-SYSTEM}"                  # role allowed to fire it (matches the scheduler's RequestInfo)
+
+# MDMS (step 2). No default seed — off unless explicitly requested.
+ESCALATION_SEED="${ESCALATION_SEED:-false}"               # true = create schema+data if missing
+MAX_DEPTH="${MAX_DEPTH:-3}"                               # only used when seeding
+SLA_BY_LEVEL="${SLA_BY_LEVEL:-3600000,14400000,86400000}" # only used when seeding (ms, one per level)
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+# HRMS link (step 3). REQUIRED — no default, this is org-chart data.
+EMPLOYEE_UUID="${EMPLOYEE_UUID:-}"                        # REQUIRED for step 3 — case manager (or any) employee uuid
+SUPERVISOR_UUID="${SUPERVISOR_UUID:-}"                    # REQUIRED for step 3 — their new reportingTo target
+DB_CONTAINER="${DB_CONTAINER:-docker-postgres}"           # postgres container name
+DB_USER="${DB_USER:-egov}"                                # db user
+DB_NAME="${DB_NAME:-egov}"                                # db name
+
+# Deploy (step 5). PGR_SERVICES_IMAGE REQUIRED — this script never builds it.
+PGR_SERVICES_IMAGE="${PGR_SERVICES_IMAGE:-}"              # REQUIRED for step 5 — pre-built/pushed image tag
+PGR_ESCALATION_STATES="${PGR_ESCALATION_STATES:-INVESTIGATION}" # comma-separated applicationStatus values to scan
+SYSTEM_USER_UUID="${SYSTEM_USER_UUID:-}"                  # optional — if empty, deploy runs lookup-system-user itself
+COMPOSE_FILES="${COMPOSE_FILES:-docker-compose.egov-digit.yaml docker-compose.fast-path.yml docker-compose.migrations.yml docker-compose.monitoring.yml docker-compose.bomet.yml}"
+COMPOSE_PROFILES="${COMPOSE_PROFILES:-mcp,notifications}"
+PGR_SERVICE_NAME="${PGR_SERVICE_NAME:-pgr-services}"      # compose service name
+PGR_CONTAINER="${PGR_CONTAINER:-digit-pgr-services-1}"    # actual container name (project-prefixed)
+
+DRY_RUN="${DRY_RUN:-false}"                               # true = print commands, run nothing
+
+BASIC_OAUTH="Basic ZWdvdi11c2VyLWNsaWVudDo="               # egov-user-client: (empty secret) — same for every DIGIT tenant
+
+# -----------------------------------------------------------------------------
+# Presentation helpers.
+# -----------------------------------------------------------------------------
+C_RESET=""; C_BOLD=""; C_RED=""; C_GRN=""; C_YEL=""; C_CYN=""; C_DIM=""
+init_colors() {
+  if [[ -n "${NO_COLOR:-}" ]] || [[ ! -t 1 ]]; then return; fi
+  C_RESET=$'\033[0m'; C_BOLD=$'\033[1m'; C_RED=$'\033[31m'; C_GRN=$'\033[32m'
+  C_YEL=$'\033[33m'; C_CYN=$'\033[36m'; C_DIM=$'\033[2m'
+}
+step()  { printf '\n%s==> [%s] %s%s\n' "${C_BOLD}${C_CYN}" "$1" "$2" "${C_RESET}"; }
+log()   { printf '   %s%s%s\n' "${C_DIM}" "$*" "${C_RESET}"; }
+ok()    { printf '   %s[ OK ]%s %s\n' "${C_GRN}" "${C_RESET}" "$*"; }
+warn()  { printf '   %s[WARN]%s %s\n' "${C_YEL}" "${C_RESET}" "$*"; }
+err()   { printf '   %s[FAIL]%s %s\n' "${C_RED}" "${C_RESET}" "$*" >&2; }
+note()  { printf '   %sℹ  %s%s\n' "${C_DIM}" "$*" "${C_RESET}"; }
+
+run() {
+  local desc="$1"; shift
+  local cmd="$*"
+  log "$desc"
+  if [[ "$DRY_RUN" == true ]]; then
+    printf '   %s[dry-run]%s %s\n' "${C_YEL}" "${C_RESET}" "$cmd"
+    return 0
+  fi
+  eval "$cmd"
+}
+
+require() {
+  local desc="$1"; shift
+  if [[ "$DRY_RUN" == true ]]; then printf '   %s[dry-run]%s require: %s\n' "${C_YEL}" "${C_RESET}" "$desc"; return 0; fi
+  if eval "$@" >/dev/null 2>&1; then ok "precondition: $desc"; return 0
+  else err "PRECONDITION FAILED: $desc"; return 1; fi
+}
+
+# -----------------------------------------------------------------------------
+# Core helpers.
+# -----------------------------------------------------------------------------
+mint_token() {
+  curl -s -X POST "$DIGIT_URL/user/oauth/token" \
+    -H "Authorization: $BASIC_OAUTH" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    --data-urlencode "grant_type=password" \
+    --data-urlencode "username=$ADMIN_USER" \
+    --data-urlencode "password=$ADMIN_PASS" \
+    --data-urlencode "tenantId=$TENANT" \
+    --data-urlencode "scope=read" \
+    --data-urlencode "userType=EMPLOYEE" 2>/dev/null \
+  | python3 -c 'import sys,json
+try: print(json.load(sys.stdin).get("access_token","") or "")
+except Exception: print("")' 2>/dev/null
+}
+
+db_psql() {
+  # db_psql <sql> — run a SQL statement in $DB_CONTAINER, print tuples-only output.
+  # No -it here: every call site captures stdout via $(...), and -t needs a
+  # real TTY, which a captured subprocess doesn't have — it fails hard with
+  # "the input device is not a TTY". For interactive ad-hoc use, run
+  # `sudo docker exec -it "$DB_CONTAINER" psql -U "$DB_USER" -d "$DB_NAME"` by hand instead.
+  sudo docker exec "$DB_CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" -tAc "$1"
+}
+
+compose() {
+  local files=() f
+  for f in $COMPOSE_FILES; do files+=(-f "$f"); done
+  run "compose $*" "cd '$DIGIT_HOME' && sudo COMPOSE_PROFILES='$COMPOSE_PROFILES' docker compose ${files[*]} $*"
+}
+
+# =============================================================================
+# STEP 1 — workflow-action: add ESCALATE (self-loop) to ESCALATE_STATE.
+#   pre : token mints; BusinessService exists for TENANT
+#   act : fetch BusinessService, append the action if not already present
+#   post: DB shows the action with the expected role
+# =============================================================================
+do_workflow_action() {
+  step "workflow-action" "Add ESCALATE ($ESCALATE_STATE self-loop, role $ESCALATE_ROLE) to $BUSINESS_SERVICE / $TENANT"
+
+  local tok; tok=$(mint_token)
+  require "obtained an admin token for tenant $TENANT" '[[ -n "$tok" ]]' || return 1
+
+  log "Fetching $BUSINESS_SERVICE business service for $TENANT…"
+  local bs_json
+  bs_json=$(curl -s -X POST "$DIGIT_URL/egov-workflow-v2/egov-wf/businessservice/_search?tenantId=$TENANT&businessServices=$BUSINESS_SERVICE" \
+    -H 'Content-Type: application/json' \
+    -d "{\"RequestInfo\":{\"apiId\":\"enable-escalation\",\"authToken\":\"$tok\"}}")
+
+  local already
+  already=$(python3 -c "
+import json,sys
+d = json.loads('''$bs_json''')
+bs = d['BusinessServices'][0]
+for s in bs['states']:
+    if s.get('state') == '$ESCALATE_STATE':
+        print('yes' if any(a['action']=='ESCALATE' for a in (s.get('actions') or [])) else 'no')
+        break
+else:
+    print('no-state')
+")
+
+  if [[ "$already" == "yes" ]]; then
+    ok "ESCALATE already present on $ESCALATE_STATE — nothing to do"
+    return 0
+  fi
+  if [[ "$already" == "no-state" ]]; then
+    err "state $ESCALATE_STATE not found on $BUSINESS_SERVICE for $TENANT"
+    return 1
+  fi
+
+  log "Appending ESCALATE action and pushing the update…"
+  if [[ "$DRY_RUN" == true ]]; then
+    printf '   %s[dry-run]%s would POST businessservice/_update with ESCALATE added to %s\n' "${C_YEL}" "${C_RESET}" "$ESCALATE_STATE"
+    return 0
+  fi
+  local update_payload
+  update_payload=$(python3 -c "
+import json
+d = json.loads('''$bs_json''')
+bs = d['BusinessServices'][0]
+for s in bs['states']:
+    if s.get('state') == '$ESCALATE_STATE':
+        s['actions'].append({'tenantId': '$TENANT', 'currentState': s['uuid'], 'action': 'ESCALATE',
+                              'nextState': s['uuid'], 'roles': ['$ESCALATE_ROLE'], 'active': True})
+print(json.dumps({'RequestInfo': {'apiId': 'enable-escalation', 'authToken': '$tok'}, 'BusinessServices': [bs]}))
+")
+  curl -s -X POST "$DIGIT_URL/egov-workflow-v2/egov-wf/businessservice/_update" \
+    -H 'Content-Type: application/json' -d "$update_payload" >/dev/null
+
+  # workflow-v2's businessservice/_update returns 200 once the write is
+  # accepted, not once it's visible in postgres (same async persist-then-index
+  # lag PGR's own records have) — poll briefly instead of checking once.
+  local roles i=0
+  while [[ $i -lt 10 ]]; do
+    roles=$(db_psql "
+select a.roles from eg_wf_businessservice_v2 b
+join eg_wf_state_v2 s on s.businessserviceid=b.uuid
+join eg_wf_action_v2 a on a.currentstate=s.uuid
+where b.businessservice='$BUSINESS_SERVICE' and b.tenantid='$TENANT' and s.state='$ESCALATE_STATE' and a.action='ESCALATE';")
+    [[ -n "$roles" ]] && break
+    sleep 1; i=$((i+1))
+  done
+  if [[ "$roles" == *"$ESCALATE_ROLE"* ]]; then
+    ok "verified: ESCALATE on $ESCALATE_STATE now has role(s) $roles"
+  else
+    err "ESCALATE action not found after update (waited ${i}s)"
+    return 1
+  fi
+}
+
+# =============================================================================
+# STEP 2 — mdms-check: report (and optionally seed) RAINMAKER-PGR.EscalationConfig.
+# =============================================================================
+do_mdms_check() {
+  step "mdms-check" "Check RAINMAKER-PGR.EscalationConfig for $TENANT"
+
+  local tok; tok=$(mint_token)
+  require "obtained an admin token for tenant $TENANT" '[[ -n "$tok" ]]' || return 1
+
+  local data
+  data=$(curl -s -X POST "$DIGIT_URL/mdms-v2/v2/_search" -H 'Content-Type: application/json' \
+    -d "{\"RequestInfo\":{\"apiId\":\"enable-escalation\",\"authToken\":\"$tok\"},\"MdmsCriteria\":{\"tenantId\":\"$TENANT\",\"schemaCode\":\"RAINMAKER-PGR.EscalationConfig\",\"limit\":50}}")
+  local count
+  count=$(python3 -c "import json,sys; print(len(json.loads('''$data'''.strip()).get('mdms',[])))" 2>/dev/null || echo -1)
+
+  if [[ "$count" -gt 0 ]]; then
+    ok "EscalationConfig already present for $TENANT ($count row(s))"
+    log "$(echo "$data" | python3 -m json.tool 2>/dev/null | head -20)"
+    return 0
+  fi
+
+  warn "EscalationConfig missing for $TENANT"
+  if [[ "$ESCALATION_SEED" != true ]]; then
+    note "not seeding (ESCALATION_SEED=false) — pgr-services will fall back to its flat default SLA"
+    return 0
+  fi
+
+  log "Seeding schema (if needed) + one data row: maxDepth=$MAX_DEPTH, defaultSlaByLevel=[$SLA_BY_LEVEL]"
+  if [[ "$DRY_RUN" == true ]]; then
+    printf '   %s[dry-run]%s would create schema + data from %s/utilities/default-data-handler/src/main/resources/schema/RAINMAKER-PGR.json\n' "${C_YEL}" "${C_RESET}" "$REPO_ROOT"
+    return 0
+  fi
+  python3 - "$DIGIT_URL" "$TENANT" "$tok" "$REPO_ROOT" "$MAX_DEPTH" "$SLA_BY_LEVEL" <<'PYEOF'
+import json, sys, urllib.request
+
+url, tenant, tok, repo_root, max_depth, sla_by_level = sys.argv[1:7]
+
+def post(path, body):
+    req = urllib.request.Request(url + path, data=json.dumps(body).encode(),
+                                  headers={"Content-Type": "application/json"})
+    return urllib.request.urlopen(req, timeout=30)
+
+ri = {"apiId": "enable-escalation", "authToken": tok}
+
+schemas = json.load(open(f"{repo_root}/utilities/default-data-handler/src/main/resources/schema/RAINMAKER-PGR.json"))
+schema = next(s for s in schemas if s["code"] == "RAINMAKER-PGR.EscalationConfig")
+schema = dict(schema); schema["tenantId"] = tenant
+defn = dict(schema.get("definition") or {})
+if defn.get("x-ref-schema") == []:
+    defn.pop("x-ref-schema", None)
+    schema["definition"] = defn
+
+try:
+    post("/mdms-v2/schema/v1/_create", {"RequestInfo": ri, "SchemaDefinition": schema}).read()
+    print("schema created")
+except Exception as e:
+    print(f"schema create skipped/failed (likely already exists): {e}")
+
+row = {"maxDepth": int(max_depth), "defaultSlaByLevel": [int(x) for x in sla_by_level.split(",")], "overrides": {}}
+body = {"RequestInfo": ri, "Mdms": {"tenantId": tenant, "schemaCode": "RAINMAKER-PGR.EscalationConfig", "data": row, "isActive": True}}
+post("/mdms-v2/v2/_create/RAINMAKER-PGR.EscalationConfig", body).read()
+print("data row created")
+PYEOF
+  ok "EscalationConfig seeded for $TENANT"
+}
+
+# =============================================================================
+# STEP 3 — hrms-link: EMPLOYEE_UUID's current assignment reportingTo -> SUPERVISOR_UUID.
+#   REQUIRED inputs, no defaults — this is org-chart data, not a knob.
+# =============================================================================
+do_hrms_link() {
+  step "hrms-link" "Link EMPLOYEE_UUID -> SUPERVISOR_UUID in HRMS reportingTo"
+
+  require "EMPLOYEE_UUID is set" '[[ -n "$EMPLOYEE_UUID" ]]' || { err "set EMPLOYEE_UUID=<uuid>"; return 1; }
+  require "SUPERVISOR_UUID is set" '[[ -n "$SUPERVISOR_UUID" ]]' || { err "set SUPERVISOR_UUID=<uuid>"; return 1; }
+
+  run "UPDATE eg_hrms_assignment.reportingto for $EMPLOYEE_UUID" \
+    "db_psql \"UPDATE eg_hrms_assignment SET reportingto='$SUPERVISOR_UUID' WHERE employeeid='$EMPLOYEE_UUID' AND iscurrentassignment=true;\""
+
+  local got
+  got=$(db_psql "select reportingto from eg_hrms_assignment where employeeid='$EMPLOYEE_UUID' and iscurrentassignment=true;")
+  if [[ "$got" == "$SUPERVISOR_UUID" ]]; then
+    ok "verified: $EMPLOYEE_UUID now reports to $SUPERVISOR_UUID"
+  else
+    err "reportingTo is '$got', expected '$SUPERVISOR_UUID'"
+    return 1
+  fi
+}
+
+# =============================================================================
+# STEP 4 — lookup-system-user: discover the tenant's INTERNAL_MICROSERVICE_ROLE uuid.
+#   Read-only. Prints the uuid on success; used by `deploy` unless
+#   SYSTEM_USER_UUID is already set.
+# =============================================================================
+do_lookup_system_user() {
+  step "lookup-system-user" "Discover INTERNAL_MICROSERVICE_ROLE user uuid for $TENANT"
+
+  local uuid
+  uuid=$(db_psql "
+select u.uuid from eg_user u
+join eg_userrole_v1 r on r.user_id = u.id
+where r.role_code='INTERNAL_MICROSERVICE_ROLE' and r.user_tenantid like '${TENANT}%' and u.type='SYSTEM' and u.active=true
+limit 1;")
+
+  if [[ -z "$uuid" ]]; then
+    err "no active SYSTEM user with role INTERNAL_MICROSERVICE_ROLE found for tenant $TENANT"
+    return 1
+  fi
+  ok "INTERNAL_MICROSERVICE_ROLE uuid for $TENANT: $uuid"
+  echo "$uuid"
+}
+
+# =============================================================================
+# STEP 5 — deploy: point the running compose stack at PGR_SERVICES_IMAGE with
+# escalation config, and recreate pgr-services. Never builds an image.
+# =============================================================================
+do_deploy() {
+  step "deploy" "Deploy $PGR_SERVICE_NAME with escalation config"
+
+  require "PGR_SERVICES_IMAGE is set" '[[ -n "$PGR_SERVICES_IMAGE" ]]' || { err "set PGR_SERVICES_IMAGE=<tag> (this script does not build images)"; return 1; }
+
+  local sys_uuid="$SYSTEM_USER_UUID"
+  if [[ -z "$sys_uuid" ]]; then
+    note "SYSTEM_USER_UUID not set — running lookup-system-user"
+    sys_uuid=$(do_lookup_system_user | tail -n1)
+    [[ -n "$sys_uuid" ]] || { err "could not resolve SYSTEM_USER_UUID; pass it explicitly"; return 1; }
+  fi
+
+  log "Setting PGR_SERVICES_IMAGE in .env…"
+  if [[ "$DRY_RUN" == true ]]; then
+    printf '   %s[dry-run]%s would set PGR_SERVICES_IMAGE=%s in %s/.env\n' "${C_YEL}" "${C_RESET}" "$PGR_SERVICES_IMAGE" "$DIGIT_HOME"
+  else
+    if sudo grep -qE '^PGR_SERVICES_IMAGE=' "$DIGIT_HOME/.env" 2>/dev/null; then
+      sudo sed -i "s|^PGR_SERVICES_IMAGE=.*|PGR_SERVICES_IMAGE=${PGR_SERVICES_IMAGE}|" "$DIGIT_HOME/.env"
+    else
+      printf 'PGR_SERVICES_IMAGE=%s\n' "$PGR_SERVICES_IMAGE" | sudo tee -a "$DIGIT_HOME/.env" >/dev/null
+    fi
+  fi
+
+  log "Ensuring PGR_ESCALATION_STATES / EGOV_INTERNAL_MICROSERVICE_USER_UUID are set in the compose file…"
+  if [[ "$DRY_RUN" == true ]]; then
+    printf '   %s[dry-run]%s would set PGR_ESCALATION_STATES=%s and EGOV_INTERNAL_MICROSERVICE_USER_UUID=%s in %s/docker-compose.egov-digit.yaml\n' \
+      "${C_YEL}" "${C_RESET}" "$PGR_ESCALATION_STATES" "$sys_uuid" "$DIGIT_HOME"
+  else
+    local compose_file="$DIGIT_HOME/docker-compose.egov-digit.yaml"
+    if sudo grep -qE '^\s*PGR_ESCALATION_STATES:' "$compose_file"; then
+      sudo sed -i "s|^\(\s*\)PGR_ESCALATION_STATES:.*|\1PGR_ESCALATION_STATES: ${PGR_ESCALATION_STATES}|" "$compose_file"
+    else
+      sudo sed -i "/PGR_ESCALATION_ENABLED: 'true'/a\\      PGR_ESCALATION_STATES: ${PGR_ESCALATION_STATES}" "$compose_file"
+    fi
+    if sudo grep -qE '^\s*EGOV_INTERNAL_MICROSERVICE_USER_UUID:' "$compose_file"; then
+      sudo sed -i "s|^\(\s*\)EGOV_INTERNAL_MICROSERVICE_USER_UUID:.*|\1EGOV_INTERNAL_MICROSERVICE_USER_UUID: ${sys_uuid}|" "$compose_file"
+    else
+      sudo sed -i "/PGR_ESCALATION_STATES:/a\\      EGOV_INTERNAL_MICROSERVICE_USER_UUID: ${sys_uuid}" "$compose_file"
+    fi
+  fi
+
+  compose up -d --no-deps "$PGR_SERVICE_NAME"
+
+  if [[ "$DRY_RUN" != true ]]; then
+    log "Waiting for $PGR_CONTAINER to report healthy…"
+    local i=0
+    until [[ "$(docker inspect "$PGR_CONTAINER" --format '{{.State.Health.Status}}' 2>/dev/null)" == "healthy" ]]; do
+      sleep 3; i=$((i+1))
+      [[ $i -gt 40 ]] && { err "$PGR_CONTAINER did not become healthy in time"; return 1; }
+    done
+    ok "$PGR_CONTAINER is healthy"
+  fi
+}
+
+# =============================================================================
+# STEP 6 — verify: tail logs for the last escalation scan.
+# =============================================================================
+do_verify() {
+  step "verify" "Check pgr-services logs for the latest escalation scan"
+  # Right after a (re)start, the health check can pass slightly before the
+  # scheduler's first @Scheduled run has logged its completion line (Kafka
+  # group join + MDMS fetch take a couple seconds) — poll briefly rather than
+  # checking once, same eventual-consistency shape as workflow-action's verify.
+  local last i=0
+  while [[ $i -lt 20 ]]; do
+    last=$(docker logs "$PGR_CONTAINER" 2>&1 | grep "Escalation scan complete" | tail -n1 || true)
+    [[ -n "$last" ]] && break
+    sleep 3; i=$((i+1))
+  done
+  if [[ -z "$last" ]]; then
+    warn "no completed escalation scan found after waiting $((i*3))s in $PGR_CONTAINER logs"
+    return 1
+  fi
+  ok "$last"
+}
+
+# =============================================================================
+# main — dispatcher.
+# =============================================================================
+ALL_STEPS=(workflow-action mdms-check hrms-link lookup-system-user deploy verify)
+run_step() {
+  case "$1" in
+    workflow-action)   do_workflow_action ;;
+    mdms-check)         do_mdms_check ;;
+    hrms-link)          do_hrms_link ;;
+    lookup-system-user) do_lookup_system_user ;;
+    deploy)             do_deploy ;;
+    verify)             do_verify ;;
+    *) err "unknown step: $1"; return 1 ;;
+  esac
+}
+
+usage() {
+  sed -n '2,45p' "$0" | sed 's/^# \?//'
+}
+
+main() {
+  init_colors
+  local -a run_list=()
+  local from="" to="" only=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --dry-run) DRY_RUN=true; shift ;;
+      --list) printf '%s\n' "${ALL_STEPS[@]}"; exit 0 ;;
+      --help|-h) usage; exit 0 ;;
+      --only) only="$2"; shift 2 ;;
+      --from) from="$2"; shift 2 ;;
+      --to) to="$2"; shift 2 ;;
+      *) err "unknown argument: $1"; usage; exit 1 ;;
+    esac
+  done
+
+  if [[ -n "$only" ]]; then
+    IFS=',' read -r -a run_list <<< "$only"
+  elif [[ -n "$from" || -n "$to" ]]; then
+    local start=0 end=$(( ${#ALL_STEPS[@]} - 1 )) i
+    for i in "${!ALL_STEPS[@]}"; do
+      [[ -n "$from" && "${ALL_STEPS[$i]}" == "$from" ]] && start=$i
+      [[ -n "$to" && "${ALL_STEPS[$i]}" == "$to" ]] && end=$i
+    done
+    run_list=("${ALL_STEPS[@]:start:end-start+1}")
+  else
+    run_list=("${ALL_STEPS[@]}")
+  fi
+
+  printf '%s%s enable-escalation %s%s\n' "${C_BOLD}${C_CYN}" "$([[ "$DRY_RUN" == true ]] && echo '(DRY RUN)')" "tenant=$TENANT" "${C_RESET}"
+  local step_name failed=0
+  for step_name in "${run_list[@]}"; do
+    if ! run_step "$step_name"; then
+      err "step '$step_name' failed"
+      failed=1
+      break
+    fi
+  done
+
+  echo
+  if [[ $failed -eq 0 ]]; then ok "done"; else err "stopped on failure"; exit 1; fi
+}
+
+main "$@"


### PR DESCRIPTION
- Add pgr.escalation.states property to PGRConfiguration with default values PENDINGATLME,PENDINGFORASSIGNMENT
- Update EscalationScheduler to read escalation states from config instead of hardcoded constants, enabling per-deployment customization
- Add pgr.escalation.states property to application.properties with detailed inline documentation explaining state requirements
- Add RUNBOOK.md documenting the complete escalation feature setup, requirements, configuration, and troubleshooting
- Add enable-escalation.sh script for automated local setup of escalation feature with idempotent steps
- Allows deployments to customize which workflow states trigger escalation based on their BusinessService configuration