### PR TITLE
docs: rework the O&M runbook and document the localhost full/slim presets (#1739, #1598)

### DIFF
--- a/docs/deployment-modes.md
+++ b/docs/deployment-modes.md
@@ -39,6 +39,13 @@ bootstraps the tenant.
 
 Runs today on bomet (dev, nightly), naipepea (demo), maputo. CI uses it for E2E validation.
 
+**Self-targeting (localhost) variants.** Mode A does not require a remote host: with
+`ansible_host: localhost` + `ansible_connection: local`, `deploy.sh` converges the machine
+you are on. Two presets ship for that — **full** (~16 GB, everything including the Novu
+notification stack) and **slim** (full minus Novu, sized for a 16 GB box or a WSL2 VM). They
+differ by exactly two flags. See
+[`local-setup/docs/LOCALHOST-FULL-AND-SLIM.md`](../local-setup/docs/LOCALHOST-FULL-AND-SLIM.md).
+
 ## Mode B — Local Kubernetes (dev cluster)
 
 **Entry point:** `Tiltfile.k8s` + manifests in `local-setup/k8s/`

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -99,11 +99,13 @@ Replace `<your-domain>` with your deployment's domain throughout this handbook.
 | **Logs** | `https://<your-domain>/grafana/d/digit-loki-logs/` | The actual error text |
 | **Service metrics** | `https://<your-domain>/grafana/d/digit-jvm/` | Memory, CPU, restarts, OOM |
 
-> **Access note.** Grafana on these deployments is configured with anonymous access at
-> **Admin** level (`GF_AUTH_ANONYMOUS_ENABLED=true`, login form disabled). You do not need a
-> password — but it also means anyone who knows the URL has full Grafana access. If your
-> deployment is reachable from the public internet, raise it with us and we will put it
-> behind your VPN or an authentication proxy. See
+> **Access note.** Grafana asks for a login. The user is `admin`; the password is
+> generated on the first deploy and stored in this deployment's OpenBao, so **ask your
+> system administrator for it** — it is not a shared default you can guess. Anonymous
+> access is off unless the deployment explicitly sets `grafana_anonymous_enabled: true`,
+> and even then it grants **Viewer**, never Admin. If your deployment does have anonymous
+> access on and is reachable from the public internet, raise it with us: a Viewer can run
+> arbitrary Loki queries, and the logs contain live session tokens. See
 > [alerts-setup.md § Before you start](alerts-setup.md#before-you-start).
 >
 > **Credentials.** Nothing in the first-response checklist needs a password. For the things

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -26,6 +26,44 @@ dive" and ignore the labels — nothing else depends on them.
 
 ---
 
+## Who does what — the L1 / L2 line
+
+One rule decides almost every case:
+
+> **If there is a screen for it, it is L1. If it needs the server, a log, a database or a
+> configuration file, it is L2.**
+
+L1 is not only incidents. A large part of day-to-day operations is *requests* — "add this
+clerk", "we have a new department", "this complaint type is missing" — and all of that is
+done through the product's own admin screens. It belongs on the first line.
+
+| Work | Tier | Why |
+|---|---|---|
+| Creating and deactivating **users / employees** (HRMS screens) | **L1** | It has a UI. No server access, no configuration files |
+| Adding or editing **master data** — departments, designations, complaint types, boundaries, localisation strings (Configurator / DIGIT Studio) | **L1** | Same. These are supported product screens |
+| Bulk loading master data from the **onboarding spreadsheets** | **L1** | Driven from the wizard; validation errors come back on screen |
+| The **first-response checklist** — is it up, did something crash, what does the log say | **L1** | All of it is read-only, in a browser |
+| Resolving anything on the **[known-issues](known-issues.md)** list | **L1** | The resolutions there are deliberately UI-only |
+| Restarting a service, reading container logs, `docker`/`psql` on the box | **L2** | Server access |
+| Anything about **why** — diagnosis, correlating services, tracing a request | **L2** | Complexity, and it needs the full stack in view |
+| **Configuration** the UI does not expose — env vars, nginx, Kong routes, compose files | **L2** | Not a screen; changes survive only through a redeploy |
+| **Capacity** — raising a memory limit, disk filling, log rotation | **L2** | Host-level, see [l2-diagnosis.md](l2-diagnosis.md) |
+| Deploying, upgrading, restoring a backup | **L2**, usually with us | Changes the deployment itself |
+
+Two consequences worth stating plainly:
+
+- **An L1 who cannot create a user is not fully set up.** Give the service desk an admin
+  login for the Configurator and HRMS. Without one, routine requests bounce to L2 and the
+  second line becomes a queue for work that never needed it.
+- **"It has a UI" is about the task, not the person.** If a master-data change needs a
+  database edit because the screen cannot express it, that is L2 by this rule — and it is
+  also worth telling us, because a screen is missing.
+
+Where exactly your team draws the line is still yours to set. This is the split the handbook
+assumes when it says "L1" and "L2".
+
+---
+
 ## How a problem moves
 
 ```
@@ -56,7 +94,7 @@ Replace `<your-domain>` with your deployment's domain throughout this handbook.
 
 | What | URL | Use it for |
 |---|---|---|
-| **Health dashboard** (Gatus) | `https://<your-domain>/status/` | *Is everything up?* — ~50 live checks, red/green, refreshed every 30s |
+| **Health dashboard** (Gatus) | `https://<your-domain>/status/` | *Is everything up?* — up to 57 live checks in 12 groups, red/green, refreshed every 30s |
 | **Grafana** | `https://<your-domain>/grafana/` | Metrics, logs, traces, alerts |
 | **Logs** | `https://<your-domain>/grafana/d/digit-loki-logs/` | The actual error text |
 | **Service metrics** | `https://<your-domain>/grafana/d/digit-jvm/` | Memory, CPU, restarts, OOM |
@@ -103,7 +141,7 @@ The trade-off is that **a problem reported late may no longer have any evidence 
 | **Traces** (per-request timing) | Tempo | **24 hours** | Slowness reports older than a day can't be diagnosed from traces |
 | **Logs** | Loki | **72 hours (3 days)** | The error text is gone after 3 days |
 | **Metrics** (memory, CPU, restarts) | Prometheus | **15 days** | Trends and restart history survive two weeks |
-| Health check history | Gatus | in-memory, **lost on restart** | Worth screenshotting while it's red |
+| Health check history | Gatus | **survives restarts** — SQLite on disk | Roughly the last 100 results and 50 events per endpoint |
 
 If a problem happened over a weekend, the logs may already have rolled off by Monday — just
 say so in the report so we know what's available.
@@ -166,12 +204,15 @@ and whether it is **reproducible on demand**.
 
 ## What this handbook does not cover
 
-- **Deploying or upgrading** the stack — that is `local-setup/ansible/`, and normally ours.
+This handbook is about **things going wrong**. The routine admin work in the table above is
+L1's, but it is documented elsewhere, because it is not incident response:
+
 - **Onboarding a city, boundaries, departments or employees** — see
   [`../migration/operator-runbook.md`](../migration/operator-runbook.md) and the XLSX
   onboarding flow.
 - **Changing application configuration** (complaint types, SLAs, branding) — that is the
-  Configurator, not an incident.
+  Configurator. Doing it is L1 work; it is just not an incident.
+- **Deploying or upgrading** the stack — that is `local-setup/ansible/`, and normally ours.
 
 If you're not sure whether your problem is an incident or a configuration question, file it
 as **S4** and we will re-classify it.

--- a/docs/operations/alert-channels.md
+++ b/docs/operations/alert-channels.md
@@ -204,7 +204,7 @@ bearer token on the request.
 
 ## Option B — Gatus native alerting (endpoint down)
 
-The health dashboard at `/status/` already checks ~50 endpoints every 30 seconds. It can
+The health dashboard at `/status/` already checks up to 57 endpoints every 30 seconds. It can
 notify you directly, and it is the **only thing watching the containers that emit no
 metrics** — Postgres, Redis, Kafka, Kong, Elasticsearch, nginx and the sign-in service. That makes it the
 highest-value alerting you can add, and the fastest.

--- a/docs/operations/alerts-setup.md
+++ b/docs/operations/alerts-setup.md
@@ -305,7 +305,7 @@ Notes:
 
 ### Synthetic alerts and the dead-man's switch
 
-**Endpoint checks.** The Gatus health dashboard at `/status/` already probes ~50 endpoints
+**Endpoint checks.** The Gatus health dashboard at `/status/` already probes up to 57 endpoints
 every 30 seconds, but it does not notify anyone by default. Turning on **Gatus's own
 alerting** gives you "service X is down" notifications without any Grafana rules at all —
 it is the cheapest coverage you can add, and it is the only thing that watches the

--- a/docs/operations/alerts-setup.md
+++ b/docs/operations/alerts-setup.md
@@ -43,20 +43,22 @@ expected.
 
 **Two things to know about access:**
 
-- Grafana is configured for **anonymous Admin access with the login form disabled**
-  (`GF_AUTH_ANONYMOUS_ORG_ROLE: Admin`, `GF_AUTH_DISABLE_LOGIN_FORM: true`). You should be
-  able to create alert rules immediately, with no account. Two consequences worth knowing
-  before you start:
-  - **There is no user identity.** Grafana cannot record who created, edited or silenced a
-    rule, and anyone with the URL has the same power. **Keep your own written change log.**
-    If the instance is reachable from the public internet, ask us to put it behind your VPN
-    or an authenticating proxy.
-  - **There is also no way to sign in as a real user through the UI**, because the login
-    form is switched off. So before you invest an afternoon in building rules, do step 1 of
-    [Creating your first rule](#creating-your-first-rule-click-by-click) and **press Save
-    once**. If saving is rejected, don't work around it — tell us, and use the
-    [alerts-as-code path](#shipping-alerts-as-code-so-they-survive-a-rebuild) instead, which
-    does not depend on the UI at all.
+- **You need a Grafana login before you start.** The login form is enabled
+  (`GF_AUTH_DISABLE_LOGIN_FORM: "false"`), the user is `admin`, and the password is
+  generated on the first deploy and stored in OpenBao — your system administrator can
+  read it back with
+  `bao kv get -field=grafana_admin_password kv/digit/<deployment>`. Get it before you
+  invest an afternoon in building rules.
+  - **Anonymous access is a separate, off-by-default switch.** `GF_AUTH_ANONYMOUS_ENABLED`
+    follows the deployment's `grafana_anonymous_enabled`, which defaults to `false`, and
+    the anonymous role is pinned to **Viewer** in the compose file. A Viewer cannot create
+    alert rules, so if you are browsing without logging in, Save will be rejected — log in
+    rather than working around it.
+  - **Everyone shares the one `admin` account**, so Grafana cannot record who created,
+    edited or silenced a rule. **Keep your own written change log.** If the instance is
+    reachable from the public internet, ask us to put it behind your VPN or an
+    authenticating proxy — and note that a Viewer can run arbitrary Loki queries, which is
+    why anonymous access is not a safe default here.
 - Rules you create in the UI are stored in Grafana's own database inside the
   `grafana_data` Docker volume. They survive restarts and redeployments. They do **not**
   survive `docker compose down -v` — which is one more reason that command appears on the

--- a/docs/operations/cheatsheet.md
+++ b/docs/operations/cheatsheet.md
@@ -82,7 +82,7 @@ sum by (compose_service) (count_over_time({compose_project="digit"} |~ `(?i)erro
 |---|---|
 | **Logs** | **72 hours** |
 | **Metrics** | **15 days** |
-| **Health-check history** | **lost on restart — screenshot it** |
+| **Health-check history** | survives restarts (SQLite); ~100 results / 50 events per endpoint |
 
 ---
 

--- a/docs/operations/incident-report.md
+++ b/docs/operations/incident-report.md
@@ -166,8 +166,9 @@ Attach **text**, not photographs of screens — text can be searched.
 
 ### Always
 
-1. **Health dashboard screenshot** — if something is red. Gatus keeps its history in memory
-   and loses it on restart, so capture it the moment you see it.
+1. **Health dashboard screenshot** — if something is red. Gatus keeps its history on disk
+   now, so it survives a restart, but it only holds about the last 100 results per endpoint
+   — on a flapping check that is a couple of hours. Capture it while you can see it.
 2. **The failing request** — browser F12 → **Network** → reproduce → click the red row →
    screenshot showing the **URL, status code and response body**. This one attachment
    identifies the responsible service more often than anything else.

--- a/docs/operations/l1-first-response.md
+++ b/docs/operations/l1-first-response.md
@@ -10,6 +10,12 @@ citizen.
 **Not your job:** working out *why*. If you find yourself forming a theory about the cause,
 that's L2's work — capture what you've found and pass it on.
 
+**This page is only half of L1.** The other half is *requests* rather than faults — creating
+a user, adding a department or a complaint type, loading master data. Those are all done
+through the product's own admin screens and they are yours, not L2's; the rule is
+[**if there is a screen for it, it is L1**](README.md#who-does-what--the-l1--l2-line). This
+page covers the fault half.
+
 You do all of this from a web browser. You never touch the server, and **nothing in this
 checklist changes anything** — every step is looking, not changing. You cannot break the
 system by following this page.
@@ -43,7 +49,7 @@ described as menu clicks, so you don't have to memorise addresses.
 
 | Page | URL | What it is |
 |---|---|---|
-| **Health dashboard** | `https://<your-domain>/status/` | A page that automatically tries about 50 parts of the system every 30 seconds and colours each one green or red |
+| **Health dashboard** | `https://<your-domain>/status/` | A page that automatically tries up to 57 parts of the system every 30 seconds and colours each one green or red |
 | **Grafana** | `https://<your-domain>/grafana/` | The system's own recordings — memory, errors, logs — shown as charts and lists |
 
 **About Grafana**, because it looks intimidating the first time: it is a *viewer*. It reads
@@ -62,8 +68,11 @@ step below.
 | A **second test login**, ideally in a different office | Step 1 | Ask a colleague to try instead, and note whose account was used |
 | The **maintenance window**, written on your [cheat sheet](cheatsheet.md) | Step 3 | Ask L2 before reporting restarts |
 
-An admin login to the Configurator or HRMS is **not** assumed anywhere here. Some entries in
-[known-issues.md](known-issues.md) need one — if yours doesn't have it, those are L2's.
+An admin login to the Configurator or HRMS is **not** assumed anywhere on this page — the
+fault checklist is read-only throughout. You should still have one, because the request half
+of L1 (creating users, editing master data) is done entirely through those screens, and some
+entries in [known-issues.md](known-issues.md) need one too. If you don't have one yet, ask
+your system administrator for it; until then, those items are L2's.
 
 ← back to **[Operations handbook](README.md)** · one-page version:
 **[cheatsheet.md](cheatsheet.md)**

--- a/docs/operations/l2-diagnosis.md
+++ b/docs/operations/l2-diagnosis.md
@@ -6,6 +6,14 @@ services, read logs across the whole stack, and change configuration.
 **Your job:** take what L1 captured and identify **which component is failing and why** —
 far enough that the fix is either yours to apply or clearly a product defect to send on.
 
+**What should reach you:** anything that needs the server, a log, the database, or a
+configuration file the UI does not expose — plus every question of *why*. Work that has a
+screen (creating users, editing master data, loading the onboarding spreadsheets) is L1's,
+even when it looks administrative; see
+[Who does what](README.md#who-does-what--the-l1--l2-line). If those requests are reaching
+you, the usual cause is that the service desk has no Configurator / HRMS admin login — fix
+that once rather than absorbing the queue.
+
 This assumes [L1 first response](l1-first-response.md) has been worked, or that you're
 starting cold and have done it yourself. Every query and panel name here is real and was run
 against a live deployment.
@@ -348,20 +356,43 @@ is a deployment change, not something to apply on the box**, because anything ed
 
 | Limit | Where it lives | Notes |
 |---|---|---|
-| **JVM heap** (`-Xmx`) | `JAVA_TOOL_OPTIONS` or `JAVA_OPTS` per service in the compose file | This is the ceiling that actually causes `OutOfMemoryError`. Currently ~6.3 GB of heap is allocated across the JVM services |
-| **Container memory** | not set today | The deployed compose has **no `mem_limit` on any container**, so a container can use as much host RAM as it asks for. Only the JVM heap bounds it |
-| **Container CPU** | not set today | No `cpus` limit either — services compete freely for host CPU |
+| **JVM heap** (`-Xmx`) | `JAVA_TOOL_OPTIONS` or `JAVA_OPTS` per service in the compose file | This is the ceiling that actually causes `OutOfMemoryError`. 22 services declare `-Xmx`, totalling **~12.8 GB** — more than a 16 GB host has, so they rely on not all peaking at once |
+| **Container memory** | `deploy.resources.limits.memory` per service in the compose file | Set on **10 of the 60 services**, not on the rest — see below |
+| **Container CPU** | not set today | No `cpus` limit on any service in the deployed compose — they compete freely for host CPU |
 | **Host size** | your infrastructure | If the host itself is short of RAM or cores, no per-service change helps |
 
-Two consequences worth understanding before asking for more:
+**Which containers are actually capped.** Only the observability stack and the OTP services:
+
+| Service | Cap | | Service | Cap |
+|---|---|---|---|---|
+| `prometheus` | 512M | | `egov-otp` | 512M |
+| `loki` | 512M | | `user-otp` | 512M |
+| `tempo` | 384M | | `egov-notification-sms` | 512M |
+| `otel-collector` | 320M | | | |
+| `grafana` | 256M | | | |
+| `promtail` | 128M | | | |
+| `gatus` | 64M | | | |
+
+Everything else — every JVM service, Postgres, Redpanda, Kafka, Elasticsearch, MinIO, Kong,
+Novu — has **no container memory limit**, so only the JVM heap bounds it.
+
+> The caps use `deploy.resources.limits.memory`, not the older top-level `mem_limit` key.
+> Compose V2 applies them identically outside Swarm; if you grep for `mem_limit` you will
+> wrongly conclude nothing is capped.
+
+Three consequences worth understanding before asking for more:
 
 - **Heap is not the whole footprint.** A JVM's actual memory use runs well above `-Xmx` —
   metaspace, thread stacks, code cache and direct buffers typically add a few hundred MB per
   service. Raising every heap by 512 MB costs the host considerably more than the sum of the
   increases.
-- **With no container memory limit, a leak takes the host down rather than the container.**
-  The Linux OOM killer then picks a victim, usually the largest JVM, which may not be the
-  service at fault.
+- **On an uncapped container, a leak takes the host down rather than the container.** The
+  Linux OOM killer then picks a victim, usually the largest JVM, which may not be the service
+  at fault. That is exactly why the observability containers *are* capped: monitoring is
+  overhead, and it should not be able to evict the workload it exists to watch.
+- **A capped container behaves differently when it runs out.** It is killed on its own,
+  restarts, and shows up as a restart count rather than as host-wide memory pressure. If
+  `prometheus` or `loki` keeps restarting, suspect its cap first.
 
 ### What to send us
 

--- a/docs/operations/reference.md
+++ b/docs/operations/reference.md
@@ -20,6 +20,7 @@ all.
 - [Are the monitoring services important to keep up?](#are-the-monitoring-services-important-to-keep-up)
 - [Grafana dashboards — what each one shows](#grafana-dashboards--what-each-one-shows)
 - [The health dashboard's groups](#the-health-dashboards-groups)
+  - [Why your dashboard has fewer groups](#why-your-dashboard-has-fewer-groups)
 - [What each service does](#what-each-service-does)
 - [Metric and log coverage — what is and isn't watched](#metric-and-log-coverage--what-is-and-isnt-watched)
 - [Data retention](#data-retention)
@@ -99,7 +100,7 @@ Two rules that do not bend:
    node-exporter ────────────────────────────▶ Prometheus  (host CPU/RAM/disk)
         (only on deployments from 2026-07-22 onward)
 
-   Gatus ──HTTP/TCP probes──▶ every service    (health, in-memory)
+   Gatus ──HTTP/TCP probes──▶ every service    (health, SQLite on disk)
 
    Grafana reads Prometheus + Loki + Tempo, and is where alerts are defined.
 ```
@@ -121,7 +122,7 @@ recovered afterwards.
 
 | Service | What stops working if it goes down | Is data lost? |
 |---|---|---|
-| **gatus** | The health dashboard at `/status/` is unreachable — you lose the fastest "is anything down" check | Yes — its history is held in memory only, so the record of what was red is gone |
+| **gatus** | The health dashboard at `/status/` is unreachable — you lose the fastest "is anything down" check | **No** — history is on disk (SQLite) and survives the restart. Nothing is probed while it is down, so that window is simply blank |
 | **grafana** | You cannot view *anything*: no dashboards, no logs, no metrics. Alert rules stop being evaluated too | **No.** Collection carries on regardless, and everything reappears when Grafana returns |
 | **prometheus** | Nothing records measurements — memory, CPU, restarts, request timings | Yes — a permanent gap in the graphs covering the period it was down |
 | **loki** | Log messages are not stored | **Yes, and this is the costly one.** Anything written while it is down is gone for good |
@@ -298,21 +299,51 @@ When it does have data, the readings that matter:
 
 ## The health dashboard's groups
 
-The health dashboard sorts its ~50 checks into ten groups. Which group a red tile sits in
-tells you how serious it is before you know anything else about it.
+The dashboard sorts its checks into **12 groups**. Which group a red tile sits in tells you
+how serious it is before you know anything else about it, so read the group first and the
+service name second.
 
-| Group | What's in it | A red tile here means |
-|---|---|---|
-| **Infrastructure** | Database, connection pooler, cache, message broker, file storage | **The most serious thing on the page.** Nothing above it can work — treat it as an outage and escalate immediately |
-| **Core Services** | The shared platform: user accounts, workflow, master data, employees, boundaries, translations, ID generation, authorisation, encryption, file metadata, and the two Kafka writers | A service many features depend on. Expect several unrelated-looking symptoms at once |
-| **API Gateway** | Kong and its proxies — every API request in the system passes through here | Requests cannot be routed. Users see "502" or a blank screen |
-| **Application** | The complaint service itself and the web front end | The product people actually use |
-| **Search** | Elasticsearch, the indexer and the inbox service | Inbox and search break. Filing complaints still works |
-| **Notifications** | The notification platform, its bridge, and the config and preference services | SMS / email / WhatsApp stop going out. Everything else is unaffected |
-| **OTP** | One-time-password delivery for sign-in | Users cannot receive the code they need to log in |
-| **Sign-in / identity** | The identity provider, its database, and the token exchange service | Signing in fails |
-| **MCP** | Integration tooling | No effect on citizens or staff using the system |
-| **API Tests** | Real calls against live APIs — different from the rest, see below | Read the note below before acting on it |
+The catalogue defines **57 checks**. You will usually see fewer, because most groups are
+switched on or off to match what this deployment actually runs — see
+[Why your dashboard has fewer groups](#why-your-dashboard-has-fewer-groups) below. The
+groups are listed here worst-first, not in dashboard order.
+
+| Group | Checks | What's in it | A red tile here means |
+|---|---|---|---|
+| **Infrastructure** | 5 | PostgreSQL, PgBouncer, Redis, Redpanda (Kafka), MinIO | **The most serious thing on the page.** Nothing above it can work — treat it as an outage and escalate immediately |
+| **API Gateway** | 5 | Kong proxy, Kong admin, Kong status, and the user + workflow proxies. Every API request passes through here | Requests cannot be routed. Users see "502" or a blank screen |
+| **Core Services** | 15 | The shared platform: MDMS and MDMS backend, user, workflow, HRMS, boundary and boundary-management, localization, ID generation, access control, encryption, filestore, URL shortening, the persister, and the audit service | A service many features depend on. Expect several unrelated-looking symptoms at once |
+| **Application** | 3 | PGR services, the DIGIT UI, and the configurator | The product people actually use |
+| **API Tests** | 3 | Real calls against live APIs — different from the rest, see below | Read the note below before acting on it |
+| **Keycloak** | 3 | Keycloak, its Postgres, and the token exchange service. *Labelled `Keycloak` on the dashboard; this is the sign-in / identity group* | Signing in fails — but only on deployments that use Keycloak SSO rather than OTP login |
+| **Search** | 3 | Elasticsearch, the indexer, the inbox service | Inbox and search break. Filing complaints still works |
+| **OTP** | 3 | OTP service, user-OTP, notification-SMS — one-time-password delivery for sign-in | Users cannot receive the code they need to log in |
+| **Notifications** | 9 | Novu (API, websocket, dashboard, Mongo), the bridge and its endpoint, the config and user-preferences services, and the OTP publisher | SMS / email / WhatsApp stop going out. Everything else is unaffected |
+| **Observability** | 5 | Grafana, Prometheus, Loki, Tempo, the OTel collector | You lose visibility, not function. Nobody is blocked — see [Are the monitoring services important to keep up?](#are-the-monitoring-services-important-to-keep-up) |
+| **MCP** | 2 | The MCP server and its Postgres — integration tooling | No effect on citizens or staff using the system |
+| **Public Endpoint** | 1 | The TLS certificate on the public domain | The certificate is expiring or already invalid. Browsers will start refusing the site — act *before* it goes red if you can |
+
+### Why your dashboard has fewer groups
+
+Only **Infrastructure**, **Core Services**, **Application** and **API Tests** are always
+present. Every other group is gated on a per-deployment toggle, so a group that is absent
+usually means that feature was never deployed — not that something is broken:
+
+| Group | Present when |
+|---|---|
+| Notifications | the Novu notification stack is deployed |
+| Observability | the monitoring stack is deployed |
+| Keycloak | Keycloak SSO is in use, rather than OTP login |
+| Search | Elasticsearch / indexer / inbox are deployed |
+| OTP | real OTP delivery is enabled, rather than the mocked local OTP |
+| MCP | the MCP integration server is deployed |
+| Public Endpoint | the deployment terminates TLS on a real domain |
+
+A few individual checks are gated the same way — the audit service inside Core Services, the
+configurator inside Application, and the two proxies inside API Gateway.
+
+**Ask before you chase.** If a whole group has vanished since you last looked, that is a
+deployment change, not an outage — raise it with us rather than debugging it.
 
 **API Tests is the group worth understanding.** Every other group asks a service one simple
 question — *are you alive?* — by calling its health endpoint. A service can answer that
@@ -396,7 +427,7 @@ If notifications stop, check in this order: the provider account (credit, creden
 | **JVM metrics** (Prometheus) | The 16 instrumented Java services: `boundary-service`, `digit-config-service`, `egov-accesscontrol`, `egov-enc-service`, `egov-filestore`, `egov-hrms`, `egov-idgen`, `egov-indexer`, `egov-persister`, `egov-user`, `egov-workflow-v2`, `inbox`, `mdms-backend`, `novu-bridge`, `pgr-services`, plus dashboard web metrics | Postgres, Redis, Kafka, Kong, Elasticsearch, MinIO, nginx, the sign-in / identity service, Node services |
 | **Logs** (Loki) | **Every container** — around 44 of them | Nothing, as long as promtail is running |
 | **Traces** (Tempo) | Requests through instrumented Java services and Kong | Direct database or broker activity |
-| **Health checks** (Gatus) | ~50 endpoints across every group, including infrastructure | Anything not in the endpoint catalogue |
+| **Health checks** (Gatus) | up to 57 endpoints across 12 groups, including infrastructure | Anything not in the endpoint catalogue; groups whose feature is switched off on this deployment |
 | **Host metrics** (node-exporter) | CPU, RAM, disk, network, filesystem | **Not present on deployments installed before 2026-07-22** |
 
 The practical takeaway: for the non-Java containers, **Gatus tells you if it is alive and
@@ -414,7 +445,7 @@ reported today can still be investigated at all.
 | Metrics | Prometheus | **15 days** |
 | Logs — searchable, in Grafana | Loki | **72 hours (3 days)** |
 | Traces | Tempo | **24 hours** |
-| Health-check history | Gatus | in-memory; lost the moment the container restarts |
+| Health-check history | Gatus | on disk (SQLite), survives restarts; bounded per endpoint at ~100 results and ~50 events |
 | Container logs — the raw files on the server | Docker, on disk | Capped by the Docker daemon at **10 files × 100 MB = 1 GB per container**, oldest rotated away first |
 
 Two consequences worth knowing:

--- a/local-setup/ansible/inventory/group_vars/digit.yml
+++ b/local-setup/ansible/inventory/group_vars/digit.yml
@@ -79,9 +79,11 @@ enable_search_stack: false
 # Lowering this value on an existing box now TEARS DOWN the containers
 # that leave the selection, rather than orphaning them running (#1687).
 #
-# Footprints are the caps PROPOSED in #1612, which is still open — no
-# observability container has a `mem_limit` today, so these are a paper
-# budget and not an enforced ceiling or a measurement.
+# Footprints are approximate. The caps from #1612 have since landed as
+# `deploy.resources.limits.memory` in docker-compose.egov-digit.yaml:
+# prometheus 512M, loki 512M, tempo 384M, otel-collector 320M,
+# grafana 256M, promtail 128M, gatus 64M. So these are enforced ceilings
+# now, though the figures below are still budget rather than measurement.
 #
 # This matters because the boxes are small: 29 services declare ~12.8 GB
 # of max heap on machines that are commonly 16 GB and have NO swap, so

--- a/local-setup/ansible/inventory/host_vars/localhost-full.yml.example
+++ b/local-setup/ansible/inventory/host_vars/localhost-full.yml.example
@@ -288,11 +288,6 @@ twilio_whatsapp_from: "whatsapp:+14155238886"
 # enable_novu: true and the seeded MDMS masters.
 pgr_notification_config_driven: true
 
-# Build novu-bridge / pgr-services from source on this box instead of pulling
-# the published images. Values: true | false. Slow; only for testing a change.
-build_novu_bridge: false
-build_pgr_services: false
-
 # Which channel the bridge delivers on. Values: sms | whatsapp | email.
 novu_bridge_channel: "sms"
 

--- a/local-setup/ansible/inventory/host_vars/localhost-full.yml.example
+++ b/local-setup/ansible/inventory/host_vars/localhost-full.yml.example
@@ -1,122 +1,401 @@
-# Self-targeting local deploy (localhost, no TLS) on the dump-seeded
-# pg / pg.citya tenants — the FULL stack (Novu + MCP + both SPAs).
-# Derived from the pg.citya config validated on the eGov dev box
-# 2026-07-27; domain generalized to localhost so it works on any box.
-# Needs ~16 GB for the containers alone — on a 16 GB host use
-# localhost-slim.yml.example instead.
+# ═══════════════════════════════════════════════════════════════════════════
+# localhost — FULL profile
+#
+# A self-targeting Ansible deploy: the controller and the target are the same
+# machine, so `./deploy.sh` converges the box you are sitting at. No SSH, no
+# TLS, no DNS. Boots on the dump-seeded `pg` / `pg.citya` tenants, so there is
+# a working city, boundary hierarchy, complaint types and an ADMIN login the
+# moment the stack is up.
+#
+# FULL means every optional subsystem this profile knows about is on:
+# notifications (Novu + otp-publisher), MCP, the configurator wizard, and both
+# SPAs (legacy employee UI at /digit-ui/ and the citizen SPA at /citizen/).
+#
+# SIZING. Needs ~16 GB for the containers alone. On a 16 GB box the notification
+# stack is what tips it over — use localhost-slim.yml.example instead, which is
+# this file minus Novu. See docs/LOCALHOST-FULL-AND-SLIM.md for the comparison.
+#
+# Derived from the pg.citya config validated on the eGov dev box 2026-07-27;
+# domain generalized to localhost so it works on any box.
 #
 # Usage:
 #   cp inventory/host_vars/localhost-full.yml.example \
 #      inventory/host_vars/mybox.yml
 #   ./deploy.sh mybox
 # Login: http://localhost/digit-ui/  ADMIN / eGov@123
+#
+# Every key below has a default in inventory/group_vars/digit.yml unless marked
+# REQUIRED. inventory/host_vars/_example.yml is the exhaustive template — this
+# file is a working preset, and the comments say why each value is what it is.
+# ═══════════════════════════════════════════════════════════════════════════
 
+# ────────── Connection ──────────
+
+# REQUIRED. Where Ansible connects. `localhost` + `local` is what makes this a
+# self-targeting deploy: no SSH transport, commands run directly on this box.
+# Values: any IP/hostname; `ansible_connection` is `local` here, `ssh` (the
+# default) for a remote target.
 ansible_host: localhost
 ansible_connection: local
 
-# WORKAROUND, remove once the registry cert is renewed: the Let's Encrypt
-# wildcard for *.preview.egov.theflywheel.in expired 2026-07-25 and image
-# pulls fail with "x509: certificate has expired". Fresh box, so no
-# existing entries to preserve (on shared boxes, ALWAYS carry the box's
-# existing entries forward — this list REPLACES, it does not merge).
+# Hosts written into Docker's daemon.json `insecure-registries` (registries
+# reachable over plain HTTP or with an untrusted cert).
+#
+# This list REPLACES the group_vars default (`10.0.0.4:5000`, the Hetzner VPC
+# registry) — it does not merge. On a shared box, always carry that box's
+# existing entries forward.
+#
+# The entry below is a historical workaround for an expired Let's Encrypt
+# wildcard on *.preview.egov.theflywheel.in. A localhost deploy no longer needs
+# it: every image in docker-compose.egov-digit.yaml now comes from Docker Hub
+# (`egovio/*`) or ghcr.io over valid TLS, so the entry is inert. Keep it only if
+# you pin an image to that registry yourself.
+#
+# Values: list of `host` or `host:port`. Never a URL and never a path — Docker
+# refuses to start on those, which takes the whole stack down with it.
 insecure_registries: ["registry.preview.egov.theflywheel.in"]
 
+# ────────── Networking / TLS ──────────
+
+# REQUIRED. Public hostname. Used for nginx `server_name`, the Grafana root
+# URL, Let's Encrypt, and citizen-facing URLs the UI generates.
+# Values: any hostname. `localhost` for a local box; a real FQDN in production.
 domain: localhost
+
+# Whether nginx listens on 443 with an HTTP→HTTPS redirect and expects certs at
+# /etc/letsencrypt/live/<domain>/.
+# Values: true (default) | false. Must be false here — there is no certificate
+# for `localhost`, and true would leave you with a vhost that cannot serve.
 tls_enabled: false
 
+# ────────── DIGIT tenancy ──────────
+#
+# Four slugs, three different jobs. Getting these wrong is the most common way
+# to end up with a stack that boots but cannot log in.
+#
+# The values below match what db/full-dump.sql seeds, so leave them alone unless
+# you are deploying a different tenant.
+
+# REQUIRED. Top-level state/country tenant. Becomes STATE_LEVEL_TENANT_ID on the
+# DIGIT services: the encryption tenant for auth lookups, the MDMS state root,
+# and the boundary hierarchy root. Values: a root slug — `pg`, `ke`, `mz`.
+# Getting this wrong breaks login on any tenant with encrypted usernames,
+# because the lookup encrypts under the wrong tenant's key.
 state_root: pg
+
+# REQUIRED. Root tenant the citizen SPA binds to. Values: usually the same as
+# state_root, or a city tenant when the SPA is pinned to one city.
 state_tenant_id: pg
+
+# City tenant the citizen side resolves to on first load.
+# Values: any existing city tenant, `<state>.<city>`.
 boot_tenant: pg.citya
+
+# Single city/operating tenant for templates that need exactly one value.
 tenant_id: pg
+
+# Tenant the admin/citizen SPA lands on, rendered into globalConfigs as
+# STATE_LEVEL_TENANT_ID. The configurator's login screen derives its tenant-code
+# placeholder from this. Values: your city tenant, to keep the UI free of
+# hardcoded codes. Defaults to `pg` when unset.
 ui_state_tenant_id: pg.citya
 
+# Where the UI's map opens when there is no GPS fix and no complaint location.
+# Values: any lat/lng — put it inside your service area. This is Chandigarh.
 map_center:
   lat: 30.7333
   lng: 76.7794
 
+# Restrict which tenants may log in. Values: list of tenant ids, or `[]` (here)
+# to allow all. Most production deployments list exactly one city.
 login_tenant_allowlist: []
+
+# Employee-UI modules to hide. Values: list of module codes — commonly `["IM"]`
+# to hide inbox-v2 when enable_search_stack is false. Empty: hide nothing.
 employee_module_denylist: []
 
+# ────────── Country-specific UI configuration ──────────
+# group_vars defaults these to empty; every tenant must set them. These are
+# India values, matching the seeded `pg` (Punjab) tenant.
+
+# The boundary levels the complaint-location selector renders, highest first.
+# Values: whatever your hierarchy actually defines.
+#   India: State → District → Locality      Kenya: County → Sub-County → Ward
 pgr_boundary_highest_level: "State"
 pgr_boundary_lowest_level: "Locality"
+
+# What the smallest selectable boundary is called. Values: must be a real
+# boundary type in the hierarchy — `Locality`, `Ward`, …
 boundary_type: "Locality"
+
+# Boundary hierarchy name, rendered as HIERARCHY_TYPE. MUST match the hierarchy
+# actually created for this tenant. Values: `ADMIN` (what the dump seeds, and
+# the default), or `<CITY>_ADMIN` when the MCP wizard created the tenant. A
+# mismatch makes the complaint form's boundary picker 400 with
+# HIERARCHY_DEFINITION_DOES_NOT_EXIST_ERR.
 hierarchy_type: "ADMIN"
 
+# Citizen signup mobile-number validation. Length and allowed leading digits are
+# derived from the regex — there are no separate fields to keep in sync.
+# Values: India `+91` / `^[6-9][0-9]{9}$`; Kenya `+254` / `^0?[17][0-9]{8}$`.
 core_mobile_configs:
   countryCode: "+91"
   mobileNumberRegex: "^[6-9][0-9]{9}$"
 
+# Postal-code validation, read by the SPA as CORE_POSTAL_CONFIGS.
+# `postalCodePattern` is the only knob that matters — the error message and the
+# expected digit count are both derived from it.
+# Values: India `^[0-9]{6}$`, Kenya `^[0-9]{5}$`, Mozambique `^[0-9]{4}$`,
+# US `^[0-9]{5}(-[0-9]{4})?$`, UK an alphanumeric pattern.
+#
+# `postalCodeLength` and `postalCodeErrorMessage` below are legacy fields kept
+# for older UI builds; the pattern outranks them. MDMS outranks both: a
+# `fieldType: "postalCode"` row in `common-masters.FormValidations` wins over
+# anything here, so on a tenant that has that row, edit it instead.
 core_postal_configs:
   postalCodePattern: "^[0-9]{6}$"
   postalCodeLength: 6
   postalCodeErrorMessage: "CS_COMPLAINT_POSTALCODE_INVALID_ERROR"
 
+# ────────── Branding ──────────
+
+# Bucket name egov-filestore reports as its asset bucket.
 asset_s3_bucket: "pg-egov-assets"
+
+# Footer logos, colour and black-and-white. Values: absolute URLs, or empty for
+# none. Mirror them under /var/www/brand/ with nginx_features.brand_assets.
 footer_logo_url: ""
 footer_bw_logo_url: ""
 
+# ────────── Frontend ──────────
+
+# How the legacy employee SPA is served.
+# Values: `container` — serve the prebuilt digit-ui image (what this profile
+#           does; nothing is built on the box);
+#         `static`    — host nginx serves a bundle built on the box at deploy time;
+#         `hmr`       — esbuild dev server in tmux, live-reload on save.
 digit_ui_mode: container
+
+# Build and serve the Vite/React-19 citizen SPA at /citizen/, separate from the
+# legacy /digit-ui/ bundle. Pair with nginx_features.digit_ui_v2 — building it
+# without the nginx flag leaves the bundle on disk and unreachable.
+# Values: true | false.
 enable_digit_ui_v2: true
+
+# Git source for that SPA. Cloned on the TARGET, so native Vite binaries match
+# the runtime architecture. Values: any repo/branch; point at a fork to test one.
 digit_ui_v2_repo: "https://github.com/egovernments/Citizen-Complaint-Resolution-System.git"
 digit_ui_v2_branch: "fix/citizen-ui-v2-mobile-config"
 
+# Branch of the digit-ui-esbuild repo used when digit_ui_mode builds on the box.
+# Inert while digit_ui_mode is `container` and build_digit_ui is false.
+digit_ui_esbuild_branch: "feat/keycloak-auth-adapter"
+
+# ────────── Integration-test dashboards ──────────
+# Serve the Playwright result dashboards at /tests/ and /tests-v2/. The deploy
+# only SERVES them — the results are produced out-of-band by a test runner.
+# Values: true | false. Off here: nothing publishes results to this box.
 enable_integration_tests: false
 integration_tests_dashboard_base: "/tests-v2/"
 integration_tests_basic_auth_user: "digit-tests"
+
+# The dashboard RUN button — an on-box daemon that triggers a Playwright run.
+# CPU/RAM heavy and shares the box with the live stack. Values: true | false.
 enable_integration_tests_runner: false
 
+# ────────── Optional services ──────────
+
+# Real OTP delivery: egov-otp + user-otp + egov-notification-sms.
+# Values: true | false. False (here) means Kong mocks /user-otp/* with a canned
+# 200, so citizen login works with the fixed OTP 123456 and no SMS infra.
+# Turning it on for production also needs the mock removed from kong.yml and a
+# real SMS_PROVIDER_CLASS wired up — it defaults to Console, which only logs.
 enable_otp_services: false
+
+# Elasticsearch + egov-indexer + inbox-v2. Values: true | false.
+# Off saves ~2-3 GB. The trade: the inbox and search screens stop working —
+# pair `false` with employee_module_denylist: ["IM"] to hide the broken tab.
 enable_search_stack: false
+
+# digit-mcp + mcp-postgres. The MCP server exposes the REST shim the
+# configurator uses for tenant onboarding. Values: true | false. On here so the
+# wizard's tenant bootstrap works. Serving the shim at /v1/* also needs
+# nginx_features.mcp.
 enable_mcp: true
+
+# Build digit-mcp from the vendored in-tree source instead of pulling the
+# published image. Values: true | false.
 build_mcp: true
+
+# Build the employee SPA bundle on this box. Values: true | false.
+# False here because digit_ui_mode is `container` — the image already has it.
 build_digit_ui: false
+
+# Build the OTP publisher image on this box. Values: true | false.
 build_otp_publisher: false
-digit_ui_esbuild_branch: "feat/keycloak-auth-adapter"
+
+# Let the deploy continue when tenant bootstrap steps fail. Values: true | false.
+# True is right for a local box booting from the dump, where some bootstrap
+# steps are already satisfied and would otherwise abort the run.
 tolerate_bootstrap_failures: true
+
+# Turbopass: on-box OSM location autocomplete for the configurator's Phase 2.
+# Needs scraped OSM data under turbopass/data on the controller.
+# Values: true | false.
 enable_turbopass: false
+
+# Self-hosted Overpass for boundary-polygon fetch. Off means the configurator
+# uses the public overpass-api.de, which is rate-limited and 504-prone.
+# Requires a prepared OSM extract on the box first. Values: true | false.
 enable_overpass: false
 
+# ────────── Notifications (the full-vs-slim dividing line) ──────────
+#
+# THIS BLOCK IS THE ONLY FUNCTIONAL DIFFERENCE between this file and
+# localhost-slim.yml.example.
+
+# Turn on the `notifications` compose profile: 8 extra containers
+# (novu-api, novu-worker, novu-ws, novu-dashboard, novu-mongo, novu-bridge,
+# digit-config-service, digit-user-preferences-service), roughly +1.5-2 GB
+# resident and a slower first boot. Values: true | false.
+#
+# First deploy just brings Novu up. To actually send anything: sign up at
+# http://localhost/novu/, paste the API key into novu_api_key below along with
+# the Twilio credentials, and deploy again — the second run registers the
+# integration and workflow inside Novu.
 enable_novu: true
+
+# Build a subpath-rebased Novu dashboard so the SPA serves cleanly under /novu.
+# Values: true | false. REQUIRED true when Keycloak shares the domain, because
+# the stock image's nginx workaround hijacks the whole /auth/ prefix.
 build_novu_dashboard: false
+
+# Novu API key, copied from the dashboard after first sign-up. Empty (here)
+# skips the bootstrap step — Novu still comes up and can be configured by hand.
 novu_api_key: ""
+
+# Twilio credentials the bootstrap uses to register an SMS/WhatsApp integration.
+# The FROM number must be WhatsApp-enabled; the default is Twilio's sandbox.
+# SECRETS — prefer OpenBao over committing real values.
 twilio_account_sid: ""
 twilio_auth_token: ""
 twilio_whatsapp_from: "whatsapp:+14155238886"
+
+# Put PGR on the config-driven notification path: it reads
+# PGR.NotificationRouting + PGR.NotificationTemplate from MDMS, renders and
+# localizes per recipient, and novu-bridge becomes a thin pass-through.
+# Values: true | false (false keeps the legacy hardcoded path). Requires
+# enable_novu: true and the seeded MDMS masters.
 pgr_notification_config_driven: true
+
+# Build novu-bridge / pgr-services from source on this box instead of pulling
+# the published images. Values: true | false. Slow; only for testing a change.
 build_novu_bridge: false
 build_pgr_services: false
+
+# Which channel the bridge delivers on. Values: sms | whatsapp | email.
 novu_bridge_channel: "sms"
 
+# ────────── Keycloak SSO ──────────
+
+# Adds keycloak + token-exchange-svc and the /auth/ + /token-exchange/ nginx
+# blocks. Inert in the rest of the stack — DIGIT keeps working on OTP login
+# until auth_provider is flipped. Values: true | false.
 enable_keycloak: false
+
+# Which auth path the SPA uses. Values: `keycloak` for OIDC PKCE, `""` (here)
+# for OTP login. Do not flip until the realm is imported and a test login works.
 auth_provider: ""
+
+# OIDC public client id inside the per-tenant realm. The shipped realm template
+# defines `digit-ui`; change only if you forked the template.
 keycloak_client_id: "digit-ui"
+
+# Google federated login. Empty skips Google IdP wiring entirely.
 keycloak_google_client_id: ""
 
+# ────────── Data seeding ──────────
+
+# Init the nairobi-mdms git submodule on the controller. Values: true | false.
+# Only for tenants whose onboarding uses those JSONs.
 requires_nairobi_mdms: false
+
+# Preload db/full-dump.sql into Postgres on first boot — 54 tables, Flyway
+# history, ~20K localization rows, and the demo tenants. Values: true | false.
+#
+# REQUIRED for a fresh install: there is no SQL slow path any more, so `false`
+# on an empty database gives you a stack with no schema.
+#
+# DESTRUCTIVE on a box with existing data: the fast-path overlay also corrects
+# the named-volume mount path, which forces container recreation and wipes an
+# anonymous Postgres volume.
 db_fast_path: true
+
+# Explicit acknowledgement of that data wipe. preflight.py refuses to run
+# db_fast_path without it. Values: true | false.
 db_fast_path_ack_data_wipe: true
+
+# Run the post-deploy CI suite (XLSX dataloader + Playwright) at the end of the
+# deploy. Values: true | false. Needs a sibling `digit-ui-fix/` clone on the
+# controller. Off here — it roughly doubles deploy time.
 run_ci_tests: false
+
+# Tear the stack down before redeploying: removes containers and compose
+# networks, keeps volumes. Values: true | false. Useful on a dev box; never on
+# a tenant with live traffic.
 force_clean: false
+
+# Install the Claude Code CLI on the target and sync the controller's ~/.claude.
+# Hard-codes /root/.claude paths. Values: true | false.
 install_claude_code: false
+
+# Build the configurator SPA on this box. Values: true | false.
+#
+# False does NOT disable the configurator. With false the deploy pulls the
+# CI-built `egovio/configurator` image and host nginx proxies /configurator/ to
+# that container — a static-file nginx, negligible RAM, no on-box vite build.
+# Set true only to serve a dist you build here, which costs RAM at deploy time.
 build_configurator: false
 
+# ────────── nginx location blocks ──────────
+# Each flag renders one `location` block into the host vhost. A flag whose
+# backing service is off renders a block that proxies to nothing, so keep these
+# aligned with the enable_* flags above. Values: true | false.
+
 nginx_features:
-  brand_assets: false
-  configurator: true
-  configurator_caching: false
-  status: true
-  api_pgr: false
-  mcp: true
-  keycloak: true
-  digit_ui_v2: true
-  integration_tests: false
-  integration_tests_runner: false
+  brand_assets: false      # /brand/ — needs /var/www/brand on the host
+  configurator: true       # /configurator/ — the onboarding wizard
+  configurator_caching: false  # long-cache headers for its assets
+  status: true             # /status/ — the Gatus health dashboard
+  api_pgr: false           # /api/pgr/ — proxied to MCP for the dashboard
+  mcp: true                # /mcp + /v1/* — needs enable_mcp: true
+  keycloak: true           # /auth/ + /token-exchange/ — needs enable_keycloak: true
+                           # (true here but inert while enable_keycloak is false)
+  digit_ui_v2: true        # /citizen/ — needs enable_digit_ui_v2: true
+  integration_tests: false      # /tests/ + /tests-v2/
+  integration_tests_runner: false  # /tests/api/
+
+# Leave the operator's hand-written vhost alone instead of rendering the
+# template. Values: true | false. For boxes with routing the template cannot
+# express yet.
 nginx_preserve_vhost: false
 
+# ────────── Secrets (OpenBao) ──────────
+
+# REQUIRED. Path under the kv/ mount holding this tenant's secrets. The path
+# itself is not sensitive; what is behind it is.
+# Values: convention is kv/digit/<tenant>.
 secrets_path: kv/digit/pg.citya
 
-# Local-only bootstrap values, pinned by the db_fast_path dump — do not
-# "harden" them; the dump's data must match.
+# Seeded into OpenBao ONLY on this tenant's first deploy (cas=0). Later edits
+# here are ignored — change them with `bao kv put` or the OpenBao UI.
+#
+# These are pinned by the db_fast_path dump and must not be "hardened":
+#   * postgres_password matches the dump's roles;
+#   * elasticsearch_master_password MUST stay `asd@#$@$!132123` — the dump's
+#     eg_enc_*_keys decrypt only under that value, and a mismatch throws
+#     AEADBadTagException in egov-enc-service at boot.
+# On a real deployment (no dump) replace all of them with strong values.
 bootstrap_secrets:
   postgres_password: egov123
   mcp_db_password: egov123

--- a/local-setup/ansible/inventory/host_vars/localhost-slim.yml.example
+++ b/local-setup/ansible/inventory/host_vars/localhost-slim.yml.example
@@ -299,11 +299,6 @@ twilio_whatsapp_from: "whatsapp:+14155238886"
 # Slim: false — it would be pointing PGR at a delivery path that is not running.
 pgr_notification_config_driven: false
 
-# Build novu-bridge / pgr-services from source on this box instead of pulling
-# the published images. Values: true | false. Slow; only for testing a change.
-build_novu_bridge: false
-build_pgr_services: false
-
 # Which channel the bridge delivers on. Values: sms | whatsapp | email.
 novu_bridge_channel: "sms"
 

--- a/local-setup/ansible/inventory/host_vars/localhost-slim.yml.example
+++ b/local-setup/ansible/inventory/host_vars/localhost-slim.yml.example
@@ -1,132 +1,412 @@
-# localhost-full minus Novu — self-targeting deploy for a 16 GB host
-# (e.g. Windows/WSL2 with ~12 GB for the VM). Validated end-to-end on
-# WSL2 Ubuntu 24.04, 2026-07-29.
+# ═══════════════════════════════════════════════════════════════════════════
+# localhost — SLIM profile
 #
-# The ONLY functional delta from localhost-full.yml.example is the Novu
-# notifications stack (novu-mongo/api/worker/ws/dashboard/bridge +
-# otp-publisher, ~1.5-2 GB resident): that is the one piece that risks
-# freezing a 12 GB VM. Everything else matches: core services, PGR,
-# employee UI (same esbuild branch), citizen SPA (/citizen/),
-# configurator (/configurator/), MCP (wizard tenant bootstrap works),
-# Kong, Gatus, Jupyter, seeded pg / pg.citya tenants.
+# A self-targeting Ansible deploy: the controller and the target are the same
+# machine, so `./deploy.sh` converges the box you are sitting at. No SSH, no
+# TLS, no DNS. Boots on the dump-seeded `pg` / `pg.citya` tenants, so there is
+# a working city, boundary hierarchy, complaint types and an ADMIN login the
+# moment the stack is up.
+#
+# SLIM is localhost-full minus the notification stack, sized for a 16 GB host
+# (for example Windows/WSL2 with ~12 GB allocated to the VM). Validated
+# end-to-end on WSL2 Ubuntu 24.04, 2026-07-29.
+#
+# THE ONLY FUNCTIONAL DELTA IS NOVU. The notifications profile
+# (novu-mongo/api/worker/ws/dashboard/bridge + otp-publisher, ~1.5-2 GB
+# resident) is the one piece that risks freezing a 12 GB VM. Everything else is
+# identical to full: core services, PGR, the employee UI, the citizen SPA at
+# /citizen/, the configurator at /configurator/, MCP (so the wizard's tenant
+# bootstrap works), Kong, Gatus and the seeded pg / pg.citya tenants.
+#
+# What you give up: no SMS / email / WhatsApp is sent. Everything else in the
+# complaint lifecycle — file, assign, resolve, rate, close — works unchanged.
+# See docs/LOCALHOST-FULL-AND-SLIM.md for the comparison.
 #
 # Usage:
 #   cp inventory/host_vars/localhost-slim.yml.example \
 #      inventory/host_vars/mybox.yml
 #   ./deploy.sh mybox
 # Login: http://localhost/digit-ui/  ADMIN / eGov@123
+#
+# Every key below has a default in inventory/group_vars/digit.yml unless marked
+# REQUIRED. inventory/host_vars/_example.yml is the exhaustive template — this
+# file is a working preset, and the comments say why each value is what it is.
+# ═══════════════════════════════════════════════════════════════════════════
 
+# ────────── Connection ──────────
+
+# REQUIRED. Where Ansible connects. `localhost` + `local` is what makes this a
+# self-targeting deploy: no SSH transport, commands run directly on this box.
+# Values: any IP/hostname; `ansible_connection` is `local` here, `ssh` (the
+# default) for a remote target.
 ansible_host: localhost
 ansible_connection: local
 
-# WORKAROUND, remove once the registry cert is renewed: the Let's Encrypt
-# wildcard for *.preview.egov.theflywheel.in expired 2026-07-25 and image
-# pulls fail with "x509: certificate has expired". Fresh box, so no
-# existing entries to preserve (on shared boxes, ALWAYS carry the box's
-# existing entries forward — this list REPLACES, it does not merge).
+# Hosts written into Docker's daemon.json `insecure-registries` (registries
+# reachable over plain HTTP or with an untrusted cert).
+#
+# This list REPLACES the group_vars default (`10.0.0.4:5000`, the Hetzner VPC
+# registry) — it does not merge. On a shared box, always carry that box's
+# existing entries forward.
+#
+# The entry below is a historical workaround for an expired Let's Encrypt
+# wildcard on *.preview.egov.theflywheel.in. A localhost deploy no longer needs
+# it: every image in docker-compose.egov-digit.yaml now comes from Docker Hub
+# (`egovio/*`) or ghcr.io over valid TLS, so the entry is inert. Keep it only if
+# you pin an image to that registry yourself.
+#
+# Values: list of `host` or `host:port`. Never a URL and never a path — Docker
+# refuses to start on those, which takes the whole stack down with it.
 insecure_registries: ["registry.preview.egov.theflywheel.in"]
 
+# ────────── Networking / TLS ──────────
+
+# REQUIRED. Public hostname. Used for nginx `server_name`, the Grafana root
+# URL, Let's Encrypt, and citizen-facing URLs the UI generates.
+# Values: any hostname. `localhost` for a local box; a real FQDN in production.
 domain: localhost
+
+# Whether nginx listens on 443 with an HTTP→HTTPS redirect and expects certs at
+# /etc/letsencrypt/live/<domain>/.
+# Values: true (default) | false. Must be false here — there is no certificate
+# for `localhost`, and true would leave you with a vhost that cannot serve.
 tls_enabled: false
 
+# ────────── DIGIT tenancy ──────────
+#
+# Four slugs, three different jobs. Getting these wrong is the most common way
+# to end up with a stack that boots but cannot log in.
+#
+# The values below match what db/full-dump.sql seeds, so leave them alone unless
+# you are deploying a different tenant.
+
+# REQUIRED. Top-level state/country tenant. Becomes STATE_LEVEL_TENANT_ID on the
+# DIGIT services: the encryption tenant for auth lookups, the MDMS state root,
+# and the boundary hierarchy root. Values: a root slug — `pg`, `ke`, `mz`.
+# Getting this wrong breaks login on any tenant with encrypted usernames,
+# because the lookup encrypts under the wrong tenant's key.
 state_root: pg
+
+# REQUIRED. Root tenant the citizen SPA binds to. Values: usually the same as
+# state_root, or a city tenant when the SPA is pinned to one city.
 state_tenant_id: pg
+
+# City tenant the citizen side resolves to on first load.
+# Values: any existing city tenant, `<state>.<city>`.
 boot_tenant: pg.citya
+
+# Single city/operating tenant for templates that need exactly one value.
 tenant_id: pg
+
+# Tenant the admin/citizen SPA lands on, rendered into globalConfigs as
+# STATE_LEVEL_TENANT_ID. The configurator's login screen derives its tenant-code
+# placeholder from this. Values: your city tenant, to keep the UI free of
+# hardcoded codes. Defaults to `pg` when unset.
 ui_state_tenant_id: pg.citya
 
+# Where the UI's map opens when there is no GPS fix and no complaint location.
+# Values: any lat/lng — put it inside your service area. This is Chandigarh.
 map_center:
   lat: 30.7333
   lng: 76.7794
 
+# Restrict which tenants may log in. Values: list of tenant ids, or `[]` (here)
+# to allow all. Most production deployments list exactly one city.
 login_tenant_allowlist: []
+
+# Employee-UI modules to hide. Values: list of module codes — commonly `["IM"]`
+# to hide inbox-v2 when enable_search_stack is false. Empty: hide nothing.
 employee_module_denylist: []
 
+# ────────── Country-specific UI configuration ──────────
+# group_vars defaults these to empty; every tenant must set them. These are
+# India values, matching the seeded `pg` (Punjab) tenant.
+
+# The boundary levels the complaint-location selector renders, highest first.
+# Values: whatever your hierarchy actually defines.
+#   India: State → District → Locality      Kenya: County → Sub-County → Ward
 pgr_boundary_highest_level: "State"
 pgr_boundary_lowest_level: "Locality"
+
+# What the smallest selectable boundary is called. Values: must be a real
+# boundary type in the hierarchy — `Locality`, `Ward`, …
 boundary_type: "Locality"
+
+# Boundary hierarchy name, rendered as HIERARCHY_TYPE. MUST match the hierarchy
+# actually created for this tenant. Values: `ADMIN` (what the dump seeds, and
+# the default), or `<CITY>_ADMIN` when the MCP wizard created the tenant. A
+# mismatch makes the complaint form's boundary picker 400 with
+# HIERARCHY_DEFINITION_DOES_NOT_EXIST_ERR.
 hierarchy_type: "ADMIN"
 
+# Citizen signup mobile-number validation. Length and allowed leading digits are
+# derived from the regex — there are no separate fields to keep in sync.
+# Values: India `+91` / `^[6-9][0-9]{9}$`; Kenya `+254` / `^0?[17][0-9]{8}$`.
 core_mobile_configs:
   countryCode: "+91"
   mobileNumberRegex: "^[6-9][0-9]{9}$"
 
+# Postal-code validation, read by the SPA as CORE_POSTAL_CONFIGS.
+# `postalCodePattern` is the only knob that matters — the error message and the
+# expected digit count are both derived from it.
+# Values: India `^[0-9]{6}$`, Kenya `^[0-9]{5}$`, Mozambique `^[0-9]{4}$`,
+# US `^[0-9]{5}(-[0-9]{4})?$`, UK an alphanumeric pattern.
+#
+# `postalCodeLength` and `postalCodeErrorMessage` below are legacy fields kept
+# for older UI builds; the pattern outranks them. MDMS outranks both: a
+# `fieldType: "postalCode"` row in `common-masters.FormValidations` wins over
+# anything here, so on a tenant that has that row, edit it instead.
 core_postal_configs:
   postalCodePattern: "^[0-9]{6}$"
   postalCodeLength: 6
   postalCodeErrorMessage: "CS_COMPLAINT_POSTALCODE_INVALID_ERROR"
 
+# ────────── Branding ──────────
+
+# Bucket name egov-filestore reports as its asset bucket.
 asset_s3_bucket: "pg-egov-assets"
+
+# Footer logos, colour and black-and-white. Values: absolute URLs, or empty for
+# none. Mirror them under /var/www/brand/ with nginx_features.brand_assets.
 footer_logo_url: ""
 footer_bw_logo_url: ""
 
+# ────────── Frontend ──────────
+
+# How the legacy employee SPA is served.
+# Values: `container` — serve the prebuilt digit-ui image (what this profile
+#           does; nothing is built on the box);
+#         `static`    — host nginx serves a bundle built on the box at deploy time;
+#         `hmr`       — esbuild dev server in tmux, live-reload on save.
 digit_ui_mode: container
+
+# Build and serve the Vite/React-19 citizen SPA at /citizen/, separate from the
+# legacy /digit-ui/ bundle. Pair with nginx_features.digit_ui_v2 — building it
+# without the nginx flag leaves the bundle on disk and unreachable.
+# Values: true | false.
 enable_digit_ui_v2: true
+
+# Git source for that SPA. Cloned on the TARGET, so native Vite binaries match
+# the runtime architecture. Values: any repo/branch; point at a fork to test one.
 digit_ui_v2_repo: "https://github.com/egovernments/Citizen-Complaint-Resolution-System.git"
 digit_ui_v2_branch: "fix/citizen-ui-v2-mobile-config"
 
+# Branch of the digit-ui-esbuild repo used when digit_ui_mode builds on the box.
+# Inert while digit_ui_mode is `container` and build_digit_ui is false.
+digit_ui_esbuild_branch: "feat/keycloak-auth-adapter"
+
+# ────────── Integration-test dashboards ──────────
+# Serve the Playwright result dashboards at /tests/ and /tests-v2/. The deploy
+# only SERVES them — the results are produced out-of-band by a test runner.
+# Values: true | false. Off here: nothing publishes results to this box.
 enable_integration_tests: false
 integration_tests_dashboard_base: "/tests-v2/"
 integration_tests_basic_auth_user: "digit-tests"
+
+# The dashboard RUN button — an on-box daemon that triggers a Playwright run.
+# CPU/RAM heavy and shares the box with the live stack. Values: true | false.
 enable_integration_tests_runner: false
 
+# ────────── Optional services ──────────
+
+# Real OTP delivery: egov-otp + user-otp + egov-notification-sms.
+# Values: true | false. False (here) means Kong mocks /user-otp/* with a canned
+# 200, so citizen login works with the fixed OTP 123456 and no SMS infra.
+# Turning it on for production also needs the mock removed from kong.yml and a
+# real SMS_PROVIDER_CLASS wired up — it defaults to Console, which only logs.
 enable_otp_services: false
+
+# Elasticsearch + egov-indexer + inbox-v2. Values: true | false.
+# Off saves ~2-3 GB. The trade: the inbox and search screens stop working —
+# pair `false` with employee_module_denylist: ["IM"] to hide the broken tab.
 enable_search_stack: false
+
+# digit-mcp + mcp-postgres. The MCP server exposes the REST shim the
+# configurator uses for tenant onboarding. Values: true | false. On here so the
+# wizard's tenant bootstrap works. Serving the shim at /v1/* also needs
+# nginx_features.mcp.
 enable_mcp: true
+
+# Build digit-mcp from the vendored in-tree source instead of pulling the
+# published image. Values: true | false.
 build_mcp: true
+
+# Build the employee SPA bundle on this box. Values: true | false.
+# False here because digit_ui_mode is `container` — the image already has it.
 build_digit_ui: false
-build_otp_publisher: false         # slim: notifications path is off
-digit_ui_esbuild_branch: "feat/keycloak-auth-adapter"
+
+# Build the OTP publisher image on this box. Values: true | false.
+# Slim: the notifications path is off, so there is nothing to publish to.
+build_otp_publisher: false
+
+# Let the deploy continue when tenant bootstrap steps fail. Values: true | false.
+# True is right for a local box booting from the dump, where some bootstrap
+# steps are already satisfied and would otherwise abort the run.
 tolerate_bootstrap_failures: true
+
+# Turbopass: on-box OSM location autocomplete for the configurator's Phase 2.
+# Needs scraped OSM data under turbopass/data on the controller.
+# Values: true | false.
 enable_turbopass: false
+
+# Self-hosted Overpass for boundary-polygon fetch. Off means the configurator
+# uses the public overpass-api.de, which is rate-limited and 504-prone.
+# Requires a prepared OSM extract on the box first. Values: true | false.
 enable_overpass: false
 
-enable_novu: false                 # slim: drops the whole notifications profile
+# ────────── Notifications (the full-vs-slim dividing line) ──────────
+#
+# THIS BLOCK IS THE ONLY FUNCTIONAL DIFFERENCE between this file and
+# localhost-full.yml.example. Flip the two flags below to `true` and you have
+# the full profile — nothing else changes.
+
+# Turn on the `notifications` compose profile: 8 extra containers
+# (novu-api, novu-worker, novu-ws, novu-dashboard, novu-mongo, novu-bridge,
+# digit-config-service, digit-user-preferences-service), roughly +1.5-2 GB
+# resident and a slower first boot. Values: true | false.
+#
+# First deploy just brings Novu up. To actually send anything: sign up at
+# http://localhost/novu/, paste the API key into novu_api_key below along with
+# the Twilio credentials, and deploy again — the second run registers the
+# integration and workflow inside Novu.
+#
+# Slim: false — this drops the whole notifications profile. The Novu settings
+# below are then inert; they are kept so switching to full is a one-line change.
+enable_novu: false
+
+# Build a subpath-rebased Novu dashboard so the SPA serves cleanly under /novu.
+# Values: true | false. REQUIRED true when Keycloak shares the domain, because
+# the stock image's nginx workaround hijacks the whole /auth/ prefix.
 build_novu_dashboard: false
+
+# Novu API key, copied from the dashboard after first sign-up. Empty (here)
+# skips the bootstrap step — Novu still comes up and can be configured by hand.
 novu_api_key: ""
+
+# Twilio credentials the bootstrap uses to register an SMS/WhatsApp integration.
+# The FROM number must be WhatsApp-enabled; the default is Twilio's sandbox.
+# SECRETS — prefer OpenBao over committing real values.
 twilio_account_sid: ""
 twilio_auth_token: ""
 twilio_whatsapp_from: "whatsapp:+14155238886"
+
+# Put PGR on the config-driven notification path: it reads
+# PGR.NotificationRouting + PGR.NotificationTemplate from MDMS, renders and
+# localizes per recipient, and novu-bridge becomes a thin pass-through.
+# Values: true | false (false keeps the legacy hardcoded path). Requires
+# enable_novu: true and the seeded MDMS masters.
+#
+# Slim: false — it would be pointing PGR at a delivery path that is not running.
 pgr_notification_config_driven: false
+
+# Build novu-bridge / pgr-services from source on this box instead of pulling
+# the published images. Values: true | false. Slow; only for testing a change.
 build_novu_bridge: false
 build_pgr_services: false
+
+# Which channel the bridge delivers on. Values: sms | whatsapp | email.
 novu_bridge_channel: "sms"
 
+# ────────── Keycloak SSO ──────────
+
+# Adds keycloak + token-exchange-svc and the /auth/ + /token-exchange/ nginx
+# blocks. Inert in the rest of the stack — DIGIT keeps working on OTP login
+# until auth_provider is flipped. Values: true | false.
 enable_keycloak: false
+
+# Which auth path the SPA uses. Values: `keycloak` for OIDC PKCE, `""` (here)
+# for OTP login. Do not flip until the realm is imported and a test login works.
 auth_provider: ""
+
+# OIDC public client id inside the per-tenant realm. The shipped realm template
+# defines `digit-ui`; change only if you forked the template.
 keycloak_client_id: "digit-ui"
+
+# Google federated login. Empty skips Google IdP wiring entirely.
 keycloak_google_client_id: ""
 
+# ────────── Data seeding ──────────
+
+# Init the nairobi-mdms git submodule on the controller. Values: true | false.
+# Only for tenants whose onboarding uses those JSONs.
 requires_nairobi_mdms: false
+
+# Preload db/full-dump.sql into Postgres on first boot — 54 tables, Flyway
+# history, ~20K localization rows, and the demo tenants. Values: true | false.
+#
+# REQUIRED for a fresh install: there is no SQL slow path any more, so `false`
+# on an empty database gives you a stack with no schema.
+#
+# DESTRUCTIVE on a box with existing data: the fast-path overlay also corrects
+# the named-volume mount path, which forces container recreation and wipes an
+# anonymous Postgres volume.
 db_fast_path: true
+
+# Explicit acknowledgement of that data wipe. preflight.py refuses to run
+# db_fast_path without it. Values: true | false.
 db_fast_path_ack_data_wipe: true
+
+# Run the post-deploy CI suite (XLSX dataloader + Playwright) at the end of the
+# deploy. Values: true | false. Needs a sibling `digit-ui-fix/` clone on the
+# controller. Off here — it roughly doubles deploy time.
 run_ci_tests: false
+
+# Tear the stack down before redeploying: removes containers and compose
+# networks, keeps volumes. Values: true | false. Useful on a dev box; never on
+# a tenant with live traffic.
 force_clean: false
+
+# Install the Claude Code CLI on the target and sync the controller's ~/.claude.
+# Hard-codes /root/.claude paths. Values: true | false.
 install_claude_code: false
-# Configurator stays in even on slim: with build_configurator false the
-# deploy pulls the CI-built egovio/configurator image and host nginx
-# proxies /configurator/ to that container (a tiny static-file nginx,
-# negligible RAM) — no on-box vite build. Set true to build the dist on
-# the host and serve it from host nginx instead (costs RAM at deploy).
+
+# Build the configurator SPA on this box. Values: true | false.
+#
+# False does NOT disable the configurator. With false the deploy pulls the
+# CI-built `egovio/configurator` image and host nginx proxies /configurator/ to
+# that container — a static-file nginx, negligible RAM, no on-box vite build.
+# Set true only to serve a dist you build here, which costs RAM at deploy time.
 build_configurator: false
 
+# ────────── nginx location blocks ──────────
+# Each flag renders one `location` block into the host vhost. A flag whose
+# backing service is off renders a block that proxies to nothing, so keep these
+# aligned with the enable_* flags above. Values: true | false.
+
 nginx_features:
-  brand_assets: false
-  configurator: true
-  configurator_caching: false
-  status: true
-  api_pgr: false
-  mcp: true
-  keycloak: true
-  digit_ui_v2: true
-  integration_tests: false
-  integration_tests_runner: false
+  brand_assets: false      # /brand/ — needs /var/www/brand on the host
+  configurator: true       # /configurator/ — the onboarding wizard
+  configurator_caching: false  # long-cache headers for its assets
+  status: true             # /status/ — the Gatus health dashboard
+  api_pgr: false           # /api/pgr/ — proxied to MCP for the dashboard
+  mcp: true                # /mcp + /v1/* — needs enable_mcp: true
+  keycloak: true           # /auth/ + /token-exchange/ — needs enable_keycloak: true
+                           # (true here but inert while enable_keycloak is false)
+  digit_ui_v2: true        # /citizen/ — needs enable_digit_ui_v2: true
+  integration_tests: false      # /tests/ + /tests-v2/
+  integration_tests_runner: false  # /tests/api/
+
+# Leave the operator's hand-written vhost alone instead of rendering the
+# template. Values: true | false. For boxes with routing the template cannot
+# express yet.
 nginx_preserve_vhost: false
 
+# ────────── Secrets (OpenBao) ──────────
+
+# REQUIRED. Path under the kv/ mount holding this tenant's secrets. The path
+# itself is not sensitive; what is behind it is.
+# Values: convention is kv/digit/<tenant>.
 secrets_path: kv/digit/pg.citya
 
-# Local-only bootstrap values, pinned by the db_fast_path dump — do not
-# "harden" them; the dump's data must match.
+# Seeded into OpenBao ONLY on this tenant's first deploy (cas=0). Later edits
+# here are ignored — change them with `bao kv put` or the OpenBao UI.
+#
+# These are pinned by the db_fast_path dump and must not be "hardened":
+#   * postgres_password matches the dump's roles;
+#   * elasticsearch_master_password MUST stay `asd@#$@$!132123` — the dump's
+#     eg_enc_*_keys decrypt only under that value, and a mismatch throws
+#     AEADBadTagException in egov-enc-service at boot.
+# On a real deployment (no dump) replace all of them with strong values.
 bootstrap_secrets:
   postgres_password: egov123
   mcp_db_password: egov123

--- a/local-setup/docs/LOCALHOST-FULL-AND-SLIM.md
+++ b/local-setup/docs/LOCALHOST-FULL-AND-SLIM.md
@@ -1,0 +1,237 @@
+# Localhost deployments — full and slim
+
+The Ansible path (`local-setup/ansible/`) is normally used to deploy DIGIT to a *remote*
+server. It can also target **the machine you are sitting at**: set `ansible_host: localhost`
+and `ansible_connection: local`, and `./deploy.sh` converges this box instead of SSHing
+anywhere. No SSH keys, no DNS, no TLS certificate.
+
+Two ready-made presets ship for that, and this page is about choosing between them and
+running one.
+
+| | **full** | **slim** |
+|---|---|---|
+| Preset | `inventory/host_vars/localhost-full.yml.example` | `inventory/host_vars/localhost-slim.yml.example` |
+| Container footprint | ~16 GB | ~16 GB minus the ~1.5–2 GB Novu stack |
+| Suitable host | 32 GB, or 16 GB with nothing else running | 16 GB, incl. WSL2 with ~12 GB for the VM |
+| Notifications (Novu) | **yes** — 8 extra containers | **no** |
+| Everything else | identical | identical |
+
+---
+
+## What "full" and "slim" actually mean here
+
+They are **not** two different stacks. Slim is full with the notification subsystem turned
+off, and that is the entire difference — two flags:
+
+```yaml
+enable_novu: false                  # full: true
+pgr_notification_config_driven: false   # full: true
+```
+
+`enable_novu: false` drops the whole `notifications` compose profile: `novu-api`,
+`novu-worker`, `novu-ws`, `novu-dashboard`, `novu-mongo`, `novu-bridge`,
+`digit-config-service` and `digit-user-preferences-service` — roughly 1.5–2 GB resident.
+`pgr_notification_config_driven: false` follows from it: leaving it on would point PGR at a
+delivery path that is not running.
+
+Everything else is byte-identical between the two files. Both give you:
+
+- all core DIGIT services and `pgr-services`
+- the employee UI at `/digit-ui/` and the citizen SPA at `/citizen/`
+- the configurator wizard at `/configurator/`
+- MCP, so the wizard's tenant bootstrap works
+- Kong, and the Gatus health dashboard at `/status/`
+- the dump-seeded `pg` / `pg.citya` tenants — a working city, boundary hierarchy, complaint
+  types and an `ADMIN` login, with no onboarding step needed
+
+**What you give up on slim:** no SMS, email or WhatsApp is sent. The complaint lifecycle —
+file, assign, resolve, rate, close — is unaffected. Choose slim unless you are specifically
+working on notifications.
+
+> **Why the notification stack is the thing that gets cut.** It is the largest optional
+> block by memory, and it is the one that tips a 12 GB VM into swapping. The JVM services
+> declare far more heap than a small box has and there is usually no swap, so memory
+> pressure shows up as OOM kills rather than slowness.
+
+---
+
+## Before you start
+
+On the machine you are deploying to (which is also the controller):
+
+| Need | Why | Check |
+|---|---|---|
+| **Ansible** on `PATH` | runs the deploy | `ansible-playbook --version` |
+| **Python 3** | `scripts/preflight.py` runs before every deploy | `python3 --version` |
+| **Node.js 20+** | the citizen SPA (`enable_digit_ui_v2`) is built on the target | `node --version` |
+| **Docker + Compose v2** | the playbook installs Docker if it is missing | `docker compose version` |
+| **Root, or sudo** | almost every task uses `become` | see below |
+| RAM | see the table above | `free -h` |
+| Disk | ~50 GB for images and volumes | `df -h /` |
+
+Collections, once:
+
+```bash
+cd local-setup/ansible
+ansible-galaxy install -r requirements.yml
+```
+
+Optionally `pip3 install ansible-lint yamllint` — `deploy.sh` runs both before touching
+anything and just warns if they are absent.
+
+### The become-password gotcha
+
+`deploy.sh` calls `ansible-playbook` **without `-K`**. Deploying to a remote box that is
+normally fine, because the generated inventory connects as `root`. Running against
+`localhost` as an ordinary user, it is not: the first `become` task fails with
+`Missing sudo password`.
+
+`deploy.sh` forwards every extra argument to `ansible-playbook`, so add it yourself:
+
+```bash
+./deploy.sh mybox -K                                   # prompt for the sudo password
+./deploy.sh mybox --become-password-file ~/.sudo-pass  # or read it from a file (chmod 600)
+```
+
+Running the whole deploy as root avoids the question entirely.
+
+---
+
+## Running one
+
+### 1. Copy the preset
+
+Real `host_vars` files are gitignored — only the `.example` files are tracked. Name the copy
+whatever you want the deployment to be called; that name is the argument to `deploy.sh`.
+
+```bash
+cd local-setup/ansible
+
+# slim (recommended on 16 GB)
+cp inventory/host_vars/localhost-slim.yml.example inventory/host_vars/mybox.yml
+
+# or full
+cp inventory/host_vars/localhost-full.yml.example inventory/host_vars/mybox.yml
+```
+
+Every setting in both files is commented in place — what it does, and what values it
+accepts. **The presets run as-is**; you do not have to edit anything to get a working stack.
+Read the comments before changing values: several are pinned by the database dump and will
+break the deploy if you "harden" them, notably `elasticsearch_master_password`.
+
+No inventory edit is needed. `deploy.sh` regenerates `inventory/hosts.yml` from whatever
+`host_vars/*.yml` exist on every run.
+
+### 2. Deploy
+
+```bash
+./deploy.sh mybox -K
+```
+
+Dry-run first if you want to see what would change:
+
+```bash
+./deploy.sh mybox --check --diff
+```
+
+The first run installs Docker and Compose, creates `/opt/digit/`, syncs configs, initialises
+and unseals OpenBao and seeds secrets, loads `db/full-dump.sql` into Postgres, pulls or
+builds images, starts the stack, and waits on health gates. Later runs are idempotent — only
+changed config triggers a restart.
+
+**It looks like it hangs.** Ansible buffers a task's output until the task ends, and the
+image pull and stack-up steps are long. Watch progress from a second terminal:
+
+```bash
+tail -f /opt/digit/digit-stack-up.mybox.progress
+watch -n5 "docker ps --format '{{.Names}}\t{{.Status}}' | grep -E 'healthy|Exited|Restart'"
+```
+
+### 3. Open it
+
+`tls_enabled: false` and `domain: localhost`, so everything is plain HTTP on port 80:
+
+| What | URL |
+|---|---|
+| Employee UI | http://localhost/digit-ui/employee |
+| Citizen SPA | http://localhost/citizen/ |
+| Configurator wizard | http://localhost/configurator/ |
+| Gatus health dashboard | http://localhost/status/ |
+| Grafana | http://localhost/grafana/ |
+| Novu dashboard (**full only**) | http://localhost/novu/ |
+
+Log in as `ADMIN` / `eGov@123`. That account belongs to the **state** tenant `pg` — it does
+not authenticate against `pg.citya` or any other city tenant.
+
+---
+
+## Expected warnings
+
+**`preflight` warns about the configurator build path.** Both presets produce:
+
+```
+[WARN] configurator-build-path: nginx_features.configurator: true but configurator_build is unset
+```
+
+Harmless here. It is aimed at the `build_configurator: true` path, where nginx serves a dist
+rsynced from the controller. These presets use `build_configurator: false`, where nginx
+proxies `/configurator/` to the CI-built `egovio/configurator` container instead — nothing is
+built on the box and no dist needs to exist. Preflight exits 0.
+
+**`insecure_registries` names a registry nothing pulls from.** Both presets still carry
+`registry.preview.egov.theflywheel.in`, from a time when that registry's certificate had
+expired. Every image in `docker-compose.egov-digit.yaml` now comes from Docker Hub
+(`egovio/*`) or ghcr.io over valid TLS, so the entry is inert. Leaving it costs nothing;
+just don't read it as a dependency.
+
+---
+
+## Switching between the two
+
+Slim → full is the two flags at the top of this page. Edit them in your `host_vars/mybox.yml`
+and redeploy:
+
+```yaml
+enable_novu: true
+pgr_notification_config_driven: true
+```
+
+```bash
+./deploy.sh mybox -K
+```
+
+Novu comes up unconfigured. To actually send anything: open http://localhost/novu/, sign up
+(this creates the first organization, environment and API key), paste that key into
+`novu_api_key` along with your Twilio credentials, and deploy once more — the second run
+registers the Twilio integration and the workflow inside Novu.
+
+Full → slim is the same edit in reverse. The Novu containers are removed on the next deploy;
+Postgres and MinIO volumes are untouched.
+
+---
+
+## Turning off more
+
+If slim is still too heavy, the next things to look at, in order of what they cost:
+
+| Setting | Frees | What stops working |
+|---|---|---|
+| `enable_search_stack: false` | ~2–3 GB | Already off in both presets. The inbox and search screens — pair it with `employee_module_denylist: ["IM"]` to hide the tab |
+| `observability_level: metrics` | ~1 GB | Loki logs and Tempo traces. Gatus and the OTel collector run at every level |
+| `enable_mcp: false` | two containers | The configurator wizard's tenant bootstrap. The rest of the wizard still loads |
+| `enable_digit_ui_v2: false` | build time, not RAM | The `/citizen/` SPA. The legacy citizen flow under `/digit-ui/` is unaffected |
+
+`observability_level` is cumulative — `metrics`, then `logs`, then `traces` (the default,
+meaning everything), each level including the ones before it. The budgeted footprints in
+`group_vars/digit.yml` are ~1.2 GB at `metrics`, ~1.8 GB at `logs` and ~2.2 GB at `traces`.
+See [Enabling monitoring](../../docs/observability/enabling-monitoring.md).
+
+---
+
+## Related
+
+- [`local-setup/README.md`](../README.md) — the Docker Compose and Tilt paths, which need no Ansible
+- [`local-setup/ansible/README.md`](../ansible/README.md) — the authoritative Ansible reference
+- [`inventory/host_vars/_example.yml`](../ansible/inventory/host_vars/_example.yml) — the exhaustive template every setting is documented in
+- [`docs/deployment-modes.md`](../../docs/deployment-modes.md) — how this compares to the Kubernetes and Helm paths
+- [WINDOWS-QUICKSTART.md](../../WINDOWS-QUICKSTART.md) — the WSL2 walkthrough slim was sized for

--- a/local-setup/postman/digit-core-validation.postman_collection.json
+++ b/local-setup/postman/digit-core-validation.postman_collection.json
@@ -150,9 +150,9 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"RequestInfo\": { \"apiId\": \"digit\", \"ver\": \"1.0\", \"ts\": 0 }\n}"
+              "raw": "{\n  \"RequestInfo\": { \"apiId\": \"digit\", \"ver\": \"1.0\", \"ts\": 0 },\n  \"BoundaryTypeHierarchySearchCriteria\": { \"tenantId\": \"pg\" }\n}"
             },
-            "url": "{{baseUrl}}/boundary-service/boundary-hierarchy-definition/_search?tenantId=pg",
+            "url": "{{baseUrl}}/boundary-service/boundary-hierarchy-definition/_search",
             "description": "Fetches boundary hierarchy definitions from boundary-service v2."
           }
         }


### PR DESCRIPTION
Two documentation gaps plus one collection fix, each verified against a running
stack or against the config the claim describes rather than against memory.

## O&M runbook rework (#1739, follow-up to #1597)

Answering the review feedback, and correcting what had gone stale:

- **Gatus categories are now documented.** The catalogue holds 57 checks in 12
  groups, not "~50 in ten" — `Observability` and `Public Endpoint` were missing
  entirely, and the group the docs called "Sign-in / identity" is labelled
  `Keycloak` on the actual dashboard. Added per-group check counts (verified
  equal to the config, group by group) and a section on why a deployment sees
  fewer groups than the catalogue defines, since all but four are feature-gated.
- **Gatus history survives restarts now** (#1610 moved it to SQLite). Five
  places still said in-memory / lost on restart.
- **Container memory limits exist.** The runbook said no container has one,
  having grepped for `mem_limit`; the caps are written as
  `deploy.resources.limits.memory` and are set on 10 of 60 services. Listed
  them, and what a capped container does differently when it runs out.
- **Declared JVM heap is ~12.8 GB across 22 services**, not ~6.3 GB.
- **Added the L1/L2 line**, which the feedback asked for: anything with a screen
  is L1 — including creating users and master data — and backend, complexity and
  the server are L2. Reflected in both runbooks, and the "not covered" list no
  longer contradicts it.

Retention, log-file caps and the raise-CPU/memory procedure were already
covered; re-verified the numbers against loki-config, tempo-config, the
Prometheus flag and group_vars, and they are correct.

## Localhost full and slim (#1598)

- Commented every setting in `localhost-full.yml.example` and
  `localhost-slim.yml.example`: what it does, what values it takes, and why this
  preset picks the one it does. Comments only — parsed both before and after,
  no key or value changed.
- Added `local-setup/docs/LOCALHOST-FULL-AND-SLIM.md`: what the two profiles
  are, that they differ by exactly two flags, how to run one, the become-password
  gotcha (`deploy.sh` never passes -K, which only bites on a local target), the
  preflight warning both presets emit and why it is harmless, and how to switch.
- Both presets verified to pass `scripts/preflight.py`.

## digit-core-validation collection

One request in `digit-core-validation.postman_collection.json` returned 400: it
sent the boundary-hierarchy criteria as query parameters instead of in the body.
Fixed; all 13 requests now return 200 against a local stack.

## Not in this PR

The local-setup setup walkthroughs (`local-setup/README.md`,
`local-setup/docs/LOCAL-SETUP-GUIDE.md`, the root README) are handled
separately so one PR owns them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
