### PR TITLE
fix(digit-ui): match StateInfo by tenant code instead of picking index [0]

### DIFF
--- a/digit-ui-esbuild/packages/libraries/src/services/molecules/Store/service.js
+++ b/digit-ui-esbuild/packages/libraries/src/services/molecules/Store/service.js
@@ -37,6 +37,19 @@ const renderTenantLogos = (stateInfo, tenants) => {
   });
 };
 
+// State-level tenant onboarding can leave more than one common-masters.StateInfo
+// row visible for a given search (e.g. one for the parent root tenant and one
+// for the child state tenant). `code` is the uppercase root tenant code, so
+// match it against the tenant actually being loaded instead of assuming the
+// first array entry belongs to this tenant; fall back to [0] when nothing
+// matches so single-record deployments keep working unchanged.
+const pickStateInfo = (stateInfoList, stateCode) => {
+  const list = stateInfoList || [];
+  return (
+    list.find((info) => info?.code?.toUpperCase() === stateCode?.toUpperCase()) || list[0] || {}
+  );
+};
+
 export const StoreService = {
   getInitData: () => {
     return Storage.get("initData");
@@ -68,7 +81,7 @@ export const StoreService = {
       // return;
     }
     const { MdmsRes } = await MdmsService.init(stateCode);
-    const stateInfo = MdmsRes["common-masters"]?.StateInfo?.[0] || {};
+    const stateInfo = pickStateInfo(MdmsRes["common-masters"]?.StateInfo, stateCode);
     const uiHomePage = MdmsRes["common-masters"]?.uiHomePage?.[0] || {};
     return {
       languages: stateInfo.hasLocalisation ? stateInfo.languages : [{ label: "ENGLISH", value: Digit.Utils.getDefaultLanguage() }],
@@ -92,7 +105,7 @@ export const StoreService = {
   digitInitData: async (stateCode, enabledModules, modulePrefix) => {
 
     const { MdmsRes } = await MdmsService.init(stateCode);
-    const stateInfo = MdmsRes["common-masters"]?.StateInfo?.[0] || {};
+    const stateInfo = pickStateInfo(MdmsRes["common-masters"]?.StateInfo, stateCode);
     const uiHomePage = MdmsRes["common-masters"]?.uiHomePage?.[0] || {};
 
     const themeConfig = MdmsRes["common-masters"]?.ThemeConfig?.[0];


### PR DESCRIPTION
## Summary
- State-level tenant onboarding can leave more than one `common-masters.StateInfo` row visible in a single MDMS search (e.g. one for the parent root tenant and one for the child state tenant).
- `digit-ui-esbuild/packages/libraries/src/services/molecules/Store/service.js` unconditionally picked `StateInfo?.[0]`, so a child tenant's citizens/employees could get the parent's logo, banner, and locale/localization config instead of their own.
- Added a `pickStateInfo(list, stateCode)` helper that matches the record whose `code` (the uppercase root tenant code) equals the tenant actually being loaded, falling back to `[0]` when nothing matches so single-record deployments are unaffected. Applied in both `getTenantConfig` and `digitInitData`.

Fixes #1429

## Test plan
- [x] Verified syntax with `node --check`
- [ ] Manual verification against a tenant with duplicate StateInfo rows (parent `pg` / child state) to confirm the child's branding now loads correctly
