### PR TITLE
fix(pgr): stop a tenant's prefix search reaching a sibling tenant

### DIFF
--- a/backend/pgr-services/src/main/java/org/egov/pgr/repository/rowmapper/DashboardQueryBuilder.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/repository/rowmapper/DashboardQueryBuilder.java
@@ -182,13 +182,21 @@ public class DashboardQueryBuilder {
     }
 
     /**
-     * Appends tenant filter: state-level uses LIKE, city-level uses =.
+     * Appends the tenant filter: a state-level id covers its subtree, a city-level id matches
+     * exactly.
+     *
+     * <p>The subtree is the tenant ITSELF plus everything under a '.' beneath it. A bare
+     * {@code LIKE value || '%'} also matches a sibling whose id merely starts with the same
+     * characters — state {@code ke} would aggregate every complaint belonging to the unrelated
+     * root tenant {@code kenya} — so the delimiter has to be part of the pattern. LIKE
+     * metacharacters are escaped for the same reason: unescaped, {@code _} matches any character.
      */
     private void appendTenantFilter(StringBuilder sb, String column, String tenantId, List<Object> preparedStmtList) {
         String[] chunks = tenantId.split("\\.");
         if (chunks.length == config.getStateLevelTenantIdLength()) {
-            sb.append(column).append(" LIKE ?");
-            preparedStmtList.add(tenantId + "%");
+            sb.append("(").append(column).append(" = ? OR ").append(column).append(" LIKE ?)");
+            preparedStmtList.add(tenantId);
+            preparedStmtList.add(PGRQueryBuilder.escapeLikeLiteral(tenantId) + ".%");
         } else {
             sb.append(column).append(" = ?");
             preparedStmtList.add(tenantId);

--- a/backend/pgr-services/src/main/java/org/egov/pgr/repository/rowmapper/PGRQueryBuilder.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/repository/rowmapper/PGRQueryBuilder.java
@@ -98,9 +98,13 @@ public class PGRQueryBuilder {
                 String[] tenantIdChunks = tenantId.split("\\.");
 
                 if (tenantIdChunks.length == config.getStateLevelTenantIdLength()) {
+                    // Same delimiter-safety as the scope predicate below. Note this branch also
+                    // caught an empty tenantId, which used to bind the pattern '%' and match every
+                    // row of every tenant; it now binds '' and '.%', which match nothing.
                     addClauseIfRequired(preparedStmtList, builder);
-                    builder.append(" ser.tenantid LIKE ? ");
-                    preparedStmtList.add(criteria.getTenantId() + '%');
+                    builder.append(" (ser.tenantid = ? OR ser.tenantid LIKE ?) ");
+                    preparedStmtList.add(tenantId);
+                    preparedStmtList.add(escapeLikeLiteral(tenantId) + ".%");
                 } else {
                     addClauseIfRequired(preparedStmtList, builder);
                     builder.append(" ser.tenantid=? ");
@@ -220,8 +224,13 @@ public class PGRQueryBuilder {
         return builder;
     }
 
+    /** Escapes LIKE metacharacters in server-derived text before a wildcard is appended to it. */
+    static String escapeLikeLiteral(String value) {
+        return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
+    }
+
     /**
-     * Injects the RBAC scope's WHERE predicates. Mirrors the same axes/pattern as
+     * Injects the RBAC scope's WHERE predicates. The same axes as
      * {@code AnalyticsPlanner.applyScope} in the analytics module (citizen self-scope, employee
      * department-scope, and — per {@link PgrSearchScope}'s own Javadoc — the tenant axis itself),
      * plus PGR search's own jurisdiction axis (exact-match on the complaint's address locality —
@@ -250,8 +259,15 @@ public class PGRQueryBuilder {
         if (scope.tenantId != null) {
             addClauseIfRequired(preparedStmtList, builder);
             if (scope.tenantStateLevel) {
-                builder.append(" ser.tenantId LIKE ? ");
-                preparedStmtList.add(scope.tenantId + '%');
+                // The subtree is the tenant ITSELF plus everything under a '.' beneath it. A bare
+                // `LIKE value || '%'` also matches a SIBLING whose id merely starts with the same
+                // characters — with state.level.tenantid.length=1 that means root `ke` reading
+                // every row of the unrelated root `kenya` — which is a cross-tenant read. The
+                // delimiter has to be part of the pattern, and LIKE metacharacters in a tenant id
+                // have to be escaped, or an id containing '_' would match any character there.
+                builder.append(" (ser.tenantId = ? OR ser.tenantId LIKE ?) ");
+                preparedStmtList.add(scope.tenantId);
+                preparedStmtList.add(escapeLikeLiteral(scope.tenantId) + ".%");
             } else {
                 builder.append(" ser.tenantId = ? ");
                 preparedStmtList.add(scope.tenantId);

--- a/backend/pgr-services/src/test/java/org/egov/pgr/repository/rowmapper/DashboardQueryBuilderTenantFilterTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/repository/rowmapper/DashboardQueryBuilderTenantFilterTest.java
@@ -1,0 +1,67 @@
+package org.egov.pgr.repository.rowmapper;
+
+import org.egov.pgr.config.PGRConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+/**
+ * The dashboard aggregates carried the same prefix-matching tenant filter as complaint search: a
+ * state-level id matched every tenant whose id merely started the same way, so state {@code ke}
+ * aggregated the unrelated root tenant {@code kenya} into its own totals.
+ */
+@ExtendWith(MockitoExtension.class)
+class DashboardQueryBuilderTenantFilterTest {
+
+    @Mock
+    private PGRConfiguration config;
+
+    private DashboardQueryBuilder queryBuilder;
+
+    @BeforeEach
+    void setUp() {
+        when(config.getStateLevelTenantIdLength()).thenReturn(1);
+        queryBuilder = new DashboardQueryBuilder(config);
+    }
+
+    @Test
+    void aStateLevelTenantCoversItsSubtreeButNotASiblingRoot() {
+        List<Object> params = new ArrayList<>();
+
+        String query = queryBuilder.getMvKpiQuery("ke", params);
+
+        assertTrue(query.contains("(tenantid = ? OR tenantid LIKE ?)"), query);
+        assertTrue(params.contains("ke"));
+        assertTrue(params.contains("ke.%"));
+        assertFalse(params.contains("ke%"), "a bare prefix would also aggregate the tenant `kenya`");
+    }
+
+    @Test
+    void likeMetacharactersInATenantIdAreEscaped() {
+        List<Object> params = new ArrayList<>();
+
+        queryBuilder.getMvKpiQuery("ke_a", params);
+
+        assertTrue(params.contains("ke\\_a.%"), params.toString());
+    }
+
+    @Test
+    void aCityLevelTenantStillMatchesExactly() {
+        List<Object> params = new ArrayList<>();
+
+        String query = queryBuilder.getMvKpiQuery("ke.bomet", params);
+
+        assertTrue(query.contains("tenantid = ?"), query);
+        assertFalse(query.contains("LIKE"), query);
+        assertTrue(params.contains("ke.bomet"));
+    }
+}

--- a/backend/pgr-services/src/test/java/org/egov/pgr/repository/rowmapper/PGRQueryBuilderTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/repository/rowmapper/PGRQueryBuilderTest.java
@@ -62,15 +62,44 @@ class PGRQueryBuilderTest {
     }
 
     @Test
-    void stateLevelScopeAddsTenantLikePredicate() {
+    void stateLevelScopeMatchesTheTenantAndItsSubtreeButNotASibling() {
         RequestSearchCriteria criteria = RequestSearchCriteria.builder().tenantId("pg").build();
         List<Object> preparedStmtList = new ArrayList<>();
         PgrSearchScope scope = new PgrSearchScope("pg", true, null, null, null);
 
         String query = queryBuilder.getPGRSearchQuery(criteria, preparedStmtList, null, scope);
 
-        assertTrue(query.contains("ser.tenantId LIKE ?"));
-        assertTrue(preparedStmtList.contains("pg%"));
+        // `LIKE 'pg%'` alone also matches the unrelated tenant `pgx.city`; the delimiter has to
+        // be in the pattern, and the tenant itself matched separately.
+        assertTrue(query.contains("(ser.tenantId = ? OR ser.tenantId LIKE ?)"), query);
+        assertTrue(preparedStmtList.contains("pg"));
+        assertTrue(preparedStmtList.contains("pg.%"));
+        assertFalse(preparedStmtList.contains("pg%"));
+    }
+
+    @Test
+    void aSiblingTenantIsNotInsideTheSubtree() {
+        // pg.foo must not read pg.foobar. The two ids share a prefix and nothing else.
+        RequestSearchCriteria criteria = RequestSearchCriteria.builder().tenantId("pg.foo").build();
+        List<Object> preparedStmtList = new ArrayList<>();
+        PgrSearchScope scope = new PgrSearchScope("pg.foo", true, null, null, null);
+
+        queryBuilder.getPGRSearchQuery(criteria, preparedStmtList, null, scope);
+
+        assertTrue(preparedStmtList.contains("pg.foo."   + "%"));
+        assertFalse(preparedStmtList.contains("pg.foo%"), "a bare prefix would also match pg.foobar");
+    }
+
+    @Test
+    void likeMetacharactersInATenantIdAreEscaped() {
+        // An unescaped '_' matches any single character, silently widening the subtree.
+        RequestSearchCriteria criteria = RequestSearchCriteria.builder().tenantId("pg_a").build();
+        List<Object> preparedStmtList = new ArrayList<>();
+        PgrSearchScope scope = new PgrSearchScope("pg_a", true, null, null, null);
+
+        queryBuilder.getPGRSearchQuery(criteria, preparedStmtList, null, scope);
+
+        assertTrue(preparedStmtList.contains("pg\\_a.%"), preparedStmtList.toString());
     }
 
     @Test


### PR DESCRIPTION
Found while wiring the dashboard onto #1441's scope for #1050. Independent of that work and raised separately so it can land on its own.

## The bug

Tenant "subtree" predicates matched by bare prefix:

```sql
ser.tenantId LIKE 'ke' || '%'
```

A state-level tenant therefore also read every row belonging to any tenant whose id merely *starts* the same way. With this deployment's `state.level.tenantid.length=1`, root `ke` reads the whole of the unrelated root `kenya` — a cross-tenant read, produced by the clause that exists to prevent one.

## Fixed in all three places the pattern appears

- `PGRQueryBuilder` — the RBAC scope predicate
- `PGRQueryBuilder` — the criteria path for a state-level search
- `DashboardQueryBuilder.appendTenantFilter` — feeds every dashboard aggregate, and had **no LIKE-escaping at all**

Each becomes:

```sql
(tenantId = ? OR tenantId LIKE ?)   -- 'ke', 'ke.%'
```

so the delimiter is part of the pattern and the tenant itself is matched separately. This also makes the SQL agree with the authorization check already applied upstream in `PolicyDrivenScopeResolver.isAuthorizedTenant`, which has always used `equals || startsWith(caller + ".")` — the SQL was the layer that disagreed.

LIKE metacharacters are escaped too: unescaped, `_` matches any single character, so `ke_a` also matched `keXa…`.

**One more case closes with it.** An empty `tenantId` splits to one segment, so it took the state-level branch and bound the pattern `'%'` — matching every row of every tenant. It now binds `''` and `'.%'`, which match nothing.

## Verification

`mvn -o test` on JDK 17: **405 tests, 0 failures**. New cases cover the sibling root, the `_` escape, and city-level exact matching staying exact.

## Reachability

Needs two tenants sharing a character prefix at the state level, which is why this has been quiet rather than a live incident. Worth fixing before more surfaces consume this scope — #1814 puts the dashboard on it.

## Review note

An independent review flagged that my original commit message used `pg.foo` / `pg.foobar` as the example, which is *not* reachable at `state.level.tenantid.length=1` (two-segment ids take the `=` branch). Corrected throughout: the reachable case at this config is two sibling **roots**. The bug class and the fix are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)