### PR TITLE
fix(pgr-abac): PGR search fully backward compatible when no scope/condition is authored

### DIFF
--- a/backend/pgr-services/src/main/java/org/egov/pgr/policy/AccessPolicyRegistry.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/policy/AccessPolicyRegistry.java
@@ -283,6 +283,29 @@ public class AccessPolicyRegistry {
     }
 
     /**
+     * True when this action's Tier-1 SQL scope has genuinely nothing authored for it at all — no
+     * {@code resource.<resourceType>.scope} block AND no legacy {@code condition} either — the SAME
+     * "not configured" case {@link #getCondition} treats as backward-compatible-allow (or no action
+     * visible at all). {@code SearchAccessPolicyService} uses this to decide its Tier-1 fallback: a
+     * legacy tenant with a hand-authored {@code condition} but no {@code scope} block still gets the
+     * structural {@code DEFAULT_SCOPE_POLICY} (some restriction was already intended, just not in the
+     * new shape), but an action with NEITHER must get a fully unrestricted Tier-1 scope — otherwise
+     * Tier-1 silently imposes a jurisdiction requirement nobody ever configured, while Tier-2 (this
+     * class' {@link #getCondition}) is already allowing everything for the exact same "unconfigured"
+     * action. Deliberately does NOT catch {@link MalformedScopePolicyException} — a present-but-broken
+     * {@code scope} block is an authoring mistake, not "unconfigured", and must propagate exactly like
+     * {@link #getScopePolicy} already does for the same case.
+     */
+    public boolean isPolicyUnconfigured(String actionUrl, RequestInfo requestInfo, String tenantId, String resourceType) {
+        Map<String, Object> action = getAction(actionUrl, requestInfo, tenantId);
+        if (action == null)
+            return true;
+        if (extractScopePolicy(action, resourceType).isPresent())
+            return false;
+        return action.get("condition") == null;
+    }
+
+    /**
      * Extracts and validates the field-visibility rules for {@code resourceType} from the same
      * Action's {@code resource} JSON object: {@code resource[resourceType].attributes} is a JSON
      * object keyed by field path, each value an independent {@code {condition, onDeny}} rule — any

--- a/backend/pgr-services/src/main/java/org/egov/pgr/policy/AccessPolicyRegistry.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/policy/AccessPolicyRegistry.java
@@ -295,14 +295,46 @@ public class AccessPolicyRegistry {
      * action. Deliberately does NOT catch {@link MalformedScopePolicyException} — a present-but-broken
      * {@code scope} block is an authoring mistake, not "unconfigured", and must propagate exactly like
      * {@link #getScopePolicy} already does for the same case.
+     *
+     * <p><b>{@code resource.<resourceType>.attributes} (field masking) alone does NOT count as
+     * "configured" here</b> — this method only looks at {@code scope} and {@code condition}. An
+     * action that declares field-masking rules (e.g. REDACTing a PII field) but no {@code scope}/
+     * {@code condition} still resolves {@code true} (fully unrestricted row-level access), by design:
+     * field masking and row-level scoping are independent axes of this policy, and an operator
+     * authoring one is not implicitly opting into the other. A caller who wants "any policy at all"
+     * to imply row restriction must check {@link #getFieldVisibilityRules} separately, not read that
+     * intent into this method.
      */
     public boolean isPolicyUnconfigured(String actionUrl, RequestInfo requestInfo, String tenantId, String resourceType) {
+        return resolveScopeState(actionUrl, requestInfo, tenantId, resourceType).unconfigured();
+    }
+
+    /**
+     * Combined form of {@link #getScopePolicy} + {@link #isPolicyUnconfigured} that fetches the
+     * action exactly once instead of twice. {@code SearchAccessPolicyService#resolveScope} used to
+     * call both separately — two independent {@link #getAction} calls that, on a cache miss (a
+     * "not found"/not-visible action is never cached — see this class' Javadoc), each triggered a
+     * fresh {@code /access/v1/actions/mdms/_get} round-trip for the SAME request: a real double-fetch
+     * race and doubled hot-path load. This method is the single source both values are derived from.
+     */
+    public ScopeResolution resolveScopeState(String actionUrl, RequestInfo requestInfo, String tenantId, String resourceType) {
         Map<String, Object> action = getAction(actionUrl, requestInfo, tenantId);
         if (action == null)
-            return true;
-        if (extractScopePolicy(action, resourceType).isPresent())
-            return false;
-        return action.get("condition") == null;
+            return new ScopeResolution(Optional.empty(), true);
+        Optional<ScopePolicy> scopePolicy = extractScopePolicy(action, resourceType);
+        if (scopePolicy.isPresent())
+            return new ScopeResolution(scopePolicy, false);
+        return new ScopeResolution(Optional.empty(), action.get("condition") == null);
+    }
+
+    /**
+     * Result of {@link #resolveScopeState}: {@code scopePolicy} is the MDMS-authored
+     * {@code resource.<resourceType>.scope} when present, and {@code unconfigured} is true only when
+     * NEITHER a {@code scope} block NOR a legacy {@code condition} was authored (see
+     * {@link #isPolicyUnconfigured}'s Javadoc for what "unconfigured" does and doesn't cover).
+     * {@code scopePolicy} present always implies {@code unconfigured == false}.
+     */
+    public record ScopeResolution(Optional<ScopePolicy> scopePolicy, boolean unconfigured) {
     }
 
     /**

--- a/backend/pgr-services/src/main/java/org/egov/pgr/policy/SearchAccessPolicyService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/policy/SearchAccessPolicyService.java
@@ -31,14 +31,30 @@ import java.util.Optional;
 public class SearchAccessPolicyService {
 
     /**
-     * In-code fallback when MDMS has no {@code resource.complaint.scope} configured for this action
-     * — reproduces PGR search's structural default (jurisdiction-based, department not part of its
-     * row-scoping model) via the SAME {@link ScopePolicyEngine} the MDMS-authored path uses, so
-     * "not configured" and "configured to match today's default" behave identically.
+     * In-code fallback for a LEGACY tenant that still has a hand-authored {@code condition} on this
+     * action but no {@code resource.complaint.scope} block — reproduces PGR search's old structural
+     * default (jurisdiction-based, department not part of its row-scoping model) via the SAME
+     * {@link ScopePolicyEngine} the MDMS-authored path uses. This must NOT be applied when the action
+     * has neither a {@code scope} block NOR a {@code condition} at all — see
+     * {@link #UNRESTRICTED_SCOPE_POLICY} and {@link AccessPolicyRegistry#isPolicyUnconfigured}.
      */
     private static final ScopePolicy DEFAULT_SCOPE_POLICY = ScopePolicy.of(
             List.of("department", "jurisdiction"),
             Map.of("department", ScopeLevel.ALL, "jurisdiction", ScopeLevel.OWN));
+
+    /**
+     * Tier-1 fallback when the action has genuinely nothing authored for it — no
+     * {@code resource.complaint.scope} block AND no legacy {@code condition} either (see
+     * {@link AccessPolicyRegistry#isPolicyUnconfigured}). Zero axes means {@link ScopePolicyEngine}
+     * never restricts department or jurisdiction for anyone, matching Tier-2
+     * ({@link AccessPolicyRegistry#getCondition}'s backward-compatible {@code true} for the same
+     * "unconfigured" action) instead of silently imposing {@link #DEFAULT_SCOPE_POLICY}'s
+     * jurisdiction requirement on a tenant that never configured ANY PGR search policy at all.
+     * Citizen self-scoping and tenant/subtree authorization in
+     * {@link PolicyDrivenScopeResolver#resolve} are unaffected — those are hardcoded, not
+     * axis-driven, and still apply regardless of this policy.
+     */
+    private static final ScopePolicy UNRESTRICTED_SCOPE_POLICY = ScopePolicy.of(List.of(), Map.of());
 
     private final PolicyDrivenScopeResolver policyDrivenScopeResolver;
     private final AccessPolicyRegistry registry;
@@ -67,17 +83,28 @@ public class SearchAccessPolicyService {
      * ({@code AccessPolicyRegistry#getCondition}) deny IDENTICALLY instead — the same explicit
      * rollout gate, applied uniformly to both tiers so {@code count()} and {@code search()} can
      * never disagree once a deployment has opted in. With the gate off (today's default), this
-     * still falls back to {@link #DEFAULT_SCOPE_POLICY}, same as before.
+     * falls back to {@link #DEFAULT_SCOPE_POLICY} only when the action has a legacy hand-authored
+     * {@code condition} (some restriction was already intended); an action with NEITHER a
+     * {@code scope} block NOR a {@code condition} — genuinely never configured — gets
+     * {@link #UNRESTRICTED_SCOPE_POLICY} instead, matching Tier-2's backward-compatible allow for
+     * the same case rather than silently requiring HRMS department/jurisdiction data nobody asked
+     * for. See {@link AccessPolicyRegistry#isPolicyUnconfigured}.
      */
     public PgrSearchScope resolveScope(RequestInfo requestInfo, String tenantId, int stateLevelLen) {
         Optional<ScopePolicy> scopePolicy = registry.getScopePolicy(AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL, requestInfo, tenantId, "complaint");
-        if (scopePolicy.isEmpty() && config.isAbacStrictMode()) {
+        if (scopePolicy.isPresent())
+            return policyDrivenScopeResolver.resolve(requestInfo, tenantId, stateLevelLen, scopePolicy.get());
+
+        if (config.isAbacStrictMode()) {
             log.error("SearchAccessPolicyService: no resource.complaint.scope configured for url='{}' tenant='{}' — pgr.abac.strict-mode is enabled, failing closed (Tier-1, matching AccessPolicyRegistry#getCondition's Tier-2 fail-closed)",
                     AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL, tenantId);
             boolean stateLevel = tenantId != null && tenantId.split("\\.").length == stateLevelLen;
             return PgrSearchScope.deniedAll(tenantId, stateLevel);
         }
-        return policyDrivenScopeResolver.resolve(requestInfo, tenantId, stateLevelLen, scopePolicy.orElse(DEFAULT_SCOPE_POLICY));
+
+        boolean unconfigured = registry.isPolicyUnconfigured(AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL, requestInfo, tenantId, "complaint");
+        ScopePolicy fallback = unconfigured ? UNRESTRICTED_SCOPE_POLICY : DEFAULT_SCOPE_POLICY;
+        return policyDrivenScopeResolver.resolve(requestInfo, tenantId, stateLevelLen, fallback);
     }
 
     /**

--- a/backend/pgr-services/src/main/java/org/egov/pgr/policy/SearchAccessPolicyService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/policy/SearchAccessPolicyService.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * Tier-2 PDP for the reference access-control rule: a citizen sees only their own complaints, an
@@ -89,11 +88,18 @@ public class SearchAccessPolicyService {
      * {@link #UNRESTRICTED_SCOPE_POLICY} instead, matching Tier-2's backward-compatible allow for
      * the same case rather than silently requiring HRMS department/jurisdiction data nobody asked
      * for. See {@link AccessPolicyRegistry#isPolicyUnconfigured}.
+     *
+     * <p>Fetches the action exactly once via {@link AccessPolicyRegistry#resolveScopeState} — the
+     * scope-policy-present check and the unconfigured fallback below used to be two independent
+     * {@code AccessPolicyRegistry} calls, each capable of triggering its own
+     * {@code /access/v1/actions/mdms/_get} round-trip on a cache miss (a "not found" action is never
+     * cached), which was both a real double-fetch race and doubled hot-path load per search request.
      */
     public PgrSearchScope resolveScope(RequestInfo requestInfo, String tenantId, int stateLevelLen) {
-        Optional<ScopePolicy> scopePolicy = registry.getScopePolicy(AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL, requestInfo, tenantId, "complaint");
-        if (scopePolicy.isPresent())
-            return policyDrivenScopeResolver.resolve(requestInfo, tenantId, stateLevelLen, scopePolicy.get());
+        AccessPolicyRegistry.ScopeResolution resolution =
+                registry.resolveScopeState(AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL, requestInfo, tenantId, "complaint");
+        if (resolution.scopePolicy().isPresent())
+            return policyDrivenScopeResolver.resolve(requestInfo, tenantId, stateLevelLen, resolution.scopePolicy().get());
 
         if (config.isAbacStrictMode()) {
             log.error("SearchAccessPolicyService: no resource.complaint.scope configured for url='{}' tenant='{}' — pgr.abac.strict-mode is enabled, failing closed (Tier-1, matching AccessPolicyRegistry#getCondition's Tier-2 fail-closed)",
@@ -102,8 +108,7 @@ public class SearchAccessPolicyService {
             return PgrSearchScope.deniedAll(tenantId, stateLevel);
         }
 
-        boolean unconfigured = registry.isPolicyUnconfigured(AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL, requestInfo, tenantId, "complaint");
-        ScopePolicy fallback = unconfigured ? UNRESTRICTED_SCOPE_POLICY : DEFAULT_SCOPE_POLICY;
+        ScopePolicy fallback = resolution.unconfigured() ? UNRESTRICTED_SCOPE_POLICY : DEFAULT_SCOPE_POLICY;
         return policyDrivenScopeResolver.resolve(requestInfo, tenantId, stateLevelLen, fallback);
     }
 

--- a/backend/pgr-services/src/test/java/org/egov/pgr/policy/AccessPolicyRegistryTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/policy/AccessPolicyRegistryTest.java
@@ -344,6 +344,65 @@ class AccessPolicyRegistryTest {
                 AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL, requestInfo, "pg.city", "complaint"));
     }
 
+    // --- isPolicyUnconfigured(): Tier-1's signal for "genuinely never authored" -------------------
+
+    @Test
+    void isPolicyUnconfiguredIsTrueWhenNoActionIsVisibleAtAll() {
+        RequestInfo requestInfo = requestInfo("EMPLOYEE");
+        when(mdmsUtils.fetchAccessControlActions(requestInfo, "pg.city", AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL))
+                .thenReturn(List.of());
+
+        assertTrue(registry.isPolicyUnconfigured(AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL, requestInfo, "pg.city", "complaint"));
+    }
+
+    @Test
+    void isPolicyUnconfiguredIsTrueWhenActionHasNeitherScopeNorCondition() {
+        Map<String, Object> action = Map.of("id", 2008, "url", AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL, "enabled", true);
+        RequestInfo requestInfo = requestInfo("EMPLOYEE");
+        when(mdmsUtils.fetchAccessControlActions(requestInfo, "pg.city", AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL))
+                .thenReturn(List.of(action));
+
+        assertTrue(registry.isPolicyUnconfigured(AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL, requestInfo, "pg.city", "complaint"));
+    }
+
+    @Test
+    void isPolicyUnconfiguredIsFalseWhenAScopeBlockIsPresent() {
+        Map<String, Object> scope = Map.of("axes", List.of("department"), "default", Map.of("department", "OWN"));
+        Map<String, Object> resource = Map.of("complaint", Map.of("scope", scope));
+        Map<String, Object> action = Map.of("id", 2008, "url", AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL, "resource", resource);
+        RequestInfo requestInfo = requestInfo("EMPLOYEE");
+        when(mdmsUtils.fetchAccessControlActions(requestInfo, "pg.city", AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL))
+                .thenReturn(List.of(action));
+
+        assertFalse(registry.isPolicyUnconfigured(AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL, requestInfo, "pg.city", "complaint"));
+    }
+
+    @Test
+    void isPolicyUnconfiguredIsFalseWhenALegacyConditionIsPresentWithNoScopeBlock() {
+        Map<String, Object> action = Map.of("id", 2008, "url", AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL,
+                "condition", Map.of("==", List.of(1, 1)));
+        RequestInfo requestInfo = requestInfo("EMPLOYEE");
+        when(mdmsUtils.fetchAccessControlActions(requestInfo, "pg.city", AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL))
+                .thenReturn(List.of(action));
+
+        assertFalse(registry.isPolicyUnconfigured(AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL, requestInfo, "pg.city", "complaint"));
+    }
+
+    @Test
+    void isPolicyUnconfiguredThrowsOnAMalformedScopeRatherThanReturningTrue() {
+        // A present-but-broken scope block is an authoring mistake, not "unconfigured" — must
+        // propagate, never silently read as "apply the fully unrestricted fallback".
+        Map<String, Object> scope = Map.of("axes", List.of());
+        Map<String, Object> resource = Map.of("complaint", Map.of("scope", scope));
+        Map<String, Object> action = Map.of("id", 2008, "url", AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL, "resource", resource);
+        RequestInfo requestInfo = requestInfo("EMPLOYEE");
+        when(mdmsUtils.fetchAccessControlActions(requestInfo, "pg.city", AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL))
+                .thenReturn(List.of(action));
+
+        assertThrows(MalformedScopePolicyException.class, () -> registry.isPolicyUnconfigured(
+                AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL, requestInfo, "pg.city", "complaint"));
+    }
+
     @Test
     void getConditionGeneratesFromScopeWhenPresentIgnoringHandAuthoredCondition() {
         Map<String, Object> scope = Map.of(

--- a/backend/pgr-services/src/test/java/org/egov/pgr/policy/AccessPolicyRegistryTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/policy/AccessPolicyRegistryTest.java
@@ -366,6 +366,24 @@ class AccessPolicyRegistryTest {
     }
 
     @Test
+    void isPolicyUnconfiguredIsTrueWhenOnlyFieldMaskingAttributesArePresentWithNoScopeOrCondition() {
+        // Field masking (resource.<type>.attributes) and row-level scoping are independent axes of
+        // this policy — an action that REDACTs a PII field but declares neither scope nor condition
+        // must still resolve fully unrestricted at Tier-1/row level, matching Tier-2's
+        // backward-compatible allow. This is intentional (per product decision), not a gap to close.
+        Map<String, Object> attributes = Map.of("citizen.mobileNumber", Map.of("condition", Map.of("==", List.of(1, 2)), "onDeny", Map.of("strategy", "REDACT")));
+        Map<String, Object> resource = Map.of("complaint", Map.of("attributes", attributes));
+        Map<String, Object> action = Map.of("id", 2008, "url", AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL, "resource", resource);
+        RequestInfo requestInfo = requestInfo("EMPLOYEE");
+        when(mdmsUtils.fetchAccessControlActions(requestInfo, "pg.city", AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL))
+                .thenReturn(List.of(action));
+
+        assertTrue(registry.isPolicyUnconfigured(AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL, requestInfo, "pg.city", "complaint"));
+        assertTrue(registry.getScopePolicy(AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL, requestInfo, "pg.city", "complaint").isEmpty());
+        assertFalse(registry.getFieldVisibilityRules(AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL, requestInfo, "pg.city", "complaint").isEmpty());
+    }
+
+    @Test
     void isPolicyUnconfiguredIsFalseWhenAScopeBlockIsPresent() {
         Map<String, Object> scope = Map.of("axes", List.of("department"), "default", Map.of("department", "OWN"));
         Map<String, Object> resource = Map.of("complaint", Map.of("scope", scope));
@@ -401,6 +419,45 @@ class AccessPolicyRegistryTest {
 
         assertThrows(MalformedScopePolicyException.class, () -> registry.isPolicyUnconfigured(
                 AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL, requestInfo, "pg.city", "complaint"));
+    }
+
+    // --- resolveScopeState(): the combined getScopePolicy() + isPolicyUnconfigured() form ---------
+
+    @Test
+    void resolveScopeStateFetchesTheActionOnlyOnceWhenUnconfigured() {
+        // A "not found"/not-visible action is never cached (role-scoped API — see class Javadoc),
+        // so calling getScopePolicy() then isPolicyUnconfigured() separately for the SAME request
+        // used to trigger two independent fetchAccessControlActions round-trips. resolveScopeState
+        // must derive both facts from one fetch.
+        RequestInfo requestInfo = requestInfo("EMPLOYEE");
+        when(mdmsUtils.fetchAccessControlActions(requestInfo, "pg.city", AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL))
+                .thenReturn(List.of());
+
+        AccessPolicyRegistry.ScopeResolution resolution = registry.resolveScopeState(
+                AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL, requestInfo, "pg.city", "complaint");
+
+        assertTrue(resolution.unconfigured());
+        assertTrue(resolution.scopePolicy().isEmpty());
+        verify(mdmsUtils, times(1)).fetchAccessControlActions(requestInfo, "pg.city", AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL);
+    }
+
+    @Test
+    void resolveScopeStateFetchesTheActionOnlyOnceWhenAScopeBlockIsPresent() {
+        Map<String, Object> scope = Map.of("axes", List.of("department"), "default", Map.of("department", "OWN"));
+        Map<String, Object> resource = Map.of("complaint", Map.of("scope", scope));
+        Map<String, Object> action = Map.of("id", 2008, "url", AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL, "resource", resource);
+        RequestInfo requestInfo = requestInfo("EMPLOYEE");
+        when(mdmsUtils.fetchAccessControlActions(requestInfo, "pg.city", AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL))
+                .thenReturn(List.of(action));
+
+        AccessPolicyRegistry.ScopeResolution resolution = registry.resolveScopeState(
+                AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL, requestInfo, "pg.city", "complaint");
+
+        assertFalse(resolution.unconfigured());
+        assertTrue(resolution.scopePolicy().isPresent());
+        // Cached now (a successful resolution) — a second call must not fetch again either.
+        registry.resolveScopeState(AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL, requestInfo, "pg.city", "complaint");
+        verify(mdmsUtils, times(1)).fetchAccessControlActions(requestInfo, "pg.city", AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL);
     }
 
     @Test

--- a/backend/pgr-services/src/test/java/org/egov/pgr/policy/SearchAccessPolicyServiceTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/policy/SearchAccessPolicyServiceTest.java
@@ -40,10 +40,15 @@ import static org.mockito.Mockito.when;
  * verify what {@link ScopePolicy} actually gets fetched/passed through.
  *
  * <p>PGR complaint search's scoping rule (which axes are required per role) is declared by
- * {@code resource.complaint.scope} on the actiontest action record — see {@link ScopePolicyEngine}
- * — with an in-code jurisdiction-only fallback ({@link SearchAccessPolicyService#DEFAULT_SCOPE_POLICY})
- * when MDMS has none configured. A previous per-tenant {@code dss.DashboardConfig.departmentScoping}
- * toggle used to vary this at runtime and has been removed.
+ * {@code resource.complaint.scope} on the actiontest action record — see {@link ScopePolicyEngine}.
+ * When no {@code scope} block is configured, the fallback depends on whether the action has a
+ * legacy hand-authored {@code condition}: if it does, an in-code jurisdiction-only default
+ * ({@link SearchAccessPolicyService#DEFAULT_SCOPE_POLICY}) applies; if it has neither, the action
+ * is treated as genuinely never configured and gets
+ * {@link SearchAccessPolicyService#UNRESTRICTED_SCOPE_POLICY} instead — see the
+ * {@code resolveScope()} tests near the bottom. A previous per-tenant
+ * {@code dss.DashboardConfig.departmentScoping} toggle used to vary this at runtime and has been
+ * removed.
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -223,6 +228,50 @@ class SearchAccessPolicyServiceTest {
         verify(mockResolver).resolve(eq(requestInfo), eq(TENANT_ID), eq(2), captor.capture());
         assertEquals(ScopeLevel.ALL, captor.getValue().levelFor("ANY_ROLE", "department"));
         assertEquals(ScopeLevel.OWN, captor.getValue().levelFor("ANY_ROLE", "jurisdiction"));
+    }
+
+    @Test
+    void resolveScopeIsFullyUnrestrictedWhenActionHasNeitherScopeNorCondition() {
+        // Distinct from resolveScopeFallsBackToJurisdictionOnlyDefaultWhenNoScopeConfigured above:
+        // that test's action has a legacy hand-authored condition (@BeforeEach), so
+        // DEFAULT_SCOPE_POLICY's jurisdiction requirement is still intentional. Here the action is
+        // visible but has NEVER had any policy authored at all — Tier-2
+        // (AccessPolicyRegistry#getCondition) already treats that as backward-compatible-allow, so
+        // Tier-1 must not silently require HRMS jurisdiction data nobody configured.
+        Map<String, Object> action = Map.of("id", 2008, "url", AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL, "enabled", true);
+        when(mdmsUtils.fetchAccessControlActions(any(), eq(TENANT_ID), eq(AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL)))
+                .thenReturn(List.of(action));
+        AccessPolicyRegistry registryUnconfigured = new AccessPolicyRegistry(mdmsUtils, new ObjectMapper(), new PGRConfiguration());
+        PolicyDrivenScopeResolver mockResolver = mock(PolicyDrivenScopeResolver.class);
+        SearchAccessPolicyService serviceWithMockResolver =
+                new SearchAccessPolicyService(mockResolver, registryUnconfigured, new PolicyEvaluator(), new PolicyInputBuilder(), new PGRConfiguration());
+        RequestInfo requestInfo = requestInfo("emp-1", "EMPLOYEE");
+
+        serviceWithMockResolver.resolveScope(requestInfo, TENANT_ID, 2);
+
+        ArgumentCaptor<ScopePolicy> captor = ArgumentCaptor.forClass(ScopePolicy.class);
+        verify(mockResolver).resolve(eq(requestInfo), eq(TENANT_ID), eq(2), captor.capture());
+        assertTrue(captor.getValue().getAxes().isEmpty(), "no axes declared — no restriction on department or jurisdiction");
+    }
+
+    @Test
+    void resolveScopeIsFullyUnrestrictedWhenNoActionIsVisibleAtAll() {
+        // Same "genuinely unconfigured" treatment as the neither-scope-nor-condition case above —
+        // no MDMS entry visible at all is the SAME "not configured for this deployment" signal
+        // AccessPolicyRegistry#getCondition already treats as backward-compatible-allow.
+        when(mdmsUtils.fetchAccessControlActions(any(), eq(TENANT_ID), eq(AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL)))
+                .thenReturn(List.of());
+        AccessPolicyRegistry registryNoAction = new AccessPolicyRegistry(mdmsUtils, new ObjectMapper(), new PGRConfiguration());
+        PolicyDrivenScopeResolver mockResolver = mock(PolicyDrivenScopeResolver.class);
+        SearchAccessPolicyService serviceWithMockResolver =
+                new SearchAccessPolicyService(mockResolver, registryNoAction, new PolicyEvaluator(), new PolicyInputBuilder(), new PGRConfiguration());
+        RequestInfo requestInfo = requestInfo("emp-1", "EMPLOYEE");
+
+        serviceWithMockResolver.resolveScope(requestInfo, TENANT_ID, 2);
+
+        ArgumentCaptor<ScopePolicy> captor = ArgumentCaptor.forClass(ScopePolicy.class);
+        verify(mockResolver).resolve(eq(requestInfo), eq(TENANT_ID), eq(2), captor.capture());
+        assertTrue(captor.getValue().getAxes().isEmpty());
     }
 
     @Test

--- a/backend/pgr-services/src/test/java/org/egov/pgr/policy/SearchAccessPolicyServiceTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/policy/SearchAccessPolicyServiceTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -252,6 +253,10 @@ class SearchAccessPolicyServiceTest {
         ArgumentCaptor<ScopePolicy> captor = ArgumentCaptor.forClass(ScopePolicy.class);
         verify(mockResolver).resolve(eq(requestInfo), eq(TENANT_ID), eq(2), captor.capture());
         assertTrue(captor.getValue().getAxes().isEmpty(), "no axes declared — no restriction on department or jurisdiction");
+        // resolveScope() used to call registry.getScopePolicy() then registry.isPolicyUnconfigured()
+        // separately, each independently re-fetching on a cache miss — a real double-fetch/doubled
+        // hot-path-load bug (#1827 review). Both facts must now come from ONE fetch.
+        verify(mdmsUtils, times(1)).fetchAccessControlActions(any(), eq(TENANT_ID), eq(AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL));
     }
 
     @Test
@@ -272,6 +277,7 @@ class SearchAccessPolicyServiceTest {
         ArgumentCaptor<ScopePolicy> captor = ArgumentCaptor.forClass(ScopePolicy.class);
         verify(mockResolver).resolve(eq(requestInfo), eq(TENANT_ID), eq(2), captor.capture());
         assertTrue(captor.getValue().getAxes().isEmpty());
+        verify(mdmsUtils, times(1)).fetchAccessControlActions(any(), eq(TENANT_ID), eq(AccessPolicyRegistry.PGR_REQUEST_SEARCH_URL));
     }
 
     @Test


### PR DESCRIPTION
## Summary

`SearchAccessPolicyService.resolveScope()` fell back to `DEFAULT_SCOPE_POLICY` (jurisdiction required at level `OWN`) any time an action had no `resource.complaint.scope` block — including when the action has **never had any policy authored on it at all** (no scope block AND no legacy `condition`). That silently required HRMS jurisdiction data from every tenant that hasn't configured PGR search's ABAC, even though Tier-2 (`AccessPolicyRegistry#getCondition`) already treats that exact "genuinely unconfigured" case as backward-compatible-allow.

## Fix

Added `AccessPolicyRegistry#isPolicyUnconfigured` to distinguish two previously-conflated cases:
- **Action visible but truly bare** (no `scope`, no `condition`) → now gets a new `UNRESTRICTED_SCOPE_POLICY` (zero axes), so `ScopePolicyEngine` imposes no restriction on department or jurisdiction for anyone — matches Tier-2's backward-compatible allow instead of quietly gating on data nobody configured.
- **Legacy tenant with a hand-authored `condition` but no `scope` block** → still gets `DEFAULT_SCOPE_POLICY`, unchanged, since some restriction was already intended, just not in the new shape.

`pgr.abac.strict-mode` continues to fail closed uniformly for both sub-cases. Citizen self-scoping and tenant/subtree authorization in `PolicyDrivenScopeResolver` are untouched — those are hardcoded, not axis-driven.

## Verified live

Redeployed `pgr-services` to a running `ap` instance, then live-tested the actual regression:
1. Backed up `ap`'s action 2008 (currently has a configured `resource.complaint.scope`).
2. Stripped it to a bare shape (no `resource`, no `condition`) via the MDMS v2 API.
3. Confirmed search went from **0 results** (previously blocked — the admin test user's own HRMS jurisdiction value happens to be the tenant code itself, which matches no real complaint's locality) to **all 9 complaints, fully unrestricted** — log line confirms `departments=null jurisdictions=null (policy-driven)`.
4. Restored the original config from the backup and confirmed search returned to its prior (correctly scoped) behavior.

## Test plan

- [x] New unit tests at both layers: `AccessPolicyRegistryTest` (`isPolicyUnconfigured` — true for no-action/bare-action, false for scope-present/condition-present, propagates on malformed scope) and `SearchAccessPolicyServiceTest` (`resolveScope` resolves to zero axes for both "no action visible" and "action bare" cases).
- [x] Full `pgr-services` suite: 415 tests, 0 failures.
- [x] Live end-to-end verification on a redeployed `ap` instance (see above), including a full restore back to the pre-test live state.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>