### PR TITLE
fix(dashboard): respect analytics batch budget

### DIFF
--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsController.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsController.java
@@ -91,6 +91,7 @@ public class AnalyticsController {
                 out.put("tiles", Collections.emptyList());
                 out.put("defaultLayout", Collections.emptyList());
                 out.put("packId", null);
+                out.put("maxBatchQueries", AnalyticsService.MAX_BATCH_QUERIES);
                 // A 200 response lets the anonymous shell render an intentional unavailable
                 // screen. No KPI descriptors, layouts, counts, or query data leave the service.
                 return ResponseEntity.ok(out);
@@ -113,6 +114,7 @@ public class AnalyticsController {
             out.put("defaultLayout", pack.map(DashboardPack::getLayout).orElse(Collections.emptyList()));
             out.put("asOf", System.currentTimeMillis());
             out.put("packId", pack.map(DashboardPack::getId).orElse(null));
+            out.put("maxBatchQueries", AnalyticsService.MAX_BATCH_QUERIES);
             // Deliberately no recordCount: even a matching public pack must not become a
             // tenant-volume enumeration primitive.
             return ResponseEntity.ok(out);
@@ -263,6 +265,7 @@ public class AnalyticsController {
             // are unchanged for callers that do match a pack.
             int stateLen = config.getStateLevelTenantIdLength() == null ? 1 : config.getStateLevelTenantIdLength();
             out.put("recordCount", pack.isPresent() ? service.recordCount(tenantId, stateLen) : null);
+            out.put("maxBatchQueries", AnalyticsService.MAX_BATCH_QUERIES);
             return ResponseEntity.ok(out);
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(error(e));

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsControllerPacksTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsControllerPacksTest.java
@@ -75,5 +75,6 @@ public class AnalyticsControllerPacksTest {
         assertEquals(200, resp.getStatusCodeValue());
         assertEquals(1234L, resp.getBody().get("recordCount"));
         assertEquals("supervisor-pack", resp.getBody().get("packId"));
+        assertEquals(AnalyticsService.MAX_BATCH_QUERIES, resp.getBody().get("maxBatchQueries"));
     }
 }

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsControllerPublicTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsControllerPublicTest.java
@@ -92,6 +92,8 @@ public class AnalyticsControllerPublicTest {
         assertEquals("public-default", response.getBody().get("packId"));
         assertEquals(true, response.getBody().get("enabled"));
         assertEquals(1, ((List<?>) response.getBody().get("tiles")).size());
+        assertEquals(AnalyticsService.MAX_BATCH_QUERIES,
+                response.getBody().get("maxBatchQueries"));
         assertFalse(response.getBody().containsKey("recordCount"));
         verify(service, never()).recordCount(anyString(), anyInt());
     }
@@ -122,6 +124,8 @@ public class AnalyticsControllerPublicTest {
         assertEquals(Collections.emptyList(), response.getBody().get("tiles"));
         assertEquals(Collections.emptyList(), response.getBody().get("defaultLayout"));
         assertNull(response.getBody().get("packId"));
+        assertEquals(AnalyticsService.MAX_BATCH_QUERIES,
+                response.getBody().get("maxBatchQueries"));
         verify(kpiCatalogService, never()).getVisibleDefs(anyString(), anySet());
         verify(kpiCatalogService, never()).getBestPack(anyString(), anySet(), anyList());
         verifyNoInteractions(service);

--- a/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
@@ -33,6 +33,7 @@ import { useFilterOptions } from "./hooks/useFilterOptions";
 import { useCatalog } from "./hooks/useCatalog";
 import { useCatalogLayout, getDroppingItemForKpi, defaultSizeForKpi } from "./hooks/useCatalogLayout";
 import { runKpiBatch, runPublicKpiBatch, getTenantId } from "./services/analyticsService";
+import { errorForTile } from "./services/analyticsBatch";
 import { fetchComplaintHierarchyLevels } from "./services/complaintHierarchyService";
 import * as dashboardMetrics from "./services/dashboardMetrics";
 import { GRID_COLS, KPI_ROW_HEIGHT, DROPPING_ITEM, DROPPING_ITEM_ID } from "./constants/layoutConfig";
@@ -755,8 +756,8 @@ const AdminDashboardInner = ({ onSignOut, embedded = false, publicMode = false, 
     });
 
     const request = publicMode
-      ? runPublicKpiBatch(refs, tenantId)
-      : runKpiBatch(refs, tenantId);
+      ? runPublicKpiBatch(refs, tenantId, pack?.maxBatchQueries)
+      : runKpiBatch(refs, tenantId, pack?.maxBatchQueries);
     request
       .then((res) => {
         if (reqId !== reqIdRef.current) return;
@@ -780,7 +781,12 @@ const AdminDashboardInner = ({ onSignOut, embedded = false, publicMode = false, 
         setBatch({
           loading: false,
           results: {},
-          errors: { __batch: err?.message || t("DASHBOARD_COMMON_BATCH_FAILED", "Batch query failed") },
+          errors: {
+            __batch:
+              err?.payload?.message ||
+              err?.message ||
+              t("DASHBOARD_COMMON_BATCH_FAILED", "Batch query failed"),
+          },
           partial: true,
           asOf: null,
           calendar: null,
@@ -816,8 +822,7 @@ const AdminDashboardInner = ({ onSignOut, embedded = false, publicMode = false, 
     if (!def) return null;
 
     const assembled = assembleResult(kpiId, def, batch.results);
-    const errCode = batch.errors && batch.errors[kpiId];
-    const tileError = errCode ? { code: errCode, message: String(errCode) } : null;
+    const tileError = errorForTile(batch.errors, kpiId);
 
     return (
       <KpiTile

--- a/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
@@ -743,6 +743,7 @@ const AdminDashboardInner = ({ onSignOut, embedded = false, publicMode = false, 
       ? buildPublicRefs(tiles, kpis)
       : buildRefs(tiles, kpis, filters, hierOverrides);
     const reqId = ++reqIdRef.current;
+    const controller = typeof AbortController !== "undefined" ? new AbortController() : null;
     dashboardMetrics.markBatchStart(reqId);
     // A changed query plan must not leave the prior values visible/exportable
     // beneath new filter labels while the replacement request is in flight.
@@ -755,9 +756,13 @@ const AdminDashboardInner = ({ onSignOut, embedded = false, publicMode = false, 
       calendar: null,
     });
 
+    const requestOptions = {
+      signal: controller?.signal,
+      shouldContinue: () => reqId === reqIdRef.current,
+    };
     const request = publicMode
-      ? runPublicKpiBatch(refs, tenantId, pack?.maxBatchQueries)
-      : runKpiBatch(refs, tenantId, pack?.maxBatchQueries);
+      ? runPublicKpiBatch(refs, tenantId, pack?.maxBatchQueries, requestOptions)
+      : runKpiBatch(refs, tenantId, pack?.maxBatchQueries, requestOptions);
     request
       .then((res) => {
         if (reqId !== reqIdRef.current) return;
@@ -773,7 +778,8 @@ const AdminDashboardInner = ({ onSignOut, embedded = false, publicMode = false, 
         });
         dashboardMetrics.markAllWidgetsReady(
           countErrorWidgets(res?.errors, tiles.length),
-          reqId
+          reqId,
+          res?.roundTrips
         );
       })
       .catch((err) => {
@@ -793,6 +799,10 @@ const AdminDashboardInner = ({ onSignOut, embedded = false, publicMode = false, 
         });
         dashboardMetrics.markAllWidgetsReady(tiles.length, reqId);
       });
+    return () => {
+      if (reqIdRef.current === reqId) reqIdRef.current += 1;
+      controller?.abort();
+    };
     // refsKey captures both the tile set and the resolved params.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [refsKey, pack, tenantId, publicMode]);

--- a/digit-ui-esbuild/products/dashboard/src/hooks/useCatalog.js
+++ b/digit-ui-esbuild/products/dashboard/src/hooks/useCatalog.js
@@ -93,6 +93,7 @@ export function useCatalog(tenantId, { publicMode = false } = {}) {
             tiles: filteredTiles,
             layout: packLayout,
             enabled: !publicMode || packRes?.enabled !== false,
+            maxBatchQueries: packRes?.maxBatchQueries ?? null,
           },
           packMeta,
           error: null,

--- a/digit-ui-esbuild/products/dashboard/src/services/analyticsBatch.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/analyticsBatch.js
@@ -1,8 +1,8 @@
+import { chunkValues, runSequentialChunks } from "./sequentialChunks";
+
 /** Backend fallback for deployments that predate the advertised pack budget. */
 export const DEFAULT_MAX_BATCH_QUERIES = 50;
 
-/** Companion query keys emitted by queryPlan.js for one rendered tile. */
-const COMPANION_SUFFIXES = ["__prior", "__series", "__pins"];
 const hasOwn = (value, key) => Object.prototype.hasOwnProperty.call(value, key);
 
 function objectMap(value) {
@@ -31,7 +31,11 @@ function canonicalError(value, fallback = null) {
     const fallbackCode = fallbackError?.code || fallbackError?.error;
     return {
       code: value,
-      message: String(fallbackCode === value && fallbackError?.message ? fallbackError.message : value),
+      message: String(
+        String(fallbackCode) === String(value) && fallbackError?.message
+          ? fallbackError.message
+          : value
+      ),
     };
   }
   if (value && typeof value === "object") {
@@ -77,11 +81,7 @@ export function normalizeAnalyticsBatch(payload) {
 export function chunkQueryRefs(refs, maxBatchQueries) {
   const entries = Object.entries(objectMap(refs));
   const limit = batchLimit(maxBatchQueries);
-  const chunks = [];
-  for (let offset = 0; offset < entries.length; offset += limit) {
-    chunks.push(Object.fromEntries(entries.slice(offset, offset + limit)));
-  }
-  return chunks;
+  return chunkValues(entries, limit).map((chunk) => Object.fromEntries(chunk));
 }
 
 /**
@@ -89,11 +89,17 @@ export function chunkQueryRefs(refs, maxBatchQueries) {
  * transport fails. Sequential execution preserves the backend cap's intent:
  * adding a second HTTP request must not double concurrent PostgreSQL pressure.
  */
-export async function runChunkedAnalyticsBatch(refs, maxBatchQueries, executeChunk) {
-  const chunks = chunkQueryRefs(refs, maxBatchQueries);
-  if (!chunks.length) {
-    return { results: {}, errors: null, partial: false, asOf: null, calendar: null, scope: null };
-  }
+export async function runChunkedAnalyticsBatch(
+  refs,
+  maxBatchQueries,
+  executeChunk,
+  options = {}
+) {
+  // Preserve the old transport contract for an empty/stale query plan: the
+  // backend still owns the authoritative asOf/calendar response and the call's
+  // telemetry. An empty plan is one request, not zero requests.
+  const boundedChunks = chunkQueryRefs(refs, maxBatchQueries);
+  const chunks = boundedChunks.length ? boundedChunks : [{}];
 
   const results = Object.create(null);
   const errors = Object.create(null);
@@ -104,9 +110,10 @@ export async function runChunkedAnalyticsBatch(refs, maxBatchQueries, executeChu
   let successfulChunks = 0;
   let firstFailure = null;
 
-  for (const chunk of chunks) {
-    try {
-      const response = normalizeAnalyticsBatch(await executeChunk(chunk));
+  const outcomes = await runSequentialChunks(chunks, executeChunk, options);
+  for (const { chunk, value, error } of outcomes) {
+    if (!error) {
+      const response = normalizeAnalyticsBatch(value);
       successfulChunks += 1;
       Object.assign(results, response.results);
       if (response.errors) Object.assign(errors, response.errors);
@@ -116,7 +123,7 @@ export async function runChunkedAnalyticsBatch(refs, maxBatchQueries, executeChu
       }
       if (calendar == null && response.calendar != null) calendar = response.calendar;
       if (scope == null && response.scope != null) scope = response.scope;
-    } catch (error) {
+    } else {
       firstFailure ||= error;
       partial = true;
       const message = errorMessage(error);
@@ -133,21 +140,16 @@ export async function runChunkedAnalyticsBatch(refs, maxBatchQueries, executeChu
   return {
     results,
     errors: Object.keys(errors).length ? errors : null,
-    partial: partial || Object.keys(errors).length > 0,
+    partial,
     asOf,
     calendar,
     scope,
+    roundTrips: chunks.length,
   };
 }
 
-/** Return the first failure that makes a rendered tile incomplete. */
+/** Return only the base-query failure that prevents a tile from rendering. */
 export function errorForTile(errors, kpiId) {
   if (!errors || !kpiId) return null;
-  if (hasOwn(errors, kpiId) && errors[kpiId]) return errors[kpiId];
-  for (const suffix of COMPANION_SUFFIXES) {
-    const key = `${kpiId}${suffix}`;
-    const companion = hasOwn(errors, key) ? errors[key] : null;
-    if (companion) return companion;
-  }
-  return null;
+  return hasOwn(errors, kpiId) && errors[kpiId] ? errors[kpiId] : null;
 }

--- a/digit-ui-esbuild/products/dashboard/src/services/analyticsBatch.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/analyticsBatch.js
@@ -1,0 +1,153 @@
+/** Backend fallback for deployments that predate the advertised pack budget. */
+export const DEFAULT_MAX_BATCH_QUERIES = 50;
+
+/** Companion query keys emitted by queryPlan.js for one rendered tile. */
+const COMPANION_SUFFIXES = ["__prior", "__series", "__pins"];
+const hasOwn = (value, key) => Object.prototype.hasOwnProperty.call(value, key);
+
+function objectMap(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+function batchLimit(value) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : DEFAULT_MAX_BATCH_QUERIES;
+}
+
+function errorMessage(error) {
+  return String(error?.payload?.message || error?.message || "Analytics request failed");
+}
+
+/**
+ * Convert every supported wire error into the shape KpiTile renders.
+ *
+ * Deployed backends use {error,message} inline under results, while newer
+ * contracts may also publish a top-level errors map. Keep both readable while
+ * tenants roll independently.
+ */
+function canonicalError(value, fallback = null) {
+  const fallbackError = fallback && typeof fallback === "object" ? fallback : null;
+  if (typeof value === "string" && value) {
+    const fallbackCode = fallbackError?.code || fallbackError?.error;
+    return {
+      code: value,
+      message: String(fallbackCode === value && fallbackError?.message ? fallbackError.message : value),
+    };
+  }
+  if (value && typeof value === "object") {
+    const code = value.code || value.error || fallbackError?.code || fallbackError?.error || "query_failed";
+    const fallbackCode = fallbackError?.code || fallbackError?.error;
+    return {
+      code: String(code),
+      message: String(
+        value.message || (String(fallbackCode) === String(code) && fallbackError?.message) || code
+      ),
+    };
+  }
+  if (fallbackError) return canonicalError(fallbackError);
+  return { code: "query_failed", message: "query_failed" };
+}
+
+/** Normalize legacy inline errors and the additive top-level error contract. */
+export function normalizeAnalyticsBatch(payload) {
+  const source = objectMap(payload);
+  const results = objectMap(source.results);
+  const explicitErrors = objectMap(source.errors);
+  const errors = Object.create(null);
+
+  for (const [key, result] of Object.entries(results)) {
+    if (result && typeof result === "object" && typeof result.error === "string") {
+      errors[key] = canonicalError(result);
+    }
+  }
+  for (const [key, error] of Object.entries(explicitErrors)) {
+    errors[key] = canonicalError(error, errors[key]);
+  }
+
+  const hasErrors = Object.keys(errors).length > 0;
+  return {
+    ...source,
+    results,
+    errors: hasErrors ? errors : null,
+    partial: Boolean(source.partial) || hasErrors,
+  };
+}
+
+/** Split a named-query map without changing its insertion order or keys. */
+export function chunkQueryRefs(refs, maxBatchQueries) {
+  const entries = Object.entries(objectMap(refs));
+  const limit = batchLimit(maxBatchQueries);
+  const chunks = [];
+  for (let offset = 0; offset < entries.length; offset += limit) {
+    chunks.push(Object.fromEntries(entries.slice(offset, offset + limit)));
+  }
+  return chunks;
+}
+
+/**
+ * Execute bounded chunks sequentially, retaining successful chunks if a later
+ * transport fails. Sequential execution preserves the backend cap's intent:
+ * adding a second HTTP request must not double concurrent PostgreSQL pressure.
+ */
+export async function runChunkedAnalyticsBatch(refs, maxBatchQueries, executeChunk) {
+  const chunks = chunkQueryRefs(refs, maxBatchQueries);
+  if (!chunks.length) {
+    return { results: {}, errors: null, partial: false, asOf: null, calendar: null, scope: null };
+  }
+
+  const results = Object.create(null);
+  const errors = Object.create(null);
+  let partial = false;
+  let asOf = null;
+  let calendar = null;
+  let scope = null;
+  let successfulChunks = 0;
+  let firstFailure = null;
+
+  for (const chunk of chunks) {
+    try {
+      const response = normalizeAnalyticsBatch(await executeChunk(chunk));
+      successfulChunks += 1;
+      Object.assign(results, response.results);
+      if (response.errors) Object.assign(errors, response.errors);
+      partial = partial || response.partial;
+      if (typeof response.asOf === "number") {
+        asOf = asOf == null ? response.asOf : Math.min(asOf, response.asOf);
+      }
+      if (calendar == null && response.calendar != null) calendar = response.calendar;
+      if (scope == null && response.scope != null) scope = response.scope;
+    } catch (error) {
+      firstFailure ||= error;
+      partial = true;
+      const message = errorMessage(error);
+      for (const key of Object.keys(chunk)) {
+        errors[key] = { code: "batch_failed", message };
+      }
+    }
+  }
+
+  // Preserve the existing global-banner behaviour only when no data request
+  // succeeded at all. A partial transport failure keeps the usable tile data.
+  if (successfulChunks === 0) throw firstFailure;
+
+  return {
+    results,
+    errors: Object.keys(errors).length ? errors : null,
+    partial: partial || Object.keys(errors).length > 0,
+    asOf,
+    calendar,
+    scope,
+  };
+}
+
+/** Return the first failure that makes a rendered tile incomplete. */
+export function errorForTile(errors, kpiId) {
+  if (!errors || !kpiId) return null;
+  if (hasOwn(errors, kpiId) && errors[kpiId]) return errors[kpiId];
+  for (const suffix of COMPANION_SUFFIXES) {
+    const key = `${kpiId}${suffix}`;
+    const companion = hasOwn(errors, key) ? errors[key] : null;
+    if (companion) return companion;
+  }
+  return null;
+}

--- a/digit-ui-esbuild/products/dashboard/src/services/analyticsBatch.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/analyticsBatch.test.js
@@ -1,0 +1,168 @@
+// Run from digit-ui-esbuild/:
+//   node --test products/dashboard/src/services/analyticsBatch.test.js
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const esbuild = require("esbuild");
+
+const ENTRY = path.join(__dirname, "analyticsBatch.js");
+const OUT = path.join(os.tmpdir(), `analyticsBatch.cjs.${process.pid}.js`);
+
+esbuild.buildSync({
+  entryPoints: [ENTRY],
+  bundle: true,
+  format: "cjs",
+  platform: "neutral",
+  outfile: OUT,
+});
+process.on("exit", () => {
+  try {
+    fs.unlinkSync(OUT);
+  } catch (e) {
+    /* already gone */
+  }
+});
+
+const {
+  DEFAULT_MAX_BATCH_QUERIES,
+  chunkQueryRefs,
+  runChunkedAnalyticsBatch,
+  normalizeAnalyticsBatch,
+  errorForTile,
+} = require(OUT);
+
+function refs(count) {
+  return Object.fromEntries(
+    Array.from({ length: count }, (_, index) => [`q${index}`, { kpiId: `kpi${index}` }])
+  );
+}
+
+test("the 51-entry regression is split at the backend's 50-entry budget", () => {
+  const chunks = chunkQueryRefs(refs(51), DEFAULT_MAX_BATCH_QUERIES);
+
+  assert.deepEqual(chunks.map((chunk) => Object.keys(chunk).length), [50, 1]);
+  assert.deepEqual(chunks.flatMap((chunk) => Object.keys(chunk)), Object.keys(refs(51)));
+});
+
+test("invalid or missing advertised limits fall back to 50", () => {
+  for (const limit of [undefined, null, 0, -1, NaN, "not-a-number"]) {
+    assert.deepEqual(chunkQueryRefs(refs(51), limit).map((chunk) => Object.keys(chunk).length), [50, 1]);
+  }
+  assert.deepEqual(chunkQueryRefs(refs(51), 25).map((chunk) => Object.keys(chunk).length), [25, 25, 1]);
+});
+
+test("chunks execute sequentially and merge every result exactly once", async () => {
+  const calls = [];
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const result = await runChunkedAnalyticsBatch(refs(51), 50, async (chunk) => {
+    inFlight += 1;
+    maxInFlight = Math.max(maxInFlight, inFlight);
+    calls.push(Object.keys(chunk));
+    await Promise.resolve();
+    inFlight -= 1;
+    return {
+      results: Object.fromEntries(Object.keys(chunk).map((key) => [key, { rows: [{ total: 1 }] }])),
+      partial: false,
+      asOf: calls.length === 1 ? 200 : 100,
+      calendar: { timeZone: "Africa/Nairobi" },
+      scope: { level: "tenant" },
+    };
+  });
+
+  assert.equal(maxInFlight, 1);
+  assert.deepEqual(calls.map((keys) => keys.length), [50, 1]);
+  assert.deepEqual(Object.keys(result.results), Object.keys(refs(51)));
+  assert.equal(result.asOf, 100, "the merged freshness stamp must not overstate the older chunk");
+  assert.deepEqual(result.calendar, { timeZone: "Africa/Nairobi" });
+  assert.deepEqual(result.scope, { level: "tenant" });
+  assert.equal(result.partial, false);
+  assert.equal(result.errors, null);
+});
+
+test("one failed chunk retains successful tile data and marks only failed refs", async () => {
+  let call = 0;
+  const result = await runChunkedAnalyticsBatch(refs(51), 50, async (chunk) => {
+    call += 1;
+    if (call === 2) {
+      const error = new Error("Analytics request failed (503)");
+      error.payload = { message: "analytics temporarily unavailable" };
+      throw error;
+    }
+    return {
+      results: Object.fromEntries(Object.keys(chunk).map((key) => [key, { rows: [] }])),
+      partial: false,
+    };
+  });
+
+  assert.equal(Object.keys(result.results).length, 50);
+  assert.deepEqual(result.errors.q50, {
+    code: "batch_failed",
+    message: "analytics temporarily unavailable",
+  });
+  assert.equal(result.errors.q49, undefined);
+  assert.equal(result.partial, true);
+});
+
+test("all failed chunks preserve the existing global failure path", async () => {
+  await assert.rejects(
+    runChunkedAnalyticsBatch(refs(51), 50, async () => {
+      throw new Error("offline");
+    }),
+    /offline/
+  );
+});
+
+test("legacy inline errors become canonical without disturbing successful results", () => {
+  const ok = { columns: ["total"], rows: [{ total: 7 }] };
+  const normalized = normalizeAnalyticsBatch({
+    results: {
+      ok,
+      denied: { error: "kpi_forbidden", message: "not authorized" },
+    },
+    partial: true,
+  });
+
+  assert.equal(normalized.results.ok, ok);
+  assert.deepEqual(normalized.errors.denied, {
+    code: "kpi_forbidden",
+    message: "not authorized",
+  });
+  assert.equal(normalized.partial, true);
+});
+
+test("explicit errors are authoritative and companion failures resolve to the base tile", () => {
+  const normalized = normalizeAnalyticsBatch({
+    results: {
+      card__prior: { error: "legacy_code", message: "legacy detail" },
+    },
+    errors: {
+      card__prior: { code: "invalid_param", message: "bad comparison" },
+    },
+  });
+
+  assert.deepEqual(normalized.errors.card__prior, {
+    code: "invalid_param",
+    message: "bad comparison",
+  });
+  assert.equal(errorForTile(normalized.errors, "card"), normalized.errors.card__prior);
+  assert.equal(errorForTile(normalized.errors, "other"), null);
+});
+
+test("empty rows are successful data and reserved keys remain ordinary own keys", () => {
+  const payload = JSON.parse(
+    '{"results":{"empty":{"rows":[]},"__proto__":{"error":"kpi_forbidden","message":"denied"}}}'
+  );
+  const normalized = normalizeAnalyticsBatch(payload);
+
+  assert.equal(normalized.errors.empty, undefined);
+  assert.deepEqual(normalized.errors.__proto__, {
+    code: "kpi_forbidden",
+    message: "denied",
+  });
+  assert.equal(errorForTile(normalized.errors, "__proto__").code, "kpi_forbidden");
+  assert.equal(errorForTile({}, "constructor"), null);
+});

--- a/digit-ui-esbuild/products/dashboard/src/services/analyticsBatch.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/analyticsBatch.test.js
@@ -81,6 +81,7 @@ test("chunks execute sequentially and merge every result exactly once", async ()
   assert.deepEqual(result.scope, { level: "tenant" });
   assert.equal(result.partial, false);
   assert.equal(result.errors, null);
+  assert.equal(result.roundTrips, 2);
 });
 
 test("one failed chunk retains successful tile data and marks only failed refs", async () => {
@@ -116,6 +117,38 @@ test("all failed chunks preserve the existing global failure path", async () => 
   );
 });
 
+test("an empty ref map still performs one request for freshness metadata", async () => {
+  const calls = [];
+  const result = await runChunkedAnalyticsBatch({}, 50, async (chunk) => {
+    calls.push(chunk);
+    return { results: {}, asOf: 123, calendar: { timeZone: "Africa/Nairobi" } };
+  });
+
+  assert.deepEqual(calls, [{}]);
+  assert.equal(result.asOf, 123);
+  assert.deepEqual(result.calendar, { timeZone: "Africa/Nairobi" });
+  assert.equal(result.roundTrips, 1);
+});
+
+test("a superseded generation never starts its next sequential chunk", async () => {
+  let current = true;
+  let calls = 0;
+  await assert.rejects(
+    runChunkedAnalyticsBatch(
+      refs(51),
+      50,
+      async () => {
+        calls += 1;
+        current = false;
+        return { results: {} };
+      },
+      { shouldContinue: () => current }
+    ),
+    { name: "AbortError" }
+  );
+  assert.equal(calls, 1);
+});
+
 test("legacy inline errors become canonical without disturbing successful results", () => {
   const ok = { columns: ["total"], rows: [{ total: 7 }] };
   const normalized = normalizeAnalyticsBatch({
@@ -134,7 +167,7 @@ test("legacy inline errors become canonical without disturbing successful result
   assert.equal(normalized.partial, true);
 });
 
-test("explicit errors are authoritative and companion failures resolve to the base tile", () => {
+test("explicit errors are authoritative and companion failures do not blank base data", () => {
   const normalized = normalizeAnalyticsBatch({
     results: {
       card__prior: { error: "legacy_code", message: "legacy detail" },
@@ -148,8 +181,18 @@ test("explicit errors are authoritative and companion failures resolve to the ba
     code: "invalid_param",
     message: "bad comparison",
   });
-  assert.equal(errorForTile(normalized.errors, "card"), normalized.errors.card__prior);
+  assert.equal(errorForTile(normalized.errors, "card"), null);
+  assert.equal(errorForTile(normalized.errors, "card__prior"), normalized.errors.card__prior);
   assert.equal(errorForTile(normalized.errors, "other"), null);
+});
+
+test("string errors reuse richer fallback messages across code types", () => {
+  const normalized = normalizeAnalyticsBatch({
+    results: { card: { error: "7", message: "specific detail" } },
+    errors: { card: "7" },
+  });
+
+  assert.deepEqual(normalized.errors.card, { code: "7", message: "specific detail" });
 });
 
 test("empty rows are successful data and reserved keys remain ordinary own keys", () => {

--- a/digit-ui-esbuild/products/dashboard/src/services/analyticsBatchCatalog.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/analyticsBatchCatalog.test.js
@@ -1,0 +1,62 @@
+// Regression contract for #1758. Run from digit-ui-esbuild/:
+//   node --test products/dashboard/src/services/analyticsBatchCatalog.test.js
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const esbuild = require("esbuild");
+
+function bundle(entry, name) {
+  const outfile = path.join(os.tmpdir(), `${name}.cjs.${process.pid}.js`);
+  esbuild.buildSync({
+    entryPoints: [entry],
+    bundle: true,
+    format: "cjs",
+    platform: "neutral",
+    outfile,
+  });
+  return outfile;
+}
+
+const queryPlanOut = bundle(path.join(__dirname, "../utils/queryPlan.js"), "queryPlan-budget");
+const batchOut = bundle(path.join(__dirname, "analyticsBatch.js"), "analyticsBatch-budget");
+process.on("exit", () => {
+  for (const outfile of [queryPlanOut, batchOut]) {
+    try {
+      fs.unlinkSync(outfile);
+    } catch (e) {
+      /* already gone */
+    }
+  }
+});
+
+const { buildRefs } = require(queryPlanOut);
+const { chunkQueryRefs, DEFAULT_MAX_BATCH_QUERIES } = require(batchOut);
+
+const CATALOG = path.resolve(
+  __dirname,
+  "../../../../../ansible/nairobi-mdms/mdms/dss/KpiDefinition.json"
+);
+
+function visibleToPgrAdmin(def) {
+  if (def.status !== "published" || def.viz?.internal === true) return false;
+  const ceiling = (def.rbac?.visibleTo || []).filter((role) => role !== "PUBLIC");
+  return ceiling.length === 0 || ceiling.includes("PGR_ADMIN");
+}
+
+test("the canonical PGR_ADMIN add-all plan is chunked without losing any companion ref", () => {
+  const definitions = JSON.parse(fs.readFileSync(CATALOG, "utf8"))
+    .map((record) => record.data || record)
+    .filter(visibleToPgrAdmin);
+  const kpis = Object.fromEntries(definitions.map((def) => [def.id, { ...def, kpiId: def.id }]));
+  const tiles = definitions.map((def) => ({ kpiId: def.id }));
+  const refs = buildRefs(tiles, kpis, {}, {});
+  const chunks = chunkQueryRefs(refs, DEFAULT_MAX_BATCH_QUERIES);
+
+  assert.equal(definitions.length, 28);
+  assert.equal(Object.keys(refs).length, 51, "this is the production #1758 trigger");
+  assert.deepEqual(chunks.map((chunk) => Object.keys(chunk).length), [50, 1]);
+  assert.deepEqual(chunks.flatMap((chunk) => Object.keys(chunk)), Object.keys(refs));
+});

--- a/digit-ui-esbuild/products/dashboard/src/services/analyticsService.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/analyticsService.js
@@ -5,6 +5,7 @@ import {
   getTenantId,
   toRequestError,
 } from "./authService";
+import { runChunkedAnalyticsBatch } from "./analyticsBatch";
 
 // Re-exported for existing importers; authService is the definition.
 export { getTenantId };
@@ -131,8 +132,10 @@ export function fetchCatalog(tenantId) {
  * refs: { [tileKey]: { kpiId, params } }
  * Returns { results: { [tileKey]: { columns, rows, asOf, scope } }, partial, errors }
  */
-export function runKpiBatch(refs, tenantId) {
-  return postAnalytics("/_query", { tenantId, queries: refs });
+export function runKpiBatch(refs, tenantId, maxBatchQueries) {
+  return runChunkedAnalyticsBatch(refs, maxBatchQueries, (queries) =>
+    postAnalytics("/_query", { tenantId, queries })
+  );
 }
 
 /** Curated PUBLIC pack. The response itself contains the safe tile descriptors. */
@@ -141,6 +144,8 @@ export function fetchPublicPack(tenantId) {
 }
 
 /** PUBLIC data path. The backend accepts only curated, base kpiId references. */
-export function runPublicKpiBatch(refs, tenantId) {
-  return postPublicAnalytics("/_query", { tenantId, queries: refs });
+export function runPublicKpiBatch(refs, tenantId, maxBatchQueries) {
+  return runChunkedAnalyticsBatch(refs, maxBatchQueries, (queries) =>
+    postPublicAnalytics("/_query", { tenantId, queries })
+  );
 }

--- a/digit-ui-esbuild/products/dashboard/src/services/analyticsService.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/analyticsService.js
@@ -20,7 +20,7 @@ export function getAnalyticsBase() {
 
 const ANALYTICS_BASE = getAnalyticsBase();
 
-async function postAnalytics(path, body) {
+async function postAnalytics(path, body, signal) {
   const startedAt = typeof performance !== "undefined" ? performance.now() : Date.now();
   // The analytics API is the dashboard's primary data path, so it is the one
   // surface allowed to conclude the session is dead (sessionCritical defaults
@@ -37,6 +37,7 @@ async function postAnalytics(path, body) {
         RequestInfo: buildRequestInfo("dashboard"),
         ...body,
       }),
+      signal,
     });
   } catch (error) {
     const endedAt = typeof performance !== "undefined" ? performance.now() : Date.now();
@@ -64,7 +65,7 @@ async function postAnalytics(path, body) {
  * anonymous PUBLIC contract, so this transport always sends a role-less
  * RequestInfo and performs exactly one request.
  */
-async function postPublicAnalytics(path, body) {
+async function postPublicAnalytics(path, body, signal) {
   const url = `${ANALYTICS_BASE}/public${path}`;
   const startedAt = typeof performance !== "undefined" ? performance.now() : Date.now();
   let response;
@@ -73,6 +74,7 @@ async function postPublicAnalytics(path, body) {
       method: "POST",
       headers: { "Content-Type": "application/json", ...withTraceHeaders({}) },
       credentials: "omit",
+      signal,
       body: JSON.stringify({
         RequestInfo: {
           apiId: "Rainmaker",
@@ -132,9 +134,12 @@ export function fetchCatalog(tenantId) {
  * refs: { [tileKey]: { kpiId, params } }
  * Returns { results: { [tileKey]: { columns, rows, asOf, scope } }, partial, errors }
  */
-export function runKpiBatch(refs, tenantId, maxBatchQueries) {
-  return runChunkedAnalyticsBatch(refs, maxBatchQueries, (queries) =>
-    postAnalytics("/_query", { tenantId, queries })
+export function runKpiBatch(refs, tenantId, maxBatchQueries, options = {}) {
+  return runChunkedAnalyticsBatch(
+    refs,
+    maxBatchQueries,
+    (queries) => postAnalytics("/_query", { tenantId, queries }, options.signal),
+    options
   );
 }
 
@@ -144,8 +149,11 @@ export function fetchPublicPack(tenantId) {
 }
 
 /** PUBLIC data path. The backend accepts only curated, base kpiId references. */
-export function runPublicKpiBatch(refs, tenantId, maxBatchQueries) {
-  return runChunkedAnalyticsBatch(refs, maxBatchQueries, (queries) =>
-    postPublicAnalytics("/_query", { tenantId, queries })
+export function runPublicKpiBatch(refs, tenantId, maxBatchQueries, options = {}) {
+  return runChunkedAnalyticsBatch(
+    refs,
+    maxBatchQueries,
+    (queries) => postPublicAnalytics("/_query", { tenantId, queries }, options.signal),
+    options
   );
 }

--- a/digit-ui-esbuild/products/dashboard/src/services/authService.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/authService.js
@@ -621,13 +621,14 @@ function refreshSession() {
  */
 export async function authFetch(
   url,
-  { buildBody, method = "POST", headers, sessionCritical = true } = {}
+  { buildBody, method = "POST", headers, sessionCritical = true, signal } = {}
 ) {
   const send = () =>
     fetch(url, {
       method,
       headers: { "Content-Type": "application/json", ...headers },
       credentials: "omit",
+      signal,
       body: buildBody ? JSON.stringify(buildBody()) : undefined,
     });
 

--- a/digit-ui-esbuild/products/dashboard/src/services/boundaryService.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/boundaryService.js
@@ -6,6 +6,7 @@ import {
 } from "./authService";
 import { isPublicDashboardRuntime } from "./dashboardRuntime";
 import { withTraceHeaders } from "./dashboardMetrics";
+import { chunkValues, runSequentialChunks } from "./sequentialChunks";
 
 
 /**
@@ -18,12 +19,11 @@ export async function fetchBoundariesByCodes(codes = []) {
 
   const tenantId = getTenantId();
   const uniqueCodes = [...new Set(codes.filter(Boolean))];
-  const chunkSize = 100;
   const all = [];
   let lastError = null;
+  let successfulChunks = 0;
 
-  for (let i = 0; i < uniqueCodes.length; i += chunkSize) {
-    const chunk = uniqueCodes.slice(i, i + chunkSize);
+  const outcomes = await runSequentialChunks(chunkValues(uniqueCodes, 100), async (chunk) => {
     const params = new URLSearchParams({
       tenantId,
       codes: chunk.join(","),
@@ -34,29 +34,29 @@ export async function fetchBoundariesByCodes(codes = []) {
     // loaded, but a TOTAL failure still rethrows so the map can show its error
     // state instead of a silently blank choropleth. Auxiliary data: a 401 here
     // must never be allowed to declare the whole session dead.
-    try {
-      const response = await authFetch(`/boundary-service/boundary/_search?${params}`, {
-        headers: withTraceHeaders({}),
-        buildBody: () => ({ RequestInfo: buildRequestInfo("dashboard-boundary") }),
-        sessionCritical: false,
-      });
+    const response = await authFetch(`/boundary-service/boundary/_search?${params}`, {
+      headers: withTraceHeaders({}),
+      buildBody: () => ({ RequestInfo: buildRequestInfo("dashboard-boundary") }),
+      sessionCritical: false,
+    });
 
-      if (!response.ok) {
-        console.warn(`boundary/_search failed (${response.status})`);
-        lastError = new Error(`boundary/_search failed (${response.status})`);
-        continue;
-      }
+    if (!response.ok) throw new Error(`boundary/_search failed (${response.status})`);
 
-      const payload = await response.json();
-      const boundaries = payload?.Boundary || [];
-      all.push(...boundaries);
-    } catch (error) {
-      console.warn("boundary/_search error", error);
-      lastError = error;
+    const payload = await response.json();
+    return payload?.Boundary || [];
+  });
+
+  for (const outcome of outcomes) {
+    if (outcome.error) {
+      console.warn("boundary/_search error", outcome.error);
+      lastError = outcome.error;
+    } else {
+      successfulChunks += 1;
+      all.push(...outcome.value);
     }
   }
 
-  if (!all.length && lastError) throw lastError;
+  if (successfulChunks === 0 && lastError) throw lastError;
 
   return all;
 }

--- a/digit-ui-esbuild/products/dashboard/src/services/dashboardMetrics.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/dashboardMetrics.js
@@ -21,6 +21,7 @@ import { isPublicDashboardRuntime } from "./dashboardRuntime";
  *   dashboard.transfer.bytes          sum        Σ resource transferSize in the load window
  *                                                (network transfer incl. headers; 0 on cache hits)
  *   dashboard.error_widgets.count     sum        errored tiles at load settle (base kpiIds)
+ *   dashboard.analytics_round_trips.count sum     sequential analytics calls per settled batch
  * All histograms/sums use DELTA temporality (browsers are ephemeral emitters).
  * Variable tags (tenant/persona/layout_id/record_count_tier/ua_family/nav_type)
  * are DATAPOINT attributes; the resource carries only service.name=dashboard-web
@@ -176,6 +177,7 @@ function newLoadCtx(navType, t0, ttfbMs) {
     allReadyMs: null,
     allReadyPending: false,
     errorWidgets: 0,
+    analyticsRoundTrips: 0,
     slowApiCalls: 0,
     transferBytes: 0,
     quiesced: false, // load window closed (accumulators frozen)
@@ -266,7 +268,7 @@ export function markFirstWidgetVisible() {
  *  - one-shot load mark (all_widgets_ready + error_widgets + quiesce flush)
  *  - interaction-window close for the SAME reqId (filter_apply/persona_switch)
  */
-export function markAllWidgetsReady(errorCount = 0, reqId) {
+export function markAllWidgetsReady(errorCount = 0, reqId, roundTrips = 1) {
   if (!on()) return;
   const load = state.load;
   const needLoadMark = !!load && load.allReadyMs == null && !load.allReadyPending;
@@ -274,10 +276,14 @@ export function markAllWidgetsReady(errorCount = 0, reqId) {
   const mayCloseWindow = windowMatches(reqId);
   if (!needLoadMark && !mayCloseWindow) return;
 
+  const requestCount = Math.max(1, Number(roundTrips) || 1);
+  recordSum("dashboard.analytics_round_trips.count", requestCount);
+
   postPaint((ts) => {
     if (needLoadMark && state.load === load && load.allReadyMs == null) {
       load.allReadyMs = Math.max(0, ts - load.t0);
       load.errorWidgets = Math.max(0, Number(errorCount) || 0);
+      load.analyticsRoundTrips = requestCount;
       recordHist("dashboard.all_widgets_ready.ms", load.allReadyMs);
       if (load.errorWidgets > 0) recordSum("dashboard.error_widgets.count", load.errorWidgets);
       // Close the load window shortly after settle so buffered resource entries
@@ -705,6 +711,7 @@ function buildLoadLogRecord(load) {
     slow_api_calls: load.slowApiCalls,
     transfer_bytes: load.transferBytes,
     error_widgets: load.errorWidgets,
+    analytics_round_trips: load.analyticsRoundTrips,
     failed_api_calls: load.failedApiCalls || 0,
   });
 }

--- a/digit-ui-esbuild/products/dashboard/src/services/dashboardMetrics.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/dashboardMetrics.test.js
@@ -113,14 +113,16 @@ test("load marks are one-shot and post-paint; error/'No data' path still marks f
   flushRaf();
   assert.deepEqual(histValues(m, "dashboard.first_widget_visible.ms"), [400]);
 
-  m.markAllWidgetsReady(2, 1);
+  m.markAllWidgetsReady(2, 1, 2);
   setNow(500);
   flushRaf();
   m.markAllWidgetsReady(9, 1); // repeat: no-op for the load mark
   flushRaf();
   assert.deepEqual(histValues(m, "dashboard.all_widgets_ready.ms"), [500]);
   assert.equal(m._inspect().pending.sums["dashboard.error_widgets.count"], 2);
+  assert.equal(m._inspect().pending.sums["dashboard.analytics_round_trips.count"], 2);
   assert.equal(m._inspect().load.errorWidgets, 2);
+  assert.equal(m._inspect().load.analyticsRoundTrips, 2);
 });
 
 test("mark-before-begin buffers and reconciles at beginLoad", () => {

--- a/digit-ui-esbuild/products/dashboard/src/services/sequentialChunks.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/sequentialChunks.js
@@ -1,0 +1,47 @@
+function cancellationError() {
+  const error = new Error("Sequential request cancelled");
+  error.name = "AbortError";
+  return error;
+}
+
+function isCancelled(signal, shouldContinue) {
+  return Boolean(signal?.aborted) || (shouldContinue && !shouldContinue());
+}
+
+/** Split an array into bounded chunks while preserving input order. */
+export function chunkValues(values, limit) {
+  const chunks = [];
+  for (let offset = 0; offset < values.length; offset += limit) {
+    chunks.push(values.slice(offset, offset + limit));
+  }
+  return chunks;
+}
+
+/**
+ * Run chunks sequentially and retain both successes and failures.
+ *
+ * Callers own the domain-specific merge and total-failure policy. Cancellation
+ * is the one shared terminal condition: once a request generation is stale, no
+ * later chunk may be issued.
+ */
+export async function runSequentialChunks(
+  chunks,
+  executeChunk,
+  { signal, shouldContinue } = {}
+) {
+  const outcomes = [];
+  for (let index = 0; index < chunks.length; index += 1) {
+    if (isCancelled(signal, shouldContinue)) throw cancellationError();
+    const chunk = chunks[index];
+    try {
+      const value = await executeChunk(chunk, index);
+      outcomes.push({ chunk, value, error: null });
+    } catch (error) {
+      if (isCancelled(signal, shouldContinue) || error?.name === "AbortError") {
+        throw error?.name === "AbortError" ? error : cancellationError();
+      }
+      outcomes.push({ chunk, value: null, error });
+    }
+  }
+  return outcomes;
+}


### PR DESCRIPTION
## Summary

- advertise the backend analytics batch ceiling through authenticated and public pack responses
- split expanded dashboard query plans into sequential bounded requests and merge their result/error envelopes
- preserve successful chunks when another chunk fails, while surfacing base and companion-query errors on the affected tile
- add a production-catalog regression proving the PGR_ADMIN Add All plan expands from 28 tiles to 51 query refs and is sent as 50 + 1

## Root cause

The canonical PGR_ADMIN catalog contains 28 visible tiles, but comparison, time-series, and pin companions expand Add All into 51 named queries. The analytics endpoint atomically rejects any request above `MAX_BATCH_QUERIES = 50`, so the dashboard received HTTP 400 before any KPI was evaluated.

The client now consumes the server-advertised budget, with a fallback of 50 for older deployments. Chunks run sequentially so the fix does not increase concurrent database pressure. The response merger supports both deployed inline `{ error, message }` entries and an additive top-level `errors` map.

## Verification

- dashboard Node test suite: 247/247 passing
- targeted Java controller and batch-limit tests passing under JDK 17
- staged diff passes `git diff --check`

## Scope

This change applies only to `/dashboard-ui`. Handling the legacy `/dashboard` path is explicitly outside this effort. No dashboard layout or styling is changed.

Closes #1758