### PR TITLE
chore(persister): enable audit tracking and fix JSONPath expressions

### DIFF
--- a/local-setup/configs/egov-persister/egov-workflow-v2-persister.yml
+++ b/local-setup/configs/egov-persister/egov-workflow-v2-persister.yml
@@ -5,10 +5,16 @@ serviceMaps:
     description: Persists workflow processInstanceFromRequest details in eg_workflow_v2  table
     fromTopic: save-wf-transitions
     isTransaction: true
+    isAuditEnabled: true
+    module: Workflow
+    objecIdJsonPath: $.id
+    tenantIdJsonPath: $.tenantId
+    transactionCodeJsonPath: $.businessId
+    auditAttributeBasePath: $.ProcessInstances.*
     queryMaps:
 
     - query: INSERT INTO eg_wf_processinstance_v2( id,tenantid,businessService,businessId,moduleName,action,status,comment, assigner, stateSla,businessServiceSla, previousStatus, createdby, lastmodifiedby, createdtime, lastmodifiedtime, rating, escalated) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
-      basePath: ProcessInstances.*
+      basePath: $.ProcessInstances.*
       jsonMaps:
       - jsonPath: $.ProcessInstances.*.id
 
@@ -48,7 +54,7 @@ serviceMaps:
 
 
     - query: INSERT INTO eg_wf_document_v2( id, tenantid, active, documenttype,documentUid, processinstanceid, filestoreid, createdby, lastmodifiedby, createdtime, lastmodifiedtime) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
-      basePath: ProcessInstances.*.documents.*
+      basePath: $.ProcessInstances.*.documents.*
       jsonMaps:
       - jsonPath: $.ProcessInstances.documents.*.id
 
@@ -74,7 +80,7 @@ serviceMaps:
 
 
     - query: INSERT INTO eg_wf_assignee_v2(processinstanceid, tenantid, assignee, createdby, lastmodifiedby, createdtime, lastmodifiedtime) VALUES (?, ?, ?, ?, ?, ?, ?);
-      basePath: ProcessInstances.*.assignes.*
+      basePath: $.ProcessInstances.*.assignes.*
       jsonMaps:
       - jsonPath: $.ProcessInstances[*][?({uuid} in @.assignes[*].uuid)].id
 
@@ -97,10 +103,16 @@ serviceMaps:
     description: Persists BusinessService in the table
     fromTopic: save-wf-businessservice
     isTransaction: true
+    isAuditEnabled: true
+    module: Workflow
+    objecIdJsonPath: $.uuid
+    tenantIdJsonPath: $.tenantId
+    transactionCodeJsonPath: $.businessService
+    auditAttributeBasePath: $.BusinessServices.*
     queryMaps:
 
     - query: INSERT INTO eg_wf_businessservice_v2(businessServiceSla, businessservice, business, tenantid, uuid, geturi, posturi, createdby, createdtime, lastmodifiedby, lastmodifiedtime) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
-      basePath: BusinessServices.*
+      basePath: $.BusinessServices.*
       jsonMaps:
       - jsonPath: $.BusinessServices.*.businessServiceSla
 
@@ -128,7 +140,7 @@ serviceMaps:
 
 
     - query: INSERT INTO eg_wf_state_v2(seq, uuid, tenantid, businessserviceid, state,applicationStatus,sla,docuploadrequired, isstartstate, isterminatestate,isStateUpdatable, createdby, createdtime, lastmodifiedby, lastmodifiedtime) VALUES (nextval('seq_eg_wf_state_v2'),? , ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
-      basePath: BusinessServices.*.states.*
+      basePath: $.BusinessServices.*.states.*
       jsonMaps:
       - jsonPath: $.BusinessServices.*.states.*.uuid
 
@@ -161,7 +173,7 @@ serviceMaps:
 
 
     - query: INSERT INTO eg_wf_action_v2( uuid,tenantId,active, currentState, action, nextstate, roles, createdby, createdtime, lastmodifiedby, lastmodifiedtime) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
-      basePath: BusinessServices.*.states.*.actions.*
+      basePath: $.BusinessServices.*.states.*.actions.*
       jsonMaps:
       - jsonPath: $.BusinessServices.*.states.*.actions.*.uuid
 
@@ -193,10 +205,16 @@ serviceMaps:
     description: Persists BusinessService in the table
     fromTopic: update-wf-businessservice
     isTransaction: true
+    isAuditEnabled: true
+    module: Workflow
+    objecIdJsonPath: $.uuid
+    tenantIdJsonPath: $.tenantId
+    transactionCodeJsonPath: $.businessService
+    auditAttributeBasePath: $.BusinessServices.*
     queryMaps:
 
     - query: UPDATE eg_wf_businessservice_v2 SET businessservicesla=?,businessservice=?, business=?, geturi=?, posturi=?, lastmodifiedby=?, lastmodifiedtime=? WHERE uuid=?;
-      basePath: BusinessServices.*
+      basePath: $.BusinessServices.*
       jsonMaps:
       - jsonPath: $.BusinessServices.*.businessServiceSla
 
@@ -218,7 +236,7 @@ serviceMaps:
 
 
     - query: INSERT INTO eg_wf_state_v2(seq, uuid, tenantid, businessserviceid, state,applicationStatus,sla,docuploadrequired, isstartstate, isterminatestate,isStateUpdatable, createdby, createdtime, lastmodifiedby, lastmodifiedtime) VALUES (nextval('seq_eg_wf_state_v2'), ?,?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT (uuid) DO UPDATE SET state=EXCLUDED.state,sla=EXCLUDED.sla,docuploadrequired=EXCLUDED.docuploadrequired,isstartstate=EXCLUDED.isstartstate, isterminatestate=EXCLUDED.isterminatestate,isStateUpdatable=EXCLUDED.isStateUpdatable, lastmodifiedby=EXCLUDED.lastmodifiedby, lastmodifiedtime=EXCLUDED.lastmodifiedtime;
-      basePath: BusinessServices.*.states.*
+      basePath: $.BusinessServices.*.states.*
       jsonMaps:
 
       - jsonPath: $.BusinessServices.*.states.*.uuid
@@ -250,7 +268,7 @@ serviceMaps:
       - jsonPath: $.BusinessServices.*.states.*.auditDetails.lastModifiedTime
 
     - query: INSERT INTO eg_wf_action_v2( uuid,tenantId,active, currentState, action, nextstate, roles, createdby, createdtime, lastmodifiedby, lastmodifiedtime) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT (uuid) DO UPDATE SET active=EXCLUDED.active, action=EXCLUDED.action, nextstate=EXCLUDED.nextstate, roles=EXCLUDED.roles, lastmodifiedby=EXCLUDED.lastmodifiedby, lastmodifiedtime=EXCLUDED.lastmodifiedtime;
-      basePath: BusinessServices.*.states.*.actions.*
+      basePath: $.BusinessServices.*.states.*.actions.*
       jsonMaps:
 
       - jsonPath: $.BusinessServices.*.states.*.actions.*.uuid

--- a/local-setup/configs/egov-persister/pgr-services-persister.yml
+++ b/local-setup/configs/egov-persister/pgr-services-persister.yml
@@ -5,10 +5,16 @@ serviceMaps:
     description: Persists pgr service request in tables
     fromTopic: save-pgr-request
     isTransaction: true
+    isAuditEnabled: true
+    module: CMS
+    objecIdJsonPath: $.id
+    tenantIdJsonPath: $.tenantId
+    transactionCodeJsonPath: $.serviceRequestId
+    auditAttributeBasePath: $.service
     queryMaps:
 
     - query: INSERT INTO eg_pgr_service_v2(id, tenantid, servicecode, servicerequestid, description, accountid, additionaldetails, extended_attributes, applicationstatus, source, createdby, createdtime, lastmodifiedby, lastmodifiedtime) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
-      basePath: service
+      basePath: $.service
       jsonMaps:
       - jsonPath: $.service.id
 
@@ -43,7 +49,7 @@ serviceMaps:
       - jsonPath: $.service.auditDetails.lastModifiedTime
 
     - query: INSERT INTO eg_pgr_address_v2(id, tenantid, parentid, doorno, plotno, buildingname, street, landmark, city, pincode, locality, district, region, state, country, latitude, longitude, additionaldetails, createdby, createdtime, lastmodifiedby, lastmodifiedtime) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
-      basePath: service.address
+      basePath: $.service.address
       jsonMaps:
       - jsonPath: $.service.address.id
 
@@ -92,7 +98,7 @@ serviceMaps:
       - jsonPath: $.service.auditDetails.lastModifiedTime
 
     - query: INSERT INTO eg_pgr_document_v2(id, document_type, filestore_id, document_uid, service_id, additional_details, created_by, last_modified_by, created_time, last_modified_time) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
-      basePath: service.documents.*
+      basePath: $.service.documents.*
       jsonMaps:
       - jsonPath: $.service.documents.*.id
 
@@ -117,14 +123,21 @@ serviceMaps:
       - jsonPath: $.service.auditDetails.lastModifiedTime
 
 
+
   - version: 1.0
     description: Updates pgr service request in tables
     fromTopic: update-pgr-request
     isTransaction: true
+    isAuditEnabled: true
+    module: CMS
+    objecIdJsonPath: $.id
+    tenantIdJsonPath: $.tenantId
+    transactionCodeJsonPath: $.serviceRequestId
+    auditAttributeBasePath: $.service
     queryMaps:
 
     - query: UPDATE eg_pgr_service_v2 SET servicecode=?, rating = ?,servicerequestid=?, description=?, accountid=?, additionaldetails=?, extended_attributes=?, applicationstatus=?, lastmodifiedby=?, lastmodifiedtime=? WHERE id=?;
-      basePath: service
+      basePath: $.service
       jsonMaps:
       - jsonPath: $.service.serviceCode
 
@@ -154,9 +167,8 @@ serviceMaps:
 
 
     - query: UPDATE eg_pgr_address_v2 SET doorno=?, plotno=?, buildingname=?, street=?, landmark=?, city=?, pincode=?, locality=?, district=?, region=?, state=?, country=?, latitude=?, longitude=?,additionaldetails=?, lastmodifiedby=?, lastmodifiedtime=? WHERE id=?;
-      basePath: service.address
+      basePath: $.service.address
       jsonMaps:
-
       - jsonPath: $.service.address.doorNo
 
       - jsonPath: $.service.address.plotNo


### PR DESCRIPTION
- Enable audit tracking (isAuditEnabled: true) for workflow and PGR service persisters
- Add audit configuration properties (module, objecIdJsonPath, tenantIdJsonPath, transactionCodeJsonPath, auditAttributeBasePath)
- Fix JSONPath expressions by adding root $ prefix to all basePath and nested jsonPath references
- Update basePath queries to use standardized JSONPath syntax ($.ProcessInstances.*, $.BusinessServices.*, $.service, etc.)
- Apply fixes consistently across workflow V2, business service, and PGR service persisters
- Ensures proper audit trail generation and correct JSON parsing in persister configurations