### PR TITLE
chore: bump mdms-v2 image to maven-jdk21-f3a7c13

### DIFF
--- a/local-setup/docker-compose.db-migrations.yml
+++ b/local-setup/docker-compose.db-migrations.yml
@@ -228,7 +228,7 @@ services:
 
   # MDMS Backend (actual service)
   mdms-backend:
-    image: egovio/mdms-v2:mdms-count-api-3ac4f8e
+    image: egovio/mdms-v2:maven-jdk21-f3a7c13
     container_name: mdms-backend
     depends_on:
       pgbouncer:

--- a/local-setup/docker-compose.deploy.yaml
+++ b/local-setup/docker-compose.deploy.yaml
@@ -145,10 +145,10 @@ services:
       - egov-network
 
   # MDMS Backend
-  # mdms-count-api-3ac4f8e adds POST /v2/_count (issue #953: real totals for the
+  # maven-jdk21-f3a7c13 includes POST /v2/_count (issue #953: real totals for the
   # configurator's MDMS list pagination — see configurator DigitApiClient.mdmsCount).
   mdms-backend:
-    image: egovio/mdms-v2:mdms-count-api-3ac4f8e
+    image: egovio/mdms-v2:maven-jdk21-f3a7c13
     container_name: mdms-backend
     depends_on:
       pgbouncer:

--- a/local-setup/docker-compose.egov-digit.yaml
+++ b/local-setup/docker-compose.egov-digit.yaml
@@ -571,7 +571,7 @@ services:
 
   # MDMS Backend (actual service)
   mdms-backend:
-    image: egovio/mdms-v2:mdms-count-api-3ac4f8e
+    image: egovio/mdms-v2:maven-jdk21-f3a7c13
     depends_on:
       pgbouncer:
         condition: service_healthy

--- a/local-setup/docker-compose.registry.yml
+++ b/local-setup/docker-compose.registry.yml
@@ -443,7 +443,7 @@ services:
 
   # MDMS Backend (actual service)
   mdms-backend:
-    image: egovio/mdms-v2:mdms-count-api-3ac4f8e
+    image: egovio/mdms-v2:maven-jdk21-f3a7c13
     depends_on:
       pgbouncer:
         condition: service_healthy

--- a/local-setup/docker-compose.yml
+++ b/local-setup/docker-compose.yml
@@ -169,7 +169,7 @@ services:
 
   # MDMS Backend
   mdms-backend:
-    image: egovio/mdms-v2:mdms-count-api-3ac4f8e
+    image: egovio/mdms-v2:maven-jdk21-f3a7c13
     container_name: mdms-backend
     depends_on:
       pgbouncer:


### PR DESCRIPTION
## Summary
- Bump the pinned `egovio/mdms-v2` image tag from `mdms-count-api-3ac4f8e` to `maven-jdk21-f3a7c13` across all docker-compose files.
- Update the stale comment on `docker-compose.deploy.yaml`'s `mdms-backend` service to reference the new tag (confirmed the new tag still serves `POST /v2/_count`, used by configurator MDMS list pagination — issue #953).

## Files changed
- `local-setup/docker-compose.yml`
- `local-setup/docker-compose.deploy.yaml`
- `local-setup/docker-compose.db-migrations.yml`
- `local-setup/docker-compose.registry.yml`
- `local-setup/docker-compose.egov-digit.yaml`

## Test plan
- [ ] `docker compose up -d` on affected compose files and confirm `mdms-backend` starts healthy
- [ ] Verify configurator MDMS list pagination still works (exercises `POST /v2/_count`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)