### PR TITLE
fix(configurator): self-heal missing arm64 rollup native binary in Docker build

### DIFF
--- a/configurator/Dockerfile
+++ b/configurator/Dockerfile
@@ -19,6 +19,18 @@ COPY configurator/package.json configurator/package-lock.json ./
 COPY configurator/packages ./packages
 # Install (fallback to install if the lockfile drifted, matching the on-box script).
 RUN npm ci || npm install
+# `npm ci` above can silently OMIT a platform's rollup native optional dependency
+# (e.g. @rollup/rollup-linux-arm64-gnu) when package-lock.json was only ever
+# regenerated on x64 hosts — npm/cli#4828. That's not a lockfile-mismatch error, so
+# `npm ci` still exits 0 and the fallback above never triggers; the missing binary
+# then only surfaces later as a `vite build` crash. A plain follow-up `npm install`
+# does NOT fix this either — with the lock already present it reports "up to
+# date" and never re-resolves the missing optional package. Detect it directly
+# (requiring `rollup` is what actually throws) and, only when broken, drop the
+# lock and node_modules for a clean re-resolve against the registry for THIS
+# platform — verified this is the only combination that actually installs the
+# right native binary on arm64.
+RUN node -e "require('rollup')" || (rm -rf node_modules package-lock.json && npm install)
 COPY ui-shared /app/ui-shared
 COPY configurator .
 # Build any file: sub-package that has a build script (vite needs their dist/).


### PR DESCRIPTION
## Summary
- The SPA Build Pipeline's arm64 leg ([run 32374469745](https://github.com/egovernments/Citizen-Complaint-Resolution-System/actions/runs/32374469745)) fails `vite build` with `Cannot find module @rollup/rollup-linux-arm64-gnu` — [npm/cli#4828](https://github.com/npm/cli/issues/4828).
- `configurator/package-lock.json` only has resolved entries for the `x64-gnu`/`x64-musl` rollup optional binaries (it's only ever been regenerated on x64 hosts), so `npm ci` silently skips the `arm64-gnu` one on the native arm64 CI runner without erroring — the existing `npm ci || npm install` fallback never triggers because `npm ci` still exits 0.
- A plain follow-up `npm install` doesn't fix it either — with the lock already present it reports "up to date" and never re-resolves the missing optional package (verified locally).
- Fix: probe with `node -e "require('rollup')"` (the actual thing that throws) right after install, and only when it fails, drop `node_modules` + `package-lock.json` and reinstall fresh so npm re-resolves `optionalDependencies` against the registry for the real current platform.

## Test plan
- [x] Reproduced the failure locally via `docker buildx build --platform linux/arm64` under QEMU emulation (`tonistiigi/binfmt`) against the unfixed Dockerfile — same `Cannot find module @rollup/rollup-linux-arm64-gnu` error as the CI run.
- [x] Verified the fix resolves it: probe throws → repair runs → `npm install` correctly installs `@rollup/rollup-linux-arm64-gnu` → full build (sub-packages, `vite build`, nginx stage) succeeds end-to-end on arm64.
- [x] Verified amd64 is unaffected: probe passes immediately (no repair triggered), build completes in the same time as before.
- [ ] Confirm the real `SPA Build Pipeline` workflow run (workflow_dispatch, `configurator`) goes green on both `amd64` and `arm64` matrix legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)