### PR TITLE
fix(configurator): address PR #1754 follow-up review findings

### DIFF
--- a/configurator/packages/data-provider/src/providers/dataProvider.test.ts
+++ b/configurator/packages/data-provider/src/providers/dataProvider.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, beforeEach, mock } from 'node:test';
+import { describe, it, beforeEach, afterEach, mock } from 'node:test';
 import * as assert from 'node:assert/strict';
 import { DigitApiClient } from '../client/DigitApiClient.js';
-import { createDigitDataProvider } from './dataProvider.js';
+import { createDigitDataProvider, __setMdmsSearchAllLimitsForTesting } from './dataProvider.js';
 
 describe('createDigitDataProvider', () => {
   let client: DigitApiClient;
@@ -9,6 +9,13 @@ describe('createDigitDataProvider', () => {
   beforeEach(() => {
     client = new DigitApiClient({ url: 'https://test.example.com', stateTenantId: 'pg' });
     client.setAuth('token', { userName: 'admin', name: 'Admin', tenantId: 'pg' });
+  });
+
+  afterEach(() => {
+    // mdmsSearchAllBatchSize/MaxBatches are module-level state shared across
+    // tests — always restore defaults so one test's override can't leak into
+    // the next.
+    __setMdmsSearchAllLimitsForTesting();
   });
 
   it('returns a DataProvider with all 9 methods', () => {
@@ -174,11 +181,14 @@ describe('createDigitDataProvider', () => {
     assert.equal((captured as { reActivateEmployee: unknown }).reActivateEmployee, false);
   });
 
-  it('uses the real mdmsCount total for a generic MDMS list, not a page-size heuristic (issue #953)', async () => {
+  it('uses the real mdmsCount total for a generic MDMS list, pushing isActive down to both calls (issue #953)', async () => {
     // Departments/Designations previously faked `total` from the page just fetched
     // (`offset + perPage + 1` while a full page kept coming back), so the "X of Y"
     // footer grew every time you clicked "next" instead of showing a stable total.
-    const ALL = Array.from({ length: 730 }, (_, i) => ({
+    // Mixing in inactive rows also guards the isActive push-down: without it, mdmsSearch
+    // and mdmsCount would page through/count the inactive rows too and the total would
+    // be wrong (or the fetch would cost far more round trips than necessary).
+    const ACTIVE = Array.from({ length: 730 }, (_, i) => ({
       id: i,
       tenantId: 'pg',
       schemaCode: 'common-masters.Department',
@@ -187,13 +197,25 @@ describe('createDigitDataProvider', () => {
       isActive: true,
       auditDetails: { createdBy: 'x', lastModifiedBy: 'x', createdTime: 1, lastModifiedTime: 1 },
     }));
+    const INACTIVE = Array.from({ length: 50 }, (_, i) => ({
+      id: 1000 + i,
+      tenantId: 'pg',
+      schemaCode: 'common-masters.Department',
+      uniqueIdentifier: `DEPT_OLD_${i}`,
+      data: { code: `DEPT_OLD_${i}`, name: `Old Dept ${i}`, active: false },
+      isActive: false,
+      auditDetails: { createdBy: 'x', lastModifiedBy: 'x', createdTime: 1, lastModifiedTime: 1 },
+    }));
+    const bySelector = (isActive: boolean | undefined) =>
+      isActive === false ? INACTIVE : isActive === true ? ACTIVE : [...ACTIVE, ...INACTIVE];
 
-    mock.method(client, 'mdmsSearch', async (_t: string, _s: string, options?: { limit?: number; offset?: number }) => {
+    const mdmsSearchMock = mock.method(client, 'mdmsSearch', async (_t: string, _s: string, options?: { limit?: number; offset?: number; isActive?: boolean }) => {
       const offset = options?.offset ?? 0;
       const limit = options?.limit ?? 100;
-      return ALL.slice(offset, offset + limit);
+      return bySelector(options?.isActive).slice(offset, offset + limit);
     });
-    mock.method(client, 'mdmsCount', async () => ALL.length);
+    const mdmsCountMock = mock.method(client, 'mdmsCount', async (_t: string, _s: string, options?: { isActive?: boolean }) =>
+      bySelector(options?.isActive).length);
 
     const dp = createDigitDataProvider(client, 'pg');
     const page1 = await dp.getList('departments', {
@@ -207,9 +229,18 @@ describe('createDigitDataProvider', () => {
       filter: {},
     });
 
-    assert.equal(page1.total, 730);
+    assert.equal(page1.total, 730, 'total must come from the active-only count, not all 780 rows');
     assert.equal(page2.total, 730, 'total must stay stable across pages instead of growing');
     assert.equal(page1.data.length, 25);
+    assert.ok(mdmsCountMock.mock.calls.length > 0, 'mdmsCount must actually be called, not left dead');
+    assert.ok(
+      mdmsCountMock.mock.calls.every((call) => (call.arguments[2] as { isActive?: boolean } | undefined)?.isActive === true),
+      'mdmsCount must be called with isActive:true so its total agrees with what mdmsSearch pages through',
+    );
+    assert.ok(
+      mdmsSearchMock.mock.calls.every((call) => (call.arguments[2] as { isActive?: boolean } | undefined)?.isActive === true),
+      'isActive must be pushed down to mdmsSearch, not filtered client-side after fetching everything',
+    );
   });
 
   it('does not truncate a full-tree MDMS fetch at a single page (issue #953)', async () => {
@@ -234,6 +265,7 @@ describe('createDigitDataProvider', () => {
       const limit = options?.limit ?? 100;
       return ALL.slice(offset, offset + limit);
     });
+    mock.method(client, 'mdmsCount', async () => ALL.length);
 
     const dp = createDigitDataProvider(client, 'pg');
     const result = await dp.getList('complaint-hierarchy', {
@@ -246,10 +278,50 @@ describe('createDigitDataProvider', () => {
     assert.ok(calls > 1, 'must page through mdms-v2 rather than a single capped fetch');
   });
 
+  it('dedupes overlapping rows if mdms-v2 ever returns more than requested, instead of inflating the total', async () => {
+    // Regression guard for issue found in review: a server that treats `limit` as a
+    // hint (or resends a boundary row) could hand back the SAME record across two
+    // consecutive batches. mdmsSearchAll must dedupe by uniqueIdentifier and advance
+    // offset by the page's ACTUAL length, or the total handed to react-admin inflates.
+    __setMdmsSearchAllLimitsForTesting(10, 50);
+    const ALL = Array.from({ length: 25 }, (_, i) => ({
+      id: i,
+      tenantId: 'pg',
+      schemaCode: 'common-masters.Department',
+      uniqueIdentifier: `DEPT_${i}`,
+      data: { code: `DEPT_${i}`, name: `Dept ${i}`, active: true },
+      isActive: true,
+      auditDetails: { createdBy: 'x', lastModifiedBy: 'x', createdTime: 1, lastModifiedTime: 1 },
+    }));
+
+    mock.method(client, 'mdmsSearch', async (_t: string, _s: string, options?: { limit?: number; offset?: number }) => {
+      const offset = options?.offset ?? 0;
+      const limit = options?.limit ?? 10;
+      // Deliberately re-serve the previous batch's last row instead of the clean,
+      // non-overlapping slice the other tests use.
+      const start = Math.max(0, offset - 1);
+      return ALL.slice(start, start + limit);
+    });
+    mock.method(client, 'mdmsCount', async () => ALL.length);
+
+    const dp = createDigitDataProvider(client, 'pg');
+    const result = await dp.getList('departments', {
+      pagination: { page: 1, perPage: 25 },
+      sort: { field: 'id', order: 'ASC' },
+      filter: {},
+    });
+
+    assert.equal(result.total, 25, 'overlapping rows must be deduped, not double-counted into the total');
+  });
+
   it('sorts the full active set before paginating, not each fetched page independently', async () => {
     // mdms-v2's MdmsCriteria has no sort parameter. Ids ascending here map to names
     // DESCENDING, so a naive "sort whatever page got fetched" would only sort within
-    // a page and misorder the boundary between page 1 and page 2.
+    // a page and misorder the boundary between page 1 and page 2. The batch size is
+    // forced well below the 60-row fixture so the sort must actually span multiple
+    // mdmsSearchAll batches — otherwise per-page and full-set sorting are identical
+    // and this test can't tell them apart.
+    __setMdmsSearchAllLimitsForTesting(10, 20);
     const ALL = Array.from({ length: 60 }, (_, i) => ({
       id: i,
       tenantId: 'pg',
@@ -265,6 +337,7 @@ describe('createDigitDataProvider', () => {
       const limit = options?.limit ?? 100;
       return ALL.slice(offset, offset + limit);
     });
+    mock.method(client, 'mdmsCount', async () => ALL.length);
 
     const dp = createDigitDataProvider(client, 'pg');
     const page1 = await dp.getList('departments', {
@@ -283,21 +356,27 @@ describe('createDigitDataProvider', () => {
     assert.equal(page1.total, 60);
   });
 
-  it('throws instead of silently truncating when a schema never reaches a last page', async () => {
-    // Simulates mdms-v2 always returning a full page (bad offset handling, an
-    // ignored criterion, etc.) so mdmsSearchAll never sees a short page to stop on.
-    mock.method(client, 'mdmsSearch', async (_t: string, _s: string, options?: { limit?: number }) => {
-      const limit = options?.limit ?? 1000;
+  it('throws instead of silently truncating when a schema never reaches its own reported count', async () => {
+    // Simulates mdms-v2 always returning a full page (bad offset handling, an ignored
+    // criterion, etc.) while mdmsCount reports far more rows than paging ever reaches,
+    // so mdmsSearchAll hits its safety ceiling before catching up. Limits are forced
+    // down so this doesn't have to allocate hundreds of thousands of fixture records
+    // to prove the point.
+    __setMdmsSearchAllLimitsForTesting(5, 3);
+    mock.method(client, 'mdmsSearch', async (_t: string, _s: string, options?: { limit?: number; offset?: number }) => {
+      const limit = options?.limit ?? 5;
+      const offset = options?.offset ?? 0;
       return Array.from({ length: limit }, (_, i) => ({
-        id: i,
+        id: offset + i,
         tenantId: 'pg',
         schemaCode: 'common-masters.Department',
-        uniqueIdentifier: `DEPT_${i}`,
-        data: { code: `DEPT_${i}`, name: `Dept ${i}`, active: true },
+        uniqueIdentifier: `DEPT_${offset + i}`,
+        data: { code: `DEPT_${offset + i}`, name: `Dept ${offset + i}`, active: true },
         isActive: true,
         auditDetails: { createdBy: 'x', lastModifiedBy: 'x', createdTime: 1, lastModifiedTime: 1 },
       }));
     });
+    mock.method(client, 'mdmsCount', async () => 1000);
 
     const dp = createDigitDataProvider(client, 'pg');
     await assert.rejects(
@@ -306,7 +385,7 @@ describe('createDigitDataProvider', () => {
         sort: { field: 'id', order: 'ASC' },
         filter: {},
       }),
-      /did not finish paging/,
+      /records reported by mdmsCount/,
     );
   });
 });

--- a/configurator/packages/data-provider/src/providers/dataProvider.ts
+++ b/configurator/packages/data-provider/src/providers/dataProvider.ts
@@ -273,36 +273,72 @@ function clientPaginate(records: RaRecord[], page: number, perPage: number): RaR
 
 // Internal paging batch size for mdmsSearchAll — NOT a result cap. A tenant with more rows
 // than this just costs more round trips; nothing is ever truncated at this number.
-const MDMS_SEARCH_ALL_BATCH_SIZE = 1000;
-// Safety ceiling in case mdms-v2 ever returns full pages forever (bad offset handling, a
+const DEFAULT_MDMS_SEARCH_ALL_BATCH_SIZE = 1000;
+// Safety ceiling in case mdms-v2 ever returns pages forever (bad offset handling, a
 // criterion mdms-v2 silently ignores, etc.) — far beyond any real DIGIT master data today.
-const MDMS_SEARCH_ALL_MAX_BATCHES = 200;
+const DEFAULT_MDMS_SEARCH_ALL_MAX_BATCHES = 200;
+let mdmsSearchAllBatchSize = DEFAULT_MDMS_SEARCH_ALL_BATCH_SIZE;
+let mdmsSearchAllMaxBatches = DEFAULT_MDMS_SEARCH_ALL_MAX_BATCHES;
+
+/**
+ * Test-only hook so unit tests can exercise mdmsSearchAll's multi-batch and
+ * safety-ceiling logic with small fixtures instead of hundreds of thousands of
+ * allocated records. Never called from a production code path.
+ */
+export function __setMdmsSearchAllLimitsForTesting(batchSize = DEFAULT_MDMS_SEARCH_ALL_BATCH_SIZE, maxBatches = DEFAULT_MDMS_SEARCH_ALL_MAX_BATCHES): void {
+  mdmsSearchAllBatchSize = batchSize;
+  mdmsSearchAllMaxBatches = maxBatches;
+}
 
 /**
  * Fetches every record for a schema, paging through mdms-v2 (which has no way to return
  * "everything" in one call) instead of truncating at a single hardcoded limit. Issue #953:
  * a tenant with 630 ComplaintHierarchy rows was silently capped at the old `{ limit: 500 }`
  * single-shot fetch, before the leaf-adapter even got a chance to filter them.
+ *
+ * Bounded by `mdmsCount` (same criteria) rather than "did the last page come back short":
+ * a short/empty page is not a trustworthy end-of-data signal on its own — an environment
+ * that enforces a server-side max-limit below our batch size would return a short page
+ * while rows remain, silently reintroducing #953. `criteria` (e.g. isActive) is passed to
+ * both calls so the count and the fetched rows agree on what's being counted/paged, and
+ * `offset` advances by the page's actual length (not the requested batch size) with a
+ * uniqueIdentifier dedupe, so a server that ever returns more or fewer rows than asked
+ * can't produce gaps or duplicates.
  */
-async function mdmsSearchAll(client: DigitApiClient, tenant: string, schema: string): Promise<MdmsRecord[]> {
+async function mdmsSearchAll(client: DigitApiClient, tenant: string, schema: string, criteria?: { isActive?: boolean }): Promise<MdmsRecord[]> {
+  const expectedTotal = await client.mdmsCount(tenant, schema, criteria);
   const all: MdmsRecord[] = [];
+  const seen = new Set<string>();
   let offset = 0;
-  for (let batch = 0; batch < MDMS_SEARCH_ALL_MAX_BATCHES; batch++) {
-    const page = await client.mdmsSearch(tenant, schema, { limit: MDMS_SEARCH_ALL_BATCH_SIZE, offset });
-    all.push(...page);
-    if (page.length < MDMS_SEARCH_ALL_BATCH_SIZE) return all;
-    offset += MDMS_SEARCH_ALL_BATCH_SIZE;
+  let batches = 0;
+  while (all.length < expectedTotal && batches < mdmsSearchAllMaxBatches) {
+    batches += 1;
+    const page = await client.mdmsSearch(tenant, schema, { limit: mdmsSearchAllBatchSize, offset, ...criteria });
+    if (page.length === 0) break;
+    for (const record of page) {
+      if (seen.has(record.uniqueIdentifier)) continue;
+      seen.add(record.uniqueIdentifier);
+      all.push(record);
+    }
+    offset += page.length;
   }
-  // Still getting full pages after the safety ceiling — returning `all` here would
-  // silently hand getList/getOne/getMany an incomplete tree. Fail loudly instead.
-  throw new Error(
-    `mdmsSearchAll: schema "${schema}" on tenant "${tenant}" did not finish paging after ` +
-      `${MDMS_SEARCH_ALL_MAX_BATCHES * MDMS_SEARCH_ALL_BATCH_SIZE} records; refusing to return a partial result.`,
-  );
+  if (all.length < expectedTotal) {
+    // Either the safety ceiling was hit while mdms-v2 kept returning rows, or paging
+    // stopped short of mdmsCount's own total — returning `all` here would silently hand
+    // getList/getOne/getMany fewer records than mdms-v2 itself says exist. Fail loudly.
+    throw new Error(
+      `mdmsSearchAll: schema "${schema}" on tenant "${tenant}" retrieved ${all.length} of ` +
+        `${expectedTotal} records reported by mdmsCount; refusing to return a partial result.`,
+    );
+  }
+  return all;
 }
 
 async function mdmsGetList(client: DigitApiClient, config: ResourceConfig, tenantId: string, filter?: Record<string, unknown>): Promise<RaRecord[]> {
   const tenant = pickTenant(tenantId, filter);
+  // No isActive push-down here: the leaf-adapter (adaptHierarchyLeaves) needs inactive
+  // rows too, to resolve a leaf's parent name even when that parent has since been
+  // deactivated. Non-leaf-adapter callers filter isActive themselves below.
   const records = await mdmsSearchAll(client, tenant, config.schema!);
   if (config.leafServiceDefAdapter) return adaptHierarchyLeaves(records, config);
   return records.filter((r) => r.isActive).map((r) => normalizeMdmsRecord(r, config));
@@ -961,15 +997,19 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
       // can't represent the globally-sorted order — sorting just that page
       // (as a single `{ limit: perPage, offset }` fetch used to) reshuffles
       // each page independently instead of the full set. Page through every
-      // active record (mdmsSearchAll), sort in memory, then slice the
-      // requested page; the total then falls out of the same fetch instead
-      // of a separate `_count` call that could race with it.
+      // active record (mdmsSearchAll, with isActive pushed to the server so
+      // we don't also pay for every soft-deleted row), sort in memory, then
+      // slice the requested page. mdmsSearchAll bounds itself on mdmsCount
+      // with the SAME isActive criteria, so the total it hands back always
+      // agrees with what was actually paged through.
       if (config.type === 'mdms' && !config.leafServiceDefAdapter) {
         const filter = filterValues;
         const hasClientFilter = Object.keys(filter).some((k) => k !== TENANT_OVERRIDE_KEY);
         if (!hasClientFilter) {
           const tenant = pickTenant(tenantId, filter);
-          const all = await mdmsSearchAll(client, tenant, config.schema!);
+          const all = await mdmsSearchAll(client, tenant, config.schema!, { isActive: true });
+          // Defensive fallback for any MDMS build that ignores the isActive criterion —
+          // degrades to filtering client-side, never worse than the pre-push-down behavior.
           const active = all.filter((r) => r.isActive).map((r) => normalizeMdmsRecord(r, config));
           const sorted = clientSort(active, field, order);
           const data = clientPaginate(sorted, page, perPage);

--- a/devops/deploy-as-code/charts/core-services/mdms-v2/values.yaml
+++ b/devops/deploy-as-code/charts/core-services/mdms-v2/values.yaml
@@ -14,7 +14,12 @@ initContainers:
     enabled: true
     schemaTable: "mdms_v2_schema"
     image:
-      repository: "mdms-v2-db"
+      # PARITY: repo normalized to egovio/ to match the app image below (was bare
+      # "mdms-v2-db", which relied on a local containerd import — ImagePullBackOff
+      # on a fresh cluster). Tag intentionally stays on maven-jdk21-9f83afb: the
+      # app's mdms-count-api-3ac4f8e tag only adds POST /v2/_count on top of this
+      # base with zero SQL delta, so this migrator is still the correct one to run.
+      repository: "egovio/mdms-v2-db"
       tag: "maven-jdk21-9f83afb"
 
 # Container Configs

--- a/local-setup/k8s/core-services/mdms-backend.yaml
+++ b/local-setup/k8s/core-services/mdms-backend.yaml
@@ -17,7 +17,9 @@ spec:
     spec:
       containers:
         - name: mdms-backend
-          image: localhost:5000/egovio/mdms-v2:v2.9.2-4a60f20
+          # PARITY: matches local-setup/docker-compose*.yaml + the Helm chart (issue #953 —
+          # v2.9.2 500s on configurator writes; this tag adds POST /v2/_count).
+          image: localhost:5000/egovio/mdms-v2:mdms-count-api-3ac4f8e
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8094

--- a/local-setup/scripts/load-images.sh
+++ b/local-setup/scripts/load-images.sh
@@ -21,7 +21,7 @@ IMAGES=(
   "twinproduction/gatus:latest"
 
   # Core Services
-  "egovio/mdms-v2:v2.9.2-4a60f20"
+  "egovio/mdms-v2:mdms-count-api-3ac4f8e"
   "egovio/egov-enc-service:v2.9.2-4a60f20"
   "egovio/egov-idgen:v2.9.2-4a60f20"
   "egovio/egov-user:master-fa75ba8"


### PR DESCRIPTION
## Summary
- Follow-up to #1754 (merged). A post-merge review by @subhashini-egov (and unresolved CodeRabbit findings) identified real regressions in `mdmsSearchAll` and deployment-image parity gaps that shipped to master. This PR fixes them.

## What was wrong
`mdmsSearchAll` (the full-tree fetch backing the generic MDMS list and the Complaint-Types leaf-adapter) regressed in a follow-up commit within #1754:
- Dropped the `isActive:true` server-side push-down — paged through inactive rows too (soft-delete-heavy schemas could 6x+ the fetch and trip the safety ceiling on inactive rows alone).
- Termination relied on "did the last page come back short of the batch size" — an mdms-v2 deployment enforcing a server-side max-limit below our batch size would return a short page while rows remained, silently reintroducing #953.
- `offset` advanced by a fixed batch size regardless of what the server actually returned — a server ever returning more/fewer rows than requested could duplicate or skip rows.
- `mdmsCount` (and the mdms-v2 image bump that exists to expose it) was left completely unused — dead code, since the fetch's total came from `active.length` instead.
- Three deployment files were left on the pre-#953 `mdms-v2` tag while five compose files + the Helm chart were bumped: `local-setup/k8s/core-services/mdms-backend.yaml`, `local-setup/scripts/load-images.sh`, and the Helm chart's `initContainers.dbMigration` (bare, non-`egovio/` repository — would `ImagePullBackOff` on a fresh cluster).

## What changed
- `mdmsSearchAll` is now bounded by `mdmsCount` (called with the same criteria as the paged `mdmsSearch` calls) instead of a page-length heuristic — this un-orphans `mdmsCount` and makes the loop's stopping condition authoritative rather than a guess.
- Dedupes fetched rows by `uniqueIdentifier` and advances `offset` by the page's actual length, so a server returning more/fewer rows than requested can't produce gaps or duplicates.
- The generic MDMS list branch pushes `isActive: true` back down through `mdmsSearchAll` (restoring the original fast-path behavior); the leaf-adapter path (Complaint Types) still fetches everything, since it needs inactive rows to resolve a leaf's parent name even when that parent has since been deactivated.
- Bumped `local-setup/k8s/core-services/mdms-backend.yaml` and `local-setup/scripts/load-images.sh` to the same `mdms-count-api-3ac4f8e` tag as the rest of the stack.
- Normalized the Helm chart's `initContainers.dbMigration` repository to `egovio/mdms-v2-db` (was bare `mdms-v2-db`) and documented that its tag intentionally stays put — the count-api tag is a pure REST-endpoint addition with zero SQL delta.
- Test suite: added a dedicated regression test for the duplicate-row scenario, strengthened the mdmsCount-total test to assert `isActive` is actually pushed to both `mdmsSearch` and `mdmsCount`, and made the batch size/max-batches tunable via a test-only hook (`__setMdmsSearchAllLimitsForTesting`) so the sort-across-batches and safety-ceiling tests no longer need unrealistic fixture sizes (60 rows against a 1000-row batch, or 200,000 allocated records) to exercise the logic they claim to.

## Test plan
- [x] `configurator/packages/data-provider`: `npx tsc --noEmit` clean
- [x] `npx eslint` clean on the changed files
- [x] `npm test` — all 12 `dataProvider.test.ts` cases pass (the only suite failures are the pre-existing `dataProvider.integration.test.ts`, which requires a live DIGIT API and is unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)