### PR TITLE
fix(dashboard): make Reset also clear filters, not just KPI layout

### DIFF
--- a/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
@@ -900,6 +900,18 @@ const AdminDashboardInner = ({ onSignOut, embedded = false, publicMode = false, 
     },
     [clearFilters]
   );
+  // The header's "Reset" button and the filter bar's "Clear" link are two
+  // independent controls over two independent stores — resetLayout (from
+  // useCatalogLayout) only rebuilds the KPI grid geometry, it never touches
+  // filter state. Without also calling clearFilters here, "Reset" left the
+  // complaint-type tree filter (and every other filter) exactly as the user
+  // had set it, while "Clear" correctly restored it to "All types" — the
+  // exact inconsistency reported in egovernments/CCRS#1471.
+  const handleResetLayout = useCallback(() => {
+    dashboardMetrics.markInteraction("filter");
+    resetLayout();
+    clearFilters();
+  }, [resetLayout, clearFilters]);
 
   return (
     <DashboardLayout
@@ -909,7 +921,7 @@ const AdminDashboardInner = ({ onSignOut, embedded = false, publicMode = false, 
       visibleLayoutIds={visibleLayoutIds}
       catalogItems={catalogItems}
       onAddWidget={addKpiToLayout}
-      onResetLayout={resetLayout}
+      onResetLayout={handleResetLayout}
       onDragWidgetStart={handleDragWidgetStart}
       onDragWidgetEnd={handleDragWidgetEnd}
       onExport={handleExport}

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardHeader.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardHeader.jsx
@@ -238,7 +238,7 @@ const DashboardHeader = ({
             type="button"
             onClick={onResetLayout}
             className="dashboard-header-btn dashboard-header-reset"
-            title={t("DASHBOARD_HEADER_RESET_LAYOUT", "Reset layout")}
+            title={t("DASHBOARD_HEADER_RESET", "Reset")}
           >
             {t("DASHBOARD_HEADER_RESET", "Reset")}
           </button>}

--- a/local-setup/db/dss-mdms-seed/l10n/en_IN.json
+++ b/local-setup/db/dss-mdms-seed/l10n/en_IN.json
@@ -500,11 +500,6 @@
     "module": "rainmaker-dashboard"
   },
   {
-    "code": "DASHBOARD_HEADER_RESET_LAYOUT",
-    "message": "Reset layout",
-    "module": "rainmaker-dashboard"
-  },
-  {
     "code": "DASHBOARD_HEADER_ROLE_SCOPE_TOOLTIP",
     "message": "Dashboard tiles are scoped to your role by the analytics catalog",
     "module": "rainmaker-dashboard"

--- a/local-setup/db/dss-mdms-seed/l10n/pt_PT.json
+++ b/local-setup/db/dss-mdms-seed/l10n/pt_PT.json
@@ -500,11 +500,6 @@
     "module": "rainmaker-dashboard"
   },
   {
-    "code": "DASHBOARD_HEADER_RESET_LAYOUT",
-    "message": "Repor disposição",
-    "module": "rainmaker-dashboard"
-  },
-  {
     "code": "DASHBOARD_HEADER_ROLE_SCOPE_TOOLTIP",
     "message": "Os mosaicos do painel são limitados à sua função pelo catálogo de análise",
     "module": "rainmaker-dashboard"


### PR DESCRIPTION
## Summary
- The Dashboard header's "Reset" button and the filter bar's "Clear" link were two independent controls over two independent stores: Reset only called `resetLayout()` (rebuilds KPI widget grid geometry), never touching filter state, so the complaint-type tree filter (and every other filter) stayed exactly as set after clicking Reset, while Clear correctly restored it to "All types".
- Reset now calls both `resetLayout()` and `clearFilters()`, matching the reported expectation that "Reset" clears everything, not just widget positions.

Closes #1471

## Test plan
- [x] Full existing `products/dashboard` test suite (234 tests) passes unchanged
- [x] Syntax-checked the changed file via esbuild
- [ ] Manual repro per the issue's steps: select a complaint type filter (e.g. Grievance > All in Grievance), click Reset, confirm the type filter returns to "All types"