### PR TITLE
fix(local-setup): default otp-publisher to the published image instead of a local-only tag

### DIFF
--- a/docs/notification-onboarding/install-fresh.md
+++ b/docs/notification-onboarding/install-fresh.md
@@ -22,7 +22,7 @@ Four things must all be true for a complaint transition to deliver a message:
 
 | Piece | Turned on by | Notes |
 |---|---|---|
-| **Novu delivery stack** (8 containers) | `enable_novu: true` | `digit-config-service`, `digit-user-preferences-service`, `novu-bridge`, `novu-api`, `novu-worker`, `novu-ws`, `novu-dashboard`, `novu-mongo`. ~+1 GB RAM. |
+| **Novu delivery stack** (9 containers) | `enable_novu: true` | `digit-config-service`, `digit-user-preferences-service`, `novu-bridge`, `novu-api`, `novu-worker`, `novu-ws`, `novu-dashboard`, `novu-mongo`, `otp-publisher`. ~+1 GB RAM. |
 | **PGR on the config-driven path** | `pgr_notification_config_driven: true` | PGR reads the MDMS masters, renders per recipient, emits one event per `(recipient × channel)`. Default `false` = legacy hardcoded path. |
 | **The 3 MDMS masters seeded** | the notif-seed tasks (run automatically on a full deploy when the gate above is on) | `RAINMAKER-PGR.NotificationRouting`, `.NotificationTemplate`, `.NotificationProviderTemplate`, at the **state root** (e.g. `ke`). |
 | **A real Novu API key + a provider** | `novu_api_key` + `twilio_*` | Self-hosted Novu mints the key on first sign-up → two-deploy flow (below). |
@@ -43,7 +43,7 @@ onboarded.
 db_fast_path: true                       # dump-seeded first boot (fresh installs only)
 
 # --- notifications ---
-enable_novu: true                        # 8-container notifications profile
+enable_novu: true                        # 9-container notifications profile
 pgr_notification_config_driven: true     # PGR reads the MDMS masters + emits per-recipient events
 # seed_notifications: true               # implied by the flag above; set explicitly to force
 
@@ -80,7 +80,7 @@ cd local-setup/ansible
 
 A single deploy does everything:
 
-- Brings up the full stack **including** the 8 notification containers.
+- Brings up the full stack **including** the 9 notification containers.
 - **Mints the Novu API key programmatically** — since `novu_api_key` is empty,
   the playbook waits for `novu-api` to be healthy, then runs
   [`novu-mint-key.sh`](../../backend/novu-bridge/config/novu-mint-key.sh): one

--- a/docs/notification-onboarding/install-upgrade.md
+++ b/docs/notification-onboarding/install-upgrade.md
@@ -34,7 +34,7 @@ An upgrade has two distinct parts, and they use the playbook differently:
 
 | Part | What it does | How you run it |
 |---|---|---|
-| **A. Bring up + wire the Novu stack** | starts the 8 notification containers, bootstraps the Twilio integration + workflows, wires `NOVU_API_KEY`, force-recreates `novu-bridge` | a **full** `./deploy.sh <tenant>` (these tasks are gated on `enable_novu`, not tag-scoped) |
+| **A. Bring up + wire the Novu stack** | starts the 9 notification containers, bootstraps the Twilio integration + workflows, wires `NOVU_API_KEY`, force-recreates `novu-bridge` | a **full** `./deploy.sh <tenant>` (these tasks are gated on `enable_novu`, not tag-scoped) |
 | **B. Seed the 3 MDMS masters** | creates `NotificationRouting` / `NotificationTemplate` / `NotificationProviderTemplate` at the state root, idempotently | `./deploy.sh <tenant> --tags notifications` (repeatable, standalone) |
 
 > `--tags notifications` runs **only the seed** (part B). Bringing the Novu
@@ -49,7 +49,7 @@ An upgrade has two distinct parts, and they use the playbook differently:
 Edit `inventory/host_vars/<tenant>.yml` (do **not** change `db_fast_path`):
 
 ```yaml
-enable_novu: true                        # +8 containers, ~+1 GB RAM
+enable_novu: true                        # +9 containers, ~+1 GB RAM
 pgr_notification_config_driven: true     # cut THIS tenant onto the config-driven path
 
 novu_api_key: ""                         # empty on the first pass (Step 2)
@@ -75,7 +75,7 @@ cd local-setup/ansible
 ./deploy.sh <tenant>
 ```
 
-This starts the 8 notification containers **alongside** your running stack and
+This starts the 9 notification containers **alongside** your running stack and
 recreates `pgr-services` / `novu-bridge` with the config-driven env. Existing
 Postgres data is untouched (`db_fast_path` stays `false`).
 
@@ -143,6 +143,6 @@ confirm real delivery in the Novu dashboard / Twilio console
 
 Set `pgr_notification_config_driven: false` and redeploy `pgr-services` — PGR
 falls back to the legacy notification path immediately. The Novu stack can keep
-running harmlessly, or set `enable_novu: false` and redeploy to remove the 8
+running harmlessly, or set `enable_novu: false` and redeploy to remove the 9
 containers. Because the cutover is a single per-tenant flag, you can roll a
 fleet forward (or back) one tenant at a time.

--- a/docs/notification-onboarding/provider-onboarding-runbook.md
+++ b/docs/notification-onboarding/provider-onboarding-runbook.md
@@ -87,7 +87,7 @@ The verify-pass corrections have been folded into the body; one minor open note 
 SMS is the fully-supported delivery path. The Novu Twilio SMS integration is what actually sends.
 
 ### 3.1 Prerequisites
-- Novu stack running (enable with `enable_novu: true`; adds `novu-api`, `novu-worker`, `novu-ws`, `novu-dashboard`, `novu-mongo`, `novu-bridge`, `digit-config-service`, `digit-user-preferences-service`).
+- Novu stack running (enable with `enable_novu: true`; adds `novu-api`, `novu-worker`, `novu-ws`, `novu-dashboard`, `novu-mongo`, `novu-bridge`, `digit-config-service`, `digit-user-preferences-service`, `otp-publisher`).
 - A **real Novu environment API key**. The two-deploy flow: first boot → operator signs up at `/novu/` to mint the key → second deploy wires it. Bomet uses a Novu **DEVELOPMENT**-environment key (workflow creation is only allowed in Dev on self-hosted Novu).
 - An **SMS-capable Twilio number you OWN**, in plain E.164 (e.g. `<TWILIO_SMS_FROM_E164>`). This is a *different* number from any WhatsApp sender.
 

--- a/local-setup/ansible/inventory/host_vars/_example.yml
+++ b/local-setup/ansible/inventory/host_vars/_example.yml
@@ -322,9 +322,10 @@ enable_overpass: false
 # overpass_planet_file: /opt/overpass/data/boundaries.osm.bz2  # prepared extract
 
 # ────────── Notifications (Novu + Twilio WhatsApp) ──────────
-# Turn on the `notifications` compose profile — adds 8 containers:
+# Turn on the `notifications` compose profile — adds 9 containers:
 #   digit-config-service, digit-user-preferences-service, novu-bridge,
-#   novu-api, novu-worker, novu-ws, novu-dashboard, novu-mongo.
+#   novu-api, novu-worker, novu-ws, novu-dashboard, novu-mongo,
+#   otp-publisher (see build_otp_publisher below).
 # Roughly +1GB RAM + ~5min slower first boot.
 #
 # Workflow when enable_novu: true:
@@ -351,6 +352,14 @@ build_novu_dashboard: false
 # novu_dashboard_version: "2.3.0"   # upstream tag to rebase FROM
 # novu_base_path: "/novu"           # subpath to bake into the rebased dist
 # novu_dashboard_image: ""          # override to pin a prebuilt image instead of building
+
+# otp-publisher is the 9th container in the notifications profile: it replaces
+# Kong's mock /user-otp termination with a real OTP generator (Redis + Kafka ->
+# novu-bridge -> Twilio SMS). Leave false to pull the published multi-arch image
+# (egovio/otp-publisher:v2.12-beta); set true to build the vendored Node service
+# at utilities/otp-publisher on the box instead (tag otp-publisher:local).
+build_otp_publisher: false
+# otp_publisher_image: ""           # override to pin a different published tag
 
 # Pasted from the Novu dashboard after first sign-up.
 # https://docs.novu.co/sdks/api-keys for where to find it.

--- a/local-setup/ansible/playbook-deploy.yml
+++ b/local-setup/ansible/playbook-deploy.yml
@@ -1295,6 +1295,20 @@
              | default('novu-dashboard:local' if (build_novu_dashboard | default(false))
                        else 'ghcr.io/novuhq/novu/dashboard:' ~ (novu_dashboard_version | default('2.3.0'))) }}
 
+    # otp-publisher: same shape as MCP above. `build_otp_publisher: true` builds
+    # the vendored service on the box and tags it otp-publisher:local; otherwise
+    # pull the published image. The old default was the local-only tag in BOTH
+    # cases, so a tenant that enabled notifications without opting into the build
+    # selected an image that exists in no registry — `pull` skipped it
+    # (--ignore-pull-failures) and `up -d` then aborted the whole deploy.
+    # Override with `otp_publisher_image:` in host_vars.
+    - name: "Resolve otp-publisher image tag"
+      ansible.builtin.set_fact:
+        otp_publisher_image: >-
+          {{ otp_publisher_image
+             | default('otp-publisher:local' if (build_otp_publisher | default(false))
+                       else 'egovio/otp-publisher:v2.12-beta') }}
+
     # ==================== Compose .env (per-tenant overrides) ====================
     # Templates Grafana's public root URL (so the JVM dashboard / observability
     # links match the tenant's actual domain). Compose auto-loads .env from the

--- a/local-setup/ansible/templates/digit.env.j2
+++ b/local-setup/ansible/templates/digit.env.j2
@@ -30,9 +30,10 @@ PGR_SERVICES_IMAGE={{ pgr_services_image | default('egovio/pgr-services:master-8
 # (Docker Hub; lacks tenant-aware encryption).
 EGOV_USER_IMAGE={{ egov_user_image | default('egovio/egov-user:2.12-87e13fe') }}
 
-# otp-publisher image. Local build (otp-publisher:local) when
-# build_otp_publisher:true, else pin a registry build via `otp_publisher_image:`.
-OTP_PUBLISHER_IMAGE={{ otp_publisher_image | default('otp-publisher:local') }}
+# otp-publisher image. Resolved by the "Resolve otp-publisher image tag" task:
+# a local-only tag (otp-publisher:local) when build_otp_publisher:true, else the
+# multi-arch egovio Docker Hub build. Override with `otp_publisher_image:`.
+OTP_PUBLISHER_IMAGE={{ otp_publisher_image }}
 
 # novu-bridge image. Pass-through build (PGR pre-renders + localizes; the
 # bridge only identifies the Novu subscriber + delivers renderedBody).

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -2648,9 +2648,10 @@ services:
   # SMS-OTP path; gated behind the notifications profile (off by default).
   # Node service vendored at utilities/otp-publisher; built locally via
   # `build_otp_publisher: true` (tag otp-publisher:local) or override with
-  # OTP_PUBLISHER_IMAGE.
+  # OTP_PUBLISHER_IMAGE. The fallback is the published multi-arch build, so a
+  # bare `docker compose --profile notifications up` works without a local build.
   otp-publisher:
-    image: ${OTP_PUBLISHER_IMAGE:-otp-publisher:local}
+    image: ${OTP_PUBLISHER_IMAGE:-egovio/otp-publisher:v2.12-beta}
     container_name: otp-publisher
     restart: unless-stopped
     profiles: ["notifications"]


### PR DESCRIPTION
## The bug

`enable_novu: true` without `build_otp_publisher: true` **aborts the deploy**.

`otp-publisher` is the **9th** container in the `notifications` compose profile — not the 8 the onboarding docs list. Its image resolved to `otp-publisher:local` in both `digit.env.j2` and the compose fallback, a tag that exists in no registry.

The pull step tolerates the miss (`--ignore-pull-failures`, `playbook-deploy.yml:1831`), but `up -d` at `playbook-deploy.yml:1837` has no `ignore_errors` and no enclosing `rescue`, so the play dies there. Everything after it — Novu bootstrap, API-key minting, the MDMS notification seed, nginx — never runs.

`docs/notification-onboarding/install-fresh.md` walks operators straight into it: it tells you to set `enable_novu: true`, lists `build_novu_bridge` / `build_pgr_services`, and never mentions `build_otp_publisher`. `_example.yml` didn't mention it either.

## The image was never missing

`otp-publisher` is enrolled in `build/build-config.yml`, so the nightly pipeline has been publishing it all along. Verified against the live Docker Hub registry (anonymous manifest fetch, HTTP 200):

| Tag | Pushed | Platforms |
|---|---|---|
| `egovio/otp-publisher:v2.12-beta` | 2026-08-05 | linux/amd64, linux/arm64 |
| `egovio/otp-publisher:nightly-develop` | 2026-08-17 | linux/amd64, linux/arm64 |

Only the defaults were stale. Picked `v2.12-beta` over `nightly-develop` to match how the rest of the stack pins fixed tags; there is no `2.12-beta-<sha>` variant for this image.

## The fix

Resolve the ref the way `mcp_image` and `novu_dashboard_image` already do — a `set_fact` before `.env` is rendered that selects the local tag **only** when the tenant opted into the build:

```yaml
- name: "Resolve otp-publisher image tag"
  ansible.builtin.set_fact:
    otp_publisher_image: >-
      {{ otp_publisher_image
         | default('otp-publisher:local' if (build_otp_publisher | default(false))
                   else 'egovio/otp-publisher:v2.12-beta') }}
```

The compose fallback moves too, so a bare `docker compose --profile notifications up` works without a local build.

## Verification

All three branches exercised with `ansible-playbook` against the real expression:

| host_vars | resolves to |
|---|---|
| *(nothing set — the broken case)* | `egovio/otp-publisher:v2.12-beta` |
| `build_otp_publisher: true` | `otp-publisher:local` — **bomet's path, unchanged** |
| explicit `otp_publisher_image:` | the pin wins over both |

The resolved value is exactly 31 chars with no stray whitespace from the folded scalar (a trailing space would corrupt the `.env` line). `docker compose config` confirms the image resolution end-to-end in both directions:

```
$ docker compose --profile notifications config
otp-publisher -> egovio/otp-publisher:v2.12-beta
$ OTP_PUBLISHER_IMAGE=otp-publisher:local docker compose --profile notifications config
otp-publisher -> otp-publisher:local
```

Also re-checked every image reference in the stack (82 refs across `docker-compose.egov-digit.yaml`, the migrations/monitoring overlays and the `.env` template) against Docker Hub / ghcr.io / quay.io. **81 of 82 resolved; `otp-publisher:local` was the only miss.** After this change the stack has no unresolvable image.

## Docs

`build_otp_publisher` is now documented in `_example.yml` alongside the other notification flags, and the four places that promised 8 containers name the ninth.

## Not in scope

Two adjacent things I noticed while verifying, left for separate PRs:

- `build_pgr_services`, `build_novu_bridge` and `build_default_data_handler` have **no consumer anywhere in the repo** — they're inert knobs, and the notification-onboarding docs instruct operators to set the first two. `build_default_data_handler: true` is set in the two real host_vars.
- `EGOV_USER_IMAGE` is written into `.env` but no compose file reads it; `egov-user` is hardcoded at `egovio/egov-user:2.12-87e13fe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
