### PR TITLE
fix(pgr): keep the search context when opening a complaint's details

### DIFF
--- a/digit-ui-esbuild/products/pgr/src/configs/UICustomizations.js
+++ b/digit-ui-esbuild/products/pgr/src/configs/UICustomizations.js
@@ -110,6 +110,31 @@ function cleanObject(obj) {
   return obj;
 }
 
+/** The createdBy uuid the PGR inbox scopes itself to, or null when it does not.
+ *
+ *  Reception officers file complaints on citizens' behalf but are neither the
+ *  accountId (that's the citizen) nor ever an assignee, so an unscoped inbox
+ *  shows them nothing of their own work. Applied only when reception is the
+ *  user's SOLE CMS role — a multi-role user (e.g. reception + supervisor) keeps
+ *  the wider view their other role is entitled to.
+ *
+ *  Exported as one function so the inbox SEARCH and the row's DETAIL LINK agree
+ *  by construction. They used to decide independently: the search read the role
+ *  list, while the link compared `auditDetails.createdBy` on the row. When that
+ *  field was absent from the inbox payload the link silently dropped the param,
+ *  the details page then queried unscoped, and the officer got "No Results
+ *  Found" on a complaint they had just clicked.
+ */
+export const receptionOnlyCreatedByUuid = () => {
+  const info = Digit.UserService.getUser()?.info;
+  const cmsRoles = (info?.roles || [])
+    .map((r) => r?.code)
+    .filter((c) => c && (c.startsWith("CMS_") || c === "SUPERUSER" || c === "ADMIN"));
+  const receptionOnly =
+    cmsRoles.includes("CMS_RECEPTION_OFFICER") && cmsRoles.every((c) => c === "CMS_RECEPTION_OFFICER");
+  return receptionOnly ? info?.uuid || null : null;
+};
+
 export const UICustomizations = {
   businessServiceMap,
   updatePayload: (applicationDetails, data, action, businessService) => {
@@ -1614,13 +1639,8 @@ export const UICustomizations = {
       // correct). Applied only when reception is the user's SOLE CMS role —
       // a multi-role user (e.g. reception + supervisor) keeps the wider view
       // their other role is entitled to.
-      const cmsRoles = (Digit.UserService.getUser()?.info?.roles || [])
-        .map((r) => r?.code)
-        .filter((c) => c && (c.startsWith("CMS_") || c === "SUPERUSER" || c === "ADMIN"));
-      if (cmsRoles.includes("CMS_RECEPTION_OFFICER") && cmsRoles.every((c) => c === "CMS_RECEPTION_OFFICER")) {
-        const ownUuid = Digit.UserService.getUser()?.info?.uuid;
-        if (ownUuid) params.createdBy = ownUuid;
-      }
+      const ownCreatedByUuid = receptionOnlyCreatedByUuid();
+      if (ownCreatedByUuid) params.createdBy = ownCreatedByUuid;
 
       // Search form fields
       if (searchForm.complaintNumber) {
@@ -1749,9 +1769,12 @@ export const UICustomizations = {
             <div style={{ display: "grid" }}>
               <span className="link" style={{ display: "grid" }}>
                 {(() => {
-                  const currentUserUuid = Digit.UserService.getUser()?.info?.uuid;
-                  const creatorUuid = row?.businessObject?.service?.auditDetails?.createdBy;
-                  const query = creatorUuid && creatorUuid === currentUserUuid ? `?createdBy=${encodeURIComponent(currentUserUuid)}` : "";
+                  // Same source of truth as the inbox search (receptionOnlyCreatedByUuid).
+                  // Previously derived from the row's auditDetails.createdBy, which is not
+                  // guaranteed to be present in the inbox payload — when it was missing the
+                  // param dropped and the details page queried unscoped.
+                  const ownCreatedByUuid = receptionOnlyCreatedByUuid();
+                  const query = ownCreatedByUuid ? `?createdBy=${encodeURIComponent(ownCreatedByUuid)}` : "";
                   return (
                     <Link to={`/${window.contextPath}/employee/pgr/complaint-details/${value}${query}`}>
                       {String(value ? (column.translate ? t(column.prefix ? `${column.prefix}${value}` : value) : value) : t("ES_COMMON_NA"))}
@@ -1808,9 +1831,8 @@ export const UICustomizations = {
     MobileDetailsOnClick: (row, tenantId) => {
       const complaintNo = row?.["CS_COMMON_COMPLAINT_NO"];
       if (!complaintNo) return `/${window.contextPath}/employee/pgr/inbox-v2`;
-      const currentUserUuid = Digit.UserService.getUser()?.info?.uuid;
-      const creatorUuid = row?.businessObject?.service?.auditDetails?.createdBy || row?.businessObject?.service?.createdBy;
-      const query = creatorUuid && creatorUuid === currentUserUuid ? `?createdBy=${encodeURIComponent(currentUserUuid)}` : "";
+      const ownCreatedByUuid = receptionOnlyCreatedByUuid();
+      const query = ownCreatedByUuid ? `?createdBy=${encodeURIComponent(ownCreatedByUuid)}` : "";
       return `/${window.contextPath}/employee/pgr/complaint-details/${complaintNo}${query}`;
     },
   },

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/AdminSearch.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/AdminSearch.js
@@ -754,7 +754,11 @@ const PGRAdminSearch = () => {
                   const dept = deptCell(deptOf(s));
                   const tint = deptTint(dept.code);
                   const statusLabel = tr(`CS_COMMON_${s.applicationStatus}`, s.applicationStatus);
-                  const detailUrl = `/${window.contextPath}/employee/pgr/complaint-details/${s.serviceRequestId}`;
+                  // Mark the origin: admin search is cross-department, the plain
+                  // /v2/request/_search the details page uses by default is scoped to
+                  // the viewer. Without this a result outside their own scope opens to
+                  // an empty page. PGRDetails reads `src` and queries _admin/_search.
+                  const detailUrl = `/${window.contextPath}/employee/pgr/complaint-details/${s.serviceRequestId}?src=admin`;
                   return (
                     <tr key={s.serviceRequestId} onClick={() => history.push(detailUrl)}
                       title={tr("ES_PGR_ADMIN_VIEW", "View")}>

--- a/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
+++ b/digit-ui-esbuild/products/pgr/src/pages/employee/PGRDetails.js
@@ -8,6 +8,8 @@ import { convertEpochFormateToDate } from "../../utils";
 import TimelineWrapper from "../../components/TimeLineWrapper";
 import PGRWorkflowModal from "../../components/PGRWorkflowModal";
 import ComplaintLocationMap from "../../components/ComplaintLocationMap";
+import { useQuery } from "react-query";
+import { Request } from "@egovernments/digit-ui-libraries";
 import Urls from "../../utils/urls";
 import ComplaintPhotos from "../../components/ComplaintPhotos";
 import { buildExtendedAttributeRows, useExtendedAttributeOrder } from "../../components/PgrExtendedAttributesView";
@@ -201,10 +203,33 @@ const PGRDetails = () => {
   const location = useLocation();
   const queryParams = new URLSearchParams(location.search);
   const searchCreatedBy = queryParams.get("createdBy");
-  const { isLoading, isError, error, data: pgrData, revalidate: pgrSearchRevalidate } = Digit.Hooks.pgr.usePGRSearch(
+  // Arrived from the admin search? That endpoint is cross-department while the
+  // default /v2/request/_search is scoped to the viewer, so a result outside
+  // their own scope would resolve to nothing here. Query the same endpoint the
+  // row came from. AdminSearch stamps `src=admin` on the link it builds.
+  const fromAdminSearch = queryParams.get("src") === "admin";
+
+  // Signature is (searchparams, tenantId, filters, config) — the react-query
+  // config is the FOURTH arg; passing it third would land in `filters`.
+  const pgrSearch = Digit.Hooks.pgr.usePGRSearch(
     { serviceRequestId: id, ...(searchCreatedBy ? { createdBy: searchCreatedBy } : {}) },
-    tenantId
+    tenantId,
+    undefined,
+    { enabled: !fromAdminSearch }
   );
+
+  const adminSearch = useQuery(
+    ["pgr-admin-detail", tenantId, id],
+    () => Request({ url: Urls.pgr.adminSearch, method: "POST", auth: true, userService: true, useCache: false,
+                    params: { tenantId, serviceRequestId: id } }),
+    { enabled: fromAdminSearch, retry: false, staleTime: 0, cacheTime: 0 }
+  );
+
+  const isLoading = fromAdminSearch ? adminSearch.isLoading : pgrSearch.isLoading;
+  const isError = fromAdminSearch ? adminSearch.isError : pgrSearch.isError;
+  const error = fromAdminSearch ? adminSearch.error : pgrSearch.error;
+  const pgrData = fromAdminSearch ? adminSearch.data : pgrSearch.data;
+  const pgrSearchRevalidate = fromAdminSearch ? adminSearch.refetch : pgrSearch.revalidate;
   // CCSD-2123: schema x-order for the Additional Details rows (complainantName
   // pinned first inside buildExtendedAttributeRows regardless).
   const extAttrOrder = useExtendedAttributeOrder(pgrData?.ServiceWrappers?.[0]?.service?.extendedAttributes);


### PR DESCRIPTION
Two ways of reaching the complaint-details page lose the context the result list was built with. The details page then re-queries with a **narrower scope than the row the user just clicked**, and renders "No Results Found" on a complaint that was visible a moment earlier.

Frontend only — no API, workflow, MDMS or role changes.

## 1. Inbox → details dropped `createdBy`

The inbox scopes a reception officer to the complaints they created, and `PGRDetails` **already** honours a `createdBy` query param. The break was in the link, which re-derived the condition independently:

```js
// before — link decides from row data
const creatorUuid = row?.businessObject?.service?.auditDetails?.createdBy;
const query = creatorUuid && creatorUuid === currentUserUuid ? `?createdBy=…` : "";

// search decides from the role list
if (cmsRoles.includes("CMS_RECEPTION_OFFICER") && cmsRoles.every(c => c === "CMS_RECEPTION_OFFICER")) …
```

Two implementations of one rule. `auditDetails.createdBy` is not guaranteed to be present in the inbox payload, and when it was absent the param silently dropped and the details search ran unscoped.

Both sides now call one exported helper, `receptionOnlyCreatedByUuid()`, so the link and the search **agree by construction** rather than by happening to match. Applied to the table cell link and the mobile link.

## 2. Admin search → details queried the wrong endpoint

`AdminSearch` built a bare URL with no marker, so `PGRDetails` fell through to its default `usePGRSearch` → `/pgr-services/v2/request/_search`, which is **scoped to the viewer**. Admin search (`/v2/request/_admin/_search`) is not. Any result outside the viewer's own scope opened to an empty page.

`AdminSearch` now stamps `?src=admin` on the link, and `PGRDetails` queries `_admin/_search` when it sees it, keeping the normal hook for every other entry point. Both return the same `ServiceWrappers` shape — identical `Request` plumbing — so nothing downstream of the fetch changes.

## Notes for review

- `usePGRSearch`'s signature is `(searchparams, tenantId, filters, config)` — the react-query config is the **fourth** argument. Passing it third lands in `filters` and silently corrupts the query key. Called out in a comment at the call site because it is easy to get wrong.
- The two fetches are mutually exclusive via `enabled`, so only one request is ever in flight.
- Verified all three files parse under esbuild with the JSX loader. The duplicate-key warnings it reports in `UICustomizations.js` are pre-existing (lines 2645 / 2717 / 2726) and untouched here.

## Testing

Both defects are **code-proven**; I was not able to reproduce #2 end to end on `cms-pilot` because that environment currently holds only 17 complaints, all within one department, so there is no cross-department row to click. Reproducing it needs a viewer whose scope excludes a complaint that admin search returns.

Worth flagging separately while looking at this: `POST /v2/request/_admin/_search` returns **500 NullPointerException** when `RequestInfo.userInfo` is null, rather than 401 — same endpoint as the already-documented missing server-side authorization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
