### PR TITLE
fix(dashboard): render the "Powered by DIGIT" footer in the shipping esbuild product

### DIFF
--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardFooter.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardFooter.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+// Link target when the deployment has not configured DIGIT_HOME_URL.
+const DEFAULT_HOME_URL = "https://egov.org.in/digit/";
+
+const getConfig = (key) => window?.globalConfigs?.getConfig?.(key);
+
+// "Powered by DIGIT" attribution, matching the citizen/employee DIGIT shells.
+// The dashboard bypasses that shell — App.js routes /employee/dashboard straight
+// to AdminDashboard — so it has to render its own.
+//
+// The logo comes from globalConfigs only, with no baked-in URL, so a deployment
+// can rebrand or drop the attribution without a code change. When DIGIT_FOOTER
+// is unset we render nothing rather than a broken image, which is the same guard
+// the employee shell uses (packages/modules/core/src/pages/employee/index.js).
+const DashboardFooter = () => {
+  const logoUrl = getConfig("DIGIT_FOOTER");
+  if (!logoUrl) return null;
+
+  return (
+    <footer className="dashboard-footer tw-flex tw-flex-shrink-0 tw-items-center tw-justify-center tw-border-t tw-border-border tw-bg-surface tw-py-2">
+      <a
+        href={getConfig("DIGIT_HOME_URL") || DEFAULT_HOME_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="tw-inline-flex tw-items-center"
+      >
+        <img className="dashboard-footer-img" alt="Powered by DIGIT" src={logoUrl} />
+      </a>
+    </footer>
+  );
+};
+
+export default DashboardFooter;

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardFooter.test.js
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardFooter.test.js
@@ -1,0 +1,77 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const esbuild = require("esbuild");
+
+const ENTRY = `
+import React from "react";
+import ReactDOMServer from "react-dom/server";
+import DashboardFooter from "./DashboardFooter.jsx";
+
+export const renderFooter = () =>
+  ReactDOMServer.renderToStaticMarkup(React.createElement(DashboardFooter));
+`;
+
+function bundleEntry() {
+  const out = path.join(os.tmpdir(), `dashboard-footer.${process.pid}.cjs.js`);
+  esbuild.buildSync({
+    stdin: {
+      contents: ENTRY,
+      resolveDir: __dirname,
+      loader: "jsx",
+      sourcefile: "dashboard-footer-entry.jsx",
+    },
+    bundle: true,
+    format: "cjs",
+    platform: "node",
+    loader: { ".jsx": "jsx", ".js": "jsx" },
+    outfile: out,
+    logLevel: "silent",
+    define: { "process.env.NODE_ENV": '"test"' },
+  });
+  process.on("exit", () => {
+    try {
+      fs.unlinkSync(out);
+    } catch (e) {
+      /* already gone */
+    }
+  });
+  return out;
+}
+
+const bundledEntry = bundleEntry();
+
+function renderWithConfig(config) {
+  delete require.cache[bundledEntry];
+  global.window = { globalConfigs: { getConfig: (key) => config[key] } };
+  try {
+    return require(bundledEntry).renderFooter();
+  } finally {
+    delete global.window;
+  }
+}
+
+test("renders the attribution from the configured footer logo", () => {
+  const html = renderWithConfig({
+    DIGIT_FOOTER: "/digit-ui/brand/digit-footer.png",
+    DIGIT_HOME_URL: "https://digit.example.org/",
+  });
+  assert.match(html, /<footer[^>]*class="[^"]*dashboard-footer/);
+  assert.match(html, /src="\/digit-ui\/brand\/digit-footer\.png"/);
+  assert.match(html, /alt="Powered by DIGIT"/);
+  assert.match(html, /href="https:\/\/digit\.example\.org\/"/);
+});
+
+test("falls back to the public DIGIT home when DIGIT_HOME_URL is unset", () => {
+  const html = renderWithConfig({ DIGIT_FOOTER: "/digit-ui/brand/digit-footer.png" });
+  assert.match(html, /href="https:\/\/egov\.org\.in\/digit\/"/);
+});
+
+// The bug behind #1836: an unset DIGIT_FOOTER used to reach the <img> as an
+// empty src, painting a broken-image glyph plus its alt text. Render nothing.
+test("renders nothing rather than a broken image when the logo is unset", () => {
+  assert.equal(renderWithConfig({ DIGIT_FOOTER: "" }), "");
+  assert.equal(renderWithConfig({}), "");
+});

--- a/digit-ui-esbuild/products/dashboard/src/components/DashboardLayout.jsx
+++ b/digit-ui-esbuild/products/dashboard/src/components/DashboardLayout.jsx
@@ -3,6 +3,7 @@ import { getBrandTheme } from "../config/dashboardConfig";
 import DashboardHeader from "./DashboardHeader";
 import DashboardFilters from "./DashboardFilters";
 import Sidebar from "./Sidebar";
+import DashboardFooter from "./DashboardFooter";
 
 const DashboardLayout = ({
   children,
@@ -90,6 +91,12 @@ const DashboardLayout = ({
           )}
           {children}
         </main>
+        {/* Sibling of <main>, not a child: the shell is tw-h-screen with an
+            overflow-hidden column, so the footer must sit outside the scroll
+            container to stay pinned at the bottom. In embedded mode the
+            employee shell renders its own attribution above us, so skip ours
+            rather than stacking two. */}
+        {!embedded && <DashboardFooter />}
       </div>
     </div>
   );

--- a/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/dashboard.css
@@ -513,6 +513,12 @@
   gap: 0.5rem;
 }
 
+.dashboard-footer-img {
+  height: 1.1em;
+  width: auto;
+  cursor: pointer;
+}
+
 .dashboard-header-controls .dashboard-header-btn{
   margin: 0px;
   box-sizing: border-box;

--- a/digit-ui-esbuild/products/dashboard/src/styles/input.css
+++ b/digit-ui-esbuild/products/dashboard/src/styles/input.css
@@ -390,6 +390,12 @@
   .dashboard-header-controls {
     @apply tw-flex tw-min-w-0 tw-flex-wrap tw-items-center tw-gap-2;
   }
+
+  .dashboard-footer-img {
+    height: 1.1em;
+    width: auto;
+    cursor: pointer;
+  }
   .dashboard-header-controls .dashboard-header-btn {
     @apply tw-box-border tw-m-0 tw-inline-flex tw-h-8 tw-min-h-8 tw-max-h-8 tw-shrink-0 tw-items-center tw-justify-center tw-gap-1.5 tw-rounded-sm tw-border tw-border-solid tw-border-border tw-bg-surface tw-px-2.5 tw-py-0 tw-text-[12px] tw-font-medium tw-leading-none tw-text-foreground;
     font-family: inherit;


### PR DESCRIPTION
Part of #1836 — the dashboard half. **Stacked on #1839**, which supplies the logo asset and the non-empty config default; on its own this renders nothing, because it correctly guards on the empty `DIGIT_FOOTER`.

## Root cause

`DashboardFooter.jsx` exists only in the legacy `frontend/micro-ui/web/src/dashboard/` tree. It was never ported to `digit-ui-esbuild/products/dashboard/`, which is what actually builds and deploys, so the dashboard has had no attribution at all.

Confirmed against the deployed Bomet bundle:

```
$ curl -s https://<bomet>/digit-ui/index.js | grep -c "Powered by DIGIT"
3          # citizen + employee shells
$ curl -s https://<bomet>/digit-ui/index.js | grep -c "dashboard-footer"
0          # nothing
```

## Changes

- Port `DashboardFooter.jsx` into the esbuild product.
- Wire it into `DashboardLayout` as a **sibling of `<main>`**, not a child: the shell is `tw-h-screen` with an overflow-hidden column, so the footer has to sit outside the scroll container to stay pinned to the bottom.
- Add the `.dashboard-footer-img` sizing rule to `input.css` and its compiled equivalent in `dashboard.css`. Every `tw-` utility the component uses is already emitted in the committed CSS, so that one rule is the whole CSS delta — no full regeneration, no incidental diff.
- Add a render test.

## Why `!embedded`

In embedded mode `DashboardModule` mounts inside the employee chrome via `AppModules`, and that shell already renders its own attribution below us (`packages/modules/core/src/pages/employee/index.js:159`) — rendering ours as well would stack two footers. **Standalone and public mode** bypass the shell entirely (`App.js` routes straight to `AdminDashboard`), and those are the cases that were genuinely missing it, which matches what the report describes.

## Verification

- New `DashboardFooter.test.js` — 3/3 pass. Covers the render, the `DIGIT_HOME_URL` fallback, and the bug behind #1836: an unset `DIGIT_FOOTER` must render nothing rather than an `<img>` with an empty `src`.
- Full dashboard suite: **246/247 pass**. The one failure is `mapTooltipTeardown.test.js`, which reads `node_modules/leaflet/dist/leaflet-src.js` — absent from the minimal dependency set I installed locally. Unrelated to this change; it should pass in CI with a full `npm install`.
- `DashboardLayout.jsx` compiles clean under esbuild with the footer bundled and correctly gated.

Refs #1836