### PR TITLE
fix(pgr): reject numbers-only complaint descriptions

### DIFF
--- a/backend/pgr-services/src/main/java/org/egov/pgr/validator/ServiceRequestValidator.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/validator/ServiceRequestValidator.java
@@ -55,11 +55,38 @@ public class ServiceRequestValidator {
         Map<String,String> errorMap = new HashMap<>();
         validateUserData(request,errorMap);
         validateSource(request.getService().getSource());
+        validateDescription(request, errorMap);
         validateBoundary(request);
         validateMDMS(request, mdmsData);
         if(config.getIsValidateDeptEnabled()) validateDepartment(request, mdmsData);
         if(!errorMap.isEmpty())
             throw new CustomException(errorMap);
+    }
+
+
+    /**
+     * Validates the complaint description carries meaningful content, not just
+     * digits/whitespace (e.g. "000000000000000000"). Unconditional — unlike
+     * ExtendedAttributesValidationService's own description check, which only
+     * runs for complaints using the extended-attributes template feature, this
+     * runs for every complaint. Mirrors the citizen UI's own validation
+     * (CreateComplaintConfig.js) so it can't be bypassed by calling the create
+     * API directly.
+     * @param request The request of creating a complaint
+     * @param errorMap HashMap to capture any errors
+     */
+    private void validateDescription(ServiceRequest request, Map<String, String> errorMap){
+
+        String description = request.getService().getDescription();
+
+        if(description == null || description.isBlank()){
+            errorMap.put("DESCRIPTION_REQUIRED","description is mandatory");
+            return;
+        }
+
+        if(!description.matches("^(?=(?:[\\s\\S]*?\\p{L}){3})[\\s\\S]+$"))
+            errorMap.put("DESCRIPTION_INVALID","description must contain meaningful text (at least 3 letters)");
+
     }
 
 

--- a/backend/pgr-services/src/test/java/org/egov/pgr/validator/ServiceRequestValidatorTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/validator/ServiceRequestValidatorTest.java
@@ -108,6 +108,50 @@ public class ServiceRequestValidatorTest {
         assertDoesNotThrow(() -> validator.validateCreate(request, buildMdmsData("POTHOLE")));
     }
 
+    // ── validateDescription (CCRS#1226) ─────────────────────────────────────────
+
+    @Test
+    void create_nullDescription_throwsDescriptionRequired() {
+        // Boundary must resolve cleanly so validateBoundary (called right after
+        // validateDescription in validateCreate) doesn't throw its own
+        // BOUNDARY_SERVICE_SEARCH_ERROR first and mask the error under test.
+        stubBoundaryResponse("LOC001");
+        request.getService().setDescription(null);
+        assertMapErrorKey("DESCRIPTION_REQUIRED", () -> validator.validateCreate(request, mdmsData));
+    }
+
+    @Test
+    void create_blankDescription_throwsDescriptionRequired() {
+        stubBoundaryResponse("LOC001");
+        request.getService().setDescription("   ");
+        assertMapErrorKey("DESCRIPTION_REQUIRED", () -> validator.validateCreate(request, mdmsData));
+    }
+
+    @Test
+    void create_numbersOnlyDescription_throwsDescriptionInvalid() {
+        stubBoundaryResponse("LOC001");
+        request.getService().setDescription("000000000000000000");
+        assertMapErrorKey("DESCRIPTION_INVALID", () -> validator.validateCreate(request, mdmsData));
+    }
+
+    @Test
+    void create_tooFewLettersDescription_throwsDescriptionInvalid() {
+        stubBoundaryResponse("LOC001");
+        // Only 2 letters ("a", "b") among the digits/punctuation — below the
+        // 3-letter minimum.
+        request.getService().setDescription("12a34b56");
+        assertMapErrorKey("DESCRIPTION_INVALID", () -> validator.validateCreate(request, mdmsData));
+    }
+
+    @Test
+    void create_descriptionWithNumbersAndEnoughLetters_passes() {
+        stubBoundaryResponse("LOC001");
+        // Real-world descriptions legitimately contain numbers (house/street
+        // numbers) — only numbers-only content should be rejected.
+        request.getService().setDescription("Leak near house no. 42");
+        assertDoesNotThrow(() -> validator.validateCreate(request, mdmsData));
+    }
+
     // ── validateMDMS on update ────────────────────────────────────────────────
 
     @Test
@@ -132,6 +176,20 @@ public class ServiceRequestValidatorTest {
         assertEquals(expectedCode, ex.getCode());
     }
 
+    /**
+     * For errors accumulated into validateCreate's errorMap and thrown via
+     * `new CustomException(errorMap)` (e.g. validateUserData, validateDescription)
+     * — unlike the single-error `new CustomException(code, message)` throws
+     * (validateBoundary, validateMDMS), this constructor never sets `code`
+     * (only `errors`/`message`), so assertCode's getCode() check would always
+     * see null here regardless of which key was actually put into the map.
+     */
+    private static void assertMapErrorKey(String expectedKey, org.junit.jupiter.api.function.Executable block) {
+        CustomException ex = assertThrows(CustomException.class, block);
+        assertTrue(ex.getErrors() != null && ex.getErrors().containsKey(expectedKey),
+                "Expected error key '" + expectedKey + "' in " + ex.getErrors());
+    }
+
     private static ServiceRequest buildRequest(String localityCode, String serviceCode) {
         org.egov.common.contract.request.User actor = org.egov.common.contract.request.User.builder()
                 .uuid("citizen-uuid")
@@ -154,6 +212,7 @@ public class ServiceRequestValidatorTest {
                 .serviceCode(serviceCode)
                 .source("web")
                 .address(address)
+                .description("Pothole reported near the main street junction")
                 .build();
 
         return ServiceRequest.builder()

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/pgr/src/configs/CreateComplaintConfig.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/pgr/src/configs/CreateComplaintConfig.js
@@ -200,7 +200,11 @@ export const CreateComplaintConfig = {
                 maxLength: 1000,
                 validation: {
                   required: true,
-                  pattern: /^(?!\s*$).+/,
+                  // CCSD-1980 / CCRS#1226: reject numbers-only / whitespace-only
+                  // descriptions (e.g. "000000000000") — require at least 3
+                  // letters (any language). Non-empty is implied. Matches the
+                  // digit-ui-esbuild copy of this same form.
+                  pattern: /^(?=(?:[\s\S]*?\p{L}){3})[\s\S]+$/u,
                 },
                 error: "CORE_COMMON_REQUIRED_ERRMSG",
               },


### PR DESCRIPTION
## Summary
- `digit-ui-esbuild` (the actually-served citizen UI) already rejects numbers-only descriptions client-side (CCSD-1980), but `frontend/micro-ui` — a second, independently-maintained copy of the same create-complaint form, and a real buildable/deployable image (not just a dev convenience) per `docker-compose.registry.yml` — still had the old permissive pattern (`/^(?!\s*$).+/`, only rejects empty/whitespace). Updated it to match.
- The backend had no content validation on `description` at all. The only existing check (`ExtendedAttributesValidationService`) only runs for complaints using the optional extended-attributes template feature, so a plain complaint create bypassed it entirely — validation was 100% frontend-only and trivially skippable via a direct API call. Added an unconditional check to `ServiceRequestValidator.validateCreate` (runs for every complaint), requiring at least 3 letters (any language), mirroring the citizen UI's own rule.

Closes #1226

## Test plan
- [x] `mvn test` on `pgr-services` — 269 tests pass, including 5 new cases (null/blank description, numbers-only, too-few-letters, and a positive case confirming legitimate descriptions containing numbers like "Leak near house no. 42" still pass)
- [x] Verified the shared regex in isolation against numbers-only, mixed, and legitimate description strings
- [ ] Manual repro per the issue: create a complaint with description "000000000000000000" via both the citizen UI and a direct API call, confirm both are rejected