### PR TITLE
Fix deployed Novu workflow creation and routing (#1517)

### DIFF
--- a/backend/novu-bridge/config/.env.novu
+++ b/backend/novu-bridge/config/.env.novu
@@ -16,7 +16,7 @@ NOVU_INTEGRATION_NAME=twilio-whatsapp
 NOVU_INTEGRATION_ID=twilio-whatsapp
 NOVU_WORKFLOW_ID=complaints-whatsapp
 NOVU_WORKFLOW_NAME=ComplaintsWhatsAppWorkflow
-NOVU_SMS_BODY=Complaint {{payload.complaintNo}} status is {{payload.status}}.
+NOVU_SMS_BODY='Complaint {{payload.complaintNo}} status is {{payload.status}}'
 
 # Event workflows to create/check
 NOVU_EVENT_WORKFLOWS=COMPLAINTS.WORKFLOW.APPLY,COMPLAINTS.WORKFLOW.ASSIGN,COMPLAINTS.WORKFLOW.REASSIGN,COMPLAINTS.WORKFLOW.REJECT,COMPLAINTS.WORKFLOW.RESOLVE,COMPLAINTS.WORKFLOW.REOPEN,COMPLAINTS.WORKFLOW.RATE

--- a/backend/novu-bridge/config/bootstrap-novu-whatsapp.sh
+++ b/backend/novu-bridge/config/bootstrap-novu-whatsapp.sh
@@ -51,24 +51,16 @@ require_cmd curl
 require_cmd jq
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=load-dotenv.sh
+source "${SCRIPT_DIR}/load-dotenv.sh"
+
 NOVU_ENV_FILE="${NOVU_ENV_FILE:-${SCRIPT_DIR}/.env.novu}"
 if [[ -f "$NOVU_ENV_FILE" ]]; then
-  # EXPLICIT ENV WINS. The tracked .env.novu holds DUMMY values, so it must only
-  # FILL variables the caller did NOT already provide — never override them.
-  # Snapshot the vars we care about (name + whether set), source the file, then
-  # restore any that were already set so the dummy values can't clobber them.
-  _PRESET_VARS=(NOVU_BASE_URL NOVU_API_KEY TWILIO_ACCOUNT_SID TWILIO_AUTH_TOKEN \
-    TWILIO_WHATSAPP_FROM NOVU_ENV_NAME NOVU_ENV_COLOR NOVU_INTEGRATION_NAME \
-    NOVU_INTEGRATION_ID NOVU_WORKFLOW_ID NOVU_WORKFLOW_NAME NOVU_SMS_BODY \
-    NOVU_EVENT_WORKFLOWS NOVU_SMS_WORKFLOW_ID NOVU_EMAIL_WORKFLOW_ID)
-  declare -A _PRESET_SNAP=()
-  for _v in "${_PRESET_VARS[@]}"; do
-    [[ -n "${!_v+x}" ]] && _PRESET_SNAP[$_v]="${!_v}"
-  done
-  # shellcheck disable=SC1090
-  set -a && source "$NOVU_ENV_FILE" && set +a
-  for _v in "${!_PRESET_SNAP[@]}"; do printf -v "$_v" '%s' "${_PRESET_SNAP[$_v]}"; export "$_v"; done
-  unset _PRESET_VARS _PRESET_SNAP _v
+  # EXPLICIT ENV WINS. The tracked .env.novu holds DUMMY values, so it only
+  # fills variables the caller did not provide. Parse it as dotenv rather than
+  # shell: unquoted message bodies with spaces are valid dotenv and must not be
+  # executed as commands (issue #1517).
+  load_dotenv_defaults "$NOVU_ENV_FILE"
   echo "Loaded environment from: $NOVU_ENV_FILE (explicit env preserved)"
 fi
 

--- a/backend/novu-bridge/config/load-dotenv.sh
+++ b/backend/novu-bridge/config/load-dotenv.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# Load KEY=VALUE records without evaluating the file as shell code.
+#
+# Docker/Compose dotenv files allow unquoted values containing spaces, while
+# `source file.env` parses the words after the first space as a command. That
+# made a perfectly valid value such as
+#
+#   NOVU_SMS_BODY=Complaint {{payload.complaintNo}} status is {{payload.status}}
+#
+# abort the Novu bootstrap before it reached the API. This parser intentionally
+# implements only the dotenv surface this bootstrap needs: comments, an
+# optional `export`, quoted or unquoted values, and "caller environment wins".
+# It does not eval command substitutions or expand shell expressions.
+load_dotenv_defaults() {
+  local env_file="$1"
+  local line key value first last
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line%$'\r'}"
+    line="${line#"${line%%[![:space:]]*}"}"
+    [[ -z "$line" || "${line:0:1}" == "#" ]] && continue
+
+    if [[ "$line" == export[[:space:]]* ]]; then
+      line="${line#export}"
+      line="${line#"${line%%[![:space:]]*}"}"
+    fi
+
+    if [[ "$line" != *=* ]]; then
+      echo "Invalid dotenv entry in ${env_file}: ${line}" >&2
+      return 1
+    fi
+
+    key="${line%%=*}"
+    value="${line#*=}"
+    key="${key#"${key%%[![:space:]]*}"}"
+    key="${key%"${key##*[![:space:]]}"}"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+
+    if [[ ! "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+      echo "Invalid dotenv key in ${env_file}: ${key}" >&2
+      return 1
+    fi
+
+    # Values already present in the caller's environment always win over the
+    # tracked defaults (which intentionally contain non-secret placeholders).
+    [[ -n "${!key+x}" ]] && continue
+
+    if [[ ${#value} -ge 2 ]]; then
+      first="${value:0:1}"
+      last="${value:${#value}-1:1}"
+      if [[ ( "$first" == "'" && "$last" == "'" ) ||
+            ( "$first" == '"' && "$last" == '"' ) ]]; then
+        value="${value:1:${#value}-2}"
+      fi
+    fi
+
+    printf -v "$key" '%s' "$value"
+    export "$key"
+  done < "$env_file"
+}

--- a/devops/deploy-as-code/charts/backbone-services/backboneservices-helmfile.yaml
+++ b/devops/deploy-as-code/charts/backbone-services/backboneservices-helmfile.yaml
@@ -348,6 +348,9 @@ releases:
         annotations:
           cert-manager.io/cluster-issuer: {{ index .Values "root-ingress" "cert-issuer" | quote }}
         host: {{ .Values.global.domain | quote }}
+        # Browser code cannot resolve Kubernetes service DNS. Keep the API,
+        # dashboard and Socket.IO URLs on this deployment's public TLS origin.
+        publicOrigin: {{ printf "https://%s" .Values.global.domain | quote }}
         tls:
           - secretName: {{ printf "%s-tls-certs" .Values.global.domain | quote }}
             hosts:

--- a/devops/deploy-as-code/charts/backbone-services/novu/templates/ingress.yaml
+++ b/devops/deploy-as-code/charts/backbone-services/novu/templates/ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ .Values.ingress.name }}
+  name: {{ .Values.ingress.name }}-dashboard
   namespace: {{ include "novu.namespace" . }}
   {{- with .Values.ingress.annotations }}
   annotations:
@@ -33,4 +33,104 @@ spec:
                 name: {{ .Values.ingress.service.name }}
                 port:
                   number: {{ .Values.ingress.service.port }}
+---
+# Novu's stock dashboard is built with Vite base=/ and navigates to absolute
+# client routes such as /env/<slug>/workflows/create. Route those SPA paths and
+# root-built assets to the dashboard without rewriting them. Without /env, the
+# workflows list can render but Create workflow falls through to the platform
+# gateway on a hard navigation/refresh.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.ingress.name }}-dashboard-root-routes
+  namespace: {{ include "novu.namespace" . }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          {{- range list "/env" "/auth/sign-in" "/auth/sign-up" "/auth/organization-list" "/local-studio" "/onboarding" "/settings" "/integrations" "/partner-integrations" "/assets" "/images" "/static" "/manifest.json" "/favicon-gradient.svg" "/favicon.ico" }}
+          - path: {{ . | quote }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $.Values.ingress.service.name }}
+                port:
+                  number: {{ $.Values.ingress.service.port }}
+          {{- end }}
+          # Novu 2.3.0's dashboard initializes socket.io-client with the public
+          # origin. Socket.IO then uses its default /socket.io transport path;
+          # a path embedded in VITE_WEBSOCKET_HOSTNAME is not retained.
+          - path: "/socket.io"
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Values.ingress.ws.service.name }}
+                port:
+                  number: {{ .Values.ingress.ws.service.port }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.ingress.name }}-api
+  namespace: {{ include "novu.namespace" . }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+{{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.api.path | quote }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ .Values.ingress.api.service.name }}
+                port:
+                  number: {{ .Values.ingress.api.service.port }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.ingress.name }}-ws
+  namespace: {{ include "novu.namespace" . }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+{{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.ws.path | quote }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ .Values.ingress.ws.service.name }}
+                port:
+                  number: {{ .Values.ingress.ws.service.port }}
 {{- end }}

--- a/devops/deploy-as-code/charts/backbone-services/novu/values.yaml
+++ b/devops/deploy-as-code/charts/backbone-services/novu/values.yaml
@@ -14,6 +14,9 @@ ingress:
   # DIFFERENT environment, inherited from the upstream import — so the
   # dashboard did not serve on the deployment's own domain at all.
   host: "domain.com"
+  # Browser-facing origin. Unlike Kubernetes service names, this must resolve
+  # from the operator's browser. The helmfile overrides this alongside host.
+  publicOrigin: "https://domain.com"
   path: "/novu(/|$)(.*)"
   # Populated per deployment by the helmfile, same secret every other ingress
   # in this tree uses.
@@ -22,6 +25,16 @@ ingress:
   service:
     name: "novu-dashboard"
     port: 4000
+  api:
+    path: "/novu-api(/|$)(.*)"
+    service:
+      name: "novu-api"
+      port: 3000
+  ws:
+    path: "/novu-ws(/|$)(.*)"
+    service:
+      name: "novu-ws"
+      port: 3002
 
 # Global defaults from Novu community .env example
 # Adjust these for your environment.
@@ -171,11 +184,11 @@ api:
     - name: NODE_ENV
       value: {{ .Values.global.nodeEnv | quote }}
     - name: API_ROOT_URL
-      value: {{ printf "%s:%d" .Values.global.hostName (int .Values.api.port) | quote }}
+      value: {{ printf "%s/novu-api" .Values.ingress.publicOrigin | quote }}
     - name: PORT
       value: {{ .Values.api.port | quote }}
     - name: FRONT_BASE_URL
-      value: {{ printf "%s:%d" .Values.global.hostName (int .Values.dashboard.port) | quote }}
+      value: {{ printf "%s/novu" .Values.ingress.publicOrigin | quote }}
     - name: MONGO_URL
       value: {{ printf "mongodb://%s:%s@%s:%d/novu-db?authSource=admin" .Values.mongodb.auth.username .Values.mongodb.auth.password .Values.mongodb.name (int .Values.mongodb.port) | quote }}
     - name: MONGO_MIN_POOL_SIZE
@@ -413,11 +426,13 @@ dashboard:
     port: 4000
   env: |
     - name: VITE_API_HOSTNAME
-      value: {{ printf "http://%s:%d" .Values.api.name (int .Values.api.port) | quote }}
+      value: {{ printf "%s/novu-api" .Values.ingress.publicOrigin | quote }}
     - name: VITE_SELF_HOSTED
       value: "true"
     - name: VITE_WEBSOCKET_HOSTNAME
-      value: {{ printf "http://%s:%d" .Values.ws.name (int .Values.ws.port) | quote }}
+      # socket.io-client uses the URL origin but defaults its transport path to
+      # /socket.io; putting /novu-ws here is silently discarded by Novu 2.3.0.
+      value: {{ .Values.ingress.publicOrigin | quote }}
     - name: VITE_BASE_PATH
       value: {{ .Values.dashboard.basePath | quote }}
     - name: VITE_PUBLIC_PATH

--- a/docs/notification-onboarding/RUNBOOK.md
+++ b/docs/notification-onboarding/RUNBOOK.md
@@ -78,9 +78,18 @@ sudo docker restart kong-gateway   # a bridge recreate poisons Kong's DNS cache 
 ```
 
 **5 — Ingress** *(only if you did NOT deploy with `enable_novu:true`)* — add the nginx
-`/novu` `/novu-api` `/novu-ws` blocks + the dashboard public-URL envs, and open the port
-(`sudo ufw allow 80/tcp`). Copy the `/novu` `/novu-api` `/novu-ws` blocks from
-[`local-setup/ansible/templates/nginx-site.conf.j2`](../../local-setup/ansible/templates/nginx-site.conf.j2).
+Novu block + the dashboard public-URL envs, and open the port (`sudo ufw allow 80/tcp`).
+Copy the **entire** `enable_novu` section from
+[`local-setup/ansible/templates/nginx-site.conf.j2`](../../local-setup/ansible/templates/nginx-site.conf.j2),
+not only `/novu`, `/novu-api`, and `/novu-ws`. The stock 2.3.0 dashboard is built
+with Vite `base=/`; runtime `VITE_BASE_PATH=/novu` does not rebase its assets or
+React routes. It therefore also needs the narrowly scoped root asset/auth routes
+and `/env/`. A missing `/env/` is the characteristic failure where the workflows
+list opens but **Create workflow** (route `/env/<slug>/workflows/create`) does not,
+especially on a hard reload. Kubernetes installs get the equivalent route set
+from the Novu chart ingress template. Keep the `/socket.io/` route too: Novu 2.3.0
+uses Socket.IO's root transport path even when `VITE_WEBSOCKET_HOSTNAME` contains
+`/novu-ws`; without it the dashboard appears usable but live activity updates 404.
 
 **6 — Seed the MDMS masters** — §4 below.
 

--- a/local-setup/ansible/inventory/host_vars/_example.yml
+++ b/local-setup/ansible/inventory/host_vars/_example.yml
@@ -423,7 +423,7 @@ novu_bridge_channel: "sms"
 # DIFFERENT hosts. Prefer novu_public_base_url above — it sets all four at
 # once and keeps the paths aligned with the nginx location blocks.
 # novu_api_public_url:  "https://pilot.example.org/novu-api"
-# novu_ws_public_url:   "https://pilot.example.org/novu-ws"
+# novu_ws_public_url:   "https://ws.pilot.example.org" # origin only; Socket.IO uses /socket.io
 # novu_api_root_url:    "https://pilot.example.org/novu-api"
 # novu_front_base_url:  "https://pilot.example.org/novu"
 # novu_node_env: "production"

--- a/local-setup/ansible/templates/digit.env.j2
+++ b/local-setup/ansible/templates/digit.env.j2
@@ -78,7 +78,9 @@ MAC_JVM_OPTS={{ '-XX:TieredStopAtLevel=1 -Xshare:off' if ansible_system == 'Darw
 {% set novu_public_origin = novu_public_base_url | default(('https://' if (tls_enabled | default(true)) else 'http://') + domain) %}
 NOVU_NODE_ENV={{ novu_node_env | default('production') }}
 NOVU_API_PUBLIC_URL={{ novu_api_public_url | default(novu_public_origin + '/novu-api') }}
-NOVU_WS_PUBLIC_URL={{ novu_ws_public_url | default(novu_public_origin + '/novu-ws') }}
+# Socket.IO uses the URL origin and its fixed /socket.io transport path. A
+# /novu-ws suffix here is discarded by the Novu 2.3.0 dashboard client.
+NOVU_WS_PUBLIC_URL={{ novu_ws_public_url | default(novu_public_origin) }}
 NOVU_API_ROOT_URL={{ novu_api_root_url | default(novu_public_origin + '/novu-api') }}
 NOVU_FRONT_BASE_URL={{ novu_front_base_url | default(novu_public_origin + '/novu') }}
 # Dashboard image: locally-built subpath-rebased image when

--- a/local-setup/ansible/templates/nginx-site.conf.j2
+++ b/local-setup/ansible/templates/nginx-site.conf.j2
@@ -381,6 +381,20 @@ server {
     proxy_read_timeout 24h;
   }
 
+  # Novu 2.3.0 uses Socket.IO's default root transport path. The dashboard
+  # ignores a /novu-ws suffix in VITE_WEBSOCKET_HOSTNAME and connects here.
+  location /socket.io/ {
+    proxy_pass http://127.0.0.1:14003/socket.io/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_read_timeout 24h;
+  }
+
   # novu-bridge: the read-only configurator proxy endpoints
   # (GET /novu-bridge/novu-adapter/v1/logs|integrations) are routed by Kong
   # (see local-setup/kong/kong.yml) and auth-gated INSIDE novu-bridge by

--- a/local-setup/tests/static/deployment-contracts.test.ts
+++ b/local-setup/tests/static/deployment-contracts.test.ts
@@ -8,6 +8,7 @@
  */
 import * as fs from 'fs';
 import * as path from 'path';
+import { execFileSync } from 'child_process';
 
 const REPO_ROOT = path.resolve(__dirname, '../../..');
 const read = (rel: string) => fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8');
@@ -114,5 +115,71 @@ describe('docker-compose.egov-digit.yaml', () => {
     expect(compose).toMatch(
       /image: \$\{MCP_IMAGE:-ghcr\.io\/subhashini-egov\/digit-mcp:[0-9-]+\}/
     );
+  });
+});
+
+describe('Novu workflow creation deployment contract', () => {
+  const novuValues = read('devops/deploy-as-code/charts/backbone-services/novu/values.yaml');
+  const dashboardValues = novuValues.slice(novuValues.lastIndexOf('\ndashboard:'));
+  const novuIngress = read('devops/deploy-as-code/charts/backbone-services/novu/templates/ingress.yaml');
+  const composeEnv = read('local-setup/ansible/templates/digit.env.j2');
+  const composeNginx = read('local-setup/ansible/templates/nginx-site.conf.j2');
+  const novuEnv = read('backend/novu-bridge/config/.env.novu');
+  const dotenvLoader = path.join(
+    REPO_ROOT,
+    'backend/novu-bridge/config/load-dotenv.sh'
+  );
+
+  test('Helm gives browser code public API/WS URLs rather than cluster-only service names', () => {
+    expect(novuValues).toContain('publicOrigin: "https://domain.com"');
+    expect(novuValues).toContain('value: {{ printf "%s/novu-api" .Values.ingress.publicOrigin | quote }}');
+    expect(novuValues).toContain('value: {{ .Values.ingress.publicOrigin | quote }}');
+    // The worker correctly uses an in-cluster API URL; only values injected
+    // into browser JavaScript must be public.
+    expect(dashboardValues).not.toContain('value: {{ printf "http://%s:%d" .Values.api.name');
+    expect(dashboardValues).not.toContain('value: {{ printf "http://%s:%d" .Values.ws.name');
+  });
+
+  test('Helm exposes API, websocket, and stock-dashboard absolute SPA routes', () => {
+    expect(novuIngress).toContain('.Values.ingress.api.path');
+    expect(novuIngress).toContain('.Values.ingress.ws.path');
+    expect(novuIngress).toContain('range list "/env"');
+    expect(novuIngress).toContain('"/auth/sign-in"');
+    expect(novuIngress).toContain('"/integrations"');
+    expect(novuIngress).toContain('"/assets"');
+    expect(novuIngress).toContain('path: "/socket.io"');
+    expect(novuIngress).toContain('name: {{ .Values.ingress.ws.service.name }}');
+  });
+
+  test('Compose routes Novu Socket.IO at the root path its 2.3.0 client actually uses', () => {
+    expect(composeEnv).toContain(
+      "NOVU_WS_PUBLIC_URL={{ novu_ws_public_url | default(novu_public_origin) }}"
+    );
+    expect(composeNginx).toContain('location /socket.io/');
+    expect(composeNginx).toContain('proxy_pass http://127.0.0.1:14003/socket.io/;');
+  });
+
+  test('the tracked SMS body is quoted and dotenv loading preserves spaces and explicit env', () => {
+    expect(novuEnv).toContain(
+      "NOVU_SMS_BODY='Complaint {{payload.complaintNo}} status is {{payload.status}}'"
+    );
+
+    const probe = String.raw`
+      set -euo pipefail
+      source "$1"
+      load_dotenv_defaults <(printf '%s\n' 'NOVU_SMS_BODY=Complaint {{payload.complaintNo}} status is {{payload.status}}')
+      printf '%s\n' "$NOVU_SMS_BODY"
+      NOVU_SMS_BODY='caller wins'
+      load_dotenv_defaults <(printf '%s\n' 'NOVU_SMS_BODY=file loses')
+      printf '%s\n' "$NOVU_SMS_BODY"
+    `;
+    const output = execFileSync('bash', ['-c', probe, 'bash', dotenvLoader], {
+      encoding: 'utf8',
+    }).trim().split('\n');
+
+    expect(output).toEqual([
+      'Complaint {{payload.complaintNo}} status is {{payload.status}}',
+      'caller wins',
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- load Novu dotenv defaults safely so notification bodies containing spaces survive bootstrap
- expose the dashboard deep-link, API, and WebSocket routes required by the Helm deployment
- use an origin-only browser WebSocket URL and proxy the Socket.IO root path
- document the ingress contract and add static regression coverage

## Root cause

Issue #1517 identified a real bootstrap failure: shell-sourcing an unquoted message body splits it into commands. That occurs during workflow bootstrap, however, and cannot prevent the dashboard create form from opening.

The page-opening failure was in the deployment contract. The Novu 2.3 dashboard is built for root-relative routes: creation navigates to `/env/:environmentSlug/workflows/create`, while API and Socket.IO calls also need public browser routes. The Helm chart exposed only `/novu` and injected cluster-only service URLs. The Compose route had already gained `/env`, but its WebSocket URL still encoded `/novu-ws` as though Socket.IO treated it as a path.

## Verification

- Jest deployment and infrastructure contract suites: 20 tests passed
- Helm lint and template passed with existing-secret and TLS configuration
- rendered chart has four ingress resources, TLS on each, and `/env`, `/novu-api`, `/novu-ws`, and `/socket.io` routes
- dotenv parser checks cover quoted/unquoted spaces and caller environment precedence
- live read-only browser validation on the current Bomet and Mozambique deployments: create form opens and survives a hard reload

Refs #1517

QA should validate the deployment and owns moving the issue from To Review to Done and closing it.