### PR TITLE
feat(dashboard): add scoped multi-select filters (#1455)

### DIFF
--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsPlanner.java
@@ -236,18 +236,21 @@ public class AnalyticsPlanner {
                 parts.add(colKey + " LIKE ? || '%'");
                 continue;
             }
-            // subtree: delimiter-guarded subtree membership on a materialized dot-path column —
-            // the node itself OR any dot-descendant. Unlike a bare starts_with, the '.' guard
-            // prevents sibling-prefix collisions ('PGR' must not match 'PGRX.…'), and the eq arm
-            // keeps mixed interior+serviceable nodes (a complaint filed AT the node) in the
-            // subtree. Same allowlist as starts_with (prefix-filterable path columns only), same
-            // bound-param + LIKE-escape mechanics.
+            // subtree: delimiter-guarded subtree membership on a materialized path column —
+            // the node itself OR any descendant. Unlike a bare starts_with, the delimiter guard
+            // prevents sibling-prefix collisions ('PGR' must not match 'PGRX.…', a ward code must
+            // not match a same-prefix sibling ward), and the eq arm keeps rows attached AT the
+            // node itself in the subtree. Same allowlist as starts_with (prefix-filterable path
+            // columns only), same bound-param + LIKE-escape mechanics. The guard character is the
+            // column's own segment delimiter: complaint_node_path is dot-joined, boundary_path is
+            // pipe-joined (ancestralmaterializedpath || '|' || code — see the grain MV migration).
             if ("subtree".equals(op)) {
                 if (!prefixFilterable) throw new IllegalArgumentException(
                         "op_not_allowed: 'subtree' is only permitted on prefix-filterable path columns, not '" + colKey + "' on " + g.name);
+                String delim = "boundary_path".equals(colKey) ? "|" : ".";
                 params.add(v.asText());
                 params.add(escapeLike(v.asText()));
-                parts.add("(" + colKey + " = ? OR " + colKey + " LIKE ? || '.%')");
+                parts.add("(" + colKey + " = ? OR " + colKey + " LIKE ? || '" + delim + "%')");
                 continue;
             }
             if (!plainFilterable) throw new IllegalArgumentException(

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiQueryComposer.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiQueryComposer.java
@@ -14,7 +14,10 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
@@ -46,9 +49,18 @@ import java.util.regex.Pattern;
  *   <li>{@code ward} — a boundary/ward code; narrows to {@code ward_code = ?} <em>iff</em> the grain
  *       has a filterable {@code ward_code}. A client narrowing WITHIN the user's RBAC scope; it can
  *       never widen (row-scope is still injected on top by {@link AnalyticsPlanner#plan}).</li>
+ *   <li>{@code wards} — the multi-select form of {@code ward}; a bounded non-empty string array
+ *       narrowed with {@code ward_code IN (...)}, with every literal still JDBC-bound.</li>
  *   <li>{@code serviceCode} — a complaint type LEAF; narrows to {@code service_code = ?} iff
  *       filterable. This stays the param for leaf selections (exact match, works on every grain
  *       incl. daily); {@code complaintPath} below is for interior nodes only.</li>
+ *   <li>{@code serviceCodes} — the multi-select form of {@code serviceCode}; hierarchy selections
+ *       are expanded by the dashboard to their ABAC-scoped exact leaf codes and narrowed with
+ *       {@code service_code IN (...)}, so multi-select works on facts, events and daily.</li>
+ *   <li>{@code departments} — selected department codes narrowed with
+ *       {@code department_code IN (...)}. This remains an additional client narrowing: the
+ *       server-resolved department scope is independently applied by the planner, so the two lists
+ *       intersect and a request can never widen ABAC access.</li>
  *   <li>{@code complaintPath} — a complaint-hierarchy INTERIOR node's dot-path (e.g.
  *       {@code SANITATION.SEWAGE}); narrows to the node's whole subtree via a delimiter-guarded
  *       {@code complaint_node_path} subtree predicate ({@code = ? OR LIKE ?||'.%'}) iff the grain
@@ -117,6 +129,10 @@ public class KpiQueryComposer {
     private static final long MS_PER_DAY = 86_400_000L;
     /** Sparkline daily-series safety cap, matching the FE {@code Math.min(366, ...)}. */
     private static final int MAX_SERIES_DAYS = 366;
+    /** Maximum options emitted by the scoped DISTINCT filter-option query. */
+    static final int MAX_MULTI_FILTER_VALUES = 300;
+    /** Generous bound for one ward/service/department code; values remain JDBC-bound. */
+    static final int MAX_MULTI_FILTER_VALUE_LENGTH = 512;
     /**
      * Trend axis for a pinned def's sparkline when the request carries neither a date range nor a
      * window param — a pinned window is too narrow to be a trend (dtd would be one point).
@@ -283,13 +299,23 @@ public class KpiQueryComposer {
      */
     private void applyNarrowingParams(ObjectNode next, Grain g, JsonNode params, List<String> paramsIgnoredOut) {
         // ---- narrowing dimension filters (only if the grain supports the column) ----
-        if (params.hasNonNull("ward")) {
+        rejectScalarAndPlural(params, "ward", "wards");
+        rejectScalarAndPlural(params, "serviceCode", "serviceCodes");
+
+        if (params.hasNonNull("wards")) {
+            applyInFilter(next, g, "ward_code", stringListParam(params, "wards"));
+        } else if (params.hasNonNull("ward")) {
             String ward = params.get("ward").asText();
             if (!ward.isEmpty() && !"all".equals(ward)) applyEqFilter(next, g, "ward_code", ward);
         }
-        if (params.hasNonNull("serviceCode")) {
+        if (params.hasNonNull("serviceCodes")) {
+            applyInFilter(next, g, "service_code", stringListParam(params, "serviceCodes"));
+        } else if (params.hasNonNull("serviceCode")) {
             String svc = params.get("serviceCode").asText();
             if (!svc.isEmpty() && !"all".equals(svc)) applyEqFilter(next, g, "service_code", svc);
+        }
+        if (params.hasNonNull("departments")) {
+            applyInFilter(next, g, "department_code", stringListParam(params, "departments"));
         }
         if (params.hasNonNull("complaintPath")) {
             String path = params.get("complaintPath").asText();
@@ -819,6 +845,49 @@ public class KpiQueryComposer {
             return;   // graceful skip — never inject an unknown column.
         }
         mergeableFilterObject(query, col).put("eq", value);
+    }
+
+    /** Add {@code col IN (...)} after validating and de-duplicating a dashboard multi-select. */
+    private void applyInFilter(ObjectNode query, Grain g, String col, List<String> values) {
+        if (!g.filterable.contains(col)) {
+            log.debug("grain '{}' does not allow filtering on '{}'; skipping narrowing param", g.name, col);
+            return;
+        }
+        ArrayNode in = query.arrayNode();
+        values.forEach(in::add);
+        mergeableFilterObject(query, col).set("in", in);
+    }
+
+    /**
+     * Parse one plural filter param. Presence is deliberate: an empty/malformed selection must be
+     * rejected instead of silently turning into an unfiltered dashboard response.
+     */
+    private List<String> stringListParam(JsonNode params, String name) {
+        JsonNode raw = params.get(name);
+        if (raw == null || !raw.isArray() || raw.size() == 0)
+            throw new IllegalArgumentException("invalid_param: " + name + " must be a non-empty string array");
+        if (raw.size() > MAX_MULTI_FILTER_VALUES)
+            throw new IllegalArgumentException("invalid_param: " + name + " may contain at most "
+                    + MAX_MULTI_FILTER_VALUES + " values");
+
+        Set<String> unique = new LinkedHashSet<>();
+        for (JsonNode item : raw) {
+            if (!item.isTextual())
+                throw new IllegalArgumentException("invalid_param: " + name + " values must be strings");
+            String value = item.asText().trim();
+            if (value.isEmpty() || "all".equals(value) || value.length() > MAX_MULTI_FILTER_VALUE_LENGTH)
+                throw new IllegalArgumentException("invalid_param: " + name
+                        + " values must be non-empty codes no longer than " + MAX_MULTI_FILTER_VALUE_LENGTH);
+            unique.add(value);
+        }
+        return new ArrayList<>(unique);
+    }
+
+    /** A caller must use either the legacy scalar or the plural form, never both. */
+    private void rejectScalarAndPlural(JsonNode params, String scalar, String plural) {
+        if (params.hasNonNull(scalar) && params.hasNonNull(plural))
+            throw new IllegalArgumentException("invalid_param: use either " + scalar + " or " + plural
+                    + ", not both");
     }
 
     // ---- helpers ----

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiQueryComposer.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/KpiQueryComposer.java
@@ -59,6 +59,13 @@ import java.util.regex.Pattern;
  *       {@code paramsIgnored:["complaintPath"]} on the result envelope) so the FE can flag the
  *       widget as unfiltered. Rows with a NULL path (nodes whose own code contains '.', see the
  *       #1111 migration; flat tenants) never match a subtree filter.</li>
+ *   <li>{@code boundaryPath} — a boundary-hierarchy INTERIOR node's pipe-path (e.g.
+ *       {@code mz|maputo_cidade|distrito_x}; CCSD-2171 geography drill-down). Mirrors
+ *       {@code complaintPath} on the {@code boundary_path} column with a {@code |}-guarded
+ *       subtree predicate ({@code = ? OR LIKE ?||'|%'}); alphabet adds {@code |}, cap 512.
+ *       All three grains carry the column prefix-filterable, so unlike {@code complaintPath}
+ *       it applies on daily too. Leaf (ward) selections keep using {@code ward} (exact
+ *       {@code ward_code} eq) — this param is additive for interior nodes only.</li>
  *   <li>{@code compare: "prior"} — instead of the selected/default range, apply the
  *       <em>immediately-preceding equal-duration</em> range on the def's time column. Mirrors the FE
  *       {@code priorPeriodCreatedAtFilter()} (~1586) / {@code priorPeriodEndDateIso()} (~1360) and the
@@ -130,6 +137,19 @@ public class KpiQueryComposer {
      */
     private static final Pattern COMPLAINT_PATH_VALUE =
             Pattern.compile("^[A-Za-z0-9._/\\-]{1," + MAX_COMPLAINT_PATH_LENGTH + "}$");
+    /**
+     * {@code boundaryPath} length cap — boundary paths are longer than complaint paths
+     * (pipe-joined lowercase boundary codes, one segment per hierarchy level, each segment
+     * itself underscore-joined, e.g. {@code mz|maputo_cidade|distrito_x|municipio_maputo_katembe}).
+     */
+    static final int MAX_BOUNDARY_PATH_LENGTH = 512;
+    /**
+     * The boundary path alphabet: the complaint-path alphabet plus {@code |}, the
+     * boundary_relationship materialized-path segment delimiter. Same defense-in-depth reasoning
+     * as {@link #COMPLAINT_PATH_VALUE}.
+     */
+    private static final Pattern BOUNDARY_PATH_VALUE =
+            Pattern.compile("^[A-Za-z0-9._/|\\-]{1," + MAX_BOUNDARY_PATH_LENGTH + "}$");
 
     private final AnalyticsCatalog catalog;
 
@@ -274,6 +294,10 @@ public class KpiQueryComposer {
         if (params.hasNonNull("complaintPath")) {
             String path = params.get("complaintPath").asText();
             if (!path.isEmpty()) applyComplaintPath(next, g, path, paramsIgnoredOut);
+        }
+        if (params.hasNonNull("boundaryPath")) {
+            String path = params.get("boundaryPath").asText();
+            if (!path.isEmpty()) applyBoundaryPath(next, g, path, paramsIgnoredOut);
         }
 
         // ---- hierarchy-level rollup (#1111): rewrite service_code dimensions to the level expr ----
@@ -759,6 +783,31 @@ public class KpiQueryComposer {
             return;
         }
         mergeableFilterObject(query, "complaint_node_path").put("subtree", path);
+    }
+
+    /**
+     * Narrow to a boundary-hierarchy INTERIOR node's whole subtree (CCSD-2171: province/district
+     * selections on the dashboard's geography drill-down). Mirrors {@link #applyComplaintPath}
+     * on the {@code boundary_path} column: a delimiter-guarded {@code subtree} predicate
+     * ({@code = ? OR LIKE ?||'|%'} — boundary paths are pipe-joined, see the grain MV's
+     * {@code ancestralmaterializedpath || '|' || code}), hard {@code invalid_param} on a
+     * malformed value, and a REPORTED skip on a grain without the column. Today all three grains
+     * (facts/events/daily) carry {@code boundary_path} prefix-filterable, so the skip arm is a
+     * guard for future grains rather than a live path.
+     *
+     * <p>Leaf (ward) selections must keep using the existing {@code ward} param — exact
+     * {@code ward_code} match; {@code boundaryPath} is additive for interior nodes only.
+     */
+    private void applyBoundaryPath(ObjectNode query, Grain g, String path, List<String> paramsIgnoredOut) {
+        if (!BOUNDARY_PATH_VALUE.matcher(path).matches())
+            throw new IllegalArgumentException("invalid_param: boundaryPath must be a pipe-joined boundary path over"
+                    + " [A-Za-z0-9._/|-], at most " + MAX_BOUNDARY_PATH_LENGTH + " chars");
+        if (!g.prefixFilterable.contains("boundary_path")) {
+            log.debug("grain '{}' has no boundary_path; ignoring boundaryPath param (reported)", g.name);
+            reportIgnored(paramsIgnoredOut, "boundaryPath");
+            return;
+        }
+        mergeableFilterObject(query, "boundary_path").put("subtree", path);
     }
 
     // ---- narrowing eq filter ----

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiQueryComposerBoundaryPathTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiQueryComposerBoundaryPathTest.java
@@ -1,0 +1,178 @@
+package org.egov.pgr.analytics;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Pins the {@code boundaryPath} subtree-filter param (CCSD-2171: the dashboard geography
+ * drill-down's interior-node selections — province/district). Mirrors
+ * {@link KpiQueryComposerComplaintPathTest} on the {@code boundary_path} column with the
+ * boundary-specific deltas: the subtree guard is the PIPE delimiter (boundary paths are
+ * {@code ancestralmaterializedpath || '|' || code}), the alphabet admits {@code |}, and —
+ * unlike {@code complaint_node_path} — ALL THREE grains carry the column prefix-filterable,
+ * so the filter applies on daily instead of landing in {@code paramsIgnored}.
+ */
+public class KpiQueryComposerBoundaryPathTest {
+
+    private final ObjectMapper om = new ObjectMapper();
+    private final AnalyticsCatalog catalog = new AnalyticsCatalog();
+    private final KpiQueryComposer composer = new KpiQueryComposer(catalog);
+    private final AnalyticsPlanner planner = new AnalyticsPlanner(catalog);
+    private final AnalyticsScope stateScope = new AnalyticsScope("ke", true, null, null, null);
+    private final BusinessCalendar calendar =
+            BusinessCalendar.of(java.time.ZoneId.of("Africa/Nairobi"), 1_700_000_000_000L);
+
+    private JsonNode json(String s) {
+        try { return om.readTree(s); } catch (Exception e) { throw new RuntimeException(e); }
+    }
+
+    /** The seeded complaints-by-type base query (facts, service_code dimension). */
+    private JsonNode byTypeBase() {
+        return json("{\"grain\":\"facts\",\"window\":{\"name\":\"last_30d\",\"timeRole\":\"filed_at\"},"
+                + "\"dimensions\":[\"service_code\"],"
+                + "\"measures\":[{\"name\":\"total\",\"agg\":\"count\"}],"
+                + "\"sort\":[{\"by\":\"total\",\"dir\":\"desc\"}],\"limit\":8}");
+    }
+
+    private JsonNode dailyBase() {
+        return json("{\"grain\":\"daily\",\"dimensions\":[\"service_code\"],"
+                + "\"measures\":[{\"name\":\"open\",\"agg\":\"count\"}]}");
+    }
+
+    // ---- SQL: the PIPE-guarded subtree predicate ----
+
+    @Test
+    public void sqlSnapshotForSubtreePredicate() {
+        JsonNode merged = composer.mergeParams(byTypeBase(),
+                json("{\"boundaryPath\":\"mz|maputo_cidade\"}"), calendar);
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope, calendar);
+        assertEquals("SELECT service_code AS service_code, count(*) AS total"
+                + " FROM complaint_facts"
+                + " WHERE (boundary_path = ? OR boundary_path LIKE ? || '|%')"
+                + " AND created_at >= ? AND created_at < ? AND tenant_id LIKE ?", p.sql.substring(0, p.sql.indexOf(" GROUP BY")));
+        // eq arm binds the raw path, the LIKE arm the LIKE-escaped path ('_' is a legal boundary
+        // code character but a LIKE metachar) — the '|' guard is in the SQL, so
+        // 'mz|maputo_cidade' can never match a 'mz|maputo_cidade2|…' sibling.
+        assertEquals("mz|maputo_cidade", p.params.get(0));
+        assertEquals("mz|maputo\\_cidade", p.params.get(1));
+    }
+
+    @Test
+    public void eventsGrainAppliesSubtree() {
+        JsonNode base = json("{\"grain\":\"events\",\"dimensions\":[\"service_code\"],"
+                + "\"measures\":[{\"name\":\"n\",\"agg\":\"count\"}]}");
+        JsonNode merged = composer.mergeParams(base,
+                json("{\"boundaryPath\":\"mz|maputo_cidade|distrito_kampfumo\"}"), calendar);
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope, calendar);
+        assertTrue(p.sql.contains("FROM complaint_events"));
+        assertTrue(p.sql.contains("(boundary_path = ? OR boundary_path LIKE ? || '|%')"));
+    }
+
+    // ---- daily grain: boundary_path EXISTS there — filter applies, nothing ignored ----
+
+    @Test
+    public void dailyGrainAppliesSubtreeAndReportsNothing() {
+        List<String> ignored = new ArrayList<>();
+        JsonNode merged = composer.mergeParams(dailyBase(),
+                json("{\"boundaryPath\":\"mz|maputo_cidade\"}"), ignored, calendar);
+        assertEquals("mz|maputo_cidade",
+                merged.get("filters").get("boundary_path").get("subtree").asText());
+        assertTrue(ignored.isEmpty(), "boundary_path is prefix-filterable on daily — no skip to report");
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope, calendar);
+        assertTrue(p.sql.contains("(boundary_path = ? OR boundary_path LIKE ? || '|%')"), p.sql);
+    }
+
+    // ---- sanitizer: path alphabet + length cap ----
+
+    @Test
+    public void sqlMeaningfulValuesAreRejected() {
+        for (String bad : new String[]{
+                "mz' OR '1'='1", "a b", "x%y", "a;b", "x)--", "a\\b", "path*", "a,b",
+                "x||'y", "a\"b", "café", "a\tb"}) {
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> composer.mergeParams(byTypeBase(), json(om.createObjectNode()
+                            .put("boundaryPath", bad).toString()), calendar),
+                    "boundaryPath '" + bad + "' must be rejected");
+            assertTrue(ex.getMessage().startsWith("invalid_param"), ex.getMessage());
+        }
+    }
+
+    @Test
+    public void overlongPathIsRejected() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 40; i++) sb.append("boundary_node|");
+        String tooLong = sb.append("leaf_node").toString();   // > 512 chars, alphabet-legal
+        assertTrue(tooLong.length() > KpiQueryComposer.MAX_BOUNDARY_PATH_LENGTH);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> composer.mergeParams(byTypeBase(), json("{\"boundaryPath\":\"" + tooLong + "\"}"), calendar));
+        assertTrue(ex.getMessage().startsWith("invalid_param"), ex.getMessage());
+    }
+
+    @Test
+    public void livePathShapesAreAccepted() {
+        // Real mz shapes: pipe-joined lowercase codes, segments underscore-joined; a bare root
+        // and a full Provincia|Distrito|Municipio path both pass.
+        for (String ok : new String[]{"mz", "mz|maputo_cidade",
+                "mz|maputo_cidade|distrito_kampfumo",
+                "mz|maputo_cidade|distrito_kampfumo|municipio_maputo_katembe"}) {
+            JsonNode merged = composer.mergeParams(byTypeBase(),
+                    json("{\"boundaryPath\":\"" + ok + "\"}"), calendar);
+            assertEquals(ok, merged.get("filters").get("boundary_path").get("subtree").asText());
+        }
+    }
+
+    @Test
+    public void emptyAndAbsentAreNoOps() {
+        assertEquals(byTypeBase(), composer.mergeParams(byTypeBase(), json("{\"boundaryPath\":\"\"}"), calendar));
+        JsonNode merged = composer.mergeParams(byTypeBase(), json("{\"window\":\"last_7d\"}"), calendar);
+        assertFalse(merged.has("filters"));
+    }
+
+    // ---- composition: leaf ward eq ⊥ interior boundaryPath; complaintPath orthogonal ----
+
+    @Test
+    public void leafWardParamStaysAnExactEq() {
+        // Leaf (ward) selections keep sending ward (exact ward_code match) — boundaryPath is
+        // additive for interior nodes, not a replacement.
+        JsonNode merged = composer.mergeParams(byTypeBase(),
+                json("{\"ward\":\"municipio_maputo_katembe\",\"boundaryPath\":\"mz|maputo_cidade\"}"), calendar);
+        assertEquals("municipio_maputo_katembe",
+                merged.get("filters").get("ward_code").get("eq").asText());
+        assertEquals("mz|maputo_cidade",
+                merged.get("filters").get("boundary_path").get("subtree").asText());
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope, calendar);
+        assertTrue(p.sql.contains("ward_code = ?"));
+    }
+
+    @Test
+    public void composesWithComplaintPathOnItsOwnColumn() {
+        JsonNode merged = composer.mergeParams(byTypeBase(),
+                json("{\"complaintPath\":\"SANITATION\",\"boundaryPath\":\"mz|maputo_cidade\"}"), calendar);
+        AnalyticsPlanner.Planned p = planner.plan(merged, stateScope, calendar);
+        assertTrue(p.sql.contains("(complaint_node_path = ? OR complaint_node_path LIKE ? || '.%')"), p.sql);
+        assertTrue(p.sql.contains("(boundary_path = ? OR boundary_path LIKE ? || '|%')"), p.sql);
+    }
+
+    // ---- ABAC: params only narrow; row-scope is injected on top ----
+
+    @Test
+    public void abacRowScopeIsStillAppliedOnTopOfTheSubtreeFilter() {
+        AnalyticsScope constrained = new AnalyticsScope("ke.nairobi", false, null,
+                "KENYA.NAIROBI", java.util.List.of("DEPT_SANITATION"));
+        JsonNode merged = composer.mergeParams(byTypeBase(),
+                json("{\"boundaryPath\":\"mz|maputo_cidade\"}"), calendar);
+        AnalyticsPlanner.Planned p = planner.plan(merged, constrained, calendar);
+        assertTrue(p.sql.contains("(boundary_path = ? OR boundary_path LIKE ? || '|%')"), p.sql);
+        assertTrue(p.sql.contains("tenant_id = ?"), p.sql);                 // city tenant scope
+        assertTrue(p.sql.contains("boundary_path LIKE ?"), p.sql);          // jurisdiction subtree scope
+        assertTrue(p.sql.contains("department_code IN (?)"), p.sql);        // department scope
+        assertTrue(p.params.containsAll(java.util.List.of(
+                "mz|maputo_cidade", "ke.nairobi", "KENYA.NAIROBI%", "DEPT_SANITATION")), p.params.toString());
+    }
+}

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiQueryComposerMultiValueFilterTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/KpiQueryComposerMultiValueFilterTest.java
@@ -1,0 +1,141 @@
+package org.egov.pgr.analytics;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Contract tests for #1455 dashboard multi-select and department narrowing params. */
+public class KpiQueryComposerMultiValueFilterTest {
+
+    private final ObjectMapper om = new ObjectMapper();
+    private final AnalyticsCatalog catalog = new AnalyticsCatalog();
+    private final KpiQueryComposer composer = new KpiQueryComposer(catalog);
+    private final AnalyticsPlanner planner = new AnalyticsPlanner(catalog);
+    private final BusinessCalendar calendar =
+            BusinessCalendar.of(ZoneId.of("Africa/Nairobi"), 1_700_000_000_000L);
+
+    private JsonNode json(String source) {
+        try { return om.readTree(source); } catch (Exception e) { throw new RuntimeException(e); }
+    }
+
+    private JsonNode factsBase() {
+        return json("{\"grain\":\"facts\",\"dimensions\":[\"service_code\"],"
+                + "\"measures\":[{\"name\":\"n\",\"agg\":\"count\"}]}");
+    }
+
+    @Test
+    public void pluralParamsBecomeInFiltersAndBoundSqlValues() {
+        JsonNode merged = composer.mergeParams(factsBase(), json("{"
+                + "\"wards\":[\"WARD_A\",\"WARD_B\"],"
+                + "\"serviceCodes\":[\"TYPE_A\",\"TYPE_B\"],"
+                + "\"departments\":[\"DEPT_A\",\"DEPT_B\"]}"), calendar);
+
+        assertEquals(json("[\"WARD_A\",\"WARD_B\"]"),
+                merged.path("filters").path("ward_code").path("in"));
+        assertEquals(json("[\"TYPE_A\",\"TYPE_B\"]"),
+                merged.path("filters").path("service_code").path("in"));
+        assertEquals(json("[\"DEPT_A\",\"DEPT_B\"]"),
+                merged.path("filters").path("department_code").path("in"));
+
+        AnalyticsPlanner.Planned planned = planner.plan(merged,
+                new AnalyticsScope("ke", true, null, null, null), calendar);
+        assertTrue(planned.sql.contains("ward_code IN (?,?)"), planned.sql);
+        assertTrue(planned.sql.contains("service_code IN (?,?)"), planned.sql);
+        assertTrue(planned.sql.contains("department_code IN (?,?)"), planned.sql);
+        assertTrue(planned.params.containsAll(List.of(
+                "WARD_A", "WARD_B", "TYPE_A", "TYPE_B", "DEPT_A", "DEPT_B")));
+    }
+
+    @Test
+    public void pluralFiltersApplyOnDailyGrain() {
+        JsonNode daily = json("{\"grain\":\"daily\",\"dimensions\":[\"snapshot_date\"],"
+                + "\"measures\":[{\"name\":\"n\",\"agg\":\"count\"}]}");
+        JsonNode merged = composer.mergeParams(daily,
+                json("{\"wards\":[\"W1\"],\"serviceCodes\":[\"S1\"],\"departments\":[\"D1\"]}"),
+                calendar);
+        AnalyticsPlanner.Planned planned = planner.plan(merged,
+                new AnalyticsScope("ke", true, null, null, null), calendar);
+        assertTrue(planned.sql.contains("ward_code IN (?)"), planned.sql);
+        assertTrue(planned.sql.contains("service_code IN (?)"), planned.sql);
+        assertTrue(planned.sql.contains("department_code IN (?)"), planned.sql);
+    }
+
+    @Test
+    public void duplicatesAreRemovedWithoutChangingSelectionOrder() {
+        JsonNode merged = composer.mergeParams(factsBase(),
+                json("{\"wards\":[\" W2 \",\"W1\",\"W2\"]}"), calendar);
+        assertEquals(json("[\"W2\",\"W1\"]"),
+                merged.path("filters").path("ward_code").path("in"));
+    }
+
+    @Test
+    public void explicitDepartmentSelectionIntersectsServerResolvedAbacScope() {
+        JsonNode merged = composer.mergeParams(factsBase(),
+                json("{\"departments\":[\"DEPT_A\",\"DEPT_OUTSIDE\"]}"), calendar);
+        AnalyticsScope constrained = new AnalyticsScope(
+                "ke", true, null, null, List.of("DEPT_A"));
+        AnalyticsPlanner.Planned planned = planner.plan(merged, constrained, calendar);
+
+        assertTrue(planned.sql.contains("department_code IN (?,?)"), planned.sql);
+        assertTrue(planned.sql.contains("department_code IN (?)"), planned.sql);
+        assertEquals(2, planned.params.stream().filter("DEPT_A"::equals).count(), planned.params.toString());
+        assertTrue(planned.params.contains("DEPT_OUTSIDE"));
+    }
+
+    @Test
+    public void legacyScalarParamsRemainExactEqualityFilters() {
+        JsonNode merged = composer.mergeParams(factsBase(),
+                json("{\"ward\":\"W1\",\"serviceCode\":\"S1\"}"), calendar);
+        assertEquals("W1", merged.path("filters").path("ward_code").path("eq").asText());
+        assertEquals("S1", merged.path("filters").path("service_code").path("eq").asText());
+    }
+
+    @Test
+    public void scalarAndPluralAliasesCannotBeMixed() {
+        IllegalArgumentException ward = assertThrows(IllegalArgumentException.class,
+                () -> composer.mergeParams(factsBase(),
+                        json("{\"ward\":\"W1\",\"wards\":[\"W2\"]}"), calendar));
+        assertTrue(ward.getMessage().contains("either ward or wards"), ward.getMessage());
+
+        IllegalArgumentException service = assertThrows(IllegalArgumentException.class,
+                () -> composer.mergeParams(factsBase(),
+                        json("{\"serviceCode\":\"S1\",\"serviceCodes\":[\"S2\"]}"), calendar));
+        assertTrue(service.getMessage().contains("either serviceCode or serviceCodes"), service.getMessage());
+    }
+
+    @Test
+    public void malformedOrEmptyPluralParamsAreRejectedRatherThanUnfiltered() {
+        for (JsonNode params : List.of(
+                json("{\"wards\":[]}"),
+                json("{\"wards\":\"W1\"}"),
+                json("{\"wards\":[1]}"),
+                json("{\"wards\":[\"\"]}"),
+                json("{\"wards\":[\"   \"]}"),
+                json("{\"wards\":[\"all\"]}"))) {
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> composer.mergeParams(factsBase(), params, calendar));
+            assertTrue(ex.getMessage().startsWith("invalid_param"), ex.getMessage());
+        }
+    }
+
+    @Test
+    public void pluralParamCardinalityAndValueLengthAreBounded() {
+        ObjectNode tooMany = om.createObjectNode();
+        ArrayNode many = tooMany.putArray("serviceCodes");
+        for (int i = 0; i <= KpiQueryComposer.MAX_MULTI_FILTER_VALUES; i++) many.add("S" + i);
+        assertThrows(IllegalArgumentException.class,
+                () -> composer.mergeParams(factsBase(), tooMany, calendar));
+
+        ObjectNode tooLong = om.createObjectNode();
+        tooLong.putArray("departments").add("D".repeat(KpiQueryComposer.MAX_MULTI_FILTER_VALUE_LENGTH + 1));
+        assertThrows(IllegalArgumentException.class,
+                () -> composer.mergeParams(factsBase(), tooLong, calendar));
+    }
+}

--- a/digit-mcp/src/tools/dashboard-l10n-seed.ts
+++ b/digit-mcp/src/tools/dashboard-l10n-seed.ts
@@ -315,8 +315,28 @@ export const DASHBOARD_L10N_MESSAGES: { code: string; message: string; module: s
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "DASHBOARD_FILTERS_ACTIVE",
+    "message": "Active filters",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_ALL_DEPARTMENTS",
+    "message": "All departments",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "DASHBOARD_FILTERS_ALL_TYPES",
     "message": "All types",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_APPLY",
+    "message": "Apply",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_CANCEL",
+    "message": "Cancel",
     "module": "rainmaker-dashboard"
   },
   {
@@ -340,6 +360,26 @@ export const DASHBOARD_L10N_MESSAGES: { code: string; message: string; module: s
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "DASHBOARD_FILTERS_COMPLAINT_TYPES",
+    "message": "Complaint types",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_DEPARTMENT",
+    "message": "Department",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_DEPARTMENT_FILTER",
+    "message": "Department filter",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_DEPARTMENTS",
+    "message": "Departments",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "DASHBOARD_FILTERS_FROM",
     "message": "From",
     "module": "rainmaker-dashboard"
@@ -352,6 +392,21 @@ export const DASHBOARD_L10N_MESSAGES: { code: string; message: string; module: s
   {
     "code": "DASHBOARD_FILTERS_GEOGRAPHY",
     "message": "Geography",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_NO_MATCHES",
+    "message": "No matching options",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_REMOVE",
+    "message": "Remove",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_SEARCH_WARDS",
+    "message": "Search wards",
     "module": "rainmaker-dashboard"
   },
   {
@@ -372,6 +427,16 @@ export const DASHBOARD_L10N_MESSAGES: { code: string; message: string; module: s
   {
     "code": "DASHBOARD_FILTERS_WARD_FILTER",
     "message": "Ward filter",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_WARDS",
+    "message": "Wards",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_GEO_FILTER_ALL_IN",
+    "message": "All in",
     "module": "rainmaker-dashboard"
   },
   {
@@ -1934,8 +1999,28 @@ export const DASHBOARD_L10N_MESSAGES_PT_PT: { code: string; message: string; mod
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "DASHBOARD_FILTERS_ACTIVE",
+    "message": "Filtros ativos",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_ALL_DEPARTMENTS",
+    "message": "Todos os departamentos",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "DASHBOARD_FILTERS_ALL_TYPES",
     "message": "Todos os tipos",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_APPLY",
+    "message": "Aplicar",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_CANCEL",
+    "message": "Cancelar",
     "module": "rainmaker-dashboard"
   },
   {
@@ -1959,6 +2044,26 @@ export const DASHBOARD_L10N_MESSAGES_PT_PT: { code: string; message: string; mod
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "DASHBOARD_FILTERS_COMPLAINT_TYPES",
+    "message": "Tipos de reclamação",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_DEPARTMENT",
+    "message": "Departamento",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_DEPARTMENT_FILTER",
+    "message": "Filtro de departamento",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_DEPARTMENTS",
+    "message": "Departamentos",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "DASHBOARD_FILTERS_FROM",
     "message": "De",
     "module": "rainmaker-dashboard"
@@ -1971,6 +2076,21 @@ export const DASHBOARD_L10N_MESSAGES_PT_PT: { code: string; message: string; mod
   {
     "code": "DASHBOARD_FILTERS_GEOGRAPHY",
     "message": "Geografia",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_NO_MATCHES",
+    "message": "Nenhuma opção correspondente",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_REMOVE",
+    "message": "Remover",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_SEARCH_WARDS",
+    "message": "Pesquisar bairros",
     "module": "rainmaker-dashboard"
   },
   {
@@ -1991,6 +2111,16 @@ export const DASHBOARD_L10N_MESSAGES_PT_PT: { code: string; message: string; mod
   {
     "code": "DASHBOARD_FILTERS_WARD_FILTER",
     "message": "Filtro de bairro",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_WARDS",
+    "message": "Bairros",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_GEO_FILTER_ALL_IN",
+    "message": "Tudo em",
     "module": "rainmaker-dashboard"
   },
   {

--- a/digit-ui-esbuild/products/dashboard/src/components/ComplaintTypeTreeFilter.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/ComplaintTypeTreeFilter.jsx
@@ -2,16 +2,16 @@ import React, { useEffect, useRef, useState } from "react";
 import useDashboardT from "../i18n/useDashboardT";
 import { dimensionLabel } from "../i18n/dimensionLabel";
 import PopoverMenu, { PopoverMenuItem } from "./ui/PopoverMenu";
+import HierarchyMultiSelectFilter from "./HierarchyMultiSelectFilter";
 import {
   ALL,
   TRAIL_ELLIPSIS,
   ancestorsOf,
   browseBaseCode,
   childrenOf,
-  clearedSelection,
+  complaintMultiSelectionFromCode,
   humanizeTypeCode,
   nodeOf,
-  selectionFromCode,
   truncateTrail,
 } from "../utils/complaintTypeTree";
 
@@ -195,86 +195,24 @@ export function ComplaintTypeTreePanel({
   );
 }
 
-/** Chip content for the applied code: trailing segments + elision marker. */
-function chipModel(tree, code, allTypesLabel) {
-  const node = nodeOf(tree, code);
-  if (!node) return { segments: [allTypesLabel], elided: false, title: allTypesLabel };
-  const chain = [...ancestorsOf(tree, code), code].map((c) => nodeDisplayLabel(tree, c));
-  const segments = chain.slice(-2);
-  return {
-    segments,
-    elided: chain.length > 2,
-    title: chain.join(" › "),
-  };
-}
-
 const ComplaintTypeTreeFilter = ({ tree, filters, onFilterChange, t: tProp }) => {
   const { t: tHook } = useDashboardT();
   const t = tProp || tHook;
-
-  const code = filters?.complaintType ?? ALL;
-  const allTypesLabel = t("DASHBOARD_FILTERS_ALL_TYPES", "All types");
-  const { segments, elided, title } = chipModel(tree, code, allTypesLabel);
-
-  // UNCHANGED wire/persistence contract: applies emit the selection trio
-  // (leaf → serviceCode, interior → complaintPath) through onFilterChange.
-  const apply = (nextCode) => {
-    onFilterChange(
-      "complaintType",
-      nextCode === ALL ? clearedSelection() : selectionFromCode(tree, nextCode)
-    );
-  };
-
-  const chip = (
-    <span className="dashboard-popover-trigger-trail">
-      {elided && (
-        <>
-          <span className="dashboard-popover-trigger-seg dashboard-popover-trigger-seg--muted" aria-hidden>
-            …
-          </span>
-          <span className="dashboard-popover-trigger-sep" aria-hidden>
-            ›
-          </span>
-        </>
-      )}
-      {segments.map((segment, index) => (
-        <React.Fragment key={`${index}-${segment}`}>
-          {index > 0 && (
-            <span className="dashboard-popover-trigger-sep" aria-hidden>
-              ›
-            </span>
-          )}
-          <span
-            className={`dashboard-popover-trigger-seg${
-              index < segments.length - 1 ? " dashboard-popover-trigger-seg--muted" : ""
-            }`}
-          >
-            {segment}
-          </span>
-        </React.Fragment>
-      ))}
-    </span>
-  );
-
   return (
-    <PopoverMenu
+    <HierarchyMultiSelectFilter
+      tree={tree}
+      selections={filters?.complaintTypes ?? []}
+      label={t("DASHBOARD_FILTERS_COMPLAINT_TYPES", "Complaint types")}
+      allLabel={t("DASHBOARD_FILTERS_ALL_TYPES", "All types")}
       ariaLabel={t("DASHBOARD_FILTERS_COMPLAINT_TYPE_FILTER", "Complaint type filter")}
-      chipTitle={title}
-      chip={chip}
-      panelWidth={288}
-    >
-      {({ close }) => (
-        <ComplaintTypeTreePanel
-          tree={tree}
-          appliedCode={code}
-          t={t}
-          onApply={(nextCode) => {
-            apply(nextCode);
-            close();
-          }}
-        />
-      )}
-    </PopoverMenu>
+      labelFor={nodeDisplayLabel}
+      selectionFromCode={complaintMultiSelectionFromCode}
+      allInLabel={t("DASHBOARD_TYPE_FILTER_ALL_IN", "All in")}
+      applyLabel={t("DASHBOARD_FILTERS_APPLY", "Apply")}
+      cancelLabel={t("DASHBOARD_FILTERS_CANCEL", "Cancel")}
+      emptyLabel={t("DASHBOARD_FILTERS_NO_MATCHES", "No matching options")}
+      onChange={(selections) => onFilterChange("complaintTypes", selections)}
+    />
   );
 };
 

--- a/digit-ui-esbuild/products/dashboard/src/components/ComplaintTypeTreeFilter.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/ComplaintTypeTreeFilter.jsx
@@ -61,8 +61,22 @@ const TRAIL_MAX = 4;
  * The panel body. Exported (also for the ReactDOMServer render smoke): pure
  * React against the tree + applied code, owns only the transient browse
  * location. Mounted fresh on every open, so browse state self-resets.
+ *
+ * Hierarchy-agnostic via three optional props (defaults keep the
+ * complaint-type behaviour bit-for-bit; the geography drill-down passes its
+ * own — CCSD-2171): `labelFor(tree, code)` resolves a node's display label,
+ * `allLabel` is the virtual-root label ("All types" / "All wards"),
+ * `allInLabel` prefixes the subtree-apply row ("All in").
  */
-export function ComplaintTypeTreePanel({ tree, appliedCode, onApply, t }) {
+export function ComplaintTypeTreePanel({
+  tree,
+  appliedCode,
+  onApply,
+  t,
+  labelFor = nodeDisplayLabel,
+  allLabel,
+  allInLabel,
+}) {
   const [browseCode, setBrowseCode] = useState(() => browseBaseCode(tree, appliedCode));
   const rootRef = useRef(null);
   const mountedRef = useRef(false);
@@ -83,8 +97,9 @@ export function ComplaintTypeTreePanel({ tree, appliedCode, onApply, t }) {
     target?.focus();
   }, [browseCode]);
 
-  const allTypesLabel = t("DASHBOARD_FILTERS_ALL_TYPES", "All types");
-  const label = (c) => (c === ALL ? allTypesLabel : nodeDisplayLabel(tree, c));
+  const allTypesLabel = allLabel ?? t("DASHBOARD_FILTERS_ALL_TYPES", "All types");
+  const allInText = allInLabel ?? t("DASHBOARD_TYPE_FILTER_ALL_IN", "All in");
+  const label = (c) => (c === ALL ? allTypesLabel : labelFor(tree, c));
 
   const atRoot = browseCode === ALL || !nodeOf(tree, browseCode);
   const browse = atRoot ? ALL : browseCode;
@@ -146,10 +161,10 @@ export function ComplaintTypeTreePanel({ tree, appliedCode, onApply, t }) {
         {!atRoot && (
           <PopoverMenuItem
             selected={appliedCode === browse}
-            title={`${t("DASHBOARD_TYPE_FILTER_ALL_IN", "All in")} ${label(browse)}`}
+            title={`${allInText} ${label(browse)}`}
             onSelect={() => onApply(browse)}
           >
-            {`${t("DASHBOARD_TYPE_FILTER_ALL_IN", "All in")} ${label(browse)}`}
+            {`${allInText} ${label(browse)}`}
           </PopoverMenuItem>
         )}
         {children.map((child) => (

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardFilters.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardFilters.jsx
@@ -6,6 +6,7 @@ import {
   hasActiveFilters,
 } from "../config/globalFilterGroups";
 import ComplaintTypeTreeFilter from "./ComplaintTypeTreeFilter";
+import GeographyTreeFilter from "./GeographyTreeFilter";
 import PopoverMenu, { PopoverMenuItem, PopoverMenuGroupLabel } from "./ui/PopoverMenu";
 import useDashboardT from "../i18n/useDashboardT";
 
@@ -108,6 +109,7 @@ const DashboardFilters = ({
   const complaintTypeOptions =
     filterOptions?.complaintType ?? COMPLAINT_TYPE_OPTIONS;
   const complaintTypeTree = filterOptions?.complaintTypeTree ?? null;
+  const geographyTree = filterOptions?.geographyTree ?? null;
 
   // Date fallbacks resolve from buildDefaultFilters(timeZone) at render time — never
   // GLOBAL_FILTER_FIELDS' module-load defaultValue, which would freeze on whatever
@@ -166,26 +168,37 @@ const DashboardFilters = ({
           </div>
         </div>
 
-        <div className="dashboard-filter-inline-select-wrap">
-          <select
-            value={filterOptionsLoading && geographyOptions.length <= 1 ? "" : geography}
-            disabled={filterOptionsLoading && geographyOptions.length <= 1}
-            onChange={(e) => onFilterChange("geography", e.target.value)}
-            aria-label={t("DASHBOARD_FILTERS_WARD_FILTER", "Ward filter")}
-            className="dashboard-filter-inline-select"
-          >
-            {filterOptionsLoading && geographyOptions.length <= 1 ? (
-              <option value="">{t("DASHBOARD_COMMON_LOADING", "Loading…")}</option>
-            ) : (
-              geographyOptions.map((opt) => (
-                <option key={opt.id} value={opt.id}>
-                  {opt.label}
-                </option>
-              ))
-            )}
-          </select>
-          <FilterChevron />
-        </div>
+        {geographyTree ? (
+          // Boundary drill-down (CCSD-2171): Província → Distrito → Município
+          // via the shared tree panel; leaf → ward, interior → boundaryPath.
+          <GeographyTreeFilter
+            tree={geographyTree}
+            filters={filters}
+            onFilterChange={onFilterChange}
+            t={t}
+          />
+        ) : (
+          <div className="dashboard-filter-inline-select-wrap">
+            <select
+              value={filterOptionsLoading && geographyOptions.length <= 1 ? "" : geography}
+              disabled={filterOptionsLoading && geographyOptions.length <= 1}
+              onChange={(e) => onFilterChange("geography", e.target.value)}
+              aria-label={t("DASHBOARD_FILTERS_WARD_FILTER", "Ward filter")}
+              className="dashboard-filter-inline-select"
+            >
+              {filterOptionsLoading && geographyOptions.length <= 1 ? (
+                <option value="">{t("DASHBOARD_COMMON_LOADING", "Loading…")}</option>
+              ) : (
+                geographyOptions.map((opt) => (
+                  <option key={opt.id} value={opt.id}>
+                    {opt.label}
+                  </option>
+                ))
+              )}
+            </select>
+            <FilterChevron />
+          </div>
+        )}
 
         {complaintTypeTree ? (
           // ONE chip + traversal panel (trail, descend-in-place, "All in <X>",

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardFilters.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardFilters.jsx
@@ -1,14 +1,23 @@
 import React, { useCallback, useMemo } from "react";
 import {
   COMPLAINT_TYPE_OPTIONS,
+  DEPARTMENT_OPTIONS,
   GEOGRAPHY_OPTIONS,
   buildDefaultFilters,
   hasActiveFilters,
 } from "../config/globalFilterGroups";
 import ComplaintTypeTreeFilter from "./ComplaintTypeTreeFilter";
 import GeographyTreeFilter from "./GeographyTreeFilter";
-import PopoverMenu, { PopoverMenuItem, PopoverMenuGroupLabel } from "./ui/PopoverMenu";
+import { nodeDisplayLabel } from "./ComplaintTypeTreeFilter";
+import { boundaryDisplayLabel } from "./GeographyTreeFilter";
+import MultiSelectFilter from "./MultiSelectFilter";
 import useDashboardT from "../i18n/useDashboardT";
+import { dimensionLabel } from "../i18n/dimensionLabel";
+import {
+  normalizeHierarchySelections,
+  normalizeStringList,
+  removeHierarchySelection,
+} from "../utils/multiSelectFilters";
 
 const FunnelIcon = () => (
   <svg
@@ -27,73 +36,6 @@ const FunnelIcon = () => (
   </svg>
 );
 
-const FilterChevron = () => (
-  <svg
-    className="dashboard-filter-inline-chevron"
-    xmlns="http://www.w3.org/2000/svg"
-    width="10"
-    height="10"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2.5"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <polyline points="6 9 12 15 18 9" />
-  </svg>
-);
-
-/**
- * Degrade path for the complaint-type filter when no usable/pruned hierarchy
- * exists (flat tenant, MDMS fetch failure, empty scoped distincts): the same
- * flat {id,label,group?} option list the old native <select> showed, now
- * rendered through the shared PopoverMenu primitive (owner design pass — no
- * native selects). Consecutive same-group runs get a non-interactive group
- * label, exactly where the old <optgroup>s sat; the wire contract is
- * untouched (a bare leaf-code string through onFilterChange).
- */
-const FlatComplaintTypeMenu = ({ options, value, loading, onChange, t }) => {
-  const selected = options.find((opt) => opt.id === value);
-  return (
-    <PopoverMenu
-      ariaLabel={t("DASHBOARD_FILTERS_COMPLAINT_TYPE_FILTER", "Complaint type filter")}
-      chip={loading ? t("DASHBOARD_COMMON_LOADING", "Loading…") : selected?.label ?? String(value)}
-      chipTitle={selected?.label}
-      disabled={loading}
-      panelWidth={272}
-    >
-      {({ close }) => {
-        const rows = [];
-        let lastGroup = null;
-        for (const opt of options) {
-          if (opt.group && opt.group !== lastGroup) {
-            rows.push(
-              <PopoverMenuGroupLabel key={`group-${opt.group}`}>{opt.group}</PopoverMenuGroupLabel>
-            );
-          }
-          lastGroup = opt.group || null;
-          rows.push(
-            <PopoverMenuItem
-              key={opt.id}
-              selected={opt.id === value}
-              title={opt.label}
-              onSelect={() => {
-                onChange(opt.id);
-                close();
-              }}
-            >
-              {opt.label}
-            </PopoverMenuItem>
-          );
-        }
-        return <div className="dashboard-popover-list">{rows}</div>;
-      }}
-    </PopoverMenu>
-  );
-};
-
 const DashboardFilters = ({
   filters,
   onFilterChange,
@@ -108,17 +50,75 @@ const DashboardFilters = ({
   const geographyOptions = filterOptions?.geography ?? GEOGRAPHY_OPTIONS;
   const complaintTypeOptions =
     filterOptions?.complaintType ?? COMPLAINT_TYPE_OPTIONS;
+  const departmentOptions = filterOptions?.department ?? DEPARTMENT_OPTIONS;
   const complaintTypeTree = filterOptions?.complaintTypeTree ?? null;
   const geographyTree = filterOptions?.geographyTree ?? null;
 
   // Date fallbacks resolve from buildDefaultFilters(timeZone) at render time — never
   // GLOBAL_FILTER_FIELDS' module-load defaultValue, which would freeze on whatever
   // calendar day the JS bundle happened to first evaluate in the browser's local zone.
-  const defaultFilters = useMemo(() => buildDefaultFilters(timeZone), [timeZone]);
+  const defaultFilters = useMemo(() => buildDefaultFilters(timeZone), [
+    timeZone,
+  ]);
   const dateFrom = filters?.dateFrom ?? defaultFilters.dateFrom;
   const dateTo = filters?.dateTo ?? defaultFilters.dateTo;
-  const geography = filters?.geography ?? "all";
-  const complaintType = filters?.complaintType ?? "all";
+  const geographies = normalizeHierarchySelections(filters?.geographies);
+  const complaintTypes = normalizeHierarchySelections(filters?.complaintTypes);
+  const departments = normalizeStringList(filters?.departments);
+  const applyLabel = t("DASHBOARD_FILTERS_APPLY", "Apply");
+  const cancelLabel = t("DASHBOARD_FILTERS_CANCEL", "Cancel");
+  const noMatchesLabel = t(
+    "DASHBOARD_FILTERS_NO_MATCHES",
+    "No matching options"
+  );
+
+  const flatHierarchyValues = (selections) =>
+    selections.map((selection) => selection.code);
+  const flatHierarchySelections = (codes) =>
+    normalizeStringList(codes).map((code) => ({
+      code,
+      path: null,
+      leaf: true,
+      codes: [code],
+    }));
+
+  const activeChips = [
+    ...geographies.map((selection) => ({
+      key: `geography-${selection.code}`,
+      label: geographyTree
+        ? boundaryDisplayLabel(geographyTree, selection.code)
+        : geographyOptions.find((option) => option.id === selection.code)
+            ?.label ?? dimensionLabel(selection.code, "boundary"),
+      onRemove: () =>
+        onFilterChange(
+          "geographies",
+          removeHierarchySelection(geographies, selection.code)
+        ),
+    })),
+    ...complaintTypes.map((selection) => ({
+      key: `complaint-${selection.code}`,
+      label: complaintTypeTree
+        ? nodeDisplayLabel(complaintTypeTree, selection.code)
+        : complaintTypeOptions.find((option) => option.id === selection.code)
+            ?.label ?? dimensionLabel(selection.code, "complaintType"),
+      onRemove: () =>
+        onFilterChange(
+          "complaintTypes",
+          removeHierarchySelection(complaintTypes, selection.code)
+        ),
+    })),
+    ...departments.map((code) => ({
+      key: `department-${code}`,
+      label:
+        departmentOptions.find((option) => option.id === code)?.label ??
+        dimensionLabel(code, "department"),
+      onRemove: () =>
+        onFilterChange(
+          "departments",
+          departments.filter((department) => department !== code)
+        ),
+    })),
+  ];
 
   const openCalendar = useCallback((input) => {
     if (!input) return;
@@ -137,98 +137,144 @@ const DashboardFilters = ({
     <div className="dashboard-filters-bar tw-mb-4">
       <div className="dashboard-filters-card">
         <div className="dashboard-filters-row">
-        <div className="dashboard-filters-heading">
-          <FunnelIcon />
-          <span className="dashboard-filters-title">{t("DASHBOARD_FILTERS_TITLE", "Filters")}</span>
-        </div>
-
-        <div className="dashboard-filters-date-range">
-          <div className="dashboard-filter-inline-date-wrap">
-            <input
-              type="date"
-              value={dateFrom}
-              onChange={(e) => onFilterChange("dateFrom", e.target.value)}
-              onClick={(e) => openCalendar(e.currentTarget)}
-              aria-label={t("DASHBOARD_FILTERS_FROM_DATE", "From date")}
-              className="dashboard-filter-inline-date"
-            />
+          <div className="dashboard-filters-heading">
+            <FunnelIcon />
+            <span className="dashboard-filters-title">
+              {t("DASHBOARD_FILTERS_TITLE", "Filters")}
+            </span>
           </div>
-          <span className="dashboard-filters-date-arrow" aria-hidden>
-            →
-          </span>
-          <div className="dashboard-filter-inline-date-wrap">
-            <input
-              type="date"
-              value={dateTo}
-              onChange={(e) => onFilterChange("dateTo", e.target.value)}
-              onClick={(e) => openCalendar(e.currentTarget)}
-              aria-label={t("DASHBOARD_FILTERS_TO_DATE", "To date")}
-              className="dashboard-filter-inline-date"
-            />
-          </div>
-        </div>
 
-        {geographyTree ? (
-          // Boundary drill-down (CCSD-2171): Província → Distrito → Município
-          // via the shared tree panel; leaf → ward, interior → boundaryPath.
-          <GeographyTreeFilter
-            tree={geographyTree}
-            filters={filters}
-            onFilterChange={onFilterChange}
-            t={t}
-          />
-        ) : (
-          <div className="dashboard-filter-inline-select-wrap">
-            <select
-              value={filterOptionsLoading && geographyOptions.length <= 1 ? "" : geography}
-              disabled={filterOptionsLoading && geographyOptions.length <= 1}
-              onChange={(e) => onFilterChange("geography", e.target.value)}
-              aria-label={t("DASHBOARD_FILTERS_WARD_FILTER", "Ward filter")}
-              className="dashboard-filter-inline-select"
-            >
-              {filterOptionsLoading && geographyOptions.length <= 1 ? (
-                <option value="">{t("DASHBOARD_COMMON_LOADING", "Loading…")}</option>
-              ) : (
-                geographyOptions.map((opt) => (
-                  <option key={opt.id} value={opt.id}>
-                    {opt.label}
-                  </option>
-                ))
+          <div className="dashboard-filters-date-range">
+            <div className="dashboard-filter-inline-date-wrap">
+              <input
+                type="date"
+                value={dateFrom}
+                onChange={(e) => onFilterChange("dateFrom", e.target.value)}
+                onClick={(e) => openCalendar(e.currentTarget)}
+                aria-label={t("DASHBOARD_FILTERS_FROM_DATE", "From date")}
+                className="dashboard-filter-inline-date"
+              />
+            </div>
+            <span className="dashboard-filters-date-arrow" aria-hidden>
+              →
+            </span>
+            <div className="dashboard-filter-inline-date-wrap">
+              <input
+                type="date"
+                value={dateTo}
+                onChange={(e) => onFilterChange("dateTo", e.target.value)}
+                onClick={(e) => openCalendar(e.currentTarget)}
+                aria-label={t("DASHBOARD_FILTERS_TO_DATE", "To date")}
+                className="dashboard-filter-inline-date"
+              />
+            </div>
+          </div>
+
+          {geographyTree ? (
+            <GeographyTreeFilter
+              tree={geographyTree}
+              filters={filters}
+              onFilterChange={onFilterChange}
+              t={t}
+            />
+          ) : (
+            <MultiSelectFilter
+              options={geographyOptions}
+              values={flatHierarchyValues(geographies)}
+              label={t("DASHBOARD_FILTERS_WARDS", "Wards")}
+              allLabel={t("DASHBOARD_FILTERS_ALL_WARDS", "All wards")}
+              ariaLabel={t("DASHBOARD_FILTERS_WARD_FILTER", "Ward filter")}
+              loading={filterOptionsLoading && geographyOptions.length <= 1}
+              searchable
+              searchPlaceholder={t(
+                "DASHBOARD_FILTERS_SEARCH_WARDS",
+                "Search wards"
               )}
-            </select>
-            <FilterChevron />
+              applyLabel={applyLabel}
+              cancelLabel={cancelLabel}
+              emptyLabel={noMatchesLabel}
+              onChange={(codes) =>
+                onFilterChange("geographies", flatHierarchySelections(codes))
+              }
+            />
+          )}
+
+          {complaintTypeTree ? (
+            // Staged, ABAC-pruned hierarchy multi-select. Hierarchy nodes expand
+            // to exact scoped service codes before the query is issued.
+            <ComplaintTypeTreeFilter
+              tree={complaintTypeTree}
+              filters={filters}
+              onFilterChange={onFilterChange}
+              t={t}
+            />
+          ) : (
+            <MultiSelectFilter
+              options={complaintTypeOptions}
+              values={flatHierarchyValues(complaintTypes)}
+              label={t("DASHBOARD_FILTERS_COMPLAINT_TYPES", "Complaint types")}
+              allLabel={t("DASHBOARD_FILTERS_ALL_TYPES", "All types")}
+              ariaLabel={t(
+                "DASHBOARD_FILTERS_COMPLAINT_TYPE_FILTER",
+                "Complaint type filter"
+              )}
+              loading={filterOptionsLoading && complaintTypeOptions.length <= 1}
+              applyLabel={applyLabel}
+              cancelLabel={cancelLabel}
+              emptyLabel={noMatchesLabel}
+              onChange={(codes) =>
+                onFilterChange("complaintTypes", flatHierarchySelections(codes))
+              }
+            />
+          )}
+
+          <MultiSelectFilter
+            options={departmentOptions}
+            values={departments}
+            label={t("DASHBOARD_FILTERS_DEPARTMENTS", "Departments")}
+            allLabel={t("DASHBOARD_FILTERS_ALL_DEPARTMENTS", "All departments")}
+            ariaLabel={t(
+              "DASHBOARD_FILTERS_DEPARTMENT_FILTER",
+              "Department filter"
+            )}
+            loading={filterOptionsLoading && departmentOptions.length <= 1}
+            applyLabel={applyLabel}
+            cancelLabel={cancelLabel}
+            emptyLabel={noMatchesLabel}
+            onChange={(codes) => onFilterChange("departments", codes)}
+          />
+
+          <button
+            type="button"
+            onClick={onClearFilters}
+            disabled={!canClear}
+            className="dashboard-filters-clear-inline"
+            aria-disabled={!canClear}
+          >
+            {t("DASHBOARD_FILTERS_CLEAR", "Clear")}
+          </button>
+        </div>
+        {activeChips.length > 0 && (
+          <div
+            className="dashboard-active-filter-chips"
+            aria-label={t("DASHBOARD_FILTERS_ACTIVE", "Active filters")}
+          >
+            {activeChips.map((chip) => (
+              <span key={chip.key} className="dashboard-active-filter-chip">
+                <span>{chip.label}</span>
+                <button
+                  type="button"
+                  onClick={chip.onRemove}
+                  aria-label={`${t("DASHBOARD_FILTERS_REMOVE", "Remove")} ${
+                    chip.label
+                  }`}
+                >
+                  ×
+                </button>
+              </span>
+            ))}
           </div>
         )}
-
-        {complaintTypeTree ? (
-          // ONE chip + traversal panel (trail, descend-in-place, "All in <X>",
-          // reset), ABAC-pruned; leaf → serviceCode, interior → complaintPath.
-          <ComplaintTypeTreeFilter
-            tree={complaintTypeTree}
-            filters={filters}
-            onFilterChange={onFilterChange}
-            t={t}
-          />
-        ) : (
-          <FlatComplaintTypeMenu
-            options={complaintTypeOptions}
-            value={complaintType}
-            loading={filterOptionsLoading && complaintTypeOptions.length <= 1}
-            onChange={(id) => onFilterChange("complaintType", id)}
-            t={t}
-          />
-        )}
-
-        <button
-          type="button"
-          onClick={onClearFilters}
-          disabled={!canClear}
-          className="dashboard-filters-clear-inline"
-          aria-disabled={!canClear}
-        >
-          {t("DASHBOARD_FILTERS_CLEAR", "Clear")}
-        </button>
-        </div>
       </div>
     </div>
   );

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardHeader.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardHeader.jsx
@@ -1,8 +1,8 @@
 import React, { useMemo, useRef, useState } from "react";
 import { getProductLabel } from "../config/dashboardConfig";
-import { GEOGRAPHY_OPTIONS } from "../config/globalFilterGroups";
 import { dimensionLabel } from "../i18n/dimensionLabel";
 import useDashboardT from "../i18n/useDashboardT";
+import { normalizeHierarchySelections } from "../utils/multiSelectFilters";
 import AddKpiDropdown from "./AddKpiDropdown";
 
 /**
@@ -59,15 +59,13 @@ function formatDisplayDate(iso, language) {
 }
 
 function buildSubtitle(filters, filterOptions, t, language) {
-  const geoOptions = filterOptions?.geography ?? GEOGRAPHY_OPTIONS;
-  const geoId = filters?.geography;
-  // The geography chip is a raw boundary code — route it through the
-  // dimension-label seam; the "all" sentinel renders its localized label.
+  const geographies = normalizeHierarchySelections(filters?.geographies);
   const geo =
-    geoId && geoId !== "all"
-      ? dimensionLabel(geoId, "boundary")
-      : geoOptions.find((o) => o.id === geoId)?.label ??
-        t("DASHBOARD_HEADER_ALL_LOCALITIES", "All Localities");
+    geographies.length === 0
+      ? t("DASHBOARD_HEADER_ALL_LOCALITIES", "All Localities")
+      : geographies.length === 1
+        ? dimensionLabel(geographies[0].code, "boundary")
+        : `${geographies.length} ${t("DASHBOARD_FILTERS_WARDS", "wards")}`;
 
   let period = t("DASHBOARD_HEADER_LAST_7_DAYS", "Last 7 days");
   if (filters?.dateFrom && filters?.dateTo) {

--- a/digit-ui-esbuild/products/dashboard/src/components/GeographyTreeFilter.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/GeographyTreeFilter.jsx
@@ -1,0 +1,123 @@
+import React from "react";
+import useDashboardT from "../i18n/useDashboardT";
+import { dimensionLabel } from "../i18n/dimensionLabel";
+import PopoverMenu from "./ui/PopoverMenu";
+import { ComplaintTypeTreePanel } from "./ComplaintTypeTreeFilter";
+import { ALL, ancestorsOf, nodeOf } from "../utils/complaintTypeTree";
+import {
+  clearedGeographySelection,
+  geographySelectionFromCode,
+  humanizeBoundaryCode,
+} from "../utils/boundaryTree";
+
+/**
+ * The geography (ward) filter as a boundary drill-down — Província →
+ * Distrito → Município — instead of the flat ward list (CCSD-2171,
+ * "similar to complaint type dropdown"). Chip + traversal panel are the
+ * ComplaintTypeTreePanel verbatim (hierarchy-agnostic via labelFor/allLabel
+ * props); this wrapper owns only geography-specific labeling and the
+ * persisted-selection contract:
+ *
+ *   leaf (ward)          → { code, path, leaf:true }  → params.ward
+ *   interior ("All in")  → { code, path, leaf:false } → params.boundaryPath
+ *   "All wards" reset    → cleared trio
+ *
+ * Labels resolve through the same dimensionLabel("boundary") seam the flat
+ * select uses (localized boundary names), with a humanized last-segment
+ * fallback so a raw "municipio_maputo_katembe" never reaches the chip.
+ */
+
+export function boundaryDisplayLabel(tree, code) {
+  const node = nodeOf(tree, code);
+  const resolved = dimensionLabel(code, "boundary", node?.label);
+  return resolved === String(code) ? humanizeBoundaryCode(code) : resolved;
+}
+
+/** Chip content for the applied code: trailing segments + elision marker. */
+function chipModel(tree, code, allWardsLabel) {
+  const node = nodeOf(tree, code);
+  if (!node) return { segments: [allWardsLabel], elided: false, title: allWardsLabel };
+  const chain = [...ancestorsOf(tree, code), code].map((c) => boundaryDisplayLabel(tree, c));
+  const segments = chain.slice(-2);
+  return {
+    segments,
+    elided: chain.length > 2,
+    title: chain.join(" › "),
+  };
+}
+
+const GeographyTreeFilter = ({ tree, filters, onFilterChange, t: tProp }) => {
+  const { t: tHook } = useDashboardT();
+  const t = tProp || tHook;
+
+  const code = filters?.geography ?? ALL;
+  const allWardsLabel = t("DASHBOARD_FILTERS_ALL_WARDS", "All wards");
+  const { segments, elided, title } = chipModel(tree, code, allWardsLabel);
+
+  // Applies emit the selection trio through onFilterChange (leaf → ward,
+  // interior → boundaryPath); the flat fallback select's bare-string contract
+  // is untouched for tenants/failures without a tree.
+  const apply = (nextCode) => {
+    onFilterChange(
+      "geography",
+      nextCode === ALL ? clearedGeographySelection() : geographySelectionFromCode(tree, nextCode)
+    );
+  };
+
+  const chip = (
+    <span className="dashboard-popover-trigger-trail">
+      {elided && (
+        <>
+          <span className="dashboard-popover-trigger-seg dashboard-popover-trigger-seg--muted" aria-hidden>
+            …
+          </span>
+          <span className="dashboard-popover-trigger-sep" aria-hidden>
+            ›
+          </span>
+        </>
+      )}
+      {segments.map((segment, index) => (
+        <React.Fragment key={`${index}-${segment}`}>
+          {index > 0 && (
+            <span className="dashboard-popover-trigger-sep" aria-hidden>
+              ›
+            </span>
+          )}
+          <span
+            className={`dashboard-popover-trigger-seg${
+              index < segments.length - 1 ? " dashboard-popover-trigger-seg--muted" : ""
+            }`}
+          >
+            {segment}
+          </span>
+        </React.Fragment>
+      ))}
+    </span>
+  );
+
+  return (
+    <PopoverMenu
+      ariaLabel={t("DASHBOARD_FILTERS_WARD_FILTER", "Ward filter")}
+      chipTitle={title}
+      chip={chip}
+      panelWidth={288}
+    >
+      {({ close }) => (
+        <ComplaintTypeTreePanel
+          tree={tree}
+          appliedCode={code}
+          t={t}
+          labelFor={boundaryDisplayLabel}
+          allLabel={allWardsLabel}
+          allInLabel={t("DASHBOARD_GEO_FILTER_ALL_IN", "All in")}
+          onApply={(nextCode) => {
+            apply(nextCode);
+            close();
+          }}
+        />
+      )}
+    </PopoverMenu>
+  );
+};
+
+export default GeographyTreeFilter;

--- a/digit-ui-esbuild/products/dashboard/src/components/GeographyTreeFilter.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/GeographyTreeFilter.jsx
@@ -1,12 +1,9 @@
-import React from "react";
 import useDashboardT from "../i18n/useDashboardT";
 import { dimensionLabel } from "../i18n/dimensionLabel";
-import PopoverMenu from "./ui/PopoverMenu";
-import { ComplaintTypeTreePanel } from "./ComplaintTypeTreeFilter";
-import { ALL, ancestorsOf, nodeOf } from "../utils/complaintTypeTree";
+import HierarchyMultiSelectFilter from "./HierarchyMultiSelectFilter";
+import { nodeOf } from "../utils/complaintTypeTree";
 import {
-  clearedGeographySelection,
-  geographySelectionFromCode,
+  geographyMultiSelectionFromCode,
   humanizeBoundaryCode,
 } from "../utils/boundaryTree";
 
@@ -33,90 +30,26 @@ export function boundaryDisplayLabel(tree, code) {
   return resolved === String(code) ? humanizeBoundaryCode(code) : resolved;
 }
 
-/** Chip content for the applied code: trailing segments + elision marker. */
-function chipModel(tree, code, allWardsLabel) {
-  const node = nodeOf(tree, code);
-  if (!node) return { segments: [allWardsLabel], elided: false, title: allWardsLabel };
-  const chain = [...ancestorsOf(tree, code), code].map((c) => boundaryDisplayLabel(tree, c));
-  const segments = chain.slice(-2);
-  return {
-    segments,
-    elided: chain.length > 2,
-    title: chain.join(" › "),
-  };
-}
-
 const GeographyTreeFilter = ({ tree, filters, onFilterChange, t: tProp }) => {
   const { t: tHook } = useDashboardT();
   const t = tProp || tHook;
-
-  const code = filters?.geography ?? ALL;
-  const allWardsLabel = t("DASHBOARD_FILTERS_ALL_WARDS", "All wards");
-  const { segments, elided, title } = chipModel(tree, code, allWardsLabel);
-
-  // Applies emit the selection trio through onFilterChange (leaf → ward,
-  // interior → boundaryPath); the flat fallback select's bare-string contract
-  // is untouched for tenants/failures without a tree.
-  const apply = (nextCode) => {
-    onFilterChange(
-      "geography",
-      nextCode === ALL ? clearedGeographySelection() : geographySelectionFromCode(tree, nextCode)
-    );
-  };
-
-  const chip = (
-    <span className="dashboard-popover-trigger-trail">
-      {elided && (
-        <>
-          <span className="dashboard-popover-trigger-seg dashboard-popover-trigger-seg--muted" aria-hidden>
-            …
-          </span>
-          <span className="dashboard-popover-trigger-sep" aria-hidden>
-            ›
-          </span>
-        </>
-      )}
-      {segments.map((segment, index) => (
-        <React.Fragment key={`${index}-${segment}`}>
-          {index > 0 && (
-            <span className="dashboard-popover-trigger-sep" aria-hidden>
-              ›
-            </span>
-          )}
-          <span
-            className={`dashboard-popover-trigger-seg${
-              index < segments.length - 1 ? " dashboard-popover-trigger-seg--muted" : ""
-            }`}
-          >
-            {segment}
-          </span>
-        </React.Fragment>
-      ))}
-    </span>
-  );
-
   return (
-    <PopoverMenu
+    <HierarchyMultiSelectFilter
+      tree={tree}
+      selections={filters?.geographies ?? []}
+      label={t("DASHBOARD_FILTERS_WARDS", "Wards")}
+      allLabel={t("DASHBOARD_FILTERS_ALL_WARDS", "All wards")}
       ariaLabel={t("DASHBOARD_FILTERS_WARD_FILTER", "Ward filter")}
-      chipTitle={title}
-      chip={chip}
-      panelWidth={288}
-    >
-      {({ close }) => (
-        <ComplaintTypeTreePanel
-          tree={tree}
-          appliedCode={code}
-          t={t}
-          labelFor={boundaryDisplayLabel}
-          allLabel={allWardsLabel}
-          allInLabel={t("DASHBOARD_GEO_FILTER_ALL_IN", "All in")}
-          onApply={(nextCode) => {
-            apply(nextCode);
-            close();
-          }}
-        />
-      )}
-    </PopoverMenu>
+      labelFor={boundaryDisplayLabel}
+      selectionFromCode={geographyMultiSelectionFromCode}
+      allInLabel={t("DASHBOARD_GEO_FILTER_ALL_IN", "All in")}
+      searchable
+      searchPlaceholder={t("DASHBOARD_FILTERS_SEARCH_WARDS", "Search wards")}
+      applyLabel={t("DASHBOARD_FILTERS_APPLY", "Apply")}
+      cancelLabel={t("DASHBOARD_FILTERS_CANCEL", "Cancel")}
+      emptyLabel={t("DASHBOARD_FILTERS_NO_MATCHES", "No matching options")}
+      onChange={(selections) => onFilterChange("geographies", selections)}
+    />
   );
 };
 

--- a/digit-ui-esbuild/products/dashboard/src/components/HierarchyMultiSelectFilter.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/HierarchyMultiSelectFilter.jsx
@@ -1,0 +1,296 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import {
+  ALL,
+  TRAIL_ELLIPSIS,
+  ancestorsOf,
+  browseBaseCode,
+  childrenOf,
+  nodeOf,
+  truncateTrail,
+} from "../utils/complaintTypeTree";
+import {
+  normalizeHierarchySelections,
+  toggleHierarchySelection,
+} from "../utils/multiSelectFilters";
+import { MultiSelectChip } from "./MultiSelectFilter";
+import PopoverMenu, { PopoverMenuItem } from "./ui/PopoverMenu";
+
+const TRAIL_MAX = 4;
+const normalizedSearch = (value) =>
+  String(value ?? "")
+    .trim()
+    .toLocaleLowerCase();
+
+const HierarchyMultiSelectPanel = ({
+  tree,
+  selections,
+  labelFor,
+  selectionFromCode,
+  allLabel,
+  allInLabel,
+  searchable,
+  searchPlaceholder,
+  applyLabel,
+  cancelLabel,
+  emptyLabel,
+  onApply,
+  close,
+}) => {
+  const initial = normalizeHierarchySelections(selections);
+  const [draft, setDraft] = useState(initial);
+  const [browseCode, setBrowseCode] = useState(() =>
+    browseBaseCode(tree, initial[0]?.code ?? ALL)
+  );
+  const [search, setSearch] = useState("");
+  const rootRef = useRef(null);
+  const mountedRef = useRef(false);
+  const query = normalizedSearch(search);
+
+  useEffect(() => {
+    if (!mountedRef.current) {
+      mountedRef.current = true;
+      return;
+    }
+    rootRef.current
+      ?.querySelector(".dashboard-popover-list [data-menu-item]")
+      ?.focus();
+  }, [browseCode]);
+
+  const label = (code) => (code === ALL ? allLabel : labelFor(tree, code));
+  const selectedCodes = new Set(draft.map((selection) => selection.code));
+  const toggle = (code) => {
+    const selection = selectionFromCode(tree, code);
+    if (selection)
+      setDraft((current) => toggleHierarchySelection(current, selection));
+  };
+
+  const searchResults = useMemo(() => {
+    if (!query) return [];
+    const candidates =
+      tree?.scopedCodes instanceof Set
+        ? [...tree.scopedCodes]
+        : [...(tree?.byCode?.keys?.() ?? [])].filter(
+            (code) => nodeOf(tree, code)?.isLeaf
+          );
+    return candidates
+      .map((code) => ({
+        code,
+        label: labelFor(tree, code),
+        trail: [...ancestorsOf(tree, code), code]
+          .map((part) => labelFor(tree, part))
+          .join(" › "),
+      }))
+      .filter((entry) =>
+        normalizedSearch(
+          `${entry.label} ${entry.trail} ${entry.code}`
+        ).includes(query)
+      )
+      .slice(0, 100);
+  }, [tree, query, labelFor]);
+
+  const atRoot = browseCode === ALL || !nodeOf(tree, browseCode);
+  const browse = atRoot ? ALL : browseCode;
+  const children = childrenOf(tree, browse);
+  const trailCodes = atRoot
+    ? [ALL]
+    : [ALL, ...ancestorsOf(tree, browse), browse];
+  const trail = truncateTrail(trailCodes, TRAIL_MAX);
+
+  return (
+    <div
+      ref={rootRef}
+      className="dashboard-popover-tree dashboard-multiselect-panel"
+    >
+      {searchable && (
+        <input
+          type="search"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          onKeyDown={(event) => {
+            if (
+              ["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)
+            ) {
+              event.stopPropagation();
+            }
+          }}
+          placeholder={searchPlaceholder}
+          aria-label={searchPlaceholder}
+          className="dashboard-multiselect-search"
+          data-popover-autofocus=""
+          autoFocus
+        />
+      )}
+
+      {!query && (
+        <div className="dashboard-popover-trail" role="presentation">
+          {trail.map((crumb, index) => {
+            const current = index === trail.length - 1;
+            if (crumb === TRAIL_ELLIPSIS) {
+              return (
+                <span
+                  key={crumb}
+                  className="dashboard-popover-trail-ellipsis"
+                  aria-hidden
+                >
+                  …
+                </span>
+              );
+            }
+            if (current) {
+              return (
+                <span key={crumb} className="dashboard-popover-trail-current">
+                  {label(crumb)}
+                </span>
+              );
+            }
+            return (
+              <React.Fragment key={crumb}>
+                <button
+                  type="button"
+                  role="menuitem"
+                  data-menu-item=""
+                  className="dashboard-popover-trail-crumb"
+                  onClick={() => setBrowseCode(crumb)}
+                >
+                  {label(crumb)}
+                </button>
+                <span className="dashboard-popover-trail-sep" aria-hidden>
+                  ›
+                </span>
+              </React.Fragment>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="dashboard-popover-list dashboard-multiselect-options">
+        {query ? (
+          searchResults.length ? (
+            searchResults.map((entry) => (
+              <PopoverMenuItem
+                key={entry.code}
+                selected={selectedCodes.has(entry.code)}
+                multiple
+                title={entry.trail}
+                onSelect={() => toggle(entry.code)}
+              >
+                <span>{entry.label}</span>
+                <span className="dashboard-multiselect-result-trail">
+                  {entry.trail}
+                </span>
+              </PopoverMenuItem>
+            ))
+          ) : (
+            <div className="dashboard-multiselect-empty">{emptyLabel}</div>
+          )
+        ) : (
+          <>
+            {!atRoot && (
+              <PopoverMenuItem
+                selected={selectedCodes.has(browse)}
+                multiple
+                title={`${allInLabel} ${label(browse)}`}
+                onSelect={() => toggle(browse)}
+              >
+                {`${allInLabel} ${label(browse)}`}
+              </PopoverMenuItem>
+            )}
+            {children.map((child) => (
+              <PopoverMenuItem
+                key={child.code}
+                selected={
+                  child.isLeaf ? selectedCodes.has(child.code) : undefined
+                }
+                multiple={child.isLeaf}
+                descend={!child.isLeaf}
+                title={label(child.code)}
+                onSelect={() =>
+                  child.isLeaf ? toggle(child.code) : setBrowseCode(child.code)
+                }
+              >
+                {label(child.code)}
+              </PopoverMenuItem>
+            ))}
+          </>
+        )}
+      </div>
+
+      <div className="dashboard-multiselect-footer">
+        <button
+          type="button"
+          className="dashboard-multiselect-clear"
+          onClick={() => setDraft([])}
+        >
+          {allLabel}
+        </button>
+        <span className="dashboard-multiselect-footer-actions">
+          <button
+            type="button"
+            className="dashboard-multiselect-cancel"
+            onClick={() => close()}
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            className="dashboard-multiselect-apply"
+            onClick={() => {
+              onApply(draft);
+              close();
+            }}
+          >
+            {applyLabel}
+          </button>
+        </span>
+      </div>
+    </div>
+  );
+};
+
+const HierarchyMultiSelectFilter = ({
+  tree,
+  selections,
+  label,
+  allLabel,
+  ariaLabel,
+  labelFor,
+  selectionFromCode,
+  allInLabel,
+  searchable = false,
+  searchPlaceholder,
+  applyLabel,
+  cancelLabel,
+  emptyLabel,
+  onChange,
+}) => {
+  const count = normalizeHierarchySelections(selections).length;
+  return (
+    <PopoverMenu
+      ariaLabel={ariaLabel}
+      chip={<MultiSelectChip label={count ? label : allLabel} count={count} />}
+      chipTitle={count ? `${label}: ${count}` : allLabel}
+      panelWidth={320}
+      chipClassName={count ? "dashboard-popover-trigger--active" : ""}
+    >
+      {({ close }) => (
+        <HierarchyMultiSelectPanel
+          tree={tree}
+          selections={selections}
+          labelFor={labelFor}
+          selectionFromCode={selectionFromCode}
+          allLabel={allLabel}
+          allInLabel={allInLabel}
+          searchable={searchable}
+          searchPlaceholder={searchPlaceholder}
+          applyLabel={applyLabel}
+          cancelLabel={cancelLabel}
+          emptyLabel={emptyLabel}
+          onApply={onChange}
+          close={close}
+        />
+      )}
+    </PopoverMenu>
+  );
+};
+
+export default HierarchyMultiSelectFilter;

--- a/digit-ui-esbuild/products/dashboard/src/components/KpiTile.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/KpiTile.jsx
@@ -9,26 +9,33 @@ import LineChart from './LineChart';
 import DashboardTable from './DashboardTable';
 import ComplaintsAtRiskTable from './ComplaintsAtRiskTable';
 import OpenComplaintsByGeographyWidget from './OpenComplaintsByGeographyWidget';
-import { evaluateCompose, requiresBackendComposition } from '../utils/composeKpi';
 import { applyGroupByToColumns } from '../utils/hierLevelGrouping';
-import { formatNumber } from '../utils/numberFormat';
 import {
-  GEO_MAP_LAYER_KEYS,
-  partitionPinsByLayer,
-  summarizeWardRows,
-} from '../utils/complaintPins';
-import { getNumberTileDeltaClass, formatOfficerLabel, dimensionKindForName } from '../config/kpiDisplay';
-import {
-  resolveSlaRiskPresentation,
-  computeBreachDurationMs,
-  formatBreachDurationCompact,
-  formatWorkflowStatusLabel,
-  normalizeWorkflowStatusKey,
-} from '../config/complaintsAtRiskPresentation';
+  adaptBarRows,
+  adaptDow,
+  adaptHorizontalRows,
+  adaptLine,
+  adaptMapLayers,
+  adaptPie,
+  adaptRanked,
+  adaptSlaRiskRows,
+  adaptStacked,
+  applyFormat,
+  computeDelta,
+  defScrollKey,
+  deriveColumnsFromResult,
+  errorLabel,
+  formatDeltaDisplay,
+  resolveDeltaClass,
+  resolvePrior,
+  resolveScalar,
+  resolveSparkline,
+  resolveTileStatus,
+  statusToSeriesColor,
+} from '../utils/tileResultAdapters';
 import useDashboardT from '../i18n/useDashboardT';
-import { dimensionLabel } from '../i18n/dimensionLabel';
 import { translate as t } from '../i18n/localeRuntime';
-import { resolveTitle, resolveSubtitle, seriesEntryLabel, resolveSeriesLabel } from '../i18n/textResolver';
+import { resolveTitle, resolveSubtitle } from '../i18n/textResolver';
 import { markFirstWidgetVisible } from '../services/dashboardMetrics';
 
 /**
@@ -196,177 +203,10 @@ function renderByKind(kind, ctx) {
 }
 
 // ---------------------------------------------------------------------------
-// Column-role helpers (zero hardcoded column names)
-// ---------------------------------------------------------------------------
-
-function dimensionColumns(result, viz) {
-  const cols = (result.columns || []).filter((c) => c.role === 'dimension');
-  if (cols.length) return cols;
-  if (viz.dimensionKey) return [{ name: viz.dimensionKey }];
-  return [];
-}
-
-function measureColumns(result, viz) {
-  const cols = (result.columns || []).filter((c) => c.role === 'measure');
-  if (cols.length) return cols;
-  const keys = viz.measureKeys || (viz.measureKey ? [viz.measureKey] : []);
-  return keys.map((name) => ({ name }));
-}
-
-function primaryDimensionKey(result, viz) {
-  return dimensionColumns(result, viz)[0]?.name || viz.dimensionKey || 'label';
-}
-
-function primaryMeasure(result, viz) {
-  return measureColumns(result, viz)[0] || { name: viz.measureKey || 'total' };
-}
-
-// ---------------------------------------------------------------------------
 // Scalar / delta cards  -> KpiCard
 // Ports the formatSubMetricValue + WoW delta shaping into a generic adapter
 // driven by viz.format / viz.valueKey / viz.priorKey / viz.compose.
 // ---------------------------------------------------------------------------
-
-function resolveScalar(ctx) {
-  const { viz, result, results } = ctx;
-  // Calendar-aware averages are composed by pgr-services. If a malformed KPI definition
-  // combines one with a raw query, fail closed instead of rendering that query's total as
-  // an average. A valid backend-composed response always supplies result.value.
-  if (requiresBackendComposition(viz.compose)) {
-    return result.value != null ? Number(result.value) : null;
-  }
-  if (viz.compose && results) {
-    const composed = evaluateCompose(viz.compose, results);
-    if (composed != null) return composed;
-  }
-  if (result.value != null) return result.value;
-  if (result.values && viz.valueKey != null && result.values[viz.valueKey] != null) {
-    return Number(result.values[viz.valueKey]);
-  }
-  if (result.values) {
-    const first = Object.values(result.values)[0];
-    if (first != null) return Number(first);
-  }
-  const row0 = result.rows?.[0];
-  if (row0) {
-    const key = viz.valueKey || primaryMeasure(result, viz).name;
-    if (row0[key] != null) return Number(row0[key]);
-  }
-  return null;
-}
-
-function resolvePrior(ctx) {
-  const { viz, result } = ctx;
-  if (result.prior != null) return Number(result.prior);
-  if (viz.priorKey != null) {
-    if (result.values && result.values[viz.priorKey] != null) return Number(result.values[viz.priorKey]);
-    const row0 = result.rows?.[0];
-    if (row0 && row0[viz.priorKey] != null) return Number(row0[viz.priorKey]);
-  }
-  return null;
-}
-
-/**
- * Generalized WoW delta — mirrors resolveSparklineDelta / computeWowPercent:
- * percent metrics use a percentage-point delta, everything else a % change.
- */
-function computeDelta(current, prior, format, mode) {
-  if (current == null || prior == null || !Number.isFinite(current) || !Number.isFinite(prior)) {
-    return null;
-  }
-  // viz.delta.mode (when set) decides the unit; otherwise fall back to the format.
-  const eff = mode || (isPercentFormat(format) ? 'percentPoint' : 'percent');
-  if (eff === 'percentPoint') return normalizePct(current) - normalizePct(prior);
-  if (eff === 'days') return (current - prior) / 86400000; // ms -> whole days
-  if (eff === 'duration') return current - prior; // raw ms difference
-  if (eff === 'rating') return current - prior; // rating points
-  if (prior === 0) return null;
-  return ((current - prior) / Math.abs(prior)) * 100; // relative %
-}
-
-// Delta numbers route their NUMERIC part through the tenant mask
-// (formatNumber, null when unconfigured -> the pre-#1213 expression); the
-// arrow and pp/%/day/hr unit suffixes stay here.
-function formatDeltaDisplay(delta, format, mode) {
-  if (delta == null || !Number.isFinite(delta)) return null;
-  const arrow = delta >= 0 ? '▲' : '▼';
-  const abs = Math.abs(delta);
-  const eff = mode || (isPercentFormat(format) ? 'percentPoint' : 'percent');
-  if (eff === 'duration') {
-    return abs >= 86400000
-      ? `${arrow} ${formatNumber(abs / 86400000, { decimals: 1 }) ?? (abs / 86400000).toFixed(1)} ${t("DASHBOARD_UNIT_DAYS", "days")}`
-      : `${arrow} ${formatNumber(abs / 3600000, { decimals: 1 }) ?? (abs / 3600000).toFixed(1)} ${t("DASHBOARD_UNIT_HRS", "hrs")}`;
-  }
-  const rounded = Math.round(abs * 10) / 10;
-  const formatted =
-    formatNumber(rounded, { decimals: 1, trim: true }) ??
-    (Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1));
-  if (eff === 'days') return `${arrow} ${formatted} ${rounded === 1 ? t("DASHBOARD_UNIT_DAY", "day") : t("DASHBOARD_UNIT_DAYS", "days")}`;
-  if (eff === 'rating') return `${arrow} ${formatted}`;
-  const unit = eff === 'percentPoint' ? 'pp' : '%';
-  return `${arrow} ${formatted}${unit}`;
-}
-
-function deltaClassFor(delta) {
-  if (delta == null || !Number.isFinite(delta) || delta === 0) return undefined;
-  return delta > 0 ? 'dashboard-delta-up' : 'dashboard-delta-down';
-}
-
-// ---------------------------------------------------------------------------
-// Threshold-driven status for number cards. Ports kpiDisplay.resolveThresholdStatus
-// so the catalog can carry the on-track / breaching bands per def via
-//   viz.threshold = { kind, higherIsBetter, onTrack, breaching }
-// and the KpiCard/KpiSparklineCard value (and sparkline) colour at parity with the
-// live AdminDashboard path. When no threshold is present we fall back to the
-// static viz.accent (legacy behaviour) so non-card tiles are unaffected.
-// ---------------------------------------------------------------------------
-
-const KPI_STATUS = { ON_TRACK: 'on_track', NORMAL: 'normal', BREACHING: 'breaching' };
-
-function thresholdStatus(threshold, value) {
-  if (!threshold || value == null || !Number.isFinite(Number(value))) return null;
-  // Percent metrics come back as a 0..1 ratio from the composer; the thresholds
-  // (e.g. onTrack: 70) are expressed in display units, so normalise to 0..100.
-  const n = threshold.kind === 'percent' ? normalizePct(value) : Number(value);
-  const { higherIsBetter, onTrack, breaching } = threshold;
-  if (higherIsBetter) {
-    if (n >= onTrack) return KPI_STATUS.ON_TRACK;
-    if (n <= breaching) return KPI_STATUS.BREACHING;
-    return KPI_STATUS.NORMAL;
-  }
-  if (n <= onTrack) return KPI_STATUS.ON_TRACK;
-  if (n >= breaching) return KPI_STATUS.BREACHING;
-  return KPI_STATUS.NORMAL;
-}
-
-/** 3-state threshold status when viz.threshold is set, else the static accent. */
-function resolveTileStatus(viz, value) {
-  return thresholdStatus(viz.threshold, value) ?? viz.accent;
-}
-
-/**
- * Delta colour. With a threshold the live path colours the delta by status
- * (resolveKpiDeltaClass -> getNumberTileDeltaClass), so we hand KpiCard the same
- * status token and let it resolve the colour. Without a threshold we keep the
- * directional up/down class so legacy delta tiles are unchanged.
- */
-function resolveDeltaClass(viz, value, delta) {
-  const status = thresholdStatus(viz.threshold, value);
-  if (status) {
-    const unavailable = value == null || !Number.isFinite(Number(value));
-    return getNumberTileDeltaClass(status, { unavailable });
-  }
-  return deltaClassFor(delta);
-}
-
-/** Series stroke colour mirrors the live KpiSparklineCard status-derived colour. */
-function statusToSeriesColor(status) {
-  switch (status) {
-    case KPI_STATUS.ON_TRACK: return 'var(--status-resolved)';
-    case KPI_STATUS.BREACHING: return 'var(--status-breach)';
-    default: return null;
-  }
-}
 
 function renderNumberTileDelta(ctx) {
   const { viz, title, loading, onRemove, locale } = ctx;
@@ -393,24 +233,6 @@ function renderNumberTileDelta(ctx) {
 // Ports parseSparkline7d's "sort by date, map measure -> point" shaping into a
 // generic adapter keyed off viz.sparklineKey / viz.dateKey / viz.measureKey.
 // ---------------------------------------------------------------------------
-
-function resolveSparkline(ctx) {
-  const { viz, result } = ctx;
-  if (Array.isArray(result.sparkline)) return result.sparkline.map((n) => Number(n) || 0);
-
-  // Long-form rows -> ordered numeric series.
-  const seriesRows = viz.sparklineKey && result[viz.sparklineKey]?.rows
-    ? result[viz.sparklineKey].rows
-    : result.rows;
-  if (!seriesRows?.length) return [];
-
-  const dateKey = viz.dateKey || dimensionColumns(result, viz)[0]?.name || 'created_date';
-  const measureKey = viz.sparklineMeasureKey || primaryMeasure(result, viz).name;
-
-  return [...seriesRows]
-    .sort((a, b) => String(a[dateKey] ?? '').localeCompare(String(b[dateKey] ?? '')))
-    .map((row) => Number(row[measureKey]) || 0);
-}
 
 function renderNumberTileSparkline(ctx) {
   const { viz, title, loading, onRemove, locale } = ctx;
@@ -439,37 +261,6 @@ function renderNumberTileSparkline(ctx) {
 // dimension -> { label, count }, optionally ranked by measure desc.
 // ---------------------------------------------------------------------------
 
-function adaptBarRows(ctx) {
-  const { viz, result, locale } = ctx;
-  const dimKey = primaryDimensionKey(result, viz);
-  const measure = primaryMeasure(result, viz);
-  const isPercent = viz.format === 'percent' || viz.format === 'percentOneDecimal';
-
-  let rows = (result.rows || []).map((row) => ({
-    label: formatDimLabel(row[dimKey], viz, dimKey, locale),
-    count: percentToChartScale(Number(row[measure.name]) || 0, isPercent),
-  }));
-
-  // Histograms keep the backend bucket order; bars rank by value desc unless
-  // the descriptor pins an explicit category order.
-  if (viz.kind !== 'histogram' && !viz.categoryOrder && viz.sort !== 'none') {
-    rows = rows.sort((a, b) => b.count - a.count);
-  }
-  // Explicit category order (e.g. age buckets <1d,1-3d,3-7d,>7d) — apply it so the
-  // backend's arbitrary row order doesn't scramble an ordered axis. Substring match
-  // tolerates label formatting; unknown labels sink to the end.
-  if (viz.categoryOrder) {
-    const ord = viz.categoryOrder;
-    const idx = (l) => {
-      const i = ord.findIndex((o) => l === o || l.includes(o) || o.includes(l));
-      return i < 0 ? ord.length : i;
-    };
-    rows = rows.slice().sort((a, b) => idx(a.label) - idx(b.label));
-  }
-  if (viz.limit) rows = rows.slice(0, viz.limit);
-  return rows;
-}
-
 function renderBar(ctx, { histogram }) {
   const { viz, loading } = ctx;
   const data = adaptBarRows(ctx);
@@ -482,7 +273,7 @@ function renderBar(ctx, { histogram }) {
       colors={viz.colors}
       histogram={histogram}
       valueFormat={viz.format === 'percent' || viz.format === 'percentOneDecimal' ? 'percent' : 'count'}
-      scrollKey={histogram ? undefined : def_scrollKey(ctx)}
+      scrollKey={histogram ? undefined : defScrollKey(ctx)}
     />
   );
 }
@@ -491,43 +282,6 @@ function renderBar(ctx, { histogram }) {
 // Horizontal bar  -> HorizontalBarChart
 // Ports parseDepartmentFlowRatioBarChart: dimension -> { label, value, resolved, created }.
 // ---------------------------------------------------------------------------
-
-function adaptHorizontalRows(ctx) {
-  const { viz, result, locale } = ctx;
-  const dimKey = primaryDimensionKey(result, viz);
-  const valueKey = viz.measureKey || primaryMeasure(result, viz).name;
-  const numeratorKey = viz.numeratorKey;   // e.g. resolved
-  const denominatorKey = viz.denominatorKey; // e.g. created
-  // Roll up to display grain when several source rows share a dimension value
-  // (e.g. service_code rows -> one department_code). Mirrors the reference
-  // parseDepartmentFlowRatioBarChart roll-up; numerator/denominator sum, then
-  // value is recomputed as the ratio.
-  const grouped = new Map();
-  for (const row of result.rows || []) {
-    const key = String(row[dimKey] ?? 'Unknown');
-    const bucket = grouped.get(key) || { num: 0, den: 0, val: 0 };
-    if (numeratorKey != null) bucket.num += Number(row[numeratorKey]) || 0;
-    if (denominatorKey != null) bucket.den += Number(row[denominatorKey]) || 0;
-    bucket.val += Number(row[valueKey]) || 0;
-    grouped.set(key, bucket);
-  }
-  const isRatio = numeratorKey != null && denominatorKey != null;
-  let rows = [...grouped.entries()].map(([key, b]) => ({
-    label: formatDimLabel(key, viz, dimKey, locale),
-    value: isRatio ? (b.den > 0 ? b.num / b.den : 0) : b.val,
-    resolved: numeratorKey != null ? b.num : undefined,
-    created: denominatorKey != null ? b.den : undefined,
-  }));
-  // Drop zero-denominator categories (reference filters created<=0).
-  // Only hide zero *values* for ratio charts (e.g. flow ratio) — count bars
-  // should still show an explicit zero bar (#1028 / review on #1311).
-  if (isRatio) {
-    rows = rows.filter((r) => (r.created || 0) > 0 && Number(r.value) > 0);
-  }
-  if (viz.sort !== 'none') rows = rows.sort((a, b) => a.value - b.value);
-  if (viz.limit) rows = rows.slice(0, viz.limit);
-  return rows;
-}
 
 function renderHorizontalBar(ctx) {
   const { viz, loading } = ctx;
@@ -538,7 +292,7 @@ function renderHorizontalBar(ctx) {
     <HorizontalBarChart
       data={data}
       breakEven={viz.breakEven ?? 1}
-      scrollKey={def_scrollKey(ctx)}
+      scrollKey={defScrollKey(ctx)}
     />
   );
 }
@@ -550,73 +304,6 @@ function renderHorizontalBar(ctx) {
 //  - else pivot long-form rows (category x stackKey -> measure) into series,
 //    keyed off viz.stackSeries [{ key, label, color }].
 // ---------------------------------------------------------------------------
-
-function adaptStacked(ctx) {
-  const { viz, result, locale } = ctx;
-
-  // BE-shaped passthrough.
-  if (result.series && Array.isArray(result.series) && result.categories) {
-    return { categories: result.categories, series: result.series, colors: result.colors || viz.colors || [] };
-  }
-
-  const dimKey = primaryDimensionKey(result, viz);
-  const stackKey = viz.stackKey;
-  const measureKey = viz.measureKey || 'total';
-  const stackSeries = viz.stackSeries; // [{ key, label, color }]
-
-  // Single-series stacked (e.g. complaints-by-type "Filed").
-  if (!stackKey || !stackSeries?.length) {
-    let rows = (result.rows || []).map((row) => ({
-      label: formatDimLabel(row[dimKey], viz, dimKey, locale),
-      value: Number(row[measureKey]) || 0,
-    }));
-    if (viz.sort !== 'none') rows = rows.sort((a, b) => b.value - a.value);
-    if (viz.limit) rows = rows.slice(0, viz.limit);
-    return {
-      categories: rows.map((r) => r.label),
-      series: [{ name: resolveSeriesLabel(viz, viz.seriesLabel || t("DASHBOARD_COMMON_COUNT", "Count")), data: rows.map((r) => r.value) }],
-      colors: viz.colors || ['var(--chart-1)'],
-    };
-  }
-
-  // Pivot long-form rows into per-segment series.
-  const segKeys = new Set(stackSeries.map((d) => normalizeSeg(d.key)));
-  const categoryMap = new Map();
-  for (const row of result.rows || []) {
-    const seg = normalizeSeg(row[stackKey]);
-    if (!segKeys.has(seg)) continue;
-    const category = String(row[dimKey] ?? 'Unknown');
-    if (!categoryMap.has(category)) categoryMap.set(category, {});
-    const bucket = categoryMap.get(category);
-    const value = viz.valueTransform === 'msToHours'
-      ? msToHours(row[measureKey])
-      : Number(row[measureKey]) || 0;
-    bucket[seg] = viz.aggregate === 'set' ? value : (bucket[seg] ?? 0) + value;
-  }
-
-  let entries = [...categoryMap.entries()].map(([key, segments]) => ({
-    key,
-    segments,
-    total: Object.values(segments).reduce((s, v) => s + v, 0),
-  }));
-  entries = entries.filter((e) => e.total > 0).sort((a, b) => {
-    if (viz.sortBySegment) {
-      const d = (b.segments[normalizeSeg(viz.sortBySegment)] ?? 0) - (a.segments[normalizeSeg(viz.sortBySegment)] ?? 0);
-      if (d !== 0) return d;
-    }
-    return b.total - a.total;
-  });
-  if (viz.limit) entries = entries.slice(0, viz.limit);
-
-  return {
-    categories: entries.map((e) => formatDimLabel(e.key, viz, dimKey, locale)),
-    series: stackSeries.map((def) => ({
-      name: seriesEntryLabel(def, def.label),
-      data: entries.map((e) => e.segments[normalizeSeg(def.key)] ?? 0),
-    })),
-    colors: stackSeries.map((def) => def.color),
-  };
-}
 
 function renderStackedBar(ctx) {
   const { viz, loading } = ctx;
@@ -631,7 +318,7 @@ function renderStackedBar(ctx) {
       colors={colors}
       horizontal={viz.orientation === 'horizontal'}
       valueFormat={viz.valueFormat || (viz.valueTransform === 'msToHours' ? 'hours' : undefined)}
-      scrollKey={def_scrollKey(ctx)}
+      scrollKey={defScrollKey(ctx)}
     />
   );
 }
@@ -640,59 +327,6 @@ function renderStackedBar(ctx) {
 // Pie  -> PieChart
 // Ports parseOpenComplaintsByChannelPieChart: dimension -> { label, count, color }.
 // ---------------------------------------------------------------------------
-
-function adaptPie(ctx) {
-  const { viz, result, locale } = ctx;
-  const dimKey = primaryDimensionKey(result, viz);
-  const measure = primaryMeasure(result, viz);
-  const colors = viz.colors || [];
-  // Optional source->channel rollup (parity with parseOpenComplaintsByChannelPieChart):
-  // when viz.channelMap is present, fold raw `source` rows into named channels
-  // with fixed colours/labels before slicing.
-  if (viz.channelMap?.length) {
-    return adaptChannelPie(result, dimKey, measure, viz);
-  }
-  let rows = (result.rows || [])
-    .map((row, i) => ({
-      label: formatDimLabel(row[dimKey], viz, dimKey, locale),
-      count: Number(row[measure.name]) || 0,
-      color: colors[i],
-    }))
-    .filter((s) => s.count > 0);
-  if (viz.sort !== 'none') rows = rows.sort((a, b) => b.count - a.count);
-  return rows;
-}
-
-/** source -> channel rollup with verbatim COMPLAINT_CHANNELS labels/colours. */
-function adaptChannelPie(result, dimKey, measure, viz) {
-  const channels = viz.channelMap; // [{ id, label, color, sources:[...] }]
-  const sourceToChannel = new Map();
-  for (const ch of channels) {
-    for (const src of ch.sources || []) {
-      sourceToChannel.set(normalizeSourceKey(src), ch.id);
-    }
-  }
-  const totals = new Map(channels.map((c) => [c.id, 0]));
-  for (const row of result.rows || []) {
-    const count = Number(row[measure.name]) || 0;
-    if (count <= 0) continue;
-    const key = normalizeSourceKey(row[dimKey]);
-    const id = key ? (sourceToChannel.get(key) ?? 'other') : 'other';
-    if (totals.has(id)) totals.set(id, totals.get(id) + count);
-  }
-  return channels
-    .map((c) => ({
-      label: seriesEntryLabel(c, dimensionLabel(c.id, 'channel', c.label)),
-      count: totals.get(c.id) ?? 0,
-      color: c.color,
-    }))
-    .filter((s) => s.count > 0)
-    .sort((a, b) => (b.count - a.count) || a.label.localeCompare(b.label));
-}
-
-function normalizeSourceKey(source) {
-  return String(source ?? '').trim().toLowerCase().replace(/-/g, '_');
-}
 
 function renderPie(ctx) {
   const { loading } = ctx;
@@ -708,56 +342,6 @@ function renderPie(ctx) {
 // rewriting (daily/weekly/monthly) is a BE-side concern; the engine only needs
 // the BE-shaped { periods, defaultPeriod } or a flat { categories, series }.
 // ---------------------------------------------------------------------------
-
-function adaptLine(ctx) {
-  const { viz, result, title, locale } = ctx;
-  if (result.periods) {
-    return { periods: result.periods, defaultPeriod: result.defaultPeriod || viz.defaultPeriod || 'daily', headerTitle: result.title || title };
-  }
-  if (result.series && result.categories) {
-    return { categories: result.categories, series: result.series };
-  }
-  const dimKey = primaryDimensionKey(result, viz);
-  const rows = [...(result.rows || [])].sort((a, b) =>
-    String(a[dimKey] ?? '').localeCompare(String(b[dimKey] ?? ''))
-  );
-  const categories = rows.map((r) => formatDimLabel(r[dimKey], viz, dimKey, locale));
-
-  // Descriptor-driven multi-series with per-series colour / dual y-axis grouping.
-  // Each seriesDef is either a direct measure ({ measureKey }) or a computed
-  // ratio percent ({ numeratorKey, denominatorKey }) — ports the reference
-  // COMPLAINTS_OVER_TIME_SERIES_DEFS (Created / Resolved counts + Resolution
-  // rate / SLA compliance percents on a second axis).
-  if (viz.seriesDefs?.length) {
-    return {
-      categories,
-      series: viz.seriesDefs.map((def) => ({
-        name: seriesEntryLabel(def, def.name),
-        color: def.color,
-        yAxisGroup: def.yAxisGroup,
-        dashArray: def.dashArray ?? 0,
-        data: rows.map((r) => {
-          if (def.numeratorKey != null && def.denominatorKey != null) {
-            const num = Number(r[def.numeratorKey]) || 0;
-            const den = Number(r[def.denominatorKey]) || 0;
-            return den > 0 ? Math.round((num / den) * 1000) / 10 : 0;
-          }
-          return Number(r[def.measureKey]) || 0;
-        }),
-      })),
-    };
-  }
-
-  // Long-form fallback -> single/multi series keyed off viz.measureKeys.
-  const measures = measureColumns(result, viz);
-  return {
-    categories,
-    series: measures.map((m) => ({
-      name: seriesEntryLabel(m, m.label || m.name),
-      data: rows.map((r) => Number(r[m.name]) || 0),
-    })),
-  };
-}
 
 function renderLine(ctx) {
   const { loading } = ctx;
@@ -789,82 +373,11 @@ function renderTable(ctx) {
   return <DashboardTable columns={columns} rows={rows} emptyMessage={viz.emptyMessage || t("DASHBOARD_COMMON_NO_DATA", "No data")} />;
 }
 
-function deriveColumnsFromResult(result) {
-  return (result.columns || []).map((c) => ({
-    id: c.name,
-    label: c.label || c.name,
-    labelKey: c.labelKey,
-    align: c.role === 'measure' ? 'right' : 'left',
-    type: mapFormatToCellType(c.format),
-    thresholdKey: c.thresholdKey,
-  }));
-}
-
-function mapFormatToCellType(format) {
-  switch (format) {
-    case 'integer': return 'integer';
-    case 'percent':
-    case 'percentOneDecimal':
-    case 'percentInteger': return 'percent';
-    case 'hoursDecimal': return 'hours';
-    case 'hoursDays': return 'hoursDays';
-    case 'ratingOutOfFive': return 'rating';
-    default: return 'text';
-  }
-}
-
 // ---------------------------------------------------------------------------
 // SLA-risk table  -> ComplaintsAtRiskTable
 // The component owns its own columns; rows already carry the per-row display
 // shape (id, typeLabel, ownerName, slaLabel, breachDurationLabel, ...).
 // ---------------------------------------------------------------------------
-
-/**
- * Shape the generic at-risk grain rows into the ComplaintsAtRiskTable row
- * contract. Ports config/kpiQueries.parseComplaintsAtRiskTable verbatim (it
- * relies only on the pure presentation helpers, which survive the inversion),
- * so the inverted engine renders the rich SLA-risk table at parity with the
- * reference instead of a degraded ranked list.
- */
-function adaptSlaRiskRows(ctx) {
-  const { viz, result } = ctx;
-  const limit = viz.limit || 50;
-  return (result.rows || [])
-    .map((row, index) => {
-      const complaintId = String(row.service_request_id ?? '').trim();
-      if (!complaintId || complaintId === 'null') return null;
-
-      const slaBucket = String(row.sla_status_bucket ?? '');
-      const { slaLabel, slaLevel } = resolveSlaRiskPresentation(slaBucket);
-      const breachDurationMs = computeBreachDurationMs(
-        row.open_age_ms,
-        row.sla_target_ms,
-        slaBucket
-      );
-      const applicationStatus = String(row.application_status ?? '');
-      const subtypeKey = String(row.service_code ?? '');
-      const typeKey = String(row.service_group ?? '');
-
-      return {
-        id: complaintId,
-        typeLabel: typeKey ? dimensionLabel(typeKey, 'complaintType') : '—',
-        subtypeLabel: subtypeKey ? dimensionLabel(subtypeKey, 'complaintType') : '—',
-        locality: row.ward_code ? dimensionLabel(String(row.ward_code), 'boundary') : '—',
-        ownerName: formatOfficerLabel(row.current_assignee_uuid),
-        ownerRole: '—',
-        status: normalizeWorkflowStatusKey(applicationStatus),
-        statusLabel: formatWorkflowStatusLabel(applicationStatus),
-        slaLabel,
-        slaLevel,
-        breachDurationMs,
-        breachDurationLabel: formatBreachDurationCompact(breachDurationMs),
-        _rowKey: `risk-${index}-${complaintId}`,
-      };
-    })
-    .filter(Boolean)
-    .sort((left, right) => (right.breachDurationMs ?? -1) - (left.breachDurationMs ?? -1))
-    .slice(0, limit);
-}
 
 function renderSlaRiskTable(ctx) {
   const { loading } = ctx;
@@ -883,55 +396,6 @@ function renderSlaRiskTable(ctx) {
 // (previously the same open-only array was pinned to all three, so the Resolved
 // layer shaded "0 resolved" underneath still-open complaints).
 // ---------------------------------------------------------------------------
-
-function adaptMapLayers(ctx) {
-  const { viz, result } = ctx;
-  const dimKey = viz.dimensionKey || 'ward_code';
-  // The map tile's query returns filed/open/resolved per ward. Her map colours the
-  // Created layer by `count`, and the Open/Resolved layers by `openPct`/`resolvedPct`
-  // (share of filed, 0–100). One ward series carries all three so any layer renders.
-  const wards = (result.rows || [])
-    .filter((row) => {
-      const code = String(row[dimKey] ?? '').trim();
-      return code && code !== 'null';
-    })
-    .map((row) => {
-      const wardCode = String(row[dimKey]);
-      const filed = Number(row.filed) || 0;
-      const open = Number(row.open) || 0;
-      const resolved = Number(row.resolved) || 0;
-      return {
-        wardCode,
-        label: dimensionLabel(wardCode, 'boundary'),
-        count: filed,
-        total: filed,
-        // named counts so the choropleth hover tooltip (reads created/open/resolved) has values
-        created: filed,
-        open,
-        resolved,
-        openPct: filed > 0 ? (open / filed) * 100 : 0,
-        resolvedPct: filed > 0 ? (resolved / filed) * 100 : 0,
-      };
-    });
-  const pins = result.pins || [];
-  const statusKnown = result.pinsStatusKnown === true;
-  const { layerTotals, unmapped } = summarizeWardRows(result.rows || [], dimKey);
-  const layers = {
-    wardDetails: {},
-    complaintPinsByLayer: partitionPinsByLayer(pins, statusKnown),
-    complaintPinsError: null,
-    // 'open-only' = the tenant's catalog still has the legacy pin def, so pins
-    // cannot follow the layer; the legend says so instead of lying by omission.
-    pinSemantics: statusKnown ? 'per-layer' : 'open-only',
-    pinsTruncated: result.pinsTruncated === true,
-    layerTotals,
-    unmapped,
-  };
-  for (const key of GEO_MAP_LAYER_KEYS) {
-    layers[key] = wards;
-  }
-  return layers;
-}
 
 /**
  * The map branch is memoized on its own inputs: adaptMapLayers re-derives fresh
@@ -955,30 +419,6 @@ function renderChoroplethMap(ctx) {
 // ---------------------------------------------------------------------------
 // Ranked list + day-of-week  -> KpiTile internal displays (kept generic)
 // ---------------------------------------------------------------------------
-
-function adaptRanked(ctx) {
-  const { viz, result, locale } = ctx;
-  const dimKey = primaryDimensionKey(result, viz);
-  const measure = primaryMeasure(result, viz);
-  let rows = (result.rows || []).map((row) => ({
-    label: formatDimLabel(row[dimKey], viz, dimKey, locale),
-    value: Number(row[measure.name]) || 0,
-  }));
-  if (viz.sort !== 'none') rows = rows.sort((a, b) => b.value - a.value);
-  rows = rows.slice(0, viz.limit || 10);
-  return { rows, format: measure.format || viz.format };
-}
-
-function adaptDow(ctx) {
-  const { viz, result } = ctx;
-  const dimKey = primaryDimensionKey(result, viz);
-  const measure = primaryMeasure(result, viz);
-  const rows = (result.rows || []).map((row) => ({
-    dow: Number(row[dimKey]),
-    value: Number(row[measure.name]) || 0,
-  }));
-  return { rows, format: measure.format || viz.format };
-}
 
 function RankedListDisplay({ rows, format }) {
   const { language } = useDashboardT();
@@ -1022,150 +462,6 @@ function DowDisplay({ rows, format }) {
       ))}
     </div>
   );
-}
-
-// ---------------------------------------------------------------------------
-// Formatting (ported from formatSubMetricValue / DashboardTable formatters)
-// ---------------------------------------------------------------------------
-
-const MS_PER_DAY = 86400000;
-const MS_PER_HOUR = 3600000;
-
-// Every case routes its NUMERIC part through the tenant mask via formatNumber
-// (utils/numberFormat.js): null when no dss.DashboardConfig.numberFormat is
-// configured, so each `??` fallback keeps the pre-#1213 expression untouched.
-// Unit suffixes (%, /5, h, hr/hrs/day/days, ordinal) stay here — the mask
-// contributes separators only, decimal counts stay per-format (R3); durations
-// take the mask decimal separator too (R7).
-function applyFormat(val, format, locale) {
-  if (val == null || !Number.isFinite(Number(val))) return '—';
-  const n = Number(val);
-  switch (format) {
-    case 'integer':           return formatNumber(n, 'integer') ?? Math.round(n).toLocaleString(locale);
-    case 'percentInteger':
-    case 'percentNoDecimal':  return `${formatNumber(normalizePct(n), 'percentInteger') ?? Math.round(normalizePct(n))}%`;
-    case 'percentOneDecimal':
-    case 'percent':           return `${formatNumber(normalizePct(n), 'percent') ?? normalizePct(n).toFixed(1)}%`;
-    case 'decimalOne':        return formatNumber(n, 'decimalOne') ?? n.toFixed(1);
-    case 'decimalTwo':        return formatNumber(n, 'decimalTwo') ?? n.toFixed(2);
-    case 'ratingOutOfFive':   return `${formatNumber(n, 'ratingOutOfFive') ?? n.toFixed(1)}/5`;
-    case 'hoursDays': {
-      const hours = n / MS_PER_HOUR;
-      if (hours < 48) {
-        const r = Math.round(hours * 10) / 10;
-        const num = formatNumber(r, { decimals: 1, trim: true }) ?? (Number.isInteger(r) ? r : r.toFixed(1));
-        return `${num} ${r === 1 ? t("DASHBOARD_UNIT_HR", "hr") : t("DASHBOARD_UNIT_HRS", "hrs")}`;
-      }
-      const days = n / MS_PER_DAY;
-      const r = Math.round(days * 10) / 10;
-      const num = formatNumber(r, { decimals: 1, trim: true }) ?? (Number.isInteger(r) ? r : r.toFixed(1));
-      return `${num} ${r === 1 ? t("DASHBOARD_UNIT_DAY", "day") : t("DASHBOARD_UNIT_DAYS", "days")}`;
-    }
-    case 'hoursDecimal':      return `${formatNumber(n / MS_PER_HOUR, 'hoursDecimal') ?? (n / MS_PER_HOUR).toFixed(1)}h`;
-    case 'signedInteger':     return `${n >= 0 ? '+' : ''}${formatNumber(n, 'signedInteger') ?? Math.round(n).toLocaleString(locale)}`;
-    case 'ordinal': {
-      const v = Math.round(n) % 100;
-      const s = ['th', 'st', 'nd', 'rd'];
-      return (formatNumber(n, 'integer') ?? Math.round(n)) + (s[(v - 20) % 10] || s[v] || s[0]);
-    }
-    default: return String(val);
-  }
-}
-
-function isPercentFormat(format) {
-  return (
-    format === 'percent' ||
-    format === 'percentInteger' ||
-    format === 'percentNoDecimal' ||
-    format === 'percentOneDecimal'
-  );
-}
-
-function normalizePct(value) {
-  const n = Number(value);
-  if (!Number.isFinite(n)) return 0;
-  return n <= 1 ? n * 100 : n;
-}
-
-// DepartmentBarChart's percent mode plots 0..100, so scale ratios up.
-function percentToChartScale(value, isPercent) {
-  return isPercent ? normalizePct(value) : value;
-}
-
-function msToHours(ms) {
-  const hours = Number(ms) / MS_PER_HOUR;
-  if (!Number.isFinite(hours) || hours <= 0) return 0;
-  return Math.round(hours * 10) / 10;
-}
-
-function formatLabel(value) {
-  const s = String(value ?? '');
-  if (!s || s === 'null' || s === 'undefined') return t("DASHBOARD_COMMON_UNKNOWN", "Unknown");
-  return s;
-}
-
-/**
- * Dimension-label formatter keyed off `viz.labelFormat`. Ports the reference
- * client-side label shaping (kpiQueries.formatDimensionLabel /
- * formatOfficerStackedLabel) into the engine so chart categories match the
- * reference verbatim without per-tile code.
- *   - "dimension": localize via the dimensionLabel seam (kind derived from the
- *     query dimension name `dim`), falling back to the legacy humaniser
- *   - "officer":   mask an assignee UUID -> "Officer …<last6>" / "Unassigned"
- * No labelFormat => identity (formatLabel).
- */
-function formatDimLabel(value, viz, dim, locale) {
-  switch (viz?.labelFormat) {
-    case 'dimension': {
-      const kind = dimensionKindForName(dim);
-      return kind ? dimensionLabel(value, kind) : String(value);
-    }
-    case 'department': return dimensionLabel(value, 'department');
-    case 'officer':    return formatOfficerLabel(value);
-    case 'date-dow':   return formatDateDow(value, locale);
-    default:           return formatLabel(value);
-  }
-}
-
-// Port of kpiQueries.formatOverTimeDailyLabel: epoch-ms / yyyy-MM-dd -> short weekday.
-function formatDateDow(value, locale) {
-  const key = epochOrIsoToDateKey(value);
-  if (!key) return formatLabel(value);
-  const d = new Date(`${key}T12:00:00`);
-  if (Number.isNaN(d.getTime())) return key;
-  return d.toLocaleDateString(locale, { weekday: 'short' });
-}
-
-function epochOrIsoToDateKey(value) {
-  if (value == null || value === '') return '';
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    return new Date(value).toISOString().slice(0, 10);
-  }
-  const s = String(value).trim();
-  if (/^\d{13}$/.test(s)) return new Date(Number(s)).toISOString().slice(0, 10);
-  const iso = s.match(/^(\d{4}-\d{2}-\d{2})/);
-  return iso ? iso[1] : s;
-}
-
-function normalizeSeg(value) {
-  return String(value ?? '').toUpperCase();
-}
-
-function errorLabel(code) {
-  switch (code) {
-    case 'pii_forbidden': return t("DASHBOARD_TILE_ERR_RESTRICTED", "Restricted");
-    case 'kpi_forbidden': return t("DASHBOARD_TILE_ERR_NO_ACCESS", "No access");
-    case 'scope_forbidden': return t("DASHBOARD_TILE_ERR_OUT_OF_SCOPE", "Out of scope");
-    default: return code || t("DASHBOARD_TILE_ERR_GENERIC", "ERROR");
-  }
-}
-
-function def_scrollKey(ctx) {
-  return ctx.def?.kpiId || ctx.def?.id || undefined;
-}
-
-function formatAsOf(asOf, locale) {
-  try { return new Date(asOf).toLocaleString(locale); } catch { return String(asOf); }
 }
 
 const Placeholder = ({ message }) => (

--- a/digit-ui-esbuild/products/dashboard/src/components/MultiSelectFilter.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/MultiSelectFilter.jsx
@@ -1,0 +1,182 @@
+import React, { useMemo, useState } from "react";
+import { normalizeStringList } from "../utils/multiSelectFilters";
+import PopoverMenu, {
+  PopoverMenuGroupLabel,
+  PopoverMenuItem,
+} from "./ui/PopoverMenu";
+
+export const MultiSelectChip = ({ label, count }) => (
+  <span className="dashboard-multiselect-trigger-content">
+    <span className="dashboard-multiselect-trigger-label">{label}</span>
+    {count > 0 && (
+      <span className="dashboard-multiselect-count" aria-hidden>
+        {count}
+      </span>
+    )}
+  </span>
+);
+
+const normalizedSearch = (value) =>
+  String(value ?? "")
+    .trim()
+    .toLocaleLowerCase();
+
+const MultiSelectPanel = ({
+  options,
+  values,
+  searchable,
+  searchPlaceholder,
+  allLabel,
+  applyLabel,
+  cancelLabel,
+  emptyLabel,
+  onApply,
+  close,
+}) => {
+  const [draft, setDraft] = useState(() => normalizeStringList(values));
+  const [search, setSearch] = useState("");
+  const query = normalizedSearch(search);
+  const visible = useMemo(
+    () =>
+      options.filter(
+        (option) => !query || normalizedSearch(option.label).includes(query)
+      ),
+    [options, query]
+  );
+  const selected = new Set(draft);
+  const toggle = (id) => {
+    setDraft((current) =>
+      current.includes(id)
+        ? current.filter((value) => value !== id)
+        : [...current, id]
+    );
+  };
+
+  const rows = [];
+  let lastGroup = null;
+  for (const option of visible) {
+    if (option.group && option.group !== lastGroup) {
+      rows.push(
+        <PopoverMenuGroupLabel key={`group-${option.group}`}>
+          {option.group}
+        </PopoverMenuGroupLabel>
+      );
+    }
+    lastGroup = option.group || null;
+    rows.push(
+      <PopoverMenuItem
+        key={option.id}
+        selected={selected.has(option.id)}
+        multiple
+        title={option.label}
+        onSelect={() => toggle(option.id)}
+      >
+        {option.label}
+      </PopoverMenuItem>
+    );
+  }
+
+  return (
+    <div className="dashboard-multiselect-panel">
+      {searchable && (
+        <input
+          type="search"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          onKeyDown={(event) => {
+            if (
+              ["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)
+            ) {
+              event.stopPropagation();
+            }
+          }}
+          placeholder={searchPlaceholder}
+          aria-label={searchPlaceholder}
+          className="dashboard-multiselect-search"
+          data-popover-autofocus=""
+          autoFocus
+        />
+      )}
+      <div className="dashboard-popover-list dashboard-multiselect-options">
+        {rows.length ? (
+          rows
+        ) : (
+          <div className="dashboard-multiselect-empty">{emptyLabel}</div>
+        )}
+      </div>
+      <div className="dashboard-multiselect-footer">
+        <button
+          type="button"
+          className="dashboard-multiselect-clear"
+          onClick={() => setDraft([])}
+        >
+          {allLabel}
+        </button>
+        <span className="dashboard-multiselect-footer-actions">
+          <button
+            type="button"
+            className="dashboard-multiselect-cancel"
+            onClick={() => close()}
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            className="dashboard-multiselect-apply"
+            onClick={() => {
+              onApply(draft);
+              close();
+            }}
+          >
+            {applyLabel}
+          </button>
+        </span>
+      </div>
+    </div>
+  );
+};
+
+const MultiSelectFilter = ({
+  options = [],
+  values = [],
+  label,
+  allLabel,
+  ariaLabel,
+  loading = false,
+  searchable = false,
+  searchPlaceholder,
+  applyLabel,
+  cancelLabel,
+  emptyLabel,
+  onChange,
+}) => {
+  const choices = options.filter((option) => option.id !== "all");
+  const count = normalizeStringList(values).length;
+  return (
+    <PopoverMenu
+      ariaLabel={ariaLabel}
+      chip={<MultiSelectChip label={count ? label : allLabel} count={count} />}
+      chipTitle={count ? `${label}: ${count}` : allLabel}
+      disabled={loading}
+      panelWidth={300}
+      chipClassName={count ? "dashboard-popover-trigger--active" : ""}
+    >
+      {({ close }) => (
+        <MultiSelectPanel
+          options={choices}
+          values={values}
+          searchable={searchable}
+          searchPlaceholder={searchPlaceholder}
+          allLabel={allLabel}
+          applyLabel={applyLabel}
+          cancelLabel={cancelLabel}
+          emptyLabel={emptyLabel}
+          onApply={onChange}
+          close={close}
+        />
+      )}
+    </PopoverMenu>
+  );
+};
+
+export default MultiSelectFilter;

--- a/digit-ui-esbuild/products/dashboard/src/components/treeControls.rendersmoke.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/components/treeControls.rendersmoke.test.js
@@ -24,6 +24,7 @@ const ENTRY = `
 import React from "react";
 import ReactDOMServer from "react-dom/server";
 import ComplaintTypeTreeFilter, { ComplaintTypeTreePanel } from "./ComplaintTypeTreeFilter.jsx";
+import DashboardFilters from "./DashboardFilters.jsx";
 import GroupByLevelSelect from "./GroupByLevelSelect.jsx";
 import { PopoverMenuItem } from "./ui/PopoverMenu.jsx";
 import { buildComplaintTree } from "../utils/complaintTypeTree";
@@ -37,10 +38,15 @@ export const renderGroupBy = (props) =>
   ReactDOMServer.renderToStaticMarkup(React.createElement(GroupByLevelSelect, props));
 export const renderMenuItem = (props, label) =>
   ReactDOMServer.renderToStaticMarkup(React.createElement(PopoverMenuItem, props, label));
+export const renderDashboardFilters = (props) =>
+  ReactDOMServer.renderToStaticMarkup(React.createElement(DashboardFilters, props));
 `;
 
 function bundleEntry() {
-  const out = path.join(os.tmpdir(), `tree-controls-smoke.${process.pid}.cjs.js`);
+  const out = path.join(
+    os.tmpdir(),
+    `tree-controls-smoke.${process.pid}.cjs.js`
+  );
   esbuild.buildSync({
     stdin: {
       contents: ENTRY,
@@ -66,14 +72,25 @@ function bundleEntry() {
   return require(out);
 }
 
-const { renderFilter, renderPanel, renderGroupBy, renderMenuItem, buildComplaintTree } =
-  bundleEntry();
+const {
+  renderFilter,
+  renderPanel,
+  renderGroupBy,
+  renderMenuItem,
+  renderDashboardFilters,
+  buildComplaintTree,
+} = bundleEntry();
 
 // t: echo the seed English so assertions read naturally (the real runtime
 // echoes the KEY when unseeded — copy is not what this smoke verifies).
 const t = (key, seedEnglish) => seedEnglish || key;
 
-const rec = (code, parentCode, name) => ({ code, name: name || code, parentCode, active: true });
+const rec = (code, parentCode, name) => ({
+  code,
+  name: name || code,
+  parentCode,
+  active: true,
+});
 
 // ke PGR_TEST-shaped 4-level hierarchy: Category → Type → SubType → leaf.
 // (WaterMuddy additionally carries a 5th-level child so a browse position
@@ -107,36 +124,59 @@ test("chip smoke: root state shows All types with menu semantics", () => {
   assert.doesNotMatch(html, /<select/);
 });
 
-test("chip smoke: depth-1 interior selection shows its label", () => {
+test("chip smoke: one hierarchy selection shows the type label and count", () => {
   const html = renderFilter({
     tree: DEEP_TREE,
-    filters: { complaintType: "Infra" },
+    filters: {
+      complaintTypes: [
+        { code: "Infra", path: "Infra", leaf: false, codes: ["WaterMuddy"] },
+      ],
+    },
     onFilterChange: noop,
     t,
   });
-  assert.match(html, /Infrastructure/);
+  assert.match(html, /Complaint types/);
+  assert.match(html, /dashboard-multiselect-count[^>]*>1</);
+  assert.match(html, /dashboard-popover-trigger--active/);
   assert.doesNotMatch(html, /<select/);
 });
 
-test("chip smoke: deep leaf shows parent › leaf with elision marker", () => {
+test("chip smoke: multiple selections show their count without widening the bar", () => {
   const html = renderFilter({
     tree: DEEP_TREE,
-    filters: { complaintType: "WaterMuddy" },
+    filters: {
+      complaintTypes: [
+        {
+          code: "WaterMuddy",
+          path: "Infra.Water.WaterQuality.WaterMuddy",
+          leaf: true,
+          codes: ["WaterMuddy"],
+        },
+        {
+          code: "Pothole",
+          path: "Roads.Pothole",
+          leaf: true,
+          codes: ["Pothole"],
+        },
+      ],
+    },
     onFilterChange: noop,
     t,
   });
-  // "… › Water quality › Muddy water" — nearest ancestor + leaf, middle elided.
-  assert.match(html, /Water quality/);
-  assert.match(html, /Muddy water/);
-  assert.match(html, /dashboard-popover-trigger-seg--muted/);
-  // full trail is recoverable from the title
-  assert.match(html, /title="Infrastructure › Water supply › Water quality › Muddy water"/);
+  assert.match(html, /dashboard-multiselect-count[^>]*>2</);
+  assert.match(html, /title="Complaint types: 2"/);
+  assert.doesNotMatch(html, /WaterMuddy/);
 });
 
 /* ---------------- panel states ---------------- */
 
 test("panel smoke: root — categories listed, no All-in row, reset pinned", () => {
-  const html = renderPanel({ tree: DEEP_TREE, appliedCode: "all", onApply: noop, t });
+  const html = renderPanel({
+    tree: DEEP_TREE,
+    appliedCode: "all",
+    onApply: noop,
+    t,
+  });
   assert.match(html, /role="menuitem"/);
   assert.match(html, /Infrastructure/);
   assert.match(html, /Roads/);
@@ -148,7 +188,12 @@ test("panel smoke: root — categories listed, no All-in row, reset pinned", () 
 });
 
 test("panel smoke: interior — trail, All-in row, children", () => {
-  const html = renderPanel({ tree: DEEP_TREE, appliedCode: "Water", onApply: noop, t });
+  const html = renderPanel({
+    tree: DEEP_TREE,
+    appliedCode: "Water",
+    onApply: noop,
+    t,
+  });
   // browse opens AT the applied interior node
   assert.match(html, /dashboard-popover-trail/);
   assert.match(html, /All in Water supply/);
@@ -159,7 +204,12 @@ test("panel smoke: interior — trail, All-in row, children", () => {
 });
 
 test("panel smoke: leaf — opens at parent with the leaf checked among siblings", () => {
-  const html = renderPanel({ tree: DEEP_TREE, appliedCode: "WaterSmelly", onApply: noop, t });
+  const html = renderPanel({
+    tree: DEEP_TREE,
+    appliedCode: "WaterSmelly",
+    onApply: noop,
+    t,
+  });
   assert.match(html, /All in Water quality/);
   assert.match(html, /Muddy water/);
   assert.match(html, /data-selected="true"[^>]*>[\s\S]*?Smelly water/);
@@ -167,7 +217,12 @@ test("panel smoke: leaf — opens at parent with the leaf checked among siblings
 });
 
 test("panel smoke: 4-level-deep leaf — full trail fits, every level labeled", () => {
-  const html = renderPanel({ tree: DEEP_TREE, appliedCode: "WaterSmelly", onApply: noop, t });
+  const html = renderPanel({
+    tree: DEEP_TREE,
+    appliedCode: "WaterSmelly",
+    onApply: noop,
+    t,
+  });
   // browse opens at WaterQuality (depth 3): all › Infrastructure › Water
   // supply › Water quality — exactly TRAIL_MAX, no elision needed.
   assert.match(html, /All types/);
@@ -201,7 +256,10 @@ test("menu-item smoke: applied descend row announces via aria-current", () => {
   // An interior child that IS the applied subtree (ComplaintTypeTreePanel
   // passes selected=true + descend when browsing the applied node's parent):
   // plain menuitem (navigation row), no aria-checked, aria-current instead.
-  const html = renderMenuItem({ selected: true, descend: true, onSelect: noop }, "Water supply");
+  const html = renderMenuItem(
+    { selected: true, descend: true, onSelect: noop },
+    "Water supply"
+  );
   assert.match(html, /role="menuitem"/);
   assert.match(html, /aria-current="true"/);
   assert.doesNotMatch(html, /aria-checked/);
@@ -214,6 +272,48 @@ test("menu-item smoke: applied descend row announces via aria-current", () => {
   assert.match(radio, /role="menuitemradio"/);
   assert.match(radio, /aria-checked="true"/);
   assert.doesNotMatch(radio, /aria-current/);
+});
+
+test("filter bar smoke: ward, type and department selections stay compact and removable", () => {
+  const html = renderDashboardFilters({
+    filters: {
+      dateFrom: "2026-08-01",
+      dateTo: "2026-08-18",
+      dateRangeActive: true,
+      geographies: [
+        { code: "WARD_1", path: null, leaf: true, codes: ["WARD_1"] },
+      ],
+      complaintTypes: [
+        { code: "Pothole", path: null, leaf: true, codes: ["Pothole"] },
+      ],
+      departments: ["ROADS"],
+    },
+    filterOptions: {
+      geography: [
+        { id: "all", label: "All wards" },
+        { id: "WARD_1", label: "Ward 1" },
+      ],
+      complaintType: [
+        { id: "all", label: "All types" },
+        { id: "Pothole", label: "Pothole" },
+      ],
+      department: [
+        { id: "all", label: "All departments" },
+        { id: "ROADS", label: "Roads" },
+      ],
+    },
+    onFilterChange: noop,
+    onClearFilters: noop,
+    timeZone: "Africa/Nairobi",
+  });
+  assert.match(html, /Ward 1/);
+  assert.match(html, /Pothole/);
+  assert.match(html, /Roads/);
+  assert.match(html, /dashboard-active-filter-chip/g);
+  assert.match(html, /aria-label="Remove Ward 1"/);
+  assert.match(html, /aria-label="Remove Pothole"/);
+  assert.match(html, /aria-label="Remove Roads"/);
+  assert.doesNotMatch(html, /<select/);
 });
 
 /* ---------------- Group-by chip ---------------- */

--- a/digit-ui-esbuild/products/dashboard/src/components/ui/PopoverMenu.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/ui/PopoverMenu.jsx
@@ -112,6 +112,7 @@ const ChevronRightIcon = () => (
  */
 export const PopoverMenuItem = ({
   selected,
+  multiple = false,
   descend = false,
   muted = false,
   title,
@@ -123,7 +124,7 @@ export const PopoverMenuItem = ({
   return (
     <button
       type="button"
-      role={checkable ? "menuitemradio" : "menuitem"}
+      role={checkable ? (multiple ? "menuitemcheckbox" : "menuitemradio") : "menuitem"}
       aria-checked={checkable ? !!selected : undefined}
       aria-current={!checkable && selected ? "true" : undefined}
       data-menu-item=""
@@ -256,6 +257,7 @@ const PopoverMenu = ({
       const root = panelRef.current;
       if (!root) return;
       const target =
+        root.querySelector("[data-popover-autofocus]") ||
         root.querySelector('[data-menu-item][data-selected="true"]') ||
         root.querySelector(ITEM_SELECTOR);
       target?.focus();

--- a/digit-ui-esbuild/products/dashboard/src/config/dashboardConfig.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/dashboardConfig.js
@@ -60,5 +60,10 @@ export function getSubMetricStorageKey() {
 }
 
 export function getFiltersStorageKey() {
+  return `${getTenantId()}-supervisor-dashboard-filters-v5`;
+}
+
+/** One-release read-only bridge for scalar geography/type selections. */
+export function getLegacyFiltersStorageKey() {
   return `${getTenantId()}-supervisor-dashboard-filters-v4`;
 }

--- a/digit-ui-esbuild/products/dashboard/src/config/dashboardFilters.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/dashboardFilters.js
@@ -1,8 +1,9 @@
-import { getFiltersStorageKey, getSubMetricStorageKey } from "./dashboardConfig";
 import {
-  buildDefaultFilters,
-  sanitizeFilters,
-} from "./globalFilterGroups";
+  getFiltersStorageKey,
+  getLegacyFiltersStorageKey,
+  getSubMetricStorageKey,
+} from "./dashboardConfig";
+import { buildDefaultFilters, sanitizeFilters } from "./globalFilterGroups";
 
 const TIME_WINDOW_METRIC_IDS = [];
 
@@ -28,7 +29,9 @@ function migrateTimeWindowFromLegacy(timeZone) {
 
 export function loadDashboardFilters(timeZone) {
   try {
-    const raw = localStorage.getItem(getFiltersStorageKey());
+    const raw =
+      localStorage.getItem(getFiltersStorageKey()) ??
+      localStorage.getItem(getLegacyFiltersStorageKey());
     if (raw) {
       return sanitizeFilters(JSON.parse(raw), {}, timeZone);
     }
@@ -36,7 +39,11 @@ export function loadDashboardFilters(timeZone) {
     /* fall through */
   }
 
-  return sanitizeFilters({ timeWindow: migrateTimeWindowFromLegacy(timeZone) }, {}, timeZone);
+  return sanitizeFilters(
+    { timeWindow: migrateTimeWindowFromLegacy(timeZone) },
+    {},
+    timeZone
+  );
 }
 
 export function clearDashboardFilters(timeZone) {
@@ -58,12 +65,10 @@ export function reconcileFiltersWithOptions(filters, filterOptions, timeZone) {
   const safe = filters ?? buildDefaultFilters(timeZone);
   const next = sanitizeFilters(safe, filterOptions, timeZone);
   const changed =
-    next.geography !== safe.geography ||
-    next.complaintType !== safe.complaintType ||
-    // The tree filter's companions can be repaired (path backfilled, leaf
-    // re-derived) even when the code survives — must propagate too.
-    next.complaintTypePath !== safe.complaintTypePath ||
-    next.complaintTypeLeaf !== safe.complaintTypeLeaf ||
+    JSON.stringify(next.geographies) !== JSON.stringify(safe.geographies) ||
+    JSON.stringify(next.complaintTypes) !==
+      JSON.stringify(safe.complaintTypes) ||
+    JSON.stringify(next.departments) !== JSON.stringify(safe.departments) ||
     next.dateFrom !== safe.dateFrom ||
     next.dateTo !== safe.dateTo;
 

--- a/digit-ui-esbuild/products/dashboard/src/config/globalFilterGroups.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/globalFilterGroups.js
@@ -1,14 +1,19 @@
 import { translate } from "../i18n/localeRuntime";
 import {
-  clearedSelection,
+  ALL,
+  complaintMultiSelectionFromCode,
   normalizeComplaintTypeValue,
   repairSelection,
 } from "../utils/complaintTypeTree";
 import {
-  clearedGeographySelection,
+  geographyMultiSelectionFromCode,
   normalizeGeographyValue,
   repairGeographySelection,
 } from "../utils/boundaryTree";
+import {
+  normalizeHierarchySelections,
+  normalizeStringList,
+} from "../utils/multiSelectFilters";
 import {
   DEFAULT_TIME_ZONE,
   isValidTimeZone,
@@ -34,6 +39,15 @@ export const COMPLAINT_TYPE_OPTIONS = [
     id: "all",
     get label() {
       return translate("DASHBOARD_FILTERS_ALL_TYPES", "All types");
+    },
+  },
+];
+
+export const DEPARTMENT_OPTIONS = [
+  {
+    id: "all",
+    get label() {
+      return translate("DASHBOARD_FILTERS_ALL_DEPARTMENTS", "All departments");
     },
   },
 ];
@@ -67,27 +81,38 @@ export const GLOBAL_FILTER_FIELDS = [
     defaultValue: null,
   },
   {
-    id: "geography",
-    type: "select",
+    id: "geographies",
+    type: "multi-select",
     get label() {
       return translate("DASHBOARD_FILTERS_GEOGRAPHY", "Geography");
     },
-    defaultValue: "all",
+    defaultValue: [],
     options: GEOGRAPHY_OPTIONS,
   },
   {
-    id: "complaintType",
-    type: "select",
+    id: "complaintTypes",
+    type: "multi-select",
     get label() {
       return translate("DASHBOARD_FILTERS_COMPLAINT_TYPE", "Complaint type");
     },
-    defaultValue: "all",
+    defaultValue: [],
     options: COMPLAINT_TYPE_OPTIONS,
+  },
+  {
+    id: "departments",
+    type: "multi-select",
+    get label() {
+      return translate("DASHBOARD_FILTERS_DEPARTMENT", "Department");
+    },
+    defaultValue: [],
+    options: DEPARTMENT_OPTIONS,
   },
 ];
 
 /** @deprecated use GLOBAL_FILTER_FIELDS */
-export const GLOBAL_FILTER_GROUPS = GLOBAL_FILTER_FIELDS.filter((f) => f.type === "select");
+export const GLOBAL_FILTER_GROUPS = GLOBAL_FILTER_FIELDS.filter(
+  (f) => f.type === "multi-select"
+);
 
 /**
  * `timeZone` should be an already-resolved zone (resolveConfiguredTimeZone
@@ -108,28 +133,21 @@ export function buildDefaultFilters(timeZone) {
   );
   defaults.timeWindow = "weekly";
   defaults.dateRangeActive = true;
-  // Tree-traversal complaint-type filter companions: `complaintType` stays the
-  // selected node's code ("all" = cleared, back-compat with every consumer);
-  // path + leaf make the persisted selection self-describing so the very first
-  // batch (before the MDMS tree loads) already sends the right param shape
-  // (leaf → serviceCode, interior → complaintPath).
-  defaults.complaintTypePath = null;
-  defaults.complaintTypeLeaf = false;
-  // Geography drill-down companions (CCSD-2171), same contract: `geography`
-  // stays the selected node's code ("all" = cleared, back-compat with every
-  // consumer); path + leaf make the selection self-describing so the very
-  // first batch already sends the right param (leaf → ward, interior →
-  // boundaryPath).
-  defaults.geographyPath = null;
-  defaults.geographyLeaf = false;
   return defaults;
 }
 
 export function hasActiveFilters(filters, timeZone) {
   if (!filters) return false;
   const defaults = buildDefaultFilters(timeZone);
-  const geography = filters.geography ?? defaults.geography;
-  const complaintType = filters.complaintType ?? defaults.complaintType;
+  const geographies = normalizeHierarchySelections(
+    filters.geographies ?? defaults.geographies
+  );
+  const complaintTypes = normalizeHierarchySelections(
+    filters.complaintTypes ?? defaults.complaintTypes
+  );
+  const departments = normalizeStringList(
+    filters.departments ?? defaults.departments
+  );
   const dateFrom = filters.dateFrom ?? defaults.dateFrom;
   const dateTo = filters.dateTo ?? defaults.dateTo;
   const dateRangeActive = filters.dateRangeActive ?? defaults.dateRangeActive;
@@ -138,8 +156,9 @@ export function hasActiveFilters(filters, timeZone) {
     dateRangeActive !== defaults.dateRangeActive ||
     dateFrom !== defaults.dateFrom ||
     dateTo !== defaults.dateTo ||
-    geography !== defaults.geography ||
-    complaintType !== defaults.complaintType
+    geographies.length > 0 ||
+    complaintTypes.length > 0 ||
+    departments.length > 0
   );
 }
 
@@ -157,7 +176,8 @@ export function sanitizeFilters(raw, dynamicOptions = {}, timeZone) {
   // persistDashboardFilters(filters, dynamicOptions) can pass `null` explicitly, which
   // slips past the default and makes `dynamicOptions[field.id]` throw on the first select
   // field ("geography") — blanking the dashboard on any date-filter change. Normalize it.
-  const options = dynamicOptions && typeof dynamicOptions === "object" ? dynamicOptions : {};
+  const options =
+    dynamicOptions && typeof dynamicOptions === "object" ? dynamicOptions : {};
 
   const next = { ...defaults };
 
@@ -166,17 +186,14 @@ export function sanitizeFilters(raw, dynamicOptions = {}, timeZone) {
     if (field.type === "date" && isValidISODate(value)) {
       next[field.id] = value;
     }
-    // complaintType and geography are tree node selections — handled below.
-    if (field.type === "select" && field.id !== "complaintType" && field.id !== "geography") {
-      const fieldOptions = options[field.id] ?? field.options;
-      if (fieldOptions.some((opt) => opt.id === value)) {
-        next[field.id] = value;
-      }
-    }
   }
 
-  Object.assign(next, sanitizeComplaintTypeSelection(raw, options));
-  Object.assign(next, sanitizeGeographySelection(raw, options));
+  next.complaintTypes = sanitizeComplaintTypeSelections(raw, options);
+  next.geographies = sanitizeGeographySelections(raw, options);
+  next.departments = sanitizeFlatSelections(
+    raw.departments,
+    options.department
+  );
 
   if (["daily", "weekly", "monthly", "wow", "mom"].includes(raw.timeWindow)) {
     next.timeWindow = raw.timeWindow;
@@ -188,8 +205,9 @@ export function sanitizeFilters(raw, dynamicOptions = {}, timeZone) {
 }
 
 /**
- * Sanitize/repair the complaint-type node selection ({ complaintType,
- * complaintTypePath, complaintTypeLeaf }):
+ * Sanitize/repair the complaint-type selections. The v4 scalar trio
+ * ({ complaintType, complaintTypePath, complaintTypeLeaf }) is accepted as a
+ * one-release migration input; v5 persists self-describing selection arrays.
  *
  * - Pruned tree available (options.complaintTypeTree) — the authority:
  *   exact node wins; a vanished node walks UP its stored dot-path to the
@@ -204,56 +222,88 @@ export function sanitizeFilters(raw, dynamicOptions = {}, timeZone) {
  * - No dynamic options at all (initial localStorage load): trust the
  *   persisted trio and let reconcileFiltersWithOptions repair it when the
  *   tree arrives — clearing here would forget the selection on every reload.
- */
-/**
- * Sanitize/repair the geography node selection ({ geography, geographyPath,
- * geographyLeaf }) — sanitizeComplaintTypeSelection's rules verbatim on the
+ *
+ * Geography follows the same rules on the
  * boundary tree (options.geographyTree as the authority; flat scoped ward
  * list validates leaves only, interior selections HELD through tree-fetch
  * hiccups; no options at all → trust the persisted trio).
  */
-function sanitizeGeographySelection(raw, options) {
-  const stored = normalizeGeographyValue({
+function legacyGeographySelections(raw) {
+  if (Array.isArray(raw.geographies))
+    return normalizeHierarchySelections(raw.geographies);
+  const legacy = normalizeGeographyValue({
     code: raw.geography,
     path: raw.geographyPath,
     leaf: raw.geographyLeaf,
   });
-  let selection = stored;
-
-  if (options.geographyTree) {
-    selection = repairGeographySelection(options.geographyTree, stored);
-  } else if (options.geography && stored.leaf) {
-    selection = options.geography.some((opt) => opt.id === stored.code)
-      ? stored
-      : clearedGeographySelection();
-  }
-
-  return {
-    geography: selection.code,
-    geographyPath: selection.path,
-    geographyLeaf: selection.leaf,
-  };
+  return legacy.code === ALL
+    ? []
+    : normalizeHierarchySelections({
+        ...legacy,
+        codes: legacy.leaf ? [legacy.code] : [],
+      });
 }
 
-function sanitizeComplaintTypeSelection(raw, options) {
-  const stored = normalizeComplaintTypeValue({
+function legacyComplaintTypeSelections(raw) {
+  if (Array.isArray(raw.complaintTypes))
+    return normalizeHierarchySelections(raw.complaintTypes);
+  const legacy = normalizeComplaintTypeValue({
     code: raw.complaintType,
     path: raw.complaintTypePath,
     leaf: raw.complaintTypeLeaf,
   });
-  let selection = stored;
+  return legacy.code === ALL
+    ? []
+    : normalizeHierarchySelections({
+        ...legacy,
+        codes: legacy.leaf ? [legacy.code] : [],
+      });
+}
 
-  if (options.complaintTypeTree) {
-    selection = repairSelection(options.complaintTypeTree, stored);
-  } else if (options.complaintType && stored.leaf) {
-    selection = options.complaintType.some((opt) => opt.id === stored.code)
-      ? stored
-      : clearedSelection();
+function sanitizeGeographySelections(raw, options) {
+  const stored = legacyGeographySelections(raw);
+  if (options.geographyTree) {
+    return stored
+      .map((selection) =>
+        repairGeographySelection(options.geographyTree, selection)
+      )
+      .filter((selection) => selection.code !== ALL)
+      .map((selection) =>
+        geographyMultiSelectionFromCode(options.geographyTree, selection.code)
+      )
+      .filter(Boolean);
   }
+  if (!options.geography) return stored;
+  const valid = new Set(options.geography.map((option) => option.id));
+  return stored.filter(
+    (selection) => !selection.leaf || valid.has(selection.code)
+  );
+}
 
-  return {
-    complaintType: selection.code,
-    complaintTypePath: selection.path,
-    complaintTypeLeaf: selection.leaf,
-  };
+function sanitizeComplaintTypeSelections(raw, options) {
+  const stored = legacyComplaintTypeSelections(raw);
+  if (options.complaintTypeTree) {
+    return stored
+      .map((selection) => repairSelection(options.complaintTypeTree, selection))
+      .filter((selection) => selection.code !== ALL)
+      .map((selection) =>
+        complaintMultiSelectionFromCode(
+          options.complaintTypeTree,
+          selection.code
+        )
+      )
+      .filter(Boolean);
+  }
+  if (!options.complaintType) return stored;
+  const valid = new Set(options.complaintType.map((option) => option.id));
+  return stored.filter(
+    (selection) => !selection.leaf || valid.has(selection.code)
+  );
+}
+
+function sanitizeFlatSelections(raw, fieldOptions) {
+  const stored = normalizeStringList(raw);
+  if (!fieldOptions) return stored;
+  const valid = new Set(fieldOptions.map((option) => option.id));
+  return stored.filter((value) => valid.has(value));
 }

--- a/digit-ui-esbuild/products/dashboard/src/config/globalFilterGroups.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/globalFilterGroups.js
@@ -5,6 +5,11 @@ import {
   repairSelection,
 } from "../utils/complaintTypeTree";
 import {
+  clearedGeographySelection,
+  normalizeGeographyValue,
+  repairGeographySelection,
+} from "../utils/boundaryTree";
+import {
   DEFAULT_TIME_ZONE,
   isValidTimeZone,
   oneMonthEarlierYMD,
@@ -110,6 +115,13 @@ export function buildDefaultFilters(timeZone) {
   // (leaf → serviceCode, interior → complaintPath).
   defaults.complaintTypePath = null;
   defaults.complaintTypeLeaf = false;
+  // Geography drill-down companions (CCSD-2171), same contract: `geography`
+  // stays the selected node's code ("all" = cleared, back-compat with every
+  // consumer); path + leaf make the selection self-describing so the very
+  // first batch already sends the right param (leaf → ward, interior →
+  // boundaryPath).
+  defaults.geographyPath = null;
+  defaults.geographyLeaf = false;
   return defaults;
 }
 
@@ -154,8 +166,8 @@ export function sanitizeFilters(raw, dynamicOptions = {}, timeZone) {
     if (field.type === "date" && isValidISODate(value)) {
       next[field.id] = value;
     }
-    // complaintType is a tree node, not a flat option — handled below.
-    if (field.type === "select" && field.id !== "complaintType") {
+    // complaintType and geography are tree node selections — handled below.
+    if (field.type === "select" && field.id !== "complaintType" && field.id !== "geography") {
       const fieldOptions = options[field.id] ?? field.options;
       if (fieldOptions.some((opt) => opt.id === value)) {
         next[field.id] = value;
@@ -164,6 +176,7 @@ export function sanitizeFilters(raw, dynamicOptions = {}, timeZone) {
   }
 
   Object.assign(next, sanitizeComplaintTypeSelection(raw, options));
+  Object.assign(next, sanitizeGeographySelection(raw, options));
 
   if (["daily", "weekly", "monthly", "wow", "mom"].includes(raw.timeWindow)) {
     next.timeWindow = raw.timeWindow;
@@ -192,6 +205,36 @@ export function sanitizeFilters(raw, dynamicOptions = {}, timeZone) {
  *   persisted trio and let reconcileFiltersWithOptions repair it when the
  *   tree arrives — clearing here would forget the selection on every reload.
  */
+/**
+ * Sanitize/repair the geography node selection ({ geography, geographyPath,
+ * geographyLeaf }) — sanitizeComplaintTypeSelection's rules verbatim on the
+ * boundary tree (options.geographyTree as the authority; flat scoped ward
+ * list validates leaves only, interior selections HELD through tree-fetch
+ * hiccups; no options at all → trust the persisted trio).
+ */
+function sanitizeGeographySelection(raw, options) {
+  const stored = normalizeGeographyValue({
+    code: raw.geography,
+    path: raw.geographyPath,
+    leaf: raw.geographyLeaf,
+  });
+  let selection = stored;
+
+  if (options.geographyTree) {
+    selection = repairGeographySelection(options.geographyTree, stored);
+  } else if (options.geography && stored.leaf) {
+    selection = options.geography.some((opt) => opt.id === stored.code)
+      ? stored
+      : clearedGeographySelection();
+  }
+
+  return {
+    geography: selection.code,
+    geographyPath: selection.path,
+    geographyLeaf: selection.leaf,
+  };
+}
+
 function sanitizeComplaintTypeSelection(raw, options) {
   const stored = normalizeComplaintTypeValue({
     code: raw.complaintType,

--- a/digit-ui-esbuild/products/dashboard/src/hooks/useDashboardFilters.js
+++ b/digit-ui-esbuild/products/dashboard/src/hooks/useDashboardFilters.js
@@ -6,8 +6,10 @@ import {
   reconcileFiltersWithOptions,
   resolveSubMetricId as resolveSubMetricIdForMetric,
 } from "../config/dashboardFilters";
-import { normalizeComplaintTypeValue } from "../utils/complaintTypeTree";
-import { normalizeGeographyValue } from "../utils/boundaryTree";
+import {
+  normalizeHierarchySelections,
+  normalizeStringList,
+} from "../utils/multiSelectFilters";
 import { buildDefaultFilters } from "../config/globalFilterGroups";
 
 /** `timeZone` is the already-resolved dashboard config zone (see AdminDashboard). */
@@ -36,32 +38,10 @@ export function useDashboardFilters({ persistent = true, timeZone } = {}) {
     (groupId, value) => {
       setFilters((prev) => {
         let next;
-        if (groupId === "geography") {
-          // Geography drill-down (CCSD-2171): the tree widget sends the
-          // { code, path, leaf } node selection; the flat fallback select
-          // still sends a bare ward-code string. Persist the trio atomically
-          // so leaf → ward / interior → boundaryPath resolves without
-          // waiting for the boundary tree.
-          const selection = normalizeGeographyValue(value);
-          next = {
-            ...prev,
-            geography: selection.code,
-            geographyPath: selection.path,
-            geographyLeaf: selection.leaf,
-          };
-        } else if (groupId === "complaintType") {
-          // Tree-traversal type filter: the widget sends the { code, path,
-          // leaf } node selection (APPLY-ON-SELECT); the flat fallback select
-          // still sends a bare leaf-code string. Persist the trio atomically
-          // so leaf → serviceCode / interior → complaintPath resolves without
-          // waiting for the MDMS tree.
-          const selection = normalizeComplaintTypeValue(value);
-          next = {
-            ...prev,
-            complaintType: selection.code,
-            complaintTypePath: selection.path,
-            complaintTypeLeaf: selection.leaf,
-          };
+        if (groupId === "geographies" || groupId === "complaintTypes") {
+          next = { ...prev, [groupId]: normalizeHierarchySelections(value) };
+        } else if (groupId === "departments") {
+          next = { ...prev, departments: normalizeStringList(value) };
         } else {
           next = { ...prev, [groupId]: value };
         }

--- a/digit-ui-esbuild/products/dashboard/src/hooks/useDashboardFilters.js
+++ b/digit-ui-esbuild/products/dashboard/src/hooks/useDashboardFilters.js
@@ -7,6 +7,7 @@ import {
   resolveSubMetricId as resolveSubMetricIdForMetric,
 } from "../config/dashboardFilters";
 import { normalizeComplaintTypeValue } from "../utils/complaintTypeTree";
+import { normalizeGeographyValue } from "../utils/boundaryTree";
 import { buildDefaultFilters } from "../config/globalFilterGroups";
 
 /** `timeZone` is the already-resolved dashboard config zone (see AdminDashboard). */
@@ -35,7 +36,20 @@ export function useDashboardFilters({ persistent = true, timeZone } = {}) {
     (groupId, value) => {
       setFilters((prev) => {
         let next;
-        if (groupId === "complaintType") {
+        if (groupId === "geography") {
+          // Geography drill-down (CCSD-2171): the tree widget sends the
+          // { code, path, leaf } node selection; the flat fallback select
+          // still sends a bare ward-code string. Persist the trio atomically
+          // so leaf → ward / interior → boundaryPath resolves without
+          // waiting for the boundary tree.
+          const selection = normalizeGeographyValue(value);
+          next = {
+            ...prev,
+            geography: selection.code,
+            geographyPath: selection.path,
+            geographyLeaf: selection.leaf,
+          };
+        } else if (groupId === "complaintType") {
           // Tree-traversal type filter: the widget sends the { code, path,
           // leaf } node selection (APPLY-ON-SELECT); the flat fallback select
           // still sends a bare leaf-code string. Persist the trio atomically

--- a/digit-ui-esbuild/products/dashboard/src/hooks/useFilterOptions.js
+++ b/digit-ui-esbuild/products/dashboard/src/hooks/useFilterOptions.js
@@ -14,11 +14,12 @@ import { dimensionLabel } from "../i18n/dimensionLabel";
 import useDashboardT from "../i18n/useDashboardT";
 import {
   COMPLAINT_TYPE_OPTIONS,
+  DEPARTMENT_OPTIONS,
   GEOGRAPHY_OPTIONS,
 } from "../config/globalFilterGroups";
 
 /**
- * Fetches the global filter dropdown options (wards + complaint types) as
+ * Fetches the global filter dropdown options (wards + complaint types + departments) as
  * server-scoped distincts: one inline batch _query on the facts grain, so the
  * backend's ABAC (PrincipalScopeResolver department/ward scoping) applies —
  * a Water-dept supervisor only ever sees water complaint types.
@@ -31,7 +32,7 @@ import {
  * fetch). Labels re-derive from the cached rows on a language switch.
  *
  * Returns: { options, loading }
- * - options: { geography: [{id,label}], complaintType: [{id,label,group?}] } —
+ * - options: { geography, complaintType, department } — each is an option list;
  *   each list prepended with its "all" sentinel; a key is omitted when its
  *   query failed or returned nothing, so DashboardFilters falls back to the
  *   placeholder list for that select. null until loaded / on total failure.
@@ -51,6 +52,13 @@ const OPTION_QUERIES = {
     grain: "facts",
     window: { name: "all" },
     dimensions: ["ward_code"],
+    measures: [{ name: "n", agg: "count" }],
+    limit: 300,
+  },
+  departments: {
+    grain: "facts",
+    window: { name: "all" },
+    dimensions: ["department_code"],
     measures: [{ name: "n", agg: "count" }],
     limit: 300,
   },
@@ -92,7 +100,11 @@ function toComplaintTypeDecorator(hierarchyIndex) {
       // a one-item optgroup echoing the option's own label is just noise.
       ...(entry.rootCode !== code &&
         entry.rootLabel && {
-          group: dimensionLabel(entry.rootCode, "complaintType", entry.rootLabel),
+          group: dimensionLabel(
+            entry.rootCode,
+            "complaintType",
+            entry.rootLabel
+          ),
         }),
     };
   };
@@ -102,13 +114,21 @@ export function useFilterOptions({ enabled = true } = {}) {
   // Raw fetch payload and derived labels are split so a language switch
   // re-labels from the cached rows without re-querying the backend.
   const [raw, setRaw] = useState({
-    results: null, hierarchyRecords: null, boundaryRoots: null, loading: true,
+    results: null,
+    hierarchyRecords: null,
+    boundaryRoots: null,
+    loading: true,
   });
   const { language, i18nTick } = useDashboardT();
 
   useEffect(() => {
     if (!enabled) {
-      setRaw({ results: null, hierarchyRecords: null, boundaryRoots: null, loading: false });
+      setRaw({
+        results: null,
+        hierarchyRecords: null,
+        boundaryRoots: null,
+        loading: false,
+      });
       return undefined;
     }
     let cancelled = false;
@@ -122,11 +142,22 @@ export function useFilterOptions({ enabled = true } = {}) {
     ])
       .then(([res, hierarchyRecords, boundaryRoots]) => {
         if (cancelled) return;
-        setRaw({ results: res?.results || {}, hierarchyRecords, boundaryRoots, loading: false });
+        setRaw({
+          results: res?.results || {},
+          hierarchyRecords,
+          boundaryRoots,
+          loading: false,
+        });
       })
       .catch(() => {
         // Never block the dashboard — the selects keep their placeholder lists.
-        if (!cancelled) setRaw({ results: null, hierarchyRecords: null, boundaryRoots: null, loading: false });
+        if (!cancelled)
+          setRaw({
+            results: null,
+            hierarchyRecords: null,
+            boundaryRoots: null,
+            loading: false,
+          });
       });
     return () => {
       cancelled = true;
@@ -151,6 +182,12 @@ export function useFilterOptions({ enabled = true } = {}) {
       "ward_code",
       GEOGRAPHY_OPTIONS,
       "boundary"
+    );
+    const department = toOptionList(
+      raw.results.departments?.rows,
+      "department_code",
+      DEPARTMENT_OPTIONS,
+      "department"
     );
     // Tree-traversal complaint-type filter: the MDMS tree intersected with the
     // ABAC-scoped DISTINCT service_code list above (pruneComplaintTree). Both
@@ -177,6 +214,7 @@ export function useFilterOptions({ enabled = true } = {}) {
     const options = {
       ...(geography && { geography }),
       ...(complaintType && { complaintType }),
+      ...(department && { department }),
       ...(complaintTypeTree && { complaintTypeTree }),
       ...(geographyTree && { geographyTree }),
     };

--- a/digit-ui-esbuild/products/dashboard/src/hooks/useFilterOptions.js
+++ b/digit-ui-esbuild/products/dashboard/src/hooks/useFilterOptions.js
@@ -4,10 +4,12 @@ import {
   buildComplaintTypeIndex,
   fetchComplaintHierarchyRecords,
 } from "../services/complaintHierarchyService";
+import { fetchBoundaryTreeRoots } from "../services/boundaryHierarchyService";
 import {
   buildComplaintTree,
   pruneComplaintTree,
 } from "../utils/complaintTypeTree";
+import { buildBoundaryTree, pruneBoundaryTree } from "../utils/boundaryTree";
 import { dimensionLabel } from "../i18n/dimensionLabel";
 import useDashboardT from "../i18n/useDashboardT";
 import {
@@ -99,28 +101,32 @@ function toComplaintTypeDecorator(hierarchyIndex) {
 export function useFilterOptions({ enabled = true } = {}) {
   // Raw fetch payload and derived labels are split so a language switch
   // re-labels from the cached rows without re-querying the backend.
-  const [raw, setRaw] = useState({ results: null, hierarchyRecords: null, loading: true });
+  const [raw, setRaw] = useState({
+    results: null, hierarchyRecords: null, boundaryRoots: null, loading: true,
+  });
   const { language, i18nTick } = useDashboardT();
 
   useEffect(() => {
     if (!enabled) {
-      setRaw({ results: null, hierarchyRecords: null, loading: false });
+      setRaw({ results: null, hierarchyRecords: null, boundaryRoots: null, loading: false });
       return undefined;
     }
     let cancelled = false;
     Promise.all([
       runBatchQueries(OPTION_QUERIES),
-      // Resolves null on any failure (never rejects) — labels then fall back
-      // to the humanizer and the list stays flat, exactly the old behavior.
+      // Both hierarchy fetches resolve null on any failure (never reject) —
+      // labels then fall back to the humanizer and the affected filter stays
+      // flat, exactly the old behavior.
       fetchComplaintHierarchyRecords(),
+      fetchBoundaryTreeRoots(),
     ])
-      .then(([res, hierarchyRecords]) => {
+      .then(([res, hierarchyRecords, boundaryRoots]) => {
         if (cancelled) return;
-        setRaw({ results: res?.results || {}, hierarchyRecords, loading: false });
+        setRaw({ results: res?.results || {}, hierarchyRecords, boundaryRoots, loading: false });
       })
       .catch(() => {
         // Never block the dashboard — the selects keep their placeholder lists.
-        if (!cancelled) setRaw({ results: null, hierarchyRecords: null, loading: false });
+        if (!cancelled) setRaw({ results: null, hierarchyRecords: null, boundaryRoots: null, loading: false });
       });
     return () => {
       cancelled = true;
@@ -157,10 +163,22 @@ export function useFilterOptions({ enabled = true } = {}) {
       buildComplaintTree(raw.hierarchyRecords),
       scopedLeafCodes
     );
+    // Geography drill-down (CCSD-2171): the boundary-relationships tree
+    // intersected with the same ABAC-scoped DISTINCT ward_code list the flat
+    // select is built from. Either input missing → null, and the filter
+    // degrades to the flat ward select — the complaint-type pattern verbatim.
+    const scopedWardCodes = (raw.results.wards?.rows || [])
+      .map((row) => String(row?.ward_code ?? "").trim())
+      .filter(Boolean);
+    const geographyTree = pruneBoundaryTree(
+      buildBoundaryTree(raw.boundaryRoots),
+      scopedWardCodes
+    );
     const options = {
       ...(geography && { geography }),
       ...(complaintType && { complaintType }),
       ...(complaintTypeTree && { complaintTypeTree }),
+      ...(geographyTree && { geographyTree }),
     };
     return {
       options: Object.keys(options).length ? options : null,

--- a/digit-ui-esbuild/products/dashboard/src/services/boundaryHierarchyService.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/boundaryHierarchyService.js
@@ -1,0 +1,83 @@
+import { authFetch, buildRequestInfo, getTenantId, hasAuth } from "./authService";
+import { withTraceHeaders } from "./dashboardMetrics";
+
+/**
+ * Boundary-hierarchy fetch for the geography drill-down filter (CCSD-2171).
+ *
+ * Returns the boundary-relationships root nodes (nested { code, boundaryType,
+ * children } — the input buildBoundaryTree expects), or null on ANY failure
+ * (never rejects): no auth, no hierarchy type resolvable, HTTP error, empty
+ * tree. Callers fall back to the flat ward select, exactly like the
+ * complaint-type tree's degrade path.
+ *
+ * The hierarchy type comes from the deployment's HIERARCHY_TYPE globalConfig
+ * (the same pin the PGR employee pages use — mz: "divisao_administrativa").
+ * When unset, it is discovered from boundary-hierarchy-definition/_search
+ * (first definition at the tenant), so flat/default deployments still work
+ * without config.
+ */
+
+function getConfiguredHierarchyType() {
+  const get = window.globalConfigs?.getConfig?.bind(window.globalConfigs);
+  const pin = get?.("HIERARCHY_TYPE");
+  return typeof pin === "string" && pin.trim() ? pin.trim() : null;
+}
+
+async function discoverHierarchyType(tenantId) {
+  try {
+    const response = await authFetch(
+      `/boundary-service/boundary-hierarchy-definition/_search`,
+      {
+        headers: withTraceHeaders({}),
+        // authFetch's contract is buildBody (re-invoked with a FRESH
+        // RequestInfo on 401-refresh replays) — a plain `body` is ignored.
+        buildBody: () => ({
+          RequestInfo: buildRequestInfo("dashboard-boundary"),
+          BoundaryTypeHierarchySearchCriteria: { tenantId },
+        }),
+        sessionCritical: false,
+      }
+    );
+    if (!response.ok) return null;
+    const payload = await response.json();
+    const first = payload?.BoundaryHierarchy?.[0]?.hierarchyType;
+    return typeof first === "string" && first.trim() ? first.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Fetch the full relationships tree for the tenant's hierarchy. */
+export async function fetchBoundaryTreeRoots() {
+  if (!hasAuth()) return null;
+  try {
+    const tenantId = getTenantId();
+    const hierarchyType =
+      getConfiguredHierarchyType() || (await discoverHierarchyType(tenantId));
+    if (!hierarchyType) return null;
+
+    const params = new URLSearchParams({
+      tenantId,
+      hierarchyType,
+      includeChildren: "true",
+    });
+    const response = await authFetch(
+      `/boundary-service/boundary-relationships/_search?${params}`,
+      {
+        headers: withTraceHeaders({}),
+        buildBody: () => ({ RequestInfo: buildRequestInfo("dashboard-boundary") }),
+        sessionCritical: false,
+      }
+    );
+    if (!response.ok) {
+      console.warn(`boundary-relationships _search failed (${response.status})`);
+      return null;
+    }
+    const payload = await response.json();
+    const roots = payload?.TenantBoundary?.[0]?.boundary;
+    return Array.isArray(roots) && roots.length ? roots : null;
+  } catch (error) {
+    console.warn("boundary-relationships _search error", error);
+    return null;
+  }
+}

--- a/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
@@ -236,10 +236,6 @@
   overflow-wrap: anywhere;
 }
 
-.dashboard-filter-inline-select-wrap.dashboard-widget-group-by-wrap::after {
-  content: none !important;
-}
-
 .dashboard-drag-handle-title{
   min-width: 0px;
   font-weight: 600;
@@ -789,7 +785,9 @@
 
 .dashboard-filters-card{
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.375rem;
   border-radius: 0.25rem;
   border-width: 1px;
   border-color: var(--border);
@@ -905,15 +903,6 @@
   padding: 0;
 }
 
-.dashboard-filter-inline-select-wrap{
-  position: relative;
-  display: inline-flex;
-  height: 1.75rem;
-  flex-shrink: 0;
-  align-items: center;
-  align-self: center;
-}
-
 .dashboard-filter-inline-select{
   margin: 0px;
   box-sizing: border-box;
@@ -949,21 +938,6 @@
 
 .dashboard-filter-inline-select:focus {
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 15%, transparent);
-}
-
-.dashboard-filter-inline-select-wrap::after {
-  content: none;
-}
-
-.dashboard-filter-inline-chevron {
-  position: absolute;
-  right: 0.35rem;
-  top: 50%;
-  transform: translateY(-50%);
-  pointer-events: none;
-  width: 10px;
-  height: 10px;
-  color: var(--dashboard-muted-foreground, #6b6860);
 }
 
 .dashboard-filters-clear-inline{
@@ -1075,6 +1049,10 @@
   border-color: var(--foreground);
 }
 
+.dashboard-popover-trigger--active {
+  background-color: color-mix(in srgb, var(--muted, #f5f4f1) 55%, var(--surface, #ffffff));
+}
+
 .dashboard-popover-trigger:disabled {
   opacity: 0.5;
   cursor: default;
@@ -1129,6 +1107,37 @@
   font-weight: 400;
 }
 
+.dashboard-multiselect-trigger-content{
+  display: inline-flex;
+  min-width: 0px;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.dashboard-multiselect-trigger-label{
+  min-width: 0px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dashboard-multiselect-count{
+  display: inline-flex;
+  height: 1rem;
+  min-width: 1rem;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  background-color: var(--foreground);
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+  font-size: 9px;
+  font-weight: 600;
+  line-height: 1;
+  color: var(--surface);
+}
+
 /* ml-auto pins the caret to the chip's right edge (px-2, like the
      select-wrap's ::after caret at right: 0.5rem) when the label is
      shorter than the shared 7.5rem min width. */
@@ -1141,34 +1150,6 @@
 
 /* Chip content for hierarchical selections: "… › Parent › Node" — each
      segment ellipsizes on its own so deep leaves stay chip-sized. */
-
-.dashboard-popover-trigger-trail{
-  display: inline-flex;
-  min-width: 0px;
-  align-items: center;
-  gap: 0.25rem;
-}
-
-.dashboard-popover-trigger-seg{
-  min-width: 0px;
-  max-width: 9rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.dashboard-popover-trigger-seg--muted{
-  font-weight: 400;
-  color: var(--muted-foreground);
-}
-
-.dashboard-popover-trigger-sep{
-  flex-shrink: 0;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-          user-select: none;
-  color: var(--muted-foreground);
-}
 
 /* Panel: mirrors .dashboard-add-kpi-panel's surface language. */
 
@@ -1379,6 +1360,186 @@
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: var(--muted-foreground);
+}
+
+/* Staged multi-select controls. Applying once per panel keeps a checkbox
+     interaction from issuing the dashboard's full KPI query batch. */
+
+.dashboard-multiselect-panel{
+  display: flex;
+  min-height: 0px;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.dashboard-multiselect-search{
+  margin: 0.5rem;
+  margin-bottom: 0.25rem;
+  height: 2rem;
+  flex-shrink: 0;
+  border-radius: 4px;
+  border-width: 1px;
+  border-color: var(--border);
+  background-color: var(--surface);
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  font-size: 12px;
+  color: var(--foreground);
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  font-family: inherit;
+}
+
+.dashboard-multiselect-search:focus{
+  border-color: var(--foreground);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 15%, transparent);
+}
+
+.dashboard-multiselect-options {
+  max-height: 16rem;
+}
+
+.dashboard-multiselect-empty{
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  text-align: center;
+  font-size: 12px;
+  color: var(--muted-foreground);
+}
+
+.dashboard-multiselect-result-trail{
+  margin-top: 0.125rem;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 10px;
+  font-weight: 400;
+  color: var(--muted-foreground);
+}
+
+.dashboard-multiselect-footer{
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  border-top-width: 1px;
+  border-color: var(--border);
+  padding: 0.5rem;
+}
+
+.dashboard-multiselect-footer-actions{
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.dashboard-multiselect-clear,
+  .dashboard-multiselect-cancel,
+  .dashboard-multiselect-apply{
+  margin: 0px;
+  height: 1.75rem;
+  cursor: pointer;
+  border-radius: 4px;
+  border-width: 1px;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  font-size: 11px;
+  font-weight: 500;
+  font-family: inherit;
+}
+
+.dashboard-multiselect-clear,
+  .dashboard-multiselect-cancel{
+  border-color: transparent;
+  background-color: transparent;
+  color: var(--muted-foreground);
+}
+
+.dashboard-multiselect-clear:hover,
+  .dashboard-multiselect-cancel:hover{
+  color: var(--foreground);
+}
+
+.dashboard-multiselect-apply{
+  border-color: var(--foreground);
+  background-color: var(--foreground);
+  color: var(--surface);
+}
+
+.dashboard-multiselect-clear:focus-visible,
+  .dashboard-multiselect-cancel:focus-visible,
+  .dashboard-multiselect-apply:focus-visible{
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 30%, transparent);
+}
+
+.dashboard-active-filter-chips{
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem;
+  border-top-width: 1px;
+  border-color: var(--border);
+  padding-top: 0.375rem;
+}
+
+.dashboard-active-filter-chip{
+  display: inline-flex;
+  height: 1.5rem;
+  max-width: 100%;
+  align-items: center;
+  gap: 0.25rem;
+  border-radius: 9999px;
+  background-color: var(--muted);
+  padding-left: 0.5rem;
+  padding-right: 0.25rem;
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--foreground);
+}
+
+.dashboard-active-filter-chip > span{
+  max-width: 14rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dashboard-active-filter-chip > button{
+  margin: 0px;
+  display: inline-flex;
+  height: 1rem;
+  width: 1rem;
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  border-width: 0px;
+  background-color: transparent;
+  padding: 0px;
+  font-size: 13px;
+  line-height: 1;
+  color: var(--muted-foreground);
+}
+
+.dashboard-active-filter-chip > button:hover{
+  background-color: var(--surface);
+  color: var(--foreground);
+}
+
+.dashboard-active-filter-chip > button {
+  font-family: inherit;
+}
+
+.dashboard-active-filter-chip > button:focus-visible{
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 30%, transparent);
 }
 
 /* Widget-header wrapper for the per-widget settings gear: right-aligned

--- a/digit-ui-esbuild/products/dashboard/src/styles/input.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/input.css
@@ -589,7 +589,7 @@
   }
 
   .dashboard-filters-card {
-    @apply tw-flex tw-items-center tw-rounded tw-border tw-border-border tw-bg-surface tw-px-2.5 tw-py-1.5;
+    @apply tw-flex tw-flex-col tw-items-stretch tw-gap-1.5 tw-rounded tw-border tw-border-border tw-bg-surface tw-px-2.5 tw-py-1.5;
     min-width: 0;
     max-width: 100%;
   }
@@ -717,6 +717,10 @@
     @apply tw-border-foreground;
   }
 
+  .dashboard-popover-trigger--active {
+    background-color: color-mix(in srgb, var(--muted, #f5f4f1) 55%, var(--surface, #ffffff));
+  }
+
   .dashboard-popover-trigger:disabled {
     opacity: 0.5;
     cursor: default;
@@ -748,6 +752,18 @@
 
   .dashboard-popover-trigger-value {
     @apply tw-inline-flex tw-min-w-0 tw-items-center tw-overflow-hidden tw-font-normal;
+  }
+
+  .dashboard-multiselect-trigger-content {
+    @apply tw-inline-flex tw-min-w-0 tw-items-center tw-gap-1.5;
+  }
+
+  .dashboard-multiselect-trigger-label {
+    @apply tw-min-w-0 tw-overflow-hidden tw-text-ellipsis tw-whitespace-nowrap;
+  }
+
+  .dashboard-multiselect-count {
+    @apply tw-inline-flex tw-h-4 tw-min-w-4 tw-shrink-0 tw-items-center tw-justify-center tw-rounded-full tw-bg-foreground tw-px-1 tw-text-[9px] tw-font-semibold tw-leading-none tw-text-surface;
   }
 
   /* ml-auto pins the caret to the chip's right edge (px-2, like the
@@ -887,6 +903,87 @@
      complaint-type degrade path's category groups). */
   .dashboard-menu-group-label {
     @apply tw-px-2 tw-pb-1 tw-pt-2 tw-text-[10px] tw-font-normal tw-uppercase tw-tracking-wider tw-text-muted-foreground;
+  }
+
+  /* Staged multi-select controls. Applying once per panel keeps a checkbox
+     interaction from issuing the dashboard's full KPI query batch. */
+  .dashboard-multiselect-panel {
+    @apply tw-flex tw-min-h-0 tw-flex-col tw-overflow-hidden;
+  }
+
+  .dashboard-multiselect-search {
+    @apply tw-m-2 tw-mb-1 tw-h-8 tw-shrink-0 tw-rounded-sm tw-border tw-border-border tw-bg-surface tw-px-2 tw-text-[12px] tw-text-foreground tw-outline-none;
+    font-family: inherit;
+  }
+
+  .dashboard-multiselect-search:focus {
+    @apply tw-border-foreground;
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 15%, transparent);
+  }
+
+  .dashboard-multiselect-options {
+    max-height: 16rem;
+  }
+
+  .dashboard-multiselect-empty {
+    @apply tw-px-2 tw-py-4 tw-text-center tw-text-[12px] tw-text-muted-foreground;
+  }
+
+  .dashboard-multiselect-result-trail {
+    @apply tw-mt-0.5 tw-block tw-overflow-hidden tw-text-ellipsis tw-whitespace-nowrap tw-text-[10px] tw-font-normal tw-text-muted-foreground;
+  }
+
+  .dashboard-multiselect-footer {
+    @apply tw-flex tw-shrink-0 tw-items-center tw-justify-between tw-gap-2 tw-border-t tw-border-border tw-p-2;
+  }
+
+  .dashboard-multiselect-footer-actions {
+    @apply tw-flex tw-items-center tw-gap-1;
+  }
+
+  .dashboard-multiselect-clear,
+  .dashboard-multiselect-cancel,
+  .dashboard-multiselect-apply {
+    @apply tw-m-0 tw-h-7 tw-cursor-pointer tw-rounded-sm tw-border tw-px-2 tw-text-[11px] tw-font-medium;
+    font-family: inherit;
+  }
+
+  .dashboard-multiselect-clear,
+  .dashboard-multiselect-cancel {
+    @apply tw-border-transparent tw-bg-transparent tw-text-muted-foreground hover:tw-text-foreground;
+  }
+
+  .dashboard-multiselect-apply {
+    @apply tw-border-foreground tw-bg-foreground tw-text-surface;
+  }
+
+  .dashboard-multiselect-clear:focus-visible,
+  .dashboard-multiselect-cancel:focus-visible,
+  .dashboard-multiselect-apply:focus-visible {
+    @apply tw-outline-none;
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 30%, transparent);
+  }
+
+  .dashboard-active-filter-chips {
+    @apply tw-flex tw-flex-wrap tw-items-center tw-gap-1 tw-border-t tw-border-border tw-pt-1.5;
+  }
+
+  .dashboard-active-filter-chip {
+    @apply tw-inline-flex tw-h-6 tw-max-w-full tw-items-center tw-gap-1 tw-rounded-full tw-bg-muted tw-pl-2 tw-pr-1 tw-text-[10px] tw-font-medium tw-text-foreground;
+  }
+
+  .dashboard-active-filter-chip > span {
+    @apply tw-max-w-[14rem] tw-overflow-hidden tw-text-ellipsis tw-whitespace-nowrap;
+  }
+
+  .dashboard-active-filter-chip > button {
+    @apply tw-m-0 tw-inline-flex tw-h-4 tw-w-4 tw-cursor-pointer tw-items-center tw-justify-center tw-rounded-full tw-border-0 tw-bg-transparent tw-p-0 tw-text-[13px] tw-leading-none tw-text-muted-foreground hover:tw-bg-surface hover:tw-text-foreground;
+    font-family: inherit;
+  }
+
+  .dashboard-active-filter-chip > button:focus-visible {
+    @apply tw-outline-none;
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 30%, transparent);
   }
 
   /* Widget-header wrapper for the per-widget settings gear: right-aligned

--- a/digit-ui-esbuild/products/dashboard/src/utils/boundaryTree.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/boundaryTree.js
@@ -82,7 +82,10 @@ export function buildBoundaryTree(rootNodes) {
 export function pruneBoundaryTree(tree, scopedWardCodes) {
   if (!tree) return null;
   const scoped = new Set(
-    (Array.isArray(scopedWardCodes) ? scopedWardCodes : [...(scopedWardCodes || [])])
+    (Array.isArray(scopedWardCodes)
+      ? scopedWardCodes
+      : [...(scopedWardCodes || [])]
+    )
       .map((c) => String(c ?? "").trim())
       .filter(Boolean)
   );
@@ -112,7 +115,39 @@ export function pruneBoundaryTree(tree, scopedWardCodes) {
     roots.push(stray);
   }
 
-  return roots.length ? { byCode, roots } : null;
+  return roots.length ? { byCode, roots, scopedCodes: scoped } : null;
+}
+
+/** Exact ABAC-scoped ward codes represented by one boundary hierarchy node. */
+export function wardCodesUnder(tree, code) {
+  const node = tree?.byCode?.get(String(code)) || null;
+  if (!node) return [];
+  const scoped = tree?.scopedCodes instanceof Set ? tree.scopedCodes : null;
+  if (!scoped) {
+    const out = [];
+    const stack = [node];
+    while (stack.length) {
+      const current = stack.pop();
+      if (current.isLeaf) out.push(current.code);
+      stack.push(...current.children);
+    }
+    return out;
+  }
+  return [...scoped].filter((candidate) => {
+    const candidateNode = tree.byCode.get(candidate);
+    const candidatePath = String(candidateNode?.path ?? "");
+    return (
+      candidatePath === node.path || candidatePath.startsWith(`${node.path}|`)
+    );
+  });
+}
+
+/** Persisted multi-select entry: semantic node plus exact scoped ward-code expansion. */
+export function geographyMultiSelectionFromCode(tree, code) {
+  const selection = geographySelectionFromCode(tree, code);
+  return selection.code === ALL
+    ? null
+    : { ...selection, codes: wardCodesUnder(tree, code) };
 }
 
 /** The persisted selection trio for applying a boundary node. */
@@ -174,8 +209,10 @@ export function repairGeographySelection(tree, selection) {
     let ancestor = null;
     for (const node of tree.byCode.values()) {
       const nodePath = String(node.path ?? "");
-      if (!nodePath || (nodePath !== path && !path.startsWith(`${nodePath}|`))) continue;
-      if (!ancestor || nodePath.length > String(ancestor.path).length) ancestor = node;
+      if (!nodePath || (nodePath !== path && !path.startsWith(`${nodePath}|`)))
+        continue;
+      if (!ancestor || nodePath.length > String(ancestor.path).length)
+        ancestor = node;
     }
     if (ancestor) return geographySelectionFromCode(tree, ancestor.code);
   }

--- a/digit-ui-esbuild/products/dashboard/src/utils/boundaryTree.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/boundaryTree.js
@@ -1,0 +1,222 @@
+import { ALL } from "./complaintTypeTree";
+
+/**
+ * Boundary (geography) tree helpers for the drill-down ward filter
+ * (CCSD-2171: Província → Distrito → Município instead of a flat ward list).
+ *
+ * Mirrors utils/complaintTypeTree.js on the boundary hierarchy. The tree
+ * shape is identical ({ byCode: Map, roots: node[] }, nodes carrying
+ * { code, path, parentCode, children, isLeaf }), so ALL of that module's
+ * traversal helpers (nodeOf / childrenOf / ancestorsOf / browseBaseCode /
+ * truncateTrail) work on this tree unchanged — only building, pruning and
+ * the selection→params mapping are boundary-specific:
+ *
+ *   - paths are PIPE-joined root-down code chains ("maputo_cidade|katembe|
+ *     municipio_maputo_katembe"), matching the analytics MV's boundary_path
+ *     column byte-for-byte (ancestralmaterializedpath || '|' || code — the
+ *     boundary-service relationships response is the same root-down chain,
+ *     verified live on cms-pilot against the facts grain);
+ *   - leaf (ward) selections keep today's wire shape (params.ward, exact
+ *     ward_code match — works on every backend); interior selections send
+ *     params.boundaryPath (subtree filter; backends without the param
+ *     silently ignore it, so the dashboard degrades to unfiltered for that
+ *     selection rather than erroring — the complaintPath precedent).
+ */
+
+/** The cleared geography selection trio ({ code, path, leaf }). */
+export function clearedGeographySelection() {
+  return { code: ALL, path: null, leaf: false };
+}
+
+/**
+ * Build the boundary tree from the boundary-relationships response's nested
+ * TenantBoundary[].boundary nodes ({ code, boundaryType, children: [...] }).
+ * Paths are derived root-down as pipe-joined code chains. Labels are left
+ * undefined — boundary display names live in localization (t(code), the
+ * same seam the flat ward list uses via dimensionLabel).
+ */
+export function buildBoundaryTree(rootNodes) {
+  const byCode = new Map();
+  const roots = [];
+
+  const walk = (raw, parent) => {
+    const code = String(raw?.code ?? "").trim();
+    if (!code || byCode.has(code)) return null; // dupes: first (shallowest) wins
+    const node = {
+      code,
+      boundaryType: String(raw?.boundaryType ?? "").trim() || undefined,
+      label: undefined,
+      path: parent ? `${parent.path}|${code}` : code,
+      parentCode: parent ? parent.code : null,
+      children: [],
+      isLeaf: true,
+    };
+    byCode.set(code, node);
+    for (const childRaw of Array.isArray(raw?.children) ? raw.children : []) {
+      const child = walk(childRaw, node);
+      if (child) {
+        node.children.push(child);
+        node.isLeaf = false;
+      }
+    }
+    return node;
+  };
+
+  for (const raw of Array.isArray(rootNodes) ? rootNodes : []) {
+    const root = walk(raw, null);
+    if (root) roots.push(root);
+  }
+  return byCode.size ? { byCode, roots } : null;
+}
+
+/**
+ * ABAC/data pruning — the complaint-tree rule verbatim: intersect the full
+ * boundary tree with the scoped DISTINCT ward_code list (the same analytics
+ * distinct the flat select is built from, so the server's row-scope applies).
+ * A node survives iff its own code is scoped OR a descendant survives.
+ * Scoped ward codes with no boundary record (stray/QA rows — visible in
+ * today's flat select) are attached as root-level leaves so no currently
+ * selectable ward is lost. Returns a NEW pruned tree or null (callers fall
+ * back to the flat select).
+ */
+export function pruneBoundaryTree(tree, scopedWardCodes) {
+  if (!tree) return null;
+  const scoped = new Set(
+    (Array.isArray(scopedWardCodes) ? scopedWardCodes : [...(scopedWardCodes || [])])
+      .map((c) => String(c ?? "").trim())
+      .filter(Boolean)
+  );
+  if (!scoped.size) return null;
+
+  const byCode = new Map();
+  const pruneNode = (node) => {
+    const children = node.children.map(pruneNode).filter(Boolean);
+    if (!children.length && !scoped.has(node.code)) return null;
+    const copy = { ...node, children, isLeaf: !children.length };
+    byCode.set(copy.code, copy);
+    return copy;
+  };
+  const roots = tree.roots.map(pruneNode).filter(Boolean);
+
+  for (const code of scoped) {
+    if (byCode.has(code)) continue;
+    const stray = {
+      code,
+      label: undefined,
+      path: code,
+      parentCode: null,
+      children: [],
+      isLeaf: true,
+    };
+    byCode.set(code, stray);
+    roots.push(stray);
+  }
+
+  return roots.length ? { byCode, roots } : null;
+}
+
+/** The persisted selection trio for applying a boundary node. */
+export function geographySelectionFromCode(tree, code) {
+  if (code == null || code === ALL) return clearedGeographySelection();
+  const node = tree?.byCode?.get(String(code)) || null;
+  if (!node) return clearedGeographySelection();
+  return { code: node.code, path: node.path, leaf: node.isLeaf };
+}
+
+/**
+ * The backend's boundaryPath validation (KpiQueryComposer): the complaint
+ * path alphabet plus '|' (the boundary_path segment delimiter), max 512.
+ * Sanitize CLIENT-side for the same reason as complaintPath — a per-entry
+ * invalid_param 400 would blank every tile over one exotic boundary code.
+ */
+const BOUNDARY_PATH_RE = /^[A-Za-z0-9._/|-]{1,512}$/;
+
+export function isValidBoundaryPath(path) {
+  return typeof path === "string" && BOUNDARY_PATH_RE.test(path);
+}
+
+/**
+ * Selection → KpiQueryComposer params:
+ *   root     → {}                   (filter cleared)
+ *   leaf     → { ward }             (exact ward_code match — today's wire
+ *               shape unchanged, works on every grain and every backend)
+ *   interior → { boundaryPath }     (the node's pipe-path; subtree match on
+ *               boundary_path. Backends without the param ignore it — the
+ *               dashboard degrades to unfiltered, never an error.)
+ * Legacy persisted string-only state (leaf flag undefined) behaves exactly
+ * like today: leaf ward.
+ */
+export function geographyParams(selection) {
+  const code = selection?.code;
+  if (!code || code === ALL) return {};
+  if (selection.leaf === false && selection.path) {
+    const path = String(selection.path);
+    return isValidBoundaryPath(path) ? { boundaryPath: path } : {};
+  }
+  return { ward: String(code) };
+}
+
+/**
+ * Repair a persisted geography selection against the (pruned) tree: exact
+ * node wins; a vanished node walks UP its stored pipe-path to the nearest
+ * surviving ancestor; nothing valid → cleared. Path-prefix matching (never
+ * segment splitting) for the same reason as the complaint tree — codes are
+ * matched at pipe boundaries only.
+ */
+export function repairGeographySelection(tree, selection) {
+  const code = String(selection?.code ?? "").trim();
+  if (!code || code === ALL) return clearedGeographySelection();
+  if (!tree) return clearedGeographySelection();
+  if (tree.byCode.has(code)) return geographySelectionFromCode(tree, code);
+
+  const path = String(selection?.path ?? "").trim();
+  if (path) {
+    let ancestor = null;
+    for (const node of tree.byCode.values()) {
+      const nodePath = String(node.path ?? "");
+      if (!nodePath || (nodePath !== path && !path.startsWith(`${nodePath}|`))) continue;
+      if (!ancestor || nodePath.length > String(ancestor.path).length) ancestor = node;
+    }
+    if (ancestor) return geographySelectionFromCode(tree, ancestor.code);
+  }
+  return clearedGeographySelection();
+}
+
+/**
+ * Normalise a filter-change value into the persisted trio. The tree widget
+ * sends the trio; the flat fallback <select> sends a bare ward-code string —
+ * exactly today's contract ("all" clears).
+ */
+export function normalizeGeographyValue(value) {
+  if (value && typeof value === "object") {
+    const code = String(value.code ?? "").trim() || ALL;
+    if (code === ALL) return clearedGeographySelection();
+    return {
+      code,
+      path: value.path != null ? String(value.path) : null,
+      leaf: value.leaf !== false,
+    };
+  }
+  const code = String(value ?? "").trim();
+  if (!code || code === ALL) return clearedGeographySelection();
+  return { code, path: null, leaf: true };
+}
+
+/**
+ * Humanised fallback for boundary codes with no localization message
+ * ("municipio_maputo_katembe" → "Municipio Maputo Katembe"). Display-only;
+ * params always carry the raw code/path.
+ */
+export function humanizeBoundaryCode(code) {
+  const raw = String(code ?? "").trim();
+  if (!raw) return raw;
+  const last = raw.split("|").pop();
+  return last
+    .replace(/[_\-./]+/g, " ")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .trim()
+    .replace(/\s+/g, " ")
+    .split(" ")
+    .map((w) => (w ? w[0].toUpperCase() + w.slice(1) : w))
+    .join(" ");
+}

--- a/digit-ui-esbuild/products/dashboard/src/utils/boundaryTree.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/boundaryTree.test.js
@@ -1,0 +1,193 @@
+// Unit tests for the geography drill-down filter state (CCSD-2171):
+// boundary tree build (pipe paths matching the analytics MV), ABAC pruning,
+// selection→params (leaf ward / interior boundaryPath), repair, normalize.
+// Run from digit-ui-esbuild/:  node --test products/dashboard/src/utils/boundaryTree.test.js
+//
+// Same ESM→CJS esbuild bundling idiom as complaintTypeTree.test.js.
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const esbuild = require("esbuild");
+
+function bundle(entry) {
+  const out = path.join(
+    os.tmpdir(),
+    `${path.basename(entry, ".js")}.cjs.${process.pid}.js`
+  );
+  esbuild.buildSync({
+    entryPoints: [path.join(__dirname, entry)],
+    bundle: true,
+    format: "cjs",
+    platform: "neutral",
+    outfile: out,
+  });
+  process.on("exit", () => {
+    try {
+      fs.unlinkSync(out);
+    } catch (e) {
+      /* already gone */
+    }
+  });
+  return require(out);
+}
+
+const {
+  buildBoundaryTree,
+  pruneBoundaryTree,
+  geographySelectionFromCode,
+  clearedGeographySelection,
+  geographyParams,
+  isValidBoundaryPath,
+  repairGeographySelection,
+  normalizeGeographyValue,
+  humanizeBoundaryCode,
+} = bundle("boundaryTree.js");
+
+// The live cms-pilot shape: Provincia roots (no country node), 3 levels —
+// exactly what boundary-relationships/_search?includeChildren=true returns.
+const API_ROOTS = [
+  {
+    code: "maputo_cidade",
+    boundaryType: "Provincia",
+    children: [
+      {
+        code: "katembe",
+        boundaryType: "Distrito",
+        children: [
+          { code: "municipio_maputo_katembe", boundaryType: "Municipio", children: [] },
+        ],
+      },
+      {
+        code: "kanyaka",
+        boundaryType: "Distrito",
+        children: [
+          { code: "municipio_maputo_kanyaka", boundaryType: "Municipio", children: [] },
+        ],
+      },
+    ],
+  },
+  {
+    code: "PROVINCIA_001",
+    boundaryType: "Provincia",
+    children: [
+      {
+        code: "DISTRITO_001",
+        boundaryType: "Distrito",
+        children: [{ code: "MUNICIPIO_001", boundaryType: "Municipio", children: [] }],
+      },
+    ],
+  },
+];
+
+test("buildBoundaryTree derives pipe paths matching the analytics MV boundary_path", () => {
+  const tree = buildBoundaryTree(API_ROOTS);
+  assert.equal(tree.roots.length, 2);
+  // Verified live: facts boundary_path = "maputo_cidade|kanyaka|municipio_maputo_kanyaka"
+  assert.equal(
+    tree.byCode.get("municipio_maputo_kanyaka").path,
+    "maputo_cidade|kanyaka|municipio_maputo_kanyaka"
+  );
+  assert.equal(tree.byCode.get("katembe").path, "maputo_cidade|katembe");
+  assert.equal(tree.byCode.get("maputo_cidade").isLeaf, false);
+  assert.equal(tree.byCode.get("MUNICIPIO_001").isLeaf, true);
+});
+
+test("buildBoundaryTree handles empty/missing input", () => {
+  assert.equal(buildBoundaryTree(null), null);
+  assert.equal(buildBoundaryTree([]), null);
+});
+
+test("pruneBoundaryTree keeps only branches with scoped wards, attaches strays", () => {
+  const tree = buildBoundaryTree(API_ROOTS);
+  const pruned = pruneBoundaryTree(tree, ["municipio_maputo_katembe", "stray_ward"]);
+  // katembe branch survives, kanyaka + the QA province do not
+  assert.ok(pruned.byCode.has("maputo_cidade"));
+  assert.ok(pruned.byCode.has("katembe"));
+  assert.ok(pruned.byCode.has("municipio_maputo_katembe"));
+  assert.ok(!pruned.byCode.has("kanyaka"));
+  assert.ok(!pruned.byCode.has("PROVINCIA_001"));
+  // scoped ward with no boundary record → root-level leaf, never lost
+  assert.ok(pruned.byCode.has("stray_ward"));
+  assert.equal(pruned.byCode.get("stray_ward").parentCode, null);
+  // pruning never mutates the input
+  assert.ok(tree.byCode.has("kanyaka"));
+});
+
+test("pruneBoundaryTree with no scoped wards / no tree → null (flat fallback)", () => {
+  const tree = buildBoundaryTree(API_ROOTS);
+  assert.equal(pruneBoundaryTree(tree, []), null);
+  assert.equal(pruneBoundaryTree(null, ["x"]), null);
+});
+
+test("geographyParams: leaf → ward (today's wire shape), interior → boundaryPath", () => {
+  const tree = buildBoundaryTree(API_ROOTS);
+  const leaf = geographySelectionFromCode(tree, "municipio_maputo_katembe");
+  assert.deepEqual(geographyParams(leaf), { ward: "municipio_maputo_katembe" });
+
+  const interior = geographySelectionFromCode(tree, "katembe");
+  assert.deepEqual(geographyParams(interior), { boundaryPath: "maputo_cidade|katembe" });
+
+  assert.deepEqual(geographyParams(clearedGeographySelection()), {});
+  // legacy persisted string-only state (leaf flag undefined) → leaf ward
+  assert.deepEqual(geographyParams({ code: "w1" }), { ward: "w1" });
+});
+
+test("interior path failing backend validation is NOT sent (unfiltered beats 400)", () => {
+  assert.deepEqual(
+    geographyParams({ code: "x", path: "bad path with spaces", leaf: false }),
+    {}
+  );
+});
+
+test("isValidBoundaryPath accepts pipe paths, rejects SQL-ish garbage", () => {
+  assert.ok(isValidBoundaryPath("maputo_cidade|katembe|municipio_maputo_katembe"));
+  assert.ok(isValidBoundaryPath("mz"));
+  for (const bad of ["a b", "x%y", "a;b", "x'y", "", null, "a".repeat(513)]) {
+    assert.equal(isValidBoundaryPath(bad), false, String(bad));
+  }
+});
+
+test("repairGeographySelection: exact wins, vanished walks up pipe path, else cleared", () => {
+  const tree = buildBoundaryTree(API_ROOTS);
+  const pruned = pruneBoundaryTree(tree, ["municipio_maputo_katembe"]);
+
+  // exact node survives
+  assert.equal(
+    repairGeographySelection(pruned, { code: "katembe", path: "maputo_cidade|katembe" }).code,
+    "katembe"
+  );
+  // vanished ward (kanyaka pruned) → nearest surviving ancestor by pipe-prefix
+  const repaired = repairGeographySelection(pruned, {
+    code: "municipio_maputo_kanyaka",
+    path: "maputo_cidade|kanyaka|municipio_maputo_kanyaka",
+  });
+  assert.equal(repaired.code, "maputo_cidade");
+  // nothing valid → cleared
+  assert.equal(
+    repairGeographySelection(pruned, { code: "ghost", path: "other|ghost" }).code,
+    "all"
+  );
+  // "all" / no tree → cleared, never throws
+  assert.equal(repairGeographySelection(pruned, { code: "all" }).code, "all");
+  assert.equal(repairGeographySelection(null, { code: "katembe" }).code, "all");
+});
+
+test("normalizeGeographyValue: trio object, legacy bare string, cleared", () => {
+  assert.deepEqual(normalizeGeographyValue("w1"), { code: "w1", path: null, leaf: true });
+  assert.deepEqual(normalizeGeographyValue("all"), clearedGeographySelection());
+  assert.deepEqual(normalizeGeographyValue(null), clearedGeographySelection());
+  assert.deepEqual(
+    normalizeGeographyValue({ code: "katembe", path: "maputo_cidade|katembe", leaf: false }),
+    { code: "katembe", path: "maputo_cidade|katembe", leaf: false }
+  );
+  assert.deepEqual(normalizeGeographyValue({ code: "all" }), clearedGeographySelection());
+});
+
+test("humanizeBoundaryCode never surfaces raw underscores/pipes", () => {
+  assert.equal(humanizeBoundaryCode("municipio_maputo_katembe"), "Municipio Maputo Katembe");
+  assert.equal(humanizeBoundaryCode("a|b|distrito_x"), "Distrito X");
+  assert.equal(humanizeBoundaryCode(""), "");
+});

--- a/digit-ui-esbuild/products/dashboard/src/utils/boundaryTree.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/boundaryTree.test.js
@@ -37,6 +37,8 @@ function bundle(entry) {
 const {
   buildBoundaryTree,
   pruneBoundaryTree,
+  wardCodesUnder,
+  geographyMultiSelectionFromCode,
   geographySelectionFromCode,
   clearedGeographySelection,
   geographyParams,
@@ -57,14 +59,22 @@ const API_ROOTS = [
         code: "katembe",
         boundaryType: "Distrito",
         children: [
-          { code: "municipio_maputo_katembe", boundaryType: "Municipio", children: [] },
+          {
+            code: "municipio_maputo_katembe",
+            boundaryType: "Municipio",
+            children: [],
+          },
         ],
       },
       {
         code: "kanyaka",
         boundaryType: "Distrito",
         children: [
-          { code: "municipio_maputo_kanyaka", boundaryType: "Municipio", children: [] },
+          {
+            code: "municipio_maputo_kanyaka",
+            boundaryType: "Municipio",
+            children: [],
+          },
         ],
       },
     ],
@@ -76,7 +86,9 @@ const API_ROOTS = [
       {
         code: "DISTRITO_001",
         boundaryType: "Distrito",
-        children: [{ code: "MUNICIPIO_001", boundaryType: "Municipio", children: [] }],
+        children: [
+          { code: "MUNICIPIO_001", boundaryType: "Municipio", children: [] },
+        ],
       },
     ],
   },
@@ -102,7 +114,10 @@ test("buildBoundaryTree handles empty/missing input", () => {
 
 test("pruneBoundaryTree keeps only branches with scoped wards, attaches strays", () => {
   const tree = buildBoundaryTree(API_ROOTS);
-  const pruned = pruneBoundaryTree(tree, ["municipio_maputo_katembe", "stray_ward"]);
+  const pruned = pruneBoundaryTree(tree, [
+    "municipio_maputo_katembe",
+    "stray_ward",
+  ]);
   // katembe branch survives, kanyaka + the QA province do not
   assert.ok(pruned.byCode.has("maputo_cidade"));
   assert.ok(pruned.byCode.has("katembe"));
@@ -122,13 +137,33 @@ test("pruneBoundaryTree with no scoped wards / no tree → null (flat fallback)"
   assert.equal(pruneBoundaryTree(null, ["x"]), null);
 });
 
+test("multi-select hierarchy nodes expand only to ABAC-scoped ward codes", () => {
+  const pruned = pruneBoundaryTree(buildBoundaryTree(API_ROOTS), [
+    "municipio_maputo_katembe",
+    "municipio_maputo_kanyaka",
+    "stray_ward",
+  ]);
+  assert.deepEqual(wardCodesUnder(pruned, "maputo_cidade").sort(), [
+    "municipio_maputo_kanyaka",
+    "municipio_maputo_katembe",
+  ]);
+  assert.deepEqual(geographyMultiSelectionFromCode(pruned, "katembe"), {
+    code: "katembe",
+    path: "maputo_cidade|katembe",
+    leaf: false,
+    codes: ["municipio_maputo_katembe"],
+  });
+});
+
 test("geographyParams: leaf → ward (today's wire shape), interior → boundaryPath", () => {
   const tree = buildBoundaryTree(API_ROOTS);
   const leaf = geographySelectionFromCode(tree, "municipio_maputo_katembe");
   assert.deepEqual(geographyParams(leaf), { ward: "municipio_maputo_katembe" });
 
   const interior = geographySelectionFromCode(tree, "katembe");
-  assert.deepEqual(geographyParams(interior), { boundaryPath: "maputo_cidade|katembe" });
+  assert.deepEqual(geographyParams(interior), {
+    boundaryPath: "maputo_cidade|katembe",
+  });
 
   assert.deepEqual(geographyParams(clearedGeographySelection()), {});
   // legacy persisted string-only state (leaf flag undefined) → leaf ward
@@ -143,7 +178,9 @@ test("interior path failing backend validation is NOT sent (unfiltered beats 400
 });
 
 test("isValidBoundaryPath accepts pipe paths, rejects SQL-ish garbage", () => {
-  assert.ok(isValidBoundaryPath("maputo_cidade|katembe|municipio_maputo_katembe"));
+  assert.ok(
+    isValidBoundaryPath("maputo_cidade|katembe|municipio_maputo_katembe")
+  );
   assert.ok(isValidBoundaryPath("mz"));
   for (const bad of ["a b", "x%y", "a;b", "x'y", "", null, "a".repeat(513)]) {
     assert.equal(isValidBoundaryPath(bad), false, String(bad));
@@ -156,7 +193,10 @@ test("repairGeographySelection: exact wins, vanished walks up pipe path, else cl
 
   // exact node survives
   assert.equal(
-    repairGeographySelection(pruned, { code: "katembe", path: "maputo_cidade|katembe" }).code,
+    repairGeographySelection(pruned, {
+      code: "katembe",
+      path: "maputo_cidade|katembe",
+    }).code,
     "katembe"
   );
   // vanished ward (kanyaka pruned) → nearest surviving ancestor by pipe-prefix
@@ -167,7 +207,8 @@ test("repairGeographySelection: exact wins, vanished walks up pipe path, else cl
   assert.equal(repaired.code, "maputo_cidade");
   // nothing valid → cleared
   assert.equal(
-    repairGeographySelection(pruned, { code: "ghost", path: "other|ghost" }).code,
+    repairGeographySelection(pruned, { code: "ghost", path: "other|ghost" })
+      .code,
     "all"
   );
   // "all" / no tree → cleared, never throws
@@ -176,18 +217,32 @@ test("repairGeographySelection: exact wins, vanished walks up pipe path, else cl
 });
 
 test("normalizeGeographyValue: trio object, legacy bare string, cleared", () => {
-  assert.deepEqual(normalizeGeographyValue("w1"), { code: "w1", path: null, leaf: true });
+  assert.deepEqual(normalizeGeographyValue("w1"), {
+    code: "w1",
+    path: null,
+    leaf: true,
+  });
   assert.deepEqual(normalizeGeographyValue("all"), clearedGeographySelection());
   assert.deepEqual(normalizeGeographyValue(null), clearedGeographySelection());
   assert.deepEqual(
-    normalizeGeographyValue({ code: "katembe", path: "maputo_cidade|katembe", leaf: false }),
+    normalizeGeographyValue({
+      code: "katembe",
+      path: "maputo_cidade|katembe",
+      leaf: false,
+    }),
     { code: "katembe", path: "maputo_cidade|katembe", leaf: false }
   );
-  assert.deepEqual(normalizeGeographyValue({ code: "all" }), clearedGeographySelection());
+  assert.deepEqual(
+    normalizeGeographyValue({ code: "all" }),
+    clearedGeographySelection()
+  );
 });
 
 test("humanizeBoundaryCode never surfaces raw underscores/pipes", () => {
-  assert.equal(humanizeBoundaryCode("municipio_maputo_katembe"), "Municipio Maputo Katembe");
+  assert.equal(
+    humanizeBoundaryCode("municipio_maputo_katembe"),
+    "Municipio Maputo Katembe"
+  );
   assert.equal(humanizeBoundaryCode("a|b|distrito_x"), "Distrito X");
   assert.equal(humanizeBoundaryCode(""), "");
 });

--- a/digit-ui-esbuild/products/dashboard/src/utils/complaintTypeTree.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/complaintTypeTree.js
@@ -88,7 +88,8 @@ export function buildComplaintTree(records) {
     if (reachable.has(node.code)) continue;
     reachable.add(node.code);
     node.path =
-      node.recordPath || (parentPath ? `${parentPath}.${node.code}` : node.code);
+      node.recordPath ||
+      (parentPath ? `${parentPath}.${node.code}` : node.code);
     delete node.recordPath;
     for (const child of node.children) stack.push([child, node.path]);
   }
@@ -113,7 +114,10 @@ export function buildComplaintTree(records) {
 export function pruneComplaintTree(tree, scopedLeafCodes) {
   if (!tree) return null;
   const scoped = new Set(
-    (Array.isArray(scopedLeafCodes) ? scopedLeafCodes : [...(scopedLeafCodes || [])])
+    (Array.isArray(scopedLeafCodes)
+      ? scopedLeafCodes
+      : [...(scopedLeafCodes || [])]
+    )
       .map((c) => String(c ?? "").trim())
       .filter(Boolean)
   );
@@ -144,7 +148,39 @@ export function pruneComplaintTree(tree, scopedLeafCodes) {
     roots.push(stray);
   }
 
-  return roots.length ? { byCode, roots } : null;
+  return roots.length ? { byCode, roots, scopedCodes: scoped } : null;
+}
+
+/** Exact ABAC-scoped service codes represented by one hierarchy node. */
+export function complaintCodesUnder(tree, code) {
+  const node = nodeOf(tree, code);
+  if (!node) return [];
+  const scoped = tree?.scopedCodes instanceof Set ? tree.scopedCodes : null;
+  if (!scoped) {
+    const out = [];
+    const stack = [node];
+    while (stack.length) {
+      const current = stack.pop();
+      if (current.isLeaf) out.push(current.code);
+      stack.push(...current.children);
+    }
+    return out;
+  }
+  return [...scoped].filter((candidate) => {
+    const candidateNode = nodeOf(tree, candidate);
+    const candidatePath = String(candidateNode?.path ?? "");
+    return (
+      candidatePath === node.path || candidatePath.startsWith(`${node.path}.`)
+    );
+  });
+}
+
+/** Persisted multi-select entry: semantic node plus exact scoped service-code expansion. */
+export function complaintMultiSelectionFromCode(tree, code) {
+  const selection = selectionFromCode(tree, code);
+  return selection.code === ALL
+    ? null
+    : { ...selection, codes: complaintCodesUnder(tree, code) };
 }
 
 /** Node for a code, or null ("all" is the virtual root — also null). */
@@ -212,8 +248,13 @@ export const TRAIL_ELLIPSIS = "…<elided>";
  * recoverable by stepping up. Short trails come back untouched (same array).
  */
 export function truncateTrail(entries, max = 4) {
-  if (!Array.isArray(entries) || entries.length <= max || max < 3) return entries;
-  return [entries[0], TRAIL_ELLIPSIS, ...entries.slice(entries.length - (max - 2))];
+  if (!Array.isArray(entries) || entries.length <= max || max < 3)
+    return entries;
+  return [
+    entries[0],
+    TRAIL_ELLIPSIS,
+    ...entries.slice(entries.length - (max - 2)),
+  ];
 }
 
 /**
@@ -291,8 +332,10 @@ export function repairSelection(tree, selection) {
     let ancestor = null;
     for (const node of tree.byCode.values()) {
       const nodePath = String(node.path ?? "");
-      if (!nodePath || (nodePath !== path && !path.startsWith(`${nodePath}.`))) continue;
-      if (!ancestor || nodePath.length > String(ancestor.path).length) ancestor = node;
+      if (!nodePath || (nodePath !== path && !path.startsWith(`${nodePath}.`)))
+        continue;
+      if (!ancestor || nodePath.length > String(ancestor.path).length)
+        ancestor = node;
     }
     if (ancestor) return selectionFromCode(tree, ancestor.code);
   }

--- a/digit-ui-esbuild/products/dashboard/src/utils/complaintTypeTree.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/complaintTypeTree.test.js
@@ -39,6 +39,8 @@ const {
   ALL,
   buildComplaintTree,
   pruneComplaintTree,
+  complaintCodesUnder,
+  complaintMultiSelectionFromCode,
   nodeOf,
   childrenOf,
   parentOf,
@@ -97,10 +99,7 @@ const tree = () => buildComplaintTree(RECORDS);
 test("buildComplaintTree: structure, derived paths, record path wins", () => {
   const t = tree();
   assert.equal(t.roots.length, 2);
-  assert.deepEqual(
-    t.roots.map((r) => r.code).sort(),
-    ["ROADS", "SANITATION"]
-  );
+  assert.deepEqual(t.roots.map((r) => r.code).sort(), ["ROADS", "SANITATION"]);
 
   const garbage = nodeOf(t, "GARBAGE");
   assert.equal(garbage.path, "SANITATION.GARBAGE"); // derived from parent chain
@@ -142,7 +141,10 @@ test("buildComplaintTree: empty/no records → null", () => {
 test("prune: branches with zero scoped leaves disappear (dept-scoped view)", () => {
   // Sanitation-dept supervisor: scoped distincts only cover garbage leaves.
   const pruned = pruneComplaintTree(tree(), ["GarbageFull", "GarbageMissed"]);
-  assert.deepEqual(pruned.roots.map((r) => r.code), ["SANITATION"]);
+  assert.deepEqual(
+    pruned.roots.map((r) => r.code),
+    ["SANITATION"]
+  );
   assert.equal(nodeOf(pruned, "SEWAGE"), null); // zero scoped leaves → gone
   assert.equal(nodeOf(pruned, "ROADS"), null); // whole other branch → gone
   assert.equal(nodeOf(pruned, "GARBAGE").isLeaf, false);
@@ -167,6 +169,24 @@ test("prune: never mutates the input tree; empty scope → null", () => {
   assert.equal(pruneComplaintTree(null, ["x"]), null);
 });
 
+test("multi-select hierarchy nodes expand only to ABAC-scoped service codes", () => {
+  const pruned = pruneComplaintTree(tree(), [
+    "GarbageFull",
+    "GarbageMissed",
+    "Pothole",
+  ]);
+  assert.deepEqual(complaintCodesUnder(pruned, "GARBAGE").sort(), [
+    "GarbageFull",
+    "GarbageMissed",
+  ]);
+  assert.deepEqual(complaintMultiSelectionFromCode(pruned, "GARBAGE"), {
+    code: "GARBAGE",
+    path: "SANITATION.GARBAGE",
+    leaf: false,
+    codes: ["GarbageFull", "GarbageMissed"],
+  });
+});
+
 /* ------------------------------------------------------------------ */
 /* Traversal: descend / ascend / apply / clear                          */
 /* ------------------------------------------------------------------ */
@@ -174,15 +194,23 @@ test("prune: never mutates the input tree; empty scope → null", () => {
 test("descend: root → children are the root categories; child applies", () => {
   const t = tree();
   assert.deepEqual(
-    childrenOf(t, ALL).map((n) => n.code).sort(),
+    childrenOf(t, ALL)
+      .map((n) => n.code)
+      .sort(),
     ["ROADS", "SANITATION"]
   );
   // Selecting an interior child applies a subtree selection…
   const sel = selectionFromCode(t, "SANITATION");
-  assert.deepEqual(sel, { code: "SANITATION", path: "SANITATION", leaf: false });
+  assert.deepEqual(sel, {
+    code: "SANITATION",
+    path: "SANITATION",
+    leaf: false,
+  });
   // …and the next level's dropdown lists ITS children (traversal continues).
   assert.deepEqual(
-    childrenOf(t, sel.code).map((n) => n.code).sort(),
+    childrenOf(t, sel.code)
+      .map((n) => n.code)
+      .sort(),
     ["GARBAGE", "SEWAGE"]
   );
 });
@@ -369,7 +397,10 @@ test("repair: nothing on the stored path survives → cleared", () => {
     }),
     clearedSelection()
   );
-  assert.deepEqual(repairSelection(null, { code: "X", path: "X" }), clearedSelection());
+  assert.deepEqual(
+    repairSelection(null, { code: "X", path: "X" }),
+    clearedSelection()
+  );
 });
 
 /* ------------------------------------------------------------------ */
@@ -378,7 +409,11 @@ test("repair: nothing on the stored path survives → cleared", () => {
 
 test("normalize: trio passes through, bare string means leaf, all clears", () => {
   assert.deepEqual(
-    normalizeComplaintTypeValue({ code: "GARBAGE", path: "SANITATION.GARBAGE", leaf: false }),
+    normalizeComplaintTypeValue({
+      code: "GARBAGE",
+      path: "SANITATION.GARBAGE",
+      leaf: false,
+    }),
     { code: "GARBAGE", path: "SANITATION.GARBAGE", leaf: false }
   );
   assert.deepEqual(normalizeComplaintTypeValue("GarbageFull"), {
@@ -388,7 +423,10 @@ test("normalize: trio passes through, bare string means leaf, all clears", () =>
   });
   assert.deepEqual(normalizeComplaintTypeValue("all"), clearedSelection());
   assert.deepEqual(normalizeComplaintTypeValue(null), clearedSelection());
-  assert.deepEqual(normalizeComplaintTypeValue({ code: "all" }), clearedSelection());
+  assert.deepEqual(
+    normalizeComplaintTypeValue({ code: "all" }),
+    clearedSelection()
+  );
 });
 
 /* ------------------------------------------------------------------ */
@@ -413,14 +451,17 @@ function stubBrowserGlobals() {
     removeItem: (k) => store.delete(k),
   };
   globalThis.window = { localStorage: globalThis.localStorage };
-  return () => {
-    delete globalThis.localStorage;
-    delete globalThis.window;
+  return {
+    store,
+    restore: () => {
+      delete globalThis.localStorage;
+      delete globalThis.window;
+    },
   };
 }
 
 test("tree-fetch failure: persisted interior selection survives a reload cycle, then repairs", () => {
-  const restore = stubBrowserGlobals();
+  const { restore } = stubBrowserGlobals();
   try {
     const full = tree();
     const pruned = pruneComplaintTree(full, [
@@ -445,35 +486,40 @@ test("tree-fetch failure: persisted interior selection survives a reload cycle, 
     persistDashboardFilters(
       {
         ...loadDashboardFilters(),
-        complaintType: "GARBAGE",
-        complaintTypePath: "SANITATION.GARBAGE",
-        complaintTypeLeaf: false,
+        complaintTypes: [
+          {
+            code: "GARBAGE",
+            path: "SANITATION.GARBAGE",
+            leaf: false,
+            codes: ["GarbageFull", "GarbageMissed"],
+          },
+        ],
       },
       { ...flatOnly, complaintTypeTree: pruned }
     );
 
     // Session 2 — transient MDMS hiccup: tree fetch failed, flat list loaded.
     const reloaded = loadDashboardFilters();
-    assert.equal(reloaded.complaintType, "GARBAGE"); // cold load trusts the trio
+    assert.deepEqual(reloaded.complaintTypes, [
+      {
+        code: "GARBAGE",
+        path: "SANITATION.GARBAGE",
+        leaf: false,
+        codes: ["GarbageFull", "GarbageMissed"],
+      },
+    ]); // cold load trusts the v5 self-describing selection
     // A filter change re-persists through the sanitizer's FLAT branch — the
     // held interior trio must be persisted as-is, not cleared (regression:
     // storage was wiped here while in-memory state kept the selection).
     persistDashboardFilters({ ...reloaded, dateFrom: "2026-01-01" }, flatOnly);
 
     const afterHiccup = loadDashboardFilters();
-    assert.deepEqual(
-      {
-        code: afterHiccup.complaintType,
-        path: afterHiccup.complaintTypePath,
-        leaf: afterHiccup.complaintTypeLeaf,
-      },
-      { code: "GARBAGE", path: "SANITATION.GARBAGE", leaf: false }
-    );
+    assert.deepEqual(afterHiccup.complaintTypes, reloaded.complaintTypes);
     // In-memory reconcile against the same flat-only options agrees with
     // storage (no memory/storage split-brain).
-    assert.equal(
-      reconcileFiltersWithOptions(afterHiccup, flatOnly).complaintType,
-      "GARBAGE"
+    assert.deepEqual(
+      reconcileFiltersWithOptions(afterHiccup, flatOnly).complaintTypes,
+      reloaded.complaintTypes
     );
 
     // Session 3 — tree is back: the held selection repairs through the tree
@@ -482,23 +528,23 @@ test("tree-fetch failure: persisted interior selection survives a reload cycle, 
       ...flatOnly,
       complaintTypeTree: pruned,
     });
-    assert.deepEqual(
+    assert.deepEqual(treeBack.complaintTypes, [
       {
-        code: treeBack.complaintType,
-        path: treeBack.complaintTypePath,
-        leaf: treeBack.complaintTypeLeaf,
+        code: "GARBAGE",
+        path: "SANITATION.GARBAGE",
+        leaf: false,
+        codes: ["GarbageFull", "GarbageMissed"],
       },
-      { code: "GARBAGE", path: "SANITATION.GARBAGE", leaf: false }
-    );
+    ]);
     // …and a re-scope that dropped the whole branch repairs to cleared, so
     // holding through the hiccup never pins a permanently-invalid selection.
     const rescoped = pruneComplaintTree(full, ["Pothole"]);
-    assert.equal(
+    assert.deepEqual(
       reconcileFiltersWithOptions(afterHiccup, {
         ...flatOnly,
         complaintTypeTree: rescoped,
-      }).complaintType,
-      ALL
+      }).complaintTypes,
+      []
     );
 
     // Unchanged flat-branch behavior: a persisted LEAF still validates against
@@ -506,13 +552,50 @@ test("tree-fetch failure: persisted interior selection survives a reload cycle, 
     persistDashboardFilters(
       {
         ...reloaded,
-        complaintType: "GhostLeaf",
-        complaintTypePath: null,
-        complaintTypeLeaf: true,
+        complaintTypes: [
+          { code: "GhostLeaf", path: null, leaf: true, codes: ["GhostLeaf"] },
+        ],
       },
       flatOnly
     );
-    assert.equal(loadDashboardFilters().complaintType, ALL);
+    assert.deepEqual(loadDashboardFilters().complaintTypes, []);
+  } finally {
+    restore();
+  }
+});
+
+test("v4 scalar filter storage migrates to v5 selection arrays", () => {
+  const { store, restore } = stubBrowserGlobals();
+  try {
+    store.set(
+      "default-supervisor-dashboard-filters-v4",
+      JSON.stringify({
+        complaintType: "GarbageFull",
+        complaintTypePath: "SANITATION.GARBAGE.GarbageFull",
+        complaintTypeLeaf: true,
+        geography: "WARD_1",
+        geographyPath: "PROVINCE|WARD_1",
+        geographyLeaf: true,
+        dateRangeActive: false,
+      })
+    );
+    const migrated = loadDashboardFilters();
+    assert.deepEqual(migrated.complaintTypes, [
+      {
+        code: "GarbageFull",
+        path: "SANITATION.GARBAGE.GarbageFull",
+        leaf: true,
+        codes: ["GarbageFull"],
+      },
+    ]);
+    assert.deepEqual(migrated.geographies, [
+      {
+        code: "WARD_1",
+        path: "PROVINCE|WARD_1",
+        leaf: true,
+        codes: ["WARD_1"],
+      },
+    ]);
   } finally {
     restore();
   }
@@ -590,9 +673,15 @@ test("TRAIL_ELLIPSIS can never collide with a real code", () => {
 /* ------------------------------------------------------------------ */
 
 test("humanizeTypeCode: never surfaces a raw dotted code", () => {
-  assert.equal(humanizeTypeCode("complaints.categories.sanitation"), "Sanitation");
+  assert.equal(
+    humanizeTypeCode("complaints.categories.sanitation"),
+    "Sanitation"
+  );
   assert.equal(humanizeTypeCode("MedicalServices"), "Medical Services");
-  assert.equal(humanizeTypeCode("GARBAGE_NEEDS_ATTENTION"), "GARBAGE NEEDS ATTENTION");
+  assert.equal(
+    humanizeTypeCode("GARBAGE_NEEDS_ATTENTION"),
+    "GARBAGE NEEDS ATTENTION"
+  );
   assert.equal(humanizeTypeCode("streetLight-broken"), "Street Light Broken");
   assert.equal(humanizeTypeCode(""), "");
 });

--- a/digit-ui-esbuild/products/dashboard/src/utils/multiSelectFilters.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/multiSelectFilters.js
@@ -1,0 +1,93 @@
+/** Pure state helpers shared by the dashboard's flat and hierarchical multi-selects. */
+
+export const MAX_FILTER_SELECTIONS = 300;
+
+export function normalizeStringList(raw, max = MAX_FILTER_SELECTIONS) {
+  if (!Array.isArray(raw)) return [];
+  return [
+    ...new Set(
+      raw
+        .map((value) => String(value ?? "").trim())
+        .filter((value) => value && value !== "all")
+    ),
+  ].slice(0, max);
+}
+
+export function normalizeHierarchySelection(raw) {
+  if (!raw || typeof raw !== "object") return null;
+  const code = String(raw.code ?? "").trim();
+  if (!code || code === "all") return null;
+  return {
+    code,
+    path: raw.path != null ? String(raw.path) : null,
+    leaf: raw.leaf !== false,
+    codes: normalizeStringList(raw.codes ?? (raw.leaf !== false ? [code] : [])),
+  };
+}
+
+export function normalizeHierarchySelections(raw) {
+  const source = Array.isArray(raw) ? raw : raw ? [raw] : [];
+  const seen = new Set();
+  const selections = [];
+  for (const entry of source) {
+    const selection = normalizeHierarchySelection(entry);
+    if (!selection || seen.has(selection.code)) continue;
+    seen.add(selection.code);
+    selections.push(selection);
+    if (selections.length >= MAX_FILTER_SELECTIONS) break;
+  }
+  return selections;
+}
+
+export function selectedCodes(selections) {
+  const codes = [];
+  const seen = new Set();
+  for (const selection of normalizeHierarchySelections(selections)) {
+    const exact = selection.codes.length
+      ? selection.codes
+      : selection.leaf
+      ? [selection.code]
+      : [];
+    for (const code of exact) {
+      if (seen.has(code)) continue;
+      seen.add(code);
+      codes.push(code);
+    }
+  }
+  return codes;
+}
+
+function isSubset(left, right) {
+  if (!left.length || !right.length) return false;
+  const superset = new Set(right);
+  return left.every((code) => superset.has(code));
+}
+
+/**
+ * Toggle one hierarchy selection while canonicalizing overlap: a selected parent absorbs its
+ * descendants, and selecting a parent replaces already-selected descendants.
+ */
+export function toggleHierarchySelection(current, candidate) {
+  const selections = normalizeHierarchySelections(current);
+  const next = normalizeHierarchySelection(candidate);
+  if (!next) return selections;
+  if (selections.some((entry) => entry.code === next.code)) {
+    return selections.filter((entry) => entry.code !== next.code);
+  }
+  if (selections.some((entry) => isSubset(next.codes, entry.codes)))
+    return selections;
+  return [
+    ...selections.filter((entry) => !isSubset(entry.codes, next.codes)),
+    next,
+  ];
+}
+
+export function removeHierarchySelection(current, code) {
+  return normalizeHierarchySelections(current).filter(
+    (entry) => entry.code !== code
+  );
+}
+
+export function selectionCountLabel(count, singular, plural = singular) {
+  return `${count} ${count === 1 ? singular : plural}`;
+}

--- a/digit-ui-esbuild/products/dashboard/src/utils/multiSelectFilters.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/multiSelectFilters.test.js
@@ -1,0 +1,109 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const fs = require("node:fs");
+const os = require("node:os");
+const esbuild = require("esbuild");
+
+function bundle(entry) {
+  const out = path.join(
+    os.tmpdir(),
+    `${path.basename(entry)}.${process.pid}.cjs`
+  );
+  esbuild.buildSync({
+    entryPoints: [path.join(__dirname, entry)],
+    bundle: true,
+    format: "cjs",
+    platform: "neutral",
+    outfile: out,
+  });
+  process.on("exit", () => {
+    try {
+      fs.unlinkSync(out);
+    } catch {
+      /* already gone */
+    }
+  });
+  return require(out);
+}
+
+const {
+  normalizeStringList,
+  normalizeHierarchySelections,
+  selectedCodes,
+  toggleHierarchySelection,
+  removeHierarchySelection,
+} = bundle("multiSelectFilters.js");
+const { globalParams } = bundle("queryPlan.js");
+
+const leaf = (code) => ({ code, path: code, leaf: true, codes: [code] });
+const parent = (code, codes) => ({ code, path: code, leaf: false, codes });
+
+test("normalization trims, de-duplicates and drops sentinels", () => {
+  assert.deepEqual(normalizeStringList([" A ", "all", "", "A", null, "B"]), [
+    "A",
+    "B",
+  ]);
+  assert.deepEqual(
+    normalizeHierarchySelections([leaf("A"), leaf("A"), null, { code: "all" }]),
+    [leaf("A")]
+  );
+});
+
+test("hierarchy toggle canonicalizes parent/descendant overlap", () => {
+  const sanitation = parent("SANITATION", ["Garbage", "Sewage"]);
+  assert.deepEqual(toggleHierarchySelection([leaf("Garbage")], sanitation), [
+    sanitation,
+  ]);
+  assert.deepEqual(toggleHierarchySelection([sanitation], leaf("Garbage")), [
+    sanitation,
+  ]);
+  assert.deepEqual(toggleHierarchySelection([sanitation], sanitation), []);
+  assert.deepEqual(
+    removeHierarchySelection([sanitation, leaf("Road")], "SANITATION"),
+    [leaf("Road")]
+  );
+});
+
+test("selected hierarchy nodes expand to unique exact scoped codes", () => {
+  assert.deepEqual(
+    selectedCodes([
+      parent("SANITATION", ["Garbage", "Sewage"]),
+      leaf("Sewage"),
+      leaf("Road"),
+    ]),
+    ["Garbage", "Sewage", "Road"]
+  );
+});
+
+test("query plan preserves scalar wire shape for one value and uses plural params for many", () => {
+  assert.deepEqual(
+    globalParams({
+      geographies: [leaf("WARD_1")],
+      complaintTypes: [leaf("Pothole")],
+      departments: ["ROADS"],
+    }),
+    { ward: "WARD_1", serviceCode: "Pothole", departments: ["ROADS"] }
+  );
+
+  assert.deepEqual(
+    globalParams({
+      geographies: [parent("DISTRICT", ["WARD_1", "WARD_2"])],
+      complaintTypes: [
+        parent("SANITATION", ["Garbage", "Sewage"]),
+        leaf("Pothole"),
+      ],
+      departments: ["SANITATION", "ROADS"],
+      dateRangeActive: true,
+      dateFrom: "2026-08-01",
+      dateTo: "2026-08-18",
+    }),
+    {
+      wards: ["WARD_1", "WARD_2"],
+      serviceCodes: ["Garbage", "Sewage", "Pothole"],
+      departments: ["SANITATION", "ROADS"],
+      dateFrom: "2026-08-01",
+      dateTo: "2026-08-18",
+    }
+  );
+});

--- a/digit-ui-esbuild/products/dashboard/src/utils/queryPlan.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/queryPlan.js
@@ -1,5 +1,6 @@
 import { appliedHierLevel } from "./hierLevelGrouping";
 import { complaintTypeParams } from "./complaintTypeTree";
+import { geographyParams } from "./boundaryTree";
 
 /**
  * Query-plan helpers for the catalog dashboard (extracted from
@@ -81,9 +82,19 @@ export function isMapKind(kind) {
  */
 export function globalParams(filters) {
   const params = {};
-  if (filters?.geography && filters.geography !== "all") {
-    params.ward = filters.geography;
-  }
+  // Geography node selection (CCSD-2171): leaf ward → ward (exact ward_code,
+  // today's wire shape), interior province/district → boundaryPath (subtree
+  // on boundary_path; pre-boundaryPath backends ignore the unknown param, so
+  // interior selections degrade to unfiltered, never an error). Legacy
+  // string-only persisted state (no path/leaf) behaves exactly like today.
+  Object.assign(
+    params,
+    geographyParams({
+      code: filters?.geography,
+      path: filters?.geographyPath,
+      leaf: filters?.geographyLeaf,
+    })
+  );
   Object.assign(
     params,
     complaintTypeParams({

--- a/digit-ui-esbuild/products/dashboard/src/utils/queryPlan.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/queryPlan.js
@@ -1,6 +1,7 @@
 import { appliedHierLevel } from "./hierLevelGrouping";
 import { complaintTypeParams } from "./complaintTypeTree";
 import { geographyParams } from "./boundaryTree";
+import { normalizeStringList, selectedCodes } from "./multiSelectFilters";
 
 /**
  * Query-plan helpers for the catalog dashboard (extracted from
@@ -20,7 +21,10 @@ export const CARD_KINDS = new Set([
   "number-tile-sparkline",
   "sparkline-card",
 ]);
-export const SPARKLINE_KINDS = new Set(["number-tile-sparkline", "sparkline-card"]);
+export const SPARKLINE_KINDS = new Set([
+  "number-tile-sparkline",
+  "sparkline-card",
+]);
 export const MAP_KINDS = new Set(["map", "choropleth-map"]);
 
 // The internal pin source: map tiles fetch this alongside their ward aggregates
@@ -82,27 +86,39 @@ export function isMapKind(kind) {
  */
 export function globalParams(filters) {
   const params = {};
-  // Geography node selection (CCSD-2171): leaf ward → ward (exact ward_code,
-  // today's wire shape), interior province/district → boundaryPath (subtree
-  // on boundary_path; pre-boundaryPath backends ignore the unknown param, so
-  // interior selections degrade to unfiltered, never an error). Legacy
-  // string-only persisted state (no path/leaf) behaves exactly like today.
-  Object.assign(
-    params,
-    geographyParams({
-      code: filters?.geography,
-      path: filters?.geographyPath,
-      leaf: filters?.geographyLeaf,
-    })
-  );
-  Object.assign(
-    params,
-    complaintTypeParams({
-      code: filters?.complaintType,
-      path: filters?.complaintTypePath,
-      leaf: filters?.complaintTypeLeaf,
-    })
-  );
+  if (Array.isArray(filters?.geographies)) {
+    const wards = selectedCodes(filters.geographies);
+    if (wards.length === 1) params.ward = wards[0];
+    else if (wards.length > 1) params.wards = wards;
+  } else {
+    // One-release persisted-state compatibility for the v4 scalar selection.
+    Object.assign(
+      params,
+      geographyParams({
+        code: filters?.geography,
+        path: filters?.geographyPath,
+        leaf: filters?.geographyLeaf,
+      })
+    );
+  }
+
+  if (Array.isArray(filters?.complaintTypes)) {
+    const serviceCodes = selectedCodes(filters.complaintTypes);
+    if (serviceCodes.length === 1) params.serviceCode = serviceCodes[0];
+    else if (serviceCodes.length > 1) params.serviceCodes = serviceCodes;
+  } else {
+    Object.assign(
+      params,
+      complaintTypeParams({
+        code: filters?.complaintType,
+        path: filters?.complaintTypePath,
+        leaf: filters?.complaintTypeLeaf,
+      })
+    );
+  }
+
+  const departments = normalizeStringList(filters?.departments);
+  if (departments.length) params.departments = departments;
   if (filters?.dateRangeActive && filters?.dateFrom && filters?.dateTo) {
     params.dateFrom = filters.dateFrom; // yyyy-MM-dd
     params.dateTo = filters.dateTo; // yyyy-MM-dd
@@ -144,10 +160,16 @@ export function buildRefs(tiles, kpis, filters, hierOverrides) {
     refs[kpiId] = { kpiId, params: { ...base } };
 
     if (isCardKind(kind)) {
-      refs[`${kpiId}__prior`] = { kpiId, params: { ...base, compare: "prior" } };
+      refs[`${kpiId}__prior`] = {
+        kpiId,
+        params: { ...base, compare: "prior" },
+      };
     }
     if (isSparklineKind(kind)) {
-      refs[`${kpiId}__series`] = { kpiId, params: { ...base, series: "daily" } };
+      refs[`${kpiId}__series`] = {
+        kpiId,
+        params: { ...base, series: "daily" },
+      };
     }
     if (isMapKind(kind)) {
       // Per-complaint pins (same filters/scope) overlaid on the ward choropleth.
@@ -179,7 +201,9 @@ export function buildPublicRefs(tiles, kpis) {
 export function buildPublicRefsKey(tiles, kpis) {
   return JSON.stringify({
     public: true,
-    ids: (tiles || []).map((tile) => tile?.kpiId).filter((id) => id && kpis?.[id]),
+    ids: (tiles || [])
+      .map((tile) => tile?.kpiId)
+      .filter((id) => id && kpis?.[id]),
     versions: (tiles || []).map((tile) => kpis?.[tile?.kpiId]?.version ?? null),
   });
 }

--- a/digit-ui-esbuild/products/dashboard/src/utils/tileResultAdapters.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/tileResultAdapters.js
@@ -1,0 +1,624 @@
+/**
+ * React-free result-to-view-model adapters used by KpiTile.
+ *
+ * This module deliberately preserves the renderer's existing interpretation of
+ * catalog viz descriptors and analytics results. Keeping these transformations
+ * free of React makes the legacy result contract characterizable while the
+ * backend presentation envelope is introduced incrementally.
+ */
+
+import { formatNumber } from './numberFormat';
+import {
+  GEO_MAP_LAYER_KEYS,
+  partitionPinsByLayer,
+  summarizeWardRows,
+} from './complaintPins';
+import { evaluateCompose, requiresBackendComposition } from './composeKpi';
+import { getNumberTileDeltaClass, formatOfficerLabel, dimensionKindForName } from '../config/kpiDisplay';
+import {
+  resolveSlaRiskPresentation,
+  computeBreachDurationMs,
+  formatBreachDurationCompact,
+  formatWorkflowStatusLabel,
+  normalizeWorkflowStatusKey,
+} from '../config/complaintsAtRiskPresentation';
+import { dimensionLabel } from '../i18n/dimensionLabel';
+import { translate as t } from '../i18n/localeRuntime';
+import { seriesEntryLabel, resolveSeriesLabel } from '../i18n/textResolver';
+
+export function dimensionColumns(result, viz) {
+  const cols = (result.columns || []).filter((c) => c.role === 'dimension');
+  if (cols.length) return cols;
+  if (viz.dimensionKey) return [{ name: viz.dimensionKey }];
+  return [];
+}
+
+export function measureColumns(result, viz) {
+  const cols = (result.columns || []).filter((c) => c.role === 'measure');
+  if (cols.length) return cols;
+  const keys = viz.measureKeys || (viz.measureKey ? [viz.measureKey] : []);
+  return keys.map((name) => ({ name }));
+}
+
+export function primaryDimensionKey(result, viz) {
+  return dimensionColumns(result, viz)[0]?.name || viz.dimensionKey || 'label';
+}
+
+export function primaryMeasure(result, viz) {
+  return measureColumns(result, viz)[0] || { name: viz.measureKey || 'total' };
+}
+
+export function resolveScalar(ctx) {
+  const { viz, result, results } = ctx;
+  // Calendar-aware averages are backend-owned. A malformed definition that
+  // combines one with a raw query must fail closed instead of displaying a total.
+  if (requiresBackendComposition(viz.compose)) {
+    return result.value != null ? Number(result.value) : null;
+  }
+  if (viz.compose && results) {
+    const composed = evaluateCompose(viz.compose, results);
+    if (composed != null) return composed;
+  }
+  if (result.value != null) return result.value;
+  if (result.values && viz.valueKey != null && result.values[viz.valueKey] != null) {
+    return Number(result.values[viz.valueKey]);
+  }
+  if (result.values) {
+    const first = Object.values(result.values)[0];
+    if (first != null) return Number(first);
+  }
+  const row0 = result.rows?.[0];
+  if (row0) {
+    const key = viz.valueKey || primaryMeasure(result, viz).name;
+    if (row0[key] != null) return Number(row0[key]);
+  }
+  return null;
+}
+
+export function resolvePrior(ctx) {
+  const { viz, result } = ctx;
+  if (result.prior != null) return Number(result.prior);
+  if (viz.priorKey != null) {
+    if (result.values && result.values[viz.priorKey] != null) return Number(result.values[viz.priorKey]);
+    const row0 = result.rows?.[0];
+    if (row0 && row0[viz.priorKey] != null) return Number(row0[viz.priorKey]);
+  }
+  return null;
+}
+
+export function computeDelta(current, prior, format, mode) {
+  if (current == null || prior == null || !Number.isFinite(current) || !Number.isFinite(prior)) {
+    return null;
+  }
+  const eff = mode || (isPercentFormat(format) ? 'percentPoint' : 'percent');
+  if (eff === 'percentPoint') return normalizePct(current) - normalizePct(prior);
+  if (eff === 'days') return (current - prior) / 86400000;
+  if (eff === 'duration') return current - prior;
+  if (eff === 'rating') return current - prior;
+  if (prior === 0) return null;
+  return ((current - prior) / Math.abs(prior)) * 100;
+}
+
+export function formatDeltaDisplay(delta, format, mode) {
+  if (delta == null || !Number.isFinite(delta)) return null;
+  const arrow = delta >= 0 ? '▲' : '▼';
+  const abs = Math.abs(delta);
+  const eff = mode || (isPercentFormat(format) ? 'percentPoint' : 'percent');
+  if (eff === 'duration') {
+    return abs >= 86400000
+      ? `${arrow} ${formatNumber(abs / 86400000, { decimals: 1 }) ?? (abs / 86400000).toFixed(1)} ${t("DASHBOARD_UNIT_DAYS", "days")}`
+      : `${arrow} ${formatNumber(abs / 3600000, { decimals: 1 }) ?? (abs / 3600000).toFixed(1)} ${t("DASHBOARD_UNIT_HRS", "hrs")}`;
+  }
+  const rounded = Math.round(abs * 10) / 10;
+  const formatted =
+    formatNumber(rounded, { decimals: 1, trim: true }) ??
+    (Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1));
+  if (eff === 'days') return `${arrow} ${formatted} ${rounded === 1 ? t("DASHBOARD_UNIT_DAY", "day") : t("DASHBOARD_UNIT_DAYS", "days")}`;
+  if (eff === 'rating') return `${arrow} ${formatted}`;
+  const unit = eff === 'percentPoint' ? 'pp' : '%';
+  return `${arrow} ${formatted}${unit}`;
+}
+
+export function deltaClassFor(delta) {
+  if (delta == null || !Number.isFinite(delta) || delta === 0) return undefined;
+  return delta > 0 ? 'dashboard-delta-up' : 'dashboard-delta-down';
+}
+
+export const KPI_STATUS = { ON_TRACK: 'on_track', NORMAL: 'normal', BREACHING: 'breaching' };
+
+export function thresholdStatus(threshold, value) {
+  if (!threshold || value == null || !Number.isFinite(Number(value))) return null;
+  const n = threshold.kind === 'percent' ? normalizePct(value) : Number(value);
+  const { higherIsBetter, onTrack, breaching } = threshold;
+  if (higherIsBetter) {
+    if (n >= onTrack) return KPI_STATUS.ON_TRACK;
+    if (n <= breaching) return KPI_STATUS.BREACHING;
+    return KPI_STATUS.NORMAL;
+  }
+  if (n <= onTrack) return KPI_STATUS.ON_TRACK;
+  if (n >= breaching) return KPI_STATUS.BREACHING;
+  return KPI_STATUS.NORMAL;
+}
+
+export function resolveTileStatus(viz, value) {
+  return thresholdStatus(viz.threshold, value) ?? viz.accent;
+}
+
+export function resolveDeltaClass(viz, value, delta) {
+  const status = thresholdStatus(viz.threshold, value);
+  if (status) {
+    const unavailable = value == null || !Number.isFinite(Number(value));
+    return getNumberTileDeltaClass(status, { unavailable });
+  }
+  return deltaClassFor(delta);
+}
+
+export function statusToSeriesColor(status) {
+  switch (status) {
+    case KPI_STATUS.ON_TRACK: return 'var(--status-resolved)';
+    case KPI_STATUS.BREACHING: return 'var(--status-breach)';
+    default: return null;
+  }
+}
+
+export function resolveSparkline(ctx) {
+  const { viz, result } = ctx;
+  if (Array.isArray(result.sparkline)) return result.sparkline.map((n) => Number(n) || 0);
+  const seriesRows = viz.sparklineKey && result[viz.sparklineKey]?.rows
+    ? result[viz.sparklineKey].rows
+    : result.rows;
+  if (!seriesRows?.length) return [];
+  const dateKey = viz.dateKey || dimensionColumns(result, viz)[0]?.name || 'created_date';
+  const measureKey = viz.sparklineMeasureKey || primaryMeasure(result, viz).name;
+  return [...seriesRows]
+    .sort((a, b) => String(a[dateKey] ?? '').localeCompare(String(b[dateKey] ?? '')))
+    .map((row) => Number(row[measureKey]) || 0);
+}
+
+export function adaptBarRows(ctx) {
+  const { viz, result, locale } = ctx;
+  const dimKey = primaryDimensionKey(result, viz);
+  const measure = primaryMeasure(result, viz);
+  const isPercent = viz.format === 'percent' || viz.format === 'percentOneDecimal';
+  let rows = (result.rows || []).map((row) => ({
+    label: formatDimLabel(row[dimKey], viz, dimKey, locale),
+    count: percentToChartScale(Number(row[measure.name]) || 0, isPercent),
+  }));
+  if (viz.kind !== 'histogram' && !viz.categoryOrder && viz.sort !== 'none') {
+    rows = rows.sort((a, b) => b.count - a.count);
+  }
+  if (viz.categoryOrder) {
+    const ord = viz.categoryOrder;
+    const idx = (l) => {
+      const i = ord.findIndex((o) => l === o || l.includes(o) || o.includes(l));
+      return i < 0 ? ord.length : i;
+    };
+    rows = rows.slice().sort((a, b) => idx(a.label) - idx(b.label));
+  }
+  if (viz.limit) rows = rows.slice(0, viz.limit);
+  return rows;
+}
+
+export function adaptHorizontalRows(ctx) {
+  const { viz, result, locale } = ctx;
+  const dimKey = primaryDimensionKey(result, viz);
+  const valueKey = viz.measureKey || primaryMeasure(result, viz).name;
+  const numeratorKey = viz.numeratorKey;
+  const denominatorKey = viz.denominatorKey;
+  const grouped = new Map();
+  for (const row of result.rows || []) {
+    const key = String(row[dimKey] ?? 'Unknown');
+    const bucket = grouped.get(key) || { num: 0, den: 0, val: 0 };
+    if (numeratorKey != null) bucket.num += Number(row[numeratorKey]) || 0;
+    if (denominatorKey != null) bucket.den += Number(row[denominatorKey]) || 0;
+    bucket.val += Number(row[valueKey]) || 0;
+    grouped.set(key, bucket);
+  }
+  const isRatio = numeratorKey != null && denominatorKey != null;
+  let rows = [...grouped.entries()].map(([key, b]) => ({
+    label: formatDimLabel(key, viz, dimKey, locale),
+    value: isRatio ? (b.den > 0 ? b.num / b.den : 0) : b.val,
+    resolved: numeratorKey != null ? b.num : undefined,
+    created: denominatorKey != null ? b.den : undefined,
+  }));
+  if (isRatio) {
+    rows = rows.filter((r) => (r.created || 0) > 0 && Number(r.value) > 0);
+  }
+  if (viz.sort !== 'none') rows = rows.sort((a, b) => a.value - b.value);
+  if (viz.limit) rows = rows.slice(0, viz.limit);
+  return rows;
+}
+
+export function adaptStacked(ctx) {
+  const { viz, result, locale } = ctx;
+  if (result.series && Array.isArray(result.series) && result.categories) {
+    return { categories: result.categories, series: result.series, colors: result.colors || viz.colors || [] };
+  }
+  const dimKey = primaryDimensionKey(result, viz);
+  const stackKey = viz.stackKey;
+  const measureKey = viz.measureKey || 'total';
+  const stackSeries = viz.stackSeries;
+  if (!stackKey || !stackSeries?.length) {
+    let rows = (result.rows || []).map((row) => ({
+      label: formatDimLabel(row[dimKey], viz, dimKey, locale),
+      value: Number(row[measureKey]) || 0,
+    }));
+    if (viz.sort !== 'none') rows = rows.sort((a, b) => b.value - a.value);
+    if (viz.limit) rows = rows.slice(0, viz.limit);
+    return {
+      categories: rows.map((r) => r.label),
+      series: [{ name: resolveSeriesLabel(viz, viz.seriesLabel || t("DASHBOARD_COMMON_COUNT", "Count")), data: rows.map((r) => r.value) }],
+      colors: viz.colors || ['var(--chart-1)'],
+    };
+  }
+  const segKeys = new Set(stackSeries.map((d) => normalizeSeg(d.key)));
+  const categoryMap = new Map();
+  for (const row of result.rows || []) {
+    const seg = normalizeSeg(row[stackKey]);
+    if (!segKeys.has(seg)) continue;
+    const category = String(row[dimKey] ?? 'Unknown');
+    if (!categoryMap.has(category)) categoryMap.set(category, {});
+    const bucket = categoryMap.get(category);
+    const value = viz.valueTransform === 'msToHours'
+      ? msToHours(row[measureKey])
+      : Number(row[measureKey]) || 0;
+    bucket[seg] = viz.aggregate === 'set' ? value : (bucket[seg] ?? 0) + value;
+  }
+  let entries = [...categoryMap.entries()].map(([key, segments]) => ({
+    key,
+    segments,
+    total: Object.values(segments).reduce((sum, value) => sum + value, 0),
+  }));
+  entries = entries.filter((entry) => entry.total > 0).sort((left, right) => {
+    if (viz.sortBySegment) {
+      const difference =
+        (right.segments[normalizeSeg(viz.sortBySegment)] ?? 0) -
+        (left.segments[normalizeSeg(viz.sortBySegment)] ?? 0);
+      if (difference !== 0) return difference;
+    }
+    return right.total - left.total;
+  });
+  if (viz.limit) entries = entries.slice(0, viz.limit);
+  return {
+    categories: entries.map((entry) => formatDimLabel(entry.key, viz, dimKey, locale)),
+    series: stackSeries.map((def) => ({
+      name: seriesEntryLabel(def, def.label),
+      data: entries.map((entry) => entry.segments[normalizeSeg(def.key)] ?? 0),
+    })),
+    colors: stackSeries.map((def) => def.color),
+  };
+}
+
+export function adaptPie(ctx) {
+  const { viz, result, locale } = ctx;
+  const dimKey = primaryDimensionKey(result, viz);
+  const measure = primaryMeasure(result, viz);
+  const colors = viz.colors || [];
+  if (viz.channelMap?.length) return adaptChannelPie(result, dimKey, measure, viz);
+  let rows = (result.rows || [])
+    .map((row, index) => ({
+      label: formatDimLabel(row[dimKey], viz, dimKey, locale),
+      count: Number(row[measure.name]) || 0,
+      color: colors[index],
+    }))
+    .filter((slice) => slice.count > 0);
+  if (viz.sort !== 'none') rows = rows.sort((left, right) => right.count - left.count);
+  return rows;
+}
+
+export function adaptChannelPie(result, dimKey, measure, viz) {
+  const channels = viz.channelMap;
+  const sourceToChannel = new Map();
+  for (const channel of channels) {
+    for (const source of channel.sources || []) {
+      sourceToChannel.set(normalizeSourceKey(source), channel.id);
+    }
+  }
+  const totals = new Map(channels.map((channel) => [channel.id, 0]));
+  for (const row of result.rows || []) {
+    const count = Number(row[measure.name]) || 0;
+    if (count <= 0) continue;
+    const key = normalizeSourceKey(row[dimKey]);
+    const id = key ? (sourceToChannel.get(key) ?? 'other') : 'other';
+    if (totals.has(id)) totals.set(id, totals.get(id) + count);
+  }
+  return channels
+    .map((channel) => ({
+      label: seriesEntryLabel(channel, dimensionLabel(channel.id, 'channel', channel.label)),
+      count: totals.get(channel.id) ?? 0,
+      color: channel.color,
+    }))
+    .filter((slice) => slice.count > 0)
+    .sort((left, right) => (right.count - left.count) || left.label.localeCompare(right.label));
+}
+
+export function normalizeSourceKey(source) {
+  return String(source ?? '').trim().toLowerCase().replace(/-/g, '_');
+}
+
+export function adaptLine(ctx) {
+  const { viz, result, title, locale } = ctx;
+  if (result.periods) {
+    return { periods: result.periods, defaultPeriod: result.defaultPeriod || viz.defaultPeriod || 'daily', headerTitle: result.title || title };
+  }
+  if (result.series && result.categories) {
+    return { categories: result.categories, series: result.series };
+  }
+  const dimKey = primaryDimensionKey(result, viz);
+  const rows = [...(result.rows || [])].sort((left, right) =>
+    String(left[dimKey] ?? '').localeCompare(String(right[dimKey] ?? ''))
+  );
+  const categories = rows.map((row) => formatDimLabel(row[dimKey], viz, dimKey, locale));
+  if (viz.seriesDefs?.length) {
+    return {
+      categories,
+      series: viz.seriesDefs.map((def) => ({
+        name: seriesEntryLabel(def, def.name),
+        color: def.color,
+        yAxisGroup: def.yAxisGroup,
+        dashArray: def.dashArray ?? 0,
+        data: rows.map((row) => {
+          if (def.numeratorKey != null && def.denominatorKey != null) {
+            const numerator = Number(row[def.numeratorKey]) || 0;
+            const denominator = Number(row[def.denominatorKey]) || 0;
+            return denominator > 0 ? Math.round((numerator / denominator) * 1000) / 10 : 0;
+          }
+          return Number(row[def.measureKey]) || 0;
+        }),
+      })),
+    };
+  }
+  const measures = measureColumns(result, viz);
+  return {
+    categories,
+    series: measures.map((measure) => ({
+      name: seriesEntryLabel(measure, measure.label || measure.name),
+      data: rows.map((row) => Number(row[measure.name]) || 0),
+    })),
+  };
+}
+
+export function deriveColumnsFromResult(result) {
+  return (result.columns || []).map((column) => ({
+    id: column.name,
+    label: column.label || column.name,
+    labelKey: column.labelKey,
+    align: column.role === 'measure' ? 'right' : 'left',
+    type: mapFormatToCellType(column.format),
+    thresholdKey: column.thresholdKey,
+  }));
+}
+
+export function mapFormatToCellType(format) {
+  switch (format) {
+    case 'integer': return 'integer';
+    case 'percent':
+    case 'percentOneDecimal':
+    case 'percentInteger': return 'percent';
+    case 'hoursDecimal': return 'hours';
+    case 'hoursDays': return 'hoursDays';
+    case 'ratingOutOfFive': return 'rating';
+    default: return 'text';
+  }
+}
+
+export function adaptSlaRiskRows(ctx) {
+  const { viz, result } = ctx;
+  const limit = viz.limit || 50;
+  return (result.rows || [])
+    .map((row, index) => {
+      const complaintId = String(row.service_request_id ?? '').trim();
+      if (!complaintId || complaintId === 'null') return null;
+      const slaBucket = String(row.sla_status_bucket ?? '');
+      const { slaLabel, slaLevel } = resolveSlaRiskPresentation(slaBucket);
+      const breachDurationMs = computeBreachDurationMs(
+        row.open_age_ms,
+        row.sla_target_ms,
+        slaBucket
+      );
+      const applicationStatus = String(row.application_status ?? '');
+      const subtypeKey = String(row.service_code ?? '');
+      const typeKey = String(row.service_group ?? '');
+      return {
+        id: complaintId,
+        typeLabel: typeKey ? dimensionLabel(typeKey, 'complaintType') : '—',
+        subtypeLabel: subtypeKey ? dimensionLabel(subtypeKey, 'complaintType') : '—',
+        locality: row.ward_code ? dimensionLabel(String(row.ward_code), 'boundary') : '—',
+        ownerName: formatOfficerLabel(row.current_assignee_uuid),
+        ownerRole: '—',
+        status: normalizeWorkflowStatusKey(applicationStatus),
+        statusLabel: formatWorkflowStatusLabel(applicationStatus),
+        slaLabel,
+        slaLevel,
+        breachDurationMs,
+        breachDurationLabel: formatBreachDurationCompact(breachDurationMs),
+        _rowKey: `risk-${index}-${complaintId}`,
+      };
+    })
+    .filter(Boolean)
+    .sort((left, right) => (right.breachDurationMs ?? -1) - (left.breachDurationMs ?? -1))
+    .slice(0, limit);
+}
+
+export function adaptMapLayers(ctx) {
+  const { viz, result } = ctx;
+  const dimKey = viz.dimensionKey || 'ward_code';
+  const wards = (result.rows || [])
+    .filter((row) => {
+      const code = String(row[dimKey] ?? '').trim();
+      return code && code !== 'null';
+    })
+    .map((row) => {
+      const wardCode = String(row[dimKey]);
+      const filed = Number(row.filed) || 0;
+      const open = Number(row.open) || 0;
+      const resolved = Number(row.resolved) || 0;
+      return {
+        wardCode,
+        label: dimensionLabel(wardCode, 'boundary'),
+        count: filed,
+        total: filed,
+        created: filed,
+        open,
+        resolved,
+        openPct: filed > 0 ? (open / filed) * 100 : 0,
+        resolvedPct: filed > 0 ? (resolved / filed) * 100 : 0,
+      };
+    });
+  const pins = result.pins || [];
+  const statusKnown = result.pinsStatusKnown === true;
+  const { layerTotals, unmapped } = summarizeWardRows(result.rows || [], dimKey);
+  const layers = {
+    wardDetails: {},
+    complaintPinsByLayer: partitionPinsByLayer(pins, statusKnown),
+    complaintPinsError: null,
+    pinSemantics: statusKnown ? 'per-layer' : 'open-only',
+    pinsTruncated: result.pinsTruncated === true,
+    layerTotals,
+    unmapped,
+  };
+  for (const key of GEO_MAP_LAYER_KEYS) layers[key] = wards;
+  return layers;
+}
+
+export function adaptRanked(ctx) {
+  const { viz, result, locale } = ctx;
+  const dimKey = primaryDimensionKey(result, viz);
+  const measure = primaryMeasure(result, viz);
+  let rows = (result.rows || []).map((row) => ({
+    label: formatDimLabel(row[dimKey], viz, dimKey, locale),
+    value: Number(row[measure.name]) || 0,
+  }));
+  if (viz.sort !== 'none') rows = rows.sort((left, right) => right.value - left.value);
+  rows = rows.slice(0, viz.limit || 10);
+  return { rows, format: measure.format || viz.format };
+}
+
+export function adaptDow(ctx) {
+  const { viz, result } = ctx;
+  const dimKey = primaryDimensionKey(result, viz);
+  const measure = primaryMeasure(result, viz);
+  const rows = (result.rows || []).map((row) => ({
+    dow: Number(row[dimKey]),
+    value: Number(row[measure.name]) || 0,
+  }));
+  return { rows, format: measure.format || viz.format };
+}
+
+const MS_PER_DAY = 86400000;
+const MS_PER_HOUR = 3600000;
+
+export function applyFormat(val, format, locale) {
+  if (val == null || !Number.isFinite(Number(val))) return '—';
+  const n = Number(val);
+  switch (format) {
+    case 'integer':           return formatNumber(n, 'integer') ?? Math.round(n).toLocaleString(locale);
+    case 'percentInteger':
+    case 'percentNoDecimal':  return `${formatNumber(normalizePct(n), 'percentInteger') ?? Math.round(normalizePct(n))}%`;
+    case 'percentOneDecimal':
+    case 'percent':           return `${formatNumber(normalizePct(n), 'percent') ?? normalizePct(n).toFixed(1)}%`;
+    case 'decimalOne':        return formatNumber(n, 'decimalOne') ?? n.toFixed(1);
+    case 'decimalTwo':        return formatNumber(n, 'decimalTwo') ?? n.toFixed(2);
+    case 'ratingOutOfFive':   return `${formatNumber(n, 'ratingOutOfFive') ?? n.toFixed(1)}/5`;
+    case 'hoursDays': {
+      const hours = n / MS_PER_HOUR;
+      if (hours < 48) {
+        const rounded = Math.round(hours * 10) / 10;
+        const number = formatNumber(rounded, { decimals: 1, trim: true }) ?? (Number.isInteger(rounded) ? rounded : rounded.toFixed(1));
+        return `${number} ${rounded === 1 ? t("DASHBOARD_UNIT_HR", "hr") : t("DASHBOARD_UNIT_HRS", "hrs")}`;
+      }
+      const days = n / MS_PER_DAY;
+      const rounded = Math.round(days * 10) / 10;
+      const number = formatNumber(rounded, { decimals: 1, trim: true }) ?? (Number.isInteger(rounded) ? rounded : rounded.toFixed(1));
+      return `${number} ${rounded === 1 ? t("DASHBOARD_UNIT_DAY", "day") : t("DASHBOARD_UNIT_DAYS", "days")}`;
+    }
+    case 'hoursDecimal':      return `${formatNumber(n / MS_PER_HOUR, 'hoursDecimal') ?? (n / MS_PER_HOUR).toFixed(1)}h`;
+    case 'signedInteger':     return `${n >= 0 ? '+' : ''}${formatNumber(n, 'signedInteger') ?? Math.round(n).toLocaleString(locale)}`;
+    case 'ordinal': {
+      const value = Math.round(n) % 100;
+      const suffix = ['th', 'st', 'nd', 'rd'];
+      return (formatNumber(n, 'integer') ?? Math.round(n)) + (suffix[(value - 20) % 10] || suffix[value] || suffix[0]);
+    }
+    default: return String(val);
+  }
+}
+
+export function isPercentFormat(format) {
+  return (
+    format === 'percent' ||
+    format === 'percentInteger' ||
+    format === 'percentNoDecimal' ||
+    format === 'percentOneDecimal'
+  );
+}
+
+export function normalizePct(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return 0;
+  return number <= 1 ? number * 100 : number;
+}
+
+export function percentToChartScale(value, isPercent) {
+  return isPercent ? normalizePct(value) : value;
+}
+
+export function msToHours(ms) {
+  const hours = Number(ms) / MS_PER_HOUR;
+  if (!Number.isFinite(hours) || hours <= 0) return 0;
+  return Math.round(hours * 10) / 10;
+}
+
+export function formatLabel(value) {
+  const string = String(value ?? '');
+  if (!string || string === 'null' || string === 'undefined') return t("DASHBOARD_COMMON_UNKNOWN", "Unknown");
+  return string;
+}
+
+export function formatDimLabel(value, viz, dim, locale) {
+  switch (viz?.labelFormat) {
+    case 'dimension': {
+      const kind = dimensionKindForName(dim);
+      return kind ? dimensionLabel(value, kind) : String(value);
+    }
+    case 'department': return dimensionLabel(value, 'department');
+    case 'officer':    return formatOfficerLabel(value);
+    case 'date-dow':   return formatDateDow(value, locale);
+    default:           return formatLabel(value);
+  }
+}
+
+export function formatDateDow(value, locale) {
+  const key = epochOrIsoToDateKey(value);
+  if (!key) return formatLabel(value);
+  const date = new Date(`${key}T12:00:00`);
+  if (Number.isNaN(date.getTime())) return key;
+  return date.toLocaleDateString(locale, { weekday: 'short' });
+}
+
+export function epochOrIsoToDateKey(value) {
+  if (value == null || value === '') return '';
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return new Date(value).toISOString().slice(0, 10);
+  }
+  const string = String(value).trim();
+  if (/^\d{13}$/.test(string)) return new Date(Number(string)).toISOString().slice(0, 10);
+  const iso = string.match(/^(\d{4}-\d{2}-\d{2})/);
+  return iso ? iso[1] : string;
+}
+
+export function normalizeSeg(value) {
+  return String(value ?? '').toUpperCase();
+}
+
+export function errorLabel(code) {
+  switch (code) {
+    case 'pii_forbidden': return t("DASHBOARD_TILE_ERR_RESTRICTED", "Restricted");
+    case 'kpi_forbidden': return t("DASHBOARD_TILE_ERR_NO_ACCESS", "No access");
+    case 'scope_forbidden': return t("DASHBOARD_TILE_ERR_OUT_OF_SCOPE", "Out of scope");
+    default: return code || t("DASHBOARD_TILE_ERR_GENERIC", "ERROR");
+  }
+}
+
+export function defScrollKey(ctx) {
+  return ctx.def?.kpiId || ctx.def?.id || undefined;
+}

--- a/digit-ui-esbuild/products/dashboard/src/utils/tileResultAdapters.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/tileResultAdapters.test.js
@@ -1,0 +1,318 @@
+// Characterizes the legacy KpiTile result adapters after their behavior-neutral extraction.
+// Run from digit-ui-esbuild/:
+//   node --test products/dashboard/src/utils/tileResultAdapters.test.js
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const esbuild = require("esbuild");
+
+function bundle(entry) {
+  const out = path.join(os.tmpdir(), `${path.basename(entry, ".js")}.cjs.${process.pid}.js`);
+  esbuild.buildSync({
+    entryPoints: [path.join(__dirname, entry)],
+    bundle: true,
+    format: "cjs",
+    platform: "neutral",
+    outfile: out,
+  });
+  process.on("exit", () => {
+    try {
+      fs.unlinkSync(out);
+    } catch (error) {
+      /* already gone */
+    }
+  });
+  return require(out);
+}
+
+const adapters = bundle("tileResultAdapters.js");
+
+test("column inference preserves typed-column precedence and viz fallbacks", () => {
+  const typed = {
+    columns: [
+      { name: "ward_code", role: "dimension" },
+      { name: "total", role: "measure", format: "integer" },
+    ],
+  };
+  const conflictingViz = { dimensionKey: "service_code", measureKey: "count" };
+  assert.equal(adapters.primaryDimensionKey(typed, conflictingViz), "ward_code");
+  assert.equal(adapters.primaryMeasure(typed, conflictingViz).name, "total");
+
+  // The current backend emits string columns, so the renderer deliberately
+  // falls back to the catalog descriptor instead of inferring roles.
+  const strings = { columns: ["ward_code", "total"] };
+  assert.equal(adapters.primaryDimensionKey(strings, conflictingViz), "service_code");
+  assert.equal(adapters.primaryMeasure(strings, conflictingViz).name, "count");
+});
+
+test("scalar, prior, percent normalization, delta modes, and threshold boundaries stay exact", () => {
+  assert.equal(
+    adapters.resolveScalar({
+      viz: { valueKey: "total" },
+      result: { value: 9, values: { total: 8 }, rows: [{ total: 7 }] },
+    }),
+    9
+  );
+  assert.equal(
+    adapters.resolveScalar({ viz: { valueKey: "total" }, result: { rows: [{ total: "7" }] } }),
+    7
+  );
+  assert.equal(
+    adapters.resolveScalar({
+      viz: {
+        valueKey: "total",
+        compose: { type: "netBacklogDaily", sourceKpiIds: ["in", "out"] },
+      },
+      result: { value: 99 },
+      results: { in: { rows: [{ total: 12 }] }, out: { rows: [{ total: 5 }] } },
+    }),
+    7,
+    "the legacy FE compose result still precedes the pre-shaped scalar"
+  );
+  assert.equal(
+    adapters.resolvePrior({ viz: { priorKey: "previous" }, result: { values: { previous: "4" } } }),
+    4
+  );
+  assert.equal(adapters.normalizePct(0.75), 75);
+  assert.equal(adapters.normalizePct(1), 100);
+  assert.equal(adapters.normalizePct(1.01), 1.01);
+  assert.equal(adapters.computeDelta(0.8, 0.7, "percentOneDecimal"), 10);
+  assert.equal(adapters.computeDelta(120, 100, "integer"), 20);
+  assert.equal(adapters.computeDelta(120, 0, "integer"), null);
+  assert.equal(adapters.computeDelta(172800000, 86400000, "hoursDays", "days"), 1);
+  assert.equal(adapters.formatDeltaDisplay(1, "hoursDays", "days"), "▲ 1 day");
+
+  const highGood = { kind: "percent", higherIsBetter: true, onTrack: 85, breaching: 60 };
+  assert.equal(adapters.thresholdStatus(highGood, 0.85), "on_track");
+  assert.equal(adapters.thresholdStatus(highGood, 0.6), "breaching");
+  assert.equal(adapters.thresholdStatus(highGood, 0.7), "normal");
+  assert.equal(adapters.resolveTileStatus({ accent: "amber" }, 5), "amber");
+});
+
+test("sparkline, bar, histogram, ranked-list, and DOW adapters preserve ordering rules", () => {
+  assert.deepEqual(
+    adapters.resolveSparkline({
+      viz: { dateKey: "created_date", sparklineMeasureKey: "total" },
+      result: {
+        rows: [
+          { created_date: "2026-01-02", total: "2" },
+          { created_date: "2026-01-01", total: "1" },
+        ],
+      },
+    }),
+    [1, 2]
+  );
+
+  const barResult = {
+    columns: [
+      { name: "bucket", role: "dimension" },
+      { name: "pct", role: "measure" },
+    ],
+    rows: [
+      { bucket: "low", pct: 0.1 },
+      { bucket: "high", pct: 0.8 },
+      { bucket: "mid", pct: 0.4 },
+    ],
+  };
+  assert.deepEqual(
+    adapters.adaptBarRows({ viz: { kind: "bar", format: "percent" }, result: barResult }),
+    [
+      { label: "high", count: 80 },
+      { label: "mid", count: 40 },
+      { label: "low", count: 10 },
+    ]
+  );
+  assert.deepEqual(
+    adapters.adaptBarRows({
+      viz: { kind: "histogram", categoryOrder: ["low", "mid", "high"] },
+      result: barResult,
+    }).map((row) => row.label),
+    ["low", "mid", "high"]
+  );
+
+  const simple = {
+    columns: [
+      { name: "label", role: "dimension" },
+      { name: "total", role: "measure", format: "integer" },
+    ],
+    rows: [{ label: "B", total: 2 }, { label: "A", total: 5 }],
+  };
+  assert.deepEqual(adapters.adaptRanked({ viz: { limit: 1 }, result: simple }).rows, [
+    { label: "A", value: 5 },
+  ]);
+  assert.deepEqual(
+    adapters.adaptDow({ viz: {}, result: { ...simple, rows: [{ label: "2", total: "3" }] } }).rows,
+    [{ dow: 2, value: 3 }]
+  );
+});
+
+test("horizontal-bar adapter preserves grouped ratio math, filtering, ascending sort, and limit", () => {
+  const result = {
+    rows: [
+      { department_code: "A", filed: 5, resolved: 2 },
+      { department_code: "A", filed: 5, resolved: 3 },
+      { department_code: "B", filed: 4, resolved: 1 },
+      { department_code: "C", filed: 0, resolved: 2 },
+    ],
+  };
+  const rows = adapters.adaptHorizontalRows({
+    viz: {
+      dimensionKey: "department_code",
+      measureKey: "resolved",
+      numeratorKey: "resolved",
+      denominatorKey: "filed",
+      limit: 2,
+    },
+    result,
+  });
+  assert.deepEqual(rows, [
+    { label: "B", value: 0.25, resolved: 1, created: 4 },
+    { label: "A", value: 0.5, resolved: 5, created: 10 },
+  ]);
+});
+
+test("stacked and line adapters preserve BE-shaped passthrough and long-form pivots", () => {
+  const passthrough = {
+    categories: ["A"],
+    series: [{ name: "Total", data: [3] }],
+    colors: ["red"],
+  };
+  assert.deepEqual(
+    adapters.adaptStacked({ viz: {}, result: passthrough }),
+    passthrough
+  );
+
+  const pivoted = adapters.adaptStacked({
+    viz: {
+      dimensionKey: "service_code",
+      stackKey: "application_status",
+      measureKey: "total",
+      stackSeries: [
+        { key: "OPEN", label: "Open", color: "orange" },
+        { key: "CLOSED", label: "Closed", color: "green" },
+      ],
+    },
+    result: {
+      rows: [
+        { service_code: "A", application_status: "open", total: 2 },
+        { service_code: "A", application_status: "closed", total: 3 },
+        { service_code: "B", application_status: "open", total: 6 },
+      ],
+    },
+  });
+  assert.deepEqual(pivoted.categories, ["B", "A"]);
+  assert.deepEqual(pivoted.series.map((series) => series.data), [[6, 2], [0, 3]]);
+
+  const linePassthrough = { categories: ["d1"], series: [{ name: "Filed", data: [4] }] };
+  assert.deepEqual(adapters.adaptLine({ viz: {}, result: linePassthrough }), linePassthrough);
+  const computedLine = adapters.adaptLine({
+    viz: {
+      dimensionKey: "date",
+      seriesDefs: [{ name: "Rate", numeratorKey: "resolved", denominatorKey: "filed" }],
+    },
+    result: { rows: [{ date: "2026-01-02", filed: 4, resolved: 3 }] },
+  });
+  assert.deepEqual(computedLine.series[0].data, [75]);
+});
+
+test("pie channel rollup preserves source taxonomy, colors, zero filtering, and order", () => {
+  const data = adapters.adaptPie({
+    viz: {
+      dimensionKey: "source",
+      measureKey: "total",
+      channelMap: [
+        { id: "web", label: "Web", color: "blue", sources: ["web", "online-portal"] },
+        { id: "phone", label: "Phone", color: "green", sources: ["phone"] },
+        { id: "other", label: "Other", color: "gray", sources: [] },
+      ],
+    },
+    result: {
+      rows: [
+        { source: "ONLINE_PORTAL", total: 3 },
+        { source: "web", total: 2 },
+        { source: "walk_in", total: 4 },
+        { source: "phone", total: 0 },
+      ],
+    },
+  });
+  assert.deepEqual(data, [
+    { label: "Web", count: 5, color: "blue" },
+    { label: "Other", count: 4, color: "gray" },
+  ]);
+});
+
+test("table, SLA-risk, and map adapters preserve their current domain row contracts", () => {
+  assert.deepEqual(
+    adapters.deriveColumnsFromResult({
+      columns: [
+        { name: "service_code", role: "dimension", label: "Subtype" },
+        { name: "pct", role: "measure", format: "percentOneDecimal" },
+      ],
+    }),
+    [
+      { id: "service_code", label: "Subtype", labelKey: undefined, align: "left", type: "text", thresholdKey: undefined },
+      { id: "pct", label: "pct", labelKey: undefined, align: "right", type: "percent", thresholdKey: undefined },
+    ]
+  );
+
+  const riskRows = adapters.adaptSlaRiskRows({
+    viz: { limit: 1 },
+    result: {
+      rows: [
+        {
+          service_request_id: "CR-1",
+          service_code: "road",
+          service_group: "works",
+          ward_code: "W1",
+          application_status: "PENDINGATLME",
+          sla_status_bucket: "breached",
+          current_assignee_uuid: null,
+          open_age_ms: 10800000,
+          sla_target_ms: 3600000,
+        },
+        { service_request_id: "", sla_status_bucket: "breached" },
+      ],
+    },
+  });
+  assert.equal(riskRows.length, 1);
+  assert.equal(riskRows[0].id, "CR-1");
+  assert.equal(riskRows[0].status, "assigned");
+  assert.equal(riskRows[0].slaLevel, "breached");
+  assert.equal(riskRows[0].breachDurationMs, 7200000);
+
+  const layers = adapters.adaptMapLayers({
+    viz: { dimensionKey: "ward_code" },
+    result: {
+      rows: [
+        { ward_code: "W1", filed: 10, open: 4, resolved: 5 },
+        { ward_code: null, filed: 2, open: 1, resolved: 1 },
+      ],
+      pinsStatusKnown: true,
+      pinsTruncated: true,
+      pins: [
+        { id: "o", isOpen: true, isResolved: false },
+        { id: "r", isOpen: false, isResolved: true },
+      ],
+    },
+  });
+  assert.equal(layers.pinSemantics, "per-layer");
+  assert.equal(layers.pinsTruncated, true);
+  assert.deepEqual(layers.open.map((row) => row.wardCode), ["W1"]);
+  assert.deepEqual(layers.layerTotals, { filed: 10, open: 4, resolved: 5 });
+  assert.deepEqual(layers.unmapped, { filed: 2, open: 1, resolved: 1 });
+  assert.deepEqual(layers.complaintPinsByLayer.open.map((pin) => pin.id), ["o"]);
+  assert.deepEqual(layers.complaintPinsByLayer.resolved.map((pin) => pin.id), ["r"]);
+});
+
+test("format and ABAC error-label boundaries remain stable", () => {
+  assert.equal(adapters.applyFormat(null, "integer", "en-US"), "—");
+  assert.equal(adapters.applyFormat(0.425, "percentOneDecimal", "en-US"), "42.5%");
+  assert.equal(adapters.applyFormat(3600000, "hoursDecimal", "en-US"), "1.0h");
+  assert.equal(adapters.errorLabel("pii_forbidden"), "Restricted");
+  assert.equal(adapters.errorLabel("kpi_forbidden"), "No access");
+  assert.equal(adapters.errorLabel("scope_forbidden"), "Out of scope");
+  assert.equal(adapters.errorLabel("query_failed"), "query_failed");
+});

--- a/local-setup/db/dss-mdms-seed/README.md
+++ b/local-setup/db/dss-mdms-seed/README.md
@@ -47,7 +47,7 @@ script detects the shape in preflight and `--repair` deactivates it.
 
 ## l10n/
 
-`<locale>.json` — the `rainmaker-dashboard` message pack for that locale, 318
+`<locale>.json` — the `rainmaker-dashboard` message pack for that locale, 335
 codes each, 1:1 across locales. 65 codes carry the `CMS-DASHBOARD.` prefix and
 are referenced by the catalog's `titleKey`/`subtitleKey`/`labelKeys`; the rest
 are dashboard chrome. The prefix is part of the **code**, not a module name —

--- a/local-setup/db/dss-mdms-seed/l10n/en_IN.json
+++ b/local-setup/db/dss-mdms-seed/l10n/en_IN.json
@@ -300,8 +300,28 @@
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "DASHBOARD_FILTERS_ACTIVE",
+    "message": "Active filters",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_ALL_DEPARTMENTS",
+    "message": "All departments",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "DASHBOARD_FILTERS_ALL_TYPES",
     "message": "All types",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_APPLY",
+    "message": "Apply",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_CANCEL",
+    "message": "Cancel",
     "module": "rainmaker-dashboard"
   },
   {
@@ -325,6 +345,26 @@
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "DASHBOARD_FILTERS_COMPLAINT_TYPES",
+    "message": "Complaint types",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_DEPARTMENT",
+    "message": "Department",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_DEPARTMENT_FILTER",
+    "message": "Department filter",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_DEPARTMENTS",
+    "message": "Departments",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "DASHBOARD_FILTERS_FROM",
     "message": "From",
     "module": "rainmaker-dashboard"
@@ -337,6 +377,21 @@
   {
     "code": "DASHBOARD_FILTERS_GEOGRAPHY",
     "message": "Geography",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_NO_MATCHES",
+    "message": "No matching options",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_REMOVE",
+    "message": "Remove",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_SEARCH_WARDS",
+    "message": "Search wards",
     "module": "rainmaker-dashboard"
   },
   {
@@ -357,6 +412,16 @@
   {
     "code": "DASHBOARD_FILTERS_WARD_FILTER",
     "message": "Ward filter",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_WARDS",
+    "message": "Wards",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_GEO_FILTER_ALL_IN",
+    "message": "All in",
     "module": "rainmaker-dashboard"
   },
   {
@@ -1211,11 +1276,6 @@
   },
   {
     "code": "DASHBOARD_TYPE_FILTER_ALL_IN",
-    "message": "All in",
-    "module": "rainmaker-dashboard"
-  },
-  {
-    "code": "DASHBOARD_GEO_FILTER_ALL_IN",
     "message": "All in",
     "module": "rainmaker-dashboard"
   },

--- a/local-setup/db/dss-mdms-seed/l10n/en_IN.json
+++ b/local-setup/db/dss-mdms-seed/l10n/en_IN.json
@@ -1215,6 +1215,11 @@
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "DASHBOARD_GEO_FILTER_ALL_IN",
+    "message": "All in",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "DASHBOARD_TYPE_FILTER_NOT_APPLIED",
     "message": "Type filter not applied",
     "module": "rainmaker-dashboard"

--- a/local-setup/db/dss-mdms-seed/l10n/pt_PT.json
+++ b/local-setup/db/dss-mdms-seed/l10n/pt_PT.json
@@ -1215,6 +1215,11 @@
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "DASHBOARD_GEO_FILTER_ALL_IN",
+    "message": "Tudo em",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "DASHBOARD_TYPE_FILTER_NOT_APPLIED",
     "message": "Filtro de tipo não aplicado",
     "module": "rainmaker-dashboard"

--- a/local-setup/db/dss-mdms-seed/l10n/pt_PT.json
+++ b/local-setup/db/dss-mdms-seed/l10n/pt_PT.json
@@ -300,8 +300,28 @@
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "DASHBOARD_FILTERS_ACTIVE",
+    "message": "Filtros ativos",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_ALL_DEPARTMENTS",
+    "message": "Todos os departamentos",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "DASHBOARD_FILTERS_ALL_TYPES",
     "message": "Todos os tipos",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_APPLY",
+    "message": "Aplicar",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_CANCEL",
+    "message": "Cancelar",
     "module": "rainmaker-dashboard"
   },
   {
@@ -325,6 +345,26 @@
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "DASHBOARD_FILTERS_COMPLAINT_TYPES",
+    "message": "Tipos de reclamação",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_DEPARTMENT",
+    "message": "Departamento",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_DEPARTMENT_FILTER",
+    "message": "Filtro de departamento",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_DEPARTMENTS",
+    "message": "Departamentos",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "DASHBOARD_FILTERS_FROM",
     "message": "De",
     "module": "rainmaker-dashboard"
@@ -337,6 +377,21 @@
   {
     "code": "DASHBOARD_FILTERS_GEOGRAPHY",
     "message": "Geografia",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_NO_MATCHES",
+    "message": "Nenhuma opção correspondente",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_REMOVE",
+    "message": "Remover",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_SEARCH_WARDS",
+    "message": "Pesquisar bairros",
     "module": "rainmaker-dashboard"
   },
   {
@@ -357,6 +412,16 @@
   {
     "code": "DASHBOARD_FILTERS_WARD_FILTER",
     "message": "Filtro de bairro",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_FILTERS_WARDS",
+    "message": "Bairros",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_GEO_FILTER_ALL_IN",
+    "message": "Tudo em",
     "module": "rainmaker-dashboard"
   },
   {
@@ -1211,11 +1276,6 @@
   },
   {
     "code": "DASHBOARD_TYPE_FILTER_ALL_IN",
-    "message": "Tudo em",
-    "module": "rainmaker-dashboard"
-  },
-  {
-    "code": "DASHBOARD_GEO_FILTER_ALL_IN",
     "message": "Tudo em",
     "module": "rainmaker-dashboard"
   },


### PR DESCRIPTION
## Summary

Implements the dashboard filter enhancements tracked in #1455 and absorbs the behavior-neutral KPI rendering cleanup from #1725 / fork issue #29:

- multi-select Wards and Complaint Types, plus the requested P1 Department filter
- removable active-filter chips, per-option unselect, counts, and existing Clear-all behavior
- type-to-search for Wards, including hierarchy results
- staged Apply/Cancel so each checkbox does not refetch the full KPI batch
- v4 scalar-filter migration to the v5 multi-select storage contract
- English and Portuguese localization seed updates
- extracts KPI result-to-view adapters from `KpiTile.jsx` into a tested seam, reducing the component by roughly 730 lines without changing its rendered UI or wire contract

Same-axis selections use OR semantics through bounded `IN` parameters; different axes remain ANDed. Hierarchy selections expand to exact codes from the distinct option set already constrained by the analytics service's server-derived principal scope. Explicit Department choices are additionally intersected with that server-resolved department scope, so client filters cannot widen access.

## Dependency and cleanup stack included

`develop` does not yet contain the geography dependency that is already merged on the Mozambique release line, so this branch intentionally cherry-picks and builds on:

- #1762 — analytics `boundaryPath` support (`e25bb814d` after cherry-pick)
- #1763 — geography hierarchy drill-down (`23e3a080c` after cherry-pick)
- #1725 — behavior-neutral KPI result-adapter extraction (`37e0759e8` after cherry-pick), retained from the cleanup batch tracked in fork issue #29

The #1725 adapter implementation and characterization tests are preserved byte-for-byte. On the `develop` base, the component deliberately retains `develop`'s existing direct table-row contract rather than importing an unrelated newer-`master` comparison-table feature.

## ABAC contract compatibility

- The complete four-commit stack has been replayed cleanly onto current `master` at `80a9ee213` (the merge of #1441) on integration branch `integration/1793-abac-master-20260818`, now at `041c93008`.
- #1441 protects PGR request search/count and Configurator masters; it does **not** yet wire its access-policy engine into `/v2/analytics`.
- Dashboard analytics still relies on its existing server-side `PrincipalScopeResolver` contract. This PR preserves and narrows that scope; it does not claim to complete dashboard analytics ABAC. That separate integration remains tracked by #1050.
- Do not resolve the `master`/`develop` drift by merging all of `master` into this feature branch. Land the normal release-line sync, then replay/rebase this four-commit stack.

## Scope boundary

The legacy `/dashboard` path is explicitly outside this effort. This PR changes the current employee dashboard at `/digit-ui/employee/dashboard` only.

## Required before this is complete

### Development and review

- Let all required CI checks finish and address any failures attributable to this branch.
- Review the four-commit stack together: the first two commits deliberately bring #1762/#1763 onto `develop`; the third implements #1455; the fourth isolates the existing result-to-view compatibility seam without changing presentation.
- Obtain the required approvals and merge the whole stack. Do not merge only the frontend feature commit because multi-value requests require the backend plural-parameter contract.

### Deployment

- Deploy the updated `pgr-services` backend before, or in the same release as, the updated dashboard frontend.
- Deploy #1441 and complete its action-2008 access-control policy/strict-mode rollout before treating PGR search/count ABAC QA as conclusive.
- Treat dashboard analytics authorization as the existing `PrincipalScopeResolver` behavior until #1050 connects `/v2/analytics` to the access-policy contract.
- Seed or refresh the `rainmaker-dashboard` localization pack so the new filter labels do not render as raw keys.

### QA on `/digit-ui/employee/dashboard`

- Confirm multiple Wards and Complaint Types use OR semantics within each filter and AND semantics across filter categories.
- Confirm Department selections narrow results and never expose departments, wards, complaint types, or rows outside the signed-in user's server-resolved analytics scope.
- Confirm hierarchy parent selections cover only their visible scoped descendants across cards, charts, tables, maps, daily series, and comparison queries.
- Confirm Ward type-to-search, checkbox unselect, removable chips, staged Apply/Cancel, counts, and Clear-all behavior.
- Confirm persisted v4 scalar selections migrate safely and reload correctly under the v5 contract.
- Smoke test both English and Portuguese labels and responsive filter-bar layout.
- Regression-check that existing single-value filtering still sends the legacy scalar wire shape and returns unchanged results.
- Regression-check the existing card, sparkline, chart, ranked-list, table, SLA-risk, and map presentation after the adapter extraction; the visual appearance is intended to remain unchanged.
- Independently regression-test #1441's PGR request search/count and Configurator-master enforcement; those endpoints are not the dashboard analytics endpoint.

After development, merge, and deployment are complete, move #1455 to **To Review** for QA. Only QA should move it to **Done** or close it unless explicitly directed otherwise.

## Validation completed

On the PR branch:

- `mvn -q -Dtest=KpiQueryComposerMultiValueFilterTest,KpiQueryComposerBoundaryPathTest,KpiQueryComposerComplaintPathTest test`
- full dashboard Node suite after absorbing #1725: 260/260 passed, including the 8 adapter characterization tests
- production `npm run build`: passed (only the repository's pre-existing duplicate-key/direct-eval warnings)
- focused esbuild bundle check for `DashboardFilters`, `DashboardHeader`, and `useFilterOptions`
- `node local-setup/db/dss-mdms-seed/export-l10n.mjs --check`
- `git diff --check`

On the clean replay over current ABAC-enabled `master` (`80a9ee213`), including the adapter cleanup:

- full dashboard Node suite: 276/276 passed
- production `npm run build`: passed (only the repository's pre-existing duplicate-key/direct-eval warnings)
- 8c strict-mode validation before the behavior-neutral adapter extraction: PGR `_search` and `_count` returned 200 under the merged action-2008 ABAC contract; the exact production bundle exposed enabled Ward, Complaint Type, and Department staged filters; a real Ward selection applied successfully; live analytics probes accepted singular, plural, and combined Ward/Complaint Type/Department parameters with 200 responses.
- 8c seed limitation: tenant `ke` currently has one boundary option and zero dashboard catalog tiles. Plural UI request construction is therefore covered by the dashboard suite, while the live backend plural contract was tested directly against the populated `pg` analytics catalog.

Refs #1455, #1725
