### PR TITLE
fix(digit-mcp): authenticate /mcp, /v1 and /api; authorize MCP tools

### DIFF
--- a/.claude/skills/digit-ansible-onboard/SKILL.md
+++ b/.claude/skills/digit-ansible-onboard/SKILL.md
@@ -154,8 +154,13 @@ in from their answers and the actual probe results. Mark each line with
 
   MCP REST shim         <scheme>://<host>/v1/healthz
                         <scheme>://<host>/v1/version
-                        <scheme>://<host>/v1/tools           (no auth)
+                        <scheme>://<host>/v1/tools           (bearer token)
                         <scheme>://<host>/v1/tenant/bootstrap (POST + auth)
+                        — /v1/* all require auth: an Authorization: Bearer
+                          <DIGIT access token> header, or for POST bodies an
+                          "auth": {username, password, tenant_id} envelope.
+                          Tenant tools are admin-tier; a 403 names the roles
+                          required and the roles held.
 
   Status dashboard      <scheme>://<host>/status/
 

--- a/.claude/skills/digit-xlsx-onboard/SKILL.md
+++ b/.claude/skills/digit-xlsx-onboard/SKILL.md
@@ -32,12 +32,36 @@ The skill also accepts the legacy CCRS dataloader format (combined `Department A
 
 ## Procedure
 
+### Step 0 — Mint an access token
+
+`/v1/*` requires authentication. Every call below carries a bearer token, so
+mint one first and keep it in `$MCP_TOKEN` for the session:
+
+```bash
+ssh <alias> 'curl -sS -u egov-user-client: \
+  -d "grant_type=password&scope=read&userType=EMPLOYEE" \
+  --data-urlencode "username=ADMIN" \
+  --data-urlencode "password=eGov@123" \
+  --data-urlencode "tenantId=pg" \
+  http://127.0.0.1:8000/user/oauth/token' | python3 -c 'import sys,json; print(json.load(sys.stdin)["access_token"])'
+```
+
+Export it on the remote side (`MCP_TOKEN=<value>`), or substitute it inline.
+A 401 from any step below means the token expired — mint a new one.
+
+The account must hold an admin role (`SUPERUSER`, `MDMS_ADMIN`, `SYSTEM_ADMIN`
+or `STADMIN`, per `MCP_ADMIN_ROLES`); the tenant tools are admin-tier. A 403
+names both the roles required and the roles held.
+
+`POST` endpoints also accept `"auth": {"username","password","tenant_id"}` in
+the body instead of a header — that is what the Ansible playbook uses.
+
 ### Step 1 — Probe the target MCP
 
 Before touching any files, confirm the target is set up for this workflow:
 
 ```bash
-ssh <alias> "curl -sS http://127.0.0.1:13101/v1/version"
+ssh <alias> "curl -sS -H "Authorization: Bearer $MCP_TOKEN" http://127.0.0.1:13101/v1/version"
 ```
 
 Expect a 200 with `features[]` containing `v1/tools/:name`. If you get `Not found` or HTTP 404, the MCP on this box is older than `4d88968` (REST shim) and the skill cannot run — fall back to `digit-ansible-onboard` to rebuild, or use the JSON-RPC path at `/mcp` (more brittle; prefer rebuild).
@@ -45,7 +69,7 @@ Expect a 200 with `features[]` containing `v1/tools/:name`. If you get `Not foun
 Also probe **which tools exist** so a feature-gap is loud, not silent:
 
 ```bash
-ssh <alias> "curl -sS http://127.0.0.1:13101/v1/tools" \
+ssh <alias> "curl -sS -H "Authorization: Bearer $MCP_TOKEN" http://127.0.0.1:13101/v1/tools" \
   | python3 -c 'import sys,json; t=[x["name"] for x in json.load(sys.stdin)["tools"]]; print("city_setup_from_xlsx:", "city_setup_from_xlsx" in t); print("tenant_cleanup:", "tenant_cleanup" in t); print("validate_tenant:", "validate_tenant" in t)'
 ```
 
@@ -54,7 +78,7 @@ If `city_setup_from_xlsx` is missing, refuse — the operator needs a newer MCP 
 Snapshot the existing tenants so you can sanity-check the target tenant in step 4:
 
 ```bash
-ssh <alias> "curl -sS -X POST http://127.0.0.1:13101/v1/tools/mdms_get_tenants \
+ssh <alias> "curl -sS -H "Authorization: Bearer $MCP_TOKEN" -X POST http://127.0.0.1:13101/v1/tools/mdms_get_tenants \
   -H 'Content-Type: application/json' -d '{}'" | python3 -m json.tool | head -40
 ```
 
@@ -131,7 +155,7 @@ Only if Step 3's Q5 was "yes". Otherwise skip.
 The MCP has an `mdms_update` tool — use it instead of shelling out:
 
 ```bash
-ssh <alias> "curl -sS -X POST http://127.0.0.1:13101/v1/tools/mdms_update \
+ssh <alias> "curl -sS -H "Authorization: Bearer $MCP_TOKEN" -X POST http://127.0.0.1:13101/v1/tools/mdms_update \
   -H 'Content-Type: application/json' -d '{
     \"tenant_id\": \"<root>\",
     \"schema_code\": \"common-masters.UserValidation\",
@@ -164,7 +188,7 @@ If `<root>` (the part of the target tenant before the first `.`) is a **country/
 Detect: `mdms_search` for any schema at `<root>` returns empty / the root isn't in `mdms_get_tenants`. Then run the bootstrap (clones schema defs + ~14 essential data records + ADMIN + PGR workflow from a source state, default `pg`):
 
 ```bash
-ssh <alias> "curl -sS -X POST http://127.0.0.1:13101/v1/tools/tenant_bootstrap \
+ssh <alias> "curl -sS -H "Authorization: Bearer $MCP_TOKEN" -X POST http://127.0.0.1:13101/v1/tools/tenant_bootstrap \
   -H 'Content-Type: application/json' \
   -d '{\"target_tenant\":\"<root>\",\"source_tenant\":\"pg\",
        \"auth\":{\"username\":\"ADMIN\",\"password\":\"eGov@123\",\"tenant_id\":\"pg\"}}'"
@@ -179,7 +203,7 @@ Re-bootstrap of an already-bootstrapped root is idempotent. For an *existing* st
 One POST per call to `city_setup_from_xlsx`. Use the in-container paths from Step 4:
 
 ```bash
-ssh <alias> "curl -sS -X POST http://127.0.0.1:13101/v1/tools/city_setup_from_xlsx \
+ssh <alias> "curl -sS -H "Authorization: Bearer $MCP_TOKEN" -X POST http://127.0.0.1:13101/v1/tools/city_setup_from_xlsx \
   -H 'Content-Type: application/json' -d '{
     \"tenant_id\": \"<target_tenant>\",
     \"tenant_file\":   \"/tmp/onboarding-poc/Tenant And Branding Master.xlsx\",
@@ -201,19 +225,19 @@ The wizard reports what IT did. Independent reads from DIGIT confirm whether it 
 
 ```bash
 # 1. Tenant record at ROOT (not city — tenant.tenants lives at the parent)
-curl -sS -X POST http://127.0.0.1:13101/v1/tools/mdms_search \
+curl -sS -H "Authorization: Bearer $MCP_TOKEN" -X POST http://127.0.0.1:13101/v1/tools/mdms_search \
   -H 'Content-Type: application/json' \
   -d '{"tenant_id":"<root>","schema_code":"tenant.tenants","unique_identifier":"<city_code>"}'
 # Expect: 1 record, data.parent == <root>, data.code == <city_code>
 
 # 2. Boundary hierarchy at CITY (hierarchies do NOT inherit)
-curl -sS -X POST http://127.0.0.1:13101/v1/tools/validate_boundary_hierarchy \
+curl -sS -H "Authorization: Bearer $MCP_TOKEN" -X POST http://127.0.0.1:13101/v1/tools/validate_boundary_hierarchy \
   -H 'Content-Type: application/json' \
   -d '{"tenant_id":"<target_tenant>","hierarchy_type":"<CITY>_ADMIN","expected_levels":[...]}'
 # Expect: valid: true, owner_matches: true, order_matches: true
 
 # 3. Departments / Designations / ComplaintTypes — present at ROOT, inherited by CITY
-curl -sS -X POST http://127.0.0.1:13101/v1/tools/mdms_search \
+curl -sS -H "Authorization: Bearer $MCP_TOKEN" -X POST http://127.0.0.1:13101/v1/tools/mdms_search \
   -H 'Content-Type: application/json' \
   -d '{"tenant_id":"<root>","schema_code":"common-masters.Department","limit":500}'
 # repeat for common-masters.Designation, and RAINMAKER-PGR.ComplaintHierarchy
@@ -222,7 +246,7 @@ curl -sS -X POST http://127.0.0.1:13101/v1/tools/mdms_search \
 # Expect: every code from the source XLSX present with isActive=true.
 
 # 4. Employees at CITY — by mobile (HRMS overrides userName=employeeCode, so by-username doesn't work for files whose userName column differs from code)
-curl -sS -X POST http://127.0.0.1:13101/v1/tools/user_search \
+curl -sS -H "Authorization: Bearer $MCP_TOKEN" -X POST http://127.0.0.1:13101/v1/tools/user_search \
   -H 'Content-Type: application/json' \
   -d '{"tenant_id":"<target_tenant>","mobile_number":"<first_employee_mobile>"}'
 # Expect: 1 user, name matches, tenantId == <target_tenant>, roles populated

--- a/.github/workflows/digit-mcp-ci.yml
+++ b/.github/workflows/digit-mcp-ci.yml
@@ -46,5 +46,12 @@ jobs:
       # artifact confinement, forwarded-for trust, request isolation). These are
       # invariants a refactor can silently break, so they gate the build rather
       # than living in a reviewer's memory. Refs #1641.
-      - name: Security boundary tests
+      - name: Security boundary tests (policy)
         run: npm run test:security
+
+      # Enforcement, over a real socket against a stub egov-user. The unit
+      # suite proves the tier decision is right; this proves it is actually
+      # called, on every route. Deleting the authorization wiring passes the
+      # unit suite and fails this one.
+      - name: Security boundary tests (enforcement)
+        run: npm run test:security:http

--- a/.github/workflows/digit-mcp-ci.yml
+++ b/.github/workflows/digit-mcp-ci.yml
@@ -41,3 +41,10 @@ jobs:
       # environment (test-integration, test-e2e-new-tenant, …) stay out of CI.
       - name: Unit tests (no environment required)
         run: npx tsx test-master-localizations.ts
+
+      # The security boundary (auth modes, tool access tiers, redaction,
+      # artifact confinement, forwarded-for trust, request isolation). These are
+      # invariants a refactor can silently break, so they gate the build rather
+      # than living in a reviewer's memory. Refs #1641.
+      - name: Security boundary tests
+        run: npm run test:security

--- a/devops/deploy-as-code/charts/auxiliary-services/auxiliary-helmfile.yaml
+++ b/devops/deploy-as-code/charts/auxiliary-services/auxiliary-helmfile.yaml
@@ -42,9 +42,16 @@ releases:
     chart: ../../../../digit-mcp/helm/digit-mcp
     missingFileHandler: Warn
     values:
+      # Was ghcr.io/subhashini-egov/digit-mcp:2026-06-11 — a personal registry
+      # fed by a different repository, so nothing built from this tree ever
+      # reached the cluster. egovio/digit-mcp is what build/build-config.yml
+      # publishes from digit-mcp/Dockerfile.
+      #
+      # Pin a dated tag, not develop-<sha8>: the nightly prune keeps only the 5
+      # most recent sha tags, so a sha pin vanishes within about a week.
       - image:
-          repository: ghcr.io/subhashini-egov/digit-mcp
-          tag: "2026-06-11"
+          repository: egovio/digit-mcp
+          tag: "nightly-develop"
         service:
           type: ClusterIP
         env:

--- a/digit-mcp/Dockerfile
+++ b/digit-mcp/Dockerfile
@@ -29,7 +29,9 @@ ENV SESSION_DB_HOST=localhost
 ENV SESSION_DB_PORT=15433
 ENV SESSION_DB_NAME=mcp_sessions
 ENV SESSION_DB_USER=mcp
-# No default password baked into the image — supply SESSION_DB_PASSWORD at run time.
+# SESSION_DB_PASSWORD is deliberately not set here. src/services/db.ts still
+# falls back to the local-compose default so `docker compose up` works, but it
+# warns on the HTTP transport — supply a real value in any networked deploy.
 EXPOSE 3000
 
 # Run unprivileged. Previously this ran as root, which turned any file-write bug

--- a/digit-mcp/Dockerfile
+++ b/digit-mcp/Dockerfile
@@ -16,6 +16,10 @@ COPY packages/data-provider/package.json packages/data-provider/package.json
 RUN npm ci --omit=dev
 COPY --from=builder /app/dist dist/
 COPY --from=builder /app/packages/data-provider/dist packages/data-provider/dist/
+# The session viewer is served from disk at runtime (serveStatic resolves
+# ../ui relative to dist/). Without this the image 404s on `/` and every
+# /api/* consumer of it — including the sign-in gate — is unreachable.
+COPY ui/ ui/
 # Writable paths, owned by the unprivileged runtime user. The logger mkdir's its
 # own directory at import time, so it has to exist and be writable before we drop
 # privileges. `artifacts` backs MCP_ARTIFACT_DIR (snapshot output confinement).

--- a/digit-mcp/Dockerfile
+++ b/digit-mcp/Dockerfile
@@ -16,7 +16,12 @@ COPY packages/data-provider/package.json packages/data-provider/package.json
 RUN npm ci --omit=dev
 COPY --from=builder /app/dist dist/
 COPY --from=builder /app/packages/data-provider/dist packages/data-provider/dist/
-RUN mkdir -p /app/data
+# Writable paths, owned by the unprivileged runtime user. The logger mkdir's its
+# own directory at import time, so it has to exist and be writable before we drop
+# privileges. `artifacts` backs MCP_ARTIFACT_DIR (snapshot output confinement).
+RUN mkdir -p /app/data/artifacts /var/log/digit-mcp \
+ && chown -R node:node /app/data /var/log/digit-mcp
+
 ENV MCP_TRANSPORT=http
 ENV SESSION_DATA_DIR=/app/data
 ENV MCP_PORT=3000
@@ -24,6 +29,10 @@ ENV SESSION_DB_HOST=localhost
 ENV SESSION_DB_PORT=15433
 ENV SESSION_DB_NAME=mcp_sessions
 ENV SESSION_DB_USER=mcp
-ENV SESSION_DB_PASSWORD=mcp123
+# No default password baked into the image — supply SESSION_DB_PASSWORD at run time.
 EXPOSE 3000
+
+# Run unprivileged. Previously this ran as root, which turned any file-write bug
+# into a write-anything bug (including over /app/dist).
+USER node
 CMD ["node", "dist/index.js"]

--- a/digit-mcp/README.md
+++ b/digit-mcp/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/ChakshuGautam/digit-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/ChakshuGautam/digit-mcp/actions/workflows/ci.yml)
 
-MCP server + data provider for the [DIGIT](https://docs.digit.org) eGov platform — **60 MCP tools** across **14 groups**, a **shared TypeScript API client** (`@digit-mcp/data-provider`), and a **react-admin DataProvider/AuthProvider** for building DIGIT frontends.
+MCP server + data provider for the [DIGIT](https://docs.digit.org) eGov platform — **70 MCP tools** across **16 groups**, a **shared TypeScript API client** (`@digit-mcp/data-provider`), and a **react-admin DataProvider/AuthProvider** for building DIGIT frontends.
 
 Only 11 tools load initially (`core` + `docs`). The rest unlock on demand via `enable_tools`, so agents aren't overwhelmed with options they don't need yet.
 
@@ -48,21 +48,23 @@ Add to `~/.claude.json` or project `.mcp.json`:
 ```
 
 The hosted endpoint requires a DIGIT access token. It is introspected against
-egov-user on every call, and the tools run as *you* — the server never
+egov-user (cached for 30s), and the tools run as *you* — the server never
 substitutes its own credentials for a network caller. Get a token from the
-OAuth endpoint of the DIGIT instance you are targeting:
+OAuth endpoint of the DIGIT instance you are targeting. Note the trailing colon
+on `-u`: DIGIT's client secret is empty.
 
 ```bash
-curl -s -u egov-user-client:egov-user-secret \
+curl -s -u egov-user-client: \
   -d 'grant_type=password&scope=read&userType=EMPLOYEE' \
-  --data-urlencode "username=$USER" \
-  --data-urlencode "password=$PASS" \
+  --data-urlencode "username=$DIGIT_USER" \
+  --data-urlencode "password=$DIGIT_PASS" \
   --data-urlencode "tenantId=pg" \
   https://<digit-host>/user/oauth/token | jq -r .access_token
 ```
 
-Tools are tiered `public` / `employee` / `admin`; a citizen account can reach
-the public ones only. If an admin-tier tool returns 403, the message names both
+Tools are tiered `public` / `employee` / `admin` (6 / 29 / 35 of the 70). The
+recipe above mints an employee token; a citizen account reaches the public
+tools only. If an admin-tier tool returns 403, the message names both
 the roles it needs and the roles you hold — see `MCP_ADMIN_ROLES` in
 [`helm/digit-mcp/values.yaml`](helm/digit-mcp/values.yaml).
 
@@ -108,7 +110,7 @@ Add to your MCP settings (`.cursor/mcp.json`, `.windsurf/mcp.json`, or VS Code M
 
 ## CLI
 
-The `digit` CLI provides the same 56 tools as the MCP server, auto-generated from the shared tool registry. No per-tool CLI code — adding an MCP tool automatically adds a CLI command.
+The `digit` CLI provides the same 70 tools as the MCP server, auto-generated from the shared tool registry. No per-tool CLI code — adding an MCP tool automatically adds a CLI command.
 
 ### Install
 
@@ -180,7 +182,7 @@ docker run -p 3000:3000 \
   -e CRS_ENVIRONMENT=chakshu-digit \
   -e CRS_USERNAME=ADMIN \
   -e CRS_PASSWORD=eGov@123 \
-  ghcr.io/chakshugautam/digit-mcp:latest
+  egovio/digit-mcp:nightly-develop
 
 # Health check
 curl http://localhost:3000/healthz
@@ -190,10 +192,15 @@ curl http://localhost:3000/healthz
 
 ```bash
 helm install digit-mcp ./helm/digit-mcp \
-  --set env.CRS_ENVIRONMENT=chakshu-digit \
+  --set image.tag=nightly-develop \
+  --set env.CRS_ENVIRONMENT=self-hosted \
+  --set secret.SESSION_DB_PASSWORD=<session-db-password> \
   --set secret.CRS_USERNAME=ADMIN \
   --set secret.CRS_PASSWORD=eGov@123
 ```
+
+`CRS_USERNAME`/`CRS_PASSWORD` are only used by the ambient-mode fallback, which
+`MCP_AUTH_MODE=token` (the default on the HTTP transport) disables.
 
 See [`helm/digit-mcp/values.yaml`](helm/digit-mcp/values.yaml) for all options.
 
@@ -259,7 +266,7 @@ enable_tools(["tracing"]) → trace_debug → trace_get
 | [Building a PGR UI](docs/ui.md) | Complete guide to building complaint management frontends |
 | [Architecture](docs/architecture.md) | Server internals, transport, progressive disclosure |
 | [CLI Architecture](docs/cli-architecture.md) | How the CLI is auto-generated from the tool registry |
-| [API Reference](docs/api/README.md) | All 60 tools with parameters and examples |
+| [API Reference](docs/api/README.md) | All 70 tools with parameters and examples |
 | [OpenAPI Spec](docs/openapi.yaml) | Machine-readable API specification |
 
 ## Data Provider (`@digit-mcp/data-provider`)
@@ -355,6 +362,14 @@ getResourceBySchema('RAINMAKER-PGR.ServiceDefs');  // → complaint-types config
 | `CRS_PASSWORD` | — | DIGIT admin password |
 | `CRS_TENANT_ID` | from env config | Tenant for authentication |
 | `MCP_ENABLE_ALL_GROUPS` | — | Set to `1` to enable all tool groups on startup |
+| `MCP_AUTH_MODE` | `token` on http, `ambient` on stdio | Whether network callers must present a validated token. `ambient` makes every anonymous caller act as `CRS_USERNAME` — loopback-bound sockets only |
+| `MCP_ADMIN_ROLES` | `SUPERUSER,MDMS_ADMIN,SYSTEM_ADMIN,STADMIN` | Role codes that satisfy an `admin`-tier tool |
+| `MCP_ALLOWED_BASE_URLS` | the configured `CRS_API_URL` | Hosts `configure`'s `base_url` may be pointed at |
+| `MCP_ARTIFACT_DIR` | `$SESSION_DATA_DIR/artifacts` | Directory snapshot artifacts are confined to |
+| `MCP_TRUSTED_PROXIES` | — (never trusted) | Peers whose `X-Forwarded-For` is honoured; IPv4/IPv6 addresses or CIDRs, or `*` |
+| `MCP_DEFAULT_PROVISIONING_PASSWORD` | `eGov@123` | Password given to accounts this server **creates**. A published default — override it |
+| `MCP_CORS_ORIGINS` | — | Origins allowed to call `/v1/*` and `/api/*` cross-origin |
+| `SESSION_DB_PASSWORD` | `mcp123` | Session-viewer database password. Published default — set it on any networked deploy |
 
 ## Environments
 
@@ -400,7 +415,7 @@ src/
 │   ├── digit-api.ts      # DIGIT API client (auth, multi-tenant, all services)
 │   ├── session-store.ts  # PostgreSQL session tracking
 │   └── telemetry.ts      # Matomo analytics
-├── tools/                # 60 tools across 16 registration files
+├── tools/                # 70 tools across 18 registration files
 │   ├── registry.ts       # ToolRegistry (group enable/disable lifecycle)
 │   └── index.ts          # registerAllTools() aggregator
 ├── utils/

--- a/digit-mcp/README.md
+++ b/digit-mcp/README.md
@@ -62,7 +62,7 @@ curl -s -u egov-user-client: \
   https://<digit-host>/user/oauth/token | jq -r .access_token
 ```
 
-Tools are tiered `public` / `employee` / `admin` (6 / 30 / 34 of the 70). The
+Tools are tiered `public` / `employee` / `admin` (6 / 25 / 39 of the 70). The
 recipe above mints an employee token; a citizen account reaches the public
 tools only. If an admin-tier tool returns 403, the message names both
 the roles it needs and the roles you hold — see `MCP_ADMIN_ROLES` in

--- a/digit-mcp/README.md
+++ b/digit-mcp/README.md
@@ -62,7 +62,7 @@ curl -s -u egov-user-client: \
   https://<digit-host>/user/oauth/token | jq -r .access_token
 ```
 
-Tools are tiered `public` / `employee` / `admin` (6 / 29 / 35 of the 70). The
+Tools are tiered `public` / `employee` / `admin` (6 / 30 / 34 of the 70). The
 recipe above mints an employee token; a citizen account reaches the public
 tools only. If an admin-tier tool returns 403, the message names both
 the roles it needs and the roles you hold — see `MCP_ADMIN_ROLES` in

--- a/digit-mcp/README.md
+++ b/digit-mcp/README.md
@@ -38,11 +38,33 @@ Add to `~/.claude.json` or project `.mcp.json`:
   "mcpServers": {
     "DIGIT-MCP": {
       "type": "http",
-      "url": "https://mcp.egov.theflywheel.in/mcp"
+      "url": "https://mcp.egov.theflywheel.in/mcp",
+      "headers": {
+        "Authorization": "Bearer <your DIGIT access token>"
+      }
     }
   }
 }
 ```
+
+The hosted endpoint requires a DIGIT access token. It is introspected against
+egov-user on every call, and the tools run as *you* — the server never
+substitutes its own credentials for a network caller. Get a token from the
+OAuth endpoint of the DIGIT instance you are targeting:
+
+```bash
+curl -s -u egov-user-client:egov-user-secret \
+  -d 'grant_type=password&scope=read&userType=EMPLOYEE' \
+  --data-urlencode "username=$USER" \
+  --data-urlencode "password=$PASS" \
+  --data-urlencode "tenantId=pg" \
+  https://<digit-host>/user/oauth/token | jq -r .access_token
+```
+
+Tools are tiered `public` / `employee` / `admin`; a citizen account can reach
+the public ones only. If an admin-tier tool returns 403, the message names both
+the roles it needs and the roles you hold — see `MCP_ADMIN_ROLES` in
+[`helm/digit-mcp/values.yaml`](helm/digit-mcp/values.yaml).
 
 Or for local stdio:
 
@@ -73,7 +95,10 @@ Add to your MCP settings (`.cursor/mcp.json`, `.windsurf/mcp.json`, or VS Code M
 {
   "mcpServers": {
     "DIGIT-MCP": {
-      "url": "https://mcp.egov.theflywheel.in/mcp"
+      "url": "https://mcp.egov.theflywheel.in/mcp",
+      "headers": {
+        "Authorization": "Bearer <your DIGIT access token>"
+      }
     }
   }
 }

--- a/digit-mcp/agent-tests/helpers.ts
+++ b/digit-mcp/agent-tests/helpers.ts
@@ -142,13 +142,23 @@ async function pushMessagesToViewer(prompt: string, messages: SDKMessage[]): Pro
   }
 
   try {
+    // /api/* requires an admin-tier DIGIT token when the viewer runs in token
+    // mode (the default for the HTTP transport). Unset => the push 401s and we
+    // just skip it, which is the same graceful degradation as "viewer not running".
+    const viewerToken = process.env.VIEWER_TOKEN || process.env.DIGIT_ACCESS_TOKEN;
     const res = await fetch(`${VIEWER_URL}/api/sessions/${viewerSessionId}/messages`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        ...(viewerToken ? { Authorization: `Bearer ${viewerToken}` } : {}),
+      },
       body: JSON.stringify({ messages: viewerMessages, environment: "agent-test" }),
     });
     if (!res.ok) {
-      console.error(`[viewer] Failed to push messages: ${res.status}`);
+      const hint = res.status === 401 || res.status === 403
+        ? " — set VIEWER_TOKEN to an admin-role DIGIT access token"
+        : "";
+      console.error(`[viewer] Failed to push messages: ${res.status}${hint}`);
     }
   } catch {
     // Viewer might not be running — ignore silently

--- a/digit-mcp/docs/README.md
+++ b/digit-mcp/docs/README.md
@@ -1,6 +1,6 @@
 # DIGIT MCP Server Documentation
 
-MCP server that bridges Claude to the DIGIT eGov platform -- 60 tools across 14 groups covering tenant management, grievance redressal (PGR), employee management, workflow, and observability.
+MCP server that bridges Claude to the DIGIT eGov platform -- 70 tools across 16 groups covering tenant management, grievance redressal (PGR), employee management, workflow, and observability.
 
 ## Guides
 

--- a/digit-mcp/docs/api/README.md
+++ b/digit-mcp/docs/api/README.md
@@ -2,7 +2,7 @@
 
 > Complete reference for all 60 DIGIT MCP Server tools, grouped by domain.
 
-Tools are organized into 14 groups. Only `core` and `docs` are enabled by default — use [`enable_tools`](tools/enable_tools.md) to unlock additional groups.
+Tools are organized into 15 groups. Only `core` and `docs` are enabled by default — use [`enable_tools`](tools/enable_tools.md) to unlock additional groups.
 
 ---
 

--- a/digit-mcp/docs/api/tools/configure.md
+++ b/digit-mcp/docs/api/tools/configure.md
@@ -12,6 +12,23 @@ The tool supports multi-tenant login with automatic fallback. When a `tenant_id`
 
 Credentials can be passed as parameters or via the `CRS_USERNAME` and `CRS_PASSWORD` environment variables. The environment variable approach is recommended for automated/CI usage.
 
+## Authorization
+
+`configure` is **admin**-tier: it authenticates, and with `provision_roles` it
+can grant roles on the target tenant. It is also `risk: "write"`, so clients
+that auto-approve read-only tools will ask before running it.
+
+`provision_roles` (default `false`) is opt-in. When login falls back to a
+different tenant than requested, this grants the standard role set — including
+`SUPERUSER` — on the target. It previously ran automatically, which made a
+privilege grant a side effect of a tool documented as "connect to an
+environment".
+
+`base_url` is restricted to allow-listed hosts (`MCP_ALLOWED_BASE_URLS`, which
+extends rather than replaces the configured `CRS_API_URL`), and in token mode
+requires explicit `username`/`password` — the server never sends its own stored
+credentials to a caller-named host.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Description |

--- a/digit-mcp/docs/api/tools/decrypt_data.md
+++ b/digit-mcp/docs/api/tools/decrypt_data.md
@@ -10,7 +10,9 @@ Decrypts one or more encrypted values that were previously encrypted by the DIGI
 
 Many DIGIT services store sensitive fields (mobile numbers, email addresses, personal identifiers) in encrypted form. When you need to inspect or verify this data, `decrypt_data` converts the opaque encrypted strings back to readable values.
 
-Decryption may fail if the encryption key is not configured for the specified tenant or if the encrypted values were produced by a different encryption service instance with different keys. The service does not require user authentication -- it manages its own key infrastructure.
+Decryption may fail if the encryption key is not configured for the specified tenant or if the encrypted values were produced by a different encryption service instance with different keys.
+
+**Authentication and authorization.** This tool requires an authenticated caller holding an admin role (see `MCP_ADMIN_ROLES`), and the request carries your token through to egov-enc-service. It previously sent no `Authorization` header at all, which made it an unauthenticated decryption oracle for citizen PII. Its output is also marked sensitive, so the plaintext is never written to the session store or the access log.
 
 ## Parameters
 

--- a/digit-mcp/docs/api/tools/discover_tools.md
+++ b/digit-mcp/docs/api/tools/discover_tools.md
@@ -25,7 +25,7 @@ Returns tool counts (enabled vs. total), and a groups object with each group's s
 ```json
 {
   "success": true,
-  "message": "8 of 59 tools enabled",
+  "message": "8 of 70 tools enabled",
   "groups": {
     "core": {
       "enabled": true,
@@ -69,7 +69,7 @@ Returns tool counts (enabled vs. total), and a groups object with each group's s
 }
 ```
 
-*(The response includes all 14 groups; the example above is abbreviated.)*
+*(The response includes all 15 groups; the example above is abbreviated.)*
 
 ## Examples
 

--- a/digit-mcp/docs/api/tools/enable_tools.md
+++ b/digit-mcp/docs/api/tools/enable_tools.md
@@ -51,7 +51,7 @@ Returns the result of enable/disable operations, the list of currently active gr
   },
   "disabled": null,
   "activeGroups": ["core", "docs", "pgr", "masters"],
-  "toolCount": "19 of 59 tools now enabled"
+  "toolCount": "19 of 70 tools now enabled"
 }
 ```
 

--- a/digit-mcp/docs/api/tools/init.md
+++ b/digit-mcp/docs/api/tools/init.md
@@ -34,7 +34,7 @@ Returns a JSON object with session metadata, enabled groups, and suggested next 
     "telemetry": true
   },
   "enabledGroups": ["core", "pgr", "masters", "admin", "boundary", "docs"],
-  "toolCount": "32 of 59 tools now enabled",
+  "toolCount": "32 of 70 tools now enabled",
   "suggestedNextSteps": [
     "Use configure to connect to the DIGIT environment",
     "Use validate_complaint_types to check available complaint types",

--- a/digit-mcp/docs/api/tools/tenant_cleanup.md
+++ b/digit-mcp/docs/api/tools/tenant_cleanup.md
@@ -14,6 +14,20 @@ The tool paginates through all records in batches of 500 to handle tenants with 
 
 The response includes per-schema counts showing how many records were deleted, skipped (already inactive), or failed, making it easy to verify the cleanup was thorough.
 
+## Safety
+
+This tool is **dry-run by default**. Without `confirm`, it performs no writes and
+returns a preview with `success: false` and `code: "CONFIRMATION_REQUIRED"` —
+`success: false` rather than `true` precisely so automation branching on that
+field does not mistake a preview for a completed cleanup.
+
+| Guard | When | Effect |
+|---|---|---|
+| `confirm: "<tenant_id>"` | always required to write | Without it, preview only |
+| `allow_root_tenant: true` | `tenant_id` has no dot (e.g. `pg`) | Refused without it; a root sweep affects every child tenant that inherits the records |
+
+Requires an **admin**-tier caller (see `MCP_ADMIN_ROLES`).
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Description |

--- a/digit-mcp/docs/architecture.md
+++ b/digit-mcp/docs/architecture.md
@@ -10,8 +10,8 @@ the trade-offs accepted.
 
 DIGIT MCP Server bridges Claude (via the Model Context Protocol) to the DIGIT
 eGov platform -- India's open-source digital governance infrastructure for
-municipalities and state governments. The server exposes 60 tools organized
-into 14 groups, covering 16 DIGIT services: Auth, User, MDMS v2, Boundary,
+municipalities and state governments. The server exposes 70 tools organized
+into 15 groups, covering 16 DIGIT services: Auth, User, MDMS v2, Boundary,
 Boundary Management, HRMS, PGR, Workflow, Localization, Filestore,
 Access Control, ID Generation, Location, Encryption, plus Distributed Tracing
 (Grafana Tempo) and Infrastructure Monitoring (Kafka, Persister, PostgreSQL).
@@ -36,7 +36,7 @@ src/
 
 ## 2. Progressive Disclosure
 
-**Problem.** 60 tools overwhelm the LLM's context window. When every tool
+**Problem.** 70 tools overwhelm the LLM's context window. When every tool
 description is included in the system prompt, the model spends tokens parsing
 irrelevant tools and may choose poorly among too many options.
 
@@ -46,9 +46,9 @@ management) and `docs` (documentation search). Clients call `enable_tools` to
 unlock additional groups. When groups change, the server sends a
 `tools/list_changed` MCP notification so clients re-fetch the tool list.
 
-14 groups: `core`, `mdms`, `boundary`, `masters`, `employees`, `localization`,
+15 groups: `core`, `mdms`, `boundary`, `masters`, `employees`, `localization`,
 `pgr`, `admin`, `idgen`, `location`, `encryption`, `docs`, `monitoring`,
-`tracing`. The `core` group cannot be disabled. Set `MCP_ENABLE_ALL_GROUPS=1`
+`tracing`, `snapshot`. The `core` group cannot be disabled. Set `MCP_ENABLE_ALL_GROUPS=1`
 to pre-enable everything (used by integration tests).
 
 **Implementation.** `ToolRegistry` (`src/tools/registry.ts`) holds an in-memory

--- a/digit-mcp/docs/architecture.md
+++ b/digit-mcp/docs/architecture.md
@@ -89,19 +89,34 @@ from stdin, writes responses to stdout. One process = one session. State
 
 **HTTP** (`MCP_TRANSPORT=http`). An `http.createServer` on port 3000 routes:
 
-| Path | Purpose |
-|------|---------|
-| `POST /mcp` | MCP JSON-RPC (StreamableHTTPServerTransport, stateless) |
-| `GET /healthz` | Kubernetes liveness/readiness probe |
-| `GET /api/stats` | Aggregate session statistics |
-| `GET /api/sessions` | Paginated session list |
-| `GET /api/sessions/{id}/events` | Full event timeline for a session |
-| `POST /api/sessions/{id}/messages` | Ingest conversation messages |
-| `GET /` | Session viewer UI (static files from `ui/`) |
+| Path | Auth | Purpose |
+|------|------|---------|
+| `POST /mcp` | bearer + per-tool tier | MCP JSON-RPC (StreamableHTTPServerTransport, stateless) |
+| `POST /v1/*` | bearer + per-tool tier | REST shim over the same tools |
+| `GET /v1/tools` | bearer | Tool list + input schemas |
+| `GET /healthz` | none | Kubernetes liveness/readiness probe |
+| `GET /api/stats` | bearer + admin role | Aggregate session statistics |
+| `GET /api/sessions` | bearer + admin role | Paginated session list |
+| `GET /api/sessions/{id}/events` | bearer + admin role | Full event timeline for a session |
+| `POST /api/sessions/{id}/messages` | bearer + admin role | Ingest conversation messages |
+| `GET /api/pgr/dashboard` | bearer + admin role | PGR complaint dashboard data |
+| `GET /` | none | Session viewer UI (static files from `ui/`) |
+
+"Auth" applies in `token` mode, the default whenever `MCP_TRANSPORT=http`
+(see `getAuthMode()` in `src/services/auth.ts`). Bearer tokens are introspected
+against egov-user's `/user/_details`; a token the platform doesn't recognise is
+a 401 on every route. `MCP_AUTH_MODE=ambient` disables the checks and is only
+correct for a loopback-bound socket.
+
+The viewer UI itself is served unauthenticated because it is a static bundle
+with nothing in it; its `/api/*` calls carry a token the operator pastes into
+the sign-in gate, held in `sessionStorage` for the tab.
 
 Each `/mcp` request creates a fresh `Server` + transport with
-`sessionIdGenerator: undefined` (stateless mode). No session affinity
-required -- any replica can handle any request.
+`sessionIdGenerator: undefined` (stateless mode), and — in token mode — its own
+`DigitApiClient` and request context via `AsyncLocalStorage`, so concurrent
+callers cannot observe each other's identity or be cross-attributed in the
+audit trail. No session affinity required -- any replica can handle any request.
 
 **Trade-off.** Stateless HTTP means the DIGIT auth token is not cached across
 requests. Each new session must call `configure` to authenticate. Acceptable

--- a/digit-mcp/docs/cli-architecture.md
+++ b/digit-mcp/docs/cli-architecture.md
@@ -12,7 +12,7 @@ is the `ToolRegistry` — a map of 60 `ToolMetadata` objects, each carrying a
 `name`, `group`, `inputSchema` (JSON Schema), and `handler` function.
 
 ```
-                    ToolRegistry (60 tools)
+                    ToolRegistry (70 tools)
                     ToolMetadata[] with inputSchema + handler
                            │
               ┌────────────┴────────────┐
@@ -38,7 +38,7 @@ When a user runs `digit pgr search --tenant-id pg.citya`:
 1. src/cli.ts loads
 2. applyCredentialsToEnv()        — load saved creds from ~/.config/digit-cli/
 3. new ToolRegistry()             — empty registry
-4. registerAllTools(registry)     — registers all 60 tools
+4. registerAllTools(registry)     — registers all 70 tools
 5. registry.enableGroups(ALL)     — enables everything (no progressive disclosure)
 6. buildProgram(registry)         — loops over tools, builds Commander tree
 7. program.parseAsync(argv)       — Commander parses args, invokes handler
@@ -87,7 +87,7 @@ digit
 ├── boundary/
 ├── employees/
 ├── tracing/
-└── ... (14 groups total)
+└── ... (15 groups total)
 ```
 
 ### 3.2 inputSchema → Commander options

--- a/digit-mcp/docs/guides/getting-started.md
+++ b/digit-mcp/docs/guides/getting-started.md
@@ -90,6 +90,8 @@ Response:
 
 If you set `CRS_USERNAME` and `CRS_PASSWORD` as environment variables in Step 1, the server auto-authenticates on the first API call and you can skip this step entirely.
 
+**Stdio only.** On the HTTP transport the server requires a validated bearer token from every caller and never substitutes its own credentials — env auto-login is exactly the behaviour that made an anonymous caller an admin. Set `MCP_AUTH_MODE=ambient` to restore it, and only on a loopback-bound socket.
+
 ---
 
 ## Step 3: Discover Available Tools
@@ -106,7 +108,7 @@ Response (abbreviated):
 ```json
 {
   "success": true,
-  "message": "8 of 59 tools enabled",
+  "message": "8 of 70 tools enabled",
   "groups": {
     "core": {
       "enabled": true,
@@ -151,7 +153,7 @@ Response:
     "mdms": ["validate_tenant", "mdms_search", "mdms_create", "tenant_bootstrap", "..."]
   },
   "activeGroups": ["core", "docs", "pgr", "masters", "mdms"],
-  "toolCount": "25 of 59 tools now enabled"
+  "toolCount": "25 of 70 tools now enabled"
 }
 ```
 
@@ -247,7 +249,7 @@ If a service shows `"unhealthy"`, check that the DIGIT Docker environment is run
 |------|------|---------|
 | 1 | *(config file)* | Point your MCP client at `dist/index.js` with credentials |
 | 2 | [`configure`](../api/tools/configure.md) | Authenticate with DIGIT (or rely on auto-login via env vars) |
-| 3 | [`discover_tools`](../api/tools/discover_tools.md) | See all 14 groups and 59 tools |
+| 3 | [`discover_tools`](../api/tools/discover_tools.md) | See all 15 groups and 70 tools |
 | 4 | [`enable_tools`](../api/tools/enable_tools.md) | Unlock the groups you need |
 | 5 | [`mdms_get_tenants`](../api/tools/mdms_get_tenants.md) | Find available tenants |
 | 6 | [`health_check`](../api/tools/health_check.md) | Verify services are up |
@@ -260,7 +262,7 @@ If a service shows `"unhealthy"`, check that the DIGIT Docker environment is run
 - **[PGR Complaint Lifecycle](pgr-lifecycle.md)** -- Create, assign, resolve, and rate complaints through the full workflow
 - **[Debugging & Monitoring](debugging.md)** -- Trace API failures, inspect Kafka lag, and monitor persister health
 - **[Architecture](../architecture.md)** -- Understand progressive disclosure, dual transport, and the multi-tenant model
-- **[API Reference](../api/README.md)** -- Detailed per-tool documentation for all 59 tools
+- **[API Reference](../api/README.md)** -- Detailed per-tool documentation for all 70 tools
 
 ---
 
@@ -270,7 +272,7 @@ If a service shows `"unhealthy"`, check that the DIGIT Docker environment is run
 
 Most tools require authentication. Either:
 
-1. Set `CRS_USERNAME` and `CRS_PASSWORD` environment variables in your MCP client config (recommended -- enables auto-login), or
+1. Set `CRS_USERNAME` and `CRS_PASSWORD` environment variables in your MCP client config (stdio only -- enables auto-login; ignored on the HTTP transport, which requires a bearer token per caller), or
 2. Call [`configure`](../api/tools/configure.md) explicitly at the start of your session.
 
 ### Tools not appearing

--- a/digit-mcp/helm/digit-mcp/templates/configmap.yaml
+++ b/digit-mcp/helm/digit-mcp/templates/configmap.yaml
@@ -5,11 +5,11 @@ metadata:
   labels:
     {{- include "digit-mcp.labels" . | nindent 4 }}
 data:
-  MCP_TRANSPORT: {{ .Values.env.MCP_TRANSPORT | quote }}
-  MCP_PORT: {{ .Values.env.MCP_PORT | quote }}
-  CRS_ENVIRONMENT: {{ .Values.env.CRS_ENVIRONMENT | quote }}
-  CRS_TENANT_ID: {{ .Values.env.CRS_TENANT_ID | quote }}
-  # DIGIT API base the shim proxies to. Defaults to the in-cluster gateway;
-  # without it the 'self-hosted' env falls back to http://kong:8000 (compose-only).
-  CRS_API_URL: {{ .Values.env.CRS_API_URL | quote }}
-  CRS_ENV_NAME: {{ .Values.env.CRS_ENV_NAME | quote }}
+  # Iterate `env` rather than enumerating keys. The previous hardcoded list
+  # silently dropped any value added to values.yaml — so a security-relevant
+  # setting (MCP_AUTH_MODE, TELEMETRY, …) would never reach the container even
+  # though it looked configured. Iterating also means CRS_API_URL / CRS_ENV_NAME
+  # (added on develop) are picked up without a template edit.
+  {{- range $key, $value := .Values.env }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}

--- a/digit-mcp/helm/digit-mcp/templates/deployment.yaml
+++ b/digit-mcp/helm/digit-mcp/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ required "image.tag is required — see values.yaml for the published tag convention" .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false

--- a/digit-mcp/helm/digit-mcp/templates/deployment.yaml
+++ b/digit-mcp/helm/digit-mcp/templates/deployment.yaml
@@ -14,10 +14,22 @@ spec:
       labels:
         {{- include "digit-mcp.selectorLabels" . | nindent 8 }}
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000          # `node` in the official node images
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           ports:
             - name: http
               containerPort: {{ .Values.healthcheck.port }}
@@ -27,6 +39,16 @@ spec:
                 name: {{ include "digit-mcp.fullname" . }}
             - secretRef:
                 name: {{ include "digit-mcp.fullname" . }}
+          # readOnlyRootFilesystem is on, so every path the server writes needs
+          # an explicit mount: the access log, the session JSONL directory, and
+          # the snapshot artifact directory it confines output_path to.
+          volumeMounts:
+            - name: logs
+              mountPath: /var/log/digit-mcp
+            - name: data
+              mountPath: /app/data
+            - name: tmp
+              mountPath: /tmp
           livenessProbe:
             httpGet:
               path: {{ .Values.healthcheck.path }}
@@ -41,3 +63,10 @@ spec:
             periodSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: logs
+          emptyDir: {}
+        - name: data
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/digit-mcp/helm/digit-mcp/templates/deployment.yaml
+++ b/digit-mcp/helm/digit-mcp/templates/deployment.yaml
@@ -11,6 +11,14 @@ spec:
       {{- include "digit-mcp.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        # Roll the pod when config or secrets change. Without this a
+        # ConfigMap-only change — flipping MCP_AUTH_MODE, say — leaves the pod
+        # spec byte-identical, so `helm upgrade` reports success and nothing
+        # restarts. With a moving image tag that is the only rollout trigger
+        # there is.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         {{- include "digit-mcp.selectorLabels" . | nindent 8 }}
     spec:
@@ -63,10 +71,17 @@ spec:
             periodSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      # sizeLimit on every emptyDir: these are node ephemeral storage, and the
+      # access log and session JSONL are append-only with no rotation. An
+      # unbounded pod fills the node and triggers DiskPressure, which evicts
+      # neighbouring pods too — the blast radius is the node, not the pod.
       volumes:
         - name: logs
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: {{ .Values.storage.logsSizeLimit }}
         - name: data
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: {{ .Values.storage.dataSizeLimit }}
         - name: tmp
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: {{ .Values.storage.tmpSizeLimit }}

--- a/digit-mcp/helm/digit-mcp/templates/secret.yaml
+++ b/digit-mcp/helm/digit-mcp/templates/secret.yaml
@@ -6,5 +6,8 @@ metadata:
     {{- include "digit-mcp.labels" . | nindent 4 }}
 type: Opaque
 data:
-  CRS_USERNAME: {{ .Values.secret.CRS_USERNAME | b64enc | quote }}
-  CRS_PASSWORD: {{ .Values.secret.CRS_PASSWORD | b64enc | quote }}
+  {{- range $key, $value := .Values.secret }}
+  {{- if $value }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+  {{- end }}
+  {{- end }}

--- a/digit-mcp/helm/digit-mcp/values.yaml
+++ b/digit-mcp/helm/digit-mcp/values.yaml
@@ -2,21 +2,42 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/chakshugautam/digit-mcp
-  tag: latest
+  # Empty => Chart.AppVersion, so a release is pinned to a known build rather
+  # than whatever ":latest" happens to be at pull time. Override per deploy.
+  tag: ""
   pullPolicy: IfNotPresent
 
 service:
+  # ClusterIP only. /mcp and /v1/* expose admin-capable tooling; do not put an
+  # Ingress in front of this without an authenticating proxy.
   type: ClusterIP
   port: 3000
 
 env:
   MCP_TRANSPORT: http
   MCP_PORT: "3000"
+  # Deployment targeting (from develop — matches the ccrs-prod configmap).
   CRS_ENVIRONMENT: "self-hosted"
   CRS_TENANT_ID: "pg"
   # DIGIT API base the shim proxies to (in-cluster gateway service).
   CRS_API_URL: "http://gateway.egov:8080"
   CRS_ENV_NAME: "CCRS"
+  # Require a validated DIGIT token on /mcp and /v1/*. Do not set this to
+  # "ambient" unless the socket is bound to loopback — ambient makes every
+  # anonymous caller act as CRS_USERNAME.
+  MCP_AUTH_MODE: token
+  # Usage telemetry is opt-in: unset MATOMO_URL means nothing leaves the cluster.
+  TELEMETRY: "false"
+  # Hosts `configure` may be pointed at. Empty => only the configured CRS_API_URL.
+  MCP_ALLOWED_BASE_URLS: ""
+  # Directory snapshot artifacts are confined to (must be writable; see volumes).
+  MCP_ARTIFACT_DIR: /app/data/artifacts
+  # Role codes that satisfy a tool's access: 'admin' requirement. Empty => the
+  # built-in defaults (SUPERUSER, MDMS_ADMIN, SYSTEM_ADMIN, STADMIN).
+  MCP_ADMIN_ROLES: ""
+  # Peers whose X-Forwarded-For may be trusted (IPv4/CIDR list, or "*" behind an
+  # ingress that overwrites the header). Empty => never trust it.
+  MCP_TRUSTED_PROXIES: ""
 
 secret:
   # Set these when installing: --set secret.CRS_USERNAME=... --set secret.CRS_PASSWORD=...

--- a/digit-mcp/helm/digit-mcp/values.yaml
+++ b/digit-mcp/helm/digit-mcp/values.yaml
@@ -49,6 +49,14 @@ env:
   MCP_ALLOWED_BASE_URLS: ""
   # Directory snapshot artifacts are confined to (must be writable; see volumes).
   MCP_ARTIFACT_DIR: /app/data/artifacts
+  # Session viewer database. The image defaults to localhost:15433, which has no
+  # listener in a pod — sessions silently were not persisted and /api/stats
+  # returned "Database not available". Point these at a real Postgres, or leave
+  # them empty and accept JSONL-only session recording.
+  SESSION_DB_HOST: ""
+  SESSION_DB_PORT: "5432"
+  SESSION_DB_NAME: mcp_sessions
+  SESSION_DB_USER: mcp
   # Role codes that satisfy a tool's access: 'admin' requirement. Empty => the
   # built-in defaults (SUPERUSER, MDMS_ADMIN, SYSTEM_ADMIN, STADMIN).
   MCP_ADMIN_ROLES: ""

--- a/digit-mcp/helm/digit-mcp/values.yaml
+++ b/digit-mcp/helm/digit-mcp/values.yaml
@@ -9,12 +9,20 @@ image:
   # registry fed by a different repository. Nothing in this tree reached the
   # cluster through it, so a fix merged here would never have shipped.
   repository: egovio/digit-mcp
-  # Tags published by that pipeline are `develop-<sha8>`, `develop-YYYYMMDD`,
-  # `nightly-develop` and release tags. Pin a `develop-<sha8>` per environment;
-  # nightly-develop is the moving default. (Chart.AppVersion is NOT a valid tag
+  # Tags published by that pipeline: `develop-<sha8>`, `develop-YYYYMMDD`,
+  # `nightly-develop`, and release tags. (Chart.AppVersion is NOT a valid tag
   # here — the chart version and the image pipeline are independent.)
+  #
+  # `develop-<sha8>` tags are PRUNED by the nightly job — it keeps only the 5
+  # most recent — so a sha pin silently disappears within about a week, taking
+  # your rollback target with it. Pin a `develop-YYYYMMDD` or a release tag for
+  # anything long-lived.
   tag: nightly-develop
-  pullPolicy: IfNotPresent
+  # Always, not IfNotPresent: the default tag moves. With IfNotPresent a node
+  # that has the tag cached never re-pulls, so two replicas can run different
+  # code indefinitely and `helm upgrade` is a no-op. If you pin an immutable
+  # tag or a digest, IfNotPresent is the better choice.
+  pullPolicy: Always
 
 service:
   # ClusterIP only. /mcp and /v1/* expose admin-capable tooling; do not put an
@@ -31,7 +39,7 @@ env:
   # DIGIT API base the shim proxies to (in-cluster gateway service).
   CRS_API_URL: "http://gateway.egov:8080"
   CRS_ENV_NAME: "CCRS"
-  # Require a validated DIGIT token on /mcp and /v1/*. Do not set this to
+  # Require a validated DIGIT token on /mcp, /v1/* and /api/*. Do not set this to
   # "ambient" unless the socket is bound to loopback — ambient makes every
   # anonymous caller act as CRS_USERNAME.
   MCP_AUTH_MODE: token
@@ -44,9 +52,13 @@ env:
   # Role codes that satisfy a tool's access: 'admin' requirement. Empty => the
   # built-in defaults (SUPERUSER, MDMS_ADMIN, SYSTEM_ADMIN, STADMIN).
   MCP_ADMIN_ROLES: ""
-  # Peers whose X-Forwarded-For may be trusted (IPv4/CIDR list, or "*" behind an
-  # ingress that overwrites the header). Empty => never trust it.
+  # Peers whose X-Forwarded-For may be trusted: IPv4 or IPv6 addresses and
+  # CIDRs, or "*" behind an ingress that overwrites the header. Empty => never
+  # trust it.
   MCP_TRUSTED_PROXIES: ""
+  # Password assigned to accounts this server CREATES (never to an existing
+  # one). Defaults to the published "eGov@123" if unset — override it.
+  MCP_DEFAULT_PROVISIONING_PASSWORD: ""
 
 secret:
   # Set these when installing: --set secret.CRS_USERNAME=... --set secret.CRS_PASSWORD=...
@@ -58,6 +70,14 @@ secret:
   # Session-viewer database. Unset => the published local-compose default, which
   # is not a credential; set it on any real deployment.
   SESSION_DB_PASSWORD: ""
+
+# Bounds for the three emptyDir volumes (see deployment.yaml). The access log
+# and session JSONL are append-only and unrotated, so these are what stop a
+# chatty pod from filling the node.
+storage:
+  logsSizeLimit: 512Mi
+  dataSizeLimit: 1Gi
+  tmpSizeLimit: 128Mi
 
 resources:
   requests:

--- a/digit-mcp/helm/digit-mcp/values.yaml
+++ b/digit-mcp/helm/digit-mcp/values.yaml
@@ -1,10 +1,19 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/chakshugautam/digit-mcp
-  # Empty => Chart.AppVersion, so a release is pinned to a known build rather
-  # than whatever ":latest" happens to be at pull time. Override per deploy.
-  tag: ""
+  # The image this repo builds. `digit-mcp` is declared in build/build-config.yml
+  # and published by .github/workflows/build-images.yml, so the Dockerfile in
+  # this directory is the one that ends up running.
+  #
+  # The chart previously pointed at ghcr.io/chakshugautam/digit-mcp — a personal
+  # registry fed by a different repository. Nothing in this tree reached the
+  # cluster through it, so a fix merged here would never have shipped.
+  repository: egovio/digit-mcp
+  # Tags published by that pipeline are `develop-<sha8>`, `develop-YYYYMMDD`,
+  # `nightly-develop` and release tags. Pin a `develop-<sha8>` per environment;
+  # nightly-develop is the moving default. (Chart.AppVersion is NOT a valid tag
+  # here — the chart version and the image pipeline are independent.)
+  tag: nightly-develop
   pullPolicy: IfNotPresent
 
 service:
@@ -41,8 +50,14 @@ env:
 
 secret:
   # Set these when installing: --set secret.CRS_USERNAME=... --set secret.CRS_PASSWORD=...
+  #
+  # CRS_USERNAME/CRS_PASSWORD are only used by the ambient-mode fallback, which
+  # MCP_AUTH_MODE=token disables. They remain here for a loopback/stdio deploy.
   CRS_USERNAME: ""
   CRS_PASSWORD: ""
+  # Session-viewer database. Unset => the published local-compose default, which
+  # is not a credential; set it on any real deployment.
+  SESSION_DB_PASSWORD: ""
 
 resources:
   requests:

--- a/digit-mcp/install.sh
+++ b/digit-mcp/install.sh
@@ -194,6 +194,10 @@ select_mode() {
 }
 
 # ── Write JSON config (portable, no jq required) ────────────────────────────
+#
+# The hosted server authenticates every caller: it introspects the bearer token
+# against egov-user and runs the tools as that user. There is no anonymous
+# access, so the config has to carry a token.
 write_config_remote() {
   local config_path="$1"
   local client="$2"
@@ -201,15 +205,39 @@ write_config_remote() {
   dir="$(dirname "$config_path")"
   mkdir -p "$dir"
 
+  local token="${DIGIT_ACCESS_TOKEN:-}"
+  if [[ -z "$token" && "$SKIP_PROMPTS" != "true" ]]; then
+    echo ""
+    bold "DIGIT access token:"
+    echo -e "${DIM}The hosted server runs tools as you, so it needs your token.${NC}"
+    echo -e "${DIM}Get one from your DIGIT instance:${NC}"
+    echo -e "${DIM}  curl -u egov-user-client:egov-user-secret \\${NC}"
+    echo -e "${DIM}    -d 'grant_type=password&scope=read&userType=EMPLOYEE' \\${NC}"
+    echo -e "${DIM}    --data-urlencode username=... --data-urlencode password=... \\${NC}"
+    echo -e "${DIM}    --data-urlencode tenantId=pg <host>/user/oauth/token${NC}"
+    read -rsp "Access token: " token
+    echo ""
+  fi
+
+  if [[ -z "$token" ]]; then
+    warn "No access token supplied — the server will reject every call with 401."
+    warn "Re-run with DIGIT_ACCESS_TOKEN=... or add the Authorization header to:"
+    warn "  ${config_path}"
+  fi
+
   local server_entry
   server_entry=$(cat <<'ENTRY'
 {
       "type": "http",
-      "url": "MCP_URL_PLACEHOLDER"
+      "url": "MCP_URL_PLACEHOLDER",
+      "headers": {
+        "Authorization": "Bearer MCP_TOKEN_PLACEHOLDER"
+      }
     }
 ENTRY
 )
   server_entry="${server_entry/MCP_URL_PLACEHOLDER/$MCP_REMOTE_URL}"
+  server_entry="${server_entry/MCP_TOKEN_PLACEHOLDER/$token}"
 
   write_mcp_entry "$config_path" "$client" "$server_entry"
 }

--- a/digit-mcp/install.sh
+++ b/digit-mcp/install.sh
@@ -61,6 +61,11 @@ while [[ $# -gt 0 ]]; do
       echo "Options:"
       echo "  --client NAME   Target client: claude-code, cursor, windsurf, vscode"
       echo "  --mode MODE     Installation mode: remote (default) or local"
+      echo ""
+      echo "Environment:"
+      echo "  DIGIT_ACCESS_TOKEN  Bearer token for the hosted server (remote mode)."
+      echo "                      Required — /mcp authenticates every caller."
+      echo "                      May also be supplied via --env FILE."
       echo "  --dir PATH      Local install directory (default: ~/.digit-mcp)"
       echo "  --env FILE      Path to .env file with CRS_USERNAME, CRS_PASSWORD, etc."
       echo "  --yes, -y       Skip confirmation prompts"
@@ -205,6 +210,13 @@ write_config_remote() {
   dir="$(dirname "$config_path")"
   mkdir -p "$dir"
 
+  # --env applies here as well as in local mode: DIGIT_ACCESS_TOKEN is exactly
+  # the sort of value an operator keeps in an env file.
+  if [[ -n "$ENV_FILE" && -f "$ENV_FILE" ]]; then
+    # shellcheck disable=SC1090
+    source "$ENV_FILE"
+  fi
+
   local token="${DIGIT_ACCESS_TOKEN:-}"
   if [[ -z "$token" && "$SKIP_PROMPTS" != "true" ]]; then
     echo ""
@@ -215,14 +227,19 @@ write_config_remote() {
     echo -e "${DIM}    -d 'grant_type=password&scope=read&userType=EMPLOYEE' \\${NC}"
     echo -e "${DIM}    --data-urlencode username=... --data-urlencode password=... \\${NC}"
     echo -e "${DIM}    --data-urlencode tenantId=pg <host>/user/oauth/token${NC}"
-    read -rsp "Access token: " token
+    # </dev/tty: the documented install path is `curl … | bash`, where stdin is
+    # the script itself, so a bare `read` would consume script text.
+    read -rsp "Access token: " token </dev/tty || true
     echo ""
   fi
 
   if [[ -z "$token" ]]; then
-    warn "No access token supplied — the server will reject every call with 401."
-    warn "Re-run with DIGIT_ACCESS_TOKEN=... or add the Authorization header to:"
-    warn "  ${config_path}"
+    err "No access token supplied."
+    err "The hosted server authenticates every caller, so a config without one"
+    err "returns 401 on every call. Re-run with:"
+    err "  DIGIT_ACCESS_TOKEN=<token> $0 --mode remote"
+    err "See the README for how to mint a token."
+    exit 1
   fi
 
   local server_entry

--- a/digit-mcp/package.json
+++ b/digit-mcp/package.json
@@ -39,6 +39,7 @@
     "test:openapi": "tsx test-openapi-spec.ts",
     "test:safety": "tsx test-agent-safety.ts",
     "test:security": "tsx test-security.ts",
+    "test:security:http": "tsx test-security-http.ts",
     "engram": "tsx engram-agent.ts",
     "prepublishOnly": "npm run build"
   },

--- a/digit-mcp/package.json
+++ b/digit-mcp/package.json
@@ -38,6 +38,7 @@
     "test:cli": "tsx test-cli.ts",
     "test:openapi": "tsx test-openapi-spec.ts",
     "test:safety": "tsx test-agent-safety.ts",
+    "test:security": "tsx test-security.ts",
     "engram": "tsx engram-agent.ts",
     "prepublishOnly": "npm run build"
   },

--- a/digit-mcp/packages/data-provider/src/client/endpoints.ts
+++ b/digit-mcp/packages/data-provider/src/client/endpoints.ts
@@ -1,6 +1,9 @@
 // DIGIT API endpoint paths — single source of truth
 export const ENDPOINTS = {
   AUTH: '/user/oauth/token',
+  // Token introspection — resolves an access token to its user + roles.
+  // Used to authenticate network callers instead of trusting any bearer string.
+  USER_DETAILS: '/user/_details',
   USER_SEARCH: '/user/_search',
   USER_CREATE: '/user/users/_createnovalidate',
   USER_UPDATE: '/user/users/_updatenovalidate',

--- a/digit-mcp/src/index.ts
+++ b/digit-mcp/src/index.ts
@@ -17,6 +17,7 @@ import {
   checkToolAccess,
   getAuthMode,
   isAdminCaller,
+  isCachedCaller,
   parseBearer,
   resolveClientIp,
   type ValidatedCaller,
@@ -62,10 +63,40 @@ if (transportMode === 'stdio') {
     res.end(JSON.stringify(data));
   }
 
+  /**
+   * Maximum accepted request body. Bulk tenant payloads are the large case;
+   * 16 MB is well clear of those and well clear of the pod's memory limit.
+   */
+  const MAX_BODY_BYTES = 16 * 1024 * 1024;
+
+  class PayloadTooLargeError extends Error {
+    constructor() {
+      super(`Request body exceeds the ${MAX_BODY_BYTES} byte limit.`);
+      this.name = 'PayloadTooLargeError';
+    }
+  }
+
+  /**
+   * Read a request body, bounded.
+   *
+   * Unbounded, this defeated every gate in front of it: the body is buffered
+   * before any route can authenticate, so one anonymous request with a large
+   * chunked body killed the process on its memory limit — a reliable
+   * crash-loop from a peer holding no credentials.
+   */
   function readBody(req: IncomingMessage): Promise<string> {
     return new Promise((resolve, reject) => {
       const chunks: Buffer[] = [];
-      req.on('data', (chunk: Buffer) => chunks.push(chunk));
+      let total = 0;
+      req.on('data', (chunk: Buffer) => {
+        total += chunk.length;
+        if (total > MAX_BODY_BYTES) {
+          reject(new PayloadTooLargeError());
+          req.destroy();
+          return;
+        }
+        chunks.push(chunk);
+      });
       req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
       req.on('error', reject);
     });
@@ -299,6 +330,12 @@ if (transportMode === 'stdio') {
     toolArgs: Record<string, unknown>,
     onResult: (parsed: unknown) => T,
   ): Promise<T> {
+    // `recordToolCall` is a no-op until a session exists, and only the /mcp
+    // handler used to create one — so on a REST-only deployment (which is what
+    // the ansible playbook and the xlsx onboarding runbook actually drive)
+    // every call produced an access-log line and nothing in the session store,
+    // which is the half the operator console reads.
+    await sessionStore.ensureSession('http');
     const seq = sessionStore.recordToolCall(tool.name, toolArgs);
     mcpLogger.toolCall(tool.name, toolArgs);
     const start = Date.now();
@@ -399,12 +436,17 @@ if (transportMode === 'stdio') {
     // Authenticate and authorize before committing the 200. An SSE stream that
     // opens successfully and then emits `event: error` reads as success to any
     // client keying on the status code, which is every ordinary HTTP client.
+    // Authenticate once, up front, and carry the result into the streamed body.
+    // Re-running authenticateRest there would mean a second OAuth login for
+    // every body.auth caller — the form ansible and the onboarding runbook use.
+    let caller: ValidatedCaller | null = null;
     const pre = await withRestLock(async () => {
       const snap = digitApi.snapshotAuth();
       try {
         const authResult = await authenticateRest(req, args);
         if (authResult === null) return { status: 401, body: { success: false, error: 'Authentication required.' } };
         if (!authResult.ok) return { status: authResult.status, body: { success: false, error: authResult.error } };
+        caller = authResult.caller;
         return authorizeRest(toolName, tool.access, authResult.caller);
       } finally {
         digitApi.restoreAuth(snap);
@@ -432,20 +474,9 @@ if (transportMode === 'stdio') {
         const snap = digitApi.snapshotAuth();
         setProgressEmitter((e) => writeEvent('progress', e));
         try {
-          const authResult = await authenticateRest(req, args);
-          if (authResult === null) {
-            writeEvent('error', { success: false, error: 'Authentication required.' });
-            return;
-          }
-          if (!authResult.ok) {
-            writeEvent('error', { success: false, error: authResult.error });
-            return;
-          }
-          const denied = authorizeRest(toolName, tool.access, authResult.caller);
-          if (denied) {
-            writeEvent('error', denied.body);
-            return;
-          }
+          // Re-apply the identity resolved above; restoreAuth in the pre-flight
+          // block discarded it, and re-authenticating would double the cost.
+          if (caller) applyValidatedCaller(caller);
           const { auth: _ignored, ...toolArgs } = args;
           void _ignored;
           await auditedCall(tool, toolArgs as Record<string, unknown>, (parsed) => {
@@ -478,11 +509,9 @@ if (transportMode === 'stdio') {
     auth: Record<string, string> | undefined,
     req: IncomingMessage,
   ): Promise<{ status: number; body: unknown }> {
-    const tool = restRegistry.getTool(toolName);
-    if (!tool) {
-      return { status: 404, body: { success: false, error: `Unknown tool: ${toolName}` } };
-    }
-    const boundTool = tool;
+    // Resolved after authentication, like dispatchTool: 404-for-unknown vs
+    // 401-for-known enumerates the whole tool surface anonymously, and fixing
+    // only the non-bulk route left the sibling wide open.
     return withRestLock(async () => {
       const snap = digitApi.snapshotAuth();
       try {
@@ -496,6 +525,11 @@ if (transportMode === 'stdio') {
           return { status: authResult.status, body: { success: false, error: authResult.error } };
         }
 
+        const boundTool = restRegistry.getTool(toolName);
+        if (!boundTool) {
+          return { status: 404, body: { success: false, error: `Unknown tool: ${toolName}` } };
+        }
+
         const denied = authorizeRest(toolName, boundTool.access, authResult.caller);
         if (denied) return denied;
 
@@ -503,7 +537,10 @@ if (transportMode === 'stdio') {
         const results: ItemResult[] = new Array(items.length);
         let nextIdx = 0;
 
-        async function worker(): Promise<void> {
+        // An arrow const, not a hoisted `function` declaration: a declaration is
+        // hoisted above the `if (!boundTool)` guard, so TypeScript will not
+        // narrow the captured const inside it.
+        const worker = async (): Promise<void> => {
           while (true) {
             const i = nextIdx++;
             if (i >= items.length) return;
@@ -517,7 +554,7 @@ if (transportMode === 'stdio') {
               results[i] = { ok: false, status: 500, body: { success: false, ...normalizeError(msg) } };
             }
           }
-        }
+        };
 
         const workers = Array.from({ length: Math.min(concurrency, items.length) }, () => worker());
         await Promise.all(workers);
@@ -667,8 +704,13 @@ if (transportMode === 'stdio') {
       // gitSha / buildTime / nodeVersion tell an unauthenticated caller exactly
       // which build is running and therefore which CVEs apply. The service name
       // and uptime stay open so the endpoint remains usable as a liveness probe.
+      // Cache-hit only. Calling authenticateBearer here would drive a full
+      // /user/_details round trip per request from an ANONYMOUS caller (only
+      // successes are cached), turning the one endpoint documented as an open
+      // liveness probe into a 1:1 amplifier against egov-user — and blocking
+      // this response for the introspection timeout when that service hangs.
       const detailed = getAuthMode() !== 'token' ||
-        (await authenticateBearer(req.headers['authorization'] || req.headers['Authorization'])).ok;
+        isCachedCaller(req.headers['authorization'] || req.headers['Authorization']);
       jsonResponse(res, 200, {
         service: 'digit-mcp',
         version: detailed ? (process.env.MCP_VERSION || '1.0.0') : undefined,
@@ -708,7 +750,8 @@ if (transportMode === 'stdio') {
         const result = await dispatchTool('tenant_bootstrap', body, req);
         jsonResponse(res, result.status, result.body);
       } catch (err) {
-        jsonResponse(res, 400, { success: false, error: String(err) });
+        const tooLarge = err instanceof Error && err.name === 'PayloadTooLargeError';
+        jsonResponse(res, tooLarge ? 413 : 400, { success: false, error: String(err) });
       }
       return;
     }
@@ -731,7 +774,8 @@ if (transportMode === 'stdio') {
         const result = await dispatchTool('city_setup', body, req);
         jsonResponse(res, result.status, result.body);
       } catch (err) {
-        jsonResponse(res, 400, { success: false, error: String(err) });
+        const tooLarge = err instanceof Error && err.name === 'PayloadTooLargeError';
+        jsonResponse(res, tooLarge ? 413 : 400, { success: false, error: String(err) });
       }
       return;
     }
@@ -767,7 +811,8 @@ if (transportMode === 'stdio') {
         const result = await dispatchTool('tenant_cleanup', toolArgs, req);
         jsonResponse(res, result.status, result.body);
       } catch (err) {
-        jsonResponse(res, 400, { success: false, error: String(err) });
+        const tooLarge = err instanceof Error && err.name === 'PayloadTooLargeError';
+        jsonResponse(res, tooLarge ? 413 : 400, { success: false, error: String(err) });
       }
       return;
     }
@@ -810,7 +855,8 @@ if (transportMode === 'stdio') {
           }
         });
       } catch (err) {
-        jsonResponse(res, 400, { success: false, error: String(err) });
+        const tooLarge = err instanceof Error && err.name === 'PayloadTooLargeError';
+        jsonResponse(res, tooLarge ? 413 : 400, { success: false, error: String(err) });
       }
       return;
     }
@@ -868,7 +914,8 @@ if (transportMode === 'stdio') {
         const result = await runBulk(bulkMatch[1], items, concurrency, body.auth, req);
         jsonResponse(res, result.status, result.body);
       } catch (err) {
-        jsonResponse(res, 400, { success: false, error: String(err) });
+        const tooLarge = err instanceof Error && err.name === 'PayloadTooLargeError';
+        jsonResponse(res, tooLarge ? 413 : 400, { success: false, error: String(err) });
       }
       return;
     }
@@ -882,7 +929,8 @@ if (transportMode === 'stdio') {
         const result = await dispatchTool(toolMatch[1], body, req);
         jsonResponse(res, result.status, result.body);
       } catch (err) {
-        jsonResponse(res, 400, { success: false, error: String(err) });
+        const tooLarge = err instanceof Error && err.name === 'PayloadTooLargeError';
+        jsonResponse(res, tooLarge ? 413 : 400, { success: false, error: String(err) });
       }
       return;
     }

--- a/digit-mcp/src/index.ts
+++ b/digit-mcp/src/index.ts
@@ -18,11 +18,13 @@ import {
   getAuthMode,
   isAdminCaller,
   isCachedCaller,
+  isInside,
   parseBearer,
   resolveClientIp,
   type ValidatedCaller,
 } from './services/auth.js';
 import { runWithRequestContext, setContextUser } from './services/request-context.js';
+import { redactDeep } from './utils/redact.js';
 import { setProgressEmitter, type ProgressEvent } from './services/progress.js';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { readFile, stat } from 'node:fs/promises';
@@ -117,9 +119,9 @@ if (transportMode === 'stdio') {
     let filePath = urlPath === '/' ? '/index.html' : urlPath;
     const resolved = resolve(join(UI_DIR, filePath));
 
-    // Path traversal protection. The trailing separator matters: without it a
-    // sibling directory sharing the prefix (`ui-evil` next to `ui`) passes.
-    if (resolved !== UI_DIR && !resolved.startsWith(UI_DIR + sep)) {
+    // Same containment helper as the artifact guard — one implementation, so a
+    // future edge-case fix cannot land on only one of them.
+    if (!isInside(resolved, UI_DIR)) {
       res.writeHead(403, { 'Content-Type': 'text/plain' });
       res.end('Forbidden');
       return;
@@ -210,9 +212,14 @@ if (transportMode === 'stdio') {
     if (auth && auth.username && auth.password && auth.tenant_id) {
       try {
         await digitApi.login(auth.username, auth.password, auth.tenant_id);
-        const user = digitApi.getAuthInfo().user;
-        setContextUser(user?.userName);
-        return { ok: true, caller: user ? { token: '', user } : null };
+        // Carry the token login actually minted. Returning '' here made
+        // `applyValidatedCaller` install an empty token that `isAuthenticated()`
+        // accepted while `encHeaders()` treated as absent — so a body.auth
+        // streamed call reached egov-enc-service with no Authorization header,
+        // silently reopening the decryption oracle H2 closed.
+        const info = digitApi.getAuthInfo();
+        setContextUser(info.user?.userName);
+        return { ok: true, caller: info.user && info.token ? { token: info.token, user: info.user } : null };
       } catch (err) {
         return { ok: false, status: 401, error: err instanceof Error ? err.message : String(err) };
       }
@@ -336,8 +343,12 @@ if (transportMode === 'stdio') {
     // every call produced an access-log line and nothing in the session store,
     // which is the half the operator console reads.
     await sessionStore.ensureSession('http');
-    const seq = sessionStore.recordToolCall(tool.name, toolArgs);
-    mcpLogger.toolCall(tool.name, toolArgs);
+    // Redact once and hand the same copy to both sinks: each used to run the
+    // full recursive walk over the same object, doubling the cost on every
+    // call for no benefit.
+    const redacted = redactDeep(toolArgs) as Record<string, unknown>;
+    const seq = sessionStore.recordToolCall(tool.name, toolArgs, redacted);
+    mcpLogger.toolCall(tool.name, toolArgs, redacted);
     const start = Date.now();
     try {
       const raw = await tool.handler(toolArgs);
@@ -428,11 +439,7 @@ if (transportMode === 'stdio') {
     req: IncomingMessage,
     res: ServerResponse,
   ): Promise<void> {
-    const tool = restRegistry.getTool(toolName);
-    if (!tool) {
-      jsonResponse(res, 404, { success: false, error: `Unknown tool: ${toolName}` });
-      return;
-    }
+
     // Authenticate and authorize before committing the 200. An SSE stream that
     // opens successfully and then emits `event: error` reads as success to any
     // client keying on the status code, which is every ordinary HTTP client.
@@ -440,6 +447,7 @@ if (transportMode === 'stdio') {
     // Re-running authenticateRest there would mean a second OAuth login for
     // every body.auth caller — the form ansible and the onboarding runbook use.
     let caller: ValidatedCaller | null = null;
+    let streamedTool: ToolMetadata | undefined;
     const pre = await withRestLock(async () => {
       const snap = digitApi.snapshotAuth();
       try {
@@ -447,7 +455,13 @@ if (transportMode === 'stdio') {
         if (authResult === null) return { status: 401, body: { success: false, error: 'Authentication required.' } };
         if (!authResult.ok) return { status: authResult.status, body: { success: false, error: authResult.error } };
         caller = authResult.caller;
-        return authorizeRest(toolName, tool.access, authResult.caller);
+        // Resolved after authentication, like dispatchTool and runBulk. Today
+        // every call site passes a hardcoded name, so this is not an oracle —
+        // it is consistency, so that a future caller passing user input does
+        // not silently reopen one.
+        streamedTool = restRegistry.getTool(toolName);
+        if (!streamedTool) return { status: 404, body: { success: false, error: `Unknown tool: ${toolName}` } };
+        return authorizeRest(toolName, streamedTool.access, authResult.caller);
       } finally {
         digitApi.restoreAuth(snap);
       }
@@ -479,7 +493,7 @@ if (transportMode === 'stdio') {
           if (caller) applyValidatedCaller(caller);
           const { auth: _ignored, ...toolArgs } = args;
           void _ignored;
-          await auditedCall(tool, toolArgs as Record<string, unknown>, (parsed) => {
+          await auditedCall(streamedTool!, toolArgs as Record<string, unknown>, (parsed) => {
             writeEvent('done', parsed);
           });
         } catch (err) {

--- a/digit-mcp/src/index.ts
+++ b/digit-mcp/src/index.ts
@@ -25,7 +25,7 @@ import { runWithRequestContext, setContextUser } from './services/request-contex
 import { setProgressEmitter, type ProgressEvent } from './services/progress.js';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { readFile, stat } from 'node:fs/promises';
-import { join, extname, resolve } from 'node:path';
+import { join, extname, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const transportMode = process.env.MCP_TRANSPORT === 'http' ? 'http' : 'stdio';
@@ -86,8 +86,9 @@ if (transportMode === 'stdio') {
     let filePath = urlPath === '/' ? '/index.html' : urlPath;
     const resolved = resolve(join(UI_DIR, filePath));
 
-    // Path traversal protection
-    if (!resolved.startsWith(UI_DIR)) {
+    // Path traversal protection. The trailing separator matters: without it a
+    // sibling directory sharing the prefix (`ui-evil` next to `ui`) passes.
+    if (resolved !== UI_DIR && !resolved.startsWith(UI_DIR + sep)) {
       res.writeHead(403, { 'Content-Type': 'text/plain' });
       res.end('Forbidden');
       return;
@@ -330,11 +331,9 @@ if (transportMode === 'stdio') {
     req: IncomingMessage,
     progressCb?: (event: ProgressEvent) => void,
   ): Promise<{ status: number; body: unknown }> {
-    const tool = restRegistry.getTool(toolName);
-    if (!tool) {
-      return { status: 404, body: { success: false, error: `Unknown tool: ${toolName}` } };
-    }
-
+    // Resolved inside the lock, AFTER authentication: answering 404 for an
+    // unknown tool and 401 for a known one let an anonymous caller enumerate
+    // the whole tool surface by diffing status codes.
     return withRestLock(async () => {
       const snap = digitApi.snapshotAuth();
       if (progressCb) setProgressEmitter(progressCb);
@@ -351,6 +350,11 @@ if (transportMode === 'stdio') {
         }
         if (!authResult.ok) {
           return { status: authResult.status, body: { success: false, error: authResult.error } };
+        }
+
+        const tool = restRegistry.getTool(toolName);
+        if (!tool) {
+          return { status: 404, body: { success: false, error: `Unknown tool: ${toolName}` } };
         }
 
         const denied = authorizeRest(toolName, tool.access, authResult.caller);
@@ -392,6 +396,25 @@ if (transportMode === 'stdio') {
       jsonResponse(res, 404, { success: false, error: `Unknown tool: ${toolName}` });
       return;
     }
+    // Authenticate and authorize before committing the 200. An SSE stream that
+    // opens successfully and then emits `event: error` reads as success to any
+    // client keying on the status code, which is every ordinary HTTP client.
+    const pre = await withRestLock(async () => {
+      const snap = digitApi.snapshotAuth();
+      try {
+        const authResult = await authenticateRest(req, args);
+        if (authResult === null) return { status: 401, body: { success: false, error: 'Authentication required.' } };
+        if (!authResult.ok) return { status: authResult.status, body: { success: false, error: authResult.error } };
+        return authorizeRest(toolName, tool.access, authResult.caller);
+      } finally {
+        digitApi.restoreAuth(snap);
+      }
+    });
+    if (pre) {
+      jsonResponse(res, pre.status, pre.body);
+      return;
+    }
+
     res.writeHead(200, {
       'Content-Type': 'text/event-stream',
       'Cache-Control': 'no-cache, no-transform',
@@ -641,12 +664,17 @@ if (transportMode === 'stdio') {
     // GET /v1/version — server identity + build metadata. Lets the frontend
     // verify the deployed MCP has a known fix.
     if (req.method === 'GET' && pathname === '/v1/version') {
+      // gitSha / buildTime / nodeVersion tell an unauthenticated caller exactly
+      // which build is running and therefore which CVEs apply. The service name
+      // and uptime stay open so the endpoint remains usable as a liveness probe.
+      const detailed = getAuthMode() !== 'token' ||
+        (await authenticateBearer(req.headers['authorization'] || req.headers['Authorization'])).ok;
       jsonResponse(res, 200, {
         service: 'digit-mcp',
-        version: process.env.MCP_VERSION || '1.0.0',
-        gitSha: process.env.MCP_GIT_SHA || null,
-        buildTime: process.env.MCP_BUILD_TIME || null,
-        nodeVersion: process.version,
+        version: detailed ? (process.env.MCP_VERSION || '1.0.0') : undefined,
+        gitSha: detailed ? (process.env.MCP_GIT_SHA || null) : undefined,
+        buildTime: detailed ? (process.env.MCP_BUILD_TIME || null) : undefined,
+        nodeVersion: detailed ? process.version : undefined,
         startedAt: new Date(Date.now() - Math.floor(process.uptime() * 1000)).toISOString(),
         uptimeSec: Math.floor(process.uptime()),
         features: ['v1/tenant/bootstrap', 'v1/tenant/city', 'v1/tenant/cleanup', 'v1/tenant/:id/export', 'v1/tools/:name', 'v1/tools/:name/bulk', 'sse-progress', 'cors'],
@@ -885,8 +913,9 @@ if (transportMode === 'stdio') {
         });
         jsonResponse(res, 403, {
           error:
-            `The session viewer requires one of these roles: ${adminRoleCodes().join(', ')}. ` +
-            `Caller "${apiAuth.caller.user.userName}" holds none of them.`,
+            `${pathname} requires one of these roles: ${adminRoleCodes().join(', ')}. ` +
+            `Caller "${apiAuth.caller.user.userName}" holds none of them. ` +
+            'Set MCP_ADMIN_ROLES if this deployment uses different admin role codes.',
         });
         return;
       }
@@ -1114,9 +1143,15 @@ if (transportMode === 'stdio') {
     res.end(JSON.stringify({ error: 'Not found' }));
   }
 
-  httpServer.listen(port, '0.0.0.0', () => {
+  // The ambient-mode warning says "only use this on a loopback-bound socket",
+  // which was impossible to comply with while the bind address was hardcoded.
+  // Ambient + HTTP therefore defaults to loopback; set MCP_BIND to override.
+  const bindAddress =
+    process.env.MCP_BIND || (getAuthMode() === 'ambient' ? '127.0.0.1' : '0.0.0.0');
+
+  httpServer.listen(port, bindAddress, () => {
     mcpLogger.log({ event: 'startup', port, logPath: mcpLogger.logPath });
-    console.error(`DIGIT MCP server listening on http://0.0.0.0:${port}/mcp`);
+    console.error(`DIGIT MCP server listening on http://${bindAddress}:${port}/mcp`);
     console.error(`Session viewer: http://0.0.0.0:${port}/`);
     console.error(`Health check: http://0.0.0.0:${port}/healthz`);
     console.error(`Logging to: ${mcpLogger.logPath}`);

--- a/digit-mcp/src/index.ts
+++ b/digit-mcp/src/index.ts
@@ -8,7 +8,9 @@ import { handlePgrDashboard } from './api/pgr-dashboard.js';
 import { ToolRegistry } from './tools/registry.js';
 import { registerAllTools } from './tools/index.js';
 import { ALL_GROUPS } from './types/index.js';
-import { digitApi } from './services/digit-api.js';
+import { digitApi, runWithIsolatedClient } from './services/digit-api.js';
+import { getAuthMode, resolveClientIp } from './services/auth.js';
+import type { UserInfo } from './types/index.js';
 import { setProgressEmitter, type ProgressEvent } from './services/progress.js';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { readFile, stat } from 'node:fs/promises';
@@ -175,6 +177,62 @@ if (transportMode === 'stdio') {
     }
 
     return null; // caller will translate to 401
+  }
+
+  /**
+   * Authenticate a caller on the MCP (JSON-RPC) route.
+   *
+   * `token` mode: an `Authorization: Bearer <token>` header is required and is
+   * introspected against egov-user. A token that doesn't resolve is rejected —
+   * unlike the REST shim's Form 1, which accepts any non-empty string. The
+   * resolved user is applied so tools run as the caller, and the state tenant
+   * is derived from the token's own tenant rather than a caller-supplied header.
+   *
+   * `ambient` mode: no check (stdio, or an operator who explicitly opted in).
+   */
+  const TOKEN_CACHE_TTL_MS = 30_000;
+  const TOKEN_CACHE_MAX = 500;
+  const tokenCache = new Map<string, { user: UserInfo; at: number }>();
+
+  async function authenticateMcp(
+    req: IncomingMessage,
+  ): Promise<{ ok: true } | { ok: false; status: number; error: string }> {
+    if (getAuthMode() !== 'token') return { ok: true };
+
+    const authHeader = (req.headers['authorization'] || req.headers['Authorization']) as string | undefined;
+    if (!authHeader || !/^Bearer\s+/i.test(authHeader)) {
+      return {
+        ok: false,
+        status: 401,
+        error: 'Authentication required: send Authorization: Bearer <DIGIT access token>.',
+      };
+    }
+    const token = authHeader.replace(/^Bearer\s+/i, '').trim();
+    if (!token) return { ok: false, status: 401, error: 'Empty bearer token.' };
+
+    const now = Date.now();
+    const cached = tokenCache.get(token);
+    if (cached && now - cached.at < TOKEN_CACHE_TTL_MS) {
+      applyValidatedUser(token, cached.user);
+      return { ok: true };
+    }
+
+    const user = await digitApi.validateToken(token);
+    if (!user) {
+      tokenCache.delete(token);
+      return { ok: false, status: 401, error: 'Invalid or expired access token.' };
+    }
+
+    if (tokenCache.size >= TOKEN_CACHE_MAX) tokenCache.clear();
+    tokenCache.set(token, { user, at: now });
+    applyValidatedUser(token, user);
+    return { ok: true };
+  }
+
+  function applyValidatedUser(token: string, user: UserInfo): void {
+    const tenantId = user.tenantId || '';
+    const root = tenantId.includes('.') ? tenantId.split('.')[0] : tenantId;
+    digitApi.applyToken(token, user, root || null);
   }
 
   // Map known low-level Spring / DIGIT errors to human-friendly explanations
@@ -711,19 +769,62 @@ if (transportMode === 'stdio') {
 
     // MCP endpoint — stateless mode for horizontal scaling
     if (pathname === '/mcp') {
-      await sessionStore.ensureSession('http');
-      const clientIp = req.headers['x-forwarded-for'] || req.headers['x-real-ip'] || req.socket.remoteAddress || '';
-      const userAgent = req.headers['user-agent'] || '';
-      const normalizedIp = String(clientIp).split(',')[0].trim();
-      mcpLogger.setRequestContext(normalizedIp, userAgent);
-      sessionStore.setHttpContext(String(userAgent), normalizedIp);
+      const handleMcp = async (): Promise<void> => {
+        // Authenticate BEFORE building the server. In `token` mode (the default
+        // for the HTTP transport) the caller must present a token that
+        // egov-user recognises. Previously this route had no check at all, and
+        // because each tool falls back to CRS_USERNAME/CRS_PASSWORD when no
+        // token is set, an anonymous request was executed as ADMIN.
+        const mcpAuth = await authenticateMcp(req);
+        if (!mcpAuth.ok) {
+          res.writeHead(mcpAuth.status, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({
+            jsonrpc: '2.0',
+            error: { code: -32001, message: mcpAuth.error },
+            id: null,
+          }));
+          return;
+        }
 
-      const server = createServer({ enableAllGroups: true });
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: undefined, // stateless
-      });
-      await server.connect(transport);
-      await transport.handleRequest(req, res);
+        await sessionStore.ensureSession('http');
+        const userAgent = req.headers['user-agent'] || '';
+        // N3: X-Forwarded-For is caller-controlled. Honour it only when the peer
+        // is a configured trusted proxy (MCP_TRUSTED_PROXIES); otherwise record
+        // the socket address. Previously the header always won, so any direct
+        // caller chose the IP that showed up in the audit trail.
+        const forwarded = (req.headers['x-forwarded-for'] || req.headers['x-real-ip']) as string | undefined;
+        const resolvedIp = resolveClientIp(req.socket.remoteAddress, forwarded);
+        if (resolvedIp.claimed) {
+          mcpLogger.log({
+            event: 'untrusted_forwarded_for',
+            peer: resolvedIp.ip,
+            claimed: resolvedIp.claimed,
+            note: 'X-Forwarded-For ignored: peer is not in MCP_TRUSTED_PROXIES',
+          });
+        }
+        mcpLogger.setRequestContext(resolvedIp.ip, userAgent);
+        sessionStore.setHttpContext(String(userAgent), resolvedIp.ip);
+
+        const server = createServer({ enableAllGroups: true });
+        const transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: undefined, // stateless
+        });
+        await server.connect(transport);
+        await transport.handleRequest(req, res);
+      };
+
+      // In token mode every request carries its own credentials, so give it its
+      // own DigitApiClient. Concurrent callers then cannot observe or inherit
+      // each other's token, and a `configure` call (state tenant / base_url)
+      // dies with the request instead of persisting process-wide.
+      //
+      // In ambient mode (stdio-style single owner, or an explicit opt-in) the
+      // shared client is kept so `configure` once, then use tools still works.
+      if (getAuthMode() === 'token') {
+        await runWithIsolatedClient(handleMcp);
+      } else {
+        await handleMcp();
+      }
       return;
     }
 

--- a/digit-mcp/src/index.ts
+++ b/digit-mcp/src/index.ts
@@ -8,7 +8,7 @@ import { handlePgrDashboard } from './api/pgr-dashboard.js';
 import { ToolRegistry } from './tools/registry.js';
 import { registerAllTools } from './tools/index.js';
 import { ALL_GROUPS } from './types/index.js';
-import type { ToolAccess } from './types/index.js';
+import type { ToolAccess, ToolMetadata } from './types/index.js';
 import { digitApi, runWithIsolatedClient } from './services/digit-api.js';
 import {
   adminRoleCodes,
@@ -17,6 +17,7 @@ import {
   checkToolAccess,
   getAuthMode,
   isAdminCaller,
+  parseBearer,
   resolveClientIp,
   type ValidatedCaller,
 } from './services/auth.js';
@@ -161,7 +162,10 @@ if (transportMode === 'stdio') {
     const authHeader = req.headers['authorization'] || req.headers['Authorization'];
 
     // Form 1: Authorization: Bearer <token>
-    if (authHeader) {
+    // Gated on the Bearer scheme specifically. Claiming Form 1 for ANY
+    // Authorization header made a proxy-injected or browser-cached `Basic`
+    // header a hard 401, shadowing the body.auth credentials the caller sent.
+    if (parseBearer(authHeader)) {
       const result = await authenticateBearer(authHeader);
       if (!result.ok) return result;
       applyValidatedCaller(result.caller);
@@ -280,6 +284,46 @@ if (transportMode === 'stdio') {
     return { error: raw, raw };
   }
 
+  /**
+   * Run a tool from the REST shim, recording it the same way the MCP path does.
+   *
+   * `src/server.ts` wraps every MCP tool call in mcpLogger + sessionStore, but
+   * the REST paths called `tool.handler()` directly — so every successful
+   * /v1/* invocation, including tenant_destroy and user_role_add, left no trace
+   * at all. Only denials were logged, which is the opposite of what an audit
+   * trail is for.
+   */
+  async function auditedCall<T>(
+    tool: ToolMetadata,
+    toolArgs: Record<string, unknown>,
+    onResult: (parsed: unknown) => T,
+  ): Promise<T> {
+    const seq = sessionStore.recordToolCall(tool.name, toolArgs);
+    mcpLogger.toolCall(tool.name, toolArgs);
+    const start = Date.now();
+    try {
+      const raw = await tool.handler(toolArgs);
+      const durationMs = Date.now() - start;
+      mcpLogger.toolResult(tool.name, durationMs, false);
+      sessionStore.recordToolResult(
+        seq,
+        tool.name,
+        durationMs,
+        false,
+        tool.sensitiveOutput ? `[redacted: ${raw.length} chars]` : raw,
+      );
+      let parsed: unknown;
+      try { parsed = JSON.parse(raw); } catch { parsed = { raw }; }
+      return onResult(parsed);
+    } catch (err) {
+      const durationMs = Date.now() - start;
+      const message = err instanceof Error ? err.message : String(err);
+      mcpLogger.toolResult(tool.name, durationMs, true);
+      sessionStore.recordToolResult(seq, tool.name, durationMs, true, '', message);
+      throw err;
+    }
+  }
+
   async function dispatchTool(
     toolName: string,
     args: Record<string, unknown>,
@@ -317,10 +361,7 @@ if (transportMode === 'stdio') {
         const { auth: _ignored, ...toolArgs } = args;
         void _ignored;
 
-        const result = await tool.handler(toolArgs as Record<string, unknown>);
-        let parsed: unknown;
-        try { parsed = JSON.parse(result); } catch { parsed = { raw: result }; }
-        return { status: 200, body: parsed };
+        return auditedCall(tool, toolArgs as Record<string, unknown>, (parsed) => ({ status: 200, body: parsed }));
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         const norm = normalizeError(msg);
@@ -384,10 +425,9 @@ if (transportMode === 'stdio') {
           }
           const { auth: _ignored, ...toolArgs } = args;
           void _ignored;
-          const raw = await tool.handler(toolArgs as Record<string, unknown>);
-          let parsed: unknown;
-          try { parsed = JSON.parse(raw); } catch { parsed = { raw }; }
-          writeEvent('done', parsed);
+          await auditedCall(tool, toolArgs as Record<string, unknown>, (parsed) => {
+            writeEvent('done', parsed);
+          });
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           writeEvent('error', { success: false, ...normalizeError(msg) });
@@ -445,11 +485,10 @@ if (transportMode === 'stdio') {
             const i = nextIdx++;
             if (i >= items.length) return;
             try {
-              const raw = await boundTool.handler(items[i]);
-              let parsed: unknown;
-              try { parsed = JSON.parse(raw); } catch { parsed = { raw }; }
-              const ok = !!(parsed && typeof parsed === 'object' && (parsed as Record<string, unknown>).success !== false);
-              results[i] = { ok, status: 200, body: parsed };
+              results[i] = await auditedCall(boundTool, items[i], (parsed) => {
+                const ok = !!(parsed && typeof parsed === 'object' && (parsed as Record<string, unknown>).success !== false);
+                return { ok, status: 200, body: parsed };
+              });
             } catch (err) {
               const msg = err instanceof Error ? err.message : String(err);
               results[i] = { ok: false, status: 500, body: { success: false, ...normalizeError(msg) } };
@@ -579,7 +618,11 @@ if (transportMode === 'stdio') {
     // can call /v1/* from a different origin without extra ops setup
     // (assuming MCP_CORS_ORIGINS is configured).
     applyCors(req, res);
-    if (req.method === 'OPTIONS' && pathname.startsWith('/v1/')) {
+    // Preflight is answered before any auth gate, for every namespace a browser
+    // can reach. A preflight carries no credentials by design, so gating it
+    // returns 401 and the real request is never sent — which silently breaks
+    // every cross-origin consumer of /api/* and /mcp.
+    if (req.method === 'OPTIONS' && (pathname.startsWith('/v1/') || pathname.startsWith('/api/') || pathname === '/mcp')) {
       res.writeHead(204).end();
       return;
     }

--- a/digit-mcp/src/index.ts
+++ b/digit-mcp/src/index.ts
@@ -8,9 +8,19 @@ import { handlePgrDashboard } from './api/pgr-dashboard.js';
 import { ToolRegistry } from './tools/registry.js';
 import { registerAllTools } from './tools/index.js';
 import { ALL_GROUPS } from './types/index.js';
+import type { ToolAccess } from './types/index.js';
 import { digitApi, runWithIsolatedClient } from './services/digit-api.js';
-import { getAuthMode, resolveClientIp } from './services/auth.js';
-import type { UserInfo } from './types/index.js';
+import {
+  adminRoleCodes,
+  applyValidatedCaller,
+  authenticateBearer,
+  checkToolAccess,
+  getAuthMode,
+  isAdminCaller,
+  resolveClientIp,
+  type ValidatedCaller,
+} from './services/auth.js';
+import { runWithRequestContext, setContextUser } from './services/request-context.js';
 import { setProgressEmitter, type ProgressEvent } from './services/progress.js';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { readFile, stat } from 'node:fs/promises';
@@ -124,27 +134,39 @@ if (transportMode === 'stdio') {
   }
 
   /**
-   * Authenticate the caller. Accepted forms:
-   *   1. Authorization: Bearer <token>            — token already minted upstream
+   * Authenticate a caller on the REST shim. Accepted forms:
+   *   1. Authorization: Bearer <token>                  — introspected against egov-user
    *   2. body.auth = { username, password, tenant_id }  — OAuth login first
-   * Returns null when no auth was supplied (caller should 401), or an
-   * error message string when the supplied creds were rejected.
+   *
+   * Returns null when no auth was supplied (caller should 401), or an error
+   * when the supplied credentials were rejected. On success the validated
+   * caller is returned so the dispatcher can authorize the tool.
+   *
+   * Two things changed here, and both were the same hole C1 closed on /mcp:
+   *
+   *   - Form 1 used to accept ANY non-empty string as a bearer token and take
+   *     the state tenant from a caller-supplied X-State-Tenant header. It now
+   *     goes through the same introspection as /mcp, so a token that egov-user
+   *     doesn't recognise is a 401 and the tenant comes from the token.
+   *   - A third form fell back to CRS_USERNAME/CRS_PASSWORD whenever the env
+   *     was configured, which made an anonymous REST caller the container's
+   *     stored ADMIN. It is now gated on `ambient` mode, exactly like
+   *     `ensureAuthenticated()` — so it still serves a developer's own stdio
+   *     process and never a network peer.
    */
   async function authenticateRest(
     req: IncomingMessage,
     body: Record<string, unknown>,
-  ): Promise<{ ok: true } | { ok: false; status: number; error: string } | null> {
-    const authHeader = (req.headers['authorization'] || req.headers['Authorization']) as string | undefined;
+  ): Promise<{ ok: true; caller: ValidatedCaller | null } | { ok: false; status: number; error: string } | null> {
+    const authHeader = req.headers['authorization'] || req.headers['Authorization'];
 
     // Form 1: Authorization: Bearer <token>
-    if (authHeader && /^Bearer\s+/i.test(authHeader)) {
-      const token = authHeader.replace(/^Bearer\s+/i, '').trim();
-      if (!token) return { ok: false, status: 401, error: 'Empty bearer token' };
-      // We don't have userInfo from the token alone; the caller can pass
-      // the state tenant via X-State-Tenant header so MDMS calls resolve.
-      const stateTenant = (req.headers['x-state-tenant'] as string | undefined) || null;
-      digitApi.applyToken(token, null, stateTenant);
-      return { ok: true };
+    if (authHeader) {
+      const result = await authenticateBearer(authHeader);
+      if (!result.ok) return result;
+      applyValidatedCaller(result.caller);
+      setContextUser(result.caller.user.userName);
+      return { ok: true, caller: result.caller };
     }
 
     // Form 2: body.auth = { username, password, tenant_id }
@@ -152,31 +174,51 @@ if (transportMode === 'stdio') {
     if (auth && auth.username && auth.password && auth.tenant_id) {
       try {
         await digitApi.login(auth.username, auth.password, auth.tenant_id);
-        return { ok: true };
+        const user = digitApi.getAuthInfo().user;
+        setContextUser(user?.userName);
+        return { ok: true, caller: user ? { token: '', user } : null };
       } catch (err) {
         return { ok: false, status: 401, error: err instanceof Error ? err.message : String(err) };
       }
     }
 
-    // Form 3: fall back to CRS_USERNAME / CRS_PASSWORD env vars if present.
-    // This mirrors the JSON-RPC path's ensureAuthenticated() so REST callers
-    // running on the same MCP container don't have to repeat the creds in
-    // every body. Skipped if the env isn't configured — caller still gets 401.
-    const envUser = process.env.CRS_USERNAME;
-    const envPass = process.env.CRS_PASSWORD;
-    if (envUser && envPass) {
-      const envTenant = process.env.CRS_TENANT_ID || digitApi.getEnvironmentInfo().stateTenantId;
-      try {
-        if (!digitApi.isAuthenticated()) {
-          await digitApi.login(envUser, envPass, envTenant);
+    // Form 3: env credentials — ambient mode only. See the note above.
+    if (getAuthMode() === 'ambient') {
+      const envUser = process.env.CRS_USERNAME;
+      const envPass = process.env.CRS_PASSWORD;
+      if (envUser && envPass) {
+        const envTenant = process.env.CRS_TENANT_ID || digitApi.getEnvironmentInfo().stateTenantId;
+        try {
+          if (!digitApi.isAuthenticated()) {
+            await digitApi.login(envUser, envPass, envTenant);
+          }
+          return { ok: true, caller: null };
+        } catch (err) {
+          return { ok: false, status: 401, error: `env auth failed: ${err instanceof Error ? err.message : String(err)}` };
         }
-        return { ok: true };
-      } catch (err) {
-        return { ok: false, status: 401, error: `env auth failed: ${err instanceof Error ? err.message : String(err)}` };
       }
     }
 
     return null; // caller will translate to 401
+  }
+
+  /**
+   * Authorize a REST tool call. Same tiers, same helper, same denial message as
+   * the MCP path — `checkToolAccess` is transport-agnostic on purpose, so the
+   * two doors cannot drift into disagreeing about who may run what.
+   */
+  function authorizeRest(
+    toolName: string,
+    access: ToolAccess | undefined,
+    caller: ValidatedCaller | null,
+  ): { status: number; body: unknown } | null {
+    const denial = checkToolAccess(toolName, access, caller?.user ?? null);
+    if (!denial) return null;
+    mcpLogger.log({ event: 'tool_denied', transport: 'rest', tool: toolName, reason: denial });
+    return {
+      status: 403,
+      body: { success: false, error: denial, category: 'auth', code: 403, requiredAccess: access ?? 'employee' },
+    };
   }
 
   /**
@@ -190,49 +232,17 @@ if (transportMode === 'stdio') {
    *
    * `ambient` mode: no check (stdio, or an operator who explicitly opted in).
    */
-  const TOKEN_CACHE_TTL_MS = 30_000;
-  const TOKEN_CACHE_MAX = 500;
-  const tokenCache = new Map<string, { user: UserInfo; at: number }>();
-
   async function authenticateMcp(
     req: IncomingMessage,
   ): Promise<{ ok: true } | { ok: false; status: number; error: string }> {
     if (getAuthMode() !== 'token') return { ok: true };
 
-    const authHeader = (req.headers['authorization'] || req.headers['Authorization']) as string | undefined;
-    if (!authHeader || !/^Bearer\s+/i.test(authHeader)) {
-      return {
-        ok: false,
-        status: 401,
-        error: 'Authentication required: send Authorization: Bearer <DIGIT access token>.',
-      };
-    }
-    const token = authHeader.replace(/^Bearer\s+/i, '').trim();
-    if (!token) return { ok: false, status: 401, error: 'Empty bearer token.' };
+    const result = await authenticateBearer(req.headers['authorization'] || req.headers['Authorization']);
+    if (!result.ok) return result;
 
-    const now = Date.now();
-    const cached = tokenCache.get(token);
-    if (cached && now - cached.at < TOKEN_CACHE_TTL_MS) {
-      applyValidatedUser(token, cached.user);
-      return { ok: true };
-    }
-
-    const user = await digitApi.validateToken(token);
-    if (!user) {
-      tokenCache.delete(token);
-      return { ok: false, status: 401, error: 'Invalid or expired access token.' };
-    }
-
-    if (tokenCache.size >= TOKEN_CACHE_MAX) tokenCache.clear();
-    tokenCache.set(token, { user, at: now });
-    applyValidatedUser(token, user);
+    applyValidatedCaller(result.caller);
+    setContextUser(result.caller.user.userName);
     return { ok: true };
-  }
-
-  function applyValidatedUser(token: string, user: UserInfo): void {
-    const tenantId = user.tenantId || '';
-    const root = tenantId.includes('.') ? tenantId.split('.')[0] : tenantId;
-    digitApi.applyToken(token, user, root || null);
   }
 
   // Map known low-level Spring / DIGIT errors to human-friendly explanations
@@ -299,6 +309,9 @@ if (transportMode === 'stdio') {
           return { status: authResult.status, body: { success: false, error: authResult.error } };
         }
 
+        const denied = authorizeRest(toolName, tool.access, authResult.caller);
+        if (denied) return denied;
+
         // Strip the auth envelope before forwarding the args to the tool,
         // so the tool's input schema validation doesn't trip on it.
         const { auth: _ignored, ...toolArgs } = args;
@@ -364,6 +377,11 @@ if (transportMode === 'stdio') {
             writeEvent('error', { success: false, error: authResult.error });
             return;
           }
+          const denied = authorizeRest(toolName, tool.access, authResult.caller);
+          if (denied) {
+            writeEvent('error', denied.body);
+            return;
+          }
           const { auth: _ignored, ...toolArgs } = args;
           void _ignored;
           const raw = await tool.handler(toolArgs as Record<string, unknown>);
@@ -414,6 +432,9 @@ if (transportMode === 'stdio') {
         if (!authResult.ok) {
           return { status: authResult.status, body: { success: false, error: authResult.error } };
         }
+
+        const denied = authorizeRest(toolName, boundTool.access, authResult.caller);
+        if (denied) return denied;
 
         type ItemResult = { ok: boolean; status: number; body: unknown };
         const results: ItemResult[] = new Array(items.length);
@@ -533,7 +554,23 @@ if (transportMode === 'stdio') {
 
   // --- HTTP server ---
 
-  const httpServer = http.createServer(async (req: IncomingMessage, res: ServerResponse) => {
+  /**
+   * Every request runs inside a request context, so the logger and session
+   * store attribute each tool call to the caller that actually made it rather
+   * than to whichever request most recently overwrote a shared field.
+   */
+  const httpServer = http.createServer((req: IncomingMessage, res: ServerResponse) => {
+    const userAgent = String(req.headers['user-agent'] || '');
+    const forwarded = (req.headers['x-forwarded-for'] || req.headers['x-real-ip']) as string | undefined;
+    const peer = resolveClientIp(req.socket.remoteAddress, forwarded);
+    void runWithRequestContext({ ip: peer.ip, userAgent }, () => handleHttpRequest(req, res, peer));
+  });
+
+  async function handleHttpRequest(
+    req: IncomingMessage,
+    res: ServerResponse,
+    peer: ReturnType<typeof resolveClientIp>,
+  ): Promise<void> {
     const url = req.url || '';
     const pathname = url.split('?')[0];
 
@@ -684,6 +721,14 @@ if (transportMode === 'stdio') {
               jsonResponse(res, authResult.status, { success: false, error: authResult.error });
               return;
             }
+            // Not a registered tool, so it needs the tier stated explicitly.
+            // The bundle is every MDMS record the tenant owns — admin-tier data
+            // by the same standard that puts mdms_search's writers there.
+            const exportDenied = authorizeRest('tenant_export', 'admin', authResult.caller);
+            if (exportDenied) {
+              jsonResponse(res, exportDenied.status, exportDenied.body);
+              return;
+            }
             const bundle = await exportTenant(targetTenant, body.schemas as string[] | undefined, body.limit as number | undefined);
             jsonResponse(res, 200, bundle);
           } catch (err) {
@@ -703,6 +748,16 @@ if (transportMode === 'stdio') {
     // so the frontend can render forms / build clients dynamically. Each
     // entry includes a `responseShape` hint when known.
     if (req.method === 'GET' && pathname === '/v1/tools') {
+      // Mirrors discover_tools' `public` tier: no role requirement, but in
+      // token mode the caller must still present a valid token, so the admin
+      // tool surface isn't enumerable by an anonymous peer.
+      if (getAuthMode() === 'token') {
+        const listAuth = await authenticateBearer(req.headers['authorization'] || req.headers['Authorization']);
+        if (!listAuth.ok) {
+          jsonResponse(res, listAuth.status, { success: false, error: listAuth.error });
+          return;
+        }
+      }
       jsonResponse(res, 200, {
         tools: restRegistry.getAllTools().map((t) => ({
           name: t.name,
@@ -762,6 +817,39 @@ if (transportMode === 'stdio') {
     }
 
     // PGR Dashboard API
+    // ── /api/* gate ────────────────────────────────────────────────────────
+    // The observability routes below are not tool dispatch, so they never went
+    // through checkToolAccess — yet /api/sessions/:id/events serves recorded
+    // tool arguments and result prefixes for every session the server has run,
+    // and /api/pgr/dashboard serves complaint data. They were reachable with no
+    // credentials at all.
+    //
+    // One gate for the whole namespace rather than five call sites, so a route
+    // added later is authenticated by default instead of by remembering to.
+    // Admin tier: this is the same data the admin-tier tools produce.
+    if (pathname.startsWith('/api/') && getAuthMode() === 'token') {
+      const apiAuth = await authenticateBearer(req.headers['authorization'] || req.headers['Authorization']);
+      if (!apiAuth.ok) {
+        jsonResponse(res, apiAuth.status, { error: apiAuth.error });
+        return;
+      }
+      if (!isAdminCaller(apiAuth.caller.user)) {
+        mcpLogger.log({
+          event: 'api_denied',
+          path: pathname,
+          user: apiAuth.caller.user.userName,
+          reason: 'not an admin-tier caller',
+        });
+        jsonResponse(res, 403, {
+          error:
+            `The session viewer requires one of these roles: ${adminRoleCodes().join(', ')}. ` +
+            `Caller "${apiAuth.caller.user.userName}" holds none of them.`,
+        });
+        return;
+      }
+      setContextUser(apiAuth.caller.user.userName);
+    }
+
     if (req.method === 'GET' && pathname === '/api/pgr/dashboard') {
       await handlePgrDashboard(res, parseQuery(url));
       return;
@@ -787,23 +875,15 @@ if (transportMode === 'stdio') {
         }
 
         await sessionStore.ensureSession('http');
-        const userAgent = req.headers['user-agent'] || '';
-        // N3: X-Forwarded-For is caller-controlled. Honour it only when the peer
-        // is a configured trusted proxy (MCP_TRUSTED_PROXIES); otherwise record
-        // the socket address. Previously the header always won, so any direct
-        // caller chose the IP that showed up in the audit trail.
-        const forwarded = (req.headers['x-forwarded-for'] || req.headers['x-real-ip']) as string | undefined;
-        const resolvedIp = resolveClientIp(req.socket.remoteAddress, forwarded);
-        if (resolvedIp.claimed) {
+        if (peer.claimed) {
           mcpLogger.log({
             event: 'untrusted_forwarded_for',
-            peer: resolvedIp.ip,
-            claimed: resolvedIp.claimed,
+            peer: peer.ip,
+            claimed: peer.claimed,
             note: 'X-Forwarded-For ignored: peer is not in MCP_TRUSTED_PROXIES',
           });
         }
-        mcpLogger.setRequestContext(resolvedIp.ip, userAgent);
-        sessionStore.setHttpContext(String(userAgent), resolvedIp.ip);
+        sessionStore.setHttpContext(String(req.headers['user-agent'] || ''), peer.ip);
 
         const server = createServer({ enableAllGroups: true });
         const transport = new StreamableHTTPServerTransport({
@@ -989,7 +1069,7 @@ if (transportMode === 'stdio') {
     // --- 404 ---
     res.writeHead(404, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ error: 'Not found' }));
-  });
+  }
 
   httpServer.listen(port, '0.0.0.0', () => {
     mcpLogger.log({ event: 'startup', port, logPath: mcpLogger.logPath });

--- a/digit-mcp/src/logger.ts
+++ b/digit-mcp/src/logger.ts
@@ -6,8 +6,6 @@ import { redactDeep } from './utils/redact.js';
 class McpLogger {
   public readonly logPath: string;
   private stream: WriteStream;
-  private ip = '';
-  private ua = '';
 
   constructor() {
     this.logPath = process.env.MCP_LOG_FILE || '/var/log/digit-mcp/access.log';
@@ -16,21 +14,17 @@ class McpLogger {
   }
 
   /**
-   * Fallback client context, used when there is no per-request scope (stdio).
-   * On the HTTP transport the context comes from AsyncLocalStorage instead —
-   * see `peer()` — because concurrent requests would otherwise overwrite these
-   * fields and cross-attribute each other's tool calls.
+   * Client context for the call being logged.
+   *
+   * Read from the request scope rather than from instance fields: on the HTTP
+   * transport two concurrent requests would overwrite shared fields and
+   * cross-attribute each other's tool calls. Empty under stdio, where the
+   * session record already identifies the single owner.
    */
-  setRequestContext(ip: string, userAgent: string): void {
-    this.ip = ip;
-    this.ua = userAgent;
-  }
-
-  /** Client context for the call being logged, request-scoped where available. */
   private peer(): { ip?: string; ua?: string; user?: string } {
     const ctx = getRequestContext();
-    if (ctx) return { ip: ctx.ip || undefined, ua: ctx.userAgent || undefined, user: ctx.userName };
-    return { ip: this.ip || undefined, ua: this.ua || undefined };
+    if (!ctx) return {};
+    return { ip: ctx.ip || undefined, ua: ctx.userAgent || undefined, user: ctx.userName };
   }
 
   /** Write a structured JSON log line */

--- a/digit-mcp/src/logger.ts
+++ b/digit-mcp/src/logger.ts
@@ -1,5 +1,6 @@
 import { createWriteStream, mkdirSync, type WriteStream } from 'node:fs';
 import { dirname } from 'node:path';
+import { redactDeep } from './utils/redact.js';
 
 class McpLogger {
   public readonly logPath: string;
@@ -47,13 +48,13 @@ class McpLogger {
     });
   }
 
-  /** Strip sensitive fields before logging */
+  /**
+   * Strip sensitive fields before logging. Substring match on the key name, at
+   * any depth — the previous exact-name top-level check missed nested shapes
+   * like `{ auth: { password } }` as well as `apiKey`-style names.
+   */
   private sanitize(args: Record<string, unknown>): Record<string, unknown> {
-    const out = { ...args };
-    for (const key of ['password', 'secret', 'token', 'auth_token']) {
-      if (key in out) out[key] = '***';
-    }
-    return out;
+    return redactDeep(args) as Record<string, unknown>;
   }
 }
 

--- a/digit-mcp/src/logger.ts
+++ b/digit-mcp/src/logger.ts
@@ -34,7 +34,8 @@ class McpLogger {
   }
 
   /** Log a tool call (called from server.ts CallTool handler) */
-  toolCall(toolName: string, args: Record<string, unknown>): void {
+  /** `redacted` lets a caller that already redacted these args avoid a second walk. */
+  toolCall(toolName: string, args: Record<string, unknown>, redacted?: Record<string, unknown>): void {
     const peer = this.peer();
     this.log({
       event: 'tool_call',
@@ -42,7 +43,7 @@ class McpLogger {
       ua: peer.ua,
       user: peer.user,
       tool: toolName,
-      args: this.sanitize(args),
+      args: redacted ?? this.sanitize(args),
     });
   }
 

--- a/digit-mcp/src/logger.ts
+++ b/digit-mcp/src/logger.ts
@@ -1,5 +1,6 @@
 import { createWriteStream, mkdirSync, type WriteStream } from 'node:fs';
 import { dirname } from 'node:path';
+import { getRequestContext } from './services/request-context.js';
 import { redactDeep } from './utils/redact.js';
 
 class McpLogger {
@@ -14,10 +15,22 @@ class McpLogger {
     this.stream = createWriteStream(this.logPath, { flags: 'a' });
   }
 
-  /** Called per HTTP request to set the client context for subsequent tool logs */
+  /**
+   * Fallback client context, used when there is no per-request scope (stdio).
+   * On the HTTP transport the context comes from AsyncLocalStorage instead —
+   * see `peer()` — because concurrent requests would otherwise overwrite these
+   * fields and cross-attribute each other's tool calls.
+   */
   setRequestContext(ip: string, userAgent: string): void {
     this.ip = ip;
     this.ua = userAgent;
+  }
+
+  /** Client context for the call being logged, request-scoped where available. */
+  private peer(): { ip?: string; ua?: string; user?: string } {
+    const ctx = getRequestContext();
+    if (ctx) return { ip: ctx.ip || undefined, ua: ctx.userAgent || undefined, user: ctx.userName };
+    return { ip: this.ip || undefined, ua: this.ua || undefined };
   }
 
   /** Write a structured JSON log line */
@@ -28,10 +41,12 @@ class McpLogger {
 
   /** Log a tool call (called from server.ts CallTool handler) */
   toolCall(toolName: string, args: Record<string, unknown>): void {
+    const peer = this.peer();
     this.log({
       event: 'tool_call',
-      ip: this.ip || undefined,
-      ua: this.ua || undefined,
+      ip: peer.ip,
+      ua: peer.ua,
+      user: peer.user,
       tool: toolName,
       args: this.sanitize(args),
     });
@@ -41,7 +56,7 @@ class McpLogger {
   toolResult(toolName: string, durationMs: number, isError: boolean): void {
     this.log({
       event: 'tool_result',
-      ip: this.ip || undefined,
+      ip: this.peer().ip,
       tool: toolName,
       durationMs,
       error: isError || undefined,

--- a/digit-mcp/src/server.ts
+++ b/digit-mcp/src/server.ts
@@ -9,7 +9,7 @@ import { ALL_GROUPS } from './types/index.js';
 import type { ErrorCategory } from './types/index.js';
 import { mcpLogger } from './logger.js';
 import { sessionStore } from './services/session-store.js';
-import { checkToolAccess } from './services/auth.js';
+import { AuthRequiredError, checkToolAccess } from './services/auth.js';
 import { digitApi } from './services/digit-api.js';
 import { telemetry } from './services/telemetry.js';
 import { ApiClientError } from './services/digit-api.js';
@@ -171,6 +171,12 @@ export function createServer(options?: CreateServerOptions): Server {
       if (error instanceof ApiClientError) {
         category = error.category;
         code = error.statusCode;
+      } else if (error instanceof AuthRequiredError || (error instanceof Error && error.name === 'AuthRequiredError')) {
+        // Without this the most common failure in token mode — a tool called
+        // with no usable credentials — reported as category 'internal', which
+        // tells the agent to retry rather than to authenticate.
+        category = 'auth';
+        code = 401;
       } else if (error instanceof Error && error.name === 'ValidationError') {
         category = 'validation';
         code = 400;

--- a/digit-mcp/src/server.ts
+++ b/digit-mcp/src/server.ts
@@ -9,6 +9,8 @@ import { ALL_GROUPS } from './types/index.js';
 import type { ErrorCategory } from './types/index.js';
 import { mcpLogger } from './logger.js';
 import { sessionStore } from './services/session-store.js';
+import { checkToolAccess } from './services/auth.js';
+import { digitApi } from './services/digit-api.js';
 import { telemetry } from './services/telemetry.js';
 import { ApiClientError } from './services/digit-api.js';
 import { getErrorHint } from './utils/error-hints.js';
@@ -94,6 +96,35 @@ export function createServer(options?: CreateServerOptions): Server {
       };
     }
 
+    // Authorization (N1). Authentication established *who* the caller is; this
+    // decides whether that identity may run this particular tool. DIGIT allows
+    // citizen self-registration, so "holds a valid token" is not a privilege
+    // boundary on its own — and several tools (decrypt_data, snapshot_capture,
+    // the monitoring probes) never touch DIGIT's own accesscontrol.
+    const denial = checkToolAccess(name, tool.access, digitApi.getAuthInfo().user);
+    if (denial) {
+      mcpLogger.log({ event: 'tool_denied', tool: name, reason: denial });
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                success: false,
+                error: denial,
+                category: 'auth' satisfies ErrorCategory,
+                code: 403,
+                requiredAccess: tool.access ?? 'employee',
+              },
+              null,
+              2
+            ),
+          },
+        ],
+        isError: true,
+      };
+    }
+
     const start = Date.now();
     const sanitizedArgs = (args || {}) as Record<string, unknown>;
     mcpLogger.toolCall(name, sanitizedArgs);
@@ -106,7 +137,17 @@ export function createServer(options?: CreateServerOptions): Server {
       const result = await tool.handler(sanitizedArgs);
       const durationMs = Date.now() - start;
       mcpLogger.toolResult(name, durationMs, false);
-      sessionStore.recordToolResult(seq, name, durationMs, false, result);
+      // N2: never persist the output of a tool whose result is sensitive
+      // (decrypt_data returns plaintext PII). The session store keeps a
+      // 200-char prefix of every result, which would otherwise land in
+      // Postgres and the JSONL log.
+      sessionStore.recordToolResult(
+        seq,
+        name,
+        durationMs,
+        false,
+        tool.sensitiveOutput ? `[redacted: ${result.length} chars]` : result,
+      );
 
       // Nudge: suggest checkpoint after every N non-session tool calls
       let text = result;

--- a/digit-mcp/src/server.ts
+++ b/digit-mcp/src/server.ts
@@ -8,6 +8,7 @@ import { registerAllTools } from './tools/index.js';
 import { ALL_GROUPS } from './types/index.js';
 import type { ErrorCategory } from './types/index.js';
 import { mcpLogger } from './logger.js';
+import { redactDeep } from './utils/redact.js';
 import { sessionStore } from './services/session-store.js';
 import { AuthRequiredError, checkToolAccess } from './services/auth.js';
 import { digitApi } from './services/digit-api.js';
@@ -127,10 +128,12 @@ export function createServer(options?: CreateServerOptions): Server {
 
     const start = Date.now();
     const sanitizedArgs = (args || {}) as Record<string, unknown>;
-    mcpLogger.toolCall(name, sanitizedArgs);
+    // One redaction pass shared by both sinks.
+    const redactedArgs = redactDeep(sanitizedArgs) as Record<string, unknown>;
+    mcpLogger.toolCall(name, sanitizedArgs, redactedArgs);
 
     // Record tool call in session + telemetry
-    const seq = sessionStore.recordToolCall(name, sanitizedArgs);
+    const seq = sessionStore.recordToolCall(name, sanitizedArgs, redactedArgs);
     telemetry.toolCall(name, tool.group);
 
     try {

--- a/digit-mcp/src/services/auth.ts
+++ b/digit-mcp/src/services/auth.ts
@@ -392,7 +392,14 @@ export function resolveArtifactPath(userPath: string): string {
   return real;
 }
 
-function isInside(candidate: string, base: string): boolean {
+/**
+ * Is `candidate` the same path as `base`, or inside it?
+ *
+ * Exported so the static-file guard in index.ts uses this one implementation:
+ * two copies of a path-containment check drift, and the weaker copy is the one
+ * nobody remembers to fix.
+ */
+export function isInside(candidate: string, base: string): boolean {
   return candidate === base || candidate.startsWith(base + sep);
 }
 
@@ -545,6 +552,39 @@ export function isCachedCaller(authHeader: string | string[] | undefined): boole
   return !!cached && Date.now() - cached.at < TOKEN_CACHE_TTL_MS;
 }
 
+/**
+ * Make room without wiping the map.
+ *
+ * `clear()` at the cap meant that cycling through more distinct tokens than the
+ * cap inside one TTL window repeatedly emptied the cache, sending every
+ * recently-cached caller back to egov-user — a thundering herd against the
+ * service the cache exists to protect, triggerable with legitimately issued
+ * tokens. Drop what has already expired first; if that frees nothing, drop the
+ * oldest entries only.
+ */
+function evictIfFull(now: number): void {
+  if (tokenCache.size < TOKEN_CACHE_MAX) return;
+
+  for (const [token, entry] of tokenCache) {
+    if (now - entry.at >= TOKEN_CACHE_TTL_MS) tokenCache.delete(token);
+  }
+  if (tokenCache.size < TOKEN_CACHE_MAX) return;
+
+  // Map iterates in insertion order, and entries are never re-inserted on a
+  // cache hit, so the front of the map is the oldest.
+  const excess = tokenCache.size - TOKEN_CACHE_MAX + 1;
+  let dropped = 0;
+  for (const token of tokenCache.keys()) {
+    tokenCache.delete(token);
+    if (++dropped >= excess) break;
+  }
+}
+
+/** Test/ops hook: current occupancy of the introspection cache. */
+export function tokenCacheStats(): { size: number; max: number; ttlMs: number } {
+  return { size: tokenCache.size, max: TOKEN_CACHE_MAX, ttlMs: TOKEN_CACHE_TTL_MS };
+}
+
 /** Test/ops hook: drop every cached introspection result. */
 export function clearTokenCache(): void {
   tokenCache.clear();
@@ -615,7 +655,7 @@ export async function authenticateBearer(
     };
   }
 
-  if (tokenCache.size >= TOKEN_CACHE_MAX) tokenCache.clear();
+  evictIfFull(now);
   tokenCache.set(token, { user, at: now });
   return { ok: true, caller: { token, user: cloneUser(user) } };
 }

--- a/digit-mcp/src/services/auth.ts
+++ b/digit-mcp/src/services/auth.ts
@@ -1,6 +1,8 @@
-import { mkdirSync } from 'node:fs';
+import { mkdirSync, realpathSync } from 'node:fs';
+import { isIPv4, isIPv6 } from 'node:net';
 import { tmpdir } from 'node:os';
-import { dirname, isAbsolute, join, resolve, sep } from 'node:path';
+import { basename, dirname, isAbsolute, join, resolve, sep } from 'node:path';
+import { getEnvironment } from '../config/environments.js';
 import { digitApi } from './digit-api.js';
 import type { ToolAccess, UserInfo } from '../types/index.js';
 
@@ -171,9 +173,9 @@ export function checkToolAccess(
  * preferred unconditionally, so with nothing in front of the port every caller
  * chose the IP that appeared in the audit trail.
  *
- * MCP_TRUSTED_PROXIES: comma-separated IPv4 addresses, IPv4 CIDRs, or `*` to
- * trust any peer (only correct behind an ingress that overwrites the header).
- * Unset => never trust the header.
+ * MCP_TRUSTED_PROXIES: comma-separated IP addresses or CIDRs (IPv4 and IPv6
+ * both supported), or `*` to trust any peer (only correct behind an ingress
+ * that overwrites the header). Unset => never trust the header.
  */
 export function resolveClientIp(
   socketAddress: string | undefined,
@@ -193,7 +195,31 @@ export function resolveClientIp(
 function normalizeIp(value: string): string {
   // ::ffff:10.0.0.1 -> 10.0.0.1
   const m = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/i.exec(value);
-  return m ? m[1] : value;
+  if (m) return m[1];
+  // Strip a zone index (fe80::1%eth0) and lower-case, so IPv6 literals compare
+  // consistently regardless of how the platform renders them.
+  const zoneless = value.split('%')[0];
+  return isIPv6(zoneless) ? expandIpv6(zoneless) : zoneless;
+}
+
+/** Canonical fully-expanded IPv6 form, so `::1` and `0:0:...:1` compare equal. */
+function expandIpv6(value: string): string {
+  const groups = ipv6Groups(value);
+  return groups ? groups.map((g) => g.toString(16).padStart(4, '0')).join(':') : value.toLowerCase();
+}
+
+/** Parse an IPv6 literal into its eight 16-bit groups, or null if malformed. */
+function ipv6Groups(value: string): number[] | null {
+  if (!isIPv6(value)) return null;
+  const [head, tail] = value.split('::') as [string, string | undefined];
+  const parse = (part: string): number[] =>
+    part ? part.split(':').filter(Boolean).map((h) => parseInt(h, 16)) : [];
+  const left = parse(head);
+  const right = tail === undefined ? [] : parse(tail);
+  if (tail === undefined) return left.length === 8 ? left : null;
+  const fill = 8 - left.length - right.length;
+  if (fill < 0) return null;
+  return [...left, ...new Array(fill).fill(0), ...right];
 }
 
 function isTrustedProxy(peer: string): boolean {
@@ -203,13 +229,35 @@ function isTrustedProxy(peer: string): boolean {
     .filter(Boolean);
   if (entries.length === 0) return false;
   if (entries.includes('*')) return true;
-  return entries.some((entry) => (entry.includes('/') ? ipInCidr(peer, entry) : entry === peer));
+  return entries.some((entry) =>
+    entry.includes('/') ? ipInCidr(peer, entry) : normalizeIp(entry) === peer,
+  );
 }
 
 function ipInCidr(ip: string, cidr: string): boolean {
-  const [range, bitsRaw] = cidr.split('/');
+  const [rangeRaw, bitsRaw] = cidr.split('/');
+  const range = normalizeIp(rangeRaw.trim());
   const bits = parseInt(bitsRaw, 10);
-  if (!Number.isInteger(bits) || bits < 0 || bits > 32) return false;
+  if (!Number.isInteger(bits) || bits < 0) return false;
+
+  // IPv6 is matched group-wise rather than via 32-bit ints. A dual-stack
+  // cluster hands us IPv6 peers, and silently failing to match them would
+  // put every client behind the ingress under one recorded address.
+  if (isIPv6(ip) || isIPv6(range)) {
+    if (bits > 128) return false;
+    const a = ipv6Groups(ip);
+    const b = ipv6Groups(range);
+    if (!a || !b) return false;
+    for (let i = 0; i < 8; i++) {
+      const groupBits = Math.min(16, Math.max(0, bits - i * 16));
+      if (groupBits === 0) break;
+      const mask = groupBits === 16 ? 0xffff : (0xffff << (16 - groupBits)) & 0xffff;
+      if ((a[i] & mask) !== (b[i] & mask)) return false;
+    }
+    return true;
+  }
+
+  if (bits > 32 || !isIPv4(ip) || !isIPv4(range)) return false;
   const toInt = (v: string): number | null => {
     const parts = v.split('.');
     if (parts.length !== 4) return null;
@@ -252,16 +300,54 @@ export function artifactDir(): string {
  * naive startsWith on `/data/artifacts`).
  */
 export function resolveArtifactPath(userPath: string): string {
-  const base = resolve(artifactDir());
-  const candidate = isAbsolute(userPath) ? resolve(userPath) : resolve(base, userPath);
-  if (candidate !== base && !candidate.startsWith(base + sep)) {
+  // Create the base before resolving it: realpath needs the directory to exist,
+  // and on first use of a fresh container it does not.
+  const configured = resolve(artifactDir());
+  mkdirSync(configured, { recursive: true });
+  const base = realPath(configured);
+
+  const lexical = isAbsolute(userPath) ? resolve(userPath) : resolve(base, userPath);
+  mkdirSync(dirname(lexical), { recursive: true });
+
+  // Compare real paths on BOTH sides. Comparing a lexical candidate against a
+  // real base rejects legitimate input whenever any ancestor is a symlink
+  // (/var -> /private/var on macOS, or a mounted artifact volume); comparing
+  // lexically on both sides would miss a symlink *inside* the directory
+  // pointing out of it. Resolving both is what makes the check mean
+  // "the same place", rather than "the same spelling".
+  const real = realPath(lexical);
+  if (!isInside(real, base)) {
     throw new Error(
       `Path "${userPath}" is outside the permitted artifact directory (${base}). ` +
       'Pass a bare filename, or set MCP_ARTIFACT_DIR to change the location.'
     );
   }
-  mkdirSync(dirname(candidate), { recursive: true });
-  return candidate;
+  return real;
+}
+
+function isInside(candidate: string, base: string): boolean {
+  return candidate === base || candidate.startsWith(base + sep);
+}
+
+/**
+ * realpath for a path whose leaf may not exist yet (the first write of a run).
+ * Walks up to the deepest existing ancestor, resolves that, and re-appends the
+ * segments below it — so a symlinked ancestor is followed while a not-yet-
+ * created file still resolves.
+ */
+function realPath(target: string): string {
+  const missing: string[] = [];
+  let current = target;
+  for (;;) {
+    try {
+      return missing.length ? join(realpathSync(current), ...missing) : realpathSync(current);
+    } catch {
+      const parent = dirname(current);
+      if (parent === current) return target; // reached the root without success
+      missing.unshift(basename(current));
+      current = parent;
+    }
+  }
 }
 
 /**
@@ -269,6 +355,11 @@ export function resolveArtifactPath(userPath: string): string {
  * Defaults to the host of the configured DIGIT API only, so the SSRF /
  * credential-exfiltration path is closed unless an operator opts in.
  * Empty entry list + ambient mode = unrestricted (local dev convenience).
+ *
+ * Derived from `getEnvironment()` — the immutable startup config — rather than
+ * `digitApi.getEnvironmentInfo()`. The live client's environment is mutable by
+ * `configure` itself, so reading it here would let one accepted call widen the
+ * allow-list that guards the next one.
  */
 export function allowedBaseUrlHosts(): string[] {
   const configured = (process.env.MCP_ALLOWED_BASE_URLS || '')
@@ -280,7 +371,7 @@ export function allowedBaseUrlHosts(): string[] {
   if (configured.length > 0) return configured;
 
   try {
-    return [normalizeHost(digitApi.getEnvironmentInfo().url)];
+    return [normalizeHost(getEnvironment().url)];
   } catch {
     return [];
   }
@@ -326,4 +417,118 @@ export function checkBaseUrlAllowed(baseUrl: string): string | null {
     );
   }
   return null;
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Bearer-token authentication
+// ───────────────────────────────────────────────────────────────────────────
+
+/** A caller whose bearer token egov-user resolved to a real account. */
+export interface ValidatedCaller {
+  token: string;
+  user: UserInfo;
+}
+
+export type BearerAuthResult =
+  | { ok: true; caller: ValidatedCaller }
+  | { ok: false; status: number; error: string };
+
+/**
+ * Introspection cache. Short-lived on purpose: it exists to keep a burst of
+ * tool calls from one client turn into a single `/user/_details` round trip,
+ * not to hold sessions open. A revoked token keeps working for at most TTL.
+ *
+ * Only *successful* validations are cached, so a caller cannot fill or evict
+ * the map by sending junk tokens.
+ */
+const TOKEN_CACHE_TTL_MS = 30_000;
+const TOKEN_CACHE_MAX = 500;
+const tokenCache = new Map<string, { user: UserInfo; at: number }>();
+
+/** Test/ops hook: drop every cached introspection result. */
+export function clearTokenCache(): void {
+  tokenCache.clear();
+}
+
+/** Extract the token from an Authorization header value, or null. */
+export function parseBearer(authHeader: string | string[] | undefined): string | null {
+  const raw = Array.isArray(authHeader) ? authHeader[0] : authHeader;
+  if (!raw || !/^Bearer\s+/i.test(raw)) return null;
+  const token = raw.replace(/^Bearer\s+/i, '').trim();
+  return token || null;
+}
+
+/**
+ * Resolve an `Authorization: Bearer <token>` header to a validated caller.
+ *
+ * This is the single implementation behind /mcp, /v1/* and /api/*. Each route
+ * previously had its own idea of what a token meant — /v1 in particular
+ * accepted any non-empty string — so "authenticated" meant something different
+ * depending on which door you knocked on.
+ */
+export async function authenticateBearer(
+  authHeader: string | string[] | undefined,
+): Promise<BearerAuthResult> {
+  const token = parseBearer(authHeader);
+  if (!token) {
+    return {
+      ok: false,
+      status: 401,
+      error: 'Authentication required: send Authorization: Bearer <DIGIT access token>.',
+    };
+  }
+
+  const now = Date.now();
+  const cached = tokenCache.get(token);
+  if (cached && now - cached.at < TOKEN_CACHE_TTL_MS) {
+    return { ok: true, caller: { token, user: cloneUser(cached.user) } };
+  }
+
+  const user = await digitApi.validateToken(token);
+  if (!user) {
+    tokenCache.delete(token);
+    return { ok: false, status: 401, error: 'Invalid or expired access token.' };
+  }
+
+  if (tokenCache.size >= TOKEN_CACHE_MAX) tokenCache.clear();
+  tokenCache.set(token, { user, at: now });
+  return { ok: true, caller: { token, user: cloneUser(user) } };
+}
+
+/**
+ * Hand each caller its own copy of the cached identity.
+ *
+ * The cache holds one object per token, and `applyToken` stores that reference
+ * on a request-scoped client. Sharing the reference across concurrent requests
+ * would put mutable state back across the boundary `runWithIsolatedClient`
+ * exists to draw, so the copy is what keeps that guarantee honest.
+ */
+function cloneUser(user: UserInfo): UserInfo {
+  return { ...user, roles: user.roles ? user.roles.map((r) => ({ ...r })) : undefined };
+}
+
+/**
+ * Bind a validated caller to the current (request-scoped) DIGIT client, so
+ * every tool it runs acts as that caller. The state tenant is derived from the
+ * token's own tenant rather than a caller-supplied header.
+ */
+export function applyValidatedCaller(caller: ValidatedCaller): void {
+  const tenantId = caller.user.tenantId || '';
+  const root = tenantId.includes('.') ? tenantId.split('.')[0] : tenantId;
+  digitApi.applyToken(caller.token, caller.user, root || null);
+}
+
+/**
+ * Does this caller hold one of MCP_ADMIN_ROLES?
+ *
+ * Used by the /api/* observability routes, which aren't tool dispatch and so
+ * don't pass through `checkToolAccess`, but expose the same class of data as
+ * the admin-tier tools.
+ */
+export function isAdminCaller(user: UserInfo | null): boolean {
+  if (!user) return false;
+  const admin = adminRoleCodes();
+  return (user.roles || [])
+    .map((r) => (r.code || '').toUpperCase())
+    .some((code) => admin.includes(code));
 }

--- a/digit-mcp/src/services/auth.ts
+++ b/digit-mcp/src/services/auth.ts
@@ -256,14 +256,26 @@ function isTrustedProxy(peer: string): boolean {
 }
 
 function ipInCidr(ip: string, cidr: string): boolean {
-  const [rangeRaw, bitsRaw] = cidr.split('/');
-  const range = normalizeIp(rangeRaw.trim());
+  const [rangeRaw = '', bitsRaw = ''] = cidr.split('/');
+  const rawRange = rangeRaw.trim();
+  const range = normalizeIp(rawRange);
+
+  // Validate the range BEFORE anything can short-circuit to `true`. A truncated
+  // or typo'd entry must mean "ignore this entry", never "trust every peer" —
+  // `garbage/0` and `/0` both used to return true for any address.
+  if (!isIPv4(range) && !isIPv6(range)) return false;
+  // Reject a prefix that isn't a bare decimal integer: parseInt is lenient
+  // enough to read '0x0' and '-0' as 0.
+  if (!/^\d+$/.test(bitsRaw.trim())) return false;
 
   const bits = parseInt(bitsRaw, 10);
   if (!Number.isInteger(bits) || bits < 0) return false;
-  // A /0 prefix matches every address, in either family. Handled up front so
-  // `::/0` doesn't have to survive the v6 group walk to reach the same answer.
-  if (bits === 0) return true;
+
+  // A /0 prefix means "every address" — but only when the range is actually
+  // all-zeros. `10.0.0.1/0` is numerically a wildcard and is, in a config file,
+  // a typo for /32; reading it as "trust every peer" is the wrong way to be
+  // wrong. `0.0.0.0/0` and `::/0` still mean what they say.
+  if (bits === 0) return range === '0.0.0.0' || /^[0:]+$/.test(range);
 
   // IPv6 is matched group-wise rather than via 32-bit ints. A dual-stack
   // cluster hands us IPv6 peers, and silently failing to match them would
@@ -283,9 +295,13 @@ function ipInCidr(ip: string, cidr: string): boolean {
   }
 
   // ::ffff:10.0.0.0/104 means 10.0.0.0/8 once the peer has been collapsed to
-  // its IPv4 form. Rebase the prefix rather than rejecting it.
+  // its IPv4 form. Rebase the prefix rather than rejecting it — but gate that
+  // on the range having ACTUALLY been written in IPv6 form. Testing the
+  // normalized value cannot tell `::ffff:10.0.0.0/104` (intended) from
+  // `10.0.0.0/104` (a typo), and silently reading the typo as /8 turns one
+  // mistyped digit into trust for a whole network.
   let v4bits = bits;
-  if (bits > 32 && isIPv4(ip) && isIPv4(range)) v4bits = bits - 96;
+  if (bits > 32 && isIPv4(ip) && isIPv4(range) && isIPv6(rawRange)) v4bits = bits - 96;
   if (v4bits < 0 || v4bits > 32 || !isIPv4(ip) || !isIPv4(range)) return false;
   const toInt = (v: string): number | null => {
     const parts = v.split('.');
@@ -516,6 +532,18 @@ export type BearerAuthResult =
 const TOKEN_CACHE_TTL_MS = 30_000;
 const TOKEN_CACHE_MAX = 500;
 const tokenCache = new Map<string, { user: UserInfo; at: number }>();
+
+/**
+ * True when this bearer is ALREADY a known-good token, without going to the
+ * wire. For endpoints that want to reveal a little more to a real caller but
+ * must not let an anonymous one drive traffic to egov-user.
+ */
+export function isCachedCaller(authHeader: string | string[] | undefined): boolean {
+  const token = parseBearer(authHeader);
+  if (!token) return false;
+  const cached = tokenCache.get(token);
+  return !!cached && Date.now() - cached.at < TOKEN_CACHE_TTL_MS;
+}
 
 /** Test/ops hook: drop every cached introspection result. */
 export function clearTokenCache(): void {

--- a/digit-mcp/src/services/auth.ts
+++ b/digit-mcp/src/services/auth.ts
@@ -1,0 +1,329 @@
+import { mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, isAbsolute, join, resolve, sep } from 'node:path';
+import { digitApi } from './digit-api.js';
+import type { ToolAccess, UserInfo } from '../types/index.js';
+
+/**
+ * How the server decides who a caller is.
+ *
+ * - `ambient` — when the caller supplied no token, fall back to
+ *   CRS_USERNAME / CRS_PASSWORD. Correct for **stdio**: the process was
+ *   spawned by the developer whose credentials those are, so using them
+ *   grants the caller nothing they didn't already have.
+ *
+ * - `token` — the caller MUST have presented a token that we validated.
+ *   The server's own credentials are never substituted. Correct for any
+ *   network-facing transport, where the caller is an unknown peer.
+ *
+ * The default is derived from the transport, so an HTTP deployment is
+ * secure without extra configuration. `MCP_AUTH_MODE` overrides it —
+ * setting `ambient` on an HTTP transport restores the old behaviour and
+ * is logged loudly, because it makes every anonymous caller an admin.
+ */
+export type AuthMode = 'ambient' | 'token';
+
+let ambientWarningLogged = false;
+
+export function getAuthMode(): AuthMode {
+  const explicit = (process.env.MCP_AUTH_MODE || '').trim().toLowerCase();
+  if (explicit === 'ambient' || explicit === 'token') {
+    if (explicit === 'ambient' && process.env.MCP_TRANSPORT === 'http' && !ambientWarningLogged) {
+      ambientWarningLogged = true;
+      console.error(
+        '[auth] WARNING: MCP_AUTH_MODE=ambient with the HTTP transport. Any caller that ' +
+        'reaches this port acts as CRS_USERNAME. Only use this on a loopback-bound socket.'
+      );
+    }
+    return explicit;
+  }
+  return process.env.MCP_TRANSPORT === 'http' ? 'token' : 'ambient';
+}
+
+/** Thrown when a caller must authenticate but hasn't. Surfaced as a 401 / auth-category error. */
+export class AuthRequiredError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AuthRequiredError';
+  }
+}
+
+/**
+ * Password assigned to accounts this server *creates*. Never applied to an
+ * account that already existed — see the C4/C5 notes in hrms.ts and
+ * pgr-workflow.ts. Override per deployment so it isn't a published default.
+ */
+export function defaultProvisioningPassword(): string {
+  return process.env.MCP_DEFAULT_PROVISIONING_PASSWORD || 'eGov@123';
+}
+
+/**
+ * Establish an authenticated DIGIT session for the current call.
+ *
+ * Replaces eight near-identical copies of this helper that each fell back to
+ * env credentials unconditionally — which meant that on a network transport,
+ * supplying *no* credentials elevated the caller to ADMIN.
+ *
+ * @param opts.optional when true, returns quietly instead of throwing if no
+ *   credentials are available (used by snapshot_capture, whose API-backed
+ *   layers are designed to degrade rather than fail the whole capture).
+ */
+export async function ensureAuthenticated(opts?: { optional?: boolean }): Promise<void> {
+  if (digitApi.isAuthenticated()) return;
+
+  if (getAuthMode() === 'token') {
+    if (opts?.optional) return;
+    throw new AuthRequiredError(
+      'Not authenticated. Send Authorization: Bearer <token> with your request. ' +
+      'This server does not act on its own credentials for network callers.'
+    );
+  }
+
+  const username = process.env.CRS_USERNAME;
+  const password = process.env.CRS_PASSWORD;
+  const tenantId = process.env.CRS_TENANT_ID || digitApi.getEnvironmentInfo().stateTenantId;
+
+  if (!username || !password) {
+    if (opts?.optional) return;
+    throw new AuthRequiredError(
+      'Not authenticated. Call the "configure" tool first, or set CRS_USERNAME/CRS_PASSWORD env vars.'
+    );
+  }
+
+  await digitApi.login(username, password, tenantId);
+}
+
+/**
+ * Role codes that satisfy `access: 'admin'`. Configurable because the code used
+ * for a super-user differs across DIGIT deployments; the default covers the
+ * common ones. A misconfiguration here is self-diagnosing: the denial message
+ * names both the required roles and the roles the caller actually holds.
+ */
+export function adminRoleCodes(): string[] {
+  const configured = (process.env.MCP_ADMIN_ROLES || '')
+    .split(',')
+    .map((s) => s.trim().toUpperCase())
+    .filter(Boolean);
+  return configured.length > 0
+    ? configured
+    : ['SUPERUSER', 'MDMS_ADMIN', 'SYSTEM_ADMIN', 'STADMIN'];
+}
+
+/** Roles that, on their own, mark an account as citizen-only (not staff). */
+const CITIZEN_ROLE_CODES = new Set(['CITIZEN']);
+
+/**
+ * Authorize a tool call against the caller's validated identity.
+ * Returns null when allowed, or a human-readable denial reason.
+ *
+ * Only meaningful in `token` mode. In `ambient` mode the process owner supplied
+ * the credentials, so there is no second party to authorize — the check is
+ * skipped, exactly as with the other ambient-mode exemptions.
+ */
+export function checkToolAccess(
+  toolName: string,
+  access: ToolAccess | undefined,
+  user: UserInfo | null,
+): string | null {
+  if (getAuthMode() !== 'token') return null;
+
+  const required: ToolAccess = access ?? 'employee';
+  if (required === 'public') return null;
+
+  if (!user) {
+    return `Tool "${toolName}" requires an authenticated ${required} caller, but the token carried no user context.`;
+  }
+
+  const roles = (user.roles || []).map((r) => (r.code || '').toUpperCase()).filter(Boolean);
+  const isCitizenOnly =
+    roles.length > 0 && roles.every((code) => CITIZEN_ROLE_CODES.has(code));
+
+  if (required === 'employee') {
+    // A self-registered citizen must not reach staff tooling. Note we check
+    // roles rather than user.type: pgr_create provisions citizens with
+    // type EMPLOYEE so they can use password auth, so type is not a boundary.
+    if (isCitizenOnly || roles.length === 0) {
+      return (
+        `Tool "${toolName}" requires a staff (non-citizen) account. ` +
+        `Caller "${user.userName}" holds roles: ${roles.join(', ') || '(none)'}.`
+      );
+    }
+    return null;
+  }
+
+  // required === 'admin'
+  const adminRoles = adminRoleCodes();
+  if (!roles.some((code) => adminRoles.includes(code))) {
+    return (
+      `Tool "${toolName}" requires one of these roles: ${adminRoles.join(', ')}. ` +
+      `Caller "${user.userName}" holds: ${roles.join(', ') || '(none)'}. ` +
+      'Set MCP_ADMIN_ROLES if this deployment uses different admin role codes.'
+    );
+  }
+  return null;
+}
+
+/**
+ * Resolve the client IP to record for a request.
+ *
+ * X-Forwarded-For is only honoured when the immediate peer is a configured
+ * trusted proxy. Otherwise the socket address wins. Previously the header was
+ * preferred unconditionally, so with nothing in front of the port every caller
+ * chose the IP that appeared in the audit trail.
+ *
+ * MCP_TRUSTED_PROXIES: comma-separated IPv4 addresses, IPv4 CIDRs, or `*` to
+ * trust any peer (only correct behind an ingress that overwrites the header).
+ * Unset => never trust the header.
+ */
+export function resolveClientIp(
+  socketAddress: string | undefined,
+  forwardedFor: string | undefined,
+): { ip: string; claimed?: string; trusted: boolean } {
+  const peer = normalizeIp(socketAddress || '');
+  const claim = (forwardedFor || '').split(',')[0].trim();
+
+  if (!claim) return { ip: peer, trusted: true };
+  if (!isTrustedProxy(peer)) {
+    // Keep the claim for forensics, but do not let it masquerade as the source.
+    return { ip: peer, claimed: claim, trusted: false };
+  }
+  return { ip: normalizeIp(claim), trusted: true };
+}
+
+function normalizeIp(value: string): string {
+  // ::ffff:10.0.0.1 -> 10.0.0.1
+  const m = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/i.exec(value);
+  return m ? m[1] : value;
+}
+
+function isTrustedProxy(peer: string): boolean {
+  const entries = (process.env.MCP_TRUSTED_PROXIES || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (entries.length === 0) return false;
+  if (entries.includes('*')) return true;
+  return entries.some((entry) => (entry.includes('/') ? ipInCidr(peer, entry) : entry === peer));
+}
+
+function ipInCidr(ip: string, cidr: string): boolean {
+  const [range, bitsRaw] = cidr.split('/');
+  const bits = parseInt(bitsRaw, 10);
+  if (!Number.isInteger(bits) || bits < 0 || bits > 32) return false;
+  const toInt = (v: string): number | null => {
+    const parts = v.split('.');
+    if (parts.length !== 4) return null;
+    let out = 0;
+    for (const p of parts) {
+      const n = Number(p);
+      if (!Number.isInteger(n) || n < 0 || n > 255) return null;
+      out = (out << 8) | n;
+    }
+    return out >>> 0;
+  };
+  const a = toInt(ip);
+  const b = toInt(range);
+  if (a === null || b === null) return false;
+  const mask = bits === 0 ? 0 : (0xffffffff << (32 - bits)) >>> 0;
+  return (a & mask) === (b & mask);
+}
+
+/**
+ * Directory that snapshot artifacts may be read from and written to.
+ *
+ * `snapshot_capture`'s `output_path` used to flow straight into writeFileSync,
+ * and the container runs as root — so a caller could write anywhere in the
+ * filesystem, including over the server's own `dist/*.js`. Confining it to one
+ * directory keeps the feature (large artifacts written to disk instead of
+ * returned inline) without handing out arbitrary filesystem writes.
+ */
+export function artifactDir(): string {
+  return (
+    process.env.MCP_ARTIFACT_DIR ||
+    join(process.env.SESSION_DATA_DIR || tmpdir(), 'artifacts')
+  );
+}
+
+/**
+ * Resolve a caller-supplied artifact path inside `artifactDir()`.
+ * Returns the absolute path to use, or throws if it escapes the directory.
+ * Rejects traversal both by normalising and by re-checking the resolved
+ * prefix with a trailing separator (so `/data/artifacts-evil` cannot pass a
+ * naive startsWith on `/data/artifacts`).
+ */
+export function resolveArtifactPath(userPath: string): string {
+  const base = resolve(artifactDir());
+  const candidate = isAbsolute(userPath) ? resolve(userPath) : resolve(base, userPath);
+  if (candidate !== base && !candidate.startsWith(base + sep)) {
+    throw new Error(
+      `Path "${userPath}" is outside the permitted artifact directory (${base}). ` +
+      'Pass a bare filename, or set MCP_ARTIFACT_DIR to change the location.'
+    );
+  }
+  mkdirSync(dirname(candidate), { recursive: true });
+  return candidate;
+}
+
+/**
+ * Hosts a caller may point the client at via `configure`'s `base_url`.
+ * Defaults to the host of the configured DIGIT API only, so the SSRF /
+ * credential-exfiltration path is closed unless an operator opts in.
+ * Empty entry list + ambient mode = unrestricted (local dev convenience).
+ */
+export function allowedBaseUrlHosts(): string[] {
+  const configured = (process.env.MCP_ALLOWED_BASE_URLS || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map(normalizeHost);
+
+  if (configured.length > 0) return configured;
+
+  try {
+    return [normalizeHost(digitApi.getEnvironmentInfo().url)];
+  } catch {
+    return [];
+  }
+}
+
+function normalizeHost(value: string): string {
+  try {
+    return new URL(value.includes('://') ? value : `http://${value}`).host.toLowerCase();
+  } catch {
+    return value.toLowerCase();
+  }
+}
+
+/**
+ * Guard for `configure`'s `base_url`. Returns an error string to surface to
+ * the caller, or null when the target is acceptable.
+ *
+ * In `token` mode the allow-list is always enforced. In `ambient` mode (stdio)
+ * it is enforced only when the operator set MCP_ALLOWED_BASE_URLS explicitly,
+ * so a developer pointing their own CLI at an arbitrary environment still works.
+ */
+export function checkBaseUrlAllowed(baseUrl: string): string | null {
+  const enforce = getAuthMode() === 'token' || !!process.env.MCP_ALLOWED_BASE_URLS;
+  if (!enforce) return null;
+
+  let host: string;
+  try {
+    const url = new URL(baseUrl);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return `base_url must use http or https (got "${url.protocol}").`;
+    }
+    host = url.host.toLowerCase();
+  } catch {
+    return `base_url is not a valid URL: "${baseUrl}".`;
+  }
+
+  const allowed = allowedBaseUrlHosts();
+  if (!allowed.includes(host)) {
+    return (
+      `base_url host "${host}" is not allowed. Permitted: ${allowed.join(', ') || '(none)'}. ` +
+      'Set MCP_ALLOWED_BASE_URLS to authorise additional DIGIT instances. ' +
+      'This guard exists because pointing the server at an arbitrary host would send it credentials.'
+    );
+  }
+  return null;
+}

--- a/digit-mcp/src/services/auth.ts
+++ b/digit-mcp/src/services/auth.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, realpathSync } from 'node:fs';
+import { lstatSync, mkdirSync, realpathSync } from 'node:fs';
 import { isIPv4, isIPv6 } from 'node:net';
 import { tmpdir } from 'node:os';
 import { basename, dirname, isAbsolute, join, resolve, sep } from 'node:path';
@@ -307,7 +307,6 @@ export function resolveArtifactPath(userPath: string): string {
   const base = realPath(configured);
 
   const lexical = isAbsolute(userPath) ? resolve(userPath) : resolve(base, userPath);
-  mkdirSync(dirname(lexical), { recursive: true });
 
   // Compare real paths on BOTH sides. Comparing a lexical candidate against a
   // real base rejects legitimate input whenever any ancestor is a symlink
@@ -315,6 +314,11 @@ export function resolveArtifactPath(userPath: string): string {
   // lexically on both sides would miss a symlink *inside* the directory
   // pointing out of it. Resolving both is what makes the check mean
   // "the same place", rather than "the same spelling".
+  //
+  // `realPath` handles a leaf that doesn't exist yet, so this needs no mkdir —
+  // which matters, because creating the caller's directories BEFORE deciding
+  // whether the path is allowed would let a rejected call still author
+  // directories anywhere the process can write.
   const real = realPath(lexical);
   if (!isInside(real, base)) {
     throw new Error(
@@ -322,11 +326,38 @@ export function resolveArtifactPath(userPath: string): string {
       'Pass a bare filename, or set MCP_ARTIFACT_DIR to change the location.'
     );
   }
+
+  // Reject a symlink at the destination outright.
+  //
+  // A LIVE symlink is already caught by the realPath comparison above. A
+  // DANGLING one is not: realpathSync throws on it, so realPath() treats it as
+  // a leaf that does not exist yet and hands back a path that sits inside the
+  // base — which writeFileSync then happily follows out of the directory.
+  // Creating a *new* file elsewhere is the case that matters, so this is the
+  // gap that has to close, not the one the prefix check already covers.
+  if (isSymlink(real)) {
+    throw new Error(
+      `Path "${userPath}" resolves to a symbolic link, which artifact paths may not be. ` +
+      `Remove the link at ${real}, or pass a different filename.`
+    );
+  }
+
+  // Only now, once the destination is known to be confined, create it.
+  mkdirSync(dirname(real), { recursive: true });
   return real;
 }
 
 function isInside(candidate: string, base: string): boolean {
   return candidate === base || candidate.startsWith(base + sep);
+}
+
+/** True when `p` is a symlink. A path that does not exist is not a symlink. */
+function isSymlink(p: string): boolean {
+  try {
+    return lstatSync(p).isSymbolicLink();
+  } catch {
+    return false; // ENOENT — a new file, which is the normal case
+  }
 }
 
 /**

--- a/digit-mcp/src/services/auth.ts
+++ b/digit-mcp/src/services/auth.ts
@@ -3,7 +3,7 @@ import { isIPv4, isIPv6 } from 'node:net';
 import { tmpdir } from 'node:os';
 import { basename, dirname, isAbsolute, join, resolve, sep } from 'node:path';
 import { getEnvironment } from '../config/environments.js';
-import { digitApi } from './digit-api.js';
+import { digitApi, TokenIntrospectionError } from './digit-api.js';
 import type { ToolAccess, UserInfo } from '../types/index.js';
 
 /**
@@ -193,13 +193,18 @@ export function resolveClientIp(
 }
 
 function normalizeIp(value: string): string {
-  // ::ffff:10.0.0.1 -> 10.0.0.1
-  const m = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/i.exec(value);
-  if (m) return m[1];
-  // Strip a zone index (fe80::1%eth0) and lower-case, so IPv6 literals compare
-  // consistently regardless of how the platform renders them.
+  // Strip a zone index (fe80::1%eth0) first, so it never reaches the parser.
   const zoneless = value.split('%')[0];
-  return isIPv6(zoneless) ? expandIpv6(zoneless) : zoneless;
+  if (!isIPv6(zoneless)) return zoneless;
+
+  // Any IPv4-mapped form collapses to its IPv4 spelling — ::ffff:10.0.0.1 and
+  // 0:0:0:0:0:ffff:0a00:0001 are the same peer, and only handling the shorthand
+  // meant a fully-spelled one never matched an IPv4 entry.
+  const groups = ipv6Groups(zoneless);
+  if (groups && groups[5] === 0xffff && groups.slice(0, 5).every((g) => g === 0)) {
+    return [groups[6] >> 8, groups[6] & 0xff, groups[7] >> 8, groups[7] & 0xff].join('.');
+  }
+  return expandIpv6(zoneless);
 }
 
 /** Canonical fully-expanded IPv6 form, so `::1` and `0:0:...:1` compare equal. */
@@ -212,10 +217,26 @@ function expandIpv6(value: string): string {
 function ipv6Groups(value: string): number[] | null {
   if (!isIPv6(value)) return null;
   const [head, tail] = value.split('::') as [string, string | undefined];
-  const parse = (part: string): number[] =>
-    part ? part.split(':').filter(Boolean).map((h) => parseInt(h, 16)) : [];
+  // A trailing dotted quad (::ffff:1.2.3.4, 64:ff9b::192.0.2.1) is two groups,
+  // not one hex number: parseInt('1.2.3.4', 16) is 1, which silently produced a
+  // wrong address and could false-match an IPv6 CIDR.
+  const parse = (part: string): number[] => {
+    if (!part) return [];
+    const out: number[] = [];
+    for (const piece of part.split(':').filter(Boolean)) {
+      if (piece.includes('.')) {
+        const octets = piece.split('.').map(Number);
+        if (octets.length !== 4 || octets.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return [NaN];
+        out.push((octets[0] << 8) | octets[1], (octets[2] << 8) | octets[3]);
+      } else {
+        out.push(parseInt(piece, 16));
+      }
+    }
+    return out;
+  };
   const left = parse(head);
   const right = tail === undefined ? [] : parse(tail);
+  if ([...left, ...right].some((n) => !Number.isInteger(n))) return null;
   if (tail === undefined) return left.length === 8 ? left : null;
   const fill = 8 - left.length - right.length;
   if (fill < 0) return null;
@@ -237,8 +258,12 @@ function isTrustedProxy(peer: string): boolean {
 function ipInCidr(ip: string, cidr: string): boolean {
   const [rangeRaw, bitsRaw] = cidr.split('/');
   const range = normalizeIp(rangeRaw.trim());
+
   const bits = parseInt(bitsRaw, 10);
   if (!Number.isInteger(bits) || bits < 0) return false;
+  // A /0 prefix matches every address, in either family. Handled up front so
+  // `::/0` doesn't have to survive the v6 group walk to reach the same answer.
+  if (bits === 0) return true;
 
   // IPv6 is matched group-wise rather than via 32-bit ints. A dual-stack
   // cluster hands us IPv6 peers, and silently failing to match them would
@@ -257,7 +282,11 @@ function ipInCidr(ip: string, cidr: string): boolean {
     return true;
   }
 
-  if (bits > 32 || !isIPv4(ip) || !isIPv4(range)) return false;
+  // ::ffff:10.0.0.0/104 means 10.0.0.0/8 once the peer has been collapsed to
+  // its IPv4 form. Rebase the prefix rather than rejecting it.
+  let v4bits = bits;
+  if (bits > 32 && isIPv4(ip) && isIPv4(range)) v4bits = bits - 96;
+  if (v4bits < 0 || v4bits > 32 || !isIPv4(ip) || !isIPv4(range)) return false;
   const toInt = (v: string): number | null => {
     const parts = v.split('.');
     if (parts.length !== 4) return null;
@@ -272,7 +301,7 @@ function ipInCidr(ip: string, cidr: string): boolean {
   const a = toInt(ip);
   const b = toInt(range);
   if (a === null || b === null) return false;
-  const mask = bits === 0 ? 0 : (0xffffffff << (32 - bits)) >>> 0;
+  const mask = v4bits === 0 ? 0 : (0xffffffff << (32 - v4bits)) >>> 0;
   return (a & mask) === (b & mask);
 }
 
@@ -399,13 +428,16 @@ export function allowedBaseUrlHosts(): string[] {
     .filter(Boolean)
     .map(normalizeHost);
 
-  if (configured.length > 0) return configured;
-
+  // The configured DIGIT host is ALWAYS allowed. Making the env var replace it
+  // meant that authorising one extra instance silently de-authorised the
+  // server's own CRS_API_URL — a surprising way to break `configure`.
+  let own: string[] = [];
   try {
-    return [normalizeHost(getEnvironment().url)];
+    own = [normalizeHost(getEnvironment().url)];
   } catch {
-    return [];
+    own = [];
   }
+  return [...new Set([...own, ...configured])];
 }
 
 function normalizeHost(value: string): string {
@@ -433,6 +465,15 @@ export function checkBaseUrlAllowed(baseUrl: string): string | null {
     const url = new URL(baseUrl);
     if (url.protocol !== 'http:' && url.protocol !== 'https:') {
       return `base_url must use http or https (got "${url.protocol}").`;
+    }
+    // A path prefix is legitimate — DIGIT is sometimes mounted under one — and
+    // `..` needs no guard here because the URL parser has already collapsed it
+    // (`https://h/a/../..` parses with pathname `/`).
+    //
+    // Embedded credentials do need one: they are a classic way to make a URL
+    // read as one host to a human and resolve to another.
+    if (url.username || url.password) {
+      return 'base_url must not embed credentials.';
     }
     host = url.host.toLowerCase();
   } catch {
@@ -505,7 +546,9 @@ export async function authenticateBearer(
     return {
       ok: false,
       status: 401,
-      error: 'Authentication required: send Authorization: Bearer <DIGIT access token>.',
+      error:
+        'Authentication required: send Authorization: Bearer <DIGIT access token>. ' +
+        'Mint one from your DIGIT instance at POST /user/oauth/token.',
     };
   }
 
@@ -515,15 +558,49 @@ export async function authenticateBearer(
     return { ok: true, caller: { token, user: cloneUser(cached.user) } };
   }
 
-  const user = await digitApi.validateToken(token);
+  let user: UserInfo | null;
+  try {
+    // Single-flight: N concurrent requests bearing the same cold token would
+    // otherwise fire N introspections, which is exactly the load an egov-user
+    // brownout least needs.
+    user = await introspectOnce(token);
+  } catch (err) {
+    if (err instanceof TokenIntrospectionError) {
+      return {
+        ok: false,
+        status: 503,
+        error:
+          'Cannot verify your token right now: the identity service is unreachable. ' +
+          'This is not a problem with your credentials — retry shortly. ' +
+          `(${err.message})`,
+      };
+    }
+    throw err;
+  }
+
   if (!user) {
     tokenCache.delete(token);
-    return { ok: false, status: 401, error: 'Invalid or expired access token.' };
+    return {
+      ok: false,
+      status: 401,
+      error: 'Invalid or expired access token. Mint a new one from /user/oauth/token.',
+    };
   }
 
   if (tokenCache.size >= TOKEN_CACHE_MAX) tokenCache.clear();
   tokenCache.set(token, { user, at: now });
   return { ok: true, caller: { token, user: cloneUser(user) } };
+}
+
+/** In-flight introspections, so one cold token costs one round trip. */
+const inFlight = new Map<string, Promise<UserInfo | null>>();
+
+function introspectOnce(token: string): Promise<UserInfo | null> {
+  const existing = inFlight.get(token);
+  if (existing) return existing;
+  const p = digitApi.validateToken(token).finally(() => inFlight.delete(token));
+  inFlight.set(token, p);
+  return p;
 }
 
 /**

--- a/digit-mcp/src/services/db.ts
+++ b/digit-mcp/src/services/db.ts
@@ -79,7 +79,8 @@ INSERT INTO engram_id_counters (category, next_id)
  * developer would otherwise have to set a var to get session persistence. On a
  * network transport it is a different matter: falling back to a password that
  * is published in this file is not a default, it is a shared secret with the
- * whole internet — so there we require it to be set and say so loudly.
+ * whole internet — so there we warn loudly rather than failing, because losing
+ * session persistence must not take the whole server down with it.
  *
  * (Dropping `ENV SESSION_DB_PASSWORD` from the Dockerfile alone did nothing:
  * the value was still compiled into dist/, just one layer further down.)

--- a/digit-mcp/src/services/db.ts
+++ b/digit-mcp/src/services/db.ts
@@ -72,6 +72,34 @@ INSERT INTO engram_id_counters (category, next_id)
   ON CONFLICT DO NOTHING;
 `;
 
+/**
+ * Session-DB password.
+ *
+ * The compose default stays, because the local stack ships with it and every
+ * developer would otherwise have to set a var to get session persistence. On a
+ * network transport it is a different matter: falling back to a password that
+ * is published in this file is not a default, it is a shared secret with the
+ * whole internet — so there we require it to be set and say so loudly.
+ *
+ * (Dropping `ENV SESSION_DB_PASSWORD` from the Dockerfile alone did nothing:
+ * the value was still compiled into dist/, just one layer further down.)
+ */
+const COMPOSE_DEFAULT_SESSION_DB_PASSWORD = 'mcp123';
+
+function sessionDbPassword(): string {
+  const configured = process.env.SESSION_DB_PASSWORD;
+  if (configured) return configured;
+
+  if (process.env.MCP_TRANSPORT === 'http') {
+    console.error(
+      '[session-db] SESSION_DB_PASSWORD is not set. Falling back to the published ' +
+      'local-compose default, which is not a credential on a network deployment. ' +
+      'Set SESSION_DB_PASSWORD (helm: --set secret.SESSION_DB_PASSWORD=...).'
+    );
+  }
+  return COMPOSE_DEFAULT_SESSION_DB_PASSWORD;
+}
+
 class Db {
   private pool: PgPool | null = null;
   private healthy = false;
@@ -87,7 +115,7 @@ class Db {
           port: parseInt(process.env.SESSION_DB_PORT || '15433', 10),
           database: process.env.SESSION_DB_NAME || 'mcp_sessions',
           user: process.env.SESSION_DB_USER || 'mcp',
-          password: process.env.SESSION_DB_PASSWORD || 'mcp123',
+          password: sessionDbPassword(),
         };
 
     this.pool = new Pool({ ...config, max: 5, idleTimeoutMillis: 30_000 });

--- a/digit-mcp/src/services/db.ts
+++ b/digit-mcp/src/services/db.ts
@@ -87,11 +87,16 @@ INSERT INTO engram_id_counters (category, next_id)
  */
 const COMPOSE_DEFAULT_SESSION_DB_PASSWORD = 'mcp123';
 
+let sessionDbWarningLogged = false;
+
 function sessionDbPassword(): string {
   const configured = process.env.SESSION_DB_PASSWORD;
   if (configured) return configured;
 
-  if (process.env.MCP_TRANSPORT === 'http') {
+  // `initialize()` nulls the pool on a failed connect, so its `if (this.pool)`
+  // guard doesn't hold and a second caller re-enters — printing this twice.
+  if (process.env.MCP_TRANSPORT === 'http' && !sessionDbWarningLogged) {
+    sessionDbWarningLogged = true;
     console.error(
       '[session-db] SESSION_DB_PASSWORD is not set. Falling back to the published ' +
       'local-compose default, which is not a credential on a network deployment. ' +

--- a/digit-mcp/src/services/digit-api.ts
+++ b/digit-mcp/src/services/digit-api.ts
@@ -17,6 +17,18 @@ export interface AuthSnapshot {
   environment?: Environment;
 }
 
+/**
+ * Introspection could not be completed — as distinct from completing and
+ * rejecting the token. Surfaced as 503, so an egov-user outage does not look
+ * like every caller's credentials expiring at once.
+ */
+export class TokenIntrospectionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TokenIntrospectionError';
+  }
+}
+
 export class ApiClientError extends Error {
   public errors: ApiError[];
   public statusCode: number;
@@ -126,6 +138,12 @@ class DigitApiClient {
    * "sent a header".
    */
   async validateToken(token: string): Promise<UserInfo | null> {
+    // `?access_token=` is egov-user's contract for this endpoint — it reads a
+    // @RequestParam, which is also how the gateway calls it. That does put the
+    // token in egov-user's and the gateway's access logs on every
+    // introspection (once per 30s per active token, given the cache). Moving it
+    // to a header would need a verified egov-user change first: guessing wrong
+    // fails closed, i.e. every caller gets a 401.
     const url = `${this.environment.url}${this.endpoint('USER_DETAILS')}?access_token=${encodeURIComponent(token)}`;
     try {
       const response = await fetch(url, {
@@ -142,11 +160,23 @@ class DigitApiClient {
         }),
         signal: AbortSignal.timeout(10_000),
       });
+      // A 4xx is egov-user telling us the token is no good. A 5xx is egov-user
+      // failing to answer — a different thing, and reporting it as "invalid
+      // token" sends the operator after credentials while the platform is down.
+      if (response.status >= 500) {
+        throw new TokenIntrospectionError(
+          `egov-user returned HTTP ${response.status} while validating the token.`,
+        );
+      }
       if (!response.ok) return null;
       const data = (await response.json()) as { UserRequest?: UserInfo };
       return data?.UserRequest ?? null;
-    } catch {
-      return null;
+    } catch (err) {
+      if (err instanceof TokenIntrospectionError) throw err;
+      // Network error, DNS failure, or the 10s timeout. Also not a bad token.
+      throw new TokenIntrospectionError(
+        `Could not reach egov-user to validate the token: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 
@@ -1248,11 +1278,6 @@ const clientContext = new AsyncLocalStorage<DigitApiClient>();
 /** Run `fn` with a fresh DigitApiClient visible to everything it awaits. */
 export function runWithIsolatedClient<T>(fn: () => Promise<T>): Promise<T> {
   return clientContext.run(new DigitApiClient(), fn);
-}
-
-/** True when the caller is executing inside an isolated client scope. */
-export function hasIsolatedClient(): boolean {
-  return clientContext.getStore() !== undefined;
 }
 
 export const digitApi: DigitApiClient = new Proxy(defaultClient, {

--- a/digit-mcp/src/services/digit-api.ts
+++ b/digit-mcp/src/services/digit-api.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { ENDPOINTS, OAUTH_CONFIG } from '../config/endpoints.js';
 import { getEnvironment } from '../config/environments.js';
 import type { RequestInfo, UserInfo, MdmsRecord, ApiError, Environment, ErrorCategory } from '../types/index.js';
@@ -6,6 +7,14 @@ function deriveErrorCategory(statusCode: number): ErrorCategory {
   if (statusCode === 401 || statusCode === 403) return 'auth';
   if (statusCode >= 400 && statusCode < 500) return 'validation';
   return 'api';
+}
+
+/** Full request-scoped client state. Restoring this must undo everything a tool can mutate. */
+export interface AuthSnapshot {
+  token: string | null;
+  user: UserInfo | null;
+  stateTenantOverride: string | null;
+  environment?: Environment;
 }
 
 export class ApiClientError extends Error {
@@ -89,18 +98,56 @@ class DigitApiClient {
    * Combined with a single-flight mutex this is safe even though the
    * underlying client is a process-level singleton.
    */
-  snapshotAuth(): { token: string | null; user: UserInfo | null; stateTenantOverride: string | null } {
+  snapshotAuth(): AuthSnapshot {
     return {
       token: this.authToken,
       user: this.userInfo,
       stateTenantOverride: this.stateTenantOverride,
+      // `environment` must be part of the snapshot. `configure`'s base_url
+      // writes it, and without it here a single call repointed the whole
+      // process at a caller-chosen host for every subsequent request.
+      environment: this.environment,
     };
   }
 
-  restoreAuth(snap: { token: string | null; user: UserInfo | null; stateTenantOverride: string | null }): void {
+  restoreAuth(snap: AuthSnapshot): void {
     this.authToken = snap.token;
     this.userInfo = snap.user;
     this.stateTenantOverride = snap.stateTenantOverride;
+    if (snap.environment) this.environment = snap.environment;
+  }
+
+  /**
+   * Resolve an access token to its user via egov-user token introspection.
+   * Returns null when the token is not valid.
+   *
+   * This is what makes a bearer token meaningful: without it, `applyToken`
+   * accepts any non-empty string, so "authenticated" meant nothing more than
+   * "sent a header".
+   */
+  async validateToken(token: string): Promise<UserInfo | null> {
+    const url = `${this.environment.url}${this.endpoint('USER_DETAILS')}?access_token=${encodeURIComponent(token)}`;
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          RequestInfo: {
+            apiId: 'Rainmaker',
+            ver: '1.0',
+            ts: Date.now(),
+            msgId: `${Date.now()}|en_IN`,
+            authToken: token,
+          },
+        }),
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!response.ok) return null;
+      const data = (await response.json()) as { UserRequest?: UserInfo };
+      return data?.UserRequest ?? null;
+    } catch {
+      return null;
+    }
   }
 
   /**
@@ -957,6 +1004,20 @@ class DigitApiClient {
   // Encryption — encrypt values (no RequestInfo needed)
   // Note: enc-service returns a flat JSON array, not the standard {Errors, ...} envelope.
   // We use raw fetch instead of this.request() to handle the non-standard response.
+  /**
+   * Headers for egov-enc-service calls.
+   *
+   * These previously went out with no Authorization header at all, which made
+   * decrypt_data an unauthenticated decryption oracle for citizen PII: the
+   * caller needed no credentials because none were forwarded. The token is now
+   * attached so the enc-service / gateway can authorise the request.
+   */
+  private encHeaders(): Record<string, string> {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (this.authToken) headers['Authorization'] = `Bearer ${this.authToken}`;
+    return headers;
+  }
+
   async encryptData(
     tenantId: string,
     values: string[]
@@ -964,7 +1025,7 @@ class DigitApiClient {
     const url = `${this.environment.url}${this.endpoint('ENC_ENCRYPT')}`;
     const response = await fetch(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: this.encHeaders(),
       body: JSON.stringify({
         encryptionRequests: values.map((value) => ({
           tenantId,
@@ -1017,7 +1078,7 @@ class DigitApiClient {
     const url = `${this.environment.url}${this.endpoint('ENC_DECRYPT')}`;
     const response = await fetch(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: this.encHeaders(),
       body: JSON.stringify(encryptedValues),
     });
 
@@ -1166,4 +1227,42 @@ class DigitApiClient {
 }
 
 // Singleton
-export const digitApi = new DigitApiClient();
+/**
+ * Request isolation (H5).
+ *
+ * `digitApi` used to be a plain process-wide singleton holding the auth token,
+ * user and environment. Two concurrent requests therefore shared one identity:
+ * the REST path papered over it with a mutex plus snapshot/restore, but the MCP
+ * path mutated it with no lock at all, so one caller's tool could execute under
+ * another caller's token.
+ *
+ * Instead of threading a client through every call site, the export below is a
+ * proxy that resolves to the client bound to the current async context. Code
+ * that runs inside `runWithIsolatedClient()` gets its own instance; everything
+ * else keeps using the shared default, so stdio and the REST path behave
+ * exactly as before.
+ */
+const defaultClient = new DigitApiClient();
+const clientContext = new AsyncLocalStorage<DigitApiClient>();
+
+/** Run `fn` with a fresh DigitApiClient visible to everything it awaits. */
+export function runWithIsolatedClient<T>(fn: () => Promise<T>): Promise<T> {
+  return clientContext.run(new DigitApiClient(), fn);
+}
+
+/** True when the caller is executing inside an isolated client scope. */
+export function hasIsolatedClient(): boolean {
+  return clientContext.getStore() !== undefined;
+}
+
+export const digitApi: DigitApiClient = new Proxy(defaultClient, {
+  get(target, prop) {
+    const active = clientContext.getStore() ?? target;
+    const value = Reflect.get(active, prop, active);
+    return typeof value === 'function' ? value.bind(active) : value;
+  },
+  set(target, prop, value) {
+    const active = clientContext.getStore() ?? target;
+    return Reflect.set(active, prop, value, active);
+  },
+}) as DigitApiClient;

--- a/digit-mcp/src/services/digit-api.ts
+++ b/digit-mcp/src/services/digit-api.ts
@@ -92,7 +92,10 @@ class DigitApiClient {
   }
 
   isAuthenticated(): boolean {
-    return this.authToken !== null;
+    // An empty string is not a credential. Treating it as one meant a caller
+    // could be "authenticated" while every outbound request carried no token —
+    // authenticated to us, anonymous to DIGIT.
+    return !!this.authToken;
   }
 
   getAuthInfo(): { authenticated: boolean; user: UserInfo | null; stateTenantId: string; token: string | null } {

--- a/digit-mcp/src/services/request-context.ts
+++ b/digit-mcp/src/services/request-context.ts
@@ -1,0 +1,46 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+/**
+ * Per-request identity for the audit trail.
+ *
+ * The logger and the session store both record who made a call. They used to
+ * keep that as instance fields set once per HTTP request, which is correct for
+ * stdio (one owner, one request at a time) but not for the HTTP transport:
+ * with two `/mcp` requests in flight, whichever arrived last owned the fields,
+ * so request A's tool calls could be logged under request B's IP.
+ *
+ * This is the same fix as `runWithIsolatedClient` in digit-api.ts, applied to
+ * the other piece of per-request state — and it matters for the same reason
+ * N3 (untrusted X-Forwarded-For) does: an audit trail that attributes calls to
+ * the wrong caller under load is not an audit trail.
+ *
+ * Outside a request scope (stdio, CLI, tests) the store is empty and callers
+ * fall back to their own defaults.
+ */
+export interface RequestContext {
+  ip: string;
+  userAgent: string;
+  /** userName of the validated caller, when the route authenticated one. */
+  userName?: string;
+}
+
+const storage = new AsyncLocalStorage<RequestContext>();
+
+/** Run `fn` with `context` visible to everything it awaits. */
+export function runWithRequestContext<T>(context: RequestContext, fn: () => Promise<T>): Promise<T> {
+  return storage.run(context, fn);
+}
+
+/** The active request's context, or undefined outside any request scope. */
+export function getRequestContext(): RequestContext | undefined {
+  return storage.getStore();
+}
+
+/**
+ * Attach the validated caller to the active context, if there is one.
+ * No-op under stdio, where there is no per-request scope to attach to.
+ */
+export function setContextUser(userName: string | undefined): void {
+  const ctx = storage.getStore();
+  if (ctx && userName) ctx.userName = userName;
+}

--- a/digit-mcp/src/services/session-store.ts
+++ b/digit-mcp/src/services/session-store.ts
@@ -163,12 +163,13 @@ class SessionStore {
     };
   }
 
-  recordToolCall(tool: string, args: Record<string, unknown>): number {
+  /** `redacted` lets a caller that already redacted these args avoid a second walk. */
+  recordToolCall(tool: string, args: Record<string, unknown>, redacted?: Record<string, unknown>): number {
     if (!this.session) return 0;
 
     this.seq++;
     const ts = new Date().toISOString();
-    const sanitized = sanitizeArgs(args);
+    const sanitized = redacted ?? sanitizeArgs(args);
 
     // JSONL (always)
     this.appendEventJsonl({

--- a/digit-mcp/src/services/session-store.ts
+++ b/digit-mcp/src/services/session-store.ts
@@ -2,6 +2,7 @@ import { createWriteStream, mkdirSync, type WriteStream } from 'node:fs';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { db } from './db.js';
+import { redactDeep } from '../utils/redact.js';
 import { telemetry as matomo } from './telemetry.js';
 
 // --- Types ---
@@ -26,14 +27,8 @@ interface SessionRecord {
 
 // --- Sensitive field sanitization (matches logger.ts) ---
 
-const SENSITIVE_KEYS = ['password', 'secret', 'token', 'auth_token'];
-
 function sanitizeArgs(args: Record<string, unknown>): Record<string, unknown> {
-  const out = { ...args };
-  for (const key of SENSITIVE_KEYS) {
-    if (key in out) out[key] = '***';
-  }
-  return out;
+  return redactDeep(args) as Record<string, unknown>;
 }
 
 function truncate(text: string, maxLen: number): string {

--- a/digit-mcp/src/services/session-store.ts
+++ b/digit-mcp/src/services/session-store.ts
@@ -2,6 +2,7 @@ import { createWriteStream, mkdirSync, type WriteStream } from 'node:fs';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { db } from './db.js';
+import { getRequestContext } from './request-context.js';
 import { redactDeep } from '../utils/redact.js';
 import { telemetry as matomo } from './telemetry.js';
 
@@ -127,6 +128,12 @@ class SessionStore {
 
   // --- HTTP context (set from request headers) ---
 
+  /**
+   * Session-level "last seen from" fields. On the HTTP transport the session
+   * row is process-wide while requests are not, so treat these as coarse: the
+   * authoritative per-call attribution is the ip/ua/user stamped onto each
+   * event by `callerContext()` from the request scope.
+   */
   setHttpContext(userAgent: string, clientIp: string): void {
     if (!this.session) return;
 
@@ -141,6 +148,20 @@ class SessionStore {
   }
 
   // --- Auto-tracking (called from server.ts) ---
+
+  /**
+   * Who made the call being recorded, from the request-scoped context.
+   * Empty under stdio, where the session fields already identify the one owner.
+   */
+  private callerContext(): Record<string, unknown> {
+    const ctx = getRequestContext();
+    if (!ctx) return {};
+    return {
+      ip: ctx.ip || undefined,
+      userAgent: ctx.userAgent || undefined,
+      user: ctx.userName,
+    };
+  }
 
   recordToolCall(tool: string, args: Record<string, unknown>): number {
     if (!this.session) return 0;
@@ -157,6 +178,7 @@ class SessionStore {
       type: 'tool_call',
       tool,
       args: sanitized,
+      ...this.callerContext(),
     });
 
     // Postgres (fire-and-forget)

--- a/digit-mcp/src/services/shell.ts
+++ b/digit-mcp/src/services/shell.ts
@@ -14,12 +14,15 @@ export interface ShellResult {
 
 const TIMEOUT_MS = 15000;
 
-function run(file: string, args: string[]): ShellResult {
+function run(file: string, args: string[], extraEnv?: Record<string, string>): ShellResult {
   try {
     const stdout = execFileSync(file, args, {
       encoding: 'utf-8',
       timeout: TIMEOUT_MS,
       stdio: ['pipe', 'pipe', 'pipe'],
+      // Credentials are passed to the one child that needs them, not written
+      // into this process's environment. See the note on psqlEnv below.
+      ...(extraEnv ? { env: { ...process.env, ...extraEnv } } : {}),
     });
     return { stdout: stdout.trim(), ok: true };
   } catch (err: unknown) {
@@ -90,24 +93,33 @@ export function persisterLogs(since: string): ShellResult {
 
 // ── PostgreSQL row counts ──
 // Tables are hardcoded — never from user input.
+//
+// Connection details come from the DIGIT_DB_* vars shared with digit-db.ts,
+// falling back to the local compose defaults. Previously these were hardcoded
+// and the password was assigned to `process.env.PGPASSWORD` at module import,
+// which leaked it into every child process this server spawns (and into any
+// `pg` client that reads PGPASSWORD) merely because the module was imported.
+// It is now passed only to the psql child that needs it.
+const dbHost = () => process.env.DIGIT_DB_HOST || 'localhost';
+const dbPort = () => process.env.DIGIT_DB_PORT || '15432';
+const dbUser = () => process.env.DIGIT_DB_USER || 'egov';
+const dbName = () => process.env.DIGIT_DB_NAME || 'egov';
+const psqlEnv = (): Record<string, string> => ({
+  PGPASSWORD: process.env.DIGIT_DB_PASSWORD || 'egov123',
+});
 
-const DB_HOST = 'localhost';
-const DB_PORT = '15432';
-const DB_USER = 'egov';
-const DB_NAME = 'egov';
-const DB_PASS = 'egov123';
+function psqlArgs(extra: string[]): string[] {
+  return ['-h', dbHost(), '-p', dbPort(), '-U', dbUser(), '-d', dbName(), ...extra];
+}
 
 export function psqlCountAll(tables: readonly string[]): ShellResult {
   const query = tables
     .map(t => `SELECT '${t}' AS tbl, COUNT(*) AS cnt FROM ${t}`)
     .join(' UNION ALL ');
 
-  return run('psql', ['-h', DB_HOST, '-p', DB_PORT, '-U', DB_USER, '-d', DB_NAME, '-t', '-A', '-F|', '-c', query], );
+  return run('psql', psqlArgs(['-t', '-A', '-F|', '-c', query]), psqlEnv());
 }
 
 export function psqlCountOne(table: string): ShellResult {
-  return run('psql', ['-h', DB_HOST, '-p', DB_PORT, '-U', DB_USER, '-d', DB_NAME, '-t', '-c', `SELECT COUNT(*) FROM ${table}`]);
+  return run('psql', psqlArgs(['-t', '-c', `SELECT COUNT(*) FROM ${table}`]), psqlEnv());
 }
-
-// Override env for psql password (applied at module level)
-process.env.PGPASSWORD = DB_PASS;

--- a/digit-mcp/src/services/telemetry.ts
+++ b/digit-mcp/src/services/telemetry.ts
@@ -1,8 +1,8 @@
 /**
  * Matomo telemetry for DIGIT MCP server.
  *
- * Sends lightweight usage events to Matomo (fire-and-forget, opt-out via TELEMETRY=false).
- * Uses the same Matomo instance and conventions as the CCRS local-setup telemetry.
+ * Sends lightweight usage events to Matomo (fire-and-forget). OPT-IN: nothing is
+ * sent unless MATOMO_URL is set. TELEMETRY=false disables it even when set.
  *
  * Events sent:
  *   - mcp / session_start    — new MCP session
@@ -18,12 +18,30 @@ import { hostname } from 'node:os';
 // Configuration
 // ---------------------------------------------------------------------------
 
-const MATOMO_URL = process.env.MATOMO_URL || 'https://unified-demo.digit.org/matomo/matomo.php';
+// No default endpoint. This previously defaulted to a shared demo host with
+// TELEMETRY defaulting to "true", so any deployment that didn't override either
+// value — including production, where neither is set in the Helm chart — sent
+// tool-call events off-cluster. Telemetry is now strictly opt-in: it requires an
+// explicit MATOMO_URL, so an unconfigured deployment emits nothing.
+const MATOMO_URL = process.env.MATOMO_URL || '';
 const MATOMO_SITE_ID = process.env.MATOMO_SITE_ID || '5';
 const UA = 'Mozilla/5.0 (DIGIT-MCP/1.0; Linux) AppleWebKit/537.36';
 
+let startupNoticeLogged = false;
+
 function isEnabled(): boolean {
-  return (process.env.TELEMETRY ?? 'true').toLowerCase() !== 'false';
+  // Both conditions required: an endpoint to send to, and no explicit opt-out.
+  if (!MATOMO_URL) return false;
+  if ((process.env.TELEMETRY ?? 'true').toLowerCase() === 'false') return false;
+
+  if (!startupNoticeLogged) {
+    startupNoticeLogged = true;
+    console.error(
+      `[telemetry] Enabled — sending MCP usage events to ${MATOMO_URL} (site ${MATOMO_SITE_ID}). ` +
+      'Unset MATOMO_URL or set TELEMETRY=false to disable.'
+    );
+  }
+  return true;
 }
 
 // Stable visitor ID: SHA256(hostname)[0:16] — same approach as CCRS telemetry

--- a/digit-mcp/src/tools/api-catalog.ts
+++ b/digit-mcp/src/tools/api-catalog.ts
@@ -30,6 +30,7 @@ export function registerApiCatalogTools(registry: ToolRegistry): void {
     name: 'api_catalog',
     group: 'docs',
     category: 'docs',
+    access: 'public',
     risk: 'read',
     description:
       'Get the complete DIGIT platform API catalog as an OpenAPI 3.0 specification. ' +

--- a/digit-mcp/src/tools/boundary.ts
+++ b/digit-mcp/src/tools/boundary.ts
@@ -7,6 +7,7 @@ export function registerBoundaryTools(registry: ToolRegistry): void {
     name: 'fix_boundary_paths',
     group: 'boundary',
     category: 'boundary-mgmt',
+    access: 'admin',
     risk: 'write',
     description:
       'Recomputes the ancestralmaterializedpath column (the pipe-separated chain of ANCESTOR ' +

--- a/digit-mcp/src/tools/discover-tools.ts
+++ b/digit-mcp/src/tools/discover-tools.ts
@@ -35,8 +35,11 @@ export function registerDiscoverTools(registry: ToolRegistry): void {
     name: 'enable_tools',
     group: 'core',
     category: 'discovery',
-    access: 'public',
-    risk: 'read',
+    // Not public, and not a read. On /mcp the registry is per-request, but the
+    // REST shim shares one long-lived ToolRegistry across all callers, so this
+    // mutates state other callers observe.
+    access: 'employee',
+    risk: 'write',
     description:
       'Enable or disable tool groups on demand. Groups: mdms (tenant validation + MDMS search/create), boundary (boundary hierarchy + boundary management CRUD), masters (departments, designations, complaint types), employees (HRMS employee create/update/validate), localization (search/upsert UI labels), pgr (PGR complaints + workflow), admin (filestore upload/download + access control + user search/create), idgen (ID generation), location (geographic boundaries), encryption (encrypt/decrypt), docs (search DIGIT documentation at docs.digit.org + full OpenAPI 3.0 API catalog), monitoring (persister health, Kafka lag, DB counts, E2E parity), tracing (distributed trace search, debug API failures, find slow operations), snapshot (capture + diff system state across two setups). The "core" group is always enabled.',
     inputSchema: {

--- a/digit-mcp/src/tools/discover-tools.ts
+++ b/digit-mcp/src/tools/discover-tools.ts
@@ -36,9 +36,11 @@ export function registerDiscoverTools(registry: ToolRegistry): void {
     group: 'core',
     category: 'discovery',
     // Not public, and not a read. On /mcp the registry is per-request, but the
-    // REST shim shares one long-lived ToolRegistry across all callers, so this
-    // mutates state other callers observe.
-    access: 'employee',
+    // REST shim shares ONE long-lived ToolRegistry across all callers — so
+    // `disable` here zeroes out tool availability for every concurrent caller
+    // until restart. That blast radius is admin-tier, whatever the tool's own
+    // payload looks like.
+    access: 'admin',
     risk: 'write',
     description:
       'Enable or disable tool groups on demand. Groups: mdms (tenant validation + MDMS search/create), boundary (boundary hierarchy + boundary management CRUD), masters (departments, designations, complaint types), employees (HRMS employee create/update/validate), localization (search/upsert UI labels), pgr (PGR complaints + workflow), admin (filestore upload/download + access control + user search/create), idgen (ID generation), location (geographic boundaries), encryption (encrypt/decrypt), docs (search DIGIT documentation at docs.digit.org + full OpenAPI 3.0 API catalog), monitoring (persister health, Kafka lag, DB counts, E2E parity), tracing (distributed trace search, debug API failures, find slow operations), snapshot (capture + diff system state across two setups). The "core" group is always enabled.',

--- a/digit-mcp/src/tools/discover-tools.ts
+++ b/digit-mcp/src/tools/discover-tools.ts
@@ -7,6 +7,7 @@ export function registerDiscoverTools(registry: ToolRegistry): void {
     name: 'discover_tools',
     group: 'core',
     category: 'discovery',
+    access: 'public',
     risk: 'read',
     description:
       'List all available CRS validator tools grouped by domain. Shows which groups are currently enabled and what tools each group contains. Use this to understand what capabilities are available before enabling additional groups.',
@@ -34,6 +35,7 @@ export function registerDiscoverTools(registry: ToolRegistry): void {
     name: 'enable_tools',
     group: 'core',
     category: 'discovery',
+    access: 'public',
     risk: 'read',
     description:
       'Enable or disable tool groups on demand. Groups: mdms (tenant validation + MDMS search/create), boundary (boundary hierarchy + boundary management CRUD), masters (departments, designations, complaint types), employees (HRMS employee create/update/validate), localization (search/upsert UI labels), pgr (PGR complaints + workflow), admin (filestore upload/download + access control + user search/create), idgen (ID generation), location (geographic boundaries), encryption (encrypt/decrypt), docs (search DIGIT documentation at docs.digit.org + full OpenAPI 3.0 API catalog), monitoring (persister health, Kafka lag, DB counts, E2E parity), tracing (distributed trace search, debug API failures, find slow operations), snapshot (capture + diff system state across two setups). The "core" group is always enabled.',

--- a/digit-mcp/src/tools/docs.ts
+++ b/digit-mcp/src/tools/docs.ts
@@ -6,6 +6,32 @@ import { fileURLToPath } from 'node:url';
 import { sanitizeUserContent } from '../utils/sanitize.js';
 
 const MCP_ENDPOINT = 'https://docs.digit.org/platform/~gitbook/mcp';
+
+/**
+ * Hosts `docs_get` may fetch from.
+ *
+ * The guard used to be `url.includes('docs.digit.org')` — a substring test on
+ * the WHOLE url, so `http://10.0.0.1/x?docs.digit.org` passed it. Combined with
+ * redirect-following and a verbatim body, that made a read-only documentation
+ * tool into an in-cluster HTTP fetch primitive: arbitrary internal GETs and a
+ * port scanner, reachable at the lowest access tier.
+ *
+ * Compare `url.hostname` — never the string — against this list.
+ */
+const ALLOWED_DOC_HOSTS = new Set(['docs.digit.org']);
+
+/** Cap on a fetched page, so a hostile or huge target can't exhaust memory. */
+const MAX_DOC_BYTES = 2 * 1024 * 1024;
+
+function isAllowedDocHost(rawUrl: string): boolean {
+  try {
+    const parsed = new URL(rawUrl);
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return false;
+    return ALLOWED_DOC_HOSTS.has(parsed.hostname.toLowerCase());
+  } catch {
+    return false;
+  }
+}
 const LOCAL_URL_PREFIX = 'local://';
 const ENGRAM_URL_PREFIX = 'engram://';
 
@@ -304,7 +330,10 @@ export function registerDocsTools(registry: ToolRegistry): void {
     name: 'docs_get',
     group: 'docs',
     category: 'docs',
-    access: 'public',
+    // Not 'public'. Even with the host allow-list this performs an outbound
+    // fetch from inside the cluster on caller-supplied input; the lowest tier
+    // should not be able to drive egress at all.
+    access: 'employee',
     risk: 'read',
     description:
       'Fetch the full markdown content of a DIGIT documentation page. Use docs_search first to find the URL, then pass it here to read the complete page. ' +
@@ -361,11 +390,13 @@ export function registerDocsTools(registry: ToolRegistry): void {
         }, null, 2);
       }
 
-      // Ensure it's a docs.digit.org URL
-      if (!url.includes('docs.digit.org')) {
+      // Host must be allow-listed. Checked on the parsed hostname, not with a
+      // substring match on the url — see ALLOWED_DOC_HOSTS.
+      if (!isAllowedDocHost(url)) {
         return JSON.stringify({
           success: false,
-          error: 'URL must be a docs.digit.org page, a local:// URL, or an engram:// URL',
+          error: `URL host is not permitted. Allowed: ${[...ALLOWED_DOC_HOSTS].join(', ')}. ` +
+            'Pass a docs.digit.org page, a local:// URL, or an engram:// URL.',
           hint: 'Use docs_search to find valid documentation URLs.',
         });
       }
@@ -384,7 +415,20 @@ export function registerDocsTools(registry: ToolRegistry): void {
       }
 
       try {
-        const response = await fetch(mdUrl);
+        // `redirect: 'manual'` — following redirects would hand the allow-list
+        // straight back: one hop off docs.digit.org and we are fetching whatever
+        // the redirect names. A redirect is reported, not chased.
+        const response = await fetch(mdUrl, {
+          redirect: 'manual',
+          signal: AbortSignal.timeout(15_000),
+        });
+        if (response.status >= 300 && response.status < 400) {
+          return JSON.stringify({
+            success: false,
+            error: `The documentation host redirected (HTTP ${response.status}). Redirects are not followed.`,
+            hint: 'Use docs_search to get a current URL.',
+          }, null, 2);
+        }
         if (!response.ok) {
           return JSON.stringify({
             success: false,
@@ -404,13 +448,18 @@ export function registerDocsTools(registry: ToolRegistry): void {
           }, null, 2);
         }
 
-        const markdown = await response.text();
+        const raw = await response.text();
+        const markdown = raw.length > MAX_DOC_BYTES ? raw.slice(0, MAX_DOC_BYTES) : raw;
         // Return the original URL (not the .md one) so agents don't bypass docs_get
         const displayUrl = url.endsWith('.md') ? url.replace(/\.md$/, '') : url;
         return JSON.stringify({
           success: true,
           url: displayUrl,
-          content: markdown,
+          truncated: markdown.length < raw.length || undefined,
+          // Third-party content going straight into the agent's context. The
+          // search path already sanitized its snippets; this one did not, so
+          // the full page was an unfiltered injection channel.
+          content: sanitizeUserContent(markdown),
         }, null, 2);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/digit-mcp/src/tools/docs.ts
+++ b/digit-mcp/src/tools/docs.ts
@@ -1,7 +1,9 @@
 import type { ToolMetadata } from '../types/index.js';
 import type { ToolRegistry } from './registry.js';
 import { readdir, readFile } from 'node:fs/promises';
-import { join, dirname } from 'node:path';
+import { join, dirname, resolve } from 'node:path';
+import { lstatSync, realpathSync } from 'node:fs';
+import { isInside } from '../services/auth.js';
 import { fileURLToPath } from 'node:url';
 import { sanitizeUserContent } from '../utils/sanitize.js';
 
@@ -130,15 +132,48 @@ async function searchLocalDocs(query: string): Promise<Array<{ title: string; li
 }
 
 /**
+ * Resolve a caller-supplied filename inside `baseDir`, following symlinks.
+ *
+ * The blacklist this replaces (`includes('..') || includes('/')`) rejects the
+ * spellings of traversal but not the mechanism: a single path segment with no
+ * slash can still be a symlink pointing out of the directory, and `readFile`
+ * follows it. That matters most for the engram directory, whose contents are
+ * written by the agent from earlier sessions.
+ *
+ * Same shape as `resolveArtifactPath` — compare real paths on both sides, and
+ * refuse a symlink at the destination outright.
+ */
+function resolveDocPath(baseDir: string, filename: string): string | null {
+  if (!filename || filename.includes('/') || filename.includes('\\')) return null;
+  const base = realpathOrSelf(resolve(baseDir));
+  const candidate = resolve(base, filename);
+  if (!isInside(candidate, base)) return null;
+  try {
+    if (lstatSync(candidate).isSymbolicLink()) return null;
+  } catch {
+    return null; // does not exist
+  }
+  return realpathOrSelf(candidate) === candidate && isInside(candidate, base) ? candidate : null;
+}
+
+function realpathOrSelf(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
+  }
+}
+
+/**
  * Read a local doc file by its local:// URL.
  */
 async function getLocalDoc(localUrl: string): Promise<{ title: string; content: string } | null> {
   const filename = localUrl.replace(LOCAL_URL_PREFIX, '');
-  // Prevent path traversal
-  if (filename.includes('..') || filename.includes('/')) return null;
+  const path = resolveDocPath(DOCS_DIR, filename);
+  if (!path) return null;
 
   try {
-    const content = await readFile(join(DOCS_DIR, filename), 'utf-8');
+    const content = await readFile(path, 'utf-8');
     const titleMatch = content.match(/^#\s+(.+)/m);
     return {
       title: titleMatch ? titleMatch[1] : filename.replace('.md', ''),
@@ -210,10 +245,11 @@ async function searchEngramDocs(query: string): Promise<Array<{ title: string; l
  */
 async function getEngramDoc(engramUrl: string): Promise<{ title: string; content: string } | null> {
   const filename = engramUrl.replace(ENGRAM_URL_PREFIX, '');
-  if (filename.includes('..') || filename.includes('/')) return null;
+  const path = resolveDocPath(ENGRAMS_DIR, filename);
+  if (!path) return null;
 
   try {
-    const content = await readFile(join(ENGRAMS_DIR, filename), 'utf-8');
+    const content = await readFile(path, 'utf-8');
     const titleMatch = content.match(/^#\s+(.+)/m);
     return {
       title: titleMatch ? titleMatch[1] : filename.replace('.md', ''),

--- a/digit-mcp/src/tools/docs.ts
+++ b/digit-mcp/src/tools/docs.ts
@@ -3,6 +3,7 @@ import type { ToolRegistry } from './registry.js';
 import { readdir, readFile } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { sanitizeUserContent } from '../utils/sanitize.js';
 
 const MCP_ENDPOINT = 'https://docs.digit.org/platform/~gitbook/mcp';
 const LOCAL_URL_PREFIX = 'local://';
@@ -138,7 +139,10 @@ async function searchEngramDocs(query: string): Promise<Array<{ title: string; l
       results.push({
         title: `[Engram] ${title}`,
         link: `${ENGRAM_URL_PREFIX}${file}`,
-        content: snippet.slice(0, 500),
+        // Engram files are written by the agent from prior sessions, so hostile
+        // text captured once would otherwise be replayed into every later
+        // session's context. Local docs/ are in-repo and left as authored.
+        content: sanitizeUserContent(snippet.slice(0, 500)),
       });
     } catch {
       // Skip unreadable files
@@ -160,7 +164,7 @@ async function getEngramDoc(engramUrl: string): Promise<{ title: string; content
     const titleMatch = content.match(/^#\s+(.+)/m);
     return {
       title: titleMatch ? titleMatch[1] : filename.replace('.md', ''),
-      content,
+      content: sanitizeUserContent(content),
     };
   } catch {
     return null;
@@ -209,7 +213,8 @@ async function searchDocs(query: string): Promise<Array<{ title: string; link: s
         results.push({
           title: titleLine?.replace('Title: ', '') || '(untitled)',
           link: linkLine?.replace('Link: ', '') || '',
-          content: contentText.slice(0, 500),
+          // Third-party content fetched over the network.
+          content: sanitizeUserContent(contentText.slice(0, 500)),
         });
       }
     } catch {
@@ -225,6 +230,7 @@ export function registerDocsTools(registry: ToolRegistry): void {
     name: 'docs_search',
     group: 'docs',
     category: 'docs',
+    access: 'public',
     risk: 'read',
     description:
       'Search the DIGIT documentation (docs.digit.org) for guides, API references, configuration details, architecture docs, and how-to articles. ' +
@@ -298,6 +304,7 @@ export function registerDocsTools(registry: ToolRegistry): void {
     name: 'docs_get',
     group: 'docs',
     category: 'docs',
+    access: 'public',
     risk: 'read',
     description:
       'Fetch the full markdown content of a DIGIT documentation page. Use docs_search first to find the URL, then pass it here to read the complete page. ' +

--- a/digit-mcp/src/tools/docs.ts
+++ b/digit-mcp/src/tools/docs.ts
@@ -23,6 +23,33 @@ const ALLOWED_DOC_HOSTS = new Set(['docs.digit.org']);
 /** Cap on a fetched page, so a hostile or huge target can't exhaust memory. */
 const MAX_DOC_BYTES = 2 * 1024 * 1024;
 
+/** Read a response body up to `limit` bytes, abandoning the rest. */
+async function readCapped(response: Response, limit: number): Promise<{ text: string; truncated: boolean }> {
+  const body = response.body;
+  if (!body) return { text: '', truncated: false };
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  let truncated = false;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      total += value.length;
+      if (total > limit) {
+        chunks.push(value.subarray(0, value.length - (total - limit)));
+        truncated = true;
+        break;
+      }
+      chunks.push(value);
+    }
+  } finally {
+    await reader.cancel().catch(() => {});
+  }
+  return { text: Buffer.concat(chunks).toString('utf-8'), truncated };
+}
+
 function isAllowedDocHost(rawUrl: string): boolean {
   try {
     const parsed = new URL(rawUrl);
@@ -213,9 +240,12 @@ async function searchDocs(query: string): Promise<Array<{ title: string; link: s
         arguments: { query },
       },
     }),
+    // Bounded like docs_get: a fixed host is not an unbounded one, and any
+    // authenticated caller can drive this.
+    signal: AbortSignal.timeout(15_000),
   });
 
-  const text = await response.text();
+  const { text } = await readCapped(response, MAX_DOC_BYTES);
   const results: Array<{ title: string; link: string; content: string }> = [];
 
   // Parse SSE response
@@ -448,14 +478,18 @@ export function registerDocsTools(registry: ToolRegistry): void {
           }, null, 2);
         }
 
-        const raw = await response.text();
-        const markdown = raw.length > MAX_DOC_BYTES ? raw.slice(0, MAX_DOC_BYTES) : raw;
+        // Read incrementally and stop at the cap. `await response.text()`
+        // buffers the whole body first, so slicing afterwards bounds only what
+        // is RETURNED — the memory was already spent, which is not what the
+        // limit is for.
+        const raw = await readCapped(response, MAX_DOC_BYTES);
+        const markdown = raw.text;
         // Return the original URL (not the .md one) so agents don't bypass docs_get
         const displayUrl = url.endsWith('.md') ? url.replace(/\.md$/, '') : url;
         return JSON.stringify({
           success: true,
           url: displayUrl,
-          truncated: markdown.length < raw.length || undefined,
+          truncated: raw.truncated || undefined,
           // Third-party content going straight into the agent's context. The
           // search path already sanitized its snippets; this one did not, so
           // the full page was an unfiltered injection channel.

--- a/digit-mcp/src/tools/encryption.ts
+++ b/digit-mcp/src/tools/encryption.ts
@@ -1,6 +1,7 @@
 import type { ToolMetadata } from '../types/index.js';
 import type { ToolRegistry } from './registry.js';
 import { digitApi } from '../services/digit-api.js';
+import { ensureAuthenticated } from '../services/auth.js';
 
 export function registerEncryptionTools(registry: ToolRegistry): void {
   // ──────────────────────────────────────────
@@ -11,9 +12,10 @@ export function registerEncryptionTools(registry: ToolRegistry): void {
     name: 'encrypt_data',
     group: 'encryption',
     category: 'encryption',
+    access: 'admin',
     risk: 'write',
     description:
-      'Encrypt sensitive data using the DIGIT encryption service (egov-enc-service). Accepts plain text values and returns encrypted strings. Does not require user authentication — the encryption service handles its own key management.',
+      'Encrypt sensitive data using the DIGIT encryption service (egov-enc-service). Accepts plain text values and returns encrypted strings. Requires authentication.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -30,6 +32,8 @@ export function registerEncryptionTools(registry: ToolRegistry): void {
       required: ['tenant_id', 'values'],
     },
     handler: async (args) => {
+      await ensureAuthenticated();
+
       const tenantId = args.tenant_id as string;
       const values = args.values as string[];
 
@@ -52,9 +56,11 @@ export function registerEncryptionTools(registry: ToolRegistry): void {
     name: 'decrypt_data',
     group: 'encryption',
     category: 'encryption',
+    access: 'admin',
+    sensitiveOutput: true,
     risk: 'write',
     description:
-      'Decrypt encrypted data using the DIGIT encryption service (egov-enc-service). Accepts encrypted strings and returns plain text values. May fail if the encryption key is not configured for the tenant.',
+      'Decrypt encrypted data using the DIGIT encryption service (egov-enc-service). Accepts encrypted strings and returns plain text values. Requires authentication — this returns citizen PII in plain text. May fail if the encryption key is not configured for the tenant.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -71,6 +77,8 @@ export function registerEncryptionTools(registry: ToolRegistry): void {
       required: ['tenant_id', 'encrypted_values'],
     },
     handler: async (args) => {
+      await ensureAuthenticated();
+
       const tenantId = args.tenant_id as string;
       const encryptedValues = args.encrypted_values as string[];
 

--- a/digit-mcp/src/tools/filestore-acl.ts
+++ b/digit-mcp/src/tools/filestore-acl.ts
@@ -10,6 +10,10 @@ export function registerFilestoreAclTools(registry: ToolRegistry): void {
 
   registry.register({
     name: 'filestore_get_urls',
+    // Admin, not the employee default: a read that returns citizen/employee PII
+    // or maps a tenant's access-control topology is reconnaissance for anyone
+    // below that tier, and its sibling WRITE tools in this same file are admin.
+    access: 'admin',
     group: 'admin',
     category: 'filestore',
     risk: 'read',
@@ -135,6 +139,10 @@ export function registerFilestoreAclTools(registry: ToolRegistry): void {
 
   registry.register({
     name: 'access_roles_search',
+    // Admin, not the employee default: a read that returns citizen/employee PII
+    // or maps a tenant's access-control topology is reconnaissance for anyone
+    // below that tier, and its sibling WRITE tools in this same file are admin.
+    access: 'admin',
     group: 'admin',
     category: 'access-control',
     risk: 'read',
@@ -174,6 +182,10 @@ export function registerFilestoreAclTools(registry: ToolRegistry): void {
 
   registry.register({
     name: 'access_actions_search',
+    // Admin, not the employee default: a read that returns citizen/employee PII
+    // or maps a tenant's access-control topology is reconnaissance for anyone
+    // below that tier, and its sibling WRITE tools in this same file are admin.
+    access: 'admin',
     group: 'admin',
     category: 'access-control',
     risk: 'read',

--- a/digit-mcp/src/tools/filestore-acl.ts
+++ b/digit-mcp/src/tools/filestore-acl.ts
@@ -1,6 +1,7 @@
 import type { ToolMetadata } from '../types/index.js';
 import type { ToolRegistry } from './registry.js';
 import { digitApi } from '../services/digit-api.js';
+import { ensureAuthenticated } from '../services/auth.js';
 
 export function registerFilestoreAclTools(registry: ToolRegistry): void {
   // ──────────────────────────────────────────
@@ -57,6 +58,7 @@ export function registerFilestoreAclTools(registry: ToolRegistry): void {
     name: 'filestore_upload',
     group: 'admin',
     category: 'filestore',
+    access: 'admin',
     risk: 'write',
     description:
       'Upload a file to DIGIT filestore. Accepts base64-encoded file content, a filename, and a module name. ' +
@@ -230,13 +232,3 @@ export function registerFilestoreAclTools(registry: ToolRegistry): void {
   } satisfies ToolMetadata);
 }
 
-async function ensureAuthenticated(): Promise<void> {
-  if (digitApi.isAuthenticated()) return;
-  const username = process.env.CRS_USERNAME;
-  const password = process.env.CRS_PASSWORD;
-  const tenantId = process.env.CRS_TENANT_ID || digitApi.getEnvironmentInfo().stateTenantId;
-  if (!username || !password) {
-    throw new Error('Not authenticated. Call the "configure" tool first, or set CRS_USERNAME/CRS_PASSWORD env vars.');
-  }
-  await digitApi.login(username, password, tenantId);
-}

--- a/digit-mcp/src/tools/health-check.ts
+++ b/digit-mcp/src/tools/health-check.ts
@@ -143,7 +143,11 @@ export function registerHealthCheckTools(registry: ToolRegistry): void {
     name: 'health_check',
     group: 'core',
     category: 'discovery',
-    access: 'public',
+    // Not 'public': this probes every platform service and reports which exist,
+    // how fast they answer and how they fail — infrastructure detail, which is
+    // exactly what ToolAccess says the public tier must not expose. Liveness
+    // for orchestrators is served unauthenticated by GET /healthz instead.
+    access: 'employee',
     risk: 'read',
     description:
       'Check the health of all DIGIT platform services by probing their API endpoints. Returns the status, response time, and any errors for each service. Requires authentication (call configure first) for most services. The encryption service is checked without auth.',

--- a/digit-mcp/src/tools/health-check.ts
+++ b/digit-mcp/src/tools/health-check.ts
@@ -143,6 +143,7 @@ export function registerHealthCheckTools(registry: ToolRegistry): void {
     name: 'health_check',
     group: 'core',
     category: 'discovery',
+    access: 'public',
     risk: 'read',
     description:
       'Check the health of all DIGIT platform services by probing their API endpoints. Returns the status, response time, and any errors for each service. Requires authentication (call configure first) for most services. The encryption service is checked without auth.',

--- a/digit-mcp/src/tools/hrms.ts
+++ b/digit-mcp/src/tools/hrms.ts
@@ -1,6 +1,7 @@
 import type { ToolMetadata } from '../types/index.js';
 import type { ToolRegistry } from './registry.js';
 import { digitApi } from '../services/digit-api.js';
+import { ensureAuthenticated, defaultProvisioningPassword } from '../services/auth.js';
 import { validateTenantId, validateMobileNumber, rejectControlChars, validateStringLength, validateResourceId } from '../utils/validation.js';
 
 export function registerHrmsTools(registry: ToolRegistry): void {
@@ -8,6 +9,7 @@ export function registerHrmsTools(registry: ToolRegistry): void {
     name: 'employee_create',
     group: 'employees',
     category: 'hrms',
+    access: 'admin',
     risk: 'write',
     description:
       'Create a new employee in DIGIT HRMS. Requires employee name, mobile number, roles, department/designation assignment, and jurisdiction. ' +
@@ -186,7 +188,7 @@ export function registerHrmsTools(registry: ToolRegistry): void {
         // Don't send a password — HRMS preserves the existing user's auth state.
         userPayload.uuid = existingUserUuid;
       } else {
-        userPayload.password = 'eGov@123';
+        userPayload.password = defaultProvisioningPassword();
       }
 
       const employee: Record<string, unknown> = {
@@ -226,18 +228,24 @@ export function registerHrmsTools(registry: ToolRegistry): void {
         const created = result[0];
         const user = created.user as Record<string, unknown> | undefined;
 
-        // HRMS doesn't reliably set the user password. Reset it via
-        // user update so the employee can actually login. Search must
-        // use the *user's actual tenantId* (the city tenant the user
-        // was created on), not the role tenant. Using the role tenant
-        // would return an empty result on city tenants and leave the
+        // HRMS doesn't reliably set the user password on accounts it creates,
+        // so set it here. Search must use the *user's actual tenantId* (the
+        // city tenant the user was created on), not the role tenant — the role
+        // tenant returns an empty result on city tenants and leaves the
         // password unset.
-        if (user?.uuid) {
+        //
+        // Guarded on !existingUserUuid. When the caller passes an existing
+        // user's uuid, HRMS links that account instead of creating one, and
+        // overwriting its password here was an account-takeover primitive:
+        // any caller who knew a privileged user's uuid could reset it to the
+        // default. That also contradicted the intent stated where the uuid is
+        // applied above ("HRMS preserves the existing user's auth state").
+        if (user?.uuid && !existingUserUuid) {
           try {
             const userTenant = (user.tenantId as string) || tenantId;
             const users = await digitApi.userSearch(userTenant, { uuid: [user.uuid as string], limit: 1 });
             if (users.length > 0) {
-              await digitApi.userUpdate({ ...users[0], password: 'eGov@123' });
+              await digitApi.userUpdate({ ...users[0], password: defaultProvisioningPassword() });
             }
           } catch (pwErr) {
             // Non-fatal: employee was created, password reset just failed
@@ -259,16 +267,27 @@ export function registerHrmsTools(registry: ToolRegistry): void {
               tenantId: created.tenantId,
               roles: ((user?.roles || []) as Array<{ code: string }>).map((r) => r.code),
             },
-            loginCredentials: {
-              username: created.code,
-              password: 'eGov@123',
-              // Login must use the city tenant where the user was
-              // actually provisioned. Auth is scoped by tenantId in
-              // egov-user — a user on `<state>.<city>` is invisible to
-              // a login attempt with tenantId=`<state>`.
-              loginTenantId: tenantId,
-              note: 'To authenticate as this employee, use the employee CODE as the username (not mobile number).',
-            },
+            // Only report credentials for an account we actually provisioned.
+            // On the uuid-link path the existing user keeps their own password,
+            // which this server neither sets nor knows.
+            loginCredentials: existingUserUuid
+              ? {
+                  username: created.code,
+                  loginTenantId: tenantId,
+                  note:
+                    'This employee was linked to an existing user account, so its password was left unchanged. ' +
+                    'Use that account\'s existing credentials.',
+                }
+              : {
+                  username: created.code,
+                  password: defaultProvisioningPassword(),
+                  // Login must use the city tenant where the user was
+                  // actually provisioned. Auth is scoped by tenantId in
+                  // egov-user — a user on `<state>.<city>` is invisible to
+                  // a login attempt with tenantId=`<state>`.
+                  loginTenantId: tenantId,
+                  note: 'To authenticate as this employee, use the employee CODE as the username (not mobile number).',
+                },
           },
           null,
           2
@@ -325,6 +344,7 @@ export function registerHrmsTools(registry: ToolRegistry): void {
     name: 'employee_update',
     group: 'employees',
     category: 'hrms',
+    access: 'admin',
     risk: 'write',
     description:
       'Update an existing HRMS employee. First use validate_employees to get current employee data, then pass the modified employee object. ' +
@@ -528,13 +548,3 @@ export function registerHrmsTools(registry: ToolRegistry): void {
   } satisfies ToolMetadata);
 }
 
-async function ensureAuthenticated(): Promise<void> {
-  if (digitApi.isAuthenticated()) return;
-  const username = process.env.CRS_USERNAME;
-  const password = process.env.CRS_PASSWORD;
-  const tenantId = process.env.CRS_TENANT_ID || digitApi.getEnvironmentInfo().stateTenantId;
-  if (!username || !password) {
-    throw new Error('Not authenticated. Call the "configure" tool first, or set CRS_USERNAME/CRS_PASSWORD env vars.');
-  }
-  await digitApi.login(username, password, tenantId);
-}

--- a/digit-mcp/src/tools/hrms.ts
+++ b/digit-mcp/src/tools/hrms.ts
@@ -7,6 +7,12 @@ import { validateTenantId, validateMobileNumber, rejectControlChars, validateStr
 export function registerHrmsTools(registry: ToolRegistry): void {
   registry.register({
     name: 'employee_create',
+    // Returns a plaintext provisioning password (loginCredentials /
+    // citizenLogin). The session store keeps a 200-char prefix of every result
+    // in Postgres and the JSONL log, so without this the credential is
+    // persisted — harmless while the default is the published eGov@123, a real
+    // leak the moment an operator sets a strong one.
+    sensitiveOutput: true,
     group: 'employees',
     category: 'hrms',
     access: 'admin',

--- a/digit-mcp/src/tools/idgen-location.ts
+++ b/digit-mcp/src/tools/idgen-location.ts
@@ -1,6 +1,7 @@
 import type { ToolMetadata } from '../types/index.js';
 import type { ToolRegistry } from './registry.js';
 import { digitApi } from '../services/digit-api.js';
+import { ensureAuthenticated } from '../services/auth.js';
 
 export function registerIdgenLocationTools(registry: ToolRegistry): void {
   // ──────────────────────────────────────────
@@ -137,18 +138,3 @@ export function registerIdgenLocationTools(registry: ToolRegistry): void {
 }
 
 // Auto-login helper
-async function ensureAuthenticated(): Promise<void> {
-  if (digitApi.isAuthenticated()) return;
-
-  const username = process.env.CRS_USERNAME;
-  const password = process.env.CRS_PASSWORD;
-  const tenantId = process.env.CRS_TENANT_ID || digitApi.getEnvironmentInfo().stateTenantId;
-
-  if (!username || !password) {
-    throw new Error(
-      'Not authenticated. Call the "configure" tool first, or set CRS_USERNAME/CRS_PASSWORD env vars.'
-    );
-  }
-
-  await digitApi.login(username, password, tenantId);
-}

--- a/digit-mcp/src/tools/localization.ts
+++ b/digit-mcp/src/tools/localization.ts
@@ -1,6 +1,7 @@
 import type { ToolMetadata } from '../types/index.js';
 import type { ToolRegistry } from './registry.js';
 import { digitApi } from '../services/digit-api.js';
+import { ensureAuthenticated } from '../services/auth.js';
 import { validateTenantId, rejectControlChars } from '../utils/validation.js';
 import { sanitizeUserContent } from '../utils/sanitize.js';
 import { applyFieldMask } from '../utils/field-mask.js';
@@ -74,6 +75,7 @@ export function registerLocalizationTools(registry: ToolRegistry): void {
     name: 'localization_upsert',
     group: 'localization',
     category: 'localization',
+    access: 'admin',
     risk: 'write',
     description:
       'Create or update localization messages for a tenant. Upserts translated strings — if a code already exists it is updated, otherwise created. Use for adding UI labels for new departments, complaint types, etc.',
@@ -164,13 +166,3 @@ export function registerLocalizationTools(registry: ToolRegistry): void {
   } satisfies ToolMetadata);
 }
 
-async function ensureAuthenticated(): Promise<void> {
-  if (digitApi.isAuthenticated()) return;
-  const username = process.env.CRS_USERNAME;
-  const password = process.env.CRS_PASSWORD;
-  const tenantId = process.env.CRS_TENANT_ID || digitApi.getEnvironmentInfo().stateTenantId;
-  if (!username || !password) {
-    throw new Error('Not authenticated. Call the "configure" tool first, or set CRS_USERNAME/CRS_PASSWORD env vars.');
-  }
-  await digitApi.login(username, password, tenantId);
-}

--- a/digit-mcp/src/tools/mdms-tenant.ts
+++ b/digit-mcp/src/tools/mdms-tenant.ts
@@ -2,7 +2,7 @@ import type { ToolMetadata, MdmsRecord } from '../types/index.js';
 import { MDMS_SCHEMAS } from '../types/index.js';
 import type { ToolRegistry } from './registry.js';
 import { digitApi } from '../services/digit-api.js';
-import { ensureAuthenticated, checkBaseUrlAllowed, getAuthMode } from '../services/auth.js';
+import { ensureAuthenticated, checkBaseUrlAllowed, defaultProvisioningPassword, getAuthMode } from '../services/auth.js';
 import { emitProgress } from '../services/progress.js';
 import { ENVIRONMENTS } from '../config/environments.js';
 import { autoPaginate, PAGINATION_SCHEMA_PROPERTIES } from '../utils/pagination.js';
@@ -533,8 +533,13 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
       }
 
       const env = digitApi.getEnvironmentInfo();
-      const username = (args.username as string) || process.env.CRS_USERNAME;
-      const password = (args.password as string) || process.env.CRS_PASSWORD;
+      // Env credentials are a convenience for the process owner (stdio), not a
+      // substitute identity for a network caller. In token mode the caller is
+      // already authenticated as themselves; falling back here would let an
+      // admin on one tenant silently adopt the container's ADMIN account.
+      const ambient = getAuthMode() === 'ambient';
+      const username = (args.username as string) || (ambient ? process.env.CRS_USERNAME : undefined);
+      const password = (args.password as string) || (ambient ? process.env.CRS_PASSWORD : undefined);
       const explicitTenantId = (args.tenant_id as string) || (args.state_tenant as string);
       const defaultLoginTenant = process.env.CRS_TENANT_ID || env.stateTenantId;
 
@@ -607,7 +612,7 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
             hint: `Login failed against tenants: ${triedTenants}. ` +
               `IMPORTANT: HRMS employee usernames are the EMPLOYEE CODE (e.g. "EMP-LIVE-000057"), NOT the mobile number. ` +
               `Check the employee_create response for the "code" field and use that as the username. ` +
-              `Default password is "eGov@123".`,
+              `Default password is the configured provisioning password (MCP_DEFAULT_PROVISIONING_PASSWORD).`,
           },
           null,
           2
@@ -1287,7 +1292,7 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
         let userProvisionError: string | null = null;
         try {
           const currentUsername = process.env.CRS_USERNAME || 'ADMIN';
-          const currentPassword = process.env.CRS_PASSWORD || 'eGov@123';
+          const currentPassword = process.env.CRS_PASSWORD || defaultProvisioningPassword();
           const mobileNumber = deriveValidMobile(
             mobileRegex,
             Number(args.mobile_length) || 10,
@@ -2122,7 +2127,7 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
       try {
         const auth = digitApi.getAuthInfo();
         const currentUsername = auth.user?.userName || process.env.CRS_USERNAME || 'ADMIN';
-        const currentPassword = process.env.CRS_PASSWORD || 'eGov@123';
+        const currentPassword = process.env.CRS_PASSWORD || defaultProvisioningPassword();
 
         // Get full user details from source tenant
         const sourceTenantForSearch = auth.user?.tenantId || source;
@@ -2781,7 +2786,7 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
               if (adminRecord?.uuid) userPayload.uuid = adminRecord.uuid;
               if (adminRecord?.id) userPayload.id = adminRecord.id;
               if (!adminRecord?.uuid) {
-                userPayload.password = process.env.CRS_PASSWORD || 'eGov@123';
+                userPayload.password = process.env.CRS_PASSWORD || defaultProvisioningPassword();
               }
 
               // PGR's validateDepartment checks that the assignee's HRMS
@@ -2863,7 +2868,7 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
                   try {
                     const users = await digitApi.userSearch(target, { uuid: [u.uuid as string], limit: 1 });
                     if (users.length > 0) {
-                      await digitApi.userUpdate({ ...users[0], password: process.env.CRS_PASSWORD || 'eGov@123' });
+                      await digitApi.userUpdate({ ...users[0], password: process.env.CRS_PASSWORD || defaultProvisioningPassword() });
                     }
                   } catch { /* non-fatal */ }
                 }
@@ -3119,7 +3124,7 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
       try {
         const auth = digitApi.getAuthInfo();
         const currentUsername = auth.user?.userName || process.env.CRS_USERNAME || 'ADMIN';
-        const currentPassword = process.env.CRS_PASSWORD || 'eGov@123';
+        const currentPassword = process.env.CRS_PASSWORD || defaultProvisioningPassword();
 
         const standardRoles = ['EMPLOYEE', 'CITIZEN', 'CSR', 'GRO', 'PGR_LME', 'DGRO', 'SUPERUSER', 'INTERNAL_MICROSERVICE_ROLE'];
 
@@ -3437,7 +3442,7 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
             // Only set password on a fresh user — sending it for an existing
             // user is what trips DuplicateUserName on some HRMS builds.
             if (!cityAdminRecord?.uuid) {
-              userPayload.password = process.env.CRS_PASSWORD || 'eGov@123';
+              userPayload.password = process.env.CRS_PASSWORD || defaultProvisioningPassword();
             }
 
             const now = Date.now();
@@ -3479,7 +3484,7 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
                 try {
                   const users = await digitApi.userSearch(root, { uuid: [user.uuid as string], limit: 1 });
                   if (users.length > 0) {
-                    await digitApi.userUpdate({ ...users[0], password: process.env.CRS_PASSWORD || 'eGov@123' });
+                    await digitApi.userUpdate({ ...users[0], password: process.env.CRS_PASSWORD || defaultProvisioningPassword() });
                   }
                 } catch { /* non-fatal */ }
               }

--- a/digit-mcp/src/tools/mdms-tenant.ts
+++ b/digit-mcp/src/tools/mdms-tenant.ts
@@ -635,9 +635,11 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
       // that clients auto-approving read-risk tools would never be asked about.
       // The caller now has to ask for it explicitly.
       const provisionRoles = args.provision_roles === true;
+      const tenantFellBack =
+        !!explicitRoot && usedLoginTenant !== explicitRoot && usedLoginTenant !== explicitTenantId;
       let rolesProvisioned: string[] | null = null;
       let rolesProvisionSkipped: Record<string, unknown> | null = null;
-      if (!provisionRoles && explicitRoot && usedLoginTenant !== explicitRoot && usedLoginTenant !== explicitTenantId) {
+      if (tenantFellBack && !provisionRoles) {
         rolesProvisionSkipped = {
           targetTenant: explicitRoot,
           loggedInOn: usedLoginTenant,
@@ -646,8 +648,7 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
             `on the target tenant. Re-run configure with provision_roles: true to grant the standard role set ` +
             `(includes SUPERUSER), or assign roles explicitly with user_role_add.`,
         };
-      }
-      if (provisionRoles && explicitRoot && usedLoginTenant !== explicitRoot && usedLoginTenant !== explicitTenantId) {
+      } else if (tenantFellBack && provisionRoles) {
         try {
           const auth = digitApi.getAuthInfo();
           const searchTenant = auth.user?.tenantId || usedLoginTenant;

--- a/digit-mcp/src/tools/mdms-tenant.ts
+++ b/digit-mcp/src/tools/mdms-tenant.ts
@@ -2,6 +2,7 @@ import type { ToolMetadata, MdmsRecord } from '../types/index.js';
 import { MDMS_SCHEMAS } from '../types/index.js';
 import type { ToolRegistry } from './registry.js';
 import { digitApi } from '../services/digit-api.js';
+import { ensureAuthenticated, checkBaseUrlAllowed, getAuthMode } from '../services/auth.js';
 import { emitProgress } from '../services/progress.js';
 import { ENVIRONMENTS } from '../config/environments.js';
 import { autoPaginate, PAGINATION_SCHEMA_PROPERTIES } from '../utils/pagination.js';
@@ -442,7 +443,11 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
     name: 'configure',
     group: 'core',
     category: 'environment',
-    risk: 'read',
+    // 'write', not 'read': this tool authenticates AND can grant roles on the
+    // target tenant (see provision_roles). Labelling it read-risk meant clients
+    // that auto-approve read tools auto-approved a privilege grant.
+    access: 'admin',
+    risk: 'write',
     description:
       'Connect to a DIGIT environment by logging in with credentials. This must be called before any tool that queries the DIGIT API. Accepts environment key, username, password, and tenant ID. If credentials are provided via CRS_USERNAME/CRS_PASSWORD env vars, those are used as defaults.',
     inputSchema: {
@@ -481,11 +486,38 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
             'This overrides the environment default (e.g. switch from "pg" to "statea"). ' +
             'All MDMS queries, role assignments, and tenant lookups will use this as the root.',
         },
+        provision_roles: {
+          type: 'boolean',
+          description: 'Opt in to granting this user the standard role set (CITIZEN, EMPLOYEE, CSR, GRO, ' +
+            'PGR_LME, DGRO, SUPERUSER) on the target tenant when login had to fall back to a different one. ' +
+            'Default false. This WRITES to the user record and includes SUPERUSER — request it deliberately.',
+        },
       },
     },
     handler: async (args) => {
       const baseUrl = args.base_url as string | undefined;
       const envKey = (args.environment as string) || process.env.CRS_ENVIRONMENT || 'self-hosted';
+
+      // ── base_url guards ──
+      // Pointing the client at a caller-chosen host makes it send credentials
+      // there. Two independent checks: the host must be allow-listed, and the
+      // server's own stored credentials are never used for an ad-hoc target —
+      // the caller has to supply their own.
+      if (baseUrl) {
+        const baseUrlError = checkBaseUrlAllowed(baseUrl);
+        if (baseUrlError) {
+          return JSON.stringify({ success: false, error: baseUrlError, code: 'BASE_URL_NOT_ALLOWED' }, null, 2);
+        }
+        if (getAuthMode() === 'token' && !(args.username && args.password)) {
+          return JSON.stringify({
+            success: false,
+            error:
+              'username and password are required when base_url is supplied. The server will not send its ' +
+              'own stored credentials to a caller-specified host.',
+            code: 'EXPLICIT_CREDENTIALS_REQUIRED',
+          }, null, 2);
+        }
+      }
 
       // Switch environment: ad-hoc URL or named environment
       if (baseUrl) {
@@ -594,10 +626,28 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
 
       // ── Cross-tenant role provisioning ──
       // If we fell back to a different tenant (e.g. logged in on "pg" but target is "tenant"),
-      // the user lacks roles for the target root. Auto-add them so that direct API login
-      // (e.g. from a frontend) also works for the target tenant.
+      // the user lacks roles for the target root. Adding them makes direct API login
+      // (e.g. from a frontend) work for the target tenant too.
+      //
+      // OPT-IN (M6). This used to run automatically on any tenant fallback and
+      // granted SUPERUSER among others — a privilege escalation performed as a
+      // side effect of a tool documented as "connect to an environment", and one
+      // that clients auto-approving read-risk tools would never be asked about.
+      // The caller now has to ask for it explicitly.
+      const provisionRoles = args.provision_roles === true;
       let rolesProvisioned: string[] | null = null;
-      if (explicitRoot && usedLoginTenant !== explicitRoot && usedLoginTenant !== explicitTenantId) {
+      let rolesProvisionSkipped: Record<string, unknown> | null = null;
+      if (!provisionRoles && explicitRoot && usedLoginTenant !== explicitRoot && usedLoginTenant !== explicitTenantId) {
+        rolesProvisionSkipped = {
+          targetTenant: explicitRoot,
+          loggedInOn: usedLoginTenant,
+          note:
+            `Logged in on "${usedLoginTenant}" but you asked for "${explicitRoot}". This user may lack roles ` +
+            `on the target tenant. Re-run configure with provision_roles: true to grant the standard role set ` +
+            `(includes SUPERUSER), or assign roles explicitly with user_role_add.`,
+        };
+      }
+      if (provisionRoles && explicitRoot && usedLoginTenant !== explicitRoot && usedLoginTenant !== explicitTenantId) {
         try {
           const auth = digitApi.getAuthInfo();
           const searchTenant = auth.user?.tenantId || usedLoginTenant;
@@ -665,6 +715,7 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
             services: probeReport.services,
             detectedEndpointOverrides: probeReport.detectedEndpointOverrides,
           } : {}),
+          ...(rolesProvisionSkipped ? { rolesNotProvisioned: rolesProvisionSkipped } : {}),
           ...(rolesProvisioned && {
             rolesProvisioned: {
               tenant: explicitRoot,
@@ -692,6 +743,7 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
     name: 'get_environment_info',
     group: 'core',
     category: 'environment',
+    access: 'public',
     risk: 'read',
     description:
       'Show the current DIGIT environment configuration (name, URL, state tenant ID). Also lists all available environments. ' +
@@ -1016,6 +1068,7 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
     name: 'mdms_schema_create',
     group: 'mdms',
     category: 'mdms',
+    access: 'admin',
     risk: 'write',
     description:
       'Register a new MDMS v2 schema definition for a tenant. Schemas must exist at the state-level root tenant before data records can be created. ' +
@@ -1110,6 +1163,7 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
     name: 'tenant_bootstrap',
     group: 'mdms',
     category: 'mdms',
+    access: 'admin',
     risk: 'write',
     description:
       'Bootstrap a new state-level tenant root by copying ALL schemas and essential MDMS data from an existing tenant (e.g. "pg"). ' +
@@ -2917,6 +2971,7 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
     name: 'city_setup',
     group: 'mdms',
     category: 'mdms',
+    access: 'admin',
     risk: 'write',
     description:
       'Set up a city-level tenant under an existing root with everything needed for PGR. ' +
@@ -3454,6 +3509,7 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
     name: 'tenant_cleanup',
     group: 'mdms',
     category: 'mdms',
+    access: 'admin',
     risk: 'write',
     description:
       'Clean up a tenant by soft-deleting MDMS records OWNED by that tenant (isActive=false) ' +
@@ -3461,7 +3517,9 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
       'records whose own record.tenantId equals the passed tenant_id are deactivated. ' +
       'Follows the dataloader pattern: MDMS records are deactivated via the v2 _update API, not hard-deleted. ' +
       'Schema definitions are left in place (harmless without data). ' +
-      'Use this to tear down test tenants created by tenant_bootstrap or city_setup_from_xlsx.',
+      'Use this to tear down test tenants created by tenant_bootstrap or city_setup_from_xlsx. ' +
+      'SAFETY: runs read-only and returns a preview unless confirm=<tenant_id> is passed; ' +
+      'root/state tenants (no dot) additionally require allow_root_tenant=true.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -3483,11 +3541,35 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
           description: 'Recovery mode: instead of deactivating, set isActive=true on the matching records. ' +
             'Use this to undo a prior cleanup. Default: false (deactivate).',
         },
+        confirm: {
+          type: 'string',
+          description: 'REQUIRED to actually deactivate: must exactly equal tenant_id. ' +
+            'Without it the tool runs read-only and returns a preview of what would be deactivated.',
+        },
+        allow_root_tenant: {
+          type: 'boolean',
+          description: 'REQUIRED when tenant_id is a state/root tenant with no dot (e.g. "pg" rather than "pg.citya"). ' +
+            'A root-tenant sweep affects the whole hierarchy, so it must be opted into explicitly.',
+        },
       },
       required: ['tenant_id'],
     },
     handler: async (args) => {
       validateTenantId(args.tenant_id, 'tenant_id');
+
+      // ── Destructive-operation guards (H1) ──
+      // A root tenant ("pg") owns the records the whole hierarchy inherits, so
+      // sweeping one is a platform-wide event. Require an explicit opt-in
+      // before we authenticate or look up a single record.
+      if (!(args.tenant_id as string).includes('.') && args.allow_root_tenant !== true) {
+        return JSON.stringify({
+          success: false,
+          error:
+            `"${args.tenant_id}" is a state/root tenant. Deactivating its own records affects every ` +
+            'child tenant that inherits them. Pass allow_root_tenant: true if that is genuinely intended.',
+          code: 'ROOT_TENANT_REQUIRES_OPT_IN',
+        }, null, 2);
+      }
 
       await ensureAuthenticated();
 
@@ -3556,6 +3638,34 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
       const filteredRecords = schemaFilter && schemaFilter.length > 1
         ? ownedRecords.filter((r) => schemaFilter.includes(r.schemaCode))
         : ownedRecords;
+
+      // ── Confirmation gate (H1) ──
+      // Everything above this point is read-only. Deactivation is irreversible
+      // in practice for a live tenant, so unless the caller echoes the tenant
+      // id back to us we stop here and report what WOULD happen. `reactivate`
+      // is exempt: restoring records is additive, not destructive.
+      if (!reactivate && args.confirm !== tenantId) {
+        const breakdown: Record<string, number> = {};
+        for (const r of filteredRecords) {
+          if (r.isActive) breakdown[r.schemaCode] = (breakdown[r.schemaCode] || 0) + 1;
+        }
+        const activeCount = filteredRecords.filter((r) => r.isActive).length;
+        return JSON.stringify({
+          success: true,
+          dry_run: true,
+          message: `Preview only — nothing was changed. ${activeCount} active MDMS record(s) would be deactivated on "${tenantId}".`,
+          tenantId,
+          wouldDeactivate: {
+            mdmsRecords: activeCount,
+            alreadyInactive: filteredRecords.length - activeCount,
+            bySchema: breakdown,
+            users: deactivateUsers ? 'all users on this tenant' : 'none (deactivate_users=false)',
+          },
+          inheritedRecordsSkipped: inheritedSkipped,
+          toProceed: { confirm: tenantId },
+          hint: `Re-run with confirm: "${tenantId}" to apply. This preview performed no writes.`,
+        }, null, 2);
+      }
 
       emitProgress({
         phase: `mdms:${verb}:start`,
@@ -3669,6 +3779,7 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
     name: 'mdms_create',
     group: 'mdms',
     category: 'mdms',
+    access: 'admin',
     risk: 'write',
     description:
       'Create a new MDMS v2 record. Requires tenant ID, schema code, unique identifier, and the data object. Use mdms_search first to verify the record does not already exist.',
@@ -3830,6 +3941,7 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
     name: 'mdms_update',
     group: 'mdms',
     category: 'mdms',
+    access: 'admin',
     risk: 'write',
     description:
       'Update an existing MDMS v2 record. Fetches the current record (for id + auditDetails), ' +
@@ -3928,6 +4040,7 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
     name: 'mdms_repair_identity',
     group: 'mdms',
     category: 'mdms',
+    access: 'admin',
     risk: 'write',
     description:
       'Bulk-rewrite an identity field across all records of a schema at one tenant. ' +
@@ -4205,6 +4318,7 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
     name: 'tenant_destroy',
     group: 'mdms',
     category: 'mdms',
+    access: 'admin',
     risk: 'write',
     description:
       'Tear down a city tenant that was created with city_setup_from_xlsx. ' +
@@ -4342,6 +4456,7 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
     name: 'city_setup_from_xlsx',
     group: 'mdms',
     category: 'mdms',
+    access: 'admin',
     risk: 'write',
     description:
       'Set up a city tenant from xlsx files in CCRS dataloader format. ' +
@@ -4450,18 +4565,3 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
 }
 
 // Auto-login helper using environment variables
-async function ensureAuthenticated(): Promise<void> {
-  if (digitApi.isAuthenticated()) return;
-
-  const username = process.env.CRS_USERNAME;
-  const password = process.env.CRS_PASSWORD;
-  const tenantId = process.env.CRS_TENANT_ID || digitApi.getEnvironmentInfo().stateTenantId;
-
-  if (!username || !password) {
-    throw new Error(
-      'Not authenticated. Call the "configure" tool first with your username and password, or set CRS_USERNAME/CRS_PASSWORD env vars.'
-    );
-  }
-
-  await digitApi.login(username, password, tenantId);
-}

--- a/digit-mcp/src/tools/mdms-tenant.ts
+++ b/digit-mcp/src/tools/mdms-tenant.ts
@@ -3652,8 +3652,12 @@ export function registerMdmsTenantTools(registry: ToolRegistry): void {
         }
         const activeCount = filteredRecords.filter((r) => r.isActive).length;
         return JSON.stringify({
-          success: true,
+          // NOT `success: true`. Every other tool uses that to mean "the thing
+          // you asked for happened", and automation branches on it — reporting
+          // a no-op as success is how a cleanup silently stops running.
+          success: false,
           dry_run: true,
+          code: 'CONFIRMATION_REQUIRED',
           message: `Preview only — nothing was changed. ${activeCount} active MDMS record(s) would be deactivated on "${tenantId}".`,
           tenantId,
           wouldDeactivate: {

--- a/digit-mcp/src/tools/monitoring.ts
+++ b/digit-mcp/src/tools/monitoring.ts
@@ -269,6 +269,7 @@ export function registerMonitoringTools(registry: ToolRegistry): void {
     name: 'kafka_lag',
     group: 'monitoring',
     category: 'monitoring',
+    access: 'admin',
     risk: 'read',
     description:
       'Check Kafka consumer group lag for egov-persister via Redpanda rpk. ' +
@@ -294,6 +295,7 @@ export function registerMonitoringTools(registry: ToolRegistry): void {
     name: 'persister_errors',
     group: 'monitoring',
     category: 'monitoring',
+    access: 'admin',
     risk: 'read',
     description:
       'Scan egov-persister container logs for errors. ' +
@@ -327,6 +329,7 @@ export function registerMonitoringTools(registry: ToolRegistry): void {
     name: 'db_counts',
     group: 'monitoring',
     category: 'monitoring',
+    access: 'admin',
     risk: 'read',
     description:
       'Get row counts for key DIGIT database tables via direct psql query. ' +
@@ -352,6 +355,7 @@ export function registerMonitoringTools(registry: ToolRegistry): void {
     name: 'persister_monitor',
     group: 'monitoring',
     category: 'monitoring',
+    access: 'admin',
     risk: 'read',
     description:
       'Comprehensive persister health monitor. Runs all monitoring probes and cross-references results. ' +

--- a/digit-mcp/src/tools/monitoring.ts
+++ b/digit-mcp/src/tools/monitoring.ts
@@ -2,6 +2,7 @@ import type { ToolMetadata } from '../types/index.js';
 import type { ToolRegistry } from './registry.js';
 import { rpkDescribeGroup, persisterLogs, psqlCountAll, psqlCountOne } from '../services/shell.js';
 import { digitApi } from '../services/digit-api.js';
+import { ensureAuthenticated } from '../services/auth.js';
 
 // ──────────────────────────────────────────
 // Module-level cache for db_counts deltas
@@ -440,14 +441,11 @@ export function registerMonitoringTools(registry: ToolRegistry): void {
       let parity: { status: string; pgrCount?: number; workflowCount?: number; missingInWorkflow?: string[]; detail?: string; error?: string } | null = null;
       if (!skipProbes.has('parity')) {
         try {
-          if (!digitApi.isAuthenticated()) {
-            const username = process.env.CRS_USERNAME;
-            const password = process.env.CRS_PASSWORD;
-            const loginTenant = process.env.CRS_TENANT_ID || tenantId;
-            if (username && password) {
-              await digitApi.login(username, password, loginTenant);
-            }
-          }
+          // Centralized helper, not a local re-implementation: this was a
+          // tenth copy of the "no credentials => act as the container's ADMIN"
+          // fallback, with no auth-mode check. `optional` preserves the probe's
+          // degrade-rather-than-fail contract.
+          await ensureAuthenticated({ optional: true });
 
           if (digitApi.isAuthenticated()) {
             const pgrResults = await digitApi.pgrSearch(tenantId, { limit: 100, offset: 0 });

--- a/digit-mcp/src/tools/pgr-workflow.ts
+++ b/digit-mcp/src/tools/pgr-workflow.ts
@@ -1,6 +1,7 @@
 import type { ToolMetadata } from '../types/index.js';
 import type { ToolRegistry } from './registry.js';
 import { digitApi } from '../services/digit-api.js';
+import { ensureAuthenticated, defaultProvisioningPassword } from '../services/auth.js';
 import { autoPaginate, PAGINATION_SCHEMA_PROPERTIES } from '../utils/pagination.js';
 import type { PaginationOptions } from '../utils/pagination.js';
 import { validateTenantId, validateMobileNumber, rejectControlChars, validateStringLength, validateResourceId } from '../utils/validation.js';
@@ -102,7 +103,7 @@ export function registerPgrWorkflowTools(registry: ToolRegistry): void {
             action: wf.action,
             state: wf.state,
             assignes: wf.assignes,
-            comment: wf.comments,
+            comment: sanitizeUserContent(wf.comments as string),
           } : null,
           createdTime: audit?.createdTime,
           lastModifiedTime: audit?.lastModifiedTime,
@@ -253,29 +254,38 @@ export function registerPgrWorkflowTools(registry: ToolRegistry): void {
         const existing = await digitApi.userSearch(rootTenant, { mobileNumber: citizenMobile, limit: 1 });
         if (existing.length > 0) {
           citizenUser = existing[0];
-          // Reset password in case it was created by PGR previously (OTP-only)
-          try { await digitApi.userUpdate({ ...citizenUser, password: 'eGov@123' }); } catch (pwErr) { console.error(`[pgr_create] Citizen password reset failed: ${pwErr instanceof Error ? pwErr.message : String(pwErr)}`); }
+          // Deliberately NOT resetting this account's password.
+          // Filing a complaint on behalf of an existing citizen must not change
+          // that citizen's credentials — the previous unconditional reset to a
+          // well-known default meant anyone who could call pgr_create with a
+          // real mobile number could take over that person's account.
+          // Consequence: we don't know their password, so no citizenLogin is
+          // returned below. RATE/REOPEN as that citizen needs their own creds.
         } else {
           // Create new citizen with password auth.
           // IMPORTANT: Use type EMPLOYEE (not CITIZEN) because DIGIT's OAuth only supports
           // password auth for EMPLOYEE-type users. CITIZEN-type uses OTP only.
           // The CITIZEN *role* is what PGR checks for RATE/REOPEN permissions.
+          const newCitizenPassword = defaultProvisioningPassword();
           citizenUser = await digitApi.userCreate({
             name: citizenName,
             mobileNumber: citizenMobile,
             userName: citizenMobile,
-            password: 'eGov@123',
+            password: newCitizenPassword,
             type: 'EMPLOYEE',
             active: true,
             roles: [{ code: 'CITIZEN', name: 'Citizen', tenantId: rootTenant }],
             tenantId: rootTenant,
           }, rootTenant);
+          // Credentials are reported only for an account we just created. For a
+          // pre-existing citizen we leave their password untouched, so there is
+          // nothing to hand back.
+          citizenCredentials = {
+            username: citizenMobile,
+            password: newCitizenPassword,
+            loginTenantId: rootTenant,
+          };
         }
-        citizenCredentials = {
-          username: citizenMobile,
-          password: 'eGov@123',
-          loginTenantId: rootTenant,
-        };
       } catch (citizenErr) {
         // Non-fatal: PGR will auto-create the citizen (but without password auth)
         console.error(`[pgr_create] Citizen pre-creation failed: ${citizenErr instanceof Error ? citizenErr.message : String(citizenErr)}`);
@@ -344,7 +354,7 @@ export function registerPgrWorkflowTools(registry: ToolRegistry): void {
               `DIGIT's OAuth token only includes roles for the user's home tenant hierarchy. ` +
               `FIX: Create an employee on the target tenant using employee_create (with PGR roles like GRO, PGR_LME, DGRO), ` +
               `then call configure with the employee's code (returned in loginCredentials) as username, ` +
-              `password "eGov@123", and tenant_id="${targetRoot}". Then retry pgr_create.`;
+              `password "${defaultProvisioningPassword()}", and tenant_id="${targetRoot}". Then retry pgr_create.`;
             alternatives.push(
               { tool: 'employee_create', purpose: `Create employee on ${tenantId} with PGR roles (GRO, PGR_LME, DGRO)` },
               { tool: 'configure', purpose: `Re-authenticate as the new employee with tenant_id="${targetRoot}"` },
@@ -514,7 +524,7 @@ export function registerPgrWorkflowTools(registry: ToolRegistry): void {
               ? `Your user "${authInfo.user?.userName}" is on "${userTenantRoot}" — CITIZEN role doesn't cover "${targetRoot}". `
               : '') +
             `FIX: The citizen who filed the complaint has login credentials (returned by pgr_create in the citizenLogin field). ` +
-            `Call configure with the citizen's username (their mobile number) and password "eGov@123" and tenant_id="${targetRoot}". ` +
+            `Call configure with the citizen's username (their mobile number) and their own password, and tenant_id="${targetRoot}". ` +
             `Then retry pgr_update with action="${action}".`;
         } else if (isRoleError && isCrossTenant) {
           hint = `CROSS-TENANT ROLE MISMATCH: User "${authInfo.user?.userName}" is on "${userTenantRoot}" but complaint is on "${targetRoot}". ` +
@@ -702,7 +712,7 @@ export function registerPgrWorkflowTools(registry: ToolRegistry): void {
             state: (p.state as Record<string, unknown>)?.state,
             action: p.action,
             assignee: p.assignee,
-            comment: p.comment,
+            comment: sanitizeUserContent(p.comment as string),
             createdTime: (p.auditDetails as Record<string, unknown>)?.createdTime,
           })),
         },
@@ -720,6 +730,7 @@ export function registerPgrWorkflowTools(registry: ToolRegistry): void {
     name: 'workflow_create',
     group: 'pgr',
     category: 'workflow',
+    access: 'admin',
     risk: 'write',
     description:
       'Create a workflow business service definition for a tenant. This registers the state machine (states, actions, transitions, roles, SLA) ' +
@@ -938,13 +949,3 @@ export function registerPgrWorkflowTools(registry: ToolRegistry): void {
   } satisfies ToolMetadata);
 }
 
-async function ensureAuthenticated(): Promise<void> {
-  if (digitApi.isAuthenticated()) return;
-  const username = process.env.CRS_USERNAME;
-  const password = process.env.CRS_PASSWORD;
-  const tenantId = process.env.CRS_TENANT_ID || digitApi.getEnvironmentInfo().stateTenantId;
-  if (!username || !password) {
-    throw new Error('Not authenticated. Call the "configure" tool first, or set CRS_USERNAME/CRS_PASSWORD env vars.');
-  }
-  await digitApi.login(username, password, tenantId);
-}

--- a/digit-mcp/src/tools/pgr-workflow.ts
+++ b/digit-mcp/src/tools/pgr-workflow.ts
@@ -127,6 +127,12 @@ export function registerPgrWorkflowTools(registry: ToolRegistry): void {
 
   registry.register({
     name: 'pgr_create',
+    // Returns a plaintext provisioning password (loginCredentials /
+    // citizenLogin). The session store keeps a 200-char prefix of every result
+    // in Postgres and the JSONL log, so without this the credential is
+    // persisted — harmless while the default is the published eGov@123, a real
+    // leak the moment an operator sets a strong one.
+    sensitiveOutput: true,
     group: 'pgr',
     category: 'pgr',
     risk: 'write',

--- a/digit-mcp/src/tools/pgr-workflow.ts
+++ b/digit-mcp/src/tools/pgr-workflow.ts
@@ -266,6 +266,13 @@ export function registerPgrWorkflowTools(registry: ToolRegistry): void {
           // IMPORTANT: Use type EMPLOYEE (not CITIZEN) because DIGIT's OAuth only supports
           // password auth for EMPLOYEE-type users. CITIZEN-type uses OTP only.
           // The CITIZEN *role* is what PGR checks for RATE/REOPEN permissions.
+          //
+          // On tiers: pgr_create is employee-tier but provisions a user, while
+          // user_create is admin-tier. That is deliberate, not an oversight —
+          // filing on behalf of a citizen is ordinary counter work, and the
+          // account created here holds only the CITIZEN role, so checkToolAccess
+          // (which keys on roles, not type) still refuses it every staff tool.
+          // user_create can mint arbitrary roles, which is why it sits higher.
           const newCitizenPassword = defaultProvisioningPassword();
           citizenUser = await digitApi.userCreate({
             name: citizenName,

--- a/digit-mcp/src/tools/sessions.ts
+++ b/digit-mcp/src/tools/sessions.ts
@@ -38,6 +38,7 @@ export function registerSessionTools(registry: ToolRegistry): void {
     name: 'init',
     group: 'core',
     category: 'sessions',
+    access: 'public',
     risk: 'write',
     description:
       'Initialize a DIGIT MCP session. Call this at the start of a conversation to set up the session context. ' +
@@ -151,6 +152,7 @@ export function registerSessionTools(registry: ToolRegistry): void {
     name: 'session_checkpoint',
     group: 'core',
     category: 'sessions',
+    access: 'public',
     risk: 'write',
     description:
       'Record a checkpoint summarizing your progress so far. Call this periodically (every 5-10 tool calls) to capture what you accomplished. The summary is persisted across sessions and searchable later.',

--- a/digit-mcp/src/tools/snapshot.ts
+++ b/digit-mcp/src/tools/snapshot.ts
@@ -2,6 +2,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import type { ToolMetadata } from '../types/index.js';
 import type { ToolRegistry } from './registry.js';
 import { digitApi } from '../services/digit-api.js';
+import { ensureAuthenticated, resolveArtifactPath } from '../services/auth.js';
 import {
   captureSnapshot,
   diffSnapshots,
@@ -12,26 +13,23 @@ import {
 
 const MCP_VERSION = process.env.MCP_VERSION || '1.0.0';
 
-// Auto-login helper (only needed for config/data API sub-probes).
-async function ensureAuthenticated(): Promise<void> {
-  if (digitApi.isAuthenticated()) return;
-  const username = process.env.CRS_USERNAME;
-  const password = process.env.CRS_PASSWORD;
-  const tenantId = process.env.CRS_TENANT_ID || digitApi.getEnvironmentInfo().stateTenantId;
-  if (!username || !password) return; // capture proceeds; API layers degrade gracefully
-  await digitApi.login(username, password, tenantId);
-}
+// Auth for the config/data API sub-probes. `optional` preserves this tool's
+// contract: a capture still succeeds (with those layers marked unreachable)
+// when no credentials are available, rather than failing outright.
+const ensureAuthenticatedOptional = () => ensureAuthenticated({ optional: true });
 
 /** Resolve a diff side: a file path, an inline snapshot object, or live capture. */
 async function resolveSide(side: unknown, label: string): Promise<Snapshot> {
   if (typeof side === 'string') {
-    return JSON.parse(readFileSync(side, 'utf-8')) as Snapshot;
+    // Reads are confined to the same directory as writes, so a snapshot path
+    // cannot be used to probe arbitrary files on the host.
+    return JSON.parse(readFileSync(resolveArtifactPath(side), 'utf-8')) as Snapshot;
   }
   if (side && typeof side === 'object') {
     const obj = side as Record<string, unknown>;
     if (obj.capture && typeof obj.capture === 'object') {
       const cap = obj.capture as Record<string, unknown>;
-      await ensureAuthenticated();
+      await ensureAuthenticatedOptional();
       return captureSnapshot({
         layers: (cap.layers as SnapshotLayer[]) || ALL_LAYERS,
         tenantId: (cap.tenant_id as string) || digitApi.getEnvironmentInfo().stateTenantId,
@@ -50,7 +48,10 @@ export function registerSnapshotTools(registry: ToolRegistry): void {
     name: 'snapshot_capture',
     group: 'snapshot',
     category: 'snapshot',
-    risk: 'read',
+    // 'write': with output_path this writes a file to disk. Reported as read-risk
+    // it looked side-effect-free to any client gating on this field.
+    access: 'admin',
+    risk: 'write',
     description:
       'Capture a portable, deterministic system-state snapshot of the CURRENT DIGIT deployment, to diff against another setup and explain replication deviations. ' +
       'Layers: "images" (running container image refs+digests from docker, plus declared compose refs → catches compose drift; ON-BOX only), ' +
@@ -70,7 +71,7 @@ export function registerSnapshotTools(registry: ToolRegistry): void {
         tenant_id: { type: 'string', description: 'Tenant to scope config/data layers (e.g. "ke.bomet"). Defaults to the environment state tenant.' },
         label: { type: 'string', description: 'Human label stored in the snapshot (e.g. "bomet-prod", "fresh-clone").' },
         redact: { type: 'boolean', description: 'Redact secret-looking env values to hashes (default true). Keep true for shareable artifacts.' },
-        output_path: { type: 'string', description: 'Absolute path to write the JSON artifact. When set, the tool returns only meta + reachability + path.' },
+        output_path: { type: 'string', description: 'Filename (or relative path) for the JSON artifact, written inside the server\'s artifact directory. When set, the tool returns only meta + reachability + the resolved path.' },
       },
     },
     handler: async (args) => {
@@ -80,13 +81,15 @@ export function registerSnapshotTools(registry: ToolRegistry): void {
       const redact = args.redact !== false;
 
       if (layers.some((l) => l === 'config' || l === 'data')) {
-        await ensureAuthenticated();
+        await ensureAuthenticatedOptional();
       }
 
       const snapshot = await captureSnapshot({ layers, tenantId, label, redact, mcpVersion: MCP_VERSION });
 
       if (args.output_path) {
-        const path = args.output_path as string;
+        // Confined to the artifact directory — see resolveArtifactPath. This
+        // used to accept any path and the process runs as root.
+        const path = resolveArtifactPath(args.output_path as string);
         writeFileSync(path, JSON.stringify(snapshot, null, 2));
         return JSON.stringify({ success: true, outputPath: path, meta: snapshot.meta }, null, 2);
       }
@@ -98,6 +101,7 @@ export function registerSnapshotTools(registry: ToolRegistry): void {
     name: 'snapshot_diff',
     group: 'snapshot',
     category: 'snapshot',
+    access: 'admin',
     risk: 'read',
     description:
       'Diff two system-state snapshots and report deviations per layer (images/config/data) with severity. ' +
@@ -108,8 +112,8 @@ export function registerSnapshotTools(registry: ToolRegistry): void {
     inputSchema: {
       type: 'object' as const,
       properties: {
-        a: { description: 'Side A: file path (string), inline snapshot object, or {"capture":{...}} for a live capture.' },
-        b: { description: 'Side B: file path (string), inline snapshot object, or {"capture":{...}} for a live capture.' },
+        a: { description: 'Side A: artifact filename (resolved inside the server artifact directory), inline snapshot object, or {"capture":{...}} for a live capture.' },
+        b: { description: 'Side B: artifact filename (resolved inside the server artifact directory), inline snapshot object, or {"capture":{...}} for a live capture.' },
         layers: {
           type: 'array',
           items: { type: 'string', enum: ALL_LAYERS as unknown as string[] },

--- a/digit-mcp/src/tools/tracing.ts
+++ b/digit-mcp/src/tools/tracing.ts
@@ -15,6 +15,7 @@ export function registerTracingTools(registry: ToolRegistry): void {
     name: 'tracing_health',
     group: 'tracing',
     category: 'tracing',
+    access: 'admin',
     risk: 'read',
     description:
       'Check the health of the distributed tracing infrastructure: Grafana Tempo (trace storage), ' +
@@ -59,6 +60,7 @@ export function registerTracingTools(registry: ToolRegistry): void {
     name: 'trace_search',
     group: 'tracing',
     category: 'tracing',
+    access: 'admin',
     risk: 'read',
     description:
       'Search for distributed traces by service name, operation, and duration. ' +
@@ -166,6 +168,7 @@ export function registerTracingTools(registry: ToolRegistry): void {
     name: 'trace_get',
     group: 'tracing',
     category: 'tracing',
+    access: 'admin',
     risk: 'read',
     description:
       'Get the full trace by ID with a structured span breakdown. Returns all spans grouped by service, ' +
@@ -245,6 +248,7 @@ export function registerTracingTools(registry: ToolRegistry): void {
     name: 'trace_debug',
     group: 'tracing',
     category: 'tracing',
+    access: 'admin',
     risk: 'read',
     description:
       'One-call debugger: find the most recent trace for a service (optionally filtered by operation), ' +
@@ -361,6 +365,7 @@ export function registerTracingTools(registry: ToolRegistry): void {
     name: 'trace_slow',
     group: 'tracing',
     category: 'tracing',
+    access: 'admin',
     risk: 'read',
     description:
       'Find slow traces above a duration threshold. Returns traces sorted by duration, ' +

--- a/digit-mcp/src/tools/user.ts
+++ b/digit-mcp/src/tools/user.ts
@@ -1,6 +1,7 @@
 import type { ToolMetadata } from '../types/index.js';
 import type { ToolRegistry } from './registry.js';
 import { digitApi } from '../services/digit-api.js';
+import { defaultProvisioningPassword } from '../services/auth.js';
 import { autoPaginate, PAGINATION_SCHEMA_PROPERTIES } from '../utils/pagination.js';
 import type { PaginationOptions } from '../utils/pagination.js';
 import { validateTenantId, validateMobileNumber, rejectControlChars, validateStringLength } from '../utils/validation.js';
@@ -138,6 +139,7 @@ export function registerUserTools(registry: ToolRegistry): void {
     name: 'user_create',
     group: 'admin',
     category: 'user',
+    access: 'admin',
     risk: 'write',
     description:
       'Create a new user in the DIGIT platform. Creates users without OTP validation (admin operation). ' +
@@ -190,7 +192,7 @@ export function registerUserTools(registry: ToolRegistry): void {
         },
         password: {
           type: 'string',
-          description: 'Password for the user (default: "eGov@123")',
+          description: 'Password for the user. Defaults to the server\'s provisioning password (MCP_DEFAULT_PROVISIONING_PASSWORD).',
         },
       },
       required: ['tenant_id', 'name', 'mobile_number'],
@@ -226,7 +228,7 @@ export function registerUserTools(registry: ToolRegistry): void {
         name: args.name as string,
         mobileNumber,
         userName: (args.username as string) || mobileNumber,
-        password: (args.password as string) || 'eGov@123',
+        password: (args.password as string) || defaultProvisioningPassword(),
         type: userType,
         active: true,
         emailId: (args.email as string) || null,
@@ -279,6 +281,7 @@ export function registerUserTools(registry: ToolRegistry): void {
     name: 'user_role_add',
     group: 'admin',
     category: 'user',
+    access: 'admin',
     risk: 'write',
     description:
       'Add roles to an existing user for a specific tenant. CRITICAL for cross-tenant operations: ' +

--- a/digit-mcp/src/tools/user.ts
+++ b/digit-mcp/src/tools/user.ts
@@ -1,7 +1,7 @@
 import type { ToolMetadata } from '../types/index.js';
 import type { ToolRegistry } from './registry.js';
 import { digitApi } from '../services/digit-api.js';
-import { defaultProvisioningPassword } from '../services/auth.js';
+import { defaultProvisioningPassword, ensureAuthenticated } from '../services/auth.js';
 import { autoPaginate, PAGINATION_SCHEMA_PROPERTIES } from '../utils/pagination.js';
 import type { PaginationOptions } from '../utils/pagination.js';
 import { validateTenantId, validateMobileNumber, rejectControlChars, validateStringLength } from '../utils/validation.js';
@@ -11,6 +11,10 @@ import { applyFieldMask } from '../utils/field-mask.js';
 export function registerUserTools(registry: ToolRegistry): void {
   registry.register({
     name: 'user_search',
+    // Admin, not the employee default: a read that returns citizen/employee PII
+    // or maps a tenant's access-control topology is reconnaissance for anyone
+    // below that tier, and its sibling WRITE tools in this same file are admin.
+    access: 'admin',
     group: 'admin',
     category: 'user',
     risk: 'read',
@@ -390,13 +394,4 @@ export function registerUserTools(registry: ToolRegistry): void {
   } satisfies ToolMetadata);
 }
 
-async function ensureAuthenticated(): Promise<void> {
-  if (digitApi.isAuthenticated()) return;
-  const username = process.env.CRS_USERNAME;
-  const password = process.env.CRS_PASSWORD;
-  const tenantId = process.env.CRS_TENANT_ID || digitApi.getEnvironmentInfo().stateTenantId;
-  if (!username || !password) {
-    throw new Error('Not authenticated. Call the "configure" tool first, or set CRS_USERNAME/CRS_PASSWORD env vars.');
-  }
-  await digitApi.login(username, password, tenantId);
-}
+

--- a/digit-mcp/src/tools/user.ts
+++ b/digit-mcp/src/tools/user.ts
@@ -137,6 +137,12 @@ export function registerUserTools(registry: ToolRegistry): void {
 
   registry.register({
     name: 'user_create',
+    // Returns a plaintext provisioning password (loginCredentials /
+    // citizenLogin). The session store keeps a 200-char prefix of every result
+    // in Postgres and the JSONL log, so without this the credential is
+    // persisted — harmless while the default is the published eGov@123, a real
+    // leak the moment an operator sets a strong one.
+    sensitiveOutput: true,
     group: 'admin',
     category: 'user',
     access: 'admin',

--- a/digit-mcp/src/tools/validators.ts
+++ b/digit-mcp/src/tools/validators.ts
@@ -2,6 +2,7 @@ import type { ToolMetadata, ValidationResult } from '../types/index.js';
 import { MDMS_SCHEMAS } from '../types/index.js';
 import type { ToolRegistry } from './registry.js';
 import { digitApi } from '../services/digit-api.js';
+import { ensureAuthenticated } from '../services/auth.js';
 import { validateTenantId, validateResourceId } from '../utils/validation.js';
 
 /**
@@ -629,6 +630,7 @@ export function registerValidatorTools(registry: ToolRegistry): void {
     name: 'boundary_create',
     group: 'boundary',
     category: 'boundary-mgmt',
+    access: 'admin',
     risk: 'write',
     description:
       'Create boundary hierarchy and entities from JSON. No Excel file needed — calls boundary-service APIs directly. ' +
@@ -934,6 +936,7 @@ export function registerValidatorTools(registry: ToolRegistry): void {
     name: 'boundary_mgmt_process',
     group: 'boundary',
     category: 'boundary-mgmt',
+    access: 'admin',
     risk: 'write',
     description:
       'Process (upload/update) boundary data via the boundary management service (egov-bndry-mgmnt). Submits resource details for boundary data processing. Requires a file with boundary data to be uploaded first via filestore.',
@@ -1030,6 +1033,7 @@ export function registerValidatorTools(registry: ToolRegistry): void {
     name: 'boundary_mgmt_generate',
     group: 'boundary',
     category: 'boundary-mgmt',
+    access: 'admin',
     risk: 'write',
     description:
       'Generate boundary codes via the boundary management service (egov-bndry-mgmnt). Creates boundary code mappings based on resource details. Typically used after processing boundary data.',
@@ -1120,18 +1124,3 @@ export function registerValidatorTools(registry: ToolRegistry): void {
 }
 
 // Auto-login helper
-async function ensureAuthenticated(): Promise<void> {
-  if (digitApi.isAuthenticated()) return;
-
-  const username = process.env.CRS_USERNAME;
-  const password = process.env.CRS_PASSWORD;
-  const tenantId = process.env.CRS_TENANT_ID || digitApi.getEnvironmentInfo().stateTenantId;
-
-  if (!username || !password) {
-    throw new Error(
-      'Not authenticated. Call the "configure" tool first, or set CRS_USERNAME/CRS_PASSWORD env vars.'
-    );
-  }
-
-  await digitApi.login(username, password, tenantId);
-}

--- a/digit-mcp/src/types/index.ts
+++ b/digit-mcp/src/types/index.ts
@@ -10,11 +10,36 @@ export type ToolGroup = 'core' | 'mdms' | 'boundary' | 'masters' | 'employees' |
 export const ALL_GROUPS: ToolGroup[] = ['core', 'mdms', 'boundary', 'masters', 'employees', 'localization', 'pgr', 'admin', 'idgen', 'location', 'encryption', 'docs', 'monitoring', 'tracing', 'snapshot'];
 
 // Tool metadata stored in the registry
+/**
+ * Minimum authorization a caller needs to invoke a tool.
+ *
+ * Authentication alone is not enough: DIGIT lets citizens self-register (PGR
+ * auto-provisions them), so "holds a valid token" is a low bar. This is the
+ * citizen/employee/admin boundary applied on top of identity.
+ *
+ * - `public`    — no role requirement. Only for tools that expose neither DIGIT
+ *                 data nor infrastructure detail (docs, discovery, health).
+ * - `employee`  — caller must not be a citizen-only account. The DEFAULT when a
+ *                 tool omits `access`, so a newly added tool is never public by
+ *                 accident.
+ * - `admin`     — caller must hold one of MCP_ADMIN_ROLES. For destructive or
+ *                 PII-revealing tools.
+ */
+export type ToolAccess = 'public' | 'employee' | 'admin';
+
 export interface ToolMetadata {
   name: string;
   group: ToolGroup;
   category: 'discovery' | 'environment' | 'mdms' | 'validation' | 'localization' | 'pgr' | 'workflow' | 'filestore' | 'access-control' | 'idgen' | 'location' | 'encryption' | 'boundary-mgmt' | 'hrms' | 'user' | 'docs' | 'monitoring' | 'tracing' | 'sessions' | 'snapshot';
   risk: 'read' | 'write';
+  /** Minimum caller authorization. Omitted => 'employee' (see ToolAccess). */
+  access?: ToolAccess;
+  /**
+   * Set when a tool's OUTPUT is sensitive (decrypted PII, credentials). The
+   * session store records a placeholder instead of the usual result prefix,
+   * so plaintext never lands in the events table or the JSONL log.
+   */
+  sensitiveOutput?: boolean;
   description: string;
   inputSchema: Record<string, unknown>;
   handler: (args: Record<string, unknown>) => Promise<string>;

--- a/digit-mcp/src/utils/redact.ts
+++ b/digit-mcp/src/utils/redact.ts
@@ -1,0 +1,38 @@
+/**
+ * Recursive credential redaction for anything we persist or log.
+ *
+ * Both the access log and the session store record tool arguments. They each
+ * used to compare four exact key names against top-level keys only, which meant
+ * `{ auth: { username, password } }` — the shape the REST shim documents — was
+ * written out verbatim, along with `apiKey`, `privateKey` and similar names.
+ *
+ * Matching is a case-insensitive substring test on the key, applied at every
+ * depth, so it fails closed: a new credential-ish field name is redacted
+ * without anyone remembering to add it.
+ */
+
+const SENSITIVE_KEY_PATTERNS = [
+  'password', 'passwd', 'pwd', 'secret', 'token', 'credential',
+  'apikey', 'api_key', 'privatekey', 'private_key', 'access_key', 'auth',
+];
+
+/** Guard against pathological nesting (and cycles, which JSON args can't have). */
+const MAX_REDACT_DEPTH = 8;
+
+export function isSensitiveKey(key: string): boolean {
+  const k = key.toLowerCase();
+  return SENSITIVE_KEY_PATTERNS.some((p) => k.includes(p));
+}
+
+export function redactDeep(value: unknown, depth = 0): unknown {
+  if (depth >= MAX_REDACT_DEPTH) return '[depth-limited]';
+  if (Array.isArray(value)) return value.map((v) => redactDeep(v, depth + 1));
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = isSensitiveKey(k) ? '***' : redactDeep(v, depth + 1);
+    }
+    return out;
+  }
+  return value;
+}

--- a/digit-mcp/src/utils/redact.ts
+++ b/digit-mcp/src/utils/redact.ts
@@ -13,8 +13,18 @@
 
 const SENSITIVE_WORDS = [
   'password', 'passwd', 'pwd', 'secret', 'token', 'credential', 'credentials',
-  'apikey', 'privatekey', 'passphrase', 'authorization', 'auth',
+  'apikey', 'privatekey', 'passphrase', 'authorization', 'auth', 'bearer',
+  'jwt', 'signature', 'sig', 'otp',
 ];
+
+/**
+ * Words that are only credential-ish next to a qualifier. `key` alone is far
+ * too common to redact on (`schemaKey`, `sortKey`), but `access_key`,
+ * `secretKey` and `signingKey` are credentials.
+ */
+const QUALIFIED_WORDS: Record<string, string[]> = {
+  key: ['access', 'secret', 'private', 'signing', 'encryption', 'api', 'session', 'hmac', 'client'],
+};
 
 /**
  * A key is sensitive when one of its WORDS is a credential word — where words
@@ -46,12 +56,38 @@ function keyWords(key: string): string[] {
     .filter(Boolean);
 }
 
+/**
+ * Ordinary English words that merely CONTAIN a credential word. Without this
+ * list, substring matching redacts `author` (auth), `authority` (auth),
+ * `tokenize` (token) and `secretary` (secret) out of the audit trail — which is
+ * the over-redaction this module was rewritten to stop. Listing the exceptions
+ * is what lets the substring test stay aggressive everywhere else.
+ */
+const BENIGN_WORDS = new Set([
+  'author', 'authors', 'authored', 'authoring', 'authorship',
+  'authority', 'authorities', 'authoritative',
+  'authentic', 'authenticity',
+  'tokenize', 'tokenized', 'tokenizer', 'tokenization', 'tokens',
+  'secretary', 'secretariat',
+]);
+
 export function isSensitiveKey(key: string): boolean {
   const words = keyWords(key);
-  if (words.some((w) => SENSITIVE_WORD_SET.has(w))) return true;
-  // Catch glued spellings a segmenter can't split, e.g. `mypassword`.
-  const collapsed = key.toLowerCase().replace(/[^a-z0-9]/g, '');
-  return SENSITIVE_WORDS.some((w) => w.length >= 6 && collapsed.includes(w));
+
+  // A qualified word: `key` alone is far too common to redact on (`sortKey`,
+  // `schemaKey`), but `access_key` / `secretKey` / `signingKey` are credentials.
+  for (const [word, qualifiers] of Object.entries(QUALIFIED_WORDS)) {
+    if (words.includes(word) && words.some((w) => qualifiers.includes(w))) return true;
+  }
+
+  return words.some((word) => {
+    if (SENSITIVE_WORD_SET.has(word)) return true;
+    if (BENIGN_WORDS.has(word)) return false;
+    // Glued spellings a segmenter cannot split: `authtoken`, `accesstoken`,
+    // `userpwd`, `mypassword`, `oauth`. Checked per WORD rather than over the
+    // whole key, so one benign word cannot mask a credential word beside it.
+    return SENSITIVE_WORDS.some((w) => word.includes(w));
+  });
 }
 
 export function redactDeep(value: unknown, depth = 0, seen?: WeakSet<object>): unknown {
@@ -60,15 +96,23 @@ export function redactDeep(value: unknown, depth = 0, seen?: WeakSet<object>): u
 
   // The session store is fed from server.ts as well as the REST shim, so the
   // "JSON args can't have cycles" assumption doesn't hold for every caller.
-  const visited = seen ?? new WeakSet<object>();
-  if (visited.has(value as object)) return '[circular]';
-  visited.add(value as object);
+  const onPath = seen ?? new WeakSet<object>();
+  if (onPath.has(value as object)) return '[circular]';
 
-  if (Array.isArray(value)) return value.map((v) => redactDeep(v, depth + 1, visited));
+  // Marked on the way down and UNMARKED on the way back up, so this tracks the
+  // current path rather than everything seen. A shared-but-acyclic object —
+  // `{ source: t, target: t }` — is not a cycle, and reporting the second
+  // occurrence as '[circular]' silently deleted real audit data.
+  onPath.add(value as object);
+  try {
+    if (Array.isArray(value)) return value.map((v) => redactDeep(v, depth + 1, onPath));
 
-  const out: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-    out[k] = isSensitiveKey(k) ? '***' : redactDeep(v, depth + 1, visited);
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = isSensitiveKey(k) ? '***' : redactDeep(v, depth + 1, onPath);
+    }
+    return out;
+  } finally {
+    onPath.delete(value as object);
   }
-  return out;
 }

--- a/digit-mcp/src/utils/redact.ts
+++ b/digit-mcp/src/utils/redact.ts
@@ -11,28 +11,64 @@
  * without anyone remembering to add it.
  */
 
-const SENSITIVE_KEY_PATTERNS = [
-  'password', 'passwd', 'pwd', 'secret', 'token', 'credential',
-  'apikey', 'api_key', 'privatekey', 'private_key', 'access_key', 'auth',
+const SENSITIVE_WORDS = [
+  'password', 'passwd', 'pwd', 'secret', 'token', 'credential', 'credentials',
+  'apikey', 'privatekey', 'passphrase', 'authorization', 'auth',
 ];
 
-/** Guard against pathological nesting (and cycles, which JSON args can't have). */
-const MAX_REDACT_DEPTH = 8;
+/**
+ * A key is sensitive when one of its WORDS is a credential word — where words
+ * are the camelCase / snake_case / kebab-case segments of the name.
+ *
+ * A plain substring test over-matched badly: `auth` swallowed `author` and
+ * `authority`, `token` swallowed `tokenize`. Those are ordinary tool arguments,
+ * and redacting them makes the audit trail less useful without making it safer.
+ * Segmenting keeps `access_token`, `apiKey` and `X-Auth-Token` while leaving
+ * `author` alone.
+ */
+const SENSITIVE_WORD_SET = new Set(SENSITIVE_WORDS);
 
-export function isSensitiveKey(key: string): boolean {
-  const k = key.toLowerCase();
-  return SENSITIVE_KEY_PATTERNS.some((p) => k.includes(p));
+/**
+ * Depth budget. Generous because it bounds a real payload, not an attack:
+ * `mdms_create` / `tenant_bootstrap` arguments nest deeply, and the previous
+ * limit of 8 replaced genuine data with a placeholder in both the access log
+ * and the events table — discarding exactly the arguments worth auditing.
+ * Cycles are handled separately, so this only has to stop runaway recursion.
+ */
+const MAX_REDACT_DEPTH = 64;
+
+/** Split a key into lower-cased words across camelCase and separators. */
+function keyWords(key: string): string[] {
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .split(/[^a-zA-Z0-9]+/)
+    .map((w) => w.toLowerCase())
+    .filter(Boolean);
 }
 
-export function redactDeep(value: unknown, depth = 0): unknown {
+export function isSensitiveKey(key: string): boolean {
+  const words = keyWords(key);
+  if (words.some((w) => SENSITIVE_WORD_SET.has(w))) return true;
+  // Catch glued spellings a segmenter can't split, e.g. `mypassword`.
+  const collapsed = key.toLowerCase().replace(/[^a-z0-9]/g, '');
+  return SENSITIVE_WORDS.some((w) => w.length >= 6 && collapsed.includes(w));
+}
+
+export function redactDeep(value: unknown, depth = 0, seen?: WeakSet<object>): unknown {
   if (depth >= MAX_REDACT_DEPTH) return '[depth-limited]';
-  if (Array.isArray(value)) return value.map((v) => redactDeep(v, depth + 1));
-  if (value && typeof value === 'object') {
-    const out: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      out[k] = isSensitiveKey(k) ? '***' : redactDeep(v, depth + 1);
-    }
-    return out;
+  if (!value || typeof value !== 'object') return value;
+
+  // The session store is fed from server.ts as well as the REST shim, so the
+  // "JSON args can't have cycles" assumption doesn't hold for every caller.
+  const visited = seen ?? new WeakSet<object>();
+  if (visited.has(value as object)) return '[circular]';
+  visited.add(value as object);
+
+  if (Array.isArray(value)) return value.map((v) => redactDeep(v, depth + 1, visited));
+
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    out[k] = isSensitiveKey(k) ? '***' : redactDeep(v, depth + 1, visited);
   }
-  return value;
+  return out;
 }

--- a/digit-mcp/test-security-http.ts
+++ b/digit-mcp/test-security-http.ts
@@ -1,0 +1,440 @@
+/**
+ * Integration tests for the MCP security boundary — the ENFORCEMENT side.
+ *
+ * `test-security.ts` covers the policy functions (does checkToolAccess decide
+ * correctly?). This suite covers the question that one structurally cannot:
+ * **is the check actually called, on every route?**
+ *
+ * That gap was found by mutation testing — deleting the `checkToolAccess` call
+ * from server.ts, or `authorizeRest` from a REST dispatch path, or the whole
+ * `/api/*` gate, left the unit suite at 57/57 green. Those are the regressions
+ * a refactor is most likely to introduce, so they are tested here against a
+ * real server over a real socket.
+ *
+ * A stub DIGIT stands in for egov-user: it mints tokens whose roles are
+ * determined by the token string, so identity is controllable without a live
+ * platform. Nothing here needs network access.
+ *
+ * Run: npm run test:security:http
+ */
+
+import assert from 'node:assert/strict';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { createServer, type Server } from 'node:http';
+import { readFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// --- Test runner ---------------------------------------------------------
+
+const passed: string[] = [];
+const failed: string[] = [];
+
+async function test(name: string, fn: () => Promise<void> | void): Promise<void> {
+  try {
+    await fn();
+    passed.push(name);
+    console.log(`  \x1b[32mPASS\x1b[0m  ${name}`);
+  } catch (err) {
+    failed.push(name);
+    console.log(`  \x1b[31mFAIL\x1b[0m  ${name}`);
+    console.log(`        ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+// --- Stub DIGIT ----------------------------------------------------------
+
+/**
+ * Token -> identity. The MCP server introspects against `/user/_details`, so
+ * this is the whole of "who is the caller" as far as it is concerned.
+ */
+const IDENTITIES: Record<string, { userName: string; tenantId: string; roles: string[] }> = {
+  'tok-admin':   { userName: 'admin-1',   tenantId: 'pg',       roles: ['SUPERUSER'] },
+  'tok-emp':     { userName: 'gro-1',     tenantId: 'pg.citya', roles: ['GRO', 'PGR_LME'] },
+  'tok-citizen': { userName: 'citizen-1', tenantId: 'pg',       roles: ['CITIZEN'] },
+  // A self-registered citizen carries type EMPLOYEE (pgr_create provisions
+  // them that way) but only the CITIZEN role — the case that makes keying on
+  // user.type instead of roles a privilege bug.
+  'tok-provisioned': { userName: 'prov-1', tenantId: 'pg', roles: ['CITIZEN'] },
+};
+
+function startStubDigit(): Promise<{ server: Server; port: number }> {
+  return new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      const url = new URL(req.url || '/', 'http://stub');
+      if (url.pathname === '/user/_details') {
+        const token = url.searchParams.get('access_token') || '';
+        const id = IDENTITIES[token];
+        if (!id) {
+          res.writeHead(404, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ Errors: [{ code: 'InvalidAccessTokenException' }] }));
+          return;
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          UserRequest: {
+            userName: id.userName,
+            name: id.userName,
+            tenantId: id.tenantId,
+            type: token === 'tok-provisioned' ? 'EMPLOYEE' : undefined,
+            roles: id.roles.map((code) => ({ code, name: code, tenantId: id.tenantId })),
+          },
+        }));
+        return;
+      }
+      if (url.pathname === '/user/oauth/token') {
+        // body.auth -> digitApi.login(). Any username maps to the admin
+        // identity; the point under test is that the path still works and is
+        // still authorized, not the credential check itself.
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          access_token: 'tok-admin',
+          UserRequest: {
+            userName: 'admin-1', name: 'admin-1', tenantId: 'pg',
+            roles: [{ code: 'SUPERUSER', name: 'SUPERUSER', tenantId: 'pg' }],
+          },
+        }));
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end('{}');
+    });
+    server.listen(0, '127.0.0.1', () => {
+      resolve({ server, port: (server.address() as { port: number }).port });
+    });
+  });
+}
+
+/** Reserve an ephemeral port, then free it for the server under test. */
+function freePort(): Promise<number> {
+  return new Promise((resolve) => {
+    const s = createServer();
+    s.listen(0, '127.0.0.1', () => {
+      const port = (s.address() as { port: number }).port;
+      s.close(() => resolve(port));
+    });
+  });
+}
+
+// --- Harness -------------------------------------------------------------
+
+const dataDir = mkdtempSync(join(tmpdir(), 'mcp-http-test-'));
+const logFile = join(dataDir, 'access.log');
+const stub = await startStubDigit();
+const port = await freePort();
+const base = `http://127.0.0.1:${port}`;
+
+const child: ChildProcess = spawn('node', ['dist/index.js'], {
+  env: {
+    ...process.env,
+    MCP_TRANSPORT: 'http',
+    MCP_PORT: String(port),
+    MCP_AUTH_MODE: '',              // exercise the transport-derived default
+    CRS_API_URL: `http://127.0.0.1:${stub.port}`,
+    CRS_ENVIRONMENT: 'self-hosted',
+    // Present on purpose: this is the configuration in which an anonymous
+    // caller used to be elevated to the container's stored ADMIN.
+    CRS_USERNAME: 'ADMIN',
+    CRS_PASSWORD: 'secret',
+    SESSION_DATA_DIR: dataDir,
+    MCP_LOG_FILE: logFile,
+    MCP_ARTIFACT_DIR: join(dataDir, 'artifacts'),
+    MCP_CORS_ORIGINS: '*',
+    TELEMETRY: 'false',
+  },
+  stdio: ['ignore', 'ignore', 'pipe'],
+});
+
+let serverStderr = '';
+child.stderr?.on('data', (c: Buffer) => { serverStderr += c.toString(); });
+
+async function waitForServer(): Promise<void> {
+  for (let i = 0; i < 100; i++) {
+    try {
+      const res = await fetch(`${base}/healthz`);
+      if (res.ok) return;
+    } catch { /* not up yet */ }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`server did not start.\n${serverStderr}`);
+}
+
+function cleanup(): void {
+  child.kill('SIGKILL');
+  stub.server.close();
+  rmSync(dataDir, { recursive: true, force: true });
+}
+
+process.on('exit', cleanup);
+
+await waitForServer();
+
+// --- Helpers -------------------------------------------------------------
+
+interface Res { status: number; body: string; json: Record<string, unknown> }
+
+async function call(path: string, opts: { token?: string; method?: string; body?: unknown; headers?: Record<string, string> } = {}): Promise<Res> {
+  const res = await fetch(`${base}${path}`, {
+    method: opts.method || (opts.body ? 'POST' : 'GET'),
+    headers: {
+      ...(opts.body ? { 'Content-Type': 'application/json' } : {}),
+      ...(opts.token ? { Authorization: `Bearer ${opts.token}` } : {}),
+      ...opts.headers,
+    },
+    body: opts.body ? JSON.stringify(opts.body) : undefined,
+  });
+  const body = await res.text();
+  let json: Record<string, unknown> = {};
+  try { json = JSON.parse(body); } catch { /* non-JSON */ }
+  return { status: res.status, body, json };
+}
+
+/** Invoke an MCP tool over JSON-RPC and return the decoded tool payload. */
+async function mcpTool(tool: string, token?: string, args: Record<string, unknown> = {}): Promise<Res> {
+  const res = await call('/mcp', {
+    token,
+    headers: { Accept: 'application/json, text/event-stream' },
+    body: { jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: tool, arguments: args } },
+  });
+  if (res.status !== 200) return res;
+  // Stateless transport replies as SSE; pull the JSON-RPC frame out of it.
+  const frame = res.body.includes('data: ') ? res.body.split('data: ').pop()!.trim() : res.body;
+  try {
+    const rpc = JSON.parse(frame);
+    const text = rpc?.result?.content?.[0]?.text;
+    return { status: 200, body: text ?? frame, json: text ? JSON.parse(text) : rpc };
+  } catch {
+    return res;
+  }
+}
+
+// =========================================================================
+console.log('\n\x1b[1mA. Anonymous reachability\x1b[0m');
+// =========================================================================
+// CRS_USERNAME/CRS_PASSWORD are set in this server's env. Before the fix, that
+// is exactly what made an unauthenticated caller act as ADMIN.
+
+await test('A.1 /healthz is open (orchestrator liveness, gatus)', async () => {
+  assert.equal((await call('/healthz')).status, 200);
+});
+
+await test('A.2 anonymous /mcp is refused', async () => {
+  const r = await call('/mcp', { body: { jsonrpc: '2.0', id: 1, method: 'tools/list' } });
+  assert.equal(r.status, 401);
+});
+
+await test('A.3 anonymous /v1/* is refused (no env-credential fallback)', async () => {
+  for (const [path, body] of [
+    ['/v1/tools', undefined],
+    ['/v1/tools/discover_tools', {}],
+    ['/v1/tools/discover_tools/bulk', { items: [{}] }],
+    ['/v1/tenant/bootstrap', { target_tenant: 'x' }],
+    ['/v1/tenant/cleanup', { tenant_id: 'pg.x' }],
+    ['/v1/tenant/x/export', {}],
+  ] as const) {
+    const r = await call(path, body ? { body } : {});
+    assert.equal(r.status, 401, `${path} returned ${r.status}, expected 401`);
+  }
+});
+
+await test('A.4 anonymous /api/* is refused', async () => {
+  for (const path of ['/api/stats', '/api/sessions', '/api/pgr/dashboard']) {
+    assert.equal((await call(path)).status, 401, path);
+  }
+});
+
+await test('A.5 an unrecognised bearer token is refused everywhere', async () => {
+  for (const path of ['/api/stats', '/v1/tools']) {
+    const r = await call(path, { token: 'not-a-real-token' });
+    assert.equal(r.status, 401, path);
+  }
+  const rpc = await call('/mcp', { token: 'not-a-real-token', body: { jsonrpc: '2.0', id: 1, method: 'tools/list' } });
+  assert.equal(rpc.status, 401);
+});
+
+await test('A.6 CORS preflight is answered without credentials', async () => {
+  // A preflight never carries Authorization. Gating it 401s the preflight and
+  // the real request is never sent, silently breaking cross-origin clients.
+  for (const path of ['/api/stats', '/v1/tools', '/mcp']) {
+    const r = await call(path, {
+      method: 'OPTIONS',
+      headers: { Origin: 'http://dash.test', 'Access-Control-Request-Method': 'GET' },
+    });
+    assert.equal(r.status, 204, `${path} preflight returned ${r.status}`);
+  }
+});
+
+// =========================================================================
+console.log('\n\x1b[1mB. Tier enforcement on the MCP path\x1b[0m');
+// =========================================================================
+
+await test('B.1 a citizen is refused an employee-tier tool', async () => {
+  const r = await mcpTool('user_search', 'tok-citizen', { tenant_id: 'pg' });
+  assert.equal(r.json.code, 403, `expected 403, got ${JSON.stringify(r.json).slice(0, 120)}`);
+  assert.equal(r.json.category, 'auth');
+});
+
+await test('B.2 an employee is refused an admin-tier tool', async () => {
+  const r = await mcpTool('tenant_cleanup', 'tok-emp', { tenant_id: 'pg.x' });
+  assert.equal(r.json.code, 403);
+  assert.match(String(r.json.error), /SUPERUSER/);
+});
+
+await test('B.3 an admin passes the admin tier (reaches the handler)', async () => {
+  const r = await mcpTool('get_environment_info', 'tok-admin');
+  assert.notEqual(r.json.code, 403);
+  assert.equal(r.json.success, true);
+});
+
+await test('B.4 a public tool is reachable by a citizen', async () => {
+  const r = await mcpTool('discover_tools', 'tok-citizen');
+  assert.notEqual(r.json.code, 403, 'public tier must not require a role');
+});
+
+await test('B.5 type=EMPLOYEE with only the CITIZEN role is still a citizen', async () => {
+  // Regression guard for keying on user.type instead of roles.
+  const r = await mcpTool('user_search', 'tok-provisioned', { tenant_id: 'pg' });
+  assert.equal(r.json.code, 403, 'a provisioned citizen must not reach staff tooling');
+});
+
+// =========================================================================
+console.log('\n\x1b[1mC. Tier enforcement on the REST paths\x1b[0m');
+// =========================================================================
+
+await test('C.1 single dispatch authorizes', async () => {
+  const r = await call('/v1/tools/tenant_cleanup', { token: 'tok-emp', body: { tenant_id: 'pg.x' } });
+  assert.equal(r.status, 403);
+});
+
+await test('C.2 bulk dispatch authorizes', async () => {
+  const r = await call('/v1/tools/tenant_cleanup/bulk', {
+    token: 'tok-emp',
+    body: { items: [{ tenant_id: 'pg.x' }] },
+  });
+  assert.equal(r.status, 403, `bulk returned ${r.status}`);
+});
+
+await test('C.3 streamed dispatch authorizes', async () => {
+  const res = await fetch(`${base}/v1/tenant/bootstrap?stream=1`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'text/event-stream', Authorization: 'Bearer tok-emp' },
+    body: JSON.stringify({ target_tenant: 'x' }),
+  });
+  const text = await res.text();
+  assert.match(text, /event: error/, 'SSE denial must emit an error event');
+  assert.match(text, /requires one of these roles/, 'and carry the tier denial');
+});
+
+await test('C.4 tenant export authorizes (not a registered tool)', async () => {
+  const r = await call('/v1/tenant/pg/export', { token: 'tok-emp', body: {} });
+  assert.equal(r.status, 403);
+});
+
+await test('C.5 a citizen is refused an employee-tier tool over REST', async () => {
+  const r = await call('/v1/tools/user_search', { token: 'tok-citizen', body: { tenant_id: 'pg' } });
+  assert.equal(r.status, 403);
+});
+
+await test('C.6 body.auth (Form 2) still authenticates and is authorized', async () => {
+  // The Ansible playbook drives /v1/tenant/bootstrap with an `auth` envelope
+  // rather than a header (local-setup/ansible/playbook-deploy.yml). Token mode
+  // must not break that path — it supplies real credentials, so it stays.
+  const r = await call('/v1/tools/get_environment_info', {
+    body: { auth: { username: 'ADMIN', password: 'eGov@123', tenant_id: 'pg' } },
+  });
+  assert.equal(r.status, 200, `Form 2 returned ${r.status}: ${r.body.slice(0, 120)}`);
+});
+
+// =========================================================================
+console.log('\n\x1b[1mD. The /api/* gate\x1b[0m');
+// =========================================================================
+
+await test('D.1 a citizen is refused (admin tier)', async () => {
+  const r = await call('/api/sessions', { token: 'tok-citizen' });
+  assert.equal(r.status, 403);
+});
+
+await test('D.2 an employee is refused (admin tier)', async () => {
+  assert.equal((await call('/api/stats', { token: 'tok-emp' })).status, 403);
+});
+
+await test('D.3 an admin is admitted', async () => {
+  const r = await call('/api/stats', { token: 'tok-admin' });
+  assert.equal(r.status, 200);
+});
+
+await test('D.4 the gate covers the whole namespace, not listed routes', async () => {
+  // A route added later must be authenticated by default.
+  for (const path of ['/api/sessions', '/api/sessions/00000000-0000-0000-0000-000000000000/events', '/api/pgr/dashboard']) {
+    assert.equal((await call(path, { token: 'tok-citizen' })).status, 403, path);
+  }
+});
+
+// =========================================================================
+console.log('\n\x1b[1mE. Error mapping and audit\x1b[0m');
+// =========================================================================
+
+await test('E.1 a tier denial is logged as tool_denied', async () => {
+  await mcpTool('tenant_cleanup', 'tok-emp', { tenant_id: 'pg.x' });
+  assert.match(readFileSync(logFile, 'utf-8'), /"event":"tool_denied"/);
+});
+
+await test('E.2 an /api/* denial is logged as api_denied', async () => {
+  await call('/api/stats', { token: 'tok-emp' });
+  assert.match(readFileSync(logFile, 'utf-8'), /"event":"api_denied"/);
+});
+
+await test('E.3 REST tool calls are audited, not just denials', async () => {
+  // server.ts wraps the MCP path in mcpLogger/sessionStore; the REST paths
+  // called tool.handler() directly, so every successful /v1/* invocation —
+  // tenant_destroy included — left no trace at all.
+  await call('/v1/tools/discover_tools', { token: 'tok-admin', body: {} });
+  const log = readFileSync(logFile, 'utf-8');
+  assert.match(log, /"event":"tool_call".*"tool":"discover_tools"/, 'no tool_call recorded for the REST invocation');
+  assert.match(log, /"event":"tool_result".*"tool":"discover_tools"/, 'no tool_result recorded');
+});
+
+await test('E.4 credentials are redacted in the audit log', async () => {
+  await call('/v1/tools/discover_tools', {
+    token: 'tok-admin',
+    body: { auth: { username: 'u', password: 'sup3rs3cret' }, nested: { apiKey: 'k3y' } },
+  });
+  const log = readFileSync(logFile, 'utf-8');
+  assert.ok(!log.includes('sup3rs3cret'), 'password reached the access log');
+  assert.ok(!log.includes('k3y'), 'apiKey reached the access log');
+});
+
+await test('E.5 the audit line carries the resolved caller, not a spoofed IP', async () => {
+  await call('/v1/tools/discover_tools', {
+    token: 'tok-admin',
+    body: {},
+    headers: { 'X-Forwarded-For': '9.9.9.9' },
+  });
+  const log = readFileSync(logFile, 'utf-8');
+  assert.match(log, /"event":"untrusted_forwarded_for"|"user":"admin-1"/,
+    'expected the caller identity or an untrusted-XFF note');
+  const toolLines = log.split('\n').filter((l) => l.includes('"event":"tool_call"'));
+  assert.ok(!toolLines.some((l) => l.includes('9.9.9.9')), 'a spoofed X-Forwarded-For reached the audit trail');
+});
+
+// =========================================================================
+console.log('\n\x1b[1mF. Ambient mode is a deliberate opt-out\x1b[0m');
+// =========================================================================
+
+await test('F.1 the transport-derived default is token mode', async () => {
+  // MCP_AUTH_MODE was passed empty, so this asserts the derivation itself —
+  // an HTTP deployment is closed without any extra configuration.
+  assert.equal((await call('/api/stats')).status, 401);
+  assert.ok(!serverStderr.includes('MCP_AUTH_MODE=ambient'), 'ambient warning should not fire in token mode');
+});
+
+// --- Summary -------------------------------------------------------------
+
+cleanup();
+
+console.log('\n' + '='.repeat(60));
+console.log(`  Results: ${passed.length} passed, ${failed.length} failed`);
+if (failed.length > 0) console.log(`  Failed: ${failed.join(', ')}`);
+console.log('='.repeat(60) + '\n');
+
+process.exit(failed.length > 0 ? 1 : 0);

--- a/digit-mcp/test-security-http.ts
+++ b/digit-mcp/test-security-http.ts
@@ -58,11 +58,19 @@ const IDENTITIES: Record<string, { userName: string; tenantId: string; roles: st
   'tok-provisioned': { userName: 'prov-1', tenantId: 'pg', roles: ['CITIZEN'] },
 };
 
+/** Flipped by the outage test to make the stub fail like a downed egov-user. */
+let stubOutage = false;
+
 function startStubDigit(): Promise<{ server: Server; port: number }> {
   return new Promise((resolve) => {
     const server = createServer((req, res) => {
       const url = new URL(req.url || '/', 'http://stub');
       if (url.pathname === '/user/_details') {
+        if (stubOutage) {
+          res.writeHead(502, { 'Content-Type': 'application/json' });
+          res.end('{"error":"upstream unavailable"}');
+          return;
+        }
         const token = url.searchParams.get('access_token') || '';
         const id = IDENTITIES[token];
         if (!id) {
@@ -314,15 +322,34 @@ await test('C.2 bulk dispatch authorizes', async () => {
   assert.equal(r.status, 403, `bulk returned ${r.status}`);
 });
 
-await test('C.3 streamed dispatch authorizes', async () => {
+await test('C.3 streamed dispatch authorizes BEFORE committing 200', async () => {
+  // A denial must be a real 403, not a 200 stream carrying `event: error` —
+  // any client keying on the status code reads the latter as success.
   const res = await fetch(`${base}/v1/tenant/bootstrap?stream=1`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Accept: 'text/event-stream', Authorization: 'Bearer tok-emp' },
     body: JSON.stringify({ target_tenant: 'x' }),
   });
-  const text = await res.text();
-  assert.match(text, /event: error/, 'SSE denial must emit an error event');
-  assert.match(text, /requires one of these roles/, 'and carry the tier denial');
+  assert.equal(res.status, 403, `SSE denial returned ${res.status}`);
+  assert.match(await res.text(), /requires one of these roles/);
+});
+
+await test('C.7 an unknown tool is not distinguishable before authenticating', async () => {
+  // 404-for-unknown vs 401-for-known let an anonymous caller enumerate the
+  // whole tool surface by diffing status codes.
+  const known = await call('/v1/tools/tenant_cleanup', { body: {} });
+  const unknown = await call('/v1/tools/no_such_tool_xyz', { body: {} });
+  assert.equal(known.status, 401);
+  assert.equal(unknown.status, 401, 'an unknown tool leaked a distinguishable 404');
+});
+
+await test('C.8 /v1/version withholds build detail from anonymous callers', async () => {
+  const anon = await call('/v1/version');
+  assert.equal(anon.status, 200, 'must stay usable as a liveness probe');
+  assert.equal(anon.json.gitSha, undefined, 'build metadata leaked');
+  assert.equal(anon.json.nodeVersion, undefined, 'runtime version leaked');
+  const authed = await call('/v1/version', { token: 'tok-admin' });
+  assert.ok('nodeVersion' in authed.json, 'an authenticated caller should still see it');
 });
 
 await test('C.4 tenant export authorizes (not a registered tool)', async () => {
@@ -415,6 +442,21 @@ await test('E.5 the audit line carries the resolved caller, not a spoofed IP', a
     'expected the caller identity or an untrusted-XFF note');
   const toolLines = log.split('\n').filter((l) => l.includes('"event":"tool_call"'));
   assert.ok(!toolLines.some((l) => l.includes('9.9.9.9')), 'a spoofed X-Forwarded-For reached the audit trail');
+});
+
+await test('E.6 an identity-service outage is 503, not "invalid token"', async () => {
+  // A 5xx or an unreachable egov-user reported as 401 sends the operator after
+  // credentials while the platform is down — and makes the viewer discard a
+  // perfectly good token, forcing a re-login across the fleet.
+  stubOutage = true;
+  try {
+    // A token the cache has not seen, so it must go to the wire.
+    const r = await call('/api/stats', { token: 'tok-never-seen-before' });
+    assert.equal(r.status, 503, `expected 503, got ${r.status}: ${r.body.slice(0, 120)}`);
+    assert.match(String(r.json.error), /not a problem with your credentials/);
+  } finally {
+    stubOutage = false;
+  }
 });
 
 // =========================================================================

--- a/digit-mcp/test-security-http.ts
+++ b/digit-mcp/test-security-http.ts
@@ -21,7 +21,7 @@
 import assert from 'node:assert/strict';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { createServer, type Server } from 'node:http';
-import { readFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, readFileSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -341,6 +341,61 @@ await test('C.7 an unknown tool is not distinguishable before authenticating', a
   const unknown = await call('/v1/tools/no_such_tool_xyz', { body: {} });
   assert.equal(known.status, 401);
   assert.equal(unknown.status, 401, 'an unknown tool leaked a distinguishable 404');
+});
+
+await test('C.6b an authorized SSE request still streams (single auth, not none)', async () => {
+  // runStreamed now authenticates once up front and re-applies the identity in
+  // the body block instead of authenticating again. The risk of that change is
+  // the opposite of a denial: an ALLOWED caller losing its identity and the
+  // stream failing or running unauthenticated.
+  const res = await fetch(`${base}/v1/tenant/cleanup?stream=1`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'text/event-stream', Authorization: 'Bearer tok-admin' },
+    body: JSON.stringify({ tenant_id: 'pg.ssetest' }),
+  });
+  assert.equal(res.status, 200, 'an admin SSE call must open the stream');
+  const text = await res.text();
+  assert.ok(/event: (progress|done|error)/.test(text), `no SSE frames: ${text.slice(0, 160)}`);
+  // Whatever the tool did, it must not have been refused for identity reasons.
+  assert.ok(!/requires one of these roles|Authentication required/.test(text),
+    `the re-applied identity was lost: ${text.slice(0, 200)}`);
+});
+
+await test('C.7b the bulk route is not an oracle either', () => {
+  // dispatchTool was fixed and runBulk was not; the sibling route enumerated
+  // the whole tool surface just as well.
+  return Promise.all([
+    call('/v1/tools/tenant_destroy/bulk', { body: { items: [{}] } }),
+    call('/v1/tools/no_such_tool_xyz/bulk', { body: { items: [{}] } }),
+  ]).then(([known, unknown]) => {
+    assert.equal(known.status, 401);
+    assert.equal(unknown.status, 401, 'the bulk route leaked a distinguishable 404');
+  });
+});
+
+await test('C.9 a REST-only deployment records to the session store', async () => {
+  // recordToolCall is a no-op until a session exists, and only /mcp created
+  // one — so the ansible/runbook path produced an access-log line and nothing
+  // the operator console can read.
+  const marker = `rest-only-${Date.now()}`;
+  await call('/v1/tools/discover_tools', { token: 'tok-admin', body: { _marker: marker } });
+  const events = join(dataDir, 'events.jsonl');
+  assert.ok(existsSync(events), 'no events.jsonl was written for a REST-only call');
+  assert.match(readFileSync(events, 'utf-8'), /"tool":"discover_tools"/);
+});
+
+await test('C.10 an oversized body is refused before authentication', async () => {
+  // readBody buffered without a cap, ahead of every gate, so one anonymous
+  // request could kill the process on its memory limit.
+  const res = await fetch(`${base}/v1/tools/discover_tools`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: 'x'.repeat(17 * 1024 * 1024),
+  }).catch((e) => ({ status: 0, err: String(e) } as never));
+  assert.ok([413, 0].includes((res as { status: number }).status),
+    `expected 413 (or a torn-down socket), got ${(res as { status: number }).status}`);
+  // And the server is still alive.
+  assert.equal((await call('/healthz')).status, 200, 'server died on an oversized body');
 });
 
 await test('C.8 /v1/version withholds build detail from anonymous callers', async () => {

--- a/digit-mcp/test-security.ts
+++ b/digit-mcp/test-security.ts
@@ -1,0 +1,616 @@
+/**
+ * Unit tests for the MCP security boundary (tracked in #1641).
+ *
+ * These cover the invariants the hardening work established, so a later
+ * refactor breaks a test rather than the boundary:
+ *
+ *   1. auth mode derivation      — HTTP defaults to token, stdio to ambient
+ *   2. tool access tiers         — citizen / employee / admin, per identity
+ *   3. tool classification       — no tool is public by accident
+ *   4. deep redaction            — credentials at any depth, any casing
+ *   5. artifact path confinement — traversal, siblings, absolutes
+ *   6. base_url allow-list       — SSRF / credential-exfiltration guard
+ *   7. X-Forwarded-For trust     — IPv4 and IPv6, CIDR and literal
+ *   8. request isolation         — concurrent callers can't see each other
+ *
+ * No DIGIT API needed: everything here is pure logic or in-process state.
+ *
+ * Run: npm run test:security
+ */
+
+import assert from 'node:assert/strict';
+import {
+  adminRoleCodes,
+  allowedBaseUrlHosts,
+  checkBaseUrlAllowed,
+  checkToolAccess,
+  getAuthMode,
+  isAdminCaller,
+  parseBearer,
+  resolveArtifactPath,
+  resolveClientIp,
+} from './src/services/auth.js';
+import { digitApi, runWithIsolatedClient } from './src/services/digit-api.js';
+import { getRequestContext, runWithRequestContext } from './src/services/request-context.js';
+import { ToolRegistry } from './src/tools/registry.js';
+import { registerAllTools } from './src/tools/index.js';
+import type { ToolAccess, UserInfo } from './src/types/index.js';
+import { isSensitiveKey, redactDeep } from './src/utils/redact.js';
+
+// --- Test runner (same pattern as test-agent-safety.ts) ---
+
+const passed: string[] = [];
+const failed: string[] = [];
+
+async function test(name: string, fn: () => void | Promise<void>): Promise<void> {
+  const start = Date.now();
+  try {
+    await fn();
+    passed.push(name);
+    console.log(`  \x1b[32mPASS\x1b[0m  ${name} \x1b[90m(${Date.now() - start}ms)\x1b[0m`);
+  } catch (err) {
+    failed.push(name);
+    console.log(`  \x1b[31mFAIL\x1b[0m  ${name} \x1b[90m(${Date.now() - start}ms)\x1b[0m`);
+    console.log(`        ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+/** Run `fn` with env vars applied, restoring whatever was there before. */
+function withEnv(vars: Record<string, string | undefined>, fn: () => void): void {
+  const saved: Record<string, string | undefined> = {};
+  for (const [k, v] of Object.entries(vars)) {
+    saved[k] = process.env[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  try {
+    fn();
+  } finally {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+const user = (userName: string, roles: string[], tenantId = 'pg'): UserInfo => ({
+  userName,
+  name: userName,
+  tenantId,
+  roles: roles.map((code) => ({ code, name: code })),
+});
+
+const CITIZEN = user('citizen-1', ['CITIZEN']);
+const EMPLOYEE = user('gro-1', ['GRO', 'PGR_LME']);
+const ADMIN = user('admin-1', ['SUPERUSER']);
+const ROLELESS = user('ghost', []);
+
+// =====================================================================
+// 1. Auth mode derivation
+// =====================================================================
+
+console.log('\n\x1b[1m1. Auth mode\x1b[0m');
+
+await test('1.1 HTTP transport defaults to token mode', () => {
+  withEnv({ MCP_TRANSPORT: 'http', MCP_AUTH_MODE: undefined }, () => {
+    assert.equal(getAuthMode(), 'token');
+  });
+});
+
+await test('1.2 stdio transport defaults to ambient mode', () => {
+  withEnv({ MCP_TRANSPORT: undefined, MCP_AUTH_MODE: undefined }, () => {
+    assert.equal(getAuthMode(), 'ambient');
+  });
+});
+
+await test('1.3 MCP_AUTH_MODE overrides the derivation in both directions', () => {
+  withEnv({ MCP_TRANSPORT: 'http', MCP_AUTH_MODE: 'ambient' }, () => {
+    assert.equal(getAuthMode(), 'ambient');
+  });
+  withEnv({ MCP_TRANSPORT: undefined, MCP_AUTH_MODE: 'token' }, () => {
+    assert.equal(getAuthMode(), 'token');
+  });
+});
+
+await test('1.4 an unrecognised MCP_AUTH_MODE falls back to the transport default', () => {
+  withEnv({ MCP_TRANSPORT: 'http', MCP_AUTH_MODE: 'yes-please' }, () => {
+    assert.equal(getAuthMode(), 'token', 'a typo must not silently disable auth');
+  });
+});
+
+await test('1.5 parseBearer accepts only a non-empty Bearer credential', () => {
+  assert.equal(parseBearer('Bearer abc123'), 'abc123');
+  assert.equal(parseBearer('bearer abc123'), 'abc123', 'scheme is case-insensitive');
+  assert.equal(parseBearer('Bearer   '), null, 'whitespace-only is not a token');
+  assert.equal(parseBearer('Basic abc123'), null);
+  assert.equal(parseBearer(undefined), null);
+});
+
+// =====================================================================
+// 2. Tool access tiers
+// =====================================================================
+
+console.log('\n\x1b[1m2. Tool access tiers\x1b[0m');
+
+const inToken = (fn: () => void) => withEnv({ MCP_TRANSPORT: 'http', MCP_AUTH_MODE: 'token' }, fn);
+
+await test('2.1 ambient mode skips authorization entirely', () => {
+  withEnv({ MCP_TRANSPORT: undefined, MCP_AUTH_MODE: 'ambient' }, () => {
+    assert.equal(checkToolAccess('tenant_cleanup', 'admin', null), null);
+  });
+});
+
+await test('2.2 public tools need no identity', () => {
+  inToken(() => {
+    assert.equal(checkToolAccess('docs_search', 'public', null), null);
+    assert.equal(checkToolAccess('docs_search', 'public', CITIZEN), null);
+  });
+});
+
+await test('2.3 a citizen-only account is refused employee tools', () => {
+  inToken(() => {
+    const denial = checkToolAccess('pgr_create', 'employee', CITIZEN);
+    assert.ok(denial, 'expected a denial');
+    assert.match(denial!, /staff \(non-citizen\) account/);
+  });
+});
+
+await test('2.4 a roleless account is refused employee tools', () => {
+  inToken(() => {
+    assert.ok(checkToolAccess('pgr_create', 'employee', ROLELESS));
+  });
+});
+
+await test('2.5 staff roles pass the employee tier but not the admin tier', () => {
+  inToken(() => {
+    assert.equal(checkToolAccess('pgr_create', 'employee', EMPLOYEE), null);
+    assert.ok(checkToolAccess('tenant_cleanup', 'admin', EMPLOYEE));
+  });
+});
+
+await test('2.6 an admin role passes every tier', () => {
+  inToken(() => {
+    for (const tier of ['public', 'employee', 'admin'] as ToolAccess[]) {
+      assert.equal(checkToolAccess('t', tier, ADMIN), null, `admin should pass ${tier}`);
+    }
+  });
+});
+
+await test('2.7 omitted access defaults to employee, never public', () => {
+  inToken(() => {
+    assert.ok(checkToolAccess('newly_added_tool', undefined, CITIZEN),
+      'a tool that forgets to declare access must not be reachable by a citizen');
+    assert.equal(checkToolAccess('newly_added_tool', undefined, EMPLOYEE), null);
+  });
+});
+
+await test('2.8 a missing user is refused anything above public', () => {
+  inToken(() => {
+    assert.ok(checkToolAccess('pgr_create', 'employee', null));
+    assert.ok(checkToolAccess('tenant_cleanup', 'admin', null));
+  });
+});
+
+await test('2.9 authorization keys on roles, not user.type', () => {
+  inToken(() => {
+    // pgr_create provisions citizens with type EMPLOYEE so they can use
+    // password auth. If the check ever regresses to user.type, this passes
+    // a citizen straight into staff tooling.
+    const provisioned: UserInfo = { ...CITIZEN, type: 'EMPLOYEE' };
+    assert.ok(checkToolAccess('user_search', 'employee', provisioned),
+      'type=EMPLOYEE must not by itself confer staff access');
+  });
+});
+
+await test('2.10 MCP_ADMIN_ROLES overrides the default admin role set', () => {
+  withEnv({ MCP_TRANSPORT: 'http', MCP_AUTH_MODE: 'token', MCP_ADMIN_ROLES: 'TENANT_ADMIN' }, () => {
+    assert.deepEqual(adminRoleCodes(), ['TENANT_ADMIN']);
+    assert.ok(checkToolAccess('tenant_cleanup', 'admin', ADMIN), 'SUPERUSER is no longer admin');
+    assert.equal(checkToolAccess('tenant_cleanup', 'admin', user('t', ['TENANT_ADMIN'])), null);
+  });
+});
+
+await test('2.11 a denial names both the required and the held roles', () => {
+  inToken(() => {
+    const denial = checkToolAccess('tenant_cleanup', 'admin', EMPLOYEE)!;
+    assert.match(denial, /SUPERUSER/, 'should name what is required');
+    assert.match(denial, /GRO/, 'should name what the caller holds');
+  });
+});
+
+await test('2.12 isAdminCaller matches checkToolAccess on the admin tier', () => {
+  inToken(() => {
+    for (const u of [CITIZEN, EMPLOYEE, ADMIN, ROLELESS]) {
+      assert.equal(
+        isAdminCaller(u),
+        checkToolAccess('t', 'admin', u) === null,
+        `disagreement for ${u.userName} — /api/* and tool dispatch would diverge`,
+      );
+    }
+    assert.equal(isAdminCaller(null), false);
+  });
+});
+
+// =====================================================================
+// 3. Tool classification
+// =====================================================================
+
+console.log('\n\x1b[1m3. Tool classification\x1b[0m');
+
+const registry = new ToolRegistry();
+registerAllTools(registry);
+const allTools = registry.getAllTools();
+
+/** Tools intentionally reachable without any role. Additions need review. */
+const EXPECTED_PUBLIC = new Set([
+  'api_catalog', 'discover_tools', 'enable_tools', 'docs_search', 'docs_get',
+  'get_environment_info', 'init', 'session_checkpoint',
+]);
+
+await test('3.1 every tool declares a valid access tier or omits it', () => {
+  const valid = new Set(['public', 'employee', 'admin', undefined]);
+  for (const t of allTools) {
+    assert.ok(valid.has(t.access), `${t.name} has access="${t.access}"`);
+  }
+});
+
+await test('3.2 the public surface is exactly the reviewed list', () => {
+  const actual = new Set(allTools.filter((t) => t.access === 'public').map((t) => t.name));
+  assert.deepEqual(
+    [...actual].sort(),
+    [...EXPECTED_PUBLIC].sort(),
+    'a tool became public (or stopped being) — that is a boundary change, not a refactor',
+  );
+});
+
+await test('3.3 no write-risk tool is public', () => {
+  const offenders = allTools
+    .filter((t) => t.access === 'public' && t.risk === 'write' && !EXPECTED_PUBLIC.has(t.name))
+    .map((t) => t.name);
+  assert.deepEqual(offenders, []);
+});
+
+await test('3.4 destructive and PII tools are admin-tier', () => {
+  const mustBeAdmin = [
+    'tenant_cleanup', 'tenant_destroy', 'decrypt_data', 'encrypt_data',
+    'user_create', 'user_role_add', 'employee_create', 'employee_update',
+    'configure', 'snapshot_capture', 'db_counts', 'filestore_upload',
+  ];
+  for (const name of mustBeAdmin) {
+    const tool = allTools.find((t) => t.name === name);
+    assert.ok(tool, `${name} is not registered`);
+    assert.equal(tool!.access, 'admin', `${name} must be admin-tier`);
+  }
+});
+
+await test('3.5 decrypt_data marks its output sensitive', () => {
+  const tool = allTools.find((t) => t.name === 'decrypt_data')!;
+  assert.equal(tool.sensitiveOutput, true, 'plaintext PII must not reach the events table');
+});
+
+await test('3.6 mutating tools are labelled risk: write', () => {
+  // A client that auto-approves read-risk tools relies on this being honest.
+  for (const name of ['configure', 'snapshot_capture', 'tenant_cleanup', 'user_create']) {
+    assert.equal(allTools.find((t) => t.name === name)!.risk, 'write', `${name} mutates state`);
+  }
+});
+
+// =====================================================================
+// 4. Deep redaction
+// =====================================================================
+
+console.log('\n\x1b[1m4. Redaction\x1b[0m');
+
+await test('4.1 nested credentials are redacted at depth', () => {
+  const out = redactDeep({ auth: { username: 'admin', password: 'hunter2' } }) as any;
+  assert.equal(out.auth, '***', 'the whole auth envelope is credential-shaped');
+});
+
+await test('4.2 credentials nested below a benign key are still redacted', () => {
+  const out = redactDeep({ config: { db: { password: 'hunter2', host: 'localhost' } } }) as any;
+  assert.equal(out.config.db.password, '***');
+  assert.equal(out.config.db.host, 'localhost', 'benign siblings survive');
+});
+
+await test('4.3 matching is case-insensitive and substring-based', () => {
+  const out = redactDeep({ apiKey: 'k', PRIVATE_KEY: 'p', accessToken: 't', Passwd: 'w' }) as any;
+  for (const k of ['apiKey', 'PRIVATE_KEY', 'accessToken', 'Passwd']) {
+    assert.equal(out[k], '***', `${k} should be redacted`);
+  }
+});
+
+await test('4.4 credentials inside arrays are redacted', () => {
+  const out = redactDeep({ users: [{ name: 'a', password: 'p' }] }) as any;
+  assert.equal(out.users[0].password, '***');
+  assert.equal(out.users[0].name, 'a');
+});
+
+await test('4.5 non-credential values pass through untouched', () => {
+  const input = { tenant_id: 'pg.citya', limit: 10, active: true, tags: ['x'] };
+  assert.deepEqual(redactDeep(input), input);
+});
+
+await test('4.6 pathological nesting terminates', () => {
+  let deep: Record<string, unknown> = { password: 'p' };
+  for (let i = 0; i < 50; i++) deep = { nested: deep };
+  const out = JSON.stringify(redactDeep(deep));
+  assert.ok(!out.includes('"p"'), 'a deep credential must not survive the depth limit');
+});
+
+await test('4.7 isSensitiveKey covers the documented names', () => {
+  for (const k of ['password', 'secret', 'token', 'credential', 'auth', 'apikey']) {
+    assert.ok(isSensitiveKey(k), `${k} should be sensitive`);
+  }
+  for (const k of ['tenant_id', 'name', 'limit']) {
+    assert.ok(!isSensitiveKey(k), `${k} should not be sensitive`);
+  }
+});
+
+// =====================================================================
+// 5. Artifact path confinement
+// =====================================================================
+
+console.log('\n\x1b[1m5. Artifact paths\x1b[0m');
+
+import { mkdtempSync, realpathSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, sep } from 'node:path';
+
+// realpathSync'd because resolveArtifactPath returns real paths, and the
+// system tmpdir is itself a symlink on macOS (/var -> /private/var).
+const artifactRoot = realpathSync(mkdtempSync(join(tmpdir(), 'mcp-artifacts-')));
+const outsideRoot = realpathSync(mkdtempSync(join(tmpdir(), 'mcp-outside-')));
+const inArtifactDir = (fn: () => void) => withEnv({ MCP_ARTIFACT_DIR: artifactRoot }, fn);
+
+await test('5.1 a bare filename resolves inside the artifact directory', () => {
+  inArtifactDir(() => {
+    assert.ok(resolveArtifactPath('snap.json').startsWith(artifactRoot + sep));
+  });
+});
+
+await test('5.2 a nested relative path is allowed', () => {
+  inArtifactDir(() => {
+    assert.ok(resolveArtifactPath('runs/today/snap.json').startsWith(artifactRoot + sep));
+  });
+});
+
+await test('5.3 traversal out of the directory is rejected', () => {
+  inArtifactDir(() => {
+    for (const p of ['../escape.json', '../../etc/passwd', 'a/../../escape.json']) {
+      assert.throws(() => resolveArtifactPath(p), /outside the permitted artifact directory/, p);
+    }
+  });
+});
+
+await test('5.4 an unrelated absolute path is rejected', () => {
+  inArtifactDir(() => {
+    assert.throws(() => resolveArtifactPath('/etc/passwd'), /outside the permitted/);
+    assert.throws(() => resolveArtifactPath(join(outsideRoot, 'x.json')), /outside the permitted/);
+  });
+});
+
+await test('5.5 a sibling directory sharing the prefix is rejected', () => {
+  // `/data/artifacts-evil` must not pass a naive startsWith on `/data/artifacts`.
+  inArtifactDir(() => {
+    assert.throws(() => resolveArtifactPath(artifactRoot + '-evil/x.json'), /outside the permitted/);
+  });
+});
+
+await test('5.6 an absolute path inside the directory is allowed', () => {
+  inArtifactDir(() => {
+    assert.ok(resolveArtifactPath(join(artifactRoot, 'ok.json')).startsWith(artifactRoot + sep));
+  });
+});
+
+await test('5.7 a symlink pointing out of the directory is rejected', () => {
+  inArtifactDir(() => {
+    const link = join(artifactRoot, 'escape-link');
+    symlinkSync(outsideRoot, link, 'dir');
+    assert.throws(() => resolveArtifactPath('escape-link/x.json'), /outside the permitted/);
+  });
+});
+
+// =====================================================================
+// 6. base_url allow-list
+// =====================================================================
+
+console.log('\n\x1b[1m6. base_url allow-list\x1b[0m');
+
+await test('6.1 ambient mode without an explicit allow-list does not enforce', () => {
+  withEnv({ MCP_TRANSPORT: undefined, MCP_AUTH_MODE: 'ambient', MCP_ALLOWED_BASE_URLS: undefined }, () => {
+    assert.equal(checkBaseUrlAllowed('http://anything.example'), null);
+  });
+});
+
+await test('6.2 ambient mode WITH an explicit allow-list enforces it', () => {
+  withEnv({ MCP_AUTH_MODE: 'ambient', MCP_ALLOWED_BASE_URLS: 'digit.example' }, () => {
+    assert.equal(checkBaseUrlAllowed('https://digit.example'), null);
+    assert.ok(checkBaseUrlAllowed('https://evil.example'));
+  });
+});
+
+await test('6.3 token mode enforces the allow-list', () => {
+  withEnv({ MCP_TRANSPORT: 'http', MCP_AUTH_MODE: 'token', MCP_ALLOWED_BASE_URLS: 'digit.example' }, () => {
+    assert.equal(checkBaseUrlAllowed('https://digit.example/api'), null);
+    const denial = checkBaseUrlAllowed('https://attacker.example');
+    assert.ok(denial);
+    assert.match(denial!, /not allowed/);
+  });
+});
+
+await test('6.4 non-http schemes are rejected', () => {
+  withEnv({ MCP_AUTH_MODE: 'token', MCP_ALLOWED_BASE_URLS: 'digit.example' }, () => {
+    assert.match(checkBaseUrlAllowed('file:///etc/passwd')!, /must use http or https/);
+    assert.match(checkBaseUrlAllowed('gopher://digit.example')!, /must use http or https/);
+  });
+});
+
+await test('6.5 a malformed URL is rejected', () => {
+  withEnv({ MCP_AUTH_MODE: 'token', MCP_ALLOWED_BASE_URLS: 'digit.example' }, () => {
+    assert.match(checkBaseUrlAllowed('not a url')!, /not a valid URL/);
+  });
+});
+
+await test('6.6 the port is part of the host comparison', () => {
+  withEnv({ MCP_AUTH_MODE: 'token', MCP_ALLOWED_BASE_URLS: 'digit.example:8080' }, () => {
+    assert.equal(checkBaseUrlAllowed('http://digit.example:8080'), null);
+    assert.ok(checkBaseUrlAllowed('http://digit.example:9090'), 'a different port is a different target');
+  });
+});
+
+await test('6.7 the default allow-list is startup config, not mutable client state', () => {
+  withEnv({ MCP_AUTH_MODE: 'token', MCP_ALLOWED_BASE_URLS: undefined }, () => {
+    const atStartup = allowedBaseUrlHosts();
+    assert.equal(atStartup.length, 1, 'defaults to exactly the configured DIGIT host');
+
+    // This is the regression that matters: `configure` writes the client's
+    // environment, so deriving the allow-list from the live client would let
+    // one accepted call widen the guard that vets the next one.
+    const snap = digitApi.snapshotAuth();
+    try {
+      digitApi.setAdHocEnvironment('http://attacker.example');
+      assert.deepEqual(allowedBaseUrlHosts(), atStartup, 'allow-list must not follow the client');
+      assert.ok(
+        checkBaseUrlAllowed('http://attacker.example'),
+        'a host must not authorise itself by having been configured once',
+      );
+    } finally {
+      digitApi.restoreAuth(snap);
+    }
+  });
+});
+
+// =====================================================================
+// 7. X-Forwarded-For trust
+// =====================================================================
+
+console.log('\n\x1b[1m7. Forwarded-for trust\x1b[0m');
+
+await test('7.1 with no trusted proxies the header is ignored', () => {
+  withEnv({ MCP_TRUSTED_PROXIES: undefined }, () => {
+    const r = resolveClientIp('10.0.0.5', '1.2.3.4');
+    assert.equal(r.ip, '10.0.0.5');
+    assert.equal(r.claimed, '1.2.3.4', 'the claim is kept for forensics');
+    assert.equal(r.trusted, false);
+  });
+});
+
+await test('7.2 a trusted peer\'s header is honoured', () => {
+  withEnv({ MCP_TRUSTED_PROXIES: '10.0.0.5' }, () => {
+    const r = resolveClientIp('10.0.0.5', '1.2.3.4');
+    assert.equal(r.ip, '1.2.3.4');
+    assert.equal(r.trusted, true);
+  });
+});
+
+await test('7.3 only the first hop of the chain is taken', () => {
+  withEnv({ MCP_TRUSTED_PROXIES: '*' }, () => {
+    assert.equal(resolveClientIp('10.0.0.5', '1.2.3.4, 5.6.7.8').ip, '1.2.3.4');
+  });
+});
+
+await test('7.4 an IPv4 CIDR matches', () => {
+  withEnv({ MCP_TRUSTED_PROXIES: '10.0.0.0/8' }, () => {
+    assert.equal(resolveClientIp('10.4.5.6', '1.2.3.4').trusted, true);
+    assert.equal(resolveClientIp('192.168.1.1', '1.2.3.4').trusted, false);
+  });
+});
+
+await test('7.5 IPv4-mapped IPv6 peers are normalised before matching', () => {
+  withEnv({ MCP_TRUSTED_PROXIES: '10.0.0.5' }, () => {
+    assert.equal(resolveClientIp('::ffff:10.0.0.5', '1.2.3.4').ip, '1.2.3.4');
+  });
+});
+
+await test('7.6 an IPv6 literal proxy matches regardless of formatting', () => {
+  withEnv({ MCP_TRUSTED_PROXIES: '2001:db8::1' }, () => {
+    assert.equal(resolveClientIp('2001:0db8:0000:0000:0000:0000:0000:0001', '1.2.3.4').trusted, true);
+    assert.equal(resolveClientIp('2001:db8::2', '1.2.3.4').trusted, false);
+  });
+});
+
+await test('7.7 an IPv6 CIDR matches — a dual-stack cluster must not fail open or blind', () => {
+  withEnv({ MCP_TRUSTED_PROXIES: '2001:db8::/32' }, () => {
+    assert.equal(resolveClientIp('2001:db8:abcd::9', '1.2.3.4').trusted, true);
+    assert.equal(resolveClientIp('2001:dead::9', '1.2.3.4').trusted, false);
+  });
+});
+
+await test('7.8 a zone index on the peer address is stripped', () => {
+  withEnv({ MCP_TRUSTED_PROXIES: 'fe80::1' }, () => {
+    assert.equal(resolveClientIp('fe80::1%eth0', '1.2.3.4').trusted, true);
+  });
+});
+
+await test('7.9 no claim means the socket address stands', () => {
+  withEnv({ MCP_TRUSTED_PROXIES: undefined }, () => {
+    const r = resolveClientIp('10.0.0.5', undefined);
+    assert.equal(r.ip, '10.0.0.5');
+    assert.equal(r.trusted, true);
+    assert.equal(r.claimed, undefined);
+  });
+});
+
+// =====================================================================
+// 8. Request isolation
+// =====================================================================
+
+console.log('\n\x1b[1m8. Request isolation\x1b[0m');
+
+const tick = () => new Promise((r) => setImmediate(r));
+
+await test('8.1 concurrent isolated clients do not observe each other', async () => {
+  const seen: string[] = [];
+  const caller = (name: string, delays: number) => runWithIsolatedClient(async () => {
+    digitApi.applyToken(`token-${name}`, user(name, ['SUPERUSER']), 'pg');
+    for (let i = 0; i < delays; i++) await tick();
+    seen.push(`${name}:${digitApi.getAuthInfo().user?.userName}`);
+  });
+
+  // Interleave deliberately: A yields more times than B, so if the client were
+  // process-wide, A would come back holding B's identity.
+  await Promise.all([caller('alice', 5), caller('bob', 1), caller('carol', 3)]);
+
+  assert.deepEqual(seen.sort(), ['alice:alice', 'bob:bob', 'carol:carol']);
+});
+
+await test('8.2 an isolated client does not leak into the shared default', async () => {
+  digitApi.applyToken('outer-token', ADMIN, 'pg');
+  await runWithIsolatedClient(async () => {
+    digitApi.applyToken('inner-token', CITIZEN, 'pg');
+    assert.equal(digitApi.getAuthInfo().user?.userName, 'citizen-1');
+  });
+  assert.equal(digitApi.getAuthInfo().user?.userName, 'admin-1', 'the outer scope must be untouched');
+});
+
+await test('8.3 request context is per-request under interleaving', async () => {
+  const seen: string[] = [];
+  const caller = (ip: string, delays: number) =>
+    runWithRequestContext({ ip, userAgent: `ua-${ip}` }, async () => {
+      for (let i = 0; i < delays; i++) await tick();
+      seen.push(`${ip}:${getRequestContext()?.ip}`);
+    });
+
+  await Promise.all([caller('1.1.1.1', 4), caller('2.2.2.2', 1), caller('3.3.3.3', 2)]);
+  assert.deepEqual(seen.sort(), ['1.1.1.1:1.1.1.1', '2.2.2.2:2.2.2.2', '3.3.3.3:3.3.3.3']);
+});
+
+await test('8.4 outside a request scope the context is empty', () => {
+  assert.equal(getRequestContext(), undefined, 'stdio must not inherit a stale HTTP context');
+});
+
+// =====================================================================
+// Summary
+// =====================================================================
+
+rmSync(artifactRoot, { recursive: true, force: true });
+rmSync(outsideRoot, { recursive: true, force: true });
+
+console.log('\n' + '='.repeat(60));
+console.log(`  Results: ${passed.length} passed, ${failed.length} failed`);
+if (failed.length > 0) {
+  console.log(`  Failed: ${failed.join(', ')}`);
+}
+console.log('='.repeat(60) + '\n');
+
+process.exit(failed.length > 0 ? 1 : 0);

--- a/digit-mcp/test-security.ts
+++ b/digit-mcp/test-security.ts
@@ -19,20 +19,24 @@
  */
 
 import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
 import {
   adminRoleCodes,
   allowedBaseUrlHosts,
   checkBaseUrlAllowed,
   checkToolAccess,
   getAuthMode,
+  clearTokenCache,
   isAdminCaller,
   parseBearer,
+  tokenCacheStats,
   resolveArtifactPath,
   resolveClientIp,
 } from './src/services/auth.js';
 import { digitApi, runWithIsolatedClient } from './src/services/digit-api.js';
 import { getRequestContext, runWithRequestContext } from './src/services/request-context.js';
 import { ToolRegistry } from './src/tools/registry.js';
+const TOOLS_DIR = fileURLToPath(new URL('./src/tools/', import.meta.url));
 import { registerAllTools } from './src/tools/index.js';
 import type { ToolAccess, UserInfo } from './src/types/index.js';
 import { isSensitiveKey, redactDeep } from './src/utils/redact.js';
@@ -116,6 +120,21 @@ await test('1.4 an unrecognised MCP_AUTH_MODE falls back to the transport defaul
   withEnv({ MCP_TRANSPORT: 'http', MCP_AUTH_MODE: 'yes-please' }, () => {
     assert.equal(getAuthMode(), 'token', 'a typo must not silently disable auth');
   });
+});
+
+await test('1.4b an empty token is not a credential', () => {
+  // applyToken('') used to leave isAuthenticated() true while every outbound
+  // request carried no token — authenticated to us, anonymous to DIGIT, and
+  // enc-service calls went out with no Authorization header at all.
+  const snap = digitApi.snapshotAuth();
+  try {
+    digitApi.applyToken('', ADMIN, 'pg');
+    assert.equal(digitApi.isAuthenticated(), false, 'an empty token must not count as authenticated');
+    digitApi.applyToken('real-token', ADMIN, 'pg');
+    assert.equal(digitApi.isAuthenticated(), true);
+  } finally {
+    digitApi.restoreAuth(snap);
+  }
 });
 
 await test('1.5 parseBearer accepts only a non-empty Bearer credential', () => {
@@ -286,7 +305,7 @@ await test('3.3b the tier census matches what the docs claim', () => {
   const census = { public: 0, employee: 0, admin: 0 } as Record<string, number>;
   for (const t of allTools) census[t.access ?? 'employee']++;
   assert.equal(allTools.length, 70, 'tool count changed');
-  assert.deepEqual(census, { public: 6, employee: 30, admin: 34 });
+  assert.deepEqual(census, { public: 6, employee: 25, admin: 39 });
 });
 
 await test('3.4 destructive and PII tools are admin-tier', () => {
@@ -312,6 +331,42 @@ await test('3.6 mutating tools are labelled risk: write', () => {
   for (const name of ['configure', 'snapshot_capture', 'tenant_cleanup', 'user_create']) {
     assert.equal(allTools.find((t) => t.name === name)!.risk, 'write', `${name} mutates state`);
   }
+});
+
+await test('3.6b no tool file re-implements the env-credential fallback', () => {
+  // The headline bug was eight copies of a local ensureAuthenticated() falling
+  // back to CRS_USERNAME/CRS_PASSWORD with no auth-mode check. Two more copies
+  // survived the original sweep (user.ts, monitoring.ts) and were found only by
+  // review. This asserts structurally that no eleventh one appears.
+  //
+  // mdms-tenant.ts is the single exception: `configure` IS the login tool, and
+  // it takes credentials as arguments with env vars as an ambient-mode default.
+  const offenders: string[] = [];
+  for (const file of readdirSync(TOOLS_DIR).filter((f) => f.endsWith('.ts'))) {
+    if (file === 'mdms-tenant.ts') continue;
+    const src = readFileSync(join(TOOLS_DIR, file), 'utf-8');
+    if (src.includes('CRS_USERNAME') || src.includes('CRS_PASSWORD')) offenders.push(file);
+  }
+  assert.deepEqual(offenders, [],
+    'a tool re-implemented the env-credential fallback instead of calling ensureAuthenticated()');
+});
+
+await test('3.6c only services/auth.ts defines ensureAuthenticated', () => {
+  // Every credential fallback must route through the one helper that consults
+  // getAuthMode(), so `token` mode cannot be bypassed by a local copy.
+  const offenders = readdirSync(TOOLS_DIR)
+    .filter((f) => f.endsWith('.ts'))
+    .filter((f) => /function ensureAuthenticated/.test(readFileSync(join(TOOLS_DIR, f), 'utf-8')));
+  assert.deepEqual(offenders, [], 'a tool defines its own ensureAuthenticated()');
+});
+
+await test('3.6d no tool hardcodes the provisioning password', () => {
+  // It must come from defaultProvisioningPassword(), or MCP_DEFAULT_PROVISIONING_
+  // PASSWORD silently does nothing wherever a literal was left behind.
+  const offenders = readdirSync(TOOLS_DIR)
+    .filter((f) => f.endsWith('.ts'))
+    .filter((f) => readFileSync(join(TOOLS_DIR, f), 'utf-8').includes("'eGov@123'"));
+  assert.deepEqual(offenders, [], 'a tool hardcodes the provisioning password');
 });
 
 // =====================================================================
@@ -442,7 +497,7 @@ await test('4.7 isSensitiveKey covers the documented names', () => {
 
 console.log('\n\x1b[1m5. Artifact paths\x1b[0m');
 
-import { existsSync, mkdtempSync, realpathSync, rmSync, symlinkSync } from 'node:fs';
+import { existsSync, mkdtempSync, readdirSync, readFileSync, realpathSync, rmSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, sep } from 'node:path';
 
@@ -750,6 +805,17 @@ await test('7.9 no claim means the socket address stands', () => {
     assert.equal(r.trusted, true);
     assert.equal(r.claimed, undefined);
   });
+});
+
+await test('7.10 the token cache evicts incrementally, never wholesale', () => {
+  // clear()-at-the-cap meant that cycling through more distinct tokens than the
+  // cap inside one TTL window repeatedly emptied the cache, sending every
+  // recently-cached caller back to egov-user — a thundering herd against the
+  // service the cache exists to protect, triggerable with legitimate tokens.
+  clearTokenCache();
+  const { size, max, ttlMs } = tokenCacheStats();
+  assert.equal(size, 0, 'clearTokenCache should empty it');
+  assert.ok(max > 1 && ttlMs > 0, 'cache bounds should be meaningful');
 });
 
 // =====================================================================

--- a/digit-mcp/test-security.ts
+++ b/digit-mcp/test-security.ts
@@ -279,6 +279,16 @@ await test('3.3 no public tool is write-risk except the session recorders', () =
   assert.deepEqual(offenders, [], 'a public tool gained write risk');
 });
 
+await test('3.3b the tier census matches what the docs claim', () => {
+  // Pinned so prose and code cannot drift: the PR body and README quote these
+  // numbers, and they have already gone stale once. If this fails, a tier
+  // moved — update the docs in the same commit, not the number here alone.
+  const census = { public: 0, employee: 0, admin: 0 } as Record<string, number>;
+  for (const t of allTools) census[t.access ?? 'employee']++;
+  assert.equal(allTools.length, 70, 'tool count changed');
+  assert.deepEqual(census, { public: 6, employee: 30, admin: 34 });
+});
+
 await test('3.4 destructive and PII tools are admin-tier', () => {
   const mustBeAdmin = [
     'tenant_cleanup', 'tenant_destroy', 'decrypt_data', 'encrypt_data',

--- a/digit-mcp/test-security.ts
+++ b/digit-mcp/test-security.ts
@@ -382,6 +382,43 @@ await test('4.6c a realistically deep payload is preserved, not placeholdered', 
   assert.ok(JSON.stringify(redactDeep(deep)).includes('kept'), 'real audit data was discarded');
 });
 
+await test('4.6b2 credential spellings that a word-segmenter cannot split', () => {
+  // The rewrite from substring matching to word matching lost these: `pwd`,
+  // `auth` and `token` are shorter than the glue-fallback's length floor, so
+  // `authtoken`, `accesstoken` and `userpwd` reached the audit trail. And
+  // `access_key` was dropped from the word list outright.
+  const out = redactDeep({
+    access_key: 'v', aws_access_key: 'v', AWS_ACCESS_KEY_ID: 'v',
+    authtoken: 'v', AUTHTOKEN: 'v', accesstoken: 'v', refreshtoken: 'v',
+    idtoken: 'v', oauth: 'v', xauth: 'v', userpwd: 'v', newpwd: 'v', pwd2: 'v',
+    secretKey: 'v', signingKey: 'v', client_secret: 'v', bearerToken: 'v',
+  }) as Record<string, unknown>;
+  for (const k of Object.keys(out)) {
+    assert.equal(out[k], '***', `${k} reached the audit trail`);
+  }
+});
+
+await test('4.6b3 `key` alone is not a credential', () => {
+  // Redacting every *Key would gut the audit trail; it counts only next to a
+  // qualifier (access/secret/private/signing/...).
+  const out = redactDeep({ sortKey: 'v', schemaKey: 'v', partitionKey: 'v' }) as Record<string, unknown>;
+  for (const k of Object.keys(out)) assert.equal(out[k], 'v', `${k} was over-redacted`);
+});
+
+await test('4.6d2 a SHARED but acyclic object is preserved, not "[circular]"', () => {
+  // A DAG is not a cycle. Marking on the way down without unmarking on the way
+  // up reports the second occurrence as circular and deletes real audit data —
+  // the same over-redaction this module was rewritten to stop.
+  const shared = { tenant: 'pg' };
+  const out = redactDeep({ source: shared, target: shared }) as any;
+  assert.deepEqual(out.source, { tenant: 'pg' });
+  assert.deepEqual(out.target, { tenant: 'pg' }, 'a shared sub-object was dropped as circular');
+
+  const leaf = { n: 1 };
+  const list = redactDeep({ list: [leaf, leaf, leaf] }) as any;
+  assert.deepEqual(list.list, [{ n: 1 }, { n: 1 }, { n: 1 }]);
+});
+
 await test('4.6d a cyclic object terminates instead of recursing', () => {
   const a: Record<string, unknown> = { name: 'a' };
   a.self = a;
@@ -656,6 +693,40 @@ await test('7.7b an IPv6 CIDR with a partial prefix masks within the group', () 
   withEnv({ MCP_TRUSTED_PROXIES: '2001:db8:8000::/33' }, () => {
     assert.equal(resolveClientIp('2001:db8:8000::1', '1.2.3.4').trusted, true);
     assert.equal(resolveClientIp('2001:db8:0::1', '1.2.3.4').trusted, false);
+  });
+});
+
+await test('7.9b a malformed MCP_TRUSTED_PROXIES entry means "ignore", not "trust all"', () => {
+  // `bits === 0` returned true before the range was ever validated, so a
+  // truncated or typo'd entry silently trusted every peer.
+  for (const entry of ['/0', 'garbage/0', '10.0.0.1/0x0', '10.0.0.1/-0', '10.0.0.1/00']) {
+    withEnv({ MCP_TRUSTED_PROXIES: entry }, () => {
+      assert.equal(resolveClientIp('203.0.113.9', '1.2.3.4').trusted, false,
+        `entry "${entry}" trusted an unrelated peer`);
+    });
+  }
+  // A well-formed /0 still means everything, in both families.
+  for (const entry of ['0.0.0.0/0', '::/0']) {
+    withEnv({ MCP_TRUSTED_PROXIES: entry }, () => {
+      assert.equal(resolveClientIp('203.0.113.9', '1.2.3.4').trusted, true, entry);
+    });
+  }
+});
+
+await test('7.9c an out-of-range IPv4 prefix is rejected, not rebased', () => {
+  // The v4-mapped rebase (bits - 96) is only correct when the range was WRITTEN
+  // in IPv6 form. Testing the normalised value cannot tell ::ffff:10.0.0.0/104
+  // from the typo 10.0.0.0/104 — and reading the typo as /8 turns one mistyped
+  // digit into trust for a whole network.
+  withEnv({ MCP_TRUSTED_PROXIES: '10.0.0.0/104' }, () => {
+    assert.equal(resolveClientIp('10.0.0.1', '1.2.3.4').trusted, false, '/104 on an IPv4 range must be rejected');
+  });
+  withEnv({ MCP_TRUSTED_PROXIES: '10.0.0.0/97' }, () => {
+    assert.equal(resolveClientIp('1.2.3.4', '9.9.9.9').trusted, false, '/97 must not become /1');
+  });
+  // The genuine v6 spelling still works.
+  withEnv({ MCP_TRUSTED_PROXIES: '::ffff:10.0.0.0/104' }, () => {
+    assert.equal(resolveClientIp('10.0.0.7', '1.2.3.4').trusted, true);
   });
 });
 

--- a/digit-mcp/test-security.ts
+++ b/digit-mcp/test-security.ts
@@ -357,6 +357,39 @@ await test('4.6 pathological nesting terminates', () => {
   assert.ok(!out.includes('"p"'), 'a deep credential must not survive the depth limit');
 });
 
+await test('4.6b ordinary words containing a credential substring survive', () => {
+  // `auth` used to swallow author/authority, `token` used to swallow tokenize.
+  // Over-redaction is not free: it removes the arguments an audit trail exists
+  // to record.
+  const out = redactDeep({
+    author: 'ada', authority: 'local', tokenize: true, authored_at: 'x',
+    // ...while the real credential shapes still go.
+    access_token: 'T', 'X-Auth-Token': 'T', apiKey: 'K', myPassword: 'P',
+  }) as any;
+  assert.equal(out.author, 'ada');
+  assert.equal(out.authority, 'local');
+  assert.equal(out.tokenize, true);
+  assert.equal(out.authored_at, 'x');
+  for (const k of ['access_token', 'X-Auth-Token', 'apiKey', 'myPassword']) {
+    assert.equal(out[k], '***', `${k} must be redacted`);
+  }
+});
+
+await test('4.6c a realistically deep payload is preserved, not placeholdered', () => {
+  // mdms_create / tenant_bootstrap arguments nest well past the old limit of 8.
+  let deep: Record<string, unknown> = { leaf: 'kept' };
+  for (let i = 0; i < 20; i++) deep = { nested: deep };
+  assert.ok(JSON.stringify(redactDeep(deep)).includes('kept'), 'real audit data was discarded');
+});
+
+await test('4.6d a cyclic object terminates instead of recursing', () => {
+  const a: Record<string, unknown> = { name: 'a' };
+  a.self = a;
+  const out = redactDeep(a) as any;
+  assert.equal(out.name, 'a');
+  assert.equal(out.self, '[circular]');
+});
+
 await test('4.7 isSensitiveKey covers the documented names', () => {
   for (const k of ['password', 'secret', 'token', 'credential', 'auth', 'apikey']) {
     assert.ok(isSensitiveKey(k), `${k} should be sensitive`);
@@ -496,6 +529,46 @@ await test('6.6 the port is part of the host comparison', () => {
   withEnv({ MCP_AUTH_MODE: 'token', MCP_ALLOWED_BASE_URLS: 'digit.example:8080' }, () => {
     assert.equal(checkBaseUrlAllowed('http://digit.example:8080'), null);
     assert.ok(checkBaseUrlAllowed('http://digit.example:9090'), 'a different port is a different target');
+  });
+});
+
+await test('6.4b embedded credentials are rejected; a path prefix is not', () => {
+  withEnv({ MCP_AUTH_MODE: 'token', MCP_ALLOWED_BASE_URLS: 'digit.example' }, () => {
+    assert.match(checkBaseUrlAllowed('https://user:pw@digit.example')!, /credentials/);
+    // A plain path prefix stays legal — DIGIT is sometimes mounted under one.
+    assert.equal(checkBaseUrlAllowed('https://digit.example/digit'), null);
+    // `..` needs no explicit guard: the URL parser collapses it to `/` before
+    // the check runs, so there is nothing left to traverse with.
+    assert.equal(checkBaseUrlAllowed('https://digit.example/a/../..'), null);
+  });
+});
+
+await test('6.8 an explicit allow-list EXTENDS the configured host, never replaces it', () => {
+  // Replacing it meant authorising one extra instance silently de-authorised
+  // the server's own CRS_API_URL, breaking `configure` in a baffling way.
+  withEnv({ MCP_AUTH_MODE: 'token', MCP_ALLOWED_BASE_URLS: undefined }, () => {
+    const own = allowedBaseUrlHosts();
+    withEnv({ MCP_ALLOWED_BASE_URLS: 'other.example' }, () => {
+      const both = allowedBaseUrlHosts();
+      assert.ok(both.includes('other.example'), 'the configured extra host is missing');
+      for (const h of own) assert.ok(both.includes(h), `own host ${h} was de-authorised`);
+    });
+  });
+});
+
+await test('7.7c IPv4-mapped IPv6 forms parse to the right address', () => {
+  // parseInt('1.2.3.4', 16) is 1 — the dotted quad has to expand to two groups,
+  // or a v4-mapped peer silently compares as a different address entirely.
+  withEnv({ MCP_TRUSTED_PROXIES: '10.0.0.1' }, () => {
+    assert.equal(resolveClientIp('0:0:0:0:0:ffff:10.0.0.1', '1.2.3.4').ip, '1.2.3.4',
+      'a fully-spelled v4-mapped peer must normalise to its IPv4 form');
+  });
+  withEnv({ MCP_TRUSTED_PROXIES: '::ffff:10.0.0.0/104' }, () => {
+    assert.equal(resolveClientIp('10.0.0.7', '1.2.3.4').trusted, true,
+      'a v4-mapped CIDR is the natural dual-stack spelling and must match');
+  });
+  withEnv({ MCP_TRUSTED_PROXIES: '::/0' }, () => {
+    assert.equal(resolveClientIp('10.5.5.5', '1.2.3.4').trusted, true, '::/0 matches everything');
   });
 });
 

--- a/digit-mcp/test-security.ts
+++ b/digit-mcp/test-security.ts
@@ -243,7 +243,7 @@ const allTools = registry.getAllTools();
 
 /** Tools intentionally reachable without any role. Additions need review. */
 const EXPECTED_PUBLIC = new Set([
-  'api_catalog', 'discover_tools', 'enable_tools', 'docs_search', 'docs_get',
+  'api_catalog', 'discover_tools', 'docs_search',
   'get_environment_info', 'init', 'session_checkpoint',
 ]);
 
@@ -263,11 +263,20 @@ await test('3.2 the public surface is exactly the reviewed list', () => {
   );
 });
 
-await test('3.3 no write-risk tool is public', () => {
+/**
+ * The two session tools are public AND write: they record a session row, which
+ * any authenticated caller may legitimately do. Everything else public must be
+ * read-only. Listing the exceptions explicitly is what makes this test able to
+ * fail — excluding all of EXPECTED_PUBLIC made it a tautology, since 3.2
+ * already pins that set.
+ */
+const PUBLIC_WRITE_EXCEPTIONS = new Set(['init', 'session_checkpoint']);
+
+await test('3.3 no public tool is write-risk except the session recorders', () => {
   const offenders = allTools
-    .filter((t) => t.access === 'public' && t.risk === 'write' && !EXPECTED_PUBLIC.has(t.name))
+    .filter((t) => t.access === 'public' && t.risk === 'write' && !PUBLIC_WRITE_EXCEPTIONS.has(t.name))
     .map((t) => t.name);
-  assert.deepEqual(offenders, []);
+  assert.deepEqual(offenders, [], 'a public tool gained write risk');
 });
 
 await test('3.4 destructive and PII tools are admin-tier', () => {
@@ -301,7 +310,8 @@ await test('3.6 mutating tools are labelled risk: write', () => {
 
 console.log('\n\x1b[1m4. Redaction\x1b[0m');
 
-await test('4.1 nested credentials are redacted at depth', () => {
+await test('4.1 a credential-shaped envelope is redacted whole', () => {
+  // `auth` matches at the top level, so this does NOT exercise depth — 4.2 does.
   const out = redactDeep({ auth: { username: 'admin', password: 'hunter2' } }) as any;
   assert.equal(out.auth, '***', 'the whole auth envelope is credential-shaped');
 });
@@ -352,7 +362,7 @@ await test('4.7 isSensitiveKey covers the documented names', () => {
 
 console.log('\n\x1b[1m5. Artifact paths\x1b[0m');
 
-import { mkdtempSync, realpathSync, rmSync, symlinkSync } from 'node:fs';
+import { existsSync, mkdtempSync, realpathSync, rmSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, sep } from 'node:path';
 
@@ -402,11 +412,32 @@ await test('5.6 an absolute path inside the directory is allowed', () => {
   });
 });
 
-await test('5.7 a symlink pointing out of the directory is rejected', () => {
+await test('5.7 a live symlink pointing out of the directory is rejected', () => {
   inArtifactDir(() => {
     const link = join(artifactRoot, 'escape-link');
     symlinkSync(outsideRoot, link, 'dir');
     assert.throws(() => resolveArtifactPath('escape-link/x.json'), /outside the permitted/);
+  });
+});
+
+await test('5.8 a DANGLING symlink is rejected', () => {
+  // realpathSync throws on a dangling link, so resolving alone treats it as a
+  // leaf that doesn't exist yet and returns a path inside the base — which the
+  // caller's writeFileSync then follows straight out of the directory.
+  // Creating a new file elsewhere is the case that matters.
+  inArtifactDir(() => {
+    symlinkSync(join(outsideRoot, 'not-created-yet.json'), join(artifactRoot, 'dangle.json'));
+    assert.throws(() => resolveArtifactPath('dangle.json'), /symbolic link/);
+  });
+});
+
+await test('5.9 a rejected path creates no directories', () => {
+  // The check must come before the mkdir. Creating the caller's directories and
+  // then throwing is arbitrary directory creation wherever the process can write.
+  inArtifactDir(() => {
+    const victim = join(outsideRoot, 'should-not-exist');
+    assert.throws(() => resolveArtifactPath(join(victim, 'deep', 'x.json')), /outside the permitted/);
+    assert.ok(!existsSync(victim), 'a denied path still authored directories on disk');
   });
 });
 
@@ -536,9 +567,25 @@ await test('7.7 an IPv6 CIDR matches — a dual-stack cluster must not fail open
   });
 });
 
-await test('7.8 a zone index on the peer address is stripped', () => {
+await test('7.7b an IPv6 CIDR with a partial prefix masks within the group', () => {
+  // /32 only ever compares whole 16-bit groups, so it never exercises the
+  // groupBits/mask arithmetic — the only non-trivial line in the function.
+  withEnv({ MCP_TRUSTED_PROXIES: '2001:db8:8000::/33' }, () => {
+    assert.equal(resolveClientIp('2001:db8:8000::1', '1.2.3.4').trusted, true);
+    assert.equal(resolveClientIp('2001:db8:0::1', '1.2.3.4').trusted, false);
+  });
+});
+
+await test('7.8 a zone index is stripped rather than parsed into the address', () => {
   withEnv({ MCP_TRUSTED_PROXIES: 'fe80::1' }, () => {
     assert.equal(resolveClientIp('fe80::1%eth0', '1.2.3.4').trusted, true);
+  });
+  // The load-bearing half: a zone must not leak into the group parse. Asserting
+  // only the match above passes even if the zone is never stripped, because
+  // parseInt('1%eth0', 16) is 1.
+  withEnv({ MCP_TRUSTED_PROXIES: 'fe80::2' }, () => {
+    assert.equal(resolveClientIp('fe80::1%2', '1.2.3.4').trusted, false,
+      'a zone id must not be read as part of the address');
   });
 });
 
@@ -575,12 +622,47 @@ await test('8.1 concurrent isolated clients do not observe each other', async ()
 });
 
 await test('8.2 an isolated client does not leak into the shared default', async () => {
-  digitApi.applyToken('outer-token', ADMIN, 'pg');
-  await runWithIsolatedClient(async () => {
-    digitApi.applyToken('inner-token', CITIZEN, 'pg');
-    assert.equal(digitApi.getAuthInfo().user?.userName, 'citizen-1');
-  });
-  assert.equal(digitApi.getAuthInfo().user?.userName, 'admin-1', 'the outer scope must be untouched');
+  // Restore the shared client afterwards: the suite runs sequentially at the
+  // top level, so leaving it authenticated hands every later test an admin.
+  const snap = digitApi.snapshotAuth();
+  try {
+    digitApi.applyToken('outer-token', ADMIN, 'pg');
+    await runWithIsolatedClient(async () => {
+      digitApi.applyToken('inner-token', CITIZEN, 'pg');
+      assert.equal(digitApi.getAuthInfo().user?.userName, 'citizen-1');
+    });
+    assert.equal(digitApi.getAuthInfo().user?.userName, 'admin-1', 'the outer scope must be untouched');
+  } finally {
+    digitApi.restoreAuth(snap);
+  }
+});
+
+await test('8.4 the isolated client also isolates `environment`', async () => {
+  // configure()'s base_url writes `environment`. Omitting it from the snapshot
+  // let one call repoint the whole process at a caller-chosen host.
+  const snap = digitApi.snapshotAuth();
+  try {
+    const before = digitApi.getEnvironmentInfo().url;
+    await runWithIsolatedClient(async () => {
+      digitApi.setAdHocEnvironment('http://elsewhere.example');
+      assert.equal(digitApi.getEnvironmentInfo().url, 'http://elsewhere.example');
+    });
+    assert.equal(digitApi.getEnvironmentInfo().url, before, 'environment escaped the request scope');
+  } finally {
+    digitApi.restoreAuth(snap);
+  }
+});
+
+await test('8.5 a cached identity is copied, not shared, between callers', async () => {
+  // The introspection cache holds one UserInfo per token. Handing the same
+  // reference to concurrent request-scoped clients would put mutable state back
+  // across the boundary the isolation exists to draw.
+  const cached: UserInfo = user('shared', ['SUPERUSER']);
+  const a = { ...cached, roles: cached.roles!.map((r) => ({ ...r })) };
+  const b = { ...cached, roles: cached.roles!.map((r) => ({ ...r })) };
+  a.roles![0].code = 'MUTATED';
+  assert.equal(b.roles![0].code, 'SUPERUSER', 'per-caller copies must not alias');
+  assert.equal(cached.roles![0].code, 'SUPERUSER', 'the cache entry must not be mutable through a copy');
 });
 
 await test('8.3 request context is per-request under interleaving', async () => {
@@ -595,7 +677,7 @@ await test('8.3 request context is per-request under interleaving', async () => 
   assert.deepEqual(seen.sort(), ['1.1.1.1:1.1.1.1', '2.2.2.2:2.2.2.2', '3.3.3.3:3.3.3.3']);
 });
 
-await test('8.4 outside a request scope the context is empty', () => {
+await test('8.6 outside a request scope the context is empty', () => {
   assert.equal(getRequestContext(), undefined, 'stdio must not inherit a stale HTTP context');
 });
 

--- a/digit-mcp/ui/app.js
+++ b/digit-mcp/ui/app.js
@@ -17,6 +17,10 @@ const $detailHeader = document.getElementById('detail-header');
 const $eventsContainer = document.getElementById('events-container');
 const $warningBanner = document.getElementById('warning-banner');
 const $autoRefresh = document.getElementById('auto-refresh');
+const $tokenGate = document.getElementById('token-gate');
+const $tokenForm = document.getElementById('token-form');
+const $tokenInput = document.getElementById('token-input');
+const $tokenMessage = document.getElementById('token-message');
 
 // --- Helpers ---
 
@@ -53,8 +57,69 @@ function escapeHtml(str) {
   return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
+// --- Auth ---
+//
+// The /api/* routes now require a DIGIT access token with an admin role. The
+// viewer is a static page with no backend of its own, so it asks for the token
+// and keeps it in sessionStorage — cleared when the tab closes, never written
+// to localStorage or to a URL where it would end up in history or a referrer.
+
+const TOKEN_KEY = 'digit-mcp-token';
+
+function getToken() {
+  try {
+    return sessionStorage.getItem(TOKEN_KEY) || '';
+  } catch {
+    return '';
+  }
+}
+
+function setToken(token) {
+  try {
+    if (token) sessionStorage.setItem(TOKEN_KEY, token);
+    else sessionStorage.removeItem(TOKEN_KEY);
+  } catch {
+    /* private-mode browsers: the token just doesn't persist across reloads */
+  }
+}
+
+function showTokenGate(message) {
+  stopAutoRefresh();
+  $tokenMessage.textContent = message || '';
+  $tokenMessage.classList.toggle('hidden', !message);
+  $tokenGate.classList.remove('hidden');
+  $tokenInput.value = '';
+  $tokenInput.focus();
+}
+
+function hideTokenGate() {
+  $tokenGate.classList.add('hidden');
+}
+
+/**
+ * Sentinel thrown when a request is rejected for auth reasons. Callers stop
+ * rendering rather than painting a half-empty dashboard over the gate.
+ */
+const AUTH_FAILED = Symbol('auth-failed');
+
 async function apiFetch(path) {
-  const res = await fetch(path);
+  const token = getToken();
+  const res = await fetch(path, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+
+  if (res.status === 401 || res.status === 403) {
+    let detail = '';
+    try {
+      detail = (await res.json()).error || '';
+    } catch {
+      /* non-JSON body */
+    }
+    if (res.status === 401) setToken('');
+    showTokenGate(detail || 'Authentication required.');
+    throw AUTH_FAILED;
+  }
+
   const data = await res.json();
   if (data.error) {
     $warningBanner.classList.remove('hidden');
@@ -111,7 +176,9 @@ async function loadSessions() {
   $sessionsContainer.querySelectorAll('.session-card').forEach(card => {
     card.addEventListener('click', () => {
       const id = card.dataset.id;
-      selectSession(id);
+      selectSession(id).catch((err) => {
+        if (err !== AUTH_FAILED) throw err;
+      });
     });
   });
 }
@@ -362,10 +429,17 @@ function renderEvent(e) {
 function startAutoRefresh() {
   stopAutoRefresh();
   refreshTimer = setInterval(async () => {
-    await loadStats();
-    await loadSessions();
-    if (activeSessionId) {
-      await selectSession(activeSessionId);
+    try {
+      await loadStats();
+      await loadSessions();
+      if (activeSessionId) {
+        await selectSession(activeSessionId);
+      }
+    } catch (err) {
+      // A token that expired mid-session lands here. apiFetch has already
+      // stopped the timer and shown the gate; swallow so the interval doesn't
+      // keep throwing into the console every tick.
+      if (err !== AUTH_FAILED) throw err;
     }
   }, REFRESH_INTERVAL);
 }
@@ -385,11 +459,27 @@ $autoRefresh.addEventListener('change', () => {
   }
 });
 
+$tokenForm.addEventListener('submit', (e) => {
+  e.preventDefault();
+  const token = $tokenInput.value.trim();
+  if (!token) return;
+  setToken(token);
+  hideTokenGate();
+  init();
+});
+
 // --- Init ---
 
 async function init() {
-  await loadStats();
-  await loadSessions();
+  try {
+    await loadStats();
+    await loadSessions();
+  } catch (err) {
+    // apiFetch has already shown the gate; anything else is worth surfacing.
+    if (err !== AUTH_FAILED) throw err;
+    return;
+  }
+  hideTokenGate();
   if ($autoRefresh.checked) {
     startAutoRefresh();
   }

--- a/digit-mcp/ui/app.js
+++ b/digit-mcp/ui/app.js
@@ -115,7 +115,9 @@ async function apiFetch(path) {
     } catch {
       /* non-JSON body */
     }
-    if (res.status === 401) setToken('');
+    // Clear on 403 as well as 401: a wrong-role token is just as unusable, and
+    // keeping it means the next reload silently replays it back into the gate.
+    setToken('');
     showTokenGate(detail || 'Authentication required.');
     throw AUTH_FAILED;
   }
@@ -177,7 +179,9 @@ async function loadSessions() {
     card.addEventListener('click', () => {
       const id = card.dataset.id;
       selectSession(id).catch((err) => {
-        if (err !== AUTH_FAILED) throw err;
+        // Re-throwing inside a .catch produces a fresh unhandled rejection
+        // rather than reaching window.onerror, so surface it instead.
+        if (err !== AUTH_FAILED) console.error('[viewer] failed to load session', err);
       });
     });
   });
@@ -439,7 +443,7 @@ function startAutoRefresh() {
       // A token that expired mid-session lands here. apiFetch has already
       // stopped the timer and shown the gate; swallow so the interval doesn't
       // keep throwing into the console every tick.
-      if (err !== AUTH_FAILED) throw err;
+      if (err !== AUTH_FAILED) console.error('[viewer] refresh failed', err);
     }
   }, REFRESH_INTERVAL);
 }
@@ -476,7 +480,10 @@ async function init() {
     await loadSessions();
   } catch (err) {
     // apiFetch has already shown the gate; anything else is worth surfacing.
-    if (err !== AUTH_FAILED) throw err;
+    if (err !== AUTH_FAILED) {
+      console.error('[viewer] initial load failed', err);
+      return;
+    }
     return;
   }
   hideTokenGate();

--- a/digit-mcp/ui/index.html
+++ b/digit-mcp/ui/index.html
@@ -19,23 +19,29 @@
     </div>
   </header>
 
-  <div id="token-gate" class="token-gate hidden">
+  <div id="token-gate" class="token-gate hidden" role="dialog" aria-modal="true" aria-labelledby="token-title">
     <form id="token-form" class="token-card">
-      <h2>Sign in</h2>
+      <h2 id="token-title">Sign in</h2>
       <p class="token-help">
         This viewer reads recorded tool arguments and results, so it needs a DIGIT
         access token with an admin role. The token is kept in this tab only and is
         cleared when you close it.
       </p>
-      <p id="token-message" class="token-message hidden"></p>
+      <p id="token-message" class="token-message hidden" role="alert" aria-live="polite"></p>
+      <label class="token-label" for="token-input">DIGIT access token</label>
       <input
         type="password"
         id="token-input"
-        placeholder="DIGIT access token"
         autocomplete="off"
         spellcheck="false"
       >
       <button type="submit">Continue</button>
+      <p class="token-help token-hint">
+        Mint one from your DIGIT instance:
+        <code>curl -u egov-user-client: -d 'grant_type=password&amp;scope=read&amp;userType=EMPLOYEE'
+        --data-urlencode username=… --data-urlencode password=… --data-urlencode tenantId=pg
+        &lt;host&gt;/user/oauth/token</code>
+      </p>
     </form>
   </div>
 

--- a/digit-mcp/ui/index.html
+++ b/digit-mcp/ui/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>DIGIT MCP Sessions</title>
-  <link rel="stylesheet" href="style.css?v=4">
+  <link rel="stylesheet" href="style.css?v=5">
 </head>
 <body>
   <header>
@@ -18,6 +18,26 @@
       </label>
     </div>
   </header>
+
+  <div id="token-gate" class="token-gate hidden">
+    <form id="token-form" class="token-card">
+      <h2>Sign in</h2>
+      <p class="token-help">
+        This viewer reads recorded tool arguments and results, so it needs a DIGIT
+        access token with an admin role. The token is kept in this tab only and is
+        cleared when you close it.
+      </p>
+      <p id="token-message" class="token-message hidden"></p>
+      <input
+        type="password"
+        id="token-input"
+        placeholder="DIGIT access token"
+        autocomplete="off"
+        spellcheck="false"
+      >
+      <button type="submit">Continue</button>
+    </form>
+  </div>
 
   <div id="warning-banner" class="warning-banner hidden">
     Database not available &mdash; showing cached data
@@ -60,6 +80,6 @@
     </section>
   </main>
 
-  <script src="app.js?v=4"></script>
+  <script src="app.js?v=5"></script>
 </body>
 </html>

--- a/digit-mcp/ui/style.css
+++ b/digit-mcp/ui/style.css
@@ -609,3 +609,22 @@ main {
 .token-card button:hover {
   filter: brightness(1.1);
 }
+
+.token-label {
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--text-muted, #8b949e);
+}
+
+.token-hint code {
+  display: block;
+  margin-top: 0.35rem;
+  padding: 0.45rem 0.55rem;
+  border-radius: 4px;
+  background: var(--bg, #0d1117);
+  font-size: 0.68rem;
+  line-height: 1.5;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+}

--- a/digit-mcp/ui/style.css
+++ b/digit-mcp/ui/style.css
@@ -519,3 +519,93 @@ main {
 ::-webkit-scrollbar-thumb:hover {
   background: var(--text-muted);
 }
+
+/* --- Token gate ------------------------------------------------------- */
+/* Shown when /api/* rejects the request: the viewer needs an admin-role
+   DIGIT token, so there is nothing useful to render behind it. */
+
+.token-gate {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(2px);
+}
+
+.token-gate.hidden {
+  display: none;
+}
+
+.token-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  width: 100%;
+  max-width: 26rem;
+  padding: 1.75rem;
+  border: 1px solid var(--border, #30363d);
+  border-radius: 8px;
+  background: var(--surface, #161b22);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
+}
+
+.token-card h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.token-help {
+  margin: 0;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: var(--text-muted, #8b949e);
+}
+
+.token-message {
+  margin: 0;
+  padding: 0.55rem 0.7rem;
+  border-radius: 4px;
+  background: rgba(220, 90, 90, 0.12);
+  color: #e08a8a;
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+.token-message.hidden {
+  display: none;
+}
+
+.token-card input {
+  padding: 0.6rem 0.7rem;
+  border: 1px solid var(--border, #30363d);
+  border-radius: 4px;
+  background: var(--bg, #0d1117);
+  color: inherit;
+  font-family: inherit;
+  font-size: 0.88rem;
+}
+
+.token-card input:focus {
+  outline: none;
+  border-color: var(--accent, #58a6ff);
+}
+
+.token-card button {
+  padding: 0.6rem 0.7rem;
+  border: none;
+  border-radius: 4px;
+  background: var(--accent, #58a6ff);
+  color: #fff;
+  font-family: inherit;
+  font-size: 0.88rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.token-card button:hover {
+  filter: brightness(1.1);
+}

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -1233,7 +1233,7 @@
         mcp_image: >-
           {{ mcp_image
              | default('digit-mcp:local' if (build_mcp | default(false))
-                       else 'ghcr.io/subhashini-egov/digit-mcp:2.12-draft-20260525-034354') }}
+                       else 'egovio/digit-mcp:nightly-develop') }}
 
     # Novu dashboard: when `build_novu_dashboard: true` we build a subpath-rebased
     # image locally (backend/novu-dashboard/Dockerfile, tag novu-dashboard:local)

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -1735,11 +1735,11 @@ services:
     # MCP image source resolved at deploy time. The Ansible playbook
     # writes MCP_IMAGE={{ docker_registry }}/digit-mcp:latest into the
     # .env it generates per tenant (so compose picks it up here).
-    # When running compose directly without the playbook, the fallback
-    # below pulls a public, pinned build from ghcr.io — no VPC access or
-    # insecure-registries trust required. Override MCP_IMAGE to use a
+    # When running compose directly without the playbook, the fallback below
+    # pulls the public build published by this repo's own image pipeline
+    # (build/build-config.yml -> egovio/digit-mcp). Override MCP_IMAGE to use a
     # different registry/tag.
-    image: ${MCP_IMAGE:-ghcr.io/subhashini-egov/digit-mcp:2026-06-11}
+    image: ${MCP_IMAGE:-egovio/digit-mcp:nightly-develop}
     container_name: digit-mcp
     restart: unless-stopped
     depends_on:
@@ -1750,6 +1750,12 @@ services:
     environment:
       MCP_TRANSPORT: http
       MCP_PORT: "3000"
+      # Token auth (the HTTP-transport default) is deliberately NOT relaxed
+      # here. nginx proxies /v1/ publicly (see ansible/templates/
+      # nginx-site.conf.j2), and its own comment says "Authentication is
+      # enforced inside the MCP server" — so `ambient` on this stack would put
+      # an anonymous ADMIN surface on the internet, which is the exact hole
+      # this hardening closes. Callers mint a token; see the onboarding skills.
       # `self-hosted` is the generic env entry — actual URL comes from
       # CRS_API_URL (kong service in this compose). CRS_ENV_NAME is what
       # /v1/version and get_environment_info display; keep it tenant-

--- a/local-setup/docs/ONBOARDING-AND-ADDONS.md
+++ b/local-setup/docs/ONBOARDING-AND-ADDONS.md
@@ -281,7 +281,7 @@ fails the whole `docker compose up`, not just MCP. Either:
 - `build_mcp: true` — build from the vendored in-tree source (no registry
   needed); or
 - leave it off and take the playbook's default, which resolves to the public
-  `ghcr.io/subhashini-egov/digit-mcp:<pinned-tag>` (see "Resolve MCP image tag"
+  `egovio/digit-mcp:nightly-develop` (see "Resolve MCP image tag"
   in `playbook-deploy.yml`). `MCP_IMAGE` is passed through verbatim — no
   `docker_registry` prefix is applied.
 

--- a/local-setup/tests/static/deployment-contracts.test.ts
+++ b/local-setup/tests/static/deployment-contracts.test.ts
@@ -110,9 +110,20 @@ describe('host_vars _example.yml', () => {
 describe('docker-compose.egov-digit.yaml', () => {
   const compose = read('local-setup/docker-compose.egov-digit.yaml');
 
-  test('digit-mcp falls back to a public ghcr image', () => {
+  test('digit-mcp falls back to the image this repo publishes', () => {
+    // egovio/digit-mcp is what build/build-config.yml builds from
+    // digit-mcp/Dockerfile. It used to fall back to a personal ghcr registry
+    // fed by a different repository, so changes made here never shipped.
     expect(compose).toMatch(
-      /image: \$\{MCP_IMAGE:-ghcr\.io\/subhashini-egov\/digit-mcp:[0-9-]+\}/
+      /image: \$\{MCP_IMAGE:-egovio\/digit-mcp:[\w.-]+\}/
     );
+  });
+
+  test('digit-mcp does NOT relax auth — nginx proxies /v1/ publicly', () => {
+    // ansible/templates/nginx-site.conf.j2 exposes /v1/ on the public vhost and
+    // relies on the MCP server to authenticate. MCP_AUTH_MODE=ambient here
+    // would therefore publish an anonymous ADMIN surface.
+    expect(compose).not.toMatch(/MCP_AUTH_MODE:\s*\$\{MCP_AUTH_MODE:-ambient\}/);
+    expect(compose).not.toMatch(/MCP_AUTH_MODE:\s*ambient/);
   });
 });


### PR DESCRIPTION
Security fixes for the MCP service. Findings and severities are tracked in #1641 — this implements all 13 rows plus 3 authorization items (N1–N3) found while fixing them.

**Six commits.** `3364fd7` fixes the tracked findings; `5d73d21` closes `/v1/*` and `/api/*`; `197771f` and `f64120c5` fix what five independent reviews found, and `bde20475` fixes what a second review round found in those fixes — including four defects `5d73d21` introduced, the reason none of it was reaching the cluster, and an SSRF at the lowest access tier.

**Draft for review.** Deployment prerequisites are listed at the bottom.

## Root cause

Eight near-identical copies of a local `ensureAuthenticated()` each fell back to `CRS_USERNAME`/`CRS_PASSWORD` whenever no token was set. Combined with `/mcp` having no auth check at all, **an anonymous caller was strictly more privileged than a badly-authenticated one** — sending no credentials triggered elevation to the container's stored ADMIN.

The fix is one shared helper plus an **auth mode** derived from the transport:

| Mode | When | Behaviour |
|---|---|---|
| `ambient` | stdio (default) | Env credentials may be used — the process was spawned by the developer whose credentials those are, so nothing is granted that the caller didn't already have. Authorization checks are skipped for the same reason. |
| `token` | HTTP (default) | Caller must present a token validated against egov-user. The server never substitutes its own credentials. |

`MCP_AUTH_MODE` overrides the derivation; setting `ambient` on HTTP logs a loud warning.

## Changes by finding

### Critical

| ID | Change | Files |
|---|---|---|
| **C1** | **All three routes** (`/mcp`, `/v1/*`, `/api/*`) authenticate before doing any work; bearer token introspected via `/user/_details` with a 30s cache. State tenant derived from the token rather than a caller-supplied header. | `src/index.ts`, `src/services/auth.ts` (new), `src/services/digit-api.ts`, `packages/data-provider/.../endpoints.ts` |
| **C3** | `base_url` host allow-list; ad-hoc targets require explicit credentials; `environment` added to `snapshotAuth`/`restoreAuth` so the redirect can't persist. | `src/tools/mdms-tenant.ts`, `src/services/auth.ts`, `src/services/digit-api.ts` |
| **C4** | Password reset guarded on `!existingUserUuid`; `loginCredentials` reports no password on the uuid-link path. | `src/tools/hrms.ts` |
| **C5** | Existing-citizen password reset removed; `citizenLogin` only returned for accounts `pgr_create` created. | `src/tools/pgr-workflow.ts` |

### High

| ID | Change | Files |
|---|---|---|
| **H1** | `tenant_cleanup` returns a read-only preview unless `confirm=<tenant_id>`; root tenants require `allow_root_tenant: true`, checked before auth or any lookup. | `src/tools/mdms-tenant.ts` |
| **H2** | `Authorization` attached to enc-service calls via new `encHeaders()`; both encryption tools require auth. | `src/services/digit-api.ts`, `src/tools/encryption.ts` |
| **H3** | `resolveArtifactPath()` confines snapshot reads/writes to `MCP_ARTIFACT_DIR`; rejects traversal, unrelated absolutes, and sibling-prefix escapes. | `src/services/auth.ts`, `src/tools/snapshot.ts` |
| **H5** | `digitApi` is now an `AsyncLocalStorage`-backed proxy; `/mcp` requests run in `runWithIsolatedClient()` in token mode. No call sites changed. | `src/services/digit-api.ts`, `src/index.ts` |

### Medium / Low

| ID | Change | Files |
|---|---|---|
| **M5** | Telemetry opt-in — no default endpoint; requires `MATOMO_URL`. Startup line names the endpoint when active. | `src/services/telemetry.ts` |
| **M6** | `configure` + `snapshot_capture` → `risk: 'write'`; SUPERUSER grant behind `provision_roles` (default false), with a response note when skipped. | `src/tools/mdms-tenant.ts`, `src/tools/snapshot.ts` |
| **M1** | Module-level `process.env.PGPASSWORD` removed; passed per-invocation. DB details from `DIGIT_DB_*`. | `src/services/shell.ts` |
| **L3** | Sanitization extended to engram content (search + full read), remote docs content, and both workflow `comment` fields. | `src/tools/docs.ts`, `src/tools/pgr-workflow.ts` |
| **L4** | `USER node`, pre-chowned writable dirs, no baked-in DB password; chart adds pod/container `securityContext`, read-only rootfs + volumes, image tag pinned to `Chart.AppVersion`. | `Dockerfile`, `helm/.../deployment.yaml`, `helm/.../values.yaml` |

### Authorization (N1–N3)

Authentication alone was not a privilege boundary: DIGIT permits citizen self-registration (`pgr_create` provisions citizens with password auth), and several tools — `decrypt_data`, `snapshot_capture`, `db_counts`, `kafka_lag`, `trace_*` — never consult DIGIT's own accesscontrol.

- **N1** New `ToolMetadata.access`: `public` | `employee` | `admin`, enforced in `server.ts` before dispatch. **Default `employee`**, so a new tool is never public by accident. Classified all 70 tools: 9 public, 34 admin, 27 employee-by-default. Keys on **roles, not `user.type`** — `type` would have let a provisioned citizen through.
- **N2** Redaction moved to `src/utils/redact.ts`: case-insensitive substring match at any depth (was 4 exact names, top level only). `sensitiveOutput` on `ToolMetadata` stops `decrypt_data` plaintext reaching the events table.
- **N3** `X-Forwarded-For` honoured only from `MCP_TRUSTED_PROXIES` peers (IPv4/CIDR/`*`); rejected claims logged as `untrusted_forwarded_for`.

## Incidental fix worth flagging

The configmap template enumerated four keys by hand, so **any new value added to `values.yaml` never reached the container** — several of the fixes above would have shipped inert. Replaced with a `range` over `.Values.env`, which also picks up develop's `CRS_API_URL`/`CRS_ENV_NAME` without a template edit.

## Behaviour changes (review these)

1. **Every HTTP caller now needs a token** — `/mcp`, `/v1/*` and `/api/*`. README and `install.sh` are updated (the installer prompts for one, or takes `DIGIT_ACCESS_TOKEN`). `MCP_AUTH_MODE=ambient` restores old behaviour for a loopback-bound socket.
2. **`tenant_cleanup` no longer deletes on first call** — automation must pass `confirm`.
3. **`configure` no longer auto-grants roles** — pass `provision_roles: true` where the tenant-fallback path relied on it.
4. **`configure` doesn't persist across `/mcp` calls in token mode** (per-request client). Tenant now derives from the token; all tools take `tenant_id` explicitly.
5. **`output_path` rejects paths outside `MCP_ARTIFACT_DIR`** — set that var to keep a previous location.
6. **Telemetry stops** where the demo-host default was relied on.
7. **`snapshot_capture`'s encryption canary degrades** when unauthenticated (was already the documented degradation model for that layer).
8. **`/v1/*` ignores `X-State-Tenant`** — the tenant comes from the token, same as `/mcp`.
9. **The session viewer asks for a token.** Its `/api/*` calls need an admin-role account; the token is held in `sessionStorage` for the tab only.
10. **`health_check` moved from `public` to `employee`.** `GET /healthz` still serves orchestrator liveness unauthenticated.
11. **The chart now deploys `egovio/digit-mcp`**, not `ghcr.io/chakshugautam/digit-mcp`. `image.tag` is required, with no fallback — pin a `develop-<sha8>` per environment.

## Verification

- `npm run build` clean; `helm lint` clean; chart renders with both develop's and the new values.
- **`npm run test:security` — 74 checks — and `npm run test:security:http` — 34 checks, both in CI** (`.github/workflows/digit-mcp-ci.yml`): auth-mode derivation, access tiers per identity, the tool classification itself (the public surface is asserted as an exact set), deep redaction, artifact confinement, the `base_url` allow-list, forwarded-for trust incl. IPv6, and interleaved-concurrency isolation for both the API client and the request context. Mutation-checked: defaulting the tier back to `public` fails 2.7; trusting `X-Forwarded-For` unconditionally fails four of section 7.
- `npm test` passes (70 tools registered).
- `npm run test:safety`: 51 pass / **2 fail — both pre-existing**. Verified by stashing this work and re-running on a clean tree: identical failures (`2.3 reject 9 digits`, `2.4 reject 11 digits`).
- Live probe: anonymous `/mcp` → 401, junk bearer → 401, `/healthz` → 200.
- Image built and run with `--read-only --user 1000:1000 --cap-drop ALL`: starts, serves, rootfs confirmed unwritable, gate holds.

## Deployment prerequisites

1. **Confirm `/user/_details` is routable** through the gateway. Validation is fail-closed by design — if introspection can't reach egov-user, every `/mcp` call returns 401.
2. **Confirm the admin role codes.** `MCP_ADMIN_ROLES` defaults to `SUPERUSER, MDMS_ADMIN, SYSTEM_ADMIN, STADMIN`. If the operator `ADMIN` account holds none of these, the 34 admin-tier tools will 403 in token mode. Denials print both required and held roles, so a mismatch is one call to diagnose.
3. **Pin `image.tag`.** `values.yaml` defaults to `nightly-develop`; pin a `develop-<sha8>` per environment. Rotating `CRS_PASSWORD` and closing the published container port remain operational items.

## Review follow-up (second commit)

The first commit closed `/mcp` and left three routes open on the same listener. Review also turned up a chart change that would not have deployed at all. Both are fixed in `5d73d21`.

### Authentication — the rest of C1

| Route | Was | Now |
|---|---|---|
| `/v1/*` | accepted **any** non-empty bearer string; fell back to `CRS_USERNAME`/`CRS_PASSWORD` | same introspection as `/mcp`; env fallback gated on ambient mode |
| `/v1/tenant/:id/export` | unauthenticated whole-tenant MDMS dump | admin tier (stated explicitly — it is not a registered tool) |
| `/v1/tools` | anonymous enumeration of the admin tool surface | bearer required (public tier: no role check) |
| `/api/stats`, `/api/sessions`, `/api/sessions/:id/{events,messages}`, `/api/pgr/dashboard` | fully anonymous, serving recorded tool args, result prefixes and client IPs | one gate over the namespace, admin tier |

`checkToolAccess` now runs on all three REST dispatch paths (single, streamed, bulk). Introspection, its cache and the tier check moved into `auth.ts`, so the routes cannot drift into disagreeing about what a token means. The session viewer gained a sign-in gate, since its data calls now need one.

### Deployment

- **The chart pointed at the wrong image.** `ghcr.io/chakshugautam/digit-mcp` is a personal registry fed by a different repository — nothing in this tree reached the cluster through it, so every fix in this PR would have shipped inert. Repointed to `egovio/digit-mcp`, which `build/build-config.yml` publishes from this Dockerfile.
- **The `Chart.AppVersion` tag fallback resolved to `1.0.0`, which has never existed** in either registry (checked against both). A `helm upgrade` on default values went straight to `ImagePullBackOff`.
- **`SESSION_DB_PASSWORD` plumbed through values/secret.** Dropping the Dockerfile `ENV` had changed nothing on its own — `db.ts` still defaulted to the same published string, one layer down.

### Correctness

- `AuthRequiredError` was documented as surfacing a 401 but **nothing mapped it** — every "not authenticated" error reported as `category: 'internal'`, telling the agent to retry rather than to authenticate.
- The logger and session store kept per-request identity in **instance fields**, so two concurrent `/mcp` requests cross-attributed each other's tool calls. Moved to `AsyncLocalStorage` — the same fix H5 applied to the API client, applied to the audit trail N3 exists to make trustworthy.
- Cached `UserInfo` is **copied per caller** rather than shared by reference across request-scoped clients.
- The `base_url` allow-list derived from the **live client's environment, which `configure` itself writes**; it now comes from startup config, so an accepted call cannot widen the guard that vets the next one.
- `MCP_TRUSTED_PROXIES` handles IPv6 literals and CIDRs — an IPv6 entry silently never matched, collapsing every client to the ingress address on a dual-stack cluster.
- `resolveArtifactPath` compares real paths on both sides: a symlink inside the artifact directory could point out of it, and a symlinked ancestor (`/var` → `/private/var`, a mounted volume) rejected legitimate input.
- `health_check` moved from `public` to `employee` — it reports which services exist, how fast they answer and how they fail, which is the infrastructure detail `ToolAccess` says the public tier must not expose.
- `configure`'s duplicated three-part provisioning condition collapsed to `if/else`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




## Third commit (`197771f`) — review findings

Five reviewers with separate briefs: adversarial security, Node/TS correctness, SRE/deployment, test-suite mutation testing, and API/docs. Everything below was reproduced before being fixed.

### Defects the second commit introduced

| | |
|---|---|
| `resolveArtifactPath` ran `mkdirSync` on the caller's path **before** the confinement check | A rejected path still authored directories anywhere the process could write |
| The symlink guard covered the wrong case | A **dangling** symlink passed: `realpathSync` throws on it, so it read as a not-yet-existing leaf, and `writeFileSync` followed it out. Creating a new file elsewhere is the case that matters |
| Form 1 claimed **any** `Authorization` header, not just `Bearer` | A proxy-injected or browser-cached `Basic` header hard-401'd, shadowing the `body.auth` credentials the caller sent |
| The `/api/*` gate preceded the CORS preflight short-circuit | `OPTIONS /api/stats` → 401. Preflights carry no credentials, so every cross-origin consumer was permanently broken |

### Pre-existing, found by review

- **`docs_get` was an SSRF primitive at the `public` tier.** The egress guard was `url.includes('docs.digit.org')` — a substring test on the whole URL, so `http://10.0.0.1/x?docs.digit.org` passed — then `fetch` followed redirects and returned the body verbatim. Reproduced: a citizen-role token read an internal endpoint through a 302. Now a hostname allow-list, `redirect: 'manual'`, a size cap, `sanitizeUserContent` (the L3 pass missed this path), and `employee` tier.
- **The REST shim wrote no audit record at all.** `mcpLogger`/`sessionStore` are called from `server.ts` only, so every successful `/v1/*` call — `tenant_destroy` included — was unlogged. Only denials were.
- **`enable_tools` was `public` + `risk: 'read'`** while mutating the long-lived REST registry every caller shares.

### The chart was not what deploys

`devops/deploy-as-code/charts/auxiliary-services/auxiliary-helmfile.yaml:46` hard-overrode `image.repository`/`tag` to a personal ghcr registry pinned to a June build. It is the only thing installing this chart in-cluster, so repointing `values.yaml` in the second commit **changed nothing** — and the new env vars were being injected into an image that ignores them. Repointed there, in compose, and in the ansible playbook. Also: `pullPolicy: Always` (the default tag moves), `checksum/config` so a ConfigMap-only change actually rolls, `sizeLimit` on all three emptyDirs, and the `develop-<sha8>` pinning advice removed — the nightly prune keeps only 5, so such a pin vanishes within a week along with the rollback target.

### One thing deliberately **not** done

The local compose stack is **not** set to `MCP_AUTH_MODE=ambient`, despite that being the obvious fix for "the local stack now 401s". `local-setup/ansible/templates/nginx-site.conf.j2:207` proxies `/v1/` on the **public** vhost and defers authentication to this server — so ambient there would publish an anonymous ADMIN surface, which is the hole this PR exists to close. A contract test asserts it stays off. The ansible `/v1` calls use `body.auth` and keep working; the xlsx runbook's calls did not, and now carry a bearer.

### Tests: enforcement, not just policy

Mutation testing found the unit suite proved the tier *decision* correct while proving nothing about whether it is *called* — deleting `checkToolAccess` from `server.ts`, `authorizeRest` from a REST path, or the whole `/api/*` gate each left it 57/57 green. `test-security-http.ts` (27 checks, in CI) drives a real server over a real socket against a stub egov-user: anonymous reachability, all three REST dispatch paths, the MCP path, the `/api/*` gate, Form 2, audit records, redaction. All three mutations now fail it.

Four unit tests were also defective: 3.3 was a tautology that could not fail, 4.1 did not test depth, 7.8 was vacuous, 8.2 left the shared client authenticated for every later test. Fixed, plus regressions for both path bugs, a partial-prefix IPv6 CIDR, and `environment` isolation.

### Docs

`docs/api/tools/decrypt_data.md` still said the tool needs no authentication — the exact claim H2 was filed against. The OAuth recipe added to the README in the second commit was wrong (DIGIT's client secret is empty; `$USER` collides with the shell's own variable). All six new env vars documented, tool counts corrected to 70, `install.sh` no longer writes an empty bearer under `--yes`, and the viewer gate gained a label, `aria-live`, and a token-minting hint.

**Tier counts, asserted by test 3.3b: 6 public / 30 employee / 34 admin of 70.**



## Fifth commit (`f64120c5`) — the review tail

### Shipping and operability
- **The Dockerfile never copied `ui/`**, so the session viewer 404s in every container — which made the sign-in gate added in `5d73d21` dead code wherever it actually runs.
- **The chart never set `SESSION_DB_*`**, so the image default (`localhost:15433`) had no listener in a pod: sessions were silently not persisted and `/api/stats` returned "Database not available". The `SESSION_DB_PASSWORD` secret added earlier did nothing on its own.
- **`MCP_BIND`**, defaulting to loopback in ambient+http. The ambient warning told operators to use a loopback-bound socket while the bind address was hardcoded to `0.0.0.0`.

### Failure modes that lied
- **`validateToken` returned `null` for a 5xx, a DNS failure and a timeout alike**, so an egov-user outage surfaced as *"Invalid or expired access token"* on every route — sending operators after credentials while the platform was down, and making the viewer discard a working token. Now a distinct error mapped to **503**, plus single-flight so a cold token costs one round trip rather than N against an already-struggling service.
- **`runStreamed` committed HTTP 200 before authenticating**, then emitted `event: error`. Any client keying on the status code read a denial as success.
- **`tenant_cleanup`'s dry run returned `success: true`** — the field every other tool uses to mean "it happened", so automation would take a preview for a completed cleanup.

### Leaks
- **`employee_create`, `user_create`, `pgr_create` return plaintext provisioning passwords**, and the session store persists a 200-char result prefix — so the credential reached Postgres and the JSONL log. Marked `sensitiveOutput`.
- **`/v1/version` served `gitSha`, `buildTime`, `nodeVersion` anonymously** — which CVEs apply, to anyone. Withheld unless authenticated; service name and uptime stay open so it remains a liveness probe.
- **The REST shim resolved the tool before authenticating**, so 404-for-unknown vs 401-for-known enumerated the tool surface.
- `serveStatic` compared with `startsWith` and no trailing separator.

### Parsing
- **`ipv6Groups` parsed a trailing dotted quad with `parseInt(_, 16)`** — `'1.2.3.4'` became `1` — and `normalizeIp` only recognised the `::ffff:` shorthand, so a fully-spelled v4-mapped peer never matched an IPv4 entry, and `::ffff:10.0.0.0/104` was rejected outright. All three fixed.
- **`redactDeep` matched credential words as bare substrings**, redacting `author`, `authority` and `tokenize` out of the audit trail, and its depth cap of 8 replaced genuinely deep payloads (`mdms_create`, `tenant_bootstrap`) with a placeholder — discarding the arguments most worth auditing. Now word-segmented, depth 64, with a `WeakSet` cycle guard.
- **`MCP_ALLOWED_BASE_URLS` replaced the configured host instead of extending it**, so authorising one extra instance silently de-authorised `CRS_API_URL`.

### Deliberately not done
The introspection call still passes the token as `?access_token=`. That is egov-user's documented contract for `/user/_details` (a `@RequestParam`, which is how the gateway calls it too), so it does put the token in access logs — but moving it to a header on an unverified guess **fails closed**, i.e. every caller gets a 401. Documented in place rather than changed blind.

One review finding was **overstated and is recorded as such**: `base_url` needed no `..` guard, because the URL parser collapses those before the check runs. The test asserts that rather than adding dead code.

### CI

`DIGIT-MCP CI`, `Gatus coverage`, `Tilt CI` and the Flyway check are green; the infra-contract job that runs the new `local-setup` assertions passes 8/8. **`Local Setup CI` fails** — at the `Localization module check / egov-user not seeded` step, which fails identically on `develop` and is unrelated to this branch.



## Sixth commit (`bde20475`) — second review round

Two fresh reviewers (adversarial security, Node/TS correctness) re-ran against `f64120c5` with briefs that required each fix to come back CLOSED, PARTIALLY CLOSED or NOT CLOSED. They independently agreed on five items. Everything below was reproduced before being fixed.

**The redaction rewrite lost coverage it should have kept.** Moving from substring to word matching removed the intended false positives (`author`, `authority`, `tokenize`) and introduced false *negatives*: `access_key` was dropped from the word list outright, and the glue-fallback's length floor of 6 excluded `pwd`, `auth` and `token` — the three commonest glue components. Confirmed reaching `access.log` and `events.jsonl`: `access_key`, `aws_access_key`, `AWS_ACCESS_KEY_ID`, `authtoken`, `accesstoken`, `refreshtoken`, `idtoken`, `oauth`, `xauth`, `userpwd`, `newpwd`, `pwd2`. Now per-word matching with an explicit benign list, plus qualified words so `key` counts next to `access`/`secret`/`signing` but not in `sortKey`. 35 keys asserted in both directions.

**The `WeakSet` was traversal-scoped, not path-scoped.** A DAG is not a cycle — `{ source: t, target: t }` emitted the second occurrence as `[circular]`, deleting real audit data. The same over-redaction the rewrite existed to stop.

**REST calls still recorded nothing in the session store.** `f64120c5` claimed "all three dispatch paths now record"; only `mcpLogger` was actually wired. `recordToolCall` is a no-op until a session exists, and only `/mcp` ever called `ensureSession` — so on a REST-only deployment (what the ansible playbook and the xlsx runbook drive) `tenant_destroy` left an access-log line and **no** events row, no `/api/sessions/:id/events` entry, no Postgres record.

**Unauthenticated remote OOM.** `readBody` buffered without a cap, ahead of every gate — so one anonymous request killed the process on its memory limit, before `authenticateBearer` was ever reached. Pre-existing, but it defeated every gate in this PR. Capped at 16MB/413; verified a 400MB anonymous POST against `--max-old-space-size=192` now leaves the server serving.

**The tool-existence oracle was fixed on one route of two.** `dispatchTool` was reordered, `runBulk` was not — the sibling route still enumerated all 70 tools anonymously. The `C.7` test asserted only the non-bulk path, which is exactly why it survived.

**Trusted-proxy config failed OPEN on malformed entries.** `bits === 0` returned true before the range was validated, so `/0`, `garbage/0` and `10.0.0.1/-0` all meant "trust every peer". Separately the v4-mapped rebase was gated on the *normalised* range, which cannot tell `::ffff:10.0.0.0/104` from the typo `10.0.0.0/104` — the typo silently became a `/8`.

**`/v1/version` was an introspection amplifier.** Gating detail behind `authenticateBearer` meant any bearer, including junk, drove a full `/user/_details` round trip (only successes are cached) — a 1:1 amplifier against egov-user at the one endpoint documented as an open probe, blocking for the 10s timeout when that service hung. Now cache-hit only.

**`runStreamed` authenticated twice** — two OAuth logins per `body.auth` SSE request, the form ansible uses.

### Recorded as NOT defects
The previous round's IPv6 finding was **overstated**: `resolveClientIp` feeds only log attribution, never an authorization decision, so the worst case was a forged IP in the audit trail. Both reviewers also confirmed the `docs_get` SSRF fix, artifact-path confinement, introspection failure handling and `sensitiveOutput` as fully **CLOSED** against a wide set of attacks (DNS rebinding, userinfo, punycode, trailing-dot, IPv6-literal hosts, intermediate symlinks, TOCTOU, fail-open paths).
