### PR TITLE
feat(dashboard): public page gets filters, Add KPI/Reset and a language switcher (#1797)

### DIFF
--- a/.github/scripts/check-gateway-whitelist-parity.py
+++ b/.github/scripts/check-gateway-whitelist-parity.py
@@ -38,6 +38,8 @@ _ENTRY = re.compile(r'\["(/[^"]+)"\]\s*=\s*true')
 KONG_ONLY_AUTH_OPTIONAL = {
     "/pgr-services/v2/analytics/public/packs",
     "/pgr-services/v2/analytics/public/_query",
+    "/pgr-services/v2/analytics/public/catalog/_search",
+    "/pgr-services/v2/analytics/public/_options",
 }
 
 

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsController.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsController.java
@@ -2,6 +2,7 @@ package org.egov.pgr.analytics;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.extern.slf4j.Slf4j;
 import org.egov.common.contract.request.RequestInfo;
@@ -27,6 +28,13 @@ import java.util.stream.Collectors;
  *   POST /v2/analytics/packs           — return best-match DashboardPack + safe tile descriptors
  *   POST /v2/analytics/catalog/_search — return all visible KpiDefinition tiles (no query/rbac)
  *
+ * Anonymous twins (Kong-only auth-optional aliases; RequestInfo is discarded by construction):
+ *   POST /v2/analytics/public/packs           — curated PUBLIC pack, fail-closed when disabled
+ *   POST /v2/analytics/public/catalog/_search — every PUBLIC-tagged published tile (Add KPI menu)
+ *   POST /v2/analytics/public/_options        — filter-bar option codes (wards / complaint types)
+ *   POST /v2/analytics/public/_query          — {kpiId[, params]} refs over PUBLIC tiles, with
+ *                                               params restricted to PUBLIC_QUERY_PARAMS
+ *
  * Body (single):  { "RequestInfo": {...}, "tenantId": "ke", "query": { ...grammar... } }
  * Body (batch):   { "RequestInfo": {...}, "tenantId": "ke", "queries": { "name": {...}, ... } }
  */
@@ -37,6 +45,20 @@ public class AnalyticsController {
 
     private static final Set<String> DASHBOARD_CONFIG_ROLES =
             Set.of("MDMS_ADMIN", "SUPERUSER", "LOC_ADMIN");
+
+    /**
+     * The only query params an anonymous caller may attach to a public KPI reference (#1797):
+     * the dashboard's global filter bar. Each is a NARROWING predicate the composer layers under
+     * the def's own query; none can widen the window, switch the aggregation level
+     * ({@code hierLevel}), fan out companions ({@code compare}/{@code series}) or reach a
+     * per-complaint source. Values are scalar strings, length-capped, and the dates must be ISO
+     * calendar days — anything else is rejected before the batch reaches the service.
+     */
+    static final Set<String> PUBLIC_QUERY_PARAMS =
+            Set.of("dateFrom", "dateTo", "ward", "serviceCode", "complaintPath");
+    static final int PUBLIC_QUERY_PARAM_MAX_LENGTH = 128;
+    private static final java.util.regex.Pattern ISO_DAY =
+            java.util.regex.Pattern.compile("\\d{4}-\\d{2}-\\d{2}");
 
     private final AnalyticsService service;
     private final KpiCatalogService kpiCatalogService;
@@ -127,9 +149,11 @@ public class AnalyticsController {
     }
 
     /**
-     * Anonymous dashboard data endpoint. Only a bounded batch of bare {@code {kpiId}} references
-     * selected by the tenant's matched PUBLIC pack is accepted. RequestInfo and caller parameters
-     * are discarded by construction before delegating to the normal analytics execution path.
+     * Anonymous dashboard data endpoint. Accepts a bounded batch of {@code {kpiId[, params]}}
+     * references over the tenant's PUBLIC-tagged published tiles (the same set the public Add-KPI
+     * menu offers; the matched PUBLIC pack must still exist as the fail-closed gate). RequestInfo
+     * is discarded by construction; {@code params} is rebuilt from the {@link #PUBLIC_QUERY_PARAMS}
+     * allow-list — never forwarded verbatim — before delegating to the normal execution path.
      */
     @PostMapping("/public/_query")
     public ResponseEntity<Map<String,Object>> publicQuery(@RequestBody JsonNode body,
@@ -153,28 +177,38 @@ public class AnalyticsController {
 
             Set<String> publicRoles = Set.of(AnalyticsService.PUBLIC_ROLE);
             List<KpiDefinition> visibleDefs = kpiCatalogService.getVisibleDefs(tenantId, publicRoles);
-            DashboardPack pack = kpiCatalogService.getBestPack(tenantId, publicRoles, visibleDefs)
+            // The pack is the fail-closed enablement gate; the tile set is the PUBLIC catalog,
+            // so a tile a visitor added from the public Add-KPI menu is queryable too (#1797).
+            kpiCatalogService.getBestPack(tenantId, publicRoles, visibleDefs)
                     .orElseThrow(() -> new IllegalArgumentException(
                             "public_pack_not_found: no PUBLIC dashboard pack is configured"));
-            Set<String> allowedKpis = new HashSet<>(
-                    pack.getTiles() == null ? Collections.emptyList() : pack.getTiles());
+            Set<String> allowedKpis = visibleDefs.stream()
+                    .map(KpiDefinition::getId).collect(Collectors.toSet());
 
             ObjectNode sanitizedQueries = mapper.createObjectNode();
             Iterator<Map.Entry<String,JsonNode>> it = queries.fields();
             while (it.hasNext()) {
                 Map.Entry<String,JsonNode> entry = it.next();
                 JsonNode ref = entry.getValue();
-                if (ref == null || !ref.isObject() || ref.size() != 1 || !ref.hasNonNull("kpiId")
+                if (ref == null || !ref.isObject() || !ref.hasNonNull("kpiId")
                         || !ref.get("kpiId").isTextual() || ref.get("kpiId").asText().isEmpty()) {
                     throw new IllegalArgumentException(
-                            "invalid_param: public queries must be bare {kpiId} references without params");
+                            "invalid_param: public queries must be {kpiId[, params]} references");
+                }
+                for (Iterator<String> names = ref.fieldNames(); names.hasNext();) {
+                    String field = names.next();
+                    if (!field.equals("kpiId") && !field.equals("params"))
+                        throw new IllegalArgumentException(
+                                "invalid_param: public queries must be {kpiId[, params]} references");
                 }
                 String kpiId = ref.get("kpiId").asText();
                 if (!allowedKpis.contains(kpiId))
                     throw new IllegalArgumentException(
-                            "kpi_forbidden: KPI is not selected by the PUBLIC dashboard pack");
+                            "kpi_forbidden: KPI is not published to the PUBLIC audience");
                 ObjectNode cleanRef = mapper.createObjectNode();
                 cleanRef.put("kpiId", kpiId);
+                ObjectNode cleanParams = sanitizePublicParams(ref.get("params"));
+                if (cleanParams != null) cleanRef.set("params", cleanParams);
                 sanitizedQueries.set(entry.getKey(), cleanRef);
             }
 
@@ -189,6 +223,62 @@ public class AnalyticsController {
             return ResponseEntity.badRequest().body(error(e));
         } catch (Exception e) {
             log.error("public analytics query failed", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(publicUnavailable());
+        }
+    }
+
+    /**
+     * Anonymous catalog: every published tile tagged PUBLIC, as safe descriptors. Feeds the public
+     * page's Add-KPI menu (#1797) — the public equivalent of "everything your role can see". Same
+     * disabled/RequestInfo contract as {@link #publicQuery}.
+     */
+    @PostMapping("/public/catalog/_search")
+    public ResponseEntity<Map<String,Object>> searchPublicCatalog(@RequestBody Map<String,Object> body){
+        try {
+            String tenantId = extractTenantId(body);
+            if (!kpiCatalogService.isPublicDashboardEnabled(tenantId)) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error(
+                        new IllegalArgumentException(
+                                "public_dashboard_disabled: public dashboard is not enabled for this tenant")));
+            }
+            List<Map<String,Object>> tiles = kpiCatalogService
+                    .getVisibleDefs(tenantId, Set.of(AnalyticsService.PUBLIC_ROLE)).stream()
+                    .map(this::safeTile)
+                    .collect(Collectors.toList());
+            Map<String,Object> out = new LinkedHashMap<>();
+            out.put("tiles", tiles);
+            out.put("total", tiles.size());
+            return ResponseEntity.ok(out);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(error(e));
+        } catch (Exception e) {
+            log.error("public analytics catalog search failed", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(publicUnavailable());
+        }
+    }
+
+    /**
+     * Anonymous filter-bar options: the ward and complaint-type codes that carry complaints on
+     * this tenant (#1797). The caller supplies nothing but the tenant; the two distinct queries
+     * are server-owned constants (see {@link AnalyticsService#publicFilterOptions}).
+     */
+    @PostMapping("/public/_options")
+    public ResponseEntity<Map<String,Object>> publicFilterOptions(@RequestBody Map<String,Object> body,
+            @RequestHeader(value = "x-trace-id", required = false) String xTraceId){
+        try {
+            String tenantId = extractTenantId(body);
+            if (!kpiCatalogService.isPublicDashboardEnabled(tenantId)) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error(
+                        new IllegalArgumentException(
+                                "public_dashboard_disabled: public dashboard is not enabled for this tenant")));
+            }
+            int stateLen = config.getStateLevelTenantIdLength() == null
+                    ? 1 : config.getStateLevelTenantIdLength();
+            return ResponseEntity.ok(service.publicFilterOptions(tenantId, stateLen, xTraceId));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(error(e));
+        } catch (Exception e) {
+            log.error("public analytics filter options failed", e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(publicUnavailable());
         }
     }
@@ -317,6 +407,37 @@ public class AnalyticsController {
     private String matchingRole(DashboardPack pack, Set<String> callerRoles) {
         if (pack.getRoles() == null || callerRoles == null) return null;
         return pack.getRoles().stream().filter(callerRoles::contains).findFirst().orElse(null);
+    }
+
+    /**
+     * Rebuild a public ref's {@code params} from the allow-list. Returns null for an absent or
+     * empty object (the ref stays bare); throws {@code invalid_param} for any foreign key,
+     * non-scalar or blank value, over-long value, or non-ISO-day date.
+     */
+    static ObjectNode sanitizePublicParams(JsonNode params) {
+        if (params == null || params.isNull()) return null;
+        if (!params.isObject())
+            throw new IllegalArgumentException("invalid_param: public params must be an object");
+        if (params.isEmpty()) return null;
+        ObjectNode clean = JsonNodeFactory.instance.objectNode();
+        for (Iterator<Map.Entry<String,JsonNode>> it = params.fields(); it.hasNext();) {
+            Map.Entry<String,JsonNode> e = it.next();
+            String name = e.getKey();
+            JsonNode v = e.getValue();
+            if (!PUBLIC_QUERY_PARAMS.contains(name))
+                throw new IllegalArgumentException("invalid_param: public queries accept only "
+                        + new TreeSet<>(PUBLIC_QUERY_PARAMS) + "; got '" + name + "'");
+            if (v == null || !v.isValueNode() || v.isNull() || v.asText().trim().isEmpty())
+                throw new IllegalArgumentException("invalid_param: " + name + " must be a non-empty scalar value");
+            String text = v.asText().trim();
+            if (text.length() > PUBLIC_QUERY_PARAM_MAX_LENGTH)
+                throw new IllegalArgumentException("invalid_param: " + name + " exceeds "
+                        + PUBLIC_QUERY_PARAM_MAX_LENGTH + " characters");
+            if ((name.equals("dateFrom") || name.equals("dateTo")) && !ISO_DAY.matcher(text).matches())
+                throw new IllegalArgumentException("invalid_param: " + name + " must be yyyy-MM-dd");
+            clean.put(name, text);
+        }
+        return clean;
     }
 
     /** Serializes a KpiDefinition for external consumption: includes viz/params but NEVER query or rbac. */

--- a/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
+++ b/backend/pgr-services/src/main/java/org/egov/pgr/analytics/AnalyticsService.java
@@ -1,6 +1,8 @@
 package org.egov.pgr.analytics;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.extern.slf4j.Slf4j;
 import org.egov.common.contract.request.RequestInfo;
 import org.egov.common.contract.request.Role;
@@ -200,6 +202,91 @@ public class AnalyticsService {
         } else {
             throw new IllegalArgumentException("invalid_param: body must contain 'query' or 'queries'");
         }
+        return out;
+    }
+
+    /**
+     * The two filter-bar option sources the dashboard derives from ABAC-scoped distincts (the
+     * employee FE posts these verbatim as an inline batch; see useFilterOptions.OPTION_QUERIES).
+     * Fixed server-owned shape so the public arm can serve them without accepting an inline body.
+     */
+    static final String PUBLIC_OPTIONS_WARDS = "wards";
+    static final String PUBLIC_OPTIONS_COMPLAINT_TYPES = "complaintTypes";
+    private static final int PUBLIC_OPTIONS_LIMIT = 300;
+
+    /**
+     * Anonymous filter-bar options (#1797). The public floor forbids inline queries — an inline
+     * body bypasses the catalog's PUBLIC opt-in — so the two distinct-dimension queries the
+     * employee filter bar runs inline are built HERE from constants, with no caller input beyond
+     * the tenant, and executed under the anonymous tenant-aggregate scope. The response mirrors
+     * the batch envelope ({@code results.wards.rows[].ward_code},
+     * {@code results.complaintTypes.rows[].service_code}) so the dashboard's option builder is
+     * shared between the two surfaces, but the per-code counts are dropped: a public caller
+     * learns WHICH codes carry complaints, never how many.
+     */
+    public Map<String,Object> publicFilterOptions(String tenantId, int stateLevelLen, String headerTraceId){
+        if (tenantId == null || tenantId.isEmpty()) throw new IllegalArgumentException("invalid_param: tenantId is required");
+        QueryTelemetry tel = new QueryTelemetry(metrics, tenantId, stateLevelLen);
+        try {
+            AnalyticsScope scope = scopeResolver.resolve(null, tenantId, stateLevelLen);
+            BusinessCalendar calendar = BusinessCalendar.of(
+                    kpiCatalogService.resolveTimeZone(tenantId), requestClock.getAsLong());
+            Map<String,Object> results = new LinkedHashMap<>();
+            boolean partial = false;
+            Map<String,String> sources = new LinkedHashMap<>();
+            sources.put(PUBLIC_OPTIONS_WARDS, "ward_code");
+            sources.put(PUBLIC_OPTIONS_COMPLAINT_TYPES, "service_code");
+            for (Map.Entry<String,String> src : sources.entrySet()) {
+                try {
+                    Map<String,Object> r = runOne(distinctDimensionQuery(src.getValue()), scope, tel,
+                            src.getKey(), "public-options", calendar);
+                    results.put(src.getKey(), codesOnly(r, src.getValue()));
+                } catch (Exception ex) {
+                    partial = true;
+                    results.put(src.getKey(), err(ex));
+                }
+            }
+            Map<String,Object> out = new LinkedHashMap<>();
+            out.put("asOf", asOf());
+            out.put("calendar", calendarInfo(calendar));
+            out.put("scope", scopeInfo(scope));
+            out.put("results", results);
+            out.put("partial", partial);
+            return out;
+        } finally {
+            if (!tel.isEmpty())
+                log.info(tel.slowQueryLine(QueryTelemetry.resolveTraceId(headerTraceId)));
+        }
+    }
+
+    /** {@code SELECT <dimension>, count(*) FROM facts (all time)} — the filter bar's distinct source. */
+    private JsonNode distinctDimensionQuery(String dimension) {
+        ObjectNode q = JsonNodeFactory.instance.objectNode();
+        q.put("grain", "facts");
+        q.putObject("window").put("name", "all");
+        q.putArray("dimensions").add(dimension);
+        q.putArray("measures").addObject().put("name", "n").put("agg", "count");
+        q.put("limit", PUBLIC_OPTIONS_LIMIT);
+        return q;
+    }
+
+    /** Project a distinct result down to its dimension column: no counts, no timing. */
+    @SuppressWarnings("unchecked")
+    private static Map<String,Object> codesOnly(Map<String,Object> result, String dimension) {
+        List<Map<String,Object>> rows = new ArrayList<>();
+        Object rawRows = result.get("rows");
+        if (rawRows instanceof List) {
+            for (Object row : (List<Object>) rawRows) {
+                if (!(row instanceof Map)) continue;
+                Object code = ((Map<String,Object>) row).get(dimension);
+                if (code == null || code.toString().trim().isEmpty()) continue;
+                rows.add(Collections.singletonMap(dimension, code));
+            }
+        }
+        Map<String,Object> out = new LinkedHashMap<>();
+        out.put("columns", Collections.singletonList(dimension));
+        out.put("rows", rows);
+        out.put("rowCount", rows.size());
         return out;
     }
 

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsControllerPublicTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsControllerPublicTest.java
@@ -266,25 +266,137 @@ public class AnalyticsControllerPublicTest {
     }
 
     @Test
-    public void publicQueryRejectsCallerParamsAndKpisOutsideThePack() throws Exception {
+    public void publicQueryForwardsOnlyAllowListedFilterParams() throws Exception {
         KpiDefinition def = publicDef("cl_public");
-        DashboardPack pack = publicPack("cl_public");
         when(kpiCatalogService.getVisibleDefs(eq("ke"), eq(Set.of("PUBLIC"))))
                 .thenReturn(Collections.singletonList(def));
         when(kpiCatalogService.getBestPack(eq("ke"), eq(Set.of("PUBLIC")), any()))
-                .thenReturn(Optional.of(pack));
+                .thenReturn(Optional.of(publicPack("cl_public")));
+        when(service.query(any(JsonNode.class), isNull(), eq("ke"), eq(1), isNull()))
+                .thenReturn(Map.of("results", Collections.emptyMap()));
 
-        ResponseEntity<Map<String,Object>> withParams = controller.publicQuery(mapper.readTree(
-                "{\"tenantId\":\"ke\",\"queries\":{\"tile\":{" +
-                        "\"kpiId\":\"cl_public\",\"params\":{\"ward\":\"W1\"}}}}"), null);
-        ResponseEntity<Map<String,Object>> outsidePack = controller.publicQuery(mapper.readTree(
-                "{\"tenantId\":\"ke\",\"queries\":{\"tile\":{" +
-                        "\"kpiId\":\"cl_other\"}}}"), null);
+        ResponseEntity<Map<String,Object>> response = controller.publicQuery(mapper.readTree(
+                "{\"tenantId\":\"ke\",\"queries\":{\"tile\":{\"kpiId\":\"cl_public\"," +
+                        "\"params\":{\"dateFrom\":\"2026-07-01\",\"dateTo\":\"2026-07-31\"," +
+                        "\"ward\":\" W1 \",\"serviceCode\":\"Pothole\",\"complaintPath\":\"Roads\"}}}}"),
+                null);
 
-        assertEquals(400, withParams.getStatusCodeValue());
-        assertEquals("invalid_param", withParams.getBody().get("error"));
-        assertEquals(400, outsidePack.getStatusCodeValue());
-        assertEquals("kpi_forbidden", outsidePack.getBody().get("error"));
+        assertEquals(200, response.getStatusCodeValue());
+        ArgumentCaptor<JsonNode> sanitized = ArgumentCaptor.forClass(JsonNode.class);
+        verify(service).query(sanitized.capture(), isNull(), eq("ke"), eq(1), isNull());
+        JsonNode params = sanitized.getValue().at("/queries/tile/params");
+        assertEquals(mapper.readTree("{\"dateFrom\":\"2026-07-01\",\"dateTo\":\"2026-07-31\"," +
+                "\"ward\":\"W1\",\"serviceCode\":\"Pothole\",\"complaintPath\":\"Roads\"}"), params);
+    }
+
+    @Test
+    public void publicQueryAllowsAnyPublicTileNotJustPackTiles() throws Exception {
+        when(kpiCatalogService.getVisibleDefs(eq("ke"), eq(Set.of("PUBLIC"))))
+                .thenReturn(Arrays.asList(publicDef("cl_public"), publicDef("cl_public_extra")));
+        when(kpiCatalogService.getBestPack(eq("ke"), eq(Set.of("PUBLIC")), any()))
+                .thenReturn(Optional.of(publicPack("cl_public")));
+        when(service.query(any(JsonNode.class), isNull(), eq("ke"), eq(1), isNull()))
+                .thenReturn(Map.of("results", Collections.emptyMap()));
+
+        ResponseEntity<Map<String,Object>> added = controller.publicQuery(mapper.readTree(
+                "{\"tenantId\":\"ke\",\"queries\":{\"tile\":{\"kpiId\":\"cl_public_extra\"}}}"), null);
+        ResponseEntity<Map<String,Object>> notPublic = controller.publicQuery(mapper.readTree(
+                "{\"tenantId\":\"ke\",\"queries\":{\"tile\":{\"kpiId\":\"cl_officer_pii\"}}}"), null);
+
+        assertEquals(200, added.getStatusCodeValue());
+        assertEquals(400, notPublic.getStatusCodeValue());
+        assertEquals("kpi_forbidden", notPublic.getBody().get("error"));
+        verify(service, times(1)).query(any(JsonNode.class), isNull(), eq("ke"), eq(1), isNull());
+    }
+
+    @Test
+    public void publicQueryRejectsEveryParamOutsideTheAllowList() throws Exception {
+        KpiDefinition def = publicDef("cl_public");
+        when(kpiCatalogService.getVisibleDefs(eq("ke"), eq(Set.of("PUBLIC"))))
+                .thenReturn(Collections.singletonList(def));
+        when(kpiCatalogService.getBestPack(eq("ke"), eq(Set.of("PUBLIC")), any()))
+                .thenReturn(Optional.of(publicPack("cl_public")));
+
+        String[] rejected = {
+                "{\"hierLevel\":\"1\"}",                       // aggregation level
+                "{\"compare\":\"prior\"}",                     // companion fan-out
+                "{\"series\":\"daily\"}",
+                "{\"window\":\"all\"}",                        // window override
+                "{\"ward\":[\"W1\",\"W2\"]}",                 // non-scalar
+                "{\"ward\":\"   \"}",                          // blank
+                "{\"dateFrom\":\"01/07/2026\"}",               // not an ISO day
+                "{\"serviceCode\":\"" + "x".repeat(129) + "\"}", // over-long
+        };
+        for (String params : rejected) {
+            ResponseEntity<Map<String,Object>> response = controller.publicQuery(mapper.readTree(
+                    "{\"tenantId\":\"ke\",\"queries\":{\"tile\":{" +
+                            "\"kpiId\":\"cl_public\",\"params\":" + params + "}}}"), null);
+            assertEquals(400, response.getStatusCodeValue(), params);
+            assertEquals("invalid_param", response.getBody().get("error"), params);
+        }
+        // A foreign top-level field on the ref is rejected too (nothing but kpiId/params).
+        ResponseEntity<Map<String,Object>> foreign = controller.publicQuery(mapper.readTree(
+                "{\"tenantId\":\"ke\",\"queries\":{\"tile\":{" +
+                        "\"kpiId\":\"cl_public\",\"query\":{\"grain\":\"facts\"}}}}"), null);
+        assertEquals(400, foreign.getStatusCodeValue());
+        assertEquals("invalid_param", foreign.getBody().get("error"));
         verifyNoInteractions(service);
+    }
+
+    @Test
+    public void publicCatalogListsEveryPublicTileAndIgnoresSpoofedRequestInfo() {
+        when(kpiCatalogService.getVisibleDefs(eq("ke"), eq(Set.of("PUBLIC"))))
+                .thenReturn(Arrays.asList(publicDef("cl_public"), publicDef("cl_public_extra")));
+
+        ResponseEntity<Map<String,Object>> response = controller.searchPublicCatalog(Map.of(
+                "tenantId", "ke",
+                "RequestInfo", Map.of("userInfo", Map.of("roles", List.of(Map.of("code", "SUPERUSER"))))));
+
+        assertEquals(200, response.getStatusCodeValue());
+        assertEquals(2, response.getBody().get("total"));
+        @SuppressWarnings("unchecked")
+        List<Map<String,Object>> tiles = (List<Map<String,Object>>) response.getBody().get("tiles");
+        assertEquals(List.of("cl_public", "cl_public_extra"),
+                tiles.stream().map(t -> t.get("kpiId")).collect(java.util.stream.Collectors.toList()));
+        for (Map<String,Object> tile : tiles) {
+            assertFalse(tile.containsKey("query"));
+            assertFalse(tile.containsKey("rbac"));
+        }
+        verify(kpiCatalogService, never()).getVisibleDefs(anyString(), eq(Set.of("SUPERUSER")));
+    }
+
+    @Test
+    public void publicCatalogAndOptionsFailClosedWhenDisabled() {
+        when(kpiCatalogService.isPublicDashboardEnabled("ke")).thenReturn(false);
+
+        ResponseEntity<Map<String,Object>> catalog = controller.searchPublicCatalog(Map.of("tenantId", "ke"));
+        ResponseEntity<Map<String,Object>> options = controller.publicFilterOptions(Map.of("tenantId", "ke"), null);
+
+        assertEquals(404, catalog.getStatusCodeValue());
+        assertEquals("public_dashboard_disabled", catalog.getBody().get("error"));
+        assertEquals(404, options.getStatusCodeValue());
+        assertEquals("public_dashboard_disabled", options.getBody().get("error"));
+        verifyNoInteractions(service);
+        verify(kpiCatalogService, never()).getVisibleDefs(anyString(), any());
+    }
+
+    @Test
+    public void publicOptionsDelegateToTheServerOwnedDistinctsAndHideFailures() {
+        when(service.publicFilterOptions("ke", 1, "trace-9"))
+                .thenReturn(Map.of("results", Map.of("wards", Map.of("rows", List.of(Map.of("ward_code", "W1"))))));
+
+        ResponseEntity<Map<String,Object>> response = controller.publicFilterOptions(Map.of(
+                "tenantId", "ke",
+                "RequestInfo", Map.of("authToken", "stolen")), "trace-9");
+
+        assertEquals(200, response.getStatusCodeValue());
+        assertTrue(response.getBody().containsKey("results"));
+        verify(service).publicFilterOptions("ke", 1, "trace-9");
+
+        when(service.publicFilterOptions("ke", 1, null))
+                .thenThrow(new RuntimeException("select password from private_table"));
+        ResponseEntity<Map<String,Object>> failure = controller.publicFilterOptions(Map.of("tenantId", "ke"), null);
+        assertEquals(500, failure.getStatusCodeValue());
+        assertFalse(failure.getBody().toString().contains("private_table"));
     }
 }

--- a/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsServicePublicOptionsTest.java
+++ b/backend/pgr-services/src/test/java/org/egov/pgr/analytics/AnalyticsServicePublicOptionsTest.java
@@ -1,0 +1,114 @@
+package org.egov.pgr.analytics;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.time.ZoneId;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * The anonymous filter-bar option source (#1797): server-owned distinct queries, anonymous
+ * tenant-aggregate scope, codes only on the wire.
+ */
+public class AnalyticsServicePublicOptionsTest {
+
+    private AnalyticsPlanner planner;
+    private JdbcTemplate jdbc;
+    private PrincipalScopeResolver scopeResolver;
+    private KpiCatalogService kpiCatalogService;
+    private AnalyticsService service;
+
+    @BeforeEach
+    public void setUp() {
+        planner = mock(AnalyticsPlanner.class);
+        jdbc = mock(JdbcTemplate.class);
+        scopeResolver = mock(PrincipalScopeResolver.class);
+        kpiCatalogService = mock(KpiCatalogService.class);
+        service = new AnalyticsService(planner, null, jdbc, kpiCatalogService, scopeResolver,
+                null, new AnalyticsMetrics(), null);
+        when(kpiCatalogService.resolveTimeZone("ke")).thenReturn(ZoneId.of("Africa/Nairobi"));
+        when(scopeResolver.resolve(isNull(), eq("ke"), eq(1)))
+                .thenReturn(new AnalyticsScope("ke", true, null, null, null));
+        when(planner.plan(any(JsonNode.class), any(), any())).thenAnswer(inv -> {
+            JsonNode q = inv.getArgument(0);
+            String dim = q.get("dimensions").get(0).asText();
+            return new AnalyticsPlanner.Planned("SELECT " + dim, new ArrayList<>(),
+                    Arrays.asList(dim, "n"), "facts");
+        });
+    }
+
+    private static Map<String,Object> row(String col, Object code, long n) {
+        Map<String,Object> r = new LinkedHashMap<>();
+        r.put(col, code);
+        r.put("n", n);
+        return r;
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void runsTheTwoFixedDistinctsUnderAnonymousScopeAndStripsCounts() {
+        when(jdbc.queryForList(eq("SELECT ward_code"), any(Object[].class)))
+                .thenReturn(Arrays.asList(row("ward_code", "W1", 7), row("ward_code", " ", 1),
+                        row("ward_code", null, 2), row("ward_code", "W2", 3)));
+        when(jdbc.queryForList(eq("SELECT service_code"), any(Object[].class)))
+                .thenReturn(Collections.singletonList(row("service_code", "Pothole", 9)));
+
+        Map<String,Object> out = service.publicFilterOptions("ke", 1, null);
+
+        // Anonymous principal: no RequestInfo ever reaches the resolver.
+        verify(scopeResolver).resolve(isNull(), eq("ke"), eq(1));
+
+        // The planned nodes are the server-owned constants, not anything caller-shaped.
+        ArgumentCaptor<JsonNode> planned = ArgumentCaptor.forClass(JsonNode.class);
+        verify(planner, times(2)).plan(planned.capture(), any(), any());
+        for (JsonNode q : planned.getAllValues()) {
+            assertEquals("facts", q.get("grain").asText());
+            assertEquals("all", q.at("/window/name").asText());
+            assertEquals(1, q.get("dimensions").size());
+            assertEquals("count", q.at("/measures/0/agg").asText());
+        }
+
+        Map<String,Object> results = (Map<String,Object>) out.get("results");
+        assertEquals(new HashSet<>(Arrays.asList("wards", "complaintTypes")), results.keySet());
+        Map<String,Object> wards = (Map<String,Object>) results.get("wards");
+        List<Map<String,Object>> wardRows = (List<Map<String,Object>>) wards.get("rows");
+        // Blank / null codes dropped; counts never leave the service.
+        assertEquals(Arrays.asList(Map.of("ward_code", "W1"), Map.of("ward_code", "W2")), wardRows);
+        assertEquals(Collections.singletonList("ward_code"), wards.get("columns"));
+        assertFalse(wards.containsKey("tookMs"));
+        Map<String,Object> types = (Map<String,Object>) results.get("complaintTypes");
+        assertEquals(Collections.singletonList(Map.of("service_code", "Pothole")), types.get("rows"));
+        assertEquals(Boolean.FALSE, out.get("partial"));
+        assertTrue(out.containsKey("calendar"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void oneFailingDistinctLeavesTheOtherUsable() {
+        when(jdbc.queryForList(eq("SELECT ward_code"), any(Object[].class)))
+                .thenThrow(new RuntimeException("boom"));
+        when(jdbc.queryForList(eq("SELECT service_code"), any(Object[].class)))
+                .thenReturn(Collections.singletonList(row("service_code", "Pothole", 9)));
+
+        Map<String,Object> out = service.publicFilterOptions("ke", 1, null);
+
+        Map<String,Object> results = (Map<String,Object>) out.get("results");
+        assertEquals(Boolean.TRUE, out.get("partial"));
+        assertTrue(((Map<String,Object>) results.get("wards")).containsKey("error"));
+        assertEquals(Collections.singletonList(Map.of("service_code", "Pothole")),
+                ((Map<String,Object>) results.get("complaintTypes")).get("rows"));
+    }
+
+    @Test
+    public void missingTenantIsRejectedBeforeAnyWork() {
+        assertThrows(IllegalArgumentException.class, () -> service.publicFilterOptions("", 1, null));
+        verifyNoInteractions(scopeResolver, jdbc, planner);
+    }
+}

--- a/digit-mcp/src/tools/dashboard-l10n-seed.ts
+++ b/digit-mcp/src/tools/dashboard-l10n-seed.ts
@@ -465,6 +465,11 @@ export const DASHBOARD_L10N_MESSAGES: { code: string; message: string; module: s
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "DASHBOARD_HEADER_LANGUAGE",
+    "message": "Language",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "DASHBOARD_HEADER_LAST_7_DAYS",
     "message": "Last 7 days",
     "module": "rainmaker-dashboard"
@@ -2081,6 +2086,11 @@ export const DASHBOARD_L10N_MESSAGES_PT_PT: { code: string; message: string; mod
   {
     "code": "DASHBOARD_HEADER_KPIS_AVAILABLE",
     "message": "KPIs disponíveis para a sua função",
+    "module": "rainmaker-dashboard"
+  },
+  {
+    "code": "DASHBOARD_HEADER_LANGUAGE",
+    "message": "Idioma",
     "module": "rainmaker-dashboard"
   },
   {

--- a/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/AdminDashboard.jsx
@@ -421,18 +421,21 @@ const AdminDashboardInner = ({ onSignOut, embedded = false, publicMode = false, 
   });
   useEffect(() => () => dashboardMetrics.flush("unmount"), []);
   const { t, language, i18nTick } = useDashboardT();
+  // Public persists too (#1797) — under public-only storage keys, see
+  // config/dashboardConfig.js — and draws its option lists from the anonymous
+  // /public/_options endpoint instead of the inline distinct batch.
   const { filters, setFilter, clearFilters, applyFilterOptions } =
-    useDashboardFilters({ persistent: !publicMode, timeZone });
+    useDashboardFilters({ persistent: true, timeZone });
   const { options: filterOptions, loading: filterOptionsLoading } =
-    useFilterOptions({ enabled: !publicMode });
+    useFilterOptions({ enabled: true, publicMode });
   const tenantId = useMemo(() => getTenantId(), []);
 
   // Feed the server-scoped option lists into the filter store so persisted
   // filter values that no longer match any option get reconciled
   // (reconcileFiltersWithOptions) instead of silently sending dead params.
   useEffect(() => {
-    if (!publicMode && filterOptions) applyFilterOptions(filterOptions);
-  }, [filterOptions, applyFilterOptions, publicMode]);
+    if (filterOptions) applyFilterOptions(filterOptions);
+  }, [filterOptions, applyFilterOptions]);
   const { loading: catalogLoading, kpis, pack, error: catalogError } =
     useCatalog(tenantId, { publicMode });
 
@@ -484,7 +487,7 @@ const AdminDashboardInner = ({ onSignOut, embedded = false, publicMode = false, 
     addKpiToLayout,
     visibleLayoutIds,
     findDragHoverTarget,
-  } = useCatalogLayout(kpis, pack?.layout, { persistent: !publicMode });
+  } = useCatalogLayout(kpis, pack?.layout, { persistent: true });
 
   const [draggingWidgetId, setDraggingWidgetId] = useState(null);
   const draggingWidgetIdRef = useRef(null);
@@ -709,7 +712,7 @@ const AdminDashboardInner = ({ onSignOut, embedded = false, publicMode = false, 
   // BEFORE the new locale's bundles finish fetching, so the names must also
   // re-resolve when the messages actually land ("added" store event).
   const catalogItems = useMemo(
-    () => publicMode ? [] :
+    () =>
       Object.values(kpis)
         .filter((def) => !def.viz?.internal) // hide internal companion sources (e.g. map pins)
         .map((def) => ({
@@ -719,7 +722,7 @@ const AdminDashboardInner = ({ onSignOut, embedded = false, publicMode = false, 
           itemType: isCardKind(def.viz?.kind) ? "kpi" : "widget",
         })),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- i18nTick re-resolves titles on late bundle arrival
-    [kpis, language, i18nTick, publicMode]
+    [kpis, language, i18nTick]
   );
 
   // Re-run the batch whenever the catalog resolves, the filters change, or a
@@ -729,7 +732,7 @@ const AdminDashboardInner = ({ onSignOut, embedded = false, publicMode = false, 
   // Group-by change would never refire this effect).
   const refsKey = useMemo(
     () => publicMode
-      ? buildPublicRefsKey(tiles, kpis)
+      ? buildPublicRefsKey(tiles, kpis, filters)
       : buildRefsKey(tiles, kpis, filters, hierOverrides),
     [tiles, filters, kpis, hierOverrides, publicMode]
   );
@@ -740,7 +743,7 @@ const AdminDashboardInner = ({ onSignOut, embedded = false, publicMode = false, 
       return;
     }
     const refs = publicMode
-      ? buildPublicRefs(tiles, kpis)
+      ? buildPublicRefs(tiles, kpis, filters)
       : buildRefs(tiles, kpis, filters, hierOverrides);
     const reqId = ++reqIdRef.current;
     const controller = typeof AbortController !== "undefined" ? new AbortController() : null;
@@ -926,7 +929,7 @@ const AdminDashboardInner = ({ onSignOut, embedded = false, publicMode = false, 
   return (
     <DashboardLayout
       embedded={embedded}
-      readOnly={publicMode}
+      readOnly={false}
       publicMode={publicMode}
       visibleLayoutIds={visibleLayoutIds}
       catalogItems={catalogItems}
@@ -1002,9 +1005,9 @@ const AdminDashboardInner = ({ onSignOut, embedded = false, publicMode = false, 
           containerPadding={[0, 0]}
           compactType={null}
           allowOverlap={false}
-          isDraggable={!publicMode}
-          isResizable={!publicMode}
-          isDroppable={!publicMode && isExternalDrag}
+          isDraggable
+          isResizable
+          isDroppable={isExternalDrag}
           droppingItem={droppingItem}
           onDrop={handleGridDrop}
           onDropDragOver={handleDropDragOver}
@@ -1021,7 +1024,7 @@ const AdminDashboardInner = ({ onSignOut, embedded = false, publicMode = false, 
             const ignoredNote = typeFilterIgnored(batch.results?.[item.i]) ? (
               <TypeFilterIgnoredNote />
             ) : null;
-            const removeBtn = publicMode ? null : (
+            const removeBtn = (
               <WidgetRemoveButton
                 label={`${t("DASHBOARD_COMMON_REMOVE", "Remove")} ${resolveTitle(kpis[item.i]) || item.i}`}
                 onClick={(e) => {
@@ -1106,7 +1109,7 @@ const AdminDashboardInner = ({ onSignOut, embedded = false, publicMode = false, 
                 </div>
                 {ignoredNote}
                 {lastUpdatedLabel && <CardUpdatedStamp label={lastUpdatedLabel} />}
-                {!publicMode && <ResizeGrip />}
+                <ResizeGrip />
               </section>
             );
           })}

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardHeader.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardHeader.jsx
@@ -4,6 +4,7 @@ import { GEOGRAPHY_OPTIONS } from "../config/globalFilterGroups";
 import { dimensionLabel } from "../i18n/dimensionLabel";
 import useDashboardT from "../i18n/useDashboardT";
 import AddKpiDropdown from "./AddKpiDropdown";
+import LanguageMenu from "./LanguageMenu";
 
 /**
  * Derive the row-scope indicator from the analytics `scope` object the backend
@@ -103,6 +104,9 @@ const DashboardHeader = ({
   scope,
   readOnly = false,
   publicMode = false,
+  // The standalone/public shell has no host TopBar, so it carries its own
+  // language switcher (#1797); embedded leaves that to DigitUI.
+  showLanguageMenu = false,
 }) => {
   const [addKpiOpen, setAddKpiOpen] = useState(false);
   const addKpiRef = useRef(null);
@@ -111,12 +115,12 @@ const DashboardHeader = ({
   // `language` re-keys the memos on language switch; `i18nTick` re-keys them
   // when a locale bundle arrives asynchronously after the switch (t is stable).
   const rowScope = useMemo(() => buildRowScope(scope), [scope, language, i18nTick]);
+  // Every mode shows the same "<ward> · <period>" context line — the public
+  // page now has the filter bar too (#1797) and its visitors need to see what
+  // the numbers are scoped to. "Public view" survives as a pill beside the title.
   const subtitle = useMemo(
-    () =>
-      publicMode
-        ? t("DASHBOARD_HEADER_PUBLIC_SUBTITLE", "Public view")
-        : buildSubtitle(filters, filterOptions, t, language),
-    [publicMode, filters, filterOptions, t, language, i18nTick]
+    () => buildSubtitle(filters, filterOptions, t, language),
+    [filters, filterOptions, t, language, i18nTick]
   );
   // ONE full-phrase key wins when seeded — splicing the DASHBOARD_PRODUCT_LABEL
   // globalConfig onto a translated "Operations" produced mixed-language titles
@@ -140,6 +144,11 @@ const DashboardHeader = ({
               {title}
             </h1>
             <p className="tw-text-[11px] tw-text-muted-foreground">{subtitle}</p>
+            {publicMode ? (
+              <span className="tw-inline-flex tw-items-center tw-gap-1 tw-rounded-full tw-border tw-border-border tw-bg-surface-2 tw-px-2 tw-py-0.5 tw-text-[10px] tw-font-medium tw-uppercase tw-tracking-wide tw-text-muted-foreground">
+                {t("DASHBOARD_HEADER_PUBLIC_SUBTITLE", "Public view")}
+              </span>
+            ) : null}
             {scopedRole ? (
               <span
                 title={t(
@@ -209,6 +218,8 @@ const DashboardHeader = ({
         </div>
 
         <div className="dashboard-header-controls">
+          {showLanguageMenu && <LanguageMenu />}
+
           {!readOnly && <div className="dashboard-header-kpi-anchor">
             <button
               ref={addKpiRef}

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardLayout.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardLayout.jsx
@@ -50,6 +50,9 @@ const DashboardLayout = ({
       className={`dashboard-root${embedded ? " dashboard-embedded" : ""}${publicMode ? " dashboard-public" : ""} tw-flex tw-h-screen tw-overflow-hidden tw-bg-background tw-font-sans tw-text-foreground`}
       style={brandStyle}
     >
+      {/* The employee nav sidebar stays off the public page; its filter bar,
+          Add KPI / Reset and language switcher render through the header and
+          main column like every other mode (#1797). */}
       {!embedded && !publicMode && <Sidebar onSignOut={onSignOut} />}
       <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col tw-overflow-hidden">
         <DashboardHeader
@@ -70,6 +73,7 @@ const DashboardLayout = ({
           scope={scope}
           readOnly={readOnly}
           publicMode={publicMode}
+          showLanguageMenu={!embedded}
         />
         <main
           className={

--- a/digit-ui-esbuild/products/dashboard/src/components/LanguageMenu.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/LanguageMenu.jsx
@@ -1,0 +1,83 @@
+import React, { useEffect, useState } from "react";
+import PopoverMenu, { PopoverMenuItem } from "./ui/PopoverMenu";
+import { setLanguage } from "../i18n/localeRuntime";
+import useDashboardT from "../i18n/useDashboardT";
+import { fetchStateLanguages } from "../services/stateInfoService";
+
+const GlobeIcon = () => (
+  <svg
+    width="13"
+    height="13"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden
+  >
+    <circle cx="12" cy="12" r="10" />
+    <path d="M2 12h20" />
+    <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+  </svg>
+);
+
+/**
+ * Language switcher for the standalone/public shell (#1797). Embedded mode
+ * never mounts this — the DigitUI TopBar's ChangeLanguage owns the switch there.
+ *
+ * Options come from the tenant's `common-masters.StateInfo.languages` (the
+ * same master the TopBar reads); selecting one calls the runtime's
+ * setLanguage, which re-fetches the bundle and notifies every useDashboardT
+ * subscriber. Renders nothing until the list resolves, and stays hidden for a
+ * tenant that declares a single language — a one-item menu is just noise.
+ */
+const LanguageMenu = () => {
+  const { t, language } = useDashboardT();
+  const [languages, setLanguages] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchStateLanguages().then((list) => {
+      if (!cancelled) setLanguages(list);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!languages || languages.length < 2) return null;
+
+  const current = languages.find((l) => l.value === language);
+  return (
+    <PopoverMenu
+      ariaLabel={t("DASHBOARD_HEADER_LANGUAGE", "Language")}
+      icon={<GlobeIcon />}
+      chip={current?.label ?? language}
+      chipTitle={t("DASHBOARD_HEADER_LANGUAGE", "Language")}
+      align="end"
+      panelWidth={200}
+      chipClassName="dashboard-language-chip"
+    >
+      {({ close }) => (
+        <div className="dashboard-popover-list">
+          {languages.map((option) => (
+            <PopoverMenuItem
+              key={option.value}
+              selected={option.value === language}
+              title={option.label}
+              onSelect={() => {
+                setLanguage(option.value);
+                close();
+              }}
+            >
+              {option.label}
+            </PopoverMenuItem>
+          ))}
+        </div>
+      )}
+    </PopoverMenu>
+  );
+};
+
+export default LanguageMenu;

--- a/digit-ui-esbuild/products/dashboard/src/config/dashboardConfig.js
+++ b/digit-ui-esbuild/products/dashboard/src/config/dashboardConfig.js
@@ -1,3 +1,5 @@
+import { isPublicDashboardRuntime } from "../services/dashboardRuntime";
+
 /**
  * Default brand palette — override per tenant via globalConfigs (see keys below).
  * Defaults mirror the canonical palette tokens (--primary / --chrome /
@@ -51,14 +53,19 @@ export function getSystemTitle() {
   return `${getStateLabel()} — ${getProductLabel()} System`;
 }
 
+// The anonymous public page persists under its own `-public` suffix (#1797):
+// a visitor's filter selection must survive a reload, but may never read or
+// overwrite the employee slot a logged-in user on the same browser relies on.
+const publicSuffix = () => (isPublicDashboardRuntime() ? "-public" : "");
+
 export function getLayoutStorageKey() {
-  return `${getTenantId()}-supervisor-dashboard-layout-v31`;
+  return `${getTenantId()}-supervisor-dashboard-layout-v31${publicSuffix()}`;
 }
 
 export function getSubMetricStorageKey() {
-  return `${getTenantId()}-supervisor-dashboard-submetrics-v1`;
+  return `${getTenantId()}-supervisor-dashboard-submetrics-v1${publicSuffix()}`;
 }
 
 export function getFiltersStorageKey() {
-  return `${getTenantId()}-supervisor-dashboard-filters-v4`;
+  return `${getTenantId()}-supervisor-dashboard-filters-v4${publicSuffix()}`;
 }

--- a/digit-ui-esbuild/products/dashboard/src/hooks/useCatalog.js
+++ b/digit-ui-esbuild/products/dashboard/src/hooks/useCatalog.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { fetchPack, fetchCatalog, fetchPublicPack } from '../services/analyticsService';
+import { fetchPack, fetchCatalog, fetchPublicPack, fetchPublicCatalog } from '../services/analyticsService';
 import { markInteraction, setPackMeta } from '../services/dashboardMetrics';
 
 // Role set observed at the previous catalog fetch (module-scoped: survives
@@ -61,16 +61,23 @@ export function useCatalog(tenantId, { publicMode = false } = {}) {
 
     let cancelled = false;
     const request = publicMode
-      // Public is a curated, read-only surface. /public/packs already contains
-      // every descriptor it may render, so never open or call catalog/_search.
-      ? fetchPublicPack(tenantId).then((packRes) => [packRes, null])
+      // Public: the pack is the fail-closed gate, so read it first; only an
+      // enabled tenant gets the PUBLIC catalog (the Add-KPI menu source, #1797).
+      // A catalog failure degrades to the pack's own descriptors rather than
+      // blanking a page that can still render its default tiles.
+      ? fetchPublicPack(tenantId).then((packRes) =>
+          packRes?.enabled === false
+            ? [packRes, null]
+            : fetchPublicCatalog(tenantId)
+                .catch(() => null)
+                .then((catalogRes) => [packRes, catalogRes]))
       : Promise.all([fetchPack(tenantId), fetchCatalog(tenantId)]);
     request
       .then(([packRes, catalogRes]) => {
         if (cancelled) return;
-        const catalogTiles = publicMode
-          ? (packRes?.tiles || [])
-          : (catalogRes?.tiles || []);
+        const catalogTiles = catalogRes?.tiles?.length
+          ? catalogRes.tiles
+          : (packRes?.tiles || []);
         const allKpis = Object.fromEntries(
           catalogTiles.map(k => [k.kpiId, k])
         );

--- a/digit-ui-esbuild/products/dashboard/src/hooks/useCatalogLayout.js
+++ b/digit-ui-esbuild/products/dashboard/src/hooks/useCatalogLayout.js
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { GRID_COLS, DROPPING_ITEM_ID } from "../constants/layoutConfig";
 import { getEmployeeInfo, getTenantId } from "../services/authService";
+import { isPublicDashboardRuntime } from "../services/dashboardRuntime";
 import { createCatalogDragGeometry, isCatalogCard } from "../utils/catalogDragGeometry";
 import {
   storageKeyFor,
+  publicStorageKeyFor,
   readSavedLayout,
   persistLayout,
   buildSeedLayout,
@@ -30,6 +32,7 @@ export function getDroppingItemForKpi(kpiId, kpis) {
 }
 
 function scopedStorageKey() {
+  if (isPublicDashboardRuntime()) return publicStorageKeyFor(getTenantId());
   return storageKeyFor(getTenantId(), getEmployeeInfo()?.uuid);
 }
 

--- a/digit-ui-esbuild/products/dashboard/src/hooks/useFilterOptions.js
+++ b/digit-ui-esbuild/products/dashboard/src/hooks/useFilterOptions.js
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { runBatchQueries } from "../services/analyticsService";
+import { runBatchQueries, fetchPublicFilterOptions, getTenantId } from "../services/analyticsService";
 import {
   buildComplaintTypeIndex,
   fetchComplaintHierarchyRecords,
@@ -96,7 +96,12 @@ function toComplaintTypeDecorator(hierarchyIndex) {
   };
 }
 
-export function useFilterOptions({ enabled = true } = {}) {
+/**
+ * `publicMode` swaps the inline distinct batch for the anonymous
+ * /public/_options endpoint (#1797) — same envelope, server-owned queries,
+ * counts stripped — so everything below the fetch is shared.
+ */
+export function useFilterOptions({ enabled = true, publicMode = false } = {}) {
   // Raw fetch payload and derived labels are split so a language switch
   // re-labels from the cached rows without re-querying the backend.
   const [raw, setRaw] = useState({ results: null, hierarchyRecords: null, loading: true });
@@ -109,7 +114,7 @@ export function useFilterOptions({ enabled = true } = {}) {
     }
     let cancelled = false;
     Promise.all([
-      runBatchQueries(OPTION_QUERIES),
+      publicMode ? fetchPublicFilterOptions(getTenantId()) : runBatchQueries(OPTION_QUERIES),
       // Resolves null on any failure (never rejects) — labels then fall back
       // to the humanizer and the list stays flat, exactly the old behavior.
       fetchComplaintHierarchyRecords(),
@@ -125,7 +130,7 @@ export function useFilterOptions({ enabled = true } = {}) {
     return () => {
       cancelled = true;
     };
-  }, [enabled]);
+  }, [enabled, publicMode]);
 
   return useMemo(() => {
     if (!raw.results) return { options: null, loading: raw.loading };

--- a/digit-ui-esbuild/products/dashboard/src/i18n/localeRuntime.js
+++ b/digit-ui-esbuild/products/dashboard/src/i18n/localeRuntime.js
@@ -8,10 +8,12 @@
  *   call in Module.js, and the ChangeLanguage dropdown in the host TopBar
  *   drives language switches.
  *
- * - Standalone (dev harness, DashboardLogin): no Digit runtime exists, so a
- *   minimal in-module store fetches the same bundles straight from
- *   /localization/messages/v1/_search, keyed off localStorage["Employee.locale"]
- *   (the key the host writes on every language change).
+ * - Standalone (dev harness, DashboardLogin) and Public: no Digit runtime
+ *   exists, so a minimal in-module store fetches the same bundles straight from
+ *   /localization/messages/v1/_search. The harness keys the locale off
+ *   localStorage["Employee.locale"] (what the host writes on every language
+ *   change); the public page off its own PUBLIC_LOCALE_KEY. setLanguage() is
+ *   the in-page switch for both (#1797); embedded keeps the host TopBar's.
  *
  * The dashboard subtree stays self-contained: no @egovernments or
  * react-i18next imports — the host instance is reached via window.i18next.
@@ -20,31 +22,99 @@ import { getTenantId } from "../config/dashboardConfig";
 import { isPublicDashboardRuntime } from "../services/dashboardRuntime";
 
 const FALLBACK_LOCALE = "en_IN";
-const STANDALONE_MODULES = [
-  "rainmaker-dashboard",
-  "rainmaker-pgr",
-  "rainmaker-common",
-  "rainmaker-boundary-admin",
-];
+
+/**
+ * Where the standalone runtime remembers the visitor's language. The public
+ * page gets its OWN key (#1797): reading `Employee.locale` there would hand a
+ * co-hosted employee session's language to an anonymous page, and writing it
+ * from the public switcher would silently re-language the employee app.
+ */
+export const PUBLIC_LOCALE_KEY = "ccrs.dashboard.public-locale.v1";
+const EMPLOYEE_LOCALE_KEY = "Employee.locale";
+
+const globalConfig = (key) => {
+  try {
+    return window.globalConfigs?.getConfig?.(key) || undefined;
+  } catch (e) {
+    return undefined;
+  }
+};
+
+/**
+ * Same bundle set Module.js loads into the host i18next, derived the same way:
+ * the boundary pack follows globalConfigs.HIERARCHY_TYPE (hardcoding `admin`
+ * silently dropped ward names on every non-ADMIN tenant).
+ */
+export function standaloneModules() {
+  const hierarchyType = String(globalConfig("HIERARCHY_TYPE") || "ADMIN").toLowerCase();
+  return [
+    "rainmaker-dashboard",
+    "rainmaker-pgr",
+    "rainmaker-common",
+    `rainmaker-boundary-${hierarchyType}`,
+  ];
+}
 
 const standalone = {
   messages: {}, // { [locale]: { [code]: message } }
   pending: {}, // { [locale]: Promise }
   listeners: new Set(),
+  // Active locale once setLanguage() has run this page load. Storage is only
+  // the across-reloads memory: a browser that refuses localStorage (private
+  // mode, quota) must still switch language for the current visit.
+  locale: null,
 };
 
 const hostI18next = () => (typeof window !== "undefined" ? window.i18next : undefined);
 
+const localeStorageKey = () =>
+  isPublicDashboardRuntime() ? PUBLIC_LOCALE_KEY : EMPLOYEE_LOCALE_KEY;
+
+/**
+ * Deployment default for a visitor who has never picked a language: the same
+ * LOCALE_DEFAULT + "_" + LOCALE_REGION composition the employee app boots with
+ * (globalConfigs), else en_IN.
+ */
+function defaultLocale() {
+  const lang = globalConfig("LOCALE_DEFAULT");
+  const region = globalConfig("LOCALE_REGION");
+  return lang && region ? `${lang}_${region}` : FALLBACK_LOCALE;
+}
+
 const readStoredLocale = () => {
   try {
-    return window.localStorage.getItem("Employee.locale") || FALLBACK_LOCALE;
+    return window.localStorage.getItem(localeStorageKey()) || defaultLocale();
   } catch (e) {
-    return FALLBACK_LOCALE;
+    return defaultLocale();
   }
 };
 
 export function getLanguage() {
-  return hostI18next()?.language || readStoredLocale();
+  return hostI18next()?.language || standalone.locale || readStoredLocale();
+}
+
+/**
+ * Switch the standalone runtime's language (#1797). No-op when a host i18next
+ * exists — there the DigitUI TopBar owns the switch. Standalone: remember the
+ * choice under the mode-appropriate key, load the bundle (memoised), stamp
+ * <html lang>, and notify every useDashboardT subscriber so the whole tree —
+ * including imperatively-drawn charts keyed on `language` — re-renders.
+ */
+export function setLanguage(locale) {
+  if (!locale || hostI18next()) return Promise.resolve();
+  standalone.locale = locale;
+  try {
+    window.localStorage.setItem(localeStorageKey(), locale);
+  } catch (e) {
+    /* private mode / quota — the switch still applies for this page load */
+  }
+  try {
+    if (typeof document !== "undefined") document.documentElement.lang = locale.split("_")[0];
+  } catch (e) {
+    /* ignore */
+  }
+  notifyStandalone();
+  return loadStandaloneMessages(locale, standaloneAuthToken());
 }
 
 export function exists(key) {
@@ -89,7 +159,7 @@ function loadStandaloneMessages(locale, authToken) {
   if (standalone.messages[locale]) return Promise.resolve();
   if (standalone.pending[locale]) return standalone.pending[locale];
   const params = new URLSearchParams({
-    module: STANDALONE_MODULES.join(","),
+    module: standaloneModules().join(","),
     locale,
     tenantId: getTenantId(),
   });
@@ -129,16 +199,19 @@ function loadStandaloneMessages(locale, authToken) {
  */
 export function ensureMessages() {
   if (hostI18next()) return Promise.resolve();
-  let authToken = null;
-  if (!isPublicDashboardRuntime()) {
-    try {
-      authToken = window.localStorage.getItem("Employee.token");
-    } catch (e) {
-      /* ignore */
-    }
-  }
+  const authToken = standaloneAuthToken();
   const locales = [...new Set([getLanguage(), FALLBACK_LOCALE])];
   return Promise.all(locales.map((locale) => loadStandaloneMessages(locale, authToken)));
+}
+
+/** The dev harness attaches its employee token; the public runtime never reads storage for one. */
+function standaloneAuthToken() {
+  if (isPublicDashboardRuntime()) return null;
+  try {
+    return window.localStorage.getItem("Employee.token");
+  } catch (e) {
+    return null;
+  }
 }
 
 /**

--- a/digit-ui-esbuild/products/dashboard/src/services/analyticsService.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/analyticsService.js
@@ -148,7 +148,28 @@ export function fetchPublicPack(tenantId) {
   return postPublicAnalytics("/packs", { tenantId });
 }
 
-/** PUBLIC data path. The backend accepts only curated, base kpiId references. */
+/**
+ * POST /v2/analytics/public/catalog/_search — every PUBLIC-tagged published tile
+ * (#1797). Feeds the public Add-KPI menu; same safe tile shape as fetchCatalog.
+ */
+export function fetchPublicCatalog(tenantId) {
+  return postPublicAnalytics("/catalog/_search", { tenantId });
+}
+
+/**
+ * POST /v2/analytics/public/_options — filter-bar option codes (#1797). The
+ * response mirrors the inline-batch envelope useFilterOptions already reads
+ * (results.wards.rows[].ward_code / results.complaintTypes.rows[].service_code)
+ * so one option builder serves both surfaces; counts are stripped server-side.
+ */
+export function fetchPublicFilterOptions(tenantId) {
+  return postPublicAnalytics("/_options", { tenantId });
+}
+
+/**
+ * PUBLIC data path. The backend accepts {kpiId[, params]} references over
+ * PUBLIC-tagged tiles, with params limited to the global filter bar.
+ */
 export function runPublicKpiBatch(refs, tenantId, maxBatchQueries, options = {}) {
   return runChunkedAnalyticsBatch(
     refs,

--- a/digit-ui-esbuild/products/dashboard/src/services/complaintHierarchyService.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/complaintHierarchyService.js
@@ -5,6 +5,7 @@ import {
   hasAuth,
 } from "./authService";
 import { selectHierarchyDefinition, orderedLevels } from "../utils/hierLevelGrouping";
+import { isPublicDashboardRuntime } from "./dashboardRuntime";
 import { withTraceHeaders } from "./dashboardMetrics";
 
 /**
@@ -13,7 +14,7 @@ import { withTraceHeaders } from "./dashboardMetrics";
  * Falls back to the legacy service name when no config is present
  * (e.g. the standalone dashboard build without globalConfigs.js).
  */
-function getMdmsSearchUrl() {
+export function getMdmsSearchUrl() {
   const get = window.globalConfigs?.getConfig?.bind(window.globalConfigs);
   const contextPath =
     get?.("MDMS_V1_CONTEXT_PATH") ||
@@ -88,7 +89,10 @@ export function buildComplaintTypeIndex(records) {
  * humanized flat labels without blocking the dashboard.
  */
 export async function fetchComplaintHierarchyRecords() {
-  if (!hasAuth()) return null;
+  // The master is anonymously readable (MDMS _search is auth-optional on
+  // Kong); the public runtime sends a role-less single-shot request, exactly
+  // like boundaryService, so the public filter bar gets the same tree (#1797).
+  if (!hasAuth() && !isPublicDashboardRuntime()) return null;
 
   try {
     const response = await authFetch(getMdmsSearchUrl(), {

--- a/digit-ui-esbuild/products/dashboard/src/services/publicAnalyticsIsolation.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/publicAnalyticsIsolation.test.js
@@ -76,18 +76,31 @@ test("public pack and query never read or send stored employee credentials", asy
   const calls = [];
   const observed = installBrowser(async (url, init) => {
     calls.push({ url, init, body: JSON.parse(init.body) });
-    return response({ json: url.endsWith("/packs") ? { tiles: [] } : { results: {} } });
+    return response({ json: url.endsWith("/_query") || url.endsWith("/_options") ? { results: {} } : { tiles: [] } });
   });
   delete require.cache[require.resolve(OUT)];
-  const { fetchPublicPack, runPublicKpiBatch } = require(OUT);
+  const { fetchPublicPack, fetchPublicCatalog, fetchPublicFilterOptions, runPublicKpiBatch } = require(OUT);
 
   await fetchPublicPack("ke");
-  await runPublicKpiBatch({ created: { kpiId: "created" } }, "ke");
+  await fetchPublicCatalog("ke");
+  await fetchPublicFilterOptions("ke");
+  await runPublicKpiBatch(
+    { created: { kpiId: "created", params: { ward: "W1", dateFrom: "2026-07-01", dateTo: "2026-07-31" } } },
+    "ke"
+  );
 
   assert.deepEqual(calls.map((call) => call.url), [
     "/pgr-services/v2/analytics/public/packs",
+    "/pgr-services/v2/analytics/public/catalog/_search",
+    "/pgr-services/v2/analytics/public/_options",
     "/pgr-services/v2/analytics/public/_query",
   ]);
+  // The filter params ride the anonymous transport untouched (#1797) — the
+  // backend's allow-list, not this layer, decides what is acceptable.
+  assert.deepEqual(calls[3].body.queries.created.params,
+    { ward: "W1", dateFrom: "2026-07-01", dateTo: "2026-07-31" });
+  // The options endpoint takes nothing but the tenant.
+  assert.deepEqual(Object.keys(calls[2].body).sort(), ["RequestInfo", "tenantId"]);
   for (const call of calls) {
     assert.equal(call.init.credentials, "omit");
     assert.equal(call.body.RequestInfo.authToken, undefined);

--- a/digit-ui-esbuild/products/dashboard/src/services/publicRuntimeIsolation.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/publicRuntimeIsolation.test.js
@@ -12,6 +12,8 @@ const esbuild = require("esbuild");
 const OUT = path.join(os.tmpdir(), `publicRuntimeIsolation.cjs.${process.pid}.js`);
 const PUBLIC_ENTRY = path.resolve(__dirname, "../../../../public/public-dashboard.html");
 const DASHBOARD_LAYOUT = path.resolve(__dirname, "../components/DashboardLayout.jsx");
+const ADMIN_DASHBOARD = path.resolve(__dirname, "../AdminDashboard.jsx");
+const LOCALE_OUT = path.join(os.tmpdir(), `publicRuntimeIsolation.locale.cjs.${process.pid}.js`);
 const DASHBOARD_STYLES = path.resolve(__dirname, "../styles/input.css");
 const DASHBOARD_PACKS = path.resolve(
   __dirname,
@@ -45,11 +47,36 @@ esbuild.buildSync({
     "process.env.REACT_APP_STATE_LEVEL_TENANT_ID": '""',
   },
 });
+esbuild.buildSync({
+  stdin: {
+    contents: `
+      import { configurePublicDashboardRuntime } from './dashboardRuntime.js';
+      import { getLanguage, setLanguage, subscribe, translate, PUBLIC_LOCALE_KEY } from '../i18n/localeRuntime.js';
+      import { storageKeyFor, publicStorageKeyFor } from '../utils/layoutStore.js';
+      import { getFiltersStorageKey, getLayoutStorageKey } from '../config/dashboardConfig.js';
+      export { configurePublicDashboardRuntime, getLanguage, setLanguage, subscribe, translate, PUBLIC_LOCALE_KEY,
+               storageKeyFor, publicStorageKeyFor, getFiltersStorageKey, getLayoutStorageKey };
+    `,
+    resolveDir: __dirname,
+    sourcefile: "public-locale-test-entry.js",
+    loader: "js",
+  },
+  bundle: true,
+  format: "cjs",
+  platform: "neutral",
+  outfile: LOCALE_OUT,
+  define: {
+    "process.env.NODE_ENV": '"production"',
+    "process.env.REACT_APP_STATE_LEVEL_TENANT_ID": '""',
+  },
+});
 process.on("exit", () => {
-  try {
-    fs.unlinkSync(OUT);
-  } catch (e) {
-    /* already gone */
+  for (const f of [OUT, LOCALE_OUT]) {
+    try {
+      fs.unlinkSync(f);
+    } catch (e) {
+      /* already gone */
+    }
   }
 });
 
@@ -107,6 +134,7 @@ test("public-only chrome has seeded localization messages", () => {
   const messages = JSON.parse(fs.readFileSync(EN_MESSAGES, "utf8"));
   const byCode = Object.fromEntries(messages.map(({ code, message }) => [code, message]));
   assert.equal(byCode.DASHBOARD_HEADER_PUBLIC_SUBTITLE, "Public view");
+  assert.equal(byCode.DASHBOARD_HEADER_LANGUAGE, "Language");
   assert.equal(byCode.DASHBOARD_PUBLIC_NOT_AVAILABLE_TITLE, "Public dashboard is not available");
   assert.equal(
     byCode.DASHBOARD_PUBLIC_NOT_AVAILABLE_DESCRIPTION,
@@ -117,11 +145,71 @@ test("public-only chrome has seeded localization messages", () => {
   }
 });
 
-test("public entry omits the employee navigation sidebar", () => {
+test("public entry omits the employee navigation sidebar but keeps the filter bar and controls (#1797)", () => {
   const source = fs.readFileSync(DASHBOARD_LAYOUT, "utf8");
   assert.match(source, /!embedded\s*&&\s*!publicMode\s*&&\s*<Sidebar/);
   assert.match(source, /publicMode\s*\?\s*" dashboard-public"/);
   assert.match(source, /<DashboardHeader/);
+  // The filter bar follows readOnly, never publicMode: the public page must
+  // not be able to hide it again by mode alone.
+  assert.match(source, /\{!readOnly\s*&&\s*\(\s*<DashboardFilters/);
+  assert.doesNotMatch(source, /!publicMode\s*&&\s*\(?\s*<DashboardFilters/);
+  // The in-page language switcher mounts for every non-embedded shell.
+  assert.match(source, /showLanguageMenu=\{!embedded\}/);
+
+  const admin = fs.readFileSync(ADMIN_DASHBOARD, "utf8");
+  assert.match(admin, /readOnly=\{false\}/, "public renders Add KPI / Reset / filters like employee");
+  assert.doesNotMatch(admin, /readOnly=\{publicMode\}/);
+  assert.doesNotMatch(admin, /isDraggable=\{!publicMode\}/);
+  assert.match(admin, /useFilterOptions\(\{\s*enabled:\s*true,\s*publicMode\s*\}\)/);
+  assert.match(admin, /buildPublicRefs\(tiles,\s*kpis,\s*filters\)/);
+});
+
+test("public language switch and persistence never touch employee storage keys", async () => {
+  const writes = [];
+  const reads = [];
+  global.window = {
+    globalConfigs: { getConfig: (key) => ({ STATE_LEVEL_TENANT_ID: "ke", HIERARCHY_TYPE: "REVENUE" })[key] },
+    localStorage: {
+      getItem: (key) => { reads.push(key); return null; },
+      setItem: (key, value) => { writes.push([key, value]); },
+      removeItem: (key) => { writes.push([key, null]); },
+    },
+    sessionStorage: { getItem: () => null, setItem: () => {}, removeItem: () => {} },
+    dispatchEvent: () => {},
+  };
+  global.document = { documentElement: {} };
+  const fetched = [];
+  global.fetch = async (url) => {
+    fetched.push(url);
+    return { ok: true, json: async () => ({ messages: [{ code: "DASHBOARD_HEADER_LANGUAGE", message: "Idioma" }] }) };
+  };
+  delete require.cache[require.resolve(LOCALE_OUT)];
+  const mod = require(LOCALE_OUT);
+  mod.configurePublicDashboardRuntime();
+
+  assert.equal(mod.getLanguage(), "en_IN");
+  let ticks = 0;
+  mod.subscribe(() => { ticks += 1; });
+  await mod.setLanguage("pt_PT");
+
+  assert.equal(mod.getLanguage(), "pt_PT");
+  assert.equal(mod.translate("DASHBOARD_HEADER_LANGUAGE", "Language"), "Idioma");
+  assert.ok(ticks >= 2, "subscribers notified on switch and on bundle arrival");
+  assert.equal(global.document.documentElement.lang, "pt");
+  assert.deepEqual(writes, [[mod.PUBLIC_LOCALE_KEY, "pt_PT"]]);
+  assert.ok(!reads.some((k) => /^Employee\./.test(k)), `employee keys read: ${reads}`);
+  // Bundle request follows the tenant's boundary hierarchy, and carries no token.
+  assert.match(fetched[0], /module=rainmaker-dashboard%2Crainmaker-pgr%2Crainmaker-common%2Crainmaker-boundary-revenue/);
+  assert.match(fetched[0], /locale=pt_PT/);
+
+  // Layout / filter slots live in the public namespace, disjoint from every
+  // employee slot (which end in a user uuid / carry no suffix).
+  assert.equal(mod.publicStorageKeyFor("ke"), "ccrs.dashboard.catalog-layout.v1.ke.public");
+  assert.equal(mod.storageKeyFor("ke", null), null);
+  assert.match(mod.getFiltersStorageKey(), /-public$/);
+  assert.match(mod.getLayoutStorageKey(), /-public$/);
+  delete global.document;
 });
 
 test("public grid reflows instead of squeezing desktop columns on small screens", () => {

--- a/digit-ui-esbuild/products/dashboard/src/services/stateInfoService.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/stateInfoService.js
@@ -1,0 +1,52 @@
+import { authFetch, buildRequestInfo, getTenantId } from "./authService";
+import { getMdmsSearchUrl } from "./complaintHierarchyService";
+import { withTraceHeaders } from "./dashboardMetrics";
+
+/**
+ * The languages a tenant offers, for the standalone/public language switcher
+ * (#1797). Same master and same selection rule as the employee app's TopBar
+ * dropdown (packages/libraries Store/service.js): `common-masters.StateInfo`
+ * at the state root, first record, `languages` only when `hasLocalisation`.
+ *
+ * MDMS v1 `_search` is auth-optional on Kong, and in the public runtime
+ * authFetch sends a role-less single-shot request, so this needs no session.
+ * Resolves to [] on any failure — the switcher simply stays hidden.
+ *
+ * @returns {Promise<Array<{label: string, value: string}>>}
+ */
+export async function fetchStateLanguages() {
+  try {
+    const response = await authFetch(getMdmsSearchUrl(), {
+      headers: withTraceHeaders({}),
+      sessionCritical: false,
+      buildBody: () => ({
+        RequestInfo: buildRequestInfo("dashboard-state-info"),
+        MdmsCriteria: {
+          tenantId: getTenantId(),
+          moduleDetails: [
+            { moduleName: "common-masters", masterDetails: [{ name: "StateInfo" }] },
+          ],
+        },
+      }),
+    });
+    if (!response.ok) {
+      console.warn(`egov-mdms-service StateInfo _search failed (${response.status})`);
+      return [];
+    }
+    const payload = await response.json();
+    return languagesFromStateInfo(payload?.MdmsRes?.["common-masters"]?.StateInfo);
+  } catch (error) {
+    console.warn("StateInfo _search error", error);
+    return [];
+  }
+}
+
+/** Pure: StateInfo records -> [{label, value}] (exported for tests). */
+export function languagesFromStateInfo(records) {
+  const info = Array.isArray(records) ? records[0] : null;
+  if (!info || info.hasLocalisation !== true || !Array.isArray(info.languages)) return [];
+  const seen = new Set();
+  return info.languages
+    .filter((l) => l && typeof l.value === "string" && l.value && !seen.has(l.value) && seen.add(l.value))
+    .map((l) => ({ value: l.value, label: typeof l.label === "string" && l.label ? l.label : l.value }));
+}

--- a/digit-ui-esbuild/products/dashboard/src/services/stateInfoService.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/services/stateInfoService.test.js
@@ -1,0 +1,112 @@
+// Language list for the standalone/public switcher (#1797).
+// Run from digit-ui-esbuild/:
+//   node --test products/dashboard/src/services/stateInfoService.test.js
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const esbuild = require("esbuild");
+
+const OUT = path.join(os.tmpdir(), `stateInfoService.cjs.${process.pid}.js`);
+esbuild.buildSync({
+  stdin: {
+    contents: `
+      import { configurePublicDashboardRuntime } from './dashboardRuntime.js';
+      import { fetchStateLanguages, languagesFromStateInfo } from './stateInfoService.js';
+      export { configurePublicDashboardRuntime, fetchStateLanguages, languagesFromStateInfo };
+    `,
+    resolveDir: __dirname,
+    sourcefile: "state-info-test-entry.js",
+    loader: "js",
+  },
+  bundle: true,
+  format: "cjs",
+  platform: "neutral",
+  outfile: OUT,
+  define: {
+    "process.env.NODE_ENV": '"production"',
+    "process.env.REACT_APP_STATE_LEVEL_TENANT_ID": '""',
+  },
+});
+process.on("exit", () => {
+  try {
+    fs.unlinkSync(OUT);
+  } catch (e) {
+    /* already gone */
+  }
+});
+
+function load() {
+  delete require.cache[require.resolve(OUT)];
+  return require(OUT);
+}
+
+test("languagesFromStateInfo mirrors the TopBar rule: first record, hasLocalisation gate, de-duped", () => {
+  const { languagesFromStateInfo } = load();
+  const ke = [
+    {
+      code: "KE",
+      hasLocalisation: true,
+      languages: [
+        { label: "English", value: "en_IN" },
+        { label: "Swahili", value: "sw_KE" },
+        { label: "dup", value: "en_IN" },
+        { value: "fr_FR" }, // label falls back to the code
+        { label: "broken" }, // no value → dropped
+        null,
+      ],
+    },
+    { code: "ke", hasLocalisation: true, languages: [{ label: "X", value: "xx_XX" }] },
+  ];
+  assert.deepEqual(languagesFromStateInfo(ke), [
+    { value: "en_IN", label: "English" },
+    { value: "sw_KE", label: "Swahili" },
+    { value: "fr_FR", label: "fr_FR" },
+  ]);
+  assert.deepEqual(languagesFromStateInfo([{ hasLocalisation: false, languages: [{ value: "en_IN" }] }]), []);
+  assert.deepEqual(languagesFromStateInfo([]), []);
+  assert.deepEqual(languagesFromStateInfo(undefined), []);
+});
+
+test("fetchStateLanguages reads StateInfo anonymously in the public runtime and degrades to []", async () => {
+  const calls = [];
+  let reads = 0;
+  global.window = {
+    globalConfigs: { getConfig: (key) => ({ STATE_LEVEL_TENANT_ID: "ke", MDMS_V1_CONTEXT_PATH: "mdms-v2" })[key] },
+    localStorage: { getItem: () => { reads += 1; return JSON.stringify("employee-secret"); }, setItem() {}, removeItem() {} },
+    sessionStorage: { getItem: () => null, setItem() {}, removeItem() {} },
+    dispatchEvent() {},
+  };
+  global.fetch = async (url, init) => {
+    calls.push({ url, body: JSON.parse(init.body) });
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        MdmsRes: { "common-masters": { StateInfo: [{ hasLocalisation: true, languages: [{ label: "English", value: "en_IN" }, { label: "Português", value: "pt_PT" }] }] } },
+      }),
+    };
+  };
+  const mod = load();
+  mod.configurePublicDashboardRuntime();
+
+  const languages = await mod.fetchStateLanguages();
+
+  assert.deepEqual(languages, [{ value: "en_IN", label: "English" }, { value: "pt_PT", label: "Português" }]);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "/mdms-v2/v1/_search");
+  assert.equal(calls[0].body.RequestInfo.authToken, undefined);
+  assert.equal(calls[0].body.RequestInfo.userInfo, undefined);
+  assert.equal(calls[0].body.MdmsCriteria.tenantId, "ke");
+  assert.deepEqual(calls[0].body.MdmsCriteria.moduleDetails, [
+    { moduleName: "common-masters", masterDetails: [{ name: "StateInfo" }] },
+  ]);
+  assert.equal(reads, 0, "public runtime never inspects employee storage");
+
+  global.fetch = async () => ({ ok: false, status: 401, json: async () => ({}) });
+  assert.deepEqual(await mod.fetchStateLanguages(), []);
+  global.fetch = async () => { throw new Error("offline"); };
+  assert.deepEqual(await mod.fetchStateLanguages(), []);
+});

--- a/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
@@ -544,6 +544,16 @@
        appearance: none;
 }
 
+/* Language switcher chip (standalone/public header, #1797): match the
+     header buttons' 2rem height so the controls row stays one line. */
+
+.dashboard-header-controls .dashboard-language-chip{
+  height: 2rem;
+  min-height: 2rem;
+  min-width: 0px;
+  flex-shrink: 0;
+}
+
 .dashboard-header-controls .dashboard-header-btn:hover{
   background-color: var(--muted);
 }

--- a/digit-ui-esbuild/products/dashboard/src/styles/input.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/input.css
@@ -398,6 +398,12 @@
     appearance: none;
   }
 
+  /* Language switcher chip (standalone/public header, #1797): match the
+     header buttons' 2rem height so the controls row stays one line. */
+  .dashboard-header-controls .dashboard-language-chip {
+    @apply tw-h-8 tw-min-h-8 tw-min-w-0 tw-shrink-0;
+  }
+
   .dashboard-header-controls .dashboard-header-btn:hover {
     @apply tw-bg-muted;
   }

--- a/digit-ui-esbuild/products/dashboard/src/utils/layoutStore.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/layoutStore.js
@@ -36,6 +36,18 @@ export function storageKeyFor(tenantId, userId) {
   return `${LEGACY_STORAGE_KEY}.${tenantId}.${userId}`;
 }
 
+/**
+ * The anonymous public page has no user identity, yet its visitor still
+ * expects a rearranged page to survive a reload (#1797). Its slot is a fixed
+ * per-tenant key in its own `.public` namespace — disjoint by construction
+ * from every employee slot (those end in a user uuid), so a public visit on a
+ * shared machine can never read or clobber an employee's saved layout.
+ */
+export function publicStorageKeyFor(tenantId) {
+  if (!tenantId) return null;
+  return `${LEGACY_STORAGE_KEY}.${tenantId}.public`;
+}
+
 const CARD_KINDS = new Set([
   "number-tile-delta",
   "number-tile",

--- a/digit-ui-esbuild/products/dashboard/src/utils/publicQueryPlan.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/publicQueryPlan.test.js
@@ -1,4 +1,4 @@
-// Read-only public query plan (#1540).
+// Public query plan (#1540; filter-aware since #1797).
 // Run from digit-ui-esbuild/:
 //   node --test products/dashboard/src/utils/publicQueryPlan.test.js
 
@@ -29,26 +29,94 @@ process.on("exit", () => {
 
 const { buildPublicRefs, buildPublicRefsKey } = require(OUT);
 
-test("public plan emits one bare base reference per curated tile", () => {
+const NO_FILTERS = { geography: "all", complaintType: "all", dateRangeActive: false };
+
+test("public plan emits one bare base reference per curated tile when nothing narrows", () => {
   const kpis = {
     card: { version: "1", viz: { kind: "number-tile-sparkline" } },
     map: { version: "2", viz: { kind: "map" } },
   };
   const tiles = [{ kpiId: "card" }, { kpiId: "map" }, { kpiId: "not-in-pack" }];
 
-  assert.deepEqual(buildPublicRefs(tiles, kpis), {
+  assert.deepEqual(buildPublicRefs(tiles, kpis, NO_FILTERS), {
     card: { kpiId: "card" },
     map: { kpiId: "map" },
   });
-  assert.equal(buildPublicRefs(tiles, kpis).card__prior, undefined);
-  assert.equal(buildPublicRefs(tiles, kpis).card__series, undefined);
-  assert.equal(buildPublicRefs(tiles, kpis).map__pins, undefined);
-  assert.match(buildPublicRefsKey(tiles, kpis), /"public":true/);
+  const refs = buildPublicRefs(tiles, kpis, NO_FILTERS);
+  assert.equal(refs.card__prior, undefined);
+  assert.equal(refs.card__series, undefined);
+  assert.equal(refs.map__pins, undefined);
+  assert.equal(Object.hasOwn(refs.card, "params"), false);
+  assert.match(buildPublicRefsKey(tiles, kpis, NO_FILTERS), /"public":true/);
 });
 
-test("public plan ignores filters, overrides and unknown tile ids by construction", () => {
+test("public plan carries exactly the filter-bar params and nothing else (#1797)", () => {
+  const kpis = {
+    card: { version: "1", viz: { kind: "number-tile-sparkline" } },
+    bar: { version: "1", viz: { kind: "bar" } },
+  };
+  const tiles = [{ kpiId: "card" }, { kpiId: "bar" }];
+  const filters = {
+    geography: "W1",
+    complaintType: "Pothole",
+    complaintTypePath: null,
+    complaintTypeLeaf: true,
+    dateRangeActive: true,
+    dateFrom: "2026-07-01",
+    dateTo: "2026-07-31",
+  };
+
+  const refs = buildPublicRefs(tiles, kpis, filters);
+  const expectedParams = {
+    ward: "W1",
+    serviceCode: "Pothole",
+    dateFrom: "2026-07-01",
+    dateTo: "2026-07-31",
+  };
+  assert.deepEqual(refs, {
+    card: { kpiId: "card", params: expectedParams },
+    bar: { kpiId: "bar", params: expectedParams },
+  });
+  // Still no companion fan-out: the backend's public allow-list has no
+  // compare/series/hierLevel, and the plan must never ask for them.
+  assert.deepEqual(Object.keys(refs).sort(), ["bar", "card"]);
+  for (const ref of Object.values(refs)) {
+    assert.deepEqual(Object.keys(ref.params).sort(), ["dateFrom", "dateTo", "serviceCode", "ward"]);
+  }
+  // Each ref owns its params object — mutating one must not leak into the other.
+  refs.card.params.ward = "W2";
+  assert.equal(refs.bar.params.ward, "W1");
+
+  // The batch effect key must change when a filter changes, else the page
+  // never refetches after the visitor picks a ward.
+  assert.notEqual(
+    buildPublicRefsKey(tiles, kpis, filters),
+    buildPublicRefsKey(tiles, kpis, { ...filters, geography: "W2" })
+  );
+  assert.notEqual(
+    buildPublicRefsKey(tiles, kpis, filters),
+    buildPublicRefsKey(tiles, kpis, NO_FILTERS)
+  );
+});
+
+test("an interior complaint-type node narrows via complaintPath, not serviceCode", () => {
+  const kpis = { bar: { version: "1", viz: { kind: "bar" } } };
+  const refs = buildPublicRefs([{ kpiId: "bar" }], kpis, {
+    geography: "all",
+    complaintType: "Roads",
+    complaintTypePath: "Roads",
+    complaintTypeLeaf: false,
+    dateRangeActive: false,
+  });
+  assert.deepEqual(refs.bar.params, { complaintPath: "Roads" });
+});
+
+test("public plan ignores hierarchy overrides and unknown tile ids by construction", () => {
   const kpis = { only: { version: "1", viz: { kind: "bar" } } };
-  const refs = buildPublicRefs([{ kpiId: "only" }, null, {}, { kpiId: "unknown" }], kpis);
+  const refs = buildPublicRefs([{ kpiId: "only" }, null, {}, { kpiId: "unknown" }], kpis, NO_FILTERS);
   assert.deepEqual(refs, { only: { kpiId: "only" } });
   assert.equal(Object.hasOwn(refs.only, "params"), false);
+  // buildPublicRefs takes no hierOverrides argument at all — there is no seam
+  // through which a Group-by level could reach the public wire.
+  assert.equal(buildPublicRefs.length, 3);
 });

--- a/digit-ui-esbuild/products/dashboard/src/utils/queryPlan.js
+++ b/digit-ui-esbuild/products/dashboard/src/utils/queryPlan.js
@@ -152,27 +152,32 @@ export function buildRefs(tiles, kpis, filters, hierOverrides) {
 }
 
 /**
- * Public requests are intentionally narrower than the employee query plan.
- * Membership, layout, windows and disclosure policy belong to the curated
- * public pack/backend endpoint. The browser sends one bare kpiId reference per
- * laid-out tile: no user filters, hierarchy overrides, comparison/series fanout
- * or per-complaint map pin source.
+ * Public requests are narrower than the employee query plan. Membership,
+ * layout, windows and disclosure policy belong to the PUBLIC catalog/backend
+ * endpoints. The browser sends one reference per laid-out tile carrying ONLY
+ * the global filter-bar params (globalParams — the backend's public allow-list,
+ * #1797): no hierarchy overrides, comparison/series fan-out or per-complaint
+ * map pin source. `params` is omitted when no filter narrows anything so the
+ * bare-ref wire shape stays valid against older backends.
  */
-export function buildPublicRefs(tiles, kpis) {
+export function buildPublicRefs(tiles, kpis, filters) {
   const refs = {};
+  const params = globalParams(filters);
+  const hasParams = Object.keys(params).length > 0;
   for (const tile of tiles || []) {
     const kpiId = tile?.kpiId;
     if (!kpiId || !kpis?.[kpiId]) continue;
-    refs[kpiId] = { kpiId };
+    refs[kpiId] = hasParams ? { kpiId, params: { ...params } } : { kpiId };
   }
   return refs;
 }
 
-export function buildPublicRefsKey(tiles, kpis) {
+export function buildPublicRefsKey(tiles, kpis, filters) {
   return JSON.stringify({
     public: true,
     ids: (tiles || []).map((tile) => tile?.kpiId).filter((id) => id && kpis?.[id]),
     versions: (tiles || []).map((tile) => kpis?.[tile?.kpiId]?.version ?? null),
+    gp: globalParams(filters),
   });
 }
 

--- a/docs/dashboard-configuration/20-packs-and-rbac.md
+++ b/docs/dashboard-configuration/20-packs-and-rbac.md
@@ -184,6 +184,35 @@ An unauthenticated / role-less caller degrades to the synthetic `PUBLIC` role
 This is a deliberate degrade-to-curated-aggregates, not a lock-out; it closed the old fail-open
 where anonymous callers could read every `visibleTo: []` tile.
 
+#### The public dashboard page (`/digit-ui/public-dashboard`, #1540 / #1797)
+
+The anonymous page never touches the mixed-auth endpoints above. It uses four Kong-only
+auth-optional aliases under `/v2/analytics/public/*` (`AnalyticsController`), each of which
+**discards `RequestInfo` by construction** and fails closed when
+`dss.DashboardConfig.publicDashboardEnabled` is not `true`:
+
+| alias | returns | feeds |
+|---|---|---|
+| `POST …/public/packs` | the matched `PUBLIC` pack: tiles + default layout (no `recordCount`); `{enabled:false}` when disabled | default page |
+| `POST …/public/catalog/_search` | every published def with `"PUBLIC"` in `visibleTo` (safe descriptors) | the **Add KPI** menu |
+| `POST …/public/_options` | ward / complaint-type **codes** that carry complaints (counts stripped); the two distinct queries are server constants, the caller sends only `tenantId` | the filter bar's dropdowns |
+| `POST …/public/_query` | batch of `{kpiId[, params]}` refs | tile data |
+
+`/public/_query` accepts a ref for **any PUBLIC-tagged def** (not only pack tiles — the pack is
+the enablement gate, `visibleTo` is the disclosure boundary), and its `params` are rebuilt from a
+fixed allow-list — `dateFrom`, `dateTo`, `ward`, `serviceCode`, `complaintPath` — i.e. exactly
+the global filter bar. Each value must be a non-empty scalar ≤ 128 chars and the dates ISO
+calendar days; any other key (`hierLevel`, `compare`, `series`, `window`, …), shape or value is a
+whole-batch `400 invalid_param`. So the anonymous page gets the same Ward / Complaint type / date
+filters as the employee dashboard, but no companion fan-out (no prior-period deltas or
+sparklines), no Group-by level switch and no per-complaint pin source.
+
+**Which knob grants what, publicly:** tag a def `PUBLIC` → it appears in the public Add KPI
+menu and is queryable anonymously; add it to the `public-default` pack → it is on the page by
+default. Untag it → both disappear on the next config-cache refresh. The visitor's own layout and
+filter choices persist only in their browser (`ccrs.dashboard.*.public` keys, disjoint from every
+employee slot).
+
 ## 3. Error codes and what to do about them
 
 Per-entry in a batch (`results.<name>.error` + top-level `partial: true`) or a 400 body on a
@@ -212,7 +241,8 @@ emits `scope_incomplete`, which currently falls through to the raw-code default 
 | role R gets a curated default dashboard | add R to a pack's `roles` (and X to its `tiles`/`layout`) | `dss.DashboardPack` (MDMS) |
 | role R sees only its own department's numbers | give the user an HRMS assignment with that department; keep R out of `TENANT_WIDE_ROLES` | HRMS + (code constant, deploy) |
 | role R sees the whole tenant | grant one of the `TENANT_WIDE_ROLES` (e.g. `PGR_SUPERVISOR`) | HRMS/user roles |
-| anonymous/public page shows KPI X | add `"PUBLIC"` to X's `visibleTo` | `dss.KpiDefinition` (MDMS) |
+| anonymous/public page can show KPI X (Add KPI menu + anonymous query) | add `"PUBLIC"` to X's `visibleTo` | `dss.KpiDefinition` (MDMS) |
+| anonymous/public page shows KPI X **by default** | also list X in the `public-default` pack's `tiles` + `layout` | `dss.DashboardPack` (MDMS) |
 | role R can *open the dashboard view at all* (home card, deep-link route) | add R to `dss.DashboardConfig` `allowedRoles` (MDMS; the FE falls back to its built-in `DASHBOARD_ROLES` when the record is absent) **and** a `Dashboard` `tenant.citymodule` row (home card) — **a different system entirely** | `70-esbuild-embedding.md` §4, `30-view-access.md` |
 | role R gets a *sidebar* entry for the dashboard | ACCESSCONTROL actions/roleactions | `30-view-access.md` §2 (note the live bomet sidebar outage, `80-live-bomet-state.md` §5) |
 

--- a/docs/dashboard-configuration/90-localization.md
+++ b/docs/dashboard-configuration/90-localization.md
@@ -27,6 +27,31 @@ shell at boot. The TopBar language dropdown (host `ChangeLanguage`) drives local
 dashboard re-renders in place, including the imperatively-drawn Leaflet layers and pin popups
 (re-keyed on `i18n.language`).
 
+### 1.1 The public page (`/digit-ui/public-dashboard`)
+
+There is no DigitUI shell and no host i18next on the anonymous page, so
+`products/dashboard/src/i18n/localeRuntime.js` fetches the same four bundles itself from
+`/localization/messages/v1/_search` (auth-optional on Kong) at the **state root**, for the active
+locale **plus `en_IN`** as the fallback chain. Since #1797 the page carries its own language
+switcher (`components/LanguageMenu.jsx`, in the header):
+
+- **options** come from `common-masters.StateInfo[0].languages` at the state root, exactly like
+  the TopBar (`hasLocalisation` must be `true`; a single declared language hides the menu);
+- **switching** calls `setLanguage()`, which remembers the choice under
+  `localStorage["ccrs.dashboard.public-locale.v1"]` — deliberately *not* `Employee.locale`, so a
+  public visit never reads or rewrites the language of an employee session in the same browser —
+  loads the bundle and re-renders every `useDashboardT` consumer in place;
+- **first visit** defaults to `globalConfigs` `LOCALE_DEFAULT` + `_` + `LOCALE_REGION` (the
+  employee app's boot locale), else `en_IN`.
+
+**Seeding caveat (bomet).** The menu lists whatever `StateInfo.languages` declares; it does not
+know whether a `rainmaker-dashboard` pack exists for that locale. `ke` declares `en_IN` +
+`sw_KE`, but only `en_IN` and `pt_PT` dashboard packs ship in
+`local-setup/db/dss-mdms-seed/l10n/` — so picking Swahili on bomet today renders the dashboard's
+own chrome in the English fallback until a `sw_KE` pack is upserted (`enable-dashboard.sh`
+already warns on exactly this mismatch). The fix is data: translate the pack, upsert it at the
+state root, cache-bust (§4.1).
+
 Two resolution seams in `products/dashboard/src/i18n/`:
 
 - `translate(key, seedEnglish)` / `useDashboardT()` — chrome strings; missing ⇒ raw key.

--- a/local-setup/db/dss-mdms-seed/l10n/en_IN.json
+++ b/local-setup/db/dss-mdms-seed/l10n/en_IN.json
@@ -450,6 +450,11 @@
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "DASHBOARD_HEADER_LANGUAGE",
+    "message": "Language",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "DASHBOARD_HEADER_LAST_7_DAYS",
     "message": "Last 7 days",
     "module": "rainmaker-dashboard"

--- a/local-setup/db/dss-mdms-seed/l10n/pt_PT.json
+++ b/local-setup/db/dss-mdms-seed/l10n/pt_PT.json
@@ -450,6 +450,11 @@
     "module": "rainmaker-dashboard"
   },
   {
+    "code": "DASHBOARD_HEADER_LANGUAGE",
+    "message": "Idioma",
+    "module": "rainmaker-dashboard"
+  },
+  {
     "code": "DASHBOARD_HEADER_LAST_7_DAYS",
     "message": "Últimos 7 dias",
     "module": "rainmaker-dashboard"

--- a/local-setup/kong/kong.yml
+++ b/local-setup/kong/kong.yml
@@ -146,6 +146,11 @@ plugins:
           -- They are exact AUTH_OPTIONAL matches and exact regex routes below.
           ["/pgr-services/v2/analytics/public/packs"]=true,
           ["/pgr-services/v2/analytics/public/_query"]=true,
+          -- #1797: the public page's Add-KPI menu and filter-bar option lists. Same
+          -- contract: RequestInfo discarded server-side, PUBLIC-tagged tiles only,
+          -- the options endpoint takes nothing but tenantId.
+          ["/pgr-services/v2/analytics/public/catalog/_search"]=true,
+          ["/pgr-services/v2/analytics/public/_options"]=true,
         }
         local uri = kong.request.get_path()
         local is_protected = not AUTH_OPTIONAL[uri]
@@ -600,6 +605,44 @@ services:
   - name: pgr-public-analytics-query-route
     paths:
     - ~/pgr-services/v2/analytics/public/_query$
+    methods:
+    - POST
+    strip_path: false
+    regex_priority: 100
+    plugins:
+    - name: rate-limiting
+      config:
+        minute: 60
+        policy: local
+        limit_by: ip
+        fault_tolerant: true
+        hide_client_headers: false
+    - name: request-size-limiting
+      config:
+        allowed_payload_size: 1
+        size_unit: megabytes
+  - name: pgr-public-analytics-catalog-route
+    paths:
+    - ~/pgr-services/v2/analytics/public/catalog/_search$
+    methods:
+    - POST
+    strip_path: false
+    regex_priority: 100
+    plugins:
+    - name: rate-limiting
+      config:
+        minute: 60
+        policy: local
+        limit_by: ip
+        fault_tolerant: true
+        hide_client_headers: false
+    - name: request-size-limiting
+      config:
+        allowed_payload_size: 1
+        size_unit: megabytes
+  - name: pgr-public-analytics-options-route
+    paths:
+    - ~/pgr-services/v2/analytics/public/_options$
     methods:
     - POST
     strip_path: false

--- a/local-setup/tests/static/infra-contracts.test.ts
+++ b/local-setup/tests/static/infra-contracts.test.ts
@@ -29,6 +29,8 @@ describe('Kong declarative route syntax', () => {
     expect(KONG_REGEX_PATHS.filter((routePath) => routePath.startsWith('~/pgr-services/v2/analytics/public/'))).toEqual([
       '~/pgr-services/v2/analytics/public/packs$',
       '~/pgr-services/v2/analytics/public/_query$',
+      '~/pgr-services/v2/analytics/public/catalog/_search$',
+      '~/pgr-services/v2/analytics/public/_options$',
     ]);
   });
 });


### PR DESCRIPTION
## Summary

Closes #1797 (P0). The public dashboard (`/digit-ui/public-dashboard`) now has the same top bar as the employee dashboard — **Start/End date, Ward, Complaint type, Clear**, plus **Add KPI** and **Reset** — and an in-page **language switcher**.

The public page is the employee dashboard mounted with `mode="public"`; #1703 deliberately stripped it to a zero-input page in three places (UI hidden behind `readOnly=publicMode`, bare `{kpiId}` refs, and a backend that rejected any `params`). This PR re-opens each layer behind a fixed allow-list rather than removing the boundary.

## Backend — public APIs (`pgr-services`)

| endpoint | change |
|---|---|
| `POST /v2/analytics/public/_query` | accepts `{kpiId[, params]}`; `params` rebuilt from the allow-list **`dateFrom`, `dateTo`, `ward`, `serviceCode`, `complaintPath`** (scalar, ≤128 chars, dates ISO) — anything else is `400 invalid_param`. Reachable KPIs = every published def tagged `PUBLIC` (the pack remains the fail-closed enablement gate). No `compare`/`series`/`hierLevel`/`window`. |
| `POST /v2/analytics/public/catalog/_search` | **new** — PUBLIC catalog as safe descriptors; feeds the Add KPI menu. |
| `POST /v2/analytics/public/_options` | **new** — ward / complaint-type codes that carry complaints, from two server-owned distinct queries under the anonymous scope; counts stripped; caller sends only `tenantId`. |

RequestInfo is still discarded by construction on all four aliases; all fail closed when `publicDashboardEnabled` is not `true`.

**Gateway:** both new paths are Kong auth-optional with the same 60/min/IP + 1 MB limits as the existing two. `check-gateway-whitelist-parity.py` and `infra-contracts.test.ts` updated; the K8s Spring gateway deliberately stays closed (it does not strip spoofed `userInfo`).

## Frontend (`products/dashboard`)

- Filter bar, Clear, Add KPI, Reset, drag/resize/remove render in public mode; `buildPublicRefs` carries `globalParams(filters)`; `useCatalog` reads the public catalog; `useFilterOptions` reads `/public/_options` (same envelope shape, so the option builder is shared); the complaint-type tree loads anonymously the way `boundaryService` already did.
- Visitor layout/filters persist under **public-only keys** (`…catalog-layout.v1.<tenant>.public`, `…-filters-v4-public`) — disjoint from every employee slot.
- `LanguageMenu` in the standalone/public header, fed by `common-masters.StateInfo.languages` (same master as the TopBar). `localeRuntime.setLanguage()` switches in place and remembers the choice under `ccrs.dashboard.public-locale.v1`.
- Two latent bugs fixed on the way: the public page was reading `Employee.locale` (inheriting a co-hosted employee session's language), and the standalone boundary bundle was hardcoded to `rainmaker-boundary-admin` instead of following `HIERARCHY_TYPE`.
- Header shows the `<ward> · <period>` context line in every mode; "Public view" survives as a pill.

## Seeds & docs

- `DASHBOARD_HEADER_LANGUAGE` added to the generated l10n packs (`dashboard-l10n-seed.ts` → `export-l10n.mjs --check` clean).
- `docs/dashboard-configuration/20-packs-and-rbac.md`: the four public aliases, the param allow-list, and "tag `PUBLIC` → Add KPI menu; list in `public-default` → on by default".
- `docs/dashboard-configuration/90-localization.md`: the switcher, its storage key, and the **bomet caveat** — `ke` declares `en_IN` + `sw_KE`, but only `en_IN`/`pt_PT` dashboard packs exist, so Swahili renders the dashboard chrome in the English fallback until an `sw_KE` pack is upserted (data, not code; `enable-dashboard.sh` already warns on this).

## Out of scope (not in the issue)

Prior-period deltas / sparklines on public cards, per-widget Group-by, the employee sidebar. Also pre-existing and untouched: the public page computes default dates in the Nairobi fallback zone because it cannot read `dss.DashboardConfig.timeZone` — worth its own ticket.

## Verification

- `pgr-services`: 168 analytics tests green (`AnalyticsController*`, `AnalyticsService*`, `KpiCatalogService*`, `PrincipalScopeResolver*`, `KpiQueryComposer*`) — `AnalyticsControllerPublicTest` rewritten (17), new `AnalyticsServicePublicOptionsTest` (3).
- dashboard: 255 Node tests green; `npm run build` emits both entries.
- `check-gateway-whitelist-parity.py` (+ `--self-test`), `infra-contracts.test.ts`, `export-l10n.mjs --check`, `git diff --check` all clean.
- Mutation-checked: re-hiding the filter bar, dropping params from the public plan, leaking `Employee.locale`, and removing `ward` from the backend allow-list each turn the corresponding test red.
- **Not yet done:** a live browser pass on a composed environment (local stack was down). Suggested smoke: open the public page → filter bar present, changing Ward/dates re-queries; Add KPI lists the PUBLIC tiles; language menu lists StateInfo languages and switches in place; a hand-crafted `/public/_query` with `params:{hierLevel:"1"}` or a non-PUBLIC kpiId returns 400; DevTools shows no `authToken`/`userInfo` on any request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
